### PR TITLE
fix(cockpit): expose controls to chat and voice

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
@@ -10,7 +10,8 @@
  * fetching container lives in `agent-orchestrator.tsx`.
  */
 import { Bot, CircleUser, Users, Workflow, Wrench } from "lucide-react";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
+import { useAgentElement } from "../../../agent-surface/useAgentElement";
 import type {
   OrchestratorRoomParticipant,
   OrchestratorRoomRoster,
@@ -157,6 +158,37 @@ function ParticipantRow({
   );
 }
 
+function RoomOpenButton({
+  room,
+  onSelectRoom,
+  children,
+}: {
+  room: OrchestratorRoomRoster;
+  onSelectRoom: (taskId: string) => void;
+  children: ReactNode;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: `cockpit-open-room-${room.taskId}`,
+    role: "button",
+    label: `Open ${room.taskTitle}`,
+    group: "cockpit-task-rooms",
+    description: "Open this coding task room",
+  });
+  return (
+    <Button
+      ref={ref}
+      onClick={() => onSelectRoom(room.taskId)}
+      aria-label={room.taskTitle}
+      data-testid="orchestrator-room-open"
+      variant="ghost"
+      className="flex h-auto w-full items-center justify-start gap-1.5 whitespace-normal rounded-sm px-0 py-0 text-left font-normal transition-colors hover:bg-bg-hover"
+      {...agentProps}
+    >
+      {children}
+    </Button>
+  );
+}
+
 function RoomCard({
   room,
   t,
@@ -214,15 +246,9 @@ function RoomCard({
   return (
     <div className="space-y-1.5 p-2" data-testid="orchestrator-room-card">
       {onSelectRoom ? (
-        <Button
-          onClick={() => onSelectRoom(room.taskId)}
-          aria-label={room.taskTitle}
-          data-testid="orchestrator-room-open"
-          variant="ghost"
-          className="flex h-auto w-full items-center justify-start gap-1.5 whitespace-normal rounded-sm px-0 py-0 text-left font-normal transition-colors hover:bg-bg-hover"
-        >
+        <RoomOpenButton room={room} onSelectRoom={onSelectRoom}>
           {header}
-        </Button>
+        </RoomOpenButton>
       ) : (
         <div className="flex items-center gap-1.5">{header}</div>
       )}

--- a/packages/ui/src/components/cockpit/CockpitModePicker.tsx
+++ b/packages/ui/src/components/cockpit/CockpitModePicker.tsx
@@ -2,6 +2,8 @@
  * Renders the cockpit mode cards and Eliza Cloud tier toggle without importing
  * plugin or server code into the UI package.
  */
+
+import { useAgentElement } from "../../agent-surface/useAgentElement";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { SegmentedControl } from "../ui/segmented-control";
@@ -25,6 +27,60 @@ const BADGE_CLASS: Record<CockpitModeBadge, string> = {
   sub: "text-muted border-border",
   exp: "text-destructive border-destructive/40",
 };
+
+function ModeOptionButton({
+  option,
+  isActive,
+  disabled,
+  select,
+}: {
+  option: ReturnType<typeof visibleCockpitModeOptions>[number];
+  isActive: boolean;
+  disabled: boolean;
+  select: (toConfig: (tier: ElizaCloudTier) => CockpitModeConfig) => void;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: `cockpit-mode-${option.id}`,
+    role: "button",
+    label: option.title,
+    group: "cockpit-new-session-mode",
+    description: option.subtitle,
+    status: isActive ? "active" : "inactive",
+  });
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      aria-pressed={isActive}
+      disabled={disabled}
+      data-testid={`cockpit-mode-${option.id}`}
+      onClick={() => select(option.toConfig)}
+      className={cn(
+        "h-auto w-full justify-between gap-3 rounded-md border px-3.5 py-2.5 text-left transition-colors",
+        isActive
+          ? "border-accent bg-accent-subtle"
+          : "border-border hover:bg-bg-hover",
+        disabled && "cursor-not-allowed opacity-60",
+      )}
+      {...agentProps}
+    >
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-semibold text-txt">
+          {option.title}
+        </span>
+        <span className="truncate text-xs text-muted">{option.subtitle}</span>
+      </span>
+      <span
+        className={cn(
+          "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+          BADGE_CLASS[option.badge],
+        )}
+      >
+        {BADGE_LABEL[option.badge]}
+      </span>
+    </Button>
+  );
+}
 
 export interface CockpitModePickerProps {
   /** The currently-selected mode config. */
@@ -68,37 +124,12 @@ export function CockpitModePicker({
         const isActive = option.id === selectedId;
         return (
           <div key={option.id} className="flex flex-col gap-2">
-            <Button
-              variant="ghost"
-              aria-pressed={isActive}
+            <ModeOptionButton
+              option={option}
+              isActive={isActive}
               disabled={disabled}
-              data-testid={`cockpit-mode-${option.id}`}
-              onClick={() => select(option.toConfig)}
-              className={cn(
-                "h-auto w-full justify-between gap-3 rounded-md border px-3.5 py-2.5 text-left transition-colors",
-                isActive
-                  ? "border-accent bg-accent-subtle"
-                  : "border-border hover:bg-bg-hover",
-                disabled && "cursor-not-allowed opacity-60",
-              )}
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="truncate text-sm font-semibold text-txt">
-                  {option.title}
-                </span>
-                <span className="truncate text-xs text-muted">
-                  {option.subtitle}
-                </span>
-              </span>
-              <span
-                className={cn(
-                  "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-                  BADGE_CLASS[option.badge],
-                )}
-              >
-                {BADGE_LABEL[option.badge]}
-              </span>
-            </Button>
+              select={select}
+            />
 
             {isActive && option.id === "eliza-cloud" ? (
               <SegmentedControl<ElizaCloudTier>
@@ -117,11 +148,17 @@ export function CockpitModePicker({
                     value: "small",
                     label: "Fast",
                     testId: "cockpit-tier-small",
+                    agentId: "cockpit-new-session-tier-fast",
+                    agentLabel: "Use Fast tier",
+                    agentGroup: "cockpit-new-session-mode",
                   },
                   {
                     value: "large",
                     label: "Smart",
                     testId: "cockpit-tier-large",
+                    agentId: "cockpit-new-session-tier-smart",
+                    agentLabel: "Use Smart tier",
+                    agentGroup: "cockpit-new-session-mode",
                   },
                 ]}
               />

--- a/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
+++ b/packages/ui/src/components/cockpit/CockpitNewSessionForm.tsx
@@ -4,6 +4,7 @@
  */
 import { useId, useState } from "react";
 
+import { useAgentElement } from "../../agent-surface/useAgentElement";
 import type { CodingAgentCreateTaskInput } from "../../api/client-types-cloud";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
@@ -75,6 +76,36 @@ export function CockpitNewSessionForm({
   const [workdir, setWorkdir] = useState("");
   const repoListId = useId();
 
+  const { ref: goalRef, agentProps: goalAgentProps } =
+    useAgentElement<HTMLTextAreaElement>({
+      id: "cockpit-new-session-goal",
+      role: "textarea",
+      label: "Coding session goal",
+      group: "cockpit-new-session",
+      description: "Describe the coding work the agent should complete",
+      getValue: () => goal,
+      onFill: setGoal,
+    });
+  const { ref: repoRef, agentProps: repoAgentProps } =
+    useAgentElement<HTMLInputElement>({
+      id: "cockpit-new-session-repo",
+      role: "text-input",
+      label: "Coding session repository",
+      group: "cockpit-new-session",
+      description: "Set the repository or leave blank for a scratch workspace",
+      getValue: () => repo,
+      onFill: setRepo,
+    });
+  const { ref: workdirRef, agentProps: workdirAgentProps } =
+    useAgentElement<HTMLInputElement>({
+      id: "cockpit-new-session-workdir",
+      role: "text-input",
+      label: "Coding session working directory",
+      group: "cockpit-new-session",
+      description: "Set a directory within the selected repository",
+      getValue: () => workdir,
+      onFill: setWorkdir,
+    });
   const hasWorkdirWithoutRepo =
     workdir.trim().length > 0 && repo.trim().length === 0;
   const canSubmit = goal.trim().length > 0 && !hasWorkdirWithoutRepo && !busy;
@@ -86,6 +117,16 @@ export function CockpitNewSessionForm({
       normalizeCockpitSpawnTarget({ repo, workdir }),
     );
   };
+  const { ref: startRef, agentProps: startAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-new-session-start",
+      role: "button",
+      label: "Start coding agent",
+      group: "cockpit-new-session",
+      description: "Create the task and spawn the selected coding agent",
+      status: busy ? "starting" : canSubmit ? "ready" : "disabled",
+      onActivate: canSubmit ? submit : undefined,
+    });
 
   const hasKnownRepos = knownRepos.length > 0;
 
@@ -103,12 +144,14 @@ export function CockpitNewSessionForm({
           What should the agent do?
         </span>
         <Textarea
+          ref={goalRef}
           id="cockpit-goal-input"
           data-testid="cockpit-goal-input"
           value={goal}
           onChange={(e) => setGoal(e.target.value)}
           placeholder="e.g. Fix the failing auth tests in this repo and open a PR"
           rows={3}
+          {...goalAgentProps}
           // Cmd/Ctrl+Enter submits (the composer convention).
           onKeyDown={(e) => {
             if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
@@ -124,6 +167,7 @@ export function CockpitNewSessionForm({
           Repo <span className="font-normal text-muted">(optional)</span>
         </span>
         <Input
+          ref={repoRef}
           id="cockpit-repo-input"
           data-testid="cockpit-repo-input"
           value={repo}
@@ -134,6 +178,7 @@ export function CockpitNewSessionForm({
           autoComplete="off"
           autoCapitalize="off"
           spellCheck={false}
+          {...repoAgentProps}
         />
         {hasKnownRepos ? (
           <datalist id={repoListId} data-testid="cockpit-repo-suggestions">
@@ -155,6 +200,7 @@ export function CockpitNewSessionForm({
           <span className="font-normal text-muted">(optional)</span>
         </span>
         <Input
+          ref={workdirRef}
           id="cockpit-workdir-input"
           data-testid="cockpit-workdir-input"
           value={workdir}
@@ -169,6 +215,7 @@ export function CockpitNewSessionForm({
           autoComplete="off"
           autoCapitalize="off"
           spellCheck={false}
+          {...workdirAgentProps}
         />
         {hasWorkdirWithoutRepo ? (
           <span
@@ -193,10 +240,12 @@ export function CockpitNewSessionForm({
       </div>
 
       <Button
+        ref={startRef}
         type="submit"
         data-testid="cockpit-start-button"
         disabled={!canSubmit}
         className="w-full"
+        {...startAgentProps}
       >
         {busy ? "Starting…" : "Start agent"}
       </Button>

--- a/packages/ui/src/components/cockpit/CockpitTierToggle.tsx
+++ b/packages/ui/src/components/cockpit/CockpitTierToggle.tsx
@@ -42,12 +42,18 @@ export function CockpitTierToggle({
           label: "Fast",
           disabled,
           testId: "cockpit-tier-small",
+          agentId: "cockpit-session-tier-fast",
+          agentLabel: "Use Fast tier",
+          agentGroup: "cockpit-session",
         },
         {
           value: "large",
           label: "Smart",
           disabled,
           testId: "cockpit-tier-large",
+          agentId: "cockpit-session-tier-smart",
+          agentLabel: "Use Smart tier",
+          agentGroup: "cockpit-session",
         },
       ]}
     />

--- a/packages/ui/src/components/cockpit/CockpitView.test.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.test.tsx
@@ -85,6 +85,36 @@ describe("CockpitView", () => {
     expect(onSelectRoom).toHaveBeenCalledWith("t1");
   });
 
+  it("exposes every rendered Cockpit control to chat and voice", () => {
+    const { container } = render(
+      <CockpitView
+        rooms={ROSTER}
+        onCreateSession={vi.fn()}
+        onSelectRoom={vi.fn()}
+      />,
+    );
+    const controls = Array.from(
+      container.querySelectorAll<HTMLElement>("button, input, textarea"),
+    );
+    expect(controls.length).toBeGreaterThan(0);
+    expect(
+      controls.map((control) => ({
+        testId: control.dataset.testid,
+        agentId: control.dataset.agentId,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ agentId: "cockpit-open-room-t1" }),
+        expect.objectContaining({ agentId: "cockpit-new-session-goal" }),
+        expect.objectContaining({ agentId: "cockpit-new-session-start" }),
+      ]),
+    );
+    expect(
+      controls.filter((control) => !control.dataset.agentId),
+      "every Cockpit control must have a data-agent-id",
+    ).toEqual([]);
+  });
+
   it("starting a session calls onCreateSession with a create-task input", async () => {
     const user = userEvent.setup();
     const onCreateSession = vi.fn();

--- a/packages/ui/src/components/ui/segmented-control.tsx
+++ b/packages/ui/src/components/ui/segmented-control.tsx
@@ -5,6 +5,7 @@
  */
 import type * as React from "react";
 
+import { useAgentElement } from "../../agent-surface/useAgentElement";
 import { cn } from "../../lib/utils";
 
 export interface SegmentedControlItem<T extends string> {
@@ -13,6 +14,66 @@ export interface SegmentedControlItem<T extends string> {
   badge?: React.ReactNode;
   disabled?: boolean;
   testId?: string;
+  /** Stable agent-surface id when this choice is chat/voice controllable. */
+  agentId?: string;
+  agentLabel?: string;
+  agentGroup?: string;
+}
+
+function SegmentedControlButton<T extends string>({
+  item,
+  isActive,
+  isTabList,
+  onValueChange,
+  buttonClassName,
+  activeButtonClassName,
+  inactiveButtonClassName,
+}: {
+  item: SegmentedControlItem<T>;
+  isActive: boolean;
+  isTabList: boolean;
+  onValueChange: (value: T) => void;
+  buttonClassName?: string;
+  activeButtonClassName?: string;
+  inactiveButtonClassName?: string;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: item.agentId ?? item.value,
+    role: isTabList ? "tab" : "button",
+    label:
+      item.agentLabel ??
+      (typeof item.label === "string" ? item.label : item.value),
+    group: item.agentGroup,
+    status: isActive ? "active" : "inactive",
+  });
+
+  return (
+    // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-selected is emitted only with the paired tab role
+    <button
+      ref={ref}
+      type="button"
+      data-segmented-control-button
+      data-testid={item.testId}
+      disabled={item.disabled}
+      onClick={() => !item.disabled && onValueChange(item.value)}
+      role={isTabList ? "tab" : undefined}
+      aria-selected={isTabList ? isActive : undefined}
+      aria-pressed={isTabList ? undefined : isActive}
+      tabIndex={isTabList && !isActive ? -1 : undefined}
+      className={cn(
+        "relative inline-flex items-center gap-1.5 rounded-sm px-3.5 py-2 text-xs font-semibold transition-colors",
+        isActive
+          ? "bg-accent-subtle text-txt"
+          : "text-muted hover:bg-bg-hover hover:text-txt",
+        buttonClassName,
+        isActive ? activeButtonClassName : inactiveButtonClassName,
+      )}
+      {...agentProps}
+    >
+      {item.label}
+      {item.badge}
+    </button>
+  );
 }
 
 export interface SegmentedControlProps<T extends string>
@@ -51,7 +112,18 @@ export function SegmentedControl<T extends string>({
     >
       {items.map((item) => {
         const isActive = item.value === value;
-        return (
+        return item.agentId ? (
+          <SegmentedControlButton
+            key={item.value}
+            item={item}
+            isActive={isActive}
+            isTabList={isTabList}
+            onValueChange={onValueChange}
+            buttonClassName={buttonClassName}
+            activeButtonClassName={activeButtonClassName}
+            inactiveButtonClassName={inactiveButtonClassName}
+          />
+        ) : (
           // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-selected is emitted only with the paired tab role
           <button
             key={item.value}

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
@@ -46,20 +46,25 @@ type ButtonMockProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "size"> & {
   children?: ReactNode;
   onPress?: MouseEventHandler<HTMLButtonElement>;
   size?: string;
+  unstyled?: boolean;
   variant?: string;
 };
 
-vi.mock("@elizaos/ui", () => ({
+vi.mock("@elizaos/ui/api", () => ({
   client: {
     spawnPtySession: mocks.spawnPtySession,
     stopPtySession: mocks.stopPtySession,
     onWsEvent: mocks.onWsEvent,
   },
+}));
+
+vi.mock("@elizaos/ui/components/ui/button", () => ({
   Button: (props: ButtonMockProps) => {
     const {
       children,
       variant: _variant,
       size: _size,
+      unstyled: _unstyled,
       agent: _agent,
       onPress,
       onClick,

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
@@ -1,4 +1,9 @@
-// Renders the tap-in PTY terminal used by the coding cockpit.
+/**
+ * Runs the Cockpit's tap-in PTY session and exposes its lifecycle controls to
+ * the active view agent surface without bypassing the server's PTY policy.
+ */
+
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client } from "@elizaos/ui/api";
 import { Button } from "@elizaos/ui/components/ui/button";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -38,6 +43,40 @@ type InteractivePtyClient = typeof client & {
 };
 
 const ptyClient = client as InteractivePtyClient;
+
+function TerminalRecoveryButton({
+  id,
+  label,
+  description,
+  onClick,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  onClick: () => void;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id,
+    role: "button",
+    label,
+    group: "cockpit-terminal",
+    description,
+    onActivate: onClick,
+  });
+  return (
+    <Button
+      ref={ref}
+      type="button"
+      size="sm"
+      data-testid={id}
+      onClick={onClick}
+      style={{ marginTop: 10 }}
+      {...agentProps}
+    >
+      {label.startsWith("Restart") ? "Restart" : "Retry"}
+    </Button>
+  );
+}
 
 /**
  * The "tap-in, drive it directly" pillar of the cockpit: launches a REAL
@@ -159,6 +198,15 @@ export function CockpitInteractiveTerminal({
     if (id) void ptyClient.stopPtySession(id);
     onClose?.();
   }, [onClose]);
+  const { ref: closeRef, agentProps: closeAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-terminal-close",
+      role: "button",
+      label: "Close interactive terminal",
+      group: "cockpit-terminal",
+      description: "Stop the terminal session and return to the cockpit",
+      onActivate: close,
+    });
 
   return (
     <div
@@ -185,10 +233,12 @@ export function CockpitInteractiveTerminal({
       >
         <span>{headerLabel}</span>
         <Button
+          ref={closeRef}
           unstyled
           type="button"
           data-testid="cockpit-terminal-close"
           onClick={close}
+          {...closeAgentProps}
           style={{
             background: "transparent",
             border: "none",
@@ -230,17 +280,12 @@ export function CockpitInteractiveTerminal({
               {kind} session ended
               {exitCode !== null ? ` (exit ${exitCode})` : ""}.
             </div>
-            <Button
-              type="button"
-              size="sm"
-              data-testid="cockpit-terminal-restart"
+            <TerminalRecoveryButton
+              id="cockpit-terminal-restart"
+              label="Restart interactive terminal"
+              description="Start a new terminal after the prior session ended"
               onClick={retry}
-              style={{
-                marginTop: 10,
-              }}
-            >
-              Restart
-            </Button>
+            />
           </div>
         ) : null}
 
@@ -254,17 +299,12 @@ export function CockpitInteractiveTerminal({
             }}
           >
             <div>{error}</div>
-            <Button
-              type="button"
-              size="sm"
-              data-testid="cockpit-terminal-retry"
+            <TerminalRecoveryButton
+              id="cockpit-terminal-retry"
+              label="Retry interactive terminal"
+              description="Retry starting the interactive terminal after an error"
               onClick={retry}
-              style={{
-                marginTop: 10,
-              }}
-            >
-              Retry
-            </Button>
+            />
           </div>
         ) : null}
 

--- a/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitRoute.tsx
@@ -1,4 +1,6 @@
 /** Composes the mobile coding cockpit route from deck, session, and terminal panes. */
+
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client } from "@elizaos/ui/api";
 import type {
   CodingAgentCreateTaskInput,
@@ -15,6 +17,62 @@ import { CockpitSessionPane } from "./CockpitSessionPane";
 
 /** How often the deck re-polls the live task-room roster. */
 const ROOMS_POLL_INTERVAL_MS = 4_000;
+
+function TerminalLaunchButtons({
+  onSelect,
+}: {
+  onSelect: (tier: CockpitTerminalTier) => void;
+}) {
+  const { ref: fastRef, agentProps: fastAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-open-terminal-fast",
+      role: "button",
+      label: "Open Fast interactive terminal",
+      group: "cockpit-terminal",
+      description: "Start an interactive eliza-code terminal on the Fast tier",
+    });
+  const { ref: smartRef, agentProps: smartAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-open-terminal-smart",
+      role: "button",
+      label: "Open Smart interactive terminal",
+      group: "cockpit-terminal",
+      description: "Start an interactive eliza-code terminal on the Smart tier",
+    });
+  return (
+    <div
+      style={{
+        position: "absolute",
+        right: 16,
+        bottom: 16,
+        display: "flex",
+        gap: 8,
+        zIndex: 10,
+      }}
+    >
+      <Button
+        ref={fastRef}
+        type="button"
+        size="sm"
+        data-testid="cockpit-open-terminal-fast"
+        onClick={() => onSelect("fast")}
+        {...fastAgentProps}
+      >
+        ⌨ Terminal · Fast
+      </Button>
+      <Button
+        ref={smartRef}
+        type="button"
+        size="sm"
+        data-testid="cockpit-open-terminal-smart"
+        onClick={() => onSelect("smart")}
+        {...smartAgentProps}
+      >
+        ⌨ Terminal · Smart
+      </Button>
+    </div>
+  );
+}
 
 /**
  * Route container for the coding cockpit. Wires the presentational
@@ -149,33 +207,7 @@ export function CockpitRoute() {
       />
 
       {terminalTier === null ? (
-        <div
-          style={{
-            position: "absolute",
-            right: 16,
-            bottom: 16,
-            display: "flex",
-            gap: 8,
-            zIndex: 10,
-          }}
-        >
-          <Button
-            type="button"
-            size="sm"
-            data-testid="cockpit-open-terminal-fast"
-            onClick={() => setTerminalTier("fast")}
-          >
-            ⌨ Terminal · Fast
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            data-testid="cockpit-open-terminal-smart"
-            onClick={() => setTerminalTier("smart")}
-          >
-            ⌨ Terminal · Smart
-          </Button>
-        </div>
+        <TerminalLaunchButtons onSelect={setTerminalTier} />
       ) : (
         <div
           data-testid="cockpit-terminal-overlay"

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
@@ -59,7 +59,18 @@ const calls = {
 // select) and only needs `ref` + `agentProps` back; the production hook is a
 // registration side effect for the agent overlay.
 vi.mock("@elizaos/ui/agent-surface", () => ({
-  useAgentElement: () => ({ ref: () => {}, agentProps: {} }),
+  useAgentElement: (descriptor: {
+    id: string;
+    role?: string;
+    label: string;
+  }) => ({
+    ref: () => {},
+    agentProps: {
+      "data-agent-id": descriptor.id,
+      "data-agent-role": descriptor.role ?? "region",
+      "data-agent-label": descriptor.label,
+    },
+  }),
 }));
 
 // Keep the real UI components while replacing the API client boundary.
@@ -475,6 +486,27 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
         /deliver/i,
       ),
     );
+  });
+
+  it("leaves no rendered drill-in control outside the agent bridge", async () => {
+    const { container } = renderPane();
+    await screen.findByTestId("orchestrator-user-message");
+    const controls = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        'button, input:not([type="hidden"]), textarea, [role="combobox"]',
+      ),
+    ).filter((control) => !control.closest('[aria-hidden="true"]'));
+    expect(
+      controls
+        .filter((control) => !control.closest("[data-agent-id]"))
+        .map(
+          (control) =>
+            control.getAttribute("data-testid") ??
+            control.getAttribute("aria-label") ??
+            `${control.tagName.toLowerCase()}:${control.textContent?.trim()}:${control.className}`,
+        ),
+      "every rendered Cockpit session control must have a data-agent-id",
+    ).toEqual([]);
   });
 });
 

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -23,6 +23,7 @@
  * taskId and passes `onBack` to return to the deck.
  */
 
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client } from "@elizaos/ui/api";
 import type { CodingAgentSession } from "@elizaos/ui/api/client-types-cloud";
 import {
@@ -66,6 +67,45 @@ export interface CockpitSessionPaneProps {
   t?: Translate;
   /** BCP-47 locale for clock/number formatting in the transcript. */
   locale?: string;
+}
+
+function CockpitDetailsButton({
+  open,
+  onToggle,
+  label,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  label: string;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "cockpit-session-details",
+    role: "toggle",
+    label,
+    group: "cockpit-session-navigation",
+    description: "Show or hide task controls and details",
+    status: open ? "open" : "closed",
+    onActivate: onToggle,
+  });
+  return (
+    <Button
+      ref={ref}
+      unstyled
+      type="button"
+      onClick={onToggle}
+      aria-pressed={open}
+      data-testid="cockpit-session-details-toggle"
+      title={label}
+      className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors ${
+        open
+          ? "bg-accent/15 text-accent"
+          : "text-muted hover:bg-bg-hover/40 hover:text-txt"
+      }`}
+      {...agentProps}
+    >
+      <PanelRight className="h-4 w-4" aria-hidden />
+    </Button>
+  );
 }
 
 export function CockpitSessionPane({
@@ -256,7 +296,35 @@ export function CockpitSessionPane({
     }),
     onSubmit: onComposerSubmit,
   });
-
+  const { ref: backRef, agentProps: backAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-session-back",
+      role: "button",
+      label: "Back to all task rooms",
+      group: "cockpit-session-navigation",
+      description: "Return to the coding cockpit room deck",
+      onActivate: onBack,
+    });
+  const { ref: transcriptRef, agentProps: transcriptAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-session-view-transcript",
+      role: "tab",
+      label: "Show task transcript",
+      group: "cockpit-session-view",
+      description: "Show messages, tool activity, and results for this task",
+      status: view === "transcript" ? "active" : "inactive",
+      onActivate: () => setView("transcript"),
+    });
+  const { ref: terminalRef, agentProps: terminalAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-session-view-terminal",
+      role: "tab",
+      label: "Show terminal output",
+      group: "cockpit-session-view",
+      description: "Show the terminal output for this task's active session",
+      status: view === "terminal" ? "active" : "inactive",
+      onActivate: () => setView("terminal"),
+    });
   return (
     <div
       className="flex h-full min-h-0 w-full flex-col bg-bg"
@@ -264,6 +332,7 @@ export function CockpitSessionPane({
     >
       <header className="flex shrink-0 items-center gap-2 border-border/40 border-b px-3 py-2">
         <Button
+          ref={backRef}
           unstyled
           type="button"
           onClick={onBack}
@@ -272,6 +341,7 @@ export function CockpitSessionPane({
             defaultValue: "Back to all rooms",
           })}
           data-testid="cockpit-session-back"
+          {...backAgentProps}
         >
           <ArrowLeft className="h-4 w-4" aria-hidden />
         </Button>
@@ -294,11 +364,13 @@ export function CockpitSessionPane({
           })}
         >
           <Button
+            ref={transcriptRef}
             unstyled
             type="button"
             onClick={() => setView("transcript")}
             aria-pressed={view === "transcript"}
             data-testid="cockpit-view-transcript"
+            {...transcriptAgentProps}
             title={t("cockpit.session.transcript", {
               defaultValue: "Transcript",
             })}
@@ -311,11 +383,13 @@ export function CockpitSessionPane({
             <ScrollText className="h-4 w-4" aria-hidden />
           </Button>
           <Button
+            ref={terminalRef}
             unstyled
             type="button"
             onClick={() => setView("terminal")}
             aria-pressed={view === "terminal"}
             data-testid="cockpit-view-terminal"
+            {...terminalAgentProps}
             title={t("cockpit.session.watch", {
               defaultValue: "Watch (terminal output)",
             })}
@@ -329,21 +403,11 @@ export function CockpitSessionPane({
           </Button>
         </fieldset>
         {isMobile && detail ? (
-          <Button
-            unstyled
-            type="button"
-            onClick={() => setInspectorOpen((prev) => !prev)}
-            aria-pressed={inspectorOpen}
-            data-testid="cockpit-session-details-toggle"
-            title={t("cockpit.session.details", { defaultValue: "Details" })}
-            className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors ${
-              inspectorOpen
-                ? "bg-accent/15 text-accent"
-                : "text-muted hover:bg-bg-hover/40 hover:text-txt"
-            }`}
-          >
-            <PanelRight className="h-4 w-4" aria-hidden />
-          </Button>
+          <CockpitDetailsButton
+            open={inspectorOpen}
+            onToggle={() => setInspectorOpen((prev) => !prev)}
+            label={t("cockpit.session.details", { defaultValue: "Details" })}
+          />
         ) : null}
       </header>
 

--- a/plugins/plugin-task-coordinator/src/CockpitTerminalPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitTerminalPanel.test.tsx
@@ -76,10 +76,19 @@ const ui = vi.hoisted(() => {
   return { client, emit };
 });
 
-vi.mock("@elizaos/ui", () => ({
+vi.mock("@elizaos/ui/api", () => ({
   client: ui.client,
+}));
+
+vi.mock("@elizaos/ui/components/ui/button", () => ({
   Button: (props: Record<string, unknown>) => {
-    const { children, variant: _variant, size: _size, ...rest } = props;
+    const {
+      children,
+      variant: _variant,
+      size: _size,
+      unstyled: _unstyled,
+      ...rest
+    } = props;
     return React.createElement(
       "button",
       { type: "button", ...rest },
@@ -200,5 +209,25 @@ describe("CockpitTerminalPanel — pretty ⇄ CLI toggle", () => {
     fireEvent.change(input, { target: { value: "ls -la" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(ui.client.sendPtyInput).toHaveBeenCalledWith("s1", "ls -la\n");
+  });
+
+  it("exposes every readable-terminal control to the agent bridge", () => {
+    const { container } = render(
+      <CockpitTerminalPanel activeSessionId="s1" sessions={sessions} />,
+    );
+    const controls = Array.from(
+      container.querySelectorAll<HTMLElement>("button, input"),
+    );
+    expect(controls.length).toBeGreaterThan(0);
+    expect(
+      controls
+        .filter((control) => !control.dataset.agentId)
+        .map(
+          (control) =>
+            control.getAttribute("data-testid") ??
+            control.getAttribute("aria-label") ??
+            control.tagName.toLowerCase(),
+        ),
+    ).toEqual([]);
   });
 });

--- a/plugins/plugin-task-coordinator/src/CockpitTerminalPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitTerminalPanel.tsx
@@ -1,4 +1,9 @@
-// Streams read-only PTY output into the cockpit session panel.
+/**
+ * Streams task-scoped PTY output into the Cockpit and switches between its
+ * readable and raw terminal renderers over the same authorized session.
+ */
+
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import type { CodingAgentSession } from "@elizaos/ui/api/client-types-cloud";
 import { Button } from "@elizaos/ui/components/ui/button";
 import { TerminalSquare } from "lucide-react";
@@ -46,6 +51,26 @@ export function CockpitTerminalPanel({
   const [mode, setMode] = useState<TerminalMode>("pretty");
   const sessionId = activeSessionId ?? "";
   const hasSession = sessionId.length > 0;
+  const { ref: prettyRef, agentProps: prettyAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-terminal-view-pretty",
+      role: "tab",
+      label: "Show readable terminal",
+      group: "cockpit-terminal-view",
+      description: "Show buffered terminal output with line input controls",
+      status: mode === "pretty" ? "active" : "inactive",
+      onActivate: () => setMode("pretty"),
+    });
+  const { ref: cliRef, agentProps: cliAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-terminal-view-cli",
+      role: "tab",
+      label: "Show raw terminal",
+      group: "cockpit-terminal-view",
+      description: "Show the raw xterm terminal surface",
+      status: mode === "cli" ? "active" : "inactive",
+      onActivate: () => setMode("cli"),
+    });
 
   return (
     <div
@@ -63,6 +88,7 @@ export function CockpitTerminalPanel({
           className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-black/30 p-0.5"
         >
           <Button
+            ref={prettyRef}
             type="button"
             size="sm"
             variant={mode === "pretty" ? "default" : "ghost"}
@@ -71,10 +97,12 @@ export function CockpitTerminalPanel({
             aria-pressed={mode === "pretty"}
             data-testid="cockpit-term-toggle-pretty"
             onClick={() => setMode("pretty")}
+            {...prettyAgentProps}
           >
             Pretty
           </Button>
           <Button
+            ref={cliRef}
             type="button"
             size="sm"
             variant={mode === "cli" ? "default" : "ghost"}
@@ -83,6 +111,7 @@ export function CockpitTerminalPanel({
             aria-pressed={mode === "cli"}
             data-testid="cockpit-term-toggle-cli"
             onClick={() => setMode("cli")}
+            {...cliAgentProps}
           >
             CLI
           </Button>
@@ -106,7 +135,7 @@ export function CockpitTerminalPanel({
             variant="full"
             activeSessionId={sessionId}
             sessions={sessions}
-            onClose={onClose ?? noop}
+            onClose={onClose}
           />
         ) : (
           <div data-testid="cockpit-term-cli" className="h-full w-full">
@@ -116,8 +145,4 @@ export function CockpitTerminalPanel({
       </div>
     </div>
   );
-}
-
-function noop(): void {
-  // No-op default close handler when the host does not supply one.
 }

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -1,3 +1,7 @@
+/**
+ * Renders the multi-agent orchestration workbench and its reusable task
+ * inspector, preserving one set of task mutation handlers across host views.
+ */
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client } from "@elizaos/ui/api";
 import type {
@@ -1231,6 +1235,47 @@ function AddAgentForm({
   );
 }
 
+function AgentDeleteDialogCancel({ label }: { label: string }) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "inspector-delete-cancel",
+    role: "button",
+    label,
+    group: "orchestrator-inspector-delete-confirmation",
+    description: "Cancel deleting this task",
+  });
+  return (
+    <AlertDialogCancel ref={ref} {...agentProps}>
+      {label}
+    </AlertDialogCancel>
+  );
+}
+
+function AgentDeleteDialogConfirm({
+  label,
+  onDelete,
+}: {
+  label: string;
+  onDelete: () => void;
+}) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "inspector-delete-confirm",
+    role: "button",
+    label,
+    group: "orchestrator-inspector-delete-confirmation",
+    description: "Permanently delete this task and its transcript",
+  });
+  return (
+    <AlertDialogAction
+      ref={ref}
+      onClick={onDelete}
+      className="bg-red-600 hover:bg-red-700"
+      {...agentProps}
+    >
+      {label}
+    </AlertDialogAction>
+  );
+}
+
 function ControlButton({
   agentId,
   description,
@@ -1632,15 +1677,17 @@ export function TaskInspector({
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>
-                {t("orchestrator.action.cancel", { defaultValue: "Cancel" })}
-              </AlertDialogCancel>
-              <AlertDialogAction
-                onClick={onDelete}
-                className="bg-red-600 hover:bg-red-700"
-              >
-                {t("orchestrator.action.delete", { defaultValue: "Delete" })}
-              </AlertDialogAction>
+              <AgentDeleteDialogCancel
+                label={t("orchestrator.action.cancel", {
+                  defaultValue: "Cancel",
+                })}
+              />
+              <AgentDeleteDialogConfirm
+                label={t("orchestrator.action.delete", {
+                  defaultValue: "Delete",
+                })}
+                onDelete={onDelete}
+              />
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/plugins/plugin-task-coordinator/src/PtyConsoleBase.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyConsoleBase.tsx
@@ -8,6 +8,8 @@
  * silently trimmed from the head. Backs the PtyConsoleDrawer /
  * PtyConsoleSidePanel wrappers and fills the `@elizaos/ui` PtyConsoleBase slot.
  */
+
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { client } from "@elizaos/ui/api";
 import type { CodingAgentSession } from "@elizaos/ui/api/client-types-cloud";
 import { Button } from "@elizaos/ui/components/ui/button";
@@ -27,7 +29,7 @@ const MAX_BUFFER_CHARS = 200_000;
 export interface PtyConsoleBaseProps {
   activeSessionId: string;
   sessions: CodingAgentSession[];
-  onClose: () => void;
+  onClose?: () => void;
   variant: "drawer" | "side-panel" | "full";
 }
 
@@ -101,6 +103,44 @@ export function PtyConsoleBase({
   const stopSession = useCallback(() => {
     void client.stopCodingAgent(activeSessionId);
   }, [activeSessionId]);
+  const { ref: interruptRef, agentProps: interruptAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-terminal-interrupt",
+      role: "button",
+      label: "Interrupt terminal process",
+      group: "cockpit-terminal-controls",
+      description: "Send Ctrl-C to the active terminal session",
+      onActivate: () => sendInput("\u0003"),
+    });
+  const { ref: stopRef, agentProps: stopAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-terminal-stop",
+      role: "button",
+      label: "Stop terminal session",
+      group: "cockpit-terminal-controls",
+      description: "Stop the active coding-agent terminal session",
+      onActivate: stopSession,
+    });
+  const { ref: inputRef, agentProps: inputAgentProps } =
+    useAgentElement<HTMLInputElement>({
+      id: "cockpit-terminal-input",
+      role: "text-input",
+      label: "Terminal input",
+      group: "cockpit-terminal-controls",
+      description: "Enter a line to send to the active terminal session",
+      getValue: () => input,
+      onFill: setInput,
+    });
+  const { ref: sendRef, agentProps: sendAgentProps } =
+    useAgentElement<HTMLButtonElement>({
+      id: "cockpit-terminal-send",
+      role: "button",
+      label: "Send terminal input",
+      group: "cockpit-terminal-controls",
+      description: "Send the prepared line to the active terminal session",
+      status: input.length > 0 ? "ready" : "empty",
+      onActivate: sendLine,
+    });
 
   return (
     <section
@@ -119,32 +159,28 @@ export function PtyConsoleBase({
           </div>
         </div>
         <Button
+          ref={interruptRef}
           variant="ghost"
           size="icon"
           onClick={() => sendInput("\u0003")}
           title="Interrupt"
           aria-label="Interrupt terminal"
+          {...interruptAgentProps}
         >
           <Square className="h-4 w-4" aria-hidden />
         </Button>
         <Button
+          ref={stopRef}
           variant="ghost"
           size="icon"
           onClick={stopSession}
           title="Stop session"
           aria-label="Stop terminal session"
+          {...stopAgentProps}
         >
           <Square className="h-4 w-4 fill-current" aria-hidden />
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          title="Close"
-          aria-label="Close terminal"
-        >
-          <X className="h-4 w-4" aria-hidden />
-        </Button>
+        {onClose ? <PtyCloseButton onClose={onClose} /> : null}
       </header>
       <div
         ref={scrollerRef}
@@ -156,6 +192,7 @@ export function PtyConsoleBase({
       </div>
       <footer className="flex h-11 shrink-0 items-center gap-2 border-t border-border/60 px-2">
         <Input
+          ref={inputRef}
           value={input}
           onChange={(event) => setInput(event.currentTarget.value)}
           onKeyDown={onInputKeyDown}
@@ -163,18 +200,45 @@ export function PtyConsoleBase({
           aria-label="Terminal input"
           autoComplete="off"
           spellCheck={false}
+          {...inputAgentProps}
         />
         <Button
+          ref={sendRef}
           variant="ghost"
           size="icon"
           onClick={sendLine}
           title="Send"
           aria-label="Send terminal input"
+          {...sendAgentProps}
         >
           <Send className="h-4 w-4" aria-hidden />
         </Button>
       </footer>
     </section>
+  );
+}
+
+function PtyCloseButton({ onClose }: { onClose: () => void }) {
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "cockpit-terminal-panel-close",
+    role: "button",
+    label: "Close terminal panel",
+    group: "cockpit-terminal-controls",
+    description: "Close the terminal panel",
+    onActivate: onClose,
+  });
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      onClick={onClose}
+      title="Close"
+      aria-label="Close terminal"
+      {...agentProps}
+    >
+      <X className="h-4 w-4" aria-hidden />
+    </Button>
   );
 }
 

--- a/plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx
@@ -1,4 +1,9 @@
-// Renders collapsible reasoning blocks in orchestrator transcripts.
+/**
+ * Renders agent-addressable reasoning blocks in task transcripts while
+ * preserving the streaming shimmer and disclosure state.
+ */
+
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
 import { Brain, ChevronRight } from "lucide-react";
 import { type ReactNode, useState } from "react";
@@ -89,10 +94,12 @@ function humanizeDuration(ms: number): string {
  *   "Thinking…" label and the shimmer).
  */
 export function ReasoningCell({
+  agentId,
   text,
   durationMs,
   streaming,
 }: {
+  agentId: string;
   text: string;
   durationMs?: number;
   streaming?: boolean;
@@ -104,6 +111,15 @@ export function ReasoningCell({
     : durationMs !== undefined
       ? `Thought for ${humanizeDuration(durationMs)}`
       : "Thought";
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: agentId,
+    role: "toggle",
+    label: header,
+    group: "orchestrator-transcript",
+    description: "Show or hide this reasoning block",
+    status: open ? "open" : "closed",
+    onActivate: () => setOpen((value) => !value),
+  });
 
   return (
     <div
@@ -111,11 +127,13 @@ export function ReasoningCell({
       data-testid="orchestrator-reasoning"
     >
       <Button
+        ref={ref}
         unstyled
         type="button"
         onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
         className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
+        {...agentProps}
       >
         <ChevronRight
           className={`h-3 w-3 shrink-0 text-muted transition-transform ${

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -1,4 +1,9 @@
-// Builds the orchestrator conversation stream from events and tool messages.
+/**
+ * Renders normalized task conversation blocks, including agent-addressable
+ * tool and reasoning disclosures shared by Orchestrator and Cockpit views.
+ */
+
+import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
 import {
   Check,
@@ -248,20 +253,33 @@ function ToolCallCard({
   const [open, setOpen] = useState(
     () => hasBody && tool.kind !== "read" && tool.kind !== "search",
   );
+  const toggle = () => {
+    onInspect?.();
+    setOpen((value) => !value);
+  };
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: `orchestrator-tool-${tool.groupKey}`,
+    role: "toggle",
+    label: `${toolVerb(tool)} ${target ?? tool.title}`,
+    group: "orchestrator-transcript",
+    description: "Show or hide this tool call's details",
+    status: open ? "open" : "closed",
+    clickable: hasBody,
+    onActivate: hasBody ? toggle : undefined,
+  });
   return (
     <div
       className="rounded-md border border-border/50 bg-card/50"
       data-testid="orchestrator-tool-call"
     >
       <Button
+        ref={ref}
         unstyled
         type="button"
         disabled={!hasBody}
-        onClick={() => {
-          onInspect?.();
-          setOpen((value) => !value);
-        }}
+        onClick={toggle}
         className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left disabled:cursor-default"
+        {...agentProps}
       >
         {hasBody ? (
           <ChevronRight
@@ -378,6 +396,7 @@ export function ConversationBlockView({
   if (block.kind === "reasoning") {
     return (
       <ReasoningCell
+        agentId={`orchestrator-reasoning-${block.key}`}
         text={block.text}
         durationMs={block.durationMs}
         streaming={block.streaming}


### PR DESCRIPTION
## Summary
- expose Cockpit launch, mode, tier, navigation, transcript, terminal, room, disclosure, and confirmation controls through production agent-element semantics
- preserve the existing task-inspector confirmation flow and canonical PTY spawn, input, interrupt, stop, retry, and close paths
- remove the inert embedded terminal Close control when no close handler exists
- add exhaustive DOM coverage that rejects rendered Cockpit controls without agent IDs

Part of #24102.

## Validation
- `bun run --cwd plugins/plugin-task-coordinator test` — 31 files / 242 tests passed before the conflict-free rebase
- focused Cockpit test tranche — 61 tests passed before the conflict-free rebase
- `bun run --cwd plugins/plugin-task-coordinator build:types` — passed
- `bun run --cwd packages/ui typecheck` — passed
- touched-file Biome check — passed
- `git diff --check` — passed
- broad dependency build — 59/59 tasks passed

Post-rebase note: a rerun of the configured focused Vitest lane remained alive without producing completion output in the shared host; no source conflicts occurred during the rebase. A direct `bun test` attempt was invalid because it bypassed the packages jsdom/Vitest configuration and is not counted as evidence.

## Evidence
- Tests enumerate every rendered base Cockpit button/input and every session-pane/terminal control, asserting stable `data-agent-id` coverage.
- Browser smoke was attempted, but the app-shell fixture redirected `/cockpit` to Home because that fixture does not register the Cockpit route. No browser result is claimed.
- Screenshots/video: N/A for this draft; changes are agent metadata and removal of an inert button, with no visual redesign.

## Self-review
- Agent activations delegate only to the existing React handlers.
- Delete and restart approval behavior is unchanged.
- PTY authorization and lifecycle remain server-owned; no alternate terminal mutation API was added.
- Read-only room widgets do not register phantom clickable controls.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cockpit-agent-bridge]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->