### PR TITLE
fix(core): honor metadata.paused for one-shot tasks in the scheduler tick

### DIFF
--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -739,4 +739,68 @@ describe("TaskService orphaned-task self-heal (missing worker)", () => {
 		expect(tasks.get("op-paused")?.metadata?.paused).toBe(true);
 		expect(execute).not.toHaveBeenCalled();
 	});
+
+	it("does not execute a paused one-shot task when it becomes due, and keeps the row", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("ONE_SHOT", { name: "ONE_SHOT", execute });
+		tasks.set("paused-one-shot", {
+			id: "paused-one-shot" as UUID,
+			name: "ONE_SHOT",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+			dueAt: T0 + 5_000,
+			metadata: { paused: true },
+		});
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		// Well past the due time: the scheduler must honor the operator pause
+		// exactly as it does for repeat tasks — no execution, no delete.
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(execute).not.toHaveBeenCalled();
+		const row = tasks.get("paused-one-shot");
+		expect(row).toBeDefined();
+		expect(row?.metadata?.paused).toBe(true);
+	});
+
+	it("executes a one-shot task that was never paused once it is due", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("ONE_SHOT", { name: "ONE_SHOT", execute });
+		tasks.set("due-one-shot", {
+			id: "due-one-shot" as UUID,
+			name: "ONE_SHOT",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+			dueAt: T0 + 5_000,
+		});
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(tasks.has("due-one-shot")).toBe(false);
+	});
+
+	it("resumeTask with runImmediately executes a paused one-shot exactly once", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("ONE_SHOT", { name: "ONE_SHOT", execute });
+		tasks.set("resumed-one-shot", {
+			id: "resumed-one-shot" as UUID,
+			name: "ONE_SHOT",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+			metadata: { paused: true },
+		});
+
+		service = (await TaskService.start(runtime)) as TaskService;
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(execute).not.toHaveBeenCalled();
+
+		// Explicit operator resume: unpause + immediate manual run override.
+		await service.resumeTask("resumed-one-shot" as UUID, true);
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -21,7 +21,10 @@ const T0 = new Date("2026-01-01T00:00:00.000Z").getTime();
  * exactly when the tick re-queries without external nudges.
  */
 function makeTaskRuntime(options?: {
-	getTasks?: (params: { tags?: string[]; agentIds?: UUID[] }) => Promise<Task[]>;
+	getTasks?: (params: {
+		tags?: string[];
+		agentIds?: UUID[];
+	}) => Promise<Task[]>;
 }) {
 	const tasks = new Map<string, Task>();
 	const workers = new Map<string, TaskWorker>();

--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -20,7 +20,9 @@ const T0 = new Date("2026-01-01T00:00:00.000Z").getTime();
  * Deliberately does NOT auto-markDirty on mutation — the tests below exercise
  * exactly when the tick re-queries without external nudges.
  */
-function makeTaskRuntime() {
+function makeTaskRuntime(options?: {
+	getTasks?: (params: { tags?: string[]; agentIds?: UUID[] }) => Promise<Task[]>;
+}) {
 	const tasks = new Map<string, Task>();
 	const workers = new Map<string, TaskWorker>();
 	const noop = () => undefined;
@@ -33,8 +35,10 @@ function makeTaskRuntime() {
 			workers.set(worker.name, worker);
 		},
 		getTaskWorker: (name: string) => workers.get(name),
-		getTasks: async (_params: { tags?: string[]; agentIds?: UUID[] }) =>
-			Array.from(tasks.values()),
+		getTasks:
+			options?.getTasks ??
+			(async (_params: { tags?: string[]; agentIds?: UUID[] }) =>
+				Array.from(tasks.values())),
 		getTask: async (id: UUID) => tasks.get(id) ?? null,
 		getTasksByName: async (name: string) =>
 			Array.from(tasks.values()).filter((t) => t.name === name),
@@ -738,6 +742,52 @@ describe("TaskService orphaned-task self-heal (missing worker)", () => {
 		await vi.advanceTimersByTimeAsync(30_000);
 		expect(tasks.get("op-paused")?.metadata?.paused).toBe(true);
 		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("runs at most one already-selected execution when pauseTask lands mid-tick", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("ONE_SHOT", { name: "ONE_SHOT", execute });
+		tasks.set("mid-tick-pause", {
+			id: "mid-tick-pause" as UUID,
+			name: "ONE_SHOT",
+			agentId: AGENT_ID,
+			tags: ["queue"],
+			dueAt: T0 - 1,
+		});
+
+		// Gate the FIRST getTasks (the in-flight tick) so pauseTask can land
+		// while the tick holds a stale, pre-pause snapshot — the production
+		// interleaving the already-selected-work semantics describe.
+		let releaseTick: ((snapshot: Task[]) => void) | null = null;
+		const tickSnapshot = new Promise<Task[]>((resolve) => {
+			releaseTick = resolve;
+		});
+		let firstCall = true;
+		(runtime as unknown as { getTasks: unknown }).getTasks = async () => {
+			if (!firstCall) return Array.from(tasks.values());
+			firstCall = false;
+			return await tickSnapshot;
+		};
+
+		service = (await TaskService.start(runtime)) as TaskService;
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		// Stale snapshot captured BEFORE the pause persists.
+		const stale = Array.from(tasks.values());
+		await service.pauseTask("mid-tick-pause" as UUID);
+		expect(tasks.get("mid-tick-pause")?.metadata?.paused).toBe(true);
+
+		releaseTick?.(stale);
+		await vi.advanceTimersByTimeAsync(2_000);
+		// The already-selected execution completes its lifecycle exactly once…
+		expect(execute).toHaveBeenCalledTimes(1);
+		// …including the normal one-shot delete (documented semantics).
+		expect(tasks.has("mid-tick-pause")).toBe(false);
+
+		// Every subsequent tick observes the pause state and selects nothing.
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(execute).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not execute a paused one-shot task when it becomes due, and keeps the row", async () => {

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -589,16 +589,16 @@ export class TaskService extends Service {
 		for (const task of validation.tasks) {
 			// Non-repeat tasks: run when due (or immediately if no dueAt/scheduledAt). WHY: one-shot "run at time X" (e.g. follow-up) uses dueAt or metadata.scheduledAt.
 			if (!task.tags?.includes("repeat")) {
-			// A paused one-shot must not run and must not reach the
-			// execute-and-delete lifecycle — pauseTask() promises that ticks
-			// after the pause skip the row until resumeTask(). The repeat
-			// branch below has its own paused skip; this mirrors it for
-			// one-shots (#24277). A tick that captured this snapshot before
-			// pauseTask persisted may still run once — documented as
-			// already-selected-work semantics on pauseTask().
-			if (task.metadata?.paused === true) {
-				continue;
-			}
+				// A paused one-shot must not run and must not reach the
+				// execute-and-delete lifecycle — pauseTask() promises that ticks
+				// after the pause skip the row until resumeTask(). The repeat
+				// branch below has its own paused skip; this mirrors it for
+				// one-shots (#24277). A tick that captured this snapshot before
+				// pauseTask persisted may still run once — documented as
+				// already-selected-work semantics on pauseTask().
+				if (task.metadata?.paused === true) {
+					continue;
+				}
 				const dueMs = resolveDueTime(task);
 				if (dueMs != null && now < dueMs) continue;
 				try {

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -37,7 +37,9 @@ function resolveDueTime(task: Task): number | null {
 /**
  * Each tick validates due `queue` tasks against their worker's `shouldRun`,
  * then runs `worker.execute`. Repeat tasks reschedule on their interval (with
- * failure backoff); one-shot tasks are deleted after running.
+ * failure backoff); one-shot tasks are deleted after running. A task paused via
+ * `metadata.paused` (operator or API) is skipped by every tick regardless of
+ * tags — a paused one-shot stays in the store until it is resumed.
  */
 export class TaskService extends Service {
 	private timer: NodeJS.Timeout | null = null;
@@ -587,6 +589,13 @@ export class TaskService extends Service {
 		for (const task of validation.tasks) {
 			// Non-repeat tasks: run when due (or immediately if no dueAt/scheduledAt). WHY: one-shot "run at time X" (e.g. follow-up) uses dueAt or metadata.scheduledAt.
 			if (!task.tags?.includes("repeat")) {
+				// A paused one-shot must not run and must not reach the
+				// execute-and-delete lifecycle — pauseTask() promises the row
+				// survives until resumeTask(). The repeat branch below has its
+				// own paused skip; this mirrors it for one-shots (#24277).
+				if (task.metadata?.paused === true) {
+					continue;
+				}
 				const dueMs = resolveDueTime(task);
 				if (dueMs != null && now < dueMs) continue;
 				try {

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -589,13 +589,16 @@ export class TaskService extends Service {
 		for (const task of validation.tasks) {
 			// Non-repeat tasks: run when due (or immediately if no dueAt/scheduledAt). WHY: one-shot "run at time X" (e.g. follow-up) uses dueAt or metadata.scheduledAt.
 			if (!task.tags?.includes("repeat")) {
-				// A paused one-shot must not run and must not reach the
-				// execute-and-delete lifecycle — pauseTask() promises the row
-				// survives until resumeTask(). The repeat branch below has its
-				// own paused skip; this mirrors it for one-shots (#24277).
-				if (task.metadata?.paused === true) {
-					continue;
-				}
+			// A paused one-shot must not run and must not reach the
+			// execute-and-delete lifecycle — pauseTask() promises that ticks
+			// after the pause skip the row until resumeTask(). The repeat
+			// branch below has its own paused skip; this mirrors it for
+			// one-shots (#24277). A tick that captured this snapshot before
+			// pauseTask persisted may still run once — documented as
+			// already-selected-work semantics on pauseTask().
+			if (task.metadata?.paused === true) {
+				continue;
+			}
 				const dueMs = resolveDueTime(task);
 				if (dueMs != null && now < dueMs) continue;
 				try {
@@ -979,7 +982,18 @@ export class TaskService extends Service {
 	}
 
 	/**
-	 * Pauses a task. The scheduler will skip it until resumed.
+	 * Pauses a task. Every scheduler tick AFTER the pause is persisted skips
+	 * the task until it is resumed, and a paused task is never deleted by the
+	 * tick loop.
+	 *
+	 * Already-selected-work semantics: Task rows carry no version column, so
+	 * pause is not CAS-atomic with tick selection. A tick that captured its
+	 * Task snapshot BEFORE the pause landed may execute that one selection to
+	 * completion (including the normal one-shot delete). Everything selected
+	 * afterwards observes `metadata.paused` and skips. Callers needing
+	 * hard at-most-zero execution must gate the worker itself (e.g. check
+	 * paused inside worker.execute).
+	 *
 	 * Preserves existing metadata (updatedAt, updateInterval, etc.).
 	 */
 	async pauseTask(taskId: UUID): Promise<void> {


### PR DESCRIPTION
# Relates to

Fixes #24277

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (`825d62e618`); zero conflicts; lanes rerun post-sync (36/36).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.
      All gates within this PR's scope pass; repo-wide upstream blockers unchanged (see Known gaps / failures).

# Risks

**Low.** The tick-loop guard adds one skip branch for paused one-shot tasks.
Review follow-up (2c293b53e2) changes no runtime behavior: it defines the
already-selected-work contract on `pauseTask()` in documentation and pins it
with an interleaved concurrency regression. Callers that never pause one-shot
tasks see zero behavioral change — covered by the never-paused control test.

# Background

## What does this PR do?

Makes `TaskService` honor `metadata.paused === true` for **one-shot**
(non-`repeat`) tasks. Previously the paused skip existed only in the repeat
branch, so an operator/API pause on a pending one-shot task was silently
inverted into guaranteed execution: when the task became due, the tick ran it,
and the normal one-shot lifecycle then deleted the row — destroying both the
pause and the suppressed work.

## Pause semantics (review follow-up)

Task rows carry no version column, so pause cannot be CAS-atomic with tick
selection. This PR defines the explicit **already-selected-work** contract on
`pauseTask()` instead of overclaiming:

1. Every scheduler tick that starts after the pause is persisted skips the task.
2. A tick that captured its Task snapshot before the pause landed may execute
   that one already-selected work to completion, including the normal one-shot
   delete — at most once.
3. A paused row is never deleted by any later tick; only an already-selected
   execution completes its lifecycle.
4. Callers needing hard at-most-zero execution must gate inside their worker.

The new regression reproduces the production interleaving: `getTasks` for the
in-flight tick is gated, `pauseTask` persists against the live store while the
tick waits, the stale pre-pause snapshot is released, and the test proves
exactly-once execution followed by no further selections.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/task.ts` — non-repeat branch of `runTick()` (paused skip) and the `pauseTask()` semantics block.
- `packages/core/src/services/task.test.ts` — three one-shot pause tests plus the mid-tick interleaving test.

## Detailed testing steps

None: Automated tests are acceptable.

```bash
bun run --cwd packages/core test -- src/services/task.test.ts
```

1. `does not execute a paused one-shot task when it becomes due, and keeps the row` — red on unmodified `develop`, green here.
2. `executes a one-shot task that was never paused once it is due` — control: unchanged lifecycle still runs and deletes.
3. `resumeTask with runImmediately executes a paused one-shot exactly once` — deliberate override path preserved.
4. `runs at most one already-selected execution when pauseTask lands mid-tick` — review follow-up: stale-snapshot race behaves exactly as documented.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d8d953e181583560ed299f5c293e521a9ba73524 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface,
      desktop and mobile, or an explicit not-applicable statement follows.
  N/A - core-only scheduling change with no rendered UI surface; the before
  state is the failing vitest transcript pasted inside the backend-logs row
  below.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface,
      desktop and mobile, or an explicit not-applicable statement follows.
  N/A - same reason; the after state is the 36-passed lane summary pasted
  inside the backend-logs row below.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or an explicit
      not-applicable statement follows.
  N/A - no UI flow exists; the complete observable behavior (tick selects vs
  skips a task, and what happens to the row) is asserted directly by the four
  tests listed under Testing.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end.
  Red run on unmodified develop (f19b4fae99), captured by the deterministic
  timer TaskService harness:

  ```text
  ❯ src/services/task.test.ts:761:23   (transcript trimmed)
     761|   expect(execute).not.toHaveBeenCalled()
  AssertionError: expected the execute worker to not be called, but got 1 call
  Number of calls: 1

  Test Files  1 failed (1)
       Tests  1 failed | 2 passed (26 total in file)
  ```

  Green run on this branch (d8d953e181583560ed299f5c293e521a9ba73524) after
  rebase onto latest origin/develop (825d62e618):

  ```text
  bun run --cwd packages/core test -- src/services/task.test.ts src/services/task-scheduler.test.ts
  Test Files  2 passed (2)
       Tests  36 passed (36)
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or an explicit not-applicable statement follows.
  N/A - packages/core scheduler internals; no client or network surface is
  touched by this diff.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or an explicit not-applicable statement follows.
  N/A - no model invocation is involved; deterministic fake-timer scheduling
  control flow only.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or an explicit
      not-applicable statement plus equivalent captured state follows.
  Captured state — task-store rows driven by the real tick loop under fake
  timers, asserted by the tests:

  ```text
  paused one-shot, 30s past due:
    worker.execute calls = 0
    row retained: { metadata: { paused: true } }

  never-paused control, past due:
    worker.execute calls = 1 ; row deleted from store

  resumeTask(id, true) override on paused one-shot:
    ticks while paused: 0 executions
    after resume: exactly 1 execution

  mid-tick pauseTask interleave (review follow-up):
    stale snapshot released → exactly 1 execution, lifecycle delete completes
    all subsequent ticks → 0 further executions
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or an explicit
      not-applicable statement follows when the change has no rendered surface.
  N/A - this change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path is touched by this change.

## Backend + frontend logs

Full transcripts are pasted inside the backend-logs evidence row above.
Frontend: N/A - core-only change.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI; failing-test transcript inside the backend-logs row.

### After

N/A - no UI; passing-test transcript inside the backend-logs row.

### Walkthrough video

N/A - no user-facing flow to walk through.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface.

## Known gaps / failures

Repo-wide lanes fail identically on clean `origin/develop` with no files of
this PR involved (`git diff origin/develop` touches only
`packages/core/src/services/{task.ts,task.test.ts}`):

1. `@elizaos/cloud-api#typecheck` — dangling import of removed module
   `../../bluebubbles/route` left by the bluebubbles webhook-diversion removal
   (#24283 follow-up).
2. `@elizaos/agent#lint:check` — pre-existing biome findings from #23501
   (`8a860cd703`).
3. `src/providers/recent-errors.test.ts` — one pre-existing failure reproducing
   on clean develop.
4. `audit:scripts` coupling-stale allowlist drift and
   `audit:mock-module-exports` pre-existing baseline — upstream states also
   documented in #24315/#24321.

All gates within this PR's scope pass: `packages/core` typecheck, Node build,
biome clean on both touched files, and 36/36 across the task + scheduler lanes.

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [ox-alpha-contribution]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer exact-head repair receipt

At current-develop rebased head `d8d953e181583560ed299f5c293e521a9ba73524`, Biome mechanically formatted only the two changed files; no scheduler or test semantics changed. Independent review confirmed the explicit already-selected-work contract matches the serialized local and daemon tick owners: a pre-pause snapshot may complete its one-shot lifecycle once, while persisted paused snapshots skip and retain the row. The regression gates `getTasks`, captures the pre-pause value snapshot before `pauseTask` replaces the stored row, releases it only after the persisted pause assertion, then proves one completion and no later execution. Exact Biome and `git diff --check` pass; evidence validates. Independent focused execution was attempted but this sparse checkout stops before collection on missing `uuid`; the contributor's source-equivalent exact 36/36 task+scheduler transcript remains the executable proof.

## Current-develop maintainer restamp (2026-08-21)

Rebased by preserving all three authored commits onto `develop@825d62e6180f2449769668c9057cf6a28639950b`; zero conflicts. Exact head `d8d953e181583560ed299f5c293e521a9ba73524` passed:

- `packages/core` task + task-scheduler suites: 2 files, 36/36 tests.
- `packages/core` typecheck: pass.
- Node build including declarations: pass.
- Scoped Biome and `git diff --check`: pass.

The implementation patch is source-equivalent to the previously approved head; only ancestry and commit IDs changed.