### PR TITLE
feat(cloud): bind Personal Shared provider groups

### DIFF
--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -314,6 +314,12 @@ async function edgeLedger(
         ? body.state
         : null;
     },
+    // The edge flow records complete delivery receipts separately. Personal
+    // Shared groups use the gateway Redis ledger, where this per-chunk value
+    // repairs a failed receipt POST without resending provider messages.
+    async readChunkProviderMessageId() {
+      return null;
+    },
     async claimChunk(chunkIndex, chunkDigest) {
       return (
         (

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -837,6 +837,25 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
+  test("does not let a second administrator take over an active owner binding", async () => {
+    consumeGroupClaimAndBind.mockImplementationOnce(async () => ({
+      status: "already_bound" as const,
+    }));
+    const response = await request({
+      ...validGroup,
+      message: "/eliza_link 23456789",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_claim_already_bound",
+        reply: expect.stringContaining("already linked to another Eliza owner"),
+      },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
   test("routes a bound mention in its stable group conversation", async () => {
     resolveGroupBinding.mockImplementationOnce(
       async () => canonicalGroupBinding,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -100,6 +100,23 @@ const coordinateSharedHistory = mock(async () => [
     createdAt: 101,
   },
 ]);
+const issueGroupClaim = mock(async () => undefined);
+const consumeGroupClaimAndBind = mock(
+  async (): Promise<
+    | { status: "invalid" }
+    | { status: "bound"; binding: Record<string, unknown> }
+  > => ({ status: "invalid" }),
+);
+const resolveGroupBinding = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const setGroupResponsePolicy = mock(async () => null);
+const revokeGroupBinding = mock(async () => false);
+const applyGroupMembershipChange = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const recordGroupDeliveryReceipts = mock(async () => 0);
+const hasGroupDeliveryReceipt = mock(async () => false);
 const namespace = {
   getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
 };
@@ -149,6 +166,18 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
 mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
   coordinateSharedHistory,
 }));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    issueClaim: issueGroupClaim,
+    consumeClaimAndBind: consumeGroupClaimAndBind,
+    resolveBinding: resolveGroupBinding,
+    setResponsePolicy: setGroupResponsePolicy,
+    revokeBinding: revokeGroupBinding,
+    applyMembershipChange: applyGroupMembershipChange,
+    recordDeliveryReceipts: recordGroupDeliveryReceipts,
+    hasDeliveryReceipt: hasGroupDeliveryReceipt,
+  },
+}));
 mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
   resolveSharedRuntimeWorkerRequestContext: () => ({
     namespace,
@@ -187,6 +216,7 @@ function request(
 const valid = {
   platform: "telegram",
   project: "eliza-app",
+  connectorAccountId: "telegram:test-bot",
   chatId: "123456789",
   telegramUserId: "123456789",
   telegramUsername: "nubs",
@@ -198,9 +228,41 @@ const valid = {
 const validPhone = {
   platform: "blooio",
   project: "eliza-app",
+  connectorAccountId: "blooio:test-number",
   phoneNumber: "+15551234567",
   messageId: "blooio:eliza:message-42",
   message: "hello from Messages",
+};
+
+const canonicalGroupBinding = {
+  id: "00000000-0000-4000-8000-000000000030",
+  organization_id: "00000000-0000-4000-8000-000000000001",
+  owner_user_id: "00000000-0000-4000-8000-000000000002",
+  personal_agent_id: "personal:3e91680e-2611-5ff5-b759-c16b990967bd",
+  platform: "telegram",
+  project: "eliza-app",
+  connector_account_id: "telegram:test-bot",
+  provider_chat_id: "-100123456789",
+  conversation_id: "group:00000000-0000-5000-8000-000000000030",
+  state: "active",
+  response_policy: "mention_only",
+  created_by_platform_user_id: "123456789",
+};
+
+const validGroup = {
+  platform: "telegram",
+  chatType: "supergroup",
+  project: "eliza-app",
+  connectorAccountId: "telegram:test-bot",
+  chatId: "-100123456789",
+  actor: {
+    platformUserId: "123456789",
+    displayName: "Nubs",
+    role: "administrator",
+  },
+  messageId: "telegram:eliza:group-42",
+  message: "@ElizaIsNotABot hello",
+  invocation: "mention",
 };
 
 describe("personal Shared messaging deliveries", () => {
@@ -216,6 +278,17 @@ describe("personal Shared messaging deliveries", () => {
     bridge.mockClear();
     importCanonicalConversation.mockClear();
     coordinateSharedHistory.mockClear();
+    issueGroupClaim.mockClear();
+    consumeGroupClaimAndBind.mockClear();
+    resolveGroupBinding.mockClear();
+    setGroupResponsePolicy.mockClear();
+    revokeGroupBinding.mockClear();
+    applyGroupMembershipChange.mockClear();
+    recordGroupDeliveryReceipts.mockClear();
+    hasGroupDeliveryReceipt.mockClear();
+    applyGroupMembershipChange.mockImplementation(async () => null);
+    recordGroupDeliveryReceipts.mockImplementation(async () => 0);
+    hasGroupDeliveryReceipt.mockImplementation(async () => false);
     enqueueAgentResumeOnce.mockClear();
     enqueueAgentWakeOnce.mockClear();
     triggerImmediate.mockClear();
@@ -700,6 +773,156 @@ describe("personal Shared messaging deliveries", () => {
     const renewedSession = runOnboardingChat.mock.calls[2]?.[0].sessionId;
     expect(firstSession).toBe(retrySession);
     expect(renewedSession).not.toBe(firstSession);
+  });
+
+  test("issues a one-time owner-bound group claim without entering inference", async () => {
+    const response = await request({ ...valid, message: "/group" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_claim_issued" },
+    });
+    expect(issueGroupClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerUserId: "00000000-0000-4000-8000-000000000002",
+        platform: "telegram",
+        connectorAccountId: "telegram:test-bot",
+        issuedToPlatformUserId: "123456789",
+        codeHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      }),
+    );
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("fails a Telegram group link closed without verified admin authority", async () => {
+    const response = await request({
+      ...validGroup,
+      actor: { ...validGroup.actor, role: "unknown" },
+      message: "/eliza_link 23456789",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_admin_required" },
+    });
+    expect(consumeGroupClaimAndBind).not.toHaveBeenCalled();
+  });
+
+  test("binds a verified Telegram admin to the pre-existing owner identity", async () => {
+    consumeGroupClaimAndBind.mockImplementationOnce(async () => ({
+      status: "bound" as const,
+      binding: canonicalGroupBinding,
+    }));
+    const response = await request({
+      ...validGroup,
+      message: "/eliza_link 23456789",
+      invocation: "command",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_bound",
+        account: {
+          userId: canonicalGroupBinding.owner_user_id,
+          organizationId: canonicalGroupBinding.organization_id,
+        },
+      },
+    });
+    expect(consumeGroupClaimAndBind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerChatId: "-100123456789",
+        actorPlatformUserId: "123456789",
+      }),
+    );
+  });
+
+  test("routes a bound mention in its stable group conversation", async () => {
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+    const response = await request(validGroup);
+
+    expect(response.status).toBe(200);
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledWith(
+      expect.objectContaining({ id: canonicalGroupBinding.personal_agent_id }),
+      namespace,
+      {
+        warmConversation: true,
+        conversationId: canonicalGroupBinding.conversation_id,
+      },
+    );
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: canonicalGroupBinding.personal_agent_id }),
+      canonicalGroupBinding.conversation_id,
+      expect.stringMatching(/^Nubs \[participant [0-9a-f]{8}\]: /),
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      validGroup.messageId,
+      "platform",
+      undefined,
+      undefined,
+      { type: "GROUP", source: "telegram" },
+    );
+  });
+
+  test("keeps mention-only groups silent for ambient traffic", async () => {
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+    const response = await request({ ...validGroup, invocation: "ambient" });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_silent", reply: "" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("suspends and restores only an existing Telegram group binding", async () => {
+    applyGroupMembershipChange.mockImplementation(
+      async () => canonicalGroupBinding,
+    );
+    const response = await request({
+      eventType: "membership",
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
+      chatId: "-100123456789",
+      messageId: "telegram:membership:42",
+      membershipChange: "removed",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_membership_removed", reply: "" },
+    });
+    expect(applyGroupMembershipChange).toHaveBeenCalledWith({
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
+      providerChatId: "-100123456789",
+      membershipChange: "removed",
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("records provider egress receipts without entering inference", async () => {
+    recordGroupDeliveryReceipts.mockImplementationOnce(async () => 1);
+    const response = await request({
+      eventType: "delivery_receipt",
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "blooio:test-number",
+      chatId: "chat_group_123",
+      sourceMessageId: "blooio:eliza-app:incoming-42",
+      providerMessageIds: ["outgoing-42"],
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_delivery_receipt_recorded", inserted: 1 },
+    });
+    expect(recordGroupDeliveryReceipts).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });
 
   test("auto-registers a first phone message without provisioning an agent row", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -289,6 +289,8 @@ describe("personal Shared messaging deliveries", () => {
     applyGroupMembershipChange.mockImplementation(async () => null);
     recordGroupDeliveryReceipts.mockImplementation(async () => 0);
     hasGroupDeliveryReceipt.mockImplementation(async () => false);
+    setGroupResponsePolicy.mockImplementation(async () => canonicalGroupBinding);
+    revokeGroupBinding.mockImplementation(async () => true);
     enqueueAgentResumeOnce.mockClear();
     enqueueAgentWakeOnce.mockClear();
     triggerImmediate.mockClear();
@@ -894,6 +896,36 @@ describe("personal Shared messaging deliveries", () => {
 
     await expect(response.json()).resolves.toMatchObject({
       data: { code: "group_silent", reply: "" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("does not report a policy update after the active binding changed", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => canonicalGroupBinding);
+    setGroupResponsePolicy.mockImplementationOnce(async () => null);
+    const response = await request({
+      ...validGroup,
+      message: "Eliza ambient on",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_binding_changed" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("does not report a disconnect after the active binding changed", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => canonicalGroupBinding);
+    revokeGroupBinding.mockImplementationOnce(async () => false);
+    const response = await request({
+      ...validGroup,
+      message: "Eliza leave",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_binding_changed" },
     });
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -104,6 +104,7 @@ const issueGroupClaim = mock(async () => undefined);
 const consumeGroupClaimAndBind = mock(
   async (): Promise<
     | { status: "invalid" }
+    | { status: "already_bound" }
     | { status: "bound"; binding: Record<string, unknown> }
   > => ({ status: "invalid" }),
 );
@@ -289,7 +290,9 @@ describe("personal Shared messaging deliveries", () => {
     applyGroupMembershipChange.mockImplementation(async () => null);
     recordGroupDeliveryReceipts.mockImplementation(async () => 0);
     hasGroupDeliveryReceipt.mockImplementation(async () => false);
-    setGroupResponsePolicy.mockImplementation(async () => canonicalGroupBinding);
+    setGroupResponsePolicy.mockImplementation(
+      async () => canonicalGroupBinding,
+    );
     revokeGroupBinding.mockImplementation(async () => true);
     enqueueAgentResumeOnce.mockClear();
     enqueueAgentWakeOnce.mockClear();
@@ -901,7 +904,9 @@ describe("personal Shared messaging deliveries", () => {
   });
 
   test("does not report a policy update after the active binding changed", async () => {
-    resolveGroupBinding.mockImplementationOnce(async () => canonicalGroupBinding);
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
     setGroupResponsePolicy.mockImplementationOnce(async () => null);
     const response = await request({
       ...validGroup,
@@ -916,7 +921,9 @@ describe("personal Shared messaging deliveries", () => {
   });
 
   test("does not report a disconnect after the active binding changed", async () => {
-    resolveGroupBinding.mockImplementationOnce(async () => canonicalGroupBinding);
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
     revokeGroupBinding.mockImplementationOnce(async () => false);
     const response = await request({
       ...validGroup,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -458,7 +458,7 @@ app.post("/", async (c) => {
                     ? "That group link was already used. DM Eliza `/group` for a new one if you are reconnecting."
                     : claimed.status === "already_bound"
                       ? "This group is already linked to another Eliza owner. That owner must disconnect it before a different owner can link it."
-                    : "That group link is not valid for this account or sender. DM Eliza `/group` yourself and paste the exact command here.",
+                      : "That group link is not valid for this account or sender. DM Eliza `/group` yourself and paste the exact command here.",
             },
           });
         }
@@ -529,7 +529,8 @@ app.post("/", async (c) => {
             success: true,
             data: {
               code: "group_binding_changed",
-              reply: "This group link changed before the policy update. Reconnect it and try again.",
+              reply:
+                "This group link changed before the policy update. Reconnect it and try again.",
             },
           });
         }

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1,11 +1,13 @@
 /** Runs a trusted messaging delivery through one rowless personal Shared turn. */
 
+import { ChannelType } from "@elizaos/core/edge";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
   PersonalDeliveryAccountResolutionError,
   resolvePersonalDeliveryProjection,
 } from "@/api-app/personal-delivery-projection";
+import { personalSharedGroupsRepository } from "@/db/repositories/personal-shared-groups";
 import type { AgentSandbox } from "@/db/schemas/agent-sandboxes";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
@@ -38,6 +40,8 @@ const MAX_TELEGRAM_VOICE_BASE64_LENGTH =
 const DEFAULT_WHISPER_MODEL = "Systran/faster-whisper-small";
 const FAILURE_STAGE_HEADER = "X-Eliza-Failure-Stage";
 const FAILURE_NAME_HEADER = "X-Eliza-Failure-Name";
+const GROUP_CLAIM_TTL_MS = 10 * 60_000;
+const GROUP_CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
 
 type DeliveryStage =
   | "authentication"
@@ -84,14 +88,54 @@ const telegramVoiceNoteSchema = z.object({
     .max(15 * 60),
 });
 
-const sharedMessageSchema = z.discriminatedUnion("platform", [
+const projectSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/i);
+const connectorAccountIdSchema = z.string().trim().min(3).max(160);
+const groupActorSchema = z.object({
+  platformUserId: z.string().trim().min(1).max(160),
+  displayName: z.string().trim().min(1).max(128).optional(),
+  role: z.enum(["creator", "administrator", "member", "unknown", "possessor"]),
+});
+const groupFields = {
+  project: projectSchema,
+  connectorAccountId: connectorAccountIdSchema,
+  chatId: z.string().trim().min(1).max(160),
+  actor: groupActorSchema,
+  messageId: z.string().trim().min(1).max(160),
+  message: z.string().trim().min(1).max(4000),
+  invocation: z.enum(["mention", "command", "reply", "ambient"]),
+  replyToMessageId: z.string().trim().min(1).max(160).optional(),
+};
+
+const sharedMessageSchema = z.union([
+  z.object({
+    eventType: z.literal("membership"),
+    platform: z.literal("telegram"),
+    project: projectSchema,
+    connectorAccountId: connectorAccountIdSchema,
+    chatId: z.string().trim().min(1).max(160),
+    messageId: z.string().trim().min(1).max(160),
+    membershipChange: z.enum(["joined", "removed"]),
+  }),
+  z.object({
+    eventType: z.literal("delivery_receipt"),
+    platform: z.enum(["telegram", "blooio"]),
+    project: projectSchema,
+    connectorAccountId: connectorAccountIdSchema,
+    chatId: z.string().trim().min(1).max(160),
+    sourceMessageId: z.string().trim().min(1).max(160),
+    providerMessageIds: z
+      .array(z.string().trim().min(1).max(160))
+      .min(1)
+      .max(8),
+  }),
   z
     .object({
       platform: z.literal("telegram"),
-      project: z
-        .string()
-        .trim()
-        .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/i),
+      project: projectSchema,
+      connectorAccountId: connectorAccountIdSchema,
       chatId: z
         .string()
         .trim()
@@ -110,6 +154,11 @@ const sharedMessageSchema = z.discriminatedUnion("platform", [
       (input) => input.message !== undefined || input.voiceNote !== undefined,
     ),
   z.object({
+    platform: z.literal("telegram"),
+    chatType: z.enum(["group", "supergroup"]),
+    ...groupFields,
+  }),
+  z.object({
     platform: z.literal("discord"),
     discordUserId: z
       .string()
@@ -123,10 +172,8 @@ const sharedMessageSchema = z.discriminatedUnion("platform", [
   }),
   z.object({
     platform: z.enum(["twilio", "blooio"]),
-    project: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9][a-z0-9_-]{0,63}$/i),
+    project: projectSchema,
+    connectorAccountId: connectorAccountIdSchema,
     phoneNumber: z
       .string()
       .trim()
@@ -134,7 +181,57 @@ const sharedMessageSchema = z.discriminatedUnion("platform", [
     messageId: z.string().trim().min(1).max(160),
     message: z.string().trim().min(1).max(4000),
   }),
+  z.object({
+    platform: z.literal("blooio"),
+    chatType: z.literal("group"),
+    ...groupFields,
+  }),
 ]);
+
+type SharedMessage = z.infer<typeof sharedMessageSchema>;
+type GroupMessage = Extract<
+  SharedMessage,
+  { chatType: "group" | "supergroup" }
+>;
+
+function isGroupMessage(message: SharedMessage): message is GroupMessage {
+  return "chatType" in message;
+}
+
+function groupClaimCommand(message: string): string | null {
+  const match = message.match(
+    /^(?:\/eliza_link(?:@[a-z0-9_]{5,32})?|eliza\s+link)\s+([2-9A-HJ-NP-Z]{8})$/i,
+  );
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function groupPolicyCommand(
+  message: string,
+): "mention_only" | "ambient" | null {
+  const match = message.match(
+    /^(?:\/eliza_ambient(?:@[a-z0-9_]{5,32})?|eliza\s+ambient)\s+(on|off)$/i,
+  );
+  if (!match) return null;
+  return match[1].toLowerCase() === "on" ? "ambient" : "mention_only";
+}
+
+function isGroupLeaveCommand(message: string): boolean {
+  return /^(?:\/eliza_leave(?:@[a-z0-9_]{5,32})?|eliza\s+leave)$/i.test(
+    message,
+  );
+}
+
+function isGroupClaimRequest(message: string): boolean {
+  return /^(?:\/group(?:@[a-z0-9_]{5,32})?|eliza\s+group)$/i.test(message);
+}
+
+function createGroupClaimCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  return Array.from(
+    bytes,
+    (byte) => GROUP_CODE_ALPHABET[byte % GROUP_CODE_ALPHABET.length],
+  ).join("");
+}
 
 function decodeTelegramVoiceNote(
   input: z.infer<typeof telegramVoiceNoteSchema>,
@@ -243,8 +340,46 @@ app.post("/", async (c) => {
         "validation_error",
       );
     }
+    if ("eventType" in parsed.data) {
+      if (parsed.data.eventType === "membership") {
+        const binding =
+          await personalSharedGroupsRepository.applyMembershipChange({
+            platform: "telegram",
+            project: parsed.data.project,
+            connectorAccountId: parsed.data.connectorAccountId,
+            providerChatId: parsed.data.chatId,
+            membershipChange: parsed.data.membershipChange,
+          });
+        return c.json({
+          success: true,
+          data: {
+            code: binding
+              ? `group_membership_${parsed.data.membershipChange}`
+              : "group_membership_unchanged",
+            reply: "",
+          },
+        });
+      }
+      const inserted =
+        await personalSharedGroupsRepository.recordDeliveryReceipts({
+          platform: parsed.data.platform,
+          project: parsed.data.project,
+          connectorAccountId: parsed.data.connectorAccountId,
+          providerChatId: parsed.data.chatId,
+          sourceMessageId: parsed.data.sourceMessageId,
+          providerMessageIds: parsed.data.providerMessageIds,
+        });
+      return c.json({
+        success: true,
+        data: { code: "group_delivery_receipt_recorded", inserted },
+      });
+    }
     let telegramVoiceBytes: Uint8Array | undefined;
-    if (parsed.data.platform === "telegram" && parsed.data.voiceNote) {
+    if (
+      parsed.data.platform === "telegram" &&
+      !isGroupMessage(parsed.data) &&
+      parsed.data.voiceNote
+    ) {
       try {
         telegramVoiceBytes = decodeTelegramVoiceNote(parsed.data.voiceNote);
       } catch {
@@ -277,12 +412,175 @@ app.post("/", async (c) => {
     const accountStartedAt = performance.now();
     let account: { userId: string; organizationId: string };
     let accountResolution = "phone-query";
+    let groupConversationId: string | undefined;
+    let groupActorLabel: string | undefined;
+    let groupPersonalAgentId: string | undefined;
     let dedicated:
       | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
       | null
       | undefined;
     let isNewPersonalAccount = false;
-    if (parsed.data.platform === "telegram") {
+    if (isGroupMessage(parsed.data)) {
+      const claimCode = groupClaimCommand(parsed.data.message);
+      if (claimCode) {
+        if (
+          parsed.data.platform === "telegram" &&
+          parsed.data.actor.role !== "creator" &&
+          parsed.data.actor.role !== "administrator"
+        ) {
+          return c.json({
+            success: true,
+            data: {
+              code: "group_admin_required",
+              reply:
+                "Only a Telegram group creator or administrator can link Eliza. Make Eliza an admin, then have the same owner retry the link command.",
+            },
+          });
+        }
+        const claimed =
+          await personalSharedGroupsRepository.consumeClaimAndBind({
+            codeHash: await sha256Hex(claimCode),
+            platform: parsed.data.platform,
+            project: parsed.data.project,
+            connectorAccountId: parsed.data.connectorAccountId,
+            providerChatId: parsed.data.chatId,
+            actorPlatformUserId: parsed.data.actor.platformUserId,
+          });
+        if (claimed.status !== "bound") {
+          return c.json({
+            success: true,
+            data: {
+              code: `group_claim_${claimed.status}`,
+              reply:
+                claimed.status === "expired"
+                  ? "That group link expired. DM Eliza `/group` for a fresh code, then paste the new link command here."
+                  : claimed.status === "already_used"
+                    ? "That group link was already used. DM Eliza `/group` for a new one if you are reconnecting."
+                    : "That group link is not valid for this account or sender. DM Eliza `/group` yourself and paste the exact command here.",
+            },
+          });
+        }
+        return c.json({
+          success: true,
+          data: {
+            code: "group_bound",
+            identity: {
+              id: claimed.binding.personal_agent_id,
+              runtime: "shared" as const,
+            },
+            account: {
+              userId: claimed.binding.owner_user_id,
+              organizationId: claimed.binding.organization_id,
+            },
+            reply:
+              "Eliza is linked to this group. I respond to explicit mentions, commands, and replies by default. The owner can say `Eliza ambient on`, `Eliza ambient off`, or `Eliza leave`.",
+          },
+        });
+      }
+
+      const binding = await personalSharedGroupsRepository.resolveBinding({
+        platform: parsed.data.platform,
+        project: parsed.data.project,
+        connectorAccountId: parsed.data.connectorAccountId,
+        providerChatId: parsed.data.chatId,
+      });
+      if (binding?.state !== "active") {
+        return c.json({
+          success: true,
+          data: {
+            code: binding ? "group_binding_suspended" : "group_not_bound",
+            reply:
+              parsed.data.invocation === "ambient"
+                ? ""
+                : binding
+                  ? "This group link is inactive. The owner can DM Eliza `/group` to reconnect it."
+                  : "This group is not linked yet. DM your Eliza `/group`, then paste the one-time link command here.",
+          },
+        });
+      }
+
+      const requestedPolicy = groupPolicyCommand(parsed.data.message);
+      const ownerControl =
+        requestedPolicy !== null || isGroupLeaveCommand(parsed.data.message);
+      if (
+        ownerControl &&
+        parsed.data.actor.platformUserId !== binding.created_by_platform_user_id
+      ) {
+        return c.json({
+          success: true,
+          data: {
+            code: "group_owner_required",
+            reply:
+              "Only the owner who linked Eliza can change this group's response policy.",
+          },
+        });
+      }
+
+      if (requestedPolicy) {
+        await personalSharedGroupsRepository.setResponsePolicy({
+          bindingId: binding.id,
+          ownerUserId: binding.owner_user_id,
+          policy: requestedPolicy,
+        });
+        return c.json({
+          success: true,
+          data: {
+            code: "group_policy_updated",
+            reply:
+              requestedPolicy === "ambient"
+                ? "Ambient replies are on. I may respond without a mention when I have something useful to add. Say `Eliza ambient off` to return to mention-only."
+                : "Mention-only is on. I will answer explicit mentions, commands, and replies to me.",
+          },
+        });
+      }
+      if (isGroupLeaveCommand(parsed.data.message)) {
+        await personalSharedGroupsRepository.revokeBinding({
+          bindingId: binding.id,
+          ownerUserId: binding.owner_user_id,
+        });
+        return c.json({
+          success: true,
+          data: {
+            code: "group_binding_revoked",
+            reply:
+              "This group is disconnected from your Eliza. Remove the bot/account here, or DM Eliza `/group` later to reconnect.",
+          },
+        });
+      }
+      const verifiedInvocation =
+        parsed.data.platform === "blooio" &&
+        parsed.data.invocation === "reply" &&
+        (!parsed.data.replyToMessageId ||
+          !(await personalSharedGroupsRepository.hasDeliveryReceipt({
+            bindingId: binding.id,
+            providerMessageId: parsed.data.replyToMessageId,
+          })))
+          ? "ambient"
+          : parsed.data.invocation;
+      if (
+        binding.response_policy === "mention_only" &&
+        verifiedInvocation === "ambient"
+      ) {
+        return c.json({
+          success: true,
+          data: { code: "group_silent", reply: "" },
+        });
+      }
+
+      account = {
+        userId: binding.owner_user_id,
+        organizationId: binding.organization_id,
+      };
+      accountResolution = "group-binding";
+      groupConversationId = binding.conversation_id;
+      groupPersonalAgentId = binding.personal_agent_id;
+      const actorDigest = (
+        await sha256Hex(
+          `${parsed.data.platform}\n${parsed.data.actor.platformUserId}`,
+        )
+      ).slice(0, 8);
+      groupActorLabel = `${parsed.data.actor.displayName ?? "Participant"} [participant ${actorDigest}]`;
+    } else if (parsed.data.platform === "telegram") {
       const delivery = await resolvePersonalDeliveryProjection(
         c.env,
         {
@@ -340,6 +638,53 @@ app.post("/", async (c) => {
       userId: account.userId,
       organizationId: account.organizationId,
     });
+    if (groupConversationId && !groupConversationId.startsWith("group:")) {
+      throw new Error("Invalid Personal Shared group conversation authority");
+    }
+    if (groupConversationId && groupPersonalAgentId !== agent.id) {
+      throw new Error(
+        "Personal Shared group binding does not match its canonical owner",
+      );
+    }
+
+    if (
+      !isGroupMessage(parsed.data) &&
+      (parsed.data.platform === "telegram" ||
+        parsed.data.platform === "blooio") &&
+      isGroupClaimRequest(parsed.data.message ?? "")
+    ) {
+      const code = createGroupClaimCode();
+      await personalSharedGroupsRepository.issueClaim({
+        codeHash: await sha256Hex(code),
+        organizationId: account.organizationId,
+        ownerUserId: account.userId,
+        personalAgentId: agent.id,
+        platform: parsed.data.platform,
+        project: parsed.data.project,
+        connectorAccountId: parsed.data.connectorAccountId,
+        issuedToPlatformUserId:
+          parsed.data.platform === "telegram"
+            ? parsed.data.telegramUserId
+            : parsed.data.phoneNumber,
+        expiresAt: new Date(Date.now() + GROUP_CLAIM_TTL_MS),
+      });
+      const linkCommand =
+        parsed.data.platform === "telegram"
+          ? `/eliza_link ${code}`
+          : `Eliza link ${code}`;
+      return c.json({
+        success: true,
+        data: {
+          code: "group_claim_issued",
+          identity: { id: agent.id, runtime: "shared" as const },
+          account: {
+            userId: account.userId,
+            organizationId: account.organizationId,
+          },
+          reply: `Add Eliza to the group, then send this there within 10 minutes:\n\n${linkCommand}\n\nUse the same ${parsed.data.platform === "telegram" ? "Telegram account" : "iMessage identity"} that requested this code.`,
+        },
+      });
+    }
     if (dedicated === undefined) {
       dedicated = await findActivePersonalDedicatedTarget(
         account.organizationId,
@@ -356,7 +701,13 @@ app.post("/", async (c) => {
           const timing = prewarmPersonalSharedAgentTurnCaches(
             agent,
             worker.namespace,
-            { warmConversation: isNewPersonalAccount },
+            {
+              warmConversation:
+                isNewPersonalAccount || Boolean(groupConversationId),
+              ...(groupConversationId
+                ? { conversationId: groupConversationId }
+                : {}),
+            },
           ).then(() => performance.now() - startedAt);
           worker.executionCtx.waitUntil(timing);
           return timing;
@@ -364,6 +715,7 @@ app.post("/", async (c) => {
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
+      !isGroupMessage(parsed.data) &&
       parsed.data.voiceNote &&
       telegramVoiceBytes
     ) {
@@ -388,6 +740,9 @@ app.post("/", async (c) => {
         },
       );
     }
+    if (deliveryMessage && groupActorLabel) {
+      deliveryMessage = `${groupActorLabel}: ${deliveryMessage}`;
+    }
     if (!deliveryMessage) {
       return jsonError(
         c,
@@ -398,6 +753,7 @@ app.post("/", async (c) => {
     }
     if (
       parsed.data.platform === "telegram" &&
+      !isGroupMessage(parsed.data) &&
       /^\/connect(?:@[a-z0-9_]{5,32})?$/i.test(deliveryMessage)
     ) {
       stage = "account_claim";
@@ -500,23 +856,25 @@ app.post("/", async (c) => {
         method: "message.send",
         params: {
           text: deliveryMessage,
-          roomId: agent.id,
-          conversationId: agent.id,
+          roomId: groupConversationId ?? agent.id,
+          conversationId: groupConversationId ?? agent.id,
           canonicalBridgeBase: dedicated.bridge_url,
           userId: account.userId,
           clientMessageId: parsed.data.messageId,
           platformName: parsed.data.platform,
           source: parsed.data.platform,
-          ...(parsed.data.platform === "telegram" ||
-          parsed.data.platform === "discord"
-            ? {
-                senderName:
-                  parsed.data.displayName ??
-                  (parsed.data.platform === "telegram"
-                    ? parsed.data.telegramUsername
-                    : parsed.data.discordUsername),
-              }
-            : {}),
+          ...(isGroupMessage(parsed.data)
+            ? { senderName: groupActorLabel }
+            : parsed.data.platform === "telegram" ||
+                parsed.data.platform === "discord"
+              ? {
+                  senderName:
+                    parsed.data.displayName ??
+                    (parsed.data.platform === "telegram"
+                      ? parsed.data.telegramUsername
+                      : parsed.data.discordUsername),
+                }
+              : {}),
         },
       };
       let response = await elizaSandboxService.bridge(
@@ -525,9 +883,14 @@ app.post("/", async (c) => {
         bridgeRequest,
       );
       if (response.error?.message === "Bridge returned HTTP 404") {
-        const history = await coordinateSharedHistory(agent.id, agent.id, {
-          namespace: worker.namespace,
-        });
+        const conversationId = groupConversationId ?? agent.id;
+        const history = await coordinateSharedHistory(
+          agent.id,
+          conversationId,
+          {
+            namespace: worker.namespace,
+          },
+        );
         const importableHistory = history.filter(
           (
             message,
@@ -554,7 +917,7 @@ app.post("/", async (c) => {
             ? await elizaSandboxService.importCanonicalConversation(
                 dedicated.id,
                 account.organizationId,
-                agent.id,
+                conversationId,
                 importMessages,
               )
             : null;
@@ -562,7 +925,7 @@ app.post("/", async (c) => {
           receipt = await elizaSandboxService.importCanonicalConversation(
             dedicated.id,
             account.organizationId,
-            agent.id,
+            conversationId,
             [],
           );
         }
@@ -619,8 +982,9 @@ app.post("/", async (c) => {
     }
     const prewarmMs = await personalPrewarm;
     const sharedStartedAt = performance.now();
-    const trustedDelivery =
-      parsed.data.platform === "telegram"
+    const trustedDelivery = isGroupMessage(parsed.data)
+      ? undefined
+      : parsed.data.platform === "telegram"
         ? {
             platform: "telegram" as const,
             project: parsed.data.project,
@@ -638,17 +1002,31 @@ app.post("/", async (c) => {
                 discordUserId: parsed.data.discordUserId,
               }
             : undefined;
-    const result = await sharedRestMessageSend(
-      agent,
-      agent.id,
-      deliveryMessage,
-      agent.agent_name ?? "Eliza",
-      worker.executionCtx,
-      worker.namespace,
-      parsed.data.messageId,
-      "platform",
-      trustedDelivery,
-    );
+    const result = groupConversationId
+      ? await sharedRestMessageSend(
+          agent,
+          groupConversationId,
+          deliveryMessage,
+          agent.agent_name ?? "Eliza",
+          worker.executionCtx,
+          worker.namespace,
+          parsed.data.messageId,
+          "platform",
+          undefined,
+          undefined,
+          { type: ChannelType.GROUP, source: parsed.data.platform },
+        )
+      : await sharedRestMessageSend(
+          agent,
+          agent.id,
+          deliveryMessage,
+          agent.agent_name ?? "Eliza",
+          worker.executionCtx,
+          worker.namespace,
+          parsed.data.messageId,
+          "platform",
+          trustedDelivery,
+        );
     // The same values ship on `Server-Timing` below; a second uncorrelated
     // per-turn log on the hot path would only duplicate them.
     const providerTiming = sharedTurnServerTiming(result.timing);

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -456,6 +456,8 @@ app.post("/", async (c) => {
                   ? "That group link expired. DM Eliza `/group` for a fresh code, then paste the new link command here."
                   : claimed.status === "already_used"
                     ? "That group link was already used. DM Eliza `/group` for a new one if you are reconnecting."
+                    : claimed.status === "already_bound"
+                      ? "This group is already linked to another Eliza owner. That owner must disconnect it before a different owner can link it."
                     : "That group link is not valid for this account or sender. DM Eliza `/group` yourself and paste the exact command here.",
             },
           });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -519,11 +519,20 @@ app.post("/", async (c) => {
       }
 
       if (requestedPolicy) {
-        await personalSharedGroupsRepository.setResponsePolicy({
+        const updated = await personalSharedGroupsRepository.setResponsePolicy({
           bindingId: binding.id,
           ownerUserId: binding.owner_user_id,
           policy: requestedPolicy,
         });
+        if (!updated) {
+          return c.json({
+            success: true,
+            data: {
+              code: "group_binding_changed",
+              reply: "This group link changed before the policy update. Reconnect it and try again.",
+            },
+          });
+        }
         return c.json({
           success: true,
           data: {
@@ -536,10 +545,19 @@ app.post("/", async (c) => {
         });
       }
       if (isGroupLeaveCommand(parsed.data.message)) {
-        await personalSharedGroupsRepository.revokeBinding({
+        const revoked = await personalSharedGroupsRepository.revokeBinding({
           bindingId: binding.id,
           ownerUserId: binding.owner_user_id,
         });
+        if (!revoked) {
+          return c.json({
+            success: true,
+            data: {
+              code: "group_binding_changed",
+              reply: "This group link changed before it could be disconnected.",
+            },
+          });
+        }
         return c.json({
           success: true,
           data: {

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -54,6 +54,10 @@ export interface TelegramDeliveryReceipt {
 export interface TelegramReplyDeliveryHooks {
   prepare(chunks: readonly string[]): Promise<void>;
   shouldSend(chunkIndex: number, chunk: string): Promise<boolean>;
+  deliveredProviderMessageId?(
+    chunkIndex: number,
+    chunk: string,
+  ): Promise<string | null>;
   accepted(
     chunkIndex: number,
     chunk: string,
@@ -544,6 +548,11 @@ export async function sendTelegramReply(
         deliveryHooks &&
         !(await deliveryHooks.shouldSend(chunkIndex, chunk))
       ) {
+        const priorProviderMessageId =
+          await deliveryHooks.deliveredProviderMessageId?.(chunkIndex, chunk);
+        if (priorProviderMessageId) {
+          providerMessageIds.push(priorProviderMessageId);
+        }
         break;
       }
       try {

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -19,6 +19,7 @@ export interface TelegramConnectorLogger {
 
 export interface TelegramConnectorConfig {
   botToken?: string;
+  botUsername?: string;
   webhookSecret?: string;
 }
 
@@ -32,6 +33,10 @@ export interface TelegramConnectorEvent {
   senderName?: string;
   text: string;
   isCommand: boolean;
+  groupInvocation?: "mention" | "command" | "reply" | "ambient";
+  groupActorRole?: "creator" | "administrator" | "member" | "unknown";
+  membershipChange?: "joined" | "removed";
+  replyToMessageId?: string;
   providerSentAtMs?: number;
   voiceNote?: {
     fileId: string;
@@ -65,7 +70,7 @@ export interface TelegramResolvedVoiceNote {
   durationSeconds: number;
 }
 
-interface TelegramMessage {
+export interface TelegramMessage {
   message_id: number;
   date?: number;
   from?: {
@@ -77,6 +82,20 @@ interface TelegramMessage {
   chat: { id: number; type: string };
   text?: string;
   caption?: string;
+  entities?: Array<{
+    type: string;
+    offset: number;
+    length: number;
+  }>;
+  caption_entities?: Array<{
+    type: string;
+    offset: number;
+    length: number;
+  }>;
+  reply_to_message?: {
+    message_id?: number;
+    from?: { is_bot?: boolean; username?: string };
+  };
   voice?: {
     file_id: string;
     duration: number;
@@ -88,6 +107,85 @@ interface TelegramMessage {
 interface TelegramUpdate {
   update_id: number;
   message?: TelegramMessage;
+  my_chat_member?: {
+    date?: number;
+    from?: { id: number; first_name?: string; username?: string };
+    chat: { id: number; type: string };
+    new_chat_member?: { status?: string };
+  };
+}
+
+export interface TelegramGroupPolicy {
+  /** Username returned by Bot API getMe, without the leading @. */
+  botUsername: string;
+  /** Opt-in for privacy-disabled/admin bots that should see ambient traffic. */
+  allowAmbient?: boolean;
+}
+
+function normalizedTelegramUsername(value: string): string {
+  return value.trim().replace(/^@/, "").toLowerCase();
+}
+
+function entityText(
+  text: string,
+  entity: { offset: number; length: number },
+): string {
+  return text.slice(entity.offset, entity.offset + entity.length);
+}
+
+/**
+ * Default group policy: respond only to a command delivered to the bot, an
+ * explicit @mention of this bot, or a reply to one of its messages. Ambient
+ * replies require an explicit opt-in even if Telegram privacy mode is off.
+ */
+export function classifyTelegramGroupInvocation(
+  message: TelegramMessage,
+  text: string,
+  policy: TelegramGroupPolicy,
+): TelegramConnectorEvent["groupInvocation"] | null {
+  const botUsername = normalizedTelegramUsername(policy.botUsername);
+  if (!botUsername) return null;
+  if (
+    message.reply_to_message?.from?.is_bot &&
+    normalizedTelegramUsername(message.reply_to_message.from.username ?? "") ===
+      botUsername
+  ) {
+    return "reply";
+  }
+  const entities = message.text ? message.entities : message.caption_entities;
+  for (const entity of entities ?? []) {
+    if (
+      !Number.isInteger(entity.offset) ||
+      !Number.isInteger(entity.length) ||
+      entity.offset < 0 ||
+      entity.length <= 0 ||
+      entity.offset + entity.length > text.length
+    ) {
+      continue;
+    }
+    const value = entityText(text, entity);
+    if (
+      entity.type === "mention" &&
+      normalizedTelegramUsername(value) === botUsername
+    ) {
+      return "mention";
+    }
+    if (entity.type === "bot_command") {
+      const target = value.match(/@([a-z0-9_]{5,32})$/i)?.[1];
+      if (!target || normalizedTelegramUsername(target) === botUsername) {
+        return "command";
+      }
+    }
+  }
+  return policy.allowAmbient ? "ambient" : null;
+}
+
+export function isTelegramGroupInvocation(
+  message: TelegramMessage,
+  text: string,
+  policy: TelegramGroupPolicy,
+): boolean {
+  return classifyTelegramGroupInvocation(message, text, policy) !== null;
 }
 
 export class TelegramApiTransportError extends Error {
@@ -136,6 +234,7 @@ function exceedsTelegramVoiceSizeLimit(size: number): boolean {
 export function parseTelegramWebhook(
   rawBody: string,
   logger?: TelegramConnectorLogger,
+  groupPolicy?: TelegramGroupPolicy,
 ): TelegramConnectorEvent | null {
   let update: TelegramUpdate;
   try {
@@ -146,12 +245,56 @@ export function parseTelegramWebhook(
     return null;
   }
 
+  const membership = update.my_chat_member;
+  if (
+    membership &&
+    (membership.chat.type === "group" || membership.chat.type === "supergroup")
+  ) {
+    const status = membership.new_chat_member?.status;
+    const membershipChange =
+      status === "member" || status === "administrator"
+        ? "joined"
+        : status === "left" || status === "kicked"
+          ? "removed"
+          : null;
+    if (!membershipChange) return null;
+    return {
+      platform: "telegram",
+      messageId: String(update.update_id),
+      platformRecordId: String(update.update_id),
+      chatId: String(membership.chat.id),
+      chatType: membership.chat.type,
+      senderId: String(membership.from?.id ?? membership.chat.id),
+      senderName: membership.from?.first_name,
+      text: "",
+      isCommand: false,
+      membershipChange,
+      ...(typeof membership.date === "number" &&
+      Number.isInteger(membership.date) &&
+      membership.date > 0
+        ? { providerSentAtMs: membership.date * 1_000 }
+        : {}),
+      rawPayload: update,
+    };
+  }
+
   const message = update.message;
-  if (message?.chat.type !== "private") return null;
+  if (!message) return null;
+  const isPrivate = message.chat.type === "private";
+  const isGroup =
+    message.chat.type === "group" || message.chat.type === "supergroup";
+  if (!isPrivate && !isGroup) return null;
   const text = message.text || message.caption || "";
   const voice = message.voice;
   if (!text && !voice) return null;
   if (message.from?.is_bot) return null;
+  const groupInvocation =
+    isGroup && groupPolicy
+      ? classifyTelegramGroupInvocation(message, text, groupPolicy)
+      : null;
+  if (isGroup && !groupInvocation) {
+    return null;
+  }
 
   if (
     voice &&
@@ -180,6 +323,10 @@ export function parseTelegramWebhook(
     senderName: message.from?.first_name,
     text,
     isCommand: text.startsWith("/"),
+    ...(groupInvocation ? { groupInvocation } : {}),
+    ...(Number.isInteger(message.reply_to_message?.message_id)
+      ? { replyToMessageId: String(message.reply_to_message?.message_id) }
+      : {}),
     ...(typeof message.date === "number" &&
     Number.isInteger(message.date) &&
     message.date > 0
@@ -265,6 +412,50 @@ async function telegramApi<T>(
     );
   }
   return data.result as T;
+}
+
+const telegramBotUsernameCache = new Map<string, Promise<string>>();
+
+/** Resolve this credential's public username without exposing the token. */
+export async function resolveTelegramBotUsername(
+  config: TelegramConnectorConfig,
+): Promise<string> {
+  const configured = config.botUsername?.trim().replace(/^@/, "");
+  if (configured) return configured;
+  const botToken = config.botToken;
+  if (!botToken) return "";
+  let pending = telegramBotUsernameCache.get(botToken);
+  if (!pending) {
+    pending = telegramApi<{ username?: unknown }>(botToken, "getMe")
+      .then((me) => (typeof me.username === "string" ? me.username.trim() : ""))
+      .catch((error) => {
+        telegramBotUsernameCache.delete(botToken);
+        throw error;
+      });
+    telegramBotUsernameCache.set(botToken, pending);
+  }
+  return pending;
+}
+
+/** Verify the sender's current group authority using Telegram's Bot API. */
+export async function resolveTelegramGroupActorRole(
+  config: TelegramConnectorConfig,
+  chatId: string,
+  userId: string,
+): Promise<"creator" | "administrator" | "member" | "unknown"> {
+  if (!config.botToken) return "unknown";
+  const member = await telegramApi<{ status?: unknown }>(
+    config.botToken,
+    "getChatMember",
+    { chat_id: chatId, user_id: userId },
+  );
+  return member.status === "creator"
+    ? "creator"
+    : member.status === "administrator"
+      ? "administrator"
+      : member.status === "member" || member.status === "restricted"
+        ? "member"
+        : "unknown";
 }
 
 function assertValidTelegramChunkLength(maxLength: number): void {

--- a/packages/cloud/services/_common/src/telegram-delivery.ts
+++ b/packages/cloud/services/_common/src/telegram-delivery.ts
@@ -19,6 +19,10 @@ export interface TelegramDeliveryLedger {
     chunkIndex: number,
     chunkDigest: string,
   ): Promise<TelegramDeliveryState | null>;
+  readChunkProviderMessageId(
+    chunkIndex: number,
+    chunkDigest: string,
+  ): Promise<string | null>;
   claimChunk(chunkIndex: number, chunkDigest: string): Promise<boolean>;
   releaseChunk(chunkIndex: number, chunkDigest: string): Promise<void>;
   markChunkDelivered(
@@ -32,6 +36,10 @@ export interface TelegramDeliveryLedger {
 export interface TelegramDeliveryHooks {
   prepare(chunks: readonly string[]): Promise<void>;
   shouldSend(chunkIndex: number, chunk: string): Promise<boolean>;
+  deliveredProviderMessageId(
+    chunkIndex: number,
+    chunk: string,
+  ): Promise<string | null>;
   accepted(
     chunkIndex: number,
     chunk: string,
@@ -109,6 +117,9 @@ export async function executeTelegramDelivery(
       }
       activeChunk = { index, digest };
       return true;
+    },
+    async deliveredProviderMessageId(index) {
+      return ledger.readChunkProviderMessageId(index, requireChunk(index));
     },
     async accepted(index, _chunk, providerMessageId) {
       const digest = requireChunk(index);

--- a/packages/cloud/services/_common/tests/telegram-connector-delivery.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-delivery.test.ts
@@ -108,6 +108,30 @@ describe("sendTelegramReply delivery state", () => {
     expect(events).toEqual(["prepare:1", "claim:0", "rejected:0"]);
   });
 
+  test("returns persisted provider ids when an accepted chunk is replayed", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("an already-delivered chunk must not be resent");
+    }) as unknown as typeof fetch;
+    const events: string[] = [];
+    const replayHooks = hooks(events);
+    replayHooks.shouldSend = async (index) => {
+      events.push(`claim:${index}`);
+      return false;
+    };
+    replayHooks.deliveredProviderMessageId = async () => "provider-prior";
+
+    const receipt = await sendTelegramReply(
+      { botToken: "test-token" },
+      event,
+      "reply",
+      undefined,
+      replayHooks,
+    );
+
+    expect(receipt.providerMessageIds).toEqual(["provider-prior"]);
+    expect(events).toEqual(["prepare:1", "claim:0"]);
+  });
+
   test("keeps transport failure uncertain", async () => {
     globalThis.fetch = mock(async () => {
       throw new Error("socket reset after write");

--- a/packages/cloud/services/_common/tests/telegram-connector-groups.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-groups.test.ts
@@ -1,0 +1,183 @@
+/** Exercises Telegram's explicit-invocation group response policy. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  parseTelegramWebhook,
+  resolveTelegramGroupActorRole,
+} from "../src/telegram-connector";
+
+function update(message: Record<string, unknown>): string {
+  return JSON.stringify({
+    update_id: 7001,
+    message: {
+      message_id: 88,
+      date: 1_786_283_200,
+      from: { id: 42, first_name: "Ada", is_bot: false },
+      chat: { id: -100123456789, type: "supergroup" },
+      ...message,
+    },
+  });
+}
+
+const policy = { botUsername: "ElizaIsNotABot" };
+
+describe("parseTelegramWebhook group policy", () => {
+  test("keeps group support opt-in", () => {
+    expect(
+      parseTelegramWebhook(update({ text: "@ElizaIsNotABot hi" })),
+    ).toBeNull();
+  });
+
+  test("accepts an explicit mention of this bot", () => {
+    const event = parseTelegramWebhook(
+      update({
+        text: "@ElizaIsNotABot hi",
+        entities: [{ type: "mention", offset: 0, length: 15 }],
+      }),
+      undefined,
+      policy,
+    );
+
+    expect(event).toMatchObject({
+      chatId: "-100123456789",
+      chatType: "supergroup",
+      senderId: "42",
+      senderName: "Ada",
+      groupInvocation: "mention",
+    });
+  });
+
+  test("rejects an explicit mention of a different bot", () => {
+    expect(
+      parseTelegramWebhook(
+        update({
+          text: "@AnotherBot hi",
+          entities: [{ type: "mention", offset: 0, length: 11 }],
+        }),
+        undefined,
+        policy,
+      ),
+    ).toBeNull();
+  });
+
+  test("accepts a command addressed to this bot and rejects another target", () => {
+    expect(
+      parseTelegramWebhook(
+        update({
+          text: "/help@ElizaIsNotABot",
+          entities: [{ type: "bot_command", offset: 0, length: 20 }],
+        }),
+        undefined,
+        policy,
+      ),
+    ).not.toBeNull();
+    expect(
+      parseTelegramWebhook(
+        update({
+          text: "/help@AnotherBot",
+          entities: [{ type: "bot_command", offset: 0, length: 16 }],
+        }),
+        undefined,
+        policy,
+      ),
+    ).toBeNull();
+  });
+
+  test("accepts a reply to this bot but not an arbitrary bot", () => {
+    expect(
+      parseTelegramWebhook(
+        update({
+          text: "following up",
+          reply_to_message: {
+            message_id: 77,
+            from: { is_bot: true, username: "ElizaIsNotABot" },
+          },
+        }),
+        undefined,
+        policy,
+      ),
+    ).toMatchObject({
+      groupInvocation: "reply",
+      replyToMessageId: "77",
+    });
+    expect(
+      parseTelegramWebhook(
+        update({
+          text: "following up",
+          reply_to_message: {
+            from: { is_bot: true, username: "AnotherBot" },
+          },
+        }),
+        undefined,
+        policy,
+      ),
+    ).toBeNull();
+  });
+
+  test("keeps ambient replies off unless explicitly enabled", () => {
+    expect(
+      parseTelegramWebhook(update({ text: "ambient" }), undefined, policy),
+    ).toBeNull();
+    expect(
+      parseTelegramWebhook(update({ text: "ambient" }), undefined, {
+        ...policy,
+        allowAmbient: true,
+      }),
+    ).toMatchObject({ groupInvocation: "ambient" });
+    expect(
+      parseTelegramWebhook(
+        update({
+          text: "@ElizaIsNotABot explicit",
+          entities: [{ type: "mention", offset: 0, length: 15 }],
+        }),
+        undefined,
+        { ...policy, allowAmbient: true },
+      ),
+    ).toMatchObject({ groupInvocation: "mention" });
+  });
+
+  test("normalizes bot membership removal without requiring message policy", () => {
+    const event = parseTelegramWebhook(
+      JSON.stringify({
+        update_id: 7002,
+        my_chat_member: {
+          date: 1_786_283_201,
+          from: { id: 42, first_name: "Ada" },
+          chat: { id: -100123456789, type: "supergroup" },
+          new_chat_member: { status: "kicked" },
+        },
+      }),
+    );
+
+    expect(event).toMatchObject({
+      messageId: "7002",
+      chatId: "-100123456789",
+      chatType: "supergroup",
+      membershipChange: "removed",
+    });
+  });
+
+  test("verifies link authority through the current Telegram membership", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toEndWith("/getChatMember");
+      await expect(request.json()).resolves.toEqual({
+        chat_id: "-100123456789",
+        user_id: "42",
+      });
+      return Response.json({ ok: true, result: { status: "administrator" } });
+    }) as typeof fetch;
+    try {
+      await expect(
+        resolveTelegramGroupActorRole(
+          { botToken: "test-token" },
+          "-100123456789",
+          "42",
+        ),
+      ).resolves.toBe("administrator");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/cloud/services/_common/tests/telegram-delivery.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-delivery.test.ts
@@ -51,6 +51,9 @@ function memoryLedger(initial: TelegramDeliveryState | null = null): {
       async readChunk(index) {
         return state.chunks.get(index) ?? null;
       },
+      async readChunkProviderMessageId(index) {
+        return state.providerMessageIds.get(index) ?? null;
+      },
       async claimChunk(index) {
         if (state.chunks.has(index)) return false;
         state.chunks.set(index, "uncertain");
@@ -91,6 +94,23 @@ describe("executeTelegramDelivery", () => {
     expect(memory.state.chunks.get(0)).toBe("delivered");
     expect(memory.state.providerMessageIds.get(0)).toBe("provider-1");
     expect(memory.state.delivery).toBe("delivered");
+  });
+
+  test("recovers a provider id for a chunk accepted by an earlier attempt", async () => {
+    const memory = memoryLedger();
+    memory.state.plan = [
+      "5782b18687e6cf8a482fc32d2db5b196d8821c458a0c069c6acf3953446e7bb5",
+    ];
+    memory.state.chunks.set(0, "delivered");
+    memory.state.providerMessageIds.set(0, "provider-prior");
+
+    await executeTelegramDelivery(memory.ledger, async (hooks) => {
+      await hooks.prepare(["reply"]);
+      expect(await hooks.shouldSend(0, "reply")).toBe(false);
+      expect(await hooks.deliveredProviderMessageId(0, "reply")).toBe(
+        "provider-prior",
+      );
+    });
   });
 
   test("releases processing when generation fails before egress", async () => {

--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
@@ -179,7 +179,8 @@ describe("blooio extractEvent", () => {
 
     expect(event).not.toBeNull();
     expect(event?.messageId).toBe("msg_v4_abc123");
-    expect(event?.chatId).toBe("+15551234567");
+    expect(event?.chatId).toBe("chat_abc123");
+    expect(event?.chatType).toBe("private");
     expect(event?.senderId).toBe("+15551234567");
     expect(event?.channelId).toBe("ch_abc123");
     expect(event?.channelType).toBe("blooio");
@@ -232,11 +233,21 @@ describe("blooio extractEvent", () => {
     expect(event).toBeNull();
   });
 
-  test("skips group messages", async () => {
+  test("preserves group thread and participant identity", async () => {
     const event = await blooioAdapter.extractEvent(
-      inboundPayload({ is_group: true }),
+      v4InboundPayload({
+        chat_id: "chat_group_123",
+        is_group: true,
+        group: { group_id: "grp_123", member_count: 4 },
+        reply_to_message_id: "msg_eliza_previous",
+      }),
     );
-    expect(event).toBeNull();
+    expect(event).toMatchObject({
+      chatId: "chat_group_123",
+      chatType: "group",
+      senderId: "+15551234567",
+      replyToMessageId: "msg_eliza_previous",
+    });
   });
 
   test("skips non message.received events", async () => {
@@ -378,12 +389,15 @@ describe("blooio sendReply", () => {
   }
 
   test("pins a v4 reply to the exact inbound WhatsApp channel", async () => {
-    let body: Record<string, unknown> = {};
+    let captured: { url: string; body: Record<string, unknown> } | null = null;
     globalThis.fetch = (async (
-      _url: string | URL | Request,
+      url: string | URL | Request,
       init?: RequestInit,
     ) => {
-      body = JSON.parse(String(init?.body));
+      captured = {
+        url: String(url),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      };
       return Response.json({ id: "out_whatsapp_1" });
     }) as typeof fetch;
 
@@ -391,16 +405,45 @@ describe("blooio sendReply", () => {
       makeConfig(),
       {
         ...chatEvent,
+        chatId: "chat_whatsapp_123",
         channelId: "ch_whatsapp_123",
         channelType: "whatsapp_business",
         protocol: "whatsapp",
       },
       "hi",
     );
-    expect(body).toEqual({
-      to: "+15551234567",
-      from: "ch_whatsapp_123",
-      text: "hi",
+    expect(captured).toEqual({
+      url: "https://api.blooio.com/v4/chats/chat_whatsapp_123/messages",
+      body: { text: "hi" },
+    });
+  });
+
+  test("replies to a group through its existing provider chat", async () => {
+    let captured: { url: string; body: Record<string, unknown> } | null = null;
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = {
+        url: String(url),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      };
+      return Response.json({ id: "out_group_1" });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendReply(
+      makeConfig(),
+      {
+        ...chatEvent,
+        chatId: "chat_group_123",
+        chatType: "group",
+      },
+      "hello group",
+    );
+
+    expect(captured).toEqual({
+      url: "https://api.blooio.com/v4/chats/chat_group_123/messages",
+      body: { text: "hello group" },
     });
   });
 
@@ -459,6 +502,63 @@ describe("blooio sendTypingIndicator", () => {
     await expect(
       blooioAdapter.sendTypingIndicator(makeConfig(), chatEvent),
     ).resolves.toBeUndefined();
+  });
+
+  test("uses v4 chat-scoped read and typing actions", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      calls.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        ...(init?.body
+          ? { body: JSON.parse(String(init.body)) as unknown }
+          : {}),
+      });
+      return Response.json({ data: { state: "started" } });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendTypingIndicator(makeConfig(), {
+      ...chatEvent,
+      chatId: "chat_group_123",
+      chatType: "group",
+    });
+
+    expect(calls).toEqual([
+      {
+        url: "https://api.blooio.com/v4/chats/chat_group_123/read",
+        method: "POST",
+      },
+      {
+        url: "https://api.blooio.com/v4/chats/chat_group_123/typing",
+        method: "POST",
+        body: { state: "started" },
+      },
+    ]);
+  });
+
+  test("stops a v4 chat typing indicator after the turn", async () => {
+    let captured: { url: string; method: string } | null = null;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = { url: String(input), method: init?.method ?? "GET" };
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    await blooioAdapter.stopTypingIndicator?.(makeConfig(), {
+      ...chatEvent,
+      chatId: "chat_group_123",
+      chatType: "group",
+    });
+
+    expect(captured).toEqual({
+      url: "https://api.blooio.com/v4/chats/chat_group_123/typing",
+      method: "DELETE",
+    });
   });
 
   test("does nothing without an API key", async () => {

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -102,6 +102,7 @@ const envKeys = [
   "ELIZA_APP_TWILIO_AUTH_TOKEN",
   "ELIZA_APP_TWILIO_PHONE_NUMBER",
   "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
 ] as const;
 const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
 
@@ -243,6 +244,7 @@ describe("gateway webhook handler e2e routing", () => {
       message: "My name is Ada",
       platform: "twilio",
       project: "eliza-app",
+      connectorAccountId: "+15550000000",
       phoneNumber: "+15551234567",
       messageId: `twilio:eliza-app:${event.messageId}`,
     });
@@ -257,6 +259,7 @@ describe("gateway webhook handler e2e routing", () => {
   });
 
   test("routes an unresolved Blooio iMessage to the same phone Shared path", async () => {
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
     const redis = new MemoryRedis();
     const event: ChatEvent = {
       platform: "blooio",
@@ -318,11 +321,166 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sharedBody).toEqual({
       platform: "blooio",
       project: "eliza-app",
+      connectorAccountId: "+15550000001",
       phoneNumber: "+15551234567",
       messageId: "blooio:eliza-app:blooio-message-1",
       message: "hello from iMessage",
     });
     expect(replies).toEqual(["hello from personal Eliza"]);
+  });
+
+  test("preserves a Blooio group thread and records provider egress before reply classification", async () => {
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
+    const redis = new MemoryRedis();
+    const event: ChatEvent = {
+      platform: "blooio",
+      messageId: "blooio-group-message-1",
+      chatId: "chat_group_123",
+      chatType: "group",
+      senderId: "+15551234567",
+      senderName: "Ada",
+      text: "following up",
+      replyToMessageId: "provider-eliza-reply-0",
+      rawPayload: {},
+    };
+    const sendReplyWithReceipt = mock(async () => ({
+      providerMessageIds: ["provider-eliza-reply-1"],
+    }));
+    const adapter: PlatformAdapter = {
+      platform: "blooio",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendTypingIndicator: mock(async () => undefined),
+      stopTypingIndicator: mock(async () => undefined),
+      sendReply: mock(async () => undefined),
+      sendReplyWithReceipt,
+    };
+    let turnBody: Record<string, unknown> | null = null;
+    let receiptBody: Record<string, unknown> | null = null;
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_receipt") {
+          receiptBody = body;
+          return Response.json({ success: true, data: { inserted: 1 } });
+        }
+        turnBody = body;
+        return Response.json({
+          success: true,
+          data: { reply: "group reply" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      new Request("https://gateway.example/webhook/eliza-app/blooio", {
+        method: "POST",
+        body: "{}",
+      }),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(() => receiptBody !== null, "group provider receipt");
+    expect(turnBody).toEqual({
+      platform: "blooio",
+      chatType: "group",
+      project: "eliza-app",
+      connectorAccountId: "+15550000001",
+      chatId: "chat_group_123",
+      actor: {
+        platformUserId: "+15551234567",
+        displayName: "Ada",
+        role: "possessor",
+      },
+      messageId: "blooio:eliza-app:blooio-group-message-1",
+      message: "following up",
+      invocation: "reply",
+      replyToMessageId: "provider-eliza-reply-0",
+    });
+    expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+    expect(receiptBody).toEqual({
+      eventType: "delivery_receipt",
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550000001",
+      chatId: "chat_group_123",
+      sourceMessageId: "blooio:eliza-app:blooio-group-message-1",
+      providerMessageIds: ["provider-eliza-reply-1"],
+    });
+  });
+
+  test("forwards Telegram membership removal without model or provider egress", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const redis = new MemoryRedis();
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "membership-update-1",
+      chatId: "-100123456789",
+      chatType: "supergroup",
+      senderId: "123456789",
+      text: "",
+      membershipChange: "removed",
+      rawPayload: {},
+    };
+    const sendReply = mock(async () => undefined);
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply,
+      sendReplyWithReceipt: mock(async () => ({ providerMessageIds: [] })),
+    };
+    let membershipBody: Record<string, unknown> | null = null;
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        membershipBody = (await request.json()) as Record<string, unknown>;
+        return Response.json({ success: true, data: { reply: "" } });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      }),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    await waitFor(() => membershipBody !== null, "membership delivery");
+    expect(membershipBody).toEqual({
+      eventType: "membership",
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId:
+        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      chatId: "-100123456789",
+      messageId: "telegram:eliza-app:membership-update-1",
+      membershipChange: "removed",
+    });
+    expect(sendReply).not.toHaveBeenCalled();
   });
 
   test("refuses Telegram egress when another worker atomically claimed delivery", async () => {
@@ -530,6 +688,8 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sharedBody).toEqual({
       platform: "telegram",
       project: "eliza-app",
+      connectorAccountId:
+        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
       chatId: "chat-1",
       telegramUserId: "123456789",
       displayName: "Ada",
@@ -744,6 +904,8 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sharedBody).toEqual({
       platform: "telegram",
       project: "eliza-app",
+      connectorAccountId:
+        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
       chatId: "chat-1",
       telegramUserId: "123456789",
       displayName: "Ada",
@@ -953,6 +1115,7 @@ describe("gateway webhook handler e2e routing", () => {
     expect(personalBody).toEqual({
       platform: "twilio",
       project: "eliza-app",
+      connectorAccountId: "+15550000000",
       phoneNumber: "+15551234567",
       messageId: "twilio:eliza-app:SM_linked_1",
       message: "Are you running?",

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -346,12 +346,13 @@ describe("gateway webhook handler e2e routing", () => {
     const sendReplyWithReceipt = mock(async () => ({
       providerMessageIds: ["provider-eliza-reply-1"],
     }));
+    const stopTypingIndicator = mock(async () => undefined);
     const adapter: PlatformAdapter = {
       platform: "blooio",
       verifyWebhook: mock(async () => true),
       extractEvent: mock(async () => event),
       sendTypingIndicator: mock(async () => undefined),
-      stopTypingIndicator: mock(async () => undefined),
+      stopTypingIndicator,
       sendReply: mock(async () => undefined),
       sendReplyWithReceipt,
     };
@@ -409,6 +410,7 @@ describe("gateway webhook handler e2e routing", () => {
       replyToMessageId: "provider-eliza-reply-0",
     });
     expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+    expect(stopTypingIndicator).toHaveBeenCalledTimes(1);
     expect(receiptBody).toEqual({
       eventType: "delivery_receipt",
       platform: "blooio",
@@ -434,11 +436,12 @@ describe("gateway webhook handler e2e routing", () => {
       rawPayload: {},
     };
     const sendReply = mock(async () => undefined);
+    const sendTypingIndicator = mock(async () => undefined);
     const adapter: PlatformAdapter = {
       platform: "telegram",
       verifyWebhook: mock(async () => true),
       extractEvent: mock(async () => event),
-      sendTypingIndicator: mock(async () => undefined),
+      sendTypingIndicator,
       sendReply,
       sendReplyWithReceipt: mock(async () => ({ providerMessageIds: [] })),
     };
@@ -481,6 +484,7 @@ describe("gateway webhook handler e2e routing", () => {
       membershipChange: "removed",
     });
     expect(sendReply).not.toHaveBeenCalled();
+    expect(sendTypingIndicator).not.toHaveBeenCalled();
   });
 
   test("refuses Telegram egress when another worker atomically claimed delivery", async () => {

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -1,6 +1,6 @@
 /**
- * Authenticates Blooio webhook fan-in and maps stable one-to-one message
- * deliveries onto the gateway's deduplicated chat contract.
+ * Authenticates Blooio webhook fan-in and preserves the provider's stable chat
+ * and participant identities across one-to-one and group deliveries.
  */
 import crypto from "node:crypto";
 import { z } from "zod";
@@ -9,6 +9,7 @@ import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 
 const BLOOIO_V2_API_BASE = "https://api.blooio.com/v2/api";
 const BLOOIO_V4_MESSAGES_URL = "https://api.blooio.com/v4/messages";
+const BLOOIO_V4_CHATS_URL = "https://api.blooio.com/v4/chats";
 
 export class BlooioApiResponseError extends Error {
   constructor(
@@ -31,9 +32,11 @@ const BlooioV2WebhookEventSchema = z.object({
   external_id: z.string().nullish(),
   internal_id: z.string().nullish(),
   sender: z.string().trim().min(1).nullish(),
+  chat_id: z.string().trim().min(1).nullish(),
   channel_id: z.string().trim().min(1).nullish(),
   channel_type: z.string().trim().min(1).nullish(),
   text: z.string().nullish(),
+  reply_to_message_id: z.string().trim().min(1).nullish(),
   attachments: z.array(BlooioAttachmentSchema).nullish(),
   protocol: z.string().nullish(),
   is_group: z.boolean().nullish(),
@@ -45,7 +48,7 @@ const BlooioV4MessageSchema = z
   .object({
     id: z.string().trim().min(1).nullish(),
     message_id: z.string().trim().min(1).nullish(),
-    chat_id: z.string().nullish(),
+    chat_id: z.string().trim().min(1).nullish(),
     channel_id: z.string().trim().min(1).nullish(),
     channel_type: z.string().trim().min(1).nullish(),
     sender: z.string().trim().min(1).nullish(),
@@ -55,6 +58,7 @@ const BlooioV4MessageSchema = z
       .object({ identifier: z.string().trim().min(1).nullish() })
       .nullish(),
     text: z.string().nullish(),
+    reply_to_message_id: z.string().trim().min(1).nullish(),
     attachments: z.array(BlooioAttachmentSchema).nullish(),
     protocol: z.string().nullish(),
     is_group: z.boolean().nullish(),
@@ -86,9 +90,11 @@ function parseWebhookEvent(data: unknown): BlooioWebhookEvent | null {
     external_id: sender,
     internal_id: message.recipient ?? message.channel_address,
     sender,
+    chat_id: message.chat_id,
     channel_id: message.channel_id,
     channel_type: message.channel_type,
     text: message.text,
+    reply_to_message_id: message.reply_to_message_id,
     attachments: message.attachments,
     protocol: message.protocol,
     is_group: message.is_group ?? message.group != null,
@@ -152,14 +158,23 @@ async function sendBlooioMessage(
     "Idempotency-Key": `gw-reply-${event.messageId}`,
   };
 
+  // A provider chat id is the only safe reply target for a group and is also
+  // the strongest thread-affinity signal for a v4 one-to-one delivery. The
+  // chat already owns its channel and participants, so v4 explicitly forbids
+  // supplying `from` or `to` on this endpoint.
+  const hasProviderChatId =
+    event.chatId !== event.senderId || /^chat_/i.test(event.chatId);
+  const url = hasProviderChatId
+    ? `${BLOOIO_V4_CHATS_URL}/${encodeURIComponent(event.chatId)}/messages`
+    : BLOOIO_V4_MESSAGES_URL;
   const from = event.channelId ?? config.fromNumber;
-  const body: { to: string; text: string; from?: string } = {
-    to: event.senderId,
-    text,
-  };
-  if (from) body.from = from;
+  const body: { text: string; to?: string; from?: string } = { text };
+  if (!hasProviderChatId) {
+    body.to = event.senderId;
+    if (from) body.from = from;
+  }
 
-  const response = await fetch(BLOOIO_V4_MESSAGES_URL, {
+  const response = await fetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -298,7 +313,6 @@ export const blooioAdapter: PlatformAdapter = {
     }
 
     if (event.event !== "message.received") return null;
-    if (event.is_group) return null;
 
     // Blooio documents message_id as the stable identifier for message
     // deliveries. internal_id is the receiving number and external_id is the
@@ -331,7 +345,8 @@ export const blooioAdapter: PlatformAdapter = {
     return {
       platform: "blooio",
       messageId: event.message_id,
-      chatId: event.sender,
+      chatId: event.chat_id ?? event.sender,
+      chatType: event.is_group ? "group" : "private",
       channelId: event.channel_id ?? undefined,
       channelType: event.channel_type ?? undefined,
       protocol: event.protocol ?? undefined,
@@ -340,6 +355,7 @@ export const blooioAdapter: PlatformAdapter = {
         mediaUrls.length > 0 && !text
           ? `[media: ${mediaUrls.join(", ")}]`
           : text,
+      replyToMessageId: event.reply_to_message_id ?? undefined,
       providerSentAtMs: providerSentAtMs(event),
       mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
       rawPayload: data,
@@ -368,18 +384,67 @@ export const blooioAdapter: PlatformAdapter = {
   ): Promise<void> {
     if (!config.apiKey) return;
     try {
-      const url = `${BLOOIO_V2_API_BASE}/chats/${encodeURIComponent(event.senderId)}/read`;
       const headers: Record<string, string> = {
         Authorization: `Bearer ${config.apiKey}`,
         "Content-Type": "application/json",
       };
-      if (config.fromNumber) headers["X-From-Number"] = config.fromNumber;
-
-      await fetch(url, { method: "POST", headers });
+      if (/^chat_/i.test(event.chatId)) {
+        const chatBase = `${BLOOIO_V4_CHATS_URL}/${encodeURIComponent(event.chatId)}`;
+        const [read, typing] = await Promise.all([
+          fetch(`${chatBase}/read`, { method: "POST", headers }),
+          fetch(`${chatBase}/typing`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ state: "started" }),
+          }),
+        ]);
+        if (!read.ok || !typing.ok) {
+          throw new BlooioApiResponseError(
+            !read.ok ? read.status : typing.status,
+            "Blooio chat feedback was rejected",
+          );
+        }
+      } else {
+        const url = `${BLOOIO_V2_API_BASE}/chats/${encodeURIComponent(event.chatId)}/read`;
+        if (config.fromNumber) headers["X-From-Number"] = config.fromNumber;
+        const response = await fetch(url, { method: "POST", headers });
+        if (!response.ok) {
+          throw new BlooioApiResponseError(
+            response.status,
+            "Blooio read receipt was rejected",
+          );
+        }
+      }
     } catch (error) {
       // error-policy:J4 typing is a non-critical UX affordance; a failed
       // indicator is observable but must not fail message delivery.
       logger.warn("Blooio typing indicator failed", {
+        error: error instanceof Error ? error.message : String(error),
+        messageId: event.messageId,
+      });
+    }
+  },
+
+  async stopTypingIndicator(config, event): Promise<void> {
+    if (!config.apiKey || !/^chat_/i.test(event.chatId)) return;
+    try {
+      const response = await fetch(
+        `${BLOOIO_V4_CHATS_URL}/${encodeURIComponent(event.chatId)}/typing`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${config.apiKey}` },
+        },
+      );
+      if (!response.ok) {
+        throw new BlooioApiResponseError(
+          response.status,
+          "Blooio stop-typing request was rejected",
+        );
+      }
+    } catch (error) {
+      // error-policy:J4 typing cleanup is presentation-only and cannot change
+      // the already-resolved model or egress result.
+      logger.warn("Blooio stop typing failed", {
         error: error instanceof Error ? error.message : String(error),
         messageId: event.messageId,
       });

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -2,6 +2,8 @@
 
 import {
   parseTelegramWebhook,
+  resolveTelegramBotUsername,
+  resolveTelegramGroupActorRole,
   resolveTelegramVoiceNote,
   sendTelegramReply,
   sendTelegramTyping,
@@ -37,6 +39,10 @@ function asTelegramEvent(event: ChatEvent): TelegramConnectorEvent {
     senderName: event.senderName,
     text: event.text,
     isCommand: event.isCommand ?? event.text.startsWith("/"),
+    groupInvocation: event.groupInvocation,
+    groupActorRole: event.groupActorRole,
+    membershipChange: event.membershipChange,
+    replyToMessageId: event.replyToMessageId,
     providerSentAtMs: event.providerSentAtMs,
     voiceNote: event.voiceNote,
     rawPayload: event.rawPayload,
@@ -67,8 +73,52 @@ export const telegramAdapter: PlatformAdapter = {
     return verified;
   },
 
-  async extractEvent(rawBody: string): Promise<ChatEvent | null> {
-    return parseTelegramWebhook(rawBody, logger);
+  async extractEvent(rawBody: string, config): Promise<ChatEvent | null> {
+    let group = false;
+    try {
+      const payload = JSON.parse(rawBody) as {
+        message?: { chat?: { type?: unknown } };
+      };
+      group =
+        payload.message?.chat?.type === "group" ||
+        payload.message?.chat?.type === "supergroup";
+    } catch {
+      return parseTelegramWebhook(rawBody, logger);
+    }
+    if (!group) return parseTelegramWebhook(rawBody, logger);
+    let botUsername = config?.botUsername ?? "";
+    try {
+      botUsername = await resolveTelegramBotUsername(config ?? {});
+    } catch (error) {
+      logger.warn(
+        "Telegram bot identity lookup failed; group mentions will remain silent",
+        {
+          error: error instanceof Error ? error.name : "OtherError",
+        },
+      );
+    }
+    const event = parseTelegramWebhook(rawBody, logger, {
+      botUsername,
+      // Forward ambient facts to Cloud; the durable binding owns whether they
+      // may enter the model. Telegram privacy mode may still hide them.
+      allowAmbient: true,
+    });
+    if (event && /^\/eliza_link(?:@[a-z0-9_]{5,32})?\s+/i.test(event.text)) {
+      try {
+        event.groupActorRole = await resolveTelegramGroupActorRole(
+          config ?? {},
+          event.chatId,
+          event.senderId,
+        );
+      } catch (error) {
+        logger.warn(
+          "Telegram group authority lookup failed; link remains fail-closed",
+          { error: error instanceof Error ? error.name : "OtherError" },
+        );
+        event.groupActorRole = "unknown";
+      }
+    }
+    return event;
   },
 
   async resolveVoiceNote(config, event) {

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -15,6 +15,14 @@ export interface ChatEvent {
   senderName?: string;
   text: string;
   isCommand?: boolean;
+  /** Deterministic group-policy classification, before model should-respond. */
+  groupInvocation?: "mention" | "command" | "reply" | "ambient";
+  /** Provider-verified sender authority for group-control operations. */
+  groupActorRole?: "creator" | "administrator" | "member" | "unknown";
+  /** Bot/account membership transition for a provider group. */
+  membershipChange?: "joined" | "removed";
+  /** Provider message referenced by an inline reply, when exposed. */
+  replyToMessageId?: string;
   /** Provider-accepted message time, used only for coarse ingress latency. */
   providerSentAtMs?: number;
   mediaUrls?: string[];
@@ -41,7 +49,10 @@ export interface PlatformAdapter {
     rawBody: string,
     config: WebhookConfig,
   ): Promise<boolean>;
-  extractEvent(rawBody: string): Promise<ChatEvent | null>;
+  extractEvent(
+    rawBody: string,
+    config?: WebhookConfig,
+  ): Promise<ChatEvent | null>;
   sendReply(
     config: WebhookConfig,
     event: ChatEvent,
@@ -55,6 +66,8 @@ export interface PlatformAdapter {
     deliveryHooks?: TelegramDeliveryHooks,
   ): Promise<PlatformDeliveryReceipt>;
   sendTypingIndicator(config: WebhookConfig, event: ChatEvent): Promise<void>;
+  /** Clears an explicit provider typing state when the adapter supports it. */
+  stopTypingIndicator?(config: WebhookConfig, event: ChatEvent): Promise<void>;
   /** Resolve provider-owned voice bytes while credentials are still local. */
   resolveVoiceNote?(
     config: WebhookConfig,
@@ -77,6 +90,7 @@ export interface ResolvedVoiceNote {
 export interface WebhookConfig {
   // Telegram
   botToken?: string;
+  botUsername?: string;
   webhookSecret?: string;
   // Blooio
   apiKey?: string;

--- a/packages/cloud/services/gateway-webhook/src/connector-account.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/connector-account.test.ts
@@ -1,0 +1,30 @@
+/** Verifies stable, non-secret connector identities across credential rotation. */
+import { describe, expect, test } from "bun:test";
+import {
+  credentialFingerprint,
+  resolveConnectorAccountId,
+} from "./connector-account";
+
+describe("resolveConnectorAccountId", () => {
+  test("keeps the Telegram bot account stable when its secret rotates", () => {
+    expect(
+      resolveConnectorAccountId("telegram", {
+        botToken: "123456789:old-secret",
+      }),
+    ).toBe("bot:123456789");
+    expect(
+      resolveConnectorAccountId("telegram", {
+        botToken: "123456789:new-secret",
+      }),
+    ).toBe("bot:123456789");
+  });
+
+  test("never exposes a nonstandard Telegram credential", () => {
+    const token = "opaque-test-credential";
+    const accountId = resolveConnectorAccountId("telegram", {
+      botToken: token,
+    });
+    expect(accountId).toBe(`bot:${credentialFingerprint(token)}`);
+    expect(accountId).not.toContain(token);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/connector-account.ts
+++ b/packages/cloud/services/gateway-webhook/src/connector-account.ts
@@ -16,10 +16,18 @@ export function resolveConnectorAccountId(
   config: WebhookConfig,
 ): string | undefined {
   switch (platform) {
-    case "telegram":
-      return config.botToken
-        ? `bot:${credentialFingerprint(config.botToken)}`
-        : undefined;
+    case "telegram": {
+      if (!config.botToken) return undefined;
+      // Telegram documents the decimal prefix as the immutable bot user id.
+      // Token rotation changes only the credential suffix, so binding durable
+      // group ownership to a full-token fingerprint would silently orphan
+      // every group after a routine security rotation. Keep the fingerprint
+      // fallback solely for nonstandard test/proxy credentials.
+      const botId = config.botToken.match(/^(\d{1,20}):/)?.[1];
+      return botId
+        ? `bot:${botId}`
+        : `bot:${credentialFingerprint(config.botToken)}`;
+    }
     case "whatsapp":
       return config.phoneNumberId ?? config.businessPhone;
     case "twilio":

--- a/packages/cloud/services/gateway-webhook/src/webhook-config.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-config.ts
@@ -26,6 +26,7 @@ export function resolveSharedWebhookConfig(
   switch (platform) {
     case "telegram":
       base.botToken = getProjectEnv(project, "TELEGRAM_BOT_TOKEN");
+      base.botUsername = getProjectEnv(project, "TELEGRAM_BOT_USERNAME");
       base.webhookSecret = getProjectEnv(project, "TELEGRAM_WEBHOOK_SECRET");
       break;
     case "blooio":

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -7,6 +7,7 @@ import {
   executeTelegramDelivery,
   type TelegramDeliveryHooks,
   type TelegramDeliveryLedger,
+  type TelegramDeliveryState,
   TelegramEgressAlreadyClaimedError,
 } from "@elizaos/cloud-services-common/telegram-delivery";
 import type {
@@ -209,6 +210,33 @@ function redisTelegramDeliveryLedger(
   const planKey = `${dedupKey}:plan`;
   const chunkKey = (chunkIndex: number, chunkDigest: string) =>
     `${dedupKey}:chunk:${chunkIndex}:${chunkDigest}`;
+  const decodeChunk = (
+    encoded: string | null,
+  ): { state: TelegramDeliveryState; providerMessageId?: string } | null => {
+    if (encoded === "uncertain" || encoded === "delivered") {
+      return { state: encoded };
+    }
+    if (!encoded) return null;
+    try {
+      const parsed = JSON.parse(encoded) as {
+        state?: unknown;
+        providerMessageId?: unknown;
+      };
+      if (
+        parsed.state === "delivered" &&
+        typeof parsed.providerMessageId === "string"
+      ) {
+        return {
+          state: "delivered",
+          providerMessageId: parsed.providerMessageId,
+        };
+      }
+    } catch {
+      // error-policy:J3 Redis delivery state is untrusted persisted input; an
+      // invalid value is treated as absent, never as permission to resend.
+    }
+    return null;
+  };
   return {
     async read() {
       const state = await redis.get<string>(dedupKey);
@@ -244,8 +272,16 @@ function redisTelegramDeliveryLedger(
         : "conflict";
     },
     async readChunk(chunkIndex, chunkDigest) {
-      const state = await redis.get<string>(chunkKey(chunkIndex, chunkDigest));
-      return state === "uncertain" || state === "delivered" ? state : null;
+      return (
+        decodeChunk(await redis.get<string>(chunkKey(chunkIndex, chunkDigest)))
+          ?.state ?? null
+      );
+    },
+    async readChunkProviderMessageId(chunkIndex, chunkDigest) {
+      return (
+        decodeChunk(await redis.get<string>(chunkKey(chunkIndex, chunkDigest)))
+          ?.providerMessageId ?? null
+      );
     },
     async claimChunk(chunkIndex, chunkDigest) {
       return Boolean(
@@ -258,10 +294,12 @@ function redisTelegramDeliveryLedger(
     async releaseChunk(chunkIndex, chunkDigest) {
       await redis.del(chunkKey(chunkIndex, chunkDigest));
     },
-    async markChunkDelivered(chunkIndex, chunkDigest) {
-      await redis.set(chunkKey(chunkIndex, chunkDigest), "delivered", {
-        ex: TELEGRAM_DELIVERY_TTL_SECONDS,
-      });
+    async markChunkDelivered(chunkIndex, chunkDigest, providerMessageId) {
+      await redis.set(
+        chunkKey(chunkIndex, chunkDigest),
+        JSON.stringify({ state: "delivered", providerMessageId }),
+        { ex: TELEGRAM_DELIVERY_TTL_SECONDS },
+      );
     },
     async markDelivered() {
       await redis.set(dedupKey, TELEGRAM_DELIVERED, {
@@ -533,7 +571,12 @@ async function processMessage(
   // forwarding used `userId` as its room and forked connector turns away from
   // the imported `personal:*` conversation.
   if (!explicitAgentId && isPersonalElizaTransport(adapter.platform)) {
-    const stopTyping = beginTypingFeedback(adapter, config, event);
+    // Membership transitions mutate routing state only. Emitting a typing
+    // action while the bot is being removed is both misleading and violates
+    // the no-provider-egress membership contract.
+    const stopTyping = event.membershipChange
+      ? () => undefined
+      : beginTypingFeedback(adapter, config, event);
     try {
       const timing = await sendPersonalSharedReply(
         adapter,
@@ -802,7 +845,14 @@ function beginTypingFeedback(
       error: err instanceof Error ? err.message : String(err),
     });
   });
-  return () => undefined;
+  return () => {
+    adapter.stopTypingIndicator?.(config, event).catch((err) => {
+      logger.debug("stopTypingIndicator failed", {
+        platform: adapter.platform,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
 }
 
 async function sendUnlinkedReply(
@@ -1024,7 +1074,17 @@ async function sendPersonalSharedReply(
     );
   }
   const cloudServerTiming = response.headers.get("Server-Timing");
-  const body: unknown = await response.json();
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    // error-policy:J3 a successful transport response is still untrusted until
+    // its JSON contract parses; provider egress has not started at this point.
+    throw new PersonalSharedPreEgressError(
+      "personal Shared chat returned invalid JSON",
+      { cause: error },
+    );
+  }
   const cloudMs = attemptResult.durationMs;
   const reply =
     body && typeof body === "object" && "data" in body

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -334,7 +334,7 @@ export async function handleWebhook(
     });
   }
 
-  const event = await adapter.extractEvent(rawBody);
+  const event = await adapter.extractEvent(rawBody, config);
   if (!event) {
     return ackResponse(adapter.platform);
   }
@@ -354,6 +354,8 @@ export async function handleWebhook(
       if (
         !agentId &&
         project === configuredPersonalProject &&
+        event.chatType !== "group" &&
+        event.chatType !== "supergroup" &&
         deps.deliveryAuthoritySecret !== undefined
       ) {
         return forwardPersonalTelegramToEdge(
@@ -776,6 +778,16 @@ function isPersonalElizaTransport(
   );
 }
 
+function groupInvocationForEvent(
+  event: ChatEvent,
+): "mention" | "command" | "reply" | "ambient" {
+  if (event.groupInvocation) return event.groupInvocation;
+  if (event.replyToMessageId) return "reply";
+  if (/^\s*(?:\/|eliza\b)/i.test(event.text)) return "command";
+  if (/(?:^|\s)@eliza\b/i.test(event.text)) return "mention";
+  return "ambient";
+}
+
 function beginTypingFeedback(
   adapter: PlatformAdapter,
   config: WebhookConfig,
@@ -832,6 +844,22 @@ async function sendPersonalSharedReply(
 ): Promise<PersonalSharedDeliveryTiming> {
   const { cloudBaseUrl, getAuthHeader } = deps;
   const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
+  const connectorAccountId = resolveConnectorAccountId(
+    adapter.platform,
+    config,
+  );
+  if (!connectorAccountId) {
+    throw new PersonalSharedPreEgressError(
+      "connector account identity is not configured",
+    );
+  }
+  const isGroup = event.chatType === "group" || event.chatType === "supergroup";
+  const sendReplyWithReceipt = adapter.sendReplyWithReceipt;
+  if (isGroup && !sendReplyWithReceipt) {
+    throw new PersonalSharedPreEgressError(
+      "group connector cannot return a provider delivery receipt",
+    );
+  }
   const voiceNote = event.voiceNote
     ? await adapter.resolveVoiceNote?.(config, event)
     : undefined;
@@ -853,24 +881,61 @@ async function sendPersonalSharedReply(
         ...authHeader,
       },
       body: JSON.stringify(
-        adapter.platform === "telegram"
+        event.membershipChange
           ? {
+              eventType: "membership",
               platform: "telegram",
               project,
+              connectorAccountId,
               chatId: event.chatId,
-              telegramUserId: event.senderId,
-              displayName: event.senderName,
               messageId: `telegram:${project}:${event.messageId}`,
-              ...(event.text ? { message: event.text } : {}),
-              ...(voiceNote ? { voiceNote } : {}),
+              membershipChange: event.membershipChange,
             }
-          : {
-              platform: adapter.platform,
-              project,
-              phoneNumber: event.senderId,
-              messageId: `${adapter.platform}:${project}:${event.messageId}`,
-              message: event.text,
-            },
+          : isGroup &&
+              (adapter.platform === "telegram" || adapter.platform === "blooio")
+            ? {
+                platform: adapter.platform,
+                chatType: event.chatType,
+                project,
+                connectorAccountId,
+                chatId: event.chatId,
+                actor: {
+                  platformUserId: event.senderId,
+                  ...(event.senderName
+                    ? { displayName: event.senderName }
+                    : {}),
+                  role:
+                    adapter.platform === "telegram"
+                      ? (event.groupActorRole ?? "unknown")
+                      : "possessor",
+                },
+                messageId: `${adapter.platform}:${project}:${event.messageId}`,
+                message: event.text,
+                invocation: groupInvocationForEvent(event),
+                ...(event.replyToMessageId
+                  ? { replyToMessageId: event.replyToMessageId }
+                  : {}),
+              }
+            : adapter.platform === "telegram"
+              ? {
+                  platform: "telegram",
+                  project,
+                  connectorAccountId,
+                  chatId: event.chatId,
+                  telegramUserId: event.senderId,
+                  displayName: event.senderName,
+                  messageId: `telegram:${project}:${event.messageId}`,
+                  ...(event.text ? { message: event.text } : {}),
+                  ...(voiceNote ? { voiceNote } : {}),
+                }
+              : {
+                  platform: adapter.platform,
+                  project,
+                  connectorAccountId,
+                  phoneNumber: event.senderId,
+                  messageId: `${adapter.platform}:${project}:${event.messageId}`,
+                  message: event.text,
+                },
       ),
       signal: AbortSignal.timeout(
         voiceNote ? PERSONAL_SHARED_VOICE_TIMEOUT_MS : 30_000,
@@ -981,7 +1046,54 @@ async function sendPersonalSharedReply(
     };
   }
   const egressStartedAt = Date.now();
-  await adapter.sendReply(config, event, reply, deliveryHooks);
+  if (isGroup) {
+    if (!sendReplyWithReceipt) {
+      throw new PersonalSharedPreEgressError(
+        "group connector cannot return a provider delivery receipt",
+      );
+    }
+    const receipt = await sendReplyWithReceipt(
+      config,
+      event,
+      reply,
+      deliveryHooks,
+    );
+    const receiptBody = JSON.stringify({
+      eventType: "delivery_receipt",
+      platform: adapter.platform,
+      project,
+      connectorAccountId,
+      chatId: event.chatId,
+      sourceMessageId: `${adapter.platform}:${project}:${event.messageId}`,
+      providerMessageIds: receipt.providerMessageIds,
+    });
+    const postReceipt = (header: Record<string, string>) =>
+      fetch(`${cloudBaseUrl}/api/internal/eliza-app/personal-shared/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [ELIZA_TRACE_ID_HEADER]: traceId,
+          ...header,
+        },
+        body: receiptBody,
+        signal: AbortSignal.timeout(10_000),
+      });
+    let receiptResponse = await postReceipt(authHeader);
+    if (receiptResponse.status === 401 || receiptResponse.status === 403) {
+      await receiptResponse.body?.cancel();
+      authHeader = await reauth();
+      receiptResponse = await postReceipt(authHeader);
+    }
+    if (!receiptResponse.ok) {
+      await receiptResponse.body?.cancel();
+      throw new Error(
+        `group delivery receipt persistence failed (${receiptResponse.status})`,
+      );
+    }
+    await receiptResponse.body?.cancel();
+  } else {
+    await adapter.sendReply(config, event, reply, deliveryHooks);
+  }
   return {
     cloudMs,
     cloudAttempts: attemptResult.attempts,

--- a/packages/cloud/shared/src/db/index.ts
+++ b/packages/cloud/shared/src/db/index.ts
@@ -1,5 +1,6 @@
 // Coordinates cloud DB index behavior shared by repositories and services.
 export { userCharactersRepository } from "./repositories/characters";
 export { dockerNodesRepository } from "./repositories/docker-nodes";
+export { personalSharedGroupsRepository } from "./repositories/personal-shared-groups";
 export { voiceImprintsRepository } from "./repositories/voice-imprints";
 export type { DockerNode } from "./schemas/docker-nodes";

--- a/packages/cloud/shared/src/db/migrations/0297_personal_shared_group_bindings.sql
+++ b/packages/cloud/shared/src/db/migrations/0297_personal_shared_group_bindings.sql
@@ -1,0 +1,65 @@
+-- One canonical Personal Shared agent may be explicitly bound to provider groups.
+
+CREATE TABLE personal_shared_group_claims (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code_hash text NOT NULL UNIQUE,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  owner_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  personal_agent_id text NOT NULL,
+  platform text NOT NULL CHECK (platform IN ('telegram', 'blooio')),
+  project text NOT NULL,
+  connector_account_id text NOT NULL,
+  issued_to_platform_user_id text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX personal_shared_group_claims_expires_idx
+  ON personal_shared_group_claims (expires_at);
+CREATE INDEX personal_shared_group_claims_owner_idx
+  ON personal_shared_group_claims (owner_user_id, platform);
+
+CREATE TABLE personal_shared_group_bindings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  owner_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  personal_agent_id text NOT NULL,
+  platform text NOT NULL CHECK (platform IN ('telegram', 'blooio')),
+  project text NOT NULL,
+  connector_account_id text NOT NULL,
+  provider_chat_id text NOT NULL,
+  conversation_id text NOT NULL,
+  state text NOT NULL DEFAULT 'active'
+    CHECK (state IN ('active', 'suspended', 'revoked')),
+  response_policy text NOT NULL DEFAULT 'mention_only'
+    CHECK (response_policy IN ('mention_only', 'ambient')),
+  created_by_platform_user_id text NOT NULL,
+  last_verified_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX personal_shared_group_bindings_provider_chat_uidx
+  ON personal_shared_group_bindings
+  (platform, project, connector_account_id, provider_chat_id);
+CREATE INDEX personal_shared_group_bindings_owner_idx
+  ON personal_shared_group_bindings (owner_user_id, state);
+
+CREATE TABLE personal_shared_group_delivery_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  binding_id uuid NOT NULL REFERENCES personal_shared_group_bindings(id) ON DELETE CASCADE,
+  platform text NOT NULL CHECK (platform IN ('telegram', 'blooio')),
+  project text NOT NULL,
+  connector_account_id text NOT NULL,
+  provider_chat_id text NOT NULL,
+  source_message_id text NOT NULL,
+  provider_message_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX personal_shared_group_delivery_receipts_provider_uidx
+  ON personal_shared_group_delivery_receipts
+  (platform, project, connector_account_id, provider_chat_id, provider_message_id);
+CREATE INDEX personal_shared_group_delivery_receipts_binding_created_idx
+  ON personal_shared_group_delivery_receipts (binding_id, created_at);

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1961,6 +1961,13 @@
       "when": 1793822400000,
       "tag": "0296_mcp_usage_canonical_receipts",
       "breakpoints": true
+    },
+    {
+      "idx": 280,
+      "version": "7",
+      "when": 1793908800000,
+      "tag": "0297_personal_shared_group_bindings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Exercises Personal Shared group claims and bindings against isolated PGlite,
+ * including atomic consumption, tenant-takeover resistance, and safe reclaim.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_A = "71000000-0000-4000-8000-000000000001";
+const ORG_B = "71000000-0000-4000-8000-000000000002";
+const USER_A = "71000000-0000-4000-8000-000000000011";
+const USER_B = "71000000-0000-4000-8000-000000000012";
+const CHAT_ID = "chat_group_contract";
+const CONNECTOR_ID = "blooio:+15550000001";
+const NOW = new Date("2026-08-22T00:00:00.000Z");
+
+let closeDatabaseConnectionsForTests:
+  | typeof import("../client").closeDatabaseConnectionsForTests
+  | undefined;
+let getPgliteClientForTests: typeof import("../client").getPgliteClientForTests;
+let repository: typeof import("./personal-shared-groups").personalSharedGroupsRepository;
+
+async function issue(input: {
+  codeHash: string;
+  organizationId: string;
+  ownerUserId: string;
+  personalAgentId: string;
+  platformUserId: string;
+}): Promise<void> {
+  await repository.issueClaim({
+    codeHash: input.codeHash,
+    organizationId: input.organizationId,
+    ownerUserId: input.ownerUserId,
+    personalAgentId: input.personalAgentId,
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR_ID,
+    issuedToPlatformUserId: input.platformUserId,
+    expiresAt: new Date(NOW.getTime() + 60_000),
+  });
+}
+
+async function consume(codeHash: string, platformUserId: string) {
+  return repository.consumeClaimAndBind({
+    codeHash,
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR_ID,
+    providerChatId: CHAT_ID,
+    actorPlatformUserId: platformUserId,
+    verifiedAt: NOW,
+  });
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests, getPgliteClientForTests } = await import("../client"));
+  ({ personalSharedGroupsRepository: repository } = await import("./personal-shared-groups"));
+  const database = getPgliteClientForTests();
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+  `);
+  const migration = await Bun.file(
+    new URL("../migrations/0297_personal_shared_group_bindings.sql", import.meta.url),
+  ).text();
+  await database.exec(migration);
+});
+
+beforeEach(async () => {
+  await getPgliteClientForTests().exec(`
+    TRUNCATE personal_shared_group_delivery_receipts,
+      personal_shared_group_bindings,
+      personal_shared_group_claims,
+      users,
+      organizations CASCADE;
+    INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
+    INSERT INTO users (id) VALUES ('${USER_A}'), ('${USER_B}');
+  `);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+});
+
+describe("personalSharedGroupsRepository", () => {
+  test("consumes an actor-bound claim once and creates its deterministic binding", async () => {
+    await issue({
+      codeHash: "claim-a",
+      organizationId: ORG_A,
+      ownerUserId: USER_A,
+      personalAgentId: "personal:owner-a",
+      platformUserId: "+15551110001",
+    });
+
+    expect(await consume("claim-a", "+15551119999")).toEqual({
+      status: "invalid",
+    });
+    const attempts = await Promise.all([
+      consume("claim-a", "+15551110001"),
+      consume("claim-a", "+15551110001"),
+    ]);
+    expect(attempts.map(({ status }) => status).sort()).toEqual(["already_used", "bound"]);
+    const result = attempts.find(({ status }) => status === "bound");
+    if (!result || result.status !== "bound") {
+      throw new Error("expected a bound claim");
+    }
+    expect(result.status).toBe("bound");
+    expect(result.binding).toMatchObject({
+      organization_id: ORG_A,
+      owner_user_id: USER_A,
+      personal_agent_id: "personal:owner-a",
+      state: "active",
+      response_policy: "mention_only",
+    });
+    expect(result.binding.conversation_id).toMatch(/^group:[0-9a-f-]{36}$/);
+  });
+
+  test("does not let a second tenant replace an active or suspended binding", async () => {
+    await issue({
+      codeHash: "claim-owner-a",
+      organizationId: ORG_A,
+      ownerUserId: USER_A,
+      personalAgentId: "personal:owner-a",
+      platformUserId: "+15551110001",
+    });
+    expect((await consume("claim-owner-a", "+15551110001")).status).toBe("bound");
+
+    await issue({
+      codeHash: "claim-owner-b",
+      organizationId: ORG_B,
+      ownerUserId: USER_B,
+      personalAgentId: "personal:owner-b",
+      platformUserId: "+15551110002",
+    });
+    expect(await consume("claim-owner-b", "+15551110002")).toEqual({
+      status: "already_bound",
+    });
+    expect(
+      await repository.resolveBinding({
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR_ID,
+        providerChatId: CHAT_ID,
+      }),
+    ).toMatchObject({
+      organization_id: ORG_A,
+      owner_user_id: USER_A,
+      personal_agent_id: "personal:owner-a",
+    });
+
+    await repository.applyMembershipChange({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      providerChatId: CHAT_ID,
+      membershipChange: "removed",
+      verifiedAt: NOW,
+    });
+    await issue({
+      codeHash: "claim-owner-b-suspended",
+      organizationId: ORG_B,
+      ownerUserId: USER_B,
+      personalAgentId: "personal:owner-b",
+      platformUserId: "+15551110002",
+    });
+    expect(await consume("claim-owner-b-suspended", "+15551110002")).toEqual({
+      status: "already_bound",
+    });
+  });
+
+  test("allows a new owner only after the prior owner explicitly revokes", async () => {
+    await issue({
+      codeHash: "claim-before-revoke",
+      organizationId: ORG_A,
+      ownerUserId: USER_A,
+      personalAgentId: "personal:owner-a",
+      platformUserId: "+15551110001",
+    });
+    const first = await consume("claim-before-revoke", "+15551110001");
+    if (first.status !== "bound") throw new Error("expected first binding");
+    expect(
+      await repository.revokeBinding({
+        bindingId: first.binding.id,
+        ownerUserId: USER_A,
+      }),
+    ).toBe(true);
+
+    await issue({
+      codeHash: "claim-after-revoke",
+      organizationId: ORG_B,
+      ownerUserId: USER_B,
+      personalAgentId: "personal:owner-b",
+      platformUserId: "+15551110002",
+    });
+    const rebound = await consume("claim-after-revoke", "+15551110002");
+    expect(rebound.status).toBe("bound");
+    if (rebound.status !== "bound") throw new Error("expected rebound claim");
+    expect(rebound.binding).toMatchObject({
+      organization_id: ORG_B,
+      owner_user_id: USER_B,
+      personal_agent_id: "personal:owner-b",
+      created_by_platform_user_id: "+15551110002",
+      state: "active",
+    });
+  });
+
+  test("records provider receipts idempotently and only for an active binding", async () => {
+    await issue({
+      codeHash: "claim-receipts",
+      organizationId: ORG_A,
+      ownerUserId: USER_A,
+      personalAgentId: "personal:owner-a",
+      platformUserId: "+15551110001",
+    });
+    const bound = await consume("claim-receipts", "+15551110001");
+    if (bound.status !== "bound") throw new Error("expected receipt binding");
+    const receipt = {
+      platform: "blooio" as const,
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      providerChatId: CHAT_ID,
+      sourceMessageId: "incoming-1",
+      providerMessageIds: ["outgoing-1"],
+    };
+    expect(await repository.recordDeliveryReceipts(receipt)).toBe(1);
+    expect(await repository.recordDeliveryReceipts(receipt)).toBe(0);
+    expect(
+      await repository.hasDeliveryReceipt({
+        bindingId: bound.binding.id,
+        providerMessageId: "outgoing-1",
+      }),
+    ).toBe(true);
+    await repository.revokeBinding({
+      bindingId: bound.binding.id,
+      ownerUserId: USER_A,
+    });
+    expect(
+      await repository.recordDeliveryReceipts({
+        ...receipt,
+        sourceMessageId: "incoming-2",
+        providerMessageIds: ["outgoing-2"],
+      }),
+    ).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -129,14 +129,8 @@ export const personalSharedGroupsRepository = {
           and(
             eq(personalSharedGroupBindings.platform, input.platform),
             eq(personalSharedGroupBindings.project, input.project),
-            eq(
-              personalSharedGroupBindings.connector_account_id,
-              input.connectorAccountId,
-            ),
-            eq(
-              personalSharedGroupBindings.provider_chat_id,
-              input.providerChatId,
-            ),
+            eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+            eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
           ),
         )
         .limit(1);
@@ -182,6 +176,11 @@ export const personalSharedGroupsRepository = {
             last_verified_at: now,
             updated_at: now,
           },
+          // An active or suspended binding is tenant authority, not a
+          // last-writer-wins cache entry. The existing owner may reconnect it,
+          // and a deliberately revoked group may be claimed anew, but another
+          // participant cannot replace a live owner's billing and policy
+          // boundary merely by presenting their own valid claim.
           setWhere: or(
             eq(personalSharedGroupBindings.owner_user_id, claim.owner_user_id),
             eq(personalSharedGroupBindings.state, "revoked"),

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -1,5 +1,5 @@
 /** Atomic claim and binding authority for Personal Shared provider groups. */
-import { and, eq, gt, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { v5 as uuidv5 } from "uuid";
 import { dbWrite } from "../client";
 import {
@@ -34,7 +34,7 @@ export function personalSharedGroupConversationId(input: {
 
 export type ConsumePersonalSharedGroupClaimResult =
   | { status: "bound"; binding: PersonalSharedGroupBinding }
-  | { status: "invalid" | "expired" | "already_used" };
+  | { status: "invalid" | "expired" | "already_used" | "already_bound" };
 
 export const personalSharedGroupsRepository = {
   async issueClaim(input: {
@@ -122,6 +122,31 @@ export const personalSharedGroupsRepository = {
         connectorAccountId: input.connectorAccountId,
         providerChatId: input.providerChatId,
       });
+      const [existing] = await tx
+        .select()
+        .from(personalSharedGroupBindings)
+        .where(
+          and(
+            eq(personalSharedGroupBindings.platform, input.platform),
+            eq(personalSharedGroupBindings.project, input.project),
+            eq(
+              personalSharedGroupBindings.connector_account_id,
+              input.connectorAccountId,
+            ),
+            eq(
+              personalSharedGroupBindings.provider_chat_id,
+              input.providerChatId,
+            ),
+          ),
+        )
+        .limit(1);
+      if (
+        existing &&
+        existing.owner_user_id !== claim.owner_user_id &&
+        existing.state !== "revoked"
+      ) {
+        return { status: "already_bound" } as const;
+      }
       const [binding] = await tx
         .insert(personalSharedGroupBindings)
         .values({
@@ -157,9 +182,13 @@ export const personalSharedGroupsRepository = {
             last_verified_at: now,
             updated_at: now,
           },
+          setWhere: or(
+            eq(personalSharedGroupBindings.owner_user_id, claim.owner_user_id),
+            eq(personalSharedGroupBindings.state, "revoked"),
+          ),
         })
         .returning();
-      if (!binding) throw new Error("Personal Shared group binding was not returned");
+      if (!binding) return { status: "already_bound" } as const;
       return { status: "bound", binding } as const;
     });
   },

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -1,0 +1,311 @@
+/** Atomic claim and binding authority for Personal Shared provider groups. */
+import { and, eq, gt, isNull } from "drizzle-orm";
+import { v5 as uuidv5 } from "uuid";
+import { dbWrite } from "../client";
+import {
+  type PersonalSharedGroupBinding,
+  type PersonalSharedGroupPlatform,
+  type PersonalSharedGroupResponsePolicy,
+  personalSharedGroupBindings,
+  personalSharedGroupClaims,
+  personalSharedGroupDeliveryReceipts,
+} from "../schemas/personal-shared-groups";
+
+const PERSONAL_SHARED_GROUP_NAMESPACE = "987af3c6-5e48-4ad7-a5b6-883b51d0c904";
+
+export function personalSharedGroupConversationId(input: {
+  personalAgentId: string;
+  platform: PersonalSharedGroupPlatform;
+  project: string;
+  connectorAccountId: string;
+  providerChatId: string;
+}): string {
+  return `group:${uuidv5(
+    [
+      input.personalAgentId,
+      input.platform,
+      input.project,
+      input.connectorAccountId,
+      input.providerChatId,
+    ].join("\n"),
+    PERSONAL_SHARED_GROUP_NAMESPACE,
+  )}`;
+}
+
+export type ConsumePersonalSharedGroupClaimResult =
+  | { status: "bound"; binding: PersonalSharedGroupBinding }
+  | { status: "invalid" | "expired" | "already_used" };
+
+export const personalSharedGroupsRepository = {
+  async issueClaim(input: {
+    codeHash: string;
+    organizationId: string;
+    ownerUserId: string;
+    personalAgentId: string;
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    issuedToPlatformUserId: string;
+    expiresAt: Date;
+  }): Promise<void> {
+    await dbWrite.transaction(async (tx) => {
+      const now = new Date();
+      await tx
+        .update(personalSharedGroupClaims)
+        .set({ consumed_at: now })
+        .where(
+          and(
+            eq(personalSharedGroupClaims.owner_user_id, input.ownerUserId),
+            eq(personalSharedGroupClaims.platform, input.platform),
+            eq(personalSharedGroupClaims.project, input.project),
+            eq(personalSharedGroupClaims.connector_account_id, input.connectorAccountId),
+            isNull(personalSharedGroupClaims.consumed_at),
+          ),
+        );
+      await tx.insert(personalSharedGroupClaims).values({
+        code_hash: input.codeHash,
+        organization_id: input.organizationId,
+        owner_user_id: input.ownerUserId,
+        personal_agent_id: input.personalAgentId,
+        platform: input.platform,
+        project: input.project,
+        connector_account_id: input.connectorAccountId,
+        issued_to_platform_user_id: input.issuedToPlatformUserId,
+        expires_at: input.expiresAt,
+      });
+    });
+  },
+
+  async consumeClaimAndBind(input: {
+    codeHash: string;
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId: string;
+    actorPlatformUserId: string;
+    verifiedAt?: Date;
+  }): Promise<ConsumePersonalSharedGroupClaimResult> {
+    return dbWrite.transaction(async (tx) => {
+      const now = input.verifiedAt ?? new Date();
+      const [claim] = await tx
+        .update(personalSharedGroupClaims)
+        .set({ consumed_at: now })
+        .where(
+          and(
+            eq(personalSharedGroupClaims.code_hash, input.codeHash),
+            eq(personalSharedGroupClaims.platform, input.platform),
+            eq(personalSharedGroupClaims.project, input.project),
+            eq(personalSharedGroupClaims.connector_account_id, input.connectorAccountId),
+            eq(personalSharedGroupClaims.issued_to_platform_user_id, input.actorPlatformUserId),
+            isNull(personalSharedGroupClaims.consumed_at),
+            gt(personalSharedGroupClaims.expires_at, now),
+          ),
+        )
+        .returning();
+
+      if (!claim) {
+        const [observed] = await tx
+          .select()
+          .from(personalSharedGroupClaims)
+          .where(eq(personalSharedGroupClaims.code_hash, input.codeHash))
+          .limit(1);
+        if (!observed) return { status: "invalid" } as const;
+        if (observed.consumed_at) return { status: "already_used" } as const;
+        if (observed.expires_at <= now) return { status: "expired" } as const;
+        return { status: "invalid" } as const;
+      }
+
+      const conversationId = personalSharedGroupConversationId({
+        personalAgentId: claim.personal_agent_id,
+        platform: input.platform,
+        project: input.project,
+        connectorAccountId: input.connectorAccountId,
+        providerChatId: input.providerChatId,
+      });
+      const [binding] = await tx
+        .insert(personalSharedGroupBindings)
+        .values({
+          organization_id: claim.organization_id,
+          owner_user_id: claim.owner_user_id,
+          personal_agent_id: claim.personal_agent_id,
+          platform: input.platform,
+          project: input.project,
+          connector_account_id: input.connectorAccountId,
+          provider_chat_id: input.providerChatId,
+          conversation_id: conversationId,
+          state: "active",
+          response_policy: "mention_only",
+          created_by_platform_user_id: input.actorPlatformUserId,
+          last_verified_at: now,
+          updated_at: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            personalSharedGroupBindings.platform,
+            personalSharedGroupBindings.project,
+            personalSharedGroupBindings.connector_account_id,
+            personalSharedGroupBindings.provider_chat_id,
+          ],
+          set: {
+            organization_id: claim.organization_id,
+            owner_user_id: claim.owner_user_id,
+            personal_agent_id: claim.personal_agent_id,
+            conversation_id: conversationId,
+            state: "active",
+            response_policy: "mention_only",
+            created_by_platform_user_id: input.actorPlatformUserId,
+            last_verified_at: now,
+            updated_at: now,
+          },
+        })
+        .returning();
+      if (!binding) throw new Error("Personal Shared group binding was not returned");
+      return { status: "bound", binding } as const;
+    });
+  },
+
+  async resolveBinding(input: {
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId: string;
+  }): Promise<PersonalSharedGroupBinding | null> {
+    const [binding] = await dbWrite
+      .select()
+      .from(personalSharedGroupBindings)
+      .where(
+        and(
+          eq(personalSharedGroupBindings.platform, input.platform),
+          eq(personalSharedGroupBindings.project, input.project),
+          eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+          eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
+        ),
+      )
+      .limit(1);
+    return binding ?? null;
+  },
+
+  async setResponsePolicy(input: {
+    bindingId: string;
+    ownerUserId: string;
+    policy: PersonalSharedGroupResponsePolicy;
+  }): Promise<PersonalSharedGroupBinding | null> {
+    const [binding] = await dbWrite
+      .update(personalSharedGroupBindings)
+      .set({ response_policy: input.policy, updated_at: new Date() })
+      .where(
+        and(
+          eq(personalSharedGroupBindings.id, input.bindingId),
+          eq(personalSharedGroupBindings.owner_user_id, input.ownerUserId),
+          eq(personalSharedGroupBindings.state, "active"),
+        ),
+      )
+      .returning();
+    return binding ?? null;
+  },
+
+  async revokeBinding(input: { bindingId: string; ownerUserId: string }): Promise<boolean> {
+    const [binding] = await dbWrite
+      .update(personalSharedGroupBindings)
+      .set({ state: "revoked", updated_at: new Date() })
+      .where(
+        and(
+          eq(personalSharedGroupBindings.id, input.bindingId),
+          eq(personalSharedGroupBindings.owner_user_id, input.ownerUserId),
+        ),
+      )
+      .returning({ id: personalSharedGroupBindings.id });
+    return Boolean(binding);
+  },
+
+  async applyMembershipChange(input: {
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId: string;
+    membershipChange: "joined" | "removed";
+    verifiedAt?: Date;
+  }): Promise<PersonalSharedGroupBinding | null> {
+    const now = input.verifiedAt ?? new Date();
+    const [binding] = await dbWrite
+      .update(personalSharedGroupBindings)
+      .set({
+        state: input.membershipChange === "joined" ? "active" : "suspended",
+        last_verified_at: now,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(personalSharedGroupBindings.platform, input.platform),
+          eq(personalSharedGroupBindings.project, input.project),
+          eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+          eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
+          eq(
+            personalSharedGroupBindings.state,
+            input.membershipChange === "joined" ? "suspended" : "active",
+          ),
+        ),
+      )
+      .returning();
+    return binding ?? null;
+  },
+
+  async recordDeliveryReceipts(input: {
+    platform: PersonalSharedGroupPlatform;
+    project: string;
+    connectorAccountId: string;
+    providerChatId: string;
+    sourceMessageId: string;
+    providerMessageIds: string[];
+  }): Promise<number> {
+    return dbWrite.transaction(async (tx) => {
+      const [binding] = await tx
+        .select({ id: personalSharedGroupBindings.id })
+        .from(personalSharedGroupBindings)
+        .where(
+          and(
+            eq(personalSharedGroupBindings.platform, input.platform),
+            eq(personalSharedGroupBindings.project, input.project),
+            eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+            eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
+            eq(personalSharedGroupBindings.state, "active"),
+          ),
+        )
+        .limit(1);
+      if (!binding || input.providerMessageIds.length === 0) return 0;
+      const inserted = await tx
+        .insert(personalSharedGroupDeliveryReceipts)
+        .values(
+          input.providerMessageIds.map((providerMessageId) => ({
+            binding_id: binding.id,
+            platform: input.platform,
+            project: input.project,
+            connector_account_id: input.connectorAccountId,
+            provider_chat_id: input.providerChatId,
+            source_message_id: input.sourceMessageId,
+            provider_message_id: providerMessageId,
+          })),
+        )
+        .onConflictDoNothing()
+        .returning({ id: personalSharedGroupDeliveryReceipts.id });
+      return inserted.length;
+    });
+  },
+
+  async hasDeliveryReceipt(input: {
+    bindingId: string;
+    providerMessageId: string;
+  }): Promise<boolean> {
+    const [receipt] = await dbWrite
+      .select({ id: personalSharedGroupDeliveryReceipts.id })
+      .from(personalSharedGroupDeliveryReceipts)
+      .where(
+        and(
+          eq(personalSharedGroupDeliveryReceipts.binding_id, input.bindingId),
+          eq(personalSharedGroupDeliveryReceipts.provider_message_id, input.providerMessageId),
+        ),
+      )
+      .limit(1);
+    return Boolean(receipt);
+  },
+};

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -96,6 +96,7 @@ export * from "./organizations";
 export * from "./payment-request-receipts";
 export * from "./payment-requests";
 export * from "./personal-account-convergences";
+export * from "./personal-shared-groups";
 export * from "./phone-gateway-devices";
 export * from "./pii-scrub-markers";
 export * from "./platform-credentials";

--- a/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
@@ -1,0 +1,138 @@
+/** Durable owner claims and provider-chat bindings for one canonical Personal Shared agent. */
+import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
+import { check, index, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+export type PersonalSharedGroupPlatform = "telegram" | "blooio";
+export type PersonalSharedGroupBindingState = "active" | "suspended" | "revoked";
+export type PersonalSharedGroupResponsePolicy = "mention_only" | "ambient";
+
+export const personalSharedGroupClaims = pgTable(
+  "personal_shared_group_claims",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    code_hash: text("code_hash").notNull().unique(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    owner_user_id: uuid("owner_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    personal_agent_id: text("personal_agent_id").notNull(),
+    platform: text("platform").$type<PersonalSharedGroupPlatform>().notNull(),
+    project: text("project").notNull(),
+    connector_account_id: text("connector_account_id").notNull(),
+    issued_to_platform_user_id: text("issued_to_platform_user_id").notNull(),
+    expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumed_at: timestamp("consumed_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    platform_check: check(
+      "personal_shared_group_claims_platform_check",
+      sql`${table.platform} IN ('telegram', 'blooio')`,
+    ),
+    expires_idx: index("personal_shared_group_claims_expires_idx").on(table.expires_at),
+    owner_idx: index("personal_shared_group_claims_owner_idx").on(
+      table.owner_user_id,
+      table.platform,
+    ),
+  }),
+);
+
+export const personalSharedGroupBindings = pgTable(
+  "personal_shared_group_bindings",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    owner_user_id: uuid("owner_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    personal_agent_id: text("personal_agent_id").notNull(),
+    platform: text("platform").$type<PersonalSharedGroupPlatform>().notNull(),
+    project: text("project").notNull(),
+    connector_account_id: text("connector_account_id").notNull(),
+    provider_chat_id: text("provider_chat_id").notNull(),
+    conversation_id: text("conversation_id").notNull(),
+    state: text("state").$type<PersonalSharedGroupBindingState>().notNull().default("active"),
+    response_policy: text("response_policy")
+      .$type<PersonalSharedGroupResponsePolicy>()
+      .notNull()
+      .default("mention_only"),
+    created_by_platform_user_id: text("created_by_platform_user_id").notNull(),
+    last_verified_at: timestamp("last_verified_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    platform_check: check(
+      "personal_shared_group_bindings_platform_check",
+      sql`${table.platform} IN ('telegram', 'blooio')`,
+    ),
+    state_check: check(
+      "personal_shared_group_bindings_state_check",
+      sql`${table.state} IN ('active', 'suspended', 'revoked')`,
+    ),
+    policy_check: check(
+      "personal_shared_group_bindings_policy_check",
+      sql`${table.response_policy} IN ('mention_only', 'ambient')`,
+    ),
+    provider_chat_unique: uniqueIndex("personal_shared_group_bindings_provider_chat_uidx").on(
+      table.platform,
+      table.project,
+      table.connector_account_id,
+      table.provider_chat_id,
+    ),
+    owner_idx: index("personal_shared_group_bindings_owner_idx").on(
+      table.owner_user_id,
+      table.state,
+    ),
+  }),
+);
+
+export const personalSharedGroupDeliveryReceipts = pgTable(
+  "personal_shared_group_delivery_receipts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    binding_id: uuid("binding_id")
+      .notNull()
+      .references(() => personalSharedGroupBindings.id, {
+        onDelete: "cascade",
+      }),
+    platform: text("platform").$type<PersonalSharedGroupPlatform>().notNull(),
+    project: text("project").notNull(),
+    connector_account_id: text("connector_account_id").notNull(),
+    provider_chat_id: text("provider_chat_id").notNull(),
+    source_message_id: text("source_message_id").notNull(),
+    provider_message_id: text("provider_message_id").notNull(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    platform_check: check(
+      "personal_shared_group_delivery_receipts_platform_check",
+      sql`${table.platform} IN ('telegram', 'blooio')`,
+    ),
+    provider_unique: uniqueIndex("personal_shared_group_delivery_receipts_provider_uidx").on(
+      table.platform,
+      table.project,
+      table.connector_account_id,
+      table.provider_chat_id,
+      table.provider_message_id,
+    ),
+    binding_created_idx: index("personal_shared_group_delivery_receipts_binding_created_idx").on(
+      table.binding_id,
+      table.created_at,
+    ),
+  }),
+);
+
+export type PersonalSharedGroupClaim = InferSelectModel<typeof personalSharedGroupClaims>;
+export type NewPersonalSharedGroupClaim = InferInsertModel<typeof personalSharedGroupClaims>;
+export type PersonalSharedGroupBinding = InferSelectModel<typeof personalSharedGroupBindings>;
+export type NewPersonalSharedGroupBinding = InferInsertModel<typeof personalSharedGroupBindings>;
+export type PersonalSharedGroupDeliveryReceipt = InferSelectModel<
+  typeof personalSharedGroupDeliveryReceipts
+>;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -183,7 +183,7 @@ export async function prewarmSharedAgentTurnCaches(
 export async function prewarmPersonalSharedAgentTurnCaches(
   agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,
   namespace: RuntimeDurableObjectNamespace,
-  options: { warmConversation?: boolean } = {},
+  options: { warmConversation?: boolean; conversationId?: string } = {},
 ): Promise<void> {
   const legs: PrewarmLeg[] = [
     {
@@ -194,7 +194,7 @@ export async function prewarmPersonalSharedAgentTurnCaches(
   if (options.warmConversation !== false) {
     legs.push({
       leg: "conversation-object",
-      run: coordinateSharedConversationPrewarm(agent.id, agent.id, {
+      run: coordinateSharedConversationPrewarm(agent.id, options.conversationId ?? agent.id, {
         namespace,
         startEmpty: true,
       }),


### PR DESCRIPTION
## Summary

- add durable one-time owner claims and canonical provider-chat group bindings
- preserve one stable group conversation across Shared and Dedicated routing
- enforce Telegram admin authority, membership suspend/restore, owner-only policy/revoke controls, and mention-only defaults
- preserve Blooio group threads and require durable outbound receipts before reply-to classification
- keep provider egress idempotent and forward membership removal without inference or a send

## Verification

- 41 Personal Shared route tests pass
- 8 Telegram group-policy tests pass
- 56 gateway/Blooio tests pass
- gateway-webhook typecheck passes
- drizzle migration check passes
- Biome and git diff checks pass

## Safety and rollout

This is a draft only. It has not been merged or deployed, and no live provider action was taken from this branch. The frozen 13-file source WIP remains byte-exact at its recorded fingerprint.

@lalalune Please review the trust and migration contract before this leaves draft.