### PR TITLE
fix(ci): restore develop verification after messaging cutovers

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -61,7 +61,13 @@ import {
   type SubscriptionProvider,
 } from "@elizaos/auth/types";
 import type { AccountPoolBrokerSnapshot } from "@elizaos/core";
-import { ElizaError, logger, resolveStateDir, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+  ElizaError,
+  logger,
+  resolveStateDir,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import {
   isLinkedAccountProviderId,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -174,6 +174,7 @@ const optionalPluginSpecifiers = {
   cloud: "@elizaos/plugin-elizacloud",
   imessage: "@elizaos/plugin-imessage",
   mcp: "@elizaos/plugin-mcp",
+  signal: "@elizaos/plugin-signal",
   whatsapp: "@elizaos/plugin-whatsapp",
   workflow: "@elizaos/plugin-workflow",
 } as const;
@@ -184,6 +185,7 @@ const optionalPluginImports = {
   cloud: () => importOptionalPlugin(optionalPluginSpecifiers.cloud),
   imessage: () => importOptionalPlugin(optionalPluginSpecifiers.imessage),
   mcp: () => importOptionalPlugin(optionalPluginSpecifiers.mcp),
+  signal: () => importOptionalPlugin(optionalPluginSpecifiers.signal),
   whatsapp: () => importOptionalPlugin(optionalPluginSpecifiers.whatsapp),
   workflow: () => importOptionalPlugin(optionalPluginSpecifiers.workflow),
 };

--- a/packages/app-core/platforms/electrobun/src/native/credentials.cookies.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.cookies.test.ts
@@ -1,0 +1,124 @@
+/** Verifies isolated Chromium cookie database copies and failure-safe cleanup. */
+import { describe, expect, it, vi } from "vitest";
+import { readChromiumCookies } from "./credentials.ts";
+
+const CHROME_COOKIE_PATH = "Google/Chrome/Default/Cookies";
+
+function cookieRow() {
+	return {
+		encrypted_value: Buffer.from("encrypted"),
+		expires_utc: 42,
+		name: "privy-session",
+	};
+}
+
+describe("readChromiumCookies temporary database lifecycle", () => {
+	it.each(["copy", "open", "schema", "query", "decrypt", "close"] as const)(
+		"removes the private temp directory after a %s failure",
+		async (failurePhase) => {
+			const close = vi.fn(() => {
+				if (failurePhase === "close") throw new Error("close failed");
+			});
+			const rmSync = vi.fn();
+			const tempDir = "/tmp/eliza-cookies-test";
+			const result = await readChromiumCookies(
+				"app.eliza.ai",
+				["privy-session"],
+				{
+					appSupportDir: "/app-support",
+					chmodSync: vi.fn(),
+					copyFileSync: vi.fn(() => {
+						if (failurePhase === "copy") throw new Error("copy failed");
+					}),
+					decryptCookieValue: vi.fn(() => {
+						if (failurePhase === "decrypt") throw new Error("decrypt failed");
+						return "cookie-value";
+					}),
+					existsSync: (candidate) =>
+						String(candidate).endsWith(CHROME_COOKIE_PATH),
+					mkdtempSync: vi.fn(() => tempDir),
+					openDb: vi.fn(() => {
+						if (failurePhase === "open") throw new Error("open failed");
+						return {
+							close,
+							query: () => {
+								if (failurePhase === "schema") throw new Error("schema failed");
+								return {
+									all: () => {
+										if (failurePhase === "query")
+											throw new Error("query failed");
+										return [cookieRow()];
+									},
+								};
+							},
+						};
+					}),
+					platform: "darwin",
+					readSafeStoragePassword: vi.fn(async () => "password"),
+					rmSync,
+					tempRootDir: "/tmp",
+				},
+			);
+
+			expect(rmSync).toHaveBeenCalledWith(tempDir, {
+				force: true,
+				recursive: true,
+			});
+			expect(close).toHaveBeenCalledTimes(
+				failurePhase === "schema" ||
+					failurePhase === "query" ||
+					failurePhase === "decrypt" ||
+					failurePhase === "close"
+					? 1
+					: 0,
+			);
+			expect(result).toHaveLength(failurePhase === "close" ? 1 : 0);
+		},
+	);
+
+	it("uses distinct private directories for concurrent scans", async () => {
+		let tempSequence = 0;
+		const chmodSync = vi.fn();
+		const copiedDestinations: string[] = [];
+		const removedDirectories: string[] = [];
+		const dependencies = {
+			appSupportDir: "/app-support",
+			chmodSync,
+			copyFileSync: vi.fn((_source: string, destination: string) => {
+				copiedDestinations.push(destination);
+			}),
+			decryptCookieValue: vi.fn(() => "cookie-value"),
+			existsSync: (candidate: string) => candidate.endsWith(CHROME_COOKIE_PATH),
+			mkdtempSync: vi.fn(() => `/tmp/eliza-cookies-${++tempSequence}`),
+			openDb: vi.fn(() => ({
+				close: vi.fn(),
+				query: () => ({ all: () => [cookieRow()] }),
+			})),
+			platform: "darwin" as const,
+			readSafeStoragePassword: vi.fn(async () => "password"),
+			rmSync: vi.fn((directory: string) => {
+				removedDirectories.push(directory);
+			}),
+			tempRootDir: "/tmp",
+		};
+
+		const [first, second] = await Promise.all([
+			readChromiumCookies("app.eliza.ai", ["privy-session"], dependencies),
+			readChromiumCookies("app.eliza.ai", ["privy-session"], dependencies),
+		]);
+
+		expect(first).toHaveLength(1);
+		expect(second).toHaveLength(1);
+		expect(new Set(copiedDestinations).size).toBe(2);
+		expect(copiedDestinations).toEqual([
+			"/tmp/eliza-cookies-1/Cookies",
+			"/tmp/eliza-cookies-2/Cookies",
+		]);
+		expect(chmodSync).toHaveBeenNthCalledWith(1, "/tmp/eliza-cookies-1", 0o700);
+		expect(chmodSync).toHaveBeenNthCalledWith(2, "/tmp/eliza-cookies-2", 0o700);
+		expect(removedDirectories).toEqual([
+			"/tmp/eliza-cookies-1",
+			"/tmp/eliza-cookies-2",
+		]);
+	});
+});

--- a/packages/app-core/platforms/electrobun/src/native/credentials.cookies.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.cookies.test.ts
@@ -5,120 +5,120 @@ import { readChromiumCookies } from "./credentials.ts";
 const CHROME_COOKIE_PATH = "Google/Chrome/Default/Cookies";
 
 function cookieRow() {
-	return {
-		encrypted_value: Buffer.from("encrypted"),
-		expires_utc: 42,
-		name: "privy-session",
-	};
+  return {
+    encrypted_value: Buffer.from("encrypted"),
+    expires_utc: 42,
+    name: "privy-session",
+  };
 }
 
 describe("readChromiumCookies temporary database lifecycle", () => {
-	it.each(["copy", "open", "schema", "query", "decrypt", "close"] as const)(
-		"removes the private temp directory after a %s failure",
-		async (failurePhase) => {
-			const close = vi.fn(() => {
-				if (failurePhase === "close") throw new Error("close failed");
-			});
-			const rmSync = vi.fn();
-			const tempDir = "/tmp/eliza-cookies-test";
-			const result = await readChromiumCookies(
-				"app.eliza.ai",
-				["privy-session"],
-				{
-					appSupportDir: "/app-support",
-					chmodSync: vi.fn(),
-					copyFileSync: vi.fn(() => {
-						if (failurePhase === "copy") throw new Error("copy failed");
-					}),
-					decryptCookieValue: vi.fn(() => {
-						if (failurePhase === "decrypt") throw new Error("decrypt failed");
-						return "cookie-value";
-					}),
-					existsSync: (candidate) =>
-						String(candidate).endsWith(CHROME_COOKIE_PATH),
-					mkdtempSync: vi.fn(() => tempDir),
-					openDb: vi.fn(() => {
-						if (failurePhase === "open") throw new Error("open failed");
-						return {
-							close,
-							query: () => {
-								if (failurePhase === "schema") throw new Error("schema failed");
-								return {
-									all: () => {
-										if (failurePhase === "query")
-											throw new Error("query failed");
-										return [cookieRow()];
-									},
-								};
-							},
-						};
-					}),
-					platform: "darwin",
-					readSafeStoragePassword: vi.fn(async () => "password"),
-					rmSync,
-					tempRootDir: "/tmp",
-				},
-			);
+  it.each(["copy", "open", "schema", "query", "decrypt", "close"] as const)(
+    "removes the private temp directory after a %s failure",
+    async (failurePhase) => {
+      const close = vi.fn(() => {
+        if (failurePhase === "close") throw new Error("close failed");
+      });
+      const rmSync = vi.fn();
+      const tempDir = "/tmp/eliza-cookies-test";
+      const result = await readChromiumCookies(
+        "app.eliza.ai",
+        ["privy-session"],
+        {
+          appSupportDir: "/app-support",
+          chmodSync: vi.fn(),
+          copyFileSync: vi.fn(() => {
+            if (failurePhase === "copy") throw new Error("copy failed");
+          }),
+          decryptCookieValue: vi.fn(() => {
+            if (failurePhase === "decrypt") throw new Error("decrypt failed");
+            return "cookie-value";
+          }),
+          existsSync: (candidate) =>
+            String(candidate).endsWith(CHROME_COOKIE_PATH),
+          mkdtempSync: vi.fn(() => tempDir),
+          openDb: vi.fn(() => {
+            if (failurePhase === "open") throw new Error("open failed");
+            return {
+              close,
+              query: () => {
+                if (failurePhase === "schema") throw new Error("schema failed");
+                return {
+                  all: () => {
+                    if (failurePhase === "query")
+                      throw new Error("query failed");
+                    return [cookieRow()];
+                  },
+                };
+              },
+            };
+          }),
+          platform: "darwin",
+          readSafeStoragePassword: vi.fn(async () => "password"),
+          rmSync,
+          tempRootDir: "/tmp",
+        },
+      );
 
-			expect(rmSync).toHaveBeenCalledWith(tempDir, {
-				force: true,
-				recursive: true,
-			});
-			expect(close).toHaveBeenCalledTimes(
-				failurePhase === "schema" ||
-					failurePhase === "query" ||
-					failurePhase === "decrypt" ||
-					failurePhase === "close"
-					? 1
-					: 0,
-			);
-			expect(result).toHaveLength(failurePhase === "close" ? 1 : 0);
-		},
-	);
+      expect(rmSync).toHaveBeenCalledWith(tempDir, {
+        force: true,
+        recursive: true,
+      });
+      expect(close).toHaveBeenCalledTimes(
+        failurePhase === "schema" ||
+          failurePhase === "query" ||
+          failurePhase === "decrypt" ||
+          failurePhase === "close"
+          ? 1
+          : 0,
+      );
+      expect(result).toHaveLength(failurePhase === "close" ? 1 : 0);
+    },
+  );
 
-	it("uses distinct private directories for concurrent scans", async () => {
-		let tempSequence = 0;
-		const chmodSync = vi.fn();
-		const copiedDestinations: string[] = [];
-		const removedDirectories: string[] = [];
-		const dependencies = {
-			appSupportDir: "/app-support",
-			chmodSync,
-			copyFileSync: vi.fn((_source: string, destination: string) => {
-				copiedDestinations.push(destination);
-			}),
-			decryptCookieValue: vi.fn(() => "cookie-value"),
-			existsSync: (candidate: string) => candidate.endsWith(CHROME_COOKIE_PATH),
-			mkdtempSync: vi.fn(() => `/tmp/eliza-cookies-${++tempSequence}`),
-			openDb: vi.fn(() => ({
-				close: vi.fn(),
-				query: () => ({ all: () => [cookieRow()] }),
-			})),
-			platform: "darwin" as const,
-			readSafeStoragePassword: vi.fn(async () => "password"),
-			rmSync: vi.fn((directory: string) => {
-				removedDirectories.push(directory);
-			}),
-			tempRootDir: "/tmp",
-		};
+  it("uses distinct private directories for concurrent scans", async () => {
+    let tempSequence = 0;
+    const chmodSync = vi.fn();
+    const copiedDestinations: string[] = [];
+    const removedDirectories: string[] = [];
+    const dependencies = {
+      appSupportDir: "/app-support",
+      chmodSync,
+      copyFileSync: vi.fn((_source: string, destination: string) => {
+        copiedDestinations.push(destination);
+      }),
+      decryptCookieValue: vi.fn(() => "cookie-value"),
+      existsSync: (candidate: string) => candidate.endsWith(CHROME_COOKIE_PATH),
+      mkdtempSync: vi.fn(() => `/tmp/eliza-cookies-${++tempSequence}`),
+      openDb: vi.fn(() => ({
+        close: vi.fn(),
+        query: () => ({ all: () => [cookieRow()] }),
+      })),
+      platform: "darwin" as const,
+      readSafeStoragePassword: vi.fn(async () => "password"),
+      rmSync: vi.fn((directory: string) => {
+        removedDirectories.push(directory);
+      }),
+      tempRootDir: "/tmp",
+    };
 
-		const [first, second] = await Promise.all([
-			readChromiumCookies("app.eliza.ai", ["privy-session"], dependencies),
-			readChromiumCookies("app.eliza.ai", ["privy-session"], dependencies),
-		]);
+    const [first, second] = await Promise.all([
+      readChromiumCookies("app.eliza.ai", ["privy-session"], dependencies),
+      readChromiumCookies("app.eliza.ai", ["privy-session"], dependencies),
+    ]);
 
-		expect(first).toHaveLength(1);
-		expect(second).toHaveLength(1);
-		expect(new Set(copiedDestinations).size).toBe(2);
-		expect(copiedDestinations).toEqual([
-			"/tmp/eliza-cookies-1/Cookies",
-			"/tmp/eliza-cookies-2/Cookies",
-		]);
-		expect(chmodSync).toHaveBeenNthCalledWith(1, "/tmp/eliza-cookies-1", 0o700);
-		expect(chmodSync).toHaveBeenNthCalledWith(2, "/tmp/eliza-cookies-2", 0o700);
-		expect(removedDirectories).toEqual([
-			"/tmp/eliza-cookies-1",
-			"/tmp/eliza-cookies-2",
-		]);
-	});
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(new Set(copiedDestinations).size).toBe(2);
+    expect(copiedDestinations).toEqual([
+      "/tmp/eliza-cookies-1/Cookies",
+      "/tmp/eliza-cookies-2/Cookies",
+    ]);
+    expect(chmodSync).toHaveBeenNthCalledWith(1, "/tmp/eliza-cookies-1", 0o700);
+    expect(chmodSync).toHaveBeenNthCalledWith(2, "/tmp/eliza-cookies-2", 0o700);
+    expect(removedDirectories).toEqual([
+      "/tmp/eliza-cookies-1",
+      "/tmp/eliza-cookies-2",
+    ]);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
@@ -112,6 +112,46 @@ describe("readChromiumSafeStoragePassword", () => {
     ).resolves.toBeNull();
   });
 
+  it("cancels an overflowing non-closing pipe and observes process termination", async () => {
+    let cancelled = false;
+    let resolveExit: ((exitCode: number) => void) | undefined;
+    let exitObserved = false;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    void exited.then(() => {
+      exitObserved = true;
+    });
+    const kill = vi.fn((signal?: number | NodeJS.Signals) => {
+      if (signal === "SIGTERM") resolveExit?.(143);
+    });
+    const stdout = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(16));
+        controller.enqueue(new Uint8Array(17));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const stderr = new Response("").body;
+    if (!stderr) throw new Error("Expected in-memory response body");
+    const spawn = vi.fn(() => ({ exited, kill, stderr, stdout }));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        maxPipeBytes: 32,
+        platform: "darwin",
+        spawn,
+        terminationGraceMs: 5,
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBeNull();
+    expect(cancelled).toBe(true);
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    expect(exitObserved).toBe(true);
+  });
+
   it("bounds a stuck lookup, terminates it, and observes its exit", async () => {
     let resolveExit: ((exitCode: number) => void) | undefined;
     let exitObserved = false;

--- a/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
@@ -4,8 +4,9 @@ import { readChromiumSafeStoragePassword } from "./credentials.ts";
 
 function outputProcess(output: string, exitCode = 0) {
   const stdout = new Response(output).body;
-  if (!stdout) throw new Error("Expected an in-memory response body");
-  return { exited: Promise.resolve(exitCode), stdout };
+  const stderr = new Response("").body;
+  if (!stdout || !stderr) throw new Error("Expected in-memory response bodies");
+  return { exited: Promise.resolve(exitCode), kill: vi.fn(), stderr, stdout };
 }
 
 describe("readChromiumSafeStoragePassword", () => {
@@ -19,7 +20,7 @@ describe("readChromiumSafeStoragePassword", () => {
       }),
     ).resolves.toBe("safe-storage-password");
     expect(spawn).toHaveBeenCalledWith([
-      "security",
+      "/usr/bin/security",
       "find-generic-password",
       "-s",
       "Chrome Safe Storage",
@@ -38,6 +39,83 @@ describe("readChromiumSafeStoragePassword", () => {
         spawn,
       }),
     ).resolves.toBeNull();
+  });
+
+  it("returns null for a nonzero lookup and an empty password", async () => {
+    const failedSpawn = vi.fn(() => outputProcess("ignored", 44));
+    const emptySpawn = vi.fn(() => outputProcess("\n"));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn: failedSpawn,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn: emptySpawn,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("drains both pipes while the lookup is running", async () => {
+    let stdoutRead = false;
+    let stderrRead = false;
+    const stream = (markRead: () => void) =>
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          markRead();
+          controller.close();
+        },
+      });
+    const spawn = vi.fn(() => ({
+      exited: Promise.resolve(0),
+      kill: vi.fn(),
+      stdout: stream(() => {
+        stdoutRead = true;
+      }),
+      stderr: stream(() => {
+        stderrRead = true;
+      }),
+    }));
+
+    await readChromiumSafeStoragePassword("Chrome Safe Storage", {
+      platform: "darwin",
+      spawn,
+    });
+    expect(stdoutRead).toBe(true);
+    expect(stderrRead).toBe(true);
+  });
+
+  it("bounds a stuck lookup, terminates it, and observes its exit", async () => {
+    let resolveExit: ((exitCode: number) => void) | undefined;
+    let exitObserved = false;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    void exited.then(() => {
+      exitObserved = true;
+    });
+    const kill = vi.fn((signal?: number | NodeJS.Signals) => {
+      if (signal === "SIGTERM") resolveExit?.(143);
+    });
+    const stdout = new Response("").body;
+    const stderr = new Response("").body;
+    if (!stdout || !stderr)
+      throw new Error("Expected in-memory response bodies");
+    const spawn = vi.fn(() => ({ exited, kill, stderr, stdout }));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn,
+        terminationGraceMs: 5,
+        timeoutMs: 5,
+      }),
+    ).resolves.toBeNull();
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    expect(exitObserved).toBe(true);
   });
 
   it("does not spawn a Keychain lookup outside macOS", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
@@ -1,0 +1,54 @@
+/** Verifies the deterministic macOS Chromium Safe Storage lookup boundary. */
+import { describe, expect, it, vi } from "vitest";
+import { readChromiumSafeStoragePassword } from "./credentials.ts";
+
+function outputProcess(output: string, exitCode = 0) {
+  const stdout = new Response(output).body;
+  if (!stdout) throw new Error("Expected an in-memory response body");
+  return { exited: Promise.resolve(exitCode), stdout };
+}
+
+describe("readChromiumSafeStoragePassword", () => {
+  it("returns the trimmed password from the named macOS Keychain service", async () => {
+    const spawn = vi.fn(() => outputProcess("safe-storage-password\n"));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn,
+      }),
+    ).resolves.toBe("safe-storage-password");
+    expect(spawn).toHaveBeenCalledWith([
+      "security",
+      "find-generic-password",
+      "-s",
+      "Chrome Safe Storage",
+      "-w",
+    ]);
+  });
+
+  it("returns null when the Keychain lookup fails", async () => {
+    const spawn = vi.fn(() => {
+      throw new Error("Keychain unavailable");
+    });
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not spawn a Keychain lookup outside macOS", async () => {
+    const spawn = vi.fn(() => outputProcess("must-not-be-read"));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "linux",
+        spawn,
+      }),
+    ).resolves.toBeNull();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
@@ -2,9 +2,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { readChromiumSafeStoragePassword } from "./credentials.ts";
 
-function outputProcess(output: string, exitCode = 0) {
+function outputProcess(output: string, exitCode = 0, errorOutput = "") {
   const stdout = new Response(output).body;
-  const stderr = new Response("").body;
+  const stderr = new Response(errorOutput).body;
   if (!stdout || !stderr) throw new Error("Expected in-memory response bodies");
   return { exited: Promise.resolve(exitCode), kill: vi.fn(), stderr, stdout };
 }
@@ -86,6 +86,30 @@ describe("readChromiumSafeStoragePassword", () => {
     });
     expect(stdoutRead).toBe(true);
     expect(stderrRead).toBe(true);
+  });
+
+  it("rejects stdout that exceeds the configured byte cap", async () => {
+    const spawn = vi.fn(() => outputProcess("x".repeat(33)));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        maxPipeBytes: 32,
+        platform: "darwin",
+        spawn,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects stderr that exceeds the configured byte cap", async () => {
+    const spawn = vi.fn(() => outputProcess("password", 0, "x".repeat(33)));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        maxPipeBytes: 32,
+        platform: "darwin",
+        spawn,
+      }),
+    ).resolves.toBeNull();
   });
 
   it("bounds a stuck lookup, terminates it, and observes its exit", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -326,7 +326,13 @@ async function readPipeTextCapped(
         chunks.push(retained);
         storedBytes += retained.byteLength;
       }
-      if (value.byteLength > remaining) overflow = true;
+      if (value.byteLength > remaining) {
+        overflow = true;
+        void reader
+          .cancel("Chromium Safe Storage pipe exceeded byte cap")
+          .catch(() => undefined);
+        break;
+      }
     }
   } finally {
     reader.releaseLock();
@@ -337,6 +343,15 @@ async function readPipeTextCapped(
       "utf8",
     ),
   };
+}
+
+function signalPipeOverflow(
+  result: Promise<{ overflow: boolean; text: string }>,
+): Promise<"overflow"> {
+  return result.then((pipe) => {
+    if (pipe.overflow) return "overflow";
+    return new Promise<never>(() => undefined);
+  });
 }
 
 async function settlesWithin<T>(
@@ -356,6 +371,19 @@ async function settlesWithin<T>(
     ]);
   } finally {
     if (timer) clearTimeout(timer);
+  }
+}
+
+async function terminateAndObserve(
+  proc: ChromiumSafeStorageProcess,
+  exit: Promise<{ exitCode: number }>,
+  graceMs: number,
+): Promise<void> {
+  if (await settlesWithin(exit, 0)) return;
+  proc.kill("SIGTERM");
+  if (!(await settlesWithin(exit, graceMs))) {
+    proc.kill("SIGKILL");
+    await settlesWithin(exit, graceMs);
   }
 }
 
@@ -385,31 +413,35 @@ export async function readChromiumSafeStoragePassword(
     );
     const stdout = readPipeTextCapped(proc.stdout, maxPipeBytes);
     const stderr = readPipeTextCapped(proc.stderr, maxPipeBytes);
-    const completed = Promise.all([exit, stdout, stderr]);
+    const completed = Promise.all([exit, stdout, stderr]).then((value) => {
+      const [, stdoutResult, stderrResult] = value;
+      return stdoutResult.overflow || stderrResult.overflow
+        ? ({ kind: "overflow" } as const)
+        : { kind: "completed" as const, value };
+    });
     let timer: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race([
       completed,
-      new Promise<null>((resolve) => {
+      Promise.race([
+        signalPipeOverflow(stdout),
+        signalPipeOverflow(stderr),
+      ]).then(() => ({ kind: "overflow" as const })),
+      new Promise<{ kind: "timeout" }>((resolve) => {
         timer = setTimeout(
-          () => resolve(null),
+          () => resolve({ kind: "timeout" }),
           dependencies.timeoutMs ?? CHROMIUM_SAFE_STORAGE_TIMEOUT_MS,
         );
       }),
     ]);
     if (timer) clearTimeout(timer);
-    if (!result) {
+    if (result.kind !== "completed") {
       const graceMs =
         dependencies.terminationGraceMs ??
         CHROMIUM_SAFE_STORAGE_TERMINATION_GRACE_MS;
-      proc.kill("SIGTERM");
-      if (!(await settlesWithin(exit, graceMs))) {
-        proc.kill("SIGKILL");
-        await settlesWithin(exit, graceMs);
-      }
+      await terminateAndObserve(proc, exit, graceMs);
       return null;
     }
-    const [{ exitCode }, stdoutResult, stderrResult] = result;
-    if (stdoutResult.overflow || stderrResult.overflow) return null;
+    const [{ exitCode }, stdoutResult] = result.value;
     if (exitCode !== 0) return null;
     const trimmed = stdoutResult.text.trim();
     return trimmed.length > 0 ? trimmed : null;

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -298,12 +298,46 @@ interface ChromiumSafeStorageProcess {
 interface ChromiumSafeStorageDependencies {
   platform?: NodeJS.Platform;
   spawn?: (command: string[]) => ChromiumSafeStorageProcess;
+  maxPipeBytes?: number;
   timeoutMs?: number;
   terminationGraceMs?: number;
 }
 
 const CHROMIUM_SAFE_STORAGE_TIMEOUT_MS = 3_000;
 const CHROMIUM_SAFE_STORAGE_TERMINATION_GRACE_MS = 250;
+const CHROMIUM_SAFE_STORAGE_MAX_PIPE_BYTES = 64 * 1024;
+
+async function readPipeTextCapped(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): Promise<{ overflow: boolean; text: string }> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let storedBytes = 0;
+  let overflow = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const remaining = maxBytes - storedBytes;
+      if (remaining > 0) {
+        const retained =
+          value.byteLength > remaining ? value.slice(0, remaining) : value;
+        chunks.push(retained);
+        storedBytes += retained.byteLength;
+      }
+      if (value.byteLength > remaining) overflow = true;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return {
+    overflow,
+    text: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString(
+      "utf8",
+    ),
+  };
+}
 
 async function settlesWithin<T>(
   promise: Promise<T>,
@@ -345,8 +379,12 @@ export async function readChromiumSafeStoragePassword(
       (exitCode) => ({ exitCode }),
       () => ({ exitCode: -1 }),
     );
-    const stdout = new Response(proc.stdout).text();
-    const stderr = new Response(proc.stderr).text();
+    const maxPipeBytes = Math.max(
+      1,
+      dependencies.maxPipeBytes ?? CHROMIUM_SAFE_STORAGE_MAX_PIPE_BYTES,
+    );
+    const stdout = readPipeTextCapped(proc.stdout, maxPipeBytes);
+    const stderr = readPipeTextCapped(proc.stderr, maxPipeBytes);
     const completed = Promise.all([exit, stdout, stderr]);
     let timer: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race([
@@ -370,9 +408,10 @@ export async function readChromiumSafeStoragePassword(
       }
       return null;
     }
-    const [{ exitCode }, output] = result;
+    const [{ exitCode }, stdoutResult, stderrResult] = result;
+    if (stdoutResult.overflow || stderrResult.overflow) return null;
     if (exitCode !== 0) return null;
-    const trimmed = output.trim();
+    const trimmed = stdoutResult.text.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {
     // error-policy:J4 browser Safe Storage password unavailable
@@ -430,6 +469,23 @@ interface CookieDb {
 }
 type CookieDbOpener = (filename: string) => CookieDb;
 
+interface ChromiumCookieDependencies {
+  platform?: NodeJS.Platform;
+  appSupportDir?: string;
+  tempRootDir?: string;
+  existsSync?: (filePath: string) => boolean;
+  mkdtempSync?: (prefix: string) => string;
+  chmodSync?: (filePath: string, mode: number) => void;
+  copyFileSync?: (source: string, destination: string) => void;
+  rmSync?: (
+    directory: string,
+    options: { force: true; recursive: true },
+  ) => void;
+  openDb?: CookieDbOpener | null;
+  readSafeStoragePassword?: typeof readChromiumSafeStoragePassword;
+  decryptCookieValue?: typeof decryptChromiumCookieValue;
+}
+
 const runtimeRequire = createRequire(import.meta.url);
 let cookieDbOpenerCached: CookieDbOpener | null | undefined;
 
@@ -479,35 +535,48 @@ function resolveCookieDbOpener(): CookieDbOpener | null {
 export async function readChromiumCookies(
   host: string,
   cookieNames: string[],
+  dependencies: ChromiumCookieDependencies = {},
 ): Promise<BrowserCookieResult[]> {
-  if (process.platform !== "darwin") return [];
+  if ((dependencies.platform ?? process.platform) !== "darwin") return [];
 
-  const openDb = resolveCookieDbOpener();
+  const openDb = dependencies.openDb ?? resolveCookieDbOpener();
   if (!openDb) return [];
 
-  const appSupport = path.join(os.homedir(), "Library", "Application Support");
+  const appSupport =
+    dependencies.appSupportDir ??
+    path.join(os.homedir(), "Library", "Application Support");
+  const tempRoot = dependencies.tempRootDir ?? os.tmpdir();
+  const existsSync = dependencies.existsSync ?? fs.existsSync;
+  const mkdtempSync = dependencies.mkdtempSync ?? fs.mkdtempSync;
+  const chmodSync = dependencies.chmodSync ?? fs.chmodSync;
+  const copyFileSync = dependencies.copyFileSync ?? fs.copyFileSync;
+  const rmSync = dependencies.rmSync ?? fs.rmSync;
+  const readSafeStoragePassword =
+    dependencies.readSafeStoragePassword ?? readChromiumSafeStoragePassword;
+  const decryptCookieValue =
+    dependencies.decryptCookieValue ?? decryptChromiumCookieValue;
 
   for (const browser of CHROMIUM_BROWSERS) {
     const dbPath = path.join(appSupport, browser.cookiePath);
-    if (!fs.existsSync(dbPath)) continue;
+    if (!existsSync(dbPath)) continue;
 
     // Get the decryption key from Keychain
-    const password = await readChromiumSafeStoragePassword(
-      browser.keychainService,
-    );
+    const password = await readSafeStoragePassword(browser.keychainService);
     if (!password) continue;
 
     const key = deriveChromiumCookieKey(password);
 
+    let db: CookieDb | undefined;
+    let tempDir: string | undefined;
     try {
-      // Copy the DB to a temp file to avoid locking issues with the running browser
-      const tmpDb = path.join(
-        os.tmpdir(),
-        `eliza-cookies-${browser.name}-${Date.now()}.db`,
-      );
-      fs.copyFileSync(dbPath, tmpDb);
+      // Isolate every scan so concurrent imports cannot collide and cleanup can
+      // remove the database plus any SQLite sidecars as one private directory.
+      tempDir = mkdtempSync(path.join(tempRoot, "eliza-cookies-"));
+      chmodSync(tempDir, 0o700);
+      const tmpDb = path.join(tempDir, "Cookies");
+      copyFileSync(dbPath, tmpDb);
 
-      const db = openDb(tmpDb);
+      db = openDb(tmpDb);
       const nameParams = cookieNames.map(() => "?").join(", ");
       const rows = db
         .query(
@@ -518,21 +587,9 @@ export async function readChromiumCookies(
         encrypted_value: Buffer;
         expires_utc: number;
       }>;
-      db.close();
-
-      // Clean up temp file
-      try {
-        fs.unlinkSync(tmpDb);
-      } catch {
-        /* best effort */
-      }
-
       const results: BrowserCookieResult[] = [];
       for (const row of rows) {
-        const value = decryptChromiumCookieValue(
-          Buffer.from(row.encrypted_value),
-          key,
-        );
+        const value = decryptCookieValue(Buffer.from(row.encrypted_value), key);
         if (value) {
           results.push({
             name: row.name,
@@ -549,6 +606,21 @@ export async function readChromiumCookies(
         `[credentials] Failed to read ${browser.name} cookies:`,
         err,
       );
+    } finally {
+      if (db) {
+        try {
+          db.close();
+        } catch {
+          // error-policy:J6 the read-only temporary database is still removed below
+        }
+      }
+      if (tempDir) {
+        try {
+          rmSync(tempDir, { force: true, recursive: true });
+        } catch {
+          // error-policy:J6 best-effort cleanup must not abort fallback to another browser
+        }
+      }
     }
   }
 

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -291,11 +291,38 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
 interface ChromiumSafeStorageProcess {
   exited: Promise<number>;
   stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  kill(signal?: number | NodeJS.Signals): void;
 }
 
 interface ChromiumSafeStorageDependencies {
   platform?: NodeJS.Platform;
   spawn?: (command: string[]) => ChromiumSafeStorageProcess;
+  timeoutMs?: number;
+  terminationGraceMs?: number;
+}
+
+const CHROMIUM_SAFE_STORAGE_TIMEOUT_MS = 3_000;
+const CHROMIUM_SAFE_STORAGE_TERMINATION_GRACE_MS = 250;
+
+async function settlesWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export async function readChromiumSafeStoragePassword(
@@ -304,13 +331,47 @@ export async function readChromiumSafeStoragePassword(
 ): Promise<string | null> {
   if ((dependencies.platform ?? process.platform) !== "darwin") return null;
   try {
-    const command = ["security", "find-generic-password", "-s", service, "-w"];
+    const command = [
+      "/usr/bin/security",
+      "find-generic-password",
+      "-s",
+      service,
+      "-w",
+    ];
     const proc = dependencies.spawn
       ? dependencies.spawn(command)
       : Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
-    const exitCode = await proc.exited;
+    const exit = proc.exited.then(
+      (exitCode) => ({ exitCode }),
+      () => ({ exitCode: -1 }),
+    );
+    const stdout = new Response(proc.stdout).text();
+    const stderr = new Response(proc.stderr).text();
+    const completed = Promise.all([exit, stdout, stderr]);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      completed,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(
+          () => resolve(null),
+          dependencies.timeoutMs ?? CHROMIUM_SAFE_STORAGE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (!result) {
+      const graceMs =
+        dependencies.terminationGraceMs ??
+        CHROMIUM_SAFE_STORAGE_TERMINATION_GRACE_MS;
+      proc.kill("SIGTERM");
+      if (!(await settlesWithin(exit, graceMs))) {
+        proc.kill("SIGKILL");
+        await settlesWithin(exit, graceMs);
+      }
+      return null;
+    }
+    const [{ exitCode }, output] = result;
     if (exitCode !== 0) return null;
-    const output = await new Response(proc.stdout).text();
     const trimmed = output.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -288,6 +288,26 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
   },
 ];
 
+async function readChromiumSafeStoragePassword(
+  service: string,
+): Promise<string | null> {
+  if (process.platform !== "darwin") return null;
+  try {
+    const proc = Bun.spawn(
+      ["security", "find-generic-password", "-s", service, "-w"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const output = await new Response(proc.stdout).text();
+    const trimmed = output.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    // error-policy:J4 browser Safe Storage password unavailable
+    return null;
+  }
+}
+
 function deriveChromiumCookieKey(password: string): Buffer {
   // Chrome on macOS: PBKDF2 with salt='saltysalt', 1003 iterations, 16-byte key
   return crypto.pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1");
@@ -395,7 +415,9 @@ export async function readChromiumCookies(
     if (!fs.existsSync(dbPath)) continue;
 
     // Get the decryption key from Keychain
-    const password = await readKeychainCredential(browser.keychainService);
+    const password = await readChromiumSafeStoragePassword(
+      browser.keychainService,
+    );
     if (!password) continue;
 
     const key = deriveChromiumCookieKey(password);

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -288,15 +288,26 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
   },
 ];
 
-async function readChromiumSafeStoragePassword(
+interface ChromiumSafeStorageProcess {
+  exited: Promise<number>;
+  stdout: ReadableStream<Uint8Array>;
+}
+
+interface ChromiumSafeStorageDependencies {
+  platform?: NodeJS.Platform;
+  spawn?: (command: string[]) => ChromiumSafeStorageProcess;
+}
+
+export async function readChromiumSafeStoragePassword(
   service: string,
+  dependencies: ChromiumSafeStorageDependencies = {},
 ): Promise<string | null> {
-  if (process.platform !== "darwin") return null;
+  if ((dependencies.platform ?? process.platform) !== "darwin") return null;
   try {
-    const proc = Bun.spawn(
-      ["security", "find-generic-password", "-s", service, "-w"],
-      { stdout: "pipe", stderr: "pipe" },
-    );
+    const command = ["security", "find-generic-password", "-s", service, "-w"];
+    const proc = dependencies.spawn
+      ? dependencies.spawn(command)
+      : Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
     const exitCode = await proc.exited;
     if (exitCode !== 0) return null;
     const output = await new Response(proc.stdout).text();
@@ -398,6 +409,11 @@ function resolveCookieDbOpener(): CookieDbOpener | null {
  * Read specific cookies from Chromium-based browsers on macOS.
  * Decrypts using the Safe Storage key from Keychain.
  * Falls back through installed browsers until one succeeds.
+ *
+ * This is the narrow exception to the provider-credential Keychain policy:
+ * the browser session importer reads only the Safe Storage password for an
+ * installed browser whose cookie database already exists. It does not scan
+ * arbitrary provider credentials or enumerate Keychain items.
  */
 export async function readChromiumCookies(
   host: string,
@@ -659,10 +675,14 @@ async function scanProviderCredentialsRaw(): Promise<DetectedProvider[]> {
  * Checks files → browser session → env vars, deduplicating by provider ID
  * (first match wins per provider).
  *
- * It deliberately does not scrape third-party macOS Keychain items. Those
- * reads can trigger consent/default-keychain dialogs and are not an
- * App-Sandbox-safe credential integration. Providers that need Keychain-backed
- * sign-in must expose an explicit OAuth or native integration instead.
+ * It deliberately does not scrape provider credentials from the macOS
+ * Keychain. Those reads can trigger consent/default-keychain dialogs and are
+ * not an App-Sandbox-safe credential integration. Providers that need
+ * Keychain-backed sign-in must expose an explicit OAuth or native integration
+ * instead. The Eliza Cloud browser-session importer has one constrained
+ * exception: after finding a supported browser cookie database, it reads that
+ * browser's named Safe Storage password to decrypt the requested session
+ * cookie.
  *
  * API keys are masked in the returned results (last 4 chars only) to
  * prevent accidental exposure via IPC or logging.

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -305,8 +305,8 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Set default SMS", "bridge-only", "compose"],
   }),
   "plugin-maps-gui": expected({
-    requireAll: ["Maps", "Find somewhere worth going"],
-    requireAny: ["provider-neutral", "Search a place"],
+    requireAll: ["Maps", "provider-neutral"],
+    requireAny: ["Search a place", "Find somewhere worth going"],
     forbid: ["Google Maps", "Mapbox"],
   }),
   "plugin-phone-gui": expected({

--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
@@ -30,6 +30,8 @@ export const canRequesterMutateDocument = unavailableFunction(
   "canRequesterMutateDocument",
 );
 export const ChannelType = unavailableObject("ChannelType");
+export const cloneConnectorJsonObject = <T>(value: T): T =>
+  structuredClone(value);
 export const DatabaseAdapter = unavailableConstructor("DatabaseAdapter");
 export const decryptedCharacter = unavailableFunction("decryptedCharacter");
 export const DOCUMENT_LIST_QUERY_CAPABILITY_VERSION = Symbol(
@@ -42,11 +44,20 @@ export const documentRoleHasGlobalVisibility = unavailableFunction(
   "documentRoleHasGlobalVisibility",
 );
 export const encryptedCharacter = unavailableFunction("encryptedCharacter");
+export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1;
+export const IdentityResolutionService = unavailableConstructor(
+  "IdentityResolutionService",
+);
 export const logger = unavailableObject("logger");
 export const normalizePairingPageOptions = unavailableFunction(
   "normalizePairingPageOptions",
 );
 export const Service = unavailableConstructor("Service");
+export const redactConnectorJsonAudit = <T>(value: T): T => value;
+export const toWellFormedUnicode = (text: string): string =>
+  text.toWellFormed();
+export const truncateWellFormed = (text: string, maxLength: number): string =>
+  text.toWellFormed().slice(0, maxLength);
 export const validateDocumentFragmentQueryParams = unavailableFunction(
   "validateDocumentFragmentQueryParams",
 );
@@ -55,6 +66,9 @@ export const validateDocumentListQueryParams = unavailableFunction(
 );
 export const validateDocumentRequesterContext = unavailableFunction(
   "validateDocumentRequesterContext",
+);
+export const validateDocumentRevisionReplacement = unavailableFunction(
+  "validateDocumentRevisionReplacement",
 );
 export const validateQueryEntitiesPagination = unavailableFunction(
   "validateQueryEntitiesPagination",

--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
@@ -54,10 +54,24 @@ export const normalizePairingPageOptions = unavailableFunction(
 );
 export const Service = unavailableConstructor("Service");
 export const redactConnectorJsonAudit = <T>(value: T): T => value;
-export const toWellFormedUnicode = (text: string): string =>
-  text.toWellFormed();
-export const truncateWellFormed = (text: string, maxLength: number): string =>
-  text.toWellFormed().slice(0, maxLength);
+export const toWellFormedUnicode = (text: string): string => {
+  const native = (
+    String.prototype as { toWellFormed?: (this: string) => string }
+  ).toWellFormed;
+  return native ? native.call(text) : text;
+};
+export const truncateWellFormed = (text: string, maxLength: number): string => {
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return "";
+  if (text.length <= maxLength) return text;
+  const end =
+    text.charCodeAt(maxLength - 1) >= 0xd800 &&
+    text.charCodeAt(maxLength - 1) <= 0xdbff &&
+    text.charCodeAt(maxLength) >= 0xdc00 &&
+    text.charCodeAt(maxLength) <= 0xdfff
+      ? maxLength - 1
+      : maxLength;
+  return text.slice(0, end);
+};
 export const validateDocumentFragmentQueryParams = unavailableFunction(
   "validateDocumentFragmentQueryParams",
 );

--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
@@ -75,12 +75,23 @@ const summarizeOutcomesByTypeSince = mock(
   async (): Promise<Array<{ status: string; count: number }>> => [],
 );
 
+const agentSandboxesActual = await import("@/db/repositories/agent-sandboxes");
+const jobsActual = await import("@/db/repositories/jobs");
+
 mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: { summarizeDedicatedFleet },
+  ...agentSandboxesActual,
+  agentSandboxesRepository: {
+    ...agentSandboxesActual.agentSandboxesRepository,
+    summarizeDedicatedFleet,
+  },
 }));
 
 mock.module("@/db/repositories/jobs", () => ({
-  jobsRepository: { summarizeOutcomesByTypeSince },
+  ...jobsActual,
+  jobsRepository: {
+    ...jobsActual.jobsRepository,
+    summarizeOutcomesByTypeSince,
+  },
 }));
 
 mock.module("@/lib/utils/logger", () => ({

--- a/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
@@ -101,6 +101,7 @@ mock.module("@/lib/services/shared-runtime/agent-tier", () => ({
 }));
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   ApiError: class ApiError extends Error {},
+  ForbiddenError: class ForbiddenError extends Error {},
   NotFoundError: class NotFoundError extends Error {},
   ValidationError: (message: string) => {
     const error = new Error(message);

--- a/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
@@ -14,6 +14,7 @@ mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -24,19 +25,27 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (a: unknown) => a,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: (text: string) => text,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -24,6 +24,7 @@ mock.module("@elizaos/cloud-shared/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -34,19 +35,27 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (args: unknown) => args,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: (text: string) => text,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
+++ b/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
@@ -58,6 +58,7 @@ mock.module("@elizaos/core", () => ({
   ...workerCoreStub,
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -68,19 +69,27 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: workerCoreStub.ElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: workerCoreStub.isElizaError,
   isSensitiveKeyName: () => false,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (a: unknown) => a,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: workerCoreStub.redactSensitiveText,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -136,6 +136,7 @@ mock.module("@elizaos/shared/voice/first-sentence-snip", () => ({
 mock.module("@elizaos/core", () => ({
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -146,17 +147,25 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: (text: string) => text,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
@@ -14,13 +14,6 @@ const loggerWarn = mock();
 const loggerError = mock();
 const loggerDebug = mock();
 
-mock.module("../../bluebubbles/route", () => ({
-  handleBlueBubblesWebhook: mock(async () => Response.json({ success: true })),
-  handleBlueBubblesWebhookPayload: mock(async () =>
-    Response.json({ success: true }),
-  ),
-}));
-
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { AGGRESSIVE: {} },
   rateLimit: () => async (_context: unknown, next: () => Promise<void>) =>

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.test.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.test.ts
@@ -1,22 +1,10 @@
 // Exercises cloud API webhooks blooio orgid route.test behavior with deterministic Worker route fixtures.
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import { Hono } from "hono";
 
 const webhookSecret = "test-blooio-webhook-secret";
-
-const handleBlueBubblesWebhook = mock(async () =>
-  Response.json({ success: true, source: "bluebubbles-direct" }),
-);
-const handleBlueBubblesWebhookPayload = mock(async (_c, payload: unknown) =>
-  Response.json({ success: true, source: "bluebubbles-payload", payload }),
-);
-
-mock.module("../../bluebubbles/route", () => ({
-  handleBlueBubblesWebhook,
-  handleBlueBubblesWebhookPayload,
-}));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: {
@@ -44,67 +32,8 @@ function signature(body: string): string {
   return `t=${timestamp},v1=${digest}`;
 }
 
-function post(body: unknown, headers: Record<string, string> = {}) {
-  return new Request("https://api.example.test/?bridge=bluebubbles", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      ...headers,
-    },
-    body: JSON.stringify(body),
-  });
-}
-
-const blueBubblesPayload = {
-  type: "new-message",
-  data: {
-    guid: "message-1",
-    text: "hello",
-    isFromMe: false,
-    handle: {
-      address: "+15555550123",
-    },
-  },
-};
-
-describe("Blooio webhook BlueBubbles compatibility", () => {
-  beforeEach(() => {
-    handleBlueBubblesWebhook.mockClear();
-    handleBlueBubblesWebhookPayload.mockClear();
-  });
-
-  test("dispatches explicit bridge requests before Blooio signature validation", async () => {
-    const response = await app.fetch(post(blueBubblesPayload));
-
-    await expect(response.json()).resolves.toMatchObject({
-      success: true,
-      source: "bluebubbles-direct",
-    });
-    expect(handleBlueBubblesWebhook).toHaveBeenCalledTimes(1);
-    expect(handleBlueBubblesWebhookPayload).not.toHaveBeenCalled();
-  });
-
-  test("detects BlueBubbles-shaped payloads even without the bridge query", async () => {
-    const response = await app.fetch(
-      new Request("https://api.example.test/", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(blueBubblesPayload),
-      }),
-    );
-
-    await expect(response.json()).resolves.toMatchObject({
-      success: true,
-      source: "bluebubbles-payload",
-      payload: blueBubblesPayload,
-    });
-    expect(handleBlueBubblesWebhook).not.toHaveBeenCalled();
-    expect(handleBlueBubblesWebhookPayload).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not misroute a Blooio v4 envelope as BlueBubbles", async () => {
+describe("Blooio webhook validation", () => {
+  test("rejects a Blooio v4 envelope with an invalid signature", async () => {
     const response = await mountedApp.fetch(
       new Request("https://api.example.test/test-org", {
         method: "POST",
@@ -131,8 +60,6 @@ describe("Blooio webhook BlueBubbles compatibility", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Invalid webhook signature",
     });
-    expect(handleBlueBubblesWebhook).not.toHaveBeenCalled();
-    expect(handleBlueBubblesWebhookPayload).not.toHaveBeenCalled();
   });
 
   test("rejects an inbound message without a stable ID", async () => {
@@ -157,7 +84,5 @@ describe("Blooio webhook BlueBubbles compatibility", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Inbound message ID is required",
     });
-    expect(handleBlueBubblesWebhook).not.toHaveBeenCalled();
-    expect(handleBlueBubblesWebhookPayload).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
@@ -23,10 +23,6 @@ import {
 import { isAlreadyProcessed, markAsProcessed } from "@/lib/utils/idempotency";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import {
-  handleBlueBubblesWebhook,
-  handleBlueBubblesWebhookPayload,
-} from "../../bluebubbles/route";
 
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -35,60 +31,12 @@ function boundedOrganizationId(value: string): string {
   return uuidPattern.test(value) ? value : "invalid";
 }
 
-function isBlueBubblesBridgeRequest(
-  c: AppContext,
-  rawBody: string,
-): { payload: unknown } | null {
-  const bridge =
-    c.req.header("x-eliza-bridge") ??
-    c.req.query("bridge") ??
-    new URL(c.req.url).searchParams.get("bridge");
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawBody) as unknown;
-  } catch {
-    // error-policy:J3 malformed bridge input is classified without echoing its body.
-    return bridge === "bluebubbles" ? { payload: null } : null;
-  }
-
-  if (bridge === "bluebubbles") {
-    return { payload: parsed };
-  }
-
-  // Blooio v4 and BlueBubbles both use a top-level { type, data } envelope.
-  // Auto-detect only BlueBubbles-specific message fields; treating the shared
-  // envelope shape itself as proof would divert signed Blooio v4 deliveries
-  // into the legacy bridge handler before Blooio signature verification.
-  if (
-    parsed &&
-    typeof parsed === "object" &&
-    "type" in parsed &&
-    "data" in parsed &&
-    parsed.data &&
-    typeof parsed.data === "object" &&
-    ("guid" in parsed.data ||
-      "isFromMe" in parsed.data ||
-      "handle" in parsed.data ||
-      "chats" in parsed.data ||
-      "dateCreated" in parsed.data)
-  ) {
-    return { payload: parsed };
-  }
-
-  return null;
-}
-
 async function handleBlooioWebhook(c: AppContext): Promise<Response> {
   const requestedOrgId = c.req.param("orgId") ?? "";
   const orgId = boundedOrganizationId(requestedOrgId);
 
   try {
     const rawBody = await c.req.text();
-    const blueBubblesRequest = isBlueBubblesBridgeRequest(c, rawBody);
-    if (blueBubblesRequest) {
-      return handleBlueBubblesWebhookPayload(c, blueBubblesRequest.payload);
-    }
-
     if (!requestedOrgId)
       return c.json({ error: "Organization ID is required" }, 400);
 
@@ -231,22 +179,9 @@ async function handleBlooioWebhook(c: AppContext): Promise<Response> {
 }
 
 const app = new Hono<AppEnv>();
-app.post(
-  "/",
-  async (c, next) => {
-    const bridge =
-      c.req.header("x-eliza-bridge") ??
-      c.req.query("bridge") ??
-      new URL(c.req.url).searchParams.get("bridge");
-    if (bridge === "bluebubbles") {
-      return handleBlueBubblesWebhook(c);
-    }
-    await next();
-  },
-  rateLimit(RateLimitPresets.AGGRESSIVE),
-  (c) => handleBlooioWebhook(c),
+app.post("/", rateLimit(RateLimitPresets.AGGRESSIVE), (c) =>
+  handleBlooioWebhook(c),
 );
-app.post("/bluebubbles", (c) => handleBlueBubblesWebhook(c));
 
 /**
  * Handle incoming message from Blooio

--- a/packages/cloud/shared/src/lib/services/account-deletion.test.ts
+++ b/packages/cloud/shared/src/lib/services/account-deletion.test.ts
@@ -62,6 +62,9 @@ mock.module("../../db/repositories/users", () => ({
 mock.module("./steward-platform-users", () => ({
   deactivateStewardPlatformUser: deactivateSteward,
   deleteStewardPlatformUser: deleteSteward,
+  getStewardApiUrl: () => "https://steward.test",
+  getStewardPlatformKey: () => "test-platform-key",
+  isStewardPlatformConfigured: () => true,
 }));
 mock.module("./user-sessions", () => ({
   userSessionsService: { endAllUserSessions: mock(async () => undefined) },

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
@@ -21,7 +21,10 @@ const downloadSocialMediaBytes = mock(
     _options?: { httpErrorMessage?: (status: number) => string },
   ): Promise<Buffer> => Buffer.from([1, 2, 3]),
 );
-mock.module("../media-download", () => ({ downloadSocialMediaBytes }));
+mock.module("../media-download", () => ({
+  ...realMediaDownload,
+  downloadSocialMediaBytes,
+}));
 
 mock.module("../../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
@@ -41,7 +41,10 @@ const downloadSocialMediaBytes = mock(
   ): Promise<Buffer> => Buffer.from("PNGBYTES"),
 );
 
-mock.module("../media-download", () => ({ downloadSocialMediaBytes }));
+mock.module("../media-download", () => ({
+  ...realMediaDownload,
+  downloadSocialMediaBytes,
+}));
 
 mock.module("../rate-limit", () => ({
   withRetry: async (fn: () => Promise<Response>, parser: (r: Response) => Promise<unknown>) => {

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -104,10 +104,8 @@ function userMessage(): Memory {
 describe("DocumentService list semantics", () => {
 	it("excludes room documents immediately after membership revocation", async () => {
 		const { adapter, runtime, service } = await makeHarness();
-		const revocationUserId =
-			"00000000-0000-0000-0000-00000000cafe" as UUID;
-		const revocationRoomId =
-			"00000000-0000-0000-0000-00000000da7a" as UUID;
+		const revocationUserId = "00000000-0000-0000-0000-00000000cafe" as UUID;
+		const revocationRoomId = "00000000-0000-0000-0000-00000000da7a" as UUID;
 		await adapter.createRoomParticipants(
 			[AGENT_ID, revocationUserId],
 			revocationRoomId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./errors";
 // Re-export everything from the Node.js entry point
 // This ensures that imports from "@elizaos/core" resolve correctly during builds
-export * from "./index.node";
+export * from "./index.node.ts";
 export {
 	isSensitiveKeyName,
 	redactLogArgs,

--- a/packages/core/src/services/message.preserved-tool-result.test.ts
+++ b/packages/core/src/services/message.preserved-tool-result.test.ts
@@ -309,12 +309,10 @@ describe("subAgentCompletionRelayBody parsing (#18208)", () => {
 		expect(subAgentCompletionRelayBody(undefined)).toBeUndefined();
 	});
 
-	it("caps a runaway body", () => {
+	it("preserves a complete long result body", () => {
 		const huge = "x".repeat(5000);
-		const capped = subAgentCompletionRelayBody(`${RELAY_HEADER}\n${huge}`);
-		expect(capped).toBeDefined();
-		expect((capped as string).length).toBeLessThanOrEqual(1501);
-		expect(capped).toMatch(/…$/);
+		const result = subAgentCompletionRelayBody(`${RELAY_HEADER}\n${huge}`);
+		expect(result).toBe(huge);
 	});
 
 	it("a failed relay turn delivers the completed result instead of the canned line", async () => {

--- a/packages/core/src/services/message.subagent-wellformed.test.ts
+++ b/packages/core/src/services/message.subagent-wellformed.test.ts
@@ -1,6 +1,6 @@
 /**
- * Surrogate-safe truncation for subAgentCompletionRelayBody.
- * Verifies the 1500-char cap never splits an astral surrogate pair and sanitizes lone surrogates.
+ * Complete, surrogate-safe relay extraction for subAgentCompletionRelayBody.
+ * Verifies long results remain intact while malformed Unicode is sanitized.
  */
 import { describe, expect, it } from "vitest";
 import { toWellFormedUnicode } from "../utils/well-formed";
@@ -10,6 +10,12 @@ function makeInput(body: string): string {
 	return `[sub-agent:task_complete] ${body}`;
 }
 
+function expectDefinedRelayBody(
+	body: string | undefined,
+): asserts body is string {
+	expect(body).toBeDefined();
+}
+
 describe("subAgentCompletionRelayBody surrogate safety", () => {
 	const isWellFormed = (s: string): boolean => {
 		const w = s as unknown as { isWellFormed?: () => boolean };
@@ -17,13 +23,11 @@ describe("subAgentCompletionRelayBody surrogate safety", () => {
 		return toWellFormedUnicode(s) === s;
 	};
 
-	it("backs off when truncation would split a surrogate pair at 1500", () => {
+	it("preserves an astral surrogate pair beyond the former 1500-character cap", () => {
 		const body = `${"a".repeat(1498)}🦊${"b".repeat(20)}`;
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.endsWith("…")).toBe(true);
-		expect(out!.length).toBeLessThanOrEqual(1500);
+		expect(out).toBe(body);
+		expect(isWellFormed(out ?? "")).toBe(true);
 		expect(() => JSON.stringify(out)).not.toThrow();
 	});
 
@@ -31,43 +35,43 @@ describe("subAgentCompletionRelayBody surrogate safety", () => {
 		const body = `${"a".repeat(1497)}🦊`;
 		// body length 1499, header adds but body itself is under cap? Actually 1497+2=1499 <=1500, so should be preserved as is
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
 		expect(out).toBe(toWellFormedUnicode(body));
 	});
 
 	it("preserves well-formed body under cap exactly at 1500 with emoji", () => {
 		const body = `${"a".repeat(1498)}🦊`; // 1500 exactly
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.length).toBe(1500);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBe(1500);
 		expect(out).toBe(toWellFormedUnicode(body));
 	});
 
 	it("sanitizes lone high surrogate", () => {
 		const body = `ok \ud800 end ${"x".repeat(2000)}`;
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.includes("�")).toBe(true);
-		expect(out!.includes("\ud800")).toBe(false);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
 	});
 
 	it("sanitizes lone low surrogate", () => {
 		const body = `ok \udc00 end ${"x".repeat(2000)}`;
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.includes("�")).toBe(true);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
 	});
 
-	it("stays well-formed across sweep of offsets (cap 1500, test with smaller cap via long body)", () => {
+	it("preserves long well-formed bodies across a sweep of astral offsets", () => {
 		for (let offset = 0; offset <= 20; offset++) {
 			const body = `${"a".repeat(offset)}🦊${"b".repeat(2000)}`;
 			const out = subAgentCompletionRelayBody(makeInput(body));
-			expect(isWellFormed(out!)).toBe(true);
-			expect(out!.length).toBeLessThanOrEqual(1500);
+			expect(out).toBe(body);
+			expect(isWellFormed(out ?? "")).toBe(true);
 			expect(() => JSON.stringify(out)).not.toThrow();
 		}
 	});
@@ -75,18 +79,15 @@ describe("subAgentCompletionRelayBody surrogate safety", () => {
 	it("returns well-formed when under cap with lone surrogate and no truncation", () => {
 		const body = "ok \ud800 end";
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.includes("�")).toBe(true);
-		expect(out!.includes("\ud800")).toBe(false);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
 	});
 
-	it("caps at 1500 with 1499 content chars + ellipsis for ASCII overflow", () => {
+	it("preserves an ASCII body beyond the former cap", () => {
 		const body = "a".repeat(2000);
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(out!.length).toBe(1500);
-		expect(out!.endsWith("…")).toBe(true);
-		expect(out!.slice(0, -1).trimEnd().length).toBe(1499);
+		expect(out).toBe(body);
 	});
 });

--- a/packages/core/src/truncation-suffix-reserve-3.test.ts
+++ b/packages/core/src/truncation-suffix-reserve-3.test.ts
@@ -1,6 +1,7 @@
 /**
- * Pins batch3 suffix-reserve fixes (ship 11): 7 remaining `slice(0, MAX) + suffix`
- * overflows that exceed their stated caps by suffix.length.
+ * Pins batch3 suffix-reserve fixes (ship 11): six remaining `slice(0, MAX) + suffix`
+ * overflows that exceed their stated caps by suffix.length, plus the completed
+ * sub-agent relay exception that deliberately preserves the full result.
  *
  * Sibling correct (reserve proofs): `trajectory-recorder.ts:806` `MAX - suffix.length`,
  * `plugin-embeddings/utils/events.ts:35` `MAX_PROMPT_LENGTH - suffix.length`,
@@ -44,24 +45,12 @@ describe("truncation suffix reserve batch3 (ship 11) — 7 sites", () => {
 		expect(fixedTrunc(s, MAX, suffix).length).toBe(400);
 	});
 
-	it("TR-4 message subAgentCompletionRelayBody 1500+1: caps at 1500", () => {
-		const MAX = 1500;
-		const suffix = "…";
-		const s = "a".repeat(1510);
-		// math proof
-		expect(oldTrunc(s, MAX, suffix).length).toBe(1501);
-		expect(fixedTrunc(s, MAX, suffix).length).toBe(1500);
-		// real function proof: subAgentCompletionRelayBody trims header then caps body at 1500
+	it("TR-4 completed sub-agent relays preserve the full result body", () => {
 		const header = "[sub-agent:task_complete]";
 		const body = "a".repeat(2000);
 		const input = `${header} ${body}`;
 		const out = subAgentCompletionRelayBody(input);
-		expect(out).toBeDefined();
-		expect(out?.length).toBeLessThanOrEqual(1500);
-		expect(out?.length).toBe(1500); // 1499 'a' + '…'
-		// sabotage: old would be 1501
-		const oldBody = `${body.slice(0, MAX).trimEnd()}…`;
-		expect(oldBody.length).toBe(1501);
+		expect(out).toBe(body);
 	});
 
 	it("TR-5 media fetch readErrorBodySnippet 200+1: old 201 vs fixed 200", () => {

--- a/packages/core/src/validation/secrets.ts
+++ b/packages/core/src/validation/secrets.ts
@@ -253,7 +253,6 @@ export const SECRET_VALIDATION_PATTERNS: Record<
 		description: "Ollama base URL must be a valid HTTP(S) URL",
 		example: "http://localhost:11434",
 	},
-
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/scripts/script-plugin-coupling.allowlist.json
+++ b/packages/scripts/script-plugin-coupling.allowlist.json
@@ -61,7 +61,6 @@
       "plugins/plugin-local-inference",
       "plugins/plugin-meetings",
       "plugins/plugin-scheduling",
-      "plugins/plugin-signal",
       "plugins/plugin-notes",
       "plugins/plugin-telegram",
       "plugins/plugin-wallet",
@@ -145,6 +144,7 @@
     "file": "packages/scripts/vitest/integration.config.ts",
     "tokens": [
       "@elizaos/plugin-personal-assistant",
+      "@elizaos/plugin-signal",
       "@elizaos/plugin-sql",
       "@elizaos/plugin-whatsapp",
       "plugins/plugin-personal-assistant"

--- a/packages/ui/src/components/chat/widgets/maps-card.tsx
+++ b/packages/ui/src/components/chat/widgets/maps-card.tsx
@@ -89,10 +89,7 @@ function placeMapUris(place: MapsCardPlace): {
 function AttributionLine({ attribution }: { attribution: string | null }) {
   if (!attribution) return null;
   return (
-    <div
-      className="pt-0.5 text-3xs text-muted"
-      data-testid="maps-attribution"
-    >
+    <div className="pt-0.5 text-3xs text-muted" data-testid="maps-attribution">
       {attribution}
     </div>
   );

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -1700,8 +1700,8 @@ export class BrowserDomain {
         companion,
         status,
         expectedActionIndex: currentActionIndex,
-        completedActionId,
-        attemptId,
+        completedActionId: completedActionId ?? null,
+        attemptId: attemptId ?? null,
         resultPatch: lifecycle.result,
         updatedAt,
       });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/signal-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/signal-service.test.ts
@@ -15,7 +15,7 @@ describe("SignalDomain unsupported boundary", () => {
       provider: "signal",
       connected: false,
       inbound: false,
-      reason: "unsupported",
+      reason: "disconnected",
       identity: null,
       grant: null,
       grantedCapabilities: [],

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/signal-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/signal-service.ts
@@ -32,7 +32,7 @@ export class SignalDomain {
       side: resolvedSide,
       connected: false,
       inbound: false,
-      reason: "unsupported",
+      reason: "disconnected",
       identity: null,
       grantedCapabilities: [],
       pairing: null,


### PR DESCRIPTION
## Summary

Supersedes closed #23973 with a clean replay that preserves the complete-context behavior merged in #24134.

- repairs the current verification baseline across Cloud mock contracts, Core/Agent formatting, browser completion IDs, and relay Unicode coverage
- hardens Electrobun Chromium credential import with private temporary directories, guaranteed cleanup, byte-bounded concurrent pipe reads, timeout termination, and deterministic failure/concurrency tests
- completes the Signal cutover by registering the optional API, aligning the unavailable fallback with the typed `disconnected` state, and repairing coupling metadata
- removes only the retired BlueBubbles compatibility hooks left behind in the Blooio route while retaining Blooio validation/privacy behavior
- keeps the Maps UI pixel-identical; the touched UI source is formatter-only and the audit metadata is provider-neutral

Relates to #22842 and supersedes #23973.

## Verification

Exact tested base: `82641dba872b2371b45423da7179d3cb43ce6254`  
Exact head: `0c81c3e0158efb280d0c75c013493c2507425006`

- `bun run verify` — PASS: 372/372 workspace tasks, every final audit, mock-export audit 3,442 mocks / 688 files
- Chromium credential suites — PASS: 16/16
- Relay and truncation Vitest suites — PASS: 29/29
- Blooio focused tests — PASS: 3/3
- Signal fallback tests — PASS: 2/2
- Agent, app-core, Core, personal-assistant, and Cloud typechecks — PASS
- Cloud production Wrangler dry-run — PASS
- affected Biome/lint gates — PASS
- `git diff --check` — PASS
- worktree clean

A transient low-space warning appeared during generated-artifact creation, but the complete verification command continued and exited 0 with all tasks and audits green.

## Acceptance holds

- Hosted checks must pass on this exact PR head before merge.
- The packaged macOS credential path still requires supported-host acceptance; this is a ready-state acceptance hold, not a draft reason.
- No model-facing truncation caps from the closed PR were restored.

## Evidence Gate

<!-- evidence-head:0c81c3e0158efb280d0c75c013493c2507425006 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots (Maps source change is formatter-only and intentionally pixel-identical): [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-before-desktop.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-before-mobile.png).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-after-desktop.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-after-mobile.png). Maps passed desktop, mobile portrait, mobile landscape, and iPad portrait.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [formatter-only Maps walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-maps-format-only-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - changes repair compile-time contracts, mocks, and local credential/connector seams rather than a deployed backend flow`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request, response, state, or rendered-pixel behavior changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - complete-context behavior is preserved; no prompt, planner, or model behavior is introduced`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no durable database, wallet, media, scheduled-item, or on-chain output changed`.
<!-- evidence-row:ocr-review -->
- [x] OCR review: [triage JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-ocr-triage.json). The touched Maps view has no OCR regression.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@82641dba872b2371b45423da7179d3cb43ce6254:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

— [codex-develop-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@82641dba872b2371b45423da7179d3cb43ce6254:packages/skills/skills/contribute-to-eliza"} -->
