### PR TITLE
fix(cloud): remove retired BlueBubbles diversion from Blooio

### DIFF
--- a/packages/cloud/api/AGENTS.md
+++ b/packages/cloud/api/AGENTS.md
@@ -116,7 +116,7 @@ Add an endpoint:
 - `/api/health` is answered directly in `index.ts` (never boots the full app) — keep it dependency-free.
 - The global auth middleware allowlists public paths in `middleware/auth.ts`; programmatic auth (`X-API-Key`, `Bearer eliza_*`) passes through and is validated per-route, not by the gate.
 - `src/stubs/*` exist because workerd lacks some node-only deps; they are wired via `wrangler.toml` aliases/`[define]`, not by direct import. Don't import node-only modules in route code.
-- Special-cased routes registered manually in `bootstrap-app.ts` (root `/`, `/steward*`, blooio/bluebubbles webhooks, legacy birdeye 308 redirect, jwks, OIDC discovery + OIDC jwks) bypass the codegen tree — keep that list in sync when touching those surfaces. The OIDC pair must stay root-mounted: relying parties derive `/.well-known/openid-configuration` from the issuer origin and never look under `/api`.
+- Special-cased routes registered manually in `bootstrap-app.ts` (root `/`, `/steward*`, legacy birdeye 308 redirect, jwks, OIDC discovery + OIDC jwks) bypass the codegen tree — keep that list in sync when touching those surfaces. Connector webhooks, including Blooio, are owned only by the generated route tree. The OIDC pair must stay root-mounted: relying parties derive `/.well-known/openid-configuration` from the issuer origin and never look under `/api`.
 - This is the only `@elizaos/*` package with no published consumers; treat `wrangler.toml` + `index.ts` as the contract.
 
 ## Verification

--- a/packages/cloud/api/CLAUDE.md
+++ b/packages/cloud/api/CLAUDE.md
@@ -116,7 +116,7 @@ Add an endpoint:
 - `/api/health` is answered directly in `index.ts` (never boots the full app) — keep it dependency-free.
 - The global auth middleware allowlists public paths in `middleware/auth.ts`; programmatic auth (`X-API-Key`, `Bearer eliza_*`) passes through and is validated per-route, not by the gate.
 - `src/stubs/*` exist because workerd lacks some node-only deps; they are wired via `wrangler.toml` aliases/`[define]`, not by direct import. Don't import node-only modules in route code.
-- Special-cased routes registered manually in `bootstrap-app.ts` (root `/`, `/steward*`, blooio/bluebubbles webhooks, legacy birdeye 308 redirect, jwks, OIDC discovery + OIDC jwks) bypass the codegen tree — keep that list in sync when touching those surfaces. The OIDC pair must stay root-mounted: relying parties derive `/.well-known/openid-configuration` from the issuer origin and never look under `/api`.
+- Special-cased routes registered manually in `bootstrap-app.ts` (root `/`, `/steward*`, legacy birdeye 308 redirect, jwks, OIDC discovery + OIDC jwks) bypass the codegen tree — keep that list in sync when touching those surfaces. Connector webhooks, including Blooio, are owned only by the generated route tree. The OIDC pair must stay root-mounted: relying parties derive `/.well-known/openid-configuration` from the issuer origin and never look under `/api`.
 - This is the only `@elizaos/*` package with no published consumers; treat `wrangler.toml` + `index.ts` as the contract.
 
 ## Verification

--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/dedupe.test.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/dedupe.test.ts
@@ -1,8 +1,8 @@
 /**
  * Telegram webhook fail-closed auth + replay dedupe (#12227 L4, #12878).
  *
- * Two findings, both exercised against the REAL route handler with the
- * dependency surface mocked (matches `webhooks/bluebubbles/route.test.ts`):
+ * Two findings, both exercised against the real route handler with its
+ * external dependency surface replaced by deterministic fixtures:
  *   (L4a) dev fall-open: previously, when no webhook secret was stored for an
  *         org, any non-production request fell through and processed the update
  *         with NO auth. The route now fails closed everywhere; the only bypass

--- a/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
+++ b/packages/cloud/api/v1/telegram/webhook/[orgId]/route.ts
@@ -106,8 +106,8 @@ async function handleTelegramWebhook(
     return Response.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  // Replay dedupe on Telegram's monotonic `update_id` (matches the crypto/
-  // stripe/bluebubbles webhooks). Telegram re-delivers an update until it gets a
+  // Replay dedupe on Telegram's monotonic `update_id` (matches other signed
+  // provider webhooks). Telegram re-delivers an update until it gets a
   // 200, so without this a slow handler causes the same message to be routed to
   // the agent multiple times (duplicate reply + double credit spend). Scoped per
   // org so two orgs' independent update_id sequences can't collide. (finding L4)
@@ -135,8 +135,8 @@ async function handleTelegramWebhook(
   // throws we must roll it back — otherwise the marker "poisons" this update_id
   // and Telegram's retry is short-circuited as a duplicate, dropping the update
   // forever. On failure: delete the marker and re-throw so the route returns a
-  // 5xx and the provider retry re-processes (matches the crypto/stripe/
-  // bluebubbles rollback-on-failed-enqueue pattern). (finding L4)
+  // 5xx and the provider retry re-processes (matches the shared webhook
+  // rollback-on-failed-enqueue pattern). (finding L4)
   try {
     // Handle my_chat_member updates (bot added/removed from chats)
     if ("my_chat_member" in update) {

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
@@ -14,13 +14,6 @@ const loggerWarn = mock();
 const loggerError = mock();
 const loggerDebug = mock();
 
-mock.module("../../bluebubbles/route", () => ({
-  handleBlueBubblesWebhook: mock(async () => Response.json({ success: true })),
-  handleBlueBubblesWebhookPayload: mock(async () =>
-    Response.json({ success: true }),
-  ),
-}));
-
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { AGGRESSIVE: {} },
   rateLimit: () => async (_context: unknown, next: () => Promise<void>) =>

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.test.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.test.ts
@@ -1,22 +1,19 @@
-// Exercises cloud API webhooks blooio orgid route.test behavior with deterministic Worker route fixtures.
+/**
+ * Proves the real Blooio route has one signed provider authority and preserves
+ * its payload-validation and idempotency contracts under deterministic fixtures.
+ */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import { Hono } from "hono";
 
 const webhookSecret = "test-blooio-webhook-secret";
-
-const handleBlueBubblesWebhook = mock(async () =>
-  Response.json({ success: true, source: "bluebubbles-direct" }),
-);
-const handleBlueBubblesWebhookPayload = mock(async (_c, payload: unknown) =>
-  Response.json({ success: true, source: "bluebubbles-payload", payload }),
-);
-
-mock.module("../../bluebubbles/route", () => ({
-  handleBlueBubblesWebhook,
-  handleBlueBubblesWebhookPayload,
-}));
+const organizationId = "11111111-1111-4111-8111-111111111111";
+const processedKeys = new Set<string>();
+const isAlreadyProcessed = mock(async (key: string) => processedKeys.has(key));
+const markAsProcessed = mock(async (key: string) => {
+  processedKeys.add(key);
+});
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: {
@@ -33,6 +30,11 @@ mock.module("@/lib/services/blooio-automation", () => ({
   },
 }));
 
+mock.module("@/lib/utils/idempotency", () => ({
+  isAlreadyProcessed,
+  markAsProcessed,
+}));
+
 const { default: app } = await import("./route");
 const mountedApp = new Hono().route("/:orgId", app);
 
@@ -44,18 +46,36 @@ function signature(body: string): string {
   return `t=${timestamp},v1=${digest}`;
 }
 
-function post(body: unknown, headers: Record<string, string> = {}) {
-  return new Request("https://api.example.test/?bridge=bluebubbles", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      ...headers,
+function request(
+  body: string,
+  options: {
+    path?: string;
+    query?: string;
+    headers?: Record<string, string>;
+  } = {},
+): Request {
+  const path = options.path ?? "";
+  const query = options.query ? `?${options.query}` : "";
+  return new Request(
+    `https://api.example.test/${organizationId}${path}${query}`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...options.headers,
+      },
+      body,
     },
-    body: JSON.stringify(body),
-  });
+  );
 }
 
-const blueBubblesPayload = {
+function fetchRoute(requestValue: Request): Promise<Response> {
+  return Promise.resolve(
+    mountedApp.fetch(requestValue, { NODE_ENV: "production" }),
+  );
+}
+
+const retiredBridgePayload = {
   type: "new-message",
   data: {
     guid: "message-1",
@@ -67,97 +87,124 @@ const blueBubblesPayload = {
   },
 };
 
-describe("Blooio webhook BlueBubbles compatibility", () => {
+describe("Blooio webhook authority", () => {
   beforeEach(() => {
-    handleBlueBubblesWebhook.mockClear();
-    handleBlueBubblesWebhookPayload.mockClear();
+    processedKeys.clear();
+    isAlreadyProcessed.mockClear();
+    markAsProcessed.mockClear();
   });
 
-  test("dispatches explicit bridge requests before Blooio signature validation", async () => {
-    const response = await app.fetch(post(blueBubblesPayload));
+  test("contains no deleted bridge import, discriminator, or child route", async () => {
+    const source = await Bun.file(
+      new URL("./route.ts", import.meta.url),
+    ).text();
 
-    await expect(response.json()).resolves.toMatchObject({
-      success: true,
-      source: "bluebubbles-direct",
-    });
-    expect(handleBlueBubblesWebhook).toHaveBeenCalledTimes(1);
-    expect(handleBlueBubblesWebhookPayload).not.toHaveBeenCalled();
+    expect(source).not.toContain("../../bluebubbles/route");
+    expect(source).not.toContain('header("x-eliza-bridge")');
+    expect(source).not.toContain('query("bridge")');
+    expect(source).not.toContain('app.post("/bluebubbles"');
   });
 
-  test("detects BlueBubbles-shaped payloads even without the bridge query", async () => {
-    const response = await app.fetch(
-      new Request("https://api.example.test/", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(blueBubblesPayload),
+  test("does not let bridge query or header metadata bypass Blooio signing", async () => {
+    const body = JSON.stringify(retiredBridgePayload);
+    const requests = [
+      request(body, { query: "bridge=bluebubbles" }),
+      request(body, { headers: { "x-eliza-bridge": "bluebubbles" } }),
+    ];
+
+    for (const requestValue of requests) {
+      const response = await fetchRoute(requestValue);
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        error: "Invalid webhook signature",
+      });
+    }
+
+    expect(isAlreadyProcessed).not.toHaveBeenCalled();
+    expect(markAsProcessed).not.toHaveBeenCalled();
+  });
+
+  test("does not expose a retired bridge child route", async () => {
+    const body = JSON.stringify(retiredBridgePayload);
+    const response = await fetchRoute(
+      request(body, {
+        path: "/bluebubbles",
+        headers: { "x-blooio-signature": signature(body) },
       }),
     );
 
-    await expect(response.json()).resolves.toMatchObject({
-      success: true,
-      source: "bluebubbles-payload",
-      payload: blueBubblesPayload,
-    });
-    expect(handleBlueBubblesWebhook).not.toHaveBeenCalled();
-    expect(handleBlueBubblesWebhookPayload).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(404);
+    expect(isAlreadyProcessed).not.toHaveBeenCalled();
+    expect(markAsProcessed).not.toHaveBeenCalled();
   });
 
-  test("does not misroute a Blooio v4 envelope as BlueBubbles", async () => {
-    const response = await mountedApp.fetch(
-      new Request("https://api.example.test/test-org", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-blooio-signature": "t=0,v1=invalid",
-        },
-        body: JSON.stringify({
-          id: "evt_blooio_v4",
-          type: "message.received",
-          created_at: 1_786_291_200_000,
-          data: {
-            id: "msg_blooio_v4",
-            sender: "+15555550123",
-            recipient: "+18087881821",
-            text: "hello",
-          },
-        }),
+  test("validates a signed non-Blooio envelope as provider input", async () => {
+    const body = JSON.stringify(retiredBridgePayload);
+    const response = await fetchRoute(
+      request(body, {
+        query: "bridge=bluebubbles",
+        headers: { "x-blooio-signature": signature(body) },
       }),
-      { NODE_ENV: "production" },
     );
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "Invalid webhook signature",
+      error: "Invalid webhook payload",
     });
-    expect(handleBlueBubblesWebhook).not.toHaveBeenCalled();
-    expect(handleBlueBubblesWebhookPayload).not.toHaveBeenCalled();
+    expect(isAlreadyProcessed).not.toHaveBeenCalled();
+    expect(markAsProcessed).not.toHaveBeenCalled();
   });
 
-  test("rejects an inbound message without a stable ID", async () => {
+  test("accepts a signed Blooio v4 event and deduplicates its retry", async () => {
+    const body = JSON.stringify({
+      id: "evt_blooio_v4",
+      type: "message.sent",
+      created_at: 1_786_291_200_000,
+      data: {
+        id: "msg_blooio_v4",
+        sender: "+15555550123",
+        recipient: "+18087881821",
+        text: "hello",
+      },
+    });
+    const headers = { "x-blooio-signature": signature(body) };
+
+    const firstResponse = await fetchRoute(request(body, { headers }));
+    expect(firstResponse.status).toBe(200);
+    await expect(firstResponse.json()).resolves.toEqual({ success: true });
+    expect(isAlreadyProcessed).toHaveBeenCalledWith("blooio:msg_blooio_v4");
+    expect(markAsProcessed).toHaveBeenCalledWith(
+      "blooio:msg_blooio_v4",
+      "blooio",
+    );
+
+    const retryResponse = await fetchRoute(request(body, { headers }));
+    expect(retryResponse.status).toBe(200);
+    await expect(retryResponse.json()).resolves.toEqual({
+      success: true,
+      status: "already_processed",
+    });
+    expect(isAlreadyProcessed).toHaveBeenCalledTimes(2);
+    expect(markAsProcessed).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a signed inbound message without a stable ID", async () => {
     const body = JSON.stringify({
       event: "message.received",
       sender: "+15555550123",
       text: "hello",
     });
-    const response = await mountedApp.fetch(
-      new Request("https://api.example.test/test-org", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-blooio-signature": signature(body),
-        },
-        body,
+    const response = await fetchRoute(
+      request(body, {
+        headers: { "x-blooio-signature": signature(body) },
       }),
-      { NODE_ENV: "production" },
     );
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: "Inbound message ID is required",
     });
-    expect(handleBlueBubblesWebhook).not.toHaveBeenCalled();
-    expect(handleBlueBubblesWebhookPayload).not.toHaveBeenCalled();
+    expect(isAlreadyProcessed).not.toHaveBeenCalled();
+    expect(markAsProcessed).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
@@ -1,8 +1,7 @@
 /**
- * Blooio Webhook Handler
- *
- * Receives inbound iMessage/SMS messages from Blooio and routes them
- * to the appropriate agent for processing.
+ * Authenticates and processes Blooio webhook deliveries for one organization.
+ * Every production POST passes through Blooio signature validation before
+ * payload parsing, idempotency, or agent routing.
  */
 
 import { Hono } from "hono";
@@ -23,10 +22,6 @@ import {
 import { isAlreadyProcessed, markAsProcessed } from "@/lib/utils/idempotency";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import {
-  handleBlueBubblesWebhook,
-  handleBlueBubblesWebhookPayload,
-} from "../../bluebubbles/route";
 
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -35,60 +30,12 @@ function boundedOrganizationId(value: string): string {
   return uuidPattern.test(value) ? value : "invalid";
 }
 
-function isBlueBubblesBridgeRequest(
-  c: AppContext,
-  rawBody: string,
-): { payload: unknown } | null {
-  const bridge =
-    c.req.header("x-eliza-bridge") ??
-    c.req.query("bridge") ??
-    new URL(c.req.url).searchParams.get("bridge");
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawBody) as unknown;
-  } catch {
-    // error-policy:J3 malformed bridge input is classified without echoing its body.
-    return bridge === "bluebubbles" ? { payload: null } : null;
-  }
-
-  if (bridge === "bluebubbles") {
-    return { payload: parsed };
-  }
-
-  // Blooio v4 and BlueBubbles both use a top-level { type, data } envelope.
-  // Auto-detect only BlueBubbles-specific message fields; treating the shared
-  // envelope shape itself as proof would divert signed Blooio v4 deliveries
-  // into the legacy bridge handler before Blooio signature verification.
-  if (
-    parsed &&
-    typeof parsed === "object" &&
-    "type" in parsed &&
-    "data" in parsed &&
-    parsed.data &&
-    typeof parsed.data === "object" &&
-    ("guid" in parsed.data ||
-      "isFromMe" in parsed.data ||
-      "handle" in parsed.data ||
-      "chats" in parsed.data ||
-      "dateCreated" in parsed.data)
-  ) {
-    return { payload: parsed };
-  }
-
-  return null;
-}
-
 async function handleBlooioWebhook(c: AppContext): Promise<Response> {
   const requestedOrgId = c.req.param("orgId") ?? "";
   const orgId = boundedOrganizationId(requestedOrgId);
 
   try {
     const rawBody = await c.req.text();
-    const blueBubblesRequest = isBlueBubblesBridgeRequest(c, rawBody);
-    if (blueBubblesRequest) {
-      return handleBlueBubblesWebhookPayload(c, blueBubblesRequest.payload);
-    }
-
     if (!requestedOrgId)
       return c.json({ error: "Organization ID is required" }, 400);
 
@@ -231,22 +178,9 @@ async function handleBlooioWebhook(c: AppContext): Promise<Response> {
 }
 
 const app = new Hono<AppEnv>();
-app.post(
-  "/",
-  async (c, next) => {
-    const bridge =
-      c.req.header("x-eliza-bridge") ??
-      c.req.query("bridge") ??
-      new URL(c.req.url).searchParams.get("bridge");
-    if (bridge === "bluebubbles") {
-      return handleBlueBubblesWebhook(c);
-    }
-    await next();
-  },
-  rateLimit(RateLimitPresets.AGGRESSIVE),
-  (c) => handleBlooioWebhook(c),
+app.post("/", rateLimit(RateLimitPresets.AGGRESSIVE), (c) =>
+  handleBlooioWebhook(c),
 );
-app.post("/bluebubbles", (c) => handleBlueBubblesWebhook(c));
 
 /**
  * Handle incoming message from Blooio

--- a/packages/cloud/e2e/README.md
+++ b/packages/cloud/e2e/README.md
@@ -60,7 +60,6 @@ secondary identities (attacker / other-user / end-user).
 | `tests/dashboard.spec.ts`     | seeded user reaches dashboard with test-auth session, localStorage writable   |
 | `tests/account-deletion.spec.ts` | authenticated public deletion page → explicit confirmation → Steward deactivation + Cloud user/org/API-key deactivation, with unrelated-tenant preservation |
 | `tests/provision.spec.ts`     | create agent → cron tick → sandbox `running`, control-plane sees the sandbox  |
-| `tests/bluebubbles-gateway.spec.ts` | real local registration/auth/DB/router plus the relay subprocess onboards an unknown sender, completes an authenticated phone link, routes the next text to that user's agent, sends its reply through BlueBubbles, reports connected status, and rejects the revoked credential |
 | `tests/deprovision.spec.ts`   | DELETE agent → async `agent_delete` job → polls to `deleted` / 404            |
 | `tests/stuck-cleanup.spec.ts` | aged `provisioning` row with no job → cleanup cron → sandbox `error`          |
 | `tests/domain-purchase-harness.spec.ts` | harness-logic verification for the money-gated domain-purchase lane against the registrar dev stub: full chain, price ceiling, ledger, 402/409/502-refund/idempotency negatives |


### PR DESCRIPTION
# Relates to

Closes #24283. Completes the webhook descope left by #24268 without restoring a BlueBubbles runtime, route, or test mock.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Exact-head scoped gates were rerun after the final sync; the earlier aggregate `bun run verify` result and its unrelated lint failure are recorded below.
- [x] A reviewer can confirm the change works from the route tests, production Worker bundle, and booted Worker evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a2a941add8ed657bbd47dcc6e5ed4c085a9021fa`; zero conflicts and current at the final pre-push fetch.
- [x] Focused tests, Cloud typecheck, production Worker dry-run, changed-file Biome, guide parity, and booted Worker E2E were rerun on exact head `29883331cf39efc5c48fbc435143f56d81b48d77`.

# Risks

Medium and intentionally fail-closed. Requests that used the unsupported `bridge=bluebubbles`, `x-eliza-bridge: bluebubbles`, payload auto-detection, or `/bluebubbles` child path no longer divert around Blooio authentication. Supported Blooio POSTs retain the same signature, parsing, rate-limit, idempotency, and routing path.

# Background

## What does this PR do?

- Removes the dangling import of the deleted `webhooks/bluebubbles/route` module.
- Removes query/header dispatch, body-shape auto-detection, and the child compatibility route.
- Replaces BlueBubbles mocks and success assertions with real Hono-route fail-closed regressions.
- Proves signed Blooio v4 delivery and retry idempotency remain intact.
- Removes stale Cloud route authority and deleted-E2E documentation plus legacy cross-references.

## What kind of change is this?

Bug fix and security hardening for a retired transport path.

# Documentation changes needed?

The affected Cloud API authority guide and stale Cloud E2E inventory were updated. `CLAUDE.md` and `AGENTS.md` remain byte-identical.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/webhooks/blooio/[orgId]/route.ts`
2. `packages/cloud/api/webhooks/blooio/[orgId]/route.test.ts`

## Detailed testing steps

```bash
bun test packages/cloud/api/webhooks/blooio/[orgId]/route.test.ts packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
bun run --cwd packages/cloud/api typecheck
E2E_ONLY=group-f-connectors bun run --cwd packages/cloud/api test:e2e
bun run check:agents-claude
```

Expected:

- 7/7 focused route tests pass.
- TypeScript and production Wrangler dry-run pass; no deleted-module resolution error.
- Booted PGlite + Worker connector batch passes 36/36.
- The booted lane proves Worker startup, route registration, Blooio health 200, and fail-closed boundary behavior. Its permissive signed case returns 500 without a seeded provider secret/database and is not claimed as happy-path proof.
- The focused real-Hono test computes a real HMAC over the exact request body and proves signed Blooio v4 success plus retry idempotency.

# Evidence Gate

<!-- evidence-head:29883331cf39efc5c48fbc435143f56d81b48d77 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or rendered surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or rendered surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a Worker routing/authentication change with no interactive UI.
<!-- evidence-row:backend-logs -->
- [x] [24293-pr24293-worker-e2e-36cases-29883331-redacted.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24293-pr24293-worker-e2e-36cases-29883331-redacted.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider-model, or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change removes routing authority and creates no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-mediated behavior.

## Backend + frontend logs

The **backend-logs Evidence Gate row links the actual 330-line redacted raw Wrangler/Worker/test excerpt** from exact head `29883331cf39efc5c48fbc435143f56d81b48d77`. It includes Worker readiness, health traffic, every connector case, actual Blooio responses, and the `36 pass`/`0 fail` summary. Expected `dev` exit 143 is Wrangler teardown after the passing suite.

The booted E2E test named `valid signed payload with SKIP_WEBHOOK_VERIFICATION` accepts 200 or 500 and returned 500 in this no-secret/no-DB harness; it is evidence of boot/routing/boundary behavior, not signed happy-path success. The focused route test is the signed happy-path proof: it generates an HMAC from the exact raw body, receives 200 for a Blooio v4 event, and verifies an `already_processed` retry without duplicate handling.

Production Worker bundle:

```text
wrangler deploy --env production --dry-run
Total Upload: 26966.53 KiB / gzip: 6508.93 KiB
--dry-run: exiting now.
```

Focused route result:

```text
7 pass
0 fail
42 expect() calls
```

Frontend logs: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` on the prior head reached the workspace lint fan-out but current `develop` fails on untouched files. Representative failures include formatting in `packages/core/src/features/documents/service-list.test.ts` and `packages/core/src/validation/secrets.ts`, plus existing lint diagnostics in `packages/core/src/features/trust/should-respond-risk-gate.surrogate.test.ts`, `packages/core/src/access-control/audience-egress.ts`, and unrelated `packages/agent` files. This PR changes none of those paths. On the exact final head, the owning Cloud API typecheck, production Worker dry-run, focused tests, changed-file Biome checks, guide parity, and booted Worker E2E all pass.

AI provider/model: OpenAI / gpt-6.5-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribution skill not invoked
Attribution status: self-reported
— [fix-24283-bluebubbles-descope]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-6.5-sol","client":"Codex Desktop","skill_revision":"N/A - contribution skill not invoked"} -->


