### PR TITLE
fix(agent): validate connector metadata before provider effects

### DIFF
--- a/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
+++ b/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
@@ -14,12 +14,14 @@
  * side fails the same way on an adapter-supplied audit row, whose `metadata`
  * column no layer between the row and the redaction walk bounds.
  *
- * These tests pin the bounded behaviour: an over-budget write is rejected with
- * a 400, an over-budget stored value is still served with an explicit marker,
- * and honest nested metadata is untouched.
+ * These tests pin both bounded layers: route-walk failures and the stricter
+ * connector-storage projection are rejected with a 400 before provider
+ * callbacks run, an over-budget stored value is served with an explicit
+ * marker, and honest nested metadata is untouched.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  type ConnectorAccountPatch,
   getConnectorAccountManager,
   InMemoryDatabaseAdapter,
 } from "@elizaos/core";
@@ -36,6 +38,10 @@ const ACCOUNT_ID = "3a899cd0-170f-4b3e-932e-46ec68119b35";
 
 /** Comfortably past the V8 recursion limit for these frames. */
 const OVERFLOW_DEPTH = 60_000;
+/** One level beyond the connector-storage depth accepted by core. */
+const STORAGE_OVERFLOW_DEPTH = 17;
+/** Wide enough to exceed core's storage-node budget but not the route budget. */
+const STORAGE_OVERFLOW_WIDTH = 2_100;
 
 function deepChain(depth: number): Record<string, unknown> {
   const root: Record<string, unknown> = {};
@@ -47,6 +53,12 @@ function deepChain(depth: number): Record<string, unknown> {
   }
   cursor.leaf = "end";
   return root;
+}
+
+function wideObject(width: number): Record<string, unknown> {
+  return Object.fromEntries(
+    Array.from({ length: width }, (_, index) => [`field_${index}`, index]),
+  );
 }
 
 function createRuntime(adapter?: InMemoryDatabaseAdapter) {
@@ -100,6 +112,65 @@ async function newAdapter(): Promise<InMemoryDatabaseAdapter> {
 }
 
 describe("connector account metadata walk bounds (real route handler)", () => {
+  it("rejects storage-over-deep POST metadata before a provider create side effect", async () => {
+    const runtime = createRuntime(await newAdapter());
+    const manager = getConnectorAccountManager(runtime as never);
+    const createAccount = vi.fn(async (input: ConnectorAccountPatch) => input);
+    manager.registerProvider({ provider: PROVIDER, createAccount });
+    const pathname = `/api/connectors/${PROVIDER}/accounts`;
+    const { ctx, captured } = createContext(runtime, "POST", pathname, {
+      label: "deep-for-storage",
+      metadata: { root: deepChain(STORAGE_OVERFLOW_DEPTH) },
+    });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(createAccount).not.toHaveBeenCalled();
+  });
+
+  it("rejects storage-over-wide PATCH metadata before a provider patch side effect", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    await manager.upsertAccount(PROVIDER, {
+      id: ACCOUNT_ID,
+      provider: PROVIDER,
+      label: "user@example.com",
+      role: "OWNER",
+      accessGate: "open",
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: {},
+    } as never);
+    const patchAccount = vi.fn(
+      async (_accountId: string, patch: ConnectorAccountPatch) => patch,
+    );
+    manager.registerProvider({ provider: PROVIDER, patchAccount });
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${ACCOUNT_ID}`;
+    const { ctx, captured } = createContext(runtime, "PATCH", pathname, {
+      metadata: wideObject(STORAGE_OVERFLOW_WIDTH),
+    });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(patchAccount).not.toHaveBeenCalled();
+  });
+
   it("rejects an over-deep POST body with a 400 instead of escaping the handler", async () => {
     const runtime = createRuntime(await newAdapter());
     const pathname = `/api/connectors/${PROVIDER}/accounts`;

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -12,12 +12,15 @@
  */
 import type http from "node:http";
 import {
+  CONNECTOR_JSON_UNBOUNDED,
   type ConnectorAccount,
+  type ConnectorAccountJsonObject,
   type ConnectorAccountPatch,
   type ConnectorAccountPurpose,
   type ConnectorAccountRole,
   type ConnectorAccountStatus,
   type ConnectorOAuthFlow,
+  cloneConnectorJsonObject,
   DEFAULT_PRIVACY_LEVEL,
   ElizaError,
   getConnectorAccountManager,
@@ -364,8 +367,28 @@ function cleanMetadata(value: unknown): Metadata | undefined {
 
 function isUnboundedMetadataGraph(error: unknown): boolean {
   return (
-    error instanceof ElizaError && error.code === BLOCKED_OBJECT_GRAPH_UNBOUNDED
+    error instanceof ElizaError &&
+    (error.code === BLOCKED_OBJECT_GRAPH_UNBOUNDED ||
+      error.code === CONNECTOR_JSON_UNBOUNDED)
   );
+}
+
+/**
+ * Validate sanitized metadata against the stricter durable-storage projection
+ * before the manager can invoke a registered provider callback. The route
+ * walker intentionally has a looser budget, so relying on the adapter alone
+ * would allow a provider side effect before persistence rejects the patch.
+ */
+function validatePatchMetadataForStorage(
+  patch: ConnectorAccountPatch,
+): ConnectorAccountPatch {
+  if (patch.metadata === undefined) return patch;
+  return {
+    ...patch,
+    metadata: cloneConnectorJsonObject(
+      patch.metadata as ConnectorAccountJsonObject,
+    ),
+  };
 }
 
 function redactAuditMetadata(value: unknown): unknown {
@@ -758,12 +781,13 @@ export async function handleConnectorAccountRoutes(
       }
       let createPatch: ConnectorAccountPatch;
       try {
-        createPatch = accountPatchFromBody(parsed.data);
+        createPatch = validatePatchMetadataForStorage(
+          accountPatchFromBody(parsed.data),
+        );
       } catch (err) {
-        // error-policy:J1 route boundary — an over-budget caller body becomes a
-        // 400 rather than escaping the handler with no response written. Any
-        // other error is rethrown, so this narrows one shape rather than
-        // swallowing the class.
+        // error-policy:J1 route boundary — an over-budget caller body at either
+        // the route-walk or durable-storage budget becomes a 400 before any
+        // provider callback. Every other error is rethrown.
         if (!isUnboundedMetadataGraph(err)) throw err;
         error(res, UNBOUNDED_METADATA_MESSAGE, 400);
         return true;
@@ -812,11 +836,12 @@ export async function handleConnectorAccountRoutes(
         }
         let patch: ConnectorAccountPatch;
         try {
-          patch = accountPatchFromBody(parsed.data, existing.metadata);
+          patch = validatePatchMetadataForStorage(
+            accountPatchFromBody(parsed.data, existing.metadata),
+          );
         } catch (err) {
-          // error-policy:J1 route boundary — same translation as the POST path
-          // above; an over-budget patch body becomes a 400 and every other
-          // error is rethrown.
+          // error-policy:J1 route boundary — same pre-provider translation as
+          // the POST path above; every unrelated failure is rethrown.
           if (!isUnboundedMetadataGraph(err)) throw err;
           error(res, UNBOUNDED_METADATA_MESSAGE, 400);
           return true;


### PR DESCRIPTION
# Relates to

Closes #23805. This is the narrow follow-up to the P1 gap recorded on merged
PR #23809; it does not duplicate that PR's route-walker work.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@9fdf63831baa5afa01a1f8fcbce4ae71c53ebe65` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; unrelated baseline failures are recorded below.
- [x] A reviewer can confirm the behavior from the RED/GREEN route results and provider-callback assertions below.

# Sync with develop

- [x] Rebased onto `origin/develop@9fdf63831baa5afa01a1f8fcbce4ae71c53ebe65`; zero conflicts.
- [x] `bun run verify` was run post-sync; the exact unrelated lint/typecheck blockers are listed under **Known gaps / failures**.

# Risks

Low. The change is confined to authenticated connector-account `POST` and
`PATCH` routes. It reuses core's existing durable connector-JSON projection,
after the route's secret/reserved-key sanitization and before any registered
provider callback. Only the two typed bounded-graph errors become HTTP 400;
provider, database, and unrelated failures are still rethrown.

# Background

## What does this PR do?

PR #23809 bounded the route metadata walk at depth 32 / 100,000 nodes, but core
persistence is stricter: depth 16 / 2,048 nodes / 64 KiB strings. Metadata in
that gap reached `ConnectorAccountManager.createAccount` or `patchAccount`,
which invokes a registered provider callback before storage rejects the row as
`CONNECTOR_JSON_UNBOUNDED`.

This change validates the final sanitized/merged metadata with
`cloneConnectorJsonObject` before the manager call. It maps only
`BLOCKED_OBJECT_GRAPH_UNBOUNDED` and `CONNECTOR_JSON_UNBOUNDED` to the existing
400 response. The PATCH path validates the final merged metadata, not merely
the submitted delta.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This aligns the HTTP route with an existing core persistence contract.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts`:

- depth-17 POST metadata returns 400 and never invokes `createAccount`;
- storage-node-over-budget PATCH metadata returns 400 and never invokes `patchAccount`.

Both tests drive the real route handler and real connector-account manager with
the repository's in-memory database adapter.

## Detailed testing steps

```bash
bunx vitest run --root packages/agent \
  src/api/connector-account-routes.metadata-bounds.test.ts \
  src/api/blocked-object-keys.test.ts \
  src/api/connector-account-routes.durable.test.ts \
  src/api/connector-account-routes.test.ts \
  src/api/connector-routes.test.ts \
  src/api/server-helpers.test.ts
# 6 files passed, 63 tests passed

bunx vitest run --root packages/core \
  src/database/connector-json.test.ts \
  src/database/inMemoryConnectorAccountStorage.test.ts \
  src/connectors/account-manager.test.ts
# 3 files passed, 41 tests passed

bunx @biomejs/biome check \
  packages/agent/src/api/connector-account-routes.ts \
  packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
# Checked 2 files; no fixes applied

bun run --cwd packages/agent build
# exit 0
```

TDD proof on the pre-fix base: the two new route cases failed with
`ConnectorJsonUnboundedError` (`depth` and `nodes`) while the six existing cases
passed. The two relevant base files are byte-identical between that RED base
and the final rebase base. On exact head `cfa80d3d5a3a35c8c8dc2708ba209574f5edbbdf`, all eight cases pass.

# Evidence Gate

<!-- evidence-head:cfa80d3d5a3a35c8c8dc2708ba209574f5edbbdf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend route and tests only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend route and tests only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow; the observable contract is the HTTP result and provider callback count.
<!-- evidence-row:backend-logs -->
- [x] Exact-head production-route regression transcript:

```text
$ bunx vitest run --root packages/agent src/api/connector-account-routes.metadata-bounds.test.ts src/api/blocked-object-keys.test.ts src/api/connector-account-routes.durable.test.ts src/api/connector-account-routes.test.ts src/api/connector-routes.test.ts src/api/server-helpers.test.ts
Test Files  6 passed (6); Tests  63 passed (63)
Both over-budget route requests returned HTTP 400 and the registered create/patch provider callbacks remained at zero calls.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request client changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider-model, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head persistence-contract transcript:

```text
$ bunx vitest run --root packages/core src/database/connector-json.test.ts src/database/inMemoryConnectorAccountStorage.test.ts src/connectors/account-manager.test.ts
Test Files  3 passed (3); Tests  41 passed (41)
The route artifact is `{ status: 400 }` before provider mutation; core bounded connector-JSON persistence contracts remain green.
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - connector-account HTTP validation only; no model invocation.

## Backend + frontend logs

Backend: 63/63 focused agent assertions and 41/41 core contract assertions pass
on the exact rebased head. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT surface.

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` stops on two unrelated current-base errors: `packages/agent/src/api/server.ts:2556` rejects the existing `"signal"` route key, and `packages/cloud/shared/src/db/repositories/users.ts:4` cannot resolve the existing `@elizaos/plugin-todos/edge` export. Neither file is in this diff.
- Full `packages/agent` lint and root `bun run verify` stop on unrelated current-base Biome findings, led by `packages/agent/src/api/interactions-routes.test.ts` and additional untouched core files. Both changed files pass Biome directly.
- No hosted check result is claimed here; fork PR workflows may remain queued or absent.

AI assistance: yes
Models used: openai/gpt-5.6-sol, openai/gpt-5.6-luna, openai/gpt-5.6-terra
Client / agent tooling: Codex Desktop multi-agent orchestration
Contribution skill revision: elizaOS/eliza@9fdf63831baa5afa01a1f8fcbce4ae71c53ebe65:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [rndrntwrk-23805-followup]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9fdf63831baa5afa01a1f8fcbce4ae71c53ebe65:packages/skills/skills/contribute-to-eliza"} -->
