### PR TITLE
fix(cloud): fence snapshot service authority

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-snapshot-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-snapshot-authority.pglite.test.ts
@@ -1,0 +1,803 @@
+/**
+ * Exercises snapshot lifecycle authority and atomic persistence against real
+ * PGlite rows. Network capture is deterministic, while admission, advisory
+ * locking, row locking, backup planning, catalogue writes, metadata CAS, and
+ * pruning use the production service and repositories.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { type AgentSandbox, agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import {
+  type AgentBackupStateData,
+  agentSandboxBackups,
+  agentSandboxes,
+  CONTAINER_BACKED_EXECUTION_TIERS,
+} from "../../db/schemas/agent-sandboxes";
+import { organizations } from "../../db/schemas/organizations";
+import { users } from "../../db/schemas/users";
+import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-schema";
+import {
+  ElizaSandboxService,
+  SNAPSHOT_CAPTURE_TRANSIENT,
+  SNAPSHOT_ENDPOINT_UNSUPPORTED,
+} from "./eliza-sandbox";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const AMBIENT_HEAVY_PAYLOAD_STORAGE = process.env.SQL_HEAVY_PAYLOAD_STORAGE;
+const AMBIENT_HEAVY_PAYLOAD_MIN_BYTES = process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES;
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+const PGLITE_TIMEOUT = 300_000;
+const API_TOKEN = "snapshot-authority-token";
+const DELETION_ATTEMPT_ID = "00000000-0000-4000-8000-000000229471";
+const ORIGINAL_FETCH = globalThis.fetch;
+const AUTHORITY_CHANGED = "Sandbox changed while snapshot was being captured";
+const TIER_REJECTION = "Agent snapshot requires a container-backed execution tier";
+const POOL_REJECTION = "Agent snapshot cannot target pool-owned capacity";
+const DELETED_REJECTION = "Agent snapshot cannot target a deleted agent";
+const DELETION_REJECTION = "Agent snapshot cannot start while agent deletion is in progress";
+
+let pgliteReady = true;
+let sequence = 0;
+
+function unique(prefix: string): string {
+  sequence += 1;
+  return `${prefix}-${sequence}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function state(overrides: Partial<AgentBackupStateData> = {}): AgentBackupStateData {
+  return {
+    memories: [],
+    config: { source: "snapshot-authority" },
+    workspaceFiles: {},
+    ...overrides,
+  };
+}
+
+function fullManifest(agentId: string): NonNullable<AgentBackupStateData["manifest"]> {
+  return {
+    schemaVersion: 1,
+    format: "elizaos.agent-backup",
+    createdAt: "2026-08-22T00:00:00.000Z",
+    agentId,
+    components: {
+      database: { kind: "none", reason: "fixture", sha256: "database" },
+      media: { kind: "file-set", rootLabel: "state-dir", files: [], sha256: "media" },
+      vault: { kind: "file-set", rootLabel: "state-dir", files: [], sha256: "vault" },
+      character: { runtimeCharacter: { name: "Snapshot Agent" }, sha256: "character" },
+      stateFiles: { kind: "file-set", rootLabel: "state-dir", files: [], sha256: "state" },
+    },
+    integrity: { componentHashes: {} },
+  };
+}
+
+async function seedOwner(): Promise<{ organizationId: string; userId: string }> {
+  const [organization] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Snapshot Authority", slug: unique("snapshot-authority") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ organization_id: organization.id, steward_user_id: unique("steward") })
+    .returning();
+  if (!organization || !user) throw new Error("Snapshot authority owner seed failed");
+  return { organizationId: organization.id, userId: user.id };
+}
+
+async function seedSandbox(overrides: Partial<AgentSandbox> = {}): Promise<AgentSandbox> {
+  const owner = await seedOwner();
+  const [sandbox] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: owner.organizationId,
+      user_id: owner.userId,
+      agent_name: unique("snapshot-agent"),
+      execution_tier: "dedicated-lazy",
+      status: "running",
+      sandbox_id: unique("sandbox"),
+      node_id: unique("node"),
+      container_name: unique("container"),
+      bridge_url: "http://127.0.0.1:21060",
+      health_url: "http://127.0.0.1:3000/health",
+      bridge_port: 21060,
+      web_ui_port: 3000,
+      headscale_ip: "100.64.0.10",
+      environment_vars: { ELIZA_API_TOKEN: API_TOKEN },
+      environment_revision: 7,
+      lifecycle_revision: 11,
+      pool_status: null,
+      deleted_at: null,
+      deletion_attempt_id: null,
+      ...overrides,
+      deletion_started_at:
+        overrides.deletion_attempt_id != null && overrides.deletion_started_at === undefined
+          ? new Date("2026-08-22T00:30:00.000Z")
+          : (overrides.deletion_started_at ?? null),
+    })
+    .returning();
+  if (!sandbox) throw new Error("Snapshot authority sandbox seed failed");
+  return sandbox;
+}
+
+async function seedLegacyBackups(agentId: string, count = 11): Promise<void> {
+  if (count === 0) return;
+  await dbWrite.insert(agentSandboxBackups).values(
+    Array.from({ length: count }, (_, index) => ({
+      sandbox_record_id: agentId,
+      snapshot_type: "manual" as const,
+      state_data: state({ config: { index } }),
+      state_data_storage: "inline" as const,
+      size_bytes: 64,
+      backup_kind: "full" as const,
+      created_at: new Date(Date.UTC(2026, 7, 1, 0, 0, index)),
+    })),
+  );
+}
+
+async function backupCount(agentId: string): Promise<number> {
+  const rows = await dbWrite
+    .select({ id: agentSandboxBackups.id })
+    .from(agentSandboxBackups)
+    .where(eq(agentSandboxBackups.sandbox_record_id, agentId));
+  return rows.length;
+}
+
+async function durableState(agentId: string): Promise<{
+  backups: number;
+  lastBackupAt: Date | null;
+  lifecycleRevision: number | null;
+}> {
+  const [sandbox] = await dbWrite
+    .select({
+      lastBackupAt: agentSandboxes.last_backup_at,
+      lifecycleRevision: agentSandboxes.lifecycle_revision,
+    })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId));
+  return {
+    backups: await backupCount(agentId),
+    lastBackupAt: sandbox?.lastBackupAt ?? null,
+    lifecycleRevision: sandbox?.lifecycleRevision ?? null,
+  };
+}
+
+function installSnapshotFetch(
+  options: {
+    responseState?: AgentBackupStateData;
+    status?: number;
+    body?: string;
+    beforeResponse?: () => Promise<void>;
+  } = {},
+) {
+  return mock(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    expect(url).toEndWith("/api/snapshot");
+    await options.beforeResponse?.();
+    if (options.status !== undefined && options.status !== 200) {
+      return new Response(options.body ?? "snapshot failure", {
+        status: options.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return Response.json(options.responseState ?? state());
+  });
+}
+
+async function expectInitialRefusal(sandbox: AgentSandbox, expectedError: string): Promise<void> {
+  await seedLegacyBackups(sandbox.id);
+  const before = await durableState(sandbox.id);
+  const fetchMock = installSnapshotFetch();
+  globalThis.fetch = fetchMock;
+
+  await expect(
+    new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+  ).resolves.toEqual({ success: false, error: expectedError });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(await durableState(sandbox.id)).toEqual(before);
+}
+
+async function expectPostFetchRefusal(
+  mutate: (sandbox: AgentSandbox) => Promise<void>,
+  expectedError: string,
+): Promise<void> {
+  const sandbox = await seedSandbox();
+  await seedLegacyBackups(sandbox.id);
+  const fetchMock = installSnapshotFetch({
+    beforeResponse: async () => mutate(sandbox),
+  });
+  globalThis.fetch = fetchMock;
+
+  await expect(
+    new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+  ).resolves.toEqual({ success: false, error: expectedError });
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(await backupCount(sandbox.id)).toBe(11);
+  const [after] = await dbWrite
+    .select({ lastBackupAt: agentSandboxes.last_backup_at })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, sandbox.id));
+  expect(after?.lastBackupAt ?? null).toBeNull();
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      await dbWrite.execute(sql.raw(ddl));
+    }
+  } catch {
+    pgliteReady = false;
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  process.env.SQL_HEAVY_PAYLOAD_STORAGE = "inline";
+  delete process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES;
+  await dbWrite.execute(
+    sql.raw('DROP TRIGGER IF EXISTS "snapshot_metadata_block" ON "agent_sandboxes"'),
+  );
+  await dbWrite.execute(
+    sql.raw('DROP TRIGGER IF EXISTS "snapshot_backup_insert_block" ON "agent_sandbox_backups"'),
+  );
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+afterEach(async () => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (pgliteReady) {
+    await dbWrite.execute(
+      sql.raw('DROP TRIGGER IF EXISTS "snapshot_metadata_block" ON "agent_sandboxes"'),
+    );
+    await dbWrite.execute(
+      sql.raw('DROP TRIGGER IF EXISTS "snapshot_backup_insert_block" ON "agent_sandbox_backups"'),
+    );
+  }
+});
+
+afterAll(async () => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (AMBIENT_HEAVY_PAYLOAD_STORAGE === undefined) {
+    delete process.env.SQL_HEAVY_PAYLOAD_STORAGE;
+  } else {
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = AMBIENT_HEAVY_PAYLOAD_STORAGE;
+  }
+  if (AMBIENT_HEAVY_PAYLOAD_MIN_BYTES === undefined) {
+    delete process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES;
+  } else {
+    process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES = AMBIENT_HEAVY_PAYLOAD_MIN_BYTES;
+  }
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("ElizaSandboxService snapshot initial authority", () => {
+  test("missing and foreign-tenant rows remain indistinguishable with zero effects", async () => {
+    const sandbox = await seedSandbox();
+    await seedLegacyBackups(sandbox.id);
+    const before = await durableState(sandbox.id);
+    const fetchMock = installSnapshotFetch();
+    globalThis.fetch = fetchMock;
+
+    const service = new ElizaSandboxService();
+    await expect(service.snapshot(crypto.randomUUID(), sandbox.organization_id)).resolves.toEqual({
+      success: false,
+      error: "Sandbox is not running",
+    });
+    await expect(service.snapshot(sandbox.id, crypto.randomUUID())).resolves.toEqual({
+      success: false,
+      error: "Sandbox is not running",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await durableState(sandbox.id)).toEqual(before);
+  });
+
+  test("Shared stopped rows reject on tier before status or bridge work", async () => {
+    await expectInitialRefusal(
+      await seedSandbox({ execution_tier: "shared", status: "stopped" }),
+      TIER_REJECTION,
+    );
+  });
+
+  test("unknown stopped rows with every bad field reject on tier first", async () => {
+    await expectInitialRefusal(
+      await seedSandbox({
+        execution_tier: "future-tier" as never,
+        status: "stopped",
+        pool_status: "unclaimed",
+        deleted_at: new Date("2026-08-22T01:00:00.000Z"),
+        deletion_attempt_id: DELETION_ATTEMPT_ID,
+      }),
+      TIER_REJECTION,
+    );
+  });
+
+  test("pool-owned stopped rows reject before deleted and deletion-attempt fields", async () => {
+    await expectInitialRefusal(
+      await seedSandbox({
+        status: "stopped",
+        pool_status: "unclaimed",
+        deleted_at: new Date("2026-08-22T01:00:00.000Z"),
+        deletion_attempt_id: DELETION_ATTEMPT_ID,
+      }),
+      POOL_REJECTION,
+    );
+  });
+
+  test("deleted stopped rows reject before a deletion-attempt field", async () => {
+    await expectInitialRefusal(
+      await seedSandbox({
+        status: "stopped",
+        deleted_at: new Date("2026-08-22T01:00:00.000Z"),
+        deletion_attempt_id: DELETION_ATTEMPT_ID,
+      }),
+      DELETED_REJECTION,
+    );
+  });
+
+  test("deletion-owned rows reject before the preserved status check", async () => {
+    await expectInitialRefusal(
+      await seedSandbox({
+        status: "deletion_pending",
+        deletion_attempt_id: DELETION_ATTEMPT_ID,
+      }),
+      DELETION_REJECTION,
+    );
+  });
+
+  test("a canonical stopped row keeps the existing not-running result", async () => {
+    await expectInitialRefusal(await seedSandbox({ status: "stopped" }), "Sandbox is not running");
+  });
+});
+
+describe("ElizaSandboxService snapshot post-capture authority", () => {
+  test("tier loss after fetch wins over every later authority field", async () => {
+    await expectPostFetchRefusal(async (sandbox) => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          execution_tier: "shared",
+          pool_status: "unclaimed",
+          deleted_at: new Date("2026-08-22T02:00:00.000Z"),
+          deletion_attempt_id: DELETION_ATTEMPT_ID,
+          deletion_started_at: new Date("2026-08-22T01:30:00.000Z"),
+        })
+        .where(eq(agentSandboxes.id, sandbox.id));
+    }, TIER_REJECTION);
+  });
+
+  test("pool ownership acquired after fetch wins over deleted and deletion-attempt fields", async () => {
+    await expectPostFetchRefusal(async (sandbox) => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          pool_status: "unclaimed",
+          deleted_at: new Date("2026-08-22T02:00:00.000Z"),
+          deletion_attempt_id: DELETION_ATTEMPT_ID,
+          deletion_started_at: new Date("2026-08-22T01:30:00.000Z"),
+        })
+        .where(eq(agentSandboxes.id, sandbox.id));
+    }, POOL_REJECTION);
+  });
+
+  test("deletion after fetch wins over a deletion-attempt field", async () => {
+    await expectPostFetchRefusal(async (sandbox) => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          deleted_at: new Date("2026-08-22T02:00:00.000Z"),
+          deletion_attempt_id: DELETION_ATTEMPT_ID,
+          deletion_started_at: new Date("2026-08-22T01:30:00.000Z"),
+        })
+        .where(eq(agentSandboxes.id, sandbox.id));
+    }, DELETED_REJECTION);
+  });
+
+  test("a deletion attempt acquired after fetch prevents persistence", async () => {
+    await expectPostFetchRefusal(async (sandbox) => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          deletion_attempt_id: DELETION_ATTEMPT_ID,
+          deletion_started_at: new Date("2026-08-22T01:30:00.000Z"),
+        })
+        .where(eq(agentSandboxes.id, sandbox.id));
+    }, DELETION_REJECTION);
+  });
+
+  test("a stopped transition after fetch prevents persistence", async () => {
+    await expectPostFetchRefusal(async (sandbox) => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ status: "stopped" })
+        .where(eq(agentSandboxes.id, sandbox.id));
+    }, "Sandbox is not running");
+  });
+
+  test("a lifecycle-generation change after fetch prevents persistence", async () => {
+    await expectPostFetchRefusal(async (sandbox) => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ agent_name: unique("renamed") })
+        .where(eq(agentSandboxes.id, sandbox.id));
+    }, AUTHORITY_CHANGED);
+  });
+
+  test("authority loss prevents oversized backup preparation before its inline-storage refusal", async () => {
+    const sandbox = await seedSandbox();
+    const fetchMock = installSnapshotFetch({
+      responseState: state({ workspaceFiles: { "oversized.bin": "x".repeat(1_100_000) } }),
+      beforeResponse: async () => {
+        await dbWrite
+          .update(agentSandboxes)
+          .set({ agent_name: unique("renamed-before-preparation") })
+          .where(eq(agentSandboxes.id, sandbox.id));
+      },
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ).resolves.toEqual({ success: false, error: AUTHORITY_CHANGED });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await backupCount(sandbox.id)).toBe(0);
+    const [after] = await dbWrite
+      .select({ lastBackupAt: agentSandboxes.last_backup_at })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(after?.lastBackupAt).toBeNull();
+  });
+
+  test("a bridge or locator change after fetch prevents persistence", async () => {
+    for (const update of [
+      { bridge_url: "http://127.0.0.1:22060" },
+      { health_url: "http://127.0.0.1:3100/health" },
+      { sandbox_id: unique("replacement-sandbox") },
+      { node_id: unique("replacement-node") },
+      { container_name: unique("replacement-container") },
+      { bridge_port: 22060 },
+      { web_ui_port: 3100 },
+      { headscale_ip: "100.64.0.11" },
+      { environment_revision: 8 },
+    ] satisfies Array<Partial<AgentSandbox>>) {
+      await expectPostFetchRefusal(async (sandbox) => {
+        await dbWrite.update(agentSandboxes).set(update).where(eq(agentSandboxes.id, sandbox.id));
+      }, AUTHORITY_CHANGED);
+    }
+  });
+
+  test("row loss after fetch prevents an orphan backup", async () => {
+    const sandbox = await seedSandbox();
+    const fetchMock = installSnapshotFetch({
+      beforeResponse: async () => {
+        await dbWrite.delete(agentSandboxes).where(eq(agentSandboxes.id, sandbox.id));
+      },
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ).resolves.toEqual({ success: false, error: AUTHORITY_CHANGED });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await backupCount(sandbox.id)).toBe(0);
+  });
+
+  test("an ABA locator change is fenced by the lifecycle generation", async () => {
+    const sandbox = await seedSandbox();
+    const originalBridge = sandbox.bridge_url;
+    const fetchMock = installSnapshotFetch({
+      beforeResponse: async () => {
+        await dbWrite
+          .update(agentSandboxes)
+          .set({ bridge_url: "http://127.0.0.1:22060" })
+          .where(eq(agentSandboxes.id, sandbox.id));
+        await dbWrite
+          .update(agentSandboxes)
+          .set({ bridge_url: originalBridge })
+          .where(eq(agentSandboxes.id, sandbox.id));
+      },
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ).resolves.toEqual({ success: false, error: AUTHORITY_CHANGED });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await backupCount(sandbox.id)).toBe(0);
+    const [after] = await dbWrite
+      .select({ bridgeUrl: agentSandboxes.bridge_url, lastBackupAt: agentSandboxes.last_backup_at })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(after).toEqual({ bridgeUrl: originalBridge, lastBackupAt: null });
+  });
+});
+
+describe("ElizaSandboxService snapshot atomic persistence", () => {
+  test("lost metadata CAS prevents backup preparation and insert", async () => {
+    const sandbox = await seedSandbox();
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE OR REPLACE FUNCTION block_snapshot_metadata_update()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF NEW.last_backup_at IS DISTINCT FROM OLD.last_backup_at THEN
+          RETURN NULL;
+        END IF;
+        RETURN NEW;
+      END;
+      $$
+    `),
+    );
+    await dbWrite.execute(
+      sql.raw(`
+      CREATE TRIGGER snapshot_metadata_block
+      BEFORE UPDATE ON agent_sandboxes
+      FOR EACH ROW EXECUTE FUNCTION block_snapshot_metadata_update()
+    `),
+    );
+    const fetchMock = installSnapshotFetch({
+      responseState: state({ workspaceFiles: { "oversized.bin": "x".repeat(1_100_000) } }),
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ).rejects.toThrow("Backup metadata update lost its sandbox row");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await backupCount(sandbox.id)).toBe(0);
+    const [after] = await dbWrite
+      .select({
+        lastBackupAt: agentSandboxes.last_backup_at,
+        lifecycleRevision: agentSandboxes.lifecycle_revision,
+      })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(after).toEqual({ lastBackupAt: null, lifecycleRevision: 11 });
+  });
+
+  test("rolls the metadata update back when the backup insert fails", async () => {
+    const sandbox = await seedSandbox();
+    await dbWrite.execute(
+      sql.raw(`
+        CREATE OR REPLACE FUNCTION block_snapshot_backup_insert()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          RAISE EXCEPTION 'snapshot backup insert blocked';
+        END;
+        $$
+      `),
+    );
+    await dbWrite.execute(
+      sql.raw(`
+        CREATE TRIGGER snapshot_backup_insert_block
+        BEFORE INSERT ON agent_sandbox_backups
+        FOR EACH ROW EXECUTE FUNCTION block_snapshot_backup_insert()
+      `),
+    );
+    const before = await durableState(sandbox.id);
+    const fetchMock = installSnapshotFetch();
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ).rejects.toThrow('Failed query: insert into "agent_sandbox_backups"');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await durableState(sandbox.id)).toEqual(before);
+  });
+
+  test("two captures of one generation serialize and only one commits", async () => {
+    const sandbox = await seedSandbox();
+    let arrivals = 0;
+    let release: (() => void) | undefined;
+    const bothCaptured = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchMock = mock(async () => {
+      arrivals += 1;
+      if (arrivals === 2) release?.();
+      await bothCaptured;
+      return Response.json(state());
+    });
+    globalThis.fetch = fetchMock;
+
+    const results = await Promise.all([
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(results.filter(({ success }) => success)).toHaveLength(1);
+    expect(results.filter(({ error }) => error === AUTHORITY_CHANGED)).toHaveLength(1);
+    expect(await backupCount(sandbox.id)).toBe(1);
+    const [after] = await dbWrite
+      .select({ lastBackupAt: agentSandboxes.last_backup_at })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandbox.id));
+    expect(after?.lastBackupAt).toBeInstanceOf(Date);
+  });
+
+  test.each([...CONTAINER_BACKED_EXECUTION_TIERS])(
+    "commits one backup and its timestamp atomically for canonical %s",
+    async (executionTier) => {
+      const sandbox = await seedSandbox({
+        execution_tier: executionTier,
+        pool_status: null,
+        deleted_at: null,
+        deletion_attempt_id: null,
+      });
+      const capturedState = state({ config: { executionTier } });
+      const fetchMock = installSnapshotFetch({ responseState: capturedState });
+      globalThis.fetch = fetchMock;
+
+      const result = await new ElizaSandboxService().snapshot(
+        sandbox.id,
+        sandbox.organization_id,
+        "manual",
+      );
+
+      expect(result).toMatchObject({
+        success: true,
+        backup: {
+          sandbox_record_id: sandbox.id,
+          snapshot_type: "manual",
+          backup_kind: "full",
+          state_data: capturedState,
+        },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(await backupCount(sandbox.id)).toBe(1);
+      const [after] = await dbWrite
+        .select({ lastBackupAt: agentSandboxes.last_backup_at })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, sandbox.id));
+      expect(after?.lastBackupAt).toBeInstanceOf(Date);
+    },
+  );
+
+  test("preserves bounded chain-safe pruning after commit", async () => {
+    const sandbox = await seedSandbox();
+    await seedLegacyBackups(sandbox.id);
+    globalThis.fetch = installSnapshotFetch({
+      responseState: state({ workspaceFiles: { replacement: "y".repeat(2_000) } }),
+    });
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "manual"),
+    ).resolves.toMatchObject({ success: true });
+
+    expect(await backupCount(sandbox.id)).toBe(10);
+  });
+});
+
+describe("ElizaSandboxService snapshot preserved capture and planning semantics", () => {
+  test("keeps endpoint-unsupported and structured transient results free of durable writes", async () => {
+    const unsupported = await seedSandbox();
+    globalThis.fetch = installSnapshotFetch({ status: 404, body: "not found" });
+    await expect(
+      new ElizaSandboxService().snapshot(unsupported.id, unsupported.organization_id, "auto"),
+    ).resolves.toEqual({ success: false, error: SNAPSHOT_ENDPOINT_UNSUPPORTED });
+    expect(await durableState(unsupported.id)).toMatchObject({ backups: 0, lastBackupAt: null });
+
+    const transient = await seedSandbox();
+    globalThis.fetch = installSnapshotFetch({
+      status: 503,
+      body: JSON.stringify({ code: "PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT" }),
+    });
+    await expect(
+      new ElizaSandboxService().snapshot(transient.id, transient.organization_id, "auto"),
+    ).resolves.toEqual({
+      success: false,
+      error: SNAPSHOT_CAPTURE_TRANSIENT,
+      retryable: true,
+    });
+    expect(await durableState(transient.id)).toMatchObject({ backups: 0, lastBackupAt: null });
+  });
+
+  test("keeps the full-manifest requirement before durable writes", async () => {
+    const sandbox = await seedSandbox();
+    globalThis.fetch = installSnapshotFetch();
+
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "pre-move"),
+    ).resolves.toEqual({
+      success: false,
+      error: "pre-move snapshot did not include a full-agent manifest",
+    });
+    expect(await durableState(sandbox.id)).toMatchObject({ backups: 0, lastBackupAt: null });
+
+    const manifestState = state({ manifest: fullManifest(sandbox.id) });
+    globalThis.fetch = installSnapshotFetch({ responseState: manifestState });
+    await expect(
+      new ElizaSandboxService().snapshot(sandbox.id, sandbox.organization_id, "pre-move"),
+    ).resolves.toMatchObject({
+      success: true,
+      backup: { snapshot_type: "pre-move", backup_kind: "full" },
+    });
+  });
+
+  test("preserves incremental and full backup planning", async () => {
+    const incrementalSandbox = await seedSandbox();
+    const large = "x".repeat(50_000);
+    const base = await agentSandboxesRepository.createBackup({
+      sandbox_record_id: incrementalSandbox.id,
+      snapshot_type: "manual",
+      state_data: state({ workspaceFiles: { "large.bin": large } }),
+      size_bytes: large.length,
+      backup_kind: "full",
+    });
+    const incrementalState = state({
+      workspaceFiles: { "large.bin": large, "note.txt": "small" },
+    });
+    globalThis.fetch = installSnapshotFetch({ responseState: incrementalState });
+
+    const incremental = await new ElizaSandboxService().snapshot(
+      incrementalSandbox.id,
+      incrementalSandbox.organization_id,
+      "manual",
+    );
+    expect(incremental).toMatchObject({
+      success: true,
+      backup: {
+        backup_kind: "incremental",
+        parent_backup_id: base.id,
+        content_hash: expect.any(String),
+        size_bytes: expect.any(Number),
+      },
+    });
+    if (!incremental.backup) throw new Error("Incremental snapshot did not return its backup");
+    expect(
+      await agentSandboxesRepository.getReconstructedBackupState(incremental.backup.id),
+    ).toEqual(incrementalState);
+
+    const fullSandbox = await seedSandbox();
+    await agentSandboxesRepository.createBackup({
+      sandbox_record_id: fullSandbox.id,
+      snapshot_type: "manual",
+      state_data: state({ workspaceFiles: { a: "x".repeat(1_000) } }),
+      size_bytes: 1_000,
+      backup_kind: "full",
+    });
+    const fullState = state({
+      workspaceFiles: { a: "y".repeat(1_000), b: "z".repeat(1_000) },
+    });
+    globalThis.fetch = installSnapshotFetch({ responseState: fullState });
+    const full = await new ElizaSandboxService().snapshot(
+      fullSandbox.id,
+      fullSandbox.organization_id,
+      "manual",
+    );
+    expect(full).toMatchObject({
+      success: true,
+      backup: { backup_kind: "full", content_hash: expect.any(String) },
+    });
+    if (!full.backup) throw new Error("Full snapshot did not return its backup");
+    expect(await agentSandboxesRepository.getReconstructedBackupState(full.backup.id)).toEqual(
+      fullState,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -11044,23 +11044,59 @@ describe("ElizaSandboxService.transferStateForRelocation", () => {
     return calls;
   }
 
-  async function runTransfer(sandbox: AgentSandbox) {
+  async function runTransfer(
+    sandbox: AgentSandbox,
+    options: { wireSnapshotTransaction?: boolean } = {},
+  ) {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    return (
-      new ElizaSandboxService() as unknown as {
-        transferStateForRelocation: (o: {
-          agentId: string;
-          orgId: string;
-          targetBridgeUrl: string;
-          authRec: Pick<AgentSandbox, "id" | "environment_vars">;
-        }) => Promise<{ transferred: boolean; reason?: string; detail?: string }>;
-      }
-    ).transferStateForRelocation({
-      agentId: sandbox.id,
-      orgId: sandbox.organization_id,
-      targetBridgeUrl: "https://blue.example",
-      authRec: sandbox,
+    const service = new ElizaSandboxService() as unknown as {
+      transferStateForRelocation: (o: {
+        agentId: string;
+        orgId: string;
+        targetBridgeUrl: string;
+        authRec: Pick<AgentSandbox, "id" | "environment_vars">;
+      }) => Promise<{ transferred: boolean; reason?: string; detail?: string }>;
+      lockLifecycle: (tx: unknown, agentId: string, orgId: string) => Promise<void>;
+      getAgentForLifecycleMutation: (
+        tx: unknown,
+        agentId: string,
+        orgId: string,
+      ) => Promise<AgentSandbox | undefined>;
+      persistAuthorizedSnapshotWithinTransaction: (
+        tx: unknown,
+        rec: AgentSandbox,
+        organizationId: string,
+        snapshotType: string,
+        plannedInput: Parameters<typeof agentSandboxesRepository.createBackup>[0],
+      ) => Promise<AgentSandboxBackup>;
+    };
+    const transfer = () =>
+      service.transferStateForRelocation({
+        agentId: sandbox.id,
+        orgId: sandbox.organization_id,
+        targetBridgeUrl: "https://blue.example",
+        authRec: sandbox,
+      });
+    if (!options.wireSnapshotTransaction) return transfer();
+
+    upgradeTransactionImpl = async (fn) => fn({ execute: async () => ({ rows: [] }) });
+    const lockSpy = spyOn(service, "lockLifecycle").mockResolvedValue(undefined);
+    const currentSpy = spyOn(service, "getAgentForLifecycleMutation").mockResolvedValue(sandbox);
+    const persistSpy = spyOn(
+      service,
+      "persistAuthorizedSnapshotWithinTransaction",
+    ).mockImplementation(async (_tx, rec, _organizationId, _snapshotType, plannedInput) => {
+      await agentSandboxesRepository.update(rec.id, { last_backup_at: new Date() });
+      return await agentSandboxesRepository.createBackup(plannedInput);
     });
+    try {
+      return await transfer();
+    } finally {
+      lockSpy.mockRestore();
+      currentSpy.mockRestore();
+      persistSpy.mockRestore();
+      upgradeTransactionImpl = null;
+    }
   }
 
   test("an image with no snapshot endpoint is unrelocatable, and nothing is pushed", async () => {
@@ -11124,7 +11160,7 @@ describe("ElizaSandboxService.transferStateForRelocation", () => {
     );
     bridgeStub({ restoreStatus: 500 });
     try {
-      const outcome = await runTransfer(sandbox);
+      const outcome = await runTransfer(sandbox, { wireSnapshotTransaction: true });
       expect(outcome.transferred).toBe(false);
       expect(outcome.reason).toBe("push-failed");
     } finally {
@@ -11157,7 +11193,7 @@ describe("ElizaSandboxService.transferStateForRelocation", () => {
     );
     const calls = bridgeStub({});
     try {
-      const outcome = await runTransfer(sandbox);
+      const outcome = await runTransfer(sandbox, { wireSnapshotTransaction: true });
       expect(outcome.transferred).toBe(true);
       expect(calls.some((u) => u.endsWith("/api/snapshot"))).toBe(true);
       expect(calls.some((u) => u.endsWith("/api/restore"))).toBe(true);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -24,6 +24,7 @@ import {
   type AgentSandboxBackupMetadata,
   type AgentSandboxStatus,
   agentSandboxesRepository,
+  hydrateAgentSandboxBackup,
   PRE_DELETE_BACKUP_RETENTION_MS,
   prepareAgentBackupInsertData,
 } from "../../db/repositories/agent-sandboxes";
@@ -38,6 +39,7 @@ import {
   agentSandboxes,
   type NewAgentSandbox,
   type NewAgentSandboxBackup,
+  type StoredAgentSandboxBackup,
   WARM_POOL_ORG_ID,
 } from "../../db/schemas/agent-sandboxes";
 import { dockerNodes } from "../../db/schemas/docker-nodes";
@@ -548,6 +550,64 @@ export interface SnapshotResult {
   backup?: AgentSandboxBackup;
   error?: string;
   retryable?: boolean;
+}
+
+type SnapshotAuthorityCapture = Pick<
+  AgentSandbox,
+  | "id"
+  | "organization_id"
+  | "status"
+  | "execution_tier"
+  | "pool_status"
+  | "deleted_at"
+  | "deletion_attempt_id"
+  | "sandbox_id"
+  | "node_id"
+  | "container_name"
+  | "bridge_url"
+  | "health_url"
+  | "bridge_port"
+  | "web_ui_port"
+  | "headscale_ip"
+  | "environment_revision"
+  | "lifecycle_revision"
+>;
+
+const SNAPSHOT_AUTHORITY_CHANGED = "Sandbox changed while snapshot was being captured";
+
+function snapshotAuthorityRejection(rec: SnapshotAuthorityCapture): string | undefined {
+  if (!isContainerBackedExecutionTier(rec.execution_tier)) {
+    return "Agent snapshot requires a container-backed execution tier";
+  }
+  if (rec.pool_status !== null) {
+    return "Agent snapshot cannot target pool-owned capacity";
+  }
+  if (rec.deleted_at !== null) {
+    return "Agent snapshot cannot target a deleted agent";
+  }
+  if (rec.deletion_attempt_id !== null) {
+    return "Agent snapshot cannot start while agent deletion is in progress";
+  }
+  return undefined;
+}
+
+function snapshotCaptureStillCanonical(
+  current: SnapshotAuthorityCapture,
+  captured: SnapshotAuthorityCapture,
+): boolean {
+  return (
+    current.execution_tier === captured.execution_tier &&
+    current.sandbox_id === captured.sandbox_id &&
+    current.node_id === captured.node_id &&
+    current.container_name === captured.container_name &&
+    current.bridge_url === captured.bridge_url &&
+    current.health_url === captured.health_url &&
+    current.bridge_port === captured.bridge_port &&
+    current.web_ui_port === captured.web_ui_port &&
+    current.headscale_ip === captured.headscale_ip &&
+    current.environment_revision === captured.environment_revision &&
+    current.lifecycle_revision === captured.lifecycle_revision
+  );
 }
 
 /**
@@ -7198,8 +7258,21 @@ export class ElizaSandboxService {
     orgId: string,
     type: AgentBackupSnapshotType = "manual",
   ): Promise<SnapshotResult> {
-    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
-    if (!rec?.bridge_url) return { success: false, error: "Sandbox is not running" };
+    // Both repository seams read the tenant-scoped primary. This is only an
+    // early snapshot for avoiding network work, never a lock or CAS: authority
+    // is re-read under the lifecycle lock after capture and backup planning.
+    const rec =
+      (await agentSandboxesRepository.findRunningSandbox(agentId, orgId)) ??
+      (await agentSandboxesRepository.findByIdAndOrgForWrite(agentId, orgId));
+    if (!rec) return { success: false, error: "Sandbox is not running" };
+
+    const initialAuthorityRejection = snapshotAuthorityRejection(rec);
+    if (initialAuthorityRejection) {
+      return { success: false, error: initialAuthorityRejection };
+    }
+    if (rec.status !== "running" || !rec.bridge_url) {
+      return { success: false, error: "Sandbox is not running" };
+    }
 
     let stateData: AgentBackupStateData;
     let sizeBytes: number;
@@ -7236,13 +7309,42 @@ export class ElizaSandboxService {
       };
     }
 
-    const backup = await agentSandboxesRepository.createBackup(
-      await this.buildBackupInput(rec.id, type, stateData, sizeBytes),
-    );
+    // Capture and incremental/full planning intentionally stay outside the
+    // lifecycle transaction. No durable backup preparation or write begins
+    // until the locked canonical row proves this exact capture still owns the
+    // same running container generation.
+    const plannedInput = await this.buildBackupInput(rec.id, type, stateData, sizeBytes);
+    const persisted = await dbWrite.transaction(async (tx) => {
+      await this.lockLifecycle(tx, agentId, orgId);
+      const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
+      if (!current) {
+        return { success: false as const, error: SNAPSHOT_AUTHORITY_CHANGED };
+      }
 
-    await agentSandboxesRepository.update(rec.id, {
-      last_backup_at: new Date(),
+      const currentAuthorityRejection = snapshotAuthorityRejection(current);
+      if (currentAuthorityRejection) {
+        return { success: false as const, error: currentAuthorityRejection };
+      }
+      if (current.status !== "running") {
+        return { success: false as const, error: "Sandbox is not running" };
+      }
+      if (!snapshotCaptureStillCanonical(current, rec)) {
+        return { success: false as const, error: SNAPSHOT_AUTHORITY_CHANGED };
+      }
+
+      const storedBackup = await this.persistAuthorizedSnapshotWithinTransaction(
+        tx,
+        current,
+        orgId,
+        type,
+        plannedInput,
+      );
+      return { success: true as const, storedBackup };
     });
+
+    if (!persisted.success) return persisted;
+
+    const backup = await hydrateAgentSandboxBackup(persisted.storedBackup);
     await agentSandboxesRepository.pruneBackups(rec.id, MAX_BACKUPS);
     logger.info("[agent-sandbox] Backup created", {
       agentId,
@@ -11322,6 +11424,62 @@ export class ElizaSandboxService {
       sizeBytes,
       bridgeUrl: rec.bridge_url,
     };
+  }
+
+  private async persistAuthorizedSnapshotWithinTransaction(
+    tx: LifecycleTx,
+    rec: SnapshotAuthorityCapture,
+    organizationId: string,
+    type: AgentBackupSnapshotType,
+    plannedInput: NewAgentSandboxBackup,
+  ): Promise<StoredAgentSandboxBackup> {
+    const [sandbox] = await tx
+      .update(agentSandboxes)
+      .set({ last_backup_at: new Date(), updated_at: new Date() })
+      .where(
+        and(
+          eq(agentSandboxes.id, rec.id),
+          eq(agentSandboxes.organization_id, organizationId),
+          eq(agentSandboxes.status, "running"),
+          eq(agentSandboxes.execution_tier, rec.execution_tier),
+          sql`${agentSandboxes.pool_status} IS NULL`,
+          sql`${agentSandboxes.deleted_at} IS NULL`,
+          sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
+          sql`${agentSandboxes.sandbox_id} IS NOT DISTINCT FROM ${rec.sandbox_id}`,
+          sql`${agentSandboxes.node_id} IS NOT DISTINCT FROM ${rec.node_id}`,
+          sql`${agentSandboxes.container_name} IS NOT DISTINCT FROM ${rec.container_name}`,
+          sql`${agentSandboxes.bridge_url} IS NOT DISTINCT FROM ${rec.bridge_url}`,
+          sql`${agentSandboxes.health_url} IS NOT DISTINCT FROM ${rec.health_url}`,
+          sql`${agentSandboxes.bridge_port} IS NOT DISTINCT FROM ${rec.bridge_port}`,
+          sql`${agentSandboxes.web_ui_port} IS NOT DISTINCT FROM ${rec.web_ui_port}`,
+          sql`${agentSandboxes.headscale_ip} IS NOT DISTINCT FROM ${rec.headscale_ip}`,
+          eq(agentSandboxes.environment_revision, rec.environment_revision),
+          eq(agentSandboxes.lifecycle_revision, rec.lifecycle_revision),
+        ),
+      )
+      .returning({ id: agentSandboxes.id });
+    if (!sandbox) {
+      throw new ElizaError("Backup metadata update lost its sandbox row", {
+        code: "AGENT_BACKUP_SANDBOX_MISSING",
+        context: { sandboxRecordId: rec.id, organizationId, snapshotType: type },
+        severity: "fatal",
+      });
+    }
+
+    // Preparation is deliberately after the locked metadata CAS so lost
+    // authority cannot reach encryption or object storage. A provider PUT
+    // cannot be rolled back if the later SQL insert/commit fails; that remains
+    // the existing object-GC residual, not cross-system atomicity.
+    const insertData = await prepareAgentBackupInsertData(plannedInput, organizationId);
+    const [backup] = await tx.insert(agentSandboxBackups).values(insertData).returning();
+    if (!backup) {
+      throw new ElizaError("Backup insert did not return the persisted row", {
+        code: "AGENT_BACKUP_INSERT_MISSING",
+        context: { sandboxRecordId: rec.id, organizationId, snapshotType: type },
+        severity: "fatal",
+      });
+    }
+    return backup;
   }
 
   private async persistSnapshotWithinTransaction(


### PR DESCRIPTION
# Ready for review

#23949 has merged. This PR is retargeted to `develop`, reduced to its intended three-file delta, and revalidated on the exact resulting head.

# Relates to

- #22947 — bounded service-authority/CAS slice for direct `snapshot()` calls. This does not close the issue.
- Depends on #23949 for the canonical container-backed execution-tier contract used here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Exact three-file delta over the approved #23949 head.
- [x] Named clean-stack-base differential baseline and exact-head local proof.
- [x] Two independent reviewers restamped the exact commit with no P0–P3 finding.

# Sync with stack base

- [x] Exact head: `30c5704ec4b2d21cb77572f9218f8d78417224b8`.
- [x] Exact parent/base: `8330c9bf14a8c40a0a3c65bbb780bb3e900a5802`.
- [x] #23949 is merged and this exact three-file delta is rebased onto its squash merge.
- [x] The delta is exactly three files: one production service, one new PGlite authority suite, and narrow transaction-harness wiring in the existing service test.
- [x] At claim time, the exhaustive open-PR file scan found only the intentional #23949 overlap on these paths; the new PGlite path was unique.

# Risks

Medium. A snapshot reads mutable state from a live container and then writes durable metadata and backup content. Before this change, authority could move to Shared, pool-owned, deleted, deletion-owned, stopped, or a different container generation during the network capture while `snapshot()` still persisted the old bytes.

# Background

## What does this PR do?

The initial primary read now returns precise authority refusals before any bridge work, in this order:

1. canonical container-backed execution tier;
2. no pool ownership;
3. not deleted;
4. no deletion attempt;
5. running status and a bridge URL.

HTTP capture, manifest validation, and full/incremental planning stay outside the lifecycle transaction. Persistence then:

1. acquires the existing lifecycle advisory lock;
2. re-reads the tenant row with `SELECT ... FOR UPDATE`;
3. repeats authority precedence;
4. proves the same tier, sandbox/node/container locators, bridge/health URLs and ports, headscale IP, environment revision, and lifecycle revision;
5. performs a guarded `last_backup_at` metadata update first;
6. only after that CAS, prepares/encrypts/offloads the backup and inserts it in the same PostgreSQL transaction;
7. hydrates the committed backup and prunes the bounded chain after commit.

The metadata update advances the database-owned lifecycle revision. Therefore two captures of one generation serialize and exactly one can commit; the second observes that its capture generation is stale.

Exact messages remain explicit:

- `Agent snapshot requires a container-backed execution tier`
- `Agent snapshot cannot target pool-owned capacity`
- `Agent snapshot cannot target a deleted agent`
- `Agent snapshot cannot start while agent deletion is in progress`
- `Sandbox changed while snapshot was being captured`

The two positive `transferStateForRelocation` fixtures only gain the transaction seam required by the new boundary; their capture/manifest/restore assertions are unchanged. The real transaction remains exercised by isolated PGlite tests.

Historical production/test authors inventoried before implementation: Claude Fable 5, Derek Barnes, felirami, kenjohnscreates, ngngocnhan1997-hub, nothingxnowhere, nubs/NubsCarson, Rui Hu, Shaw, Sol, Stan, standujar, and Zorba the Buddhah. The new test path has no history.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is required. This tightens an existing backend lifecycle contract.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/eliza-sandbox.ts`
2. `packages/cloud/shared/src/lib/services/eliza-sandbox-snapshot-authority.pglite.test.ts`
3. `packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts` transaction wiring near `transferStateForRelocation`

## Detailed testing steps

Exact candidate: `30c5704ec4b2d21cb77572f9218f8d78417224b8`  
Exact stack base: `8330c9bf14a8c40a0a3c65bbb780bb3e900a5802`  
Toolchain: Node `24.15.0`, Bun `1.3.14`.

- `bun --conditions=eliza-source test --coverage-reporter=lcov --coverage-dir=/private/tmp/eliza-slice-p-head-coverage-pglite packages/cloud/shared/src/lib/services/eliza-sandbox-snapshot-authority.pglite.test.ts`
  - 27 pass, 0 fail, 187 expect calls on the exact head.
- Original clean-stack differential harness: the final 27-test file was run unchanged against the pre-merge #23949 stack base `4bcbe539d6d02d22e91991cec2ac72fe64f043be`. The retargeted exact head then passed all 27 tests on current develop.
  - Baseline: 10 pass, 17 fail, 102 expect calls.
  - The 17 failures are exactly five initial authority refusals, ten post-capture authority/generation fences, the lost-metadata-CAS tripwire, and same-generation concurrency.
  - The ten base passes are missing/foreign tenant indistinguishability, canonical stopped behavior, insert-failure durability, three canonical tier successes, pruning, endpoint/transient behavior, manifest behavior, and full/incremental planning.
- `bun --conditions=eliza-source test ... eliza-sandbox.test.ts -t 'ElizaSandboxService.transferStateForRelocation'`
  - 4/4 pass, 12 expect calls.
- `... -t 'ElizaSandboxService snapshot — endpoint capability'`
  - 3/3 pass, 5 expect calls.
- `... -t 'snapshot hydration budgets'`
  - 6/6 pass, 7 expect calls.
- Full historical `eliza-sandbox.test.ts`: 242 pass / 1 named baseline failure / 1,638 expect calls. The unchanged account-deletion assertion expects `captureUnsupportedGeneration`, while the exact stack base already emits `captureWaiverGeneration`.
- Standard shared typecheck passes.
- Explicit TypeScript 6 gate from `packages/cloud/shared`: `node ../../../node_modules/@typescript/typescript6/bin/tsc6 --noEmit` — passes.
- `bunx @biomejs/biome check` on the exact three files — passes.
- `bun run --cwd packages/cloud/shared check:tenant-scope` — passes across 128 repository files.
- `git diff --check 8330c9bf14a8c40a0a3c65bbb780bb3e900a5802..30c5704ec4b2d21cb77572f9218f8d78417224b8` — passes.
- Two independent exact-head reviews found no P0–P3 finding, no secret, and confirmed the three committed blobs match the reviewed bytes.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:30c5704ec4b2d21cb77572f9218f8d78417224b8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Backend-only lifecycle authority change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Backend-only lifecycle authority change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - No user-driven visual flow or frontend behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - No live snapshot was captured; deterministic exact-head PGlite rows exercise locking, CAS, persistence, rollback, and concurrency.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code, console behavior, or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No prompt, action, inference provider, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - No external durable artifact was created; exact database and backup effects are asserted in isolated PGlite.
<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface or visible text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No prompt, action, inference provider, model, or LLM behavior changes.

## Backend + frontend logs

N/A - Exercising a stale snapshot against a live container could read user state and create a durable backup. Exact-head PGlite tests prove the database authority boundary without live mutation.

## Screenshots (before / after) + video walkthrough

N/A - Backend-only change with no UI surface.

## Audio / voice walkthrough

N/A - No audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- PostgreSQL rolls the metadata update and backup row back atomically. An R2 PUT made during backup preparation cannot be rolled back if the later SQL insert or commit fails; such an object can be orphaned. This PR does not claim cross-system atomicity.
- Hydration and pruning remain post-commit and may report an error after durable persistence, matching historical behavior.
- For a worker snapshot whose authority changes during network capture, this service returns the authority-change result. The next locked claim is terminally rejected by #24270; the same worker pass and compatibility restart behavior remain separate residuals.
- Restore, suspend/sleep/wake, upgrade/downgrade, and internal deletion snapshot paths remain later #22947 slices; this PR does not claim closure.
- On exact head `30c5704ec4b2d21cb77572f9218f8d78417224b8`, `bun run verify` exits 1 only in the unrelated `@elizaos/agent#lint:check` baseline with 5 errors, 39 warnings, and 7 infos. No `packages/agent` file differs between stack base and head. Focused tests, both shared typechecks, exact-file Biome, tenant-scope, and diff checks pass.
- No live row, backup, lifecycle writeback, credential, deployment, migration, worker/provider resource, or infrastructure setting was changed. Hosted CI is not claimed as green; only exact-head local exit codes are used as proof.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-snapshot-service-authority]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->


