### PR TITLE
fix(scheduling): centralize deferred runner readiness

### DIFF
--- a/packages/core/src/__tests__/runtime-stop.test.ts
+++ b/packages/core/src/__tests__/runtime-stop.test.ts
@@ -238,6 +238,7 @@ describe("AgentRuntime.stop", () => {
 		expect(runtime.getLifecycleState()).toBe("stopping");
 		expect(runtime.getStopSignal().aborted).toBe(true);
 		await stopStarted.promise;
+		expect(runtime.getLifecycleState()).toBe("stopping");
 		expect(reentrantStop).not.toBeNull();
 		let secondSettled = false;
 		const second = runtime.stop().then(() => {
@@ -251,6 +252,16 @@ describe("AgentRuntime.stop", () => {
 		expect(stopCalls).toBe(1);
 		expect(secondSettled).toBe(true);
 		expect(runtime.getLifecycleState()).toBe("stopped");
+	});
+
+	it("reports a failed initialization instead of a running lifecycle", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+
+		await expect(
+			runtime.initialize({ skipMigrations: true }),
+		).rejects.toThrow();
+
+		expect(runtime.getLifecycleState()).toBe("failed");
 	});
 
 	it("fails fast without stopping resources beneath a noncooperative room owner", async () => {

--- a/packages/core/src/__tests__/runtime-stop.test.ts
+++ b/packages/core/src/__tests__/runtime-stop.test.ts
@@ -204,7 +204,10 @@ describe("AgentRuntime.stop", () => {
 
 	it("makes reentrant and concurrent stop callers await one teardown", async () => {
 		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		expect(runtime.getLifecycleState()).toBe("initializing");
+		expect(runtime.getStopSignal().aborted).toBe(false);
 		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		expect(runtime.getLifecycleState()).toBe("running");
 		const stopStarted = createDeferred<void>();
 		const finishStop = createDeferred<void>();
 		let stopCalls = 0;
@@ -232,6 +235,8 @@ describe("AgentRuntime.stop", () => {
 		await runtime.registerService(DeferredStopService);
 		await runtime.getServiceLoadPromise(DeferredStopService.serviceType);
 		const first = runtime.stop();
+		expect(runtime.getLifecycleState()).toBe("stopping");
+		expect(runtime.getStopSignal().aborted).toBe(true);
 		await stopStarted.promise;
 		expect(reentrantStop).not.toBeNull();
 		let secondSettled = false;
@@ -245,6 +250,7 @@ describe("AgentRuntime.stop", () => {
 		await Promise.all([first, second, reentrantStop]);
 		expect(stopCalls).toBe(1);
 		expect(secondSettled).toBe(true);
+		expect(runtime.getLifecycleState()).toBe("stopped");
 	});
 
 	it("fails fast without stopping resources beneath a noncooperative room owner", async () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1420,6 +1420,8 @@ export class AgentRuntime implements IAgentRuntime {
 	private stopped = false;
 	/** Set permanently at the first stop request, before any drain can yield. */
 	private stopRequested = false;
+	/** Typed cancellation boundary for deferred plugin/service startup. */
+	private readonly stopController = new AbortController();
 	/** The active stop attempt; concurrent callers await the same teardown. */
 	private stopPromise: Promise<void> | null = null;
 
@@ -2605,6 +2607,9 @@ export class AgentRuntime implements IAgentRuntime {
 		this.stopPromise = stopAttempt;
 		if (!this.stopRequested) {
 			this.stopRequested = true;
+			this.stopController.abort(
+				new DOMException("Runtime stop requested", "AbortError"),
+			);
 			// Freeze connector/service ingress before the first shutdown await. Without
 			// this phase, a gateway delivery can begin a new turn while the runtime is
 			// already waiting for its room-owner drain, behind the eventual service-stop
@@ -5855,6 +5860,16 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 		const key = this.resolveServiceTypeAlias(serviceType) as ServiceTypeName;
 		return this.serviceRegistrationStatus.get(key) || "unknown";
+	}
+
+	getLifecycleState(): "initializing" | "running" | "stopping" | "stopped" {
+		if (this.stopped) return "stopped";
+		if (this.stopRequested) return "stopping";
+		return this.initResolver ? "initializing" : "running";
+	}
+
+	getStopSignal(): AbortSignal {
+		return this.stopController.signal;
 	}
 
 	/**

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1420,6 +1420,8 @@ export class AgentRuntime implements IAgentRuntime {
 	private stopped = false;
 	/** Set permanently at the first stop request, before any drain can yield. */
 	private stopRequested = false;
+	/** Records an initialization attempt that released waiters by failing. */
+	private initializationFailed = false;
 	/** Typed cancellation boundary for deferred plugin/service startup. */
 	private readonly stopController = new AbortController();
 	/** The active stop attempt; concurrent callers await the same teardown. */
@@ -2889,9 +2891,11 @@ export class AgentRuntime implements IAgentRuntime {
 		/** Allow running without a persistent database adapter (benchmarks/tests). */
 		allowNoDatabase?: boolean;
 	}): Promise<void> {
+		this.initializationFailed = false;
 		try {
 			await this._initializeCore(options);
 		} catch (err) {
+			this.initializationFailed = true;
 			// error-policy:J2 Release initialization waiters before preserving
 			// the original initialization failure for the caller.
 			// Always resolve initPromise so eager service starts and stop()
@@ -5862,9 +5866,16 @@ export class AgentRuntime implements IAgentRuntime {
 		return this.serviceRegistrationStatus.get(key) || "unknown";
 	}
 
-	getLifecycleState(): "initializing" | "running" | "stopping" | "stopped" {
-		if (this.stopped) return "stopped";
-		if (this.stopRequested) return "stopping";
+	getLifecycleState():
+		| "initializing"
+		| "running"
+		| "failed"
+		| "stopping"
+		| "stopped" {
+		if (this.stopRequested) {
+			return this.stopped && this.stopPromise === null ? "stopped" : "stopping";
+		}
+		if (this.initializationFailed) return "failed";
 		return this.initResolver ? "initializing" : "running";
 	}
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -570,6 +570,10 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 	/** When true, TaskService does not start a timer; host drives via runDueTasks(). WHY: no long-lived process in serverless. */
 	serverless?: boolean;
 	initPromise: Promise<void>;
+	/** Current terminal lifecycle phase for cancellable deferred startup. */
+	getLifecycleState(): "initializing" | "running" | "stopping" | "stopped";
+	/** Aborts synchronously when terminal runtime shutdown is first requested. */
+	getStopSignal(): AbortSignal;
 	messageService: IMessageService | null;
 	providers: Provider[];
 	actions: Action[];

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -570,10 +570,10 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 	/** When true, TaskService does not start a timer; host drives via runDueTasks(). WHY: no long-lived process in serverless. */
 	serverless?: boolean;
 	initPromise: Promise<void>;
-	/** Current terminal lifecycle phase for cancellable deferred startup. */
-	getLifecycleState(): "initializing" | "running" | "stopping" | "stopped";
-	/** Aborts synchronously when terminal runtime shutdown is first requested. */
-	getStopSignal(): AbortSignal;
+	/** Optional lifecycle capability for cancellable deferred startup. */
+	getLifecycleState?(): "initializing" | "running" | "stopping" | "stopped";
+	/** Optional signal that aborts when terminal runtime shutdown is requested. */
+	getStopSignal?(): AbortSignal;
 	messageService: IMessageService | null;
 	providers: Provider[];
 	actions: Action[];

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -571,7 +571,12 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 	serverless?: boolean;
 	initPromise: Promise<void>;
 	/** Optional lifecycle capability for cancellable deferred startup. */
-	getLifecycleState?(): "initializing" | "running" | "stopping" | "stopped";
+	getLifecycleState?():
+		| "initializing"
+		| "running"
+		| "failed"
+		| "stopping"
+		| "stopped";
 	/** Optional signal that aborts when terminal runtime shutdown is requested. */
 	getStopSignal?(): AbortSignal;
 	messageService: IMessageService | null;

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -16,6 +16,10 @@ import {
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const schedulingMocks = vi.hoisted(() => ({
+  waitForScheduledTaskRunnerService: vi.fn(async () => ({})),
+}));
+
 // Isolate PA's own init wiring (registries, workers, policies, the scheduler
 // identity under test) from the cross-plugin connector boot. Each connector
 // package has its own dedicated suite; here they are neutralized so init runs
@@ -35,6 +39,11 @@ vi.mock("@elizaos/plugin-health", async (importOriginal) => ({
   registerHealthDefaultPacks: vi.fn(),
   registerCircadianInsightContract: vi.fn(),
   createDefaultCircadianInsightContract: vi.fn(() => ({})),
+}));
+vi.mock("@elizaos/plugin-scheduling", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  waitForScheduledTaskRunnerService:
+    schedulingMocks.waitForScheduledTaskRunnerService,
 }));
 
 import { areLifeOpsActivitySignalsActive } from "./lifeops/activity-signal-lifecycle.js";
@@ -165,5 +174,23 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
     expect(worker).toBeDefined();
     // When enabled, shouldRun consults live app state (not a hardcoded false).
     expect(typeof worker?.shouldRun).toBe("function");
+  });
+
+  it("uses scheduling-owned runner readiness for enabled startup work", async () => {
+    delete process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER;
+    const { runtime } = createRecordingRuntime();
+
+    await personalAssistantPlugin.init?.({}, runtime);
+
+    await vi.waitFor(() => {
+      expect(
+        schedulingMocks.waitForScheduledTaskRunnerService,
+      ).toHaveBeenCalled();
+    });
+    for (const call of schedulingMocks.waitForScheduledTaskRunnerService.mock
+      .calls) {
+      expect(call).toHaveLength(1);
+      expect(call[0]).toBe(runtime);
+    }
   });
 });

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -185,7 +185,7 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
     await vi.waitFor(() => {
       expect(
         schedulingMocks.waitForScheduledTaskRunnerService,
-      ).toHaveBeenCalled();
+      ).toHaveBeenCalledTimes(2);
     });
     for (const call of schedulingMocks.waitForScheduledTaskRunnerService.mock
       .calls) {

--- a/plugins/plugin-scheduling/src/plugin.test.ts
+++ b/plugins/plugin-scheduling/src/plugin.test.ts
@@ -114,6 +114,28 @@ describe("scheduling plugin boot", () => {
     );
   });
 
+  it("uses the central heavy-boot window for registration after 30 seconds", async () => {
+    vi.useFakeTimers();
+    let registered = false;
+    const service = {} as ScheduledTaskRunnerService;
+    const getServiceLoadPromise = vi.fn(async () => service);
+    const runtime = {
+      initPromise: Promise.resolve(),
+      hasService: () => registered,
+      getServiceRegistrationStatus: () =>
+        registered ? "registered" : "unknown",
+      getServiceLoadPromise,
+    } as unknown as IAgentRuntime;
+
+    const load = waitForScheduledTaskRunnerService(runtime);
+    await vi.advanceTimersByTimeAsync(30_250);
+    expect(getServiceLoadPromise).not.toHaveBeenCalled();
+
+    registered = true;
+    await vi.advanceTimersByTimeAsync(250);
+    await expect(load).resolves.toBe(service);
+  });
+
   it("fails at the bounded deadline when the declaration never registers", async () => {
     vi.useFakeTimers();
     const getServiceLoadPromise = vi.fn();
@@ -169,7 +191,7 @@ describe("scheduling plugin boot", () => {
     vi.useFakeTimers();
     const runtime = {
       initPromise: Promise.resolve(),
-      stopped: false,
+      stopRequested: false,
       hasService: () => false,
       getServiceRegistrationStatus: () => "unknown",
       getServiceLoadPromise: vi.fn(),
@@ -183,7 +205,11 @@ describe("scheduling plugin boot", () => {
       code: "SCHEDULED_TASK_RUNNER_WAIT_STOPPED",
     });
     await vi.advanceTimersByTimeAsync(100);
-    (runtime as IAgentRuntime & { stopped: boolean }).stopped = true;
+    (
+      runtime as IAgentRuntime & {
+        stopRequested: boolean;
+      }
+    ).stopRequested = true;
     await vi.advanceTimersByTimeAsync(100);
 
     await outcome;

--- a/plugins/plugin-scheduling/src/plugin.test.ts
+++ b/plugins/plugin-scheduling/src/plugin.test.ts
@@ -189,9 +189,11 @@ describe("scheduling plugin boot", () => {
 
   it("stops polling when runtime shutdown begins", async () => {
     vi.useFakeTimers();
+    const stop = new AbortController();
     const runtime = {
       initPromise: Promise.resolve(),
-      stopRequested: false,
+      getLifecycleState: () => (stop.signal.aborted ? "stopping" : "running"),
+      getStopSignal: () => stop.signal,
       hasService: () => false,
       getServiceRegistrationStatus: () => "unknown",
       getServiceLoadPromise: vi.fn(),
@@ -205,15 +207,79 @@ describe("scheduling plugin boot", () => {
       code: "SCHEDULED_TASK_RUNNER_WAIT_STOPPED",
     });
     await vi.advanceTimersByTimeAsync(100);
-    (
-      runtime as IAgentRuntime & {
-        stopRequested: boolean;
-      }
-    ).stopRequested = true;
-    await vi.advanceTimersByTimeAsync(100);
+    stop.abort();
 
     await outcome;
     expect(runtime.getServiceLoadPromise).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("observes runtime shutdown while initialization is still pending", async () => {
+    const stop = new AbortController();
+    const runtime = {
+      initPromise: new Promise<void>(() => undefined),
+      getLifecycleState: () =>
+        stop.signal.aborted ? "stopping" : "initializing",
+      getStopSignal: () => stop.signal,
+      hasService: vi.fn(),
+      getServiceRegistrationStatus: vi.fn(),
+      getServiceLoadPromise: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    const load = waitForScheduledTaskRunnerService(runtime);
+    const outcome = expect(load).rejects.toMatchObject({
+      code: "SCHEDULED_TASK_RUNNER_WAIT_STOPPED",
+    });
+    stop.abort();
+
+    await outcome;
+    expect(runtime.hasService).not.toHaveBeenCalled();
+    expect(runtime.getServiceLoadPromise).not.toHaveBeenCalled();
+  });
+
+  it("observes runtime shutdown while the registered service is loading", async () => {
+    const stop = new AbortController();
+    let markLoadStarted!: () => void;
+    const loadStarted = new Promise<void>((resolve) => {
+      markLoadStarted = resolve;
+    });
+    const runtime = {
+      initPromise: Promise.resolve(),
+      getLifecycleState: () => (stop.signal.aborted ? "stopping" : "running"),
+      getStopSignal: () => stop.signal,
+      hasService: () => true,
+      getServiceRegistrationStatus: () => "registered",
+      getServiceLoadPromise: vi.fn(() => {
+        markLoadStarted();
+        return new Promise(() => undefined);
+      }),
+    } as unknown as IAgentRuntime;
+
+    const load = waitForScheduledTaskRunnerService(runtime);
+    const outcome = expect(load).rejects.toMatchObject({
+      code: "SCHEDULED_TASK_RUNNER_WAIT_STOPPED",
+    });
+    await loadStarted;
+    stop.abort();
+
+    await outcome;
+    expect(runtime.getServiceLoadPromise).toHaveBeenCalledOnce();
+  });
+
+  it("validates wait bounds before awaiting runtime initialization", async () => {
+    const runtime = {
+      initPromise: new Promise<void>(() => undefined),
+      hasService: vi.fn(),
+      getServiceRegistrationStatus: vi.fn(),
+      getServiceLoadPromise: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    await expect(
+      waitForScheduledTaskRunnerService(runtime, {
+        registrationPollMs: Number.NaN,
+      }),
+    ).rejects.toMatchObject({ code: "SCHEDULED_TASK_RUNNER_WAIT_INVALID" });
+    expect(runtime.hasService).not.toHaveBeenCalled();
   });
 
   it("cancels the pending poll immediately when its owner aborts", async () => {

--- a/plugins/plugin-scheduling/src/plugin.test.ts
+++ b/plugins/plugin-scheduling/src/plugin.test.ts
@@ -214,6 +214,43 @@ describe("scheduling plugin boot", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("retains shutdown detection for runtimes with the legacy stopped flag", async () => {
+    vi.useFakeTimers();
+    const runtime = {
+      initPromise: Promise.resolve(),
+      stopped: false,
+      hasService: () => false,
+      getServiceRegistrationStatus: () => "unknown",
+      getServiceLoadPromise: vi.fn(),
+    } as unknown as IAgentRuntime & { stopped: boolean };
+
+    const load = waitForScheduledTaskRunnerService(runtime);
+    const outcome = expect(load).rejects.toMatchObject({
+      code: "SCHEDULED_TASK_RUNNER_WAIT_STOPPED",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    runtime.stopped = true;
+    await vi.advanceTimersByTimeAsync(250);
+
+    await outcome;
+    expect(runtime.getServiceLoadPromise).not.toHaveBeenCalled();
+  });
+
+  it("rejects startup after runtime initialization has failed", async () => {
+    const runtime = {
+      initPromise: Promise.resolve(),
+      getLifecycleState: () => "failed" as const,
+      hasService: vi.fn(),
+      getServiceRegistrationStatus: vi.fn(),
+      getServiceLoadPromise: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    await expect(
+      waitForScheduledTaskRunnerService(runtime),
+    ).rejects.toMatchObject({ code: "SCHEDULED_TASK_RUNNER_WAIT_STOPPED" });
+    expect(runtime.hasService).not.toHaveBeenCalled();
+  });
+
   it("observes runtime shutdown while initialization is still pending", async () => {
     const stop = new AbortController();
     const runtime = {

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -63,6 +63,8 @@ function runnerWaitStopped(
       : undefined;
   return (
     signal?.aborted === true ||
+    (runtime as IAgentRuntime & { stopped?: boolean }).stopped === true ||
+    lifecycle === "failed" ||
     lifecycle === "stopping" ||
     lifecycle === "stopped"
   );

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -40,7 +40,10 @@ export const SCHEDULED_TASK_RUNNER_REGISTRATION_FAILED =
 export const SCHEDULED_TASK_RUNNER_WAIT_STOPPED =
   "SCHEDULED_TASK_RUNNER_WAIT_STOPPED";
 
-const DEFAULT_RUNNER_REGISTRATION_TIMEOUT_MS = 30_000;
+// Deferred plugin registration can legitimately trail runtime initialization
+// on a cold, plugin-heavy boot. Keep the observed boot allowance in the
+// scheduling owner so every consumer shares one readiness contract.
+const DEFAULT_RUNNER_REGISTRATION_TIMEOUT_MS = 120_000;
 const DEFAULT_RUNNER_REGISTRATION_POLL_MS = 250;
 
 export interface WaitForScheduledTaskRunnerServiceOptions {
@@ -54,9 +57,14 @@ function runnerWaitStopped(
   runtime: IAgentRuntime,
   signal?: AbortSignal,
 ): boolean {
+  const lifecycle = runtime as IAgentRuntime & {
+    stopped?: boolean;
+    stopRequested?: boolean;
+  };
   return (
     signal?.aborted === true ||
-    (runtime as IAgentRuntime & { stopped?: boolean }).stopped === true
+    lifecycle.stopRequested === true ||
+    lifecycle.stopped === true
   );
 }
 

--- a/plugins/plugin-scheduling/src/plugin.ts
+++ b/plugins/plugin-scheduling/src/plugin.ts
@@ -57,15 +57,28 @@ function runnerWaitStopped(
   runtime: IAgentRuntime,
   signal?: AbortSignal,
 ): boolean {
-  const lifecycle = runtime as IAgentRuntime & {
-    stopped?: boolean;
-    stopRequested?: boolean;
-  };
+  const lifecycle =
+    typeof runtime.getLifecycleState === "function"
+      ? runtime.getLifecycleState()
+      : undefined;
   return (
     signal?.aborted === true ||
-    lifecycle.stopRequested === true ||
-    lifecycle.stopped === true
+    lifecycle === "stopping" ||
+    lifecycle === "stopped"
   );
+}
+
+function runnerWaitSignal(
+  runtime: IAgentRuntime,
+  ownerSignal?: AbortSignal,
+): AbortSignal | undefined {
+  const runtimeSignal =
+    typeof runtime.getStopSignal === "function"
+      ? runtime.getStopSignal()
+      : undefined;
+  if (!ownerSignal) return runtimeSignal;
+  if (!runtimeSignal) return ownerSignal;
+  return AbortSignal.any([runtimeSignal, ownerSignal]);
 }
 
 function runnerWaitStoppedError(serviceType: string): ElizaError {
@@ -157,12 +170,6 @@ export async function waitForScheduledTaskRunnerService(
   runtime: IAgentRuntime,
   options: WaitForScheduledTaskRunnerServiceOptions = {},
 ): Promise<ScheduledTaskRunnerService> {
-  await waitForPromise(runtime.initPromise, options.signal);
-
-  const serviceType = ScheduledTaskRunnerService.serviceType;
-  if (runnerWaitStopped(runtime, options.signal)) {
-    throwRunnerWaitStopped(serviceType);
-  }
   const timeoutMs = requireDuration(
     options.registrationTimeoutMs,
     DEFAULT_RUNNER_REGISTRATION_TIMEOUT_MS,
@@ -175,10 +182,19 @@ export async function waitForScheduledTaskRunnerService(
     "registrationPollMs",
     false,
   );
-  const deadline = Date.now() + timeoutMs;
+  const signal = runnerWaitSignal(runtime, options.signal);
+  await waitForPromise(runtime.initPromise, signal);
+
+  const serviceType = ScheduledTaskRunnerService.serviceType;
+  if (runnerWaitStopped(runtime, signal)) {
+    throwRunnerWaitStopped(serviceType);
+  }
+  // Startup readiness is elapsed-time based; wall-clock corrections must not
+  // shorten the registration allowance or keep a dependent service hung.
+  const deadline = performance.now() + timeoutMs;
 
   while (!runtime.hasService(serviceType)) {
-    if (runnerWaitStopped(runtime, options.signal)) {
+    if (runnerWaitStopped(runtime, signal)) {
       throwRunnerWaitStopped(serviceType);
     }
     const status = runtime.getServiceRegistrationStatus(serviceType);
@@ -189,7 +205,7 @@ export async function waitForScheduledTaskRunnerService(
       });
     }
 
-    const remainingMs = deadline - Date.now();
+    const remainingMs = deadline - performance.now();
     if (remainingMs <= 0) {
       throw new ElizaError(
         "Scheduled task runner was not registered before the startup deadline",
@@ -199,16 +215,16 @@ export async function waitForScheduledTaskRunnerService(
         },
       );
     }
-    await waitForPoll(Math.min(pollMs, remainingMs), options.signal);
+    await waitForPoll(Math.min(pollMs, remainingMs), signal);
   }
 
-  if (runnerWaitStopped(runtime, options.signal)) {
+  if (runnerWaitStopped(runtime, signal)) {
     throwRunnerWaitStopped(serviceType);
   }
 
   return (await waitForPromise(
     runtime.getServiceLoadPromise(serviceType),
-    options.signal,
+    signal,
   )) as ScheduledTaskRunnerService;
 }
 


### PR DESCRIPTION
## Summary

- extend the scheduling-owned default runner registration window from 30s to 120s for observed plugin-heavy cold boots
- observe runtime shutdown through an optional lifecycle capability and synchronous stop signal
- distinguish failed initialization and in-progress teardown from a completed stop
- retain structural `runtime.stopped` detection for older compatible runtimes
- preserve source compatibility for third-party and mock `IAgentRuntime` implementations
- prove personal-assistant startup uses the central readiness contract without a local timeout override
- preserve #24260 cancellable waits, typed failure/timeout behavior, and owner AbortSignal cancellation

This is the focused follow-up to #24260. Its merged implementation centralized the wait correctly, but retained the old 30-second default and only observed the late stopped flag.

Fixes #24311

## Exact-head verification

Head: `3116c299d9949fe49232462a73a027ef54b73ad5`

- PASS — core runtime-stop suite: 9/9
- PASS — scheduling plugin suite: 15/15
- PASS — personal-assistant startup suite: 5/5
- PASS — core typecheck
- PASS — core full Node/browser/edge/testing build plus packed Node, browser-condition, exact-flat Vite, edge declaration, and runtime import verification
- PASS — Biome on all seven changed files
- PASS — `git diff --check`
- PASS — 160 `CLAUDE.md`/`AGENTS.md` parity pairs
- BASELINE HOLD — root `bun run verify` reaches the pre-existing repository i18n gate and fails on missing locale keys in unrelated app/UI files. This PR changes no locale or rendered UI file.
- BASELINE HOLD — scheduling typecheck reaches the pre-existing missing optional `@elizaos/capacitor-secure-store` declaration in `packages/ui/src/bridge/storage-bridge.ts`; no changed file is named.

## Evidence Gate

<!-- evidence-head:3116c299d9949fe49232462a73a027ef54b73ad5 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime lifecycle and deferred startup code only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime lifecycle and deferred startup code only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; the observable contract is startup completion, typed cancellation, and service registration.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused execution transcript:

  ```text
  packages/core/src/__tests__/runtime-stop.test.ts: 9 passed / 9
  plugins/plugin-scheduling/src/plugin.test.ts: 15 passed / 15
  plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts: 5 passed / 5
  core multi-target build and packed export consumers: PASS
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend, browser console, or network request path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-planning, or model-facing content path is changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic runtime artifacts inspected:

  ```text
  lifecycle: initializing → running; failed initialization → failed; shutdown stays stopping through blocked teardown → stopped
  cancellation: runtime stop signal aborted synchronously at the first stop request
  consumer call: personal-assistant invoked waitForScheduledTaskRunnerService(runtime) with no local timeout options
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels are rendered by this change.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: self-reported
