### PR TITLE
fix(coding-tools): bind shell confirmation to execution scope

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -3573,6 +3573,47 @@ describe("destructive-bulk confirm gate", () => {
     );
   });
 
+  it("rejects a confirmation when the resolved execution directory changes", async () => {
+    const runCommand = vi.fn(async () => ({
+      output: "",
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const { runtime, session } = await makeRuntime({
+      capabilityRouter: makeShellRouter(runCommand),
+    });
+    const command = "rm -rf ./relative-target";
+    const originalDirectory = process.cwd();
+    const changedDirectory = path.join(process.cwd(), "src");
+    const original = makeMessage(
+      undefined,
+      `remove the relative target in ${originalDirectory}`,
+    );
+    const blocked = requireActionResult(
+      await shellAction.handler?.(runtime, original, undefined, {
+        command,
+        cwd: originalDirectory,
+      }),
+    );
+    const challenge = confirmationChallenge(blocked);
+    session.setCwd(String(original.roomId), changedDirectory);
+
+    const result = requireActionResult(
+      await shellAction.handler?.(
+        runtime,
+        confirmationMessage(original, challenge),
+        undefined,
+        { command, confirm: true, confirmation_challenge: challenge },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    expect((result.data as Record<string, unknown>).confirmation_failure).toBe(
+      "cwd_mismatch",
+    );
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
   it("expires challenges and consumes a successful challenge exactly once", async () => {
     const runCommand = vi.fn(async () => ({
       output: "executed",

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -1707,6 +1707,7 @@ export const shellAction: Action = {
             runtime,
             token: readStringParam(options, "confirmation_challenge"),
             command,
+            executionDirectory: cwd,
             message,
           })
         : ({ authorized: false, reason: "missing" } as const);
@@ -1714,6 +1715,7 @@ export const shellAction: Action = {
         const challenge = issueDestructiveChallenge({
           runtime,
           command,
+          executionDirectory: cwd,
           message,
         });
         const redactedReason = verdict.reason

--- a/plugins/plugin-coding-tools/src/lib/destructive-confirmation.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-confirmation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Exercises the deterministic destructive-command confirmation authority in
+ * memory, including one-use consumption and execution-directory binding.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  consumeDestructiveChallenge,
+  issueDestructiveChallenge,
+} from "./destructive-confirmation.js";
+
+const runtime = {} as IAgentRuntime;
+
+function message(id: string, text: string): Memory {
+  return {
+    id: id as UUID,
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    entityId: "22222222-2222-2222-2222-222222222222" as UUID,
+    roomId: "33333333-3333-3333-3333-333333333333" as UUID,
+    content: { text },
+    createdAt: 1,
+  } as Memory;
+}
+
+describe("destructive confirmation execution context", () => {
+  it("rejects a changed cwd without consuming the original authority", () => {
+    const command = "rm -rf ./relative-target";
+    const issuedFrom = message(
+      "44444444-4444-4444-4444-444444444444",
+      "remove the relative target",
+    );
+    const token = issueDestructiveChallenge({
+      runtime,
+      command,
+      executionDirectory: "/workspace/original",
+      message: issuedFrom,
+      now: 1,
+    });
+    expect(typeof token).toBe("string");
+    const confirmedFrom = message(
+      "55555555-5555-5555-5555-555555555555",
+      `confirm ${token}`,
+    );
+
+    expect(
+      consumeDestructiveChallenge({
+        runtime,
+        token,
+        command,
+        executionDirectory: "/workspace/changed",
+        message: confirmedFrom,
+        now: 2,
+      }),
+    ).toEqual({ authorized: false, reason: "cwd_mismatch" });
+    expect(
+      consumeDestructiveChallenge({
+        runtime,
+        token,
+        command,
+        executionDirectory: "/workspace/original",
+        message: confirmedFrom,
+        now: 2,
+      }),
+    ).toEqual({ authorized: true });
+    expect(
+      consumeDestructiveChallenge({
+        runtime,
+        token,
+        command,
+        executionDirectory: "/workspace/original",
+        message: confirmedFrom,
+        now: 2,
+      }),
+    ).toEqual({ authorized: false, reason: "missing" });
+  });
+});

--- a/plugins/plugin-coding-tools/src/lib/destructive-confirmation.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-confirmation.ts
@@ -1,7 +1,7 @@
 /**
  * Holds short-lived one-time shell confirmation challenges per runtime.
- * Entries contain only an opaque nonce and command digest, never command text,
- * and authorization is bound to the requesting entity and room.
+ * Entries contain only an opaque nonce, command digest, and execution context,
+ * never command text; authorization is bound to the requester and room.
  */
 import { createHash, randomBytes } from "node:crypto";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
@@ -11,6 +11,7 @@ const MAX_CHALLENGES_PER_RUNTIME = 64;
 
 interface Challenge {
   commandDigest: string;
+  executionDirectory: string;
   entityId: string;
   issuingMessageId: string;
   roomId: string;
@@ -46,6 +47,7 @@ function sweep(entries: Map<string, Challenge>, now: number): void {
 export function issueDestructiveChallenge(args: {
   runtime: IAgentRuntime;
   command: string;
+  executionDirectory: string;
   message: Memory;
   now?: number;
 }): string | undefined {
@@ -62,6 +64,7 @@ export function issueDestructiveChallenge(args: {
   for (const [token, challenge] of entries) {
     if (
       challenge.commandDigest === commandDigest &&
+      challenge.executionDirectory === args.executionDirectory &&
       challenge.roomId === roomId &&
       challenge.entityId === entityId
     ) {
@@ -71,6 +74,7 @@ export function issueDestructiveChallenge(args: {
   const token = randomBytes(18).toString("base64url");
   entries.set(token, {
     commandDigest,
+    executionDirectory: args.executionDirectory,
     roomId,
     entityId,
     issuingMessageId,
@@ -89,6 +93,7 @@ export type ChallengeConsumption =
         | "requester_mismatch"
         | "room_mismatch"
         | "command_mismatch"
+        | "cwd_mismatch"
         | "same_message"
         | "token_not_confirmed";
     };
@@ -103,6 +108,7 @@ export function consumeDestructiveChallenge(args: {
   runtime: IAgentRuntime;
   token: string | undefined;
   command: string;
+  executionDirectory: string;
   message: Memory;
   now?: number;
 }): ChallengeConsumption {
@@ -126,6 +132,9 @@ export function consumeDestructiveChallenge(args: {
   }
   if (challenge.commandDigest !== destructiveCommandDigest(args.command)) {
     return { authorized: false, reason: "command_mismatch" };
+  }
+  if (challenge.executionDirectory !== args.executionDirectory) {
+    return { authorized: false, reason: "cwd_mismatch" };
   }
   if (!confirmsToken(args.message.content?.text, args.token)) {
     return { authorized: false, reason: "token_not_confirmed" };


### PR DESCRIPTION
## Summary

- bind destructive shell confirmation challenges to the canonical execution directory already resolved by `SandboxService`
- include the directory in duplicate-challenge identity and reject scope mismatch without consuming the original authority
- pass the resolved directory through the exported `SHELL` action issue/consume boundary
- add pure lifecycle and real exported-action regressions for execution-scope changes

This is the post-merge consolidation for #23354 and #23374. The merged parser now retains the earlier hardening and passes the identified adversarial shell cases; this PR closes the remaining confirmation-scope gap. A private repository security advisory contains the sensitive analysis.

## Validation

- pinned Bun 1.3.14 classifier + confirmation: 254/254
- pure confirmation authority lifecycle: 1/1
- exported `SHELL` execution-scope regression: 1/1 (149 filtered/skipped)
- `@elizaos/plugin-coding-tools` typecheck: pass
- `@elizaos/plugin-coding-tools` build: pass
- Biome on all four touched files: pass
- diff integrity: pass

Closes the post-merge review findings from #23354 and #23374.
