### PR TITLE
fix(discord): drain overflow drafts on abort

### DIFF
--- a/plugins/plugin-discord/__tests__/draft-stream.test.ts
+++ b/plugins/plugin-discord/__tests__/draft-stream.test.ts
@@ -6,6 +6,7 @@
  */
 import type {
 	ActionRowBuilder,
+	Message as DiscordMessage,
 	MessageActionRowComponentBuilder,
 	TextChannel,
 } from "discord.js";
@@ -129,6 +130,43 @@ describe("draft-stream finalize components (#14527)", () => {
 		expect(deletions).toEqual(["late-snapshot"]);
 		expect(controller.isDone()).toBe(true);
 		vi.useRealTimers();
+	});
+
+	it("deletes an overflow snapshot whose send settles during discard", async () => {
+		let sendCount = 0;
+		let resolveOverflow!: (message: DiscordMessage) => void;
+		const deletions: string[] = [];
+		const message = (id: string) =>
+			({
+				id,
+				delete: async () => {
+					deletions.push(id);
+				},
+			}) as DiscordMessage;
+		const channel = {
+			send: () => {
+				sendCount += 1;
+				if (sendCount === 1) {
+					return Promise.resolve(message("first-chunk"));
+				}
+				return new Promise<DiscordMessage>((resolve) => {
+					resolveOverflow = resolve;
+				});
+			},
+		} as unknown as TextChannel;
+		const controller = createDraftStreamController({ maxChars: 24 });
+		await controller.start(channel);
+
+		const finalize = controller.finalize(
+			"First chunk is complete. Second chunk is still being delivered.",
+		);
+		await vi.waitFor(() => expect(sendCount).toBe(2));
+		const discard = controller.discard();
+		resolveOverflow(message("overflow-chunk"));
+
+		await Promise.all([finalize, discard]);
+		expect(deletions).toEqual(["overflow-chunk", "first-chunk"]);
+		expect(controller.isDone()).toBe(true);
 	});
 
 	it("attaches components to the finalized message", async () => {

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -68,7 +68,7 @@ export function createDraftStreamController(
 	let throttleTimer: ReturnType<typeof setTimeout> | null = null;
 	let started = false;
 	let done = false;
-	const activeSnapshots = new Set<Promise<boolean>>();
+	const activeSnapshots = new Set<Promise<unknown>>();
 
 	const clearThrottle = () => {
 		if (throttleTimer) {
@@ -161,17 +161,20 @@ export function createDraftStreamController(
 		}
 	};
 
-	const sendTrackedSnapshot = (
-		text: string,
-		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
-	): Promise<boolean> => {
-		const snapshot = sendSnapshot(text, components);
+	const trackActiveSnapshot = <T>(snapshot: Promise<T>): Promise<T> => {
 		activeSnapshots.add(snapshot);
 		void snapshot.then(
 			() => activeSnapshots.delete(snapshot),
 			() => activeSnapshots.delete(snapshot),
 		);
 		return snapshot;
+	};
+
+	const sendTrackedSnapshot = (
+		text: string,
+		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
+	): Promise<boolean> => {
+		return trackActiveSnapshot(sendSnapshot(text, components));
 	};
 
 	const waitForActiveSnapshots = async (): Promise<void> => {
@@ -307,19 +310,24 @@ export function createDraftStreamController(
 			}
 			try {
 				const isLastChunk = remaining.length === 0;
-				const overflowMessage = await channel.send({
-					content: chunk,
-					...(isLastChunk && components && components.length > 0
-						? { components }
-						: {}),
-					...(draftReplyToMessageId && draftReplyToMode === "all"
-						? {
-								reply: { messageReference: draftReplyToMessageId },
-							}
-						: {}),
-				});
-				lastSentMessage = overflowMessage;
-				sentMessages.push(overflowMessage);
+				await trackActiveSnapshot(
+					channel
+						.send({
+							content: chunk,
+							...(isLastChunk && components && components.length > 0
+								? { components }
+								: {}),
+							...(draftReplyToMessageId && draftReplyToMode === "all"
+								? {
+										reply: { messageReference: draftReplyToMessageId },
+									}
+								: {}),
+						})
+						.then((overflowMessage) => {
+							lastSentMessage = overflowMessage;
+							sentMessages.push(overflowMessage);
+						}),
+				);
 			} catch (error) {
 				warn(
 					`draft-stream: overflow send failed: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary

- track multi-message overflow sends in the same active draft set as initial/final snapshots
- keep each overflow tracked until its Discord message is appended to the deletion list
- prove a concurrent designed-abort discard waits for and deletes both the first and late overflow chunks

This is the narrow post-merge teardown correction found while validating #24258. Reply modes, chunk payloads, and final-component placement are unchanged.

Fixes #24333

## Verification

- `bun vitest run plugins/plugin-discord/__tests__/draft-stream.test.ts` (8/8)
- `bun run --cwd plugins/plugin-discord typecheck`
- `bun x biome check plugins/plugin-discord/draft-stream.ts plugins/plugin-discord/__tests__/draft-stream.test.ts`
- `git diff --check`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: self-reported