### PR TITLE
feat(core): preserve progressive content across projections and archives

### DIFF
--- a/docs/design/context-content/progressive-content-access-research-and-test-report.md
+++ b/docs/design/context-content/progressive-content-access-research-and-test-report.md
@@ -33,6 +33,19 @@ The first 1,000-operation 10 MiB FILE benchmark was a calibration run, not a CI 
 
 Deliberate remaining boundaries are explicit: legacy prompt builders using `formatActionResultsForPrompt` are not yet routed through the final-request budget, and there is no private shell-output spill lifecycle, generic content URI/action, restored conversation compaction or manifest, context-inspector UI, live-provider trajectory, or soak/Postgres matrix in the keyless PR lane. Stored memory and attachment reads still materialize their existing database row, Gmail fetches the provider body before slicing, and richer PDF/DOCX/OCR/MIME corpus producers are follow-up adapter lanes. These are not described as complete central-projection or bounded-source-I/O proof.
 
+### Second-pass completion audit
+
+The post-merge audit found four priority corrections for M4. First, the native trajectory projector was not yet the only model-facing ActionResult serializer: ActionState, post-turn evaluation, reflection, message state, and grounded action replies retained full-body bypasses. Second, no runtime-derived content manifest existed for an archive or future compaction seam. Third, multi-attachment results retained only the first `ReadView`, and oversized pinned documents could disappear without an item-specific identity/reference. Fourth, the FILE benchmark and deterministic action scenario were useful but materially narrower than the goal's performance and autonomous-planning acceptance.
+
+The M4 follow-up therefore stays deliberately small:
+
+- Share one feature-gated legacy/native ActionResult projection implementation, with `promptData` replacing `data` and typed failure for nonrecoverable overflow.
+- Add a versioned, strict, content-free reference/range manifest derived identically from active and archived trajectory steps; do not restore automatic compaction or add storage.
+- Retain every attachment `ReadView` and give every oversized pinned document a fair excerpt plus its document identity/reference.
+- Keep private tool-output spill in M5, after authorization, retention, atomic publication, redaction, and reference-aware GC over the existing content-addressed byte layer are approved.
+
+This does not close the full goal. The completion audit still requires truly bounded document/message/attachment storage reads, measured Gmail acquisition caching, room-scoped manifest persistence and restart readback, deterministic autonomous planning, credentialed live-model trials, real-format corpora, context-inspector E2E, real Postgres, mutation killing, and soak/performance evidence.
+
 ## Method and limits
 
 - Audited maintained source and tests in core, agent, app-core, coding tools, documents, Google Workspace/inbox, scenario runner, evidence, and root test orchestration.
@@ -227,6 +240,17 @@ Concurrency cases include many readers at one revision; writer/continuation race
 - Record distributions, not averages alone.
 - Compare against the previous accepted baseline; do not hard-code speculative universal milliseconds in the initial PR.
 - Establish budgets after at least five stable repetitions on a pinned CI host. Report p99 only with at least 1,000 measured local operations; otherwise label it insufficient-sample.
+
+The second pass identified two measurement corrections. The measured child currently retains its generated source buffer, so it cannot prove source-size-independent RSS; scale runs must generate/write outside the measured reader process or release the generator buffer before the baseline sample. Also, a 1,000-operation run leaves 999 warm samples after separating the cold sample, while the current percentile helper reports null below 1,000. Percentiles must be defined for every nonempty sample set, and the report must record cold sample count separately from warm p50/p95/p99.
+
+| Lane | Required proof |
+| --- | --- |
+| PR deterministic | Contract/property/conformance tests, tiny real-format goldens, PGLite, strict fixture planner, mutation catalog, source-I/O counters |
+| Post-merge | Fresh-process restart/readback, real local API/UI, generated medium corpus, concurrency 1/8/32/64, five pinned benchmark repetitions |
+| Nightly/release | Real Postgres, full format/extraction shards, provider-qualified live models, fault/concurrency matrix, storage/cleanup evidence |
+| Scheduled soak | At least 100,000 mixed operations or six hours, positive leaking control, RSS/heap/external/FD/DB/WAL series, abort/revoke/mutate/restart/expire cycles |
+
+Every lane records generator schema/revision/seed/manifest SHA, exact commit, runtime versions, machine/OS/CPU/RAM, database/provider, sample count, concurrency, warm/cold state, latency distribution, throughput, memory series, source bytes, serialized bytes, cleanup inventory, and failures. A selected live lane treats missing credentials as failure, while keyless PR lanes remain deterministic and provider-free.
 - PR gates catch large regressions; nightly lanes use tighter statistical comparisons and larger corpora.
 
 Initial invariant budgets, which are architecture-independent:

--- a/docs/design/context-content/progressive-content-access-spec.md
+++ b/docs/design/context-content/progressive-content-access-spec.md
@@ -1,6 +1,6 @@
 # Progressive content access specification
 
-Status: experimental implementation candidate; projection is opt-in
+Status: experimental implementation candidate; projection is opt-in; M4 follow-up under review
 
 Date: 2026-08-21
 
@@ -138,6 +138,8 @@ Budgets are computed after final serialization, including JSON, line-number gutt
 
 The current experimental implementation applies this policy to native trajectory planner/evaluator rendering. Legacy prompt builders that serialize `ActionResult` values directly must migrate to the same final-request projector before the feature can be described as central across all model-facing paths or enabled by default.
 
+The M4 follow-up uses `renderActionResultsForModel` as the migration bridge for legacy prompt builders. When the rollout flag is enabled, ActionState, post-turn evaluation, reflection, message-state injection, and grounded action replies apply the same `promptData`-over-`data` rule and omit only validated recoverable pages. The legacy display formatter remains the disabled-rollout compatibility path. Native planner requests reject an over-budget post-projection request explicitly. Per-provider planner failover rerendering and tokenizer-backed final-wire counts remain rollout gates; the runtime must not truncate an opaque prompt after typed ActionResults have been serialized.
+
 ### 6.2 Per-result and aggregate policy
 
 - Apply a per-result inline budget.
@@ -224,6 +226,8 @@ interface CompactionContentManifest {
 ```
 
 The runtime derives this from the access ledger and actual mutations. It is schema-validated, redacted, size-bounded, and authorization-covered. Recoverability must not depend on prose mentioning every reference.
+
+The M4 follow-up introduces the versioned strict schema and a deterministic trajectory-derived snapshot across active and archived steps. The snapshot rejects unknown fields, native paths, revision conflicts, excessive references/ranges/processes, and oversized serialized manifests. It does not grant access, extend retention, restore removed automatic compaction, or claim restart durability. Room-scoped capture, persistence in existing session-summary metadata, reauthorization, and fresh-process readback remain required before compaction continuity is complete.
 
 ## 9. Security and failure semantics
 

--- a/packages/agent/src/actions/grounded-action-reply.context-preservation.test.ts
+++ b/packages/agent/src/actions/grounded-action-reply.context-preservation.test.ts
@@ -4,6 +4,8 @@
  * covers context serialization and recent-action rendering, not a replica of
  * a private helper.
  */
+
+import { createHash } from "node:crypto";
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { renderGroundedActionReply } from "./grounded-action-reply.ts";
@@ -27,6 +29,7 @@ function isWellFormed(value: string): boolean {
 async function capturePrompt(options: {
   context?: Record<string, unknown>;
   state?: State;
+  projectionEnabled?: boolean;
 }): Promise<string> {
   let prompt = "";
   const runtime = {
@@ -35,6 +38,7 @@ async function capturePrompt(options: {
       return "Done.";
     }),
     getMemories: vi.fn(async () => []),
+    getSetting: vi.fn(() => options.projectionEnabled ?? false),
     character: { name: "TestAgent" },
   } as unknown as IAgentRuntime;
 
@@ -103,5 +107,43 @@ describe("grounded reply prompt Unicode preservation", () => {
 
     expect(contextLine).toContain("🦊");
     expect(isWellFormed(contextLine ?? "")).toBe(true);
+  });
+
+  it("keeps a recoverable reference but removes its page from the model prompt", async () => {
+    const page = `LATE_PAGE_CANARY_${"x".repeat(20_000)}`;
+    const state = {
+      data: {
+        actionResults: [
+          {
+            success: true,
+            text: page,
+            data: { actionName: "FILE", rawBody: page },
+            promptData: {
+              actionName: "FILE",
+              readView: {
+                reference: {
+                  kind: "file",
+                  ref: "opaque-file",
+                  revision: "r1",
+                },
+                slice: {
+                  range: { unit: "byte", start: 0, end: 10, total: 20 },
+                  hasPrevious: false,
+                  hasMore: true,
+                  nextOffset: 10,
+                  revision: "r1",
+                  completeness: "partial-recoverable",
+                  sliceSha256: createHash("sha256").update(page).digest("hex"),
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as State;
+
+    const prompt = await capturePrompt({ state, projectionEnabled: true });
+    expect(prompt).toContain("opaque-file");
+    expect(prompt).not.toContain("LATE_PAGE_CANARY");
   });
 });

--- a/packages/agent/src/actions/grounded-action-reply.ts
+++ b/packages/agent/src/actions/grounded-action-reply.ts
@@ -9,8 +9,10 @@
 import type { ActionResult, IAgentRuntime, Memory, State } from "@elizaos/core";
 import {
   getTrajectoryContext,
+  isProgressiveContentProjectionEnabled,
   ModelType,
   parseJSONObjectFromText,
+  renderActionResultsForModel,
   toWellFormedUnicode,
 } from "@elizaos/core";
 import { asRecord } from "@elizaos/shared";
@@ -134,13 +136,20 @@ export function extractActionResultsFromState(
   );
 }
 
-function summarizeActionResult(result: ActionResult): ActionHistoryItem | null {
+function summarizeActionResult(
+  result: ActionResult,
+  projectionEnabled = false,
+): ActionHistoryItem | null {
   const data = asRecord(result.data);
   const actionName =
     (typeof data?.actionName === "string" && data.actionName.trim()) ||
     "ACTION";
-  const resultText =
-    typeof result.text === "string" && result.text.trim().length > 0
+  const resultText = projectionEnabled
+    ? renderActionResultsForModel([result], {
+        header: "",
+        omitRecoverableText: true,
+      }).text
+    : typeof result.text === "string" && result.text.trim().length > 0
       ? result.text.trim()
       : "";
   const title =
@@ -168,9 +177,10 @@ function summarizeActionResult(result: ActionResult): ActionHistoryItem | null {
 export function summarizeRecentActionHistory(
   state: State | undefined,
   limit = 4,
+  projectionEnabled = false,
 ): string[] {
   const summarized = extractActionResultsFromState(state)
-    .map((result) => summarizeActionResult(result))
+    .map((result) => summarizeActionResult(result, projectionEnabled))
     .filter((item): item is ActionHistoryItem => item !== null);
   const deduped: string[] = [];
   const seen = new Set<string>();
@@ -302,7 +312,11 @@ export async function renderGroundedActionReply(
     message: args.message,
     state: args.state,
   });
-  const recentActionHistory = summarizeRecentActionHistory(args.state, 4);
+  const recentActionHistory = summarizeRecentActionHistory(
+    args.state,
+    4,
+    isProgressiveContentProjectionEnabled(args.runtime),
+  );
   const trajectorySummary = await summarizeActiveTrajectory(args.runtime);
   const characterVoice = args.preferCharacterVoice
     ? buildCharacterVoiceContext(args.runtime)

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -22,9 +22,12 @@
 import { v4 } from "uuid";
 import z from "zod";
 import { getEntityDetails } from "../../../entities.ts";
+import { isProgressiveContentProjectionEnabled } from "../../../runtime/content-projection-policy.ts";
+import { renderActionResultsForModel } from "../../../runtime/planner-rendering.ts";
 import { EvaluatorPriority } from "../../../services/evaluator-priorities.ts";
 import type { RelationshipsService } from "../../../services/relationships.ts";
 import type {
+	ActionResult,
 	Entity,
 	Evaluator,
 	IAgentRuntime,
@@ -46,6 +49,7 @@ import type {
 } from "../../../types/memory.ts";
 import { MemoryType } from "../../../types/memory.ts";
 import type { JsonValue } from "../../../types/primitives.ts";
+import { formatActionResultsForPrompt } from "../../../utils/action-results.ts";
 import { isSyntheticConversationArtifactMemory } from "../../../utils/synthetic-conversation-artifact.ts";
 import {
 	buildFactKeywordsForStorage,
@@ -295,7 +299,7 @@ interface FactPrepared extends ReflectionPrepared {
 }
 
 interface SuccessPrepared extends ReflectionPrepared {
-	actionResults: unknown[];
+	actionResults: ActionResult[];
 }
 
 interface FactCandidate {
@@ -452,9 +456,14 @@ function formatRelationships(
 	);
 }
 
-function actionResultsFromState(state: State | undefined): unknown[] {
+function actionResultsFromState(state: State | undefined): ActionResult[] {
 	const raw = state?.data?.actionResults;
-	return Array.isArray(raw) ? raw : [];
+	return Array.isArray(raw)
+		? raw.filter(
+				(value): value is ActionResult =>
+					value !== null && typeof value === "object" && "success" in value,
+			)
+		: [];
 }
 
 const reflectionContextByMessage = new WeakMap<
@@ -1203,7 +1212,7 @@ export const successEvaluator: Evaluator<SuccessOutput, SuccessPrepared> = {
 					: actionResultsFromState(state),
 		};
 	},
-	prompt({ prepared, options }) {
+	prompt({ runtime, prepared, options }) {
 		return `Evaluate if current user task is complete after agent response.
 
 Rules:
@@ -1217,7 +1226,15 @@ Recent messages:
 ${formatRecentMessages(prepared.recentMessages)}
 
 Action results:
-${JSON.stringify(prepared.actionResults, null, 2)}`;
+${
+	isProgressiveContentProjectionEnabled(runtime)
+		? renderActionResultsForModel(prepared.actionResults, {
+				omitRecoverableText: true,
+			}).text
+		: formatActionResultsForPrompt(prepared.actionResults, {
+				includeData: true,
+			})
+}`;
 	},
 	parse(output) {
 		const result = SuccessOutputSchema.safeParse(output);

--- a/packages/core/src/features/basic-capabilities/providers/actionState.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actionState.test.ts
@@ -3,8 +3,9 @@
  * Unicode normalization guarantees.
  */
 
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { normalizeThoughtText } from "./actionState.ts";
+import { actionStateProvider, normalizeThoughtText } from "./actionState.ts";
 
 function isWellFormed(value: string): boolean {
 	for (let index = 0; index < value.length; index += 1) {
@@ -50,5 +51,61 @@ describe("normalizeThoughtText Unicode boundaries", () => {
 		const out = normalizeThoughtText(lone);
 		expect(out).toBe("thought \uFFFD test");
 		expect(isWellFormed(out)).toBe(true);
+	});
+});
+
+describe("ACTION_STATE progressive projection", () => {
+	it("removes recoverable bodies from every provider text carrier", async () => {
+		const canary = `BEGIN_PRIVATE_PAGE_${"x".repeat(20_000)}_END`;
+		const actionResult = {
+			success: true,
+			text: canary,
+			data: { actionName: "FILE", rawBody: canary },
+			promptData: {
+				actionName: "FILE",
+				readView: {
+					reference: { kind: "file", ref: "opaque-file", revision: "r1" },
+					slice: {
+						range: { unit: "byte", start: 0, end: 10, total: 20 },
+						hasPrevious: false,
+						hasMore: true,
+						nextOffset: 10,
+						revision: "r1",
+						completeness: "partial-recoverable",
+						sliceSha256: createHash("sha256").update(canary).digest("hex"),
+					},
+				},
+			},
+		};
+		const result = await actionStateProvider.get(
+			{
+				getSetting: () => true,
+				getMemories: async () => [],
+			} as never,
+			{ roomId: "00000000-0000-0000-0000-000000000001" } as never,
+			{
+				data: {
+					actionResults: [actionResult],
+					workingMemory: {
+						file: { actionName: "FILE", result: actionResult, timestamp: 1 },
+					},
+					actionPlan: {
+						thought: "read",
+						currentStep: 1,
+						totalSteps: 2,
+						steps: [
+							{ action: "FILE", status: "completed", result: actionResult },
+							{ action: "REPLY", status: "pending" },
+						],
+					},
+				},
+				values: {},
+				text: "",
+			} as never,
+		);
+
+		expect(result.text).toContain("opaque-file");
+		expect(result.text).not.toContain("BEGIN_PRIVATE_PAGE");
+		expect(JSON.stringify(result.data)).toContain("BEGIN_PRIVATE_PAGE");
 	});
 });

--- a/packages/core/src/features/basic-capabilities/providers/actionState.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actionState.ts
@@ -11,7 +11,9 @@
  * "No action state available" rather than throwing.
  */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
+import { isProgressiveContentProjectionEnabled } from "../../../runtime/content-projection-policy.ts";
 import { stringifyForDiagnostics } from "../../../runtime/json-output.ts";
+import { renderActionResultsForModel } from "../../../runtime/planner-rendering.js";
 import type {
 	ActionResult,
 	IAgentRuntime,
@@ -57,6 +59,7 @@ export const actionStateProvider: Provider = {
 		state: State,
 	): Promise<ProviderResult> => {
 		try {
+			const projectionEnabled = isProgressiveContentProjectionEnabled(runtime);
 			const actionResults = state.data.actionResults ?? [];
 			const actionPlan = state.data.actionPlan;
 			const workingMemory = state.data.workingMemory;
@@ -101,7 +104,14 @@ export const actionStateProvider: Provider = {
 								stepText += `\n   Error: ${step.error}`;
 							}
 							if (step.result?.text) {
-								stepText += `\n   Result: ${toWellFormedUnicode(step.result.text)}`;
+								stepText += projectionEnabled
+									? `\n   Result: ${
+											renderActionResultsForModel([step.result], {
+												header: "",
+												omitRecoverableText: true,
+											}).text
+										}`
+									: `\n   Result: ${toWellFormedUnicode(step.result.text)}`;
 							}
 
 							return stepText;
@@ -114,9 +124,14 @@ export const actionStateProvider: Provider = {
 			// Format previous action results
 			let resultsText = "";
 			if (actionResults.length > 0) {
-				resultsText = formatActionResultsForPrompt(actionResults, {
-					header: "# Current Chain Action Results",
-				});
+				resultsText = projectionEnabled
+					? renderActionResultsForModel(actionResults, {
+							header: "# Current Chain Action Results",
+							omitRecoverableText: true,
+						}).text
+					: formatActionResultsForPrompt(actionResults, {
+							header: "# Current Chain Action Results",
+						});
 			} else {
 				resultsText = "";
 			}
@@ -131,8 +146,12 @@ export const actionStateProvider: Provider = {
 					.sort((a, b) => b[1].timestamp - a[1].timestamp)
 					.map(([key, entry]) => {
 						const result: ActionResult = entry.result;
-						const resultText =
-							typeof result.text === "string" && result.text.trim().length > 0
+						const resultText = projectionEnabled
+							? renderActionResultsForModel([result], {
+									header: "",
+									omitRecoverableText: true,
+								}).text
+							: typeof result.text === "string" && result.text.trim().length > 0
 								? toWellFormedUnicode(result.text)
 								: result.data
 									? formatDataForPrompt(result.data)
@@ -188,7 +207,9 @@ export const actionStateProvider: Provider = {
 								const status = memContent.actionStatus || "unknown";
 								const planStep = memContent.planStep || "";
 								const rawText = memContent.text || "";
-								const text = toWellFormedUnicode(rawText);
+								const text = projectionEnabled
+									? ""
+									: toWellFormedUnicode(rawText);
 
 								let memText = `  - ${actionName} (${status})`;
 								if (planStep) {

--- a/packages/core/src/features/basic-capabilities/providers/actionState.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actionState.ts
@@ -207,9 +207,7 @@ export const actionStateProvider: Provider = {
 								const status = memContent.actionStatus || "unknown";
 								const planStep = memContent.planStep || "";
 								const rawText = memContent.text || "";
-								const text = projectionEnabled
-									? ""
-									: toWellFormedUnicode(rawText);
+								const text = toWellFormedUnicode(rawText);
 
 								let memText = `  - ${actionName} (${status})`;
 								if (planStep) {

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -189,7 +189,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		);
 		expect(result.text).toContain(PINNED_DOCUMENT_TRUNCATION_MARKER);
 		expect(result.text).toContain("X".repeat(100));
-		expect(result.text).toContain(`reference: document:${oversized.id}`);
+		expect(result.text).toContain(`reference document:${oversized.id}`);
 		expect(result.data?.pinnedDocumentsTruncated).toBe(true);
 		expect(result.data?.pinnedDocumentIds).toEqual([oversized.id]);
 		expect(warn).toHaveBeenCalledWith(
@@ -197,6 +197,19 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 			expect.stringContaining("explicitly truncated"),
 		);
 		warn.mockRestore();
+	});
+
+	it("keeps fair pinned excerpts and wrappers inside the declared budget", () => {
+		const documents = Array.from({ length: 25 }, (_, index) =>
+			document(`${index}-${"title".repeat(80)}`, "X".repeat(40_000), true),
+		);
+		const rendered = renderPinnedDocuments(documents, 8_000);
+		expect(rendered.truncated).toBe(true);
+		expect(rendered.includedIds).toHaveLength(25);
+		expect(rendered.text.length).toBeLessThanOrEqual(32_000);
+		for (const item of documents) {
+			expect(rendered.text).toContain(`reference document:${item.id}`);
+		}
 	});
 
 	it("rejects repeating pagination cursors when listing pinned documents", async () => {

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -188,9 +188,10 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 			document("query", "unrelated query"),
 		);
 		expect(result.text).toContain(PINNED_DOCUMENT_TRUNCATION_MARKER);
-		expect(result.text).not.toContain("X".repeat(100));
+		expect(result.text).toContain("X".repeat(100));
+		expect(result.text).toContain(`reference: document:${oversized.id}`);
 		expect(result.data?.pinnedDocumentsTruncated).toBe(true);
-		expect(result.data?.pinnedDocumentIds).toEqual([]);
+		expect(result.data?.pinnedDocumentIds).toEqual([oversized.id]);
 		expect(warn).toHaveBeenCalledWith(
 			expect.objectContaining({ tokenBudget: 8_000 }),
 			expect.stringContaining("explicitly truncated"),

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -212,6 +212,26 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		}
 	});
 
+	it("preserves complete pinned titles and rejects identity-only overflow", () => {
+		const longTitle = `critical-${"owner-authored-title-".repeat(20)}`;
+		const rendered = renderPinnedDocuments(
+			[document(longTitle, "complete source", true)],
+			8_000,
+		);
+		expect(rendered.text).toContain(longTitle);
+
+		expect(() =>
+			renderPinnedDocuments(
+				[document(`critical-${"X".repeat(40_000)}`, "source", true)],
+				8_000,
+			),
+		).toThrowError(
+			expect.objectContaining({
+				code: "PINNED_DOCUMENT_IDENTITY_BUDGET_EXCEEDED",
+			}),
+		);
+	});
+
 	it("rejects repeating pagination cursors when listing pinned documents", async () => {
 		const agentId = "00000000-0000-0000-0000-0000000000a1" as UUID;
 		const queryDocumentsMock = vi.fn(async () => ({

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -25,7 +25,6 @@ import { normalizeDocumentSourceValue } from "./utils.ts";
 
 const PINNED_DOCUMENT_TOKEN_BUDGET = 8_000;
 const APPROXIMATE_CHARACTERS_PER_TOKEN = 4;
-const PINNED_DOCUMENT_TITLE_MAX_CHARACTERS = 120;
 
 export const PINNED_DOCUMENT_TRUNCATION_MARKER =
 	"[Pinned document content omitted from this prompt. Use DOCUMENT read with its document ID to page the exact source.]";
@@ -63,13 +62,10 @@ export function renderPinnedDocuments(
 	const blocks: string[] = [];
 	const maximumCharacters = tokenBudget * APPROXIMATE_CHARACTERS_PER_TOKEN;
 	let truncated = false;
-	const headers = pinned.map((document, index) => {
-		const title = truncateWellFormed(
-			getDocumentTitle(document, index),
-			PINNED_DOCUMENT_TITLE_MAX_CHARACTERS,
-		);
-		return `## ${title} (${document.id}; reference document:${document.id})`;
-	});
+	const headers = pinned.map(
+		(document, index) =>
+			`## ${getDocumentTitle(document, index)} (${document.id}; reference document:${document.id})`,
+	);
 	const blockSeparators = Math.max(0, pinned.length - 1) * 2;
 	const headerNewlines = pinned.length;
 	const markerSeparator = pinned.length > 0 ? 2 : 0;

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -9,6 +9,7 @@
  * per-turn cache scope.
  */
 
+import { ElizaError } from "../../errors.ts";
 import { logger } from "../../logger";
 import {
 	type IAgentRuntime,
@@ -24,6 +25,7 @@ import { normalizeDocumentSourceValue } from "./utils.ts";
 
 const PINNED_DOCUMENT_TOKEN_BUDGET = 8_000;
 const APPROXIMATE_CHARACTERS_PER_TOKEN = 4;
+const PINNED_DOCUMENT_TITLE_MAX_CHARACTERS = 120;
 
 export const PINNED_DOCUMENT_TRUNCATION_MARKER =
 	"[Pinned document content omitted from this prompt. Use DOCUMENT read with its document ID to page the exact source.]";
@@ -54,18 +56,42 @@ export function renderPinnedDocuments(
 			);
 			return titleOrder || String(a.id ?? "").localeCompare(String(b.id ?? ""));
 		});
+	if (pinned.length === 0) {
+		return { text: "", truncated: false, includedIds: [] };
+	}
 	const includedIds: Array<Memory["id"]> = [];
 	const blocks: string[] = [];
 	const maximumCharacters = tokenBudget * APPROXIMATE_CHARACTERS_PER_TOKEN;
 	let truncated = false;
-	const identityCatalog = pinned
-		.map(
-			(document, index) =>
-				`- ${getDocumentTitle(document, index)} (${document.id}; reference: document:${document.id})`,
-		)
-		.join("\n");
+	const headers = pinned.map((document, index) => {
+		const title = truncateWellFormed(
+			getDocumentTitle(document, index),
+			PINNED_DOCUMENT_TITLE_MAX_CHARACTERS,
+		);
+		return `## ${title} (${document.id}; reference document:${document.id})`;
+	});
+	const blockSeparators = Math.max(0, pinned.length - 1) * 2;
+	const headerNewlines = pinned.length;
+	const markerSeparator = pinned.length > 0 ? 2 : 0;
 	const fixedCharacters =
-		identityCatalog.length + PINNED_DOCUMENT_TRUNCATION_MARKER.length + 4;
+		headers.reduce((total, header) => total + header.length, 0) +
+		headerNewlines +
+		blockSeparators +
+		markerSeparator +
+		PINNED_DOCUMENT_TRUNCATION_MARKER.length;
+	if (fixedCharacters > maximumCharacters) {
+		throw new ElizaError(
+			"Pinned document identities exceed the configured prompt budget",
+			{
+				code: "PINNED_DOCUMENT_IDENTITY_BUDGET_EXCEEDED",
+				context: {
+					documentCount: pinned.length,
+					maximumCharacters,
+					identityCharacters: fixedCharacters,
+				},
+			},
+		);
+	}
 	const fairContentCharacters =
 		pinned.length === 0
 			? 0
@@ -76,13 +102,13 @@ export function renderPinnedDocuments(
 	for (const [index, document] of pinned.entries()) {
 		const content = document.content.text ?? "";
 		const excerpt = truncateWellFormed(content, fairContentCharacters);
-		const block = `## ${getDocumentTitle(document, index)} (${document.id})\n${excerpt}`;
+		const block = `${headers[index]}\n${excerpt}`;
 		blocks.push(block);
 		includedIds.push(document.id);
 		if (excerpt.length < content.length) truncated = true;
 	}
 	if (truncated) {
-		blocks.push(`${PINNED_DOCUMENT_TRUNCATION_MARKER}\n${identityCatalog}`);
+		blocks.push(PINNED_DOCUMENT_TRUNCATION_MARKER);
 	}
 	return { text: blocks.join("\n\n"), truncated, includedIds };
 }

--- a/packages/core/src/features/documents/provider.ts
+++ b/packages/core/src/features/documents/provider.ts
@@ -17,6 +17,7 @@ import {
 	type Provider,
 } from "../../types";
 import { addHeader } from "../../utils";
+import { truncateWellFormed } from "../../utils/well-formed.ts";
 import { DocumentService } from "./service.ts";
 import type { DocumentMetadataExtended } from "./types.ts";
 import { normalizeDocumentSourceValue } from "./utils.ts";
@@ -56,23 +57,33 @@ export function renderPinnedDocuments(
 	const includedIds: Array<Memory["id"]> = [];
 	const blocks: string[] = [];
 	const maximumCharacters = tokenBudget * APPROXIMATE_CHARACTERS_PER_TOKEN;
-	let usedCharacters = 0;
 	let truncated = false;
+	const identityCatalog = pinned
+		.map(
+			(document, index) =>
+				`- ${getDocumentTitle(document, index)} (${document.id}; reference: document:${document.id})`,
+		)
+		.join("\n");
+	const fixedCharacters =
+		identityCatalog.length + PINNED_DOCUMENT_TRUNCATION_MARKER.length + 4;
+	const fairContentCharacters =
+		pinned.length === 0
+			? 0
+			: Math.max(
+					0,
+					Math.floor((maximumCharacters - fixedCharacters) / pinned.length),
+				);
 	for (const [index, document] of pinned.entries()) {
-		const block = `## ${getDocumentTitle(document, index)} (${document.id})\n${document.content.text ?? ""}`;
-		const separatorCharacters = blocks.length > 0 ? 2 : 0;
-		if (
-			usedCharacters + separatorCharacters + block.length >
-			maximumCharacters
-		) {
-			truncated = true;
-			continue;
-		}
+		const content = document.content.text ?? "";
+		const excerpt = truncateWellFormed(content, fairContentCharacters);
+		const block = `## ${getDocumentTitle(document, index)} (${document.id})\n${excerpt}`;
 		blocks.push(block);
 		includedIds.push(document.id);
-		usedCharacters += separatorCharacters + block.length;
+		if (excerpt.length < content.length) truncated = true;
 	}
-	if (truncated) blocks.push(PINNED_DOCUMENT_TRUNCATION_MARKER);
+	if (truncated) {
+		blocks.push(`${PINNED_DOCUMENT_TRUNCATION_MARKER}\n${identityCatalog}`);
+	}
 	return { text: blocks.join("\n\n"), truncated, includedIds };
 }
 

--- a/packages/core/src/features/working-memory/readAttachmentAction.delivery.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.delivery.test.ts
@@ -304,6 +304,9 @@ describe("ATTACHMENT read delivery selection", () => {
 		);
 		expect(calls[0]?.prompt).toContain("SECOND-");
 		expect(JSON.stringify(result?.promptData)).not.toContain("SECOND-");
+		expect(
+			(result?.promptData as { readViews?: unknown[] } | undefined)?.readViews,
+		).toHaveLength(1);
 	});
 
 	it("rejects a stale attachment revision before answer generation or delivery", async () => {

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -1173,6 +1173,7 @@ export const readAttachmentAction: Action = {
 						notProcessed: record.attachment.notProcessed,
 					})),
 					readView: pagedRecords[0]?.readView,
+					readViews: pagedRecords.map((record) => record.readView),
 					clipboard: projectClipboardResult(clipboardResult),
 					suppressActionResultClipboard: clipboardResult.requested,
 				},
@@ -1181,6 +1182,7 @@ export const readAttachmentAction: Action = {
 					action: "read",
 					attachmentIds: pagedRecords.map((record) => record.attachment.id),
 					readView: pagedRecords[0]?.readView,
+					readViews: pagedRecords.map((record) => record.readView),
 				},
 			};
 		} catch (error) {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -259,6 +259,8 @@ export {
 	registerCandidateActionBackstopRule,
 } from "./runtime/candidate-action-backstop";
 export * from "./runtime/cleanup-scope";
+export * from "./runtime/content-access-manifest";
+export * from "./runtime/content-projection-policy";
 export * from "./runtime/context-gates";
 export * from "./runtime/context-registry";
 export {
@@ -293,6 +295,7 @@ export {
 // layers (message service, orchestrator completion relays) can recognize it
 // by identity and drop it as redundant next to an authoritative outcome.
 export { FAILED_TOOL_FALLBACK_MESSAGE } from "./runtime/planner-loop";
+export { renderActionResultsForModel } from "./runtime/planner-rendering";
 export * from "./runtime/response-grammar";
 export * from "./runtime/response-handler-evaluators";
 export * from "./runtime/response-handler-field-evaluator";

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -221,13 +221,13 @@ describe("toolMessageContent", () => {
 		);
 	});
 
-	it("retains nested search references when oversized search prose is omitted", () => {
+	it("does not treat reference-only search metadata as a recoverable page", () => {
 		const reference = {
 			kind: "document" as const,
 			ref: "document:00000000-0000-0000-0000-000000000001",
 			revision: "rev:stable",
 		};
-		const parsed = JSON.parse(
+		expect(() =>
 			toolMessageContent(
 				{
 					success: true,
@@ -236,13 +236,7 @@ describe("toolMessageContent", () => {
 				},
 				{ maxSerializedTokens: 100 },
 			),
-		);
-		expect(parsed.text).toBeUndefined();
-		expect(parsed.promptData.results).toEqual([{ reference }]);
-		expect(parsed.contentProjection).toEqual({
-			textIncluded: false,
-			reason: "model-input-budget",
-		});
+		).toThrow(/Non-recoverable tool result exceeds/u);
 	});
 
 	it("does not treat an arbitrary nested reference as proof that result text is recoverable", () => {

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -127,6 +127,20 @@ describe("renderActionResultsForModel", () => {
 			),
 		).toThrow(/Non-recoverable tool result exceeds/u);
 	});
+
+	it("redacts credentials from legacy model-facing results", () => {
+		const rendered = renderActionResultsForModel([
+			{
+				success: true,
+				text: "completed with sk-test-secret-value",
+				data: { apiKey: "must-not-leak", actionName: "FETCH" },
+			},
+		]);
+
+		expect(rendered.text).not.toContain("sk-test-secret-value");
+		expect(rendered.text).not.toContain("must-not-leak");
+		expect(rendered.text).toContain("[REDACTED]");
+	});
 });
 
 describe("toolMessageContent", () => {
@@ -200,6 +214,28 @@ describe("toolMessageContent", () => {
 		});
 		expect(rendered).not.toContain("/raw/path");
 		expect(rendered).not.toContain("must-not-duplicate");
+	});
+
+	it("omits recoverable legacy-data text without discarding its continuation", () => {
+		const text = `BEGIN${"x".repeat(20_000)}END`;
+		const readView = readViewFor(text);
+		const parsed = JSON.parse(
+			toolMessageContent(
+				{
+					success: true,
+					text,
+					data: { actionName: "FILE", readView },
+				},
+				{ maxSerializedTokens: 500 },
+			),
+		);
+
+		expect(parsed.text).toBeUndefined();
+		expect(parsed.data.readView).toEqual(readView);
+		expect(parsed.contentProjection).toEqual({
+			textIncluded: false,
+			reason: "model-input-budget",
+		});
 	});
 
 	it("preserves exact page text and its validated slice hash when included", () => {

--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import type { ChatMessage } from "../../types/model";
 import {
 	projectToolResultForModel,
+	renderActionResultsForModel,
 	toolMessageContent,
 	trajectoryStepsToMessages,
 } from "../planner-rendering";
@@ -78,6 +79,53 @@ describe("trajectoryStepsToMessages", () => {
 				`${index}:${"z".repeat(50_000)}:${index}`,
 			);
 		}
+	});
+});
+
+describe("renderActionResultsForModel", () => {
+	it("removes recoverable page text while retaining its exact continuation", () => {
+		const page = `BEGIN${"x".repeat(20_000)}END`;
+		const rendered = renderActionResultsForModel(
+			[
+				{
+					success: true,
+					text: page,
+					data: { actionName: "FILE", rawBody: "SECOND_CARRIER" },
+					promptData: { actionName: "FILE", readView: readViewFor(page) },
+				},
+			],
+			{ omitRecoverableText: true },
+		);
+
+		expect(rendered.text).toContain("file_opaque");
+		expect(rendered.text).not.toContain("BEGIN");
+		expect(rendered.text).not.toContain("SECOND_CARRIER");
+		expect(rendered.stats).toEqual({
+			resultCount: 1,
+			pagesIncluded: 0,
+			pagesOmitted: 1,
+			omissionReasons: { "model-input-budget": 1 },
+		});
+	});
+
+	it("fails rather than dropping a non-recoverable oversized result", () => {
+		expect(() =>
+			renderActionResultsForModel(
+				[
+					{
+						success: true,
+						text: "x".repeat(20_000),
+						data: { actionName: "BASH" },
+					},
+				],
+				{
+					projectionBudget: {
+						perResultTokens: 100,
+						aggregateTokens: 100,
+					},
+				},
+			),
+		).toThrow(/Non-recoverable tool result exceeds/u);
 	});
 });
 

--- a/packages/core/src/runtime/content-access-manifest.test.ts
+++ b/packages/core/src/runtime/content-access-manifest.test.ts
@@ -75,6 +75,32 @@ describe("deriveCompactionContentManifest", () => {
 		expect(JSON.stringify(manifest)).not.toContain("source bytes");
 	});
 
+	it("preserves legacy data references across the archive boundary", () => {
+		const manifest = deriveCompactionContentManifest(
+			{
+				archivedSteps: [
+					{
+						iteration: 1,
+						toolCall: { name: "FILE" },
+						result: {
+							success: true,
+							data: { readView: readView(40, 60) },
+						},
+					},
+				],
+				steps: [],
+			},
+			{ lastUsedAt: "2026-08-22T12:00:00.000Z" },
+		);
+
+		expect(manifest.contentRefs).toMatchObject([
+			{
+				reference: { kind: "file", ref: "opaque-file", revision: "rev-1" },
+				rangesUsed: [{ unit: "byte", start: 40, end: 60 }],
+			},
+		]);
+	});
+
 	it("fails explicitly instead of silently truncating the manifest", () => {
 		expect(() =>
 			deriveCompactionContentManifest(

--- a/packages/core/src/runtime/content-access-manifest.test.ts
+++ b/packages/core/src/runtime/content-access-manifest.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Exercises the deterministic compaction content manifest against real
+ * progressive-read contracts, including archive survival and strict bounds.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ElizaError } from "../errors";
+import { buildReadSlice, buildReadView } from "../types/content";
+import { deriveCompactionContentManifest } from "./content-access-manifest";
+
+const digest = "a".repeat(64);
+
+function readView(start: number, end: number) {
+	return buildReadView({
+		reference: { kind: "file", ref: "opaque-file", revision: "rev-1" },
+		slice: buildReadSlice({
+			range: { unit: "byte", start, end, total: 100 },
+			completeness: end < 100 ? "partial-recoverable" : "complete",
+			sliceSha256: digest,
+			revision: "rev-1",
+		}),
+	});
+}
+
+describe("deriveCompactionContentManifest", () => {
+	it("deduplicates ranges and preserves archived continuation metadata", () => {
+		const manifest = deriveCompactionContentManifest(
+			{
+				archivedSteps: [
+					{
+						iteration: 1,
+						toolCall: { name: "FILE" },
+						result: {
+							success: true,
+							text: "source bytes never enter the manifest",
+							promptData: { readView: readView(0, 20) },
+						},
+					},
+				],
+				steps: [
+					{
+						iteration: 2,
+						toolCall: { name: "FILE" },
+						result: {
+							success: true,
+							promptData: {
+								first: readView(0, 20),
+								second: readView(20, 40),
+							},
+						},
+					},
+				],
+			},
+			{ lastUsedAt: "2026-08-22T12:00:00.000Z" },
+		);
+
+		expect(manifest.schemaVersion).toBe(1);
+		expect(manifest.contentRefs).toEqual([
+			{
+				reference: {
+					kind: "file",
+					ref: "opaque-file",
+					revision: "rev-1",
+				},
+				revision: "rev-1",
+				reason: "tool:FILE",
+				rangesUsed: [
+					{ unit: "byte", start: 0, end: 20 },
+					{ unit: "byte", start: 20, end: 40 },
+				],
+				lastUsedAt: "2026-08-22T12:00:00.000Z",
+				retained: true,
+			},
+		]);
+		expect(JSON.stringify(manifest)).not.toContain("source bytes");
+	});
+
+	it("fails explicitly instead of silently truncating the manifest", () => {
+		expect(() =>
+			deriveCompactionContentManifest(
+				{
+					archivedSteps: [],
+					steps: [
+						{
+							iteration: 1,
+							result: {
+								success: true,
+								promptData: {
+									a: readView(0, 20),
+									b: readView(20, 40),
+								},
+							},
+						},
+					],
+				},
+				{
+					lastUsedAt: "2026-08-22T12:00:00.000Z",
+					maxRangesPerReference: 1,
+				},
+			),
+		).toThrowError(
+			expect.objectContaining<Partial<ElizaError>>({
+				code: "CONTENT_MANIFEST_BOUND_EXCEEDED",
+			}),
+		);
+	});
+});

--- a/packages/core/src/runtime/content-access-manifest.test.ts
+++ b/packages/core/src/runtime/content-access-manifest.test.ts
@@ -104,4 +104,56 @@ describe("deriveCompactionContentManifest", () => {
 			}),
 		);
 	});
+
+	it("rejects conflicting revisions for one native reference", () => {
+		const secondRevision = {
+			...readView(20, 40),
+			reference: {
+				kind: "file" as const,
+				ref: "opaque-file",
+				revision: "rev-2",
+			},
+			slice: { ...readView(20, 40).slice, revision: "rev-2" },
+		};
+		expect(() =>
+			deriveCompactionContentManifest(
+				{
+					archivedSteps: [
+						{
+							iteration: 1,
+							result: {
+								success: true,
+								promptData: { readView: readView(0, 20) },
+							},
+						},
+					],
+					steps: [
+						{
+							iteration: 2,
+							result: {
+								success: true,
+								promptData: { readView: secondRevision },
+							},
+						},
+					],
+				},
+				{ lastUsedAt: "2026-08-22T12:00:00.000Z" },
+			),
+		).toThrow(/conflicting source revisions/u);
+	});
+
+	it("rejects an object beyond the traversal depth instead of losing it", () => {
+		const nested = { a: { b: { c: { readView: readView(0, 20) } } } };
+		expect(() =>
+			deriveCompactionContentManifest(
+				{
+					archivedSteps: [],
+					steps: [
+						{ iteration: 1, result: { success: true, promptData: nested } },
+					],
+				},
+				{ lastUsedAt: "2026-08-22T12:00:00.000Z", maxDepth: 2 },
+			),
+		).toThrow(/depth bound/u);
+	});
 });

--- a/packages/core/src/runtime/content-access-manifest.ts
+++ b/packages/core/src/runtime/content-access-manifest.ts
@@ -57,7 +57,7 @@ function canonicalTimestamp(value: string, label: string): string {
 }
 
 function referenceKey(reference: ContentReference): string {
-	return `${reference.kind}\u0000${reference.ref}\u0000${reference.revision ?? ""}`;
+	return `${reference.kind}\u0000${reference.ref}`;
 }
 
 function rangeKey(range: CompactionContentRange): string {
@@ -127,6 +127,26 @@ export function deriveCompactionContentManifest(
 				rangeKeys: new Set(),
 			};
 			entries.set(key, entry);
+		} else {
+			const existingRevision = entry.revision ?? entry.reference.revision;
+			const incomingRevision = reference.revision;
+			if (
+				existingRevision !== undefined &&
+				incomingRevision !== undefined &&
+				existingRevision !== incomingRevision
+			) {
+				throw new ElizaError(
+					"Content manifest encountered conflicting source revisions",
+					{
+						code: "CONTENT_MANIFEST_REVISION_CONFLICT",
+						context: { kind: reference.kind },
+					},
+				);
+			}
+			if (existingRevision === undefined && incomingRevision !== undefined) {
+				entry.reference = reference;
+				entry.revision = incomingRevision;
+			}
 		}
 		if (!range) return;
 		const keyForRange = rangeKey(range);
@@ -176,12 +196,17 @@ export function deriveCompactionContentManifest(
 				addReference(current.value, reason);
 				continue;
 			}
-			if (
-				current.depth >= maxDepth ||
-				current.value === null ||
-				typeof current.value !== "object"
-			) {
+			if (current.value === null || typeof current.value !== "object") {
 				continue;
+			}
+			if (current.depth >= maxDepth) {
+				throw new ElizaError(
+					"Content manifest traversal exceeds the configured depth bound",
+					{
+						code: "CONTENT_MANIFEST_BOUND_EXCEEDED",
+						context: { bound: "depth", maxDepth },
+					},
+				);
 			}
 			for (const child of Array.isArray(current.value)
 				? current.value

--- a/packages/core/src/runtime/content-access-manifest.ts
+++ b/packages/core/src/runtime/content-access-manifest.ts
@@ -1,0 +1,213 @@
+/**
+ * Derives the content-reference ledger that an archive or future compaction
+ * seam must retain independently of an LLM-authored summary. The walker reads
+ * only model-safe prompt projections, applies strict traversal bounds, and
+ * never copies source text into the manifest.
+ */
+
+import { ElizaError } from "../errors";
+import {
+	type ContentReference,
+	isContentReference,
+	isReadView,
+} from "../types/content";
+import {
+	COMPACTION_CONTENT_MANIFEST_MAX_RANGES_PER_REFERENCE,
+	COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES,
+	COMPACTION_CONTENT_MANIFEST_SCHEMA_VERSION,
+	type CompactionContentEntry,
+	type CompactionContentManifest,
+	type CompactionContentRange,
+	validateCompactionContentManifest,
+} from "../types/content-manifest";
+import type { PlannerTrajectory } from "./planner-types";
+
+export interface DeriveCompactionContentManifestOptions {
+	lastUsedAt: string;
+	maxReferences?: number;
+	maxRangesPerReference?: number;
+	maxVisitedValues?: number;
+	maxDepth?: number;
+}
+
+const DEFAULT_MAX_REFERENCES = COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES;
+const DEFAULT_MAX_RANGES_PER_REFERENCE =
+	COMPACTION_CONTENT_MANIFEST_MAX_RANGES_PER_REFERENCE;
+const DEFAULT_MAX_VISITED_VALUES = 10_000;
+const DEFAULT_MAX_DEPTH = 8;
+
+function positiveSafeInteger(
+	value: number | undefined,
+	fallback: number,
+	label: string,
+): number {
+	if (value === undefined) return fallback;
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new TypeError(`${label} must be a positive safe integer`);
+	}
+	return value;
+}
+
+function canonicalTimestamp(value: string, label: string): string {
+	const epoch = Date.parse(value);
+	if (!Number.isFinite(epoch) || new Date(epoch).toISOString() !== value) {
+		throw new TypeError(`${label} must be an ISO-8601 UTC timestamp`);
+	}
+	return value;
+}
+
+function referenceKey(reference: ContentReference): string {
+	return `${reference.kind}\u0000${reference.ref}\u0000${reference.revision ?? ""}`;
+}
+
+function rangeKey(range: CompactionContentRange): string {
+	return `${range.unit}:${range.start}:${range.end}`;
+}
+
+/**
+ * Build a content-free manifest from the prompt-safe projections in a planner
+ * trajectory. Active and archived steps are treated identically so moving a
+ * settled step across an archive boundary cannot erase its continuation state.
+ */
+export function deriveCompactionContentManifest(
+	trajectory: Pick<PlannerTrajectory, "steps" | "archivedSteps">,
+	options: DeriveCompactionContentManifestOptions,
+): CompactionContentManifest {
+	const maxReferences = positiveSafeInteger(
+		options.maxReferences,
+		DEFAULT_MAX_REFERENCES,
+		"maxReferences",
+	);
+	const maxRangesPerReference = positiveSafeInteger(
+		options.maxRangesPerReference,
+		DEFAULT_MAX_RANGES_PER_REFERENCE,
+		"maxRangesPerReference",
+	);
+	const maxVisitedValues = positiveSafeInteger(
+		options.maxVisitedValues,
+		DEFAULT_MAX_VISITED_VALUES,
+		"maxVisitedValues",
+	);
+	const maxDepth = positiveSafeInteger(
+		options.maxDepth,
+		DEFAULT_MAX_DEPTH,
+		"maxDepth",
+	);
+	const lastUsedAt = canonicalTimestamp(options.lastUsedAt, "lastUsedAt");
+	const entries = new Map<
+		string,
+		CompactionContentEntry & { rangeKeys: Set<string> }
+	>();
+	let visitedValues = 0;
+
+	const addReference = (
+		reference: ContentReference,
+		reason: string,
+		range?: CompactionContentRange,
+	) => {
+		const key = referenceKey(reference);
+		let entry = entries.get(key);
+		if (!entry) {
+			if (entries.size >= maxReferences) {
+				throw new ElizaError(
+					"Content manifest exceeds the configured reference bound",
+					{
+						code: "CONTENT_MANIFEST_BOUND_EXCEEDED",
+						context: { bound: "references", maxReferences },
+					},
+				);
+			}
+			entry = {
+				reference,
+				...(reference.revision ? { revision: reference.revision } : {}),
+				reason,
+				rangesUsed: [],
+				lastUsedAt,
+				retained: true,
+				rangeKeys: new Set(),
+			};
+			entries.set(key, entry);
+		}
+		if (!range) return;
+		const keyForRange = rangeKey(range);
+		if (entry.rangeKeys.has(keyForRange)) return;
+		if (entry.rangesUsed.length >= maxRangesPerReference) {
+			throw new ElizaError(
+				"Content manifest exceeds the configured per-reference range bound",
+				{
+					code: "CONTENT_MANIFEST_BOUND_EXCEEDED",
+					context: {
+						bound: "ranges",
+						maxRangesPerReference,
+					},
+				},
+			);
+		}
+		entry.rangeKeys.add(keyForRange);
+		entry.rangesUsed.push(range);
+	};
+
+	const visit = (root: unknown, reason: string) => {
+		const pending: Array<{ value: unknown; depth: number }> = [
+			{ value: root, depth: 0 },
+		];
+		while (pending.length > 0) {
+			const current = pending.pop();
+			if (!current) break;
+			visitedValues++;
+			if (visitedValues > maxVisitedValues) {
+				throw new ElizaError(
+					"Content manifest traversal exceeds the configured value bound",
+					{
+						code: "CONTENT_MANIFEST_BOUND_EXCEEDED",
+						context: { bound: "values", maxVisitedValues },
+					},
+				);
+			}
+			if (isReadView(current.value)) {
+				addReference(current.value.reference, reason, {
+					unit: current.value.slice.range.unit,
+					start: current.value.slice.range.start,
+					end: current.value.slice.range.end,
+				});
+				continue;
+			}
+			if (isContentReference(current.value)) {
+				addReference(current.value, reason);
+				continue;
+			}
+			if (
+				current.depth >= maxDepth ||
+				current.value === null ||
+				typeof current.value !== "object"
+			) {
+				continue;
+			}
+			for (const child of Array.isArray(current.value)
+				? current.value
+				: Object.values(current.value as Record<string, unknown>)) {
+				pending.push({ value: child, depth: current.depth + 1 });
+			}
+		}
+	};
+
+	for (const step of [...trajectory.archivedSteps, ...trajectory.steps]) {
+		if (!step.result?.promptData) continue;
+		visit(step.result.promptData, `tool:${step.toolCall?.name ?? "unknown"}`);
+	}
+
+	return validateCompactionContentManifest({
+		schemaVersion: COMPACTION_CONTENT_MANIFEST_SCHEMA_VERSION,
+		contentRefs: [...entries.values()].map(
+			({ rangeKeys: _rangeKeys, ...entry }) => ({
+				...entry,
+				rangesUsed: [...entry.rangesUsed].sort(
+					(a, b) =>
+						a.unit.localeCompare(b.unit) || a.start - b.start || a.end - b.end,
+				),
+			}),
+		),
+		modifiedFiles: [],
+		pendingProcesses: [],
+	});
+}

--- a/packages/core/src/runtime/content-access-manifest.ts
+++ b/packages/core/src/runtime/content-access-manifest.ts
@@ -217,8 +217,14 @@ export function deriveCompactionContentManifest(
 	};
 
 	for (const step of [...trajectory.archivedSteps, ...trajectory.steps]) {
-		if (!step.result?.promptData) continue;
-		visit(step.result.promptData, `tool:${step.toolCall?.name ?? "unknown"}`);
+		if (!step.result) continue;
+		// Match the model projection contract: promptData replaces legacy data
+		// when present, while data remains the authoritative carrier for older
+		// ActionResults. Scanning only promptData would archive a rendered legacy
+		// ReadView without its continuation reference.
+		const projectedData = step.result.promptData ?? step.result.data;
+		if (projectedData === undefined) continue;
+		visit(projectedData, `tool:${step.toolCall?.name ?? "unknown"}`);
 	}
 
 	return validateCompactionContentManifest({

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2475,6 +2475,20 @@ async function callPlanner(params: {
 		{ src: "planner-loop", contentProjection },
 		"Computed progressive content projection",
 	);
+	if (projectionEnabled && modelInputBudget.shouldCompact) {
+		throw new ElizaError(
+			"Planner model input exceeds the resolved context budget after content projection",
+			{
+				code: "PLANNER_INPUT_OVER_BUDGET",
+				context: {
+					estimatedInputTokens: modelInputBudget.estimatedInputTokens,
+					compactionThresholdTokens: modelInputBudget.compactionThresholdTokens,
+					contextWindowTokens: modelInputBudget.contextWindowTokens,
+					resultCount: contentProjection.resultCount,
+				},
+			},
+		);
+	}
 	const prefixHashes = computePrefixHashes(renderedInput.promptSegments);
 	const cachePrefixHashes = computePrefixHashes(renderedInput.cacheKeySegments);
 	const prefixHash =

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -71,6 +71,7 @@ export function renderActionResultsForModel(
 		header?: string;
 		projectionBudget?: ContentProjectionBudget;
 		omitRecoverableText?: boolean;
+		redactText?: ToolDiagnosticTextRedactor;
 	} = {},
 ): RenderedActionResultsForModel {
 	if (results.length === 0) {
@@ -93,8 +94,13 @@ export function renderActionResultsForModel(
 	let pagesIncluded = 0;
 	let pagesOmitted = 0;
 	const omissionReasons: Record<string, number> = {};
+	const redactText = options.redactText ?? composeToolDiagnosticRedactor();
 	const rendered = results.map((result, index) => {
-		const body = toolMessageContent(result as PlannerToolResult, {
+		const safeResult = projectToolDiagnosticValue(
+			result,
+			redactText,
+		) as PlannerToolResult;
+		const body = toolMessageContent(safeResult, {
 			...(fairResultBudget === undefined
 				? {}
 				: { maxSerializedTokens: fairResultBudget }),
@@ -262,7 +268,9 @@ export function toolMessageContent(
 		onProjection?: (observation: ToolResultProjectionObservation) => void;
 	} = {},
 ): string {
-	const validatedReadView = hasRecoverableContentLocator(result.promptData);
+	const validatedReadView = hasRecoverableContentLocator(
+		result.promptData ?? result.data,
+	);
 	const projected = projectToolResultForModel(
 		result,
 		options.omitRecoverableText,
@@ -381,7 +389,9 @@ export function projectToolResultForModel(
 ): PlannerToolResult & {
 	contentProjection?: { textIncluded: boolean; reason?: string };
 } {
-	const hasReadView = hasRecoverableContentLocator(result.promptData);
+	const hasReadView = hasRecoverableContentLocator(
+		result.promptData ?? result.data,
+	);
 	const projected = { ...result };
 	if (result.promptData !== undefined) {
 		delete projected.data;

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -13,7 +13,7 @@ import {
 	type ToolDiagnosticTextRedactor,
 } from "../security/tool-diagnostics";
 import type { ActionResult } from "../types/components";
-import { isContentReference, isReadView } from "../types/content";
+import { isReadView } from "../types/content";
 import type { ChatMessage, ChatMessageContentPart } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
 import { getActionResultActionName } from "../utils/action-results";
@@ -329,22 +329,6 @@ export interface ToolResultProjectionObservation {
 }
 
 function hasRecoverableContentLocator(value: unknown): boolean {
-	if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-		const results = (value as Record<string, unknown>).results;
-		if (
-			Array.isArray(results) &&
-			results.length > 0 &&
-			results.every(
-				(item) =>
-					item !== null &&
-					typeof item === "object" &&
-					!Array.isArray(item) &&
-					isContentReference((item as Record<string, unknown>).reference),
-			)
-		) {
-			return true;
-		}
-	}
 	const pending: Array<{ value: unknown; depth: number }> = [
 		{ value, depth: 0 },
 	];

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -12,9 +12,11 @@ import {
 	projectToolDiagnosticValue,
 	type ToolDiagnosticTextRedactor,
 } from "../security/tool-diagnostics";
+import type { ActionResult } from "../types/components";
 import { isContentReference, isReadView } from "../types/content";
 import type { ChatMessage, ChatMessageContentPart } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
+import { getActionResultActionName } from "../utils/action-results";
 import { stringifyForModel } from "./json-output";
 import {
 	type ContentProjectionBudget,
@@ -50,6 +52,78 @@ export interface ToolResultProjectionStats {
 	pagesIncluded: number;
 	pagesOmitted: number;
 	omissionReasons: Record<string, number>;
+}
+
+export interface RenderedActionResultsForModel {
+	text: string;
+	stats: ToolResultProjectionStats;
+}
+
+/**
+ * Render legacy ActionResults through the same promptData-over-data and
+ * recoverable-page projection used by native tool messages. This is the
+ * migration bridge for prompt builders that cannot yet carry structured tool
+ * messages; non-model display code should keep using its display formatter.
+ */
+export function renderActionResultsForModel(
+	results: readonly ActionResult[],
+	options: {
+		header?: string;
+		projectionBudget?: ContentProjectionBudget;
+		omitRecoverableText?: boolean;
+	} = {},
+): RenderedActionResultsForModel {
+	if (results.length === 0) {
+		return {
+			text: "No action results available.",
+			stats: {
+				resultCount: 0,
+				pagesIncluded: 0,
+				pagesOmitted: 0,
+				omissionReasons: {},
+			},
+		};
+	}
+	const fairResultBudget = options.projectionBudget
+		? Math.min(
+				options.projectionBudget.perResultTokens,
+				Math.floor(options.projectionBudget.aggregateTokens / results.length),
+			)
+		: undefined;
+	let pagesIncluded = 0;
+	let pagesOmitted = 0;
+	const omissionReasons: Record<string, number> = {};
+	const rendered = results.map((result, index) => {
+		const body = toolMessageContent(result as PlannerToolResult, {
+			...(fairResultBudget === undefined
+				? {}
+				: { maxSerializedTokens: fairResultBudget }),
+			omitRecoverableText: options.omitRecoverableText,
+			onProjection: (observation) => {
+				if (!observation.validatedReadView) return;
+				if (observation.textIncluded) {
+					pagesIncluded++;
+					return;
+				}
+				pagesOmitted++;
+				const reason = observation.omissionReason ?? "unknown";
+				omissionReasons[reason] = (omissionReasons[reason] ?? 0) + 1;
+			},
+		});
+		const status = result.success === false ? "failed" : "succeeded";
+		return `${index + 1}. ${getActionResultActionName(result)} - ${status}\n${JSON.stringify(JSON.parse(body))}`;
+	});
+	return {
+		text: [options.header ?? "# Current Chain Action Results", ...rendered]
+			.filter(Boolean)
+			.join("\n\n"),
+		stats: {
+			resultCount: results.length,
+			pagesIncluded,
+			pagesOmitted,
+			omissionReasons,
+		},
+	};
 }
 
 /**

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -8,10 +8,12 @@
  * a json_object request so a doomed schema round-trip is not repaid every turn.
  */
 import { v4 as uuidv4 } from "uuid";
+import { isProgressiveContentProjectionEnabled } from "../runtime/content-projection-policy.ts";
 import {
 	stringifyForDiagnostics,
 	stringifyForModel,
 } from "../runtime/json-output.ts";
+import { renderActionResultsForModel } from "../runtime/planner-rendering.ts";
 import { isMobilePlatform } from "../runtime-env.ts";
 import { setTrajectoryPurpose } from "../trajectory-context.ts";
 import type {
@@ -201,10 +203,15 @@ function buildPrompt(params: {
 		latestMessage,
 		responseTexts,
 		actionResults: Array.isArray(actionResults)
-			? formatActionResultsForPrompt(actionResults as ActionResult[], {
-					header: "",
-					includeData: true,
-				})
+			? isProgressiveContentProjectionEnabled(runtime)
+				? renderActionResultsForModel(actionResults as ActionResult[], {
+						header: "",
+						omitRecoverableText: true,
+					}).text
+				: formatActionResultsForPrompt(actionResults as ActionResult[], {
+						header: "",
+						includeData: true,
+					})
 			: stringifyForPrompt(actionResults ?? []),
 		providerContext,
 	};

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -90,6 +90,7 @@ import {
 	getCandidateActionBackstopRules,
 } from "../runtime/candidate-action-backstop";
 import { isCanonicalModelCapabilityDisabled } from "../runtime/canonical-model-capabilities.ts";
+import { isProgressiveContentProjectionEnabled } from "../runtime/content-projection-policy";
 import { filterProvidersByContextGate } from "../runtime/context-gates.ts";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
@@ -161,6 +162,7 @@ import {
 	runPlannerLoop,
 	summarizeActionResultForPlanner,
 } from "../runtime/planner-loop";
+import { renderActionResultsForModel } from "../runtime/planner-rendering";
 import {
 	extractReplyTextFromTranscript,
 	looksLikeRawFieldTranscript,
@@ -7715,7 +7717,7 @@ export async function runShortcutGate(args: {
 		};
 	}
 	const resultState = actionResult
-		? withActionResultsForPrompt(args.state, [actionResult])
+		? withActionResultsForPrompt(args.state, [actionResult], args.runtime)
 		: args.state;
 	const shortcutActionResults = actionResult ? [actionResult] : [];
 	const shortcutReplyDecision = evaluatePlannedReplyEgress({
@@ -9785,7 +9787,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		);
 		const finalPlannerState =
 			actionResults.length > 0
-				? withActionResultsForPrompt(plannerState, actionResults)
+				? withActionResultsForPrompt(plannerState, actionResults, args.runtime)
 				: plannerState;
 		const plannedTextRaw = String(plannerResult.finalMessage ?? "").trim();
 		const deliveredMediaUrls = collectMediaDeliveryUrls(actionResults);
@@ -12199,12 +12201,18 @@ async function rewriteActionCallbackInCharacter(args: {
 export function withActionResultsForPrompt(
 	state: State,
 	actionResults: ActionResult[],
+	runtime?: IAgentRuntime,
 ): State {
+	const promptActionResults = isProgressiveContentProjectionEnabled(runtime)
+		? renderActionResultsForModel(actionResults, {
+				omitRecoverableText: true,
+			}).text
+		: formatActionResultsForPrompt(actionResults);
 	return {
 		...state,
 		values: {
 			...state.values,
-			actionResults: formatActionResultsForPrompt(actionResults),
+			actionResults: promptActionResults,
 		},
 		data: {
 			...state.data,

--- a/packages/core/src/types/content-manifest.test.ts
+++ b/packages/core/src/types/content-manifest.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Verifies that persisted compaction manifests accept only bounded,
+ * model-safe reference metadata and reject hostile or ambiguous shapes.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateCompactionContentManifest } from "./content-manifest";
+
+const baseManifest = {
+	schemaVersion: 1,
+	contentRefs: [
+		{
+			reference: { kind: "document", ref: "document-opaque", revision: "r1" },
+			revision: "r1",
+			reason: "tool:DOCUMENT",
+			rangesUsed: [{ unit: "fragment", start: 4, end: 7 }],
+			lastUsedAt: "2026-08-22T12:00:00.000Z",
+			retained: true,
+		},
+	],
+	modifiedFiles: [],
+	pendingProcesses: [],
+};
+
+describe("validateCompactionContentManifest", () => {
+	it("accepts the versioned reference/range schema", () => {
+		expect(validateCompactionContentManifest(baseManifest)).toEqual(
+			baseManifest,
+		);
+	});
+
+	it("rejects native paths and unknown fields", () => {
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				contentRefs: [
+					{
+						...baseManifest.contentRefs[0],
+						reference: { kind: "file", ref: "/private/secret.txt" },
+					},
+				],
+			}),
+		).toThrow(/opaque token/u);
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				rawSummary: "do not persist me",
+			}),
+		).toThrow(/unsupported field/u);
+	});
+
+	it("rejects revision mismatches and excessive range ledgers", () => {
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				contentRefs: [
+					{
+						...baseManifest.contentRefs[0],
+						revision: "r2",
+					},
+				],
+			}),
+		).toThrow(/revision mismatch/u);
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				contentRefs: [
+					{
+						...baseManifest.contentRefs[0],
+						rangesUsed: Array.from({ length: 65 }, (_, index) => ({
+							unit: "byte",
+							start: index,
+							end: index + 1,
+						})),
+					},
+				],
+			}),
+		).toThrow(/too many ranges/u);
+	});
+});

--- a/packages/core/src/types/content-manifest.test.ts
+++ b/packages/core/src/types/content-manifest.test.ts
@@ -77,4 +77,34 @@ describe("validateCompactionContentManifest", () => {
 			}),
 		).toThrow(/too many ranges/u);
 	});
+
+	it("rejects duplicate locators, cross-entry conflicts, and modified-file mismatches", () => {
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				contentRefs: [
+					baseManifest.contentRefs[0],
+					{
+						...baseManifest.contentRefs[0],
+						revision: "r2",
+						reference: {
+							...baseManifest.contentRefs[0].reference,
+							revision: "r2",
+						},
+					},
+				],
+			}),
+		).toThrow(/conflicting revisions/u);
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				modifiedFiles: [
+					{
+						reference: { kind: "file", ref: "opaque-file", revision: "r1" },
+						revision: "r2",
+					},
+				],
+			}),
+		).toThrow(/modified file reference revision mismatch/u);
+	});
 });

--- a/packages/core/src/types/content-manifest.test.ts
+++ b/packages/core/src/types/content-manifest.test.ts
@@ -106,5 +106,20 @@ describe("validateCompactionContentManifest", () => {
 				],
 			}),
 		).toThrow(/modified file reference revision mismatch/u);
+		expect(() =>
+			validateCompactionContentManifest({
+				...baseManifest,
+				modifiedFiles: [
+					{
+						reference: { kind: "file", ref: "opaque-file", revision: "r1" },
+						revision: "r1",
+					},
+					{
+						reference: { kind: "file", ref: "opaque-file", revision: "r2" },
+						revision: "r2",
+					},
+				],
+			}),
+		).toThrow(/modified files contain conflicting revisions/u);
 	});
 });

--- a/packages/core/src/types/content-manifest.ts
+++ b/packages/core/src/types/content-manifest.ts
@@ -208,6 +208,7 @@ export function validateCompactionContentManifest(
 	if (input.modifiedFiles.length > COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES) {
 		throw new TypeError("content manifest has too many modified files");
 	}
+	const seenModifiedFiles = new Map<string, string | undefined>();
 	const modifiedFiles = input.modifiedFiles.map((raw, index) => {
 		const item = record(raw, `modifiedFiles[${index}]`);
 		exactKeys(item, MODIFIED_FILE_KEYS, `modifiedFiles[${index}]`);
@@ -226,6 +227,15 @@ export function validateCompactionContentManifest(
 		) {
 			throw new TypeError("modified file reference revision mismatch");
 		}
+		const key = `${reference.kind}\u0000${reference.ref}`;
+		if (seenModifiedFiles.has(key)) {
+			const priorRevision = seenModifiedFiles.get(key);
+			if (priorRevision !== revision) {
+				throw new TypeError("modified files contain conflicting revisions");
+			}
+			throw new TypeError("modified files contain a duplicate reference");
+		}
+		seenModifiedFiles.set(key, revision);
 		return { reference, ...(revision ? { revision } : {}) };
 	});
 	if (!Array.isArray(input.pendingProcesses)) {

--- a/packages/core/src/types/content-manifest.ts
+++ b/packages/core/src/types/content-manifest.ts
@@ -126,6 +126,7 @@ export function validateCompactionContentManifest(
 	if (input.contentRefs.length > COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES) {
 		throw new TypeError("content manifest has too many references");
 	}
+	const seenReferences = new Map<string, string | undefined>();
 	const contentRefs = input.contentRefs.map((rawEntry, entryIndex) => {
 		const entry = record(rawEntry, `contentRefs[${entryIndex}]`);
 		exactKeys(entry, ENTRY_KEYS, `contentRefs[${entryIndex}]`);
@@ -141,6 +142,15 @@ export function validateCompactionContentManifest(
 		) {
 			throw new TypeError("content manifest reference revision mismatch");
 		}
+		const key = `${reference.kind}\u0000${reference.ref}`;
+		if (seenReferences.has(key)) {
+			const priorRevision = seenReferences.get(key);
+			if (priorRevision !== revision) {
+				throw new TypeError("content manifest contains conflicting revisions");
+			}
+			throw new TypeError("content manifest contains a duplicate reference");
+		}
+		seenReferences.set(key, revision);
 		if (!Array.isArray(entry.rangesUsed)) {
 			throw new TypeError(
 				`contentRefs[${entryIndex}].rangesUsed must be an array`,
@@ -209,6 +219,13 @@ export function validateCompactionContentManifest(
 			item.revision === undefined
 				? reference.revision
 				: nonempty(item.revision, `modifiedFiles[${index}].revision`);
+		if (
+			reference.revision !== undefined &&
+			revision !== undefined &&
+			reference.revision !== revision
+		) {
+			throw new TypeError("modified file reference revision mismatch");
+		}
 		return { reference, ...(revision ? { revision } : {}) };
 	});
 	if (!Array.isArray(input.pendingProcesses)) {

--- a/packages/core/src/types/content-manifest.ts
+++ b/packages/core/src/types/content-manifest.ts
@@ -1,0 +1,252 @@
+/**
+ * Defines and validates the content-only archive manifest retained beside an
+ * LLM summary. The schema carries opaque native references and exact ranges,
+ * never source text, native paths, credentials, or ambient authorization.
+ */
+
+import {
+	type ContentReference,
+	READ_RANGE_UNITS,
+	type ReadRangeUnit,
+	validateContentReference,
+} from "./content";
+
+export const COMPACTION_CONTENT_MANIFEST_SCHEMA_VERSION = 1 as const;
+export const COMPACTION_CONTENT_MANIFEST_MAX_BYTES = 256 * 1024;
+export const COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES = 256;
+export const COMPACTION_CONTENT_MANIFEST_MAX_RANGES_PER_REFERENCE = 64;
+export const COMPACTION_CONTENT_MANIFEST_MAX_PENDING_PROCESSES = 128;
+
+export interface CompactionContentRange {
+	unit: ReadRangeUnit;
+	start: number;
+	end: number;
+}
+
+export interface CompactionContentEntry {
+	reference: ContentReference;
+	revision?: string;
+	reason: string;
+	rangesUsed: CompactionContentRange[];
+	lastUsedAt: string;
+	retained: boolean;
+	expiresAt?: string;
+}
+
+export interface CompactionContentManifest {
+	schemaVersion: typeof COMPACTION_CONTENT_MANIFEST_SCHEMA_VERSION;
+	contentRefs: CompactionContentEntry[];
+	modifiedFiles: Array<{
+		reference: ContentReference;
+		revision?: string;
+	}>;
+	pendingProcesses: Array<{
+		id: string;
+		outputReference?: ContentReference;
+		offset?: number;
+	}>;
+}
+
+const MANIFEST_KEYS = new Set([
+	"schemaVersion",
+	"contentRefs",
+	"modifiedFiles",
+	"pendingProcesses",
+]);
+const ENTRY_KEYS = new Set([
+	"reference",
+	"revision",
+	"reason",
+	"rangesUsed",
+	"lastUsedAt",
+	"retained",
+	"expiresAt",
+]);
+const RANGE_KEYS = new Set(["unit", "start", "end"]);
+const MODIFIED_FILE_KEYS = new Set(["reference", "revision"]);
+const PENDING_PROCESS_KEYS = new Set(["id", "outputReference", "offset"]);
+const RANGE_UNITS = new Set<string>(READ_RANGE_UNITS);
+const SAFE_ID = /^[A-Za-z0-9._:~-]{1,256}$/u;
+
+function record(value: unknown, label: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new TypeError(`${label} must be an object`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function exactKeys(
+	value: Record<string, unknown>,
+	allowed: ReadonlySet<string>,
+	label: string,
+): void {
+	const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+	if (unknown.length > 0) {
+		throw new TypeError(
+			`${label} contains unsupported field(s): ${unknown.join(", ")}`,
+		);
+	}
+}
+
+function nonnegative(value: unknown, label: string): number {
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+		throw new TypeError(`${label} must be a nonnegative safe integer`);
+	}
+	return value;
+}
+
+function nonempty(value: unknown, label: string): string {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new TypeError(`${label} must be a nonempty string`);
+	}
+	return value;
+}
+
+function timestamp(value: unknown, label: string): string {
+	const text = nonempty(value, label);
+	const epoch = Date.parse(text);
+	if (!Number.isFinite(epoch) || new Date(epoch).toISOString() !== text) {
+		throw new TypeError(`${label} must be an ISO-8601 UTC timestamp`);
+	}
+	return text;
+}
+
+/** Strictly validate an untrusted persisted content manifest. */
+export function validateCompactionContentManifest(
+	value: unknown,
+): CompactionContentManifest {
+	const input = record(value, "content manifest");
+	exactKeys(input, MANIFEST_KEYS, "content manifest");
+	if (input.schemaVersion !== COMPACTION_CONTENT_MANIFEST_SCHEMA_VERSION) {
+		throw new TypeError("content manifest schemaVersion is unsupported");
+	}
+	if (!Array.isArray(input.contentRefs)) {
+		throw new TypeError("content manifest contentRefs must be an array");
+	}
+	if (input.contentRefs.length > COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES) {
+		throw new TypeError("content manifest has too many references");
+	}
+	const contentRefs = input.contentRefs.map((rawEntry, entryIndex) => {
+		const entry = record(rawEntry, `contentRefs[${entryIndex}]`);
+		exactKeys(entry, ENTRY_KEYS, `contentRefs[${entryIndex}]`);
+		const reference = validateContentReference(entry.reference);
+		const revision =
+			entry.revision === undefined
+				? reference.revision
+				: nonempty(entry.revision, `contentRefs[${entryIndex}].revision`);
+		if (
+			reference.revision !== undefined &&
+			revision !== undefined &&
+			reference.revision !== revision
+		) {
+			throw new TypeError("content manifest reference revision mismatch");
+		}
+		if (!Array.isArray(entry.rangesUsed)) {
+			throw new TypeError(
+				`contentRefs[${entryIndex}].rangesUsed must be an array`,
+			);
+		}
+		if (
+			entry.rangesUsed.length >
+			COMPACTION_CONTENT_MANIFEST_MAX_RANGES_PER_REFERENCE
+		) {
+			throw new TypeError("content manifest entry has too many ranges");
+		}
+		const rangesUsed = entry.rangesUsed.map((rawRange, rangeIndex) => {
+			const range = record(
+				rawRange,
+				`contentRefs[${entryIndex}].rangesUsed[${rangeIndex}]`,
+			);
+			exactKeys(range, RANGE_KEYS, "content manifest range");
+			if (typeof range.unit !== "string" || !RANGE_UNITS.has(range.unit)) {
+				throw new TypeError("content manifest range unit is unsupported");
+			}
+			const start = nonnegative(range.start, "content manifest range.start");
+			const end = nonnegative(range.end, "content manifest range.end");
+			if (start > end)
+				throw new TypeError("content manifest range start exceeds end");
+			return { unit: range.unit as ReadRangeUnit, start, end };
+		});
+		if (typeof entry.retained !== "boolean") {
+			throw new TypeError(
+				`contentRefs[${entryIndex}].retained must be boolean`,
+			);
+		}
+		return {
+			reference,
+			...(revision ? { revision } : {}),
+			reason: nonempty(entry.reason, `contentRefs[${entryIndex}].reason`),
+			rangesUsed,
+			lastUsedAt: timestamp(
+				entry.lastUsedAt,
+				`contentRefs[${entryIndex}].lastUsedAt`,
+			),
+			retained: entry.retained,
+			...(entry.expiresAt === undefined
+				? {}
+				: {
+						expiresAt: timestamp(
+							entry.expiresAt,
+							`contentRefs[${entryIndex}].expiresAt`,
+						),
+					}),
+		};
+	});
+	if (!Array.isArray(input.modifiedFiles)) {
+		throw new TypeError("content manifest modifiedFiles must be an array");
+	}
+	if (input.modifiedFiles.length > COMPACTION_CONTENT_MANIFEST_MAX_REFERENCES) {
+		throw new TypeError("content manifest has too many modified files");
+	}
+	const modifiedFiles = input.modifiedFiles.map((raw, index) => {
+		const item = record(raw, `modifiedFiles[${index}]`);
+		exactKeys(item, MODIFIED_FILE_KEYS, `modifiedFiles[${index}]`);
+		const reference = validateContentReference(item.reference);
+		if (reference.kind !== "file") {
+			throw new TypeError("modifiedFiles references must have kind=file");
+		}
+		const revision =
+			item.revision === undefined
+				? reference.revision
+				: nonempty(item.revision, `modifiedFiles[${index}].revision`);
+		return { reference, ...(revision ? { revision } : {}) };
+	});
+	if (!Array.isArray(input.pendingProcesses)) {
+		throw new TypeError("content manifest pendingProcesses must be an array");
+	}
+	if (
+		input.pendingProcesses.length >
+		COMPACTION_CONTENT_MANIFEST_MAX_PENDING_PROCESSES
+	) {
+		throw new TypeError("content manifest has too many pending processes");
+	}
+	const pendingProcesses = input.pendingProcesses.map((raw, index) => {
+		const item = record(raw, `pendingProcesses[${index}]`);
+		exactKeys(item, PENDING_PROCESS_KEYS, `pendingProcesses[${index}]`);
+		const id = nonempty(item.id, `pendingProcesses[${index}].id`);
+		if (!SAFE_ID.test(id))
+			throw new TypeError("pending process id is not opaque");
+		return {
+			id,
+			...(item.outputReference === undefined
+				? {}
+				: { outputReference: validateContentReference(item.outputReference) }),
+			...(item.offset === undefined
+				? {}
+				: { offset: nonnegative(item.offset, "pending process offset") }),
+		};
+	});
+	const manifest: CompactionContentManifest = {
+		schemaVersion: COMPACTION_CONTENT_MANIFEST_SCHEMA_VERSION,
+		contentRefs,
+		modifiedFiles,
+		pendingProcesses,
+	};
+	if (
+		new TextEncoder().encode(JSON.stringify(manifest)).byteLength >
+		COMPACTION_CONTENT_MANIFEST_MAX_BYTES
+	) {
+		throw new TypeError("content manifest exceeds its serialized byte bound");
+	}
+	return manifest;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -30,6 +30,7 @@ export * from "./components";
 // Connector setup HTTP-route contract (distinct from ./setup onboarding wizard)
 export * from "./connector-setup";
 export * from "./content";
+export * from "./content-manifest";
 export * from "./contexts";
 export * from "./database";
 export * from "./documents";


### PR DESCRIPTION
Progresses #24286. This is the opt-in M4 follow-up to #24305; it does not close the larger rollout goal.

## What changed

- adds one `renderActionResultsForModel` migration bridge for native and legacy model-facing ActionResults, preserving `promptData`-over-`data`, fair aggregate projection, and fail-explicit nonrecoverable overflow;
- feature-gates that projection across ActionState, message-state injection, post-turn evaluation, reflection, and grounded action replies;
- rejects a planner request that remains over its resolved context budget after final projection instead of relying on a provider context-length error;
- adds a versioned, strict, content-free compaction/archive manifest for model-safe references and exact ranges across both active and archived trajectory steps;
- rejects unknown fields, raw paths, duplicate/conflicting revisions, excessive references/ranges/depth/processes, and oversized serialized manifests;
- retains every attachment `ReadView` and gives every oversized pinned document a bounded fair excerpt plus its item-specific document reference;
- updates the specification and research/test report with the second-pass completion audit and the required PR/post-merge/nightly/soak matrix.

The manifest is a schema and deterministic trajectory snapshot, not restored automatic compaction, authority, retention extension, or restart-durable storage. Private tool-output spill remains M5 after its storage lifecycle is approved.

## Exact-head verification

Head: `c54f83419269c97d10ebc8850be7d360432c46a0` on `origin/develop@27152f0bcca5549d63c9efde2e41a036e90c6162`.

- core typecheck passed;
- 10 focused core production-path files: 221/221 tests passed;
- grounded action reply: 11/11 tests passed;
- independent adversarial review initially found five defects; all were repaired and the final re-review verdict is ACCEPT with no remaining findings;
- core Node/browser/edge/testing build and packed import verification passed;
- `git diff --check` passed.

Repository-wide `bun run verify` currently stops in the unchanged i18n gate because current `develop` is missing 9 English keys and over 990 fallback keys in several locale files. Package-wide core lint likewise reports unchanged surrogate/audience-egress formatting and unused-import findings. Agent typecheck reaches unchanged missing optional workspace packages (`plugin-capacitor-bridge`, `plugin-wallet`, `plugin-video`, `plugin-vision`, `plugin-notes`, `plugin-todos`, `cloud-routing`). None of those files are changed here; hosted CI remains authoritative for the rebased head.

## Evidence

<!-- evidence-head:c54f83419269c97d10ebc8850be7d360432c46a0 -->

- UI screenshots/video/OCR: N/A — no rendered UI surface changed.
- Live-model trajectory: N/A for this opt-in contract/refactor PR — scheduled provider-qualified continuation discovery remains a pre-default gate in #24286.
- Backend/domain evidence: focused production-path tests exercise real serializers, provider prompt capture, strict manifest construction/validation, archived-step preservation, pinned-document bounds, and attachment continuation metadata.

## Known staged work

- Per-provider planner failover rerendering and tokenizer-backed final-wire counts remain required before enabling projection by default.
- Room-scoped manifest capture, session-summary persistence, reauthorization, and fresh-process readback remain required before claiming compaction continuity.
- Documents, stored messages, and stored attachments still require chunked/indexed storage for source-size-independent I/O; Gmail requires measured one-time acquisition/cache semantics.
- Strict fixture planning, credentialed live-model trials, real PDF/DOCX/XLSX/OCR/MIME corpora, context-inspector E2E, real Postgres, explicit mutant killing, and soak/performance matrices remain open in #24286.

<!-- evidence-row:backend-logs -->
- [x] Focused exact-head test output summarized above; hosted logs pending

<!-- evidence-row:domain-artifacts -->
- [x] Strict manifest and prompt-capture tests at exact head

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no live provider credential selected; scheduled live proof remains a pre-default gate

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-progressive-content-m4]

