### PR TITLE
fix(agent): parse rm short-option clusters safely

### DIFF
--- a/packages/agent/src/services/vfs-builtin-shell.test.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.test.ts
@@ -150,4 +150,62 @@ describe("runVfsBuiltinShell", () => {
       stderr: "",
     });
   });
+
+  // A short-option cluster carries every flag in it, so every spelling that
+  // contains r or R removes a tree. `-Rf`, `-fR` and `-rvf` used to parse as
+  // non-recursive, so `fsp.rm` threw EISDIR and the command exited 1 with the
+  // directory still in place.
+  // Distinct project ids per case: a case-insensitive filesystem would fold
+  // `-r`/`-R` and `-rf`/`-Rf` onto the same sandbox directory.
+  it.each([
+    ["-r", "lower"],
+    ["-R", "upper"],
+    ["-rf", "lowerforce"],
+    ["-fr", "forcelower"],
+    ["-Rf", "upperforce"],
+    ["-fR", "forceupper"],
+    ["-rvf", "verboseforce"],
+  ])("removes a directory tree with rm %s", async (flag, id) => {
+    const projectId = `rmflags-${id}`;
+    const vfs = createVirtualFilesystemService({ projectId });
+    await vfs.initialize();
+    await vfs.writeFile("doomed/nested/file.txt", "contents");
+
+    const result = await runVfsBuiltinShell({
+      cwdUri: `vfs://${projectId}/`,
+      command: "rm",
+      args: [flag, "doomed"],
+    });
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    await expect(vfs.readFile("doomed/nested/file.txt")).rejects.toThrow();
+  });
+
+  it("still refuses to remove a directory without a recursive flag", async () => {
+    const vfs = createVirtualFilesystemService({ projectId: "rmnonrecursive" });
+    await vfs.initialize();
+    await vfs.writeFile("kept/file.txt", "contents");
+
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://rmnonrecursive/",
+      command: "rm",
+      args: ["-f", "kept"],
+    });
+
+    expect(result.exitCode).toBe(1);
+    await expect(vfs.readFile("kept/file.txt")).resolves.toBe("contents");
+  });
+
+  it("still swallows a missing target under -f", async () => {
+    const vfs = createVirtualFilesystemService({ projectId: "rmmissing" });
+    await vfs.initialize();
+
+    const result = await runVfsBuiltinShell({
+      cwdUri: "vfs://rmmissing/",
+      command: "rm",
+      args: ["-f", "never-existed"],
+    });
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+  });
 });

--- a/packages/agent/src/services/vfs-builtin-shell.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.ts
@@ -272,8 +272,14 @@ async function rm(
   args: string[],
 ): Promise<VfsBuiltinCommandResult> {
   const optionArgs = args.filter((arg) => arg.startsWith("-"));
+  // A short-option cluster carries every flag in it: `-Rf` is `-R -f`, which is
+  // how `force` below already reads its own flag. Matching whole strings meant
+  // only four spellings counted, so `rm -Rf dir` (and `-fR`, `-rvf`, …) parsed
+  // as non-recursive: `fsp.rm` then threw EISDIR, the command exited 1, and the
+  // tree was still there. Long options are left alone; none were recognised
+  // before this change either.
   const recursive = optionArgs.some(
-    (arg) => arg === "-r" || arg === "-R" || arg === "-rf" || arg === "-fr",
+    (arg) => !arg.startsWith("--") && (arg.includes("r") || arg.includes("R")),
   );
   const force = optionArgs.some((arg) => arg.includes("f"));
   const targets = args.filter((arg) => !arg.startsWith("-"));


### PR DESCRIPTION
# Relates to

Closes #24109. Supersedes #24112, #24129, and #24215 by preserving the safe contributor implementation from #24112 on current `develop`.

## Summary

- Parses real short-option clusters so `-Rf`, `-fR`, and `-rvf` enable recursive VFS deletion.
- Explicitly excludes long options, preventing the destructive `--verbose` / `--preserve-root` regression found in the alternative branches.
- Preserves non-recursive directory refusal and force-on-missing behavior.
- Retains the original contributor authorship through the cherry-picked commit.

## Current-base verification

Base: `develop@75916820b8f228cf48a356df0f2c0b20ed11aaf0`
Head: `d19840dd2752467d3cd44ade02552007c3d236b7`

- PASS — real Vitest lane: `vfs-builtin-shell.test.ts`, 13/13.
- PASS — scoped Biome on both changed files.
- PASS — `git diff --check`.
- EXPECTED BASE/INSTALL HOLD — package typecheck reports current workspace missing optional dependency/export surfaces and unrelated current-develop diagnostics; neither changed file is named.

## Evidence Gate

<!-- evidence-head:d19840dd2752467d3cd44ade02552007c3d236b7 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; backend VFS argv parsing only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; backend VFS argv parsing only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow; filesystem outcomes are asserted directly.
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head transcript:

  ```text
  RUN v4.1.10 /tmp/eliza-pr-24112
  Test Files  1 passed (1)
  Tests       13 passed (13); Duration 5.04s; pinned Bun 1.3.14 / Node 24.15.0 runtime
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action-planning, or provider path.
<!-- evidence-row:domain-artifacts -->
- [x] Captured filesystem outcomes from the real VFS harness:

  ```text
  -r/-R/-rf/-fr/-Rf/-fR/-rvf: target nested file absent after exit 0
  rm -f <non-empty-dir>: nested file retained and command exits nonzero
  rm -f <missing-target>: target remains absent and command exits 0 with empty stderr
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

Original implementation: @ss251 in #24112.
