### PR TITLE
fix(core): validate hosted metadata at admission boundary before stableStringify

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -20,6 +20,7 @@ import {
 	normalizeEntityMatches,
 	readEntityResolutionField,
 } from "./entity-matches";
+import { ElizaError } from "./errors";
 import { logger } from "./logger";
 // Type-only (erased at runtime, so no cycle with roles.ts, which imports
 // createUniqueUuid from this module). The role-resolution values are pulled via a
@@ -37,7 +38,11 @@ import {
 	type World,
 } from "./types";
 import * as utils from "./utils";
-import { stableStringify } from "./utils/deterministic";
+import {
+	budgetSpreadBudget,
+	STABLE_STRINGIFY_UNBOUNDED,
+	stableStringifyBounded,
+} from "./utils/deterministic";
 
 type EntityDetailsRecord = Pick<
 	Entity,
@@ -594,6 +599,17 @@ export async function getEntityDetails({
 					return undefined;
 				};
 
+				try {
+					budgetSpreadBudget(mergedData, entity.metadata);
+				} catch (error) {
+					throw error instanceof ElizaError
+						? error
+						: new ElizaError("entity data spread unbounded", {
+								code: STABLE_STRINGIFY_UNBOUNDED,
+								cause: error,
+								context: { reason: "spread-budget" },
+							});
+				}
 				uniqueEntities.set(entityId, {
 					id: entityId,
 					agentId: entity.agentId,
@@ -602,7 +618,7 @@ export async function getEntityDetails({
 						: entity.names[0],
 					names: entity.names,
 					metadata: entity.metadata,
-					data: stableStringify({ ...mergedData, ...entity.metadata }),
+					data: stableStringifyBounded({ ...mergedData, ...entity.metadata }),
 				});
 			}
 
@@ -626,7 +642,7 @@ function formatEntityNames(names: string[]): string {
 }
 
 export function formatEntityMetadata(metadata: unknown): string {
-	return stableStringify(metadata);
+	return stableStringifyBounded(metadata);
 }
 
 export function formatEntities({ entities }: { entities: Entity[] }) {

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -111,7 +111,7 @@ export { Semaphore } from "./utils/batch-queue/semaphore.js";
 export * from "./utils/buffer";
 export * from "./utils/channel-utils";
 export * from "./utils/description-compressed-lint";
-export { stableStringify } from "./utils/deterministic";
+export { STABLE_STRINGIFY_UNBOUNDED, budgetSpreadBudget, stableStringify, stableStringifyBounded } from "./utils/deterministic";
 export * from "./utils/environment";
 export * from "./utils/html-raw-text";
 export * from "./utils/prompt-compression";

--- a/packages/core/src/utils/deterministic.bounded.test.ts
+++ b/packages/core/src/utils/deterministic.bounded.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Bounded deterministic stringify: accessor, proxy, depth, breadth, string, and boundary guards.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors.ts";
+import {
+	MAX_STABLE_STRINGIFY_BYTES,
+	MAX_STABLE_STRINGIFY_DEPTH,
+	MAX_STABLE_STRINGIFY_EDGES,
+	MAX_STABLE_STRINGIFY_NODES,
+	STABLE_STRINGIFY_UNBOUNDED,
+	stableStringifyBounded,
+} from "./deterministic.ts";
+
+function isUnbounded(error: unknown, reason?: string): boolean {
+	if (!(error instanceof ElizaError)) return false;
+	if (error.code !== STABLE_STRINGIFY_UNBOUNDED) return false;
+	if (reason)
+		return (error.context as Record<string, unknown>)?.reason === reason;
+	return true;
+}
+
+describe("stableStringifyBounded", () => {
+	it("spread-accessor: getter not invoked", () => {
+		let invoked = false;
+		const obj = {};
+		Object.defineProperty(obj, "x", {
+			get() {
+				invoked = true;
+				return 1;
+			},
+			enumerable: true,
+			configurable: true,
+		});
+		expect(() => stableStringifyBounded(obj)).toThrow();
+		try {
+			stableStringifyBounded(obj);
+		} catch (e) {
+			expect(isUnbounded(e, "accessor")).toBe(true);
+		}
+		expect(invoked).toBe(false);
+
+		const proxy = new Proxy(
+			{ a: 1 },
+			{
+				get() {
+					invoked = true;
+					return 1;
+				},
+				ownKeys() {
+					throw new Error("trap");
+				},
+			},
+		);
+		expect(() => stableStringifyBounded(proxy)).toThrow();
+	});
+
+	it("revoked/classification-proxy: traps translated", () => {
+		const { proxy: revoked } = Proxy.revocable({ a: 1 }, {});
+		// revoke
+		// @ts-expect-error
+		revoked; // keep ref
+		const p = Proxy.revocable({ a: 1 }, {}).proxy;
+		// revoke then access should throw bounded
+		const rev = Proxy.revocable({ a: 1 }, {});
+		rev.revoke();
+		expect(() => stableStringifyBounded(rev.proxy)).toThrow();
+
+		const poisoned = { a: 1 } as Record<string, unknown>;
+		const d = new Date();
+		// poison Symbol.toStringTag with accessor
+		Object.defineProperty(d, Symbol.toStringTag, {
+			get() {
+				throw new Error("poison");
+			},
+			enumerable: false,
+			configurable: true,
+		});
+		expect(() => stableStringifyBounded(d)).toThrow();
+		try {
+			stableStringifyBounded(d);
+		} catch (e) {
+			expect(isUnbounded(e, "date-brand")).toBe(true);
+		}
+	});
+
+	it("deep-prototype: only own enumerable keys", () => {
+		const proto = { inherited: 999 };
+		const obj = Object.create(proto);
+		(Object.assign(obj, { own: 1 }) as Record<string, unknown>).own = 1;
+		// polluted __proto__ own key should be data, not prototype
+		const polluted: Record<string, unknown> = {};
+		Object.defineProperty(polluted, "__proto__", {
+			value: { evil: 1 },
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		});
+		polluted.a = 1;
+		const out = stableStringifyBounded(polluted);
+		expect(out).toContain('"__proto__"');
+		expect(out).toContain('"a":1');
+		// inherited not serialized
+		const out2 = stableStringifyBounded(obj);
+		expect(out2).not.toContain("inherited");
+		// null prototype
+		const nullProto = Object.create(null) as Record<string, unknown>;
+		nullProto.b = 2;
+		nullProto.a = 1;
+		expect(stableStringifyBounded(nullProto)).toBe('{"a":1,"b":2}');
+	});
+
+	it("huge-breadth: rejects before sort", () => {
+		const big: Record<string, number> = {};
+		for (let i = 0; i < MAX_STABLE_STRINGIFY_NODES + 10; i++) big[`k${i}`] = i;
+		expect(() => stableStringifyBounded(big)).toThrow();
+		try {
+			stableStringifyBounded(big);
+		} catch (e) {
+			expect(
+				isUnbounded(e, "keys") ||
+					isUnbounded(e, "nodes") ||
+					isUnbounded(e, "edges"),
+			).toBe(true);
+		}
+	});
+
+	it("huge-string: utf8-length precheck", () => {
+		const huge = "a".repeat(MAX_STABLE_STRINGIFY_BYTES);
+		expect(() => stableStringifyBounded(huge)).toThrow();
+		try {
+			stableStringifyBounded(huge);
+		} catch (e) {
+			expect(isUnbounded(e)).toBe(true);
+		}
+		const uni = "😀".repeat(400_000); // each is 2 code units, ~4 bytes utf8
+		expect(() => stableStringifyBounded(uni)).toThrow();
+	});
+
+	it("sparse-array: holes become null", () => {
+		const arr: unknown[] = [];
+		arr[2] = 1;
+		arr.length = 4;
+		// holes at 0,1,3
+		const out = stableStringifyBounded(arr);
+		expect(out).toBe("[null,null,1,null]");
+		// accessor index throws
+		const arr2: unknown[] = [1, 2];
+		Object.defineProperty(arr2, "0", {
+			get() {
+				throw new Error("x");
+			},
+			enumerable: true,
+			configurable: true,
+		});
+		expect(() => stableStringifyBounded(arr2)).toThrow();
+	});
+
+	it("exact-boundaries and compat", () => {
+		// depth limit
+		let deep: unknown = 0;
+		for (let i = 0; i < MAX_STABLE_STRINGIFY_DEPTH; i++) deep = { a: deep };
+		expect(() => stableStringifyBounded(deep)).not.toThrow();
+		let tooDeep: unknown = 0;
+		for (let i = 0; i < MAX_STABLE_STRINGIFY_DEPTH + 2; i++)
+			tooDeep = { a: tooDeep };
+		expect(() => stableStringifyBounded(tooDeep)).toThrow();
+		try {
+			stableStringifyBounded(tooDeep);
+		} catch (e) {
+			expect(isUnbounded(e, "depth")).toBe(true);
+		}
+
+		// byte-for-byte compat
+		expect(stableStringifyBounded({ b: 2, a: 1 })).toBe('{"a":1,"b":2}');
+		const d = new Date("2026-01-01T00:00:00.000Z");
+		expect(stableStringifyBounded(d)).toBe('"2026-01-01T00:00:00.000Z"');
+		expect(stableStringifyBounded({ z: 1, ä: 2, B: 3, a: 4 })).toBe(
+			'{"B":3,"a":4,"z":1,"ä":2}',
+		);
+	});
+});

--- a/packages/core/src/utils/deterministic.ts
+++ b/packages/core/src/utils/deterministic.ts
@@ -5,7 +5,449 @@
  * provides stableStringify — key-order-independent JSON for stable hashing/IDs.
  */
 
+import { ElizaError } from "../errors.ts";
 import { EXAMPLE_NAMES } from "./example-names";
+
+export const MAX_STABLE_STRINGIFY_DEPTH = 64;
+export const MAX_STABLE_STRINGIFY_NODES = 2048;
+export const MAX_STABLE_STRINGIFY_EDGES = 2048;
+export const MAX_STABLE_STRINGIFY_BYTES = 1_048_576; // 1 MiB serialized cap
+
+export const STABLE_STRINGIFY_UNBOUNDED = "STABLE_STRINGIFY_UNBOUNDED";
+
+export type StableStringifyReason =
+	| "accessor"
+	| "keys"
+	| "utf8-length"
+	| "date-brand"
+	| "spread-budget"
+	| "depth"
+	| "nodes"
+	| "edges"
+	| "cycle"
+	| "prototype"
+	| "bytes";
+
+type WalkCtx = {
+	visits: number;
+	edges: number;
+	ancestors: WeakSet<object>;
+};
+
+function failUnbounded(
+	reason: StableStringifyReason,
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(`stableStringify: unbounded ${reason}`, {
+		code: STABLE_STRINGIFY_UNBOUNDED,
+		context: { reason, ...context },
+		severity: "fatal",
+	});
+}
+
+function failUnsafeAccessor(key: string): never {
+	throw new ElizaError(
+		`stableStringify: accessor property ${key} cannot be serialized safely`,
+		{
+			code: STABLE_STRINGIFY_UNBOUNDED,
+			context: { reason: "accessor" as StableStringifyReason, key },
+			severity: "fatal",
+		},
+	);
+}
+
+function reserveVisit(ctx: WalkCtx): void {
+	ctx.visits += 1;
+	if (ctx.visits > MAX_STABLE_STRINGIFY_NODES) {
+		failUnbounded("nodes", {
+			visits: ctx.visits,
+			max: MAX_STABLE_STRINGIFY_NODES,
+		});
+	}
+}
+
+function reserveEdge(ctx: WalkCtx): void {
+	ctx.edges += 1;
+	if (ctx.edges > MAX_STABLE_STRINGIFY_EDGES) {
+		failUnbounded("edges", {
+			edges: ctx.edges,
+			max: MAX_STABLE_STRINGIFY_EDGES,
+		});
+	}
+}
+
+function getOwnDataValue(
+	source: Record<PropertyKey, unknown>,
+	key: PropertyKey,
+): unknown {
+	let descriptor: PropertyDescriptor | undefined;
+	try {
+		descriptor = Object.getOwnPropertyDescriptor(source, key);
+	} catch (error) {
+		throw new ElizaError("stableStringify: cannot inspect property", {
+			code: STABLE_STRINGIFY_UNBOUNDED,
+			cause: error,
+			context: {
+				reason: "accessor" as StableStringifyReason,
+				key: String(key),
+			},
+			severity: "fatal",
+		});
+	}
+	if (!descriptor) return undefined;
+	if (!("value" in descriptor)) {
+		failUnsafeAccessor(String(key));
+	}
+	return descriptor.value;
+}
+
+function getDateTimestamp(value: object): number | undefined {
+	try {
+		let tag: string;
+		try {
+			tag = Object.prototype.toString.call(value);
+		} catch (error) {
+			throw new ElizaError("stableStringify: date brand check failed", {
+				code: STABLE_STRINGIFY_UNBOUNDED,
+				cause: error,
+				context: { reason: "date-brand" as StableStringifyReason },
+				severity: "fatal",
+			});
+		}
+		if (tag !== "[object Date]") return undefined;
+		// Also guard Symbol.toStringTag poisoning path explicitly
+		try {
+			// Accessing Symbol.toStringTag may invoke accessor
+			const maybeTag = (value as Record<symbol, unknown>)[Symbol.toStringTag];
+			// We don't use maybeTag; just ensure access doesn't throw leaked error
+			void maybeTag;
+		} catch (error) {
+			throw new ElizaError("stableStringify: date brand check failed", {
+				code: STABLE_STRINGIFY_UNBOUNDED,
+				cause: error,
+				context: { reason: "date-brand" as StableStringifyReason },
+				severity: "fatal",
+			});
+		}
+		return Date.prototype.getTime.call(value);
+	} catch (error) {
+		if (error instanceof ElizaError) throw error;
+		throw new ElizaError("stableStringify: date brand check failed", {
+			code: STABLE_STRINGIFY_UNBOUNDED,
+			cause: error,
+			context: { reason: "date-brand" as StableStringifyReason },
+			severity: "fatal",
+		});
+	}
+}
+
+function isPlainArray(value: unknown): boolean {
+	try {
+		return Array.isArray(value);
+	} catch (error) {
+		throw new ElizaError("stableStringify: array brand check failed", {
+			code: STABLE_STRINGIFY_UNBOUNDED,
+			cause: error,
+			context: { reason: "prototype" as StableStringifyReason },
+			severity: "fatal",
+		});
+	}
+}
+
+function sortStableBoundedInner(
+	value: unknown,
+	depth: number,
+	ctx: WalkCtx,
+): unknown {
+	if (depth > MAX_STABLE_STRINGIFY_DEPTH) {
+		failUnbounded("depth", { depth, max: MAX_STABLE_STRINGIFY_DEPTH });
+	}
+	reserveVisit(ctx);
+
+	if (value === null || typeof value !== "object") {
+		if (typeof value === "string") {
+			// UTF-16 length precheck before any encoder allocation
+			if (value.length * 3 > MAX_STABLE_STRINGIFY_BYTES) {
+				failUnbounded("utf8-length", {
+					length: value.length,
+					estimatedBytes: value.length * 3,
+					max: MAX_STABLE_STRINGIFY_BYTES,
+				});
+			}
+			// Exact byte accounting via TextEncoder (bounded sink)
+			const encoded = new TextEncoder().encode(value);
+			if (encoded.byteLength > MAX_STABLE_STRINGIFY_BYTES) {
+				failUnbounded("bytes", {
+					bytes: encoded.byteLength,
+					max: MAX_STABLE_STRINGIFY_BYTES,
+				});
+			}
+			// Also check key budget for strings is not needed; nodes already counted
+		}
+		if (typeof value === "bigint") {
+			// JSON.stringify would throw; keep same observable but bounded
+			throw new TypeError("Do not know how to serialize a BigInt");
+		}
+		return value;
+	}
+
+	// Guarded Date check
+	const ts = getDateTimestamp(value as object);
+	if (ts !== undefined) {
+		// Keep native Date#toJSON behavior via returning Date instance for JSON.stringify
+		return value;
+	}
+
+	if (ctx.ancestors.has(value as object)) {
+		failUnbounded("cycle", { depth });
+	}
+
+	if (isPlainArray(value)) {
+		const arr = value as unknown[];
+		ctx.ancestors.add(value as object);
+		try {
+			// Reserve edges for holes too
+			for (let i = 0; i < arr.length; i += 1) {
+				reserveEdge(ctx);
+			}
+			// Map preserving holes as null per JSON semantics is done via JSON.stringify later;
+			// here we produce array with null for holes to keep deterministic
+			const out: unknown[] = new Array(arr.length);
+			for (let i = 0; i < arr.length; i += 1) {
+				if (!(i in arr)) {
+					out[i] = null;
+					continue;
+				}
+				// Descriptor-safe read for index
+				const v = getOwnDataValue(
+					arr as unknown as Record<PropertyKey, unknown>,
+					i,
+				);
+				out[i] = sortStableBoundedInner(v, depth + 1, ctx);
+			}
+			// Handle non-index own enumerable string props on arrays (rare) via descriptor walk
+			let ownKeys: (string | symbol)[];
+			try {
+				ownKeys = Reflect.ownKeys(arr);
+			} catch (error) {
+				throw new ElizaError("stableStringify: cannot enumerate array keys", {
+					code: STABLE_STRINGIFY_UNBOUNDED,
+					cause: error,
+					context: { reason: "keys" as StableStringifyReason },
+					severity: "fatal",
+				});
+			}
+			// If array has extra enumerable string keys beyond indices, merge them as object-like?
+			// JSON.stringify ignores non-index props on arrays, so we ignore them too for compat.
+			// But count them for budget.
+			if (ownKeys.length > arr.length) {
+				// Count extra edges for non-index keys
+				for (const k of ownKeys) {
+					if (typeof k === "string" && !/^\d+$/.test(k)) {
+						reserveEdge(ctx);
+					}
+				}
+			}
+			return out;
+		} finally {
+			ctx.ancestors.delete(value as object);
+		}
+	}
+
+	// Plain object path - stage on null prototype
+	const proto = (() => {
+		try {
+			return Object.getPrototypeOf(value);
+		} catch (error) {
+			throw new ElizaError("stableStringify: cannot get prototype", {
+				code: STABLE_STRINGIFY_UNBOUNDED,
+				cause: error,
+				context: { reason: "prototype" as StableStringifyReason },
+				severity: "fatal",
+			});
+		}
+	})();
+	// For determinism, we canonicalize only plain objects; other protos pass through as-is? For bounded safety, treat non-plain as empty? Keep historical: sort any object.
+	// But guard prototype pollution: stage on null prototype then restore.
+
+	ctx.ancestors.add(value as object);
+	try {
+		let ownKeys: (string | symbol)[];
+		try {
+			ownKeys = Reflect.ownKeys(value as object);
+		} catch (error) {
+			throw new ElizaError("stableStringify: cannot enumerate keys", {
+				code: STABLE_STRINGIFY_UNBOUNDED,
+				cause: error,
+				context: { reason: "keys" as StableStringifyReason },
+				severity: "fatal",
+			});
+		}
+		// Incremental budget before sort/alloc
+		if (ownKeys.length > MAX_STABLE_STRINGIFY_NODES) {
+			failUnbounded("keys", {
+				keys: ownKeys.length,
+				max: MAX_STABLE_STRINGIFY_NODES,
+			});
+		}
+		// Reserve edges for each own key
+		for (let i = 0; i < ownKeys.length; i += 1) reserveEdge(ctx);
+
+		// Filter to own enumerable string keys via descriptor-only
+		const stringKeys: string[] = [];
+		for (const k of ownKeys) {
+			if (typeof k !== "string") continue;
+			let desc: PropertyDescriptor | undefined;
+			try {
+				desc = Object.getOwnPropertyDescriptor(value as object, k);
+			} catch (error) {
+				throw new ElizaError("stableStringify: cannot inspect descriptor", {
+					code: STABLE_STRINGIFY_UNBOUNDED,
+					cause: error,
+					context: { reason: "accessor" as StableStringifyReason, key: k },
+					severity: "fatal",
+				});
+			}
+			if (!desc) continue;
+			if (!desc.enumerable) continue;
+			if (!("value" in desc)) {
+				failUnsafeAccessor(k);
+			}
+			// String key bytes precheck
+			if (k.length * 3 > MAX_STABLE_STRINGIFY_BYTES) {
+				failUnbounded("utf8-length", {
+					key: k,
+					length: k.length,
+					max: MAX_STABLE_STRINGIFY_BYTES,
+				});
+			}
+			stringKeys.push(k);
+		}
+
+		// Code-unit order sort (historical)
+		stringKeys.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+		const staged = Object.create(null) as Record<string, unknown>;
+		for (const key of stringKeys) {
+			const rawVal = getOwnDataValue(
+				value as Record<PropertyKey, unknown>,
+				key,
+			);
+			const sorted = sortStableBoundedInner(rawVal, depth + 1, ctx);
+			// Guard defineProperty failure
+			try {
+				Object.defineProperty(staged, key, {
+					value: sorted,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				});
+			} catch (error) {
+				throw new ElizaError("stableStringify: cannot define property", {
+					code: STABLE_STRINGIFY_UNBOUNDED,
+					cause: error,
+					context: { reason: "prototype" as StableStringifyReason, key },
+					severity: "fatal",
+				});
+			}
+		}
+		// Restore prototype for JSON.stringify semantics? Null-prototype object stringifies same; keep null-proto to avoid __proto__ pollution.
+		// Preserve historical proto for plain objects: set back to original proto after staging so instanceof checks downstream not needed (we already returned Date)
+		try {
+			Object.setPrototypeOf(staged, proto);
+		} catch {
+			// ignore
+		}
+		return staged;
+	} finally {
+		ctx.ancestors.delete(value as object);
+	}
+}
+
+export function stableStringifyBounded(value: unknown): string {
+	let sorted: unknown;
+	try {
+		sorted = sortStableBoundedInner(value, 0, {
+			visits: 0,
+			edges: 0,
+			ancestors: new WeakSet(),
+		});
+	} catch (error) {
+		if (error instanceof ElizaError) throw error;
+		// Reflection trap leakage
+		throw new ElizaError("stableStringify: reflection failed", {
+			code: STABLE_STRINGIFY_UNBOUNDED,
+			cause: error,
+			context: { reason: "prototype" as StableStringifyReason },
+			severity: "fatal",
+		});
+	}
+	const json = JSON.stringify(sorted);
+	// JSON.stringify returns undefined for top-level undefined/function/symbol; mirror historical
+	if (json === undefined) return undefined as unknown as string;
+	// Byte budget on final output
+	if (json.length * 3 > MAX_STABLE_STRINGIFY_BYTES) {
+		// Precheck before encoder
+		failUnbounded("utf8-length", {
+			length: json.length,
+			max: MAX_STABLE_STRINGIFY_BYTES,
+		});
+	}
+	const bytes = new TextEncoder().encode(json).byteLength;
+	if (bytes > MAX_STABLE_STRINGIFY_BYTES) {
+		failUnbounded("bytes", { bytes, max: MAX_STABLE_STRINGIFY_BYTES });
+	}
+	return json;
+}
+
+/** Hoisted spread budget: count Reflect.ownKeys of each arg before materializing spread. */
+export function budgetSpreadBudget(...sources: unknown[]): void {
+	let totalKeys = 0;
+	for (const src of sources) {
+		if (src == null || typeof src !== "object") continue;
+		let keys: (string | symbol)[];
+		try {
+			keys = Reflect.ownKeys(src as object);
+		} catch (error) {
+			throw new ElizaError("stableStringify: cannot enumerate spread source", {
+				code: STABLE_STRINGIFY_UNBOUNDED,
+				cause: error,
+				context: { reason: "spread-budget" as StableStringifyReason },
+				severity: "fatal",
+			});
+		}
+		totalKeys += keys.length;
+		if (totalKeys > MAX_STABLE_STRINGIFY_NODES) {
+			failUnbounded("keys", {
+				keys: totalKeys,
+				max: MAX_STABLE_STRINGIFY_NODES,
+				reason: "spread-budget" as StableStringifyReason,
+			});
+		}
+		// Also check descriptors for accessors without invoking
+		for (const k of keys) {
+			let desc: PropertyDescriptor | undefined;
+			try {
+				desc = Object.getOwnPropertyDescriptor(src as object, k);
+			} catch (error) {
+				throw new ElizaError("stableStringify: cannot inspect spread source", {
+					code: STABLE_STRINGIFY_UNBOUNDED,
+					cause: error,
+					context: {
+						reason: "spread-budget" as StableStringifyReason,
+						key: String(k),
+					},
+					severity: "fatal",
+				});
+			}
+			if (desc && !("value" in desc)) {
+				failUnsafeAccessor(String(k));
+			}
+		}
+	}
+}
+
+// ---- Unchanged deterministic helpers below ----
 
 const UINT32_MAX = 0x100000000;
 

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -18,7 +18,12 @@
  *    skip: pause suppresses proactive behavior, and chaining is proactive.
  */
 
-import { ElizaError, stableStringify } from "@elizaos/core/edge";
+import {
+  budgetSpreadBudget,
+  ElizaError,
+  STABLE_STRINGIFY_UNBOUNDED,
+  stableStringifyBounded,
+} from "@elizaos/core/edge";
 import { decideDispatchPolicy } from "../dispatch-policy.js";
 import type { DispatchResult } from "../dispatch-types.js";
 import type { CompletionCheckRegistry } from "./completion-check-registry.js";
@@ -1150,9 +1155,34 @@ export function createScheduledTaskRunner(
     task: ScheduledTask,
     receipt: { sourceAgentId: string; cutoverToken: string },
   ): Promise<{ task: ScheduledTask; imported: boolean }> {
+    try {
+      budgetSpreadBudget(
+        task,
+        (task as unknown as Record<string, unknown>).metadata,
+      );
+    } catch (error) {
+      throw error instanceof ElizaError
+        ? error
+        : new ElizaError("scheduled task import unbounded", {
+            code: STABLE_STRINGIFY_UNBOUNDED,
+            cause: error,
+            context: { reason: "spread-budget" },
+          });
+    }
+    let taskDigest: string;
+    try {
+      taskDigest = stableStringifyBounded(task);
+    } catch (error) {
+      throw error instanceof ElizaError
+        ? error
+        : new ElizaError("scheduled task digest unbounded", {
+            code: STABLE_STRINGIFY_UNBOUNDED,
+            cause: error,
+            context: { reason: "spread-budget" },
+          });
+    }
     const existing = await deps.store.get(task.taskId);
     const existingReceipt = existing?.metadata?.sharedCutoverImport;
-    const taskDigest = stableStringify(task);
     if (existing) {
       if (
         existingReceipt !== null &&
@@ -1176,7 +1206,27 @@ export function createScheduledTaskRunner(
     if (validationIssues.length > 0) {
       throw new ScheduledTaskValidationError(validationIssues, "importedTask");
     }
-    const imported = structuredClone(task);
+    let imported: ScheduledTask;
+    try {
+      imported = structuredClone(task);
+    } catch (error) {
+      throw new ElizaError("scheduled task clone unbounded", {
+        code: STABLE_STRINGIFY_UNBOUNDED,
+        cause: error,
+        context: { reason: "spread-budget" },
+      });
+    }
+    try {
+      budgetSpreadBudget(imported.metadata);
+    } catch (error) {
+      throw error instanceof ElizaError
+        ? error
+        : new ElizaError("scheduled task metadata spread unbounded", {
+            code: STABLE_STRINGIFY_UNBOUNDED,
+            cause: error,
+            context: { reason: "spread-budget" },
+          });
+    }
     imported.metadata = {
       ...(imported.metadata ?? {}),
       sharedCutoverImport: {


### PR DESCRIPTION
**Scope:** `packages/core/src/utils/deterministic.ts` (additive), `packages/core/src/entities.ts`, `plugins/plugin-scheduling/src/scheduled-task/runner.ts`

**Summary:** Replacement for #24186 per content-budget review. Keeps `stableStringify` deterministic and compatible for admitted values. Adds additive `stableStringifyBounded` + `budgetSpreadBudget` used only at hosted-metadata admission boundaries (entity `getEntityDetails`/`formatEntityMetadata` and scheduled-task `importTask`) so hostile spread/getter and unbounded depth/breadth/string cannot reach stringify via `Reflect.ownKeys`/`getOwnPropertyDescriptor` budget before spread and descriptor-only walk.

**Why not inside primitive:** No hard ceilings injected into the generic `stableStringify` identity primitive — boundary-specific validation per review, with `stableStringifyBounded` as explicit opt-in for untrusted inputs.

**Risk:** Low. No change to `stableStringify` observable for admitted plain JSON; callers that previously called `stableStringify` on arbitrary hosted input now go through bounded path and fail fast with `STABLE_STRINGIFY_UNBOUNDED`.

**Tests:** `deterministic.bounded.test.ts` (7) covering spread-accessor, revoked-proxy, deep-prototype, huge-breadth-before-sort, huge-string UTF-16 precheck, sparse-array, exact boundaries; existing `deterministic.test.ts` (12) still green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
skill_revision: elizaOS/eliza@42edf0f5a2:packages/skills/skills/contribute-to-eliza
evidenceHead: HEAD
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@42edf0f5a2:packages/skills/skills/contribute-to-eliza"} -->
