### PR TITLE
fix(cloud): emit anonymous hourly Retry-After

### DIFF
--- a/packages/cloud/api/__tests__/anonymous-chat-admission.test.ts
+++ b/packages/cloud/api/__tests__/anonymous-chat-admission.test.ts
@@ -333,4 +333,119 @@ describe("anonymous chat admission client", () => {
     expect(aborts).toBe(2);
     expect(elapsedMs).toBeLessThan(2_500);
   });
+
+  test("preserves only matching positive hourly retry advice", async () => {
+    const gate = new AnonymousChatGate(
+      { storage: new TestStorage() } as unknown as DurableObjectState,
+      {} as never,
+    );
+    const credential = {
+      sessionToken: "secret-session-token",
+      context: {
+        sessionId: "session-a",
+        userId: "user-a",
+        messageCount: 10,
+        messagesLimit: 20,
+      },
+    };
+    const executionCtx = { waitUntil() {} };
+    const reserveWith = (response: Response) =>
+      runWithCloudBindingsAsync(
+        createBindings(gate, async () => response),
+        () =>
+          reserveAnonymousChatSlot(
+            credential,
+            "request-hourly-limited",
+            executionCtx,
+          ),
+      );
+
+    await expect(
+      reserveWith(
+        Response.json(
+          {
+            admitted: false,
+            reason: "hourly_limit",
+            remaining: 0,
+            limit: 10,
+            retryAfter: 17,
+          },
+          { status: 429, headers: { "Retry-After": "17" } },
+        ),
+      ),
+    ).resolves.toEqual({
+      kind: "limited",
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+      retryAfter: 17,
+    });
+
+    for (const [bodyRetryAfter, headerRetryAfter] of [
+      [17, "18"],
+      [0, "0"],
+      [1.5, "1.5"],
+      [17, "017"],
+    ] as const) {
+      await expect(
+        reserveWith(
+          Response.json(
+            {
+              admitted: false,
+              reason: "hourly_limit",
+              remaining: 0,
+              limit: 10,
+              retryAfter: bodyRetryAfter,
+            },
+            { status: 429, headers: { "Retry-After": headerRetryAfter } },
+          ),
+        ),
+      ).resolves.toEqual({ kind: "unavailable" });
+    }
+
+    for (const response of [
+      Response.json(
+        {
+          admitted: false,
+          reason: "hourly_limit",
+          remaining: 0,
+          limit: 10,
+          retryAfter: 17,
+        },
+        { status: 429 },
+      ),
+      Response.json(
+        {
+          admitted: false,
+          reason: "hourly_limit",
+          remaining: 0,
+          limit: 10,
+        },
+        { status: 429, headers: { "Retry-After": "17" } },
+      ),
+    ]) {
+      await expect(reserveWith(response)).resolves.toEqual({
+        kind: "unavailable",
+      });
+    }
+
+    await expect(
+      reserveWith(
+        Response.json(
+          {
+            admitted: false,
+            reason: "message_limit",
+            remaining: 0,
+            limit: 10,
+          },
+          { status: 429 },
+        ),
+      ),
+    ).resolves.toEqual({
+      kind: "limited",
+      reason: "message_limit",
+      remaining: 0,
+      limit: 10,
+    });
+  });
 });

--- a/packages/cloud/api/__tests__/anonymous-chat-gate.test.ts
+++ b/packages/cloud/api/__tests__/anonymous-chat-gate.test.ts
@@ -174,6 +174,82 @@ describe("AnonymousChatGate", () => {
     ]);
   });
 
+  test("returns authoritative hourly retry advice through the reset boundary", async () => {
+    const windowStartedAt = 1_800_000_000_000;
+    let now = windowStartedAt + 60 * 60 * 1_000 - 1_001;
+    spyOn(Date, "now").mockImplementation(() => now);
+
+    const beforeBoundary = createGate();
+    await hydrate(beforeBoundary, {
+      hourlyMessageCount: 10,
+      hourlyResetAtMs: windowStartedAt,
+      expiresAtMs: windowStartedAt + 2 * 60 * 60 * 1_000,
+    });
+    const twoSeconds = await post(beforeBoundary, "/lease", {
+      requestId: "request-before-boundary",
+    });
+    expect(twoSeconds.status).toBe(429);
+    expect(twoSeconds.headers.get("Retry-After")).toBe("2");
+    expect(await twoSeconds.json()).toMatchObject({
+      admitted: false,
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+      retryAfter: 2,
+    });
+
+    now = windowStartedAt + 60 * 60 * 1_000;
+    const atBoundary = createGate();
+    await hydrate(atBoundary, {
+      hourlyMessageCount: 10,
+      hourlyResetAtMs: windowStartedAt,
+      expiresAtMs: windowStartedAt + 2 * 60 * 60 * 1_000,
+    });
+    const oneSecond = await post(atBoundary, "/lease", {
+      requestId: "request-at-boundary",
+    });
+    expect(oneSecond.status).toBe(429);
+    expect(oneSecond.headers.get("Retry-After")).toBe("1");
+    expect(await oneSecond.json()).toHaveProperty("retryAfter", 1);
+
+    now += 1;
+    const afterBoundary = createGate();
+    await hydrate(afterBoundary, {
+      hourlyMessageCount: 10,
+      hourlyResetAtMs: windowStartedAt,
+      expiresAtMs: windowStartedAt + 2 * 60 * 60 * 1_000,
+    });
+    const rolledOver = await post(afterBoundary, "/lease", {
+      requestId: "request-after-boundary",
+    });
+    expect(rolledOver.status).toBe(200);
+    expect(rolledOver.headers.get("Retry-After")).toBeNull();
+    expect(await rolledOver.json()).toMatchObject({
+      admitted: true,
+      snapshot: { hourlyMessageCount: 1 },
+    });
+  });
+
+  test("does not invent retry advice for the lifetime message limit", async () => {
+    const gate = createGate();
+    await hydrate(gate, { messageCount: 1, messagesLimit: 1 });
+
+    const response = await post(gate, "/lease", {
+      requestId: "request-lifetime-limited",
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(body).toMatchObject({
+      admitted: false,
+      reason: "message_limit",
+      remaining: 0,
+      limit: 1,
+    });
+    expect(body).not.toHaveProperty("retryAfter");
+  });
+
   test("commits the quota lease and its recovery alarm atomically", async () => {
     const storage = new TestStorage();
     const gate = createGate(storage);

--- a/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
@@ -32,15 +32,15 @@ mock.module("ai", () => ({
   streamText,
 }));
 
-const getCurrentUser = mock(async () => {
+const getCurrentUser = mock(async (): Promise<unknown> => {
   throw new Error("database auth must not run on the Worker hot path");
 });
 mock.module("@/lib/auth/workers-hono-auth", () => ({ getCurrentUser }));
 
-const getAnonymousUser = mock(async () => {
+const getAnonymousUser = mock(async (): Promise<unknown> => {
   throw new Error("anonymous database auth must not run for an org caller");
 });
-const reserveAnonymousMessageSlot = mock(async () => {
+const reserveAnonymousMessageSlot = mock(async (): Promise<unknown> => {
   throw new Error("anonymous database quota must not run for an org caller");
 });
 mock.module("@/lib/auth-anonymous", () => ({
@@ -52,23 +52,25 @@ let anonymousResolutionImpl: () => Promise<unknown> = async () => {
   throw new Error("anonymous gate must not run for an org caller");
 };
 const resolveAnonymousChatContext = mock(() => anonymousResolutionImpl());
-const reserveAnonymousChatSlot = mock(async () => ({
-  kind: "admitted" as const,
-  lease: {
-    credential: {
-      sessionToken: "anonymous-token",
-      context: {
-        sessionId: "anonymous-session",
-        userId: "anonymous-user",
-        messageCount: 0,
-        messagesLimit: 10,
+const reserveAnonymousChatSlot = mock(
+  async (): Promise<unknown> => ({
+    kind: "admitted" as const,
+    lease: {
+      credential: {
+        sessionToken: "anonymous-token",
+        context: {
+          sessionId: "anonymous-session",
+          userId: "anonymous-user",
+          messageCount: 0,
+          messagesLimit: 10,
+        },
       },
+      requestId: "anonymous-request",
     },
-    requestId: "anonymous-request",
-  },
-  remaining: 9,
-  limit: 10,
-}));
+    remaining: 9,
+    limit: 10,
+  }),
+);
 const refundAnonymousChatSlot = mock(async () => undefined);
 const commitAnonymousChatSlot = mock(async () => undefined);
 const markAnonymousChatSlotDispatched = mock(async () => {
@@ -114,7 +116,7 @@ mock.module("@/lib/providers/language-model", () => ({
   resolveAiProviderSource: () => "openai",
 }));
 
-const shouldBlockUser = mock(async () => {
+const shouldBlockUser = mock(async (): Promise<boolean> => {
   throw new Error("database moderation must not run after cached auth");
 });
 mock.module("@/lib/services/content-moderation", () => ({
@@ -458,6 +460,161 @@ describe("/v1/chat Worker cache hot path", () => {
     expect(streamText).not.toHaveBeenCalled();
     expect(refundAnonymousChatSlot).toHaveBeenCalledTimes(1);
     expect(commitAnonymousChatSlot).not.toHaveBeenCalled();
+  });
+
+  test("returns the Durable Object hourly Retry-After before provider dispatch", async () => {
+    authResolutionImpl = async () => ({ kind: "slow_path" as const });
+    anonymousResolutionImpl = async () => ({
+      kind: "ready" as const,
+      blocked: false,
+      credential: {
+        sessionToken: "anonymous-token",
+        context: {
+          sessionId: "anonymous-session",
+          userId: "anonymous-user",
+          messageCount: 0,
+          messagesLimit: 10,
+        },
+      },
+    });
+    reserveAnonymousChatSlot.mockResolvedValueOnce({
+      kind: "limited",
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+      retryAfter: 23,
+    });
+    const executionCtx = {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const response = await chatRoute.fetch(
+      new Request("https://api.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "eliza-anon-session=anonymous-token",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      {} as never,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("23");
+    await expect(response.json()).resolves.toMatchObject({
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+    });
+    expect(streamText).not.toHaveBeenCalled();
+    expect(markAnonymousChatSlotDispatched).not.toHaveBeenCalled();
+    expect(reserveAnonymousMessageSlot).not.toHaveBeenCalled();
+  });
+
+  test("returns the database fallback hourly Retry-After before provider dispatch", async () => {
+    getCurrentUser.mockResolvedValueOnce(null);
+    getAnonymousUser.mockResolvedValueOnce({
+      user: { id: "anonymous-user", organization_id: null },
+      session: {
+        id: "anonymous-session",
+        session_token: "anonymous-token",
+        message_count: 0,
+        messages_limit: 10,
+      },
+    });
+    shouldBlockUser.mockResolvedValueOnce(false);
+    reserveAnonymousMessageSlot.mockResolvedValueOnce({
+      allowed: false,
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+      retryAfter: 31,
+    });
+
+    const response = await chatRoute.fetch(
+      new Request("https://api.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "eliza-anon-session=anonymous-token",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      {} as never,
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("31");
+    await expect(response.json()).resolves.toMatchObject({
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+    });
+    expect(reserveAnonymousMessageSlot).toHaveBeenCalledWith("anonymous-token");
+    expect(streamText).not.toHaveBeenCalled();
+    expect(markAnonymousChatSlotDispatched).not.toHaveBeenCalled();
+    expect(reserveAnonymousChatSlot).not.toHaveBeenCalled();
+  });
+
+  test("keeps the non-resetting message limit free of Retry-After", async () => {
+    authResolutionImpl = async () => ({ kind: "slow_path" as const });
+    anonymousResolutionImpl = async () => ({
+      kind: "ready" as const,
+      blocked: false,
+      credential: {
+        sessionToken: "anonymous-token",
+        context: {
+          sessionId: "anonymous-session",
+          userId: "anonymous-user",
+          messageCount: 10,
+          messagesLimit: 10,
+        },
+      },
+    });
+    reserveAnonymousChatSlot.mockResolvedValueOnce({
+      kind: "limited",
+      reason: "message_limit",
+      remaining: 0,
+      limit: 10,
+    });
+    const executionCtx = {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const response = await chatRoute.fetch(
+      new Request("https://api.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "eliza-anon-session=anonymous-token",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      }),
+      {} as never,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({
+      reason: "message_limit",
+      remaining: 0,
+      limit: 10,
+    });
+    expect(streamText).not.toHaveBeenCalled();
+    expect(markAnonymousChatSlotDispatched).not.toHaveBeenCalled();
   });
 
   test("settles the admission when the UI-message stream tears down without callbacks", async () => {

--- a/packages/cloud/api/src/anonymous-chat-gate.ts
+++ b/packages/cloud/api/src/anonymous-chat-gate.ts
@@ -164,6 +164,13 @@ function rotateHourlyWindow(ledger: ReadyLedger, now: number): void {
   }
 }
 
+function hourlyRetryAfterSeconds(
+  hourlyResetAtMs: number,
+  nowMs: number,
+): number {
+  return Math.max(1, Math.ceil((hourlyResetAtMs + HOUR_MS - nowMs) / 1_000));
+}
+
 function snapshot(ledger: CounterSnapshot): CounterSnapshot {
   return {
     sessionId: ledger.sessionId,
@@ -370,14 +377,22 @@ export class AnonymousChatGate {
       );
     }
     if (ledger.hourlyMessageCount >= ledger.hourlyLimit) {
+      if (ledger.hourlyResetAtMs === null) {
+        return jsonError("Anonymous chat hourly window is unavailable", 503);
+      }
+      const retryAfter = hourlyRetryAfterSeconds(ledger.hourlyResetAtMs, now);
       return Response.json(
         {
           admitted: false,
           reason: "hourly_limit",
           remaining: 0,
           limit: ledger.hourlyLimit,
+          retryAfter,
         },
-        { status: 429 },
+        {
+          status: 429,
+          headers: { "Retry-After": String(retryAfter) },
+        },
       );
     }
 

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -159,6 +159,42 @@ function retryableWarmingResponse(c: AppContext, area: string): Response {
   );
 }
 
+type AnonymousLimitResponse =
+  | {
+      reason: "message_limit";
+      remaining: number;
+      limit: number;
+    }
+  | {
+      reason: "hourly_limit";
+      remaining: number;
+      limit: number;
+      retryAfter: number;
+    };
+
+function anonymousLimitResponse(
+  c: AppContext,
+  limitResult: AnonymousLimitResponse,
+): Response {
+  const error =
+    limitResult.reason === "message_limit"
+      ? `You've reached your free message limit (${limitResult.limit} messages). Sign up to continue chatting!`
+      : "You've reached the hourly rate limit. Please wait an hour or sign up for unlimited access.";
+  const body = {
+    error,
+    requiresSignup: true,
+    reason: limitResult.reason,
+    limit: limitResult.limit,
+    remaining: limitResult.remaining,
+  };
+  if (limitResult.reason === "hourly_limit") {
+    return c.json(body, 429, {
+      "Retry-After": String(limitResult.retryAfter),
+    });
+  }
+  return c.json(body, 429);
+}
+
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
@@ -471,20 +507,7 @@ app.post("/", async (c) => {
           );
         }
         if (leaseResolution.kind === "limited") {
-          const error =
-            leaseResolution.reason === "message_limit"
-              ? `You've reached your free message limit (${leaseResolution.limit} messages). Sign up to continue chatting!`
-              : "You've reached the hourly rate limit. Please wait an hour or sign up for unlimited access.";
-          return c.json(
-            {
-              error,
-              requiresSignup: true,
-              reason: leaseResolution.reason,
-              limit: leaseResolution.limit,
-              remaining: leaseResolution.remaining,
-            },
-            429,
-          );
+          return anonymousLimitResponse(c, leaseResolution);
         }
 
         const lease: AnonymousChatGateLease = leaseResolution.lease;
@@ -516,20 +539,7 @@ app.post("/", async (c) => {
           anonymousSession.session_token,
         );
         if (!limitCheck.allowed) {
-          const error =
-            limitCheck.reason === "message_limit"
-              ? `You've reached your free message limit (${limitCheck.limit} messages). Sign up to continue chatting!`
-              : "You've reached the hourly rate limit. Please wait an hour or sign up for unlimited access.";
-          return c.json(
-            {
-              error,
-              requiresSignup: true,
-              reason: limitCheck.reason,
-              limit: limitCheck.limit,
-              remaining: limitCheck.remaining,
-            },
-            429,
-          );
+          return anonymousLimitResponse(c, limitCheck);
         }
         let refunded = false;
         refundAnonymousMessageSlot = async () => {

--- a/packages/cloud/shared/src/db/repositories/anonymous-sessions.test.ts
+++ b/packages/cloud/shared/src/db/repositories/anonymous-sessions.test.ts
@@ -1,4 +1,9 @@
-// Exercises cloud DB anonymous sessions behavior with deterministic repository fixtures.
+/**
+ * Exercises anonymous-session persistence against a real isolated PGlite database.
+ * A fake clock makes lifetime and hourly quota boundaries deterministic while
+ * retaining the repository's production SQL and atomic update behavior.
+ */
+
 import {
   afterAll,
   afterEach,

--- a/packages/cloud/shared/src/db/repositories/anonymous-sessions.test.ts
+++ b/packages/cloud/shared/src/db/repositories/anonymous-sessions.test.ts
@@ -1,9 +1,19 @@
 // Exercises cloud DB anonymous sessions behavior with deterministic repository fixtures.
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { sql } from "drizzle-orm";
 
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
+process.env.ANON_HOURLY_LIMIT ||= "10";
 
 let dbWrite: typeof import("../helpers").dbWrite;
 let closeDatabaseConnectionsForTests: typeof import("../client").closeDatabaseConnectionsForTests;
@@ -53,6 +63,10 @@ afterAll(async () => {
   expect(pgliteReady).toBe(true);
   await dbWrite.execute(sql`DROP TABLE IF EXISTS anonymous_sessions`);
   await closeDatabaseConnectionsForTests();
+});
+
+afterEach(() => {
+  setSystemTime();
 });
 
 describe("AnonymousSessionsRepository free-message reservations", () => {
@@ -131,5 +145,51 @@ describe("AnonymousSessionsRepository free-message reservations", () => {
 
     const stored = await anonymousSessionsRepository.getByToken("anon-token-2");
     expect(stored?.message_count).toBe(0);
+  });
+
+  test("refuses at the hourly boundary and resets one millisecond later", async () => {
+    const sessionId = "00000000-0000-4000-8000-000000000103";
+    const hourlyLimit = Number.parseInt(process.env.ANON_HOURLY_LIMIT ?? "10", 10);
+    const windowStartedAt = new Date("2027-01-15T12:00:00.000Z");
+    await dbWrite.execute(sql`
+      INSERT INTO anonymous_sessions (
+        id,
+        session_token,
+        user_id,
+        hourly_message_count,
+        hourly_reset_at,
+        expires_at
+      )
+      VALUES (
+        ${sessionId},
+        'anon-token-hourly-active',
+        '00000000-0000-4000-8000-000000000203',
+        ${hourlyLimit},
+        ${windowStartedAt},
+        '2099-01-01T00:00:00.000Z'
+      )
+    `);
+
+    setSystemTime(windowStartedAt.getTime() + 60 * 60 * 1_000);
+    await expect(anonymousSessionsRepository.incrementHourlyCount(sessionId)).resolves.toEqual({
+      allowed: false,
+      remaining: 0,
+      retryAfter: 1,
+    });
+
+    const atBoundary = await anonymousSessionsRepository.getByToken("anon-token-hourly-active");
+    expect(atBoundary?.hourly_reset_at?.getTime()).toBe(windowStartedAt.getTime());
+
+    setSystemTime(windowStartedAt.getTime() + 60 * 60 * 1_000 + 1);
+    await expect(anonymousSessionsRepository.incrementHourlyCount(sessionId)).resolves.toEqual({
+      allowed: true,
+      remaining: hourlyLimit - 1,
+    });
+
+    const rolledOver = await anonymousSessionsRepository.getByToken("anon-token-hourly-active");
+    expect(rolledOver?.hourly_message_count).toBe(1);
+    expect(rolledOver?.hourly_reset_at?.getTime()).toBe(
+      windowStartedAt.getTime() + 60 * 60 * 1_000 + 1,
+    );
   });
 });

--- a/packages/cloud/shared/src/db/repositories/anonymous-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/anonymous-sessions.ts
@@ -1,4 +1,5 @@
 // Persists anonymous sessions records for cloud services through the shared DB boundary.
+import { ElizaError } from "@elizaos/core";
 import { and, eq, gt, gte, lt, sql } from "drizzle-orm";
 import { mutateRowCount } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -25,6 +26,12 @@ export interface AnonymousChatGateCounterSnapshot {
   hourlyResetAt: Date | null;
   lastMessageAt: Date;
 }
+
+export type AnonymousHourlyRateLimitResult =
+  | { allowed: true; remaining: number }
+  | { allowed: false; remaining: 0; retryAfter: number };
+
+const HOUR_MS = 60 * 60 * 1_000;
 
 /**
  * Repository for anonymous session database operations.
@@ -209,10 +216,10 @@ export class AnonymousSessionsRepository {
    *
    * @throws Error if session not found.
    */
-  async incrementHourlyCount(sessionId: string): Promise<{ allowed: boolean; remaining: number }> {
+  async incrementHourlyCount(sessionId: string): Promise<AnonymousHourlyRateLimitResult> {
     const hourlyLimit = Number.parseInt(process.env.ANON_HOURLY_LIMIT || "10", 10);
     const now = new Date();
-    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const oneHourAgo = new Date(now.getTime() - HOUR_MS);
 
     // Use a single atomic update with conditional logic
     // This resets the counter if the hour has passed, otherwise increments
@@ -246,7 +253,24 @@ export class AnonymousSessionsRepository {
 
     // Check if limit exceeded after update
     if (updated.hourly_message_count > hourlyLimit) {
-      return { allowed: false, remaining: 0 };
+      if (!updated.hourly_reset_at) {
+        throw new ElizaError("Anonymous hourly window is unavailable after quota update", {
+          code: "ANONYMOUS_HOURLY_WINDOW_UNAVAILABLE",
+          context: {
+            sessionId,
+            hourlyMessageCount: updated.hourly_message_count,
+          },
+          severity: "fatal",
+        });
+      }
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfter: Math.max(
+          1,
+          Math.ceil((updated.hourly_reset_at.getTime() + HOUR_MS - now.getTime()) / 1_000),
+        ),
+      };
     }
 
     return {

--- a/packages/cloud/shared/src/db/repositories/anonymous-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/anonymous-sessions.ts
@@ -1,4 +1,9 @@
-// Persists anonymous sessions records for cloud services through the shared DB boundary.
+/**
+ * Owns anonymous-session persistence and atomic quota accounting for Cloud services.
+ * Repository results carry the authoritative hourly reset advice consumed by
+ * admission layers, so callers do not recalculate window state after mutation.
+ */
+
 import { ElizaError } from "@elizaos/core";
 import { and, eq, gt, gte, lt, sql } from "drizzle-orm";
 import { mutateRowCount } from "../execute-helpers";

--- a/packages/cloud/shared/src/lib/auth-anonymous.retry-after.test.ts
+++ b/packages/cloud/shared/src/lib/auth-anonymous.retry-after.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.ANON_HOURLY_LIMIT ||= "10";
+
+const getByToken = mock(async (): Promise<Record<string, unknown> | null> => null);
+const reserveMessageSlot = mock(async (): Promise<Record<string, unknown> | null> => null);
+const checkRateLimit = mock(
+  async (): Promise<Record<string, unknown>> => ({
+    allowed: true,
+    remaining: 9,
+  }),
+);
+const refundMessageSlot = mock(async (): Promise<unknown> => null);
+
+mock.module("./services/anonymous-sessions", () => ({
+  anonymousSessionsService: {
+    getByToken,
+    reserveMessageSlot,
+    checkRateLimit,
+    refundMessageSlot,
+  },
+}));
+mock.module("../db/helpers", () => ({ dbRead: {} }));
+mock.module("../db/schemas/user-identities", () => ({ userIdentities: {} }));
+mock.module("./services/users", () => ({ usersService: {} }));
+mock.module("./utils/logger", () => ({
+  logger: { debug: mock(), error: mock(), info: mock(), warn: mock() },
+}));
+
+const { checkAnonymousLimit, reserveAnonymousMessageSlot } = await import("./auth-anonymous");
+
+beforeEach(() => {
+  getByToken.mockReset();
+  reserveMessageSlot.mockReset();
+  checkRateLimit.mockReset();
+  refundMessageSlot.mockReset();
+  getByToken.mockResolvedValue({
+    id: "anonymous-session",
+    message_count: 2,
+    messages_limit: 10,
+  });
+});
+
+describe("reserveAnonymousMessageSlot Retry-After propagation", () => {
+  test("preserves authoritative hourly retry advice on the legacy check path", async () => {
+    checkRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      retryAfter: 29,
+    });
+
+    await expect(checkAnonymousLimit("anonymous-token")).resolves.toEqual({
+      allowed: false,
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+      retryAfter: 29,
+    });
+    expect(checkRateLimit).toHaveBeenCalledWith("anonymous-session");
+    expect(reserveMessageSlot).not.toHaveBeenCalled();
+    expect(refundMessageSlot).not.toHaveBeenCalled();
+  });
+
+  test("preserves authoritative hourly retry advice after refunding the slot", async () => {
+    reserveMessageSlot.mockResolvedValue({
+      id: "anonymous-session",
+      message_count: 3,
+      messages_limit: 10,
+    });
+    checkRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      retryAfter: 37,
+    });
+    refundMessageSlot.mockResolvedValue({ id: "anonymous-session" });
+
+    await expect(reserveAnonymousMessageSlot("anonymous-token")).resolves.toEqual({
+      allowed: false,
+      reason: "hourly_limit",
+      remaining: 0,
+      limit: 10,
+      retryAfter: 37,
+    });
+    expect(checkRateLimit).toHaveBeenCalledWith("anonymous-session");
+    expect(refundMessageSlot).toHaveBeenCalledWith("anonymous-session");
+  });
+
+  test("does not invent retry advice for a lifetime message refusal", async () => {
+    reserveMessageSlot.mockResolvedValue(null);
+
+    const result = await reserveAnonymousMessageSlot("anonymous-token");
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "message_limit",
+      remaining: 0,
+      limit: 10,
+    });
+    expect(result).not.toHaveProperty("retryAfter");
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(refundMessageSlot).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/auth-anonymous.retry-after.test.ts
+++ b/packages/cloud/shared/src/lib/auth-anonymous.retry-after.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies anonymous quota refusal metadata through the mocked service boundary.
+ * The deterministic harness proves hourly retry advice survives both legacy
+ * checks and atomic reservation refunds without dispatching downstream work.
+ */
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 process.env.ANON_HOURLY_LIMIT ||= "10";

--- a/packages/cloud/shared/src/lib/auth-anonymous.ts
+++ b/packages/cloud/shared/src/lib/auth-anonymous.ts
@@ -26,12 +26,23 @@ function hashTokenForLogging(token: string): string {
   return createHash("sha256").update(token).digest("hex").slice(0, 8);
 }
 
-export async function checkAnonymousLimit(sessionId: string): Promise<{
-  allowed: boolean;
-  reason?: "message_limit" | "hourly_limit";
-  remaining: number;
-  limit: number;
-}> {
+export type AnonymousLimitCheck =
+  | { allowed: true; remaining: number; limit: number }
+  | {
+      allowed: false;
+      reason: "message_limit";
+      remaining: 0;
+      limit: number;
+    }
+  | {
+      allowed: false;
+      reason: "hourly_limit";
+      remaining: 0;
+      limit: number;
+      retryAfter: number;
+    };
+
+export async function checkAnonymousLimit(sessionId: string): Promise<AnonymousLimitCheck> {
   const session = await anonymousSessionsService.getByToken(sessionId);
 
   if (!session) {
@@ -55,6 +66,7 @@ export async function checkAnonymousLimit(sessionId: string): Promise<{
       reason: "hourly_limit",
       remaining: 0,
       limit: ANON_HOURLY_LIMIT,
+      retryAfter: rateLimitResult.retryAfter,
     };
   }
 
@@ -65,12 +77,7 @@ export async function checkAnonymousLimit(sessionId: string): Promise<{
   };
 }
 
-export async function reserveAnonymousMessageSlot(sessionId: string): Promise<{
-  allowed: boolean;
-  reason?: "message_limit" | "hourly_limit";
-  remaining: number;
-  limit: number;
-}> {
+export async function reserveAnonymousMessageSlot(sessionId: string): Promise<AnonymousLimitCheck> {
   const session = await anonymousSessionsService.getByToken(sessionId);
 
   if (!session) {
@@ -95,6 +102,7 @@ export async function reserveAnonymousMessageSlot(sessionId: string): Promise<{
       reason: "hourly_limit",
       remaining: 0,
       limit: ANON_HOURLY_LIMIT,
+      retryAfter: rateLimitResult.retryAfter,
     };
   }
 

--- a/packages/cloud/shared/src/lib/services/anonymous-chat-admission.ts
+++ b/packages/cloud/shared/src/lib/services/anonymous-chat-admission.ts
@@ -75,9 +75,16 @@ export type AnonymousChatLeaseResolution =
     }
   | {
       kind: "limited";
-      reason: "message_limit" | "hourly_limit";
+      reason: "message_limit";
       remaining: number;
       limit: number;
+    }
+  | {
+      kind: "limited";
+      reason: "hourly_limit";
+      remaining: number;
+      limit: number;
+      retryAfter: number;
     }
   | { kind: "warming" }
   | { kind: "rejected" }
@@ -201,6 +208,16 @@ function parseSnapshot(value: unknown): AnonymousChatGateSnapshot | null {
     hourlyResetAtMs: snapshot.hourlyResetAtMs,
     lastMessageAtMs: snapshot.lastMessageAtMs,
   };
+}
+
+function positiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function positiveCanonicalInteger(value: string | null): number | null {
+  if (!value || !/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 async function hydrateGate(stub: RuntimeDurableObjectStub, sessionToken: string): Promise<void> {
@@ -351,8 +368,9 @@ export async function reserveAnonymousChatSlot(
     return { kind: "rejected" };
   }
   if (response.status === 429) {
+    const retryAfterHeader = positiveCanonicalInteger(response.headers.get("Retry-After"));
     if (
-      (body.reason === "message_limit" || body.reason === "hourly_limit") &&
+      body.reason === "message_limit" &&
       typeof body.remaining === "number" &&
       typeof body.limit === "number"
     ) {
@@ -361,6 +379,22 @@ export async function reserveAnonymousChatSlot(
         reason: body.reason,
         remaining: body.remaining,
         limit: body.limit,
+      };
+    }
+    if (
+      body.reason === "hourly_limit" &&
+      typeof body.remaining === "number" &&
+      typeof body.limit === "number" &&
+      positiveSafeInteger(body.retryAfter) &&
+      retryAfterHeader !== null &&
+      retryAfterHeader === body.retryAfter
+    ) {
+      return {
+        kind: "limited",
+        reason: body.reason,
+        remaining: body.remaining,
+        limit: body.limit,
+        retryAfter: body.retryAfter,
       };
     }
     return { kind: "unavailable" };

--- a/packages/cloud/shared/src/lib/services/anonymous-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/anonymous-sessions.ts
@@ -1,4 +1,9 @@
-// Coordinates cloud service anonymous sessions behavior behind route handlers.
+/**
+ * Coordinates anonymous-session repository operations for Cloud route services.
+ * Quota results remain authoritative across this boundary, while lifecycle
+ * mutations invalidate the Durable Object admission cache by session token.
+ */
+
 import {
   type AnonymousHourlyRateLimitResult,
   anonymousSessionsRepository,

--- a/packages/cloud/shared/src/lib/services/anonymous-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/anonymous-sessions.ts
@@ -1,5 +1,8 @@
 // Coordinates cloud service anonymous sessions behavior behind route handlers.
-import { anonymousSessionsRepository } from "../../db/repositories";
+import {
+  type AnonymousHourlyRateLimitResult,
+  anonymousSessionsRepository,
+} from "../../db/repositories";
 import type { AnonymousSession } from "../../db/schemas";
 import { invalidateAnonymousChatGateByToken } from "./anonymous-chat-admission";
 
@@ -41,9 +44,7 @@ class AnonymousSessionsService {
     return anonymousSessionsRepository.refundMessageSlot(sessionId);
   }
 
-  async checkRateLimit(
-    sessionId: string,
-  ): Promise<{ allowed: boolean; remaining: number; retryAfter?: number }> {
+  async checkRateLimit(sessionId: string): Promise<AnonymousHourlyRateLimitResult> {
     return anonymousSessionsRepository.incrementHourlyCount(sessionId);
   }
 


### PR DESCRIPTION
# Relates to

Closes #24296.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      blockers are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      exact-head evidence summarized below. Artifact links will be attached as
      soon as GitHub allocates the PR number.

# Sync with develop

- [x] Exact-head validation used `origin/develop@5c1d3d604fdd0ce8a3ce7e95598c7407af14e0e3`
      with zero conflicts. Final validation was regenerated before the final docs-only base advance; the code tree was unchanged, and evidence was restamped at exact head `aaa68fa3a79a3f147325c87f5e25fd98b4c283bf`.
- [x] `bun run verify` was run post-sync; its exact unrelated blockers are
      documented in **Known gaps / failures** below.

# Risks

Low. This changes only anonymous hourly-quota refusal metadata. A defect could
overstate or drop the delay returned to a client, so the code preserves the
existing strict window boundary, derives from each authority's evaluated row or
ledger, validates the internal response fail-closed, and stops before provider
dispatch. Lifetime `message_limit`, quota values, persistence schema, billing,
provider behavior, UI, and live configuration remain unchanged.

# Background

## What does this PR do?

- Adds authoritative integer `Retry-After` advice to hourly anonymous-chat 429s
  from both the Durable Object and atomic database fallback.
- Preserves that value through the admission/service/auth layers without
  recalculating the window.
- Requires the Durable Object body and header to contain the same positive,
  safe, canonical integer before the route trusts it.
- Leaves the non-resetting lifetime message cap without reset advice while
  #24121 remains undecided.
- Adds fake-clock, PGlite, propagation, route, and zero-provider-dispatch proof.

## What kind of change is this?

Bug fix (non-breaking response-contract completion).

# Documentation changes needed?

No project documentation change is required. The response contract and its
strict boundary are recorded in the issue, types, tests, and attached domain
artifact.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/api/src/anonymous-chat-gate.ts` and
`packages/cloud/shared/src/db/repositories/anonymous-sessions.ts`, then follow
the discriminated propagation through `anonymous-chat-admission.ts`,
`auth-anonymous.ts`, and `/v1/chat/route.ts`. The fake-clock and PGlite tests
make the exact reset boundary visible without reading the implementation.

## Detailed testing steps

1. Use Bun 1.3.14 and run `bun install --frozen-lockfile`.
2. Run the five focused test files separately because Bun `mock.module` state is
   process-global. Expect 31 tests / 195 assertions / 0 failures.
3. Run the three related route/entry/CSRF files separately. Expect 58 tests /
   291 assertions / 0 failures.
4. Run `lint:check` and `typecheck` in `packages/cloud/api` and
   `packages/cloud/shared`, then `bun run verify:cloud`, `bun run verify`, and
   `git diff --check`.

# Evidence Gate

<!-- evidence-head:aaa68fa3a79a3f147325c87f5e25fd98b4c283bf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-only response/header change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-only response/header change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing click flow or rendered state changed.
<!-- evidence-row:backend-logs -->
- [x] [24318-24296-anonymous-hourly-verification-e2f7207.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24318-24296-anonymous-hourly-verification-e2f7207.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console state, or browser network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the refusal path is required to stop before any provider/model call.
<!-- evidence-row:domain-artifacts -->
- [x] [24318-24296-anonymous-hourly-boundary-e2f7207.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24318-24296-anonymous-hourly-boundary-e2f7207.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changes. The route
tests assert that hourly refusal occurs before provider dispatch.

## Backend + frontend logs

Exact head `aaa68fa3a79a3f147325c87f5e25fd98b4c283bf` on Bun 1.3.14:

```text
Focused: 31 tests, 195 assertions, 0 failures
Related: 58 tests, 291 assertions, 0 failures
Combined: 89 tests, 486 assertions, 0 failures
cloud-api lint: PASS (1358 files)
cloud-shared lint: PASS (2286 files)
cloud-shared typecheck: PASS
cloud-api typecheck / verify:cloud: inherited failures in three unrelated test lines
git diff --check: PASS
guide parity: PASS (160 CLAUDE.md/AGENTS.md pairs)
header remediation: comment-only gate PASS (four files; code tokens identical)
independent source review: CLEAN (no P0-P3); final docs-only rebase was conflict-free and touched no PR paths
```

Frontend logs: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - server-only response/header change with no rendered UI surface.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `packages/cloud/api` typecheck and `bun run verify:cloud` stop on three
  inherited errors: `personal-shared/messages/route.test.ts:294` and
  `apps-create-postgres.integration.test.ts:252,290`. Those files are unchanged
  by this PR and are present in the exact base named above.
- No live anonymous session or provider call was created. The safe exact-head
  proof drives the real Durable Object implementation and an isolated PGlite
  database, and asserts zero provider dispatch.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5c1d3d604fdd0ce8a3ce7e95598c7407af14e0e3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-anonymous-hourly-retry-after]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@5c1d3d604fdd0ce8a3ce7e95598c7407af14e0e3:packages/skills/skills/contribute-to-eliza"} -->



