### PR TITLE
feat(test-mocks): add production registry upstream harness

### DIFF
--- a/packages/agent/src/services/plugin-installer.test.ts
+++ b/packages/agent/src/services/plugin-installer.test.ts
@@ -360,6 +360,27 @@ describe("package-manager lock provenance", () => {
     });
   });
 
+  it("extracts npm prefix-install provenance from an absolute package-lock key", () => {
+    expect(
+      extractNpmLockProvenance(
+        {
+          packages: {
+            "/tmp/install/node_modules/@vendor/canonical-plugin": {
+              version: "2.4.1",
+              resolved: "https://registry.example/canonical-plugin-2.4.1.tgz",
+              integrity: "sha512-YXBwcm92ZWQ=",
+            },
+          },
+        },
+        "@vendor/canonical-plugin",
+        "2.4.1",
+      ),
+    ).toEqual({
+      resolved: "https://registry.example/canonical-plugin-2.4.1.tgz",
+      integrity: "sha512-YXBwcm92ZWQ=",
+    });
+  });
+
   it("extracts Bun SRI without fabricating an unavailable tarball URL", () => {
     expect(
       extractBunLockProvenance(

--- a/packages/agent/src/services/plugin-installer.test.ts
+++ b/packages/agent/src/services/plugin-installer.test.ts
@@ -536,6 +536,107 @@ describe("installPlugin service-path artifacts", () => {
     },
   );
 
+  it.each(["partial failure", "timeout"] as const)(
+    "cleans Bun output before npm fallback after %s",
+    async (failureMode) => {
+      await useIsolatedState();
+      let npmSawCleanTarget = false;
+      execFileMock.mockImplementation(
+        (
+          command: string,
+          args: string[],
+          options: { cwd?: string } | ((error: Error | null) => void),
+          callback?: ExecCallback,
+        ) => {
+          const cb = typeof options === "function" ? options : callback;
+          const cwd = typeof options === "object" ? options.cwd : undefined;
+          if (command === "bun" && args?.[0] === "--version") {
+            completeExec(cb, null, "1.3.14\n");
+            return;
+          }
+          if (command === "bun" && args?.[0] === "add" && cwd) {
+            fsSync.writeFileSync(path.join(cwd, "bun-partial-output"), "bad");
+            fsSync.mkdirSync(path.join(cwd, "node_modules", "attacker"), {
+              recursive: true,
+            });
+            const error = new Error(
+              failureMode === "timeout" ? "install timed out" : "bun failed",
+            );
+            if (failureMode === "timeout") error.name = "TimeoutError";
+            completeExec(cb, error);
+            return;
+          }
+          if (command === "npm" && args?.[0] === "install") {
+            const prefixIndex = args.indexOf("--prefix");
+            const npmTarget =
+              cwd ?? (prefixIndex >= 0 ? args[prefixIndex + 1] : undefined);
+            if (!npmTarget) {
+              completeExec(cb, new Error("npm target missing"));
+              return;
+            }
+            const manifest = JSON.parse(
+              fsSync.readFileSync(path.join(npmTarget, "package.json"), "utf8"),
+            ) as { private?: boolean; dependencies?: Record<string, unknown> };
+            npmSawCleanTarget =
+              !fsSync.existsSync(path.join(npmTarget, "bun-partial-output")) &&
+              !fsSync.existsSync(path.join(npmTarget, "node_modules")) &&
+              manifest.private === true &&
+              Object.keys(manifest.dependencies ?? {}).length === 0;
+            installPackageArtifact(npmTarget, {
+              name: "@vendor/canonical-plugin",
+              version: "2.4.1",
+            });
+            completeExec(cb);
+            return;
+          }
+          completeExec(cb, new Error(`unexpected command: ${command}`));
+        },
+      );
+      vi.spyOn(registryClient, "getPluginInfo").mockResolvedValue(
+        registryInfo({ localPath: undefined }),
+      );
+
+      const result = await installPlugin("friendly-registry-alias");
+
+      expect(npmSawCleanTarget).toBe(true);
+      expect(result).toMatchObject({
+        success: true,
+        provenance: { source: "npm", packageManager: "npm" },
+      });
+    },
+  );
+
+  it("fails closed when a clean npm fallback target cannot be proven", async () => {
+    await useIsolatedState();
+    const commands: string[] = [];
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        options: { cwd?: string } | ((error: Error | null) => void),
+        callback?: ExecCallback,
+      ) => {
+        commands.push(command);
+        const cb = typeof options === "function" ? options : callback;
+        if (command === "bun" && args?.[0] === "--version") {
+          completeExec(cb, null, "1.3.14\n");
+          return;
+        }
+        completeExec(cb, new Error("bun left partial output"));
+      },
+    );
+    vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("cleanup denied"));
+    vi.spyOn(registryClient, "getPluginInfo").mockResolvedValue(
+      registryInfo({ localPath: undefined }),
+    );
+
+    const result = await installPlugin("friendly-registry-alias");
+
+    expect(result).toMatchObject({ success: false });
+    expect(result.error).toMatch(/refusing local or Git fallback/);
+    expect(commands).toEqual(["bun", "bun"]);
+  });
+
   it("records a local workspace install with its real source artifact", async () => {
     const stateDir = await useIsolatedState();
     const localSource = await fs.mkdtemp(

--- a/packages/agent/src/services/plugin-installer.ts
+++ b/packages/agent/src/services/plugin-installer.ts
@@ -132,6 +132,19 @@ export interface PluginInstallOptions {
   expected?: PluginInstallExpectation;
 }
 
+/**
+ * Instance-local boundaries used by Cloud synthetic worlds. Production callers
+ * omit this object and retain the canonical registry plus detected package
+ * manager; a custom package registry is restricted to HTTPS or literal
+ * loopback HTTP and is passed as an argument, never process-global npm config.
+ */
+export interface PluginInstallerRuntime {
+  getPluginInfo: typeof getPluginInfo;
+  packageRegistryUrl?: string;
+  packageManager?: "bun" | "npm";
+  packageManagerTimeoutMs?: number;
+}
+
 export type InstallProvenance =
   | {
       source: "local";
@@ -424,8 +437,23 @@ export function installPlugin(
   onProgress?: ProgressCallback,
   requestedVersionOrOptions?: string | PluginInstallOptions,
 ): Promise<InstallResult> {
+  return installPluginWithRuntime(
+    pluginName,
+    onProgress,
+    requestedVersionOrOptions,
+    { getPluginInfo },
+  );
+}
+
+/** Exercise the production installer with an isolated registry/runtime. */
+export function installPluginWithRuntime(
+  pluginName: string,
+  onProgress: ProgressCallback | undefined,
+  requestedVersionOrOptions: string | PluginInstallOptions | undefined,
+  runtime: PluginInstallerRuntime,
+): Promise<InstallResult> {
   return serialise(() =>
-    _installPlugin(pluginName, onProgress, requestedVersionOrOptions),
+    _installPlugin(pluginName, onProgress, requestedVersionOrOptions, runtime),
   );
 }
 
@@ -433,13 +461,14 @@ async function _installPlugin(
   pluginName: string,
   onProgress?: ProgressCallback,
   requestedVersionOrOptions?: string | PluginInstallOptions,
+  runtime: PluginInstallerRuntime = { getPluginInfo },
 ): Promise<InstallResult> {
   const emit = (phase: InstallPhase, message: string) =>
     onProgress?.({ phase, pluginName, message });
 
   emit("resolving", `Looking up ${pluginName} in registry...`);
 
-  const info = await getPluginInfo(pluginName);
+  const info = await runtime.getPluginInfo(pluginName);
   if (!info) {
     return {
       success: false,
@@ -454,8 +483,16 @@ async function _installPlugin(
   // Resolve and approval-check the canonical npm package before any install
   // directory is created or child process can execute.
   let plan: PluginInstallPlan;
+  let packageRegistryUrl: string | undefined;
+  let packageManagerTimeoutMs: number | undefined;
   try {
     plan = resolvePluginInstallPlan(info, requestedVersionOrOptions);
+    packageRegistryUrl = runtime.packageRegistryUrl
+      ? validatePackageRegistryUrl(runtime.packageRegistryUrl)
+      : undefined;
+    packageManagerTimeoutMs = validatePackageManagerTimeout(
+      runtime.packageManagerTimeoutMs,
+    );
   } catch (err) {
     // error-policy:J1 installPlugin translates validation failures into its
     // established structured result boundary.
@@ -495,7 +532,7 @@ async function _installPlugin(
   let installedVersion = npmVersion;
   let installSource: "npm" | "path" = "npm";
   let provenance: InstallProvenance | undefined;
-  const pm = await detectPackageManager();
+  const pm = runtime.packageManager ?? (await detectPackageManager());
   let installed = false;
 
   // Approval-bound installs intentionally use the exact npm package/version.
@@ -544,6 +581,8 @@ async function _installPlugin(
         canonicalName,
         npmVersion,
         targetDir,
+        packageRegistryUrl,
+        packageManagerTimeoutMs,
       );
       installedVersion = await readInstalledVersion(
         targetDir,
@@ -575,8 +614,13 @@ async function _installPlugin(
         `[plugin-installer] npm failed for ${canonicalName}: ${npmErr instanceof Error ? npmErr.message : String(npmErr)}`,
       );
       await cleanupInstallTarget(targetDir);
-      if (plan.approvalBound) {
-        const msg = `Approved npm install failed for ${canonicalName}@${npmVersion}; refusing local or Git fallback`;
+      if (
+        plan.approvalBound ||
+        packageRegistryUrl !== undefined ||
+        isIntegrityFailure(npmErr)
+      ) {
+        const authority = plan.approvalBound ? "Approved" : "Authoritative";
+        const msg = `${authority} npm install failed for ${canonicalName}@${npmVersion}; refusing local or Git fallback`;
         emit("error", msg);
         return {
           success: false,
@@ -801,11 +845,19 @@ async function runPackageInstall(
   packageName: string,
   version: string,
   targetDir: string,
+  packageRegistryUrl?: string,
+  timeoutMs?: number,
 ): Promise<"bun" | "npm"> {
   assertValidPackageName(packageName);
   assertValidVersion(version);
   const spec = `${packageName}@${version}`;
-  return installSpecWithFallback(pm, spec, targetDir);
+  return installSpecWithFallback(
+    pm,
+    spec,
+    targetDir,
+    packageRegistryUrl,
+    timeoutMs,
+  );
 }
 
 async function runLocalPathInstall(
@@ -826,16 +878,18 @@ async function installSpecWithFallback(
   pm: "bun" | "npm",
   spec: string,
   targetDir: string,
+  packageRegistryUrl?: string,
+  timeoutMs?: number,
 ): Promise<"bun" | "npm"> {
   try {
-    await runInstallSpec(pm, spec, targetDir);
+    await runInstallSpec(pm, spec, targetDir, packageRegistryUrl, timeoutMs);
     return pm;
   } catch (primaryErr) {
     if (pm === "npm") throw primaryErr;
     logger.warn(
       `[plugin-installer] ${pm} install failed for ${spec}; retrying with npm: ${primaryErr instanceof Error ? primaryErr.message : String(primaryErr)}`,
     );
-    await runInstallSpec("npm", spec, targetDir);
+    await runInstallSpec("npm", spec, targetDir, packageRegistryUrl, timeoutMs);
     return "npm";
   }
 }
@@ -844,7 +898,21 @@ async function runInstallSpec(
   pm: "bun" | "npm",
   spec: string,
   targetDir: string,
+  packageRegistryUrl?: string,
+  timeoutMs?: number,
 ): Promise<void> {
+  const registryArgs = packageRegistryUrl
+    ? ["--registry", validatePackageRegistryUrl(packageRegistryUrl)]
+    : [];
+  const isolatedRegistryArgs = packageRegistryUrl
+    ? [
+        "--prefer-online",
+        "--fetch-retries",
+        "0",
+        "--cache",
+        path.join(targetDir, ".npm-cache"),
+      ]
+    : [];
   // SECURITY: --ignore-scripts prevents npm postinstall/preinstall scripts
   // from executing arbitrary code on the host. Without this flag, any
   // package (including compromised registered plugins) can run shell
@@ -852,19 +920,86 @@ async function runInstallSpec(
   // backdoors, or exfiltrating credentials.
   switch (pm) {
     case "bun":
-      await execFileAsync("bun", ["add", "--ignore-scripts", spec], {
-        cwd: targetDir,
-      });
+      await execFileAsync(
+        "bun",
+        ["add", "--ignore-scripts", ...registryArgs, spec],
+        { cwd: targetDir, timeout: timeoutMs },
+      );
       break;
     default:
       await execFileAsync(
         "npm",
-        ["install", "--ignore-scripts", spec, "--prefix", targetDir],
+        [
+          "install",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          ...isolatedRegistryArgs,
+          ...registryArgs,
+          spec,
+          "--prefix",
+          targetDir,
+        ],
         // npm is a `.cmd` shim on Windows; Node can't spawn it without a shell.
         // `spec` is validated by assertValidPackageName/assertValidVersion.
-        { shell: process.platform === "win32" },
+        { shell: process.platform === "win32", timeout: timeoutMs },
       );
   }
+}
+
+function validatePackageManagerTimeout(
+  value: number | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || value < 1 || value > 300_000) {
+    throw new ElizaError(
+      "Package manager timeout must be an integer from 1 to 300000ms",
+      {
+        code: "PLUGIN_INSTALL_INVALID_TIMEOUT",
+        context: {},
+      },
+    );
+  }
+  return value;
+}
+
+function isIntegrityFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\bEINTEGRITY\b|integrity checksum failed/i.test(message);
+}
+
+function validatePackageRegistryUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch (cause) {
+    throw new ElizaError("Package registry URL must be absolute", {
+      code: "PLUGIN_INSTALL_INVALID_REGISTRY_URL",
+      context: {},
+      cause,
+    });
+  }
+  const loopback =
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1" ||
+    parsed.hostname === "[::1]";
+  if (
+    (parsed.protocol !== "https:" &&
+      !(parsed.protocol === "http:" && loopback)) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new ElizaError(
+      "Package registry URL must use HTTPS or literal loopback HTTP and contain no credentials, query, or fragment",
+      {
+        code: "PLUGIN_INSTALL_INVALID_REGISTRY_URL",
+        context: {},
+      },
+    );
+  }
+  return parsed.toString();
 }
 
 async function cleanupInstallTarget(targetDir: string): Promise<void> {
@@ -959,10 +1094,18 @@ export function extractNpmLockProvenance(
   const packageKey = `node_modules/${packageName}`;
   const packages = isRecord(lock.packages) ? lock.packages : null;
   const dependencies = isRecord(lock.dependencies) ? lock.dependencies : null;
+  const packageCandidates = packages
+    ? Object.entries(packages)
+        .filter(
+          ([key, value]) =>
+            isRecord(value) &&
+            (key === packageKey ||
+              key.replaceAll("\\", "/").endsWith(`/${packageKey}`)),
+        )
+        .map(([, value]) => value as Record<string, unknown>)
+    : [];
   const candidate =
-    (packages && isRecord(packages[packageKey])
-      ? packages[packageKey]
-      : null) ??
+    (packageCandidates.length === 1 ? packageCandidates[0] : null) ??
     (dependencies && isRecord(dependencies[packageName])
       ? dependencies[packageName]
       : null);

--- a/packages/agent/src/services/plugin-installer.ts
+++ b/packages/agent/src/services/plugin-installer.ts
@@ -617,7 +617,8 @@ async function _installPlugin(
       if (
         plan.approvalBound ||
         packageRegistryUrl !== undefined ||
-        isIntegrityFailure(npmErr)
+        isIntegrityFailure(npmErr) ||
+        isPackageManagerFallbackSafetyFailure(npmErr)
       ) {
         const authority = plan.approvalBound ? "Approved" : "Authoritative";
         const msg = `${authority} npm install failed for ${canonicalName}@${npmVersion}; refusing local or Git fallback`;
@@ -887,10 +888,47 @@ async function installSpecWithFallback(
   } catch (primaryErr) {
     if (pm === "npm") throw primaryErr;
     logger.warn(
-      `[plugin-installer] ${pm} install failed for ${spec}; retrying with npm: ${primaryErr instanceof Error ? primaryErr.message : String(primaryErr)}`,
+      `[plugin-installer] ${pm} install failed for ${spec}; cleaning the isolated target before retrying with npm: ${primaryErr instanceof Error ? primaryErr.message : String(primaryErr)}`,
     );
+    await resetInstallTargetForPackageManagerFallback(targetDir);
     await runInstallSpec("npm", spec, targetDir, packageRegistryUrl, timeoutMs);
     return "npm";
+  }
+}
+
+async function resetInstallTargetForPackageManagerFallback(
+  targetDir: string,
+): Promise<void> {
+  if (!isWithinPluginsDir(targetDir)) {
+    throw new ElizaError(
+      "Refusing package-manager fallback outside the plugin install directory",
+      {
+        code: "PLUGIN_INSTALL_FALLBACK_TARGET_UNSAFE",
+        context: { targetDir },
+        severity: "fatal",
+      },
+    );
+  }
+  try {
+    await fs.rm(targetDir, { recursive: true, force: true });
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(
+      path.join(targetDir, "package.json"),
+      JSON.stringify({ private: true, dependencies: {} }, null, 2),
+      { encoding: "utf8", flag: "wx" },
+    );
+  } catch (cause) {
+    // error-policy:J2 npm must never inherit partial Bun output; failure to
+    // prove a clean isolated target aborts the fallback with its cause.
+    throw new ElizaError(
+      "Could not establish a clean target for package-manager fallback",
+      {
+        code: "PLUGIN_INSTALL_FALLBACK_TARGET_NOT_CLEAN",
+        context: { targetDir },
+        cause,
+        severity: "fatal",
+      },
+    );
   }
 }
 
@@ -966,6 +1004,14 @@ function validatePackageManagerTimeout(
 function isIntegrityFailure(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /\bEINTEGRITY\b|integrity checksum failed/i.test(message);
+}
+
+function isPackageManagerFallbackSafetyFailure(error: unknown): boolean {
+  return (
+    error instanceof ElizaError &&
+    (error.code === "PLUGIN_INSTALL_FALLBACK_TARGET_UNSAFE" ||
+      error.code === "PLUGIN_INSTALL_FALLBACK_TARGET_NOT_CLEAN")
+  );
 }
 
 function validatePackageRegistryUrl(raw: string): string {

--- a/packages/agent/src/services/registry-client-network.ts
+++ b/packages/agent/src/services/registry-client-network.ts
@@ -3,12 +3,19 @@
  * absent generated document may fall back to the flat index; corrupt or failed
  * authoritative responses never become a healthy index result.
  */
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { isCloudReachable } from "@elizaos/shared";
 import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability.ts";
 import type { RegistryPluginInfo } from "./registry-client-types.ts";
 
 const DEFAULT_TIMEOUT_MS = 2_500;
+export const MAX_REGISTRY_JSON_BYTES = 16 * 1024 * 1024;
+export const MAX_REGISTRY_JSON_DEPTH = 32;
+export const MAX_REGISTRY_JSON_NODES = 100_000;
+export const MAX_REGISTRY_JSON_WIDTH = 10_000;
+export const MAX_REGISTRY_JSON_STRING_BYTES = 256 * 1024;
+const MAX_REGISTRY_HEADER_BYTES = 512;
+const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1_000;
 const PACKAGE_NAME = /^(?:@[a-zA-Z0-9][\w.-]*\/)?[a-zA-Z0-9][\w.-]*$/;
 const GITHUB_REPOSITORY = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
@@ -29,14 +36,16 @@ export class RegistryUpstreamError extends ElizaError {
     options: {
       status?: number;
       retryAfterMs?: number | null;
+      code?: string;
       cause?: unknown;
     } = {},
   ) {
     super(message, {
       code:
-        options.status === undefined
+        options.code ??
+        (options.status === undefined
           ? "REGISTRY_UPSTREAM_PROTOCOL_FAILED"
-          : "REGISTRY_UPSTREAM_HTTP_FAILED",
+          : "REGISTRY_UPSTREAM_HTTP_FAILED"),
       context: {
         status: options.status ?? null,
         retryAfterMs: options.retryAfterMs ?? null,
@@ -196,13 +205,16 @@ function init(params: FetchFromNetworkParams, sourceUrl: string): RequestInit {
   if (params.cacheValidator?.sourceUrl === sourceUrl) {
     headers.set("if-none-match", params.cacheValidator.etag);
   }
-  return { headers, redirect: "error", signal: signal(params) };
+  // `manual` prevents following redirects while still allowing a standards-
+  // compliant 304 response through Bun's fetch implementation. Actual 3xx
+  // redirects are rejected below as HTTP protocol failures.
+  return { headers, redirect: "manual", signal: signal(params) };
 }
 
 function etag(response: Response): string | null {
   const value = response.headers.get("etag");
   if (!value) return null;
-  if (value.length > 512 || /[\r\n]/.test(value)) {
+  if (value.length > MAX_REGISTRY_HEADER_BYTES || /[\r\n]/.test(value)) {
     throw new RegistryUpstreamError("Registry ETag is malformed");
   }
   return value;
@@ -211,17 +223,220 @@ function etag(response: Response): string | null {
 function retryAfterMs(response: Response, now: () => number): number | null {
   const value = response.headers.get("retry-after");
   if (!value) return null;
-  if (/^\d+$/.test(value)) return Number(value) * 1_000;
+  if (value.length > 128 || /[\r\n]/.test(value)) return null;
+  if (/^\d{1,10}$/.test(value)) {
+    const seconds = Number(value);
+    return Number.isSafeInteger(seconds)
+      ? Math.min(seconds * 1_000, MAX_RETRY_AFTER_MS)
+      : null;
+  }
   const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? Math.max(0, timestamp - now()) : null;
+  return Number.isFinite(timestamp)
+    ? Math.min(Math.max(0, timestamp - now()), MAX_RETRY_AFTER_MS)
+    : null;
 }
 
-async function overlays(
-  plugins: Map<string, RegistryPluginInfo>,
-  params: FetchFromNetworkParams,
-): Promise<void> {
-  await params.applyLocalWorkspaceApps(plugins);
-  await params.applyNodeModulePlugins(plugins);
+function cancelBody(response: Response, reason: string): void {
+  if (!response.body) return;
+  // error-policy:J6 rejecting the response is authoritative; stream teardown
+  // is observed but must not delay the typed boundary failure.
+  void response.body.cancel(reason).catch((error) => {
+    logger.debug(
+      `[registry-client] Response cancellation failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}
+
+function protocolFailure(
+  message: string,
+  code: string,
+  cause?: unknown,
+): RegistryUpstreamError {
+  return new RegistryUpstreamError(message, { code, cause });
+}
+
+export function validateRegistryJsonShape(root: unknown): void {
+  const encoder = new TextEncoder();
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: root, depth: 0 },
+  ];
+  let nodes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    nodes += 1;
+    if (nodes > MAX_REGISTRY_JSON_NODES) {
+      throw protocolFailure(
+        "Registry JSON exceeds the node limit",
+        "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+      );
+    }
+    if (current.depth > MAX_REGISTRY_JSON_DEPTH) {
+      throw protocolFailure(
+        "Registry JSON exceeds the depth limit",
+        "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+      );
+    }
+    if (typeof current.value === "string") {
+      if (
+        encoder.encode(current.value).byteLength >
+        MAX_REGISTRY_JSON_STRING_BYTES
+      ) {
+        throw protocolFailure(
+          "Registry JSON exceeds the string limit",
+          "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+        );
+      }
+      continue;
+    }
+    if (Array.isArray(current.value)) {
+      if (current.value.length > MAX_REGISTRY_JSON_WIDTH) {
+        throw protocolFailure(
+          "Registry JSON exceeds the array width limit",
+          "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+        );
+      }
+      for (const value of current.value) {
+        pending.push({ value, depth: current.depth + 1 });
+      }
+      continue;
+    }
+    if (isRecord(current.value)) {
+      const entries = Object.entries(current.value);
+      if (entries.length > MAX_REGISTRY_JSON_WIDTH) {
+        throw protocolFailure(
+          "Registry JSON exceeds the object width limit",
+          "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+        );
+      }
+      for (const [key, value] of entries) {
+        if (encoder.encode(key).byteLength > MAX_REGISTRY_JSON_STRING_BYTES) {
+          throw protocolFailure(
+            "Registry JSON exceeds the key limit",
+            "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+          );
+        }
+        pending.push({ value, depth: current.depth + 1 });
+      }
+    }
+  }
+}
+
+async function readRegistryJson(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type");
+  if (
+    !contentType ||
+    contentType.length > MAX_REGISTRY_HEADER_BYTES ||
+    !/^(?:application\/json|[^;\s]+\/[^;\s]+\+json)(?:\s*;|$)/i.test(
+      contentType,
+    )
+  ) {
+    cancelBody(response, "registry content type rejected");
+    throw protocolFailure(
+      "Registry response must use a JSON content type",
+      "REGISTRY_UPSTREAM_CONTENT_TYPE_INVALID",
+    );
+  }
+  const contentEncoding = response.headers.get("content-encoding");
+  if (
+    contentEncoding &&
+    (contentEncoding.length > MAX_REGISTRY_HEADER_BYTES ||
+      contentEncoding.trim().toLowerCase() !== "identity")
+  ) {
+    cancelBody(response, "registry content encoding rejected");
+    throw protocolFailure(
+      "Registry response content encoding is unsupported",
+      "REGISTRY_UPSTREAM_CONTENT_ENCODING_UNSUPPORTED",
+    );
+  }
+  const declared = response.headers.get("content-length");
+  if (declared !== null) {
+    if (!/^\d{1,16}$/.test(declared)) {
+      cancelBody(response, "registry content length rejected");
+      throw protocolFailure(
+        "Registry response Content-Length is malformed",
+        "REGISTRY_UPSTREAM_BODY_TOO_LARGE",
+      );
+    }
+    const declaredBytes = Number(declared);
+    if (
+      !Number.isSafeInteger(declaredBytes) ||
+      declaredBytes > MAX_REGISTRY_JSON_BYTES
+    ) {
+      cancelBody(response, "registry declared body exceeds limit");
+      throw protocolFailure(
+        "Registry response exceeds the body limit",
+        "REGISTRY_UPSTREAM_BODY_TOO_LARGE",
+      );
+    }
+  }
+  if (!response.body) {
+    throw protocolFailure(
+      "Registry response body is missing",
+      "REGISTRY_UPSTREAM_JSON_INVALID",
+    );
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      total += chunk.value.byteLength;
+      if (total > MAX_REGISTRY_JSON_BYTES) {
+        // error-policy:J6 the limit failure is authoritative; cancellation is
+        // teardown and is intentionally not awaited.
+        void reader
+          .cancel("registry streamed body exceeds limit")
+          .catch(() => undefined);
+        throw protocolFailure(
+          "Registry response exceeds the body limit",
+          "REGISTRY_UPSTREAM_BODY_TOO_LARGE",
+        );
+      }
+      chunks.push(chunk.value);
+    }
+  } catch (cause) {
+    if (cause instanceof RegistryUpstreamError) throw cause;
+    // error-policy:J6 the read failure is already authoritative.
+    void reader.cancel("registry response read failed").catch(() => undefined);
+    throw protocolFailure(
+      "Registry response body could not be read",
+      "REGISTRY_UPSTREAM_BODY_READ_FAILED",
+      cause,
+    );
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch (cause) {
+    throw protocolFailure(
+      "Registry response is not valid UTF-8",
+      "REGISTRY_UPSTREAM_UTF8_INVALID",
+      cause,
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch (cause) {
+    throw protocolFailure(
+      "Registry response contains malformed JSON",
+      "REGISTRY_UPSTREAM_JSON_INVALID",
+      cause,
+    );
+  }
+  validateRegistryJsonShape(value);
+  return value;
 }
 
 function cached(
@@ -443,8 +658,12 @@ async function requestJson(
       cause,
     });
   }
-  if (allowNotFound && response.status === 404) return null;
+  if (allowNotFound && response.status === 404) {
+    cancelBody(response, "generated registry absent");
+    return null;
+  }
   if (response.status !== 304 && !response.ok) {
+    cancelBody(response, "registry HTTP response rejected");
     span.failure({ statusCode: response.status, errorKind: "http_error" });
     throw new RegistryUpstreamError(
       `${operation} failed with HTTP ${response.status}`,
@@ -470,26 +689,14 @@ async function generated(
   );
   if (!response) return null;
   if (response.status === 304) {
-    const snapshot = cached(params, sourceUrl, response);
-    await overlays(snapshot.plugins, params);
-    return snapshot;
+    return cached(params, sourceUrl, response);
   }
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (cause) {
-    // error-policy:J2 retain the JSON parser cause in the typed upstream failure.
-    throw new RegistryUpstreamError(
-      "Generated registry returned malformed JSON",
-      { cause },
-    );
-  }
+  const body = await readRegistryJson(response);
   const registry = record(record(body, "root").registry, "registry");
   const plugins = new Map<string, RegistryPluginInfo>();
   for (const [name, entry] of Object.entries(registry)) {
     plugins.set(name, parseEntry(name, entry, params.sanitizeSandbox));
   }
-  await overlays(plugins, params);
   return { sourceUrl, etag: etag(response), plugins, notModified: false };
 }
 
@@ -506,19 +713,9 @@ async function index(
   if (!response)
     throw new RegistryUpstreamError("Index registry unexpectedly absent");
   if (response.status === 304) {
-    const snapshot = cached(params, sourceUrl, response);
-    await overlays(snapshot.plugins, params);
-    return snapshot;
+    return cached(params, sourceUrl, response);
   }
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (cause) {
-    // error-policy:J2 retain the JSON parser cause in the typed upstream failure.
-    throw new RegistryUpstreamError("Index registry returned malformed JSON", {
-      cause,
-    });
-  }
+  const body = await readRegistryJson(response);
   const plugins = new Map<string, RegistryPluginInfo>();
   for (const [name, rawRef] of Object.entries(record(body, "index"))) {
     if (!PACKAGE_NAME.test(name))
@@ -548,7 +745,6 @@ async function index(
       thirdParty: !builtIn,
     });
   }
-  await overlays(plugins, params);
   return { sourceUrl, etag: etag(response), plugins, notModified: false };
 }
 

--- a/packages/agent/src/services/registry-client-network.ts
+++ b/packages/agent/src/services/registry-client-network.ts
@@ -236,15 +236,21 @@ function retryAfterMs(response: Response, now: () => number): number | null {
     : null;
 }
 
-function cancelBody(response: Response, reason: string): void {
-  if (!response.body) return;
+function observeCancellation(
+  target: { cancel(reason?: unknown): Promise<void> },
+  reason: string,
+): void {
   // error-policy:J6 rejecting the response is authoritative; stream teardown
-  // is observed but must not delay the typed boundary failure.
-  void response.body.cancel(reason).catch((error) => {
+  // failure is explicitly observed at debug level without replacing it.
+  void target.cancel(reason).catch((error) => {
     logger.debug(
       `[registry-client] Response cancellation failed: ${error instanceof Error ? error.message : String(error)}`,
     );
   });
+}
+
+function cancelBody(response: Response, reason: string): void {
+  if (response.body) observeCancellation(response.body, reason);
 }
 
 function protocolFailure(
@@ -385,11 +391,7 @@ async function readRegistryJson(response: Response): Promise<unknown> {
       if (chunk.done) break;
       total += chunk.value.byteLength;
       if (total > MAX_REGISTRY_JSON_BYTES) {
-        // error-policy:J6 the limit failure is authoritative; cancellation is
-        // teardown and is intentionally not awaited.
-        void reader
-          .cancel("registry streamed body exceeds limit")
-          .catch(() => undefined);
+        observeCancellation(reader, "registry streamed body exceeds limit");
         throw protocolFailure(
           "Registry response exceeds the body limit",
           "REGISTRY_UPSTREAM_BODY_TOO_LARGE",
@@ -399,8 +401,7 @@ async function readRegistryJson(response: Response): Promise<unknown> {
     }
   } catch (cause) {
     if (cause instanceof RegistryUpstreamError) throw cause;
-    // error-policy:J6 the read failure is already authoritative.
-    void reader.cancel("registry response read failed").catch(() => undefined);
+    observeCancellation(reader, "registry response read failed");
     throw protocolFailure(
       "Registry response body could not be read",
       "REGISTRY_UPSTREAM_BODY_READ_FAILED",

--- a/packages/agent/src/services/registry-client-network.ts
+++ b/packages/agent/src/services/registry-client-network.ts
@@ -1,27 +1,51 @@
 /**
- * Network-fetch layer for the plugin/app marketplace registry. Loads the
- * registry from the cloud over HTTP, preferring the richer generated registry
- * over the flat index registry, and normalizes each entry into a
- * `RegistryPluginInfo` map (including app metadata). Both fetches race under a
- * single short timeout and are gated by a cloud-reachability probe; any network
- * absence, 404, or timeout is treated as an expected fallback
- * (`RegistryNetworkFallbackError`) so the caller can fall back to a local
- * snapshot. Every attempt runs inside a marketplace telemetry span, and callers
- * supply the local-workspace / node-module overlay hooks that merge on-disk
- * plugins into the result.
+ * Resolves marketplace metadata through the production HTTP protocol. Only an
+ * absent generated document may fall back to the flat index; corrupt or failed
+ * authoritative responses never become a healthy index result.
  */
+import { ElizaError } from "@elizaos/core";
 import { isCloudReachable } from "@elizaos/shared";
 import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability.ts";
 import type { RegistryPluginInfo } from "./registry-client-types.ts";
 
-const REGISTRY_FETCH_TIMEOUT_MS = 2_500;
+const DEFAULT_TIMEOUT_MS = 2_500;
+const PACKAGE_NAME = /^(?:@[a-zA-Z0-9][\w.-]*\/)?[a-zA-Z0-9][\w.-]*$/;
+const GITHUB_REPOSITORY = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
 export class RegistryNetworkFallbackError extends Error {
   readonly expectedLocalFallback = true;
-
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "RegistryNetworkFallbackError";
+  }
+}
+
+export class RegistryUpstreamError extends ElizaError {
+  override readonly name = "RegistryUpstreamError";
+  readonly status: number | null;
+  readonly retryAfterMs: number | null;
+  constructor(
+    message: string,
+    options: {
+      status?: number;
+      retryAfterMs?: number | null;
+      cause?: unknown;
+    } = {},
+  ) {
+    super(message, {
+      code:
+        options.status === undefined
+          ? "REGISTRY_UPSTREAM_PROTOCOL_FAILED"
+          : "REGISTRY_UPSTREAM_HTTP_FAILED",
+      context: {
+        status: options.status ?? null,
+        retryAfterMs: options.retryAfterMs ?? null,
+      },
+      cause: options.cause,
+      severity: options.status === 429 ? "ephemeral" : "fatal",
+    });
+    this.status = options.status ?? null;
+    this.retryAfterMs = options.retryAfterMs ?? null;
   }
 }
 
@@ -43,18 +67,25 @@ export function isExpectedRegistryNetworkFallback(
   );
 }
 
-function isExpectedRegistryNotFound(resp: Response): boolean {
-  return resp.status === 404;
+export interface RegistryNetworkCacheValidator {
+  sourceUrl: string;
+  etag: string;
+  plugins: Map<string, RegistryPluginInfo>;
 }
 
-function createRegistryFetchInit(): RequestInit {
-  return {
-    redirect: "error",
-    signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
-  };
+export interface RegistryNetworkSnapshot {
+  sourceUrl: string;
+  etag: string | null;
+  plugins: Map<string, RegistryPluginInfo>;
+  notModified: boolean;
 }
 
-interface FetchFromNetworkParams {
+export type RegistryFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface FetchFromNetworkParams {
   generatedRegistryUrl: string;
   indexRegistryUrl: string;
   applyLocalWorkspaceApps: (
@@ -64,229 +95,438 @@ interface FetchFromNetworkParams {
     plugins: Map<string, RegistryPluginInfo>,
   ) => Promise<void>;
   sanitizeSandbox: (value?: string) => string;
+  fetchImpl?: RegistryFetch;
+  cloudReachable?: () => Promise<boolean>;
+  timeoutMs?: number;
+  now?: () => number;
+  signal?: AbortSignal;
+  cacheValidator?: RegistryNetworkCacheValidator | null;
 }
 
-/**
- * Fetch + parse the generated registry. Returns the parsed plugin map on a
- * 200, or `null` when the endpoint is absent (404) or the request fails — in
- * which case the caller falls through to the index registry.
- */
-async function fetchGeneratedRegistry(
-  params: FetchFromNetworkParams,
-): Promise<Map<string, RegistryPluginInfo> | null> {
-  const {
-    generatedRegistryUrl,
-    applyLocalWorkspaceApps,
-    applyNodeModulePlugins,
-    sanitizeSandbox,
-  } = params;
+type JsonRecord = Record<string, unknown>;
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
-  const generatedSpan = createIntegrationTelemetrySpan({
-    boundary: "marketplace",
-    operation: "fetch_generated_registry",
-    timeoutMs: REGISTRY_FETCH_TIMEOUT_MS,
-  });
-  try {
-    const resp = await fetch(generatedRegistryUrl, createRegistryFetchInit());
-    if (resp.ok) {
-      const data = (await resp.json()) as {
-        registry: Record<
-          string,
-          {
-            git: {
-              repo: string;
-              v0: { branch: string | null };
-              v1: { branch: string | null };
-              v2: { branch: string | null };
-            };
-            npm: {
-              repo: string;
-              v0: string | null;
-              v1: string | null;
-              v2: string | null;
-            };
-            supports: { v0: boolean; v1: boolean; v2: boolean };
-            description: string;
-            homepage: string | null;
-            topics: string[];
-            stargazers_count: number;
-            language: string;
-            origin?: string;
-            source?: string;
-            support?: string;
-            builtIn?: boolean;
-            firstParty?: boolean;
-            thirdParty?: boolean;
-            status?: string;
-            kind?: string;
-            registryKind?: string;
-            directory?: string | null;
-            app?: {
-              displayName: string;
-              category: string;
-              launchType: string;
-              launchUrl: string | null;
-              icon: string | null;
-              heroImage?: string | null;
-              capabilities: string[];
-              minPlayers: number | null;
-              maxPlayers: number | null;
-              runtimePlugin?: string;
-              bridgeExport?: string;
-              uiExtension?: {
-                detailPanelId: string;
-              };
-              viewer?: {
-                url: string;
-                embedParams?: Record<string, string>;
-                postMessageAuth?: boolean;
-                sandbox?: string;
-              };
-              session?: {
-                mode: "viewer" | "spectate-and-steer" | "external";
-                features?: Array<
-                  "commands" | "telemetry" | "pause" | "resume" | "suggestions"
-                >;
-              };
-              developerOnly?: boolean;
-              visibleInAppStore?: boolean;
-              mainTab?: boolean;
-              catalogSection?: string;
-              featured?: boolean;
-              defaultHidden?: boolean;
-              scope?: string;
-            };
-          }
-        >;
-      };
-      const plugins = new Map<string, RegistryPluginInfo>();
-      for (const [name, e] of Object.entries(data.registry)) {
-        const info: RegistryPluginInfo = {
-          name,
-          gitRepo: e.git.repo,
-          gitUrl: `https://github.com/${e.git.repo}.git`,
-          directory: e.directory ?? null,
-          description: e.description || "",
-          homepage: e.homepage,
-          topics: e.topics || [],
-          stars: e.stargazers_count || 0,
-          language: e.language || "TypeScript",
-          npm: {
-            package: e.npm.repo,
-            v0Version: e.npm.v0,
-            v1Version: e.npm.v1,
-            v2Version: e.npm.v2,
-          },
-          git: {
-            v0Branch: e.git.v0.branch ?? null,
-            v1Branch: e.git.v1.branch ?? null,
-            v2Branch: e.git.v2.branch ?? null,
-          },
-          supports: e.supports,
-          origin: e.origin,
-          source: e.source,
-          support: e.support,
-          builtIn: e.builtIn,
-          firstParty: e.firstParty,
-          thirdParty: e.thirdParty,
-          status: e.status,
-          registryKind: e.registryKind,
-        };
-
-        if (e.kind) {
-          info.kind = e.kind;
-        }
-        if (e.kind === "app" || e.app) {
-          info.kind = "app";
-        }
-        if (e.app) {
-          info.appMeta = {
-            displayName: e.app.displayName,
-            category: e.app.category,
-            launchType: e.app.launchType,
-            launchUrl: e.app.launchUrl,
-            icon: e.app.icon,
-            heroImage: e.app.heroImage ?? null,
-            capabilities: e.app.capabilities || [],
-            minPlayers: e.app.minPlayers ?? null,
-            maxPlayers: e.app.maxPlayers ?? null,
-            runtimePlugin: e.app.runtimePlugin,
-            bridgeExport: e.app.bridgeExport,
-            uiExtension: e.app.uiExtension,
-            viewer: e.app.viewer
-              ? {
-                  ...e.app.viewer,
-                  sandbox: sanitizeSandbox(e.app.viewer.sandbox),
-                }
-              : undefined,
-            session: e.app.session,
-            developerOnly: e.app.developerOnly,
-            visibleInAppStore: e.app.visibleInAppStore,
-            mainTab: e.app.mainTab,
-            catalogSection: e.app.catalogSection,
-            featured: e.app.featured,
-            defaultHidden: e.app.defaultHidden,
-            scope: e.app.scope,
-          };
-        }
-
-        plugins.set(name, info);
-      }
-      await applyLocalWorkspaceApps(plugins);
-      await applyNodeModulePlugins(plugins);
-      generatedSpan.success({ statusCode: resp.status });
-      return plugins;
-    }
-    if (!isExpectedRegistryNotFound(resp)) {
-      generatedSpan.failure({
-        statusCode: resp.status,
-        errorKind: "http_error",
-      });
-    }
-    return null;
-  } catch (err) {
-    generatedSpan.failure({ error: err });
-    // caller logs fallback warnings
-    return null;
+function record(value: unknown, field: string): JsonRecord {
+  if (!isRecord(value))
+    throw new RegistryUpstreamError(`${field} must be an object`);
+  return value;
+}
+function string(value: unknown, field: string): string {
+  if (typeof value !== "string")
+    throw new RegistryUpstreamError(`${field} must be a string`);
+  return value;
+}
+function nullableString(value: unknown, field: string): string | null {
+  return value === null ? null : string(value, field);
+}
+function optionalString(value: unknown, field: string): string | undefined {
+  return value === undefined ? undefined : string(value, field);
+}
+function boolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean")
+    throw new RegistryUpstreamError(`${field} must be boolean`);
+  return value;
+}
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+  return value === undefined ? undefined : boolean(value, field);
+}
+function strings(value: unknown, field: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    throw new RegistryUpstreamError(`${field} must be a string array`);
   }
+  return value;
+}
+function number(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new RegistryUpstreamError(`${field} must be finite`);
+  }
+  return value;
+}
+function nullableNumber(value: unknown, field: string): number | null {
+  return value === null ? null : number(value, field);
 }
 
-/**
- * Fetch + parse the index registry. Throws `RegistryNetworkFallbackError` (or
- * the raw network error) when it cannot be loaded, signalling the caller to
- * use the local snapshot.
- */
-async function fetchIndexRegistry(
-  params: FetchFromNetworkParams,
-): Promise<Map<string, RegistryPluginInfo>> {
-  const { indexRegistryUrl, applyLocalWorkspaceApps, applyNodeModulePlugins } =
-    params;
-
-  const indexSpan = createIntegrationTelemetrySpan({
-    boundary: "marketplace",
-    operation: "fetch_index_registry",
-    timeoutMs: REGISTRY_FETCH_TIMEOUT_MS,
-  });
-  let resp: Response;
+function validateUrl(raw: string, field: string): string {
+  let parsed: URL;
   try {
-    resp = await fetch(indexRegistryUrl, createRegistryFetchInit());
-  } catch (err) {
-    indexSpan.failure({ error: err });
-    throw err;
+    parsed = new URL(raw);
+  } catch (cause) {
+    // error-policy:J2 preserve the parser cause in the typed boundary error.
+    throw new RegistryUpstreamError(`${field} must be an absolute URL`, {
+      cause,
+    });
   }
-  if (!resp.ok) {
-    if (!isExpectedRegistryNotFound(resp)) {
-      indexSpan.failure({ statusCode: resp.status, errorKind: "http_error" });
-    }
-    throw new RegistryNetworkFallbackError(
-      `index.json: ${resp.status} ${resp.statusText}`,
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new RegistryUpstreamError(
+      `${field} must not contain credentials, query, or fragment`,
     );
   }
-  const data = (await resp.json()) as Record<string, string>;
+  const loopback =
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1" ||
+    parsed.hostname === "[::1]";
+  if (
+    parsed.protocol !== "https:" &&
+    !(parsed.protocol === "http:" && loopback)
+  ) {
+    throw new RegistryUpstreamError(
+      `${field} must use HTTPS or literal loopback HTTP`,
+    );
+  }
+  return parsed.toString();
+}
+
+function signal(params: FetchFromNetworkParams): AbortSignal {
+  const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60_000) {
+    throw new RegistryUpstreamError(
+      "Registry timeout must be an integer from 1 to 60000ms",
+    );
+  }
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return params.signal ? AbortSignal.any([params.signal, timeout]) : timeout;
+}
+
+function init(params: FetchFromNetworkParams, sourceUrl: string): RequestInit {
+  const headers = new Headers({ accept: "application/json" });
+  if (params.cacheValidator?.sourceUrl === sourceUrl) {
+    headers.set("if-none-match", params.cacheValidator.etag);
+  }
+  return { headers, redirect: "error", signal: signal(params) };
+}
+
+function etag(response: Response): string | null {
+  const value = response.headers.get("etag");
+  if (!value) return null;
+  if (value.length > 512 || /[\r\n]/.test(value)) {
+    throw new RegistryUpstreamError("Registry ETag is malformed");
+  }
+  return value;
+}
+
+function retryAfterMs(response: Response, now: () => number): number | null {
+  const value = response.headers.get("retry-after");
+  if (!value) return null;
+  if (/^\d+$/.test(value)) return Number(value) * 1_000;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? Math.max(0, timestamp - now()) : null;
+}
+
+async function overlays(
+  plugins: Map<string, RegistryPluginInfo>,
+  params: FetchFromNetworkParams,
+): Promise<void> {
+  await params.applyLocalWorkspaceApps(plugins);
+  await params.applyNodeModulePlugins(plugins);
+}
+
+function cached(
+  params: FetchFromNetworkParams,
+  sourceUrl: string,
+  response: Response,
+): RegistryNetworkSnapshot {
+  const validator = params.cacheValidator;
+  if (!validator || validator.sourceUrl !== sourceUrl) {
+    throw new RegistryUpstreamError(
+      "Registry returned 304 without a matching cache",
+      {
+        status: response.status,
+      },
+    );
+  }
+  return {
+    sourceUrl,
+    etag: etag(response) ?? validator.etag,
+    plugins: new Map(validator.plugins),
+    notModified: true,
+  };
+}
+
+function parseEntry(
+  name: string,
+  raw: unknown,
+  sanitizeSandbox: (value?: string) => string,
+): RegistryPluginInfo {
+  if (!PACKAGE_NAME.test(name))
+    throw new RegistryUpstreamError(`Invalid package ${name}`);
+  const entry = record(raw, name);
+  const git = record(entry.git, `${name}.git`);
+  const npm = record(entry.npm, `${name}.npm`);
+  const supports = record(entry.supports, `${name}.supports`);
+  const repo = string(git.repo, `${name}.git.repo`);
+  const npmPackage = string(npm.repo, `${name}.npm.repo`);
+  if (!GITHUB_REPOSITORY.test(repo) || !PACKAGE_NAME.test(npmPackage)) {
+    throw new RegistryUpstreamError(`Invalid registry identity for ${name}`);
+  }
+  const branch = (key: "v0" | "v1" | "v2") =>
+    nullableString(
+      record(git[key], `${name}.git.${key}`).branch,
+      `${name}.git.${key}.branch`,
+    );
+  const version = (key: "v0" | "v1" | "v2") =>
+    nullableString(npm[key], `${name}.npm.${key}`);
+  const info: RegistryPluginInfo = {
+    name,
+    gitRepo: repo,
+    gitUrl: `https://github.com/${repo}.git`,
+    directory:
+      entry.directory === undefined
+        ? null
+        : nullableString(entry.directory, `${name}.directory`),
+    description: string(entry.description, `${name}.description`),
+    homepage: nullableString(entry.homepage, `${name}.homepage`),
+    topics: strings(entry.topics, `${name}.topics`),
+    stars: number(entry.stargazers_count, `${name}.stargazers_count`),
+    language: string(entry.language, `${name}.language`),
+    npm: {
+      package: npmPackage,
+      v0Version: version("v0"),
+      v1Version: version("v1"),
+      v2Version: version("v2"),
+    },
+    git: {
+      v0Branch: branch("v0"),
+      v1Branch: branch("v1"),
+      v2Branch: branch("v2"),
+    },
+    supports: {
+      v0: boolean(supports.v0, `${name}.supports.v0`),
+      v1: boolean(supports.v1, `${name}.supports.v1`),
+      v2: boolean(supports.v2, `${name}.supports.v2`),
+    },
+    origin: optionalString(entry.origin, `${name}.origin`),
+    source: optionalString(entry.source, `${name}.source`),
+    support: optionalString(entry.support, `${name}.support`),
+    builtIn: optionalBoolean(entry.builtIn, `${name}.builtIn`),
+    firstParty: optionalBoolean(entry.firstParty, `${name}.firstParty`),
+    thirdParty: optionalBoolean(entry.thirdParty, `${name}.thirdParty`),
+    status: optionalString(entry.status, `${name}.status`),
+    registryKind: optionalString(entry.registryKind, `${name}.registryKind`),
+  };
+  const kind = optionalString(entry.kind, `${name}.kind`);
+  if (kind) info.kind = kind;
+  if (entry.app !== undefined) {
+    const app = record(entry.app, `${name}.app`);
+    info.kind = "app";
+    info.appMeta = {
+      displayName: string(app.displayName, `${name}.app.displayName`),
+      category: string(app.category, `${name}.app.category`),
+      launchType: string(app.launchType, `${name}.app.launchType`),
+      launchUrl: nullableString(app.launchUrl, `${name}.app.launchUrl`),
+      icon: nullableString(app.icon, `${name}.app.icon`),
+      heroImage:
+        app.heroImage === undefined
+          ? null
+          : nullableString(app.heroImage, `${name}.app.heroImage`),
+      capabilities: strings(app.capabilities, `${name}.app.capabilities`),
+      minPlayers: nullableNumber(app.minPlayers, `${name}.app.minPlayers`),
+      maxPlayers: nullableNumber(app.maxPlayers, `${name}.app.maxPlayers`),
+      runtimePlugin: optionalString(
+        app.runtimePlugin,
+        `${name}.app.runtimePlugin`,
+      ),
+      bridgeExport: optionalString(
+        app.bridgeExport,
+        `${name}.app.bridgeExport`,
+      ),
+      developerOnly: optionalBoolean(
+        app.developerOnly,
+        `${name}.app.developerOnly`,
+      ),
+      visibleInAppStore: optionalBoolean(
+        app.visibleInAppStore,
+        `${name}.app.visibleInAppStore`,
+      ),
+      mainTab: optionalBoolean(app.mainTab, `${name}.app.mainTab`),
+      catalogSection: optionalString(
+        app.catalogSection,
+        `${name}.app.catalogSection`,
+      ),
+      featured: optionalBoolean(app.featured, `${name}.app.featured`),
+      defaultHidden: optionalBoolean(
+        app.defaultHidden,
+        `${name}.app.defaultHidden`,
+      ),
+      scope: optionalString(app.scope, `${name}.app.scope`),
+    };
+    if (app.uiExtension !== undefined) {
+      const uiExtension = record(app.uiExtension, `${name}.app.uiExtension`);
+      info.appMeta.uiExtension = {
+        detailPanelId: string(
+          uiExtension.detailPanelId,
+          `${name}.app.uiExtension.detailPanelId`,
+        ),
+      };
+    }
+    if (app.session !== undefined) {
+      const session = record(app.session, `${name}.app.session`);
+      const mode = string(session.mode, `${name}.app.session.mode`);
+      if (!new Set(["viewer", "spectate-and-steer", "external"]).has(mode)) {
+        throw new RegistryUpstreamError(`${name}.app.session.mode is invalid`);
+      }
+      const features =
+        session.features === undefined
+          ? undefined
+          : strings(session.features, `${name}.app.session.features`);
+      const allowedFeatures = new Set([
+        "commands",
+        "telemetry",
+        "pause",
+        "resume",
+        "suggestions",
+      ]);
+      if (features?.some((feature) => !allowedFeatures.has(feature))) {
+        throw new RegistryUpstreamError(
+          `${name}.app.session.features is invalid`,
+        );
+      }
+      info.appMeta.session = {
+        mode: mode as "viewer" | "spectate-and-steer" | "external",
+        features: features as
+          | Array<"commands" | "telemetry" | "pause" | "resume" | "suggestions">
+          | undefined,
+      };
+    }
+    if (app.viewer !== undefined) {
+      const viewer = record(app.viewer, `${name}.app.viewer`);
+      const embed = viewer.embedParams;
+      if (
+        embed !== undefined &&
+        (!isRecord(embed) ||
+          !Object.values(embed).every((v) => typeof v === "string"))
+      ) {
+        throw new RegistryUpstreamError(
+          `${name}.app.viewer.embedParams is invalid`,
+        );
+      }
+      info.appMeta.viewer = {
+        url: string(viewer.url, `${name}.app.viewer.url`),
+        embedParams: embed as Record<string, string> | undefined,
+        postMessageAuth: optionalBoolean(
+          viewer.postMessageAuth,
+          `${name}.app.viewer.postMessageAuth`,
+        ),
+        sandbox: sanitizeSandbox(
+          optionalString(viewer.sandbox, `${name}.app.viewer.sandbox`),
+        ),
+      };
+    }
+  }
+  return info;
+}
+
+async function requestJson(
+  params: FetchFromNetworkParams,
+  sourceUrl: string,
+  operation: string,
+  allowNotFound: boolean,
+): Promise<Response | null> {
+  const span = createIntegrationTelemetrySpan({
+    boundary: "marketplace",
+    operation,
+    timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+  let response: Response;
+  try {
+    response = await (params.fetchImpl ?? fetch)(
+      sourceUrl,
+      init(params, sourceUrl),
+    );
+  } catch (cause) {
+    // error-policy:J2 retain the transport cause in a typed upstream failure.
+    span.failure({ error: cause });
+    throw new RegistryUpstreamError(`${operation} request failed`, {
+      cause,
+    });
+  }
+  if (allowNotFound && response.status === 404) return null;
+  if (response.status !== 304 && !response.ok) {
+    span.failure({ statusCode: response.status, errorKind: "http_error" });
+    throw new RegistryUpstreamError(
+      `${operation} failed with HTTP ${response.status}`,
+      {
+        status: response.status,
+        retryAfterMs: retryAfterMs(response, params.now ?? Date.now),
+      },
+    );
+  }
+  span.success({ statusCode: response.status });
+  return response;
+}
+
+async function generated(
+  params: FetchFromNetworkParams,
+  sourceUrl: string,
+): Promise<RegistryNetworkSnapshot | null> {
+  const response = await requestJson(
+    params,
+    sourceUrl,
+    "fetch_generated_registry",
+    true,
+  );
+  if (!response) return null;
+  if (response.status === 304) {
+    const snapshot = cached(params, sourceUrl, response);
+    await overlays(snapshot.plugins, params);
+    return snapshot;
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    // error-policy:J2 retain the JSON parser cause in the typed upstream failure.
+    throw new RegistryUpstreamError(
+      "Generated registry returned malformed JSON",
+      { cause },
+    );
+  }
+  const registry = record(record(body, "root").registry, "registry");
   const plugins = new Map<string, RegistryPluginInfo>();
-  for (const [name, gitRef] of Object.entries(data)) {
-    const repo = gitRef.replace(/^github:/, "");
-    const isBuiltIn = name.startsWith("@elizaos/");
+  for (const [name, entry] of Object.entries(registry)) {
+    plugins.set(name, parseEntry(name, entry, params.sanitizeSandbox));
+  }
+  await overlays(plugins, params);
+  return { sourceUrl, etag: etag(response), plugins, notModified: false };
+}
+
+async function index(
+  params: FetchFromNetworkParams,
+  sourceUrl: string,
+): Promise<RegistryNetworkSnapshot> {
+  const response = await requestJson(
+    params,
+    sourceUrl,
+    "fetch_index_registry",
+    false,
+  );
+  if (!response)
+    throw new RegistryUpstreamError("Index registry unexpectedly absent");
+  if (response.status === 304) {
+    const snapshot = cached(params, sourceUrl, response);
+    await overlays(snapshot.plugins, params);
+    return snapshot;
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    // error-policy:J2 retain the JSON parser cause in the typed upstream failure.
+    throw new RegistryUpstreamError("Index registry returned malformed JSON", {
+      cause,
+    });
+  }
+  const plugins = new Map<string, RegistryPluginInfo>();
+  for (const [name, rawRef] of Object.entries(record(body, "index"))) {
+    if (!PACKAGE_NAME.test(name))
+      throw new RegistryUpstreamError(`Invalid package ${name}`);
+    const repo = string(rawRef, name).replace(/^github:/, "");
+    if (!GITHUB_REPOSITORY.test(repo))
+      throw new RegistryUpstreamError(`Invalid repository for ${name}`);
+    const builtIn = name.startsWith("@elizaos/");
     plugins.set(name, {
       name,
       gitRepo: repo,
@@ -300,50 +540,38 @@ async function fetchIndexRegistry(
       npm: { package: name, v0Version: null, v1Version: null, v2Version: null },
       git: { v0Branch: null, v1Branch: null, v2Branch: "next" },
       supports: { v0: false, v1: false, v2: false },
-      origin: isBuiltIn ? "builtin" : "third-party",
-      source: isBuiltIn ? "builtin" : "third-party",
-      support: isBuiltIn ? "first-party" : "community",
-      builtIn: isBuiltIn,
-      firstParty: isBuiltIn,
-      thirdParty: !isBuiltIn,
+      origin: builtIn ? "builtin" : "third-party",
+      source: builtIn ? "builtin" : "third-party",
+      support: builtIn ? "first-party" : "community",
+      builtIn,
+      firstParty: builtIn,
+      thirdParty: !builtIn,
     });
   }
-  await applyLocalWorkspaceApps(plugins);
-  await applyNodeModulePlugins(plugins);
-  indexSpan.success({ statusCode: resp.status });
-  return plugins;
+  await overlays(plugins, params);
+  return { sourceUrl, etag: etag(response), plugins, notModified: false };
 }
 
-/**
- * Resolve the plugin registry from the network, preferring the generated
- * registry over the index registry.
- *
- * Both network attempts are issued concurrently so a doomed-offline boot
- * waits out a single ~2.5s timeout instead of two sequential ones. The
- * generated result still wins whenever it loads; the index result is only
- * consulted (and its failure only surfaced) when the generated registry is
- * absent. When the cloud is already known to be unreachable for this boot we
- * skip both fetches entirely and go straight to the local-snapshot fallback.
- */
-export async function fetchFromNetwork(
+/** Resolve a network snapshot, preferring generated metadata over the index. */
+export async function fetchRegistrySnapshot(
   params: FetchFromNetworkParams,
-): Promise<Map<string, RegistryPluginInfo>> {
-  if (!(await isCloudReachable())) {
+): Promise<RegistryNetworkSnapshot> {
+  const generatedUrl = validateUrl(
+    params.generatedRegistryUrl,
+    "generatedRegistryUrl",
+  );
+  const indexUrl = validateUrl(params.indexRegistryUrl, "indexRegistryUrl");
+  if (!(await (params.cloudReachable ?? isCloudReachable)())) {
     throw new RegistryNetworkFallbackError(
       "cloud unreachable at boot — using local registry snapshot",
     );
   }
+  return (await generated(params, generatedUrl)) ?? index(params, indexUrl);
+}
 
-  const generatedResult = fetchGeneratedRegistry(params);
-  const indexResult = fetchIndexRegistry(params);
-  // Prevent an unhandled rejection if the generated registry wins the race and
-  // we never await the index attempt; its failure is only relevant as a
-  // fallback when the generated registry is absent.
-  indexResult.catch(() => {});
-
-  const generated = await generatedResult;
-  if (generated) {
-    return generated;
-  }
-  return indexResult;
+/** Compatibility wrapper for callers that only need the plugin map. */
+export async function fetchFromNetwork(
+  params: FetchFromNetworkParams,
+): Promise<Map<string, RegistryPluginInfo>> {
+  return (await fetchRegistrySnapshot(params)).plugins;
 }

--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `refreshRegistry` clears the caches and then delegates to
+ * `getRegistryPlugins`, which returns any load that is already in flight. That
+ * load carries a pre-refresh snapshot, so a force-refresh must not adopt it —
+ * nor let it stamp a fresh TTL over the refreshed result afterwards.
+ *
+ * The registry caches are module-level, so every case re-imports the module
+ * through `vi.resetModules()`.
+ */
+
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let stateDir: string;
+let fetchImpl: () => Promise<Map<string, unknown>>;
+let fetchCalls = 0;
+
+vi.mock("../config/paths.ts", () => ({
+  resolveStateDir: () => stateDir,
+}));
+
+vi.mock("../config/config.ts", () => ({
+  loadElizaConfig: () => ({}),
+  saveElizaConfig: () => {},
+}));
+
+vi.mock("./registry-client-local.ts", () => ({
+  applyLocalWorkspaceApps: async () => {},
+  applyNodeModulePlugins: async () => {},
+}));
+
+vi.mock("./registry-client-network.ts", () => ({
+  fetchFromNetwork: async () => {
+    fetchCalls += 1;
+    return fetchImpl();
+  },
+  isExpectedRegistryNetworkFallback: () => true,
+}));
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const PAYLOAD_A = () => new Map([["plugin-a", { name: "plugin-a" }]]);
+const PAYLOAD_B = () => new Map([["plugin-b", { name: "plugin-b" }]]);
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./registry-client.ts");
+}
+
+beforeEach(async () => {
+  stateDir = await fsp.mkdtemp(path.join(os.tmpdir(), "registry-refresh-"));
+  fetchCalls = 0;
+  fetchImpl = async () => PAYLOAD_A();
+});
+
+afterEach(async () => {
+  await fsp.rm(stateDir, { recursive: true, force: true });
+});
+
+describe("refreshRegistry", () => {
+  it("does not adopt a load that started before the refresh", async () => {
+    fetchImpl = async () => {
+      await sleep(200);
+      return PAYLOAD_A();
+    };
+    const { getRegistryPlugins, refreshRegistry } = await loadModule();
+
+    const inFlight = getRegistryPlugins();
+    await sleep(20);
+    fetchImpl = async () => PAYLOAD_B();
+
+    const refreshed = await refreshRegistry();
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+
+    // The refreshed snapshot must also survive the older load completing.
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-b"]);
+    await inFlight;
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-b"]);
+  });
+
+  it("still refetches when no load is in flight", async () => {
+    const { refreshRegistry } = await loadModule();
+
+    const refreshed = await refreshRegistry();
+
+    expect([...refreshed.keys()]).toEqual(["plugin-a"]);
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("still shares one load between concurrent callers", async () => {
+    fetchImpl = async () => {
+      await sleep(50);
+      return PAYLOAD_A();
+    };
+    const { getRegistryPlugins } = await loadModule();
+
+    const [first, second, third] = await Promise.all([
+      getRegistryPlugins(),
+      getRegistryPlugins(),
+      getRegistryPlugins(),
+    ]);
+
+    expect(fetchCalls).toBe(1);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it("still serves a fresh file cache without a network call", async () => {
+    await fsp.mkdir(path.join(stateDir, "cache"), { recursive: true });
+    await fsp.writeFile(
+      path.join(stateDir, "cache", "registry.json"),
+      JSON.stringify({
+        fetchedAt: Date.now(),
+        plugins: [["plugin-file", { name: "plugin-file" }]],
+      }),
+    );
+    const { getRegistryPlugins } = await loadModule();
+
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-file"]);
+    expect(fetchCalls).toBe(0);
+  });
+});

--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -32,16 +32,35 @@ vi.mock("./registry-client-local.ts", () => ({
 }));
 
 vi.mock("./registry-client-network.ts", () => ({
-  fetchFromNetwork: async () => {
+  fetchRegistrySnapshot: async () => {
     fetchCalls += 1;
-    return fetchImpl();
+    return {
+      sourceUrl: "https://plugins.eliza.app/generated-registry.json",
+      etag: '"fixture"',
+      plugins: await fetchImpl(),
+      notModified: false,
+    };
   },
   isExpectedRegistryNetworkFallback: () => true,
 }));
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const PAYLOAD_A = () => new Map([["plugin-a", { name: "plugin-a" }]]);
-const PAYLOAD_B = () => new Map([["plugin-b", { name: "plugin-b" }]]);
+const plugin = (name: string) => ({
+  name,
+  gitRepo: `fixture/${name}`,
+  gitUrl: `https://github.com/fixture/${name}.git`,
+  directory: null,
+  description: "fixture",
+  homepage: null,
+  topics: [],
+  stars: 0,
+  language: "TypeScript",
+  npm: { package: name, v0Version: null, v1Version: null, v2Version: "1.0.0" },
+  git: { v0Branch: null, v1Branch: null, v2Branch: "main" },
+  supports: { v0: false, v1: false, v2: true },
+});
+const PAYLOAD_A = () => new Map([["plugin-a", plugin("plugin-a")]]);
+const PAYLOAD_B = () => new Map([["plugin-b", plugin("plugin-b")]]);
 
 async function loadModule() {
   vi.resetModules();
@@ -112,7 +131,9 @@ describe("refreshRegistry", () => {
       path.join(stateDir, "cache", "registry.json"),
       JSON.stringify({
         fetchedAt: Date.now(),
-        plugins: [["plugin-file", { name: "plugin-file" }]],
+        sourceUrl: "https://plugins.eliza.app/generated-registry.json",
+        etag: '"fixture"',
+        plugins: [["plugin-file", plugin("plugin-file")]],
       }),
     );
     const { getRegistryPlugins } = await loadModule();

--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -32,6 +32,8 @@ vi.mock("./registry-client-local.ts", () => ({
 }));
 
 vi.mock("./registry-client-network.ts", () => ({
+  MAX_REGISTRY_JSON_BYTES: 16 * 1024 * 1024,
+  validateRegistryJsonShape: () => {},
   fetchRegistrySnapshot: async () => {
     fetchCalls += 1;
     return {
@@ -121,8 +123,10 @@ describe("refreshRegistry", () => {
     ]);
 
     expect(fetchCalls).toBe(1);
-    expect(first).toBe(second);
-    expect(second).toBe(third);
+    expect(first).toStrictEqual(second);
+    expect(second).toStrictEqual(third);
+    expect(first).not.toBe(second);
+    expect(second).not.toBe(third);
   });
 
   it("still serves a fresh file cache without a network call", async () => {

--- a/packages/agent/src/services/registry-client-runtime.test.ts
+++ b/packages/agent/src/services/registry-client-runtime.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Exercises registry authority caching with real cache stores and deterministic
+ * clocks. Network responses are in-memory protocol fixtures; concurrency,
+ * cancellation, disk fencing, overlay isolation, and mutation boundaries use
+ * the production RegistryClient implementation without a fake runtime.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_REGISTRY_JSON_BYTES } from "./registry-client-network.ts";
+import {
+  createFileRegistryCacheStore,
+  type RegistryCacheRecord,
+  type RegistryCacheStore,
+  RegistryClient,
+} from "./registry-client-runtime.ts";
+import type { RegistryPluginInfo } from "./registry-client-types.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+function plugin(name: string, description = "upstream"): RegistryPluginInfo {
+  return {
+    name,
+    gitRepo: `fixture/${name}`,
+    gitUrl: `https://github.com/fixture/${name}.git`,
+    directory: null,
+    description,
+    homepage: null,
+    topics: [],
+    stars: 0,
+    language: "TypeScript",
+    npm: {
+      package: name,
+      v0Version: null,
+      v1Version: null,
+      v2Version: "1.0.0",
+    },
+    git: { v0Branch: null, v1Branch: null, v2Branch: "main" },
+    supports: { v0: false, v1: false, v2: true },
+  };
+}
+
+function record(fetchedAt: number, name = "plugin-a"): RegistryCacheRecord {
+  return {
+    fetchedAt,
+    sourceUrl: "https://registry.example/generated-registry.json",
+    etag: '"fixture"',
+    plugins: [[name, plugin(name)]],
+  };
+}
+
+function registryResponse(name: string): Response {
+  const entry = plugin(name);
+  return Response.json({
+    registry: {
+      [name]: {
+        git: {
+          repo: entry.gitRepo,
+          v0: { branch: null },
+          v1: { branch: null },
+          v2: { branch: "main" },
+        },
+        npm: {
+          repo: name,
+          v0: null,
+          v1: null,
+          v2: "1.0.0",
+        },
+        supports: entry.supports,
+        directory: null,
+        description: entry.description,
+        homepage: null,
+        topics: [],
+        stargazers_count: 0,
+        language: "TypeScript",
+      },
+    },
+  });
+}
+
+function client(options: {
+  cacheStore: RegistryCacheStore;
+  now?: () => number;
+  fetchImpl?: () => Promise<Response>;
+  applyLocalWorkspaceApps?: (
+    plugins: Map<string, RegistryPluginInfo>,
+  ) => Promise<void>;
+}): RegistryClient {
+  return new RegistryClient({
+    generatedRegistryUrl: "https://registry.example/generated-registry.json",
+    indexRegistryUrl: "https://registry.example/index.json",
+    cacheStore: options.cacheStore,
+    now: options.now,
+    cacheTtlMs: 100,
+    fetchImpl: options.fetchImpl,
+    cloudReachable: async () => true,
+    applyLocalWorkspaceApps:
+      options.applyLocalWorkspaceApps ?? (async () => {}),
+    applyNodeModulePlugins: async () => {},
+    sanitizeSandbox: (value) => value ?? "allow-scripts",
+    getConfiguredEndpoints: () => [],
+    mergeCustomEndpoints: async () => {},
+  });
+}
+
+describe("RegistryClient authority isolation", () => {
+  it("preserves a nearly expired disk age when promoting it to memory", async () => {
+    let now = 99;
+    let fetchCalls = 0;
+    const instance = client({
+      cacheStore: {
+        read: async () => record(0),
+        write: async () => true,
+        remove: async () => {},
+      },
+      now: () => now,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return registryResponse("plugin-network");
+      },
+    });
+
+    expect([...(await instance.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-a",
+    ]);
+    now = 101;
+    expect([...(await instance.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-network",
+    ]);
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("reapplies overlays per read without caching them or caller mutations", async () => {
+    let overlayGeneration = 0;
+    const authority = record(0);
+    const instance = client({
+      cacheStore: {
+        read: async () => structuredClone(authority),
+        write: async () => true,
+        remove: async () => {},
+      },
+      now: () => 1,
+      applyLocalWorkspaceApps: async (plugins) => {
+        overlayGeneration += 1;
+        const upstream = plugins.get("plugin-a");
+        if (upstream) upstream.description = `overlay-${overlayGeneration}`;
+        plugins.set("plugin-local", plugin("plugin-local"));
+      },
+    });
+
+    const first = await instance.getRegistryPlugins();
+    expect(first.get("plugin-a")?.description).toBe("overlay-1");
+    first.delete("plugin-a");
+    const local = first.get("plugin-local");
+    if (local) local.description = "caller-corruption";
+
+    const second = await instance.getRegistryPlugins();
+    expect(second.get("plugin-a")?.description).toBe("overlay-2");
+    expect(second.get("plugin-local")?.description).toBe("upstream");
+    expect(authority.plugins[0]?.[1].description).toBe("upstream");
+    expect(first).not.toBe(second);
+  });
+
+  it("generation-fences a delayed disk promotion across refresh", async () => {
+    let releaseFirstRead: ((value: RegistryCacheRecord) => void) | undefined;
+    let reads = 0;
+    const delayed = new Promise<RegistryCacheRecord>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    const store: RegistryCacheStore = {
+      read: async () => {
+        reads += 1;
+        return reads === 1 ? delayed : null;
+      },
+      write: async (_record, shouldCommit) => shouldCommit(),
+      remove: async () => {},
+    };
+    const instance = client({
+      cacheStore: store,
+      now: () => 1,
+      fetchImpl: async () => registryResponse("plugin-network"),
+    });
+
+    const stale = instance.getRegistryPlugins();
+    const refreshed = instance.refreshRegistry();
+    expect([...(await refreshed).keys()]).toEqual(["plugin-network"]);
+    releaseFirstRead?.(record(0, "plugin-stale"));
+    expect([...(await stale).keys()]).toEqual(["plugin-stale"]);
+    expect([...(await instance.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-network",
+    ]);
+  });
+
+  it("isolates caller cancellation while preserving one shared load", async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+    let fetchCalls = 0;
+    const response = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const instance = client({
+      cacheStore: {
+        read: async () => null,
+        write: async () => true,
+        remove: async () => {},
+      },
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return response;
+      },
+    });
+    const controller = new AbortController();
+    const cancelled = instance.getRegistryPlugins({
+      signal: controller.signal,
+    });
+    const survivor = instance.getRegistryPlugins();
+    controller.abort(new DOMException("caller stopped", "AbortError"));
+
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    resolveFetch?.(registryResponse("plugin-network"));
+    expect([...(await survivor).keys()]).toEqual(["plugin-network"]);
+    expect(fetchCalls).toBe(1);
+    expect([...(await instance.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-network",
+    ]);
+  });
+});
+
+describe("file registry cache admission", () => {
+  it("bounds bytes, rejects invalid UTF-8, and cleans fenced temp writes", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "registry-cache-admission-"),
+    );
+    temporaryDirectories.push(directory);
+    const file = path.join(directory, "registry.json");
+    const store = createFileRegistryCacheStore(file);
+
+    await fs.writeFile(file, new Uint8Array(MAX_REGISTRY_JSON_BYTES + 1));
+    await expect(store.read()).resolves.toBeNull();
+    await fs.writeFile(file, Uint8Array.from([0xc3, 0x28]));
+    await expect(store.read()).resolves.toBeNull();
+
+    await expect(store.write(record(0), () => false)).resolves.toBe(false);
+    expect(
+      (await fs.readdir(directory)).filter((name) => name.endsWith(".tmp")),
+    ).toEqual([]);
+
+    vi.spyOn(fs, "rename").mockRejectedValueOnce(new Error("rename denied"));
+    await expect(store.write(record(0), () => true)).rejects.toThrow(
+      "rename denied",
+    );
+    expect(
+      (await fs.readdir(directory)).filter((name) => name.endsWith(".tmp")),
+    ).toEqual([]);
+  });
+});

--- a/packages/agent/src/services/registry-client-runtime.test.ts
+++ b/packages/agent/src/services/registry-client-runtime.test.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MAX_REGISTRY_JSON_BYTES } from "./registry-client-network.ts";
 import {
@@ -20,6 +21,7 @@ import type { RegistryPluginInfo } from "./registry-client-types.ts";
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(
     temporaryDirectories
       .splice(0)
@@ -232,9 +234,47 @@ describe("RegistryClient authority isolation", () => {
       "plugin-network",
     ]);
   });
+
+  it("observes a detached authority failure for a pre-aborted caller", async () => {
+    const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+    const controller = new AbortController();
+    controller.abort(new DOMException("caller stopped", "AbortError"));
+    const instance = client({
+      cacheStore: {
+        read: async () => null,
+        write: async () => true,
+        remove: async () => {},
+      },
+      fetchImpl: async () => {
+        throw new Error("detached upstream failed");
+      },
+    });
+
+    await expect(
+      instance.getRegistryPlugins({ signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    await vi.waitFor(() => {
+      expect(debug).toHaveBeenCalledWith(
+        expect.stringContaining("Detached authority load failed"),
+      );
+    });
+  });
 });
 
 describe("file registry cache admission", () => {
+  it("rethrows operational cache read failures as typed errors", async () => {
+    const openFailure = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+    });
+    vi.spyOn(fs, "open").mockRejectedValueOnce(openFailure);
+    const store = createFileRegistryCacheStore("/not-readable/registry.json");
+
+    await expect(store.read()).rejects.toMatchObject({
+      code: "REGISTRY_CACHE_READ_FAILED",
+      cause: openFailure,
+    });
+  });
+
   it("bounds bytes, rejects invalid UTF-8, and cleans fenced temp writes", async () => {
     const directory = await fs.mkdtemp(
       path.join(os.tmpdir(), "registry-cache-admission-"),

--- a/packages/agent/src/services/registry-client-runtime.ts
+++ b/packages/agent/src/services/registry-client-runtime.ts
@@ -6,7 +6,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import type { RegistryEndpoint } from "../config/types.eliza.ts";
 import {
   fetchRegistrySnapshot,
@@ -25,6 +25,10 @@ import type { RegistryPluginInfo } from "./registry-client-types.ts";
 const DEFAULT_TTL_MS = 3_600_000;
 const LOCAL_FALLBACK_TTL_MS = 5 * 60_000;
 const CACHE_READ_CHUNK_BYTES = 64 * 1024;
+
+class InvalidRegistryCacheError extends Error {
+  override readonly name = "InvalidRegistryCacheError";
+}
 
 export interface RegistryCacheRecord {
   fetchedAt: number;
@@ -154,7 +158,9 @@ async function readBoundedCacheFile(filePath: string): Promise<Uint8Array> {
       if (bytesRead === 0) break;
       total += bytesRead;
       if (total > MAX_REGISTRY_JSON_BYTES) {
-        throw new Error("Registry cache exceeds the byte limit");
+        throw new InvalidRegistryCacheError(
+          "Registry cache exceeds the byte limit",
+        );
       }
       chunks.push(buffer.subarray(0, bytesRead));
     }
@@ -170,6 +176,16 @@ async function readBoundedCacheFile(filePath: string): Promise<Uint8Array> {
   return bytes;
 }
 
+function observeDetachedAuthorityLoad<T>(shared: Promise<T>): void {
+  // error-policy:J5 the pre-aborted caller observes its AbortError; the
+  // detached authority rejection is separately observed and logged here.
+  void shared.catch((error) => {
+    logger.debug(
+      `[registry-client] Detached authority load failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  });
+}
+
 function waitForCaller<T>(
   shared: Promise<T>,
   signal?: AbortSignal,
@@ -179,7 +195,7 @@ function waitForCaller<T>(
     // The authority load is intentionally caller-independent; retain an
     // observer so its eventual bounded failure cannot become unhandled after
     // this already-cancelled caller leaves.
-    void shared.catch(() => undefined);
+    observeDetachedAuthorityLoad(shared);
     return Promise.reject(
       signal.reason ??
         new DOMException("Registry request aborted", "AbortError"),
@@ -219,8 +235,29 @@ export function createFileRegistryCacheStore(
     async read() {
       await mutationTail;
       const resolved = resolveFilePath();
+      let bytes: Uint8Array;
       try {
-        const bytes = await readBoundedCacheFile(resolved);
+        bytes = await readBoundedCacheFile(resolved);
+      } catch (error) {
+        // error-policy:J1 only absence and an explicitly bounded oversized
+        // cache map to cache-miss; operational filesystem failures stay fatal.
+        if (
+          error instanceof InvalidRegistryCacheError ||
+          (typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT")
+        ) {
+          return null;
+        }
+        throw new ElizaError("Registry cache could not be read", {
+          code: "REGISTRY_CACHE_READ_FAILED",
+          context: { filePath: resolved },
+          cause: error,
+          severity: "fatal",
+        });
+      }
+      try {
         const value = JSON.parse(
           new TextDecoder("utf-8", { fatal: true }).decode(bytes),
         ) as unknown;

--- a/packages/agent/src/services/registry-client-runtime.ts
+++ b/packages/agent/src/services/registry-client-runtime.ts
@@ -1,0 +1,348 @@
+/**
+ * Owns one registry client's clock, cache, transport, and generation. Instances
+ * make synthetic worlds isolated without mutable process-global test switches;
+ * the public registry module retains one production-default instance.
+ */
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { logger } from "@elizaos/core";
+import type { RegistryEndpoint } from "../config/types.eliza.ts";
+import {
+  fetchRegistrySnapshot,
+  isExpectedRegistryNetworkFallback,
+  type RegistryFetch,
+  type RegistryNetworkSnapshot,
+} from "./registry-client-network.ts";
+import {
+  getPluginInfoFromRegistry,
+  normalizePluginLookupAlias,
+} from "./registry-client-queries.ts";
+import type { RegistryPluginInfo } from "./registry-client-types.ts";
+
+const DEFAULT_TTL_MS = 3_600_000;
+const LOCAL_FALLBACK_TTL_MS = 5 * 60_000;
+
+export interface RegistryCacheRecord {
+  fetchedAt: number;
+  sourceUrl: string | null;
+  etag: string | null;
+  plugins: Array<[string, RegistryPluginInfo]>;
+}
+
+export interface RegistryCacheStore {
+  read(): Promise<RegistryCacheRecord | null>;
+  write(
+    record: RegistryCacheRecord,
+    shouldCommit: () => boolean,
+  ): Promise<boolean>;
+  remove(): Promise<void>;
+}
+
+export interface RegistryClientOptions {
+  generatedRegistryUrl: string;
+  indexRegistryUrl: string;
+  cacheStore: RegistryCacheStore;
+  now?: () => number;
+  fetchImpl?: RegistryFetch;
+  cloudReachable?: () => Promise<boolean>;
+  timeoutMs?: number;
+  cacheTtlMs?: number;
+  applyLocalWorkspaceApps: (
+    plugins: Map<string, RegistryPluginInfo>,
+  ) => Promise<void>;
+  applyNodeModulePlugins: (
+    plugins: Map<string, RegistryPluginInfo>,
+  ) => Promise<void>;
+  sanitizeSandbox: (value?: string) => string;
+  getConfiguredEndpoints: () => RegistryEndpoint[];
+  mergeCustomEndpoints: (
+    plugins: Map<string, RegistryPluginInfo>,
+    endpoints: RegistryEndpoint[],
+  ) => Promise<void>;
+}
+
+function isRegistryPluginInfo(
+  value: unknown,
+  key: string,
+): value is RegistryPluginInfo {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  const plugin = value as Partial<RegistryPluginInfo>;
+  return (
+    plugin.name === key &&
+    typeof plugin.gitRepo === "string" &&
+    typeof plugin.gitUrl === "string" &&
+    typeof plugin.description === "string" &&
+    (plugin.homepage === null || typeof plugin.homepage === "string") &&
+    Array.isArray(plugin.topics) &&
+    plugin.topics.every((topic) => typeof topic === "string") &&
+    typeof plugin.stars === "number" &&
+    Number.isFinite(plugin.stars) &&
+    typeof plugin.language === "string" &&
+    typeof plugin.npm === "object" &&
+    plugin.npm !== null &&
+    typeof plugin.npm.package === "string" &&
+    typeof plugin.git === "object" &&
+    plugin.git !== null &&
+    typeof plugin.supports === "object" &&
+    plugin.supports !== null &&
+    typeof plugin.supports.v0 === "boolean" &&
+    typeof plugin.supports.v1 === "boolean" &&
+    typeof plugin.supports.v2 === "boolean"
+  );
+}
+
+function parseCacheRecord(value: unknown): RegistryCacheRecord | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return null;
+  const candidate = value as Partial<RegistryCacheRecord>;
+  if (
+    typeof candidate.fetchedAt !== "number" ||
+    !Number.isFinite(candidate.fetchedAt) ||
+    (candidate.sourceUrl !== null && typeof candidate.sourceUrl !== "string") ||
+    (candidate.etag !== null && typeof candidate.etag !== "string") ||
+    !Array.isArray(candidate.plugins)
+  ) {
+    return null;
+  }
+  const seen = new Set<string>();
+  for (const entry of candidate.plugins) {
+    if (
+      !Array.isArray(entry) ||
+      entry.length !== 2 ||
+      typeof entry[0] !== "string" ||
+      seen.has(entry[0]) ||
+      !isRegistryPluginInfo(entry[1], entry[0])
+    ) {
+      return null;
+    }
+    seen.add(entry[0]);
+  }
+  if ((candidate.sourceUrl === null) !== (candidate.etag === null)) return null;
+  return candidate as RegistryCacheRecord;
+}
+
+/** Create an atomic JSON cache whose final rename is generation-fenced. */
+export function createFileRegistryCacheStore(
+  filePath: string | (() => string),
+): RegistryCacheStore {
+  const resolveFilePath = () =>
+    path.resolve(typeof filePath === "function" ? filePath() : filePath);
+  let mutationTail: Promise<void> = Promise.resolve();
+  const mutate = <T>(operation: () => Promise<T>): Promise<T> => {
+    const run = mutationTail.then(operation, operation);
+    // error-policy:J5 every mutation rejection is returned through `run`; this
+    // branch only keeps the private serialization tail usable.
+    mutationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  };
+  return {
+    async read() {
+      await mutationTail;
+      const resolved = resolveFilePath();
+      try {
+        return parseCacheRecord(
+          JSON.parse(await fs.readFile(resolved, "utf8")) as unknown,
+        );
+      } catch {
+        // error-policy:J3 an absent or corrupt cache is explicitly invalid and
+        // triggers authoritative resolution; it is never a valid empty map.
+        return null;
+      }
+    },
+    write(record, shouldCommit) {
+      return mutate(async () => {
+        const resolved = resolveFilePath();
+        await fs.mkdir(path.dirname(resolved), { recursive: true });
+        const temporary = `${resolved}.${crypto.randomUUID()}.tmp`;
+        await fs.writeFile(temporary, JSON.stringify(record), {
+          encoding: "utf8",
+          flag: "wx",
+        });
+        if (!shouldCommit()) {
+          await fs.rm(temporary, { force: true });
+          return false;
+        }
+        await fs.rename(temporary, resolved);
+        return true;
+      });
+    },
+    remove() {
+      return mutate(async () => {
+        const resolved = resolveFilePath();
+        try {
+          await fs.unlink(resolved);
+        } catch (error) {
+          // error-policy:J1 ENOENT is the cache-store boundary's explicit
+          // absent state; every other filesystem failure remains fatal.
+          if (
+            typeof error !== "object" ||
+            error === null ||
+            !("code" in error) ||
+            error.code !== "ENOENT"
+          ) {
+            throw error;
+          }
+        }
+      });
+    },
+  };
+}
+
+export class RegistryClient {
+  readonly #options: RegistryClientOptions;
+  readonly #now: () => number;
+  readonly #ttlMs: number;
+  #memory: {
+    plugins: Map<string, RegistryPluginInfo>;
+    fetchedAt: number;
+    ttlMs: number;
+  } | null = null;
+  #load: Promise<Map<string, RegistryPluginInfo>> | null = null;
+  #generation = 0;
+
+  constructor(options: RegistryClientOptions) {
+    this.#options = options;
+    this.#now = options.now ?? Date.now;
+    this.#ttlMs = options.cacheTtlMs ?? DEFAULT_TTL_MS;
+    if (!Number.isInteger(this.#ttlMs) || this.#ttlMs < 1) {
+      throw new Error("Registry cache TTL must be a positive integer");
+    }
+  }
+
+  invalidateMemory(): void {
+    this.#memory = null;
+    this.#load = null;
+    this.#generation += 1;
+  }
+
+  async getRegistryPlugins(
+    input: { signal?: AbortSignal } = {},
+  ): Promise<Map<string, RegistryPluginInfo>> {
+    const now = this.#now();
+    if (this.#memory && now - this.#memory.fetchedAt < this.#memory.ttlMs) {
+      return this.#memory.plugins;
+    }
+
+    const cached = await this.#options.cacheStore.read();
+    if (cached && now - cached.fetchedAt < this.#ttlMs) {
+      const plugins = new Map(cached.plugins);
+      await this.#options.applyLocalWorkspaceApps(plugins);
+      await this.#options.applyNodeModulePlugins(plugins);
+      await this.#options.mergeCustomEndpoints(
+        plugins,
+        this.#options.getConfiguredEndpoints(),
+      );
+      this.#memory = { plugins, fetchedAt: now, ttlMs: this.#ttlMs };
+      return plugins;
+    }
+    if (this.#load) return this.#load;
+
+    const generation = this.#generation;
+    const load = this.#loadRegistry(generation, cached, input.signal).finally(
+      () => {
+        if (this.#load === load) this.#load = null;
+      },
+    );
+    this.#load = load;
+    return load;
+  }
+
+  async #loadRegistry(
+    generation: number,
+    cached: RegistryCacheRecord | null,
+    requestSignal?: AbortSignal,
+  ): Promise<Map<string, RegistryPluginInfo>> {
+    logger.info("[registry-client] Fetching plugin registry...");
+    let snapshot: RegistryNetworkSnapshot | null = null;
+    let cachePlugins: Map<string, RegistryPluginInfo> | null = null;
+    let plugins: Map<string, RegistryPluginInfo>;
+    let ttlMs = this.#ttlMs;
+    try {
+      snapshot = await fetchRegistrySnapshot({
+        generatedRegistryUrl: this.#options.generatedRegistryUrl,
+        indexRegistryUrl: this.#options.indexRegistryUrl,
+        applyLocalWorkspaceApps: this.#options.applyLocalWorkspaceApps,
+        applyNodeModulePlugins: this.#options.applyNodeModulePlugins,
+        sanitizeSandbox: this.#options.sanitizeSandbox,
+        fetchImpl: this.#options.fetchImpl,
+        cloudReachable: this.#options.cloudReachable,
+        timeoutMs: this.#options.timeoutMs,
+        now: this.#now,
+        signal: requestSignal,
+        cacheValidator:
+          cached?.sourceUrl && cached.etag
+            ? {
+                sourceUrl: cached.sourceUrl,
+                etag: cached.etag,
+                plugins: new Map(cached.plugins),
+              }
+            : null,
+      });
+      plugins = snapshot.plugins;
+      cachePlugins = new Map(plugins);
+    } catch (error) {
+      // error-policy:J4 only the typed offline condition degrades to explicit
+      // local discovery; protocol and validation failures remain fatal.
+      if (!isExpectedRegistryNetworkFallback(error)) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      logger.debug(
+        `[registry-client] Remote registry unavailable; using local discovery: ${message}`,
+      );
+      plugins = new Map();
+      await this.#options.applyLocalWorkspaceApps(plugins);
+      await this.#options.applyNodeModulePlugins(plugins);
+      ttlMs = LOCAL_FALLBACK_TTL_MS;
+    }
+    await this.#options.mergeCustomEndpoints(
+      plugins,
+      this.#options.getConfiguredEndpoints(),
+    );
+    logger.info(`[registry-client] Loaded ${plugins.size} plugins`);
+    if (generation !== this.#generation) return plugins;
+
+    const fetchedAt = this.#now();
+    this.#memory = { plugins, fetchedAt, ttlMs };
+    if (snapshot) {
+      const record: RegistryCacheRecord = {
+        fetchedAt,
+        sourceUrl: snapshot.etag ? snapshot.sourceUrl : null,
+        etag: snapshot.etag,
+        plugins: [...(cachePlugins ?? plugins).entries()],
+      };
+      try {
+        await this.#options.cacheStore.write(
+          record,
+          () => generation === this.#generation,
+        );
+      } catch (error) {
+        // error-policy:J4 the authoritative result remains available while
+        // the cache failure is surfaced as an explicit warning.
+        logger.warn(`[registry-client] Cache write failed: ${String(error)}`);
+      }
+    }
+    return plugins;
+  }
+
+  async refreshRegistry(
+    input: { signal?: AbortSignal } = {},
+  ): Promise<Map<string, RegistryPluginInfo>> {
+    this.invalidateMemory();
+    await this.#options.cacheStore.remove();
+    return this.getRegistryPlugins(input);
+  }
+
+  async getPluginInfo(name: string): Promise<RegistryPluginInfo | null> {
+    const plugins = await this.getRegistryPlugins();
+    const normalizedName = normalizePluginLookupAlias(name);
+    for (const candidate of new Set([normalizedName, name])) {
+      const info = getPluginInfoFromRegistry(plugins, candidate);
+      if (info) return info;
+    }
+    return null;
+  }
+}

--- a/packages/agent/src/services/registry-client-runtime.ts
+++ b/packages/agent/src/services/registry-client-runtime.ts
@@ -11,8 +11,10 @@ import type { RegistryEndpoint } from "../config/types.eliza.ts";
 import {
   fetchRegistrySnapshot,
   isExpectedRegistryNetworkFallback,
+  MAX_REGISTRY_JSON_BYTES,
   type RegistryFetch,
   type RegistryNetworkSnapshot,
+  validateRegistryJsonShape,
 } from "./registry-client-network.ts";
 import {
   getPluginInfoFromRegistry,
@@ -22,6 +24,7 @@ import type { RegistryPluginInfo } from "./registry-client-types.ts";
 
 const DEFAULT_TTL_MS = 3_600_000;
 const LOCAL_FALLBACK_TTL_MS = 5 * 60_000;
+const CACHE_READ_CHUNK_BYTES = 64 * 1024;
 
 export interface RegistryCacheRecord {
   fetchedAt: number;
@@ -100,8 +103,12 @@ function parseCacheRecord(value: unknown): RegistryCacheRecord | null {
   if (
     typeof candidate.fetchedAt !== "number" ||
     !Number.isFinite(candidate.fetchedAt) ||
+    candidate.fetchedAt < 0 ||
     (candidate.sourceUrl !== null && typeof candidate.sourceUrl !== "string") ||
     (candidate.etag !== null && typeof candidate.etag !== "string") ||
+    (typeof candidate.sourceUrl === "string" &&
+      candidate.sourceUrl.length > 2_048) ||
+    (typeof candidate.etag === "string" && candidate.etag.length > 512) ||
     !Array.isArray(candidate.plugins)
   ) {
     return null;
@@ -121,6 +128,74 @@ function parseCacheRecord(value: unknown): RegistryCacheRecord | null {
   }
   if ((candidate.sourceUrl === null) !== (candidate.etag === null)) return null;
   return candidate as RegistryCacheRecord;
+}
+
+function clonePlugins(
+  plugins: Map<string, RegistryPluginInfo>,
+): Map<string, RegistryPluginInfo> {
+  return new Map(
+    [...plugins].map(([name, info]) => [name, structuredClone(info)]),
+  );
+}
+
+async function readBoundedCacheFile(filePath: string): Promise<Uint8Array> {
+  const handle = await fs.open(filePath, "r");
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const buffer = new Uint8Array(CACHE_READ_CHUNK_BYTES);
+      const { bytesRead } = await handle.read(
+        buffer,
+        0,
+        buffer.byteLength,
+        null,
+      );
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > MAX_REGISTRY_JSON_BYTES) {
+        throw new Error("Registry cache exceeds the byte limit");
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    await handle.close();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function waitForCaller<T>(
+  shared: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return shared;
+  if (signal.aborted) {
+    // The authority load is intentionally caller-independent; retain an
+    // observer so its eventual bounded failure cannot become unhandled after
+    // this already-cancelled caller leaves.
+    void shared.catch(() => undefined);
+    return Promise.reject(
+      signal.reason ??
+        new DOMException("Registry request aborted", "AbortError"),
+    );
+  }
+  return new Promise<T>((resolve, reject) => {
+    const aborted = () =>
+      reject(
+        signal.reason ??
+          new DOMException("Registry request aborted", "AbortError"),
+      );
+    signal.addEventListener("abort", aborted, { once: true });
+    shared.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", aborted);
+    });
+  });
 }
 
 /** Create an atomic JSON cache whose final rename is generation-fenced. */
@@ -145,9 +220,12 @@ export function createFileRegistryCacheStore(
       await mutationTail;
       const resolved = resolveFilePath();
       try {
-        return parseCacheRecord(
-          JSON.parse(await fs.readFile(resolved, "utf8")) as unknown,
-        );
+        const bytes = await readBoundedCacheFile(resolved);
+        const value = JSON.parse(
+          new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+        ) as unknown;
+        validateRegistryJsonShape(value);
+        return parseCacheRecord(value);
       } catch {
         // error-policy:J3 an absent or corrupt cache is explicitly invalid and
         // triggers authoritative resolution; it is never a valid empty map.
@@ -159,16 +237,27 @@ export function createFileRegistryCacheStore(
         const resolved = resolveFilePath();
         await fs.mkdir(path.dirname(resolved), { recursive: true });
         const temporary = `${resolved}.${crypto.randomUUID()}.tmp`;
-        await fs.writeFile(temporary, JSON.stringify(record), {
-          encoding: "utf8",
-          flag: "wx",
-        });
-        if (!shouldCommit()) {
-          await fs.rm(temporary, { force: true });
-          return false;
+        let promoted = false;
+        try {
+          await fs.writeFile(temporary, JSON.stringify(record), {
+            encoding: "utf8",
+            flag: "wx",
+          });
+          if (!shouldCommit()) return false;
+          await fs.rename(temporary, resolved);
+          promoted = true;
+          return true;
+        } finally {
+          if (!promoted) {
+            // error-policy:J6 the original write/promotion outcome remains
+            // authoritative; cleanup prevents abandoned partial cache files.
+            await fs.rm(temporary, { force: true }).catch((error) => {
+              logger.debug(
+                `[registry-client] Temporary cache cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            });
+          }
         }
-        await fs.rename(temporary, resolved);
-        return true;
       });
     },
     remove() {
@@ -224,42 +313,61 @@ export class RegistryClient {
     input: { signal?: AbortSignal } = {},
   ): Promise<Map<string, RegistryPluginInfo>> {
     const now = this.#now();
-    if (this.#memory && now - this.#memory.fetchedAt < this.#memory.ttlMs) {
-      return this.#memory.plugins;
+    const memoryAge = this.#memory ? now - this.#memory.fetchedAt : -1;
+    if (this.#memory && memoryAge >= 0 && memoryAge < this.#memory.ttlMs) {
+      return this.#decorate(this.#memory.plugins);
     }
+    let load = this.#load;
+    if (!load) {
+      const generation = this.#generation;
+      load = this.#resolveAuthority(generation).finally(() => {
+        if (this.#load === load) this.#load = null;
+      });
+      this.#load = load;
+    }
+    const authority = await waitForCaller(load, input.signal);
+    return this.#decorate(authority);
+  }
 
+  async #resolveAuthority(
+    generation: number,
+  ): Promise<Map<string, RegistryPluginInfo>> {
     const cached = await this.#options.cacheStore.read();
-    if (cached && now - cached.fetchedAt < this.#ttlMs) {
+    const now = this.#now();
+    const cacheAge = cached ? now - cached.fetchedAt : -1;
+    if (cached && cacheAge >= 0 && cacheAge < this.#ttlMs) {
       const plugins = new Map(cached.plugins);
-      await this.#options.applyLocalWorkspaceApps(plugins);
-      await this.#options.applyNodeModulePlugins(plugins);
-      await this.#options.mergeCustomEndpoints(
-        plugins,
-        this.#options.getConfiguredEndpoints(),
-      );
-      this.#memory = { plugins, fetchedAt: now, ttlMs: this.#ttlMs };
+      if (generation === this.#generation) {
+        this.#memory = {
+          plugins: clonePlugins(plugins),
+          fetchedAt: cached.fetchedAt,
+          ttlMs: this.#ttlMs,
+        };
+      }
       return plugins;
     }
-    if (this.#load) return this.#load;
+    return this.#loadRegistry(generation, cached);
+  }
 
-    const generation = this.#generation;
-    const load = this.#loadRegistry(generation, cached, input.signal).finally(
-      () => {
-        if (this.#load === load) this.#load = null;
-      },
+  async #decorate(
+    authority: Map<string, RegistryPluginInfo>,
+  ): Promise<Map<string, RegistryPluginInfo>> {
+    const plugins = clonePlugins(authority);
+    await this.#options.applyLocalWorkspaceApps(plugins);
+    await this.#options.applyNodeModulePlugins(plugins);
+    await this.#options.mergeCustomEndpoints(
+      plugins,
+      this.#options.getConfiguredEndpoints(),
     );
-    this.#load = load;
-    return load;
+    return plugins;
   }
 
   async #loadRegistry(
     generation: number,
     cached: RegistryCacheRecord | null,
-    requestSignal?: AbortSignal,
   ): Promise<Map<string, RegistryPluginInfo>> {
     logger.info("[registry-client] Fetching plugin registry...");
     let snapshot: RegistryNetworkSnapshot | null = null;
-    let cachePlugins: Map<string, RegistryPluginInfo> | null = null;
     let plugins: Map<string, RegistryPluginInfo>;
     let ttlMs = this.#ttlMs;
     try {
@@ -273,7 +381,6 @@ export class RegistryClient {
         cloudReachable: this.#options.cloudReachable,
         timeoutMs: this.#options.timeoutMs,
         now: this.#now,
-        signal: requestSignal,
         cacheValidator:
           cached?.sourceUrl && cached.etag
             ? {
@@ -283,8 +390,7 @@ export class RegistryClient {
               }
             : null,
       });
-      plugins = snapshot.plugins;
-      cachePlugins = new Map(plugins);
+      plugins = clonePlugins(snapshot.plugins);
     } catch (error) {
       // error-policy:J4 only the typed offline condition degrades to explicit
       // local discovery; protocol and validation failures remain fatal.
@@ -294,25 +400,19 @@ export class RegistryClient {
         `[registry-client] Remote registry unavailable; using local discovery: ${message}`,
       );
       plugins = new Map();
-      await this.#options.applyLocalWorkspaceApps(plugins);
-      await this.#options.applyNodeModulePlugins(plugins);
       ttlMs = LOCAL_FALLBACK_TTL_MS;
     }
-    await this.#options.mergeCustomEndpoints(
-      plugins,
-      this.#options.getConfiguredEndpoints(),
-    );
-    logger.info(`[registry-client] Loaded ${plugins.size} plugins`);
+    logger.info(`[registry-client] Loaded ${plugins.size} upstream plugins`);
     if (generation !== this.#generation) return plugins;
 
     const fetchedAt = this.#now();
-    this.#memory = { plugins, fetchedAt, ttlMs };
+    this.#memory = { plugins: clonePlugins(plugins), fetchedAt, ttlMs };
     if (snapshot) {
       const record: RegistryCacheRecord = {
         fetchedAt,
         sourceUrl: snapshot.etag ? snapshot.sourceUrl : null,
         etag: snapshot.etag,
-        plugins: [...(cachePlugins ?? plugins).entries()],
+        plugins: [...clonePlugins(plugins).entries()],
       };
       try {
         await this.#options.cacheStore.write(

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -7,7 +7,6 @@
  * @module services/registry-client
  */
 
-import fs from "node:fs/promises";
 import path from "node:path";
 import { logger } from "@elizaos/core";
 import { loadElizaConfig, saveElizaConfig } from "../config/config.ts";
@@ -29,10 +28,6 @@ import {
   applyNodeModulePlugins,
 } from "./registry-client-local.ts";
 import {
-  fetchFromNetwork as fetchRegistryFromNetwork,
-  isExpectedRegistryNetworkFallback,
-} from "./registry-client-network.ts";
-import {
   getPluginInfoFromRegistry,
   normalizePluginLookupAlias,
   scoreEntries,
@@ -41,6 +36,13 @@ import {
   toPluginListItem,
   toSearchResults,
 } from "./registry-client-queries.ts";
+import {
+  createFileRegistryCacheStore,
+  type RegistryCacheRecord,
+  type RegistryCacheStore,
+  RegistryClient,
+  type RegistryClientOptions,
+} from "./registry-client-runtime.ts";
 import type {
   RegistryAppInfo,
   RegistryPluginInfo,
@@ -55,7 +57,6 @@ import type {
 const GENERATED_REGISTRY_URL =
   "https://plugins.eliza.app/generated-registry.json";
 const INDEX_REGISTRY_URL = "https://plugins.eliza.app/index.json";
-const CACHE_TTL_MS = 3_600_000; // 1 hour
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -70,98 +71,17 @@ export type {
   RegistrySearchResult,
 } from "./registry-client-types.ts";
 
-// ---------------------------------------------------------------------------
-// Cache state
-// ---------------------------------------------------------------------------
-
-let memoryCache: {
-  plugins: Map<string, RegistryPluginInfo>;
-  fetchedAt: number;
-  ttlMs?: number;
-} | null = null;
-let registryLoadPromise: Promise<Map<string, RegistryPluginInfo>> | null = null;
-/**
- * Bumped every time the registry caches are invalidated. A load that started
- * before the bump carries a pre-invalidation snapshot, so it must not publish
- * that snapshot (or stamp a fresh TTL over it) once it finally resolves.
- */
-let registryGeneration = 0;
-
-const LOCAL_FALLBACK_CACHE_TTL_MS = 5 * 60_000;
-
-// ---------------------------------------------------------------------------
-// Network fetch + parse (inlined wire types — not exported)
-// ---------------------------------------------------------------------------
-
-async function fetchFromNetwork(): Promise<Map<string, RegistryPluginInfo>> {
-  try {
-    return await fetchRegistryFromNetwork({
-      generatedRegistryUrl: GENERATED_REGISTRY_URL,
-      indexRegistryUrl: INDEX_REGISTRY_URL,
-      applyLocalWorkspaceApps,
-      applyNodeModulePlugins,
-      sanitizeSandbox,
-    });
-  } catch (err) {
-    if (!isExpectedRegistryNetworkFallback(err)) {
-      logger.warn(
-        `[registry-client] generated-registry/index fallback failed: ${String(err)}`,
-      );
-    }
-    throw err;
-  }
-}
-
-async function buildLocalRegistrySnapshot(): Promise<
-  Map<string, RegistryPluginInfo>
-> {
-  const plugins = new Map<string, RegistryPluginInfo>();
-  await applyLocalWorkspaceApps(plugins);
-  await applyNodeModulePlugins(plugins);
-  return plugins;
-}
-
-// ---------------------------------------------------------------------------
-// File cache
-// ---------------------------------------------------------------------------
-
 function cacheFilePath(): string {
   return path.join(resolveStateDir(), "cache", "registry.json");
 }
 
-async function readFileCache(): Promise<Map<
-  string,
-  RegistryPluginInfo
-> | null> {
-  try {
-    const raw = await fs.readFile(cacheFilePath(), "utf-8");
-    const parsed = JSON.parse(raw) as {
-      fetchedAt: number;
-      plugins: Array<[string, RegistryPluginInfo]>;
-    };
-    if (typeof parsed.fetchedAt !== "number" || !Array.isArray(parsed.plugins))
-      return null;
-    if (Date.now() - parsed.fetchedAt > CACHE_TTL_MS) return null;
-    return new Map(parsed.plugins);
-  } catch {
-    return null;
-  }
-}
-
-async function writeFileCache(
-  plugins: Map<string, RegistryPluginInfo>,
-): Promise<void> {
-  const filePath = cacheFilePath();
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(
-    filePath,
-    JSON.stringify({
-      fetchedAt: Date.now(),
-      plugins: [...plugins.entries()],
-    }),
-    "utf-8",
-  );
-}
+export {
+  createFileRegistryCacheStore,
+  type RegistryCacheRecord,
+  type RegistryCacheStore,
+  RegistryClient,
+  type RegistryClientOptions,
+};
 
 // ---------------------------------------------------------------------------
 // Multi-endpoint management
@@ -200,7 +120,7 @@ export function addRegistryEndpoint(label: string, url: string): void {
     { label, url: normalised, enabled: true },
   ];
   saveElizaConfig(cfg);
-  memoryCache = null;
+  defaultRegistryClient.invalidateMemory();
 }
 
 /** Remove a custom registry endpoint by URL. Cannot remove the default. */
@@ -220,7 +140,7 @@ export function removeRegistryEndpoint(url: string): void {
   if (!cfg.plugins) cfg.plugins = {};
   cfg.plugins.registryEndpoints = updated;
   saveElizaConfig(cfg);
-  memoryCache = null;
+  defaultRegistryClient.invalidateMemory();
 }
 
 /** Toggle an endpoint's enabled status. */
@@ -234,12 +154,23 @@ export function toggleRegistryEndpoint(url: string, enabled: boolean): void {
   if (!cfg.plugins) cfg.plugins = {};
   cfg.plugins.registryEndpoints = endpoints;
   saveElizaConfig(cfg);
-  memoryCache = null;
+  defaultRegistryClient.invalidateMemory();
 }
 
 export function isDefaultEndpoint(url: string): boolean {
   return isDefaultEndpointForUrl(url, GENERATED_REGISTRY_URL);
 }
+
+const defaultRegistryClient = new RegistryClient({
+  generatedRegistryUrl: GENERATED_REGISTRY_URL,
+  indexRegistryUrl: INDEX_REGISTRY_URL,
+  cacheStore: createFileRegistryCacheStore(cacheFilePath),
+  applyLocalWorkspaceApps,
+  applyNodeModulePlugins,
+  sanitizeSandbox,
+  getConfiguredEndpoints,
+  mergeCustomEndpoints,
+});
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -249,100 +180,14 @@ export function isDefaultEndpoint(url: string): boolean {
 export async function getRegistryPlugins(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  if (
-    memoryCache &&
-    Date.now() - memoryCache.fetchedAt < (memoryCache.ttlMs ?? CACHE_TTL_MS)
-  ) {
-    return memoryCache.plugins;
-  }
-
-  const fromFile = await readFileCache();
-  if (fromFile) {
-    await applyLocalWorkspaceApps(fromFile);
-    await applyNodeModulePlugins(fromFile);
-    await mergeCustomEndpoints(fromFile, getConfiguredEndpoints());
-    memoryCache = { plugins: fromFile, fetchedAt: Date.now() };
-    return fromFile;
-  }
-
-  if (registryLoadPromise) {
-    return registryLoadPromise;
-  }
-
-  const generation = registryGeneration;
-  const load: Promise<Map<string, RegistryPluginInfo>> = (async () => {
-    logger.info("[registry-client] Fetching plugin registry...");
-    let plugins: Map<string, RegistryPluginInfo>;
-    let usedLocalFallback = false;
-    try {
-      plugins = await fetchFromNetwork();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (isExpectedRegistryNetworkFallback(err)) {
-        logger.debug(
-          `[registry-client] Remote registry unavailable; using local registry discovery: ${message}`,
-        );
-      } else {
-        logger.warn(
-          `[registry-client] Falling back to local registry discovery: ${message}`,
-        );
-      }
-      plugins = await buildLocalRegistrySnapshot();
-      usedLocalFallback = true;
-    }
-    await mergeCustomEndpoints(plugins, getConfiguredEndpoints());
-    logger.info(`[registry-client] Loaded ${plugins.size} plugins`);
-
-    // The caches were invalidated after this load started, so this snapshot is
-    // already known to be stale. Hand it to the callers that are awaiting it,
-    // but never publish it.
-    if (generation !== registryGeneration) return plugins;
-
-    memoryCache = {
-      plugins,
-      fetchedAt: Date.now(),
-      ttlMs: usedLocalFallback ? LOCAL_FALLBACK_CACHE_TTL_MS : CACHE_TTL_MS,
-    };
-    if (!usedLocalFallback) {
-      writeFileCache(plugins).catch((err) =>
-        logger.warn(`[registry-client] Cache write failed: ${String(err)}`),
-      );
-    }
-
-    return plugins;
-  })().finally(() => {
-    // Only clear the slot if it is still this load's; an invalidation may have
-    // already replaced it with a newer one.
-    if (registryLoadPromise === load) registryLoadPromise = null;
-  });
-  registryLoadPromise = load;
-
-  return load;
-}
-
-/**
- * Drop every cached registry snapshot, including one that is still loading.
- * Clearing `memoryCache` alone is not enough: an in-flight load returns its
- * pre-invalidation snapshot to the refresher and then republishes it with a
- * fresh TTL, which suppresses later refreshes for the full cache lifetime.
- */
-function invalidateRegistryCaches(): void {
-  memoryCache = null;
-  registryLoadPromise = null;
-  registryGeneration += 1;
+  return defaultRegistryClient.getRegistryPlugins();
 }
 
 /** Force-refresh from network. */
 export async function refreshRegistry(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  invalidateRegistryCaches();
-  try {
-    await fs.unlink(cacheFilePath());
-  } catch {
-    // Missing cache files are fine; the network refresh below repopulates it.
-  }
-  return getRegistryPlugins();
+  return defaultRegistryClient.refreshRegistry();
 }
 
 /** Look up a plugin by name (exact → @elizaos/ prefix → bare suffix). */

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -80,6 +80,12 @@ let memoryCache: {
   ttlMs?: number;
 } | null = null;
 let registryLoadPromise: Promise<Map<string, RegistryPluginInfo>> | null = null;
+/**
+ * Bumped every time the registry caches are invalidated. A load that started
+ * before the bump carries a pre-invalidation snapshot, so it must not publish
+ * that snapshot (or stamp a fresh TTL over it) once it finally resolves.
+ */
+let registryGeneration = 0;
 
 const LOCAL_FALLBACK_CACHE_TTL_MS = 5 * 60_000;
 
@@ -263,7 +269,8 @@ export async function getRegistryPlugins(): Promise<
     return registryLoadPromise;
   }
 
-  registryLoadPromise = (async () => {
+  const generation = registryGeneration;
+  const load: Promise<Map<string, RegistryPluginInfo>> = (async () => {
     logger.info("[registry-client] Fetching plugin registry...");
     let plugins: Map<string, RegistryPluginInfo>;
     let usedLocalFallback = false;
@@ -286,6 +293,11 @@ export async function getRegistryPlugins(): Promise<
     await mergeCustomEndpoints(plugins, getConfiguredEndpoints());
     logger.info(`[registry-client] Loaded ${plugins.size} plugins`);
 
+    // The caches were invalidated after this load started, so this snapshot is
+    // already known to be stale. Hand it to the callers that are awaiting it,
+    // but never publish it.
+    if (generation !== registryGeneration) return plugins;
+
     memoryCache = {
       plugins,
       fetchedAt: Date.now(),
@@ -299,17 +311,32 @@ export async function getRegistryPlugins(): Promise<
 
     return plugins;
   })().finally(() => {
-    registryLoadPromise = null;
+    // Only clear the slot if it is still this load's; an invalidation may have
+    // already replaced it with a newer one.
+    if (registryLoadPromise === load) registryLoadPromise = null;
   });
+  registryLoadPromise = load;
 
-  return registryLoadPromise;
+  return load;
+}
+
+/**
+ * Drop every cached registry snapshot, including one that is still loading.
+ * Clearing `memoryCache` alone is not enough: an in-flight load returns its
+ * pre-invalidation snapshot to the refresher and then republishes it with a
+ * fresh TTL, which suppresses later refreshes for the full cache lifetime.
+ */
+function invalidateRegistryCaches(): void {
+  memoryCache = null;
+  registryLoadPromise = null;
+  registryGeneration += 1;
 }
 
 /** Force-refresh from network. */
 export async function refreshRegistry(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  memoryCache = null;
+  invalidateRegistryCaches();
   try {
     await fs.unlink(cacheFilePath());
   } catch {

--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -25,6 +25,12 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/registry/` (export `./registry`) — resettable loopback marketplace and
+  npm-package upstream. It serves the generated and index registry protocols,
+  conditional ETags, npm packuments, and deterministic tarballs to the real
+  `@elizaos/agent` registry client and installer. Its virtual clock, queued
+  faults, generation fence, and redacted observation log support repeatable
+  cache, reset, cancellation, and artifact-integrity scenarios.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.
@@ -67,6 +73,12 @@ mockoon-cli start --data packages/cloud/test-mocks/mockoon/control-plane-static.
 Use programmatically by awaiting `startHetznerMock` / `startControlPlaneMock`,
 pointing the real client at the returned `url`, then calling `stop()` in
 teardown.
+
+Use `startRegistryMock()` for marketplace scenarios. Pass its generated,
+index, and package-registry URLs to instance-local agent collaborators; do not
+mutate process-wide fetch or npm configuration. `reset()` advances the server
+generation and clears current observations, while requests admitted by an old
+generation remain available through stale-observation readback for assertions.
 
 ## Conventions / gotchas
 

--- a/packages/cloud/test-mocks/CLAUDE.md
+++ b/packages/cloud/test-mocks/CLAUDE.md
@@ -25,6 +25,12 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/registry/` (export `./registry`) — resettable loopback marketplace and
+  npm-package upstream. It serves the generated and index registry protocols,
+  conditional ETags, npm packuments, and deterministic tarballs to the real
+  `@elizaos/agent` registry client and installer. Its virtual clock, queued
+  faults, generation fence, and redacted observation log support repeatable
+  cache, reset, cancellation, and artifact-integrity scenarios.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.
@@ -67,6 +73,12 @@ mockoon-cli start --data packages/cloud/test-mocks/mockoon/control-plane-static.
 Use programmatically by awaiting `startHetznerMock` / `startControlPlaneMock`,
 pointing the real client at the returned `url`, then calling `stop()` in
 teardown.
+
+Use `startRegistryMock()` for marketplace scenarios. Pass its generated,
+index, and package-registry URLs to instance-local agent collaborators; do not
+mutate process-wide fetch or npm configuration. `reset()` advances the server
+generation and clears current observations, while requests admitted by an old
+generation remain available through stale-observation readback for assertions.
 
 ## Conventions / gotchas
 

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -2,6 +2,29 @@
 
 Stateful, in-process mocks of third-party cloud APIs used by Eliza Cloud. Designed for use in unit / integration tests and local development without hitting real provider APIs.
 
+## Plugin registry mock
+
+`@elizaos/cloud-test-mocks/registry` starts a real loopback HTTP marketplace
+and npm-compatible package upstream. It is designed for the production
+`RegistryClient` and plugin installer, not a substitute client. The mock serves
+generated registry metadata with flat-index fallback, conditional ETags and
+304 responses, npm packuments, and deterministic tar artifacts with SHA-512
+integrity metadata.
+
+The controller exposes a virtual clock, resettable seeded state, queued HTTP,
+malformed, delay, stall, redirect, and artifact faults, plus redacted request
+observations. Reset advances a generation fence so a request admitted before
+reset cannot publish into the new world; stale request observations remain
+separately inspectable.
+
+```ts
+import { startRegistryMock } from "@elizaos/cloud-test-mocks/registry";
+
+const upstream = await startRegistryMock({ seed: "scenario-a" });
+// Construct the real RegistryClient and installer with upstream.urls.
+await upstream.stop();
+```
+
 ## Managed provider contract harness
 
 `@elizaos/cloud-test-mocks/provider-contract` provides a reusable real-HTTP

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -9,7 +9,8 @@
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
     "./steward": "./src/steward/index.ts",
-    "./provider-contract": "./src/provider-contract/index.ts"
+    "./provider-contract": "./src/provider-contract/index.ts",
+    "./registry": "./src/registry/index.ts"
   },
   "bin": {
     "hetzner-mock": "./bin/hetzner-mock.ts",

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -2,4 +2,5 @@
 export * as controlPlane from "./control-plane";
 export * from "./hetzner";
 export * as providerContract from "./provider-contract";
+export * from "./registry";
 export * from "./steward";

--- a/packages/cloud/test-mocks/src/registry/index.ts
+++ b/packages/cloud/test-mocks/src/registry/index.ts
@@ -1,0 +1,392 @@
+/**
+ * Hosts a resettable marketplace plus npm-compatible artifact registry over
+ * real loopback HTTP. State, faults, virtual time, and observations are bound
+ * to a generation so a request admitted before reset cannot mutate or appear
+ * in the current synthetic world.
+ */
+import crypto from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { startFetchServer } from "../fetch-server.ts";
+
+const PACKAGE_NAME = "@synthetic/plugin-weather";
+const PACKAGE_VERSION = "1.0.0";
+
+export type RegistryMockFault =
+  | { kind: "status"; status: number; retryAfterSeconds?: number }
+  | { kind: "malformed-json" }
+  | { kind: "delay"; ms: number }
+  | { kind: "stall" }
+  | { kind: "redirect"; location?: string }
+  | { kind: "integrity-mismatch" }
+  | { kind: "corrupt-artifact" };
+
+export interface RegistryMockObservation {
+  sequence: number;
+  generation: number;
+  at: number;
+  method: string;
+  path: string;
+  ifNoneMatch: string | null;
+  authorization: "[REDACTED]" | null;
+  status: number;
+  stale: boolean;
+}
+
+export interface RegistryMockReadback {
+  generation: number;
+  now: number;
+  observations: RegistryMockObservation[];
+  staleObservations: RegistryMockObservation[];
+}
+
+export interface RegistryMockSeed {
+  packageName?: string;
+  version?: string;
+  description?: string;
+}
+
+interface NormalizedSeed {
+  packageName: string;
+  version: string;
+  description: string;
+}
+
+function normalizeSeed(seed: RegistryMockSeed = {}): NormalizedSeed {
+  return {
+    packageName: seed.packageName ?? PACKAGE_NAME,
+    version: seed.version ?? PACKAGE_VERSION,
+    description:
+      seed.description ?? "Deterministic synthetic weather connector",
+  };
+}
+
+function writeOctal(
+  buffer: Buffer,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const encoded = value
+    .toString(8)
+    .padStart(length - 1, "0")
+    .slice(-(length - 1));
+  buffer.write(`${encoded}\0`, offset, length, "ascii");
+}
+
+function tarEntry(name: string, contents: Buffer): Buffer {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, "utf8");
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, contents.length);
+  writeOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  const checksumText = checksum.toString(8).padStart(6, "0");
+  header.write(`${checksumText}\0 `, 148, 8, "ascii");
+  const padding = Buffer.alloc((512 - (contents.length % 512)) % 512);
+  return Buffer.concat([header, contents, padding]);
+}
+
+function packageArtifact(seed: NormalizedSeed): Buffer {
+  const manifest = Buffer.from(
+    `${JSON.stringify(
+      {
+        name: seed.packageName,
+        version: seed.version,
+        type: "module",
+        main: "index.js",
+        exports: "./index.js",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const source = Buffer.from(
+    `export const syntheticRegistryArtifact = ${JSON.stringify(seed.description)};\n`,
+  );
+  const tar = Buffer.concat([
+    tarEntry("package/package.json", manifest),
+    tarEntry("package/index.js", source),
+    Buffer.alloc(1024),
+  ]);
+  return gzipSync(tar, { level: 9 });
+}
+
+function etag(body: Uint8Array): string {
+  return `"sha256-${crypto.createHash("sha256").update(body).digest("hex")}"`;
+}
+
+function sri(body: Uint8Array): string {
+  return `sha512-${crypto.createHash("sha512").update(body).digest("base64")}`;
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}
+
+function stall(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) reject(signal.reason);
+    signal.addEventListener("abort", () => reject(signal.reason), {
+      once: true,
+    });
+  });
+}
+
+export async function startRegistryMock(seedInput: RegistryMockSeed = {}) {
+  let seed = normalizeSeed(seedInput);
+  let generation = 1;
+  let now = 1_700_000_000_000;
+  let sequence = 0;
+  let observations: RegistryMockObservation[] = [];
+  let staleObservations: RegistryMockObservation[] = [];
+  const faults = new Map<string, RegistryMockFault[]>();
+  let origin = "";
+
+  const server = await startFetchServer(async (request) => {
+    const admittedGeneration = generation;
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const normalizedPath = path.replace(/%2f/gi, "%2f");
+    const faultQueue = faults.get(path) ?? faults.get(normalizedPath);
+    const fault = faultQueue?.shift();
+    const record = (status: number): void => {
+      const observation: RegistryMockObservation = {
+        sequence: ++sequence,
+        generation: admittedGeneration,
+        at: now,
+        method: request.method,
+        path,
+        ifNoneMatch: request.headers.get("if-none-match"),
+        authorization: request.headers.has("authorization")
+          ? "[REDACTED]"
+          : null,
+        status,
+        stale: admittedGeneration !== generation,
+      };
+      if (observation.stale) staleObservations.push(observation);
+      else observations.push(observation);
+    };
+
+    if (fault?.kind === "delay") {
+      try {
+        await abortableDelay(fault.ms, request.signal);
+      } catch (error) {
+        // error-policy:J2 bind cancellation to an observation, then preserve
+        // its cause across the mock HTTP boundary.
+        record(499);
+        throw new Error("Synthetic delayed request aborted", { cause: error });
+      }
+      if (admittedGeneration !== generation) {
+        record(409);
+        return new Response("stale synthetic generation", { status: 409 });
+      }
+    } else if (fault?.kind === "stall") {
+      try {
+        await stall(request.signal);
+      } catch (error) {
+        // error-policy:J2 bind cancellation to an observation, then preserve
+        // its cause across the mock HTTP boundary.
+        record(499);
+        throw new Error("Synthetic stalled request aborted", { cause: error });
+      }
+    } else if (fault?.kind === "status") {
+      record(fault.status);
+      return new Response("synthetic status fault", {
+        status: fault.status,
+        headers:
+          fault.retryAfterSeconds === undefined
+            ? undefined
+            : { "retry-after": String(fault.retryAfterSeconds) },
+      });
+    } else if (fault?.kind === "malformed-json") {
+      record(200);
+      return new Response("{not-json", {
+        headers: { "content-type": "application/json" },
+      });
+    } else if (fault?.kind === "redirect") {
+      record(302);
+      return Response.redirect(
+        fault.location ?? `${origin}/redirect-target`,
+        302,
+      );
+    }
+
+    const artifact = packageArtifact(seed);
+    const generatedBody = Buffer.from(
+      JSON.stringify({
+        registry: {
+          [seed.packageName]: {
+            git: {
+              repo: "synthetic/plugin-weather",
+              v0: { branch: null },
+              v1: { branch: null },
+              v2: { branch: "main" },
+            },
+            npm: {
+              repo: seed.packageName,
+              v0: null,
+              v1: null,
+              v2: seed.version,
+            },
+            supports: { v0: false, v1: false, v2: true },
+            directory: null,
+            description: seed.description,
+            homepage: null,
+            topics: ["synthetic", "weather"],
+            stargazers_count: 42,
+            language: "TypeScript",
+            origin: "third-party",
+            source: "synthetic",
+            support: "community",
+            builtIn: false,
+            firstParty: false,
+            thirdParty: true,
+            status: "active",
+            registryKind: "plugin",
+          },
+        },
+      }),
+    );
+
+    if (path === "/generated-registry.json") {
+      const tag = etag(generatedBody);
+      if (request.headers.get("if-none-match") === tag) {
+        record(304);
+        return new Response(null, { status: 304, headers: { etag: tag } });
+      }
+      record(200);
+      return new Response(generatedBody, {
+        headers: { "content-type": "application/json", etag: tag },
+      });
+    }
+    if (path === "/index.json") {
+      const body = Buffer.from(
+        JSON.stringify({
+          [seed.packageName]: "github:synthetic/plugin-weather",
+        }),
+      );
+      const tag = etag(body);
+      if (request.headers.get("if-none-match") === tag) {
+        record(304);
+        return new Response(null, { status: 304, headers: { etag: tag } });
+      }
+      record(200);
+      return new Response(body, {
+        headers: { "content-type": "application/json", etag: tag },
+      });
+    }
+
+    const encodedName = seed.packageName.replace("/", "%2f");
+    if (
+      normalizedPath === `/npm/${encodedName}` ||
+      path === `/npm/${seed.packageName}`
+    ) {
+      const integrity =
+        fault?.kind === "integrity-mismatch"
+          ? `sha512-${Buffer.alloc(64).toString("base64")}`
+          : sri(artifact);
+      const tarballName = seed.packageName.split("/").at(-1);
+      const body = {
+        name: seed.packageName,
+        "dist-tags": { latest: seed.version },
+        versions: {
+          [seed.version]: {
+            name: seed.packageName,
+            version: seed.version,
+            dist: {
+              tarball: `${origin}/npm/${encodedName}/-/${tarballName}-${seed.version}.tgz`,
+              integrity,
+              shasum: crypto.createHash("sha1").update(artifact).digest("hex"),
+            },
+          },
+        },
+      };
+      record(200);
+      return Response.json(body);
+    }
+    if (
+      normalizedPath.endsWith(`-${seed.version}.tgz`) &&
+      normalizedPath.startsWith(`/npm/${encodedName}/-/`)
+    ) {
+      const corruptOffset = Math.min(20, artifact.length - 1);
+      const originalByte = artifact.at(corruptOffset);
+      if (originalByte === undefined)
+        throw new Error("Synthetic artifact is empty");
+      const bytes =
+        fault?.kind === "corrupt-artifact"
+          ? Buffer.concat([
+              artifact.subarray(0, corruptOffset),
+              Buffer.from([originalByte ^ 0xff]),
+              artifact.subarray(corruptOffset + 1),
+            ])
+          : artifact;
+      record(200);
+      return new Response(Uint8Array.from(bytes).buffer, {
+        headers: { "content-type": "application/octet-stream" },
+      });
+    }
+
+    record(404);
+    return new Response("not found", { status: 404 });
+  });
+
+  origin = `http://${server.hostname}:${server.port}`;
+  return {
+    origin,
+    generatedRegistryUrl: `${origin}/generated-registry.json`,
+    indexRegistryUrl: `${origin}/index.json`,
+    packageRegistryUrl: `${origin}/npm/`,
+    enqueueFault(path: string, fault: RegistryMockFault): void {
+      const queue = faults.get(path) ?? [];
+      queue.push(fault);
+      faults.set(path, queue);
+    },
+    advanceTime(ms: number): void {
+      if (!Number.isInteger(ms) || ms < 0)
+        throw new Error("advanceTime requires non-negative integer ms");
+      now += ms;
+    },
+    now(): number {
+      return now;
+    },
+    reset(nextSeed: RegistryMockSeed = seedInput): void {
+      seed = normalizeSeed(nextSeed);
+      generation += 1;
+      now = 1_700_000_000_000;
+      sequence = 0;
+      observations = [];
+      staleObservations = [];
+      faults.clear();
+    },
+    readback(): RegistryMockReadback {
+      return {
+        generation,
+        now,
+        observations: structuredClone(observations),
+        staleObservations: structuredClone(staleObservations),
+      };
+    },
+    stop: server.stop,
+  };
+}

--- a/packages/cloud/test-mocks/src/registry/index.ts
+++ b/packages/cloud/test-mocks/src/registry/index.ts
@@ -17,6 +17,13 @@ export type RegistryMockFault =
   | { kind: "delay"; ms: number }
   | { kind: "stall" }
   | { kind: "redirect"; location?: string }
+  | {
+      kind: "raw-json-response";
+      body: string | number[];
+      contentType?: string;
+      contentEncoding?: string;
+      contentLength?: string;
+    }
   | { kind: "integrity-mismatch" }
   | { kind: "corrupt-artifact" };
 
@@ -230,6 +237,20 @@ export async function startRegistryMock(seedInput: RegistryMockSeed = {}) {
         fault.location ?? `${origin}/redirect-target`,
         302,
       );
+    } else if (fault?.kind === "raw-json-response") {
+      record(200);
+      const headers = new Headers();
+      if (fault.contentType !== undefined)
+        headers.set("content-type", fault.contentType);
+      if (fault.contentEncoding !== undefined)
+        headers.set("content-encoding", fault.contentEncoding);
+      if (fault.contentLength !== undefined)
+        headers.set("content-length", fault.contentLength);
+      const body =
+        typeof fault.body === "string"
+          ? fault.body
+          : Uint8Array.from(fault.body);
+      return new Response(body, { headers });
     }
 
     const artifact = packageArtifact(seed);
@@ -361,6 +382,9 @@ export async function startRegistryMock(seedInput: RegistryMockSeed = {}) {
       const queue = faults.get(path) ?? [];
       queue.push(fault);
       faults.set(path, queue);
+    },
+    pendingFaultCount(path: string): number {
+      return faults.get(path)?.length ?? 0;
     },
     advanceTime(ms: number): void {
       if (!Number.isInteger(ms) || ms < 0)

--- a/packages/cloud/test-mocks/test/registry-protocol.test.ts
+++ b/packages/cloud/test-mocks/test/registry-protocol.test.ts
@@ -6,7 +6,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { logger } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { installPluginWithRuntime } from "../../../agent/src/services/plugin-installer.ts";
 import {
   createFileRegistryCacheStore,
@@ -32,6 +33,7 @@ const originalStateDir = process.env.ELIZA_STATE_DIR;
 const originalConfigPath = process.env.ELIZA_CONFIG_PATH;
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(runningServers.splice(0).map((server) => server.stop()));
   await Promise.all(
     temporaryDirectories
@@ -299,6 +301,35 @@ describe("registry marketplace protocol", () => {
     });
     await Promise.resolve();
     expect(cancelled).toBe(true);
+
+    const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+    const rejectedCancellation = new ReadableStream<Uint8Array>({
+      cancel() {
+        return Promise.reject(new Error("cancel rejected"));
+      },
+    });
+    await expect(
+      fetchRegistrySnapshot({
+        generatedRegistryUrl:
+          "https://registry.example/generated-registry.json",
+        indexRegistryUrl: "https://registry.example/index.json",
+        fetchImpl: async () =>
+          new Response(rejectedCancellation, {
+            headers: {
+              "content-type": "application/json",
+              "content-encoding": "gzip",
+            },
+          }),
+        cloudReachable: async () => true,
+      }),
+    ).rejects.toMatchObject({
+      code: "REGISTRY_UPSTREAM_CONTENT_ENCODING_UNSUPPORTED",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(debug).toHaveBeenCalledWith(
+      expect.stringContaining("Response cancellation failed"),
+    );
 
     for (const retryAfter of ["9".repeat(1_000), "9999999999"]) {
       let caught: unknown;

--- a/packages/cloud/test-mocks/test/registry-protocol.test.ts
+++ b/packages/cloud/test-mocks/test/registry-protocol.test.ts
@@ -14,6 +14,11 @@ import {
 } from "../../../agent/src/services/registry-client.ts";
 import {
   fetchRegistrySnapshot,
+  MAX_REGISTRY_JSON_BYTES,
+  MAX_REGISTRY_JSON_DEPTH,
+  MAX_REGISTRY_JSON_NODES,
+  MAX_REGISTRY_JSON_STRING_BYTES,
+  MAX_REGISTRY_JSON_WIDTH,
   RegistryUpstreamError,
 } from "../../../agent/src/services/registry-client-network.ts";
 import {
@@ -94,8 +99,10 @@ describe("registry marketplace protocol", () => {
       client.getRegistryPlugins(),
       client.getRegistryPlugins(),
     ]);
-    expect(first).toBe(second);
-    expect(second).toBe(third);
+    expect(first).toStrictEqual(second);
+    expect(second).toStrictEqual(third);
+    expect(first).not.toBe(second);
+    expect(second).not.toBe(third);
     expect(first.get("@synthetic/plugin-weather")?.npm.v2Version).toBe("1.0.0");
     expect(upstream.readback().observations).toMatchObject([
       { path: "/generated-registry.json", status: 200, ifNoneMatch: null },
@@ -163,6 +170,7 @@ describe("registry marketplace protocol", () => {
       },
       {
         fault: { kind: "stall" },
+        timeoutMs: 20,
         abort: true,
         verify: (error) => expect(error).toBeInstanceOf(Error),
       },
@@ -183,7 +191,141 @@ describe("registry marketplace protocol", () => {
         caught = error;
       }
       testCase.verify(caught);
+      if (testCase.abort) {
+        // Caller cancellation is isolated from the shared authority load. Let
+        // that load reach its own bounded timeout before stopping its server.
+        await new Promise((resolve) => setTimeout(resolve, 30));
+      }
       await runningServers.pop()?.stop();
+    }
+  });
+
+  it("rejects adversarial loopback JSON before schema admission", async () => {
+    let deep = "null";
+    for (let depth = 0; depth <= MAX_REGISTRY_JSON_DEPTH; depth += 1) {
+      deep = `[${deep}]`;
+    }
+    const nodeRows = Array.from({ length: MAX_REGISTRY_JSON_WIDTH }, () =>
+      Array(10).fill(0),
+    );
+    expect(MAX_REGISTRY_JSON_WIDTH * 11).toBeGreaterThan(
+      MAX_REGISTRY_JSON_NODES,
+    );
+    const cases: Array<{
+      body: string | number[];
+      contentType?: string;
+      code: string;
+    }> = [
+      {
+        body: "{}",
+        contentType: "text/plain",
+        code: "REGISTRY_UPSTREAM_CONTENT_TYPE_INVALID",
+      },
+      {
+        body: [0xc3, 0x28],
+        contentType: "application/json",
+        code: "REGISTRY_UPSTREAM_UTF8_INVALID",
+      },
+      {
+        body: deep,
+        contentType: "application/json",
+        code: "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+      },
+      {
+        body: JSON.stringify(Array(MAX_REGISTRY_JSON_WIDTH + 1).fill(0)),
+        contentType: "application/json",
+        code: "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+      },
+      {
+        body: JSON.stringify(nodeRows),
+        contentType: "application/json",
+        code: "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+      },
+      {
+        body: JSON.stringify("x".repeat(MAX_REGISTRY_JSON_STRING_BYTES + 1)),
+        contentType: "application/json",
+        code: "REGISTRY_UPSTREAM_JSON_LIMIT_EXCEEDED",
+      },
+      {
+        body: "x".repeat(MAX_REGISTRY_JSON_BYTES + 1),
+        contentType: "application/json",
+        code: "REGISTRY_UPSTREAM_BODY_TOO_LARGE",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { upstream, client } = await harness();
+      upstream.enqueueFault("/generated-registry.json", {
+        kind: "raw-json-response",
+        body: testCase.body,
+        contentType: testCase.contentType,
+      });
+      await expect(client.getRegistryPlugins()).rejects.toMatchObject({
+        code: testCase.code,
+      });
+      await runningServers.pop()?.stop();
+    }
+  }, 30_000);
+
+  it("bounds success headers and cancels rejected response streams", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{}"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    await expect(
+      fetchRegistrySnapshot({
+        generatedRegistryUrl:
+          "https://registry.example/generated-registry.json",
+        indexRegistryUrl: "https://registry.example/index.json",
+        fetchImpl: async () =>
+          new Response(body, {
+            headers: {
+              "content-type": "application/json",
+              "content-encoding": "gzip",
+            },
+          }),
+        cloudReachable: async () => true,
+        applyLocalWorkspaceApps: async () => {},
+        applyNodeModulePlugins: async () => {},
+        sanitizeSandbox: (value) => value ?? "allow-scripts",
+      }),
+    ).rejects.toMatchObject({
+      code: "REGISTRY_UPSTREAM_CONTENT_ENCODING_UNSUPPORTED",
+    });
+    await Promise.resolve();
+    expect(cancelled).toBe(true);
+
+    for (const retryAfter of ["9".repeat(1_000), "9999999999"]) {
+      let caught: unknown;
+      try {
+        await fetchRegistrySnapshot({
+          generatedRegistryUrl:
+            "https://registry.example/generated-registry.json",
+          indexRegistryUrl: "https://registry.example/index.json",
+          fetchImpl: async () =>
+            new Response("rate limited", {
+              status: 429,
+              headers: { "retry-after": retryAfter },
+            }),
+          cloudReachable: async () => true,
+          applyLocalWorkspaceApps: async () => {},
+          applyNodeModulePlugins: async () => {},
+          sanitizeSandbox: (value) => value ?? "allow-scripts",
+        });
+      } catch (error) {
+        // error-policy:J1 inspect the public typed boundary below.
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(RegistryUpstreamError);
+      expect((caught as RegistryUpstreamError).retryAfterMs).toSatisfy(
+        (value: number | null) =>
+          value === null || value <= 24 * 60 * 60 * 1_000,
+      );
     }
   });
 
@@ -199,7 +341,11 @@ describe("registry marketplace protocol", () => {
     });
     upstream.advanceTime(101);
     const old = client.getRegistryPlugins();
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    for (let attempts = 0; attempts < 100; attempts += 1) {
+      if (upstream.pendingFaultCount("/generated-registry.json") === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    expect(upstream.pendingFaultCount("/generated-registry.json")).toBe(0);
     upstream.reset({ description: "post-reset registry" });
 
     await expect(old).rejects.toMatchObject({ status: 409 });

--- a/packages/cloud/test-mocks/test/registry-protocol.test.ts
+++ b/packages/cloud/test-mocks/test/registry-protocol.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Drives the production agent registry client and plugin installer against a
+ * real resettable HTTP marketplace/npm upstream. No client method, package
+ * manager, response, or installed artifact is mocked.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installPluginWithRuntime } from "../../../agent/src/services/plugin-installer.ts";
+import {
+  createFileRegistryCacheStore,
+  RegistryClient,
+} from "../../../agent/src/services/registry-client.ts";
+import {
+  fetchRegistrySnapshot,
+  RegistryUpstreamError,
+} from "../../../agent/src/services/registry-client-network.ts";
+import {
+  type RegistryMockFault,
+  startRegistryMock,
+} from "../src/registry/index.ts";
+
+const temporaryDirectories: string[] = [];
+const runningServers: Array<{ stop(): Promise<void> }> = [];
+const originalStateDir = process.env.ELIZA_STATE_DIR;
+const originalConfigPath = process.env.ELIZA_CONFIG_PATH;
+
+afterEach(async () => {
+  await Promise.all(runningServers.splice(0).map((server) => server.stop()));
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+  if (originalStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = originalStateDir;
+  if (originalConfigPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+  else process.env.ELIZA_CONFIG_PATH = originalConfigPath;
+});
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function harness(options: { timeoutMs?: number; ttlMs?: number } = {}) {
+  const upstream = await startRegistryMock();
+  runningServers.push(upstream);
+  const state = await temporaryDirectory("eliza-registry-protocol-");
+  const client = new RegistryClient({
+    generatedRegistryUrl: upstream.generatedRegistryUrl,
+    indexRegistryUrl: upstream.indexRegistryUrl,
+    cacheStore: createFileRegistryCacheStore(path.join(state, "registry.json")),
+    now: upstream.now,
+    cacheTtlMs: options.ttlMs ?? 100,
+    timeoutMs: options.timeoutMs ?? 1_000,
+    cloudReachable: async () => true,
+    applyLocalWorkspaceApps: async () => {},
+    applyNodeModulePlugins: async () => {},
+    sanitizeSandbox: (value) => value ?? "allow-scripts",
+    getConfiguredEndpoints: () => [],
+    mergeCustomEndpoints: async () => {},
+  });
+  return { upstream, state, client };
+}
+
+describe("registry marketplace protocol", () => {
+  it("rejects unsafe endpoint seams before transport", async () => {
+    let fetchCalls = 0;
+    await expect(
+      fetchRegistrySnapshot({
+        generatedRegistryUrl: "http://attacker.example/generated-registry.json",
+        indexRegistryUrl: "https://plugins.eliza.app/index.json",
+        fetchImpl: async () => {
+          fetchCalls += 1;
+          return new Response();
+        },
+        cloudReachable: async () => true,
+        applyLocalWorkspaceApps: async () => {},
+        applyNodeModulePlugins: async () => {},
+        sanitizeSandbox: (value) => value ?? "allow-scripts",
+      }),
+    ).rejects.toBeInstanceOf(RegistryUpstreamError);
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("uses ETag/304 after virtual TTL expiry and singleflights concurrent callers", async () => {
+    const { upstream, client } = await harness();
+
+    const [first, second, third] = await Promise.all([
+      client.getRegistryPlugins(),
+      client.getRegistryPlugins(),
+      client.getRegistryPlugins(),
+    ]);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+    expect(first.get("@synthetic/plugin-weather")?.npm.v2Version).toBe("1.0.0");
+    expect(upstream.readback().observations).toMatchObject([
+      { path: "/generated-registry.json", status: 200, ifNoneMatch: null },
+    ]);
+
+    upstream.advanceTime(101);
+    const validated = await client.getRegistryPlugins();
+    expect(validated.get("@synthetic/plugin-weather")?.description).toContain(
+      "synthetic weather",
+    );
+    expect(upstream.readback().observations).toMatchObject([
+      { status: 200, ifNoneMatch: null },
+      { status: 304, ifNoneMatch: expect.stringMatching(/^"sha256-/) },
+    ]);
+  });
+
+  it("falls back to index only for generated 404", async () => {
+    const { upstream, client } = await harness();
+    upstream.enqueueFault("/generated-registry.json", {
+      kind: "status",
+      status: 404,
+    });
+
+    const registry = await client.getRegistryPlugins();
+
+    expect(registry.get("@synthetic/plugin-weather")?.gitRepo).toBe(
+      "synthetic/plugin-weather",
+    );
+    expect(
+      upstream
+        .readback()
+        .observations.map(({ path, status }) => ({ path, status })),
+    ).toEqual([
+      { path: "/generated-registry.json", status: 404 },
+      { path: "/index.json", status: 200 },
+    ]);
+  });
+
+  it("fails authoritative 429, malformed JSON, redirects, timeout, and cancellation", async () => {
+    const cases: Array<{
+      fault: RegistryMockFault;
+      verify(error: unknown): void;
+      timeoutMs?: number;
+      abort?: boolean;
+    }> = [
+      {
+        fault: { kind: "status", status: 429, retryAfterSeconds: 3 },
+        verify: (error) => {
+          expect(error).toBeInstanceOf(RegistryUpstreamError);
+          expect(error).toMatchObject({ status: 429, retryAfterMs: 3_000 });
+        },
+      },
+      {
+        fault: { kind: "malformed-json" },
+        verify: (error) => expect(error).toBeInstanceOf(RegistryUpstreamError),
+      },
+      {
+        fault: { kind: "redirect" },
+        verify: (error) => expect(error).toBeInstanceOf(Error),
+      },
+      {
+        fault: { kind: "stall" },
+        timeoutMs: 20,
+        verify: (error) => expect(error).toBeInstanceOf(Error),
+      },
+      {
+        fault: { kind: "stall" },
+        abort: true,
+        verify: (error) => expect(error).toBeInstanceOf(Error),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { upstream, client } = await harness({
+        timeoutMs: testCase.timeoutMs,
+      });
+      upstream.enqueueFault("/generated-registry.json", testCase.fault);
+      const controller = new AbortController();
+      if (testCase.abort) controller.abort(new Error("synthetic cancellation"));
+      let caught: unknown;
+      try {
+        await client.getRegistryPlugins({ signal: controller.signal });
+      } catch (error) {
+        // error-policy:J1 the test captures the public rejection for case-specific assertions.
+        caught = error;
+      }
+      testCase.verify(caught);
+      await runningServers.pop()?.stop();
+    }
+  });
+
+  it("rejects corrupt cache and prevents pre-reset requests from publishing", async () => {
+    const { upstream, state, client } = await harness();
+    await fs.writeFile(path.join(state, "registry.json"), "{corrupt");
+    expect((await client.getRegistryPlugins()).size).toBe(1);
+
+    await client.refreshRegistry();
+    upstream.enqueueFault("/generated-registry.json", {
+      kind: "delay",
+      ms: 50,
+    });
+    upstream.advanceTime(101);
+    const old = client.getRegistryPlugins();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    upstream.reset({ description: "post-reset registry" });
+
+    await expect(old).rejects.toMatchObject({ status: 409 });
+    const fresh = await client.refreshRegistry();
+    expect(fresh.get("@synthetic/plugin-weather")?.description).toBe(
+      "post-reset registry",
+    );
+    expect(upstream.readback().staleObservations).toMatchObject([
+      { path: "/generated-registry.json", status: 409, stale: true },
+    ]);
+    const cache = JSON.parse(
+      await fs.readFile(path.join(state, "registry.json"), "utf8"),
+    );
+    expect(cache.plugins[0][1].description).toBe("post-reset registry");
+  });
+
+  it("replays byte-equivalent state and redacts credentials in readback", async () => {
+    const { upstream } = await harness();
+    const run = async () => {
+      const response = await fetch(upstream.generatedRegistryUrl, {
+        headers: { authorization: "Bearer never-record-this" },
+      });
+      const bytes = Buffer.from(await response.arrayBuffer());
+      return {
+        digest: bytes.toString("hex"),
+        observations: upstream
+          .readback()
+          .observations.map(({ generation: _generation, ...entry }) => entry),
+      };
+    };
+
+    const first = await run();
+    upstream.reset();
+    const second = await run();
+
+    expect(second).toEqual(first);
+    expect(second.observations[0]?.authorization).toBe("[REDACTED]");
+    expect(JSON.stringify(upstream.readback())).not.toContain(
+      "never-record-this",
+    );
+  });
+});
+
+describe("registry artifact installation", () => {
+  it("rejects an unsafe npm registry before creating an install target", async () => {
+    const { state, client } = await harness();
+    process.env.ELIZA_STATE_DIR = state;
+    process.env.ELIZA_CONFIG_PATH = path.join(state, "eliza.json");
+
+    const result = await installPluginWithRuntime(
+      "@synthetic/plugin-weather",
+      undefined,
+      undefined,
+      {
+        getPluginInfo: client.getPluginInfo.bind(client),
+        packageRegistryUrl: "http://attacker.example/npm/",
+        packageManager: "npm",
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      installPath: "",
+      error: expect.stringContaining("literal loopback HTTP"),
+    });
+    await expect(
+      fs.access(path.join(state, "plugins", "installed")),
+    ).rejects.toBeDefined();
+  });
+
+  it("installs and reads the exact mock-served artifact with npm SRI provenance", async () => {
+    const { upstream, state, client } = await harness();
+    process.env.ELIZA_STATE_DIR = state;
+    process.env.ELIZA_CONFIG_PATH = path.join(state, "eliza.json");
+
+    const result = await installPluginWithRuntime(
+      "@synthetic/plugin-weather",
+      undefined,
+      {
+        expected: {
+          packageName: "@synthetic/plugin-weather",
+          version: "1.0.0",
+        },
+      },
+      {
+        getPluginInfo: client.getPluginInfo.bind(client),
+        packageRegistryUrl: upstream.packageRegistryUrl,
+        packageManager: "npm",
+        packageManagerTimeoutMs: 5_000,
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      version: "1.0.0",
+      provenance: {
+        source: "npm",
+        packageName: "@synthetic/plugin-weather",
+        version: "1.0.0",
+        packageManager: "npm",
+        resolved: expect.stringMatching(/plugin-weather-1\.0\.0\.tgz$/),
+        integrity: expect.stringMatching(/^sha512-/),
+      },
+    });
+    const installedSource = await fs.readFile(
+      path.join(
+        result.installPath,
+        "node_modules",
+        "@synthetic",
+        "plugin-weather",
+        "index.js",
+      ),
+      "utf8",
+    );
+    expect(installedSource).toContain(
+      "Deterministic synthetic weather connector",
+    );
+    expect(upstream.readback().observations.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining([
+        "/generated-registry.json",
+        "/npm/@synthetic%2fplugin-weather",
+        "/npm/@synthetic%2fplugin-weather/-/plugin-weather-1.0.0.tgz",
+      ]),
+    );
+  }, 30_000);
+
+  it("fails missing and integrity-mismatched artifacts without retaining an install", async () => {
+    for (const mode of ["missing", "integrity", "corrupt"] as const) {
+      const { upstream, state, client } = await harness();
+      process.env.ELIZA_STATE_DIR = state;
+      process.env.ELIZA_CONFIG_PATH = path.join(state, "eliza.json");
+      const encoded = "/npm/@synthetic%2fplugin-weather";
+      upstream.enqueueFault(
+        mode === "missing" || mode === "corrupt"
+          ? `${encoded}/-/plugin-weather-1.0.0.tgz`
+          : encoded,
+        mode === "missing"
+          ? { kind: "status", status: 404 }
+          : mode === "corrupt"
+            ? { kind: "corrupt-artifact" }
+            : { kind: "integrity-mismatch" },
+      );
+      if (mode === "corrupt") {
+        upstream.enqueueFault(`${encoded}/-/plugin-weather-1.0.0.tgz`, {
+          kind: "corrupt-artifact",
+        });
+        upstream.enqueueFault(`${encoded}/-/plugin-weather-1.0.0.tgz`, {
+          kind: "corrupt-artifact",
+        });
+      }
+
+      const result = await installPluginWithRuntime(
+        "@synthetic/plugin-weather",
+        undefined,
+        undefined,
+        {
+          getPluginInfo: client.getPluginInfo.bind(client),
+          packageRegistryUrl: upstream.packageRegistryUrl,
+          packageManager: "npm",
+          packageManagerTimeoutMs: 5_000,
+        },
+      );
+
+      expect(result.success).toBe(false);
+      await expect(fs.access(result.installPath)).rejects.toBeDefined();
+      await runningServers.pop()?.stop();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
# Relates to

Refs #24092 — scoped registry-upstream/mock-services slice only. Depends on open prerequisite #24118 for the refresh-generation fix visibly stacked in this branch.

- [x] This PR targets `develop` and is rebased onto current `origin/develop` (`e92396f7482c43c8e52ce1e71dafe23905845b9e`) with zero conflicts.
- [x] Dependencies are installed and focused production-path gates were replayed on the exact evidence head.
- [x] A reviewer can confirm the change from the linked backend transcript and domain report.

# Risks

Medium. This hardens the registry network/cache authority boundary and package-manager fallback cleanup. Production defaults remain unchanged; custom HTTP endpoints remain limited to literal loopback hosts.

# Background

## What does this PR do?

- Adds an instance-owned production `RegistryClient` and resettable real-HTTP registry/npm upstream.
- Bounds registry admission before schema parsing: JSON content type, identity encoding, 16 MiB body, fatal UTF-8, depth 32, width 10,000, nodes 100,000, and string size 256 KiB, with stable typed failures and stream cancellation.
- Preserves disk cache age, bounds disk reads and headers, caches upstream authority only, reapplies local overlays on every read, returns mutation-isolated clones, and generation-fences promotion/temp writes.
- Defines caller-isolated cancellation over shared singleflight: one caller can abort without cancelling the authority load or another caller.
- Drives the real installer/package manager against loopback artifacts. Bun partial/timeout output is removed before npm fallback; inability to prove a clean target fails closed before npm or Git fallback.
- Covers generated/index fallback, ETag/304, virtual TTL, reset/replay, malformed/adversarial responses, cancellation, real tar bytes, SRI provenance, missing artifacts, and integrity mismatch.

The branch intentionally contains a visibly attributed replay of open PR #24118 as a prerequisite; it does not hide or duplicate ownership of that fix.

## What kind of change is this?

Feature/fix: non-breaking deterministic test infrastructure plus production boundary hardening.

# Testing

## Where should a reviewer start?

`packages/cloud/test-mocks/test/registry-protocol.test.ts` drives the real production client and installer through loopback HTTP. `packages/agent/src/services/registry-client-runtime.test.ts` covers virtual-clock, cache-authority, mutation, generation, and cancellation invariants.

## Exact-head gates

- Agent focused Vitest: 3 files, 36/36 passed.
- Cloud loopback protocol: 11/11 passed, 52 assertions, including real npm artifact install.
- Agent build: passed.
- Cloud test-mocks typecheck: passed.
- Biome changed files: passed; cloud package lint exits zero with two unrelated pre-existing warnings.
- Guide parity: 160 tracked pairs passed.
- Agent aggregate typecheck remains blocked by unrelated unresolved optional plugin exports/types listed under known gaps.

# Evidence Gate

<!-- evidence-head:ee03479be4b4fc3e040ca4e35fbcf3e82bc774b0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI or rendered surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI or rendered surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend protocol behavior is exercised at the real production boundary
<!-- evidence-row:backend-logs -->
- [x] [24285-24092-registry-final-real.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24285-24092-registry-final-real.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic transport, cache, and installer work invokes no LLM
<!-- evidence-row:domain-artifacts -->
- [x] [24285-24092-registry-final-domain-report.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24285-24092-registry-final-domain-report.md)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

The linked report records the admission limits, cache-authority invariants, cancellation behavior, fallback cleanup, installed-byte/SRI proof, deterministic replay, and redaction assertions. Real-LLM trajectory, visual, frontend, audio, and OCR evidence are inapplicable because this slice changes deterministic backend protocol infrastructure only.

# Known gaps / failures

- Open PR #24118 is a required composition dependency for the visibly stacked refresh-generation fix. Rebase and drop the equivalent commit if it merges first.
- Current generated/index registry formats expose no pagination contract, and `RegistryEndpoint` exposes no credential field; pagination and authenticated custom metadata endpoints remain unsupported rather than fabricated.
- Shared #24076–#24078 lease/control/ledger composition and Cloud scenario/E2E wiring remain open under #24092.
- Agent aggregate typecheck is blocked by unrelated unresolved optional-package exports for capacitor bridge, wallet diagnostics, video, vision, notes, todos, plus an existing signal plugin-key mismatch. Changed-file Biome, focused tests, agent build, and Cloud typecheck pass.
- Host Node is 24.19.0 while the repository pins 24.15.0; focused lanes used pinned Bun 1.3.14.

This remains a draft partial slice. It does not close #24092 or claim real-provider certification.






