### PR TITLE
feat(documents): authorize independent direct grants

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -168,6 +168,7 @@ visible.
 - The model-output contract is `<response>` XML (with `<actions>`/`<providers>`/`<text>`); plain text is tolerated and treated as a `REPLY`.
 - DB mutation methods on `IDatabaseAdapter` return `Promise<boolean>` so callers can distinguish success/failure (`types/database.ts`).
 - The task system (`services/task.ts`, `services/task-scheduler.ts`) is the single place scheduled work runs; only tasks tagged `queue` are polled. Three modes: local timer, per-daemon (`startTaskScheduler`), serverless (`{ serverless: true }` + `runDueTasks()`).
+- Document reads use `roomId` as the single room entitlement and join it to the requester's current room set inside the adapter. `directGrantEntityIds` is a bounded, validated, read-only exception that remains valid without room membership; it never opens `agent-private` documents and never grants mutation authority. Malformed or duplicate grant arrays make the parent unreadable.
 - `runtime.ts` is intentionally large and load-bearing; navigate by symbol and
   ownership boundary rather than reading it top to bottom or adding another
   unrelated responsibility.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -168,6 +168,7 @@ visible.
 - The model-output contract is `<response>` XML (with `<actions>`/`<providers>`/`<text>`); plain text is tolerated and treated as a `REPLY`.
 - DB mutation methods on `IDatabaseAdapter` return `Promise<boolean>` so callers can distinguish success/failure (`types/database.ts`).
 - The task system (`services/task.ts`, `services/task-scheduler.ts`) is the single place scheduled work runs; only tasks tagged `queue` are polled. Three modes: local timer, per-daemon (`startTaskScheduler`), serverless (`{ serverless: true }` + `runDueTasks()`).
+- Document reads use `roomId` as the single room entitlement and join it to the requester's current room set inside the adapter. `directGrantEntityIds` is a bounded, validated, read-only exception that remains valid without room membership; it never opens `agent-private` documents and never grants mutation authority. Malformed or duplicate grant arrays make the parent unreadable.
 - `runtime.ts` is intentionally large and load-bearing; navigate by symbol and
   ownership boundary rather than reading it top to bottom or adding another
   unrelated responsibility.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,6 +4,13 @@
 
 `@elizaos/core` is the runtime and contract layer of elizaOS. It defines the `AgentRuntime` and the plugin abstractions (actions, providers, evaluators, services, models, routes, events), the canonical type system, and the supporting subsystems (memory, search, settings, scheduling, prompts). It is consumed by `@elizaos/agent` (which also hosts the HTTP API server), `@elizaos/app-core` (the API + dashboard host), and every `@elizaos/*` plugin.
 
+Document authorization treats a document's `roomId` as its single room
+entitlement and evaluates it against current requester membership inside the
+adapter before rows, counts, fragments, or ranking are produced. Explicit
+`directGrantEntityIds` are read-only and independent of room membership; they
+cannot expose `agent-private` documents or confer mutation authority. Invalid
+or duplicate grant arrays fail closed.
+
 ## Key concepts
 
 - **AgentRuntime:** Central orchestrator for the agent lifecycle, plugin loading, and the message loop.

--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -204,6 +204,59 @@ describe("document-list capability contract", () => {
 		);
 	});
 
+	it("keeps direct grants independent from room membership without opening agent-private data", () => {
+		const granted = {
+			...document(30),
+			metadata: {
+				type: MemoryType.DOCUMENT,
+				scope: "owner-private",
+				directGrantEntityIds: [REQUESTER_ID],
+			},
+		};
+		const agentOnly = {
+			...document(31),
+			metadata: {
+				type: MemoryType.DOCUMENT,
+				scope: "agent-private",
+				directGrantEntityIds: [REQUESTER_ID],
+			},
+		};
+		const userParams = {
+			...params,
+			requesterRole: "USER" as const,
+			requesterRoomIds: [],
+		};
+
+		expect(isDocumentVisibleToRequester(granted, userParams)).toBe(true);
+		expect(isDocumentVisibleToRequester(agentOnly, userParams)).toBe(false);
+		expect(
+			isDocumentVisibleToRequester(granted, {
+				...userParams,
+				requesterRole: "GUEST",
+			}),
+		).toBe(false);
+		expect(canRequesterMutateDocument(granted, userParams)).toBe(false);
+	});
+
+	it("fails closed on malformed or duplicate direct grants", () => {
+		for (const directGrantEntityIds of [
+			["not-a-uuid"],
+			[REQUESTER_ID, REQUESTER_ID],
+			"not-an-array",
+		]) {
+			const malformed = {
+				...document(32),
+				metadata: {
+					type: MemoryType.DOCUMENT,
+					scope: "global",
+					directGrantEntityIds,
+				},
+			};
+			expect(readDocumentMutationSnapshot(malformed)).toBeNull();
+			expect(isDocumentVisibleToRequester(malformed, params)).toBe(false);
+		}
+	});
+
 	it("keeps guest and unresolved document authority fail-closed", () => {
 		const global = document(3);
 		const privateDocument = {
@@ -317,17 +370,31 @@ describe("document-list capability contract", () => {
 			...document(10),
 			metadata: {
 				...document(10).metadata,
+				directGrantEntityIds: [REQUESTER_ID],
 				ingestionAttemptId,
 				ingestionState: "pending",
 			},
 		} as Memory;
 		const snapshot = readDocumentMutationSnapshot(pending);
 		expect(snapshot).toMatchObject({
+			directGrantEntityIds: [REQUESTER_ID],
 			ingestionAttemptId,
 			ingestionState: "pending",
 		});
 		if (!snapshot) throw new Error("expected a valid ingestion snapshot");
 		expect(documentMutationSnapshotMatches(pending, snapshot)).toBe(true);
+		expect(
+			documentMutationSnapshotMatches(
+				{
+					...pending,
+					metadata: {
+						...pending.metadata,
+						directGrantEntityIds: [],
+					} as Memory["metadata"],
+				},
+				snapshot,
+			),
+		).toBe(false);
 		expect(
 			documentMutationSnapshotMatches(
 				{

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -269,6 +269,26 @@ function readUuidMetadata(
 	return isUuid(value) ? value : undefined;
 }
 
+const DOCUMENT_DIRECT_GRANT_LIMIT = 1_000;
+
+function readDirectGrantEntityIds(
+	metadata: Record<string, unknown>,
+): UUID[] | null {
+	const value = metadata.directGrantEntityIds;
+	if (value === undefined) return [];
+	if (!Array.isArray(value) || value.length > DOCUMENT_DIRECT_GRANT_LIMIT) {
+		return null;
+	}
+	const grants: UUID[] = [];
+	const seen = new Set<string>();
+	for (const entityId of value) {
+		if (!isUuid(entityId) || seen.has(entityId)) return null;
+		seen.add(entityId);
+		grants.push(entityId);
+	}
+	return grants;
+}
+
 function readDocumentRevision(metadata: unknown): number | null {
 	if (metadata === null || typeof metadata !== "object") return null;
 	const value = Reflect.get(metadata, "documentRevision");
@@ -302,6 +322,8 @@ export function readDocumentMutationSnapshot(
 	if (metadata.scopedToEntityId !== undefined && !scopedToEntityId) return null;
 	const addedBy = readUuidMetadata(metadata, "addedBy");
 	if (metadata.addedBy !== undefined && !addedBy) return null;
+	const directGrantEntityIds = readDirectGrantEntityIds(metadata);
+	if (!directGrantEntityIds) return null;
 	const revision = readDocumentRevision(metadata);
 	if (revision === null) return null;
 	const ingestionAttemptId = readUuidMetadata(metadata, "ingestionAttemptId");
@@ -330,6 +352,7 @@ export function readDocumentMutationSnapshot(
 			: {}),
 		...(scopedToEntityId ? { scopedToEntityId } : {}),
 		...(addedBy ? { addedBy } : {}),
+		...(directGrantEntityIds.length > 0 ? { directGrantEntityIds } : {}),
 	};
 }
 
@@ -364,6 +387,10 @@ export function validateDocumentRevisionReplacement(
 		replacementSnapshot.scope !== params.expected.scope ||
 		replacementSnapshot.roomId !== params.expected.roomId ||
 		replacementSnapshot.entityId !== params.expected.entityId ||
+		!uuidArraysEqual(
+			replacementSnapshot.directGrantEntityIds,
+			params.expected.directGrantEntityIds,
+		) ||
 		replacementSnapshot.scopedToEntityId !== params.expected.scopedToEntityId ||
 		replacementSnapshot.addedBy !== params.expected.addedBy ||
 		replacementSnapshot.ingestionAttemptId !==
@@ -426,9 +453,20 @@ export function isDocumentVisibleToRequester(
 	if (documentRoleHasGlobalVisibility(params.requesterRole)) {
 		return true;
 	}
+	if (params.requesterRole === "GUEST") {
+		return (
+			params.requesterRoomIds.includes(snapshot.roomId) &&
+			snapshot.scope === "global"
+		);
+	}
+	if (
+		snapshot.scope !== "agent-private" &&
+		snapshot.directGrantEntityIds?.includes(params.requesterEntityId)
+	) {
+		return true;
+	}
 	if (!params.requesterRoomIds.includes(snapshot.roomId)) return false;
 	if (snapshot.scope === "global") return true;
-	if (params.requesterRole === "GUEST") return false;
 	if (snapshot.scope !== "user-private") return false;
 	if (params.requesterRole === "ADMIN") return true;
 	return snapshot.scopedToEntityId === params.requesterEntityId;
@@ -469,11 +507,24 @@ export function documentMutationSnapshotMatches(
 		actual.scope === expected.scope &&
 		actual.roomId === expected.roomId &&
 		actual.entityId === expected.entityId &&
+		uuidArraysEqual(
+			actual.directGrantEntityIds,
+			expected.directGrantEntityIds,
+		) &&
 		actual.scopedToEntityId === expected.scopedToEntityId &&
 		actual.addedBy === expected.addedBy &&
 		actual.revision === expected.revision &&
 		actual.ingestionAttemptId === expected.ingestionAttemptId &&
 		actual.ingestionState === expected.ingestionState
+	);
+}
+
+function uuidArraysEqual(left?: UUID[], right?: UUID[]): boolean {
+	const normalizedLeft = left ?? [];
+	const normalizedRight = right ?? [];
+	return (
+		normalizedLeft.length === normalizedRight.length &&
+		normalizedLeft.every((value, index) => value === normalizedRight[index])
 	);
 }
 

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -164,6 +164,8 @@ export interface AddDocumentOptions {
 	content: string;
 	scope?: DocumentVisibilityScope;
 	scopedToEntityId?: UUID;
+	/** Read-only entity grants that remain valid independently of room membership. */
+	directGrantEntityIds?: UUID[];
 	addedBy?: UUID;
 	addedByRole?: DocumentAddedByRole;
 	addedFrom?: DocumentAddedFrom;

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -125,6 +125,7 @@ export interface DocumentMutationSnapshot {
 	scope: DocumentListScope;
 	roomId: UUID;
 	entityId: UUID;
+	directGrantEntityIds?: UUID[];
 	scopedToEntityId?: UUID;
 	addedBy?: UUID;
 	revision: number;

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -107,6 +107,8 @@ export interface BaseMetadata {
 export interface DocumentMetadata {
 	base?: BaseMetadata;
 	type?: "document";
+	/** Read-only entity grants that remain valid independently of room membership. */
+	directGrantEntityIds?: UUID[];
 	/** Served original-bytes file (content-addressed) linked to this document. */
 	mediaUrl?: string;
 	/** Served original-bytes file (content-addressed) linked to this document. */

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -138,6 +138,7 @@ Settings are read via `runtime.getSetting(key)` inside `plugin.init`.
 - **Drizzle subpath export.** Common Drizzle query helpers (`eq`, `sql`, `and`, etc.) are re-exported from `@elizaos/plugin-sql` and `@elizaos/plugin-sql/drizzle` to avoid direct drizzle-orm version coupling in consumer code.
 - **Vector dimensions are active-width scoped.** `ensureEmbeddingDimension(n)` selects the current vector column, and runtime boot calls `clearEmbeddingsOutsideActiveDimension()` to delete vectors in other dimension columns and queue those memories for re-embedding at the active width. Memory rows survive; stale vectors do not.
 - **RLS is PostgreSQL-only.** PGlite does not support Row Level Security. The `ENABLE_DATA_ISOLATION` path is silently skipped on PGlite.
+- **Document entitlements are query-time authority.** Document list, lookup, and fragment queries authorize the parent before constructing results. Current room IDs satisfy the parent's single room entitlement; validated `directGrantEntityIds` provide read-only access outside the room, except for `agent-private` documents. Never materialize per-member document grants or move these predicates after pagination/ranking.
 - **Tests live under `src/__tests__/`** and run via vitest configured in `src/vitest.config.ts`.
 
 ## Verification

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -138,6 +138,7 @@ Settings are read via `runtime.getSetting(key)` inside `plugin.init`.
 - **Drizzle subpath export.** Common Drizzle query helpers (`eq`, `sql`, `and`, etc.) are re-exported from `@elizaos/plugin-sql` and `@elizaos/plugin-sql/drizzle` to avoid direct drizzle-orm version coupling in consumer code.
 - **Vector dimensions are active-width scoped.** `ensureEmbeddingDimension(n)` selects the current vector column, and runtime boot calls `clearEmbeddingsOutsideActiveDimension()` to delete vectors in other dimension columns and queue those memories for re-embedding at the active width. Memory rows survive; stale vectors do not.
 - **RLS is PostgreSQL-only.** PGlite does not support Row Level Security. The `ENABLE_DATA_ISOLATION` path is silently skipped on PGlite.
+- **Document entitlements are query-time authority.** Document list, lookup, and fragment queries authorize the parent before constructing results. Current room IDs satisfy the parent's single room entitlement; validated `directGrantEntityIds` provide read-only access outside the room, except for `agent-private` documents. Never materialize per-member document grants or move these predicates after pagination/ranking.
 - **Tests live under `src/__tests__/`** and run via vitest configured in `src/vitest.config.ts`.
 
 ## Verification

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -123,6 +123,12 @@ export const plugin = {
 
 Destructive changes (column drops, type changes) are blocked by default. Set `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS=true` to allow them.
 
+Document list, lookup, and fragment queries authorize each parent before
+pagination, counts, bytes, or ranking. A parent `roomId` is its room entitlement
+and is joined to current requester membership. Validated
+`directGrantEntityIds` provide read-only access independent of room membership,
+but never expose `agent-private` documents or grant mutation authority.
+
 Message-search DDL is also guarded on production Postgres. The generated column and GIN indexes are still installed automatically for development/test and embedded PGlite. For production Postgres, schedule the table rewrite/index creation and run with `ELIZA_APPLY_MESSAGE_SEARCH_OBJECTS=true` once the deployment window is approved.
 
 ## Connection Management

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -311,6 +311,82 @@ describe("document list query (real SQL parity)", () => {
     }
   });
 
+  it("authorizes direct grants outside current rooms before list and fragment construction", async () => {
+    const otherRoomId = v4() as UUID;
+    await adapter.createRooms([
+      {
+        id: otherRoomId,
+        agentId,
+        worldId,
+        name: "direct-grant-room",
+        source: "test",
+        type: ChannelType.DM,
+      } as Room,
+    ]);
+    const granted = document(20, {
+      roomId: otherRoomId,
+      metadata: {
+        scope: "owner-private",
+        directGrantEntityIds: [REQUESTER_ID],
+      },
+    });
+    const agentOnly = document(21, {
+      roomId: otherRoomId,
+      metadata: {
+        scope: "agent-private",
+        directGrantEntityIds: [REQUESTER_ID],
+      },
+    });
+    const fragment = document(22, {
+      roomId: otherRoomId,
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: granted.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    });
+    await seedSql([granted, agentOnly]);
+    await adapter.createMemories([{ memory: fragment, tableName: "document_fragments" }]);
+    const inMemory = await seedInMemory([granted, agentOnly]);
+    await inMemory.createMemories([{ memory: fragment, tableName: "document_fragments" }]);
+    const context = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [],
+      requesterRole: "USER" as const,
+    };
+
+    const sqlDocuments = await adapter.queryDocuments({ ...context, limit: 10, offset: 0 });
+    const memoryDocuments = await inMemory.queryDocuments({ ...context, limit: 10, offset: 0 });
+    expect(sqlDocuments).toEqual(memoryDocuments);
+    expect(ids(sqlDocuments.documents)).toEqual([granted.id]);
+    expect(await adapter.getDocument({ ...context, documentId: granted.id as UUID })).toMatchObject(
+      {
+        id: granted.id,
+      }
+    );
+    expect(
+      ids(
+        await adapter.queryDocumentFragments({
+          ...context,
+          documentId: granted.id as UUID,
+          limit: 10,
+        })
+      )
+    ).toEqual([fragment.id as UUID]);
+    expect(
+      await adapter.queryDocuments({ ...context, requesterRole: "GUEST", limit: 10, offset: 0 })
+    ).toEqual(
+      await inMemory.queryDocuments({
+        ...context,
+        requesterRole: "GUEST",
+        limit: 10,
+        offset: 0,
+      })
+    );
+  });
+
   it("filters fragment pages by exact authorized parent before pagination", async () => {
     const firstParent = document(1);
     const secondParent = document(2);
@@ -584,6 +660,10 @@ describe("document list query (real SQL parity)", () => {
       document(5, { metadata: { addedBy: "not-a-uuid" } }),
       document(6, { metadata: { documentRevision: 1.5 } }),
       document(9, { metadata: { documentRevision: "1" } }),
+      document(11, { metadata: { directGrantEntityIds: ["not-a-uuid"] } }),
+      document(12, {
+        metadata: { directGrantEntityIds: [REQUESTER_ID, REQUESTER_ID] },
+      }),
     ];
     const validParent = document(2, {
       metadata: {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -234,6 +234,22 @@ function validDocumentAuthorizationMetadata(metadata: SQLWrapper): SQL {
       OR ${metadata}->>'addedBy' ~* ${DOCUMENT_UUID_PATTERN}
     )
     AND (
+      NOT (${metadata} ? 'directGrantEntityIds')
+      OR (
+        jsonb_typeof(${metadata}->'directGrantEntityIds') = 'array'
+        AND jsonb_array_length(${metadata}->'directGrantEntityIds') <= 1000
+        AND NOT EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements_text(${metadata}->'directGrantEntityIds') AS grant_id
+          WHERE grant_id !~* ${DOCUMENT_UUID_PATTERN}
+        )
+        AND jsonb_array_length(${metadata}->'directGrantEntityIds') = (
+          SELECT COUNT(DISTINCT grant_id)
+          FROM jsonb_array_elements_text(${metadata}->'directGrantEntityIds') AS grant_id
+        )
+      )
+    )
+    AND (
       ${metadata}->>'scope' <> 'user-private'
       OR ${metadata}->>'scopedToEntityId' ~* ${DOCUMENT_UUID_PATTERN}
     )
@@ -242,6 +258,40 @@ function validDocumentAuthorizationMetadata(metadata: SQLWrapper): SQL {
       NOT (${metadata} ? 'ingestionState')
       OR ${metadata}->>'ingestionState' = 'ready'
     )
+  )`;
+}
+
+function documentDirectGrantCondition(
+  params: DocumentListQueryParams | DocumentGetQueryParams | DocumentFragmentQueryParams,
+  metadata: SQLWrapper = memoryTable.metadata
+): SQL {
+  if (
+    params.requesterRole === "UNRESOLVED" ||
+    params.requesterRole === "GUEST" ||
+    documentRoleHasGlobalVisibility(params.requesterRole)
+  ) {
+    return sql`false`;
+  }
+  return sql`(
+    ${metadata}->>'scope' <> 'agent-private'
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements_text(
+        COALESCE(${metadata}->'directGrantEntityIds', '[]'::jsonb)
+      ) AS grant_id
+      WHERE grant_id = ${params.requesterEntityId}
+    )
+  )`;
+}
+
+function documentRoomOrDirectGrantCondition(
+  params: DocumentListQueryParams | DocumentGetQueryParams | DocumentFragmentQueryParams,
+  roomCondition: SQL,
+  metadata: SQLWrapper = memoryTable.metadata
+): SQL {
+  return sql`(
+    ${roomCondition}
+    OR ${documentDirectGrantCondition(params, metadata)}
   )`;
 }
 
@@ -259,7 +309,10 @@ function documentVisibilityCondition(
   if (params.requesterRole === "ADMIN") {
     return sql`(
       ${validAuthorizationMetadata}
-      AND ${metadata}->>'scope' IN ('global', 'user-private')
+      AND (
+        ${metadata}->>'scope' IN ('global', 'user-private')
+        OR ${documentDirectGrantCondition(params, metadata)}
+      )
     )`;
   }
   if (params.requesterRole === "GUEST") {
@@ -271,6 +324,8 @@ function documentVisibilityCondition(
   return sql`(
     ${validAuthorizationMetadata}
     AND (
+      ${documentDirectGrantCondition(params, metadata)}
+      OR
       ${metadata}->>'scope' = 'global'
       OR (
         ${metadata}->>'scope' = 'user-private'
@@ -1769,9 +1824,12 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       ];
       if (!hasGlobalVisibility) {
         visibleConditions.push(
-          params.requesterRoomIds.length > 0
-            ? inArray(memoryTable.roomId, params.requesterRoomIds)
-            : sql`false`
+          documentRoomOrDirectGrantCondition(
+            params,
+            params.requesterRoomIds.length > 0
+              ? inArray(memoryTable.roomId, params.requesterRoomIds)
+              : sql`false`
+          )
         );
       }
       visibleConditions.push(documentVisibilityCondition(params));
@@ -2118,9 +2176,12 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       ...(hasGlobalVisibility
         ? []
         : [
-            params.requesterRoomIds.length > 0
-              ? inArray(memoryTable.roomId, params.requesterRoomIds)
-              : sql`false`,
+            documentRoomOrDirectGrantCondition(
+              params,
+              params.requesterRoomIds.length > 0
+                ? inArray(memoryTable.roomId, params.requesterRoomIds)
+                : sql`false`
+            ),
           ]),
       documentVisibilityCondition(params),
     ];
@@ -2186,9 +2247,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       ];
       if (!hasGlobalVisibility) {
         conditions.push(
-          params.requesterRoomIds.length > 0
-            ? inArray(parent.roomId, params.requesterRoomIds)
-            : sql`false`
+          documentRoomOrDirectGrantCondition(
+            params,
+            params.requesterRoomIds.length > 0
+              ? inArray(parent.roomId, params.requesterRoomIds)
+              : sql`false`,
+            parent.metadata
+          )
         );
       }
       if (params.roomId) conditions.push(eq(parent.roomId, params.roomId));


### PR DESCRIPTION
Relates to #24246 and #24242.

## Outcome
- treats a parent document `roomId` as its single room entitlement evaluated against current membership inside adapter queries
- adds bounded, validated `directGrantEntityIds` as read-only access independent of room membership
- applies direct grants to list, lookup, and fragment queries before count, pagination, bytes, or ranking
- keeps GUEST and `agent-private` data closed; direct grants never confer mutation authority
- includes direct grants in mutation snapshots so concurrent ACL changes fence stale writes
- fails closed on malformed, oversized, or duplicate grant arrays with SQL/in-memory parity

This is the storage/query foundation. Owner/admin ACL mutation routes, confirmation-bound natural-language sharing, and Knowledge UI controls remain subsequent slices of #24246.

## Verification at head
- `bun test packages/core/src/database/document-list-query.test.ts` — 15 passed
- real migrated PGlite `document-list-query.real.test.ts -t 'direct grants|malformed parent'` — 2 passed
- `bun run --cwd packages/core typecheck` — passed
- `bun run --cwd packages/core build` — passed including packed consumer verification
- `bun run --cwd plugins/plugin-sql typecheck` — passed
- changed-file Biome and `git diff --check` — passed
- `bun run check:agents-claude` — 159 pairs passed

## Evidence
The real PGlite test writes an out-of-room owner-private parent plus fragment and proves SQL/in-memory parity for the directly granted USER. It proves the grant cannot open `agent-private` content, GUEST remains denied, fragment bytes are parent-authorized, and malformed/duplicate arrays are invisible even to privileged reads.

## Attribution
- Model: OpenAI / gpt-5.6-sol
- Tool: Codex Desktop / multi-agent
- Skill: N/A - no repository contribution skill used
