### PR TITLE
fix(core): retire completed follow-ups from the scheduler

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -653,6 +653,13 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	// ── Task CRUD (batch-only) ───────────────────────────────────────────
 	abstract createTasks(tasks: Task[]): Promise<UUID[]>;
 	abstract getTasksByIds(taskIds: UUID[]): Promise<Task[]>;
+	/**
+	 * Optional-adapter compatibility default. Official adapters override this
+	 * with a storage-atomic transition; returning false fails closed.
+	 */
+	async updatePendingTask(_id: UUID, _task: Partial<Task>): Promise<boolean> {
+		return false;
+	}
 	abstract updateTasks(
 		updates: Array<{ id: UUID; task: Partial<Task> }>,
 	): Promise<void>;

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1975,6 +1975,19 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		return tasks;
 	}
 
+	async updatePendingTask(id: UUID, task: Partial<Task>): Promise<boolean> {
+		const existing = this.tasks.get(String(id));
+		if (
+			!existing?.tags?.includes("queue") ||
+			(existing.metadata?.status != null &&
+				existing.metadata.status !== "pending")
+		) {
+			return false;
+		}
+		this.tasks.set(String(id), { ...existing, ...task, id });
+		return true;
+	}
+
 	async updateTasks(
 		updates: Array<{ id: UUID; task: Partial<Task> }>,
 	): Promise<void> {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11858,6 +11858,17 @@ ${section_end}`;
 		return tasks[0] ?? null;
 	}
 
+	async updatePendingTask(id: UUID, task: Partial<Task>): Promise<boolean> {
+		const updated =
+			(await this.adapter.updatePendingTask?.call(this.adapter, id, task)) ??
+			false;
+		if (updated) {
+			this._markLocalTasksDirty();
+			this._notifyCompanionTasksDirty();
+		}
+		return updated;
+	}
+
 	async updateTask(id: UUID, task: Partial<Task>): Promise<void> {
 		await this.adapter.updateTasks([{ id, task }]);
 		this._markLocalTasksDirty();

--- a/packages/core/src/services/follow-up.test.ts
+++ b/packages/core/src/services/follow-up.test.ts
@@ -58,7 +58,7 @@ function makeRuntime() {
 		getTasks: async (params: { tags?: string[]; agentIds?: UUID[] }) =>
 			Array.from(tasks.values()).filter((task) =>
 				(params.tags ?? []).every((tag) => task.tags?.includes(tag)),
-		),
+			),
 		getTask: async (id: UUID) => tasks.get(id) ?? null,
 		getTasksByName: async (name: string) =>
 			Array.from(tasks.values()).filter((t) => t.name === name),
@@ -72,11 +72,23 @@ function makeRuntime() {
 			if (!existing) throw new Error(`no task ${id}`);
 			tasks.set(id, { ...existing, ...patch });
 		},
+		updatePendingTask: async (id: UUID, patch: Partial<Task>) => {
+			const existing = tasks.get(id);
+			if (
+				!existing?.tags?.includes("queue") ||
+				(existing.metadata?.status != null &&
+					existing.metadata.status !== "pending")
+			) {
+				return false;
+			}
+			tasks.set(id, { ...existing, ...patch });
+			return true;
+		},
 		deleteTask: async (id: UUID) => {
 			tasks.delete(id);
 		},
 	} as unknown as IAgentRuntime;
-	return { runtime, tasks, workers, memories };
+	return { runtime, tasks, workers, memories, relationshipsService, contact };
 }
 
 describe("FollowUpService completion lifecycle", () => {
@@ -167,7 +179,44 @@ describe("FollowUpService completion lifecycle", () => {
 		await followUps.stop();
 	});
 
-	it("fires at most one already-selected execution when completeFollowUp lands mid-tick", async () => {
+	it("retries contact cleanup after task completion already persisted", async () => {
+		const { runtime, tasks, memories, relationshipsService, contact } =
+			makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+		const task = await followUps.scheduleFollowUp(
+			ENTITY_ID,
+			new Date(T0 + 5_000),
+			"contact cleanup retry",
+		);
+
+		const realUpdateContact = relationshipsService.updateContact;
+		let failCleanup = true;
+		relationshipsService.updateContact = async (entityId, patch) => {
+			if (failCleanup) {
+				failCleanup = false;
+				throw new Error("contact store unavailable");
+			}
+			await realUpdateContact(entityId, patch);
+		};
+
+		await expect(
+			followUps.completeFollowUp(task.id as UUID, "handled"),
+		).rejects.toThrow("contact store unavailable");
+		expect(tasks.get(task.id as string)?.metadata?.status).toBe("completed");
+		expect(contact.customFields.nextFollowUpAt).toBeDefined();
+
+		await followUps.completeFollowUp(task.id as UUID, "handled");
+		expect(contact.customFields.nextFollowUpAt).toBeUndefined();
+		expect(contact.customFields.nextFollowUpReason).toBeUndefined();
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(memories).toHaveLength(0);
+		expect(tasks.has(task.id as string)).toBe(true);
+
+		await followUps.stop();
+	});
+
+	it("does not fire or delete when completion wins after a stale tick selection", async () => {
 		const { runtime, tasks, memories } = makeRuntime();
 		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
 		service = (await TaskService.start(runtime)) as TaskService;
@@ -179,47 +228,40 @@ describe("FollowUpService completion lifecycle", () => {
 		);
 		await vi.advanceTimersByTimeAsync(1_000);
 
-		// Gate the next scheduler getTasks so completion can land while the
-		// tick holds a queued, pre-completion snapshot — the production
-		// interleaving the already-selected-work semantics describe.
-		let releaseTick: ((snapshot: Task[]) => void) | null = null;
-		const tickSnapshot = new Promise<Task[]>((resolve) => {
-			releaseTick = resolve;
+		const realTransition = runtime.updatePendingTask.bind(runtime);
+		let releaseClaim: (() => void) | null = null;
+		const claimBlocked = new Promise<void>((resolve) => {
+			releaseClaim = resolve;
 		});
-		let firstCall = true;
-		(runtime as unknown as { getTasks: unknown }).getTasks = async (
-			params: { tags?: string[] },
-		) => {
-			if (!firstCall) {
-				return Array.from(tasks.values()).filter((candidate) =>
-					(params.tags ?? []).every((tag) =>
-						candidate.tags?.includes(tag),
-					),
-				);
+		let claimAttempted: (() => void) | null = null;
+		const attempted = new Promise<void>((resolve) => {
+			claimAttempted = resolve;
+		});
+		(
+			runtime as { updatePendingTask: IAgentRuntime["updatePendingTask"] }
+		).updatePendingTask = async (id, patch) => {
+			if (patch.metadata?.status === "executing") {
+				claimAttempted?.();
+				await claimBlocked;
 			}
-			firstCall = false;
-			return await tickSnapshot;
+			return realTransition(id, patch);
 		};
 
-		await vi.advanceTimersByTimeAsync(10_000);
-
-		// Stale snapshot captured BEFORE completion persists.
-		const stale = Array.from(tasks.values());
+		const ticking = vi.advanceTimersByTimeAsync(10_000);
+		await attempted;
 		await followUps.completeFollowUp(task.id as UUID, "handled early");
 		const stored = tasks.get(task.id as string);
 		expect(stored?.tags?.includes("queue")).toBe(false);
 		expect(stored?.metadata?.status).toBe("completed");
 
-		releaseTick?.(stale);
-		await vi.advanceTimersByTimeAsync(2_000);
-		// The already-selected execution completes its lifecycle exactly once…
-		expect(memories).toHaveLength(1);
-		// …including the normal one-shot delete (documented semantics).
-		expect(tasks.has(task.id as string)).toBe(false);
+		releaseClaim?.();
+		await ticking;
+		expect(memories).toHaveLength(0);
+		expect(tasks.has(task.id as string)).toBe(true);
 
 		// Every subsequent poll observes the retired state: no further fires.
 		await vi.advanceTimersByTimeAsync(30_000);
-		expect(memories).toHaveLength(1);
+		expect(memories).toHaveLength(0);
 
 		await followUps.stop();
 	});

--- a/packages/core/src/services/follow-up.test.ts
+++ b/packages/core/src/services/follow-up.test.ts
@@ -52,8 +52,13 @@ function makeRuntime() {
 			memories.push(memory);
 		},
 		emitEvent: async () => undefined,
-		getTasks: async (_params: { tags?: string[]; agentIds?: UUID[] }) =>
-			Array.from(tasks.values()),
+		// Honors the requested-tags contract of the real adapters: only tasks
+		// carrying EVERY requested tag are returned, so the tests below prove
+		// that a completed row actually leaves the scheduler's polling set.
+		getTasks: async (params: { tags?: string[]; agentIds?: UUID[] }) =>
+			Array.from(tasks.values()).filter((task) =>
+				(params.tags ?? []).every((tag) => task.tags?.includes(tag)),
+		),
 		getTask: async (id: UUID) => tasks.get(id) ?? null,
 		getTasksByName: async (name: string) =>
 			Array.from(tasks.values()).filter((t) => t.name === name),
@@ -158,6 +163,63 @@ describe("FollowUpService completion lifecycle", () => {
 		expect(memories).toHaveLength(0);
 		const row = tasks.get("legacy-completed");
 		expect(row?.metadata?.status).toBe("completed");
+
+		await followUps.stop();
+	});
+
+	it("fires at most one already-selected execution when completeFollowUp lands mid-tick", async () => {
+		const { runtime, tasks, memories } = makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		const task = await followUps.scheduleFollowUp(
+			ENTITY_ID,
+			new Date(T0 + 5_000),
+			"completion race window",
+		);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		// Gate the next scheduler getTasks so completion can land while the
+		// tick holds a queued, pre-completion snapshot — the production
+		// interleaving the already-selected-work semantics describe.
+		let releaseTick: ((snapshot: Task[]) => void) | null = null;
+		const tickSnapshot = new Promise<Task[]>((resolve) => {
+			releaseTick = resolve;
+		});
+		let firstCall = true;
+		(runtime as unknown as { getTasks: unknown }).getTasks = async (
+			params: { tags?: string[] },
+		) => {
+			if (!firstCall) {
+				return Array.from(tasks.values()).filter((candidate) =>
+					(params.tags ?? []).every((tag) =>
+						candidate.tags?.includes(tag),
+					),
+				);
+			}
+			firstCall = false;
+			return await tickSnapshot;
+		};
+
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		// Stale snapshot captured BEFORE completion persists.
+		const stale = Array.from(tasks.values());
+		await followUps.completeFollowUp(task.id as UUID, "handled early");
+		const stored = tasks.get(task.id as string);
+		expect(stored?.tags?.includes("queue")).toBe(false);
+		expect(stored?.metadata?.status).toBe("completed");
+
+		releaseTick?.(stale);
+		await vi.advanceTimersByTimeAsync(2_000);
+		// The already-selected execution completes its lifecycle exactly once…
+		expect(memories).toHaveLength(1);
+		// …including the normal one-shot delete (documented semantics).
+		expect(tasks.has(task.id as string)).toBe(false);
+
+		// Every subsequent poll observes the retired state: no further fires.
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(memories).toHaveLength(1);
 
 		await followUps.stop();
 	});

--- a/packages/core/src/services/follow-up.test.ts
+++ b/packages/core/src/services/follow-up.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for FollowUpService lifecycle: a completed follow-up must never fire
+ * through the task scheduler and its completion record must survive. Driven
+ * by fake timers over the real TaskService tick loop with an in-memory store.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { Task, TaskWorker } from "../types/task";
+import { FollowUpService } from "./followUp.ts";
+import { TaskService } from "./task.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ENTITY_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const T0 = new Date("2026-01-01T00:00:00.000Z").getTime();
+
+function makeRuntime() {
+	const tasks = new Map<string, Task>();
+	const workers = new Map<string, TaskWorker>();
+	const memories: unknown[] = [];
+	const noop = () => undefined;
+	const contact = {
+		entityId: ENTITY_ID,
+		names: ["Test Contact"],
+		customFields: {} as Record<string, unknown>,
+	};
+	const relationshipsService = {
+		getContact: async () => contact,
+		updateContact: async (
+			_entityId: UUID,
+			patch: { customFields: Record<string, unknown> },
+		) => {
+			contact.customFields = patch.customFields;
+		},
+		searchContacts: async () => [contact],
+		getRelationshipInsights: async () => ({ needsAttention: [] }),
+		analyzeRelationship: async () => null,
+	};
+	const runtime = {
+		agentId: AGENT_ID,
+		serverless: false,
+		logger: { debug: noop, info: noop, warn: noop, error: noop },
+		reportError: vi.fn(),
+		registerTaskWorker: (worker: TaskWorker) => {
+			workers.set(worker.name, worker);
+		},
+		getTaskWorker: (name: string) => workers.get(name),
+		getServiceLoadPromise: async () => relationshipsService,
+		getEntityById: async (id: UUID) =>
+			id === ENTITY_ID ? { id, names: ["Test Contact"] } : null,
+		createMemory: async (memory: unknown) => {
+			memories.push(memory);
+		},
+		emitEvent: async () => undefined,
+		getTasks: async (_params: { tags?: string[]; agentIds?: UUID[] }) =>
+			Array.from(tasks.values()),
+		getTask: async (id: UUID) => tasks.get(id) ?? null,
+		getTasksByName: async (name: string) =>
+			Array.from(tasks.values()).filter((t) => t.name === name),
+		createTask: async (task: Task) => {
+			const id = (task.id ?? `task-${tasks.size + 1}`) as UUID;
+			tasks.set(id, { ...task, id });
+			return id;
+		},
+		updateTask: async (id: UUID, patch: Partial<Task>) => {
+			const existing = tasks.get(id);
+			if (!existing) throw new Error(`no task ${id}`);
+			tasks.set(id, { ...existing, ...patch });
+		},
+		deleteTask: async (id: UUID) => {
+			tasks.delete(id);
+		},
+	} as unknown as IAgentRuntime;
+	return { runtime, tasks, workers, memories };
+}
+
+describe("FollowUpService completion lifecycle", () => {
+	let service: TaskService | null = null;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(T0);
+	});
+
+	afterEach(async () => {
+		if (service) {
+			await service.stop();
+			service = null;
+		}
+		vi.useRealTimers();
+	});
+
+	it("does not fire a completed follow-up when its due time passes, and keeps the record", async () => {
+		const { runtime, tasks, workers, memories } = makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		const task = await followUps.scheduleFollowUp(
+			ENTITY_ID,
+			new Date(T0 + 5_000),
+			"check in after intro call",
+		);
+		expect(workers.has("follow_up")).toBe(true);
+
+		// Operator completes the follow-up before it is due.
+		await followUps.completeFollowUp(task.id as UUID);
+
+		// Well past the original due time: no reminder may fire and the
+		// completion record must survive the scheduler.
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(memories).toHaveLength(0);
+
+		const row = tasks.get(task.id as string);
+		expect(row).toBeDefined();
+		expect(row?.metadata?.status).toBe("completed");
+
+		await followUps.stop();
+	});
+
+	it("still fires a pending follow-up once it is due", async () => {
+		const { runtime, tasks, memories } = makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		const task = await followUps.scheduleFollowUp(
+			ENTITY_ID,
+			new Date(T0 + 5_000),
+			"pending control",
+		);
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(memories).toHaveLength(1);
+		expect(tasks.has(task.id as string)).toBe(false);
+
+		await followUps.stop();
+	});
+
+	it("does not fire a completed row that still carries the queue tag (legacy storage)", async () => {
+		const { runtime, tasks, memories } = makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		// A row persisted by an older build: completed but never unqueued.
+		tasks.set("legacy-completed", {
+			id: "legacy-completed" as UUID,
+			name: "follow_up",
+			agentId: AGENT_ID,
+			tags: ["follow-up", "queue"],
+			dueAt: T0 + 5_000,
+			metadata: {
+				targetEntityId: ENTITY_ID,
+				reason: "legacy",
+				status: "completed",
+			},
+		});
+
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(memories).toHaveLength(0);
+		const row = tasks.get("legacy-completed");
+		expect(row?.metadata?.status).toBe("completed");
+
+		await followUps.stop();
+	});
+});

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -198,8 +198,14 @@ export class FollowUpService extends Service {
 				throw new Error(`Task ${taskId} not found`);
 			}
 
-			// Update task metadata
+			// Update task metadata and unqueue the task. WHY drop the "queue"
+			// tag: the scheduler polls only queue-tagged rows, and nothing else
+			// consults metadata.status — leaving the tag would fire the reminder
+			// at dueAt even though the operator already completed it, after
+			// which the one-shot lifecycle deletes the record. Keeping the row
+			// (without "queue") preserves the completion history.
 			await this.runtime.updateTask(taskId, {
+				tags: (task.tags ?? []).filter((tag) => tag !== "queue"),
 				metadata: {
 					...task.metadata,
 					status: "completed",
@@ -358,6 +364,11 @@ export class FollowUpService extends Service {
 				runtime: IAgentRuntime,
 				task: Task,
 			): Promise<boolean> => {
+				// Execution gate for rows stored before completion stopped
+				// unqueueing them: an explicitly completed follow-up must never
+				// fire. Rows without a status field stay runnable (backward
+				// compatibility with tasks created outside scheduleFollowUp).
+				if (task.metadata?.status === "completed") return false;
 				const targetEntityId = task.metadata?.targetEntityId as
 					| UUID
 					| undefined;

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -196,18 +196,13 @@ export class FollowUpService extends Service {
 	 * loses its "queue" tag so no subsequent tick polls or selects it, and the
 	 * completion record (status, completedAt, notes) is preserved.
 	 *
-	 * Already-selected-work semantics: Task rows carry no version column, so
-	 * completion is not CAS-atomic with tick selection. A tick that captured
-	 * the queued Task snapshot BEFORE this update persisted may fire that one
-	 * selection to completion (including the normal one-shot delete of the
-	 * row). Every selection afterwards observes either the dropped "queue" tag
-	 * or the completed-status worker gate and skips. If the racing execution
-	 * deletes the row first, a later completeFollowUp call throws "Task not
-	 * found" — the follow-up already fired.
+	 * Completion and worker execution compete through the storage adapter's
+	 * atomic pending-task transition. Once completion returns, even a scheduler
+	 * tick holding a stale queued snapshot cannot claim, fire, or delete the row.
 	 */
 	async completeFollowUp(taskId: UUID, notes?: string): Promise<void> {
 		try {
-			const task = await this.runtime.getTask(taskId);
+			let task = await this.runtime.getTask(taskId);
 			if (!task) {
 				throw new Error(`Task ${taskId} not found`);
 			}
@@ -218,7 +213,7 @@ export class FollowUpService extends Service {
 			// at dueAt even though the operator already completed it, after
 			// which the one-shot lifecycle deletes the record. Keeping the row
 			// (without "queue") preserves the completion history.
-			await this.runtime.updateTask(taskId, {
+			const completed = await this.runtime.updatePendingTask(taskId, {
 				tags: (task.tags ?? []).filter((tag) => tag !== "queue"),
 				metadata: {
 					...task.metadata,
@@ -227,6 +222,25 @@ export class FollowUpService extends Service {
 					completionNotes: notes,
 				},
 			});
+			if (!completed) {
+				const current = await this.runtime.getTask(taskId);
+				if (current?.metadata?.status === "completed") {
+					if (current.tags?.includes("queue")) {
+						await this.runtime.updateTask(taskId, {
+							tags: current.tags.filter((tag) => tag !== "queue"),
+						});
+					}
+					task = current;
+				} else {
+					throw new Error(
+						current
+							? current.metadata?.status === "pending"
+								? `Task ${taskId} could not be completed atomically`
+								: `Task ${taskId} is already executing`
+							: `Task ${taskId} not found`,
+					);
+				}
+			}
 
 			// Clear next follow-up from contact
 			const targetEntityId = task.metadata?.targetEntityId as UUID;
@@ -396,6 +410,13 @@ export class FollowUpService extends Service {
 				task: Task,
 			) => {
 				try {
+					if (!task.id) return { preserveTask: true };
+					const claimed = await runtime.updatePendingTask(task.id, {
+						tags: (task.tags ?? []).filter((tag) => tag !== "queue"),
+						metadata: { ...task.metadata, status: "executing" },
+					});
+					if (!claimed) return { preserveTask: true };
+
 					const targetEntityId = task.metadata?.targetEntityId as UUID;
 					const message =
 						(task.metadata?.message as string) || "Time for a follow-up!";

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -191,6 +191,20 @@ export class FollowUpService extends Service {
 		return upcomingFollowUps;
 	}
 
+	/**
+	 * Marks a follow-up completed and retires it from the scheduler: the row
+	 * loses its "queue" tag so no subsequent tick polls or selects it, and the
+	 * completion record (status, completedAt, notes) is preserved.
+	 *
+	 * Already-selected-work semantics: Task rows carry no version column, so
+	 * completion is not CAS-atomic with tick selection. A tick that captured
+	 * the queued Task snapshot BEFORE this update persisted may fire that one
+	 * selection to completion (including the normal one-shot delete of the
+	 * row). Every selection afterwards observes either the dropped "queue" tag
+	 * or the completed-status worker gate and skips. If the racing execution
+	 * deletes the row first, a later completeFollowUp call throws "Task not
+	 * found" — the follow-up already fired.
+	 */
 	async completeFollowUp(taskId: UUID, notes?: string): Promise<void> {
 		try {
 			const task = await this.runtime.getTask(taskId);

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -786,6 +786,9 @@ export class TaskService extends Service {
 				JsonValue | object
 			>;
 			const result = await worker.execute(this.runtime, taskOptions, task);
+			if (result?.preserveTask) {
+				return;
+			}
 
 			if (task.tags?.includes("repeat")) {
 				const latestTask = await this.runtime.getTask(task.id);

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1633,6 +1633,12 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	// getTasksByName() are query methods (filter by room, tags, name).
 	createTasks(tasks: Task[]): Promise<UUID[]>;
 	getTasksByIds(taskIds: UUID[]): Promise<Task[]>;
+	/**
+	 * Atomically updates a queued task only while its lifecycle status is
+	 * pending (or absent for legacy rows). The queue tag and status predicate
+	 * are evaluated by storage in the same mutation that applies `task`.
+	 */
+	updatePendingTask?(id: UUID, task: Partial<Task>): Promise<boolean>;
 	updateTasks(updates: Array<{ id: UUID; task: Partial<Task> }>): Promise<void>;
 	deleteTasks(taskIds: UUID[]): Promise<void>;
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -1338,6 +1338,7 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 
 	createTask(task: Task): Promise<UUID>;
 	getTask(id: UUID): Promise<Task | null>;
+	updatePendingTask(id: UUID, task: Partial<Task>): Promise<boolean>;
 	updateTask(id: UUID, task: Partial<Task>): Promise<void>;
 	deleteTask(id: UUID): Promise<void>;
 

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -33,13 +33,15 @@ export interface TaskWorker {
 	 * The core execution logic for the task. This function is called by the runtime when a task needs to be processed.
 	 * It receives the `AgentRuntime`, task-specific `options`, and the `Task` object itself.
 	 * May return `{ nextInterval?: number }` to dynamically adjust the task's updateInterval (recurring tasks only).
+	 * `preserveTask` tells the scheduler that execution deliberately did not
+	 * consume the row, so a concurrent lifecycle transition remains durable.
 	 * WHY return nextInterval: workers can adapt rate (e.g. back off under load) without separate updateTask calls.
 	 */
 	execute: (
 		runtime: IAgentRuntime,
 		options: Record<string, JsonValue | object>,
 		task: Task,
-	) => Promise<undefined | { nextInterval?: number }>;
+	) => Promise<undefined | { nextInterval?: number; preserveTask?: boolean }>;
 	/**
 	 * Called by the scheduler before each run -- "should this task run now?"
 	 * If absent, the task always passes scheduler validation.

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -371,6 +371,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
   private ready = false;
   private readonly agentId: UUID;
   private documentMutationTail: Promise<void> = Promise.resolve();
+  private taskMutationTail: Promise<void> = Promise.resolve();
 
   constructor(storage: IStorage, agentId: UUID) {
     super();
@@ -2016,6 +2017,26 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       if (task) tasks.push(task);
     }
     return tasks;
+  }
+
+  async updatePendingTask(id: UUID, task: Partial<Task>): Promise<boolean> {
+    const operation = async () => {
+      const existing = await this.storage.get<Task>(COLLECTIONS.TASKS, id);
+      if (
+        !existing?.tags?.includes("queue") ||
+        (existing.metadata?.status != null && existing.metadata.status !== "pending")
+      ) {
+        return false;
+      }
+      await this.storage.set(COLLECTIONS.TASKS, id, { ...existing, ...task, id });
+      return true;
+    };
+    const run = this.taskMutationTail.then(operation, operation);
+    this.taskMutationTail = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
   }
 
   async updateTasks(updates: Array<{ id: UUID; task: Partial<Task> }>): Promise<void> {

--- a/plugins/plugin-inmemorydb/task-transition.test.ts
+++ b/plugins/plugin-inmemorydb/task-transition.test.ts
@@ -1,0 +1,40 @@
+/** Proves pending task transitions are serialized by the in-memory adapter. */
+import type { Task, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const AGENT_ID = "20000000-0000-0000-0000-000000000001" as UUID;
+const TASK_ID = "20000000-0000-0000-0000-000000000002" as UUID;
+
+describe("plugin-inmemorydb pending task transitions", () => {
+  it("allows exactly one competing lifecycle transition", async () => {
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+    await adapter.initialize();
+    await adapter.createTasks([
+      {
+        id: TASK_ID,
+        agentId: AGENT_ID,
+        name: "follow_up",
+        tags: ["queue", "follow-up"],
+        metadata: { status: "pending" },
+      } satisfies Task,
+    ]);
+
+    const [completed, claimed] = await Promise.all([
+      adapter.updatePendingTask(TASK_ID, {
+        tags: ["follow-up"],
+        metadata: { status: "completed" },
+      }),
+      adapter.updatePendingTask(TASK_ID, {
+        tags: ["follow-up"],
+        metadata: { status: "executing" },
+      }),
+    ]);
+
+    expect([completed, claimed].filter(Boolean)).toHaveLength(1);
+    const [stored] = await adapter.getTasksByIds([TASK_ID]);
+    expect(stored.tags).not.toContain("queue");
+    expect(["completed", "executing"]).toContain(stored.metadata?.status);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
@@ -139,6 +139,35 @@ describe("Task Integration Tests", () => {
       expect(retrieved?.metadata).toEqual({ status: "completed" });
     });
 
+    it("allows exactly one pending-task lifecycle transition", async () => {
+      const taskId = uuidv4() as UUID;
+      await adapter.createTask({
+        id: taskId,
+        roomId: testRoomId,
+        worldId: testWorldId,
+        entityId: testEntityId,
+        name: "Contended Task",
+        tags: ["queue", "follow-up"],
+        metadata: { status: "pending" },
+      });
+
+      const [completed, claimed] = await Promise.all([
+        adapter.updatePendingTask(taskId, {
+          tags: ["follow-up"],
+          metadata: { status: "completed" },
+        }),
+        adapter.updatePendingTask(taskId, {
+          tags: ["follow-up"],
+          metadata: { status: "executing" },
+        }),
+      ]);
+
+      expect([completed, claimed].filter(Boolean)).toHaveLength(1);
+      const stored = await adapter.getTask(taskId);
+      expect(stored?.tags).not.toContain("queue");
+      expect(["completed", "executing"]).toContain(stored?.metadata?.status);
+    });
+
     it("should delete a task", async () => {
       const taskId = uuidv4() as UUID;
       const task: Task = {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -7079,6 +7079,33 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     return tasks;
   }
 
+  async updatePendingTask(id: UUID, task: Partial<Task>): Promise<boolean> {
+    return this.withRetry(async () => {
+      return this.withDatabase(async () => {
+        const updateValues: Partial<typeof taskTable.$inferInsert> = {
+          updatedAt: new Date(),
+        };
+        if (task.tags !== undefined) updateValues.tags = task.tags;
+        if (task.metadata !== undefined) {
+          updateValues.metadata = task.metadata as typeof taskTable.$inferInsert.metadata;
+        }
+        const updated = await this.db
+          .update(taskTable)
+          .set(updateValues)
+          .where(
+            and(
+              eq(taskTable.id, id),
+              eq(taskTable.agentId, this.agentId),
+              sql`${taskTable.tags} @> ARRAY['queue']::text[]`,
+              sql`COALESCE(${taskTable.metadata}->>'status', 'pending') = 'pending'`
+            )
+          )
+          .returning();
+        return updated.length === 1;
+      });
+    });
+  }
+
   async updateTasks(updates: Array<{ id: UUID; task: Partial<Task> }>): Promise<void> {
     for (const { id, task } of updates) {
       await this.updateTask(id, task);


### PR DESCRIPTION
# Relates to

Fixes #24310

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` (`f73b0399e6`) with zero conflicts.
- [x] The affected core scheduler, official SQL adapter, and official in-memory adapter gates pass on pinned Bun 1.3.14.
- [x] A reviewer can verify the lifecycle contract from the evidence below.

# What changed

Completed follow-ups now compete with scheduler execution through one storage-atomic pending-task transition:

1. `completeFollowUp()` atomically changes `pending + queue` to `completed + unqueued` and preserves the row.
2. The `follow_up` worker must atomically claim that same state as `executing + unqueued` before creating a reminder or emitting `follow_up:due`.
3. If completion wins, a worker holding any stale scheduler snapshot cannot claim it and returns `preserveTask`, so `TaskService` does not delete the completed row.
4. If execution wins first, completion does not report false success; it reports that the task is already executing.
5. Legacy completed rows are still blocked by `shouldRun`, and completion idempotently removes a leftover queue tag.
6. Official PostgreSQL/PGlite and in-memory adapters implement the transition atomically. The public adapter hook is optional for compatibility; unsupported third-party adapters fail closed instead of firing unsafely.

This replaces the earlier "one already-selected firing is accepted" draft contract. The implementation now matches issue #24310: once completion returns, the reminder never fires and the completion row survives, regardless of stale tick timing.

# Risk

Medium and bounded to task lifecycle plumbing. The adapter method is additive and optional, official adapters implement it, and workers that do not return `preserveTask` keep their existing scheduler lifecycle.

# Testing

Reviewer entry points:

- `packages/core/src/services/followUp.ts`
- `packages/core/src/services/follow-up.test.ts`
- `packages/core/src/services/task.ts`
- `plugins/plugin-sql/src/base.ts`
- `plugins/plugin-inmemorydb/adapter.ts`

Pinned Bun 1.3.14 results at head `ebb920f6ec4b35e1b1be1b56a88213b1d116ddc2`:

```text
bun run --cwd packages/core test -- src/services/follow-up.test.ts src/services/task.test.ts src/services/task-scheduler.test.ts
Test Files 3 passed (3); Tests 41 passed (41)

bun run --cwd plugins/plugin-inmemorydb test -- task-transition.test.ts
Test Files 1 passed (1); Tests 1 passed (1)

VITEST_LANE=post-merge bunx vitest run __tests__/integration/task.real.test.ts --config vitest.config.ts
Test Files 1 passed (1); Tests 6 passed (6), real isolated PGlite

bun run --cwd packages/core typecheck
bun run --cwd plugins/plugin-sql typecheck
bun run --cwd plugins/plugin-inmemorydb typecheck
all passed

bun run --cwd packages/core build:node
passed

Biome on all 13 changed source/test files; git diff --check
passed
```

The full core suite completed with `616 passed / 34 failed files` (`7784 passed / 66 failed tests`). The failures are broad existing develop drift in unrelated prompt truncation/snapshot, document authorization, audience disclosure, trajectory, and action-retrieval suites; none involve follow-up, task scheduler, task adapter transition, or changed files. The exact affected suites and both real adapter contention tests are green.

# Evidence Gate

<!-- evidence-head:ebb920f6ec4b35e1b1be1b56a88213b1d116ddc2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - core scheduler/storage change with no rendered UI; the failing pre-fix reminder-count transcript is the before artifact.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; the passing race and adapter test transcripts are the after artifacts.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow; the deterministic scheduler interleave exercises the complete observable lifecycle.
<!-- evidence-row:backend-logs -->
- [x] [24315-pr24315-backend-tests-ebb920f6.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24315-pr24315-backend-tests-ebb920f6.txt)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator path is changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24315-pr24315-domain-artifact.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24315-pr24315-domain-artifact.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

- Hosted PR smoke is currently queued on the saturated runner; queued is not a failing check.
- Full-core failures are recorded above. Focused lifecycle, scheduler, type, build, format, and both official storage-adapter CAS gates pass.

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: elizaOS/eliza@a2a941add8ed657bbd47dcc6e5ed4c085a9021fa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [ox-alpha-contribution-2]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"elizaOS/eliza@a2a941add8ed657bbd47dcc6e5ed4c085a9021fa:packages/skills/skills/contribute-to-eliza"} -->



