### PR TITLE
fix(cloud): cover managed DoorDash MCP E2E

### DIFF
--- a/packages/cloud/api/test/e2e/group-g-mcps.test.ts
+++ b/packages/cloud/api/test/e2e/group-g-mcps.test.ts
@@ -1,7 +1,7 @@
 /**
  * Group G — MCP integration bridges.
  *
- * Covers `/api/mcps/<provider>/:transport` for all 17 provider routes mounted
+ * Covers `/api/mcps/<provider>/:transport` for every provider route mounted
  * by `_router.generated.ts`, backed by one shared gateway
  * (`src/lib/mcp/mcps-transport-gateway.ts`). Its contract is exact:
  *
@@ -11,6 +11,9 @@
  *   - built-in providers (`time`, `weather`, `crypto`) → real Workers-safe
  *     JSON-RPC transport: GET 405, POST tools/list 200 with a
  *     `jsonrpc: "2.0"` result listing the provider's tools
+ *   - managed providers (`doordash`) → GET 405, unauthenticated JSON-RPC
+ *     calls fail inside the protocol, and authenticated tools/list exposes the
+ *     guarded Cloud-managed tool surface
  *   - every other provider → 501 `not_yet_migrated` fallback envelope
  *
  * These routes are public-path-prefixed in `auth.ts`, so no response may be
@@ -22,10 +25,19 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { api, getBaseUrl, isServerReachable } from "./_helpers/api";
+import {
+  api,
+  bearerHeaders,
+  getBaseUrl,
+  isServerReachable,
+} from "./_helpers/api";
 
 // Built-in bridges run a real JSON-RPC transport in the Worker itself.
 const BUILTIN_PROVIDERS = ["time", "weather", "crypto"] as const;
+
+// Managed bridges run in the Worker but require an authenticated Cloud
+// identity before exposing tools or creating a user-isolated browser session.
+const MANAGED_PROVIDERS = ["doordash"] as const;
 
 // OAuth/vendor providers answer 501 until an operator sets
 // MCP_<PROVIDER>_STREAMABLE_HTTP_URL to proxy an external server.
@@ -33,7 +45,6 @@ const PROXY_PROVIDERS = [
   "airtable",
   "asana",
   "dropbox",
-  "doordash",
   "github",
   "google",
   "hubspot",
@@ -53,6 +64,22 @@ const BUILTIN_TOOL_NAMES: Record<string, string[]> = {
   time: ["get_current_time"],
   weather: ["get_current_weather", "search_location"],
   crypto: ["get_price", "get_market_data", "list_trending"],
+};
+
+const MANAGED_TOOL_NAMES: Record<string, string[]> = {
+  doordash: [
+    "doordash_auth_check",
+    "doordash_auth_clear",
+    "doordash_set_address",
+    "doordash_search",
+    "doordash_menu",
+    "doordash_add_to_cart",
+    "remove_from_cart",
+    "doordash_cart",
+    "order_history",
+    "doordash_checkout",
+    "doordash_track_order",
+  ],
 };
 
 const REAL_TRANSPORT = "mcp";
@@ -85,12 +112,22 @@ function jsonRpcToolsList(): Record<string, unknown> {
 
 async function postToolsList(
   basePath: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; text: string }> {
+  return postJsonRpc(basePath, jsonRpcToolsList(), headers);
+}
+
+async function postJsonRpc(
+  basePath: string,
+  request: Record<string, unknown>,
+  headers: Record<string, string> = {},
 ): Promise<{ status: number; text: string }> {
   for (let attempt = 0; attempt < 2; attempt++) {
-    const res = await api.post(basePath, jsonRpcToolsList(), {
+    const res = await api.post(basePath, request, {
       headers: {
         Accept: "application/json, text/event-stream",
         "Content-Type": "application/json",
+        ...headers,
       },
     });
     const text = await res.text();
@@ -131,6 +168,137 @@ describeE2E("Group G — MCP provider bridges", () => {
         expect(body.id).toBe(1);
         const names = (body.result?.tools ?? []).map((tool) => tool.name);
         expect(names).toEqual(BUILTIN_TOOL_NAMES[provider]);
+      });
+
+      test(`${provider}: garbage :transport is 404 unsupported_transport`, async () => {
+        const res = await api.get(`/api/mcps/${provider}/garbage-transport`);
+        expect(res.status).toBe(404);
+        const body = (await res.json()) as { error?: string };
+        expect(body.error).toBe("unsupported_transport");
+      });
+    });
+  }
+
+  for (const provider of MANAGED_PROVIDERS) {
+    describe(`/api/mcps/${provider}/:transport (managed)`, () => {
+      const basePath = `/api/mcps/${provider}/${REAL_TRANSPORT}`;
+      const proxied = upstreamConfigured(provider);
+
+      test(`${provider}: GET is 405 when managed locally`, async () => {
+        const res = await api.get(basePath);
+        if (proxied) {
+          expect(res.status).not.toBe(401);
+          return;
+        }
+        expect(res.status).toBe(405);
+        const body = (await res.json()) as { error?: string };
+        expect(body.error).toBe("Method not allowed");
+      });
+
+      test(`${provider}: unauthenticated tools/list fails inside JSON-RPC`, async () => {
+        const res = await postToolsList(basePath);
+        if (proxied) {
+          expect(res.status).not.toBe(401);
+          return;
+        }
+        expect(res.status).toBe(200);
+        const body = JSON.parse(res.text) as {
+          jsonrpc?: string;
+          id?: number;
+          error?: { code?: number; message?: string };
+        };
+        expect(body.jsonrpc).toBe("2.0");
+        expect(body.id).toBe(1);
+        expect(body.error?.code).toBe(-32001);
+        expect(body.error?.message).toBe(
+          "DoorDash requires authenticated Cloud access",
+        );
+      });
+
+      test(`${provider}: authenticated tools/list exposes the managed tools`, async () => {
+        const res = await postToolsList(basePath, bearerHeaders());
+        if (proxied) {
+          expect(res.status).not.toBe(401);
+          return;
+        }
+        expect(res.status).toBe(200);
+        const body = JSON.parse(res.text) as {
+          jsonrpc?: string;
+          id?: number;
+          result?: {
+            tools?: Array<{
+              name?: string;
+              description?: string;
+              inputSchema?: Record<string, unknown>;
+            }>;
+          };
+        };
+        expect(body.jsonrpc).toBe("2.0");
+        expect(body.id).toBe(1);
+        const names = (body.result?.tools ?? []).map((tool) => tool.name);
+        expect(names).toEqual(MANAGED_TOOL_NAMES[provider]);
+        const checkout = body.result?.tools?.find(
+          (tool) => tool.name === "doordash_checkout",
+        );
+        expect(checkout).toMatchObject({
+          description: expect.stringContaining("only with confirm=true"),
+          inputSchema: {
+            additionalProperties: false,
+            properties: {
+              confirm: { type: "boolean" },
+              conversationId: {
+                maxLength: 256,
+                minLength: 1,
+                type: "string",
+              },
+              expectedCheckoutDigest: {
+                pattern: "^[a-f0-9]{64}$",
+                type: "string",
+              },
+            },
+            required: ["conversationId"],
+            type: "object",
+          },
+        });
+      });
+
+      test(`${provider}: confirmed checkout without its exact digest is rejected`, async () => {
+        const res = await postJsonRpc(
+          basePath,
+          {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/call",
+            params: {
+              name: "doordash_checkout",
+              arguments: {
+                confirm: true,
+                conversationId: "e2e-managed-mcp-approval-boundary",
+              },
+            },
+          },
+          bearerHeaders(),
+        );
+        if (proxied) {
+          expect(res.status).not.toBe(401);
+          return;
+        }
+        expect(res.status).toBe(200);
+        const body = JSON.parse(res.text) as {
+          jsonrpc?: string;
+          id?: number;
+          result?: {
+            content?: Array<{ type?: string; text?: string }>;
+            isError?: boolean;
+          };
+        };
+        expect(body).toMatchObject({
+          jsonrpc: "2.0",
+          id: 2,
+          result: { isError: true },
+        });
+        const errorText = body.result?.content?.[0]?.text ?? "";
+        expect(errorText).toContain("expectedCheckoutDigest is required");
       });
 
       test(`${provider}: garbage :transport is 404 unsupported_transport`, async () => {


### PR DESCRIPTION
Closes #24328

## Summary

- classify DoorDash as a managed Cloud MCP provider instead of an unconfigured generic proxy
- assert the unauthenticated JSON-RPC authorization boundary
- assert authenticated `tools/list` exposes the exact guarded DoorDash tool surface
- assert confirmed checkout without its exact digest fails before any provider-side mutation
- retain upstream-override and unsupported-transport coverage

## Exact-head validation

Head: `214772177c2d205c81f307b78a2548da720c1112` rebased on `origin/develop@825d62e6180f2449769668c9057cf6a28639950b`.

- `E2E_ONLY=group-g-mcps TEST_REQUEST_TIMEOUT_MS=60000 RUN_STEWARD_WALLET_E2E=0 bun run --cwd packages/cloud/api test:e2e` — **56 passed, 0 failed**, using the real local Cloudflare Worker, PGlite database, Browser Run binding, and `DoorDashCheckoutGate` Durable Object. The five DoorDash cases observed GET 405, unauthenticated JSON-RPC `-32001`, authenticated exact managed tool inventory, digest-required checkout rejection, and unsupported-transport 404.
- `bun test packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts` — **10 passed, 0 failed**.
- changed-file Biome — passed.
- `bun run check:agents-claude` — 160 tracked guide pairs passed.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run --cwd packages/cloud/api typecheck` reaches three unrelated current-`develop` diagnostics outside this one-file test diff: `internal/eliza-app/personal-shared/messages/route.test.ts:294` (TS2322) and `packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts:252,290` (TS18048). The real Worker E2E compiles and executes the changed test at exact head.

## Evidence Gate

<!-- evidence-head:214772177c2d205c81f307b78a2548da720c1112 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed; this PR only changes Cloud Worker E2E coverage.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed; this PR only changes Cloud Worker E2E coverage.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user interface or visual workflow changed in this test-only PR.

<!-- evidence-row:backend-logs -->
- [x] [Exact-head real Worker E2E transcript: 56 passed, 0 failed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24329-worker-e2e-214772177c.log)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend process or browser client is part of the changed Worker contract.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider inference, planner, or agent action behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - this test-only contract repair creates no persistent domain artifact, paid order, or external provider mutation.

## Acceptance boundary

This source repair does not deploy Cloud or place a DoorDash order. Deployment and any credentialed provider-side mutation remain separate, explicitly authorized operations.
