### PR TITLE
fix(cloud): enforce Hetzner lifecycle authority

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/compute-provider-characterization.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider-characterization.test.ts
@@ -59,6 +59,22 @@ function queueStatus(status: number, body?: unknown): void {
   );
 }
 
+function actionEnvelope(
+  id: number,
+  command: string,
+  status: "running" | "success" | "error",
+  resource?: { id: number; type: string },
+) {
+  return {
+    id,
+    command,
+    status,
+    progress: status === "success" ? 100 : 0,
+    resources: resource ? [resource] : [],
+    error: status === "error" ? { code: "failed", message: "provider failure" } : null,
+  };
+}
+
 function lastRequest(): RecordedRequest {
   const req = recorded.at(-1);
   if (!req) throw new Error("no request was recorded");
@@ -220,12 +236,17 @@ describe("HetznerCloudClient transport", () => {
     expect(req.headers["Content-Type"]).toBe("application/json");
   });
 
-  test("a 204 No Content response maps to undefined (delete path)", async () => {
-    queueStatus(204);
+  test("server delete awaits its action and proves exact target absence", async () => {
+    queueJson({
+      action: actionEnvelope(70, "delete_server", "success", { id: 7, type: "server" }),
+    });
+    queueStatus(404, { error: { code: "not_found", message: "gone" } });
     const result = await client().deleteServer(7);
     expect(result).toBeUndefined();
-    expect(lastRequest().method).toBe("DELETE");
-    expect(lastRequest().url).toBe(`${API_BASE}/servers/7`);
+    expect(recorded.map(({ method, url }) => ({ method, url }))).toEqual([
+      { method: "DELETE", url: `${API_BASE}/servers/7` },
+      { method: "GET", url: `${API_BASE}/servers/7` },
+    ]);
   });
 
   test("a transport-level fetch rejection maps to transport_error", async () => {
@@ -319,6 +340,11 @@ describe("HetznerCloudClient servers", () => {
     expect(lastRequest().url).toBe(`${API_BASE}/servers/42`);
   });
 
+  test("getServer rejects a mismatched by-id response", async () => {
+    queueJson({ server: { id: 43, name: "wrong" } });
+    await expect(client().getServer(42)).rejects.toMatchObject({ code: "server_error" });
+  });
+
   test("getServer returns null on 404 (does not throw)", async () => {
     queueStatus(404, { error: { code: "not_found", message: "no such server" } });
     const server = await client().getServer(999);
@@ -326,7 +352,13 @@ describe("HetznerCloudClient servers", () => {
   });
 
   test("createServer remaps camelCase input to the Hetzner wire body", async () => {
-    queueJson({ server: { id: 100, name: "n1" }, root_password: "pw" });
+    queueJson({
+      server: { id: 100, name: "n1" },
+      action: actionEnvelope(1, "create_server", "success", { id: 100, type: "server" }),
+      next_actions: [],
+      root_password: "pw",
+    });
+    queueJson({ server: { id: 100, name: "n1", status: "running" } });
     const input: CreateServerInput = {
       name: "n1",
       serverType: "cax21",
@@ -340,7 +372,7 @@ describe("HetznerCloudClient servers", () => {
     };
     const result = await client().createServer(input);
 
-    const req = lastRequest();
+    const req = recorded[0] as RecordedRequest;
     expect(req.method).toBe("POST");
     expect(req.url).toBe(`${API_BASE}/servers`);
     expect(req.body).toEqual({
@@ -361,6 +393,7 @@ describe("HetznerCloudClient servers", () => {
       server: {
         id: 100,
         name: "n1",
+        status: "running",
         publicIpv4: null,
         firewallAttachments: [],
       } as never,
@@ -369,7 +402,13 @@ describe("HetznerCloudClient servers", () => {
   });
 
   test("createServer omits ssh_keys/networks/labels when empty", async () => {
-    queueJson({ server: { id: 101 }, root_password: null });
+    queueJson({
+      server: { id: 101 },
+      action: actionEnvelope(2, "create_server", "success", { id: 101, type: "server" }),
+      next_actions: [],
+      root_password: null,
+    });
+    queueJson({ server: { id: 101, status: "running" } });
     await client().createServer({
       name: "n2",
       serverType: "cax21",
@@ -381,7 +420,7 @@ describe("HetznerCloudClient servers", () => {
       firewallIds: [],
       labels: {},
     });
-    expect(lastRequest().body).toEqual({
+    expect(recorded[0]?.body).toEqual({
       name: "n2",
       server_type: "cax21",
       location: "fsn1",
@@ -406,13 +445,17 @@ describe("HetznerCloudClient servers", () => {
   });
 
   test("powerOff / powerOn POST to the action endpoints and return the action", async () => {
-    queueJson({ action: { id: 5, command: "stop_server", status: "running", progress: 0 } });
+    queueJson({
+      action: actionEnvelope(5, "stop_server", "running", { id: 7, type: "server" }),
+    });
     const off = await client().powerOff(7);
     expect(lastRequest().method).toBe("POST");
     expect(lastRequest().url).toBe(`${API_BASE}/servers/7/actions/poweroff`);
     expect(off).toMatchObject({ id: 5, status: "running" });
 
-    queueJson({ action: { id: 6, command: "start_server", status: "running", progress: 0 } });
+    queueJson({
+      action: actionEnvelope(6, "start_server", "running", { id: 7, type: "server" }),
+    });
     await client().powerOn(7);
     expect(lastRequest().url).toBe(`${API_BASE}/servers/7/actions/poweron`);
   });
@@ -424,14 +467,21 @@ describe("HetznerCloudClient servers", () => {
 
 describe("HetznerCloudClient volumes", () => {
   test("createVolume remaps sizeGb→size and defaults format to ext4", async () => {
-    queueJson({ volume: { id: 200, name: "v1" } });
+    queueJson({
+      volume: { id: 200, name: "v1" },
+      action: actionEnvelope(20, "create_volume", "success", { id: 200, type: "volume" }),
+      next_actions: [],
+    });
+    queueJson({
+      volume: { id: 200, name: "v1", status: "available", server: null, linux_device: null },
+    });
     const input: CreateVolumeInput = {
       name: "v1",
       sizeGb: 50,
       location: "fsn1",
     };
     await client().createVolume(input);
-    const req = lastRequest();
+    const req = recorded[0] as RecordedRequest;
     expect(req.method).toBe("POST");
     expect(req.url).toBe(`${API_BASE}/volumes`);
     expect(req.body).toEqual({
@@ -442,30 +492,63 @@ describe("HetznerCloudClient volumes", () => {
     });
   });
 
-  test("createVolume includes server/automount=false/labels when set", async () => {
-    queueJson({ volume: { id: 201 } });
+  test("createVolume uses server-exclusive placement and preserves automount", async () => {
+    queueJson({
+      volume: { id: 201 },
+      action: actionEnvelope(21, "create_volume", "success", { id: 201, type: "volume" }),
+      next_actions: [],
+    });
+    queueJson({
+      volume: {
+        id: 201,
+        status: "available",
+        server: 77,
+        linux_device: "/dev/disk/by-id/scsi-0HC_Volume_201",
+      },
+    });
     await client().createVolume({
       name: "v2",
       sizeGb: 10,
       location: "nbg1",
       format: "xfs",
       serverId: 77,
-      automount: false,
+      automount: true,
       labels: { tier: "data" },
     });
-    expect(lastRequest().body).toEqual({
+    expect(recorded[0]?.body).toEqual({
       name: "v2",
       size: 10,
-      location: "nbg1",
       format: "xfs",
       server: 77,
-      automount: false,
+      automount: true,
       labels: { tier: "data" },
     });
   });
 
+  test("createVolume rejects invalid server identity before transport", async () => {
+    await expect(
+      client().createVolume({
+        name: "invalid-server",
+        sizeGb: 10,
+        location: "nbg1",
+        serverId: 0,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    await expect(
+      client().createVolume({
+        name: "invalid-automount",
+        sizeGb: 10,
+        location: "nbg1",
+        automount: true,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    expect(recorded).toHaveLength(0);
+  });
+
   test("attachVolume body is {server, automount} and defaults automount=false", async () => {
-    queueJson({ action: { id: 9, command: "attach_volume", status: "running", progress: 0 } });
+    queueJson({
+      action: actionEnvelope(9, "attach_volume", "running", { id: 200, type: "volume" }),
+    });
     await client().attachVolume(200, 77);
     const req = lastRequest();
     expect(req.method).toBe("POST");
@@ -474,7 +557,9 @@ describe("HetznerCloudClient volumes", () => {
   });
 
   test("detachVolume POSTs to the detach action endpoint", async () => {
-    queueJson({ action: { id: 10, command: "detach_volume", status: "running", progress: 0 } });
+    queueJson({
+      action: actionEnvelope(10, "detach_volume", "running", { id: 200, type: "volume" }),
+    });
     await client().detachVolume(200);
     expect(lastRequest().url).toBe(`${API_BASE}/volumes/200/actions/detach`);
     expect(lastRequest().method).toBe("POST");
@@ -482,10 +567,11 @@ describe("HetznerCloudClient volumes", () => {
 
   test("deleteVolume issues a DELETE and resolves undefined on 204", async () => {
     queueStatus(204);
+    queueStatus(404, { error: { code: "not_found", message: "gone" } });
     const result = await client().deleteVolume(200);
     expect(result).toBeUndefined();
-    expect(lastRequest().method).toBe("DELETE");
-    expect(lastRequest().url).toBe(`${API_BASE}/volumes/200`);
+    expect(recorded[0]?.method).toBe("DELETE");
+    expect(recorded[0]?.url).toBe(`${API_BASE}/volumes/200`);
   });
 
   test("getVolume returns null on 404", async () => {
@@ -513,14 +599,14 @@ describe("HetznerCloudClient volumes", () => {
 
 describe("HetznerCloudClient waitForAction", () => {
   test("returns immediately when the first poll reports success", async () => {
-    queueJson({ action: { id: 50, command: "create_server", status: "success", progress: 100 } });
+    queueJson({ action: actionEnvelope(50, "create_server", "success") });
     const action = await client().waitForAction(50);
     expect(action).toMatchObject({ id: 50, status: "success" });
     expect(lastRequest().url).toBe(`${API_BASE}/actions/50`);
     expect(recorded.length).toBe(1);
   });
 
-  test("returns an error action without throwing (status !== running)", async () => {
+  test("throws when the provider reports a terminal action error", async () => {
     queueJson({
       action: {
         id: 51,
@@ -530,8 +616,7 @@ describe("HetznerCloudClient waitForAction", () => {
         error: { code: "boom", message: "failed" },
       },
     });
-    const action = await client().waitForAction(51);
-    expect(action.status).toBe("error");
+    await expect(client().waitForAction(51)).rejects.toMatchObject({ code: "server_error" });
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.error-policy.test.ts
@@ -15,12 +15,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { CreateServerInput, CreateVolumeInput } from "./compute-provider";
-import {
-  ACTION_STATUS_COMPLETED,
-  ACTION_STATUS_ERRORED,
-  ComputeFakeError,
-  InMemoryComputeProvider,
-} from "./compute-provider-fake";
+import { ComputeFakeError, InMemoryComputeProvider } from "./compute-provider-fake";
 
 function serverInput(over: Partial<CreateServerInput> = {}): CreateServerInput {
   return {
@@ -84,19 +79,15 @@ describe("internal failure propagates (fail-closed)", () => {
     await expect(p.waitForAction(424242)).rejects.toMatchObject({ code: "not_found" });
   });
 
-  test("waitForAction on a poisoned id surfaces `errored` observably — not fabricated `completed`", async () => {
+  test("waitForAction on a poisoned id rejects instead of fabricating completion", async () => {
     const p = new InMemoryComputeProvider();
     const { server } = await p.createServer(serverInput());
     const action = await p.powerOff(server.id as number);
     p.poisonAction(action.id as number);
 
-    const done = await p.waitForAction(action.id as number);
-    // Mirrors the real Hetzner client returning the error action (not throwing),
-    // but the failure MUST remain observable: status errored + populated error.
-    expect(done.status).toBe(ACTION_STATUS_ERRORED);
-    expect(done.status).not.toBe(ACTION_STATUS_COMPLETED);
-    expect(done.error).not.toBeNull();
-    expect(done.error).toMatchObject({ code: "action_failed" });
+    await expect(p.waitForAction(action.id as number)).rejects.toMatchObject({
+      code: "action_failed",
+    });
   });
 
   test("tick with invalid input throws invalid_input — the clock never silently no-ops", () => {

--- a/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.test.ts
@@ -19,7 +19,6 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import type { CreateServerInput, CreateVolumeInput } from "./compute-provider";
 import {
   ACTION_STATUS_COMPLETED,
-  ACTION_STATUS_ERRORED,
   ACTION_STATUS_IN_PROGRESS,
   ComputeFakeError,
   InMemoryComputeProvider,
@@ -229,18 +228,18 @@ describe("actions", () => {
     expect((await provider.waitForAction(on.id as number)).status).toBe(ACTION_STATUS_COMPLETED);
   });
 
-  test("waitForAction resolves a poisoned id to `errored` WITHOUT throwing", async () => {
+  test("waitForAction rejects a poisoned id", async () => {
     const { server } = await provider.createServer(serverInput());
     const vol = await provider.createVolume(volumeInput());
     const action = await provider.attachVolume(vol.id as number, server.id as number);
 
     provider.poisonAction(action.id as number);
-    const done = await provider.waitForAction(action.id as number);
-    expect(done.status).toBe(ACTION_STATUS_ERRORED);
-    expect(done.error).toMatchObject({ code: "action_failed" });
+    await expect(provider.waitForAction(action.id as number)).rejects.toMatchObject({
+      code: "action_failed",
+    });
   });
 
-  test("pre-seeded poisonedActionIds also resolve errored", async () => {
+  test("pre-seeded poisonedActionIds also reject", async () => {
     // First minted action id under default seeding is deterministic; create a
     // server (id 1) then an action — but rather than guess, poison by capture.
     const p = new InMemoryComputeProvider();
@@ -253,7 +252,9 @@ describe("actions", () => {
     const v2 = await seeded.createVolume(volumeInput());
     const a2 = await seeded.attachVolume(v2.id as number, s2.id as number);
     expect(a2.id).toBe(action.id); // deterministic id reuse
-    expect((await seeded.waitForAction(a2.id as number)).status).toBe(ACTION_STATUS_ERRORED);
+    await expect(seeded.waitForAction(a2.id as number)).rejects.toMatchObject({
+      code: "action_failed",
+    });
   });
 
   test("waitForAction on an unknown action id throws not_found", async () => {

--- a/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider-fake.ts
@@ -19,9 +19,8 @@
  *    the clock. A server flips `new → active` because ticks were *advanced* past
  *    its `activeAtTick`, not because `getServer` was *called*.
  *  - `waitForAction` does NOT sleep. It force-resolves the action to terminal
- *    (`completed`, or `errored` for a poisoned id) and returns it. Poisoned
- *    actions resolve to an `error` action WITHOUT throwing (mirrors the real
- *    Hetzner client returning the error action rather than rejecting).
+ *    success, while poisoned ids reject with the same fail-fast contract as
+ *    production providers.
  *
  * Status vocabulary (DO-native, self-consistent; the interface only requires
  * `status: string`, so the fake is free to pick its own strings):
@@ -65,7 +64,7 @@ export const ACTION_STATUS_ERRORED = "errored";
  */
 export class ComputeFakeError extends Error {
   constructor(
-    public readonly code: "no_capacity" | "not_found" | "invalid_input",
+    public readonly code: "no_capacity" | "not_found" | "invalid_input" | "action_failed",
     message: string,
   ) {
     super(message);
@@ -332,9 +331,8 @@ export class InMemoryComputeProvider implements ComputeProvider {
   // ----------------------------------------------------------------------
 
   /**
-   * Resolve an action to terminal WITHOUT sleeping. A poisoned id resolves to
-   * `errored` (and returns it; does not throw). An unknown action id throws
-   * `ComputeFakeError("not_found")`.
+   * Resolve an action to terminal WITHOUT sleeping. Poisoned and unknown ids
+   * reject so consumer tests exercise the same failure contract as production.
    */
   async waitForAction(actionId: number, _timeoutMs?: number): Promise<ComputeAction> {
     const rec = this.actions.get(actionId);
@@ -344,6 +342,7 @@ export class InMemoryComputeProvider implements ComputeProvider {
     if (this.poisonedActionIds.has(actionId)) {
       rec.status = ACTION_STATUS_ERRORED;
       rec.error = { code: "action_failed", message: `action ${actionId} failed (poisoned)` };
+      throw new ComputeFakeError("action_failed", rec.error.message);
     } else {
       rec.status = ACTION_STATUS_COMPLETED;
       rec.error = null;

--- a/packages/cloud/shared/src/lib/services/containers/compute-provider.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider.ts
@@ -138,7 +138,7 @@ export interface CreateVolumeInput {
   name: string;
   /** Volume size in GiB (providers allocate whole GiB). */
   sizeGb: number;
-  /** Provider location code (must match the server it will attach to). */
+  /** Provider location for unattached creation; attached providers may derive it from `serverId`. */
   location: string;
   /** Filesystem format applied at creation time. Default `ext4`. */
   format?: "ext4" | "xfs";
@@ -177,7 +177,7 @@ export interface ComputeProvider {
   // -- Server lifecycle ----------------------------------------------------
   listServers(labels?: Record<string, string>): Promise<ComputeServer[]>;
   getServer(id: number): Promise<ComputeServer | null>;
-  /** Returns before the server is ready; poll `getServer`/`waitForAction`. */
+  /** Returns the provider's authoritative post-create server representation. */
   createServer(input: CreateServerInput): Promise<ProvisionedServer>;
   /** Provider 404 on delete is treated as success by consumers. */
   deleteServer(id: number): Promise<void>;
@@ -197,6 +197,7 @@ export interface ComputeProvider {
   deleteVolume(id: number): Promise<void>;
 
   // -- The load-bearing async primitive ------------------------------------
+  /** Returns a terminal action; strict providers reject terminal provider failures. */
   waitForAction(actionId: number, timeoutMs?: number): Promise<ComputeAction>;
 
   // -- Catalog (read-only) -------------------------------------------------

--- a/packages/cloud/shared/src/lib/services/containers/compute-provider.ts
+++ b/packages/cloud/shared/src/lib/services/containers/compute-provider.ts
@@ -197,7 +197,7 @@ export interface ComputeProvider {
   deleteVolume(id: number): Promise<void>;
 
   // -- The load-bearing async primitive ------------------------------------
-  /** Returns a terminal action; strict providers reject terminal provider failures. */
+  /** Returns terminal success and rejects terminal provider failures. */
   waitForAction(actionId: number, timeoutMs?: number): Promise<ComputeAction>;
 
   // -- Catalog (read-only) -------------------------------------------------

--- a/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.test.ts
@@ -553,7 +553,7 @@ describe("DigitalOceanComputeProvider volumes", () => {
 });
 
 // ---------------------------------------------------------------------------
-// waitForAction — poll loop, success, error (no throw), timeout
+// waitForAction — poll loop, success, terminal error, timeout
 // ---------------------------------------------------------------------------
 
 describe("DigitalOceanComputeProvider waitForAction", () => {
@@ -576,12 +576,12 @@ describe("DigitalOceanComputeProvider waitForAction", () => {
     expect(h.recorded.length).toBe(2);
   });
 
-  test("returns an errored action WITHOUT throwing", async () => {
+  test("rejects a terminal errored action", async () => {
     const h = makeHarness();
     h.queueJson({ action: { id: 52, status: "errored", type: "create" } });
-    const action = await h.provider.waitForAction(52);
-    expect(action.status).toBe("error"); // errored → error
-    expect(action.error).toMatchObject({ code: "errored" });
+    await expect(h.provider.waitForAction(52)).rejects.toMatchObject({
+      code: "server_error",
+    });
   });
 
   test("throws transport_error when the deadline is already past (no fetch)", async () => {

--- a/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.ts
+++ b/packages/cloud/shared/src/lib/services/containers/digitalocean-provider.ts
@@ -13,7 +13,7 @@
  *  - **No synchronous "ready" on create.** `POST /droplets` returns a droplet
  *    in status `new`; the droplet boots out of band. `createServer` therefore
  *    returns a `ProvisionedServer` immediately (status `new`) and callers poll
- *    `getServer` — identical contract to Hetzner.
+ *    `getServer`.
  *  - **No root password.** DO never returns a root password on create, so
  *    `ProvisionedServer.rootPassword` is always `null`.
  *  - **Volume ids are UUID strings**, not numbers. Droplet / action / image
@@ -452,7 +452,13 @@ export class DigitalOceanComputeProvider implements ComputeProvider {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const data = await this.request<{ action: DOAction }>("GET", `/actions/${actionId}`);
-      if (data.action.status !== "in-progress") return mapAction(data.action);
+      if (data.action.status === "completed") return mapAction(data.action);
+      if (data.action.status === "errored") {
+        throw new DigitalOceanComputeError(
+          "server_error",
+          `DigitalOcean action ${actionId} failed`,
+        );
+      }
       await this.sleep(2000);
     }
     throw new DigitalOceanComputeError(

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Exercises Hetzner lifecycle authority with a deterministic fetch harness.
+ * The real client validates provider envelopes, deadline propagation, terminal
+ * actions, and exact-resource readback without making external requests.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { HetznerCloudClient } from "./hetzner-cloud-api";
+
+type ResponseFactory = (init: RequestInit | undefined) => Response | Promise<Response>;
+
+const TOKEN = "lifecycle-test-token";
+let originalFetch: typeof globalThis.fetch;
+let responses: ResponseFactory[];
+let requests: Array<{ method: string; path: string }>;
+
+function json(body: unknown, status = 200): void {
+  responses.push(() => Response.json(body, { status }));
+}
+
+function empty(status = 204): void {
+  responses.push(() => new Response(null, { status }));
+}
+
+function action(
+  id: number,
+  command: string,
+  status: "running" | "success" | "error",
+  resource: { id: number; type: string },
+) {
+  return {
+    id,
+    command,
+    status,
+    progress: status === "success" ? 100 : 0,
+    resources: [resource],
+    error: status === "error" ? { code: "provider_failed", message: "failed" } : null,
+  };
+}
+
+function server(id: number, status = "running") {
+  return {
+    id,
+    name: `node-${id}`,
+    status,
+    public_net: { ipv4: null, ipv6: null, firewalls: [] },
+  };
+}
+
+function volume(id: number, serverId: number | null = null) {
+  return {
+    id,
+    name: `volume-${id}`,
+    status: "available",
+    server: serverId,
+    linux_device: serverId === null ? null : `/dev/disk/by-id/scsi-0HC_Volume_${id}`,
+  };
+}
+
+function client(options: { requestTimeoutMs?: number; lifecycleTimeoutMs?: number } = {}) {
+  return HetznerCloudClient.withToken(TOKEN, options);
+}
+
+function createServerInput() {
+  return {
+    name: "node-41",
+    serverType: "cax21",
+    location: "fsn1",
+    image: "ubuntu-24.04",
+    userData: "#cloud-config\n",
+  };
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  responses = [];
+  requests = [];
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : input.toString());
+    requests.push({ method: init?.method ?? "GET", path: url.pathname });
+    const next = responses.shift();
+    if (!next) throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+    return next(init);
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Hetzner lifecycle envelopes", () => {
+  test("rejects incomplete create acceptance before polling or readback", async () => {
+    json({ server: server(41), root_password: null, next_actions: [] }, 201);
+
+    await expect(client().createServer(createServerInput())).rejects.toMatchObject({
+      code: "server_error",
+    });
+    expect(requests).toHaveLength(1);
+  });
+
+  test("awaits every returned action and returns only exact running readback", async () => {
+    json(
+      {
+        server: server(41, "initializing"),
+        action: action(1, "create_server", "running", { id: 41, type: "server" }),
+        next_actions: [action(2, "attach_network", "running", { id: 900, type: "network" })],
+        root_password: null,
+      },
+      201,
+    );
+    json({ action: action(1, "create_server", "success", { id: 41, type: "server" }) });
+    json({ action: action(2, "attach_network", "success", { id: 900, type: "network" }) });
+    json({ server: server(41) });
+
+    await expect(client().createServer(createServerInput())).resolves.toMatchObject({
+      server: { id: 41, status: "running" },
+    });
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/servers",
+      "/v1/actions/1",
+      "/v1/actions/2",
+      "/v1/servers/41",
+    ]);
+  });
+
+  test("rejects terminal action errors and mismatched action IDs without readback", async () => {
+    json(
+      {
+        server: server(41, "initializing"),
+        action: action(3, "create_server", "running", { id: 41, type: "server" }),
+        next_actions: [],
+        root_password: null,
+      },
+      201,
+    );
+    json({ action: action(4, "create_server", "success", { id: 41, type: "server" }) });
+
+    await expect(client().createServer(createServerInput())).rejects.toMatchObject({
+      code: "server_error",
+    });
+    expect(requests.map(({ path }) => path)).toEqual(["/v1/servers", "/v1/actions/3"]);
+
+    responses = [];
+    requests = [];
+    json({ action: action(5, "delete_server", "error", { id: 41, type: "server" }) });
+    await expect(client().waitForAction(5)).rejects.toMatchObject({ code: "server_error" });
+  });
+
+  test("rejects mismatched by-id server and volume readbacks", async () => {
+    json({ server: server(42) });
+    await expect(client().getServer(41)).rejects.toMatchObject({ code: "server_error" });
+
+    json({ volume: volume(52) });
+    await expect(client().getVolume(51)).rejects.toMatchObject({ code: "server_error" });
+  });
+});
+
+describe("Hetzner lifecycle deadlines and absence", () => {
+  test("keeps the request timer active while the response body is read", async () => {
+    responses.push((init) => {
+      const signal = init?.signal;
+      return {
+        status: 200,
+        ok: true,
+        headers: new Headers(),
+        text: () =>
+          new Promise<string>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("body read aborted")), {
+              once: true,
+            });
+          }),
+      } as Response;
+    });
+
+    await expect(client({ requestTimeoutMs: 10 }).listServers()).rejects.toMatchObject({
+      code: "transport_error",
+    });
+  });
+
+  test("shares one deadline across every returned action instead of resetting per poll", async () => {
+    json(
+      {
+        server: server(41, "initializing"),
+        action: action(11, "create_server", "running", { id: 41, type: "server" }),
+        next_actions: [action(12, "attach_network", "running", { id: 900, type: "network" })],
+        root_password: null,
+      },
+      201,
+    );
+    responses.push(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve(
+                Response.json({
+                  action: action(11, "create_server", "success", {
+                    id: 41,
+                    type: "server",
+                  }),
+                }),
+              ),
+            20,
+          );
+        }),
+    );
+    responses.push((init) => {
+      const signal = init?.signal;
+      return {
+        status: 200,
+        ok: true,
+        headers: new Headers(),
+        text: () =>
+          new Promise<string>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("deadline reached")), {
+              once: true,
+            });
+          }),
+      } as Response;
+    });
+
+    const startedAt = Date.now();
+    await expect(
+      client({ requestTimeoutMs: 1_000, lifecycleTimeoutMs: 100 }).createServer(
+        createServerInput(),
+      ),
+    ).rejects.toMatchObject({ code: "transport_error" });
+    expect(Date.now() - startedAt).toBeLessThan(350);
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/servers",
+      "/v1/actions/11",
+      "/v1/actions/12",
+    ]);
+  });
+
+  test("does not treat action-poll 404 as target absence", async () => {
+    json({
+      action: action(8, "delete_server", "running", { id: 41, type: "server" }),
+    });
+    json({ error: { code: "not_found", message: "action missing" } }, 404);
+
+    await expect(client().deleteServer(41)).rejects.toMatchObject({ code: "not_found" });
+    expect(requests.map(({ path }) => path)).toEqual(["/v1/servers/41", "/v1/actions/8"]);
+  });
+
+  test("server deletion settles every returned action before absence readback", async () => {
+    json({
+      action: action(31, "delete_server", "success", {
+        id: 41,
+        type: "server",
+      }),
+      next_actions: [
+        action(32, "detach_network", "running", {
+          id: 900,
+          type: "network",
+        }),
+      ],
+    });
+    json({
+      action: action(32, "detach_network", "success", {
+        id: 900,
+        type: "network",
+      }),
+    });
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
+
+    await expect(client().deleteServer(41)).resolves.toBeUndefined();
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/servers/41",
+      "/v1/actions/32",
+      "/v1/servers/41",
+    ]);
+  });
+
+  test("accepts only exact target 404 as idempotent server deletion", async () => {
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
+    await expect(client().deleteServer(41)).resolves.toBeUndefined();
+    expect(requests).toEqual([{ method: "DELETE", path: "/v1/servers/41" }]);
+  });
+
+  test("volume delete requires exact post-delete absence", async () => {
+    empty();
+    json({ volume: volume(51) });
+    await expect(client().deleteVolume(51)).rejects.toMatchObject({ code: "server_error" });
+
+    responses = [];
+    requests = [];
+    empty();
+    json({ error: { code: "not_found", message: "volume missing" } }, 404);
+    await expect(client().deleteVolume(51)).resolves.toBeUndefined();
+  });
+
+  test("volume delete accepts 204 or settles a complete JSON lifecycle envelope", async () => {
+    json({
+      action: action(41, "delete_volume", "running", {
+        id: 51,
+        type: "volume",
+      }),
+      next_actions: [
+        action(42, "detach_volume", "running", {
+          id: 51,
+          type: "volume",
+        }),
+      ],
+    });
+    json({
+      action: action(41, "delete_volume", "success", {
+        id: 51,
+        type: "volume",
+      }),
+    });
+    json({
+      action: action(42, "detach_volume", "success", {
+        id: 51,
+        type: "volume",
+      }),
+    });
+    json({ error: { code: "not_found", message: "volume missing" } }, 404);
+
+    await expect(client().deleteVolume(51)).resolves.toBeUndefined();
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/volumes/51",
+      "/v1/actions/41",
+      "/v1/actions/42",
+      "/v1/volumes/51",
+    ]);
+
+    responses = [];
+    requests = [];
+    json({ next_actions: [] });
+    await expect(client().deleteVolume(51)).rejects.toMatchObject({
+      code: "server_error",
+    });
+    expect(requests).toEqual([{ method: "DELETE", path: "/v1/volumes/51" }]);
+  });
+
+  test("create-volume readback proves attachment and device state", async () => {
+    json({
+      volume: volume(51, 41),
+      action: action(9, "create_volume", "success", { id: 51, type: "volume" }),
+      next_actions: [],
+    });
+    json({ volume: volume(51, 99) });
+
+    await expect(
+      client().createVolume({
+        name: "volume-51",
+        sizeGb: 10,
+        location: "fsn1",
+        serverId: 41,
+      }),
+    ).rejects.toMatchObject({ code: "server_error" });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.lifecycle.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { HetznerCloudClient } from "./hetzner-cloud-api";
+import { HetznerAcceptedResourceError, HetznerCloudClient } from "./hetzner-cloud-api";
 
 type ResponseFactory = (init: RequestInit | undefined) => Response | Promise<Response>;
 
@@ -91,11 +91,15 @@ afterEach(() => {
 describe("Hetzner lifecycle envelopes", () => {
   test("rejects incomplete create acceptance before polling or readback", async () => {
     json({ server: server(41), root_password: null, next_actions: [] }, 201);
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
 
     await expect(client().createServer(createServerInput())).rejects.toMatchObject({
       code: "server_error",
+      resourceType: "server",
+      resourceId: 41,
+      compensation: "succeeded",
     });
-    expect(requests).toHaveLength(1);
+    expect(requests.map(({ path }) => path)).toEqual(["/v1/servers", "/v1/servers/41"]);
   });
 
   test("awaits every returned action and returns only exact running readback", async () => {
@@ -134,11 +138,16 @@ describe("Hetzner lifecycle envelopes", () => {
       201,
     );
     json({ action: action(4, "create_server", "success", { id: 41, type: "server" }) });
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
 
     await expect(client().createServer(createServerInput())).rejects.toMatchObject({
       code: "server_error",
     });
-    expect(requests.map(({ path }) => path)).toEqual(["/v1/servers", "/v1/actions/3"]);
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/servers",
+      "/v1/actions/3",
+      "/v1/servers/41",
+    ]);
 
     responses = [];
     requests = [];
@@ -171,6 +180,7 @@ describe("Hetzner lifecycle deadlines and absence", () => {
           }),
       } as Response;
     });
+    json({ error: { code: "not_found", message: "server missing" } }, 404);
 
     await expect(client({ requestTimeoutMs: 10 }).listServers()).rejects.toMatchObject({
       code: "transport_error",
@@ -230,7 +240,123 @@ describe("Hetzner lifecycle deadlines and absence", () => {
       "/v1/servers",
       "/v1/actions/11",
       "/v1/actions/12",
+      "/v1/servers/41",
     ]);
+  });
+
+  test("polls accepted server readback through initializing", async () => {
+    json(
+      {
+        server: server(41, "initializing"),
+        action: action(13, "create_server", "success", {
+          id: 41,
+          type: "server",
+        }),
+        next_actions: [],
+        root_password: null,
+      },
+      201,
+    );
+    json({ server: server(41, "initializing") });
+    json({ server: server(41, "running") });
+
+    await expect(
+      client({ lifecycleTimeoutMs: 1_000 }).createServer(createServerInput()),
+    ).resolves.toMatchObject({ server: { id: 41, status: "running" } });
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/servers",
+      "/v1/servers/41",
+      "/v1/servers/41",
+    ]);
+  });
+
+  test("retains the accepted server ID and both failures when cleanup fails", async () => {
+    json(
+      {
+        server: server(41, "initializing"),
+        action: action(14, "create_server", "error", {
+          id: 41,
+          type: "server",
+        }),
+        next_actions: [],
+        root_password: null,
+      },
+      201,
+    );
+    json({ error: { code: "provider_error", message: "delete failed" } }, 500);
+
+    const failure = await client()
+      .createServer(createServerInput())
+      .catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(HetznerAcceptedResourceError);
+    expect(failure).toMatchObject({
+      resourceType: "server",
+      resourceId: 41,
+      compensation: "failed",
+      primaryError: { code: "server_error" },
+      compensationError: { code: "server_error" },
+    });
+    expect((failure as Error).cause).toBeInstanceOf(AggregateError);
+  });
+
+  test("compensates an accepted volume after attachment readback mismatch", async () => {
+    json({
+      volume: volume(51, 41),
+      action: action(15, "create_volume", "success", {
+        id: 51,
+        type: "volume",
+      }),
+      next_actions: [],
+    });
+    json({ volume: volume(51, null) });
+    empty();
+    json({ error: { code: "not_found", message: "volume missing" } }, 404);
+
+    const failure = await client()
+      .createVolume({
+        name: "volume-51",
+        sizeGb: 10,
+        location: "fsn1",
+        serverId: 41,
+        automount: true,
+      })
+      .catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      resourceType: "volume",
+      resourceId: 51,
+      compensation: "succeeded",
+      primaryError: { code: "server_error" },
+    });
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/v1/volumes",
+      "/v1/volumes/51",
+      "/v1/volumes/51",
+      "/v1/volumes/51",
+    ]);
+  });
+
+  test("retains accepted volume settlement and cleanup failures", async () => {
+    json({
+      volume: volume(51),
+      action: action(16, "create_volume", "error", {
+        id: 51,
+        type: "volume",
+      }),
+      next_actions: [],
+    });
+    json({ error: { code: "provider_error", message: "delete failed" } }, 500);
+
+    const failure = await client()
+      .createVolume({ name: "volume-51", sizeGb: 10, location: "fsn1" })
+      .catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      resourceType: "volume",
+      resourceId: 51,
+      compensation: "failed",
+      primaryError: { code: "server_error" },
+      compensationError: { code: "server_error" },
+    });
+    expect((failure as Error).cause).toBeInstanceOf(AggregateError);
   });
 
   test("does not treat action-poll 404 as target absence", async () => {

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -30,6 +30,7 @@ const OFFICIAL_HCLOUD_API_BASE = "https://api.hetzner.cloud/v1";
 const REQUEST_TIMEOUT_MS = 30_000;
 const LIFECYCLE_TIMEOUT_MS = 60_000;
 const ACTION_POLL_INTERVAL_MS = 1_500;
+const RESOURCE_READBACK_POLL_INTERVAL_MS = 250;
 const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
 const NO_CONTENT = Symbol("hetzner-no-content");
 
@@ -57,6 +58,33 @@ export class HetznerCloudError extends Error {
   ) {
     super(message);
     this.name = "HetznerCloudError";
+  }
+}
+
+export class HetznerAcceptedResourceError extends HetznerCloudError {
+  readonly compensation: "succeeded" | "failed";
+
+  constructor(
+    public readonly resourceType: "server" | "volume",
+    public readonly resourceId: number,
+    public readonly primaryError: unknown,
+    public readonly compensationError?: unknown,
+  ) {
+    const compensation = compensationError ? "failed" : "succeeded";
+    const cause = compensationError
+      ? new AggregateError(
+          [primaryError, compensationError],
+          `Hetzner ${resourceType} ${resourceId} create and compensation both failed`,
+        )
+      : primaryError;
+    super(
+      primaryError instanceof HetznerCloudError ? primaryError.code : "server_error",
+      `Hetzner accepted ${resourceType} ${resourceId}, but settlement failed and compensation ${compensation}`,
+      primaryError instanceof HetznerCloudError ? primaryError.status : undefined,
+      cause,
+    );
+    this.name = "HetznerAcceptedResourceError";
+    this.compensation = compensation;
   }
 }
 
@@ -346,35 +374,57 @@ export class HetznerCloudClient implements ComputeProvider {
     );
     const createdServer = requireObject(data.server, "created server");
     const serverId = requireResourceId(createdServer.id, "created server");
-    if (data.root_password !== null && typeof data.root_password !== "string") {
-      throw malformedEnvelope("create server root_password is invalid");
-    }
-    await this.settleReturnedActions(
-      data.action,
-      data.next_actions,
-      deadline,
-      { id: serverId, type: "server" },
-      true,
-    );
-    const server = await this.getServerWithin(serverId, deadline);
-    if (!server || server.status !== "running") {
-      throw new HetznerCloudError(
-        "server_error",
-        `Hetzner Cloud API created server ${serverId} but exact readback was not running`,
+    try {
+      if (data.root_password !== null && typeof data.root_password !== "string") {
+        throw malformedEnvelope("create server root_password is invalid");
+      }
+      await this.settleReturnedActions(
+        data.action,
+        data.next_actions,
+        deadline,
+        { id: serverId, type: "server" },
+        true,
       );
+      const server = await this.waitForServerRunningWithin(serverId, deadline);
+
+      logger.info("[hcloud] Created server", {
+        serverId,
+        name: server.name,
+        type: input.serverType,
+        location: input.location,
+      });
+
+      return {
+        server,
+        rootPassword: data.root_password,
+      };
+    } catch (error) {
+      // error-policy:J2 the provider already accepted a billable resource. A
+      // fresh bounded delete is the only safe compensation authority, and the
+      // typed wrapper retains both the settlement and cleanup failures.
+      return this.compensateAcceptedResource("server", serverId, error);
     }
+  }
 
-    logger.info("[hcloud] Created server", {
-      serverId,
-      name: server.name,
-      type: input.serverType,
-      location: input.location,
-    });
-
-    return {
-      server,
-      rootPassword: data.root_password,
-    };
+  private async waitForServerRunningWithin(
+    serverId: number,
+    deadline: number,
+  ): Promise<HetznerServer> {
+    while (Date.now() < deadline) {
+      const server = await this.getServerWithin(serverId, deadline);
+      if (server?.status === "running") return server;
+      if (!server || !["initializing", "starting"].includes(server.status)) {
+        throw new HetznerCloudError(
+          "server_error",
+          `Hetzner Cloud API created server ${serverId} but exact readback entered ${server?.status ?? "absent"}`,
+        );
+      }
+      await waitWithinDeadline(deadline);
+    }
+    throw new HetznerCloudError(
+      "transport_error",
+      `Hetzner Cloud API created server ${serverId} but it did not reach running before the operation deadline`,
+    );
   }
 
   async deleteServer(serverId: number): Promise<void> {
@@ -504,44 +554,87 @@ export class HetznerCloudClient implements ComputeProvider {
     );
     const createdVolume = requireObject(data.volume, "created volume");
     const volumeId = requireResourceId(createdVolume.id, "created volume");
-    await this.settleReturnedActions(
-      data.action,
-      data.next_actions,
-      deadline,
-      { id: volumeId, type: "volume" },
-      false,
+    try {
+      await this.settleReturnedActions(
+        data.action,
+        data.next_actions,
+        deadline,
+        { id: volumeId, type: "volume" },
+        false,
+      );
+      const volume = await this.waitForVolumeAvailableWithin(volumeId, deadline);
+      const expectedServer = input.serverId ?? null;
+      if (volume.server !== expectedServer) {
+        throw new HetznerCloudError(
+          "server_error",
+          `Hetzner Cloud API created volume ${volumeId} with unexpected server attachment`,
+        );
+      }
+      const hasDevice = typeof volume.linux_device === "string" && volume.linux_device.length > 0;
+      if (
+        (expectedServer === null && volume.linux_device !== null) ||
+        (expectedServer !== null && !hasDevice)
+      ) {
+        throw new HetznerCloudError(
+          "server_error",
+          `Hetzner Cloud API created volume ${volumeId} with inconsistent device state`,
+        );
+      }
+      logger.info("[hcloud] Created volume", {
+        volumeId,
+        name: volume.name,
+        sizeGb: input.sizeGb,
+        location: input.location,
+      });
+      return volume;
+    } catch (error) {
+      // error-policy:J2 see createServer: the accepted volume ID authorizes an
+      // independent compensating delete and the wrapper preserves both errors.
+      return this.compensateAcceptedResource("volume", volumeId, error);
+    }
+  }
+
+  private async waitForVolumeAvailableWithin(
+    volumeId: number,
+    deadline: number,
+  ): Promise<HetznerVolume> {
+    while (Date.now() < deadline) {
+      const volume = await this.getVolumeWithin(volumeId, deadline);
+      if (volume?.status === "available") return volume;
+      if (!volume || volume.status !== "creating") {
+        throw new HetznerCloudError(
+          "server_error",
+          `Hetzner Cloud API created volume ${volumeId} but exact readback entered ${volume?.status ?? "absent"}`,
+        );
+      }
+      await waitWithinDeadline(deadline);
+    }
+    throw new HetznerCloudError(
+      "transport_error",
+      `Hetzner Cloud API created volume ${volumeId} but it did not reach available before the operation deadline`,
     );
-    const volume = await this.getVolumeWithin(volumeId, deadline);
-    if (!volume || volume.status !== "available") {
-      throw new HetznerCloudError(
-        "server_error",
-        `Hetzner Cloud API created volume ${volumeId} but exact readback was not available`,
-      );
+  }
+
+  private async compensateAcceptedResource<T>(
+    resourceType: "server" | "volume",
+    resourceId: number,
+    primaryError: unknown,
+  ): Promise<T> {
+    let compensationError: unknown;
+    try {
+      if (resourceType === "server") await this.deleteServer(resourceId);
+      else await this.deleteVolume(resourceId);
+    } catch (error) {
+      // error-policy:J2 the typed accepted-resource error below carries both
+      // failures so the primary settlement fault cannot be masked by cleanup.
+      compensationError = error;
     }
-    const expectedServer = input.serverId ?? null;
-    if (volume.server !== expectedServer) {
-      throw new HetznerCloudError(
-        "server_error",
-        `Hetzner Cloud API created volume ${volumeId} with unexpected server attachment`,
-      );
-    }
-    const hasDevice = typeof volume.linux_device === "string" && volume.linux_device.length > 0;
-    if (
-      (expectedServer === null && volume.linux_device !== null) ||
-      (expectedServer !== null && !hasDevice)
-    ) {
-      throw new HetznerCloudError(
-        "server_error",
-        `Hetzner Cloud API created volume ${volumeId} with inconsistent device state`,
-      );
-    }
-    logger.info("[hcloud] Created volume", {
-      volumeId,
-      name: volume.name,
-      sizeGb: input.sizeGb,
-      location: input.location,
-    });
-    return volume;
+    throw new HetznerAcceptedResourceError(
+      resourceType,
+      resourceId,
+      primaryError,
+      compensationError,
+    );
   }
 
   async attachVolume(
@@ -948,6 +1041,14 @@ function assertExactResourceId(value: unknown, expected: number, resource: strin
 
 function deadlineAfter(timeoutMs: number): number {
   return Date.now() + timeoutMs;
+}
+
+async function waitWithinDeadline(deadline: number): Promise<void> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return;
+  await new Promise((resolve) =>
+    setTimeout(resolve, Math.min(RESOURCE_READBACK_POLL_INTERVAL_MS, remaining)),
+  );
 }
 
 function assertRequestWithinDeadline(

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -28,7 +28,10 @@ export type { CreateServerInput, CreateVolumeInput, ProvisionedServer } from "./
 
 const OFFICIAL_HCLOUD_API_BASE = "https://api.hetzner.cloud/v1";
 const REQUEST_TIMEOUT_MS = 30_000;
+const LIFECYCLE_TIMEOUT_MS = 60_000;
+const ACTION_POLL_INTERVAL_MS = 1_500;
 const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
+const NO_CONTENT = Symbol("hetzner-no-content");
 
 export type HetznerCloudErrorCode =
   | "missing_token"
@@ -117,6 +120,7 @@ export interface HetznerAction {
   command: string;
   status: "running" | "success" | "error";
   progress: number;
+  resources?: Array<{ id: number; type: string }>;
   error: { code: string; message: string } | null;
 }
 
@@ -146,15 +150,18 @@ export class HetznerCloudClient implements ComputeProvider {
   private readonly token: string;
   private readonly apiBaseUrl: string;
   private readonly requestTimeoutMs: number;
+  private readonly lifecycleTimeoutMs: number;
 
   private constructor(
     token: string,
     apiBaseUrl = HCLOUD_API_BASE,
     requestTimeoutMs = REQUEST_TIMEOUT_MS,
+    lifecycleTimeoutMs = LIFECYCLE_TIMEOUT_MS,
   ) {
     this.token = token;
     this.apiBaseUrl = apiBaseUrl.replace(/\/+$/, "");
     this.requestTimeoutMs = requestTimeoutMs;
+    this.lifecycleTimeoutMs = lifecycleTimeoutMs;
   }
 
   /**
@@ -175,10 +182,19 @@ export class HetznerCloudClient implements ComputeProvider {
   }
 
   /** Construct a client with an explicit token pinned to the configured Hetzner origin. */
-  static withToken(token: string, options: { requestTimeoutMs?: number } = {}): HetznerCloudClient {
+  static withToken(
+    token: string,
+    options: { requestTimeoutMs?: number; lifecycleTimeoutMs?: number } = {},
+  ): HetznerCloudClient {
     validateToken(token);
     validateRequestTimeout(options.requestTimeoutMs);
-    return new HetznerCloudClient(token, HCLOUD_API_BASE, options.requestTimeoutMs);
+    validateRequestTimeout(options.lifecycleTimeoutMs, "lifecycleTimeoutMs");
+    return new HetznerCloudClient(
+      token,
+      HCLOUD_API_BASE,
+      options.requestTimeoutMs,
+      options.lifecycleTimeoutMs,
+    );
   }
 
   /**
@@ -189,10 +205,15 @@ export class HetznerCloudClient implements ComputeProvider {
    */
   static withTestTransport(
     token: string,
-    options: { apiBaseUrl: string; requestTimeoutMs?: number },
+    options: {
+      apiBaseUrl: string;
+      requestTimeoutMs?: number;
+      lifecycleTimeoutMs?: number;
+    },
   ): HetznerCloudClient {
     validateToken(token);
     validateRequestTimeout(options.requestTimeoutMs);
+    validateRequestTimeout(options.lifecycleTimeoutMs, "lifecycleTimeoutMs");
     if (process.env.NODE_ENV !== "test") {
       throw new HetznerCloudError(
         "invalid_input",
@@ -203,6 +224,7 @@ export class HetznerCloudClient implements ComputeProvider {
       token,
       validateLoopbackTestApiBaseUrl(options.apiBaseUrl),
       options.requestTimeoutMs,
+      options.lifecycleTimeoutMs,
     );
   }
 
@@ -265,10 +287,24 @@ export class HetznerCloudClient implements ComputeProvider {
   }
 
   async getServer(serverId: number): Promise<HetznerServer | null> {
+    validateResourceId(serverId, "serverId");
+    return this.getServerWithin(serverId, deadlineAfter(this.requestTimeoutMs));
+  }
+
+  private async getServerWithin(serverId: number, deadline: number): Promise<HetznerServer | null> {
     try {
-      const data = await this.request<{ server: HetznerServer }>("GET", `/servers/${serverId}`);
-      return mapHetznerServer(data.server);
+      const data = requireEnvelope(
+        await this.request<unknown>("GET", `/servers/${serverId}`, undefined, deadline),
+        "server readback",
+      );
+      const server = mapHetznerServer(
+        requireObject(data.server, "server readback resource") as unknown as HetznerServer,
+      );
+      assertExactResourceId(server.id, serverId, "server");
+      return server;
     } catch (err) {
+      // error-policy:J4 exact resource absence is the designed by-id read
+      // result; every other provider or transport failure remains exceptional.
       if (err instanceof HetznerCloudError && err.code === "not_found") return null;
       throw err;
     }
@@ -303,43 +339,97 @@ export class HetznerCloudClient implements ComputeProvider {
       body.labels = input.labels;
     }
 
-    const data = await this.request<{
-      server: HetznerServer;
-      root_password: string | null;
-    }>("POST", "/servers", body);
+    const deadline = deadlineAfter(this.lifecycleTimeoutMs);
+    const data = requireEnvelope(
+      await this.request<unknown>("POST", "/servers", body, deadline),
+      "create server",
+    );
+    const createdServer = requireObject(data.server, "created server");
+    const serverId = requireResourceId(createdServer.id, "created server");
+    if (data.root_password !== null && typeof data.root_password !== "string") {
+      throw malformedEnvelope("create server root_password is invalid");
+    }
+    await this.settleReturnedActions(
+      data.action,
+      data.next_actions,
+      deadline,
+      { id: serverId, type: "server" },
+      true,
+    );
+    const server = await this.getServerWithin(serverId, deadline);
+    if (!server || server.status !== "running") {
+      throw new HetznerCloudError(
+        "server_error",
+        `Hetzner Cloud API created server ${serverId} but exact readback was not running`,
+      );
+    }
 
     logger.info("[hcloud] Created server", {
-      serverId: data.server.id,
-      name: data.server.name,
+      serverId,
+      name: server.name,
       type: input.serverType,
       location: input.location,
     });
 
     return {
-      server: mapHetznerServer(data.server),
+      server,
       rootPassword: data.root_password,
     };
   }
 
   async deleteServer(serverId: number): Promise<void> {
-    await this.request<unknown>("DELETE", `/servers/${serverId}`);
+    validateResourceId(serverId, "serverId");
+    const deadline = deadlineAfter(this.lifecycleTimeoutMs);
+    let data: Record<string, unknown>;
+    try {
+      data = requireEnvelope(
+        await this.request<unknown>("DELETE", `/servers/${serverId}`, undefined, deadline),
+        "delete server",
+      );
+    } catch (error) {
+      // error-policy:J4 an exact target 404 is the provider's explicit
+      // idempotent-absence result; action-poll 404s are never handled here.
+      if (error instanceof HetznerCloudError && error.code === "not_found") return;
+      throw error;
+    }
+    await this.settleReturnedActions(
+      data.action,
+      Object.hasOwn(data, "next_actions") ? data.next_actions : [],
+      deadline,
+      { id: serverId, type: "server" },
+      true,
+    );
+    if ((await this.getServerWithin(serverId, deadline)) !== null) {
+      throw new HetznerCloudError(
+        "server_error",
+        `Hetzner Cloud API delete action completed but server ${serverId} still exists`,
+      );
+    }
     logger.info("[hcloud] Deleted server", { serverId });
   }
 
   async powerOff(serverId: number): Promise<HetznerAction> {
-    const data = await this.request<{ action: HetznerAction }>(
-      "POST",
-      `/servers/${serverId}/actions/poweroff`,
+    validateResourceId(serverId, "serverId");
+    const data = requireEnvelope(
+      await this.request<unknown>("POST", `/servers/${serverId}/actions/poweroff`),
+      "power-off server",
     );
-    return data.action;
+    return requireAcceptedAction(data.action, {
+      expectedResource: { id: serverId, type: "server" },
+      requireResources: true,
+    });
   }
 
   async powerOn(serverId: number): Promise<HetznerAction> {
-    const data = await this.request<{ action: HetznerAction }>(
-      "POST",
-      `/servers/${serverId}/actions/poweron`,
+    validateResourceId(serverId, "serverId");
+    const data = requireEnvelope(
+      await this.request<unknown>("POST", `/servers/${serverId}/actions/poweron`),
+      "power-on server",
     );
-    return data.action;
+    return requireAcceptedAction(data.action, {
+      expectedResource: { id: serverId, type: "server" },
+      requireResources: true,
+    });
   }
 
   // ----------------------------------------------------------------------
@@ -361,36 +451,97 @@ export class HetznerCloudClient implements ComputeProvider {
   }
 
   async getVolume(volumeId: number): Promise<HetznerVolume | null> {
+    validateResourceId(volumeId, "volumeId");
+    return this.getVolumeWithin(volumeId, deadlineAfter(this.requestTimeoutMs));
+  }
+
+  private async getVolumeWithin(volumeId: number, deadline: number): Promise<HetznerVolume | null> {
     try {
-      const data = await this.request<{ volume: HetznerVolume }>("GET", `/volumes/${volumeId}`);
-      return data.volume;
+      const data = requireEnvelope(
+        await this.request<unknown>("GET", `/volumes/${volumeId}`, undefined, deadline),
+        "volume readback",
+      );
+      const volume = requireObject(
+        data.volume,
+        "volume readback resource",
+      ) as unknown as HetznerVolume;
+      assertExactResourceId(volume.id, volumeId, "volume");
+      return volume;
     } catch (err) {
+      // error-policy:J4 exact resource absence is the designed by-id read
+      // result; every other provider or transport failure remains exceptional.
       if (err instanceof HetznerCloudError && err.code === "not_found") return null;
       throw err;
     }
   }
 
   async createVolume(input: CreateVolumeInput): Promise<HetznerVolume> {
+    if (input.serverId !== undefined) {
+      validateResourceId(input.serverId, "serverId");
+    }
+    if (input.automount === true && input.serverId === undefined) {
+      throw new HetznerCloudError(
+        "invalid_input",
+        "Hetzner createVolume automount requires serverId",
+      );
+    }
     const body: Record<string, unknown> = {
       name: input.name,
       size: input.sizeGb,
-      location: input.location,
       format: input.format ?? "ext4",
     };
-    if (input.serverId) body.server = input.serverId;
-    if (input.automount === false) body.automount = false;
+    if (input.serverId === undefined) body.location = input.location;
+    else body.server = input.serverId;
+    if (input.automount !== undefined) body.automount = input.automount;
     if (input.labels && Object.keys(input.labels).length > 0) {
       body.labels = input.labels;
     }
 
-    const data = await this.request<{ volume: HetznerVolume }>("POST", "/volumes", body);
+    const deadline = deadlineAfter(this.lifecycleTimeoutMs);
+    const data = requireEnvelope(
+      await this.request<unknown>("POST", "/volumes", body, deadline),
+      "create volume",
+    );
+    const createdVolume = requireObject(data.volume, "created volume");
+    const volumeId = requireResourceId(createdVolume.id, "created volume");
+    await this.settleReturnedActions(
+      data.action,
+      data.next_actions,
+      deadline,
+      { id: volumeId, type: "volume" },
+      false,
+    );
+    const volume = await this.getVolumeWithin(volumeId, deadline);
+    if (!volume || volume.status !== "available") {
+      throw new HetznerCloudError(
+        "server_error",
+        `Hetzner Cloud API created volume ${volumeId} but exact readback was not available`,
+      );
+    }
+    const expectedServer = input.serverId ?? null;
+    if (volume.server !== expectedServer) {
+      throw new HetznerCloudError(
+        "server_error",
+        `Hetzner Cloud API created volume ${volumeId} with unexpected server attachment`,
+      );
+    }
+    const hasDevice = typeof volume.linux_device === "string" && volume.linux_device.length > 0;
+    if (
+      (expectedServer === null && volume.linux_device !== null) ||
+      (expectedServer !== null && !hasDevice)
+    ) {
+      throw new HetznerCloudError(
+        "server_error",
+        `Hetzner Cloud API created volume ${volumeId} with inconsistent device state`,
+      );
+    }
     logger.info("[hcloud] Created volume", {
-      volumeId: data.volume.id,
-      name: data.volume.name,
+      volumeId,
+      name: volume.name,
       sizeGb: input.sizeGb,
       location: input.location,
     });
-    return data.volume;
+    return volume;
   }
 
   async attachVolume(
@@ -398,39 +549,147 @@ export class HetznerCloudClient implements ComputeProvider {
     serverId: number,
     automount = false,
   ): Promise<HetznerAction> {
-    const data = await this.request<{ action: HetznerAction }>(
-      "POST",
-      `/volumes/${volumeId}/actions/attach`,
-      { server: serverId, automount },
+    validateResourceId(volumeId, "volumeId");
+    validateResourceId(serverId, "serverId");
+    const data = requireEnvelope(
+      await this.request<unknown>("POST", `/volumes/${volumeId}/actions/attach`, {
+        server: serverId,
+        automount,
+      }),
+      "attach volume",
     );
-    return data.action;
+    return requireAcceptedAction(data.action, {
+      expectedResource: { id: volumeId, type: "volume" },
+      requireResources: true,
+    });
   }
 
   async detachVolume(volumeId: number): Promise<HetznerAction> {
-    const data = await this.request<{ action: HetznerAction }>(
-      "POST",
-      `/volumes/${volumeId}/actions/detach`,
+    validateResourceId(volumeId, "volumeId");
+    const data = requireEnvelope(
+      await this.request<unknown>("POST", `/volumes/${volumeId}/actions/detach`),
+      "detach volume",
     );
-    return data.action;
+    return requireAcceptedAction(data.action, {
+      expectedResource: { id: volumeId, type: "volume" },
+      requireResources: true,
+    });
   }
 
   async deleteVolume(volumeId: number): Promise<void> {
-    await this.request<unknown>("DELETE", `/volumes/${volumeId}`);
+    validateResourceId(volumeId, "volumeId");
+    const deadline = deadlineAfter(this.lifecycleTimeoutMs);
+    let deleteResponse: unknown | typeof NO_CONTENT;
+    try {
+      deleteResponse = await this.request<unknown>(
+        "DELETE",
+        `/volumes/${volumeId}`,
+        undefined,
+        deadline,
+        true,
+      );
+    } catch (error) {
+      // error-policy:J4 an exact target 404 is the provider's explicit
+      // idempotent-absence result.
+      if (error instanceof HetznerCloudError && error.code === "not_found") return;
+      throw error;
+    }
+    if (deleteResponse !== NO_CONTENT) {
+      const data = requireEnvelope(deleteResponse, "delete volume");
+      await this.settleReturnedActions(
+        data.action,
+        Object.hasOwn(data, "next_actions") ? data.next_actions : [],
+        deadline,
+        { id: volumeId, type: "volume" },
+        true,
+      );
+    }
+    if ((await this.getVolumeWithin(volumeId, deadline)) !== null) {
+      throw new HetznerCloudError(
+        "server_error",
+        `Hetzner Cloud API delete completed but volume ${volumeId} still exists`,
+      );
+    }
     logger.info("[hcloud] Deleted volume", { volumeId });
   }
 
-  /** Poll an action until it completes (success or error). */
+  /** Poll an action until terminal success, rejecting terminal provider errors. */
   async waitForAction(actionId: number, timeoutMs = 60_000): Promise<HetznerAction> {
-    const deadline = Date.now() + timeoutMs;
+    validateResourceId(actionId, "actionId");
+    validateRequestTimeout(timeoutMs, "timeoutMs");
+    return this.waitForActionUntil(actionId, deadlineAfter(timeoutMs));
+  }
+
+  private async waitForActionUntil(
+    actionId: number,
+    deadline: number,
+    expectedResource?: { id: number; type: string },
+  ): Promise<HetznerAction> {
     while (Date.now() < deadline) {
-      const data = await this.request<{ action: HetznerAction }>("GET", `/actions/${actionId}`);
-      if (data.action.status !== "running") return data.action;
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      const data = requireEnvelope(
+        await this.request<unknown>("GET", `/actions/${actionId}`, undefined, deadline),
+        "action readback",
+      );
+      const action = parseActionEnvelope(data.action, {
+        expectedId: actionId,
+        expectedResource,
+        requireResources: true,
+      });
+      if (action.status === "success") return action;
+      if (action.status === "error") throw actionFailure(action);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(ACTION_POLL_INTERVAL_MS, remaining)),
+      );
     }
     throw new HetznerCloudError(
       "transport_error",
-      `Hetzner action ${actionId} did not complete within ${timeoutMs}ms`,
+      `Hetzner action ${actionId} did not complete before the operation deadline`,
     );
+  }
+
+  private async settleReturnedActions(
+    primary: unknown,
+    nextActionsValue: unknown,
+    deadline: number,
+    expectedPrimaryResource: { id: number; type: string },
+    primaryRequired: boolean,
+  ): Promise<void> {
+    if (!Array.isArray(nextActionsValue)) {
+      throw malformedEnvelope("lifecycle response is missing next_actions");
+    }
+    const actions: Array<{
+      action: HetznerAction;
+      expectedResource?: { id: number; type: string };
+    }> = [];
+    if (primary === null || primary === undefined) {
+      if (primaryRequired) throw malformedEnvelope("lifecycle response is missing action");
+    } else {
+      actions.push({
+        action: parseActionEnvelope(primary, {
+          expectedResource: expectedPrimaryResource,
+          requireResources: true,
+        }),
+        expectedResource: expectedPrimaryResource,
+      });
+    }
+    for (const rawAction of nextActionsValue) {
+      actions.push({
+        action: parseActionEnvelope(rawAction, { requireResources: true }),
+      });
+    }
+    const actionIds = new Set<number>();
+    for (const entry of actions) {
+      if (actionIds.has(entry.action.id)) {
+        throw malformedEnvelope("lifecycle response contains a duplicate action ID");
+      }
+      actionIds.add(entry.action.id);
+      if (entry.action.status === "error") throw actionFailure(entry.action);
+      if (entry.action.status === "running") {
+        await this.waitForActionUntil(entry.action.id, deadline, entry.expectedResource);
+      }
+    }
   }
 
   // ----------------------------------------------------------------------
@@ -468,12 +727,34 @@ export class HetznerCloudClient implements ComputeProvider {
     method: "GET" | "POST" | "DELETE" | "PUT",
     path: string,
     body?: unknown,
-  ): Promise<T> {
+    deadline?: number,
+  ): Promise<T>;
+  private async request<T>(
+    method: "GET" | "POST" | "DELETE" | "PUT",
+    path: string,
+    body: unknown,
+    deadline: number,
+    distinguishNoContent: true,
+  ): Promise<T | typeof NO_CONTENT>;
+  private async request<T>(
+    method: "GET" | "POST" | "DELETE" | "PUT",
+    path: string,
+    body?: unknown,
+    deadline = deadlineAfter(this.requestTimeoutMs),
+    distinguishNoContent = false,
+  ): Promise<T | typeof NO_CONTENT> {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new HetznerCloudError(
+        "transport_error",
+        `Hetzner Cloud API ${method} ${path} exceeded its operation deadline`,
+      );
+    }
+    const requestDeadline = Date.now() + Math.min(this.requestTimeoutMs, remaining);
     const ac = new AbortController();
-    const timer = setTimeout(() => ac.abort(), this.requestTimeoutMs);
-    let response: Response;
+    const timer = setTimeout(() => ac.abort(), requestDeadline - Date.now());
     try {
-      response = await fetch(`${this.apiBaseUrl}${path}`, {
+      const response = await fetch(`${this.apiBaseUrl}${path}`, {
         method,
         headers: {
           Authorization: `Bearer ${this.token}`,
@@ -482,50 +763,203 @@ export class HetznerCloudClient implements ComputeProvider {
         body: body !== undefined ? JSON.stringify(body) : undefined,
         signal: ac.signal,
       });
-    } catch (err) {
+      assertRequestWithinDeadline(method, path, requestDeadline);
+
+      if (response.status === 204) {
+        return distinguishNoContent ? NO_CONTENT : (undefined as T);
+      }
+
+      const text = await response.text();
+      assertRequestWithinDeadline(method, path, requestDeadline);
+      let parsed: unknown;
+      try {
+        parsed = text ? JSON.parse(text) : undefined;
+      } catch {
+        // error-policy:J3 provider bytes must parse as the declared JSON
+        // envelope; malformed payloads never become successful defaults.
+        throw new HetznerCloudError(
+          "server_error",
+          `Hetzner Cloud API ${method} ${path} returned non-JSON: ${truncateWellFormed(toWellFormedUnicode(text), 200)}`,
+          response.status,
+        );
+      }
+      assertRequestWithinDeadline(method, path, requestDeadline);
+
+      if (!response.ok) {
+        const errorPayload =
+          parsed && typeof parsed === "object" && "error" in parsed
+            ? (parsed as { error: { code?: string; message?: string } }).error
+            : undefined;
+        const code = mapStatusToCode(response.status, errorPayload?.code);
+        throw new HetznerCloudError(
+          code,
+          errorPayload?.message ??
+            `Hetzner Cloud API ${method} ${path} failed with status ${response.status}`,
+          response.status,
+          undefined,
+          code === "rate_limited" ? parseRetryMetadata(response.headers) : undefined,
+        );
+      }
+
+      return parsed as T;
+    } catch (error) {
+      if (error instanceof HetznerCloudError) throw error;
+      // error-policy:J2 preserve the underlying fetch or body-read failure at
+      // the typed provider transport boundary.
       throw new HetznerCloudError(
         "transport_error",
-        `Hetzner Cloud API ${method} ${path} failed: ${err instanceof Error ? err.message : String(err)}`,
+        `Hetzner Cloud API ${method} ${path} failed: ${error instanceof Error ? error.message : String(error)}`,
         undefined,
-        err,
+        error,
       );
     } finally {
       clearTimeout(timer);
     }
+  }
+}
 
-    if (response.status === 204) {
-      return undefined as T;
+interface ActionEnvelopeOptions {
+  expectedId?: number;
+  expectedResource?: { id: number; type: string };
+  requireResources?: boolean;
+}
+
+function requireEnvelope(value: unknown, operation: string): Record<string, unknown> {
+  return requireObject(value, `${operation} response`);
+}
+
+function requireObject(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw malformedEnvelope(`${field} is not an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseActionEnvelope(value: unknown, options: ActionEnvelopeOptions = {}): HetznerAction {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw malformedEnvelope("action is not an object");
+  }
+  const action = value as Partial<HetznerAction>;
+  if (!Number.isSafeInteger(action.id) || (action.id as number) <= 0) {
+    throw malformedEnvelope("action has an invalid ID");
+  }
+  if (options.expectedId !== undefined && action.id !== options.expectedId) {
+    throw malformedEnvelope("action readback returned a different ID");
+  }
+  if (typeof action.command !== "string" || action.command.trim() === "") {
+    throw malformedEnvelope("action has an invalid command");
+  }
+  if (action.status !== "running" && action.status !== "success" && action.status !== "error") {
+    throw malformedEnvelope("action has an invalid status");
+  }
+  if (
+    !Number.isFinite(action.progress) ||
+    !Number.isInteger(action.progress) ||
+    (action.progress as number) < 0 ||
+    (action.progress as number) > 100
+  ) {
+    throw malformedEnvelope("action has invalid progress");
+  }
+  if (action.status === "error") {
+    if (
+      !action.error ||
+      typeof action.error.code !== "string" ||
+      action.error.code.trim() === "" ||
+      typeof action.error.message !== "string" ||
+      action.error.message.trim() === ""
+    ) {
+      throw malformedEnvelope("failed action is missing its provider error");
     }
+  } else if (action.error !== null) {
+    throw malformedEnvelope("non-failed action contains an error");
+  }
 
-    const text = await response.text();
-    let parsed: unknown;
-    try {
-      parsed = text ? JSON.parse(text) : undefined;
-    } catch {
-      throw new HetznerCloudError(
-        "server_error",
-        `Hetzner Cloud API ${method} ${path} returned non-JSON: ${truncateWellFormed(toWellFormedUnicode(text), 200)}`,
-        response.status,
-      );
+  const resources = action.resources;
+  if (options.requireResources && !Array.isArray(resources)) {
+    throw malformedEnvelope("action is missing resource bindings");
+  }
+  if (resources !== undefined) {
+    if (!Array.isArray(resources)) {
+      throw malformedEnvelope("action has malformed resource bindings");
     }
-
-    if (!response.ok) {
-      const errorPayload =
-        parsed && typeof parsed === "object" && "error" in parsed
-          ? (parsed as { error: { code?: string; message?: string } }).error
-          : undefined;
-      const code = mapStatusToCode(response.status, errorPayload?.code);
-      throw new HetznerCloudError(
-        code,
-        errorPayload?.message ??
-          `Hetzner Cloud API ${method} ${path} failed with status ${response.status}`,
-        response.status,
-        undefined,
-        code === "rate_limited" ? parseRetryMetadata(response.headers) : undefined,
-      );
+    for (const resource of resources) {
+      if (
+        !resource ||
+        !Number.isSafeInteger(resource.id) ||
+        resource.id <= 0 ||
+        typeof resource.type !== "string" ||
+        resource.type.trim() === ""
+      ) {
+        throw malformedEnvelope("action has malformed resource bindings");
+      }
     }
+  }
+  if (
+    options.expectedResource &&
+    !resources?.some(
+      (resource) =>
+        resource.id === options.expectedResource?.id &&
+        resource.type === options.expectedResource.type,
+    )
+  ) {
+    throw malformedEnvelope("action is not bound to the exact requested resource");
+  }
+  return action as HetznerAction;
+}
 
-    return parsed as T;
+function requireAcceptedAction(value: unknown, options: ActionEnvelopeOptions): HetznerAction {
+  const action = parseActionEnvelope(value, options);
+  if (action.status === "error") throw actionFailure(action);
+  return action;
+}
+
+function actionFailure(action: HetznerAction): HetznerCloudError {
+  return new HetznerCloudError(
+    "server_error",
+    `Hetzner action ${action.id} failed (${action.error?.code}): ${action.error?.message}`,
+  );
+}
+
+function malformedEnvelope(detail: string): HetznerCloudError {
+  return new HetznerCloudError(
+    "server_error",
+    `Hetzner Cloud API returned a malformed lifecycle response: ${detail}`,
+  );
+}
+
+function validateResourceId(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new HetznerCloudError("invalid_input", `${field} must be a positive safe integer`);
+  }
+}
+
+function requireResourceId(value: unknown, resource: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw malformedEnvelope(`${resource} has an invalid ID`);
+  }
+  return value as number;
+}
+
+function assertExactResourceId(value: unknown, expected: number, resource: string): void {
+  if (value !== expected) {
+    throw malformedEnvelope(`${resource} readback returned a different ID`);
+  }
+}
+
+function deadlineAfter(timeoutMs: number): number {
+  return Date.now() + timeoutMs;
+}
+
+function assertRequestWithinDeadline(
+  method: "GET" | "POST" | "DELETE" | "PUT",
+  path: string,
+  deadline: number,
+): void {
+  if (Date.now() >= deadline) {
+    throw new HetznerCloudError(
+      "transport_error",
+      `Hetzner Cloud API ${method} ${path} exceeded its request deadline`,
+    );
   }
 }
 
@@ -616,12 +1050,12 @@ function validateToken(token: string): void {
   }
 }
 
-function validateRequestTimeout(value: number | undefined): void {
+function validateRequestTimeout(value: number | undefined, field = "requestTimeoutMs"): void {
   if (value === undefined) return;
   if (!Number.isSafeInteger(value) || value < 1 || value > MAX_REQUEST_TIMEOUT_MS) {
     throw new HetznerCloudError(
       "invalid_input",
-      `requestTimeoutMs must be a positive safe integer no greater than ${MAX_REQUEST_TIMEOUT_MS}`,
+      `${field} must be a positive safe integer no greater than ${MAX_REQUEST_TIMEOUT_MS}`,
     );
   }
 }

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -92,7 +92,8 @@ Implements the subset of the Hetzner Cloud API that the autoscaler client in
 - `POST /v1/servers`, `GET /v1/servers`, `GET /v1/servers/{id}`, `DELETE /v1/servers/{id}`
 - `POST /v1/servers/{id}/actions/poweroff|poweron`
 - `GET /v1/actions/{id}` — pollable until `status: "success"`
-- `POST /v1/volumes`, `POST /v1/volumes/{id}/actions/attach`, `DELETE /v1/volumes/{id}`
+- `GET /v1/volumes`, `GET /v1/volumes/{id}`, `POST /v1/volumes`,
+  `POST /v1/volumes/{id}/actions/attach|detach`, `DELETE /v1/volumes/{id}`
 
 State is kept in memory and resets when the process exits.
 

--- a/packages/cloud/test-mocks/src/hetzner/server.ts
+++ b/packages/cloud/test-mocks/src/hetzner/server.ts
@@ -123,7 +123,19 @@ export function buildHetznerMockApp(options: HetznerMockAppOptions = {}): {
         filters.every(([k, v]) => s.labels[k] === v),
       );
     }
-    return c.json({ servers });
+    return c.json({
+      servers,
+      meta: {
+        pagination: {
+          page: 1,
+          per_page: servers.length,
+          previous_page: null,
+          next_page: null,
+          last_page: 1,
+          total_entries: servers.length,
+        },
+      },
+    });
   });
 
   app.get("/servers/:id", async (c) => {
@@ -201,24 +213,43 @@ export function buildHetznerMockApp(options: HetznerMockAppOptions = {}): {
     const size = typeof body.size === "number" ? body.size : null;
     const locationName =
       typeof body.location === "string" ? body.location : null;
-    if (!name || !size || !locationName) {
+    const serverId = typeof body.server === "number" ? body.server : null;
+    const hasLocation = locationName !== null;
+    const hasServer = serverId !== null;
+    if (
+      !name ||
+      !Number.isSafeInteger(size) ||
+      (size as number) <= 0 ||
+      hasLocation === hasServer ||
+      (hasLocation && (locationName as string).trim().length === 0) ||
+      (hasServer &&
+        (!Number.isSafeInteger(serverId) ||
+          (serverId as number) <= 0 ||
+          !store.servers.has(serverId as number))) ||
+      (body.automount !== undefined && typeof body.automount !== "boolean") ||
+      (body.automount === true && !hasServer)
+    ) {
       return c.json<ErrorEnvelope>(
         {
           error: {
             code: "invalid_input",
-            message: "name, size and location are required",
+            message:
+              "name, size, and exactly one valid location or server are required; automount requires a server",
           },
         },
         422,
       );
     }
-    const location = store.resolveLocation(locationName);
+    const attachedServer = hasServer ? (serverId as number) : null;
+    const location = hasServer
+      ? (store.servers.get(serverId as number) as MockServer).datacenter
+          .location
+      : store.resolveLocation(locationName as string);
     const id = store.allocVolumeId();
-    const attachedServer = typeof body.server === "number" ? body.server : null;
     const volume: MockVolume = {
       id,
       name,
-      size,
+      size: size as number,
       linux_device: attachedServer
         ? `/dev/disk/by-id/scsi-0HC_Volume_${id}`
         : null,
@@ -269,6 +300,44 @@ export function buildHetznerMockApp(options: HetznerMockAppOptions = {}): {
     return c.json({ action });
   });
 
+  app.get("/volumes", async (c) => {
+    await injectLatency("GET /volumes");
+    const labelSelector = c.req.query("label_selector");
+    let volumes = [...store.volumes.values()];
+    if (labelSelector) {
+      const filters = parseLabelSelector(labelSelector);
+      volumes = volumes.filter((volume) =>
+        filters.every(([key, value]) => volume.labels[key] === value),
+      );
+    }
+    return c.json({ volumes });
+  });
+
+  app.get("/volumes/:id", async (c) => {
+    await injectLatency("GET /volumes/:id");
+    const id = Number(c.req.param("id"));
+    const volume = store.volumes.get(id);
+    if (!volume) return notFound(c, "volume", id);
+    return c.json({ volume });
+  });
+
+  app.post("/volumes/:id/actions/detach", async (c) => {
+    await injectLatency("POST /volumes/:id/actions/detach");
+    const id = Number(c.req.param("id"));
+    const volume = store.volumes.get(id);
+    if (!volume) return notFound(c, "volume", id);
+    const action = createAction(store, "detach_volume", [
+      { id, type: "volume" },
+    ]);
+    scheduleActionSuccess(store, action.id, progression, () => {
+      const current = store.volumes.get(id);
+      if (!current) return;
+      current.server = null;
+      current.linux_device = null;
+    });
+    return c.json({ action });
+  });
+
   app.delete("/volumes/:id", async (c) => {
     await injectLatency("DELETE /volumes/:id");
     const id = Number(c.req.param("id"));
@@ -299,6 +368,8 @@ async function safeJson(c: {
       ? (parsed as Record<string, unknown>)
       : {};
   } catch {
+    // error-policy:J3 malformed mock input is represented as an invalid empty
+    // object so the route's required-field validation rejects it explicitly.
     return {};
   }
 }

--- a/packages/cloud/test-mocks/test/hetzner.test.ts
+++ b/packages/cloud/test-mocks/test/hetzner.test.ts
@@ -1,9 +1,11 @@
 /** Covers the hetzner cloud mock with deterministic in-process state and real HTTP handlers. */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { HetznerCloudClient } from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
 import { type RunningHetznerMock, startHetznerMock } from "../src/hetzner";
 
 // Speed up tests
 process.env.MOCK_HETZNER_LATENCY = "0";
+process.env.MOCK_HETZNER_ACTION_MS = "0";
 
 let mock: RunningHetznerMock;
 
@@ -126,5 +128,74 @@ describe("Hetzner mock", () => {
     expect(r.status).toBe(422);
     const body = (await r.json()) as { error: { code: string } };
     expect(body.error.code).toBe("invalid_input");
+  });
+
+  test("volume placement rejects provider-invalid location and server combinations", async () => {
+    const both = await fetch(`${mock.url}/volumes`, {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({
+        name: "invalid-volume",
+        size: 10,
+        location: "fsn1",
+        server: 42,
+      }),
+    });
+    expect(both.status).toBe(422);
+
+    const neither = await fetch(`${mock.url}/volumes`, {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ name: "invalid-volume", size: 10 }),
+    });
+    expect(neither.status).toBe(422);
+
+    const unattachedAutomount = await fetch(`${mock.url}/volumes`, {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({
+        name: "invalid-volume",
+        size: 10,
+        location: "fsn1",
+        automount: true,
+      }),
+    });
+    expect(unattachedAutomount.status).toBe(422);
+  });
+
+  test("real client proves create/readback/volume/delete lifecycle over HTTP", async () => {
+    const client = HetznerCloudClient.withTestTransport("test-token", {
+      apiBaseUrl: mock.url,
+      requestTimeoutMs: 1_000,
+      lifecycleTimeoutMs: 5_000,
+    });
+
+    const created = await client.createServer({
+      name: "client-node",
+      serverType: "cx22",
+      location: "fsn1",
+      image: "ubuntu-24.04",
+      userData: "#cloud-config\n",
+    });
+    expect(created.server).toMatchObject({ status: "running" });
+
+    const serverId = created.server.id;
+    const volume = await client.createVolume({
+      name: "client-volume",
+      sizeGb: 10,
+      location: "fsn1",
+      serverId,
+      automount: false,
+    });
+    expect(volume).toMatchObject({
+      status: "available",
+      server: serverId,
+    });
+    expect(volume.linux_device).toContain(String(volume.id));
+
+    await client.deleteVolume(volume.id);
+    expect(await client.getVolume(volume.id)).toBeNull();
+    await client.deleteServer(serverId);
+    expect(await client.getServer(serverId)).toBeNull();
   });
 });

--- a/packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts
+++ b/packages/cloud/test-mocks/test/provider-contract/hetzner-cloud-client.contract.test.ts
@@ -64,8 +64,38 @@ beforeAll(async () => {
         response: {
           status: 201,
           body: {
-            server: { id: 8, name: "node-b", public_net: {} },
+            server: {
+              id: 8,
+              name: "node-b",
+              status: "initializing",
+              public_net: {},
+            },
+            action: {
+              id: 80,
+              command: "create_server",
+              status: "success",
+              progress: 100,
+              resources: [{ id: 8, type: "server" }],
+              error: null,
+            },
+            next_actions: [],
             root_password: null,
+          },
+        },
+      },
+      {
+        id: "hetzner-get-created-server",
+        method: "GET",
+        path: "/v1/servers/8",
+        response: {
+          status: 200,
+          body: {
+            server: {
+              id: 8,
+              name: "node-b",
+              status: "running",
+              public_net: {},
+            },
           },
         },
       },
@@ -81,7 +111,28 @@ beforeAll(async () => {
           decision: "allow",
           confirmation: { state: "already_granted" },
         },
-        response: { status: 204 },
+        response: {
+          status: 201,
+          body: {
+            action: {
+              id: 70,
+              command: "delete_server",
+              status: "success",
+              progress: 100,
+              resources: [{ id: 7, type: "server" }],
+              error: null,
+            },
+          },
+        },
+      },
+      {
+        id: "hetzner-get-deleted-server",
+        method: "GET",
+        path: "/v1/servers/7",
+        response: {
+          status: 404,
+          body: { error: { code: "not_found", message: "server not found" } },
+        },
       },
     ],
   });


### PR DESCRIPTION
# Relates to

Refs #22916. This is the bounded Hetzner lifecycle-envelope tranche; it intentionally does not close the issue's legacy-row, fleet-consumer, compensation, SSH/filesystem, or credentialed-provider acceptance work.

- [x] Targets `develop` and is rebased onto `origin/develop@d1c38488865d7fc440b84ee1fd7073a007fc1db6` with zero conflicts.
- [x] A fresh independent reviewer approved the patch-equivalent exact head after the create/delete lifecycle repairs.
- [x] Source, focused tests, mock/provider contract, and exact-head evidence are complete for this bounded slice.

# Risks

Medium cloud-provider boundary change. Incorrect validation or action settlement can create orphan resources, report deletion before provider completion, or hide a provider error. The implementation therefore validates before transport, binds every returned action to one deadline, and requires exact readback/absence proof.

# What this PR does

- validates positive safe Hetzner server identities before any create-volume request;
- sends exactly one volume placement selector (`server` or `location`) and preserves both `automount: true` and `automount: false`;
- validates and settles create action plus every `next_actions` entry under one operation deadline before exact readback;
- keeps request abort deadlines active through response-body read and parse;
- settles server-delete `action` and `next_actions` before proving exact target absence;
- accepts the official volume-delete 204 response while also validating and settling a complete JSON action envelope when supplied;
- distinguishes target 404 idempotence from action-poll 404 failure;
- makes the local Hetzner mock enforce the provider placement contract and exercise the real client over HTTP.

# Scope boundary

This PR does not migrate or unquarantine legacy metadata-only nodes; modify capacity, bootstrap, maintenance, availability, or SSH/filesystem consumers; change volume attach/detach authority; or implement provisioning compensation. Those remain explicit work in #22916. No live provider call was made.

# Testing

Exact head `84ac29e24dd2904fd7da603bcb7cfb9e7fc17ff5`:

- PASS — cloud-shared lifecycle and characterization suites: 62/62 tests, 158 assertions.
- PASS — Hetzner mock HTTP and provider-contract suites: 6/6 tests, 46 assertions.
- PASS — lifecycle shared-deadline test repeated three times during independent review: 12/12 each run.
- PASS — `bun run --cwd packages/cloud/shared typecheck`.
- PASS — scoped Biome and `git diff --check`; one unchanged optional-chain warning remains in the mock server.
- PASS — `bun install` at the exact dependency graph.
- ROOT HOLD — `bun run verify` reaches only unrelated current-base lint failures in `packages/agent/src/api/interactions-routes.test.ts`, `packages/agent/src/api/accounts-routes.ts`, and a warning in `plugins/plugin-agent-orchestrator/src/services/sub-agent-inbox.ts`; this PR changes none of those files. All scoped cloud gates above pass.

# Evidence Gate

<!-- evidence-head:84ac29e24dd2904fd7da603bcb7cfb9e7fc17ff5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend provider lifecycle code only; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no frontend pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - credentialed provider logs are a protected acceptance hold; deterministic in-process and real-HTTP mock receipts above exercise valid, malformed, terminal-error, timeout, mismatch, action-chain, 204, and absence paths without credentials.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no generated or visual domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

# Protected merge / acceptance holds

- An authorized non-production Hetzner account must prove create, every returned action, exact readback, drift rejection, and delete/absence without exposing resource identifiers or credentials.
- The remaining legacy-node, direct-consumer, attach/detach, and compensation acceptance criteria in #22916 are not claimed by this bounded PR.
- The PR remains ready for review while these protected acceptance holds are explicit.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@d1c38488865d7fc440b84ee1fd7073a007fc1db6:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hetzner-lifecycle-envelope]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@d1c38488865d7fc440b84ee1fd7073a007fc1db6:packages/skills/skills/contribute-to-eliza"} -->
