### PR TITLE
test(cloud): preserve Worker verification type narrowing

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -111,7 +111,9 @@ const consumeGroupClaimAndBind = mock(
 const resolveGroupBinding = mock(
   async (): Promise<Record<string, unknown> | null> => null,
 );
-const setGroupResponsePolicy = mock(async () => null);
+const setGroupResponsePolicy = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
 const revokeGroupBinding = mock(async () => false);
 const applyGroupMembershipChange = mock(
   async (): Promise<Record<string, unknown> | null> => null,

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
@@ -216,6 +216,8 @@ realPostgres("app and initial API-key atomicity", () => {
     ) {
       throw new Error("real PostgreSQL harness was not initialized");
     }
+    const initializedAppsService = appsService;
+    const initializedApiKeysRepository = apiKeysRepository;
 
     const suffix = randomUUID();
     const [organization] = await dbWrite
@@ -249,7 +251,7 @@ realPostgres("app and initial API-key atomicity", () => {
 
     const deleteKey = spyOn(apiKeysService, "delete");
     const creates = names.map((name, index) =>
-      appsService.create({
+      initializedAppsService.create({
         name,
         organization_id: organization.id,
         created_by_user_id: user.id,
@@ -287,7 +289,7 @@ realPostgres("app and initial API-key atomicity", () => {
       const durableKeys = (
         await Promise.all(
           names.map((name) =>
-            apiKeysRepository.findByUserAndName(user.id, `${name} - App API Key`),
+            initializedApiKeysRepository.findByUserAndName(user.id, `${name} - App API Key`),
           ),
         )
       ).flat();


### PR DESCRIPTION
@lalalune — narrow staging release unblocker.

## Why

Cloud CF staging run 32555180851 admitted exact source `75916820b8f228cf48a356df0f2c0b20ed11aaf0`, passed the migration guard, and completed migrations. The Worker job then failed in `Verify Worker` before credentials or deployment because TypeScript lost intentional non-null and union narrowing in two tests.

## What

- Keep the Personal Shared response-policy mock nullable binding return type broad.
- Capture already-validated app service and repository handles before async callbacks so TypeScript preserves non-null narrowing.
- No runtime or workflow behavior changes.

## Verification

- `bun run build:core` — 59/59
- `bun run --cwd packages/cloud/api typecheck` — pass, including Wrangler dry-run bundle
- Personal Shared route test — 44/44, 180 assertions
- PostgreSQL atomicity test compiles; safely skips locally without the opt-in real PostgreSQL harness
- Biome and `git diff --check` — pass

This is intentionally draft and staging-lane scoped. Please review and merge when ready so the exact-current-develop Cloud CF staging release can be serialized.