### PR TITLE
test(cloud): explicit 60s per-test timeouts in audit-credit-packs proof suite

### DIFF
--- a/packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
+++ b/packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
@@ -4,6 +4,11 @@
  * cache per store — the in-process client is cached across tests), and runs
  * the audit as a subprocess with a hermetic environment.
  * Run: bun test packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
+ *
+ * Every test sets an explicit 60s timeout: freshDb/seed/audit spawn cold bun
+ * subprocesses that exceeded bun's 5s default on hosted runners (#23870 CI
+ * failures at ~5005ms). bunfig's [test] section has no timeout option (Bun
+ * ignores the key — oven-sh/bun#7789), so the timeout stays per-test.
  */
 import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -75,7 +80,7 @@ describe("audit-credit-packs classification (#22963)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 
   test("no Stripe key: DB-active => UNKNOWN (not ERRONEOUS), DB-inactive => DEPRECATED", async () => {
     const { dir, url } = await freshDb();
@@ -118,7 +123,7 @@ describe("audit-credit-packs classification (#22963)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 
   test("deployment currency guard: non-USD STRIPE_CURRENCY => ERRONEOUS", async () => {
     const { dir, url } = await freshDb();
@@ -145,7 +150,7 @@ describe("audit-credit-packs classification (#22963)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 
   test("deployment currency guard sticks: non-USD + DB-inactive stays ERRONEOUS (not overwritten)", async () => {
     const { dir, url } = await freshDb();
@@ -168,7 +173,7 @@ describe("audit-credit-packs classification (#22963)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 
   test("seededWiringMatches is null when the seeder env var is unset", async () => {
     const { dir, url } = await freshDb();
@@ -191,5 +196,5 @@ describe("audit-credit-packs classification (#22963)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 });

--- a/packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
+++ b/packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
@@ -9,6 +9,8 @@
  * subprocesses that exceeded bun's 5s default on hosted runners (#23870 CI
  * failures at ~5005ms). bunfig's [test] section has no timeout option (Bun
  * ignores the key — oven-sh/bun#7789), so the timeout stays per-test.
+ * Hermetic children also resolve packages from cloud-shared's isolated
+ * node_modules tree because the audit intentionally runs outside the checkout.
  */
 import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -23,6 +25,7 @@ function childEnv(dbUrl: string, extra: Record<string, string> = {}) {
   return {
     PATH: process.env.PATH ?? "",
     HOME: process.env.HOME ?? "",
+    NODE_PATH: path.resolve(import.meta.dir, "../../shared/node_modules"),
     DATABASE_URL: dbUrl,
     DISABLE_LOCAL_PGLITE_FALLBACK: "1",
     ...extra,


### PR DESCRIPTION
Follow-up to merged #23870: the 5 `audit-credit-packs.proof.test.ts` tests failed at exactly ~5005ms in the first hosted Tests (scripts) run (run 32533987083, job 96937980064) — bun's default 5s per-test timeout killing the cold `freshDb` migrate subprocess. This adds the explicit per-test timeouts the file was missing. Test-only, +10/−5, one file.

## Root cause

Two stacked facts:

1. **No explicit timeout**: none of the 5 tests passed a trailing timeout, so bun's 5s default applied. Each test spawns 2–3 cold bun subprocesses (migrate + seed + audit) against a temp PGlite store; local latency is 2.9–4.2s/test, hosted runners are slower and crossed the line.
2. **The lane-level 60s timeout is dead config**: the Tests (scripts) lane runs each file as `bun test --config=packages/scripts/bunfig.script-tests.toml ...`, and that bunfig contains `[test] timeout = 60000` — but Bun's `[test]` section has **no `timeout` option at all** (the key is silently ignored; open upstream feature requests oven-sh/bun#7789, #38728). Verified by probe on pinned bun 1.3.14: a test body sleeping 6.5s dies at 5.01s **with and without** the 60s config; the same body passes with an explicit trailing `}, 60_000)`. The root bunfig has the same dead key, so any reliance on it is unfounded.

## Change

- Every test gets an explicit trailing `}, 60_000);` timeout — matching the established pattern in `packages/cloud/shared/src/db/*` cold-PGlite migration proof tests (14 existing `}, 60_000);` / `}, 120_000);` usages).
- File header documents why the timeout stays per-test (so a future "cleanup" doesn't hoist it back into dead bunfig config).
- No skips, no retries, no behavior change.

## Verification (pinned bun 1.3.14, fresh worktree at develop tip, real install + generate-keywords + build:core)

| Gate | Result |
|---|---|
| `bun test packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts` | 5 pass / 0 fail (~20s; 2.9–4.2s per test) |
| Exact CI shape: `bun test --config=packages/scripts/bunfig.script-tests.toml --conditions=eliza-source <file>` | 5 pass / 0 fail |
| Driver shape: `node packages/scripts/run-script-test-files.mjs --config=... --concurrency=2 --timeout-ms=120000 -- <file>` | 5 pass / 0 fail |
| Mutation control: mutate audit summary string in `audit-credit-packs.ts` | 4 pass / 1 fail with a **real assertion failure** (19.9s, not a timeout) — the tests still catch a broken contract |
| `bunx @biomejs/biome check <file>` | clean |
| Rebase onto develop (8f893fb9aaa) | clean, gates re-run green at final head a78fa569 |

## Independent review

RepoPrompt (opus) review of the embedded exact-bytes diff: **APPROVE, zero must-fix**. It independently verified against Bun docs + upstream issues that `[test] timeout` is unsupported (confirming the probe), confirmed the 14-usage `60_000` repo pattern, and confirmed the driver's 120s per-file kill timer still backstops genuine hangs (so the explicit timeouts cannot mask one silently). Its comment-accuracy nit (imprecise cause attribution in the header) was adopted before push.

## Out of scope (follow-up material)

- **Lane-level fix**: `bun test` has a working `--timeout <ms>` CLI flag; adding `--timeout=60000` in `run-script-test-files.mjs` and deleting the dead `[test] timeout` key from `bunfig.script-tests.toml` (and root `bunfig.toml`) would fix this failure class for every file in the lane. Kept out to stay test-only.
- Pre-existing, untouched: `freshDb()` temp-dir leak on migrate failure; `seed()` temp dir never removed; the effect-ledger CI effects recently landed on develop (#24245) are unrelated to this lane.
- Together with #24194 (wrangler contract drift), this unblocks the develop-wide Tests (scripts) red gate.

# Evidence Gate

<!-- evidence-head:614c2710e925a93ab5350e0a19c318988ffcd8fc -->

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change to a CI proof suite; no rendered UI surface exists for subprocess-spawning bun tests.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change to a CI proof suite; no rendered UI surface exists for subprocess-spawning bun tests.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible behavior; the artifact of record is the test transcript itself, inline below.
<!-- evidence-row:backend-logs -->
- [ ] N/A - Test-only CI proof; pinned Bun 1.3.14 exact driver at head 614c2710e925a93ab5350e0a19c318988ffcd8fc passed 5/5 with 17 assertions in 20.71s after a fresh frozen install.

```
$ bun test packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
(pass) audit-credit-packs classification (#22963) > empty catalogue: clean summary, empty packs array [2891.94ms]
(pass) audit-credit-packs classification (#22963) > no Stripe key: DB-active => UNKNOWN (not ERRONEOUS), DB-inactive => DEPRECATED [3544.87ms]
(pass) audit-credit-packs classification (#22963) > deployment currency guard: non-USD STRIPE_CURRENCY => ERRONEOUS [3299.61ms]
(pass) audit-credit-packs classification (#22963) > deployment currency guard sticks: non-USD + DB-inactive stays ERRONEOUS (not overwritten) [4230.02ms]
(pass) audit-credit-packs classification (#22963) > seededWiringMatches is null when the seeder env var is unset [4220.52ms]

 5 pass
 0 fail
 17 expect() calls
Ran 5 tests across 1 file. [19.96s]
```

Exact CI-lane shape (`bun test --config=packages/scripts/bunfig.script-tests.toml --conditions=eliza-source <file>`): 5 pass / 0 fail, 20.38s. Driver shape (`node packages/scripts/run-script-test-files.mjs --config=... --concurrency=2 --timeout-ms=120000 -- <file>`): 5 pass / 0 fail, 21.53s. Probe (bun 1.3.14): test body sleeping 6.5s dies at 5.01s WITH and WITHOUT the 60s `[test] timeout` bunfig key (dead key — oven-sh/bun#7789, #38728); passes with explicit trailing `}, 60_000)`. Mutation control: audit summary string mutated => 4 pass / 1 fail, real assertion failure `expect(received).toBe(expected) Expected: 0 Received: 1` at 19.88s (not a timeout); restore => green.
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console, or network surface touched; diff is one CI test file.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, model, provider, prompt, or runtime code is touched by this test-only diff.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, scheduled tasks, or wallet output produced; the domain artifact is the CI test transcript itself (inline in backend-logs above).
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels rendered by this change; nothing to OCR.

AI provider/model: zai / glm-5.3 (manual) + opus (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->






