### PR TITLE
feat(instagram): add professional Graph API backend

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -2716,37 +2716,61 @@
       "source": "bundled",
       "tags": ["connector", "social", "social-feed", "instagram"],
       "config": {
-        "INSTAGRAM_PROXY": {
-          "type": "string",
-          "required": false,
-          "sensitive": false,
-          "label": "Proxy",
-          "help": "Proxy URL for Instagram API requests",
-          "advanced": false
-        },
-        "INSTAGRAM_PASSWORD": {
+        "INSTAGRAM_ACCESS_TOKEN": {
           "type": "secret",
           "required": true,
           "sensitive": true,
-          "label": "Password",
-          "help": "Instagram password for authentication",
+          "label": "Graph access token",
+          "help": "Access token approved for the Instagram professional account",
           "advanced": false
         },
-        "INSTAGRAM_USERNAME": {
-          "type": "string",
-          "required": true,
-          "sensitive": false,
-          "label": "Username",
-          "help": "Instagram username for authentication",
-          "advanced": false
-        },
-        "INSTAGRAM_VERIFICATION_CODE": {
+        "INSTAGRAM_APP_SECRET": {
           "type": "secret",
           "required": false,
           "sensitive": true,
-          "label": "Verification Code",
-          "help": "Two-factor authentication verification code",
+          "label": "App secret",
+          "help": "Meta app secret used to validate webhook signatures",
+          "advanced": true
+        },
+        "INSTAGRAM_GRAPH_ACCOUNT_ID": {
+          "type": "string",
+          "required": true,
+          "sensitive": false,
+          "label": "Professional account ID",
+          "help": "Instagram professional account ID associated with the token",
           "advanced": false
+        },
+        "INSTAGRAM_GRAPH_API_VERSION": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Graph API version",
+          "help": "Explicit version such as v24.0",
+          "advanced": true
+        },
+        "INSTAGRAM_GRAPH_BASE_URL": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Graph API origin",
+          "help": "HTTPS Graph origin; literal loopback HTTP is test-only",
+          "advanced": true
+        },
+        "INSTAGRAM_REQUEST_TIMEOUT_MS": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Request timeout",
+          "help": "Graph request deadline in milliseconds",
+          "advanced": true
+        },
+        "INSTAGRAM_WEBHOOK_VERIFY_TOKEN": {
+          "type": "secret",
+          "required": false,
+          "sensitive": true,
+          "label": "Webhook verify token",
+          "help": "Secret used for webhook subscription verification",
+          "advanced": true
         }
       },
       "render": {
@@ -2770,7 +2794,7 @@
       "subtype": "messaging",
       "auth": {
         "kind": "token",
-        "credentialKeys": []
+        "credentialKeys": ["INSTAGRAM_ACCESS_TOKEN"]
       }
     },
     {

--- a/plugins/plugin-instagram/AGENTS.md
+++ b/plugins/plugin-instagram/AGENTS.md
@@ -16,8 +16,9 @@ not supported. The service stays disabled when credentials are absent.
 
 - `InstagramService` (`serviceType = "instagram"`) — lifecycle manager for one or more Instagram
   accounts. On `start()` it reads config, validates credentials, and registers both the DM
-  `MessageConnector` and the feed `PostConnector` with the runtime. Exposes methods for sending DMs,
-  posting/replying to comments, liking media, following/unfollowing users, and fetching threads.
+  `MessageConnector` and the feed `PostConnector` with the runtime. Exposes Graph-backed methods for
+  scoped profiles, owned media, conversations/messages, text DMs, and comment/reply writes. Legacy
+  like/follow methods remain public for compatibility but fail explicitly as unsupported.
 
 **Actions:** none registered — DMs route through `MESSAGE`, comments through `POST`.
 

--- a/plugins/plugin-instagram/AGENTS.md
+++ b/plugins/plugin-instagram/AGENTS.md
@@ -7,7 +7,8 @@ Instagram DM and public-comment connector for elizaOS agents.
 Adds Instagram integration to an Eliza agent: DM sending (via the `MESSAGE` connector) and public
 media-comment posting (via the `POST` connector). Loaded opt-in — add
 `@elizaos/plugin-instagram` to the agent's `plugins` array.
-Requires credentials to do anything useful; the service degrades gracefully when they are absent.
+Requires approved professional-account Graph credentials; consumer username/password automation is
+not supported. The service stays disabled when credentials are absent.
 
 ## Plugin surface
 
@@ -39,6 +40,8 @@ hooks (`getChatContext`, `getUserContext`, `resolveTargets`, `listRooms`, `fetch
 src/
   index.ts                       Plugin object, init() hook, re-exports
   service.ts                     InstagramService class — connector registration + API backend boundary
+  graph-client.ts                Production Graph transport, schemas, paging, and DTO conversion
+  webhook.ts                     Raw-body signature/challenge validation and account event routing
   connector-account-provider.ts  ConnectorAccountProvider impl for ConnectorAccountManager
   accounts.ts                    Config resolution: env vars, character.settings.instagram, multi-account
   constants.ts                   INSTAGRAM_SERVICE_NAME, MAX_*, SUPPORTED_MEDIA_TYPES, EVENT_PREFIX
@@ -71,10 +74,13 @@ apply when `accountId === "default"` (the single-account case). Multi-account de
 
 | Env var | Required | Description |
 |---|---|---|
-| `INSTAGRAM_USERNAME` | **Yes** | Instagram username for the default account |
-| `INSTAGRAM_PASSWORD` | **Yes** | Instagram password for the default account |
-| `INSTAGRAM_VERIFICATION_CODE` | No | 2FA code if account requires it |
-| `INSTAGRAM_PROXY` | No | HTTP/SOCKS proxy URL for API requests |
+| `INSTAGRAM_GRAPH_ACCOUNT_ID` | **Yes** | Professional account ID for the default account |
+| `INSTAGRAM_ACCESS_TOKEN` | **Yes** | Approved Graph API access token |
+| `INSTAGRAM_APP_SECRET` | For webhooks | App secret for `X-Hub-Signature-256` validation |
+| `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` | For webhooks | Subscription verification secret |
+| `INSTAGRAM_GRAPH_API_VERSION` | No | Explicit API version (default `v24.0`) |
+| `INSTAGRAM_GRAPH_BASE_URL` | No | HTTPS Graph origin; literal loopback HTTP is test-only |
+| `INSTAGRAM_REQUEST_TIMEOUT_MS` | No | Request deadline in milliseconds |
 | `INSTAGRAM_AUTO_RESPOND_DMS` | No | `"true"` to auto-respond to DMs |
 | `INSTAGRAM_AUTO_RESPOND_COMMENTS` | No | `"true"` to auto-respond to comments |
 | `INSTAGRAM_POLLING_INTERVAL` | No | Poll interval in seconds (default `60`) |
@@ -87,10 +93,10 @@ Character-level config goes in `character.settings.instagram`:
 {
   "settings": {
     "instagram": {
-      "username": "mybot",
-      "password": "secret",
+      "instagramAccountId": "17841400000000000",
+      "accessToken": "secret",
       "accounts": {
-        "brand-a": { "username": "brand_a", "password": "..." }
+        "brand-a": { "instagramAccountId": "17841400000000001", "accessToken": "..." }
       }
     }
   }
@@ -115,10 +121,17 @@ pattern).
 
 ## Conventions / gotchas
 
-- **API backend boundary:** `InstagramService` registers the connector/account surfaces, but this
-  package does not ship a concrete Instagram API client backend. API methods fail explicitly until a
-  backend such as `instagram-private-api` or an approved Graph API adapter is wired into
-  `src/service.ts`.
+- **API backend boundary:** `InstagramGraphClient` is the only production network boundary. It uses
+  bearer headers, strict response schemas, same-origin cursors, manual redirects, bounded bodies,
+  deadlines, and redacted typed failures. Remote origins require HTTPS; literal loopback HTTP exists
+  only for real-wire protocol tests.
+- **Capability truth:** Official professional-account reads, scoped profile lookup, one-to-one text
+  sends, and media comments/replies are implemented. Consumer login, arbitrary username discovery,
+  third-party media reads, follows, and likes fail with `INSTAGRAM_CAPABILITY_UNSUPPORTED`; do not
+  add private/mobile scraping APIs.
+- **Webhook boundary:** Validate the raw body signature before parsing. Parsed events are stamped
+  with the professional account ID and stable replay identity. Durable route ingestion and shared
+  synthetic reset/ledger composition remain owned by #24093 and #24076-#24078.
 - **Multi-account:** Each configured account gets its own `InstagramService` instance. The `start()`
   static method iterates `listInstagramAccountIds()` and registers one connector pair per account.
   `INSTAGRAM_ACCOUNTS` is fail-closed: malformed/non-collection JSON is fatal, non-object entries

--- a/plugins/plugin-instagram/CLAUDE.md
+++ b/plugins/plugin-instagram/CLAUDE.md
@@ -16,8 +16,9 @@ not supported. The service stays disabled when credentials are absent.
 
 - `InstagramService` (`serviceType = "instagram"`) — lifecycle manager for one or more Instagram
   accounts. On `start()` it reads config, validates credentials, and registers both the DM
-  `MessageConnector` and the feed `PostConnector` with the runtime. Exposes methods for sending DMs,
-  posting/replying to comments, liking media, following/unfollowing users, and fetching threads.
+  `MessageConnector` and the feed `PostConnector` with the runtime. Exposes Graph-backed methods for
+  scoped profiles, owned media, conversations/messages, text DMs, and comment/reply writes. Legacy
+  like/follow methods remain public for compatibility but fail explicitly as unsupported.
 
 **Actions:** none registered — DMs route through `MESSAGE`, comments through `POST`.
 

--- a/plugins/plugin-instagram/CLAUDE.md
+++ b/plugins/plugin-instagram/CLAUDE.md
@@ -7,7 +7,8 @@ Instagram DM and public-comment connector for elizaOS agents.
 Adds Instagram integration to an Eliza agent: DM sending (via the `MESSAGE` connector) and public
 media-comment posting (via the `POST` connector). Loaded opt-in — add
 `@elizaos/plugin-instagram` to the agent's `plugins` array.
-Requires credentials to do anything useful; the service degrades gracefully when they are absent.
+Requires approved professional-account Graph credentials; consumer username/password automation is
+not supported. The service stays disabled when credentials are absent.
 
 ## Plugin surface
 
@@ -39,6 +40,8 @@ hooks (`getChatContext`, `getUserContext`, `resolveTargets`, `listRooms`, `fetch
 src/
   index.ts                       Plugin object, init() hook, re-exports
   service.ts                     InstagramService class — connector registration + API backend boundary
+  graph-client.ts                Production Graph transport, schemas, paging, and DTO conversion
+  webhook.ts                     Raw-body signature/challenge validation and account event routing
   connector-account-provider.ts  ConnectorAccountProvider impl for ConnectorAccountManager
   accounts.ts                    Config resolution: env vars, character.settings.instagram, multi-account
   constants.ts                   INSTAGRAM_SERVICE_NAME, MAX_*, SUPPORTED_MEDIA_TYPES, EVENT_PREFIX
@@ -71,10 +74,13 @@ apply when `accountId === "default"` (the single-account case). Multi-account de
 
 | Env var | Required | Description |
 |---|---|---|
-| `INSTAGRAM_USERNAME` | **Yes** | Instagram username for the default account |
-| `INSTAGRAM_PASSWORD` | **Yes** | Instagram password for the default account |
-| `INSTAGRAM_VERIFICATION_CODE` | No | 2FA code if account requires it |
-| `INSTAGRAM_PROXY` | No | HTTP/SOCKS proxy URL for API requests |
+| `INSTAGRAM_GRAPH_ACCOUNT_ID` | **Yes** | Professional account ID for the default account |
+| `INSTAGRAM_ACCESS_TOKEN` | **Yes** | Approved Graph API access token |
+| `INSTAGRAM_APP_SECRET` | For webhooks | App secret for `X-Hub-Signature-256` validation |
+| `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` | For webhooks | Subscription verification secret |
+| `INSTAGRAM_GRAPH_API_VERSION` | No | Explicit API version (default `v24.0`) |
+| `INSTAGRAM_GRAPH_BASE_URL` | No | HTTPS Graph origin; literal loopback HTTP is test-only |
+| `INSTAGRAM_REQUEST_TIMEOUT_MS` | No | Request deadline in milliseconds |
 | `INSTAGRAM_AUTO_RESPOND_DMS` | No | `"true"` to auto-respond to DMs |
 | `INSTAGRAM_AUTO_RESPOND_COMMENTS` | No | `"true"` to auto-respond to comments |
 | `INSTAGRAM_POLLING_INTERVAL` | No | Poll interval in seconds (default `60`) |
@@ -87,10 +93,10 @@ Character-level config goes in `character.settings.instagram`:
 {
   "settings": {
     "instagram": {
-      "username": "mybot",
-      "password": "secret",
+      "instagramAccountId": "17841400000000000",
+      "accessToken": "secret",
       "accounts": {
-        "brand-a": { "username": "brand_a", "password": "..." }
+        "brand-a": { "instagramAccountId": "17841400000000001", "accessToken": "..." }
       }
     }
   }
@@ -115,10 +121,17 @@ pattern).
 
 ## Conventions / gotchas
 
-- **API backend boundary:** `InstagramService` registers the connector/account surfaces, but this
-  package does not ship a concrete Instagram API client backend. API methods fail explicitly until a
-  backend such as `instagram-private-api` or an approved Graph API adapter is wired into
-  `src/service.ts`.
+- **API backend boundary:** `InstagramGraphClient` is the only production network boundary. It uses
+  bearer headers, strict response schemas, same-origin cursors, manual redirects, bounded bodies,
+  deadlines, and redacted typed failures. Remote origins require HTTPS; literal loopback HTTP exists
+  only for real-wire protocol tests.
+- **Capability truth:** Official professional-account reads, scoped profile lookup, one-to-one text
+  sends, and media comments/replies are implemented. Consumer login, arbitrary username discovery,
+  third-party media reads, follows, and likes fail with `INSTAGRAM_CAPABILITY_UNSUPPORTED`; do not
+  add private/mobile scraping APIs.
+- **Webhook boundary:** Validate the raw body signature before parsing. Parsed events are stamped
+  with the professional account ID and stable replay identity. Durable route ingestion and shared
+  synthetic reset/ledger composition remain owned by #24093 and #24076-#24078.
 - **Multi-account:** Each configured account gets its own `InstagramService` instance. The `start()`
   static method iterates `listInstagramAccountIds()` and registers one connector pair per account.
   `INSTAGRAM_ACCOUNTS` is fail-closed: malformed/non-collection JSON is fatal, non-object entries

--- a/plugins/plugin-instagram/README.md
+++ b/plugins/plugin-instagram/README.md
@@ -8,13 +8,17 @@ Adds Instagram integration to an Eliza agent:
 
 - **Direct messages** — agent can send DMs to existing Instagram threads via the `MESSAGE` connector.
 - **Media comments** — agent can post and reply to comments on Instagram media via the `POST` connector.
-- **User lookup** — resolves Instagram usernames/handles to entity objects the runtime can reason about.
+- **User lookup** — resolves consented Instagram-scoped IDs from messaging interactions.
 - **Thread browsing** — lists and searches DM threads so the runtime can pick the right target.
 - **Multi-account** — configure multiple Instagram accounts; each gets its own connector pair.
 
-> **Note:** The connector and credential plumbing is complete, but this package does not ship a
-> concrete Instagram API client backend. Runtime API methods fail explicitly until a backend such as
-> `instagram-private-api` or an approved Graph API adapter is wired into `src/service.ts`.
+The connector uses Meta's official Instagram Graph API for approved professional accounts. It does
+not log in with an Instagram username/password, automate consumer accounts, or use private/mobile
+scraping APIs. The Meta app and account must have the provider permissions required for each
+enabled operation.
+
+Protocol behavior follows Meta's official [Instagram API collection](https://www.postman.com/meta/instagram/collection/6yqw8pt/instagram-api), including the Instagram Login
+[Conversations API](https://www.postman.com/meta/instagram/folder/23987686-6a91368f-1fa8-4614-9ed6-7d1e08c21e62) and [User Profile API](https://www.postman.com/meta/instagram/folder/23987686-22b3a5b0-4a51-449a-9299-e3667d69b182).
 
 ## Installation
 
@@ -42,10 +46,13 @@ Set credentials via environment variables (single account) or in `character.sett
 
 | Variable | Required | Description |
 |---|---|---|
-| `INSTAGRAM_USERNAME` | **Yes** | Instagram username |
-| `INSTAGRAM_PASSWORD` | **Yes** | Instagram password |
-| `INSTAGRAM_VERIFICATION_CODE` | No | 2FA code if account has it enabled |
-| `INSTAGRAM_PROXY` | No | HTTP/SOCKS proxy URL for API requests |
+| `INSTAGRAM_GRAPH_ACCOUNT_ID` | **Yes** | Instagram professional account ID associated with the token |
+| `INSTAGRAM_ACCESS_TOKEN` | **Yes** | Approved Instagram Graph API access token |
+| `INSTAGRAM_APP_SECRET` | For webhooks | Meta app secret used to validate `X-Hub-Signature-256` |
+| `INSTAGRAM_WEBHOOK_VERIFY_TOKEN` | For webhooks | Secret used for webhook subscription verification |
+| `INSTAGRAM_GRAPH_API_VERSION` | No | Explicit Graph API version (default: `v24.0`) |
+| `INSTAGRAM_GRAPH_BASE_URL` | No | Graph origin; HTTPS except literal loopback HTTP in tests |
+| `INSTAGRAM_REQUEST_TIMEOUT_MS` | No | Request deadline in milliseconds (default: `15000`) |
 | `INSTAGRAM_AUTO_RESPOND_DMS` | No | `"true"` to auto-respond to DMs |
 | `INSTAGRAM_AUTO_RESPOND_COMMENTS` | No | `"true"` to auto-respond to comments |
 | `INSTAGRAM_POLLING_INTERVAL` | No | Poll interval in seconds (default: `60`) |
@@ -57,11 +64,16 @@ Set credentials via environment variables (single account) or in `character.sett
 {
   "settings": {
     "instagram": {
-      "username": "mybot",
-      "password": "secret",
+      "instagramAccountId": "17841400000000000",
+      "accessToken": "stored-in-a-secret-provider",
+      "appSecret": "stored-as-a-secret",
+      "webhookVerifyToken": "stored-as-a-secret",
       "autoRespondToDms": true,
       "accounts": {
-        "brand-a": { "username": "brand_a", "password": "..." }
+        "brand-a": {
+          "instagramAccountId": "17841400000000001",
+          "accessToken": "separate-account-token"
+        }
       }
     }
   }
@@ -82,6 +94,20 @@ These event type strings are defined in `InstagramEventType` (exported from the 
 | `INSTAGRAM_UNFOLLOW_RECEIVED` | Lost a follower |
 | `INSTAGRAM_STORY_VIEWED` | Story viewed |
 | `INSTAGRAM_STORY_REPLY_RECEIVED` | Reply to a story |
+
+## Supported capability truth
+
+- Professional-account conversation listing, message reads, one-to-one text sends, public media
+  comments/replies, scoped profile lookup, and owned-media reads use the production client.
+- Redirects, cross-origin paging cursors, malformed or oversized responses, and unencrypted remote
+  origins fail closed. Ambiguous writes are not automatically retried because these calls expose no
+  provider idempotency key.
+- Consumer-account login, arbitrary username discovery, third-party media reads, follow/unfollow,
+  media like/unlike, and private mobile API behavior are deliberately unsupported. The connector
+  never fabricates success for them.
+- Webhook helpers validate the raw-body signature before parsing and produce stable account-scoped
+  event IDs. HTTP route ownership, durable persist-before-process ingress, and shared synthetic
+  reset/ledger composition remain tracked by #24093 and #24076-#24078.
 
 ## Development
 

--- a/plugins/plugin-instagram/package.json
+++ b/plugins/plugin-instagram/package.json
@@ -67,27 +67,45 @@
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",
     "pluginParameters": {
-      "INSTAGRAM_USERNAME": {
+      "INSTAGRAM_GRAPH_ACCOUNT_ID": {
         "type": "string",
-        "description": "Instagram username for authentication",
+        "description": "Instagram professional account ID",
         "required": true,
         "sensitive": false
       },
-      "INSTAGRAM_PASSWORD": {
+      "INSTAGRAM_ACCESS_TOKEN": {
         "type": "string",
-        "description": "Instagram password for authentication",
+        "description": "Instagram Graph API access token",
         "required": true,
         "sensitive": true
       },
-      "INSTAGRAM_VERIFICATION_CODE": {
+      "INSTAGRAM_APP_SECRET": {
         "type": "string",
-        "description": "Two-factor authentication verification code",
+        "description": "Meta app secret used for webhook signatures",
         "required": false,
         "sensitive": true
       },
-      "INSTAGRAM_PROXY": {
+      "INSTAGRAM_WEBHOOK_VERIFY_TOKEN": {
         "type": "string",
-        "description": "Proxy URL for Instagram API requests",
+        "description": "Secret used for webhook subscription verification",
+        "required": false,
+        "sensitive": true
+      },
+      "INSTAGRAM_GRAPH_API_VERSION": {
+        "type": "string",
+        "description": "Explicit Instagram Graph API version",
+        "required": false,
+        "sensitive": false
+      },
+      "INSTAGRAM_GRAPH_BASE_URL": {
+        "type": "string",
+        "description": "Instagram Graph API origin (HTTPS required outside loopback tests)",
+        "required": false,
+        "sensitive": false
+      },
+      "INSTAGRAM_REQUEST_TIMEOUT_MS": {
+        "type": "string",
+        "description": "Instagram Graph request timeout in milliseconds",
         "required": false,
         "sensitive": false
       }

--- a/plugins/plugin-instagram/registry-entry.json
+++ b/plugins/plugin-instagram/registry-entry.json
@@ -7,37 +7,61 @@
   "source": "bundled",
   "tags": ["connector", "social", "social-feed", "instagram"],
   "config": {
-    "INSTAGRAM_PROXY": {
-      "type": "string",
-      "required": false,
-      "sensitive": false,
-      "label": "Proxy",
-      "help": "Proxy URL for Instagram API requests",
-      "advanced": false
-    },
-    "INSTAGRAM_PASSWORD": {
+    "INSTAGRAM_ACCESS_TOKEN": {
       "type": "secret",
       "required": true,
       "sensitive": true,
-      "label": "Password",
-      "help": "Instagram password for authentication",
+      "label": "Graph access token",
+      "help": "Access token approved for the Instagram professional account",
       "advanced": false
     },
-    "INSTAGRAM_USERNAME": {
-      "type": "string",
-      "required": true,
-      "sensitive": false,
-      "label": "Username",
-      "help": "Instagram username for authentication",
-      "advanced": false
-    },
-    "INSTAGRAM_VERIFICATION_CODE": {
+    "INSTAGRAM_APP_SECRET": {
       "type": "secret",
       "required": false,
       "sensitive": true,
-      "label": "Verification Code",
-      "help": "Two-factor authentication verification code",
+      "label": "App secret",
+      "help": "Meta app secret used to validate webhook signatures",
+      "advanced": true
+    },
+    "INSTAGRAM_GRAPH_ACCOUNT_ID": {
+      "type": "string",
+      "required": true,
+      "sensitive": false,
+      "label": "Professional account ID",
+      "help": "Instagram professional account ID associated with the token",
       "advanced": false
+    },
+    "INSTAGRAM_GRAPH_API_VERSION": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "Graph API version",
+      "help": "Explicit version such as v24.0",
+      "advanced": true
+    },
+    "INSTAGRAM_GRAPH_BASE_URL": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "Graph API origin",
+      "help": "HTTPS Graph origin; literal loopback HTTP is test-only",
+      "advanced": true
+    },
+    "INSTAGRAM_REQUEST_TIMEOUT_MS": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "Request timeout",
+      "help": "Graph request deadline in milliseconds",
+      "advanced": true
+    },
+    "INSTAGRAM_WEBHOOK_VERIFY_TOKEN": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "Webhook verify token",
+      "help": "Secret used for webhook subscription verification",
+      "advanced": true
     }
   },
   "render": {
@@ -59,6 +83,6 @@
   "subtype": "messaging",
   "auth": {
     "kind": "token",
-    "credentialKeys": []
+    "credentialKeys": ["INSTAGRAM_ACCESS_TOKEN"]
   }
 }

--- a/plugins/plugin-instagram/src/__tests__/accounts.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/accounts.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for Instagram account-config resolution (`accounts.ts`) against a
- * mocked runtime — legacy default account, named `INSTAGRAM_ACCOUNTS`, and
+ * mocked runtime — professional-account default, named `INSTAGRAM_ACCOUNTS`, and
  * character-settings sources. No live Instagram API.
  */
 import { type Content, ElizaError, type IAgentRuntime, type TargetInfo } from "@elizaos/core";
@@ -23,10 +23,10 @@ function runtime(
 }
 
 describe("Instagram account config", () => {
-  it("preserves legacy env settings as the default account", () => {
+  it("resolves Graph credentials as the default professional account", () => {
     const rt = runtime({
-      INSTAGRAM_USERNAME: "owner",
-      INSTAGRAM_PASSWORD: "password",
+      INSTAGRAM_GRAPH_ACCOUNT_ID: "owner",
+      INSTAGRAM_ACCESS_TOKEN: "password",
     });
 
     expect(resolveDefaultInstagramAccountId(rt)).toBe("default");
@@ -34,20 +34,29 @@ describe("Instagram account config", () => {
     expect(resolveInstagramAccountConfig(rt).accountId).toBe("default");
   });
 
+  it("does not reinterpret private username/password settings as Graph credentials", () => {
+    const config = resolveInstagramAccountConfig(
+      runtime({ INSTAGRAM_USERNAME: "consumer", INSTAGRAM_PASSWORD: "private-password" })
+    );
+    expect(config.accessToken).toBe("");
+    expect(config.instagramAccountId).toBe("");
+    expect(JSON.stringify(config)).not.toContain("private-password");
+  });
+
   it("resolves named accounts from INSTAGRAM_ACCOUNTS", () => {
     const rt = runtime({
       INSTAGRAM_DEFAULT_ACCOUNT_ID: "brand",
       INSTAGRAM_ACCOUNTS: JSON.stringify({
         brand: {
-          username: "brand",
-          password: "brand-password",
+          instagramAccountId: "brand",
+          accessToken: "brand-password",
         },
       }),
     });
 
     const config = resolveInstagramAccountConfig(rt);
     expect(config.accountId).toBe("brand");
-    expect(config.username).toBe("brand");
+    expect(config.instagramAccountId).toBe("brand");
   });
 });
 
@@ -91,7 +100,7 @@ describe("INSTAGRAM_ACCOUNTS fail-closed parsing (#18969)", () => {
     const rt = runtime({
       INSTAGRAM_DEFAULT_ACCOUNT_ID: "brand",
       INSTAGRAM_ACCOUNTS: JSON.stringify({
-        " brand ": { username: "brand-user", password: "brand-password" },
+        " brand ": { instagramAccountId: "brand-user", accessToken: "brand-password" },
       }),
     });
 
@@ -99,18 +108,18 @@ describe("INSTAGRAM_ACCOUNTS fail-closed parsing (#18969)", () => {
     const config = resolveInstagramAccountConfig(rt);
     expect(config.accountId).toBe("brand");
     // Pre-#18969 the padded key listed as `brand` but resolved to an empty
-    // config (no username) because lookup used the raw map key.
-    expect(config.username).toBe("brand-user");
+    // config (no professional account ID) because lookup used the raw map key.
+    expect(config.instagramAccountId).toBe("brand-user");
   });
 
   it("keeps well-formed object and array shapes working", () => {
     const objectRt = runtime({
-      INSTAGRAM_ACCOUNTS: JSON.stringify({ a: { username: "a-user" } }),
+      INSTAGRAM_ACCOUNTS: JSON.stringify({ a: { instagramAccountId: "a-user" } }),
     });
     expect(listInstagramAccountIds(objectRt)).toContain("a");
 
     const arrayRt = runtime({
-      INSTAGRAM_ACCOUNTS: JSON.stringify([{ accountId: "b", username: "b-user" }]),
+      INSTAGRAM_ACCOUNTS: JSON.stringify([{ accountId: "b", instagramAccountId: "b-user" }]),
     });
     expect(listInstagramAccountIds(arrayRt)).toContain("b");
   });
@@ -121,28 +130,28 @@ describe("INSTAGRAM_ACCOUNTS fail-closed parsing (#18969)", () => {
         null,
         "junk",
         [],
-        { id: " work ", username: "work-user" },
+        { id: " work ", instagramAccountId: "work-user" },
       ]),
     });
     expect(listInstagramAccountIds(arrayRt)).toEqual(["work"]);
-    expect(resolveInstagramAccountConfig(arrayRt, "work").username).toBe("work-user");
+    expect(resolveInstagramAccountConfig(arrayRt, "work").instagramAccountId).toBe("work-user");
 
     const objectRt = runtime({
       INSTAGRAM_ACCOUNTS: JSON.stringify({
         junk: "not-an-account",
         nestedArray: [],
-        " brand ": { username: "brand-user" },
+        " brand ": { instagramAccountId: "brand-user" },
       }),
     });
     expect(listInstagramAccountIds(objectRt)).toEqual(["brand"]);
-    expect(resolveInstagramAccountConfig(objectRt, "brand").username).toBe("brand-user");
+    expect(resolveInstagramAccountConfig(objectRt, "brand").instagramAccountId).toBe("brand-user");
   });
 
   it("fails closed when distinct entries normalize to the same id", () => {
     const rt = runtime({
       INSTAGRAM_ACCOUNTS: JSON.stringify({
-        brand: { username: "first" },
-        " brand ": { username: "second" },
+        brand: { instagramAccountId: "first" },
+        " brand ": { instagramAccountId: "second" },
       }),
     });
     expect(() => listInstagramAccountIds(rt)).toThrowError(/duplicate account id "brand"/);
@@ -154,13 +163,13 @@ describe("INSTAGRAM_ACCOUNTS fail-closed parsing (#18969)", () => {
       {
         instagram: {
           accounts: {
-            " brand ": { username: "character-brand" },
+            " brand ": { instagramAccountId: "character-brand" },
           },
         },
       }
     );
     expect(listInstagramAccountIds(rt)).toEqual(["brand"]);
-    expect(resolveInstagramAccountConfig(rt, "brand").username).toBe("character-brand");
+    expect(resolveInstagramAccountConfig(rt, "brand").instagramAccountId).toBe("character-brand");
   });
 });
 
@@ -188,12 +197,12 @@ describe("Instagram connector accounts", () => {
     const ownerSend = vi.fn();
     const brandSend = vi.fn();
     Object.assign(owner, {
-      instagramConfig: { accountId: "owner", username: "owner", password: "pw" },
+      instagramConfig: { accountId: "owner", instagramAccountId: "owner", accessToken: "pw" },
       isRunning: true,
       sendDirectMessage: ownerSend,
     });
     Object.assign(brand, {
-      instagramConfig: { accountId: "brand", username: "brand", password: "pw" },
+      instagramConfig: { accountId: "brand", instagramAccountId: "brand", accessToken: "pw" },
       isRunning: true,
       sendDirectMessage: brandSend,
     });
@@ -235,7 +244,7 @@ describe("Instagram connector accounts", () => {
     const postComment = vi.fn(async () => "comment-1");
     Object.assign(service, {
       defaultAccountId: "owner",
-      instagramConfig: { accountId: "owner", username: "owner", password: "pw" },
+      instagramConfig: { accountId: "owner", instagramAccountId: "owner", accessToken: "pw" },
       isRunning: true,
       accountServices: new Map(),
       postComment,
@@ -263,7 +272,7 @@ describe("Instagram connector accounts", () => {
     const postComment = vi.fn(async () => "comment-ok");
     Object.assign(service, {
       defaultAccountId: "owner",
-      instagramConfig: { accountId: "owner", username: "owner", password: "pw" },
+      instagramConfig: { accountId: "owner", instagramAccountId: "owner", accessToken: "pw" },
       isRunning: true,
       accountServices: new Map(),
       postComment,
@@ -282,24 +291,22 @@ describe("Instagram connector accounts", () => {
     expect(result.metadata).toMatchObject({ accountId: "owner" });
   });
 
-  it("fails API operations explicitly instead of returning synthetic Instagram data", async () => {
+  it("fails API operations explicitly when the production Graph client is absent", async () => {
     const service = Object.create(InstagramService.prototype) as InstagramService;
     Object.assign(service, {
       isRunning: true,
     });
 
-    await expect(service.sendDirectMessage("thread-1", "hello")).rejects.toThrow(
-      "requires a configured Instagram API client"
-    );
-    await expect(service.postComment("123", "hello")).rejects.toThrow(
-      "requires a configured Instagram API client"
-    );
-    await expect(service.getUserInfo(456)).rejects.toThrow(
-      "requires a configured Instagram API client"
-    );
-    await expect(service.getThreads()).rejects.toThrow(
-      "requires a configured Instagram API client"
-    );
+    for (const operation of [
+      service.sendDirectMessage("thread-1", "hello"),
+      service.postComment("123", "hello"),
+      service.getUserInfo(456),
+      service.getThreads(),
+    ]) {
+      const error = await operation.catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("INSTAGRAM_CONFIG_INVALID");
+    }
   });
 
   it("rejects media IDs with trailing junk instead of prefix-parsing them", async () => {
@@ -307,7 +314,11 @@ describe("Instagram connector accounts", () => {
     const postComment = vi.fn(async () => 99);
     Object.assign(service, {
       defaultAccountId: "default",
-      instagramConfig: { accountId: "default", username: "user", password: "password" },
+      instagramConfig: {
+        accountId: "default",
+        instagramAccountId: "user",
+        accessToken: "password",
+      },
       isRunning: true,
       postComment,
     });
@@ -328,7 +339,11 @@ describe("Instagram connector accounts", () => {
     const postComment = vi.fn(async () => "17900000000000001");
     Object.assign(service, {
       defaultAccountId: "default",
-      instagramConfig: { accountId: "default", username: "user", password: "password" },
+      instagramConfig: {
+        accountId: "default",
+        instagramAccountId: "user",
+        accessToken: "password",
+      },
       isRunning: true,
       postComment,
     });
@@ -351,7 +366,11 @@ describe("Instagram connector accounts", () => {
       const postComment = vi.fn(async () => "99");
       Object.assign(service, {
         defaultAccountId: "default",
-        instagramConfig: { accountId: "default", username: "user", password: "password" },
+        instagramConfig: {
+          accountId: "default",
+          instagramAccountId: "user",
+          accessToken: "password",
+        },
         isRunning: true,
         postComment,
       });

--- a/plugins/plugin-instagram/src/__tests__/graph-client.contract.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/graph-client.contract.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Contract tests exercise the production Instagram Graph client over a real
+ * loopback HTTP server. No client method or global fetch replacement is used.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { ElizaError } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InstagramGraphClient } from "../graph-client.js";
+
+interface WireRequest {
+  method: string;
+  url: string;
+  authorization?: string;
+  body: string;
+}
+
+describe("InstagramGraphClient loopback protocol", () => {
+  const requests: WireRequest[] = [];
+  let origin = "";
+  let mode = "healthy";
+  let server: ReturnType<typeof createServer>;
+
+  beforeEach(async () => {
+    requests.length = 0;
+    mode = "healthy";
+    server = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const body = Buffer.concat(chunks).toString("utf8");
+      requests.push({
+        method: request.method ?? "",
+        url: request.url ?? "",
+        authorization: request.headers.authorization,
+        body,
+      });
+      route(request, response, body);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+  });
+
+  function json(response: ServerResponse, status: number, value: unknown): void {
+    response.writeHead(status, { "content-type": "application/json" });
+    response.end(JSON.stringify(value));
+  }
+
+  function route(request: IncomingMessage, response: ServerResponse, body: string): void {
+    const url = new URL(request.url ?? "/", origin);
+    if (mode === "redirect") {
+      response.writeHead(302, { location: "https://attacker.invalid/secret" });
+      response.end();
+      return;
+    }
+    if (mode === "malformed") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(`{"token":"${TOKEN}"`);
+      return;
+    }
+    if (mode === "rate-limit") {
+      json(response, 429, { error: { message: `provider leaked ${TOKEN}` } });
+      return;
+    }
+    if (mode === "post-accept") {
+      json(response, 503, { error: { message: `accepted but response failed ${TOKEN}` } });
+      return;
+    }
+    if (mode === "oversized") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(`{"data":"${"x".repeat(2 * 1024 * 1024)}"}`);
+      return;
+    }
+    if (mode === "stall") return;
+    if (request.headers.authorization !== `Bearer ${TOKEN}`) {
+      json(response, 401, { error: { message: "bad auth" } });
+      return;
+    }
+    if (url.pathname === "/v24.0/account-1") {
+      json(response, 200, { id: "account-1", username: "brand", name: "Brand" });
+      return;
+    }
+    if (url.pathname === "/v24.0/user-1") {
+      json(response, 200, {
+        id: "user-1",
+        username: "one",
+        name: "One",
+        followers_count: 7,
+      });
+      return;
+    }
+    if (url.pathname === "/v24.0/account-1/media") {
+      json(response, 200, {
+        data: [
+          {
+            id: "media-1",
+            media_type: "IMAGE",
+            media_url: "https://cdn.example.invalid/media-1.jpg",
+            timestamp: "2026-08-21T12:03:00Z",
+          },
+        ],
+      });
+      return;
+    }
+    if (url.pathname === "/v24.0/account-1/conversations") {
+      if (url.searchParams.get("after") === "cursor-2") {
+        json(response, 200, {
+          data: [
+            {
+              id: "thread-2",
+              updated_time: "2026-08-21T12:01:00Z",
+              participants: { data: [{ id: "user-2", username: "two", name: "Two" }] },
+            },
+          ],
+        });
+      } else {
+        json(response, 200, {
+          data: [
+            {
+              id: "thread-1",
+              updated_time: "2026-08-21T12:00:00Z",
+              participants: {
+                data: [
+                  { id: "account-1", username: "brand", name: "Brand" },
+                  { id: "user-1", username: "one", name: "One" },
+                ],
+              },
+            },
+          ],
+          paging: {
+            next: `${origin}/v24.0/account-1/conversations?after=cursor-2&access_token=leak`,
+          },
+        });
+      }
+      return;
+    }
+    if (url.pathname === "/v24.0/thread-1") {
+      json(response, 200, {
+        messages: {
+          data: [
+            {
+              id: "message-1",
+              created_time: "2026-08-21T12:02:00Z",
+              from: { id: "user-1", username: "one", name: "One" },
+              to: { data: [{ id: "account-1", username: "brand", name: "Brand" }] },
+              message: "hello",
+            },
+          ],
+        },
+      });
+      return;
+    }
+    if (url.pathname === "/v24.0/thread-2") {
+      json(response, 200, {
+        messages: {
+          data: [
+            {
+              id: "message-2",
+              created_time: "2026-08-21T12:01:00Z",
+              from: { id: "user-2", username: "two", name: "Two" },
+              to: { data: [{ id: "account-1", username: "brand", name: "Brand" }] },
+              message: "second",
+            },
+          ],
+        },
+      });
+      return;
+    }
+    if (url.pathname === "/v24.0/account-1/messages" && request.method === "POST") {
+      expect(JSON.parse(body)).toEqual({
+        recipient: { id: "user-1" },
+        message: { text: "hello back" },
+      });
+      json(response, 200, { message_id: "outbound-1" });
+      return;
+    }
+    if (url.pathname === "/v24.0/media-1/comments" && request.method === "POST") {
+      expect(new URLSearchParams(body).get("message")).toBe("a comment");
+      json(response, 200, { id: "comment-1" });
+      return;
+    }
+    if (url.pathname === "/v24.0/comment-1/replies" && request.method === "POST") {
+      expect(new URLSearchParams(body).get("message")).toBe("a reply");
+      json(response, 200, { id: "reply-1" });
+      return;
+    }
+    json(response, 404, { error: { message: "not found" } });
+  }
+
+  function client(timeout = 2_000, accessToken = TOKEN): InstagramGraphClient {
+    return new InstagramGraphClient({
+      accessToken,
+      instagramAccountId: "account-1",
+      graphBaseUrl: origin,
+      graphApiVersion: "v24.0",
+      requestTimeoutMs: timeout,
+    });
+  }
+
+  it("authenticates, follows same-origin cursors, reads conversations, and sends through the real wire", async () => {
+    const api = client();
+    expect((await api.getOwnUser()).username).toBe("brand");
+    const threads = await api.getThreads();
+    expect(threads.map((thread) => thread.id)).toEqual(["thread-1", "thread-2"]);
+    expect((await api.getThreadMessages("thread-1"))[0]).toMatchObject({
+      id: "message-1",
+      text: "hello",
+      user: { pk: "user-1" },
+    });
+    await expect(api.sendDirectMessage("thread-1", "hello back")).resolves.toBe("outbound-1");
+    expect(requests.every((request) => request.authorization === `Bearer ${TOKEN}`)).toBe(true);
+    expect(requests.some((request) => request.url.includes("access_token="))).toBe(false);
+  });
+
+  it("posts comments and replies through form-encoded Graph operations", async () => {
+    const api = client();
+    await expect(api.postComment("media-1", "a comment")).resolves.toBe("comment-1");
+    await expect(api.replyToComment("comment-1", "a reply")).resolves.toBe("reply-1");
+  });
+
+  it("maps scoped profiles and professional-account media without numeric ID loss", async () => {
+    const api = client();
+    await expect(api.getUser("user-1")).resolves.toMatchObject({
+      pk: "user-1",
+      username: "one",
+      followerCount: 7,
+    });
+    const discoveryError = await api.getUserByUsername("@one").catch((caught: unknown) => caught);
+    expect((discoveryError as ElizaError).code).toBe("INSTAGRAM_CAPABILITY_UNSUPPORTED");
+    await expect(api.getUserMedia("account-1")).resolves.toMatchObject([
+      { pk: "media-1", mediaType: "photo" },
+    ]);
+  });
+
+  it.each([
+    ["malformed", "INSTAGRAM_GRAPH_INVALID_RESPONSE"],
+    ["rate-limit", "INSTAGRAM_GRAPH_REJECTED"],
+    ["redirect", "INSTAGRAM_GRAPH_REDIRECT"],
+    ["oversized", "INSTAGRAM_GRAPH_INVALID_RESPONSE"],
+  ])("fails closed for %s responses without leaking credentials", async (failureMode, code) => {
+    mode = failureMode;
+    const error = await client()
+      .getOwnUser()
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe(code);
+    expect(JSON.stringify(error)).not.toContain(TOKEN);
+    expect(String(error)).not.toContain(TOKEN);
+  });
+
+  it("cancels stalled reads with a stable redacted error", async () => {
+    mode = "stall";
+    const error = await client(100)
+      .getOwnUser()
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe("INSTAGRAM_GRAPH_CANCELLED");
+    expect(String(error)).not.toContain(TOKEN);
+  });
+
+  it("treats revoked credentials as a stable rejection and accepts a rotated client", async () => {
+    const revoked = await client(2_000, "revoked-token")
+      .getOwnUser()
+      .catch((caught: unknown) => caught);
+    expect((revoked as ElizaError).code).toBe("INSTAGRAM_GRAPH_REJECTED");
+    expect((revoked as ElizaError).context).toMatchObject({ status: 401, retryable: false });
+    await expect(client().getOwnUser()).resolves.toMatchObject({ pk: "account-1" });
+  });
+
+  it("classifies a post-accept server failure as an ambiguous write that must not auto-retry", async () => {
+    mode = "post-accept";
+    const error = await client()
+      .postComment("media-1", "secret submitted content")
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe("INSTAGRAM_GRAPH_AMBIGUOUS_WRITE");
+    expect(JSON.stringify(error)).not.toContain("secret submitted content");
+    expect(JSON.stringify(error)).not.toContain(TOKEN);
+    expect(requests).toHaveLength(1);
+  });
+
+  it("rejects non-loopback HTTP and cross-origin paging targets", async () => {
+    expect(
+      () =>
+        new InstagramGraphClient({
+          accessToken: TOKEN,
+          instagramAccountId: "account-1",
+          graphBaseUrl: "http://example.com",
+        })
+    ).toThrowError(/requires HTTPS/);
+
+    server.removeAllListeners("request");
+    server.on("request", (_request, response) =>
+      json(response, 200, {
+        data: [],
+        paging: { next: "https://attacker.invalid/v24.0/conversations?access_token=secret" },
+      })
+    );
+    const error = await client()
+      .getThreads()
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe("INSTAGRAM_GRAPH_REDIRECT");
+  });
+});
+
+const TOKEN = "instagram-test-token-never-log";

--- a/plugins/plugin-instagram/src/__tests__/webhook.contract.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/webhook.contract.test.ts
@@ -58,6 +58,39 @@ describe("Instagram webhook boundary", () => {
     expect(replay.map((change) => change.eventId)).toEqual(first.map((change) => change.eventId));
   });
 
+  it("keeps fallback replay IDs stable across restart-like receipt times", () => {
+    const delivery = signed({
+      object: "instagram",
+      entry: [
+        {
+          id: "account-a",
+          messaging: [
+            {
+              sender: { id: "user-a" },
+              recipient: { id: "account-a" },
+              message: { text: "delivery without provider id or time" },
+            },
+          ],
+        },
+      ],
+    });
+    const beforeRestart = parseInstagramWebhookDelivery(
+      delivery.body,
+      delivery.signature,
+      SECRET,
+      1_700_000_000_000
+    );
+    const afterRestart = parseInstagramWebhookDelivery(
+      delivery.body,
+      delivery.signature,
+      SECRET,
+      1_800_000_000_000
+    );
+    expect(afterRestart[0]?.eventId).toBe(beforeRestart[0]?.eventId);
+    expect(afterRestart[0]?.receivedAt).not.toBe(beforeRestart[0]?.receivedAt);
+    expect(beforeRestart[0]?.eventId).toMatch(/^account-a:messages:[a-f0-9]{64}:0:0$/);
+  });
+
   it("rejects tampering, malformed envelopes, and missing signatures before routing", () => {
     const delivery = signed({ object: "instagram", entry: [] });
     const tampered = Buffer.from(delivery.body);

--- a/plugins/plugin-instagram/src/__tests__/webhook.contract.test.ts
+++ b/plugins/plugin-instagram/src/__tests__/webhook.contract.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Deterministic webhook contract tests cover subscription verification, raw
+ * body signatures, multi-account demultiplexing, and stable replay identities.
+ */
+import { createHmac } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { parseInstagramWebhookDelivery, verifyInstagramWebhookChallenge } from "../webhook.js";
+
+const SECRET = "webhook-app-secret";
+
+function signed(value: unknown): { body: Buffer; signature: string } {
+  const body = Buffer.from(JSON.stringify(value));
+  const signature = `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+  return { body, signature };
+}
+
+describe("Instagram webhook boundary", () => {
+  it("returns a valid challenge and rejects the wrong verification token", () => {
+    const query = new URLSearchParams({
+      "hub.mode": "subscribe",
+      "hub.verify_token": "verify-me",
+      "hub.challenge": "challenge-123",
+    });
+    expect(verifyInstagramWebhookChallenge(query, "verify-me")).toBe("challenge-123");
+    expect(() => verifyInstagramWebhookChallenge(query, "wrong")).toThrow(ElizaError);
+  });
+
+  it("verifies raw bytes and demultiplexes stable event IDs by professional account", () => {
+    const delivery = signed({
+      object: "instagram",
+      entry: [
+        {
+          id: "account-a",
+          time: 1_777_000_000,
+          messaging: [
+            {
+              sender: { id: "user-a" },
+              recipient: { id: "account-a" },
+              message: { mid: "message-a", text: "private content" },
+            },
+          ],
+        },
+        {
+          id: "account-b",
+          time: 1_777_000_001,
+          changes: [{ field: "comments", value: { id: "comment-b", text: "public" } }],
+        },
+      ],
+    });
+    const first = parseInstagramWebhookDelivery(delivery.body, delivery.signature, SECRET);
+    const replay = parseInstagramWebhookDelivery(delivery.body, delivery.signature, SECRET);
+    expect(first.map((change) => change.accountId)).toEqual(["account-a", "account-b"]);
+    expect(first.map((change) => change.eventId)).toEqual([
+      "account-a:messages:message-a",
+      "account-b:comments:comment-b",
+    ]);
+    expect(replay.map((change) => change.eventId)).toEqual(first.map((change) => change.eventId));
+  });
+
+  it("rejects tampering, malformed envelopes, and missing signatures before routing", () => {
+    const delivery = signed({ object: "instagram", entry: [] });
+    const tampered = Buffer.from(delivery.body);
+    tampered[tampered.length - 1] = 0x20;
+    for (const [body, signature] of [
+      [tampered, delivery.signature],
+      [delivery.body, null],
+    ] as const) {
+      const error = (() => {
+        try {
+          parseInstagramWebhookDelivery(body, signature, SECRET);
+        } catch (caught) {
+          return caught;
+        }
+      })();
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe("INSTAGRAM_WEBHOOK_UNAUTHORIZED");
+    }
+  });
+});

--- a/plugins/plugin-instagram/src/accounts.ts
+++ b/plugins/plugin-instagram/src/accounts.ts
@@ -72,13 +72,13 @@ function parseAccountsJson(runtime: IAgentRuntime): Record<string, InstagramAcco
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw) as unknown;
-  } catch (error) {
-    // error-policy:J2 preserve the JSON parse cause and identify the setting
-    // whose invalid value must not degrade into an empty account collection.
+  } catch {
+    // error-policy:J2 preserve the parse category without retaining provider
+    // configuration bytes, which may contain access tokens or app secrets.
     throw invalidAccountsConfig(
       "Instagram accounts config is not valid JSON.",
       { setting: "INSTAGRAM_ACCOUNTS" },
-      error
+      new SyntaxError("Invalid JSON")
     );
   }
   if (Array.isArray(parsed)) {
@@ -134,7 +134,12 @@ export function listInstagramAccountIds(runtime: IAgentRuntime): string[] {
   const ids = new Set<string>();
   const config = characterConfig(runtime);
 
-  if (stringSetting(runtime, "INSTAGRAM_USERNAME") || config.username) {
+  if (
+    stringSetting(runtime, "INSTAGRAM_ACCESS_TOKEN") ||
+    stringSetting(runtime, "INSTAGRAM_GRAPH_ACCOUNT_ID") ||
+    config.accessToken ||
+    config.instagramAccountId
+  ) {
     ids.add(DEFAULT_INSTAGRAM_ACCOUNT_ID);
   }
 
@@ -203,24 +208,41 @@ export function resolveInstagramAccountConfig(
 
   return {
     accountId,
-    username:
-      account.username ??
-      base.username ??
-      (allowEnv ? stringSetting(runtime, "INSTAGRAM_USERNAME") : undefined) ??
+    accessToken:
+      account.accessToken ??
+      base.accessToken ??
+      (allowEnv ? stringSetting(runtime, "INSTAGRAM_ACCESS_TOKEN") : undefined) ??
       "",
-    password:
-      account.password ??
-      base.password ??
-      (allowEnv ? stringSetting(runtime, "INSTAGRAM_PASSWORD") : undefined) ??
+    instagramAccountId:
+      account.instagramAccountId ??
+      base.instagramAccountId ??
+      (allowEnv ? stringSetting(runtime, "INSTAGRAM_GRAPH_ACCOUNT_ID") : undefined) ??
       "",
-    verificationCode:
-      account.verificationCode ??
-      base.verificationCode ??
-      (allowEnv ? stringSetting(runtime, "INSTAGRAM_VERIFICATION_CODE") : undefined),
-    proxy:
-      account.proxy ??
-      base.proxy ??
-      (allowEnv ? stringSetting(runtime, "INSTAGRAM_PROXY") : undefined),
+    appSecret:
+      account.appSecret ??
+      base.appSecret ??
+      (allowEnv ? stringSetting(runtime, "INSTAGRAM_APP_SECRET") : undefined),
+    webhookVerifyToken:
+      account.webhookVerifyToken ??
+      base.webhookVerifyToken ??
+      (allowEnv ? stringSetting(runtime, "INSTAGRAM_WEBHOOK_VERIFY_TOKEN") : undefined),
+    graphBaseUrl:
+      account.graphBaseUrl ??
+      base.graphBaseUrl ??
+      (allowEnv ? stringSetting(runtime, "INSTAGRAM_GRAPH_BASE_URL") : undefined),
+    graphApiVersion:
+      account.graphApiVersion ??
+      base.graphApiVersion ??
+      (allowEnv ? stringSetting(runtime, "INSTAGRAM_GRAPH_API_VERSION") : undefined),
+    requestTimeoutMs: Number.parseInt(
+      String(
+        account.requestTimeoutMs ??
+          base.requestTimeoutMs ??
+          (allowEnv ? stringSetting(runtime, "INSTAGRAM_REQUEST_TIMEOUT_MS") : undefined) ??
+          "15000"
+      ),
+      10
+    ),
     autoRespondToDms: boolValue(
       account.autoRespondToDms ??
         base.autoRespondToDms ??

--- a/plugins/plugin-instagram/src/connector-account-provider.ts
+++ b/plugins/plugin-instagram/src/connector-account-provider.ts
@@ -29,11 +29,11 @@ export const INSTAGRAM_PROVIDER_ID = "instagram";
 
 function toConnectorAccount(runtime: IAgentRuntime, accountId: string): ConnectorAccount {
   let connected = false;
-  let username = "";
+  let externalId = "";
   try {
     const config = resolveInstagramAccountConfig(runtime, accountId);
-    username = config.username ?? "";
-    connected = Boolean(config.username && config.password);
+    externalId = config.instagramAccountId;
+    connected = Boolean(config.accessToken && config.instagramAccountId);
   } catch {
     connected = false;
   }
@@ -41,17 +41,16 @@ function toConnectorAccount(runtime: IAgentRuntime, accountId: string): Connecto
   return {
     id: accountId,
     provider: INSTAGRAM_PROVIDER_ID,
-    label: username || accountId,
+    label: externalId || accountId,
     role: "AGENT",
     purpose: ["posting", "reading"],
     accessGate: "open",
     status: connected ? "connected" : "disabled",
-    externalId: username || undefined,
-    displayHandle: username || undefined,
+    externalId: externalId || undefined,
     createdAt: now,
     updatedAt: now,
     metadata: {
-      username,
+      instagramAccountId: externalId,
     },
   };
 }

--- a/plugins/plugin-instagram/src/graph-client.ts
+++ b/plugins/plugin-instagram/src/graph-client.ts
@@ -1,0 +1,736 @@
+/**
+ * Implements the production Instagram Graph API boundary for professional
+ * accounts. The client owns authentication, transport policy, response
+ * validation, pagination, cancellation, and conversion from Graph DTOs into
+ * the connector's public domain types.
+ */
+import { ElizaError } from "@elizaos/core";
+import {
+  type InstagramMedia,
+  InstagramMediaType,
+  type InstagramMessage,
+  type InstagramThread,
+  type InstagramUser,
+} from "./types";
+
+const DEFAULT_GRAPH_ORIGIN = "https://graph.instagram.com";
+const DEFAULT_GRAPH_VERSION = "v24.0";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_PAGES = 20;
+const MAX_JSON_DEPTH = 24;
+const MAX_JSON_NODES = 20_000;
+
+export interface InstagramGraphClientConfig {
+  accessToken: string;
+  instagramAccountId: string;
+  graphBaseUrl?: string;
+  graphApiVersion?: string;
+  requestTimeoutMs?: number;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function graphError(
+  message: string,
+  code: string,
+  context: Record<string, unknown> = {},
+  cause?: unknown
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    context,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+function asRecord(value: unknown, operation: string): JsonRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw graphError(
+      "Instagram Graph API returned an invalid response.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      {
+        operation,
+        expected: "object",
+      }
+    );
+  }
+  return value as JsonRecord;
+}
+
+function requiredString(record: JsonRecord, key: string, operation: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw graphError(
+      "Instagram Graph API returned an invalid response.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      {
+        operation,
+        field: key,
+      }
+    );
+  }
+  return value;
+}
+
+function optionalString(record: JsonRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function requiredStringFrom(record: JsonRecord, keys: string[], operation: string): string {
+  for (const key of keys) {
+    const value = optionalString(record, key);
+    if (value) return value;
+  }
+  throw graphError(
+    "Instagram Graph API returned an invalid response.",
+    "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+    { operation, field: keys.join("|") }
+  );
+}
+
+function optionalNumber(record: JsonRecord, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function optionalNumberFrom(record: JsonRecord, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = optionalNumber(record, key);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function boundedJsonShape(value: unknown): void {
+  let nodes = 0;
+  const visit = (current: unknown, depth: number): void => {
+    nodes += 1;
+    if (nodes > MAX_JSON_NODES || depth > MAX_JSON_DEPTH) {
+      throw graphError(
+        "Instagram Graph API response exceeded structural limits.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE"
+      );
+    }
+    if (Array.isArray(current)) {
+      for (const item of current) visit(item, depth + 1);
+    } else if (current && typeof current === "object") {
+      for (const item of Object.values(current as JsonRecord)) visit(item, depth + 1);
+    }
+  };
+  visit(value, 0);
+}
+
+async function readBoundedBody(response: Response, operation: string): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw graphError(
+        "Instagram Graph API response was too large.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        { operation }
+      );
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw graphError(
+      "Instagram Graph API response was not valid UTF-8.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      { operation }
+    );
+  }
+}
+
+function parseGraphDate(value: unknown, operation: string): Date {
+  if (typeof value !== "string") {
+    throw graphError(
+      "Instagram Graph API returned an invalid timestamp.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      {
+        operation,
+      }
+    );
+  }
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw graphError(
+      "Instagram Graph API returned an invalid timestamp.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      {
+        operation,
+      }
+    );
+  }
+  return date;
+}
+
+function normalizeGraphOrigin(raw: string | undefined): URL {
+  let url: URL;
+  try {
+    url = new URL(raw ?? DEFAULT_GRAPH_ORIGIN);
+  } catch {
+    throw graphError("Instagram Graph API base URL is invalid.", "INSTAGRAM_CONFIG_INVALID");
+  }
+  const literalLoopback =
+    url.hostname === "127.0.0.1" || url.hostname === "[::1]" || url.hostname === "::1";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && literalLoopback)) {
+    throw graphError(
+      "Instagram Graph API requires HTTPS (literal loopback HTTP is allowed for tests).",
+      "INSTAGRAM_CONFIG_INVALID"
+    );
+  }
+  if (url.username || url.password || url.search || url.hash || url.pathname !== "/") {
+    throw graphError(
+      "Instagram Graph API base URL must contain only an origin.",
+      "INSTAGRAM_CONFIG_INVALID"
+    );
+  }
+  return url;
+}
+
+function normalizeVersion(raw: string | undefined): string {
+  const version = raw?.trim() || DEFAULT_GRAPH_VERSION;
+  if (!/^v\d+\.\d+$/.test(version)) {
+    throw graphError("Instagram Graph API version is invalid.", "INSTAGRAM_CONFIG_INVALID");
+  }
+  return version;
+}
+
+function normalizeId(value: string | number, field: string): string {
+  const id = String(value).trim();
+  if (!/^[A-Za-z0-9_.:-]{1,256}$/.test(id)) {
+    throw graphError(`Instagram ${field} is invalid.`, "INSTAGRAM_INPUT_INVALID", { field });
+  }
+  return id;
+}
+
+function toUser(value: unknown, operation: string): InstagramUser {
+  const record = asRecord(value, operation);
+  return {
+    pk: requiredStringFrom(record, ["id", "user_id"], operation),
+    username: optionalString(record, "username") ?? requiredString(record, "name", operation),
+    fullName: optionalString(record, "name"),
+    profilePicUrl:
+      optionalString(record, "profile_pic") ?? optionalString(record, "profile_picture_url"),
+    ...(typeof record.is_verified_user === "boolean"
+      ? { isVerified: record.is_verified_user }
+      : typeof record.is_verified === "boolean"
+        ? { isVerified: record.is_verified }
+        : {}),
+    followerCount: optionalNumberFrom(record, ["follower_count", "followers_count"]),
+    followingCount: optionalNumber(record, "follows_count"),
+  };
+}
+
+function mediaType(value: unknown): InstagramMediaType {
+  switch (value) {
+    case "IMAGE":
+      return InstagramMediaType.PHOTO;
+    case "VIDEO":
+      return InstagramMediaType.VIDEO;
+    case "CAROUSEL_ALBUM":
+      return InstagramMediaType.CAROUSEL;
+    case "REELS":
+      return InstagramMediaType.REEL;
+    default:
+      throw graphError(
+        "Instagram Graph API returned an unsupported media type.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        { operation: "list-media" }
+      );
+  }
+}
+
+function toMedia(value: unknown, operation: string): InstagramMedia {
+  const record = asRecord(value, operation);
+  return {
+    pk: requiredString(record, "id", operation),
+    mediaType: mediaType(record.media_type),
+    caption: optionalString(record, "caption"),
+    url: optionalString(record, "media_url") ?? optionalString(record, "permalink"),
+    thumbnailUrl: optionalString(record, "thumbnail_url"),
+    likeCount: optionalNumber(record, "like_count"),
+    commentCount: optionalNumber(record, "comments_count"),
+    takenAt:
+      record.timestamp === undefined ? undefined : parseGraphDate(record.timestamp, operation),
+  };
+}
+
+interface RequestOptions {
+  method?: "GET" | "POST";
+  query?: Record<string, string>;
+  body?: JsonRecord | URLSearchParams;
+  signal?: AbortSignal;
+  ambiguousOnNetworkFailure?: boolean;
+}
+
+export class InstagramGraphClient {
+  private readonly origin: URL;
+  private readonly version: string;
+  private readonly accessToken: string;
+  private readonly accountId: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: InstagramGraphClientConfig, fetchImpl: typeof fetch = globalThis.fetch) {
+    this.origin = normalizeGraphOrigin(config.graphBaseUrl);
+    this.version = normalizeVersion(config.graphApiVersion);
+    this.accessToken = config.accessToken.trim();
+    this.accountId = normalizeId(config.instagramAccountId, "account id");
+    this.timeoutMs = config.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = fetchImpl;
+    if (!this.accessToken || this.accessToken.length > 16_384) {
+      throw graphError(
+        "Instagram Graph access token is missing or invalid.",
+        "INSTAGRAM_CONFIG_INVALID"
+      );
+    }
+    if (!Number.isInteger(this.timeoutMs) || this.timeoutMs < 100 || this.timeoutMs > 120_000) {
+      throw graphError("Instagram Graph request timeout is invalid.", "INSTAGRAM_CONFIG_INVALID");
+    }
+  }
+
+  private url(path: string, query: Record<string, string> = {}): URL {
+    const url = new URL(`/${this.version}/${path.replace(/^\/+/, "")}`, this.origin);
+    for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value);
+    return url;
+  }
+
+  private async request(
+    path: string,
+    operation: string,
+    options: RequestOptions = {}
+  ): Promise<JsonRecord> {
+    const deadline = AbortSignal.timeout(this.timeoutMs);
+    const signal = options.signal ? AbortSignal.any([options.signal, deadline]) : deadline;
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      Authorization: `Bearer ${this.accessToken}`,
+    };
+    let body: string | undefined;
+    if (options.body instanceof URLSearchParams) {
+      headers["Content-Type"] = "application/x-www-form-urlencoded";
+      body = options.body.toString();
+    } else if (options.body) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(options.body);
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(this.url(path, options.query), {
+        method: options.method ?? "GET",
+        headers,
+        body,
+        redirect: "manual",
+        signal,
+      });
+    } catch (cause) {
+      if (signal.aborted) {
+        throw graphError(
+          "Instagram Graph API request was cancelled or timed out.",
+          "INSTAGRAM_GRAPH_CANCELLED",
+          {
+            operation,
+          }
+        );
+      }
+      throw graphError(
+        options.ambiguousOnNetworkFailure
+          ? "Instagram Graph API write outcome is unknown; automatic retry is unsafe."
+          : "Instagram Graph API request failed.",
+        options.ambiguousOnNetworkFailure
+          ? "INSTAGRAM_GRAPH_AMBIGUOUS_WRITE"
+          : "INSTAGRAM_GRAPH_TRANSPORT",
+        { operation },
+        cause
+      );
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+      throw graphError("Instagram Graph API redirect was rejected.", "INSTAGRAM_GRAPH_REDIRECT", {
+        operation,
+        status: response.status,
+      });
+    }
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+      throw graphError(
+        "Instagram Graph API response was too large.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        {
+          operation,
+        }
+      );
+    }
+    const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+    if (!contentType.startsWith("application/json")) {
+      throw graphError(
+        "Instagram Graph API returned a non-JSON response.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        {
+          operation,
+          status: response.status,
+        }
+      );
+    }
+    let text: string;
+    try {
+      text = await readBoundedBody(response, operation);
+    } catch (cause) {
+      if (cause instanceof ElizaError) throw cause;
+      if (signal.aborted) {
+        throw graphError(
+          "Instagram Graph API request was cancelled or timed out.",
+          "INSTAGRAM_GRAPH_CANCELLED",
+          { operation }
+        );
+      }
+      throw graphError(
+        "Instagram Graph API response body could not be read.",
+        "INSTAGRAM_GRAPH_TRANSPORT",
+        { operation },
+        cause
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch {
+      throw graphError(
+        "Instagram Graph API returned malformed JSON.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        {
+          operation,
+          status: response.status,
+        }
+      );
+    }
+    boundedJsonShape(parsed);
+    if (!response.ok) {
+      if (
+        options.ambiguousOnNetworkFailure &&
+        (response.status === 408 || response.status >= 500)
+      ) {
+        throw graphError(
+          "Instagram Graph API write outcome is unknown; automatic retry is unsafe.",
+          "INSTAGRAM_GRAPH_AMBIGUOUS_WRITE",
+          { operation, status: response.status }
+        );
+      }
+      const retryable = response.status === 429 || response.status >= 500;
+      throw graphError("Instagram Graph API rejected the request.", "INSTAGRAM_GRAPH_REJECTED", {
+        operation,
+        status: response.status,
+        retryable,
+      });
+    }
+    return asRecord(parsed, operation);
+  }
+
+  private async collect(
+    path: string,
+    operation: string,
+    query: Record<string, string>,
+    signal?: AbortSignal
+  ): Promise<unknown[]> {
+    const output: unknown[] = [];
+    let nextPath = path;
+    let nextQuery = query;
+    for (let page = 0; page < MAX_PAGES; page += 1) {
+      const response = await this.request(nextPath, operation, { query: nextQuery, signal });
+      if (!Array.isArray(response.data)) {
+        throw graphError(
+          "Instagram Graph API returned invalid paged data.",
+          "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+          {
+            operation,
+          }
+        );
+      }
+      output.push(...response.data);
+      const paging = response.paging;
+      const next = paging && typeof paging === "object" ? (paging as JsonRecord).next : undefined;
+      if (typeof next !== "string" || !next) return output;
+      const target = this.pagingTarget(next, operation);
+      nextPath = target.path;
+      nextQuery = target.query;
+    }
+    throw graphError(
+      "Instagram Graph API pagination exceeded its page limit.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      {
+        operation,
+      }
+    );
+  }
+
+  private pagingTarget(
+    next: string,
+    operation: string
+  ): { path: string; query: Record<string, string> } {
+    let parsed: URL;
+    try {
+      parsed = new URL(next);
+    } catch {
+      throw graphError(
+        "Instagram Graph API returned an invalid paging cursor.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        { operation }
+      );
+    }
+    if (parsed.origin !== this.origin.origin || !parsed.pathname.startsWith(`/${this.version}/`)) {
+      throw graphError(
+        "Instagram Graph API paging origin was rejected.",
+        "INSTAGRAM_GRAPH_REDIRECT",
+        {
+          operation,
+        }
+      );
+    }
+    const query: Record<string, string> = {};
+    for (const [key, value] of parsed.searchParams) {
+      if (key !== "access_token") query[key] = value;
+    }
+    return { path: parsed.pathname.slice(this.version.length + 2), query };
+  }
+
+  async getOwnUser(signal?: AbortSignal): Promise<InstagramUser> {
+    const response = await this.request(this.accountId, "get-own-user", {
+      query: {
+        fields: "id,user_id,username,name,profile_picture_url,followers_count,follows_count",
+      },
+      signal,
+    });
+    return toUser(response, "get-own-user");
+  }
+
+  async getUser(userId: string | number, signal?: AbortSignal): Promise<InstagramUser> {
+    const id = normalizeId(userId, "user id");
+    const response = await this.request(id, "get-user", {
+      query: {
+        fields:
+          "id,name,username,profile_pic,follower_count,is_verified_user,is_user_follow_business,is_business_follow_user",
+      },
+      signal,
+    });
+    return toUser(response, "get-user");
+  }
+
+  async getUserByUsername(username: string, signal?: AbortSignal): Promise<InstagramUser> {
+    void username;
+    void signal;
+    throw graphError(
+      "Instagram Login cannot resolve a username without an Instagram-scoped ID from an interaction.",
+      "INSTAGRAM_CAPABILITY_UNSUPPORTED",
+      { operation: "username-discovery" }
+    );
+  }
+
+  async getThreads(signal?: AbortSignal): Promise<InstagramThread[]> {
+    const rows = await this.collect(
+      `${this.accountId}/conversations`,
+      "list-conversations",
+      {
+        platform: "instagram",
+        fields: "id,updated_time",
+        limit: "100",
+      },
+      signal
+    );
+    const threads: InstagramThread[] = [];
+    for (let offset = 0; offset < rows.length; offset += 5) {
+      const batch = rows.slice(offset, offset + 5);
+      threads.push(
+        ...(await Promise.all(
+          batch.map(async (row) => {
+            const record = asRecord(row, "list-conversations");
+            const id = requiredString(record, "id", "list-conversations");
+            const messages = await this.getThreadMessages(id, signal);
+            const usersById = new Map<string, InstagramUser>();
+            for (const message of messages) {
+              if (message.user.pk !== this.accountId) usersById.set(message.user.pk, message.user);
+              for (const recipient of message.recipients ?? []) {
+                if (recipient.pk !== this.accountId) usersById.set(recipient.pk, recipient);
+              }
+            }
+            const users = [...usersById.values()];
+            return {
+              id,
+              users,
+              lastActivityAt:
+                record.updated_time === undefined
+                  ? undefined
+                  : parseGraphDate(record.updated_time, "list-conversations"),
+              isGroup: users.length > 1,
+              threadTitle:
+                users.map((user) => user.fullName ?? user.username).join(", ") || undefined,
+            };
+          })
+        ))
+      );
+    }
+    return threads;
+  }
+
+  async getThreadMessages(threadId: string, signal?: AbortSignal): Promise<InstagramMessage[]> {
+    const id = normalizeId(threadId, "thread id");
+    let response = await this.request(id, "get-conversation", {
+      query: { fields: "messages.limit(100){id,created_time,from,to,message,attachments}" },
+      signal,
+    });
+    const envelope = asRecord(response.messages, "get-conversation");
+    const messages = envelope.data;
+    if (!Array.isArray(messages)) {
+      throw graphError(
+        "Instagram Graph API returned invalid messages.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        {
+          operation: "get-conversation",
+        }
+      );
+    }
+    const rows = [...messages];
+    let paging = envelope.paging;
+    for (let page = 1; page < MAX_PAGES; page += 1) {
+      const next = paging && typeof paging === "object" ? (paging as JsonRecord).next : undefined;
+      if (typeof next !== "string" || !next) {
+        return rows.map((message) => this.toMessage(message, id));
+      }
+      const target = this.pagingTarget(next, "get-conversation");
+      response = await this.request(target.path, "get-conversation", {
+        query: target.query,
+        signal,
+      });
+      if (!Array.isArray(response.data)) {
+        throw graphError(
+          "Instagram Graph API returned invalid paged messages.",
+          "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+          { operation: "get-conversation" }
+        );
+      }
+      rows.push(...response.data);
+      paging = response.paging;
+    }
+    throw graphError(
+      "Instagram Graph API message pagination exceeded its page limit.",
+      "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+      { operation: "get-conversation" }
+    );
+  }
+
+  private toMessage(value: unknown, threadId: string): InstagramMessage {
+    const record = asRecord(value, "get-conversation");
+    const from = toUser(record.from, "get-conversation");
+    return {
+      id: requiredString(record, "id", "get-conversation"),
+      threadId,
+      text: optionalString(record, "message"),
+      timestamp: parseGraphDate(record.created_time, "get-conversation"),
+      user: from,
+      recipients: this.toRecipients(record.to),
+    };
+  }
+
+  private toRecipients(value: unknown): InstagramUser[] {
+    if (value === undefined) return [];
+    const data = Array.isArray(value)
+      ? value
+      : value && typeof value === "object" && Array.isArray((value as JsonRecord).data)
+        ? ((value as JsonRecord).data as unknown[])
+        : null;
+    if (!data) {
+      throw graphError(
+        "Instagram Graph API returned invalid message recipients.",
+        "INSTAGRAM_GRAPH_INVALID_RESPONSE",
+        { operation: "get-conversation" }
+      );
+    }
+    return data.map((recipient) => toUser(recipient, "get-conversation"));
+  }
+
+  async sendDirectMessage(threadId: string, text: string, signal?: AbortSignal): Promise<string> {
+    const id = normalizeId(threadId, "thread id");
+    const threads = await this.getThreads(signal);
+    const thread = threads.find((candidate) => candidate.id === id);
+    const recipient = thread?.users[0];
+    if (thread?.users.length !== 1 || !recipient) {
+      throw graphError(
+        "Instagram direct-message target is unavailable or is not a supported one-to-one conversation.",
+        "INSTAGRAM_TARGET_UNSUPPORTED"
+      );
+    }
+    const response = await this.request(`${this.accountId}/messages`, "send-message", {
+      method: "POST",
+      body: { recipient: { id: String(recipient.pk) }, message: { text } },
+      signal,
+      ambiguousOnNetworkFailure: true,
+    });
+    return requiredString(response, "message_id", "send-message");
+  }
+
+  async postComment(mediaId: string | number, text: string, signal?: AbortSignal): Promise<string> {
+    const id = normalizeId(mediaId, "media id");
+    const response = await this.request(`${id}/comments`, "post-comment", {
+      method: "POST",
+      body: new URLSearchParams({ message: text }),
+      signal,
+      ambiguousOnNetworkFailure: true,
+    });
+    return requiredString(response, "id", "post-comment");
+  }
+
+  async replyToComment(
+    commentId: string | number,
+    text: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    const id = normalizeId(commentId, "comment id");
+    const response = await this.request(`${id}/replies`, "reply-comment", {
+      method: "POST",
+      body: new URLSearchParams({ message: text }),
+      signal,
+      ambiguousOnNetworkFailure: true,
+    });
+    return requiredString(response, "id", "reply-comment");
+  }
+
+  async getUserMedia(userId: string | number, signal?: AbortSignal): Promise<InstagramMedia[]> {
+    const id = normalizeId(userId, "user id");
+    if (id !== this.accountId) {
+      throw graphError(
+        "Instagram Login exposes media only for the configured professional account.",
+        "INSTAGRAM_CAPABILITY_UNSUPPORTED",
+        { operation: "third-party-media" }
+      );
+    }
+    const rows = await this.collect(
+      `${id}/media`,
+      "list-media",
+      {
+        fields:
+          "id,caption,media_type,media_url,permalink,thumbnail_url,timestamp,like_count,comments_count",
+        limit: "100",
+      },
+      signal
+    );
+    return rows.map((row) => toMedia(row, "list-media"));
+  }
+}

--- a/plugins/plugin-instagram/src/index.ts
+++ b/plugins/plugin-instagram/src/index.ts
@@ -46,6 +46,12 @@ export {
   INSTAGRAM_PROVIDER_ID,
 } from "./connector-account-provider";
 export * from "./constants";
+export { InstagramGraphClient, type InstagramGraphClientConfig } from "./graph-client";
 export { InstagramService, validateInstagramComment } from "./service";
 export * from "./types";
+export {
+  type InstagramWebhookChange,
+  parseInstagramWebhookDelivery,
+  verifyInstagramWebhookChallenge,
+} from "./webhook";
 export default instagramPlugin;

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -3,10 +3,9 @@
  * the boundary between the runtime and the Instagram API backend. On start it
  * resolves each account's config, validates credentials, and registers both the
  * DM `MessageConnector` (source `"instagram"`) and the feed `PostConnector` with
- * the runtime. Handles inbound DM/comment ingestion into memory and outbound
- * sending, comment posting/replies, likes, and follow/unfollow. Degrades
- * gracefully when credentials are absent. Also exports `splitMessage`, the
- * length-aware chunker used for DM and comment limits.
+ * the runtime. Handles Graph-backed sends, comment posting/replies, reads, and
+ * explicit capability rejection. Also exports `splitMessage`, the length-aware
+ * chunker used for DM and comment limits.
  */
 import {
   ChannelType,
@@ -37,6 +36,7 @@ import {
   resolveInstagramAccountConfig,
 } from "./accounts";
 import { INSTAGRAM_SERVICE_NAME, MAX_COMMENT_LENGTH, MAX_DM_LENGTH } from "./constants";
+import { InstagramGraphClient } from "./graph-client";
 import type {
   InstagramConfig,
   InstagramMedia,
@@ -172,10 +172,19 @@ function normalizeInstagramMediaId(value: unknown): string | null {
   return /[1-9]/.test(trimmed) ? trimmed : null;
 }
 
-function throwMissingInstagramClient(operation: string): never {
-  throw new Error(
-    `Instagram ${operation} requires a configured Instagram API client. This package registers the connector surface but does not include a concrete Instagram client backend.`
-  );
+function unsupportedInstagramOperation(operation: string): never {
+  throw new ElizaError(`Instagram Graph API does not support ${operation}.`, {
+    code: "INSTAGRAM_CAPABILITY_UNSUPPORTED",
+    context: { operation },
+  });
+}
+
+function isExpectedDiscoveryUnavailable(error: unknown): boolean {
+  if (!(error instanceof ElizaError)) return false;
+  if (error.code === "INSTAGRAM_CAPABILITY_UNSUPPORTED") return true;
+  if (error.code !== "INSTAGRAM_GRAPH_REJECTED") return false;
+  const status = error.context?.status;
+  return status === 400 || status === 403 || status === 404;
 }
 
 /**
@@ -189,6 +198,7 @@ export class InstagramService extends Service {
   capabilityDescription = "Instagram messaging and social media integration";
 
   private instagramConfig: InstagramConfig | null = null;
+  private graphClient: InstagramGraphClient | null = null;
   private isRunning = false;
   private loggedInUser: InstagramUser | null = null;
   private accountServices = new Map<string, InstagramService>();
@@ -262,12 +272,14 @@ export class InstagramService extends Service {
         getUserContext: serviceInstance.getConnectorUserContext.bind(serviceInstance),
         getUser: async (handlerRuntime, params) => {
           if (params.username || params.handle) {
-            // error-policy:J4 no concrete Instagram client backend is bundled, so
-            // the username lookup throws by design; treat it as an unresolved
-            // user and fall through to the local entity lookup below.
+            // error-policy:J4 username discovery is permission-dependent; an
+            // expected provider rejection is represented as unresolved here.
             const user = await accountService
               .getUserByUsername(String(params.username ?? params.handle))
-              .catch(() => null);
+              .catch((error: unknown) => {
+                if (isExpectedDiscoveryUnavailable(error)) return null;
+                throw error;
+              });
             if (!user) {
               return null;
             }
@@ -357,12 +369,13 @@ export class InstagramService extends Service {
     this.defaultAccountId = normalizeInstagramAccountId(accountId ?? this.defaultAccountId);
     this.instagramConfig = resolveInstagramAccountConfig(this.runtime, this.defaultAccountId);
 
-    if (!this.instagramConfig.username || !this.instagramConfig.password) {
+    if (!this.instagramConfig.accessToken || !this.instagramConfig.instagramAccountId) {
       logger.warn("Instagram credentials not configured. Service will not be available.");
       return;
     }
 
-    logger.info(`Instagram service initialized for @${this.instagramConfig.username}`);
+    this.graphClient = new InstagramGraphClient(this.instagramConfig);
+    logger.info("Instagram professional-account Graph client initialized");
   }
 
   /**
@@ -377,10 +390,15 @@ export class InstagramService extends Service {
       throw new Error("Instagram service is already running");
     }
 
+    if (!this.graphClient) {
+      throw new ElizaError("Instagram Graph client is not configured.", {
+        code: "INSTAGRAM_CONFIG_INVALID",
+      });
+    }
     logger.info("Starting Instagram service connector surface");
-    this.loggedInUser = null;
+    this.loggedInUser = await this.graphClient.getOwnUser();
     this.isRunning = true;
-    logger.info(`Instagram service started for @${this.instagramConfig.username}`);
+    logger.info("Instagram professional-account service started");
   }
 
   /**
@@ -453,7 +471,7 @@ export class InstagramService extends Service {
       throw new Error(`Message too long: ${text.length} characters (max: ${MAX_DM_LENGTH})`);
     }
 
-    return throwMissingInstagramClient(`direct message send to thread ${threadId}`);
+    return this.requireGraphClient().sendDirectMessage(threadId, toWellFormedUnicode(text));
   }
 
   /**
@@ -468,14 +486,12 @@ export class InstagramService extends Service {
   /**
    * Post a comment on media
    */
-  async postComment(mediaId: number, text: string): Promise<number>;
-  async postComment(mediaId: string, text: string): Promise<string>;
-  async postComment(mediaId: string | number, _text: string): Promise<string | number> {
+  async postComment(mediaId: string | number, text: string): Promise<string> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    return throwMissingInstagramClient(`comment post on media ${mediaId}`);
+    return this.requireGraphClient().postComment(mediaId, validateInstagramComment(text));
   }
 
   async handleSendPost(runtime: IAgentRuntime, content: Content): Promise<Memory> {
@@ -542,72 +558,67 @@ export class InstagramService extends Service {
   /**
    * Reply to a comment
    */
-  async replyToComment(mediaId: number, commentId: number, text: string): Promise<number>;
-  async replyToComment(mediaId: string, commentId: string, text: string): Promise<string>;
   async replyToComment(
-    mediaId: string | number,
-    _commentId: string | number,
+    _mediaId: string | number,
+    commentId: string | number,
     text: string
-  ): Promise<string | number> {
-    // In a real implementation, this would tag the user and reply
-    return typeof mediaId === "string"
-      ? this.postComment(mediaId, text)
-      : this.postComment(mediaId, text);
+  ): Promise<string> {
+    return this.requireGraphClient().replyToComment(commentId, validateInstagramComment(text));
   }
 
   /**
    * Like media
    */
-  async likeMedia(mediaId: string | number): Promise<void> {
+  async likeMedia(_mediaId: string | number): Promise<void> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    throwMissingInstagramClient(`media like for ${mediaId}`);
+    unsupportedInstagramOperation("liking media");
   }
 
   /**
    * Unlike media
    */
-  async unlikeMedia(mediaId: string | number): Promise<void> {
+  async unlikeMedia(_mediaId: string | number): Promise<void> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    throwMissingInstagramClient(`media unlike for ${mediaId}`);
+    unsupportedInstagramOperation("unliking media");
   }
 
   /**
    * Follow a user
    */
-  async followUser(userId: number): Promise<void> {
+  async followUser(_userId: number): Promise<void> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    throwMissingInstagramClient(`user follow for ${userId}`);
+    unsupportedInstagramOperation("following users");
   }
 
   /**
    * Unfollow a user
    */
-  async unfollowUser(userId: number): Promise<void> {
+  async unfollowUser(_userId: number): Promise<void> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    throwMissingInstagramClient(`user unfollow for ${userId}`);
+    unsupportedInstagramOperation("unfollowing users");
   }
 
   /**
    * Get user info
    */
-  async getUserInfo(userId: number): Promise<InstagramUser> {
+  async getUserInfo(userId: string | number): Promise<InstagramUser> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    return throwMissingInstagramClient(`user lookup by id ${userId}`);
+    return this.requireGraphClient().getUser(userId);
   }
 
   /**
@@ -618,7 +629,7 @@ export class InstagramService extends Service {
       throw new Error("Instagram service is not running");
     }
 
-    return throwMissingInstagramClient(`user lookup by username ${username}`);
+    return this.requireGraphClient().getUserByUsername(username);
   }
 
   /**
@@ -629,7 +640,7 @@ export class InstagramService extends Service {
       throw new Error("Instagram service is not running");
     }
 
-    return throwMissingInstagramClient("thread list");
+    return this.requireGraphClient().getThreads();
   }
 
   /**
@@ -640,7 +651,7 @@ export class InstagramService extends Service {
       throw new Error("Instagram service is not running");
     }
 
-    return throwMissingInstagramClient(`thread message list for ${threadId}`);
+    return this.requireGraphClient().getThreadMessages(threadId);
   }
 
   async handleSendMessage(
@@ -781,10 +792,7 @@ export class InstagramService extends Service {
         .slice(0, limit);
     }
 
-    // error-policy:J4 this package ships the connector surface without a concrete
-    // Instagram client backend, so a platform fetch throws by design; degrade to
-    // the local message cache below rather than treating it as a hard failure.
-    const platformMessages = await this.getThreadMessages(threadId).catch(() => []);
+    const platformMessages = await this.getThreadMessages(threadId);
     if (platformMessages.length > 0) {
       const roomId =
         target?.roomId ??
@@ -863,11 +871,11 @@ export class InstagramService extends Service {
     entityId: string,
     _context: MessageConnectorQueryContext
   ): Promise<MessageConnectorUserContext | null> {
-    const numericId = Number.parseInt(entityId, 10);
-    if (!Number.isFinite(numericId)) {
+    const userId = entityId.trim();
+    if (!userId) {
       return null;
     }
-    const user = await this.getUserInfo(numericId);
+    const user = await this.getUserInfo(userId);
     return {
       entityId,
       label: user.fullName || `@${user.username}`,
@@ -976,13 +984,12 @@ export class InstagramService extends Service {
   /**
    * Get user's media
    */
-  async getUserMedia(_userId: number): Promise<InstagramMedia[]> {
+  async getUserMedia(userId: string | number): Promise<InstagramMedia[]> {
     if (!this.isRunning) {
       throw new Error("Instagram service is not running");
     }
 
-    // In a real implementation, this would fetch from Instagram API
-    return [];
+    return this.requireGraphClient().getUserMedia(userId);
   }
 
   /**
@@ -993,7 +1000,16 @@ export class InstagramService extends Service {
       return false;
     }
 
-    return !!(this.instagramConfig.username && this.instagramConfig.password);
+    return !!(this.instagramConfig.accessToken && this.instagramConfig.instagramAccountId);
+  }
+
+  private requireGraphClient(): InstagramGraphClient {
+    if (!this.graphClient) {
+      throw new ElizaError("Instagram Graph client is not configured.", {
+        code: "INSTAGRAM_CONFIG_INVALID",
+      });
+    }
+    return this.graphClient;
   }
 }
 

--- a/plugins/plugin-instagram/src/types.ts
+++ b/plugins/plugin-instagram/src/types.ts
@@ -41,7 +41,7 @@ export enum InstagramMediaType {
 /** Instagram user information */
 export interface InstagramUser {
   /** User's primary key/ID */
-  pk: number;
+  pk: string;
   /** Username */
   username: string;
   /** Full display name */
@@ -49,9 +49,9 @@ export interface InstagramUser {
   /** Profile picture URL */
   profilePicUrl?: string;
   /** Whether account is private */
-  isPrivate: boolean;
+  isPrivate?: boolean;
   /** Whether account is verified */
-  isVerified: boolean;
+  isVerified?: boolean;
   /** Number of followers */
   followerCount?: number;
   /** Number of accounts following */
@@ -61,7 +61,7 @@ export interface InstagramUser {
 /** Instagram media information */
 export interface InstagramMedia {
   /** Media's primary key/ID */
-  pk: number;
+  pk: string;
   /** Type of media */
   mediaType: InstagramMediaType;
   /** Caption text */
@@ -71,9 +71,9 @@ export interface InstagramMedia {
   /** Thumbnail URL for videos */
   thumbnailUrl?: string;
   /** Number of likes */
-  likeCount: number;
+  likeCount?: number;
   /** Number of comments */
-  commentCount: number;
+  commentCount?: number;
   /** When media was posted */
   takenAt?: Date;
   /** User who posted */
@@ -92,16 +92,18 @@ export interface InstagramMessage {
   timestamp: Date;
   /** User who sent the message */
   user: InstagramUser;
+  /** Recipients when the conversations API exposes them. */
+  recipients?: InstagramUser[];
   /** Optional attached media */
   media?: InstagramMedia;
   /** Whether message has been seen */
-  isSeen: boolean;
+  isSeen?: boolean;
 }
 
 /** Instagram comment */
 export interface InstagramComment {
   /** Comment's primary key */
-  pk: number;
+  pk: string;
   /** Comment text */
   text: string;
   /** When comment was posted */
@@ -109,9 +111,9 @@ export interface InstagramComment {
   /** User who commented */
   user: InstagramUser;
   /** Media the comment is on */
-  mediaPk: number;
+  mediaPk: string;
   /** If replying to another comment */
-  replyToPk?: number;
+  replyToPk?: string;
 }
 
 /** Instagram DM thread */
@@ -132,14 +134,20 @@ export interface InstagramThread {
 export interface InstagramConfig {
   /** Connector account identifier for this Instagram bot instance */
   accountId?: string;
-  /** Instagram username */
-  username: string;
-  /** Instagram password */
-  password: string;
-  /** Optional 2FA verification code */
-  verificationCode?: string;
-  /** Optional proxy URL */
-  proxy?: string;
+  /** Professional-account Graph API access token. */
+  accessToken: string;
+  /** Instagram professional account ID associated with the token. */
+  instagramAccountId: string;
+  /** App secret used to validate signed webhook deliveries. */
+  appSecret?: string;
+  /** Secret used for the webhook subscription verification challenge. */
+  webhookVerifyToken?: string;
+  /** Graph API origin; HTTPS except literal loopback HTTP in protocol tests. */
+  graphBaseUrl?: string;
+  /** Explicit Graph API version, for example `v24.0`. */
+  graphApiVersion?: string;
+  /** Per-request deadline in milliseconds. */
+  requestTimeoutMs?: number;
   /** Whether to auto-respond to DMs */
   autoRespondToDms?: boolean;
   /** Whether to auto-respond to comments */
@@ -193,11 +201,11 @@ export interface InstagramActionContext {
   /** Original message/event data */
   message: Record<string, unknown>;
   /** User ID */
-  userId: number;
+  userId: string;
   /** Thread ID for DMs */
   threadId?: string;
   /** Media ID for comments */
-  mediaId?: number;
+  mediaId?: string;
   /** Current state */
   state: Record<string, unknown>;
 }

--- a/plugins/plugin-instagram/src/webhook.ts
+++ b/plugins/plugin-instagram/src/webhook.ts
@@ -3,7 +3,7 @@
  * deliveries before account routing. It deliberately accepts raw bytes so the
  * HMAC is checked before JSON parsing or any durable side effect.
  */
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
 
 const MAX_WEBHOOK_BYTES = 1024 * 1024;
@@ -86,7 +86,8 @@ export function parseInstagramWebhookDelivery(
   }
 
   const output: InstagramWebhookChange[] = [];
-  for (const rawEntry of envelope.entry) {
+  const deliveryDigest = createHash("sha256").update(rawBody).digest("hex");
+  for (const [entryIndex, rawEntry] of envelope.entry.entries()) {
     if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
       throw webhookError("Instagram webhook entry is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
     }
@@ -99,7 +100,7 @@ export function parseInstagramWebhookDelivery(
     }
     const changes = Array.isArray(entry.changes) ? entry.changes : [];
     const messaging = Array.isArray(entry.messaging) ? entry.messaging : [];
-    for (const rawChange of [...changes, ...messaging]) {
+    for (const [changeIndex, rawChange] of [...changes, ...messaging].entries()) {
       if (!rawChange || typeof rawChange !== "object" || Array.isArray(rawChange)) {
         throw webhookError("Instagram webhook change is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
       }
@@ -126,7 +127,7 @@ export function parseInstagramWebhookDelivery(
             ? valueRecord.id
             : typeof change.id === "string"
               ? change.id
-              : `${accountId}:${time}:${output.length}`;
+              : `${deliveryDigest}:${entryIndex}:${changeIndex}`;
       output.push({
         accountId,
         eventId: `${accountId}:${field}:${providerId}`,

--- a/plugins/plugin-instagram/src/webhook.ts
+++ b/plugins/plugin-instagram/src/webhook.ts
@@ -1,0 +1,146 @@
+/**
+ * Validates Meta webhook subscription challenges and signed Instagram
+ * deliveries before account routing. It deliberately accepts raw bytes so the
+ * HMAC is checked before JSON parsing or any durable side effect.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
+
+const MAX_WEBHOOK_BYTES = 1024 * 1024;
+const MAX_WEBHOOK_ENTRIES = 1_000;
+
+export interface InstagramWebhookChange {
+  accountId: string;
+  eventId: string;
+  field: string;
+  value: Record<string, unknown>;
+  receivedAt: number;
+}
+
+function webhookError(message: string, code: string): ElizaError {
+  return new ElizaError(message, { code });
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, "utf8");
+  const rightBytes = Buffer.from(right, "utf8");
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}
+
+export function verifyInstagramWebhookChallenge(
+  query: URLSearchParams,
+  expectedVerifyToken: string
+): string {
+  const mode = query.get("hub.mode");
+  const token = query.get("hub.verify_token");
+  const challenge = query.get("hub.challenge");
+  if (
+    mode !== "subscribe" ||
+    !token ||
+    !expectedVerifyToken ||
+    !safeEqual(token, expectedVerifyToken) ||
+    !challenge ||
+    challenge.length > 512
+  ) {
+    throw webhookError("Instagram webhook verification failed.", "INSTAGRAM_WEBHOOK_UNAUTHORIZED");
+  }
+  return challenge;
+}
+
+export function parseInstagramWebhookDelivery(
+  rawBody: Uint8Array,
+  signatureHeader: string | null,
+  appSecret: string,
+  receivedAt = Date.now()
+): InstagramWebhookChange[] {
+  if (!appSecret || appSecret.length > 16_384) {
+    throw webhookError(
+      "Instagram webhook app secret is not configured.",
+      "INSTAGRAM_CONFIG_INVALID"
+    );
+  }
+  if (rawBody.byteLength === 0 || rawBody.byteLength > MAX_WEBHOOK_BYTES) {
+    throw webhookError("Instagram webhook body size is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+  }
+  const provided = signatureHeader?.match(/^sha256=([a-f0-9]{64})$/)?.[1];
+  const expected = createHmac("sha256", appSecret).update(rawBody).digest("hex");
+  if (!provided || !safeEqual(provided, expected)) {
+    throw webhookError(
+      "Instagram webhook signature validation failed.",
+      "INSTAGRAM_WEBHOOK_UNAUTHORIZED"
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(rawBody)) as unknown;
+  } catch {
+    throw webhookError("Instagram webhook body is invalid JSON.", "INSTAGRAM_WEBHOOK_INVALID");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw webhookError("Instagram webhook envelope is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+  }
+  const envelope = parsed as Record<string, unknown>;
+  if (envelope.object !== "instagram" || !Array.isArray(envelope.entry)) {
+    throw webhookError("Instagram webhook envelope is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+  }
+
+  const output: InstagramWebhookChange[] = [];
+  for (const rawEntry of envelope.entry) {
+    if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+      throw webhookError("Instagram webhook entry is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+    }
+    const entry = rawEntry as Record<string, unknown>;
+    const accountId = typeof entry.id === "string" ? entry.id : "";
+    const time =
+      typeof entry.time === "number" && Number.isFinite(entry.time) ? entry.time : receivedAt;
+    if (!accountId || !/^[A-Za-z0-9_.:-]{1,256}$/.test(accountId)) {
+      throw webhookError("Instagram webhook account is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+    }
+    const changes = Array.isArray(entry.changes) ? entry.changes : [];
+    const messaging = Array.isArray(entry.messaging) ? entry.messaging : [];
+    for (const rawChange of [...changes, ...messaging]) {
+      if (!rawChange || typeof rawChange !== "object" || Array.isArray(rawChange)) {
+        throw webhookError("Instagram webhook change is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+      }
+      const change = rawChange as Record<string, unknown>;
+      const field =
+        typeof change.field === "string"
+          ? change.field
+          : messaging.includes(rawChange)
+            ? "messages"
+            : "";
+      const value = field === "messages" ? change : change.value;
+      if (!field || !value || typeof value !== "object" || Array.isArray(value)) {
+        throw webhookError("Instagram webhook change is invalid.", "INSTAGRAM_WEBHOOK_INVALID");
+      }
+      const valueRecord = value as Record<string, unknown>;
+      const message =
+        valueRecord.message && typeof valueRecord.message === "object"
+          ? (valueRecord.message as Record<string, unknown>)
+          : undefined;
+      const providerId =
+        typeof message?.mid === "string"
+          ? message.mid
+          : typeof valueRecord.id === "string"
+            ? valueRecord.id
+            : typeof change.id === "string"
+              ? change.id
+              : `${accountId}:${time}:${output.length}`;
+      output.push({
+        accountId,
+        eventId: `${accountId}:${field}:${providerId}`,
+        field,
+        value: valueRecord,
+        receivedAt: time < 10_000_000_000 ? time * 1000 : time,
+      });
+      if (output.length > MAX_WEBHOOK_ENTRIES) {
+        throw webhookError(
+          "Instagram webhook contains too many entries.",
+          "INSTAGRAM_WEBHOOK_INVALID"
+        );
+      }
+    }
+  }
+  return output;
+}


### PR DESCRIPTION
# Relates to

Refs #24233, #24093, #22899, and #22896.

- [x] Targets `develop` and was rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install` and focused verification were run after sync. The unrelated root verify failure is recorded below.
- [x] Real loopback HTTP tests expose the wire behavior without replacing client methods or global fetch.

# Sync with develop

- [x] Rebased onto `origin/develop` at `e9f71fe853`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It reaches the workspace Turbo lane and then fails on pre-existing formatting/non-null assertions in `packages/agent/src/api/accounts-routes.ts` and `interactions-routes.test.ts`; this PR does not touch `packages/agent`.

# Risks

Medium. This intentionally replaces the plugin's unusable username/password configuration contract with official professional-account Graph credentials and changes provider IDs from unsafe JavaScript numbers to strings. Existing deployments using the old private-login-shaped settings remain disabled instead of being silently reinterpreted.

# Background

## What does this PR do?

This draft establishes the missing production Instagram Login Graph API prerequisite:

- adds a real production HTTP client for scoped profiles, owned media, conversations/messages, one-to-one text sends, and media comment/reply operations;
- authenticates only through bearer headers and accepts HTTP only for literal loopback protocol tests;
- strictly validates bounded UTF-8/JSON responses, same-origin cursors, IDs, timestamps, media types, redirects, cancellation, and retry classification;
- reports post-accept transport/5xx writes as ambiguous and never automatically retries them;
- adds raw-body webhook challenge/HMAC parsing with stable account-scoped replay IDs;
- removes username/password/2FA/proxy configuration from manifests and documents explicit unsupported capability truth;
- exercises the production client through a real loopback HTTP server, including pagination, auth revocation/rotation, malformed/oversized bodies, redirects, stalls, rate limits, cross-origin cursors, and ambiguous writes.

This remains a draft and uses `Refs`, not `Closes`: durable webhook route ingestion, persist-before-process/restart recovery, vault-owned account CRUD, media-message sends, provider-live qualification, and shared mock reset/ledger/Cloud composition are still open under #24233/#24093/#24076-#24078.

## What kind of change is this?

Feature and contract correction.

# Documentation changes needed?

Updated README, package guide/paired AGENTS guide, plugin parameters, registry entry, and generated first-party catalog.

# Testing

## Where should a reviewer start?

Review `plugins/plugin-instagram/src/graph-client.ts`, then run the real-wire contract in `src/__tests__/graph-client.contract.test.ts` and signature/demux contract in `src/__tests__/webhook.contract.test.ts`.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun run --cwd plugins/plugin-instagram lint:check
bun run --cwd plugins/plugin-instagram typecheck
bun run --cwd plugins/plugin-instagram test
bun run --cwd plugins/plugin-instagram build
bun run --cwd packages/registry generate:first-party:check
bun run --cwd packages/registry typecheck
bun run --cwd packages/registry test
bun run check:agents-claude
```

Exact-head results: Instagram 5 files / 52 tests pass; registry 7 files / 39 tests pass; both typechecks, plugin lint/build, generated registry parity, and 159 guide pairs pass.

# Evidence Gate

<!-- evidence-head:24addc1be8064cd9263b5430428621fc591aade9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only connector and registry contract; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only connector and registry contract; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow changed; the reviewable artifact is the loopback wire transcript asserted by the contract tests.
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head command transcript:
  <details><summary>Backend contract gates</summary>

  ```text
  Instagram: Test Files 5 passed (5); Tests 52 passed (51)
  Instagram: lint check clean; TypeScript typecheck clean; Node build complete
  Registry: Test Files 7 passed (7); Tests 39 passed (39); generated artifacts up to date
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, prompt, model, provider, or LLM decision behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact transcript:
  <details><summary>Wire and registry artifacts</summary>

  ```text
  Real loopback Graph wire: bearer auth, same-origin cursor replay, conversation/message reads, DM/comment/reply writes
  Webhook artifact: raw-body HMAC validation, two-account demultiplexing, stable replay event identities
  Registry artifact: packages/registry/src/first-party/generated.json regenerated and drift check passed
  ```
  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - connector transport/config work contains no LLM call.

## Backend + frontend logs

Backend focused evidence is the exact-head command transcript summarized in Testing. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Known gaps / failures

- Root `bun run verify` fails outside this diff in `@elizaos/agent#lint:check`: `packages/agent/src/api/accounts-routes.ts` is not formatted and `packages/agent/src/api/interactions-routes.test.ts` contains forbidden non-null assertions. The Instagram package itself passes lint/typecheck/test/build.
- No Meta sandbox/live artifact is attached because approved credentials are unavailable; provider-live certification remains separately required by #19910/#24233.
- No durable webhook HTTP ingress/restart artifact yet. This draft supplies signature parsing and stable demux identities, while #24093 and #24076-#24078 own shared persist/reset/ledger/Cloud composition.
- Meta exposes no idempotency key for these writes. Ambiguous writes fail with `INSTAGRAM_GRAPH_AMBIGUOUS_WRITE` and are deliberately not retried; readback/reconciliation remains open where the provider exposes sufficient state.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [instagram-production-backend]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A"} -->
