### PR TITLE
fix: add efficient coding-agent execution lane

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -107,6 +107,7 @@ function createResponseHandlerFieldRegistry(): ResponseHandlerFieldRegistry {
 function makeRuntime(opts: {
 	actions: Action[];
 	responses: CannedResponse[];
+	owner?: boolean;
 	contextRegistry?: ContextRegistry;
 	responseHandlerEvaluators?: import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator[];
 }): IAgentRuntime {
@@ -138,7 +139,9 @@ function makeRuntime(opts: {
 			: {}),
 		emitEvent: vi.fn(async () => undefined),
 		runActionsByMode: vi.fn(async () => undefined),
-		getSetting: vi.fn(() => undefined),
+		getSetting: vi.fn((key: string) =>
+			opts.owner && key === "ELIZA_ADMIN_ENTITY_ID" ? SENDER_ID : undefined,
+		),
 		useModel: vi.fn(
 			async (modelType: unknown, params: unknown, provider: unknown) => {
 				calls.push({ modelType, params, provider });
@@ -266,6 +269,190 @@ function readRecordedTrajectories(agentId: string): unknown[] {
 }
 
 describe("v5 happy path — message handler → planner → executor → evaluator", () => {
+	it("enters the coding planner directly without a HANDLE_RESPONSE model call", async () => {
+		const fileHandler = vi.fn(async () => ({
+			success: true,
+			text: "wrote index.ts",
+			data: { actionName: "FILE" },
+		}));
+		const fileAction = makeMockAction({
+			name: "READ",
+			contexts: ["code", "files"],
+			parameters: [
+				{
+					name: "path",
+					description: "File path",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			handler: fileHandler,
+		});
+		const mediaAction = makeMockAction({
+			name: "GENERATE_MEDIA",
+			contexts: ["files"],
+			handler: async () => ({ success: true }),
+		});
+		const runtime = makeRuntime({
+			actions: [fileAction, mediaAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						completed: true,
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "READ",
+								args: { path: "index.ts" },
+							},
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								args: { text: "Created index.ts." },
+							},
+						],
+					},
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("create index.ts"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") throw new Error("expected reply");
+		expect(result.result.responseContent?.text).toBe("Created index.ts.");
+		expect(fileHandler).toHaveBeenCalledTimes(1);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.ACTION_PLANNER,
+			ModelType.ACTION_PLANNER,
+		]);
+		const actionModes = (
+			runtime.runActionsByMode as ReturnType<typeof vi.fn>
+		).mock.calls.map(([mode]) => mode);
+		expect(actionModes).not.toContain("RESPONSE_HANDLER_BEFORE");
+		expect(actionModes).not.toContain("RESPONSE_HANDLER_DURING");
+		expect(actionModes).not.toContain("RESPONSE_HANDLER_AFTER");
+		const plannerTools = getCalls(runtime).flatMap((call) =>
+			((call.params as { tools?: Array<{ name?: string }> }).tools ?? []).map(
+				(tool) => tool.name,
+			),
+		);
+		expect(plannerTools).toContain("READ");
+		expect(plannerTools).not.toContain("GENERATE_MEDIA");
+		const firstPlannerMessages = (
+			getCalls(runtime)[0]?.params as
+				| {
+						messages?: Array<{ content?: string }>;
+				  }
+				| undefined
+		)?.messages;
+		expect(firstPlannerMessages?.[0]?.content).toContain(
+			"Complete the current coding request",
+		);
+		expect(firstPlannerMessages?.[0]?.content).not.toContain(
+			"Owner life-management side effects",
+		);
+	});
+
+	it("does not leak coding mode into the next ordinary turn", async () => {
+		const replyAction = makeMockAction({
+			name: "REPLY",
+			handler: async () => ({ success: true }),
+		});
+		const runtime = makeRuntime({
+			actions: [replyAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{ id: "reply-1", name: "REPLY", args: { text: "coded" } },
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({ contexts: ["simple"], replyText: "hello" }),
+				},
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("answer from the coding loop"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+		});
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("say hello"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.ACTION_PLANNER,
+			ModelType.RESPONSE_HANDLER,
+		]);
+	});
+
+	it("propagates a coding-loop failure instead of rescuing partial tool work", async () => {
+		const readAction = makeMockAction({
+			name: "READ",
+			contexts: ["code", "files"],
+			handler: async () => ({
+				success: true,
+				text: "partial source",
+				userFacingText: "partial source",
+			}),
+		});
+		const runtime = makeRuntime({
+			actions: [readAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{ id: "read-1", name: "READ", args: { path: "index.ts" } },
+						],
+					},
+				},
+			],
+		});
+
+		await expect(
+			runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage("fix index.ts"),
+				state: makeState(),
+				responseId: RESPONSE_ID,
+				codingMode: true,
+			}),
+		).rejects.toThrow("queue empty");
+	});
+
 	it("runs the full pipeline and records every stage to disk", async () => {
 		let webSearchCalls = 0;
 		const webSearch = makeMockAction({

--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -72,17 +72,7 @@ function executeFailureAThenSuccessB() {
 }
 
 async function withCodingFullSurface<T>(run: () => Promise<T>): Promise<T> {
-	const previous = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-	process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
-	try {
-		return await run();
-	} finally {
-		if (previous === undefined) {
-			delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-		} else {
-			process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = previous;
-		}
-	}
+	return run();
 }
 
 describe("planner-loop failed-operation correlation", () => {
@@ -906,6 +896,7 @@ describe("planner-loop failed-operation correlation", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: { id: "ctx" },
+				codingMode: true,
 				executeToolCall: vi
 					.fn()
 					.mockResolvedValueOnce({
@@ -971,6 +962,7 @@ describe("planner-loop failed-operation correlation", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: { id: "ctx" },
+				codingMode: true,
 				executeToolCall: vi
 					.fn()
 					.mockResolvedValueOnce({

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -518,7 +518,7 @@ describe("v5 planner loop skeleton", () => {
 	});
 
 	// #10132: in chat mode the planner's 1024-token output cap is fine, but a
-	// coding sub-agent (ELIZA_PLANNER_FULL_ACTION_SURFACE=1) must emit a whole
+	// coding sub-agent (selected through per-turn codingMode) must emit a whole
 	// file as a single FILE/WRITE tool-call argument — a real single-file app is
 	// ~4.6k+ tokens once JSON-escaped, so 1024 truncates it mid-stream and the
 	// build silently fails. Coding mode lifts the cap.
@@ -567,16 +567,11 @@ describe("v5 planner loop skeleton", () => {
 	const withCodingRequiredToolDefaults = async <T>(
 		run: () => Promise<T>,
 	): Promise<T> => {
-		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
 		const prevMisses = process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES;
-		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
 		delete process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES;
 		try {
 			return await run();
 		} finally {
-			if (prevSurface === undefined)
-				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
 			if (prevMisses === undefined)
 				delete process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES;
 			else process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES = prevMisses;
@@ -584,15 +579,14 @@ describe("v5 planner loop skeleton", () => {
 	};
 
 	it("raises the planner output-token cap in coding/full-surface mode (#10132)", async () => {
-		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
 		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
-		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
 		delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 		try {
 			const runtime = buildCodingPlannerRuntime();
 			await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
 				evaluate: vi.fn(async () => ({
 					success: true,
@@ -604,9 +598,6 @@ describe("v5 planner loop skeleton", () => {
 			const plannerParams = runtime.useModel.mock.calls[0][1];
 			expect(plannerParams.maxTokens).toBe(16384);
 		} finally {
-			if (prevSurface === undefined)
-				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
 			if (prevMax === undefined)
 				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 			else process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = prevMax;
@@ -614,15 +605,14 @@ describe("v5 planner loop skeleton", () => {
 	});
 
 	it("honors ELIZA_CODING_PLANNER_MAX_TOKENS in coding mode (#10132)", async () => {
-		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
 		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
-		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
 		process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = "32768";
 		try {
 			const runtime = buildCodingPlannerRuntime();
 			await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
 				evaluate: vi.fn(async () => ({
 					success: true,
@@ -634,9 +624,6 @@ describe("v5 planner loop skeleton", () => {
 			const plannerParams = runtime.useModel.mock.calls[0][1];
 			expect(plannerParams.maxTokens).toBe(32768);
 		} finally {
-			if (prevSurface === undefined)
-				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
 			if (prevMax === undefined)
 				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 			else process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = prevMax;
@@ -669,6 +656,7 @@ describe("v5 planner loop skeleton", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				tools: codingPlannerTools,
 				executeToolCall,
 				evaluate,
@@ -713,6 +701,7 @@ describe("v5 planner loop skeleton", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				tools: codingPlannerTools,
 				config: { maxRequiredToolMisses: 1 },
 				executeToolCall,
@@ -722,6 +711,154 @@ describe("v5 planner loop skeleton", () => {
 			expect(runtime.useModel).toHaveBeenCalledTimes(4);
 			expect(executeToolCall).toHaveBeenCalledTimes(1);
 			expect(result.finalMessage).toBe("Built dice.html.");
+		});
+	});
+
+	it("requires successful shell verification after a coding mutation", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "ok" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-unverified", "Built dice.html."),
+					)
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-1",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-verified", "Built and verified dice.html."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async (toolCall) => ({
+				success: true,
+				text: `${toolCall.name} succeeded`,
+			}));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(runtime.useModel).toHaveBeenCalledTimes(4);
+			expect(executeToolCall).toHaveBeenCalledTimes(2);
+			expect(result.finalMessage).toBe("Built and verified dice.html.");
+			expect(result.trajectory.evaluatorOutputs).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						decision: "CONTINUE",
+						success: false,
+					}),
+				]),
+			);
+		});
+	});
+
+	it("lets final verification supersede failed intermediate coding commands", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const toolResult = (success: boolean, text: string) => ({
+				success,
+				text,
+			});
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "draft" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-failed",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "edit-1",
+								name: "EDIT",
+								arguments: {
+									path: "dice.html",
+									old_string: "draft",
+									new_string: "fixed",
+								},
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-passed",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-verified", "Built and verified dice.html."),
+					),
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce(toolResult(true, "wrote draft"))
+				.mockResolvedValueOnce(toolResult(false, "test failed"))
+				.mockResolvedValueOnce(toolResult(true, "fixed file"))
+				.mockResolvedValueOnce(toolResult(true, "test passed"));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "EDIT", description: "Edit a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Built and verified dice.html.");
+			expect(executeToolCall).toHaveBeenCalledTimes(4);
 		});
 	});
 
@@ -760,6 +897,7 @@ describe("v5 planner loop skeleton", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				tools: [
 					{ name: "CUSTOM_BUILD_TOOL", description: "Builds something." },
 					{ name: "REPLY", description: "Reply to the user." },

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -163,6 +163,28 @@ export type {
 	PlannerTrajectory,
 } from "./planner-types";
 
+/** Minimal stable loop contract for a dedicated coding turn. */
+const CODING_PLANNER_TEMPLATE = `task: Complete the current coding request with native tools.
+
+rules:
+- act with the smallest grounded tool call; do not narrate work that was not performed
+- inspect before editing and preserve unrelated work
+- when the task names a file, READ it directly; use bounded windows for large files
+- prefer EDIT for existing files; never change tests or fixtures only to hide a failure
+- pass only schema-declared arguments; never invent placeholders
+- after a tool result, continue with the next concrete step until the task is complete
+- after WRITE or EDIT, run a successful narrow SHELL verification before finishing
+- do not claim success when a tool failed or verification is still pending
+- use messageToUser only for the final grounded result or a genuinely blocking question
+- every native tool call requires eliza_turn_scope: use more_work_pending until the final tool batch
+- when complete, call no tool and report changed files, verification, and limitations concisely
+
+context_object:
+{{contextObject}}
+
+trajectory:
+{{trajectory}}`;
+
 /**
  * Chat-lane planner output budget. Reasoning models spend completion tokens on
  * deliberation BEFORE the tool call, and with `toolChoice: required` a budget
@@ -177,17 +199,6 @@ export type {
  * (#10132).
  */
 const DEFAULT_PLANNER_MAX_TOKENS = 4096;
-
-/**
- * Coding/full-surface mode is on when the eliza-code sub-agent sets
- * `ELIZA_PLANNER_FULL_ACTION_SURFACE` (the ACP server does). Centralized so the
- * tool-call ceiling, the queue-drain cadence, and the output-token cap all read
- * the same signal.
- */
-function isCodingFullSurfaceMode(): boolean {
-	const v = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
-	return v === "1" || v === "true" || v === "yes" || v === "on";
-}
 
 /**
  * Default per-call output-token ceiling for a coding planner turn. A single
@@ -250,8 +261,8 @@ export function resolvePositivePlannerInt(
  * `ELIZA_CODING_PLANNER_MAX_TOKENS`). A set-but-malformed override throws via
  * {@link resolvePositivePlannerInt} rather than silently defaulting.
  */
-function resolvePlannerMaxTokens(): number {
-	if (!isCodingFullSurfaceMode()) {
+function resolvePlannerMaxTokens(codingMode: boolean): number {
+	if (!codingMode) {
 		return resolvePositivePlannerInt(
 			"ELIZA_PLANNER_MAX_TOKENS",
 			process.env.ELIZA_PLANNER_MAX_TOKENS,
@@ -274,7 +285,7 @@ export function resolveCodingMaxToolCalls(): number {
 	return resolvePositivePlannerInt(
 		"ELIZA_CODING_MAX_TOOL_CALLS",
 		process.env.ELIZA_CODING_MAX_TOOL_CALLS,
-		80,
+		32,
 	);
 }
 
@@ -357,14 +368,13 @@ async function runPlannerLoopIterations(
 	// arguments: runtime-known secrets composed with the shared tool-shape
 	// patterns. The raw calls stay on `trajectory.plannedQueue` for execution.
 	const redactDiagnosticText = composeToolDiagnosticRedactor(params.runtime);
-	// Coding/full-surface mode (the eliza-code sub-agent sets
-	// ELIZA_PLANNER_FULL_ACTION_SURFACE): a real build legitimately makes many
+	// Coding/full-surface mode: a real build legitimately makes many
 	// tool calls (read several files, write several, run tests). The chat default
 	// (maxToolCalls=16) caps that mid-build, ending the turn on a
 	// TrajectoryLimitExceeded with no terminal REPLY → an EMPTY relay to the user.
 	// Raise the ceiling for coding builds (still bounded). Overridable via
 	// ELIZA_CODING_MAX_TOOL_CALLS.
-	const codingMode = isCodingFullSurfaceMode();
+	const codingMode = params.codingMode === true;
 	const codingMaxToolCalls = resolveCodingMaxToolCalls();
 	// Weak coding models (e.g. Cerebras glm-4.7) sometimes answer a trivial build
 	// with a terminal REPLY ("Creating the app now…") instead of calling FILE.
@@ -388,6 +398,7 @@ async function runPlannerLoopIterations(
 	})();
 	const trajectory: PlannerTrajectory = {
 		context: plannerContext,
+		codingMode,
 		steps: [],
 		archivedSteps: [],
 		plannedQueue: [],
@@ -553,7 +564,7 @@ async function runPlannerLoopIterations(
 		return accepted;
 	};
 
-	// Coding/full-surface mode (set above from ELIZA_PLANNER_FULL_ACTION_SURFACE):
+	// Coding/full-surface mode (selected explicitly for this turn):
 	// when the model emits a batch of tool calls in a single response, execute
 	// EVERY queued call before re-evaluating. A real build needs all of its
 	// FILE/SHELL calls to run; a dedicated coding agent drains the whole batch and
@@ -926,6 +937,16 @@ async function runPlannerLoopIterations(
 					iteration,
 					message: plannerOutput.messageToUser,
 				});
+				if (
+					codingDrainQueue &&
+					deferCodingCompletionUntilMutationVerified({
+						trajectory,
+						iteration,
+						redactDiagnosticText,
+					})
+				) {
+					continue;
+				}
 				if (trajectory.steps.some((step) => step.toolCall)) {
 					// Coding mode: the model emitted a final text summary AFTER
 					// executing build tools — it's signalling completion. Finish with
@@ -1173,6 +1194,16 @@ async function runPlannerLoopIterations(
 						reason: "terminal_only_tool_calls",
 						logger: params.runtime.logger,
 					});
+					continue;
+				}
+				if (
+					codingDrainQueue &&
+					deferCodingCompletionUntilMutationVerified({
+						trajectory,
+						iteration,
+						redactDiagnosticText,
+					})
+				) {
 					continue;
 				}
 				// The messageToUser fallback applies only when a REPLY call is
@@ -1791,6 +1822,7 @@ function renderPlannerModelInput(params: {
 	context: ContextObject;
 	trajectory: PlannerTrajectory;
 	template?: string;
+	codingMode?: boolean;
 	runtime?: PlannerRuntime;
 	projectionBudget?: ContentProjectionBudget;
 	omitRecoverableText?: boolean;
@@ -1802,8 +1834,12 @@ function renderPlannerModelInput(params: {
 } {
 	const renderedContext = renderContextObject(params.context);
 	const template = params.template ?? plannerTemplate;
-	const instructions = appendMandatoryPlannerPolicy(
-		template.split("context_object:")[0] ?? template,
+	const instructions = (
+		params.codingMode
+			? template.split("context_object:")[0]
+			: appendMandatoryPlannerPolicy(
+					template.split("context_object:")[0] ?? template,
+				)
 	).trim();
 	let projectionStats: ToolResultProjectionStats = {
 		resultCount: 0,
@@ -2376,7 +2412,11 @@ async function callPlanner(params: {
 	const renderArgs = {
 		context: params.context,
 		trajectory: params.trajectory,
-		template: resolveOptimizedPlannerTemplate(params.runtime),
+		template:
+			params.trajectory.codingMode === true
+				? CODING_PLANNER_TEMPLATE
+				: resolveOptimizedPlannerTemplate(params.runtime),
+		codingMode: params.trajectory.codingMode === true,
 		runtime: params.runtime,
 	};
 	const baselineInput = renderPlannerModelInput({
@@ -2446,7 +2486,7 @@ async function callPlanner(params: {
 		// Chat planner turns stay at the small DEFAULT_PLANNER_MAX_TOKENS; a coding
 		// turn must be able to emit a whole file in one tool call, so coding mode
 		// raises the cap (see resolvePlannerMaxTokens / issue #10132).
-		maxTokens: resolvePlannerMaxTokens(),
+		maxTokens: resolvePlannerMaxTokens(params.trajectory.codingMode === true),
 	};
 	modelParams.providerOptions = {
 		...modelParams.providerOptions,
@@ -3610,6 +3650,64 @@ function isTerminalToolCall(toolCall: PlannerToolCall): boolean {
 	return isTerminalPlannerToolName(toolCall.name);
 }
 
+/**
+ * Prevents a coding turn from treating an unverified file mutation as done.
+ * A successful SHELL call after the most recent successful WRITE/EDIT is the
+ * deliberately small, provider-independent proof boundary: the model chooses
+ * the repository-appropriate command, while the runtime verifies that the
+ * command actually ran and exited successfully.
+ */
+function deferCodingCompletionUntilMutationVerified(args: {
+	trajectory: PlannerTrajectory;
+	iteration: number;
+	redactDiagnosticText?: ToolDiagnosticTextRedactor;
+}): boolean {
+	let latestMutationIndex = -1;
+	for (let index = 0; index < args.trajectory.steps.length; index++) {
+		const step = args.trajectory.steps[index];
+		const name = step?.toolCall?.name.toUpperCase();
+		if (
+			(name === "WRITE" || name === "EDIT") &&
+			step.result?.success === true
+		) {
+			latestMutationIndex = index;
+		}
+	}
+	if (latestMutationIndex < 0) return false;
+
+	const verified = args.trajectory.steps
+		.slice(latestMutationIndex + 1)
+		.some(
+			(step) =>
+				step.toolCall?.name.toUpperCase() === "SHELL" &&
+				step.result?.success === true,
+		);
+	if (verified) return false;
+
+	const evaluator: EvaluatorOutput = {
+		success: false,
+		decision: "CONTINUE",
+		thought:
+			"A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
+		messageToUser:
+			"Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
+	};
+	args.trajectory.evaluatorOutputs.push(
+		projectToolDiagnosticValue(
+			evaluator,
+			args.redactDiagnosticText ?? composeToolDiagnosticRedactor(),
+		) as EvaluatorOutput,
+	);
+	appendEvaluatorContextEvent(
+		args.trajectory,
+		evaluator,
+		args.iteration,
+		args.redactDiagnosticText,
+	);
+	args.trajectory.plannedQueue.length = 0;
+	return true;
+}
+
 function getToolDefinitionName(tool: ToolDefinition): string | undefined {
 	const maybeTool = tool as ToolDefinition & {
 		function?: { name?: unknown };
@@ -3802,6 +3900,12 @@ function terminalMessageWithFailureAuthority(
 	const unresolvedFailure =
 		latestUnresolvedFailedNonTerminalToolStep(trajectory);
 	if (!unresolvedFailure) return candidate;
+	if (
+		trajectory.codingMode === true &&
+		codingVerificationSupersedesFailure(trajectory, unresolvedFailure)
+	) {
+		return candidate;
+	}
 
 	const pendingInteraction = latestActionablePendingInteractionAfter(
 		trajectory,
@@ -3836,13 +3940,50 @@ function terminalMessageWithFailureAuthority(
 		unresolvedFailure,
 		failureReport,
 	);
-	if (!isCodingFullSurfaceMode()) return failureNote;
+	if (trajectory.codingMode !== true) return failureNote;
 	const successEvidence = toolOwnedSuccessEvidenceAfter(
 		trajectory,
 		unresolvedFailure,
 	);
 	if (successEvidence.length === 0) return failureNote;
 	return `${failureNote}\n\nWork that did complete: ${successEvidence.join(" ")}`;
+}
+
+/**
+ * A repository verification command validates the resulting tree, not the
+ * exact argument identity of every failed intermediate command. In coding
+ * mode, a successful SHELL run after the latest successful mutation therefore
+ * resolves earlier transient edit/test failures for terminal reporting. A
+ * failure after that verification remains authoritative.
+ */
+function codingVerificationSupersedesFailure(
+	trajectory: PlannerTrajectory,
+	failure: PlannerStep,
+): boolean {
+	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
+	const failureIndex = steps.lastIndexOf(failure);
+	if (failureIndex < 0) return false;
+
+	let latestMutationIndex = -1;
+	for (let index = 0; index < steps.length; index++) {
+		const step = steps[index];
+		const name = step?.toolCall?.name.toUpperCase();
+		if (
+			(name === "WRITE" || name === "EDIT") &&
+			step.result?.success === true
+		) {
+			latestMutationIndex = index;
+		}
+	}
+	if (latestMutationIndex < 0) return false;
+
+	return steps.some(
+		(step, index) =>
+			index > latestMutationIndex &&
+			index > failureIndex &&
+			step.toolCall?.name.toUpperCase() === "SHELL" &&
+			step.result?.success === true,
+	);
 }
 
 /**
@@ -4466,7 +4607,7 @@ async function ensureToolTurnFinalMessage(
 ): Promise<PlannerLoopResult> {
 	if (result.status !== "finished") return result;
 	if (result.endedWithDeliberateSilence) return result;
-	if (isCodingFullSurfaceMode()) return result;
+	if (params.codingMode === true) return result;
 	const message = result.finalMessage;
 	const unusable =
 		message === undefined ||
@@ -4547,7 +4688,7 @@ async function ensureFailedTurnFinalMessage(
 	// guarantee: its result feeds the orchestrator (which owns its own summary
 	// fallback), not a chat user, and an extra model call per failed build
 	// step would be pure overhead there.
-	if (isCodingFullSurfaceMode()) return result;
+	if (params.codingMode === true) return result;
 	if (result.finalMessage !== FAILED_TOOL_FALLBACK_MESSAGE) return result;
 	const failedStep =
 		latestUnresolvedFailedNonTerminalToolStep(result.trajectory) ??

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -224,6 +224,8 @@ export interface PlannerStep {
 
 export interface PlannerTrajectory {
 	context: ContextObject;
+	/** Internal execution-mode provenance for mode-specific terminal handling. */
+	codingMode?: boolean;
 	steps: PlannerStep[];
 	archivedSteps: PlannerStep[];
 	plannedQueue: PlannerToolCall[];
@@ -262,6 +264,8 @@ export interface PlannerLoopResult {
 export interface PlannerLoopParams {
 	runtime: PlannerRuntime;
 	context: ContextObject;
+	/** Trusted per-turn coding-loop mode; never used as an authorization signal. */
+	codingMode?: boolean;
 	config?: Partial<ChainingLoopConfig>;
 	executeToolCall: (
 		toolCall: PlannerToolCall,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1319,6 +1319,7 @@ function _resolvePromptAttachments(
  */
 type ResolvedMessageOptions = {
 	maxRetries: number;
+	codingMode: boolean;
 	continueAfterActions: boolean;
 	keepExistingResponses: boolean;
 	onStreamChunk?: StreamChunkCallback;
@@ -3063,8 +3064,8 @@ function mergeAgentContexts(
 }
 
 /**
- * The agent contexts a focused coding sub-agent (the eliza-code ACP server,
- * which sets ELIZA_PLANNER_FULL_ACTION_SURFACE) is considered to be operating in.
+ * The agent contexts a focused per-turn coding loop is considered to be
+ * operating in.
  * Used to admit the coding tools (FILE/SHELL/WORKTREE gate on these) while the
  * messaging/social chat actions stay gated off.
  */
@@ -3076,19 +3077,29 @@ const CODING_SUB_AGENT_CONTEXTS: readonly AgentContext[] = [
 ];
 
 /**
- * Parent actions a coding sub-agent never needs, excluded from its planner
- * surface even though they'd otherwise pass the coding-context gate. Each extra
- * tool schema enlarges the request, and a large tool set + a large file
+ * Exact action surface for a direct coding turn. Context overlap is too broad:
+ * attachment and media actions also carry file/automation contexts, and each
+ * extra tool schema enlarges the request. A large tool set + a large file
  * generation is exactly what makes weaker hosted models (Cerebras glm-4.7)
  * intermittently reject the request (server_error / 400) or narrate instead of
- * emitting FILE. A coding sub-agent does not open/close UI views or spawn its
- * own sub-agents, so dropping these trims the surface toward the tools that
- * actually do the work (FILE/SHELL/WORKTREE/WEB/REPLY/STOP).
+ * emitting FILE. Keep the surface aligned with the tools that actually do the
+ * work (FILE/SHELL/WORKTREE/WEB plus terminal controls).
  */
-const CODING_SUB_AGENT_EXCLUDED_ACTIONS: ReadonlySet<string> = new Set(
+const CODING_DIRECT_ACTIONS: ReadonlySet<string> = new Set(
 	// Stored in normalizeActionIdentifier() form (uppercase, underscores
 	// stripped), since that is what the filter compares against.
-	["VIEWS", "CLOSEVIEW", "CLOSEALLVIEWS", "TASKS"],
+	[
+		"READ",
+		"WRITE",
+		"EDIT",
+		"SHELL",
+		"WORKTREE",
+		"WEBFETCH",
+		"WEBSEARCH",
+		"REPLY",
+		"STOP",
+		"IGNORE",
+	],
 );
 
 function actionNameTokenKey(name: string): string {
@@ -3234,6 +3245,7 @@ export function getCachedActionCatalog(
 
 function buildV5PlannerActionSurface(params: {
 	actions: readonly Action[];
+	forceFullSurface?: boolean;
 	message: Memory;
 	state?: State;
 	messageHandler: MessageHandlerResult;
@@ -3269,12 +3281,8 @@ function buildV5PlannerActionSurface(params: {
 	// small, all-relevant tool set (FILE/SHELL/READ/EDIT/…) and MUST get them all
 	// exposed natively — otherwise the model sees a tool in the prompt but cannot
 	// call it (it lands in tier-B, described-only), narrates instead of acting, and
-	// trips the terminal-only-continuations guard. `ELIZA_PLANNER_FULL_ACTION_SURFACE=1`
-	// opts a runtime into full mode (the eliza-code ACP coding agent sets it).
-	const fullSurfaceFlag =
-		typeof process !== "undefined"
-			? process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase()
-			: undefined;
+	// trips the terminal-only-continuations guard. The trusted per-turn coding
+	// mode opts this invocation into the full surface without global state.
 	// A task_complete relay's only job is delivering the finished result. Any
 	// catalog tool on this synthetic turn invites task-management
 	// improvisation over the completed work (live 2026-08-19: the planner
@@ -3307,11 +3315,7 @@ function buildV5PlannerActionSurface(params: {
 		};
 	}
 	const forceFullSurface =
-		fullSurfaceFlag === "1" ||
-		fullSurfaceFlag === "true" ||
-		fullSurfaceFlag === "yes" ||
-		fullSurfaceFlag === "on" ||
-		params.actions.length === 0;
+		params.forceFullSurface === true || params.actions.length === 0;
 	if (forceFullSurface) {
 		return buildFullV5PlannerActionSurface({
 			actions: params.actions,
@@ -7853,11 +7857,45 @@ function withoutIntermediateVisibleText(content: Content): Content | null {
 	return hasIntermediateCallbackPayload(filtered) ? filtered : null;
 }
 
+/**
+ * Trusted host routing for a dedicated coding turn. This deliberately looks
+ * like the canonical Stage 1 tool result so the existing parsing and safety
+ * pipeline stays shared, but it is never recorded or accounted as a model
+ * response. Authorization remains owned by the normal context/action gates.
+ */
+function directCodingResponseHandlerResult(): GenerateTextResult {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "direct-coding-route",
+				name: HANDLE_RESPONSE_TOOL_NAME,
+				arguments: {
+					shouldRespond: "RESPOND",
+					contexts: [...CODING_SUB_AGENT_CONTEXTS],
+					intents: [],
+					replyText: "",
+					replyEffectStatus: "none",
+					candidateActionNames: [],
+					facts: [],
+					relationships: [],
+					topics: [],
+					addressedTo: [],
+					emotion: "none",
+				},
+			},
+		],
+		finishReason: "tool_calls",
+	};
+}
+
 export async function runV5MessageRuntimeStage1(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	state: State;
 	responseId: UUID;
+	/** Trusted per-turn direct coding-loop selection. */
+	codingMode?: boolean;
 	callback?: HandlerCallback;
 	deliveredVisibleTexts?: Set<string>;
 	plannerLoopConfig?: PlannerLoopParams["config"];
@@ -8051,38 +8089,36 @@ export async function runV5MessageRuntimeStage1(args: {
 			}),
 		);
 
-		// RESPONSE_HANDLER_BEFORE (blocking): hooks fire right before the Stage 1 model
-		// call. Used to inject providers / facts / relationships into the
-		// stable prefix.
-		await timeInferenceSpan(
-			"actions:response-handler-before",
-			() =>
-				args.runtime.runActionsByMode(
-					"RESPONSE_HANDLER_BEFORE",
-					args.message,
-					args.state,
-				),
-			{ mode: "RESPONSE_HANDLER_BEFORE" },
-		);
+		if (!args.codingMode) {
+			// RESPONSE_HANDLER_BEFORE (blocking): hooks fire right before the Stage 1
+			// model call. A direct coding turn has no such model boundary.
+			await timeInferenceSpan(
+				"actions:response-handler-before",
+				() =>
+					args.runtime.runActionsByMode(
+						"RESPONSE_HANDLER_BEFORE",
+						args.message,
+						args.state,
+					),
+				{ mode: "RESPONSE_HANDLER_BEFORE" },
+			);
 
-		// RESPONSE_HANDLER_DURING (non-blocking): fire-and-forget alongside the model
-		// call. We don't await — the user contract is "during".
-		// error-policy:J7 diagnostics-must-not-kill-the-loop — a rejection escaping
-		// runActionsByMode must not abort the turn, but it must surface.
-		const responseHandlerDuring = args.runtime
-			.runActionsByMode("RESPONSE_HANDLER_DURING", args.message, args.state)
-			.catch((err) =>
-				args.runtime.reportError("MessageService.runActionsByMode", err, {
-					mode: "RESPONSE_HANDLER_DURING",
-				}),
-			);
-		if (args.runTerminalOwner) {
-			args.runTerminalOwner.adopt(
-				"RESPONSE_HANDLER_DURING",
-				responseHandlerDuring,
-			);
-		} else {
-			void responseHandlerDuring;
+			// RESPONSE_HANDLER_DURING runs only alongside a real handler model call.
+			const responseHandlerDuring = args.runtime
+				.runActionsByMode("RESPONSE_HANDLER_DURING", args.message, args.state)
+				.catch((err) =>
+					args.runtime.reportError("MessageService.runActionsByMode", err, {
+						mode: "RESPONSE_HANDLER_DURING",
+					}),
+				);
+			if (args.runTerminalOwner) {
+				args.runTerminalOwner.adopt(
+					"RESPONSE_HANDLER_DURING",
+					responseHandlerDuring,
+				);
+			} else {
+				void responseHandlerDuring;
+			}
 		}
 
 		// Per-turn structure forcing. `buildResponseGrammar` composes the
@@ -8175,16 +8211,26 @@ export async function runV5MessageRuntimeStage1(args: {
 		// number of times before falling back to the planner.
 		const stage1RetryLimit = readStage1EmptyRetryLimit(args.runtime);
 		let stage1RetryCount = 0;
-		recordInferenceSpan(
-			"message:stage1:preprocess",
-			performance.now() - stage1PreprocessStartedAt,
-		);
-		let rawMessageHandler = (await args.runtime.useModel(
-			ModelType.RESPONSE_HANDLER,
-			stage1ModelParams,
-		)) as string | GenerateTextResult;
+		if (!args.codingMode) {
+			recordInferenceSpan(
+				"message:stage1:preprocess",
+				performance.now() - stage1PreprocessStartedAt,
+			);
+		} else {
+			args.runtime.logger.debug?.(
+				{ src: "service:message", codingMode: true },
+				"Skipping Stage 1 model call for direct coding loop",
+			);
+		}
+		let rawMessageHandler: string | GenerateTextResult = args.codingMode
+			? directCodingResponseHandlerResult()
+			: ((await args.runtime.useModel(
+					ModelType.RESPONSE_HANDLER,
+					stage1ModelParams,
+				)) as string | GenerateTextResult);
 		let stage1RetryReason = getStage1RetryReason(rawMessageHandler);
 		while (
+			!args.codingMode &&
 			stage1RetryCount < stage1RetryLimit &&
 			shouldRetryStage1Generation(
 				stage1RetryReason,
@@ -8213,9 +8259,9 @@ export async function runV5MessageRuntimeStage1(args: {
 		// right after it completes, before any later model call could overwrite the
 		// runtime-wide last-resolved-provider, so the recorded stage names the real
 		// provider instead of the fabricated "default" literal (#13623).
-		const messageHandlerProvider = args.runtime.getLastResolvedModelProvider?.(
-			ModelType.RESPONSE_HANDLER,
-		);
+		const messageHandlerProvider = args.codingMode
+			? undefined
+			: args.runtime.getLastResolvedModelProvider?.(ModelType.RESPONSE_HANDLER);
 		const rawFieldParsed = extractMessageHandlerRawParsed(rawMessageHandler);
 		// An explicit continuation turn ("finish my request", "that is good")
 		// carries no inferable intent of its own, so candidate inference runs on
@@ -8318,16 +8364,18 @@ export async function runV5MessageRuntimeStage1(args: {
 		// RESPONSE_HANDLER_AFTER (blocking): hooks fire after Stage 1 returns and the
 		// routing decision is parsed, but before the runtime acts on it.
 		// Lets a hook inspect / mutate the parsed plan.
-		await timeInferenceSpan(
-			"actions:response-handler-after",
-			() =>
-				args.runtime.runActionsByMode(
-					"RESPONSE_HANDLER_AFTER",
-					args.message,
-					args.state,
-				),
-			{ mode: "RESPONSE_HANDLER_AFTER" },
-		);
+		if (!args.codingMode) {
+			await timeInferenceSpan(
+				"actions:response-handler-after",
+				() =>
+					args.runtime.runActionsByMode(
+						"RESPONSE_HANDLER_AFTER",
+						args.message,
+						args.state,
+					),
+				{ mode: "RESPONSE_HANDLER_AFTER" },
+			);
+		}
 
 		if (!messageHandler) {
 			if (isEmptyStage1Result(rawMessageHandler)) {
@@ -8363,7 +8411,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		}
 		const parsedResponseHandlerReply = getMessageHandlerReply(messageHandler);
 
-		if (recorder && trajectoryId) {
+		if (!args.codingMode && recorder && trajectoryId) {
 			messageHandlerStageTask = recordMessageHandlerStage({
 				recorder,
 				trajectoryId,
@@ -8575,7 +8623,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler.plan.replyEffectStatus;
 		const prePatchStageOneReplyIsUngroundedAppliedClaim =
 			prePatchStageOneReplyEffectStatus === "applied";
-		const responseHandlerEvaluation = fieldRunResult?.preempt
+		const responseHandlerEvaluation = args.codingMode
 			? {
 					activeEvaluators: [],
 					appliedPatches: [],
@@ -8583,17 +8631,25 @@ export async function runV5MessageRuntimeStage1(args: {
 					candidateActionsClearedByEvaluators: false,
 					errors: [],
 				}
-			: await timeInferenceSpan("evaluators:response-handler", () =>
-					runResponseHandlerEvaluators({
-						runtime: args.runtime,
-						message: args.message,
-						state: args.state,
-						messageHandler,
-						availableContexts,
-						userRoles: [senderRole],
-						evaluators: BUILTIN_RESPONSE_HANDLER_EVALUATORS,
-					}),
-				);
+			: fieldRunResult?.preempt
+				? {
+						activeEvaluators: [],
+						appliedPatches: [],
+						candidateActionsAddedByEvaluators: [],
+						candidateActionsClearedByEvaluators: false,
+						errors: [],
+					}
+				: await timeInferenceSpan("evaluators:response-handler", () =>
+						runResponseHandlerEvaluators({
+							runtime: args.runtime,
+							message: args.message,
+							state: args.state,
+							messageHandler,
+							availableContexts,
+							userRoles: [senderRole],
+							evaluators: BUILTIN_RESPONSE_HANDLER_EVALUATORS,
+						}),
+					);
 		messageHandler.plan.contexts = filterSelectedContextsForRole(
 			messageHandler.plan.contexts,
 			availableContexts,
@@ -8862,25 +8918,25 @@ export async function runV5MessageRuntimeStage1(args: {
 			attachAvailableContexts(recomposedPlannerState, args.runtime),
 			selectedContextRoutingState,
 		);
+		if (args.codingMode === true) {
+			plannerState.data = {
+				...(plannerState.data ?? {}),
+				// Execution-mode provenance only; actions must never use this as an
+				// authorization signal. Coding tools use it to skip chat-only command
+				// rewrites that would alter an explicit repository command.
+				elizaTrustedCodingMode: true,
+			};
+		}
 		// Full-surface mode (a focused coding sub-agent): skip the relevance/role
 		// narrowing entirely and hand the planner EVERY action whose execution gates
 		// pass. The narrowing is built for big chat catalogs (retrieve the relevant
 		// few); a coding agent's whole small tool set is relevant, and narrowing was
 		// returning zero candidates → planner got no native tools → model narrated.
-		const fullSurfaceEnv =
-			typeof process !== "undefined"
-				? process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase()
-				: undefined;
-		const useFullSurface =
-			fullSurfaceEnv === "1" ||
-			fullSurfaceEnv === "true" ||
-			fullSurfaceEnv === "yes" ||
-			fullSurfaceEnv === "on";
+		const useFullSurface = args.codingMode === true;
 		const plannerCandidateActions = useFullSurface
 			? (args.runtime.actions ?? []).filter(
 					(action) =>
-						// Full-surface = the eliza-code coding sub-agent (its ACP server
-						// sets ELIZA_PLANNER_FULL_ACTION_SURFACE). It must NOT receive the
+						// Full-surface = a trusted coding turn. It must NOT receive the
 						// whole chat action catalog (MESSAGE_*/POST_*/…) — 40 tools drowns
 						// the model and it never calls FILE. Instead treat the coding
 						// contexts (code/files/terminal/automation) as active and run the
@@ -8890,11 +8946,9 @@ export async function runV5MessageRuntimeStage1(args: {
 						// messaging/social chat actions. Role still applies (FILE=ADMIN,
 						// SHELL=OWNER; the coding sub-agent runs as OWNER). UI/orchestration
 						// parents that pass the gate but a coder never needs are dropped
-						// too (see CODING_SUB_AGENT_EXCLUDED_ACTIONS) to keep the request
+						// too (see CODING_DIRECT_ACTIONS) to keep the request
 						// small enough for weaker hosted models to handle large builds.
-						!CODING_SUB_AGENT_EXCLUDED_ACTIONS.has(
-							normalizeActionIdentifier(action.name),
-						) &&
+						CODING_DIRECT_ACTIONS.has(normalizeActionIdentifier(action.name)) &&
 						// Static candidate-action set for a coding sub-agent — no concrete
 						// turn message here, so skip the private-action gate; the eventual
 						// execution still enforces it through the executor.
@@ -9056,6 +9110,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			: null;
 		const actionSurface = buildV5PlannerActionSurface({
 			actions: plannerCandidateActions,
+			forceFullSurface: args.codingMode === true,
 			message: args.message,
 			state: plannerState,
 			messageHandler,
@@ -9458,6 +9513,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				runPlannerLoop({
 					runtime: plannerRuntime,
 					context: loopContext,
+					codingMode: args.codingMode === true,
 					config: args.plannerLoopConfig,
 					tools: plannerTools.length > 0 ? plannerTools : undefined,
 					requireNonTerminalToolCall,
@@ -9594,6 +9650,11 @@ export async function runV5MessageRuntimeStage1(args: {
 					)
 				: await invokePlannerLoop(plannerContextAfterEarlyReply);
 		} catch (error) {
+			// A coding turn is an all-the-way-to-verification transaction. A
+			// successful intermediate file operation cannot rescue a loop that hit
+			// its call/token/provider limit before a grounded terminal result; doing
+			// so makes CLI/ACP report partial work as success.
+			if (args.codingMode === true) throw error;
 			const preservedAnswer = prePatchStageOneReplyIsUngroundedAppliedClaim
 				? undefined
 				: prePatchStageOneReply?.trim();
@@ -9696,11 +9757,14 @@ export async function runV5MessageRuntimeStage1(args: {
 			plannerResult.trajectory,
 			exposedPlannerActions,
 		);
-		const plannedReplyEgressDecision = evaluatePlannedReplyEgress({
-			reply: String(plannerResult.finalMessage ?? ""),
-			actionResults: egressActionResults,
-			actions: args.runtime.actions,
-		});
+		const plannedReplyEgressDecision =
+			args.codingMode === true
+				? ({ verdict: "allow" } as const)
+				: evaluatePlannedReplyEgress({
+						reply: String(plannerResult.finalMessage ?? ""),
+						actionResults: egressActionResults,
+						actions: args.runtime.actions,
+					});
 		// A reply an action callback already delivered this turn (verbatim or as
 		// a strict superset) is a planner echo: the suppression below drops it, so
 		// it never egresses. Bouncing it here instead would follow the visible,
@@ -9883,11 +9947,19 @@ export async function runV5MessageRuntimeStage1(args: {
 				effectiveReplyText = relayBody;
 			}
 		}
-		const finalReplyEgressDecision = evaluatePlannedReplyEgress({
-			reply: effectiveReplyText,
-			actionResults,
-			actions: args.runtime.actions,
-		});
+		// Coding-mode terminal claims were already checked against the concrete
+		// planner trajectory (including mandatory post-mutation SHELL proof).
+		// Generic chat egress requires EffectReceipts, which local file tools do
+		// not mint, and would replace a verified coding result with a false
+		// "couldn't verify" fallback.
+		const finalReplyEgressDecision =
+			args.codingMode === true
+				? ({ verdict: "allow" } as const)
+				: evaluatePlannedReplyEgress({
+						reply: effectiveReplyText,
+						actionResults,
+						actions: args.runtime.actions,
+					});
 		if (finalReplyEgressDecision.verdict === "reject") {
 			effectiveReplyText = finalReplyEgressDecision.fallbackReply;
 		}
@@ -12720,6 +12792,7 @@ export class DefaultMessageService implements IMessageService {
 
 				const opts: ResolvedMessageOptions = {
 					maxRetries: options?.maxRetries ?? 3,
+					codingMode: options?.codingMode === true,
 					continueAfterActions:
 						options?.continueAfterActions ??
 						parseBooleanFromText(
@@ -13680,6 +13753,7 @@ export class DefaultMessageService implements IMessageService {
 							message,
 							state,
 							responseId,
+							codingMode: opts.codingMode,
 							...(callback ? { callback } : {}),
 							deliveredVisibleTexts,
 							...(opts.roomHandlerLease

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -26,6 +26,13 @@ export interface MessageProcessingOptions {
 	maxRetries?: number;
 	useMultiStep?: boolean;
 	maxMultiStepIterations?: number;
+	/**
+	 * Run this trusted host turn as a focused coding-agent loop. Coding turns
+	 * enter the planner directly instead of spending a separate model call on
+	 * conversational Stage 1 routing. This is a per-turn execution choice, not
+	 * an authorization signal; normal role and action gates still apply.
+	 */
+	codingMode?: boolean;
 	shouldRespondModel?: ShouldRespondModelType;
 	onStreamChunk?: StreamChunkCallback;
 	/**

--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -1224,6 +1224,7 @@ During a turn: Enter queues the message, Esc/Ctrl+C aborts (queued messages are 
         room,
         text,
         identity: state.identity,
+        codingMode: true,
         abortSignal: turnAbortController.signal,
         onDelta: (delta) => {
           if (turnAbortController.signal.aborted) return;

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -114,11 +114,6 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
       // the role resolver sees the owner at boot.
       identity = ensureSessionIdentity();
       process.env.ELIZA_ADMIN_ENTITY_ID ??= identity.userId;
-      // A coding sub-agent has a small, all-relevant tool set (FILE/SHELL/READ/
-      // EDIT/…); expose them ALL as native tools (full surface, no chat-style
-      // tiering) so the model can actually CALL them instead of only seeing them
-      // described in the prompt and narrating.
-      process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
       // Headless coding sub-agent: only sql + provider + shell + coding-tools.
       // codingOnly drops mcp/goals AND the orchestrator (recursion guard).
       const runtime = await initializeAgent({
@@ -340,6 +335,7 @@ const _connection = new AgentSideConnection(
         text,
         identity,
         source: "acp",
+        codingMode: true,
       });
       await publishParsedReply(params.sessionId, response, (update) =>
         conn.sessionUpdate(update),

--- a/packages/examples/code/src/cli.ts
+++ b/packages/examples/code/src/cli.ts
@@ -15,7 +15,7 @@
 import { readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as readline from "node:readline";
-import type { AgentRuntime } from "@elizaos/core";
+import { type AgentRuntime, ElizaError } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { getAgentClient } from "./lib/agent-client.js";
 import { getCwd, setCwd } from "./lib/cwd.js";
@@ -42,6 +42,7 @@ interface CLIOptions {
   cwd: string | null;
   message: string | null;
   interactive: boolean;
+  codingOnly: boolean;
 }
 
 interface CLIResult {
@@ -95,6 +96,8 @@ Options:
   -f, --file <path>       Read message from file
   -c, --cwd <path>        Set working directory
   -i, --interactive       Force interactive mode (TUI)
+      --coding-only       Load only the direct coding runtime (no orchestrator)
+      --no-orchestrator   Alias for --coding-only
 
 Examples:
   eliza-code "What files are in the current directory?"
@@ -124,6 +127,7 @@ function parseArgs(args: string[]): CLIOptions {
     cwd: null,
     message: null,
     interactive: false,
+    codingOnly: false,
   };
 
   let i = 0;
@@ -156,6 +160,11 @@ function parseArgs(args: string[]): CLIOptions {
       case "-i":
       case "--interactive":
         options.interactive = true;
+        break;
+
+      case "--coding-only":
+      case "--no-orchestrator":
+        options.codingOnly = true;
         break;
 
       case "-f":
@@ -330,8 +339,7 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
     // step." loops). The env seeds boot-time reads; the runtime setting is
     // what getConfiguredOwnerEntityIds actually resolves per turn.
     process.env.ELIZA_ADMIN_ENTITY_ID ??= session.identity.userId;
-    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
-    runtime = await initializeAgent();
+    runtime = await initializeAgent({ codingOnly: options.codingOnly });
     (
       runtime as unknown as { setSetting?: (k: string, v: unknown) => void }
     ).setSetting?.("ELIZA_ADMIN_ENTITY_ID", session.identity.userId);
@@ -349,6 +357,7 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
       room,
       text: message,
       identity: session.identity,
+      codingMode: true,
       onDelta: shouldStream
         ? (delta) => {
             // Write deltas directly for real-time streaming.
@@ -357,6 +366,16 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
           }
         : undefined,
     });
+
+    if (!response.trim()) {
+      throw new ElizaError(
+        "The coding-agent turn ended without a final response.",
+        {
+          code: "ELIZA_CODE_EMPTY_RESPONSE",
+          severity: "fatal",
+        },
+      );
+    }
 
     if (didPrintStreaming) {
       process.stdout.write("\n");
@@ -373,6 +392,19 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
     return {
       success: true,
       response,
+      timing: {
+        startedAt,
+        completedAt,
+        durationMs: completedAt - startedAt,
+      },
+    };
+  } catch (error) {
+    // error-policy:J1 The one-shot CLI translates typed/runtime turn failures
+    // into a non-success result so JSON callers and shell exit status agree.
+    const completedAt = Date.now();
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
       timing: {
         startedAt,
         completedAt,

--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -169,7 +169,6 @@ async function runInteractive(): Promise<void> {
   // a fresh TUI two user IDs and grant OWNER to the one that sends no turns.
   const ownerUserId = await resolveTuiOwnerUserId();
   process.env.ELIZA_ADMIN_ENTITY_ID ??= ownerUserId;
-  process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
 
   // Initialize the agent
   runtime = await initializeAgent({ codingOnly: shouldRunCodingOnly() });

--- a/packages/examples/code/src/lib/agent-client.streaming.test.ts
+++ b/packages/examples/code/src/lib/agent-client.streaming.test.ts
@@ -1,6 +1,8 @@
 // Exercises the Code example behavior that this module protects.
 import { beforeEach, describe, expect, it } from "bun:test";
 import {
+  type Content,
+  FAILED_TOOL_FALLBACK_MESSAGE,
   type HandlerCallback,
   type IAgentRuntime,
   type Memory,
@@ -12,6 +14,7 @@ import { getAgentClient, resetAgentClient } from "./agent-client.js";
 import type { SessionIdentity } from "./identity.js";
 
 interface HandleMessageOptions {
+  codingMode?: boolean;
   abortSignal?: AbortSignal;
   onStreamChunk?: StreamChunkCallback;
 }
@@ -43,7 +46,11 @@ function makeRuntime(
     message: Memory,
     callback?: HandlerCallback,
     options?: HandleMessageOptions,
-  ) => Promise<{ didRespond: boolean; responseMessages: Memory[] }>,
+  ) => Promise<{
+    didRespond: boolean;
+    responseContent?: Content | null;
+    responseMessages: Memory[];
+  }>,
 ): IAgentRuntime {
   return {
     ensureConnection: async () => {},
@@ -78,12 +85,14 @@ describe("AgentClient streaming", () => {
       room: makeRoom(),
       text: "say hello",
       identity: makeIdentity(),
+      codingMode: true,
       abortSignal: abortController.signal,
       onDelta: (delta) => deltas.push(delta),
     });
 
     expect(response).toBe("hello");
     expect(deltas).toEqual(["hel", "lo"]);
+    expect(seenOptions?.codingMode).toBe(true);
     expect(seenOptions?.abortSignal).toBe(abortController.signal);
     expect(typeof seenOptions?.onStreamChunk).toBe("function");
   });
@@ -139,5 +148,77 @@ describe("AgentClient streaming", () => {
 
     expect(response).toBe("The answer is 42.");
     expect(deltas).toEqual(["The answer", " is 42."]);
+  });
+
+  it("uses the returned response content when a host callback is not invoked", async () => {
+    const runtime = makeRuntime(async () => ({
+      didRespond: true,
+      responseContent: { text: "returned directly" },
+      responseMessages: [],
+    }));
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "answer",
+        identity: makeIdentity(),
+      }),
+    ).resolves.toBe("returned directly");
+  });
+
+  it("rejects synthetic runtime replies instead of returning them as success", async () => {
+    const runtime = makeRuntime(async (_runtime, _message, callback) => {
+      await callback?.({
+        text: "Something went wrong on my end. Please try again.",
+        failureKind: "transient_failure",
+        elizaSyntheticFailure: true,
+        transient: true,
+      });
+      return {
+        didRespond: true,
+        responseContent: {
+          text: "Something went wrong on my end. Please try again.",
+          failureKind: "transient_failure",
+          elizaSyntheticFailure: true,
+          transient: true,
+        },
+        responseMessages: [],
+      };
+    });
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "run a tool",
+        identity: makeIdentity(),
+      }),
+    ).rejects.toMatchObject({
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: { failureKind: "transient_failure", transient: true },
+    });
+  });
+
+  it("rejects the planner's failed-tool fallback as a failed coding turn", async () => {
+    const runtime = makeRuntime(async () => ({
+      didRespond: true,
+      responseContent: {
+        text: `${FAILED_TOOL_FALLBACK_MESSAGE}\n\nWork that did complete: read config.go`,
+      },
+      responseMessages: [],
+    }));
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "run a tool",
+        identity: makeIdentity(),
+      }),
+    ).rejects.toMatchObject({
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: { failureKind: "unknown", transient: false },
+    });
   });
 });

--- a/packages/examples/code/src/lib/agent-client.ts
+++ b/packages/examples/code/src/lib/agent-client.ts
@@ -3,6 +3,8 @@ import {
   ChannelType,
   type Content,
   createMessageMemory,
+  ElizaError,
+  FAILED_TOOL_FALLBACK_MESSAGE,
   type IAgentRuntime,
   type Memory,
   type StreamChunkCallback,
@@ -23,6 +25,8 @@ interface SendMessageParams {
   room: ChatRoom;
   text: string;
   identity: SessionIdentity;
+  /** Enter the runtime's trusted direct coding loop for this turn. */
+  codingMode?: boolean;
   userName?: string;
   source?: string;
   channelType?: ChannelType;
@@ -166,19 +170,54 @@ class AgentClient {
     }
 
     const options =
-      params.abortSignal || onDelta
+      params.codingMode || params.abortSignal || onDelta
         ? {
+            ...(params.codingMode ? { codingMode: true } : {}),
             ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
             ...(onDelta ? { onStreamChunk: handleStreamChunk } : {}),
           }
         : undefined;
 
-    await runtime.messageService.handleMessage(
+    const result = await runtime.messageService.handleMessage(
       runtime,
       messageMemory,
       callback,
       options,
     );
+
+    const resultContent = result.responseContent;
+    const resultRecord =
+      resultContent && typeof resultContent === "object"
+        ? resultContent
+        : undefined;
+    const resultText =
+      resultRecord && typeof resultRecord.text === "string"
+        ? resultRecord.text
+        : undefined;
+    if (
+      resultRecord?.elizaSyntheticFailure === true ||
+      resultText?.startsWith(FAILED_TOOL_FALLBACK_MESSAGE) === true
+    ) {
+      const failureKind =
+        typeof resultRecord?.failureKind === "string"
+          ? resultRecord.failureKind
+          : "unknown";
+      const transient = resultRecord?.transient === true;
+      throw new ElizaError(
+        resultText?.trim()
+          ? resultText
+          : "The coding-agent turn failed before producing a result.",
+        {
+          code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+          context: { failureKind, transient },
+          severity: transient ? "ephemeral" : "fatal",
+        },
+      );
+    }
+
+    if (!response && resultRecord && resultText !== undefined) {
+      response = resultText;
+    }
 
     return response;
   }

--- a/packages/examples/code/src/lib/prompts.ts
+++ b/packages/examples/code/src/lib/prompts.ts
@@ -1,10 +1,12 @@
 // Provides shared support logic for the Code example.
 export const CODE_ASSISTANT_SYSTEM_PROMPT = `
-You are Eliza Code, an autonomous coding agent. You complete tasks by USING TOOLS to make real changes on disk — writing and editing files with the FILE action and running commands with the SHELL action — not by describing what should be done.
+You are Eliza Code, an autonomous coding agent. You complete tasks by USING TOOLS to make real changes on disk — inspecting with READ, changing files with EDIT or WRITE, and verifying with SHELL — not by describing what should be done.
 
 How you work:
-- ACT, don't narrate. When asked to build, create, write, or fix something, immediately call the FILE action with the actual file contents (and SHELL to run/verify). NEVER reply with only a description or plan such as "I'll create..." , "Creating the app now", or "Here's the code:" followed by a code block — a turn that does not call a tool leaves nothing on disk and is a FAILED turn.
-- Put the COMPLETE file content inside the FILE tool call's content argument, not in your text reply. For a single-file web app, write the whole self-contained HTML (inline CSS + JS) in one FILE call.
+- ACT, don't narrate. When asked to build, create, write, or fix something, immediately use READ/EDIT/WRITE and SHELL. NEVER reply with only a description or plan such as "I'll create..." , "Creating the app now", or "Here's the code:" followed by a code block — a turn that does not call a tool leaves nothing on disk and is a FAILED turn.
+- If the request names a file, READ that path directly instead of searching for it. Use offset/limit for targeted windows and avoid reading large files wholesale.
+- Prefer exact EDIT for an existing file; use WRITE for a new file or a deliberate complete replacement. Do not rewrite unrelated code, tests, or fixtures merely to make verification pass.
+- Put complete new-file content inside the WRITE tool call's content argument, not in your text reply. For a single-file web app, write the whole self-contained HTML (inline CSS + JS) in one WRITE call.
 - For multi-file or multi-step tasks, perform each step with its own tool call before moving on; write every file before reporting done.
 - Verify: after writing, read the file back or run it, then report the real result (e.g. the actual program output).
 - Only send a text reply (REPLY) once the work is actually done — to briefly summarize what you changed — or to ask a genuinely blocking question. Never claim a file exists unless you wrote it this session.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
@@ -412,6 +412,42 @@ describe("bridge-routes — credential bridge", () => {
     expect((body() as { value: string }).value).toBe("sk-test");
   });
 
+  it("GET rechecks session authorization immediately before disclosing a ready credential", async () => {
+    const adapter = makeAdapter({
+      tryRetrieveCredential: vi
+        .fn()
+        .mockResolvedValue({ status: "ready", value: "sk-must-not-leak" }),
+    });
+    const getSession = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "pty-1-abc", status: "running" })
+      .mockResolvedValueOnce({ id: "pty-1-abc", status: "running" })
+      .mockResolvedValueOnce({ id: "pty-1-abc", status: "stopped" });
+    const ctx = makeCtx(adapter);
+    ctx.acpService = { getSession } as unknown as RouteContext["acpService"];
+    const req = fakeRequest({
+      method: "GET",
+      url: "/api/coding-agents/pty-1-abc/credentials/OPENAI_API_KEY?token=deadbeef",
+    });
+    const { res, status, body } = fakeResponse();
+
+    await handleBridgeRoutes(
+      req,
+      res,
+      "/api/coding-agents/pty-1-abc/credentials/OPENAI_API_KEY",
+      ctx,
+    );
+
+    expect(getSession).toHaveBeenCalledTimes(3);
+    expect(adapter.tryRetrieveCredential).toHaveBeenCalledTimes(1);
+    expect(status()).toBe(410);
+    expect(body()).toEqual({
+      error: "sub-agent session became inactive before credential delivery",
+      code: "session_not_active",
+    });
+    expect(JSON.stringify(body())).not.toContain("sk-must-not-leak");
+  });
+
   it("GET propagates a 410 when scope expired", async () => {
     const adapter = makeAdapter({
       tryRetrieveCredential: vi.fn().mockResolvedValue({ status: "expired" }),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
@@ -342,6 +342,15 @@ describe("parseJudgeResponse", () => {
     expect(parsed.missing).toEqual(["c1"]);
   });
 
+  it("marks a JSON object without the verdict schema inconclusive", () => {
+    const parsed = parseJudgeResponse("{}", ["c1"]);
+    expect(parsed).toMatchObject({
+      passed: false,
+      missing: ["c1"],
+      inconclusive: true,
+    });
+  });
+
   it("trims whitespace from missing entries and drops empties", () => {
     const parsed = parseJudgeResponse(
       '{"passed": false, "summary": "s", "missing": ["  c1  ", "", "c2"]}',
@@ -376,6 +385,7 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     expect(result.summary).toMatch(/no acceptance criteria/i);
     expect(result.missing).toEqual([]);
     expect(result.rawResponse).toBe("");
+    expect(result.inconclusive).toBe(false);
   });
 
   it("short-circuits to fail when completionEvidence is empty", async () => {
@@ -425,7 +435,7 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     );
   });
 
-  it("returns a structured fail when the model throws", async () => {
+  it("returns an inconclusive verdict when the verifier model is unavailable", async () => {
     const runtime = makeMockRuntime({
       shouldThrow: new Error("provider down"),
     });
@@ -438,6 +448,7 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     expect(result.summary).toMatch(/provider down/);
     expect(result.missing).toEqual(["c1"]);
     expect(result.rawResponse).toBe("");
+    expect(result.inconclusive).toBe(true);
   });
 
   it("returns a passed verdict on a clean model response", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -351,7 +351,7 @@ describe("auto goal verification on task_complete", () => {
     expect(fake.service.sendToSession).not.toHaveBeenCalled();
   });
 
-  it("does nothing extra for a task with no acceptance criteria", async () => {
+  it("completes a criteria-free task after deterministic gates pass", async () => {
     const fake = makeFakeAcp();
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const { taskId, sessionId } = await seedTaskWithSession(store, []);
@@ -371,10 +371,17 @@ describe("auto goal verification on task_complete", () => {
     fake.emit(sessionId, "task_complete", { response: "done" });
     await until(async () => {
       const task = await store.getTask(taskId);
-      return task?.task.status === "validating";
+      return task?.task.status === "done";
     });
     const doc = await store.getTask(taskId);
-    expect(doc?.task.status).toBe("validating");
+    expect(doc?.task.status).toBe("done");
+    expect(
+      doc?.events.some(
+        (event) =>
+          event.eventType === "validation_passed" &&
+          event.data?.verifier === "criteria-free-completion-gate",
+      ),
+    ).toBe(true);
     expect(useModel).not.toHaveBeenCalled();
     expect(fake.service.sendToSession).not.toHaveBeenCalled();
   });
@@ -914,7 +921,7 @@ describe("independent read-only verifier (#8898)", () => {
     expect(useModel).not.toHaveBeenCalled();
   });
 
-  it("an inconclusive verifier verdict keeps the task validating (no false promotion)", async () => {
+  it("an inconclusive verifier verdict is retryable without consuming a worker attempt", async () => {
     const fake = makeVerifierAcp(() => INCONCLUSIVE_VERIFIER_ENVELOPE);
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const { taskId, sessionId } = await seedCodeChangeTask(store, [
@@ -952,6 +959,8 @@ describe("independent read-only verifier (#8898)", () => {
     // promotion) — so the task returns to `active`, not `done`.
     expect(doc?.task.status).toBe("active");
     expect(doc?.task.status).not.toBe("done");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBeUndefined();
+    expect(doc?.task.metadata.attemptReflections).toBeUndefined();
     expect(useModel).not.toHaveBeenCalled();
     // #20794: the worker is an `opencode` session, which never emits a
     // CompletionEnvelope — the correction must demand producible evidence,
@@ -1295,7 +1304,7 @@ describe("deterministic completion-residuals gate", () => {
     );
   });
 
-  it("a criteria-free CLEAN workspace keeps the prior behavior: parks validating, no model spend", async () => {
+  it("a criteria-free CLEAN workspace completes without model spend", async () => {
     const fake = makeFakeAcp();
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const { taskId, sessionId } = await seedTaskWithSession(store, []);
@@ -1305,19 +1314,108 @@ describe("deterministic completion-residuals gate", () => {
 
     fake.emit(sessionId, "task_complete", { response: "done" });
     await until(
-      async () =>
-        (await store.getTask(taskId))?.task.metadata.completionResiduals !==
-        undefined,
+      async () => (await store.getTask(taskId))?.task.status === "done",
     );
 
     const doc = await store.getTask(taskId);
-    expect(doc?.task.status).toBe("validating");
+    expect(doc?.task.status).toBe("done");
     expect(useModel).not.toHaveBeenCalled();
     expect(fake.service.sendToSession).not.toHaveBeenCalled();
     const snapshot = doc?.task.metadata.completionResiduals as
       | { status: string }
       | undefined;
     expect(snapshot?.status).toBe("clean");
+  });
+
+  it("a verifier-model outage reopens retryably without consuming a worker attempt", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    const useModel = vi.fn(async () => {
+      throw new Error("provider temporarily unavailable");
+    });
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      useModel,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done with evidence" });
+    await until(
+      async () =>
+        (await store.getTask(taskId))?.events.some(
+          (event) => event.eventType === "goal_verify_inconclusive",
+        ) === true,
+    );
+
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("active");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBeUndefined();
+    expect(doc?.task.metadata.attemptReflections).toBeUndefined();
+    expect(
+      doc?.events.find(
+        (event) => event.eventType === "goal_verify_inconclusive",
+      )?.data,
+    ).toMatchObject({ retryable: true, verifier: "llm-goal-verifier" });
+    expect(fake.sent.at(-1)?.text).toContain("not counted as a failed attempt");
+  });
+
+  it("an unexpected auto-verifier exception cannot leave the task validating", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    let failSettingRead = true;
+    const reportError = vi.fn();
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: (key: string) => {
+        if (
+          failSettingRead &&
+          key === "ELIZA_ORCHESTRATOR_GROUND_TRUTH_EVIDENCE"
+        ) {
+          failSettingRead = false;
+          throw new Error("settings backend offline");
+        }
+        return undefined;
+      },
+      useModel: vi.fn(async () =>
+        JSON.stringify({ passed: true, summary: "not reached", missing: [] }),
+      ),
+      reportError,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done with evidence" });
+    await until(
+      async () =>
+        (await store.getTask(taskId))?.events.some(
+          (event) => event.eventType === "auto_verify_inconclusive",
+        ) === true,
+    );
+
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("active");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBeUndefined();
+    expect(reportError).toHaveBeenCalledWith(
+      "OrchestratorTaskService.autoVerifyCompletion",
+      expect.any(Error),
+      { taskId, sessionId },
+    );
   });
 
   it("a MISSING workspace on a repo-bound task is unverifiable: stays validating WITHOUT burning an attempt (fail closed, F5a)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -334,13 +334,46 @@ async function handleGet(
       scopedToken,
     });
     if (outcome.status === "ready") {
+      // The long-poll may have waited minutes after the initial ownership
+      // check. Re-authorize at the disclosure boundary: a child that stopped,
+      // was removed, or otherwise became terminal while the adapter was
+      // waiting must never receive the plaintext even if its one-shot scope
+      // became ready in the same race.
+      const authorizedSession = await resolveActiveSession(ctx, sessionId);
+      if (!authorizedSession) {
+        sendJson(
+          res,
+          {
+            error:
+              "sub-agent session became inactive before credential delivery",
+            code: "session_not_active",
+          },
+          410,
+        );
+        return;
+      }
       // #8907: tell the origin thread the task is unblocked (best-effort).
       await emitCredentialResolved({
         runtime: ctx.runtime,
-        metadata: session.metadata,
+        metadata: authorizedSession.metadata,
         key,
-        label: session.name,
+        label: authorizedSession.name,
       });
+      // `emitCredentialResolved` may cross a connector boundary. Close that
+      // final await-shaped race as well: this check is the last operation
+      // before the synchronous plaintext response write.
+      if (!(await resolveActiveSession(ctx, sessionId))) {
+        sendJson(
+          res,
+          {
+            error:
+              "sub-agent session became inactive before credential delivery",
+            code: "session_not_active",
+          },
+          410,
+        );
+        return;
+      }
       sendJson(res, {
         key,
         value: outcome.value,

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -291,6 +291,10 @@ export interface GoalVerificationResult {
   missing: string[];
   /** Raw model response text, kept for the audit log and for tests. */
   rawResponse: string;
+  /** True when verification itself could not produce a verdict. Callers must
+   *  retry/escalate infrastructure without charging the worker's correction
+   *  budget. */
+  inconclusive: boolean;
 }
 
 const EMPTY_CRITERIA_SUMMARY =
@@ -353,6 +357,7 @@ interface ParsedJudgeResponse {
   passed: boolean;
   summary: string;
   missing: string[];
+  inconclusive: boolean;
 }
 
 function findFirstJsonObject(raw: string): string | null {
@@ -381,6 +386,7 @@ export function parseJudgeResponse(
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
       missing: [...acceptanceCriteria],
+      inconclusive: true,
     };
   }
   let parsed: unknown;
@@ -393,6 +399,7 @@ export function parseJudgeResponse(
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
       missing: [...acceptanceCriteria],
+      inconclusive: true,
     };
   }
   if (parsed === null || typeof parsed !== "object") {
@@ -400,17 +407,24 @@ export function parseJudgeResponse(
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
       missing: [...acceptanceCriteria],
+      inconclusive: true,
     };
   }
   const record = parsed as Record<string, unknown>;
   const passedRaw = record.passed;
   const summaryRaw = record.summary;
   const missingRaw = record.missing;
-  const missing = Array.isArray(missingRaw)
-    ? missingRaw
-        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-        .filter((entry) => entry.length > 0)
-    : [];
+  if (typeof passedRaw !== "boolean" || !Array.isArray(missingRaw)) {
+    return {
+      passed: false,
+      summary: MALFORMED_RESPONSE_SUMMARY,
+      missing: [...acceptanceCriteria],
+      inconclusive: true,
+    };
+  }
+  const missing = missingRaw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
   // Enforce the schema invariant: missing non-empty ⇒ passed false.
   const passed = passedRaw === true && missing.length === 0;
   const summary =
@@ -419,7 +433,7 @@ export function parseJudgeResponse(
       : passed
         ? "All acceptance criteria confirmed by verifier."
         : "Verifier did not confirm every acceptance criterion.";
-  return { passed, summary, missing };
+  return { passed, summary, missing, inconclusive: false };
 }
 
 /**
@@ -441,6 +455,7 @@ export async function verifyGoalCompletion(
       summary: EMPTY_CRITERIA_SUMMARY,
       missing: [],
       rawResponse: "",
+      inconclusive: false,
     };
   }
   if (input.completionEvidence.trim().length === 0) {
@@ -449,6 +464,7 @@ export async function verifyGoalCompletion(
       summary: EMPTY_EVIDENCE_SUMMARY,
       missing: [...input.acceptanceCriteria],
       rawResponse: "",
+      inconclusive: false,
     };
   }
   const prompt = buildVerificationPrompt(input);
@@ -462,13 +478,15 @@ export async function verifyGoalCompletion(
     raw = typeof result === "string" ? result : String(result);
   } catch (err) {
     // error-policy:J1 boundary translation — a failed verifier model call
-    // becomes a structured fail verdict naming the error, never a fake pass.
+    // becomes an explicit inconclusive verdict naming the error, never a fake
+    // pass or a worker-attributed proof failure.
     const detail = err instanceof Error ? err.message : String(err);
     return {
       passed: false,
       summary: `Verifier model call failed: ${toWellFormedUnicode(detail)}`,
       missing: [...input.acceptanceCriteria],
       rawResponse: "",
+      inconclusive: true,
     };
   }
   // Record the grill model boundary (prompt + verdict) so the scenario

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3802,9 +3802,10 @@ export class OrchestratorTaskService extends Service {
    * 3. **Independent execution verifier (#8898).** For code-change tasks
    *    ({@link shouldRunIndependentVerify}) a SEPARATE read-only ACP session re-runs
    *    the tests/diff and returns an execution-grounded verdict. A failing verdict
-   *    BLOCKS (provenance `independent-acp-verifier`); an inconclusive verdict keeps
-   *    the task `validating` (never a false promotion on a verifier crash); a
-   *    passing/skipped verdict falls through.
+   *    BLOCKS (provenance `independent-acp-verifier`); an inconclusive verdict
+   *    reopens a retryable worker turn without consuming its corrective-attempt
+   *    budget (never a false promotion on a verifier crash); a passing/skipped
+   *    verdict falls through.
    * 4. **Text judge (fallback).** {@link verifyGoalCompletion} (`ModelType.TEXT_SMALL`)
    *    judges the evidence and promotes (→ `done`) or re-prompts.
    *
@@ -3841,12 +3842,50 @@ export class OrchestratorTaskService extends Service {
       );
     } catch (err) {
       // error-policy:J7 auto-verify is fire-and-forget from the event bridge; a
-      // failure warns and must not break the session-event write path.
+      // failure warns and must not break the session-event write path. Recover
+      // the durable state too: logging alone used to strand the task forever in
+      // `validating`, with no retry surface and no terminal signal.
       this.log("warn", "auto goal verification failed", {
         taskId,
         sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
+      this.runtime.reportError?.(
+        "OrchestratorTaskService.autoVerifyCompletion",
+        err,
+        { taskId, sessionId },
+      );
+      try {
+        await this.withTaskWriteLock(taskId, () =>
+          this.retryInconclusiveVerification({
+            taskId,
+            sessionId,
+            eventType: "auto_verify_inconclusive",
+            verifier: "auto-verifier-infrastructure",
+            summary: `Automatic verification could not run: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            correction:
+              "Automatic verification was temporarily unavailable. Your work was not counted as a failed attempt. Please re-report completion with the same concrete evidence so verification can retry.",
+          }),
+        );
+      } catch (recoveryErr) {
+        // error-policy:J7 diagnostics/recovery must not reject the detached
+        // event handler. A second failure is reported distinctly.
+        this.log("error", "failed to recover inconclusive auto verification", {
+          taskId,
+          sessionId,
+          error:
+            recoveryErr instanceof Error
+              ? recoveryErr.message
+              : String(recoveryErr),
+        });
+        this.runtime.reportError?.(
+          "OrchestratorTaskService.autoVerifyRecovery",
+          recoveryErr,
+          { taskId, sessionId },
+        );
+      }
     } finally {
       this.autoVerifyInFlight.delete(taskId);
     }
@@ -4031,9 +4070,23 @@ export class OrchestratorTaskService extends Service {
       }
 
       const acceptanceCriteria = doc.task.acceptanceCriteria;
-      // Criteria-free tasks keep the prior behavior after deterministic gates:
-      // stay `validating` for a human/manual caller, with no model spend.
-      if (acceptanceCriteria.length === 0) return;
+      // With no criteria there is nothing for the model judge to decide. Once
+      // the deterministic residuals/ground-truth gates above are clear, finish
+      // explicitly instead of leaving the task permanently `validating`.
+      if (acceptanceCriteria.length === 0) {
+        await this.validateTaskLocked(taskId, {
+          passed: true,
+          summary:
+            "No acceptance criteria were specified; deterministic completion gates passed.",
+          evidence:
+            completionEvidence.trim() ||
+            rawCompletion.trim() ||
+            "Criteria-free completion passed deterministic gates.",
+          verifier: "criteria-free-completion-gate",
+        });
+        this.emitChange(taskId);
+        return;
+      }
 
       // 2. Structural envelope gate (#8895) — BEFORE any model spend.
       if (parse.present && !parse.ok) {
@@ -4219,17 +4272,10 @@ export class OrchestratorTaskService extends Service {
       );
       if (independent) {
         if (independent.inconclusive) {
-          // A verifier crash/empty verdict is never a pass — but a silent
-          // return here parked the task in `validating` forever with no
-          // re-prompt, no escalation, and no signal to the task creator
-          // (observed live: a website-build task whose final task_complete hit
-          // "no usable CompletionEnvelope" and then sat `validating` for
-          // hours while the user asked "is it done?"). Route it through the
-          // shared re-engage/escalate path like every other non-pass verdict:
-          // under the attempts cap the worker is re-prompted to re-report
-          // with the structured envelope (making the next verify decidable);
-          // at the cap the task parks on waiting_on_user instead of ghosting.
-          await this.reEngageOrEscalate({
+          // A verifier crash/empty verdict is an infrastructure outcome, not
+          // evidence that the worker failed a criterion. Re-open a retryable
+          // turn, but preserve the worker's bounded corrective-attempt budget.
+          await this.retryInconclusiveVerification({
             taskId,
             sessionId,
             correction: [
@@ -4242,11 +4288,6 @@ export class OrchestratorTaskService extends Service {
             eventType: "independent_verify_inconclusive",
             verifier: INDEPENDENT_ACP_VERIFIER_NAME,
             summary: independent.summary,
-            missing: [
-              ...independent.unmet,
-              ...independent.failedCommands.map((c) => `command failed: ${c}`),
-            ],
-            attempt: attempts,
           });
           return;
         }
@@ -4309,6 +4350,19 @@ export class OrchestratorTaskService extends Service {
         },
       );
 
+      if (verdict.inconclusive) {
+        await this.retryInconclusiveVerification({
+          taskId,
+          sessionId,
+          eventType: "goal_verify_inconclusive",
+          verifier: LLM_GOAL_VERIFIER_NAME,
+          summary: verdict.summary,
+          correction:
+            "The goal-verification model was temporarily unavailable or returned no usable verdict. Your work was not counted as a failed attempt. Please re-report completion with the same concrete evidence so verification can retry.",
+        });
+        return;
+      }
+
       if (verdict.passed) {
         await this.validateTaskLocked(taskId, {
           passed: true,
@@ -4340,6 +4394,70 @@ export class OrchestratorTaskService extends Service {
         attempt: attempts,
       });
     }
+  }
+
+  /**
+   * Re-open a task when the verifier itself could not decide. This deliberately
+   * does not write `autoVerifyAttempts` or `attemptReflections`: those counters
+   * measure worker proof failures, not provider outages, malformed judge
+   * responses, or verifier subprocess failures.
+   */
+  private async retryInconclusiveVerification(args: {
+    taskId: string;
+    sessionId: string;
+    correction: string;
+    eventType: string;
+    verifier: string;
+    summary: string;
+  }): Promise<void> {
+    const { taskId, sessionId, correction, eventType, verifier, summary } =
+      args;
+    const doc = await this.store.getTask(taskId);
+    if (doc?.task.status !== "validating") return;
+    await this.store.addEvent({
+      id: randomUUID(),
+      taskId,
+      sessionId,
+      eventType,
+      summary,
+      data: { verifier, retryable: true },
+      timestamp: Date.now(),
+      createdAt: nowIso(),
+    });
+    try {
+      await this.store.updateSession(sessionId, {
+        status: "ready",
+        taskDelivered: false,
+        stoppedAt: undefined,
+      });
+      await this.sendToTaskAgent(
+        taskId,
+        sessionId,
+        correction,
+        "validation_failed",
+      );
+      await this.advanceTaskStatus(taskId, "validation_failed");
+    } catch (sendErr) {
+      // error-policy:J1 boundary — an inconclusive verifier plus an unavailable
+      // worker is surfaced to a human instead of remaining stuck validating.
+      await this.store.addEvent({
+        id: randomUUID(),
+        taskId,
+        sessionId,
+        eventType: "auto_verify_retry_failed",
+        summary:
+          "Verification was inconclusive and its retry could not be delivered; escalating to a human.",
+        data: {
+          verifier,
+          retryable: true,
+          error: sendErr instanceof Error ? sendErr.message : String(sendErr),
+        },
+        timestamp: Date.now(),
+        createdAt: nowIso(),
+      });
+      await this.advanceTaskStatus(taskId, "awaiting_user");
+    }
+    this.emitChange(taskId);
   }
 
   /**

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -1,6 +1,6 @@
 # @elizaos/plugin-coding-tools
 
-Native Claude-Code-style coding tools (FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
+Native coding tools (READ, WRITE, EDIT, FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
 
 ## Purpose / role
 
@@ -11,13 +11,14 @@ Adds filesystem operations, shell command execution, and git worktree management
 ### Actions
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
+- **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
 - **SHELL** — `action=run` executes a command via `/bin/bash -c`; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
 
-- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects the complete retained command history (stdout/stderr/exit code), cwd, allowed directory, and file operations into context; fires only in `terminal`/`code` contexts.
-- **AVAILABLE_CODING_TOOLS** — injects the list of available tool names (`FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
+- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects a bounded projection of the last 10 commands (size-capped stdout/stderr/exit code), cwd, allowed directory, and recent file operations into context while `ShellService` retains complete history; fires only in `terminal`/`code` contexts.
+- **AVAILABLE_CODING_TOOLS** — injects the available focused and umbrella tool names (`READ`, `WRITE`, `EDIT`, `FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
 
 ### Services
 
@@ -44,6 +45,7 @@ plugins/plugin-coding-tools/
     types.ts                      Service-type constants, ToolFailure/ToolResult types, CODING_TOOLS_CONTEXTS
     actions/
       file.ts                     FILE umbrella action — routes to per-op handlers
+      direct-file-actions.ts      strict READ / WRITE / EDIT action wrappers
       bash.ts                     SHELL action implementation
       worktree.ts                 WORKTREE umbrella action
       read.ts / write.ts / edit.ts  FILE sub-handlers for read/write/edit
@@ -103,7 +105,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |
-| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Pre-stat byte cap on FILE action=read. Larger files are rejected. |
+| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Byte cap for selected FILE read content. Larger files are paged with bounded line or byte reads. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Default `head_limit` for GREP output. Set to 0 to disable. |
 
 The folded `ShellService` also retains compatibility settings for external

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -1,6 +1,6 @@
 # @elizaos/plugin-coding-tools
 
-Native Claude-Code-style coding tools (FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
+Native coding tools (READ, WRITE, EDIT, FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
 
 ## Purpose / role
 
@@ -11,13 +11,14 @@ Adds filesystem operations, shell command execution, and git worktree management
 ### Actions
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
+- **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
 - **SHELL** — `action=run` executes a command via `/bin/bash -c`; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
 
-- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects the complete retained command history (stdout/stderr/exit code), cwd, allowed directory, and file operations into context; fires only in `terminal`/`code` contexts.
-- **AVAILABLE_CODING_TOOLS** — injects the list of available tool names (`FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
+- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects a bounded projection of the last 10 commands (size-capped stdout/stderr/exit code), cwd, allowed directory, and recent file operations into context while `ShellService` retains complete history; fires only in `terminal`/`code` contexts.
+- **AVAILABLE_CODING_TOOLS** — injects the available focused and umbrella tool names (`READ`, `WRITE`, `EDIT`, `FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
 
 ### Services
 
@@ -44,6 +45,7 @@ plugins/plugin-coding-tools/
     types.ts                      Service-type constants, ToolFailure/ToolResult types, CODING_TOOLS_CONTEXTS
     actions/
       file.ts                     FILE umbrella action — routes to per-op handlers
+      direct-file-actions.ts      strict READ / WRITE / EDIT action wrappers
       bash.ts                     SHELL action implementation
       worktree.ts                 WORKTREE umbrella action
       read.ts / write.ts / edit.ts  FILE sub-handlers for read/write/edit
@@ -103,7 +105,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |
-| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Pre-stat byte cap on FILE action=read. Larger files are rejected. |
+| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Byte cap for selected FILE read content. Larger files are paged with bounded line or byte reads. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Default `head_limit` for GREP output. Set to 0 to disable. |
 
 The folded `ShellService` also retains compatibility settings for external

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -1,13 +1,14 @@
 # @elizaos/plugin-coding-tools
 
-Native Claude-Code-style coding tools for elizaOS agents. Adds filesystem operations (read, write, edit, search, glob, ls), shell command execution, and git worktree management to any Eliza agent running in a code or terminal context.
+Native coding tools for elizaOS agents. Adds focused read/write/edit actions, filesystem search and listing, shell command execution, and git worktree management to any Eliza agent running in a code or terminal context.
 
 ## What it does
 
-The plugin registers three umbrella actions and a set of supporting services:
+The plugin registers three focused file actions, three umbrella actions, and a set of supporting services:
 
 | Action | Operations | Description |
 |---|---|---|
+| **READ / WRITE / EDIT** | one operation each | Pi-shaped strict schemas for direct coding loops. They reuse FILE's sandbox, stale-file, secret, and size guards. |
 | **FILE** | `read`, `write`, `edit`, `grep`, `glob`, `ls` | All file and search operations. Relative read/write/edit paths resolve against the conversation's session cwd before sandbox validation. Optional `target=device` routes through a device filesystem bridge for mobile. |
 | **SHELL** | `run`, `start_background`, `poll_background`, `write_background`, `kill_background`, `list_background`, `clear_history`, `view_history` | `run` executes a command via `/bin/bash -c` with a per-call timeout (clamped to `[100, 600000]` ms, default 120000). Background actions return stable per-conversation handles, poll incremental stdout/stderr offsets with truncation markers, write stdin, terminate process groups, and list sessions. `view_history`/`clear_history` read or clear per-conversation command history. |
 | **WORKTREE** | `enter`, `exit` | Creates and tears down git worktrees, updating the agent's session cwd and sandbox roots automatically. |
@@ -54,7 +55,7 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read. |
-| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | File size cap for reads (bytes). Larger files are rejected. |
+| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Selected-content byte cap. Larger files require an explicit line `limit` (and optional `offset`) and are scanned with bounded memory. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Max output lines for GREP. Set to 0 to disable. |
 
 ### SHELL trust boundary

--- a/plugins/plugin-coding-tools/package.json
+++ b/plugins/plugin-coding-tools/package.json
@@ -134,7 +134,7 @@
       },
       "CODING_TOOLS_MAX_FILE_SIZE_BYTES": {
         "type": "number",
-        "description": "Pre-stat byte cap on FILE action=read. Files larger than this are rejected with a message instructing the agent to read in chunks.",
+        "description": "Byte cap for selected FILE action=read content. Larger files require an explicit line limit (and optional offset) and are scanned with bounded memory.",
         "required": false,
         "default": 262144,
         "sensitive": false

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -34,6 +34,7 @@ import {
   readNumberParam,
   readStringParam,
   successActionResult,
+  truncate,
 } from "../lib/format.js";
 import { runShell, type ShellResult } from "../lib/run-shell.js";
 import { resolveHostShell } from "../lib/terminal-capabilities.js";
@@ -54,6 +55,9 @@ const TIMEOUT_MIN_MS = 100;
 const TIMEOUT_MAX_MS = 600_000;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const USER_FACING_STDOUT_CAP_CHARS = 8_000;
+// Match Pi's model-facing shell budget: preserve the command plus useful head
+// output while preventing one noisy test/build from consuming the next turn.
+const MODEL_FACING_SHELL_OUTPUT_CHARS = 50_000;
 const SHELL_HISTORY_DEFAULT_LIMIT = 20;
 const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
@@ -1263,7 +1267,7 @@ export const shellAction: Action = {
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
-    _state?: State,
+    state?: State,
     options?: unknown,
     callback?: HandlerCallback,
   ): Promise<ActionResult> => {
@@ -1634,11 +1638,13 @@ export const shellAction: Action = {
     // of real output and inflating a 30s build past 90s. Skip all
     // message-text-keyed rewrites for the coding sub-agent; its commands run
     // verbatim.
-    const codingSubAgentShell = ((): boolean => {
-      const v =
-        process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
-      return v === "1" || v === "true" || v === "yes" || v === "on";
-    })();
+    const codingSubAgentShell =
+      state?.data?.elizaTrustedCodingMode === true ||
+      ((): boolean => {
+        const v =
+          process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
+        return v === "1" || v === "true" || v === "yes" || v === "on";
+      })();
     const destructiveGateEnabled = ((): boolean => {
       const v =
         process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM?.trim().toLowerCase();
@@ -1872,7 +1878,9 @@ export const shellAction: Action = {
     const streams = formatStreams(redactedStdout, redactedStderr, {
       showEmptyStreams: !result.stdout && !result.stderr,
     });
-    const text = streams.length > 0 ? `${head}\n${streams}` : head;
+    const fullText = streams.length > 0 ? `${head}\n${streams}` : head;
+    const bounded = truncate(fullText, MODEL_FACING_SHELL_OUTPUT_CHARS);
+    const text = bounded.text;
 
     const echoTranscript =
       process.env.ELIZA_SHELL_ECHO_TRANSCRIPT?.trim().toLowerCase();
@@ -1885,7 +1893,12 @@ export const shellAction: Action = {
     if (timedOut) {
       return failureToActionResult(
         { reason: "timeout", message: `command timed out after ${timeout}ms` },
-        { command: redactedCommand, cwd: redactedCwd, output: text },
+        {
+          command: redactedCommand,
+          cwd: redactedCwd,
+          output: text,
+          output_truncated: bounded.truncated,
+        },
       );
     }
     if (result.exitCode !== 0) {
@@ -1899,6 +1912,7 @@ export const shellAction: Action = {
           exit_code: result.exitCode,
           cwd: redactedCwd,
           output: text,
+          output_truncated: bounded.truncated,
         },
       );
     }
@@ -1909,6 +1923,7 @@ export const shellAction: Action = {
       execution_route: result.sandbox === "host" ? "host" : "sandbox",
       sandbox_backend: result.sandbox,
       signal,
+      output_truncated: bounded.truncated,
     });
     // The crypto / disk / memory / status projections are CHAT conveniences
     // keyed on the *message text*, and the coding sub-agent's message text is

--- a/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
+++ b/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
@@ -1,0 +1,104 @@
+/**
+ * Pi-shaped READ, WRITE, and EDIT actions for focused coding loops. They share
+ * the FILE umbrella's handlers and safety services while presenting small,
+ * operation-specific schemas that models can call without fabricating every
+ * unrelated optional FILE field.
+ */
+import type { Action } from "@elizaos/core";
+import { CODING_TOOLS_CONTEXTS } from "../types.js";
+import { editFileHandler } from "./edit.js";
+import { readFileHandler } from "./read.js";
+import { writeFileHandler } from "./write.js";
+
+const DIRECT_FILE_GATE = {
+  contexts: [...CODING_TOOLS_CONTEXTS],
+  contextGate: { anyOf: [...CODING_TOOLS_CONTEXTS] },
+  roleGate: { minRole: "ADMIN" as const },
+};
+
+export const readAction: Action = {
+  name: "READ",
+  ...DIRECT_FILE_GATE,
+  description:
+    "Read a UTF-8 text file with numbered lines. Use offset and limit for a bounded window.",
+  parameters: [
+    {
+      name: "file_path",
+      description: "Absolute file path.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "offset",
+      description: "Zero-based starting line; omit for the beginning.",
+      required: false,
+      schema: { type: "number" },
+    },
+    {
+      name: "limit",
+      description: "Maximum lines to return; omit for the configured cap.",
+      required: false,
+      schema: { type: "number" },
+    },
+  ],
+  validate: async () => true,
+  handler: readFileHandler,
+};
+
+export const writeAction: Action = {
+  name: "WRITE",
+  ...DIRECT_FILE_GATE,
+  description:
+    "Write complete text to a file, creating parent directories when allowed.",
+  parameters: [
+    {
+      name: "file_path",
+      description: "Absolute file path.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "content",
+      description: "Complete replacement file content.",
+      required: true,
+      schema: { type: "string" },
+    },
+  ],
+  validate: async () => true,
+  handler: writeFileHandler,
+};
+
+export const editAction: Action = {
+  name: "EDIT",
+  ...DIRECT_FILE_GATE,
+  description:
+    "Replace an exact string in a previously read file; fails on stale or ambiguous edits.",
+  parameters: [
+    {
+      name: "file_path",
+      description: "Absolute file path.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "old_string",
+      description: "Exact text currently present in the file.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "new_string",
+      description: "Exact replacement text.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "replace_all",
+      description: "Replace every exact match; defaults to false.",
+      required: false,
+      schema: { type: "boolean" },
+    },
+  ],
+  validate: async () => true,
+  handler: editFileHandler,
+};

--- a/plugins/plugin-coding-tools/src/actions/index.ts
+++ b/plugins/plugin-coding-tools/src/actions/index.ts
@@ -1,5 +1,6 @@
 /** Re-exports the FILE/SHELL/WORKTREE actions and their per-operation handlers. */
 export { shellAction } from "./bash.js";
+export { editAction, readAction, writeAction } from "./direct-file-actions.js";
 export { editFileHandler } from "./edit.js";
 export { enterWorktreeHandler } from "./enter-worktree.js";
 export { exitWorktreeHandler } from "./exit-worktree.js";

--- a/plugins/plugin-coding-tools/src/actions/read.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.test.ts
@@ -453,6 +453,78 @@ describe("READ", () => {
     }
   });
 
+  it("streams a bounded line page from a file larger than the page budget", async () => {
+    const env2 = await setupEnv("read-big-line-window", {
+      extraSettings: { CODING_TOOLS_MAX_FILE_SIZE_BYTES: 64 },
+    });
+    try {
+      const file = path.join(env2.tmpDir, "big-lines.txt");
+      const lines = Array.from({ length: 100 }, (_, index) => `line-${index}`);
+      await fs.writeFile(file, lines.join("\n"), "utf8");
+      const first = await readFileHandler(
+        env2.runtime,
+        env2.message,
+        undefined,
+        { parameters: { file_path: file, unit: "line", limit: 1 } },
+      );
+      const revision = (
+        (first.data as Record<string, unknown>).readView as {
+          reference: { revision: string };
+        }
+      ).reference.revision;
+
+      const result = await readFileHandler(
+        env2.runtime,
+        env2.message,
+        undefined,
+        {
+          parameters: {
+            file_path: file,
+            unit: "line",
+            offset: 40,
+            limit: 3,
+            expectedRevision: revision,
+          },
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toBe("line-40\nline-41\nline-42\n");
+      const data = result.data as Record<string, unknown>;
+      expect(
+        (data.readView as { slice: { range: unknown } }).slice.range,
+      ).toMatchObject({ unit: "line", start: 40, end: 43 });
+      expect(
+        (data.diagnostics as { bytesReturned: number }).bytesReturned,
+      ).toBe(Buffer.byteLength(result.text ?? ""));
+      expect(env2.fileState.get("test-room", file)).toBeDefined();
+    } finally {
+      await env2.cleanup();
+    }
+  });
+
+  it("rejects a requested line page whose selected content exceeds the byte cap", async () => {
+    const env2 = await setupEnv("read-big-line-window-cap", {
+      extraSettings: { CODING_TOOLS_MAX_FILE_SIZE_BYTES: 32 },
+    });
+    try {
+      const file = path.join(env2.tmpDir, "huge-line-page.txt");
+      await fs.writeFile(file, `${"x".repeat(128)}\ntail`, "utf8");
+      const result = await readFileHandler(
+        env2.runtime,
+        env2.message,
+        undefined,
+        { parameters: { file_path: file, unit: "line", limit: 1 } },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("line window exceeds 32 bytes");
+      expect(result.text).toContain("retry with unit=byte");
+    } finally {
+      await env2.cleanup();
+    }
+  });
+
   it("round-trips Unicode byte pages and rejects stale continuations", async () => {
     const file = path.join(env.tmpDir, "unicode.txt");
     await fs.writeFile(file, "ab😀cdéfg", "utf8");

--- a/plugins/plugin-coding-tools/src/index.ts
+++ b/plugins/plugin-coding-tools/src/index.ts
@@ -13,11 +13,14 @@
  */
 import type { Plugin } from "@elizaos/core";
 import {
+  editAction,
   fileAction,
+  readAction,
   shellAction,
   webFetchAction,
   webSearchAction,
   worktreeAction,
+  writeAction,
 } from "./actions/index.js";
 import { availableToolsProvider } from "./providers/available-tools.js";
 import {
@@ -71,6 +74,9 @@ export const codingToolsPlugin: Plugin = {
   providers: [availableToolsProvider, shellHistoryProvider],
   actions: [
     fileAction,
+    readAction,
+    writeAction,
+    editAction,
     shellAction,
     worktreeAction,
     webFetchAction,

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -5,7 +5,12 @@
  * coerce loosely-typed handler options into validated values. Keeps every action's
  * success/failure shape identical.
  */
-import type { ActionResult, IAgentRuntime } from "@elizaos/core";
+import {
+  type ActionResult,
+  type IAgentRuntime,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   type ActionResultData,
   FAILURE_TEXT_PREFIX,
@@ -52,6 +57,26 @@ export function capTranscriptForChat(text: string, maxChars = 1500): string {
     .replace(/\n$/, "");
   const omitted = middle.split("\n").length;
   return `${headPart}\n… [${omitted} lines omitted — ask to see more] …\n${tailPart}`;
+}
+
+/**
+ * Keep a model-facing tool result within a character budget without splitting
+ * UTF-16 surrogate pairs. The omitted count describes the sanitized string so
+ * malformed provider or process output cannot leak invalid Unicode downstream.
+ */
+export function truncate(
+  text: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  const sanitized = toWellFormedUnicode(text);
+  if (sanitized.length <= maxChars) {
+    return { text: sanitized, truncated: false };
+  }
+  const prefix = truncateWellFormed(sanitized, Math.max(0, maxChars));
+  return {
+    text: `${prefix}\n… [${sanitized.length - prefix.length} more chars omitted]`,
+    truncated: true,
+  };
 }
 
 export function failureToActionResult(

--- a/plugins/plugin-coding-tools/src/providers/available-tools.ts
+++ b/plugins/plugin-coding-tools/src/providers/available-tools.ts
@@ -14,6 +14,9 @@ import { CODING_TOOLS_CONTEXTS } from "../types.js";
 
 const TOOL_NAMES = [
   "FILE",
+  "READ",
+  "WRITE",
+  "EDIT",
   "SHELL",
   "WEB_FETCH",
   "WEB_SEARCH",
@@ -41,7 +44,7 @@ export const availableToolsProvider: Provider = {
     const lines = [
       "# Native coding tools",
       "",
-      "FILE reads/writes/searches, SHELL runs commands plus background sessions, WEB_FETCH reads public HTTPS pages, WEB_SEARCH researches the web, and WORKTREE manages git worktrees.",
+      "READ, WRITE, and EDIT provide focused file operations; FILE retains grep/glob/list and compatibility operations. SHELL runs commands plus background sessions, WEB_FETCH reads public HTTPS pages, WEB_SEARCH researches the web, and WORKTREE manages git worktrees.",
       "Use absolute workspace paths unless a tool says it defaults to session cwd. Configured private/system paths are blocked.",
       "SHELL background subactions: start_background returns a stable handle; poll_background reads complete incremental stdout/stderr with offsets and rejects if the complete-capture ceiling is exceeded; write_background sends stdin; kill_background terminates; list_background shows sessions.",
       "",

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -105,11 +105,11 @@ describePosixShell("shell plugin real local integration", () => {
       "}, 50);",
     ].join("");
     const result = await service.executeCommand(
-      `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+      `node -e ${JSON.stringify(script)}`,
       "room-utf8",
     );
 
-    expect(result.success).toBe(true);
+    expect(result.success, JSON.stringify(result)).toBe(true);
     expect(result.stdout).toBe("\u4f60");
     expect(result.stderr).toBe("\u4f60");
   });
@@ -135,6 +135,37 @@ describePosixShell("shell plugin real local integration", () => {
 
     expect(JSON.stringify(history)).not.toContain(secret);
     expect(JSON.stringify(provider)).not.toContain(secret);
+  });
+
+  it("bounds provider history while retaining complete service history and output", async () => {
+    const largeOutput = "z".repeat(5_000);
+    await service.executeCommand(
+      `printf '%s' '${largeOutput}'`,
+      "room-bounded-history",
+    );
+    for (let index = 1; index <= 10; index += 1) {
+      await service.executeCommand(
+        `printf 'command-${index}'`,
+        "room-bounded-history",
+      );
+    }
+
+    const stored = service.getCommandHistory("room-bounded-history");
+    expect(stored).toHaveLength(11);
+    expect(stored[0]?.stdout).toContain(largeOutput);
+    expect(stored[0]?.stdout.length).toBeGreaterThanOrEqual(largeOutput.length);
+
+    const provider = await shellHistoryProvider.get(
+      runtime,
+      { roomId: "room-bounded-history", agentId: "agent-1" } as never,
+      {} as never,
+    );
+
+    expect(provider.text).not.toContain(largeOutput);
+    expect(provider.text).toContain("command-1");
+    expect(provider.text).toContain("command-10");
+    expect(provider.data?.historyCount).toBe(10);
+    expect(provider.text?.length).toBeLessThanOrEqual(24_000);
   });
 
   it("fails closed when a command tries to escape the allowed directory", async () => {

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Verifies that SHELL_HISTORY projects a bounded recent window without mutating
+ * the ShellService-owned full command history.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ShellService } from "../services/shellService";
+import type { CommandHistoryEntry } from "../types";
+import { shellHistoryProvider } from "./shellHistoryProvider";
+
+describe("SHELL_HISTORY provider", () => {
+  it("caps recent output while leaving complete service history intact", async () => {
+    const largeOutput = "z".repeat(5_000);
+    const fullHistory: CommandHistoryEntry[] = Array.from(
+      { length: 12 },
+      (_, index) => ({
+        command: `command-${index}`,
+        stdout: index === 11 ? largeOutput : `output-${index}`,
+        stderr: "",
+        exitCode: 0,
+        timestamp: Date.UTC(2026, 0, 1, 0, index),
+        workingDirectory: "/workspace",
+      }),
+    );
+    const getCommandHistory = vi.fn(
+      (_conversationId: string, limit?: number) =>
+        limit ? fullHistory.slice(-limit) : fullHistory,
+    );
+    const service = {
+      getCommandHistory,
+      getCurrentDirectory: () => "/workspace",
+      getAllowedDirectory: () => "/workspace",
+    } as unknown as ShellService;
+    const runtime = {
+      character: {},
+      getService: (name: string) => (name === "shell" ? service : null),
+      redactSecrets: (text: string) => text,
+    } as unknown as IAgentRuntime;
+
+    const result = await shellHistoryProvider.get(
+      runtime,
+      { roomId: "room-bounded-history", agentId: "agent-1" } as never,
+      {} as never,
+    );
+
+    expect(getCommandHistory).toHaveBeenCalledWith("room-bounded-history", 10);
+    expect(fullHistory).toHaveLength(12);
+    expect(fullHistory[11]?.stdout).toBe(largeOutput);
+    expect(result.text).not.toContain("command-0");
+    expect(result.text).not.toMatch(/command-1(?:\D|$)/);
+    expect(result.text).toContain("command-2");
+    expect(result.text).toContain("command-11");
+    expect(result.text).not.toContain(largeOutput);
+    expect(result.text).toContain("characters omitted");
+    expect(result.text?.length).toBeLessThanOrEqual(24_000);
+    expect(result.data?.historyCount).toBe(10);
+  });
+});

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
@@ -20,6 +20,35 @@ import type { CommandHistoryEntry, FileOperation } from "../types";
 
 const spec = requireProviderSpec("SHELL_HISTORY");
 
+const SHELL_HISTORY_ENTRY_LIMIT = 10;
+const SHELL_HISTORY_STREAM_CHAR_LIMIT = 2_000;
+const SHELL_HISTORY_ENTRY_CHAR_LIMIT = 5_000;
+const SHELL_HISTORY_TEXT_CHAR_LIMIT = 24_000;
+const SHELL_HISTORY_FILE_OPERATION_LIMIT = 20;
+
+function capHistoryText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const marker = `\n… [${text.length - maxChars} characters omitted] …\n`;
+  const remaining = Math.max(0, maxChars - marker.length);
+  const head = Math.floor(remaining * 0.6);
+  return `${text.slice(0, head)}${marker}${text.slice(-(remaining - head))}`;
+}
+
+function renderFileOperation(
+  runtime: IAgentRuntime,
+  op: FileOperation,
+): string {
+  const target = capHistoryText(redactShellText(runtime, op.target), 500);
+  if (op.secondaryTarget) {
+    const secondary = capHistoryText(
+      redactShellText(runtime, op.secondaryTarget),
+      500,
+    );
+    return `- ${op.type}: ${target} → ${secondary}`;
+  }
+  return `- ${op.type}: ${target}`;
+}
+
 export const shellHistoryProvider: Provider = {
   name: spec.name,
   description:
@@ -60,7 +89,12 @@ export const shellHistoryProvider: Provider = {
           data: { historyCount: 0, cwd: "N/A", allowedDir: "N/A" },
         };
       }
-      const history = shellService.getCommandHistory(conversationId);
+      // Bound only the provider projection. ShellService retains the complete
+      // history and full command output for explicit history inspection.
+      const history = shellService.getCommandHistory(
+        conversationId,
+        SHELL_HISTORY_ENTRY_LIMIT,
+      );
       const cwd = redactShellText(
         runtime,
         shellService.getCurrentDirectory(conversationId),
@@ -74,8 +108,14 @@ export const shellHistoryProvider: Provider = {
       if (history.length > 0) {
         historyText = history
           .map((entry: CommandHistoryEntry) => {
-            const stdout = redactShellText(runtime, entry.stdout ?? "");
-            const stderr = redactShellText(runtime, entry.stderr ?? "");
+            const stdout = capHistoryText(
+              redactShellText(runtime, entry.stdout ?? ""),
+              SHELL_HISTORY_STREAM_CHAR_LIMIT,
+            );
+            const stderr = capHistoryText(
+              redactShellText(runtime, entry.stderr ?? ""),
+              SHELL_HISTORY_STREAM_CHAR_LIMIT,
+            );
             let entryStr = redactShellText(
               runtime,
               `[${new Date(entry.timestamp).toISOString()}] ${entry.workingDirectory}> ${entry.command}`,
@@ -102,9 +142,13 @@ export const shellHistoryProvider: Provider = {
               });
             }
 
-            return entryStr;
+            return capHistoryText(entryStr, SHELL_HISTORY_ENTRY_CHAR_LIMIT);
           })
           .join("\n\n");
+        historyText = capHistoryText(
+          historyText,
+          SHELL_HISTORY_TEXT_CHAR_LIMIT,
+        );
       }
 
       const recentFileOps = history
@@ -112,7 +156,8 @@ export const shellHistoryProvider: Provider = {
           (entry: CommandHistoryEntry) =>
             entry.fileOperations && entry.fileOperations.length > 0,
         )
-        .flatMap((entry: CommandHistoryEntry) => entry.fileOperations ?? []);
+        .flatMap((entry: CommandHistoryEntry) => entry.fileOperations ?? [])
+        .slice(-SHELL_HISTORY_FILE_OPERATION_LIMIT);
 
       let fileOpsText = "";
       if (recentFileOps.length > 0) {
@@ -121,20 +166,18 @@ export const shellHistoryProvider: Provider = {
           addHeader(
             "# Recent File Operations",
             recentFileOps
-              .map((op: FileOperation) => {
-                if (op.secondaryTarget) {
-                  return `- ${op.type}: ${redactShellText(runtime, op.target)} → ${redactShellText(runtime, op.secondaryTarget)}`;
-                }
-                return `- ${op.type}: ${redactShellText(runtime, op.target)}`;
-              })
+              .map((op: FileOperation) => renderFileOperation(runtime, op))
               .join("\n"),
           );
       }
 
-      const text = `Current Directory: ${cwd}
+      const text = capHistoryText(
+        `Current Directory: ${cwd}
 Allowed Directory: ${allowedDir}
 
-${addHeader("# Shell History", historyText)}${fileOpsText}`;
+${addHeader("# Shell History", historyText)}${fileOpsText}`,
+        SHELL_HISTORY_TEXT_CHAR_LIMIT,
+      );
 
       return {
         values: {

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -57,7 +57,14 @@ beforeEach(() => {
 vi.mock("ai", () => ({
   generateText: aiMocks.generateText,
   streamText: aiMocks.streamText,
-  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  // Mirror AI SDK v6's accessor-backed schema wrapper. The provider transport
+  // owns this object; Eliza must sanitize the plain schema before wrapping and
+  // must not deep-walk the wrapper afterward.
+  jsonSchema: (schema: unknown) =>
+    Object.defineProperty({}, "jsonSchema", {
+      enumerable: true,
+      get: () => schema,
+    }),
   Output: {
     object: ({
       schema,
@@ -686,6 +693,41 @@ describe("OpenAI native text plumbing", () => {
       },
     });
   }, 180_000);
+
+  it("reaches the response-handler transport with accessor-backed native tool schemas", async () => {
+    aiMocks.generateText.mockResolvedValue({
+      text: "ok",
+      finishReason: "stop",
+      usage: { inputTokens: 2, outputTokens: 1 },
+    });
+
+    const { handleResponseHandler } = await import("../models/text");
+    await handleResponseHandler(createRuntime(), {
+      messages: [{ role: "user", content: "decide whether to respond" }],
+      tools: [
+        {
+          name: "HANDLE_RESPONSE",
+          description: "Return the turn decision.",
+          parameters: {
+            type: "object",
+            properties: { action: { type: "string" } },
+            required: ["action"],
+          },
+        },
+      ],
+    } as never);
+
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+    const call = aiMocks.generateText.mock.calls[0][0] as {
+      tools: Record<string, { inputSchema: { jsonSchema: unknown } }>;
+    };
+    expect(call.tools.HANDLE_RESPONSE.inputSchema.jsonSchema).toMatchObject({
+      type: "object",
+      properties: { action: { type: "string" } },
+      required: ["action"],
+      additionalProperties: false,
+    });
+  });
 
   it("honors a per-call model override before slot defaults", async () => {
     aiMocks.generateText.mockResolvedValue({


### PR DESCRIPTION
## Summary

- add an explicit per-turn `codingMode` that enters the planner directly and avoids the ordinary response-handler/evaluator LLM round trip while leaving normal chat unchanged
- give coding turns a compact stable prompt, focused READ/WRITE/EDIT/SHELL surface, bounded tool output, and mutation-followed-by-verification completion rules
- make the code TUI, CLI, and ACP adapter propagate coding mode and reject synthetic/intermediate failure text as success
- harden orchestrator completion verification: verifier outages are inconclusive and retryable, criteria-free tasks can clear deterministic gates, and credential redemption reauthorizes immediately before plaintext disclosure
- retain the newer upstream resumable, revision-locked bounded READ implementation while adding oversized-file regressions and bounded shell-history projection

Progresses #24299. This PR deliberately does **not** claim full Pi parity: the trace-backed mini-benchmark found remaining model-policy and terminal-result gaps described below.

## Trace-backed benchmark

Two Flipt tasks from the checked-in SWE-bench Pro corpus were used (2/731, 0.27%). Full local trajectories were retained outside Git under `/private/tmp/coding-parity-runs/`.

| Agent / run | Task | LLM calls | Prompt/input tokens | Cache read | Cache hit | Mean context | Result |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Pi v0.84.2 | whitespace parser | 11 | 15,897 uncached | 47,744 | 75.0% | 5.8k | behavior pass |
| Eliza optimized v5 | whitespace parser | 5 | 40,299 total | 33,024 | 82.0% | 8.1k | fail: referenced an undefined helper |
| Eliza diagnostic v7 | whitespace parser | 22 | 616,979 total | 577,408 | 93.6% | 28.0k | code/tests passed; terminal result falsely failed |
| Codex | whitespace parser | 11 | 382,739 total | 346,368 | 90.5% | 34.8k | behavior pass |
| Pi v0.84.2 | env substitution | 11 | 23,344 uncached | 53,504 | 69.6% | 7.0k | fail; source corrupted |
| Eliza diagnostic v3 | env substitution | 23 | 1,464,638 total | 1,393,792 | 95.2% | 63.7k | token-cap/ungrounded terminal failure |
| Codex | env substitution | 29 | 1,316,555 total | 1,238,784 | 94.1% | 45.4k | behavior pass |

The official hidden patches for both sampled tasks were internally inconsistent with their fixtures, so the table reports independent behavior checks separately from the official grader. Claude Code could not be run because the installed CLI is not authenticated (`claude auth status`: `loggedIn: false`); no secret was requested or stored.

## Findings represented by this patch

- Eliza can reproduce Pi's minimal loop as a configured execution lane, but the generic chat pipeline is not an efficient substitute for it.
- Eliza's plugin/services/evaluator architecture is an advantage for durable tasks, secure credentials, typed completion, and review, provided those layers do not add chat-only calls or fabricate success.
- Completion must be grounded in a successful verification command after the latest mutation. Intermediate tool failures must not poison a later verified result, and intermediate tool output must never become the user-facing terminal answer.
- Orchestrator verifier infrastructure failure is not worker failure and must not consume worker attempts.
- Pi itself has no native ACP implementation; `pi-acp` is an adapter. Current OpenClaw has a native runtime and reaches Pi externally through `acpx -> pi-acp`, so parity should be measured at the typed task/result boundary rather than inferred from the runtime name.

## Verification

- core focused planner/message tests: 176 passed; core typecheck passed
- code client: 6 passed; typecheck and lint passed
- coding tools focused/unit/real shell: 32 passed after rebase; additional rebased READ/history suite: 28 passed; typecheck and lint passed
- OpenAI native plumbing: 35 passed; typecheck and lint passed
- orchestrator credential + verifier suites: 62 passed; package typecheck passed; changed-file lint clean
- guide parity: 160 `CLAUDE.md` / `AGENTS.md` pairs passed
- `git diff --check` passed; branch rebased onto current `origin/develop`

Root `bun run verify` reached the workspace typecheck/lint phase and failed only on exact-head formatting errors in untouched core files (`src/features/documents/service-list.test.ts`, `src/utils/well-formed.ts`, and `src/validation/secrets.ts`). The full orchestrator auto-goal file is independently blocked before tests by its existing import of removed `MAX_ATTEMPT_REFLECTIONS`; the changed verifier suites pass.

## Remaining acceptance work

- authenticate Claude Code locally and run the same two tasks
- rerun the final rebased Eliza lane end-to-end on a stable coding-capable model; the iterative traces prove the fixes' motivating failures but not final benchmark parity
- persist complete truncated synchronous shell output to an artifact handle, matching Pi's temp-file behavior
- add a durable typed child-result envelope (state, evidence, blocker/question, lineage, trace ID) and verifier-only retry scheduling
- expand to a statistically meaningful benchmark slice before any “on par” claim
