### PR TITLE
fix(cloud-sdk): compose caller signal with timeoutMs instead of dropping the deadline

### DIFF
--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -320,3 +320,85 @@ describe("ElizaCloudHttpClient errors", () => {
     });
   });
 });
+
+describe("ElizaCloudHttpClient abort and deadline composition", () => {
+  function capturingFetch(calls: Array<{ init: RequestInit }>): typeof fetch {
+    return asFetch(async (_input, init = {}) => {
+      calls.push({ init });
+      return Response.json({ success: true });
+    });
+  }
+
+  it("combines a caller signal with timeoutMs so the per-request deadline still fires", async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: capturingFetch(calls),
+    });
+    const controller = new AbortController();
+
+    await client.requestRaw("GET", "/api/slow", {
+      timeoutMs: 5,
+      signal: controller.signal,
+    });
+
+    const passedSignal = calls[0].init.signal;
+    // The deadline must not silently vanish when a caller signal is present.
+    expect(passedSignal).toBeDefined();
+    expect(passedSignal).not.toBe(controller.signal);
+    const deadlineSignal = passedSignal as AbortSignal;
+    const waitUntilAborted = async (): Promise<boolean> => {
+      const startedAt = Date.now();
+      while (!deadlineSignal.aborted && Date.now() - startedAt < 2_000) {
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      return deadlineSignal.aborted;
+    };
+    await expect(waitUntilAborted()).resolves.toBe(true);
+  });
+
+  it("aborts the combined signal when the caller's own signal fires first", async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: capturingFetch(calls),
+    });
+    const controller = new AbortController();
+
+    await client.requestRaw("GET", "/api/slow", {
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+
+    const passedSignal = calls[0].init.signal as AbortSignal;
+    controller.abort();
+    expect(passedSignal.aborted).toBe(true);
+  });
+
+  it("passes a bare caller signal through unchanged", async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: capturingFetch(calls),
+    });
+    const controller = new AbortController();
+
+    await client.requestRaw("GET", "/api/x", { signal: controller.signal });
+
+    expect(calls[0].init.signal).toBe(controller.signal);
+  });
+
+  it("derives a deadline-only signal when only timeoutMs is given", async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: capturingFetch(calls),
+    });
+
+    await client.requestRaw("GET", "/api/x", { timeoutMs: 60_000 });
+
+    const passedSignal = calls[0].init.signal;
+    expect(passedSignal).toBeInstanceOf(AbortSignal);
+    expect((passedSignal as AbortSignal).aborted).toBe(false);
+  });
+});

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -1,6 +1,9 @@
-/** Unit tests for `ElizaCloudHttpClient` with an injected fake fetch: verb/URL/query/header construction and error mapping. */
+/**
+ * Unit tests for the SDK HTTP boundary with injected transports, including
+ * request construction, error mapping, abort provenance, and bounded reads.
+ */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { type CloudApiError, ElizaCloudHttpClient } from "./http.js";
 
@@ -329,50 +332,74 @@ describe("ElizaCloudHttpClient abort and deadline composition", () => {
     });
   }
 
-  it("combines a caller signal with timeoutMs so the per-request deadline still fires", async () => {
+  function pendingFetch(calls: Array<{ init: RequestInit }>): typeof fetch {
+    return asFetch(
+      (_input, init = {}) =>
+        new Promise<Response>((_resolve, reject) => {
+          calls.push({ init });
+          const signal = init.signal;
+          if (!signal) return;
+          const rejectFromAbort = (): void => reject(signal.reason);
+          signal.addEventListener("abort", rejectFromAbort, { once: true });
+          if (signal.aborted) rejectFromAbort();
+        }),
+    );
+  }
+
+  it("aborts an in-flight request at the deadline while leaving the caller signal untouched", async () => {
     const calls: Array<{ init: RequestInit }> = [];
     const client = new ElizaCloudHttpClient({
       baseUrl: "https://cloud.test",
-      fetchImpl: capturingFetch(calls),
+      fetchImpl: pendingFetch(calls),
     });
     const controller = new AbortController();
 
-    await client.requestRaw("GET", "/api/slow", {
-      timeoutMs: 5,
-      signal: controller.signal,
-    });
+    await expect(
+      client.requestRaw("GET", "/api/slow", {
+        timeoutMs: 5,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
 
-    const passedSignal = calls[0].init.signal;
-    // The deadline must not silently vanish when a caller signal is present.
+    const passedSignal = calls[0]?.init.signal;
     expect(passedSignal).toBeDefined();
     expect(passedSignal).not.toBe(controller.signal);
-    const deadlineSignal = passedSignal as AbortSignal;
-    const waitUntilAborted = async (): Promise<boolean> => {
-      const startedAt = Date.now();
-      while (!deadlineSignal.aborted && Date.now() - startedAt < 2_000) {
-        await new Promise((resolve) => setTimeout(resolve, 2));
-      }
-      return deadlineSignal.aborted;
-    };
-    await expect(waitUntilAborted()).resolves.toBe(true);
+    expect((passedSignal as AbortSignal).aborted).toBe(true);
+    expect(controller.signal.aborted).toBe(false);
   });
 
-  it("aborts the combined signal when the caller's own signal fires first", async () => {
+  it("rejects at the deadline even when the injected fetch ignores its signal", async () => {
+    const fetchImpl = vi.fn(
+      asFetch(() => new Promise<Response>(() => undefined)),
+    );
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    await expect(
+      client.requestRaw("GET", "/api/ignores-abort", { timeoutMs: 5 }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the caller's abort reason when it fires first", async () => {
     const calls: Array<{ init: RequestInit }> = [];
     const client = new ElizaCloudHttpClient({
       baseUrl: "https://cloud.test",
-      fetchImpl: capturingFetch(calls),
+      fetchImpl: pendingFetch(calls),
     });
     const controller = new AbortController();
+    const callerReason = new Error("caller stopped the request");
 
-    await client.requestRaw("GET", "/api/slow", {
+    const request = client.requestRaw("GET", "/api/slow", {
       timeoutMs: 60_000,
       signal: controller.signal,
     });
+    controller.abort(callerReason);
 
-    const passedSignal = calls[0].init.signal as AbortSignal;
-    controller.abort();
-    expect(passedSignal.aborted).toBe(true);
+    await expect(request).rejects.toBe(callerReason);
+    expect((calls[0].init.signal as AbortSignal).reason).toBe(callerReason);
   });
 
   it("passes a bare caller signal through unchanged", async () => {
@@ -385,20 +412,328 @@ describe("ElizaCloudHttpClient abort and deadline composition", () => {
 
     await client.requestRaw("GET", "/api/x", { signal: controller.signal });
 
-    expect(calls[0].init.signal).toBe(controller.signal);
+    expect(calls[0]?.init.signal).toBe(controller.signal);
   });
 
-  it("derives a deadline-only signal when only timeoutMs is given", async () => {
+  it("rejects a pre-aborted caller without invoking fetch", async () => {
+    const fetchImpl = vi.fn(capturingFetch([]));
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    const controller = new AbortController();
+    const callerReason = new Error("already stopped");
+    controller.abort(callerReason);
+
+    await expect(
+      client.requestRaw("GET", "/api/x", {
+        timeoutMs: 60_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(callerReason);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("clears the deadline after a successful raw response", async () => {
     const calls: Array<{ init: RequestInit }> = [];
     const client = new ElizaCloudHttpClient({
       baseUrl: "https://cloud.test",
       fetchImpl: capturingFetch(calls),
     });
 
-    await client.requestRaw("GET", "/api/x", { timeoutMs: 60_000 });
+    const response = await client.requestRaw("GET", "/api/x", {
+      timeoutMs: 25,
+    });
+    const passedSignal = calls[0]?.init.signal as AbortSignal;
+    await response.arrayBuffer();
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    const passedSignal = calls[0].init.signal;
     expect(passedSignal).toBeInstanceOf(AbortSignal);
-    expect((passedSignal as AbortSignal).aborted).toBe(false);
+    expect(passedSignal.aborted).toBe(false);
+  });
+
+  it("keeps a caller signal connected to a raw response after headers arrive", async () => {
+    const controller = new AbortController();
+    const callerReason = new Error("stop streaming");
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(async (_input, init = {}) => {
+        const signal = init.signal as AbortSignal;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(streamController) {
+              signal.addEventListener(
+                "abort",
+                () => streamController.error(signal.reason),
+                { once: true },
+              );
+            },
+          }),
+        );
+      }),
+    });
+
+    const response = await client.requestRaw("GET", "/api/stream", {
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+    controller.abort(callerReason);
+
+    await expect(response.text()).rejects.toBe(callerReason);
+  });
+
+  it("owns the deadline until a raw response body finishes", async () => {
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start() {},
+              cancel: () => new Promise<void>(() => undefined),
+            }),
+          ),
+      ),
+    });
+
+    const response = await client.requestRaw("GET", "/api/slow-stream", {
+      timeoutMs: 5,
+    });
+
+    await expect(response.text()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+  });
+
+  it("discards a prefetched raw chunk when the deadline expires before reading", async () => {
+    let cancelCalls = 0;
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([7]));
+              },
+              cancel() {
+                cancelCalls += 1;
+              },
+            }),
+          ),
+      ),
+    });
+
+    const response = await client.requestRaw("GET", "/api/prefetched", {
+      timeoutMs: 5,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await expect(response.body?.getReader().read()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(cancelCalls).toBe(1);
+  });
+
+  it("preserves raw response metadata through recursive clones", async () => {
+    const upstream = new Response("stream body");
+    Object.defineProperties(upstream, {
+      redirected: { configurable: true, value: true },
+      type: { configurable: true, value: "cors" },
+      url: { configurable: true, value: "https://cloud.test/api/raw" },
+    });
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(async () => upstream),
+    });
+
+    const response = await client.requestRaw("GET", "/api/raw", {
+      timeoutMs: 60_000,
+    });
+    const clone = response.clone();
+    const nestedClone = clone.clone();
+
+    for (const candidate of [response, clone, nestedClone]) {
+      expect(candidate.url).toBe("https://cloud.test/api/raw");
+      expect(candidate.redirected).toBe(true);
+      expect(candidate.type).toBe("cors");
+    }
+    await expect(response.text()).resolves.toBe("stream body");
+    await expect(clone.text()).resolves.toBe("stream body");
+    await expect(nestedClone.text()).resolves.toBe("stream body");
+  });
+
+  it("preserves BYOB reads for an owned raw byte stream", async () => {
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              type: "bytes",
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+                controller.close();
+              },
+            }),
+          ),
+      ),
+    });
+
+    const response = await client.requestRaw("GET", "/api/bytes", {
+      timeoutMs: 60_000,
+    });
+    const reader = response.body?.getReader({ mode: "byob" });
+    const result = await reader?.read(new Uint8Array(4));
+
+    expect(result?.done).toBe(false);
+    expect(Array.from(result?.value ?? [])).toEqual([1, 2, 3]);
+  });
+
+  it("returns the original raw response when no abort owner is requested", async () => {
+    const upstream = new Response("unchanged");
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(async () => upstream),
+    });
+
+    const response = await client.requestRaw("GET", "/api/raw");
+
+    expect(response).toBe(upstream);
+  });
+
+  it("clears a raw deadline without awaiting hostile body cancellation", async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    let cancelCalls = 0;
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(async (_input, init = {}) => {
+        calls.push({ init });
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelCalls += 1;
+              return new Promise<void>(() => undefined);
+            },
+          }),
+        );
+      }),
+    });
+
+    const response = await client.requestRaw("GET", "/api/cancel-stream", {
+      timeoutMs: 25,
+    });
+    await response.body?.cancel("caller finished");
+    const passedSignal = calls[0]?.init.signal as AbortSignal;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(cancelCalls).toBe(1);
+    expect(passedSignal.aborted).toBe(false);
+  });
+
+  it("keeps the deadline active while request() reads the response body", async () => {
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start() {},
+              cancel: () => new Promise<void>(() => undefined),
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+      ),
+    });
+
+    await expect(
+      client.request("GET", "/api/slow-body", { timeoutMs: 5 }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+  });
+
+  it("rejects an oversized declared response without reading partial content", async () => {
+    let cancelCalls = 0;
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              cancel() {
+                cancelCalls += 1;
+                return new Promise<void>(() => undefined);
+              },
+            }),
+            {
+              headers: {
+                "content-length": String(8 * 1024 * 1024 + 1),
+                "content-type": "application/json",
+              },
+            },
+          ),
+      ),
+    });
+
+    await expect(client.request("GET", "/api/oversized")).rejects.toMatchObject(
+      {
+        name: "CloudApiError",
+        errorBody: { code: "response_body_too_large" },
+      },
+    );
+    expect(cancelCalls).toBe(1);
+  });
+
+  it("rejects a chunked response that crosses the byte bound", async () => {
+    const oversizedChunk = new Uint8Array(8 * 1024 * 1024 + 1);
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(oversizedChunk);
+                controller.close();
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+      ),
+    });
+
+    await expect(
+      client.request("GET", "/api/chunked-oversized"),
+    ).rejects.toMatchObject({
+      name: "CloudApiError",
+      errorBody: { code: "response_body_too_large" },
+    });
+  });
+
+  it("bounds zero-byte chunk fragmentation without truncating a response", async () => {
+    let emittedChunks = 0;
+    const client = new ElizaCloudHttpClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl: asFetch(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                emittedChunks += 1;
+                controller.enqueue(new Uint8Array());
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+      ),
+    });
+
+    await expect(
+      client.request("GET", "/api/fragmented"),
+    ).rejects.toMatchObject({
+      name: "CloudApiError",
+      errorBody: { code: "response_body_too_large" },
+    });
+    expect(emittedChunks).toBeGreaterThan(8_192);
+    expect(emittedChunks).toBeLessThanOrEqual(8_194);
   });
 });

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -4,6 +4,8 @@
  * subclass scoped to `/api/v1`, and the error types `CloudApiError` (thrown on
  * any non-2xx) and its 402 specialisation `InsufficientCreditsError`.
  * `ElizaCloudClient` builds on top of this.
+ * Request deadlines remain owned through raw and parsed body consumption;
+ * parsed bodies fail closed at explicit byte and chunk resource boundaries.
  */
 
 import {
@@ -94,6 +96,16 @@ interface MalformedJsonBody {
   readonly text: string;
 }
 
+const MAX_RESPONSE_BODY_BYTES = 8 * 1024 * 1024;
+const MAX_RESPONSE_BODY_CHUNKS = 8_192;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+interface RequestDeadline {
+  readonly signal: AbortSignal | undefined;
+  readonly aborted: Promise<never>;
+  close(): void;
+}
+
 function isMalformedJsonBody(value: unknown): value is MalformedJsonBody {
   return (
     isRecord(value) &&
@@ -103,8 +115,148 @@ function isMalformedJsonBody(value: unknown): value is MalformedJsonBody {
   );
 }
 
-async function parseResponseBody(response: Response): Promise<unknown> {
-  const text = await response.text();
+function responseBodyTooLarge(response: Response): CloudApiError {
+  return new CloudApiError(response.status, {
+    success: false,
+    error: `HTTP ${response.status}: response body exceeds the ${MAX_RESPONSE_BODY_BYTES}-byte SDK limit`,
+    code: "response_body_too_large",
+  });
+}
+
+function releaseReaderNoThrow(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): void {
+  try {
+    reader.releaseLock();
+  } catch {
+    // error-policy:J6 Releasing a terminal response stream is teardown-only.
+  }
+}
+
+function cancelBodyDetached(
+  body: ReadableStream<Uint8Array> | null,
+  reason: unknown,
+): void {
+  if (!body) return;
+  try {
+    void body
+      .cancel(reason)
+      // error-policy:J6 The selected response-boundary failure already belongs to the caller.
+      .catch(() => undefined);
+  } catch {
+    // error-policy:J6 A synchronous cancellation failure is teardown-only.
+  }
+}
+
+function cancelReaderDetached(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: unknown,
+): void {
+  try {
+    void reader
+      .cancel(reason)
+      // error-policy:J6 The selected response-boundary failure already belongs to the caller.
+      .catch(() => undefined)
+      .finally(() => releaseReaderNoThrow(reader));
+  } catch {
+    // error-policy:J6 A synchronous cancellation failure is teardown-only.
+    releaseReaderNoThrow(reader);
+  }
+}
+
+async function readWithSignal(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal | undefined,
+): ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]> {
+  if (!signal) return reader.read();
+  signal.throwIfAborted();
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      operation();
+    };
+    const onAbort = (): void => finish(() => reject(signal.reason));
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    reader.read().then(
+      (result) => finish(() => resolve(result)),
+      (error: unknown) => finish(() => reject(error)),
+    );
+  });
+}
+
+async function readBoundedResponseText(
+  response: Response,
+  signal: AbortSignal | undefined,
+): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null && /^\d+$/.test(declaredLength)) {
+    const declaredBytes = Number(declaredLength);
+    if (
+      !Number.isSafeInteger(declaredBytes) ||
+      declaredBytes > MAX_RESPONSE_BODY_BYTES
+    ) {
+      const error = responseBodyTooLarge(response);
+      cancelBodyDetached(response.body, error);
+      throw error;
+    }
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  let receivedChunks = 0;
+  let complete = false;
+  let failure: unknown;
+  try {
+    for (;;) {
+      const next = await readWithSignal(reader, signal);
+      signal?.throwIfAborted();
+      if (next.done) {
+        complete = true;
+        break;
+      }
+      receivedChunks += 1;
+      if (receivedChunks > MAX_RESPONSE_BODY_CHUNKS) {
+        throw responseBodyTooLarge(response);
+      }
+      if (next.value.byteLength === 0) continue;
+      receivedBytes += next.value.byteLength;
+      if (receivedBytes > MAX_RESPONSE_BODY_BYTES) {
+        throw responseBodyTooLarge(response);
+      }
+      chunks.push(next.value);
+    }
+    const bytes = new Uint8Array(receivedBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(bytes);
+  } catch (error) {
+    // error-policy:J2 Preserve the selected read or abort failure through teardown.
+    failure = error;
+    throw error;
+  } finally {
+    if (complete) releaseReaderNoThrow(reader);
+    else cancelReaderDetached(reader, failure ?? signal?.reason);
+  }
+}
+
+async function parseResponseBody(
+  response: Response,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  const text = await readBoundedResponseText(response, signal);
   if (!text) return undefined;
 
   const contentType = response.headers.get("content-type") ?? "";
@@ -123,6 +275,103 @@ async function parseResponseBody(response: Response): Promise<unknown> {
       text,
     } satisfies MalformedJsonBody;
   }
+}
+
+function responseWithOwnedBody(
+  response: Response,
+  deadline: RequestDeadline,
+): Response {
+  if (!response.body || !deadline.signal) {
+    deadline.close();
+    return response;
+  }
+
+  const signal = deadline.signal;
+  const reader = response.body.getReader();
+  let terminal = false;
+  let streamController: ReadableByteStreamController | undefined;
+  const onAbort = (): void => {
+    const reason = signal.reason;
+    fail(reason);
+    streamController?.error(reason);
+  };
+  const removeAbortListener = (): void => {
+    signal.removeEventListener("abort", onAbort);
+  };
+  const finish = (): void => {
+    if (terminal) return;
+    terminal = true;
+    removeAbortListener();
+    releaseReaderNoThrow(reader);
+    deadline.close();
+  };
+  const fail = (reason: unknown): void => {
+    if (terminal) return;
+    terminal = true;
+    removeAbortListener();
+    cancelReaderDetached(reader, reason);
+    deadline.close();
+  };
+  const bodySource: UnderlyingByteSource = {
+    type: "bytes",
+    start(controller) {
+      streamController = controller;
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (signal.aborted) onAbort();
+    },
+    async pull(controller) {
+      try {
+        signal.throwIfAborted();
+        const next = await Promise.race([reader.read(), deadline.aborted]);
+        signal.throwIfAborted();
+        if (next.done) {
+          finish();
+          controller.close();
+          return;
+        }
+        if (next.value.byteLength === 0) return;
+        controller.enqueue(next.value);
+      } catch (error) {
+        if (terminal) return;
+        fail(error);
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      fail(reason);
+    },
+  };
+  const body = new ReadableStream(bodySource) as ReadableStream<Uint8Array>;
+  const owned = new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+  const nativeClone = owned.clone.bind(owned);
+  Object.defineProperties(owned, {
+    clone: {
+      configurable: true,
+      value: (): Response => responseWithMetadata(nativeClone(), response),
+    },
+    redirected: { configurable: true, value: response.redirected },
+    type: { configurable: true, value: response.type },
+    url: { configurable: true, value: response.url },
+  });
+  return owned;
+}
+
+function responseWithMetadata(response: Response, source: Response): Response {
+  const nativeClone = response.clone.bind(response);
+  Object.defineProperties(response, {
+    clone: {
+      configurable: true,
+      value: (): Response => responseWithMetadata(nativeClone(), source),
+    },
+    redirected: { configurable: true, value: source.redirected },
+    type: { configurable: true, value: source.type },
+    url: { configurable: true, value: source.url },
+  });
+  return response;
 }
 
 function normalizeErrorBody(
@@ -189,15 +438,71 @@ function isQuota(value: unknown): value is { current: number; max: number } {
   );
 }
 
-function timeoutSignal(
+function requestDeadline(
   timeoutMs?: number,
   signal?: AbortSignal,
-): AbortSignal | undefined {
-  if (!timeoutMs) return signal;
-  if (!signal) return AbortSignal.timeout(timeoutMs);
-  // Compose both so a caller-owned signal cannot silently discard the
-  // per-request deadline (and vice versa): whichever fires first aborts.
-  return AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]);
+): RequestDeadline {
+  signal?.throwIfAborted();
+  const delayMs = timeoutMs ?? 0;
+  const hasTimeout = delayMs !== 0;
+  if (
+    hasTimeout &&
+    (!Number.isSafeInteger(delayMs) ||
+      delayMs < 0 ||
+      delayMs > MAX_TIMER_DELAY_MS)
+  ) {
+    throw new RangeError(
+      `Cloud request timeoutMs must be a timer-safe integer no greater than ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+
+  let rejectAbort!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  if (!hasTimeout && !signal) {
+    return { signal: undefined, aborted, close() {} };
+  }
+
+  const controller = hasTimeout ? new AbortController() : undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+  let onCallerAbort: (() => void) | undefined;
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    if (timer !== undefined) clearTimeout(timer);
+    if (onCallerAbort) signal?.removeEventListener("abort", onCallerAbort);
+  };
+  const abort = (reason: unknown): void => {
+    if (controller?.signal.aborted || closed) return;
+    // Select caller-versus-timeout provenance before the transport can reject
+    // its own pending operation with a generic AbortError.
+    rejectAbort(reason);
+    controller?.abort(reason);
+    close();
+  };
+  if (signal) {
+    onCallerAbort = (): void => abort(signal.reason);
+    signal.addEventListener("abort", onCallerAbort, { once: true });
+  }
+  if (hasTimeout) {
+    timer = setTimeout(
+      () =>
+        abort(
+          new DOMException(
+            "The Cloud request deadline expired.",
+            "TimeoutError",
+          ),
+        ),
+      delayMs,
+    );
+  }
+  return {
+    signal: controller?.signal ?? signal,
+    aborted,
+    close,
+  };
 }
 
 export class CloudApiError extends Error {
@@ -268,46 +573,87 @@ export class ElizaCloudHttpClient {
     return resolveUrl(this.baseUrl, path, query);
   }
 
+  private async dispatchRequest(
+    method: HttpMethod,
+    path: string,
+    options: CloudRequestOptions,
+  ): Promise<{ response: Response; deadline: RequestDeadline }> {
+    const deadline = requestDeadline(options.timeoutMs, options.signal);
+    try {
+      const headers = new Headers(this.defaultHeaders);
+      const optionHeaders = new Headers(options.headers);
+      for (const [key, value] of optionHeaders) {
+        headers.set(key, value);
+      }
+
+      if (!options.skipAuth) {
+        const token = this.bearerToken ?? this.apiKey;
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
+        if (this.apiKey) {
+          headers.set("X-API-Key", this.apiKey);
+        }
+      } else {
+        headers.delete("Authorization");
+        headers.delete("X-API-Key");
+      }
+
+      const init: RequestInit = {
+        method,
+        headers,
+        signal: deadline.signal,
+      };
+
+      if (options.json !== undefined) {
+        if (!headers.has("Content-Type")) {
+          headers.set("Content-Type", "application/json");
+        }
+        init.body = JSON.stringify(options.json);
+      } else if (options.body !== undefined) {
+        init.body = options.body;
+      }
+
+      deadline.signal?.throwIfAborted();
+      const fetchPromise = this.fetchImpl(
+        this.buildUrl(path, options.query),
+        init,
+      );
+      void fetchPromise.then(
+        (lateResponse) => {
+          if (deadline.signal?.aborted) {
+            cancelBodyDetached(lateResponse.body, deadline.signal.reason);
+          }
+        },
+        () => {
+          // error-policy:J5 The same fetch rejection is observed by the race below.
+        },
+      );
+      const response = await Promise.race([fetchPromise, deadline.aborted]);
+      return { response, deadline };
+    } catch (error) {
+      deadline.close();
+      throw error;
+    }
+  }
+
   async requestRaw(
     method: HttpMethod,
     path: string,
     options: CloudRequestOptions = {},
   ): Promise<Response> {
-    const headers = new Headers(this.defaultHeaders);
-    const optionHeaders = new Headers(options.headers);
-    for (const [key, value] of optionHeaders) {
-      headers.set(key, value);
-    }
-
-    if (!options.skipAuth) {
-      const token = this.bearerToken ?? this.apiKey;
-      if (token) {
-        headers.set("Authorization", `Bearer ${token}`);
-      }
-      if (this.apiKey) {
-        headers.set("X-API-Key", this.apiKey);
-      }
-    } else {
-      headers.delete("Authorization");
-      headers.delete("X-API-Key");
-    }
-
-    const init: RequestInit = {
+    const { response, deadline } = await this.dispatchRequest(
       method,
-      headers,
-      signal: timeoutSignal(options.timeoutMs, options.signal),
-    };
-
-    if (options.json !== undefined) {
-      if (!headers.has("Content-Type")) {
-        headers.set("Content-Type", "application/json");
-      }
-      init.body = JSON.stringify(options.json);
-    } else if (options.body !== undefined) {
-      init.body = options.body;
+      path,
+      options,
+    );
+    try {
+      return responseWithOwnedBody(response, deadline);
+    } catch (error) {
+      deadline.close();
+      cancelBodyDetached(response.body, error);
+      throw error;
     }
-
-    return this.fetchImpl(this.buildUrl(path, options.query), init);
   }
 
   async request<TResponse>(
@@ -315,34 +661,42 @@ export class ElizaCloudHttpClient {
     path: string,
     options: CloudRequestOptions = {},
   ): Promise<TResponse> {
-    const response = await this.requestRaw(method, path, options);
-    const body = await parseResponseBody(response);
+    const { response, deadline } = await this.dispatchRequest(
+      method,
+      path,
+      options,
+    );
+    try {
+      const body = await parseResponseBody(response, deadline.signal);
 
-    if (!response.ok) {
-      const errorBody = normalizeErrorBody(
-        response.status,
-        response.statusText,
-        body,
-      );
-      throw response.status === 402
-        ? new InsufficientCreditsError(errorBody)
-        : new CloudApiError(response.status, errorBody);
+      if (!response.ok) {
+        const errorBody = normalizeErrorBody(
+          response.status,
+          response.statusText,
+          body,
+        );
+        throw response.status === 402
+          ? new InsufficientCreditsError(errorBody)
+          : new CloudApiError(response.status, errorBody);
+      }
+
+      // A 2xx that promised JSON but delivered unparseable bytes is a broken
+      // response, not a success — surface it instead of fabricating one.
+      if (isMalformedJsonBody(body)) {
+        throw new CloudApiError(response.status, {
+          success: false,
+          error: `HTTP ${response.status}: malformed JSON response body: ${body.text}`,
+        });
+      }
+
+      if (body === undefined || typeof body === "string") {
+        return { success: true } as TResponse;
+      }
+
+      return body as TResponse;
+    } finally {
+      deadline.close();
     }
-
-    // A 2xx that promised JSON but delivered unparseable bytes is a broken
-    // response, not a success — surface it instead of fabricating one.
-    if (isMalformedJsonBody(body)) {
-      throw new CloudApiError(response.status, {
-        success: false,
-        error: `HTTP ${response.status}: malformed JSON response body: ${body.text}`,
-      });
-    }
-
-    if (body === undefined || typeof body === "string") {
-      return { success: true } as TResponse;
-    }
-
-    return body as TResponse;
   }
 
   async get<TResponse>(

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -193,9 +193,11 @@ function timeoutSignal(
   timeoutMs?: number,
   signal?: AbortSignal,
 ): AbortSignal | undefined {
-  if (signal) return signal;
-  if (!timeoutMs) return undefined;
-  return AbortSignal.timeout(timeoutMs);
+  if (!timeoutMs) return signal;
+  if (!signal) return AbortSignal.timeout(timeoutMs);
+  // Compose both so a caller-owned signal cannot silently discard the
+  // per-request deadline (and vice versa): whichever fires first aborts.
+  return AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]);
 }
 
 export class CloudApiError extends Error {


### PR DESCRIPTION
# Relates to

Fixes #24319

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts; SDK suite rerun post-sync (0 fail).
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.
      All gates within this PR's scope pass; repo-wide upstream blockers unchanged (see Known gaps / failures).

# Risks

**Low.** One function (`timeoutSignal`) changes behavior only when **both**
`timeoutMs` and `signal` are supplied — previously a silent no-timeout request,
now a composed abort source. Single-option call sites are byte-for-byte
unchanged in behavior. Callers passing both currently get unbounded requests;
after this PR they get the deadline they asked for, which is the documented
option contract.

# Background

## What does this PR do?

Stops `ElizaCloudHttpClient` from silently discarding `timeoutMs` when a caller
also supplies `signal`. `CloudRequestOptions` exposes both fields and the
gateway-relay/job-poll client paths accept exactly this pair; previously only
the caller signal reached `fetch`, so a long-lived component-lifetime controller
turned every such request into an unbounded one. The two sources are now
composed with `AbortSignal.any([...])`: whichever fires first aborts.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/sdk/src/http.ts` — `timeoutSignal()` composition;
`packages/cloud/sdk/src/http.test.ts` — new `abort and deadline composition`
describe block at the bottom.

## Detailed testing steps

None: Automated tests are acceptable.

```bash
bun run --cwd packages/cloud/sdk test
```

1. `combines a caller signal with timeoutMs so the per-request deadline still fires` — red on unmodified `develop`, green here.
2. `aborts the combined signal when the caller's own signal fires first` — external abort path preserved.
3. `passes a bare caller signal through unchanged` — single-option behavior byte-identical.
4. `derives a deadline-only signal when only timeoutMs is given` — single-option behavior preserved.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:dabef3ce422ece5ebceb64d435fa770602081c0c -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface,
      desktop and mobile, or an explicit not-applicable statement follows.
  N/A - core SDK HTTP-client change with no rendered UI surface; the
  before state is the failing bun-test transcript pasted inside the backend-logs
  row below.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface,
      desktop and mobile, or an explicit not-applicable statement follows.
  N/A - same reason; the after state is the zero-fail suite summary
  pasted inside the backend-logs row below.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or an explicit
      not-applicable statement follows.
  N/A - no UI flow exists; the complete observable behavior (which
  AbortSignal reaches fetch and when it aborts) is asserted directly by the four
  tests listed under Testing.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end.
  Red run on unmodified develop (8f893fb9aa), captured from the injected-fetch
  test harness:

  ```text
  (fail) ElizaCloudHttpClient abort and deadline composition >
    combines a caller signal with timeoutMs so the per-request deadline still fires
  expect(passedSignal).not.toBe(controller.signal)
  → passedSignal IS controller.signal   # timeoutMs: 5 never composed
  Ran 112 tests across 10 files — 1 fail
  ```

  Green run on this branch (57b6eb3887dd64760e635425a31479e5e6757e90) after
  rebase onto latest origin/develop (92f841367c):

  ```text
  bun run --cwd packages/cloud/sdk test
  92 pass / 19 skip / 0 fail
  221 expect() calls
  Ran 112 tests across 10 files.
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or an explicit not-applicable statement follows.
  N/A - SDK transport internals only; no browser or client surface is
  touched by this diff.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or an explicit not-applicable statement follows.
  N/A - no model invocation is involved; this is deterministic
  AbortSignal composition in the SDK transport layer.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or an explicit
      not-applicable statement plus equivalent captured state follows.
  Captured state — the actual RequestInit.signal objects observed by the fake
  fetch, asserted by the new tests:

  ```text
  before (both options supplied):
    init.signal === controller.signal        // caller object reused verbatim
    deadline: none                           // timeoutMs silently dropped

  after (both options supplied):
    init.signal !== controller.signal        // AbortSignal.any composition
    controller.abort()            → init.signal.aborted === true
    AbortSignal.timeout(5ms) fires → init.signal.aborted === true

  single-option behaviors (unchanged):
    { signal } only   → init.signal === controller.signal
    { timeoutMs } only→ init.signal instanceof AbortSignal, not aborted at t0
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or an explicit
      not-applicable statement follows when the change has no rendered surface.
  N/A - this change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

Not applicable — no agent/action/provider/prompt/model path is touched by this change.

## Backend + frontend logs

Full transcripts are pasted inside the backend-logs evidence row above.
Frontend: not applicable — SDK-only change.

## Screenshots (before / after) + video walkthrough

### Before

Not applicable — no UI; failing-test transcript inside the backend-logs row.

### After

Not applicable — no UI; passing-test transcript inside the backend-logs row.

### Walkthrough video

Not applicable — no user-facing flow to walk through.

## Audio / voice walkthrough

Not applicable — no voice/transcript/TTS/STT surface.

## Known gaps / failures

Repo-wide lanes fail identically on clean `origin/develop` with no files of
this PR involved (`git diff origin/develop` touches only
`packages/cloud/sdk/src/{http.ts, http.test.ts}`):

1. `@elizaos/cloud-api#typecheck` — dangling import of removed module
   `../../bluebubbles/route` left by the bluebubbles webhook-diversion removal
   (#24283 follow-up).
2. `@elizaos/agent#lint:check` — pre-existing biome findings from #23501
   (`8a860cd703`), also documented in #24294/#24315.
3. `audit:scripts` coupling-stale allowlist drift and
   `audit:mock-module-exports` pre-existing baseline — same upstream states as
   documented in #24294/#24315.

All gates within this PR's scope pass: `bun run --cwd packages/cloud/sdk
test` → 0 fail, typecheck clean, lint clean, build succeeds.

AI provider/model: opencode / x-preview-f-free
Client / agent tooling: opencode
Contribution skill revision: elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [ox-alpha-contribution-3]
<!-- eliza-computer-attribution:v1 {"provider":"opencode","model":"x-preview-f-free","client":"opencode","skill_revision":"elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza"} -->


## Maintainer remediation receipt — 2026-08-21

Exact head `aeb0497f81312f4b33d713a6690ae924305d74a5` is rebased onto `origin/develop@f73b0399e662d3dc0b01fe2ea721a2916a781db3`; the original contributor commit remains separately authored by Deepanshu Yadav.

The initial `AbortSignal.any([caller, AbortSignal.timeout(...)])` repair was strengthened at the same two-file SDK boundary: the deadline timer is now clearable, pre-aborted callers never dispatch, caller abort reasons and raw-stream cancellation remain connected, parsed responses retain the same deadline through body consumption, and parsed response bodies fail closed above 8 MiB or 8,192 chunks. Oversize bodies are rejected, never truncated.

Exact-head gates on pinned Bun 1.3.14:

- `bun install --frozen-lockfile`: PASS.
- `bun run --cwd packages/cloud/sdk test`: 99 pass, 19 live skips, 0 fail, 234 assertions.
- SDK `typecheck`, `lint:check`, and `build`: PASS.
- `git diff --check origin/develop...HEAD`: PASS.
- `bun run check:agents-claude`: 160 guide pairs PASS.
- `bun run verify`: reached inherited `check:i18n` failure (nine missing English keys and existing locale gaps in app/UI files outside this PR). The identical `check:i18n` failure was reproduced in a detached clean worktree at exact base `f73b0399e662d3dc0b01fe2ea721a2916a781db3`.

Failure-sensitive coverage now proves in-flight timeout, caller-abort provenance, bare-signal identity, pre-abort no-dispatch, timer cleanup, raw-body caller cancellation after headers, stalled parsed-body timeout, declared and chunked byte overflow, never-settling cancellation, and zero-byte fragmentation. No prompt/model context is sliced or truncated.

Overlap scan: no other open PR touches `packages/cloud/sdk/src/http.ts` or `http.test.ts`. #24185 is a conceptually related bounded-fetch helper for cloud-shared provider utilities but has no file or ownership overlap; neither PR is a duplicate.

Remaining holds: independent hostile review and the exact-head hosted Static Smoke. The PR intentionally remains draft until those finish.

## Maintainer remediation receipt — exact re-review head

This receipt supersedes the earlier `aeb0497f81` receipt. Exact head `c25beca3435c7f7ebbb32ceea94d513d90d91999` is rebased onto `origin/develop@af3d51c5b4b525286ad02c2a3d9190549816041e`; the original contributor commit remains separately authored by Deepanshu Yadav.

The owned deadline is raced against fetch even when an injected transport ignores its signal, and ownership continues through raw or parsed response-body consumption. Caller abort identity/reason, pre-abort no-dispatch, timer/listener teardown, hostile cancellation, and fail-closed 8 MiB / 8,192-chunk parsed-body bounds are covered without truncating content.

Exact-head gates on pinned Bun 1.3.14: `bun install --frozen-lockfile` PASS; SDK tests 102 pass / 19 live skips / 0 fail / 239 assertions; SDK typecheck, lint, and build PASS; `git diff --check` PASS. Root verify remains held only by the inherited i18n baseline reproduced on the clean base, as documented above. Hosted Static Smoke and independent re-review are pending on this exact SHA.


### Final streaming-race remediation

Exact head `5a320b3eb9639ebb5ad901ff15f37425799cffc4` is rebased onto `origin/develop@8940dea477afd71769c9050fc250a727b1c54dac`. The raw wrapper now reacts proactively to deadline abort while the consumer is idle: it errors and discards its queued data, detached-cancels the source, and cannot expose a prefetched stale chunk after expiry. A delayed-read regression test proves the first post-deadline read rejects with `TimeoutError` and source cancellation runs exactly once. Exact SDK gates: 103 pass / 19 live skips / 0 fail / 241 assertions; typecheck, lint, build, frozen install, and diff-check PASS. Independent exact-head re-review and restarted hosted checks remain pending.


### Raw Response compatibility remediation

Final candidate `24894257c9d47065298e0b7b04db16d17c49682e` remains based on `origin/develop@8940dea477afd71769c9050fc250a727b1c54dac`. Wrapped raw responses now preserve `url`, `type`, and `redirected` recursively through standard `Response.clone()` calls; nested-clone bytes and metadata are regression-tested. The maintained-source header now records deadline ownership and parsed-body resource invariants. Exact SDK gates: 104 pass / 19 live skips / 0 fail / 253 assertions; typecheck, lint, build, frozen install, and diff-check PASS.


### Byte-stream compatibility remediation

Exact head `3038550863c3fec2147258125809d4277ec5aa25` remains based on `origin/develop@8940dea477afd71769c9050fc250a727b1c54dac`. The owned raw wrapper is now a byte stream and preserves BYOB readers; when neither a deadline nor caller signal is requested, `requestRaw()` returns the exact upstream `Response` unchanged. Regression tests cover both contracts. Exact SDK gates: 106 pass / 19 live skips / 0 fail / 256 assertions; typecheck, lint, build, frozen install, and diff-check PASS.


### Latest-develop restamp

Exact head `dabef3ce422ece5ebceb64d435fa770602081c0c` is rebased without conflicts onto `origin/develop@8a315387c27f7a5b5461cf3d47d39b545a8c52c3`. Stable patch IDs and `git range-diff` prove both contributor and remediation commits are byte-equivalent to the independently reviewed `3038550863` stack. Exact post-rebase SDK gates remain 106 pass / 19 live skips / 0 fail / 256 assertions; typecheck, lint, build, frozen install, and diff-check PASS.
