### PR TITLE
fix(core): harden source export condition matrix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,11 +29,6 @@
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
-			"eliza-source": {
-				"types": "./src/index.ts",
-				"import": "./src/index.ts",
-				"default": "./src/index.ts"
-			},
 			"workerd": {
 				"types": "./dist/edge/index.d.ts",
 				"import": "./dist/edge/index.edge.js",
@@ -43,6 +38,11 @@
 				"types": "./dist/index.browser.d.ts",
 				"import": "./dist/browser/index.browser.js",
 				"default": "./dist/browser/index.browser.js"
+			},
+			"eliza-source": {
+				"types": "./src/index.ts",
+				"import": "./src/index.ts",
+				"default": "./src/index.ts"
 			},
 			"node": {
 				"types": "./dist/index.node.d.ts",
@@ -68,11 +68,6 @@
 		},
 		"./browser": {
 			"types": "./dist/index.browser.d.ts",
-			"eliza-source": {
-				"types": "./src/index.browser.ts",
-				"import": "./src/index.browser.ts",
-				"default": "./src/index.browser.ts"
-			},
 			"import": "./dist/browser/index.browser.js",
 			"default": "./dist/browser/index.browser.js"
 		},
@@ -88,15 +83,15 @@
 		},
 		"./client-public": {
 			"types": "./dist/client-public.d.ts",
-			"eliza-source": {
-				"types": "./src/client-public.ts",
-				"import": "./src/client-public.ts",
-				"default": "./src/client-public.ts"
-			},
 			"browser": {
 				"types": "./dist/client-public.d.ts",
 				"import": "./dist/browser/client-public.js",
 				"default": "./dist/browser/client-public.js"
+			},
+			"eliza-source": {
+				"types": "./src/client-public.ts",
+				"import": "./src/client-public.ts",
+				"default": "./src/client-public.ts"
 			},
 			"node": {
 				"types": "./dist/client-public.d.ts",
@@ -112,6 +107,11 @@
 		},
 		"./testing": {
 			"types": "./dist/testing/index.d.ts",
+			"eliza-source": {
+				"types": "./src/testing/index.ts",
+				"import": "./src/testing/index.ts",
+				"default": "./src/testing/index.ts"
+			},
 			"import": "./dist/testing/index.js",
 			"default": "./dist/testing/index.js"
 		},

--- a/packages/core/src/source-entry-resolution.test.ts
+++ b/packages/core/src/source-entry-resolution.test.ts
@@ -37,6 +37,12 @@ function sourceUrl(relativePath: string): string {
 	return pathToFileURL(resolve(packageRoot, relativePath)).href;
 }
 
+function consumerPackageUrl(relativePath: string): string {
+	return pathToFileURL(
+		resolve(consumerRoot, "node_modules/@elizaos/core", relativePath),
+	).href;
+}
+
 function targetExists(importer: string, specifier: string): boolean {
 	const unresolved = resolve(dirname(importer), specifier);
 	const hasModuleExtension = /\.(?:[cm]?[jt]sx?|json|node)$/.test(specifier);
@@ -136,9 +142,7 @@ describe("core source export resolution", () => {
 		expect(packageJson.exports["./testing"]["eliza-source"]).toMatchObject({
 			import: "./src/testing/index.ts",
 		});
-		for (const [specifier, conditions] of Object.entries(
-			packageJson.exports,
-		)) {
+		for (const [specifier, conditions] of Object.entries(packageJson.exports)) {
 			const conditionOrder = Object.keys(conditions);
 			const sourceIndex = conditionOrder.indexOf("eliza-source");
 			if (sourceIndex < 0) continue;
@@ -182,8 +186,10 @@ describe("core source export resolution", () => {
 			{
 				"@elizaos/core": sourceUrl("src/index.ts"),
 				"@elizaos/core/node": sourceUrl("src/index.node.ts"),
-				"@elizaos/core/browser": sourceUrl("dist/browser/index.browser.js"),
-				"@elizaos/core/edge": sourceUrl("dist/edge/index.edge.js"),
+				"@elizaos/core/browser": consumerPackageUrl(
+					"dist/browser/index.browser.js",
+				),
+				"@elizaos/core/edge": consumerPackageUrl("dist/edge/index.edge.js"),
 				"@elizaos/core/testing": sourceUrl("src/testing/index.ts"),
 			},
 			true,
@@ -205,12 +211,12 @@ describe("core source export resolution", () => {
 	it("selects verified browser and workerd builds ahead of Node source", async () => {
 		await expect(
 			runResolutionProbe("node", [], ["eliza-source", "browser"], {
-				"@elizaos/core": sourceUrl("dist/browser/index.browser.js"),
+				"@elizaos/core": consumerPackageUrl("dist/browser/index.browser.js"),
 			}),
 		).resolves.toContain("core-source-ok");
 		await expect(
 			runResolutionProbe("node", [], ["eliza-source", "workerd"], {
-				"@elizaos/core": sourceUrl("dist/edge/index.edge.js"),
+				"@elizaos/core": consumerPackageUrl("dist/edge/index.edge.js"),
 			}),
 		).resolves.toContain("core-source-ok");
 	});
@@ -240,7 +246,7 @@ describe("core source export resolution", () => {
 
 			await expect(
 				execFileAsync(
-					process.execPath,
+					"node",
 					[
 						"--conditions=eliza-source",
 						"--conditions=browser",
@@ -251,7 +257,9 @@ describe("core source export resolution", () => {
 					{ cwd: fixtureRoot, timeout: 30_000 },
 				),
 			).rejects.toMatchObject({
-				stderr: expect.stringMatching(/ERR_MODULE_NOT_FOUND/u),
+				stderr: expect.stringMatching(
+					/Cannot find module|ERR_MODULE_NOT_FOUND/u,
+				),
 			});
 
 			await writeFile(
@@ -282,7 +290,7 @@ describe("core source export resolution", () => {
 				"--config",
 				"vite.config.mjs",
 			];
-			await execFileAsync(process.execPath, viteArgs, {
+			await execFileAsync("node", viteArgs, {
 				cwd: fixtureRoot,
 				timeout: 30_000,
 			});
@@ -301,7 +309,7 @@ describe("core source export resolution", () => {
 			await rm(join(fixtureRoot, "dist"), { recursive: true, force: true });
 
 			await expect(
-				execFileAsync(process.execPath, viteArgs, {
+				execFileAsync("node", viteArgs, {
 					cwd: fixtureRoot,
 					timeout: 30_000,
 				}),

--- a/packages/core/src/source-entry-resolution.test.ts
+++ b/packages/core/src/source-entry-resolution.test.ts
@@ -1,7 +1,6 @@
 /**
- * Verifies the published source condition through real Node/tsx and Vite
- * consumers, and audits every platform barrel's relative module targets. The
- * subprocesses resolve package exports instead of test aliases.
+ * Verifies source package conditions from isolated consumers that resolve this
+ * checkout rather than repository TypeScript aliases.
  */
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
@@ -16,9 +15,9 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -26,13 +25,17 @@ const repositoryRoot = resolve(packageRoot, "../..");
 const sourceRoot = resolve(packageRoot, "src");
 const viteCli = resolve(repositoryRoot, "node_modules/vite/bin/vite.js");
 const tsxImport = import.meta.resolve("tsx");
-
 const platformEntries = [
 	"index.ts",
 	"index.node.ts",
 	"index.browser.ts",
 	"index.edge.ts",
 ] as const;
+let consumerRoot = "";
+
+function sourceUrl(relativePath: string): string {
+	return pathToFileURL(resolve(packageRoot, relativePath)).href;
+}
 
 function targetExists(importer: string, specifier: string): boolean {
 	const unresolved = resolve(dirname(importer), specifier);
@@ -47,29 +50,107 @@ function targetExists(importer: string, specifier: string): boolean {
 	return candidates.some((candidate) => existsSync(candidate));
 }
 
+async function runResolutionProbe(
+	executable: string,
+	loaderArgs: string[],
+	conditions: string[],
+	expected: Record<string, string>,
+	importRoot = false,
+): Promise<string> {
+	const probe = [
+		`const expected = ${JSON.stringify(expected)};`,
+		"for (const [specifier, target] of Object.entries(expected)) {",
+		"  const actual = import.meta.resolve(specifier);",
+		'  if (actual !== target) throw new Error(specifier + " resolved to " + actual + ", expected " + target);',
+		"}",
+		...(importRoot
+			? [
+					'const core = await import("@elizaos/core");',
+					'const nodeCore = await import("@elizaos/core/node");',
+					'if (typeof core.ElizaError !== "function") throw new Error("missing ElizaError");',
+					'if (core.ElizaError !== nodeCore.ElizaError) throw new Error("duplicate core runtime instance");',
+				]
+			: []),
+		'process.stdout.write("core-source-ok\\n");',
+	].join("\n");
+	const { stdout } = await execFileAsync(
+		executable,
+		[
+			...conditions.map((condition) => `--conditions=${condition}`),
+			...loaderArgs,
+			"--input-type=module",
+			"--eval",
+			probe,
+		],
+		{
+			cwd: consumerRoot,
+			timeout: 30_000,
+			env: {
+				...process.env,
+				TSX_TSCONFIG_PATH: join(consumerRoot, "tsconfig.json"),
+			},
+		},
+	);
+	return stdout;
+}
+
 describe("core source export resolution", () => {
-	it("keeps package conditions on the intended platform entrypoints", async () => {
+	beforeAll(async () => {
+		consumerRoot = await mkdtemp(join(tmpdir(), "eliza-core-source-consumer-"));
+		await mkdir(join(consumerRoot, "node_modules", "@elizaos"), {
+			recursive: true,
+		});
+		await symlink(
+			packageRoot,
+			join(consumerRoot, "node_modules", "@elizaos", "core"),
+			"junction",
+		);
+		await writeFile(
+			join(consumerRoot, "tsconfig.json"),
+			JSON.stringify({
+				compilerOptions: {
+					module: "NodeNext",
+					moduleResolution: "NodeNext",
+				},
+			}),
+		);
+	});
+
+	afterAll(async () => {
+		if (consumerRoot) {
+			await rm(consumerRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps unsupported browser and workerd source paths on built artifacts", async () => {
 		const packageJson = JSON.parse(
 			await readFile(resolve(packageRoot, "package.json"), "utf8"),
-		) as {
-			exports: Record<string, Record<string, unknown>>;
-		};
-		const rootExport = packageJson.exports["."];
-		const sourceExport = rootExport["eliza-source"] as Record<string, string>;
+		) as { exports: Record<string, Record<string, unknown>> };
+		const sourceExport = packageJson.exports["."]["eliza-source"];
 
-		expect(sourceExport.import).toBe("./src/index.ts");
-		expect(packageJson.exports["./node"]["eliza-source"]).toMatchObject({
-			import: "./src/index.node.ts",
+		expect(sourceExport).toMatchObject({
+			import: "./src/index.ts",
 		});
-		expect(packageJson.exports["./browser"]["eliza-source"]).toMatchObject({
-			import: "./src/index.browser.ts",
+		expect(packageJson.exports["./browser"]).not.toHaveProperty("eliza-source");
+		expect(packageJson.exports["./edge"]).not.toHaveProperty("eliza-source");
+		expect(packageJson.exports["./testing"]["eliza-source"]).toMatchObject({
+			import: "./src/testing/index.ts",
 		});
-		expect(rootExport.node).toMatchObject({
-			import: "./dist/node/index.node.js",
-		});
-		expect(rootExport.browser).toMatchObject({
-			import: "./dist/browser/index.browser.js",
-		});
+		for (const [specifier, conditions] of Object.entries(
+			packageJson.exports,
+		)) {
+			const conditionOrder = Object.keys(conditions);
+			const sourceIndex = conditionOrder.indexOf("eliza-source");
+			if (sourceIndex < 0) continue;
+			for (const platform of ["browser", "workerd"]) {
+				const platformIndex = conditionOrder.indexOf(platform);
+				if (platformIndex < 0) continue;
+				expect(
+					platformIndex,
+					`${specifier} must prefer ${platform} over eliza-source`,
+				).toBeLessThan(sourceIndex);
+			}
+		}
 	});
 
 	it("uses an explicit TypeScript hop at the package source boundary", async () => {
@@ -90,29 +171,48 @@ describe("core source export resolution", () => {
 				}
 			}
 		}
-
 		expect(missing).toEqual([]);
 	});
 
-	it("imports the real package source condition through Node and tsx", async () => {
-		const probe = [
-			'import("@elizaos/core")',
-			'.then((core) => { if (typeof core.ElizaError !== "function") throw new Error("missing ElizaError"); process.stdout.write("core-source-ok\\n"); })',
-		].join("");
-		const { stdout } = await execFileAsync(
-			process.execPath,
-			[
-				"--conditions=eliza-source",
-				"--import",
-				tsxImport,
-				"--input-type=module",
-				"--eval",
-				probe,
-			],
-			{ cwd: repositoryRoot, timeout: 30_000 },
+	it("imports the exact Node source package without repository path aliases", async () => {
+		const stdout = await runResolutionProbe(
+			"node",
+			["--import", import.meta.resolve("tsx")],
+			["eliza-source"],
+			{
+				"@elizaos/core": sourceUrl("src/index.ts"),
+				"@elizaos/core/node": sourceUrl("src/index.node.ts"),
+				"@elizaos/core/browser": sourceUrl("dist/browser/index.browser.js"),
+				"@elizaos/core/edge": sourceUrl("dist/edge/index.edge.js"),
+				"@elizaos/core/testing": sourceUrl("src/testing/index.ts"),
+			},
+			true,
 		);
-
 		expect(stdout).toContain("core-source-ok");
+	}, 30_000);
+
+	it("imports the exact Bun source package without a TypeScript loader", async () => {
+		const stdout = await runResolutionProbe(
+			"bun",
+			[],
+			["eliza-source"],
+			{ "@elizaos/core": sourceUrl("src/index.ts") },
+			true,
+		);
+		expect(stdout).toContain("core-source-ok");
+	});
+
+	it("selects verified browser and workerd builds ahead of Node source", async () => {
+		await expect(
+			runResolutionProbe("node", [], ["eliza-source", "browser"], {
+				"@elizaos/core": sourceUrl("dist/browser/index.browser.js"),
+			}),
+		).resolves.toContain("core-source-ok");
+		await expect(
+			runResolutionProbe("node", [], ["eliza-source", "workerd"], {
+				"@elizaos/core": sourceUrl("dist/edge/index.edge.js"),
+			}),
+		).resolves.toContain("core-source-ok");
 	});
 
 	it("loads the source export through an actual Vite config consumer", async () => {
@@ -137,6 +237,23 @@ describe("core source export resolution", () => {
 				join(copiedCoreRoot, "node_modules"),
 				"dir",
 			);
+
+			await expect(
+				execFileAsync(
+					process.execPath,
+					[
+						"--conditions=eliza-source",
+						"--conditions=browser",
+						"--input-type=module",
+						"--eval",
+						'import("@elizaos/core")',
+					],
+					{ cwd: fixtureRoot, timeout: 30_000 },
+				),
+			).rejects.toMatchObject({
+				stderr: expect.stringMatching(/ERR_MODULE_NOT_FOUND/u),
+			});
+
 			await writeFile(
 				join(fixtureRoot, "entry.js"),
 				"export const viteSourceConsumer = true;\n",


### PR DESCRIPTION
## Summary

- keep browser and workerd resolution on verified built artifacts before the workspace-only `eliza-source` condition
- remove unsupported source claims from `./browser` and `./edge`, while adding the Node-only `./testing` source path
- replace the merged #24347 test gap with isolated exact-package Node+tsx and Bun consumers, condition-order checks, and duplicate-runtime identity coverage

Relates to #24331.
Supersedes the condition-test gap left by #24347.

## Verification

- `bun test packages/core/src/source-entry-resolution.test.ts` — 6 passed, 0 failed, 13 expectations
- `bun run --cwd packages/core typecheck` — passed
- `bun run --cwd packages/core build` — Node, browser, edge, testing bundles and declarations passed; packed edge declarations/runtime and packed Node/browser-condition/exact-flat Vite consumers passed
- `bun x biome check packages/core/package.json packages/core/src/index.ts packages/core/src/source-entry-resolution.test.ts` — passed
- `git diff --check origin/develop...HEAD` — passed

## Evidence

- Runtime/package artifact: isolated temporary consumers resolve the exact checkout package by file URL; Node+tsx and Bun import source successfully, browser/workerd select built artifacts, and root plus `/node` share the same `ElizaError` identity.
- UI screenshots: N/A — package export and test-only change with no rendered surface.
- Walkthrough video: N/A — no interactive or UI flow changed.
- Frontend console/network logs: N/A — no frontend or network behavior changed.
- Backend logs: N/A — no running backend path changed.
- Live-model trajectory: N/A — no agent, model, prompt, provider, or action behavior changed.
- Native/device evidence: N/A — no native, mobile, desktop, or device surface changed.