### PR TITLE
fix(core): make source entry resolution explicit

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./errors";
 // Re-export everything from the Node.js entry point
 // This ensures that imports from "@elizaos/core" resolve correctly during builds
-export * from "./index.node";
+export * from "./index.node.ts";
 // Unwraps the untrusted-content envelope to the user's verbatim text. Public
 // because orchestration surfaces that forward a user message onward (e.g. a
 // deterministic follow-up send) must never embed the security banner in a

--- a/packages/core/src/source-entry-resolution.test.ts
+++ b/packages/core/src/source-entry-resolution.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Verifies the published source condition through a real Node/tsx package
+ * import and audits every platform barrel's relative module targets. The
+ * subprocess resolves the workspace package export instead of a test alias.
+ */
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageRoot, "../..");
+const sourceRoot = resolve(packageRoot, "src");
+
+const platformEntries = [
+	"index.ts",
+	"index.node.ts",
+	"index.browser.ts",
+	"index.edge.ts",
+] as const;
+
+function targetExists(importer: string, specifier: string): boolean {
+	const unresolved = resolve(dirname(importer), specifier);
+	const hasModuleExtension = /\.(?:[cm]?[jt]sx?|json|node)$/.test(specifier);
+	const candidates = hasModuleExtension
+		? [unresolved, unresolved.replace(/\.js$/, ".ts")]
+		: [
+				`${unresolved}.ts`,
+				`${unresolved}.tsx`,
+				resolve(unresolved, "index.ts"),
+			];
+	return candidates.some((candidate) => existsSync(candidate));
+}
+
+describe("core source export resolution", () => {
+	it("keeps package conditions on the intended platform entrypoints", async () => {
+		const packageJson = JSON.parse(
+			await readFile(resolve(packageRoot, "package.json"), "utf8"),
+		) as {
+			exports: Record<string, Record<string, unknown>>;
+		};
+		const rootExport = packageJson.exports["."];
+		const sourceExport = rootExport["eliza-source"] as Record<string, string>;
+
+		expect(sourceExport.import).toBe("./src/index.ts");
+		expect(packageJson.exports["./node"]["eliza-source"]).toMatchObject({
+			import: "./src/index.node.ts",
+		});
+		expect(packageJson.exports["./browser"]["eliza-source"]).toMatchObject({
+			import: "./src/index.browser.ts",
+		});
+		expect(rootExport.node).toMatchObject({
+			import: "./dist/node/index.node.js",
+		});
+		expect(rootExport.browser).toMatchObject({
+			import: "./dist/browser/index.browser.js",
+		});
+	});
+
+	it("uses an explicit TypeScript hop at the package source boundary", async () => {
+		const source = await readFile(resolve(sourceRoot, "index.ts"), "utf8");
+		expect(source).toContain('export * from "./index.node.ts";');
+		expect(source).not.toMatch(/from ["']\.\/index\.node["']/);
+	});
+
+	it("keeps every platform barrel relative specifier resolvable", async () => {
+		const missing: string[] = [];
+		for (const entry of platformEntries) {
+			const absoluteEntry = resolve(sourceRoot, entry);
+			const source = await readFile(absoluteEntry, "utf8");
+			const specifiers = source.matchAll(/\bfrom\s+["'](\.[^"']+)["']/g);
+			for (const match of specifiers) {
+				if (!targetExists(absoluteEntry, match[1])) {
+					missing.push(`${entry}: ${match[1]}`);
+				}
+			}
+		}
+
+		expect(missing).toEqual([]);
+	});
+
+	it("imports the real package source condition through Node and tsx", async () => {
+		const probe = [
+			'import("@elizaos/core")',
+			'.then((core) => { if (typeof core.ElizaError !== "function") throw new Error("missing ElizaError"); process.stdout.write("core-source-ok\\n"); })',
+		].join("");
+		const { stdout } = await execFileAsync(
+			process.execPath,
+			[
+				"--conditions=eliza-source",
+				"--import",
+				"tsx",
+				"--input-type=module",
+				"--eval",
+				probe,
+			],
+			{ cwd: repositoryRoot, timeout: 30_000 },
+		);
+
+		expect(stdout).toContain("core-source-ok");
+	});
+});


### PR DESCRIPTION
## Summary

- make the default `@elizaos/core` source entry explicitly re-export `./index.node.ts`
- preserve the existing Node/browser/edge/testing conditional-export layout and generated-distribution contract
- add a source-resolution regression that audits all four platform barrels and imports the real workspace package through Node + tsx with the `eliza-source` condition

Closes #24331

## Why

The `eliza-source` package condition selects `packages/core/src/index.ts`. That package boundary should name its TypeScript target explicitly so Node/Vite source-mode loading does not depend on extensionless TypeScript inference before the loader owns the remainder of the graph. This changes the owning export convention; it does not add a Vite alias or depend on generated `dist` output.

## Validation

Current rebased head `dbf8049a7537484536714876c33151c3704a20fe`, pinned Node `24.15.0` and Bun `1.3.14`:

- changed-file Biome: passed
- `packages/core/src/source-entry-resolution.test.ts`: 4/4 passed
  - package-condition map selects the intended source and built targets
  - the package boundary uses the explicit `.ts` hop
  - all relative specifiers in `index.ts`, `index.node.ts`, `index.browser.ts`, and `index.edge.ts` resolve to source targets
  - a child process imports the real `@elizaos/core` package with `node --conditions=eliza-source --import tsx`
- `bun run --cwd packages/core typecheck`: passed
- `node packages/scripts/verify-package-runtime-exports.mjs packages/core`: 11/11 runtime exports verified
- `git diff --check`: passed

On the immediately preceding rebased head with the same two-file patch, `bun run --cwd packages/core build` passed all Node, browser, edge, and testing bundles, rewrote 1,848 declaration specifiers in 524 files, and verified packed edge plus Node/browser/exact-flat Vite consumers. The final lightweight rebase changed no relevant core file.

## Broad-lane boundary

- package-wide core lint currently reports unrelated existing findings in access-control, surrogate, document, well-formed, and validation files; both changed files pass Biome
- the full core Vitest lane was stopped at the shared-host storage safety floor after exposing unrelated failures across prompt snapshots, audience policy, document services, and trajectory tests; it is not claimed as a pass
- no production UI changed, so screenshots, mobile captures, and walkthrough video are N/A
- no model/prompt/action behavior changed, so live-model trajectories are N/A
- no native/device/connector behavior changed, so platform captures are N/A

The PR is ready after independent source review and exact-head maintainer validation.

AI provider/model: OpenAI / gpt-6.5-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribution skill not invoked
Attribution status: self-reported
— [core-source-resolution]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-6.5-sol","client":"Codex Desktop","skill_revision":"N/A - contribution skill not invoked"} -->
## Current-base maintainer receipt

Exact head `dbf8049a7537484536714876c33151c3704a20fe` on base `765dad077f090b3f5edcfb2162f4ffcea51b6547` was independently rebuilt on Linux with pinned Bun 1.3.14 and Node 24.15.0: source-entry regression 4/4, core typecheck, changed-file Biome, diff check, all Node/browser/edge/testing bundles, 1,848 declaration rewrites, packed edge and Node/browser/exact-flat Vite consumers, and 11/11 runtime export verification all passed.

## Evidence Gate

<!-- evidence-head:dbf8049a7537484536714876c33151c3704a20fe -->
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - package resolution has no rendered UI.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - package resolution has no rendered UI.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive UI flow changed.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

<details><summary>Exact-head Linux validation transcript</summary>

```text
Source-entry regression: 1 file passed, 4 tests passed.
Core typecheck and changed-file Biome: passed; git diff --check: clean.
Node/browser/edge/testing bundles, packed consumers, and runtime exports 11/11: passed.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend runtime path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model-facing behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no persisted domain state changed; packed package artifacts were directly imported and verified.`

