### PR TITLE
feat(interactions): add durable negotiated sessions

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -37,6 +37,13 @@ is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 
+The bundled `eliza` plugin registers `MessageInteractionHostService` as the one
+runtime authority connectors resolve through `MESSAGE_INTERACTION_HOST_SERVICE`.
+Connectors submit capability profiles and trusted render bindings to `prepare`,
+then send authenticated inbound provider receipts to `consume`. Only host-owned
+effect handlers execute retained operations; completed receipts preserve the
+provider event, canonical inbound event, audit id, and app-state proof for replay.
+
 ## Approval-bound plugin installation
 
 `installPlugin` always installs the canonical npm package declared by the

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -26,6 +26,17 @@ See `package.json` for `build`, `lint`, and other scripts.
 unsuccessful `TaskResult` with a stable `errorCode`; it never falls back to
 ordinary `TEXT_LARGE` synthesis and labels that output as research.
 
+## Message-interaction session persistence
+
+`FileMessageInteractionSessionStore` is the durable single-host adapter for
+core's message-interaction session authority. It serializes independent local
+processes, writes a 0600 regular file through same-filesystem fsync and atomic
+rename, fails fast on corruption and symlinks, recovers only stale locks whose
+owner is no longer alive, and exposes explicit expiry collection. Its boundary
+is one machine and one state directory. Multi-host deployments must supply a
+transactional database implementation of `MessageInteractionSessionStore` and
+use the session replay key as the effect or outbox idempotency key.
+
 ## Approval-bound plugin installation
 
 `installPlugin` always installs the canonical npm package declared by the

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -37,6 +37,11 @@ is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 
+The file authority durably commits an effect before dispatch. If the process
+dies after that commit but before retaining the receipt, the session remains
+`committed` for operator reconciliation; it is never lease-transferred,
+automatically retried, revoked as if cancellation succeeded, or garbage-collected.
+
 The bundled `eliza` plugin registers `MessageInteractionHostService` as the one
 runtime authority connectors resolve through `MESSAGE_INTERACTION_HOST_SERVICE`.
 Connectors submit capability profiles and trusted render bindings to `prepare`,

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -32,8 +32,10 @@ ordinary `TEXT_LARGE` synthesis and labels that output as research.
 core's message-interaction session authority. It serializes independent local
 processes, writes a 0600 regular file through same-filesystem fsync and atomic
 rename, fails fast on corruption and symlinks, qualifies Linux lock owners by
-boot/process generation (with a bounded portable recovery ceiling), and exposes
-explicit expiry collection. Its boundary
+boot/process generation, and generation-fences stale takeover and release with
+an atomically published transition marker. An unpublished owner has a bounded
+recovery ceiling;
+a live PID that cannot be generation-qualified fails closed. Its boundary
 is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -31,8 +31,9 @@ ordinary `TEXT_LARGE` synthesis and labels that output as research.
 `FileMessageInteractionSessionStore` is the durable single-host adapter for
 core's message-interaction session authority. It serializes independent local
 processes, writes a 0600 regular file through same-filesystem fsync and atomic
-rename, fails fast on corruption and symlinks, recovers only stale locks whose
-owner is no longer alive, and exposes explicit expiry collection. Its boundary
+rename, fails fast on corruption and symlinks, qualifies Linux lock owners by
+boot/process generation (with a bounded portable recovery ceiling), and exposes
+explicit expiry collection. Its boundary
 is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
@@ -40,7 +41,11 @@ use the session replay key as the effect or outbox idempotency key.
 The file authority durably commits an effect before dispatch. If the process
 dies after that commit but before retaining the receipt, the session remains
 `committed` for operator reconciliation; it is never lease-transferred,
-automatically retried, revoked as if cancellation succeeded, or garbage-collected.
+automatically retried, or revoked as if cancellation succeeded. The store lists
+ambiguous commits and accepts only a verified receipt to reconcile them without
+re-execution. Completed receipts are retained for seven days and unreconciled
+commits for thirty days by default, after which bounded collection prevents
+permanent capacity exhaustion.
 
 The bundled `eliza` plugin registers `MessageInteractionHostService` as the one
 runtime authority connectors resolve through `MESSAGE_INTERACTION_HOST_SERVICE`.

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -75,6 +75,7 @@ import {
   knowledgeGraphSchema,
 } from "../services/knowledge-graph/index.ts";
 import { AgentMediaGenerationService } from "../services/media-generation.ts";
+import { MessageInteractionHostService } from "../services/message-interaction-host.ts";
 import { OwnerBindingService } from "../services/owner-binding.ts";
 import { pendantSessionSchema } from "../services/pendant-session/index.ts";
 import { PendingPromptsService } from "../services/pending-prompts/index.ts";
@@ -130,6 +131,7 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       NotificationPushService as ServiceClass,
       ElizaCharacterPersistenceService as ServiceClass,
       AgentMediaGenerationService as ServiceClass,
+      MessageInteractionHostService as ServiceClass,
       LocalFileStorageService as ServiceClass,
       PermissionRegistry as ServiceClass,
       KnowledgeGraphService as ServiceClass,

--- a/packages/agent/src/services/__fixtures__/message-interaction-claim-child.ts
+++ b/packages/agent/src/services/__fixtures__/message-interaction-claim-child.ts
@@ -1,0 +1,12 @@
+/** Executes one file-store claim in a separate process for lock/CAS tests. */
+
+import fs from "node:fs/promises";
+import { FileMessageInteractionSessionStore } from "../message-interaction-session-store.ts";
+
+const [stateDirectory, contextPath] = process.argv.slice(2);
+if (!stateDirectory || !contextPath)
+  throw new Error("state directory and context path are required");
+const context = JSON.parse(await fs.readFile(contextPath, "utf8"));
+const store = new FileMessageInteractionSessionStore({ stateDirectory });
+const result = await store.claimIfCurrent(context);
+process.stdout.write(result.status);

--- a/packages/agent/src/services/__fixtures__/message-interaction-claim-child.ts
+++ b/packages/agent/src/services/__fixtures__/message-interaction-claim-child.ts
@@ -7,6 +7,12 @@ const [stateDirectory, contextPath] = process.argv.slice(2);
 if (!stateDirectory || !contextPath)
   throw new Error("state directory and context path are required");
 const context = JSON.parse(await fs.readFile(contextPath, "utf8"));
-const store = new FileMessageInteractionSessionStore({ stateDirectory });
+const store = new FileMessageInteractionSessionStore({
+  stateDirectory,
+  // Eight independent Bun processes deliberately contend on a durable fsync
+  // path. Keep the assertion about serialization independent of host I/O load;
+  // lock-timeout behavior has its own deterministic coverage.
+  lockTimeoutMs: 120_000,
+});
 const result = await store.claimIfCurrent(context);
 process.stdout.write(result.status);

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -29,6 +29,7 @@ export {
   type EscalationState,
   registerEscalationChannel,
 } from "./escalation.ts";
+export * from "./message-interaction-session-store.ts";
 export * from "./overlay-app-presence.ts";
 export {
   type IPermissionsRegistry,

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -29,6 +29,7 @@ export {
   type EscalationState,
   registerEscalationChannel,
 } from "./escalation.ts";
+export * from "./message-interaction-host.ts";
 export * from "./message-interaction-session-store.ts";
 export * from "./overlay-app-presence.ts";
 export {

--- a/packages/agent/src/services/message-interaction-host.test.ts
+++ b/packages/agent/src/services/message-interaction-host.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Exercises the real host coordinator with core's in-memory atomic store.
+ * The harness is deterministic and proves binding denial, expiry, revocation,
+ * receipt retention, replay, and exactly-once effect dispatch.
+ */
+
+import { mkdtemp, realpath, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  BUTTON_INTERACTION_PROFILE,
+  createConnectorInteractionCapabilityProfile,
+  decodeMessageInteractionCallback,
+  type IAgentRuntime,
+  InMemoryMessageInteractionSessionStore,
+  resolveMessageInteractionHost,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageInteractionHostService } from "./message-interaction-host.ts";
+
+const START = Date.parse("2026-08-21T00:00:00.000Z");
+
+const block = {
+  kind: "choice" as const,
+  id: "approve-1",
+  scope: "approval",
+  options: [
+    { value: "approve", label: "Approve" },
+    { value: "deny", label: "Deny" },
+  ],
+};
+
+const bindings = {
+  actorId: "actor-a",
+  audience: { kind: "room", id: "room-a" },
+  agentId: "agent-a",
+  connector: { source: "connector", accountId: "account-a" },
+  roomId: "room-a",
+  sourceMessageId: "message-a",
+};
+
+const profile = createConnectorInteractionCapabilityProfile({
+  template: BUTTON_INTERACTION_PROFILE,
+  source: "connector",
+  accountId: "account-a",
+  targetKind: "room",
+  targetId: "room-a",
+});
+
+function runtime(): IAgentRuntime {
+  return {
+    agentId: "agent-a",
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    redactSecrets: (text: string) => text,
+  } as never;
+}
+
+function fixture() {
+  let now = START;
+  const service = new MessageInteractionHostService(runtime(), {
+    store: new InMemoryMessageInteractionSessionStore(),
+    clock: () => now,
+    referenceFactory: () => "0123456789abcdef0123456789abcdef",
+    claimTtlMs: 100,
+  });
+  const execute = vi.fn(
+    async ({ idempotencyKey }: { idempotencyKey: string }) => ({
+      receiptId: `receipt-${idempotencyKey}`,
+      canonicalInboundEventId: `memory-${idempotencyKey}`,
+      auditId: `audit-${idempotencyKey}`,
+      appStateResult: { taskState: "approved" },
+      result: { accepted: true },
+    }),
+  );
+  const unregister = service.registerEffectHandler("approve_operation", {
+    execute,
+  });
+  const prepare = () =>
+    service.prepare({
+      block,
+      profile,
+      bindings,
+      purpose: "approval",
+      authorization: {
+        decisionId: "decision-a",
+        policyRevision: "policy-7",
+        decidedAt: "2026-08-20T23:59:59.000Z",
+      },
+      effect: { kind: "approve_operation", metadata: { operationId: "op-a" } },
+      expiresAt: "2026-08-21T00:10:00.000Z",
+    });
+  const providerReceipt = (inboundEventId = "provider-event-a") => ({
+    source: "connector",
+    accountId: "account-a",
+    inboundEventId,
+    receivedAt: new Date(now).toISOString(),
+  });
+  return {
+    service,
+    execute,
+    unregister,
+    prepare,
+    providerReceipt,
+    setNow(value: number) {
+      now = value;
+    },
+  };
+}
+
+describe("MessageInteractionHostService", () => {
+  it("resolves only a structurally complete registered host", () => {
+    const service = fixture().service;
+    expect(
+      resolveMessageInteractionHost({
+        getService: () => service,
+      } as never),
+    ).toBe(service);
+    expect(
+      resolveMessageInteractionHost({ getService: () => null } as never),
+    ).toBeNull();
+    expect(() =>
+      resolveMessageInteractionHost({ getService: () => ({}) } as never),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "INVALID_MESSAGE_INTERACTION_HOST_SERVICE",
+      }),
+    );
+  });
+
+  it("returns only renderer-safe preparation fields", async () => {
+    const { prepare } = fixture();
+    const prepared = await prepare();
+
+    expect(prepared).toMatchObject({
+      block: { kind: "choice", id: "approve-1" },
+      delivery: { mode: "native" },
+      callbackData: "is1:0123456789abcdef0123456789abcdef",
+      expiresAt: "2026-08-21T00:10:00.000Z",
+      profileId: profile.profileId,
+    });
+    expect(prepared).not.toHaveProperty("authorization");
+    expect(prepared).not.toHaveProperty("effect");
+    expect(prepared).not.toHaveProperty("bindings");
+  });
+
+  it("denies a second actor before executing the retained effect", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    const prepared = await prepare();
+
+    await expect(
+      service.consume({
+        callbackData: prepared.callbackData,
+        bindings: { ...bindings, actorId: "actor-b" },
+        response: { value: "approve" },
+        providerReceipt: providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_BINDING_MISMATCH",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("denies expiry and post-render authorization revocation", async () => {
+    const expired = fixture();
+    const expiredPrepared = await expired.prepare();
+    expired.setNow(Date.parse("2026-08-21T00:10:00.000Z"));
+    await expect(
+      expired.service.consume({
+        callbackData: expiredPrepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: expired.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_EXPIRED",
+    });
+
+    const revoked = fixture();
+    const revokedPrepared = await revoked.prepare();
+    const reference = decodeMessageInteractionCallback(
+      revokedPrepared.callbackData,
+    );
+    if (!reference) throw new Error("Expected an opaque callback reference");
+    await revoked.service.revoke({
+      reference,
+      decisionId: "decision-a",
+      now: START + 1,
+    });
+    await expect(
+      revoked.service.consume({
+        callbackData: revokedPrepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: revoked.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+    });
+    expect(expired.execute).not.toHaveBeenCalled();
+    expect(revoked.execute).not.toHaveBeenCalled();
+  });
+
+  it("retains provider, inbound, audit, and app-state proof and replays exactly once", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    const prepared = await prepare();
+    const request = {
+      callbackData: prepared.callbackData,
+      bindings,
+      response: { value: "approve" },
+      providerReceipt: providerReceipt(),
+    };
+
+    const first = await service.consume(request);
+    expect(first).toMatchObject({
+      status: "completed",
+      receipt: {
+        receiptId: "receipt-provider-event-a",
+        idempotencyKey: "provider-event-a",
+        canonicalInboundEventId: "memory-provider-event-a",
+        providerReceipt: { inboundEventId: "provider-event-a" },
+        auditId: "audit-provider-event-a",
+        appStateResult: { taskState: "approved" },
+        result: { accepted: true },
+      },
+    });
+    await expect(service.consume(request)).resolves.toMatchObject({
+      status: "replay",
+      receipt: { receiptId: "receipt-provider-event-a" },
+    });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("rejects mismatched provider authority and conflicting handlers", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    expect(() =>
+      service.registerEffectHandler("approve_operation", { execute }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "MESSAGE_INTERACTION_EFFECT_HANDLER_COLLISION",
+      }),
+    );
+    const prepared = await prepare();
+    await expect(
+      service.consume({
+        callbackData: prepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: { ...providerReceipt(), accountId: "account-b" },
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed without a host effect handler and resumes after the claim lease", async () => {
+    const fixtureValue = fixture();
+    fixtureValue.unregister();
+    const prepared = await fixtureValue.prepare();
+    const request = {
+      callbackData: prepared.callbackData,
+      bindings,
+      response: { value: "approve" },
+      providerReceipt: fixtureValue.providerReceipt(),
+    };
+
+    await expect(fixtureValue.service.consume(request)).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
+    });
+    fixtureValue.setNow(START + 101);
+    fixtureValue.service.registerEffectHandler("approve_operation", {
+      execute: fixtureValue.execute,
+    });
+    await expect(
+      fixtureValue.service.consume({
+        ...request,
+        providerReceipt: fixtureValue.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({ status: "completed" });
+    expect(fixtureValue.execute).toHaveBeenCalledOnce();
+  });
+
+  it("rejects cross-agent preparation and secret-bearing effect proof", async () => {
+    const agentMismatch = fixture();
+    await expect(
+      agentMismatch.service.prepare({
+        block,
+        profile,
+        bindings: { ...bindings, agentId: "agent-b" },
+        purpose: "approval",
+        authorization: {
+          decisionId: "decision-a",
+          policyRevision: "policy-7",
+          decidedAt: "2026-08-20T23:59:59.000Z",
+        },
+        effect: { kind: "approve_operation" },
+        expiresAt: "2026-08-21T00:10:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_AGENT_MISMATCH" });
+
+    const unsafe = fixture();
+    unsafe.unregister();
+    unsafe.service.registerEffectHandler("approve_operation", {
+      execute: async ({ idempotencyKey }) => ({
+        receiptId: `receipt-${idempotencyKey}`,
+        canonicalInboundEventId: `memory-${idempotencyKey}`,
+        auditId: `audit-${idempotencyKey}`,
+        appStateResult: { taskState: "approved" },
+        result: { apiToken: "must-not-leak" },
+      }),
+    });
+    const prepared = await unsafe.prepare();
+    await expect(
+      unsafe.service.consume({
+        callbackData: prepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: unsafe.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+    });
+  });
+
+  it("starts with the real owner-only file authority registered by the host", async () => {
+    const root = await mkdtemp(
+      path.join(await realpath(tmpdir()), "eliza-interaction-host-"),
+    );
+    const previousStateDirectory = process.env.ELIZA_STATE_DIR;
+    process.env.ELIZA_STATE_DIR = root;
+    try {
+      const service = await MessageInteractionHostService.start(runtime());
+      service.registerEffectHandler("approve_operation", {
+        execute: async ({ idempotencyKey }) => ({
+          receiptId: `receipt-${idempotencyKey}`,
+          canonicalInboundEventId: `memory-${idempotencyKey}`,
+          auditId: `audit-${idempotencyKey}`,
+          appStateResult: { taskState: "approved" },
+          result: { accepted: true },
+        }),
+      });
+      const prepared = await service.prepare({
+        block,
+        profile,
+        bindings,
+        purpose: "approval",
+        authorization: {
+          decisionId: "decision-a",
+          policyRevision: "policy-7",
+          decidedAt: new Date(Date.now() - 1_000).toISOString(),
+        },
+        effect: {
+          kind: "approve_operation",
+          metadata: { operationId: "op-a" },
+        },
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+      await expect(
+        service.consume({
+          callbackData: prepared.callbackData,
+          bindings,
+          response: { value: "approve" },
+          providerReceipt: {
+            source: "connector",
+            accountId: "account-a",
+            inboundEventId: "provider-file-event-a",
+            receivedAt: new Date().toISOString(),
+          },
+        }),
+      ).resolves.toMatchObject({ status: "completed" });
+      const filePath = path.join(
+        root,
+        "message-interactions",
+        "agent-a",
+        "message-interaction-sessions.v1.json",
+      );
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+      await service.stop();
+    } finally {
+      if (previousStateDirectory === undefined)
+        delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = previousStateDirectory;
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/agent/src/services/message-interaction-host.test.ts
+++ b/packages/agent/src/services/message-interaction-host.test.ts
@@ -39,6 +39,14 @@ const bindings = {
   sourceMessageId: "message-a",
 };
 
+const authenticatedBindings = {
+  actorId: bindings.actorId,
+  audience: bindings.audience,
+  agentId: bindings.agentId,
+  connector: bindings.connector,
+  roomId: bindings.roomId,
+};
+
 const profile = createConnectorInteractionCapabilityProfile({
   template: BUTTON_INTERACTION_PROFILE,
   source: "connector",
@@ -143,6 +151,47 @@ describe("MessageInteractionHostService", () => {
     expect(prepared).not.toHaveProperty("bindings");
   });
 
+  it("returns a validated hosted URL without retained authority fields", async () => {
+    const { service } = fixture();
+    const hostedProfile = createConnectorInteractionCapabilityProfile({
+      template: {
+        ...BUTTON_INTERACTION_PROFILE,
+        templateId: "signed-hosted-only-test",
+        blocks: {
+          ...BUTTON_INTERACTION_PROFILE.blocks,
+          choice: {
+            ...BUTTON_INTERACTION_PROFILE.blocks.choice,
+            modes: ["signed-hosted"],
+          },
+        },
+      },
+      source: "connector",
+      accountId: "account-a",
+      targetKind: "room",
+      targetId: "room-a",
+    });
+    const prepared = await service.prepare({
+      block,
+      profile: hostedProfile,
+      bindings,
+      purpose: "approval",
+      negotiationContext: { signedHostedUrl: "https://example.test/form/a" },
+      authorization: {
+        decisionId: "decision-hosted",
+        policyRevision: "policy-7",
+        decidedAt: "2026-08-20T23:59:59.000Z",
+      },
+      effect: { kind: "approve_operation" },
+      expiresAt: "2026-08-21T00:10:00.000Z",
+    });
+
+    expect(prepared).toMatchObject({
+      delivery: { mode: "signed-hosted" },
+      hostedUrl: "https://example.test/form/a",
+    });
+    expect(prepared).not.toHaveProperty("bindings");
+  });
+
   it("denies a second actor before executing the retained effect", async () => {
     const { service, execute, prepare, providerReceipt } = fixture();
     const prepared = await prepare();
@@ -150,7 +199,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       service.consume({
         callbackData: prepared.callbackData,
-        bindings: { ...bindings, actorId: "actor-b" },
+        bindings: { ...authenticatedBindings, actorId: "actor-b" },
         response: { value: "approve" },
         providerReceipt: providerReceipt(),
       }),
@@ -168,7 +217,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       expired.service.consume({
         callbackData: expiredPrepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: expired.providerReceipt(),
       }),
@@ -191,7 +240,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       revoked.service.consume({
         callbackData: revokedPrepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: revoked.providerReceipt(),
       }),
@@ -208,7 +257,7 @@ describe("MessageInteractionHostService", () => {
     const prepared = await prepare();
     const request = {
       callbackData: prepared.callbackData,
-      bindings,
+      bindings: authenticatedBindings,
       response: { value: "approve" },
       providerReceipt: providerReceipt(),
     };
@@ -246,7 +295,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       service.consume({
         callbackData: prepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: { ...providerReceipt(), accountId: "account-b" },
       }),
@@ -263,7 +312,7 @@ describe("MessageInteractionHostService", () => {
     const prepared = await fixtureValue.prepare();
     const request = {
       callbackData: prepared.callbackData,
-      bindings,
+      bindings: authenticatedBindings,
       response: { value: "approve" },
       providerReceipt: fixtureValue.providerReceipt(),
     };
@@ -318,7 +367,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       unsafe.service.consume({
         callbackData: prepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: unsafe.providerReceipt(),
       }),
@@ -361,10 +410,27 @@ describe("MessageInteractionHostService", () => {
         },
         expiresAt: new Date(Date.now() + 60_000).toISOString(),
       });
+      const reference = decodeMessageInteractionCallback(prepared.callbackData);
+      if (!reference) throw new Error("Expected an opaque callback reference");
+      await expect(service.get(reference)).resolves.toMatchObject({
+        bindings: { sourceMessageId: "message-a" },
+        consume: { state: "pending" },
+      });
+      await service.stop();
+      const restarted = await MessageInteractionHostService.start(runtime());
+      restarted.registerEffectHandler("approve_operation", {
+        execute: async ({ idempotencyKey }) => ({
+          receiptId: `receipt-${idempotencyKey}`,
+          canonicalInboundEventId: `memory-${idempotencyKey}`,
+          auditId: `audit-${idempotencyKey}`,
+          appStateResult: { taskState: "approved" },
+          result: { accepted: true },
+        }),
+      });
       await expect(
-        service.consume({
+        restarted.consume({
           callbackData: prepared.callbackData,
-          bindings,
+          bindings: authenticatedBindings,
           response: { value: "approve" },
           providerReceipt: {
             source: "connector",
@@ -381,7 +447,7 @@ describe("MessageInteractionHostService", () => {
         "message-interaction-sessions.v1.json",
       );
       expect((await stat(filePath)).mode & 0o777).toBe(0o600);
-      await service.stop();
+      await restarted.stop();
     } finally {
       if (previousStateDirectory === undefined)
         delete process.env.ELIZA_STATE_DIR;

--- a/packages/agent/src/services/message-interaction-host.test.ts
+++ b/packages/agent/src/services/message-interaction-host.test.ts
@@ -60,6 +60,7 @@ function runtime(): IAgentRuntime {
     agentId: "agent-a",
     logger: { debug() {}, info() {}, warn() {}, error() {} },
     redactSecrets: (text: string) => text,
+    reportError() {},
   } as never;
 }
 
@@ -152,7 +153,12 @@ describe("MessageInteractionHostService", () => {
   });
 
   it("returns a validated hosted URL without retained authority fields", async () => {
-    const { service } = fixture();
+    const validatingService = new MessageInteractionHostService(runtime(), {
+      store: new InMemoryMessageInteractionSessionStore(),
+      clock: () => START,
+      referenceFactory: () => "0123456789abcdef0123456789abcdef",
+      validateSignedHostedUrl: (url) => url === "https://example.test/form/a",
+    });
     const hostedProfile = createConnectorInteractionCapabilityProfile({
       template: {
         ...BUTTON_INTERACTION_PROFILE,
@@ -170,7 +176,7 @@ describe("MessageInteractionHostService", () => {
       targetKind: "room",
       targetId: "room-a",
     });
-    const prepared = await service.prepare({
+    const prepared = await validatingService.prepare({
       block,
       profile: hostedProfile,
       bindings,
@@ -318,7 +324,7 @@ describe("MessageInteractionHostService", () => {
     };
 
     await expect(fixtureValue.service.consume(request)).resolves.toMatchObject({
-      status: "denied",
+      status: "unavailable",
       code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
     });
     fixtureValue.setNow(START + 101);
@@ -372,7 +378,7 @@ describe("MessageInteractionHostService", () => {
         providerReceipt: unsafe.providerReceipt(),
       }),
     ).resolves.toMatchObject({
-      status: "denied",
+      status: "unavailable",
       code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
     });
   });

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -1,0 +1,394 @@
+/**
+ * Registers the single host-owned coordinator for durable connector interactions.
+ * It prepares safe renderer inputs and dispatches authenticated callbacks only
+ * through idempotent effect handlers owned by the application host.
+ */
+
+import path from "node:path";
+import {
+  type ConsumeMessageInteractionRequest,
+  decodeMessageInteractionCallback,
+  ElizaError,
+  type IAgentRuntime,
+  MESSAGE_INTERACTION_CALLBACK_BYTES,
+  MESSAGE_INTERACTION_HOST_SERVICE,
+  type MessageInteractionHost,
+  type MessageInteractionHostConsumeOutcome,
+  type MessageInteractionHostEffectHandler,
+  type MessageInteractionHostReceipt,
+  type MessageInteractionSession,
+  MessageInteractionSessionAuthority,
+  type MessageInteractionSessionStore,
+  negotiateInteractionDelivery,
+  type PreparedMessageInteraction,
+  type PrepareMessageInteractionRequest,
+  Service,
+} from "@elizaos/core";
+import { resolveStateDir } from "../config/paths.ts";
+import { FileMessageInteractionSessionStore } from "./message-interaction-session-store.ts";
+
+export interface MessageInteractionHostServiceOptions {
+  store?: MessageInteractionSessionStore;
+  clock?: () => number;
+  referenceFactory?: () => string;
+  claimTtlMs?: number;
+}
+
+function requiredText(value: string, pathName: string): string {
+  const normalized = value.trim();
+  if (!normalized || new TextEncoder().encode(normalized).length > 512) {
+    throw new ElizaError(`${pathName} is invalid.`, {
+      code: "INVALID_MESSAGE_INTERACTION_HOST_INPUT",
+      context: { path: pathName },
+    });
+  }
+  return normalized;
+}
+
+function assertSafeResult(
+  value: unknown,
+  pathName: string,
+  redact: (text: string) => string,
+): asserts value is Readonly<Record<string, string | number | boolean | null>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ElizaError(`${pathName} must be a result object.`, {
+      code: "INVALID_MESSAGE_INTERACTION_EFFECT_RECEIPT",
+      context: { path: pathName },
+    });
+  }
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (
+      fieldValue !== null &&
+      typeof fieldValue !== "string" &&
+      typeof fieldValue !== "number" &&
+      typeof fieldValue !== "boolean"
+    ) {
+      throw new ElizaError(`${pathName} contains a non-scalar field.`, {
+        code: "INVALID_MESSAGE_INTERACTION_EFFECT_RECEIPT",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
+    if (/secret|password|token|api.?key|oauth.*code/i.test(key)) {
+      throw new ElizaError(`${pathName} contains a secret-bearing field.`, {
+        code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
+    if (typeof fieldValue === "string" && redact(fieldValue) !== fieldValue) {
+      throw new ElizaError(`${pathName} contains secret material.`, {
+        code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
+  }
+}
+
+function hostReceipt(
+  value: unknown,
+  expectedProvider: ConsumeMessageInteractionRequest["providerReceipt"],
+  redact: (text: string) => string,
+): MessageInteractionHostReceipt {
+  if (!value || typeof value !== "object") {
+    throw new ElizaError("Interaction host receipt is invalid.", {
+      code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+    });
+  }
+  const receipt = value as Partial<MessageInteractionHostReceipt>;
+  if (
+    typeof receipt.receiptId !== "string" ||
+    typeof receipt.idempotencyKey !== "string" ||
+    receipt.status !== "completed" ||
+    typeof receipt.completedAt !== "string" ||
+    typeof receipt.canonicalInboundEventId !== "string" ||
+    !receipt.providerReceipt ||
+    typeof receipt.auditId !== "string" ||
+    !receipt.appStateResult ||
+    !receipt.result
+  ) {
+    throw new ElizaError("Interaction host receipt is incomplete.", {
+      code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+    });
+  }
+  requiredText(receipt.receiptId, "receipt.receiptId");
+  requiredText(receipt.idempotencyKey, "receipt.idempotencyKey");
+  requiredText(
+    receipt.canonicalInboundEventId,
+    "receipt.canonicalInboundEventId",
+  );
+  requiredText(receipt.auditId, "receipt.auditId");
+  if (!Number.isFinite(Date.parse(receipt.completedAt))) {
+    throw new ElizaError("Interaction receipt completion time is invalid.", {
+      code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+    });
+  }
+  if (
+    receipt.idempotencyKey !== expectedProvider.inboundEventId ||
+    receipt.providerReceipt.source !== expectedProvider.source ||
+    receipt.providerReceipt.accountId !== expectedProvider.accountId ||
+    receipt.providerReceipt.inboundEventId !==
+      expectedProvider.inboundEventId ||
+    receipt.providerReceipt.receivedAt !== expectedProvider.receivedAt
+  ) {
+    throw new ElizaError(
+      "Interaction provider receipt changed during replay.",
+      {
+        code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+      },
+    );
+  }
+  assertSafeResult(receipt.appStateResult, "receipt.appStateResult", redact);
+  assertSafeResult(receipt.result, "receipt.result", redact);
+  return structuredClone(receipt as MessageInteractionHostReceipt);
+}
+
+export class MessageInteractionHostService
+  extends Service
+  implements MessageInteractionHost
+{
+  static override serviceType = MESSAGE_INTERACTION_HOST_SERVICE;
+
+  override capabilityDescription =
+    "Durable capability-negotiated connector interactions with host-owned exactly-once effects";
+
+  private readonly store: MessageInteractionSessionStore;
+  private readonly authority: MessageInteractionSessionAuthority;
+  private readonly handlers = new Map<
+    string,
+    MessageInteractionHostEffectHandler
+  >();
+  private readonly clock: () => number;
+
+  constructor(
+    runtime: IAgentRuntime,
+    options: MessageInteractionHostServiceOptions = {},
+  ) {
+    super(runtime);
+    this.clock = options.clock ?? Date.now;
+    const agentId = requiredText(runtime.agentId, "runtime.agentId");
+    if (
+      path.basename(agentId) !== agentId ||
+      agentId === "." ||
+      agentId === ".."
+    ) {
+      throw new ElizaError("Runtime agent id is not a safe path component.", {
+        code: "INVALID_MESSAGE_INTERACTION_HOST_PATH",
+      });
+    }
+    this.store =
+      options.store ??
+      new FileMessageInteractionSessionStore({
+        stateDirectory: path.join(
+          resolveStateDir(),
+          "message-interactions",
+          agentId,
+        ),
+        clock: this.clock,
+      });
+    this.authority = new MessageInteractionSessionAuthority(this.store, {
+      clock: this.clock,
+      referenceFactory: options.referenceFactory,
+      claimTtlMs: options.claimTtlMs,
+    });
+  }
+
+  static async start(
+    runtime: IAgentRuntime,
+  ): Promise<MessageInteractionHostService> {
+    return new MessageInteractionHostService(runtime);
+  }
+
+  async stop(): Promise<void> {
+    this.handlers.clear();
+  }
+
+  registerEffectHandler(
+    kindValue: string,
+    handler: MessageInteractionHostEffectHandler,
+  ): () => void {
+    const kind = requiredText(kindValue, "effect.kind");
+    if (!handler || typeof handler.execute !== "function") {
+      throw new ElizaError("Interaction effect handler is invalid.", {
+        code: "INVALID_MESSAGE_INTERACTION_EFFECT_HANDLER",
+        context: { kind },
+      });
+    }
+    if (this.handlers.has(kind)) {
+      throw new ElizaError(
+        "Interaction effect handler is already registered.",
+        {
+          code: "MESSAGE_INTERACTION_EFFECT_HANDLER_COLLISION",
+          context: { kind },
+        },
+      );
+    }
+    this.handlers.set(kind, handler);
+    return () => {
+      if (this.handlers.get(kind) === handler) this.handlers.delete(kind);
+    };
+  }
+
+  async prepare(
+    request: PrepareMessageInteractionRequest,
+  ): Promise<PreparedMessageInteraction> {
+    if (request.bindings.agentId !== this.runtime.agentId) {
+      throw new ElizaError("Interaction belongs to another agent runtime.", {
+        code: "MESSAGE_INTERACTION_AGENT_MISMATCH",
+      });
+    }
+    const delivery = negotiateInteractionDelivery(
+      request.block,
+      request.profile,
+      {
+        ...request.negotiationContext,
+        callbackBytes: MESSAGE_INTERACTION_CALLBACK_BYTES,
+      },
+    );
+    const created = await this.authority.create({
+      ...request,
+      flow: delivery.mode,
+    });
+    return {
+      block: structuredClone(request.block),
+      delivery,
+      callbackData: created.callbackData,
+      expiresAt: created.session.expiresAt,
+      profileId: created.session.profileId,
+    };
+  }
+
+  async consume(
+    request: ConsumeMessageInteractionRequest,
+  ): Promise<MessageInteractionHostConsumeOutcome> {
+    try {
+      const reference = decodeMessageInteractionCallback(request.callbackData);
+      if (!reference) {
+        throw new ElizaError(
+          "Callback is not an opaque interaction reference.",
+          {
+            code: "INVALID_MESSAGE_INTERACTION_REFERENCE",
+          },
+        );
+      }
+      const provider = request.providerReceipt;
+      const inboundEventId = requiredText(
+        provider.inboundEventId,
+        "providerReceipt.inboundEventId",
+      );
+      if (
+        provider.source !== request.bindings.connector.source ||
+        provider.accountId !== request.bindings.connector.accountId
+      ) {
+        throw new ElizaError(
+          "Provider receipt belongs to another connector account.",
+          { code: "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH" },
+        );
+      }
+      if (!Number.isFinite(Date.parse(provider.receivedAt))) {
+        throw new ElizaError("Provider receipt time is invalid.", {
+          code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
+        });
+      }
+      if (Date.parse(provider.receivedAt) > this.clock()) {
+        throw new ElizaError("Provider receipt time is in the future.", {
+          code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
+        });
+      }
+      const prior = await this.store.get(reference);
+      if (!prior) {
+        throw new ElizaError("Interaction session was not found.", {
+          code: "MESSAGE_INTERACTION_NOT_FOUND",
+        });
+      }
+      const consumed = await this.authority.consume({
+        callbackData: request.callbackData,
+        bindings: request.bindings,
+        replayKey: inboundEventId,
+        response: request.response,
+        executor: {
+          execute: async (args) => {
+            const handler = this.handlers.get(args.effect.kind);
+            if (!handler) {
+              throw new ElizaError(
+                "Interaction effect handler is unavailable.",
+                {
+                  code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
+                  context: { kind: args.effect.kind },
+                },
+              );
+            }
+            const effect = await handler.execute({
+              ...args,
+              providerReceipt: structuredClone(provider),
+            });
+            requiredText(effect.receiptId, "effectReceipt.receiptId");
+            requiredText(
+              effect.canonicalInboundEventId,
+              "effectReceipt.canonicalInboundEventId",
+            );
+            requiredText(effect.auditId, "effectReceipt.auditId");
+            assertSafeResult(
+              effect.appStateResult,
+              "effectReceipt.appStateResult",
+              (text) => this.runtime.redactSecrets(text),
+            );
+            assertSafeResult(effect.result, "effectReceipt.result", (text) =>
+              this.runtime.redactSecrets(text),
+            );
+            return {
+              receiptId: effect.receiptId,
+              idempotencyKey: args.idempotencyKey,
+              status: "completed" as const,
+              completedAt: new Date(this.clock()).toISOString(),
+              canonicalInboundEventId: effect.canonicalInboundEventId,
+              providerReceipt: structuredClone(provider),
+              auditId: effect.auditId,
+              appStateResult: structuredClone(effect.appStateResult),
+              result: structuredClone(effect.result),
+            };
+          },
+        },
+      });
+      if ("status" in consumed && consumed.status === "in_progress") {
+        return consumed;
+      }
+      return {
+        status: prior.consume.state === "completed" ? "replay" : "completed",
+        receipt: hostReceipt(consumed, provider, (text) =>
+          this.runtime.redactSecrets(text),
+        ),
+      };
+    } catch (error) {
+      // error-policy:J1 Connector callbacks are an untrusted transport
+      // boundary; stable domain failures become explicit denied outcomes.
+      if (error instanceof ElizaError) {
+        return { status: "denied", code: error.code, message: error.message };
+      }
+      throw error;
+    }
+  }
+
+  async revoke(request: {
+    reference: string;
+    decisionId: string;
+    now?: number;
+  }): Promise<MessageInteractionSession> {
+    return this.store.revokeAuthorization({
+      reference: request.reference,
+      decisionId: request.decisionId,
+      now: request.now ?? this.clock(),
+    });
+  }
+
+  async get(reference: string): Promise<MessageInteractionSession | null> {
+    return this.store.get(reference);
+  }
+}
+
+/** Resolve the concrete host service without constructing a competing store. */
+export function resolveMessageInteractionHostService(
+  runtime: IAgentRuntime,
+): MessageInteractionHostService | null {
+  return runtime.getService<MessageInteractionHostService>(
+    MESSAGE_INTERACTION_HOST_SERVICE,
+  );
+}

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -250,6 +250,9 @@ export class MessageInteractionHostService
     return {
       block: structuredClone(request.block),
       delivery,
+      ...(delivery.mode === "signed-hosted"
+        ? { hostedUrl: request.negotiationContext?.signedHostedUrl }
+        : {}),
       callbackData: created.callbackData,
       expiresAt: created.session.expiresAt,
       profileId: created.session.profileId,
@@ -299,9 +302,26 @@ export class MessageInteractionHostService
           code: "MESSAGE_INTERACTION_NOT_FOUND",
         });
       }
+      const retained = prior.bindings;
+      if (
+        request.bindings.actorId !== retained.actorId ||
+        request.bindings.audience.kind !== retained.audience.kind ||
+        request.bindings.audience.id !== retained.audience.id ||
+        request.bindings.agentId !== retained.agentId ||
+        request.bindings.connector.source !== retained.connector.source ||
+        request.bindings.connector.accountId !== retained.connector.accountId ||
+        request.bindings.roomId !== retained.roomId
+      ) {
+        throw new ElizaError(
+          "Authenticated provider bindings do not match the retained session.",
+          { code: "MESSAGE_INTERACTION_BINDING_MISMATCH" },
+        );
+      }
       const consumed = await this.authority.consume({
         callbackData: request.callbackData,
-        bindings: request.bindings,
+        // The original outbound message binding is host-retained state. Provider
+        // callbacks authenticate the actor/room/account but cannot reconstruct it.
+        bindings: retained,
         replayKey: inboundEventId,
         response: request.response,
         executor: {

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -45,6 +45,13 @@ function requiredText(value: string, pathName: string): string {
   return normalized;
 }
 
+function canonicalTimestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+    ? parsed
+    : Number.NaN;
+}
+
 function assertSafeResult(
   value: unknown,
   pathName: string,
@@ -57,6 +64,17 @@ function assertSafeResult(
     });
   }
   for (const [key, fieldValue] of Object.entries(value)) {
+    if (
+      new TextEncoder().encode(key).length > 512 ||
+      (typeof fieldValue === "string" &&
+        new TextEncoder().encode(fieldValue).length > 65_536) ||
+      (typeof fieldValue === "number" && !Number.isFinite(fieldValue))
+    ) {
+      throw new ElizaError(`${pathName} contains an unbounded field.`, {
+        code: "INVALID_MESSAGE_INTERACTION_EFFECT_RECEIPT",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
     if (
       fieldValue !== null &&
       typeof fieldValue !== "string" &&
@@ -116,7 +134,7 @@ function hostReceipt(
     "receipt.canonicalInboundEventId",
   );
   requiredText(receipt.auditId, "receipt.auditId");
-  if (!Number.isFinite(Date.parse(receipt.completedAt))) {
+  if (!Number.isFinite(canonicalTimestamp(receipt.completedAt))) {
     throw new ElizaError("Interaction receipt completion time is invalid.", {
       code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
     });
@@ -286,12 +304,12 @@ export class MessageInteractionHostService
           { code: "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH" },
         );
       }
-      if (!Number.isFinite(Date.parse(provider.receivedAt))) {
+      if (!Number.isFinite(canonicalTimestamp(provider.receivedAt))) {
         throw new ElizaError("Provider receipt time is invalid.", {
           code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
         });
       }
-      if (Date.parse(provider.receivedAt) > this.clock()) {
+      if (canonicalTimestamp(provider.receivedAt) > this.clock()) {
         throw new ElizaError("Provider receipt time is in the future.", {
           code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
         });
@@ -317,6 +335,13 @@ export class MessageInteractionHostService
           { code: "MESSAGE_INTERACTION_BINDING_MISMATCH" },
         );
       }
+      const preparedHandler = this.handlers.get(prior.effect.kind);
+      if (!preparedHandler) {
+        throw new ElizaError("Interaction effect handler is unavailable.", {
+          code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
+          context: { kind: prior.effect.kind },
+        });
+      }
       const consumed = await this.authority.consume({
         callbackData: request.callbackData,
         // The original outbound message binding is host-retained state. Provider
@@ -326,17 +351,7 @@ export class MessageInteractionHostService
         response: request.response,
         executor: {
           execute: async (args) => {
-            const handler = this.handlers.get(args.effect.kind);
-            if (!handler) {
-              throw new ElizaError(
-                "Interaction effect handler is unavailable.",
-                {
-                  code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
-                  context: { kind: args.effect.kind },
-                },
-              );
-            }
-            const effect = await handler.execute({
+            const effect = await preparedHandler.execute({
               ...args,
               providerReceipt: structuredClone(provider),
             });

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -32,6 +32,10 @@ export interface MessageInteractionHostServiceOptions {
   clock?: () => number;
   referenceFactory?: () => string;
   claimTtlMs?: number;
+  validateSignedHostedUrl?: (
+    url: string,
+    request: PrepareMessageInteractionRequest,
+  ) => boolean;
 }
 
 function requiredText(value: string, pathName: string): string {
@@ -51,6 +55,22 @@ function canonicalTimestamp(value: string): number {
     ? parsed
     : Number.NaN;
 }
+
+const DENIED_INTERACTION_CODES = new Set([
+  "INVALID_MESSAGE_INTERACTION_REFERENCE",
+  "MESSAGE_INTERACTION_NOT_FOUND",
+  "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH",
+  "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
+  "MESSAGE_INTERACTION_BINDING_MISMATCH",
+  "MESSAGE_INTERACTION_REFERENCE_MISMATCH",
+  "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+  "MESSAGE_INTERACTION_EXPIRED",
+  "INVALID_MESSAGE_INTERACTION_RESPONSE",
+  "MESSAGE_INTERACTION_TAMPERED",
+  "MESSAGE_INTERACTION_ALREADY_CONSUMED",
+  "MESSAGE_INTERACTION_ALREADY_COMMITTED",
+  "MESSAGE_INTERACTION_ALREADY_CLAIMED",
+]);
 
 function assertSafeResult(
   value: unknown,
@@ -175,6 +195,7 @@ export class MessageInteractionHostService
     MessageInteractionHostEffectHandler
   >();
   private readonly clock: () => number;
+  private readonly validateSignedHostedUrl?: MessageInteractionHostServiceOptions["validateSignedHostedUrl"];
 
   constructor(
     runtime: IAgentRuntime,
@@ -182,6 +203,7 @@ export class MessageInteractionHostService
   ) {
     super(runtime);
     this.clock = options.clock ?? Date.now;
+    this.validateSignedHostedUrl = options.validateSignedHostedUrl;
     const agentId = requiredText(runtime.agentId, "runtime.agentId");
     if (
       path.basename(agentId) !== agentId ||
@@ -253,23 +275,34 @@ export class MessageInteractionHostService
         code: "MESSAGE_INTERACTION_AGENT_MISMATCH",
       });
     }
+    const signedHostedUrl = request.negotiationContext?.signedHostedUrl;
+    const negotiationContext = {
+      ...request.negotiationContext,
+      ...(signedHostedUrl
+        ? {
+            signedHostedUrlVerified:
+              this.validateSignedHostedUrl?.(signedHostedUrl, request) === true,
+          }
+        : {}),
+    };
     const delivery = negotiateInteractionDelivery(
       request.block,
       request.profile,
       {
-        ...request.negotiationContext,
+        ...negotiationContext,
         callbackBytes: MESSAGE_INTERACTION_CALLBACK_BYTES,
       },
     );
     const created = await this.authority.create({
       ...request,
+      negotiationContext,
       flow: delivery.mode,
     });
     return {
       block: structuredClone(request.block),
       delivery,
       ...(delivery.mode === "signed-hosted"
-        ? { hostedUrl: request.negotiationContext?.signedHostedUrl }
+        ? { hostedUrl: signedHostedUrl }
         : {}),
       callbackData: created.callbackData,
       expiresAt: created.session.expiresAt,
@@ -342,7 +375,7 @@ export class MessageInteractionHostService
           context: { kind: prior.effect.kind },
         });
       }
-      const consumed = await this.authority.consume({
+      const consumed = await this.authority.consumeWithOutcome({
         callbackData: request.callbackData,
         // The original outbound message binding is host-retained state. Provider
         // callbacks authenticate the actor/room/account but cannot reconstruct it.
@@ -383,12 +416,12 @@ export class MessageInteractionHostService
           },
         },
       });
-      if ("status" in consumed && consumed.status === "in_progress") {
+      if (consumed.status === "in_progress") {
         return consumed;
       }
       return {
-        status: prior.consume.state === "completed" ? "replay" : "completed",
-        receipt: hostReceipt(consumed, provider, (text) =>
+        status: consumed.status,
+        receipt: hostReceipt(consumed.receipt, provider, (text) =>
           this.runtime.redactSecrets(text),
         ),
       };
@@ -396,7 +429,18 @@ export class MessageInteractionHostService
       // error-policy:J1 Connector callbacks are an untrusted transport
       // boundary; stable domain failures become explicit denied outcomes.
       if (error instanceof ElizaError) {
-        return { status: "denied", code: error.code, message: error.message };
+        if (DENIED_INTERACTION_CODES.has(error.code)) {
+          return { status: "denied", code: error.code, message: error.message };
+        }
+        this.runtime.reportError("message_interaction.consume", error, {
+          connectorSource: request.bindings.connector.source,
+          connectorAccountId: request.bindings.connector.accountId,
+        });
+        return {
+          status: "unavailable",
+          code: error.code,
+          message: error.message,
+        };
       }
       throw error;
     }

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -237,6 +237,36 @@ describe("FileMessageInteractionSessionStore", () => {
     ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
   });
 
+  it("rejects hardlinked, over-permissive, and oversized store files", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    await fs.writeFile(filePath, '{"version":1,"sessions":{}}', {
+      mode: 0o644,
+    });
+    await expect(
+      new FileMessageInteractionSessionStore({ stateDirectory }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+    await fs.chmod(filePath, 0o600);
+    const linked = path.join(stateDirectory, "linked.json");
+    await fs.link(filePath, linked);
+    await expect(
+      new FileMessageInteractionSessionStore({ stateDirectory }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+    await fs.unlink(linked);
+    await fs.writeFile(filePath, "x".repeat(65), { mode: 0o600 });
+    await expect(
+      new FileMessageInteractionSessionStore({
+        stateDirectory,
+        maxStoreBytes: 64,
+      }).get("missing"),
+    ).rejects.toMatchObject({
+      code: "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+    });
+  });
+
   it("rejects a directory swapped to a symlink after initialization", async () => {
     const stateDirectory = await temporaryDirectory();
     const redirectedDirectory = await temporaryDirectory();
@@ -311,5 +341,68 @@ describe("FileMessageInteractionSessionStore", () => {
       await store.deleteExpired(Date.parse(created.session.expiresAt)),
     ).toBe(1);
     expect(await store.get(created.session.reference)).toBeNull();
+  });
+
+  it("never collects a committed ambiguous effect or completed receipt", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { store, created, now } = await seed(stateDirectory, {
+      retentionMs: 0,
+    });
+    const claim = await store.claimIfCurrent({
+      ...bindings,
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      claimTtlMs: 1,
+    });
+    expect(claim.status).toBe("acquired");
+    await store.commitIfClaimed({
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+    });
+    expect(
+      await store.deleteExpired(Date.parse(created.session.expiresAt)),
+    ).toBe(0);
+    const reopenedCommitted = new FileMessageInteractionSessionStore({
+      stateDirectory,
+    });
+    expect(
+      await reopenedCommitted.get(created.session.reference),
+    ).toMatchObject({
+      consume: { state: "committed" },
+    });
+    await reopenedCommitted.completeIfClaimed({
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      receipt: {
+        receiptId: "receipt-a",
+        idempotencyKey: "replay-a",
+        status: "completed",
+        completedAt: new Date(now).toISOString(),
+        result: { accepted: true },
+      },
+    });
+    const reopenedCompleted = new FileMessageInteractionSessionStore({
+      stateDirectory,
+    });
+    expect(
+      await reopenedCompleted.get(created.session.reference),
+    ).toMatchObject({
+      consume: {
+        state: "completed",
+        committedAt: new Date(now).toISOString(),
+        receipt: { receiptId: "receipt-a" },
+      },
+    });
+    expect(
+      await reopenedCompleted.deleteExpired(
+        Date.parse(created.session.expiresAt),
+      ),
+    ).toBe(0);
   });
 });

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Real-filesystem verification for the single-host durable interaction store:
+ * process contention, crash-safe state, stale-lock recovery, permissions,
+ * corruption, symlink rejection, and retention collection.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  BUTTON_INTERACTION_PROFILE,
+  createConnectorInteractionCapabilityProfile,
+  type MessageInteractionClaimContext,
+  MessageInteractionSessionAuthority,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileMessageInteractionSessionStore } from "./message-interaction-session-store.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await fs.mkdtemp("/private/tmp/eliza-interaction-store-");
+  roots.push(root);
+  return root;
+}
+
+const bindings = {
+  actorId: "actor-a",
+  audience: { kind: "room", id: "room-a" },
+  agentId: "agent-a",
+  connector: { source: "connector", accountId: "account-a" },
+  roomId: "room-a",
+  sourceMessageId: "message-a",
+};
+
+async function seed(
+  stateDirectory: string,
+  options: { now?: number; expiresAt?: string; retentionMs?: number } = {},
+) {
+  const now = options.now ?? Date.parse("2026-08-21T00:00:00.000Z");
+  const store = new FileMessageInteractionSessionStore({
+    stateDirectory,
+    retentionMs: options.retentionMs,
+    clock: () => now,
+  });
+  const authority = new MessageInteractionSessionAuthority(store, {
+    clock: () => now,
+    referenceFactory: () => "0123456789abcdef0123456789abcdef",
+  });
+  const profile = createConnectorInteractionCapabilityProfile({
+    template: BUTTON_INTERACTION_PROFILE,
+    source: "connector",
+    accountId: "account-a",
+    targetKind: "room",
+    targetId: "room-a",
+  });
+  const created = await authority.create({
+    block: {
+      kind: "choice",
+      id: "choice-a",
+      scope: "approval",
+      options: [{ value: "approve", label: "Approve" }],
+    },
+    profile,
+    bindings,
+    purpose: "approval",
+    flow: "native",
+    presetResponse: { value: "approve" },
+    authorization: {
+      decisionId: "decision-a",
+      policyRevision: "policy-a",
+      decidedAt: "2026-08-20T23:59:00.000Z",
+    },
+    effect: { kind: "approve" },
+    expiresAt: options.expiresAt ?? "2026-08-21T00:10:00.000Z",
+  });
+  return { store, created, now };
+}
+
+function runChild(
+  stateDirectory: string,
+  contextPath: string,
+): Promise<string> {
+  const fixture = path.join(
+    import.meta.dirname,
+    "__fixtures__",
+    "message-interaction-claim-child.ts",
+  );
+  const candidates = [
+    (() => {
+      try {
+        return execFileSync(
+          process.platform === "win32" ? "where" : "which",
+          ["bun"],
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .find(Boolean);
+      } catch {
+        // error-policy:J4 the test harness uses an explicit install fallback.
+        return undefined;
+      }
+    })(),
+    process.env.BUN_INSTALL
+      ? path.join(process.env.BUN_INSTALL, "bin", "bun")
+      : undefined,
+    path.join(
+      os.homedir(),
+      ".bun",
+      "bin",
+      process.platform === "win32" ? "bun.exe" : "bun",
+    ),
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ];
+  const bun = candidates.find((candidate): candidate is string =>
+    Boolean(candidate && existsSync(candidate)),
+  );
+  if (!bun) throw new Error("Bun is required for process contention tests");
+  return new Promise((resolve, reject) => {
+    const child = spawn(bun, [fixture, stateDirectory, contextPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`claim child exited ${code}: ${stderr}`));
+    });
+  });
+}
+
+describe("FileMessageInteractionSessionStore", () => {
+  it("serializes claims across independent processes", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created, now } = await seed(stateDirectory);
+    const context: MessageInteractionClaimContext = {
+      ...bindings,
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      claimTtlMs: 30_000,
+    };
+    const contextPath = path.join(stateDirectory, "claim.json");
+    await fs.writeFile(contextPath, JSON.stringify(context), { mode: 0o600 });
+    const outcomes = await Promise.all(
+      Array.from({ length: 8 }, () => runChild(stateDirectory, contextPath)),
+    );
+    expect(outcomes.filter((outcome) => outcome === "acquired")).toHaveLength(
+      1,
+    );
+    expect(
+      outcomes.filter((outcome) => outcome === "in_progress"),
+    ).toHaveLength(7);
+  });
+
+  it("writes a 0600 regular file and retains state across store instances", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created } = await seed(stateDirectory);
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    const stat = await fs.lstat(filePath);
+    expect(stat.isFile()).toBe(true);
+    expect(stat.mode & 0o777).toBe(0o600);
+    const reopened = new FileMessageInteractionSessionStore({ stateDirectory });
+    expect(await reopened.get(created.session.reference)).toMatchObject({
+      reference: created.session.reference,
+      consume: { state: "pending" },
+    });
+  });
+
+  it("fails fast on corruption instead of fabricating an empty store", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    await fs.writeFile(filePath, "{broken", { mode: 0o600 });
+    const store = new FileMessageInteractionSessionStore({ stateDirectory });
+    await expect(
+      store.get("0123456789abcdef0123456789abcdef"),
+    ).rejects.toMatchObject({
+      code: "CORRUPT_INTERACTION_SESSION_STORE",
+    });
+    const reference = "0123456789abcdef0123456789abcdef";
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        sessions: { [reference]: { sessionVersion: 1, reference } },
+      }),
+      { mode: 0o600 },
+    );
+    await expect(store.get(reference)).rejects.toMatchObject({
+      code: "CORRUPT_INTERACTION_SESSION_STORE",
+    });
+  });
+
+  it("rejects store-file and state-directory symlinks", async () => {
+    const targetDirectory = await temporaryDirectory();
+    const stateDirectory = await temporaryDirectory();
+    const targetFile = path.join(targetDirectory, "target.json");
+    await fs.writeFile(targetFile, '{"version":1,"sessions":{}}');
+    await fs.symlink(
+      targetFile,
+      path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+    );
+    await expect(
+      new FileMessageInteractionSessionStore({ stateDirectory }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+
+    const linkDirectory = `${stateDirectory}-link`;
+    roots.push(linkDirectory);
+    await fs.symlink(targetDirectory, linkDirectory);
+    await expect(
+      new FileMessageInteractionSessionStore({
+        stateDirectory: linkDirectory,
+      }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+  });
+
+  it("rejects a directory swapped to a symlink after initialization", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const redirectedDirectory = await temporaryDirectory();
+    const movedDirectory = `${stateDirectory}-moved`;
+    roots.push(movedDirectory);
+    const store = new FileMessageInteractionSessionStore({ stateDirectory });
+    expect(await store.get("0123456789abcdef0123456789abcdef")).toBeNull();
+    await fs.rename(stateDirectory, movedDirectory);
+    await fs.symlink(redirectedDirectory, stateDirectory);
+    await expect(
+      store.get("0123456789abcdef0123456789abcdef"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+    expect(await fs.readdir(redirectedDirectory)).toEqual([]);
+  });
+
+  it("recovers an expired lock only when its owner process is dead", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: 2_000_000_000,
+        token: "dead-owner",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    const { created } = await seed(stateDirectory, { now });
+    expect(created.session.reference).toBe("0123456789abcdef0123456789abcdef");
+  });
+
+  it("does not steal an expired lease from a live owner", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: process.pid,
+        token: "live-owner",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 10,
+      pollMs: 1,
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+    expect(await fs.lstat(lockPath)).toBeDefined();
+  });
+
+  it("collects expired sessions through the explicit retention/GC boundary", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { store, created } = await seed(stateDirectory, { retentionMs: 0 });
+    expect(
+      await store.deleteExpired(Date.parse(created.session.expiresAt)),
+    ).toBe(1);
+    expect(await store.get(created.session.reference)).toBeNull();
+  });
+});

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -34,6 +34,34 @@ async function temporaryDirectory(): Promise<string> {
   return root;
 }
 
+async function lockIdentity(lockPath: string): Promise<string> {
+  const entry = await fs.lstat(lockPath);
+  return `${entry.dev}-${entry.ino}`;
+}
+
+function barrier(): {
+  entered: Promise<void>;
+  hook: () => Promise<void>;
+  release: () => void;
+} {
+  let markEntered: () => void = () => {};
+  let release: () => void = () => {};
+  const entered = new Promise<void>((resolve) => {
+    markEntered = resolve;
+  });
+  const blocked = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    entered,
+    hook: async () => {
+      markEntered();
+      await blocked;
+    },
+    release,
+  };
+}
+
 const bindings = {
   actorId: "actor-a",
   audience: { kind: "room", id: "room-a" },
@@ -297,6 +325,7 @@ describe("FileMessageInteractionSessionStore", () => {
       JSON.stringify({
         pid: 2_000_000_000,
         processIdentity: null,
+        lockIdentity: await lockIdentity(lockPath),
         token: "dead-owner",
         createdAt: now - 10_000,
         expiresAt: now - 1,
@@ -320,6 +349,7 @@ describe("FileMessageInteractionSessionStore", () => {
       JSON.stringify({
         pid: process.pid,
         processIdentity: null,
+        lockIdentity: await lockIdentity(lockPath),
         token: "live-owner",
         createdAt: now - 10_000,
         expiresAt: now - 1,
@@ -352,6 +382,7 @@ describe("FileMessageInteractionSessionStore", () => {
       JSON.stringify({
         pid: process.pid,
         processIdentity: "different-boot:different-start",
+        lockIdentity: await lockIdentity(lockPath),
         token: "reused-pid-owner",
         createdAt: now - 10_000,
         expiresAt: now - 1,
@@ -362,7 +393,7 @@ describe("FileMessageInteractionSessionStore", () => {
     expect(created.session.reference).toBe("0123456789abcdef0123456789abcdef");
   });
 
-  it("uses the absolute recovery ceiling when process generation is unavailable", async () => {
+  it("never steals from a live PID when its generation is unavailable", async () => {
     const stateDirectory = await temporaryDirectory();
     const now = Date.parse("2026-08-21T00:00:00.000Z");
     const lockPath = path.join(
@@ -375,6 +406,7 @@ describe("FileMessageInteractionSessionStore", () => {
       JSON.stringify({
         pid: process.pid,
         processIdentity: null,
+        lockIdentity: await lockIdentity(lockPath),
         token: "unqualified-owner",
         createdAt: now - 101,
         expiresAt: now - 100,
@@ -386,8 +418,13 @@ describe("FileMessageInteractionSessionStore", () => {
       clock: () => now,
       staleLockMs: 1,
       hardStaleLockMs: 100,
+      lockTimeoutMs: 10,
+      pollMs: 1,
     });
-    await expect(store.deleteExpired(now)).resolves.toBe(0);
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+    expect(await fs.lstat(lockPath)).toBeDefined();
   });
 
   it("uses the absolute recovery ceiling while a lock owner is unpublished", async () => {
@@ -413,6 +450,201 @@ describe("FileMessageInteractionSessionStore", () => {
 
     await fs.utimes(lockPath, new Date(now - 101), new Date(now - 101));
     await expect(store.deleteExpired(now)).resolves.toBe(0);
+  });
+
+  it("fences two delayed stale recoverers from the fresh winner generation", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    const staleIdentity = await lockIdentity(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: 2_000_000_000,
+        processIdentity: null,
+        lockIdentity: staleIdentity,
+        token: "stale-generation",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+
+    let staleObservers = 0;
+    let releaseObservers: () => void = () => {};
+    const bothObserved = new Promise<void>((resolve) => {
+      releaseObservers = resolve;
+    });
+    let allowRecovery: () => void = () => {};
+    const recoveryGate = new Promise<void>((resolve) => {
+      allowRecovery = resolve;
+    });
+    const winnerRelease = barrier();
+    let releaseCalls = 0;
+    const options = {
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforeStaleRetire: async () => {
+          staleObservers += 1;
+          if (staleObservers === 2) releaseObservers();
+          await recoveryGate;
+        },
+        beforeReleaseRetire: async () => {
+          releaseCalls += 1;
+          if (releaseCalls === 1) await winnerRelease.hook();
+        },
+      },
+    };
+    const first = new FileMessageInteractionSessionStore(options).deleteExpired(
+      now,
+    );
+    const second = new FileMessageInteractionSessionStore(
+      options,
+    ).deleteExpired(now);
+    await bothObserved;
+    allowRecovery();
+    await winnerRelease.entered;
+
+    const freshIdentity = await lockIdentity(lockPath);
+    expect(freshIdentity).not.toBe(staleIdentity);
+    winnerRelease.release();
+    await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
+  });
+
+  it("revalidates after an old lock disappears and a successor acquires", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    const staleIdentity = await lockIdentity(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: 2_000_000_000,
+        processIdentity: null,
+        lockIdentity: staleIdentity,
+        token: "departing-generation",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    const recovererGate = barrier();
+    const recovering = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 20,
+      pollMs: 1,
+      lockRaceHooks: { beforeStaleRetire: recovererGate.hook },
+    }).deleteExpired(now);
+    await recovererGate.entered;
+
+    await fs.rm(lockPath, { recursive: true });
+    const successorRelease = barrier();
+    const successor = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: { beforeReleaseRetire: successorRelease.hook },
+    });
+    const successorTransaction = successor.deleteExpired(now);
+    await successorRelease.entered;
+    const successorIdentity = await lockIdentity(lockPath);
+
+    recovererGate.release();
+    await expect(recovering).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+    expect(await lockIdentity(lockPath)).toBe(successorIdentity);
+    successorRelease.release();
+    await expect(successorTransaction).resolves.toBe(0);
+  });
+
+  it("recovers a transition marker abandoned by a dead lock owner", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    const identity = await lockIdentity(lockPath);
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: 2_000_000_000,
+        processIdentity: null,
+        lockIdentity: identity,
+        token: "dead-lock-owner",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    await fs.writeFile(
+      path.join(lockPath, ".transition"),
+      JSON.stringify({
+        pid: 2_000_000_000,
+        processIdentity: null,
+        token: "dead-transition-owner",
+      }),
+      { mode: 0o600 },
+    );
+
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+    });
+    await expect(store.deleteExpired(now)).resolves.toBe(0);
+  });
+
+  it("a delayed release cannot detach a replacement lock generation", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const oldRelease = barrier();
+    const oldStore = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: { beforeReleaseRetire: oldRelease.hook },
+    });
+    const oldTransaction = oldStore.deleteExpired(now);
+    await oldRelease.entered;
+    const oldIdentity = await lockIdentity(lockPath);
+    await fs.rename(lockPath, `${lockPath}.retired-test-${oldIdentity}`);
+
+    const successorRelease = barrier();
+    const successor = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: { beforeReleaseRetire: successorRelease.hook },
+    });
+    const successorTransaction = successor.deleteExpired(now);
+    await successorRelease.entered;
+    const successorIdentity = await lockIdentity(lockPath);
+    expect(successorIdentity).not.toBe(oldIdentity);
+
+    oldRelease.release();
+    await expect(oldTransaction).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_LOST",
+    });
+    expect(await lockIdentity(lockPath)).toBe(successorIdentity);
+    successorRelease.release();
+    await expect(successorTransaction).resolves.toBe(0);
   });
 
   it("collects expired sessions through the explicit retention/GC boundary", async () => {

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -27,7 +27,9 @@ afterEach(async () => {
 });
 
 async function temporaryDirectory(): Promise<string> {
-  const root = await fs.mkdtemp("/private/tmp/eliza-interaction-store-");
+  const root = await fs.mkdtemp(
+    path.join(await fs.realpath(os.tmpdir()), "eliza-interaction-store-"),
+  );
   roots.push(root);
   return root;
 }
@@ -294,6 +296,7 @@ describe("FileMessageInteractionSessionStore", () => {
       path.join(lockPath, "owner.json"),
       JSON.stringify({
         pid: 2_000_000_000,
+        processIdentity: null,
         token: "dead-owner",
         createdAt: now - 10_000,
         expiresAt: now - 1,
@@ -316,6 +319,7 @@ describe("FileMessageInteractionSessionStore", () => {
       path.join(lockPath, "owner.json"),
       JSON.stringify({
         pid: process.pid,
+        processIdentity: null,
         token: "live-owner",
         createdAt: now - 10_000,
         expiresAt: now - 1,
@@ -334,6 +338,83 @@ describe("FileMessageInteractionSessionStore", () => {
     expect(await fs.lstat(lockPath)).toBeDefined();
   });
 
+  it("recovers an expired lock after the recorded PID is reused", async () => {
+    if (process.platform !== "linux") return;
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: process.pid,
+        processIdentity: "different-boot:different-start",
+        token: "reused-pid-owner",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    const { created } = await seed(stateDirectory, { now });
+    expect(created.session.reference).toBe("0123456789abcdef0123456789abcdef");
+  });
+
+  it("uses the absolute recovery ceiling when process generation is unavailable", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: process.pid,
+        processIdentity: null,
+        token: "unqualified-owner",
+        createdAt: now - 101,
+        expiresAt: now - 100,
+      }),
+      { mode: 0o600 },
+    );
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      staleLockMs: 1,
+      hardStaleLockMs: 100,
+    });
+    await expect(store.deleteExpired(now)).resolves.toBe(0);
+  });
+
+  it("uses the absolute recovery ceiling while a lock owner is unpublished", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.utimes(lockPath, new Date(now - 50), new Date(now - 50));
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 10,
+      staleLockMs: 1,
+      hardStaleLockMs: 100,
+      pollMs: 1,
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+
+    await fs.utimes(lockPath, new Date(now - 101), new Date(now - 101));
+    await expect(store.deleteExpired(now)).resolves.toBe(0);
+  });
+
   it("collects expired sessions through the explicit retention/GC boundary", async () => {
     const stateDirectory = await temporaryDirectory();
     const { store, created } = await seed(stateDirectory, { retentionMs: 0 });
@@ -343,7 +424,7 @@ describe("FileMessageInteractionSessionStore", () => {
     expect(await store.get(created.session.reference)).toBeNull();
   });
 
-  it("never collects a committed ambiguous effect or completed receipt", async () => {
+  it("retains terminal outcomes until their explicit collection boundary", async () => {
     const stateDirectory = await temporaryDirectory();
     const { store, created, now } = await seed(stateDirectory, {
       retentionMs: 0,
@@ -364,8 +445,14 @@ describe("FileMessageInteractionSessionStore", () => {
       now,
     });
     expect(
-      await store.deleteExpired(Date.parse(created.session.expiresAt)),
-    ).toBe(0);
+      await store.listCommitted({ committedBefore: now, limit: 10 }),
+    ).toMatchObject([
+      {
+        reference: created.session.reference,
+        consume: { state: "committed", replayKey: "replay-a" },
+      },
+    ]);
+    expect(await store.deleteExpired(now - 1)).toBe(0);
     const reopenedCommitted = new FileMessageInteractionSessionStore({
       stateDirectory,
     });
@@ -374,10 +461,9 @@ describe("FileMessageInteractionSessionStore", () => {
     ).toMatchObject({
       consume: { state: "committed" },
     });
-    await reopenedCommitted.completeIfClaimed({
+    await reopenedCommitted.reconcileCommitted({
       reference: created.session.reference,
       replayKey: "replay-a",
-      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       now,
       receipt: {
         receiptId: "receipt-a",
@@ -399,10 +485,53 @@ describe("FileMessageInteractionSessionStore", () => {
         receipt: { receiptId: "receipt-a" },
       },
     });
-    expect(
-      await reopenedCompleted.deleteExpired(
-        Date.parse(created.session.expiresAt),
-      ),
-    ).toBe(0);
+    expect(await reopenedCompleted.deleteExpired(now - 1)).toBe(0);
+    expect(await reopenedCompleted.deleteExpired(now)).toBe(1);
+    expect(await reopenedCompleted.get(created.session.reference)).toBeNull();
+  });
+
+  it("prunes retained completions before enforcing session capacity", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { store, created, now } = await seed(stateDirectory);
+    await store.claimIfCurrent({
+      ...bindings,
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      claimTtlMs: 1,
+    });
+    await store.commitIfClaimed({
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+    });
+    await store.completeIfClaimed({
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      receipt: {
+        receiptId: "receipt-a",
+        idempotencyKey: "replay-a",
+        status: "completed",
+        completedAt: new Date(now).toISOString(),
+        result: { accepted: true },
+      },
+    });
+    const bounded = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      retentionMs: 0,
+      maxSessions: 1,
+      clock: () => now + 1,
+    });
+    const replacement = structuredClone(created.session);
+    replacement.reference = "fedcba9876543210fedcba9876543210";
+    await expect(bounded.create(replacement)).resolves.toBeUndefined();
+    expect(await bounded.get(created.session.reference)).toBeNull();
+    expect(await bounded.get(replacement.reference)).toMatchObject({
+      consume: { state: "pending" },
+    });
   });
 });

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -1,0 +1,622 @@
+/**
+ * Persists message-interaction sessions for one host with cross-process atomic
+ * transitions. Multi-host deployments should implement the same store contract
+ * with a transactional database row or outbox rather than sharing this file.
+ */
+
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  applyMessageInteractionClaim,
+  applyMessageInteractionCompletion,
+  applyMessageInteractionRevocation,
+  ElizaError,
+  type MessageInteractionClaimContext,
+  type MessageInteractionClaimResult,
+  type MessageInteractionCompleteContext,
+  type MessageInteractionSession,
+  type MessageInteractionSessionStore,
+} from "@elizaos/core";
+
+interface SessionFile {
+  version: 1;
+  sessions: Record<string, MessageInteractionSession>;
+}
+
+interface LockOwner {
+  pid: number;
+  token: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validIsoDate(value: unknown): boolean {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function structurallyValidConsume(value: Record<string, unknown>): boolean {
+  if (value.state === "pending") return true;
+  if (value.state !== "claimed" && value.state !== "completed") return false;
+  if (
+    typeof value.claimId !== "string" ||
+    typeof value.replayKey !== "string" ||
+    typeof value.responseDigest !== "string" ||
+    !isRecord(value.response) ||
+    !validIsoDate(value.claimedAt) ||
+    !Number.isSafeInteger(value.attempt) ||
+    Number(value.attempt) < 1
+  )
+    return false;
+  if (value.state === "claimed") return validIsoDate(value.claimExpiresAt);
+  const receipt = value.receipt;
+  return (
+    validIsoDate(value.completedAt) &&
+    isRecord(receipt) &&
+    typeof receipt.receiptId === "string" &&
+    receipt.idempotencyKey === value.replayKey &&
+    receipt.status === "completed" &&
+    validIsoDate(receipt.completedAt) &&
+    isRecord(receipt.result)
+  );
+}
+
+function structurallyValidSession(value: unknown, reference: string): boolean {
+  if (!isRecord(value)) return false;
+  const bindings = value.bindings;
+  const authorization = value.authorization;
+  const consume = value.consume;
+  return (
+    value.sessionVersion === 1 &&
+    value.reference === reference &&
+    typeof value.purpose === "string" &&
+    ["choice", "form", "followups", "task", "secret"].includes(
+      String(value.blockKind),
+    ) &&
+    ["native", "conversational", "signed-hosted", "sensitive-request"].includes(
+      String(value.flow),
+    ) &&
+    typeof value.profileId === "string" &&
+    isRecord(bindings) &&
+    typeof bindings.actorId === "string" &&
+    isRecord(bindings.audience) &&
+    typeof bindings.audience.kind === "string" &&
+    typeof bindings.audience.id === "string" &&
+    typeof bindings.agentId === "string" &&
+    isRecord(bindings.connector) &&
+    typeof bindings.connector.source === "string" &&
+    typeof bindings.connector.accountId === "string" &&
+    typeof bindings.roomId === "string" &&
+    typeof bindings.sourceMessageId === "string" &&
+    isRecord(value.responseSchema) &&
+    Array.isArray(value.responseSchema.fields) &&
+    value.responseSchema.additionalFields === false &&
+    isRecord(authorization) &&
+    typeof authorization.decisionId === "string" &&
+    typeof authorization.policyRevision === "string" &&
+    validIsoDate(authorization.decidedAt) &&
+    ["active", "revoked"].includes(String(authorization.state)) &&
+    (authorization.revokedAt === null ||
+      validIsoDate(authorization.revokedAt)) &&
+    isRecord(value.effect) &&
+    typeof value.effect.kind === "string" &&
+    validIsoDate(value.createdAt) &&
+    validIsoDate(value.expiresAt) &&
+    isRecord(consume) &&
+    structurallyValidConsume(consume) &&
+    Number.isSafeInteger(value.revision) &&
+    Number(value.revision) >= 0
+  );
+}
+
+export interface FileMessageInteractionSessionStoreOptions {
+  stateDirectory: string;
+  fileName?: string;
+  lockTimeoutMs?: number;
+  staleLockMs?: number;
+  pollMs?: number;
+  retentionMs?: number;
+  clock?: () => number;
+}
+
+function storeError(
+  code: string,
+  message: string,
+  context?: Record<string, unknown>,
+): never {
+  throw new ElizaError(message, { code, context });
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+async function existsLstat(filePath: string) {
+  try {
+    return await fs.lstat(filePath);
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) {
+      // error-policy:J4 absence is the designed initial state for this store.
+      return null;
+    }
+    throw error;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function safeInteger(value: number, name: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    return storeError(
+      "INVALID_INTERACTION_STORE_CONFIG",
+      `${name} is invalid.`,
+      {
+        name,
+        value,
+      },
+    );
+  }
+  return value;
+}
+
+function newToken(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * A single-machine durable store. Atomic rename and directory fsync preserve a
+ * complete prior or next revision across process/power loss; the lock directory
+ * serializes independent host processes.
+ */
+export class FileMessageInteractionSessionStore
+  implements MessageInteractionSessionStore
+{
+  private readonly directory: string;
+  private readonly filePath: string;
+  private readonly lockPath: string;
+  private readonly lockTimeoutMs: number;
+  private readonly staleLockMs: number;
+  private readonly pollMs: number;
+  private readonly retentionMs: number;
+  private readonly clock: () => number;
+  private directoryIdentity: {
+    realPath: string;
+    device: number;
+    inode: number;
+  } | null = null;
+  private initialized = false;
+
+  constructor(options: FileMessageInteractionSessionStoreOptions) {
+    this.directory = path.resolve(options.stateDirectory);
+    const fileName = options.fileName ?? "message-interaction-sessions.v1.json";
+    if (
+      path.basename(fileName) !== fileName ||
+      fileName === "." ||
+      fileName === ".."
+    ) {
+      storeError(
+        "INVALID_INTERACTION_STORE_PATH",
+        "Interaction store filename must be a plain basename.",
+      );
+    }
+    this.filePath = path.join(this.directory, fileName);
+    this.lockPath = `${this.filePath}.lock`;
+    this.lockTimeoutMs = safeInteger(
+      options.lockTimeoutMs ?? 5_000,
+      "lockTimeoutMs",
+      1,
+    );
+    this.staleLockMs = safeInteger(
+      options.staleLockMs ?? 30_000,
+      "staleLockMs",
+      1,
+    );
+    this.pollMs = safeInteger(options.pollMs ?? 10, "pollMs", 1);
+    this.retentionMs = safeInteger(
+      options.retentionMs ?? 7 * 24 * 60 * 60 * 1_000,
+      "retentionMs",
+      0,
+    );
+    this.clock = options.clock ?? Date.now;
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.initialized) {
+      await this.assertDirectoryIdentity();
+      return;
+    }
+    await fs.mkdir(this.directory, { recursive: true, mode: 0o700 });
+    const directoryStat = await fs.lstat(this.directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory must be a real directory.",
+      );
+    }
+    const realDirectory = await fs.realpath(this.directory);
+    if (realDirectory !== this.directory) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory cannot traverse a symlink.",
+      );
+    }
+    this.directoryIdentity = {
+      realPath: realDirectory,
+      device: directoryStat.dev,
+      inode: directoryStat.ino,
+    };
+    const existing = await existsLstat(this.filePath);
+    if (existing?.isSymbolicLink() || (existing && !existing.isFile())) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store file must be a regular file.",
+      );
+    }
+    this.initialized = true;
+  }
+
+  private async assertDirectoryIdentity(): Promise<void> {
+    const expected = this.directoryIdentity;
+    if (!expected)
+      storeError(
+        "INTERACTION_STORE_NOT_INITIALIZED",
+        "Interaction store directory identity is unavailable.",
+      );
+    const stat = await fs.lstat(this.directory);
+    const realPath = await fs.realpath(this.directory);
+    if (
+      !stat.isDirectory() ||
+      stat.isSymbolicLink() ||
+      realPath !== expected.realPath ||
+      stat.dev !== expected.device ||
+      stat.ino !== expected.inode
+    ) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory identity changed after initialization.",
+      );
+    }
+  }
+
+  private processAlive(pid: number): boolean {
+    if (!Number.isSafeInteger(pid) || pid < 1) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      if (isErrno(error, "ESRCH")) return false;
+      if (isErrno(error, "EPERM")) return true;
+      throw error;
+    }
+  }
+
+  private async readLockOwner(): Promise<LockOwner | null> {
+    try {
+      const raw = await fs.readFile(
+        path.join(this.lockPath, "owner.json"),
+        "utf8",
+      );
+      const value = JSON.parse(raw) as Partial<LockOwner>;
+      if (
+        !Number.isSafeInteger(value.pid) ||
+        typeof value.token !== "string" ||
+        !Number.isSafeInteger(value.createdAt) ||
+        !Number.isSafeInteger(value.expiresAt)
+      ) {
+        return null;
+      }
+      return value as LockOwner;
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) {
+        // error-policy:J4 a creator may exist before its owner file is durable.
+        return null;
+      }
+      if (error instanceof SyntaxError) {
+        // error-policy:J3 malformed owner data has no authority; lock age still
+        // has to cross the stale threshold before recovery.
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async recoverStaleLock(now: number): Promise<boolean> {
+    const lockStat = await existsLstat(this.lockPath);
+    if (!lockStat) return true;
+    if (!lockStat.isDirectory() || lockStat.isSymbolicLink()) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_LOCK",
+        "Interaction store lock is not a real directory.",
+      );
+    }
+    const owner = await this.readLockOwner();
+    const stale = owner
+      ? owner.expiresAt <= now && !this.processAlive(owner.pid)
+      : lockStat.mtimeMs + this.staleLockMs <= now;
+    if (!stale) return false;
+    const quarantine = `${this.lockPath}.stale-${process.pid}-${newToken()}`;
+    try {
+      await fs.rename(this.lockPath, quarantine);
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return true;
+      throw error;
+    }
+    try {
+      await fs.rm(quarantine, { recursive: true });
+    } catch {
+      // error-policy:J6 renamed stale lock no longer blocks the authority.
+    }
+    return true;
+  }
+
+  private async acquireLock(): Promise<LockOwner> {
+    await this.initialize();
+    const startedAt = performance.now();
+    while (performance.now() - startedAt <= this.lockTimeoutMs) {
+      const now = this.clock();
+      let createdLock = false;
+      try {
+        await fs.mkdir(this.lockPath, { mode: 0o700 });
+        createdLock = true;
+        const owner: LockOwner = {
+          pid: process.pid,
+          token: newToken(),
+          createdAt: now,
+          expiresAt: now + this.staleLockMs,
+        };
+        await this.writeAndSync(path.join(this.lockPath, "owner.json"), owner);
+        return owner;
+      } catch (error) {
+        if (createdLock) {
+          try {
+            await fs.rm(this.lockPath, { recursive: true });
+          } catch {
+            // error-policy:J6 failed lock construction is already fatal; cleanup
+            // must not replace its originating filesystem error.
+          }
+        }
+        if (!isErrno(error, "EEXIST")) throw error;
+        await this.recoverStaleLock(now);
+        await delay(this.pollMs);
+      }
+    }
+    return storeError(
+      "INTERACTION_STORE_LOCK_TIMEOUT",
+      "Timed out acquiring interaction store lock.",
+    );
+  }
+
+  private async releaseLock(owner: LockOwner): Promise<void> {
+    const current = await this.readLockOwner();
+    if (!current || current.token !== owner.token) {
+      storeError(
+        "INTERACTION_STORE_LOCK_LOST",
+        "Interaction store lock ownership changed.",
+      );
+    }
+    await fs.rm(this.lockPath, { recursive: true });
+  }
+
+  private async writeAndSync(filePath: string, value: unknown): Promise<void> {
+    const handle = await fs.open(
+      filePath,
+      constants.O_CREAT |
+        constants.O_EXCL |
+        constants.O_WRONLY |
+        constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      await handle.writeFile(JSON.stringify(value, null, 2), "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private assertFile(value: unknown): SessionFile {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return storeError(
+        "CORRUPT_INTERACTION_SESSION_STORE",
+        "Interaction store root is invalid.",
+      );
+    }
+    const document = value as Partial<SessionFile>;
+    if (
+      document.version !== 1 ||
+      !document.sessions ||
+      typeof document.sessions !== "object" ||
+      Array.isArray(document.sessions)
+    ) {
+      return storeError(
+        "CORRUPT_INTERACTION_SESSION_STORE",
+        "Interaction store schema is invalid.",
+      );
+    }
+    for (const [reference, session] of Object.entries(document.sessions)) {
+      if (
+        !/^[a-f0-9]{32}$/.test(reference) ||
+        !structurallyValidSession(session, reference)
+      ) {
+        return storeError(
+          "CORRUPT_INTERACTION_SESSION_STORE",
+          "Interaction store contains an invalid session.",
+          { reference },
+        );
+      }
+    }
+    return document as SessionFile;
+  }
+
+  private async readFile(): Promise<SessionFile> {
+    const stat = await existsLstat(this.filePath);
+    if (!stat) return { version: 1, sessions: {} };
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store became a non-regular file.",
+      );
+    }
+    const handle = await fs.open(
+      this.filePath,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+    try {
+      const raw = await handle.readFile("utf8");
+      return this.assertFile(JSON.parse(raw) as unknown);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        // error-policy:J1 persistence corruption is surfaced, never reset.
+        return storeError(
+          "CORRUPT_INTERACTION_SESSION_STORE",
+          "Interaction store JSON is corrupt.",
+        );
+      }
+      throw error;
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private prune(document: SessionFile, now: number): number {
+    let deleted = 0;
+    for (const [reference, session] of Object.entries(document.sessions)) {
+      if (Date.parse(session.expiresAt) + this.retentionMs <= now) {
+        delete document.sessions[reference];
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  private async writeFile(document: SessionFile): Promise<void> {
+    const temp = `${this.filePath}.tmp-${process.pid}-${newToken()}`;
+    try {
+      await this.writeAndSync(temp, document);
+      await fs.rename(temp, this.filePath);
+      const directoryHandle = await fs.open(this.directory, constants.O_RDONLY);
+      try {
+        await directoryHandle.sync();
+      } finally {
+        await directoryHandle.close();
+      }
+    } finally {
+      try {
+        await fs.rm(temp, { force: true });
+      } catch {
+        // error-policy:J6 temp cleanup must not mask the durable write outcome.
+      }
+    }
+  }
+
+  private async transaction<T>(
+    operation: (document: SessionFile) => T | Promise<T>,
+  ): Promise<T> {
+    const owner = await this.acquireLock();
+    try {
+      await this.assertDirectoryIdentity();
+      const document = await this.readFile();
+      this.prune(document, this.clock());
+      const result = await operation(document);
+      await this.assertDirectoryIdentity();
+      await this.writeFile(document);
+      return result;
+    } finally {
+      await this.releaseLock(owner);
+    }
+  }
+
+  async create(session: MessageInteractionSession): Promise<void> {
+    await this.transaction((document) => {
+      if (document.sessions[session.reference]) {
+        storeError(
+          "MESSAGE_INTERACTION_REFERENCE_COLLISION",
+          "Interaction reference already exists.",
+        );
+      }
+      document.sessions[session.reference] = structuredClone(session);
+    });
+  }
+
+  async get(reference: string): Promise<MessageInteractionSession | null> {
+    await this.initialize();
+    const document = await this.readFile();
+    return document.sessions[reference]
+      ? structuredClone(document.sessions[reference])
+      : null;
+  }
+
+  async claimIfCurrent(
+    context: MessageInteractionClaimContext,
+  ): Promise<MessageInteractionClaimResult> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const result = applyMessageInteractionClaim(current, context);
+      document.sessions[context.reference] = structuredClone(result.session);
+      return result;
+    });
+  }
+
+  async completeIfClaimed(
+    context: MessageInteractionCompleteContext,
+  ): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const completed = applyMessageInteractionCompletion(current, context);
+      document.sessions[context.reference] = structuredClone(completed);
+      return completed;
+    });
+  }
+
+  async revokeAuthorization(args: {
+    reference: string;
+    decisionId: string;
+    now: number;
+  }): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[args.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const revoked = applyMessageInteractionRevocation(
+        current,
+        args.decisionId,
+        args.now,
+      );
+      document.sessions[args.reference] = structuredClone(revoked);
+      return revoked;
+    });
+  }
+
+  async deleteExpired(before: number): Promise<number> {
+    safeInteger(before, "before", 0);
+    return this.transaction((document) => {
+      let deleted = 0;
+      for (const [reference, session] of Object.entries(document.sessions)) {
+        if (Date.parse(session.expiresAt) <= before) {
+          delete document.sessions[reference];
+          deleted += 1;
+        }
+      }
+      return deleted;
+    });
+  }
+}

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -9,11 +9,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   applyMessageInteractionClaim,
+  applyMessageInteractionCommit,
   applyMessageInteractionCompletion,
   applyMessageInteractionRevocation,
   ElizaError,
   type MessageInteractionClaimContext,
   type MessageInteractionClaimResult,
+  type MessageInteractionCommitContext,
   type MessageInteractionCompleteContext,
   type MessageInteractionSession,
   type MessageInteractionSessionStore,
@@ -36,12 +38,53 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function validIsoDate(value: unknown): boolean {
-  return typeof value === "string" && Number.isFinite(Date.parse(value));
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+
+function validBoundedJson(value: unknown): boolean {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  let nodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || current.depth > 32 || ++nodes > 100_000) return false;
+    if (typeof current.value === "string") {
+      if (new TextEncoder().encode(current.value).length > 65_536) return false;
+      continue;
+    }
+    if (Array.isArray(current.value)) {
+      if (current.value.length > 10_000) return false;
+      for (const child of current.value)
+        stack.push({ value: child, depth: current.depth + 1 });
+      continue;
+    }
+    if (isRecord(current.value)) {
+      const entries = Object.entries(current.value);
+      if (entries.length > 10_000) return false;
+      for (const [key, child] of entries) {
+        if (
+          key === "__proto__" ||
+          key === "prototype" ||
+          key === "constructor" ||
+          new TextEncoder().encode(key).length > 512
+        )
+          return false;
+        stack.push({ value: child, depth: current.depth + 1 });
+      }
+    }
+  }
+  return true;
 }
 
 function structurallyValidConsume(value: Record<string, unknown>): boolean {
   if (value.state === "pending") return true;
-  if (value.state !== "claimed" && value.state !== "completed") return false;
+  if (
+    value.state !== "claimed" &&
+    value.state !== "committed" &&
+    value.state !== "completed"
+  )
+    return false;
   if (
     typeof value.claimId !== "string" ||
     typeof value.replayKey !== "string" ||
@@ -52,10 +95,26 @@ function structurallyValidConsume(value: Record<string, unknown>): boolean {
     Number(value.attempt) < 1
   )
     return false;
-  if (value.state === "claimed") return validIsoDate(value.claimExpiresAt);
+  if (value.state === "claimed")
+    return (
+      validIsoDate(value.claimExpiresAt) &&
+      Date.parse(String(value.claimExpiresAt)) >
+        Date.parse(String(value.claimedAt))
+    );
+  if (value.state === "committed")
+    return (
+      validIsoDate(value.committedAt) &&
+      Date.parse(String(value.committedAt)) >=
+        Date.parse(String(value.claimedAt))
+    );
   const receipt = value.receipt;
   return (
+    validIsoDate(value.committedAt) &&
     validIsoDate(value.completedAt) &&
+    Date.parse(String(value.committedAt)) >=
+      Date.parse(String(value.claimedAt)) &&
+    Date.parse(String(value.completedAt)) >=
+      Date.parse(String(value.committedAt)) &&
     isRecord(receipt) &&
     typeof receipt.receiptId === "string" &&
     receipt.idempotencyKey === value.replayKey &&
@@ -73,7 +132,16 @@ function structurallyValidSession(value: unknown, reference: string): boolean {
   return (
     value.sessionVersion === 1 &&
     value.reference === reference &&
-    typeof value.purpose === "string" &&
+    [
+      "choice",
+      "form",
+      "approval",
+      "setup",
+      "auth",
+      "task",
+      "file",
+      "followup",
+    ].includes(String(value.purpose)) &&
     ["choice", "form", "followups", "task", "secret"].includes(
       String(value.blockKind),
     ) &&
@@ -100,8 +168,9 @@ function structurallyValidSession(value: unknown, reference: string): boolean {
     typeof authorization.policyRevision === "string" &&
     validIsoDate(authorization.decidedAt) &&
     ["active", "revoked"].includes(String(authorization.state)) &&
-    (authorization.revokedAt === null ||
-      validIsoDate(authorization.revokedAt)) &&
+    ((authorization.state === "active" && authorization.revokedAt === null) ||
+      (authorization.state === "revoked" &&
+        validIsoDate(authorization.revokedAt))) &&
     isRecord(value.effect) &&
     typeof value.effect.kind === "string" &&
     validIsoDate(value.createdAt) &&
@@ -120,6 +189,8 @@ export interface FileMessageInteractionSessionStoreOptions {
   staleLockMs?: number;
   pollMs?: number;
   retentionMs?: number;
+  maxStoreBytes?: number;
+  maxSessions?: number;
   clock?: () => number;
 }
 
@@ -184,6 +255,8 @@ export class FileMessageInteractionSessionStore
   private readonly staleLockMs: number;
   private readonly pollMs: number;
   private readonly retentionMs: number;
+  private readonly maxStoreBytes: number;
+  private readonly maxSessions: number;
   private readonly clock: () => number;
   private directoryIdentity: {
     realPath: string;
@@ -223,6 +296,16 @@ export class FileMessageInteractionSessionStore
       "retentionMs",
       0,
     );
+    this.maxStoreBytes = safeInteger(
+      options.maxStoreBytes ?? 4 * 1024 * 1024,
+      "maxStoreBytes",
+      1,
+    );
+    this.maxSessions = safeInteger(
+      options.maxSessions ?? 10_000,
+      "maxSessions",
+      1,
+    );
     this.clock = options.clock ?? Date.now;
   }
 
@@ -237,6 +320,12 @@ export class FileMessageInteractionSessionStore
       storeError(
         "UNSAFE_INTERACTION_STORE_PATH",
         "Interaction store directory must be a real directory.",
+      );
+    }
+    if ((directoryStat.mode & 0o077) !== 0) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory permissions expose private state.",
       );
     }
     const realDirectory = await fs.realpath(this.directory);
@@ -256,6 +345,12 @@ export class FileMessageInteractionSessionStore
       storeError(
         "UNSAFE_INTERACTION_STORE_PATH",
         "Interaction store file must be a regular file.",
+      );
+    }
+    if (existing && (existing.nlink !== 1 || (existing.mode & 0o077) !== 0)) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store file must be private and have one filesystem link.",
       );
     }
     this.initialized = true;
@@ -298,10 +393,42 @@ export class FileMessageInteractionSessionStore
 
   private async readLockOwner(): Promise<LockOwner | null> {
     try {
-      const raw = await fs.readFile(
-        path.join(this.lockPath, "owner.json"),
-        "utf8",
+      const ownerPath = path.join(this.lockPath, "owner.json");
+      const entry = await fs.lstat(ownerPath);
+      if (
+        !entry.isFile() ||
+        entry.isSymbolicLink() ||
+        entry.nlink !== 1 ||
+        (entry.mode & 0o077) !== 0 ||
+        entry.size > 4_096
+      ) {
+        storeError(
+          "UNSAFE_INTERACTION_STORE_LOCK",
+          "Interaction store lock owner file is unsafe.",
+        );
+      }
+      const handle = await fs.open(
+        ownerPath,
+        constants.O_RDONLY | constants.O_NOFOLLOW,
       );
+      let raw: string;
+      try {
+        const opened = await handle.stat();
+        if (
+          opened.dev !== entry.dev ||
+          opened.ino !== entry.ino ||
+          opened.nlink !== 1 ||
+          opened.size > 4_096
+        ) {
+          // The prior owner may release and a contender may create a new lock
+          // between lstat and open. The changed file grants no authority; the
+          // caller treats it like an incomplete owner and waits/retries.
+          return null;
+        }
+        raw = await handle.readFile("utf8");
+      } finally {
+        await handle.close();
+      }
       const value = JSON.parse(raw) as Partial<LockOwner>;
       if (
         !Number.isSafeInteger(value.pid) ||
@@ -421,7 +548,12 @@ export class FileMessageInteractionSessionStore
   }
 
   private assertFile(value: unknown): SessionFile {
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
+    if (
+      !value ||
+      typeof value !== "object" ||
+      Array.isArray(value) ||
+      !validBoundedJson(value)
+    ) {
       return storeError(
         "CORRUPT_INTERACTION_SESSION_STORE",
         "Interaction store root is invalid.",
@@ -437,6 +569,12 @@ export class FileMessageInteractionSessionStore
       return storeError(
         "CORRUPT_INTERACTION_SESSION_STORE",
         "Interaction store schema is invalid.",
+      );
+    }
+    if (Object.keys(document.sessions).length > this.maxSessions) {
+      return storeError(
+        "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+        "Interaction store contains too many sessions.",
       );
     }
     for (const [reference, session] of Object.entries(document.sessions)) {
@@ -463,11 +601,37 @@ export class FileMessageInteractionSessionStore
         "Interaction store became a non-regular file.",
       );
     }
+    if (
+      stat.nlink !== 1 ||
+      (stat.mode & 0o077) !== 0 ||
+      stat.size > this.maxStoreBytes
+    ) {
+      return storeError(
+        stat.size > this.maxStoreBytes
+          ? "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED"
+          : "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store file is unsafe or exceeds its byte limit.",
+      );
+    }
     const handle = await fs.open(
       this.filePath,
       constants.O_RDONLY | constants.O_NOFOLLOW,
     );
     try {
+      const opened = await handle.stat();
+      if (
+        !opened.isFile() ||
+        opened.dev !== stat.dev ||
+        opened.ino !== stat.ino ||
+        opened.nlink !== 1 ||
+        (opened.mode & 0o077) !== 0 ||
+        opened.size > this.maxStoreBytes
+      ) {
+        return storeError(
+          "UNSAFE_INTERACTION_STORE_PATH",
+          "Interaction store file identity changed while opening.",
+        );
+      }
       const raw = await handle.readFile("utf8");
       return this.assertFile(JSON.parse(raw) as unknown);
     } catch (error) {
@@ -487,7 +651,11 @@ export class FileMessageInteractionSessionStore
   private prune(document: SessionFile, now: number): number {
     let deleted = 0;
     for (const [reference, session] of Object.entries(document.sessions)) {
-      if (Date.parse(session.expiresAt) + this.retentionMs <= now) {
+      if (
+        Date.parse(session.expiresAt) + this.retentionMs <= now &&
+        session.consume.state !== "committed" &&
+        session.consume.state !== "completed"
+      ) {
         delete document.sessions[reference];
         deleted += 1;
       }
@@ -496,6 +664,23 @@ export class FileMessageInteractionSessionStore
   }
 
   private async writeFile(document: SessionFile): Promise<void> {
+    if (
+      Object.keys(document.sessions).length > this.maxSessions ||
+      !validBoundedJson(document)
+    ) {
+      storeError(
+        "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+        "Interaction store exceeds its structural limits.",
+      );
+    }
+    if (
+      Buffer.byteLength(JSON.stringify(document), "utf8") > this.maxStoreBytes
+    ) {
+      storeError(
+        "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+        "Interaction store exceeds its byte limit.",
+      );
+    }
     const temp = `${this.filePath}.tmp-${process.pid}-${newToken()}`;
     try {
       await this.writeAndSync(temp, document);
@@ -584,6 +769,22 @@ export class FileMessageInteractionSessionStore
     });
   }
 
+  async commitIfClaimed(
+    context: MessageInteractionCommitContext,
+  ): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const committed = applyMessageInteractionCommit(current, context);
+      document.sessions[context.reference] = structuredClone(committed);
+      return committed;
+    });
+  }
+
   async revokeAuthorization(args: {
     reference: string;
     decisionId: string;
@@ -611,7 +812,11 @@ export class FileMessageInteractionSessionStore
     return this.transaction((document) => {
       let deleted = 0;
       for (const [reference, session] of Object.entries(document.sessions)) {
-        if (Date.parse(session.expiresAt) <= before) {
+        if (
+          Date.parse(session.expiresAt) <= before &&
+          session.consume.state !== "committed" &&
+          session.consume.state !== "completed"
+        ) {
           delete document.sessions[reference];
           deleted += 1;
         }

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -31,9 +31,21 @@ interface SessionFile {
 interface LockOwner {
   pid: number;
   processIdentity: string | null;
+  lockIdentity: string;
   token: string;
   createdAt: number;
   expiresAt: number;
+}
+
+interface LockRaceHooks {
+  beforeStaleRetire?: () => Promise<void>;
+  beforeReleaseRetire?: () => Promise<void>;
+}
+
+interface LockTransitionOwner {
+  pid: number;
+  processIdentity: string | null;
+  token: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -190,7 +202,7 @@ export interface FileMessageInteractionSessionStoreOptions {
   fileName?: string;
   lockTimeoutMs?: number;
   staleLockMs?: number;
-  /** Absolute recovery ceiling for platforms that cannot qualify a PID. */
+  /** Absolute recovery ceiling for an owner record that was never published. */
   hardStaleLockMs?: number;
   pollMs?: number;
   retentionMs?: number;
@@ -198,6 +210,8 @@ export interface FileMessageInteractionSessionStoreOptions {
   maxStoreBytes?: number;
   maxSessions?: number;
   clock?: () => number;
+  /** @internal Deterministic coordination for filesystem race tests. */
+  lockRaceHooks?: LockRaceHooks;
 }
 
 function storeError(
@@ -266,6 +280,7 @@ export class FileMessageInteractionSessionStore
   private readonly maxStoreBytes: number;
   private readonly maxSessions: number;
   private readonly clock: () => number;
+  private readonly lockRaceHooks: LockRaceHooks;
   private directoryIdentity: {
     realPath: string;
     device: number;
@@ -325,6 +340,7 @@ export class FileMessageInteractionSessionStore
       1,
     );
     this.clock = options.clock ?? Date.now;
+    this.lockRaceHooks = options.lockRaceHooks ?? {};
   }
 
   private async initialize(): Promise<void> {
@@ -434,6 +450,131 @@ export class FileMessageInteractionSessionStore
     }
   }
 
+  private lockIdentity(entry: { dev: number; ino: number }): string {
+    return `${entry.dev}-${entry.ino}`;
+  }
+
+  private async beginLockTransition(
+    lockIdentity: string,
+  ): Promise<string | null> {
+    const marker = path.join(this.lockPath, ".transition");
+    const token = newToken();
+    const candidate = path.join(this.lockPath, `.transition-${token}.tmp`);
+    try {
+      await this.writeAndSync(candidate, {
+        pid: process.pid,
+        processIdentity: await this.readProcessIdentity(process.pid),
+        token,
+      });
+      await fs.link(candidate, marker);
+    } catch (error) {
+      if (
+        isErrno(error, "ENOENT") ||
+        isErrno(error, "EEXIST") ||
+        isErrno(error, "ENOTEMPTY")
+      ) {
+        if (isErrno(error, "EEXIST")) {
+          await this.clearAbandonedTransition(lockIdentity);
+        }
+        return null;
+      }
+      throw error;
+    } finally {
+      try {
+        await fs.rm(candidate, { force: true });
+      } catch {
+        // error-policy:J6 a unique transition candidate never grants authority.
+      }
+    }
+    const current = await existsLstat(this.lockPath);
+    if (
+      !current?.isDirectory() ||
+      current.isSymbolicLink() ||
+      this.lockIdentity(current) !== lockIdentity
+    ) {
+      try {
+        await fs.rm(marker, { force: true });
+      } catch {
+        // error-policy:J6 the mismatched generation cannot be retired by us.
+      }
+      return null;
+    }
+    return marker;
+  }
+
+  private async clearAbandonedTransition(lockIdentity: string): Promise<void> {
+    const current = await existsLstat(this.lockPath);
+    if (!current || this.lockIdentity(current) !== lockIdentity) return;
+    const marker = path.join(this.lockPath, ".transition");
+    let value: Partial<LockTransitionOwner>;
+    try {
+      const raw = await fs.readFile(marker, "utf8");
+      value = JSON.parse(raw) as Partial<LockTransitionOwner>;
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return;
+      // error-policy:J3 malformed transition ownership fails closed.
+      if (error instanceof SyntaxError) return;
+      throw error;
+    }
+    if (
+      !Number.isSafeInteger(value.pid) ||
+      (value.processIdentity !== null &&
+        typeof value.processIdentity !== "string") ||
+      typeof value.token !== "string"
+    ) {
+      return;
+    }
+    const live = this.processAlive(value.pid as number);
+    const identity = live
+      ? await this.readProcessIdentity(value.pid as number)
+      : null;
+    if (
+      live &&
+      (!value.processIdentity ||
+        !identity ||
+        value.processIdentity === identity)
+    ) {
+      return;
+    }
+    const rechecked = await existsLstat(this.lockPath);
+    if (rechecked && this.lockIdentity(rechecked) === lockIdentity) {
+      await fs.rm(marker, { force: true });
+    }
+  }
+
+  /** The transition hardlink excludes release and all competing recoverers. */
+  private async retireObservedLock(
+    lockIdentity: string,
+    validate: () => Promise<boolean>,
+  ): Promise<boolean> {
+    const marker = await this.beginLockTransition(lockIdentity);
+    if (!marker) return false;
+    let valid: boolean;
+    try {
+      valid = await validate();
+    } catch (error) {
+      await fs.rm(marker, { force: true });
+      throw error;
+    }
+    if (!valid) {
+      await fs.rm(marker, { force: true });
+      return false;
+    }
+    const quarantine = `${this.lockPath}.retired-${process.pid}-${newToken()}`;
+    try {
+      await fs.rename(this.lockPath, quarantine);
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return false;
+      throw error;
+    }
+    try {
+      await fs.rm(quarantine, { recursive: true });
+    } catch {
+      // error-policy:J6 the detached generation no longer blocks the store.
+    }
+    return true;
+  }
+
   private async readLockOwner(): Promise<LockOwner | null> {
     try {
       const ownerPath = path.join(this.lockPath, "owner.json");
@@ -484,6 +625,8 @@ export class FileMessageInteractionSessionStore
         !Number.isSafeInteger(value.pid) ||
         (value.processIdentity !== null &&
           typeof value.processIdentity !== "string") ||
+        typeof value.lockIdentity !== "string" ||
+        !/^\d+-\d+$/.test(value.lockIdentity) ||
         typeof value.token !== "string" ||
         !Number.isSafeInteger(value.createdAt) ||
         !Number.isSafeInteger(value.expiresAt)
@@ -508,6 +651,42 @@ export class FileMessageInteractionSessionStore
     }
   }
 
+  private async lockIsStale(
+    lockStat: { dev: number; ino: number; mtimeMs: number },
+    now: number,
+    unpublishedMtimeMs = lockStat.mtimeMs,
+  ): Promise<boolean> {
+    const observedIdentity = this.lockIdentity(lockStat);
+    const owner = await this.readLockOwner();
+    if (!owner) {
+      // A creator publishes owner.json only after the lease is fully synced.
+      // Without an owner identity there is no safe PID-liveness decision, so
+      // incomplete or malformed locks use an absolute recovery ceiling instead
+      // of the short lease interval.
+      return unpublishedMtimeMs + this.hardStaleLockMs <= now;
+    }
+    if (owner.lockIdentity !== observedIdentity) {
+      // The owner belongs to a different directory generation. It grants no
+      // authority to remove the currently observed lock.
+      return false;
+    }
+    if (owner.expiresAt > now) return false;
+    const live = this.processAlive(owner.pid);
+    const currentIdentity = live
+      ? await this.readProcessIdentity(owner.pid)
+      : null;
+    const reusedPid = Boolean(
+      live &&
+        owner.processIdentity &&
+        currentIdentity &&
+        owner.processIdentity !== currentIdentity,
+    );
+    // If this platform cannot qualify a live PID generation, fail closed.
+    // A wall-clock ceiling would eventually steal from a paused but valid
+    // owner and reintroduce the same PID-aliasing race it is meant to solve.
+    return !live || reusedPid;
+  }
+
   private async recoverStaleLock(now: number): Promise<boolean> {
     const lockStat = await existsLstat(this.lockPath);
     if (!lockStat) return true;
@@ -517,49 +696,17 @@ export class FileMessageInteractionSessionStore
         "Interaction store lock is not a real directory.",
       );
     }
-    const owner = await this.readLockOwner();
-    let stale: boolean;
-    if (!owner) {
-      // A creator publishes owner.json only after the lease is fully synced.
-      // Without an owner identity there is no safe PID-liveness decision, so
-      // incomplete or malformed locks use the same absolute recovery ceiling
-      // as an unqualified legacy owner instead of the short lease interval.
-      stale = lockStat.mtimeMs + this.hardStaleLockMs <= now;
-    } else if (owner.expiresAt > now) {
-      stale = false;
-    } else {
-      const live = this.processAlive(owner.pid);
-      const currentIdentity = live
-        ? await this.readProcessIdentity(owner.pid)
-        : null;
-      const reusedPid = Boolean(
-        live &&
-          owner.processIdentity &&
-          currentIdentity &&
-          owner.processIdentity !== currentIdentity,
+    if (!(await this.lockIsStale(lockStat, now))) return false;
+    const observedIdentity = this.lockIdentity(lockStat);
+    await this.lockRaceHooks.beforeStaleRetire?.();
+    return this.retireObservedLock(observedIdentity, async () => {
+      const current = await existsLstat(this.lockPath);
+      return Boolean(
+        current &&
+          this.lockIdentity(current) === observedIdentity &&
+          (await this.lockIsStale(current, now, lockStat.mtimeMs)),
       );
-      const generationQualified = Boolean(
-        owner.processIdentity && currentIdentity,
-      );
-      stale =
-        !live ||
-        reusedPid ||
-        (!generationQualified && owner.createdAt + this.hardStaleLockMs <= now);
-    }
-    if (!stale) return false;
-    const quarantine = `${this.lockPath}.stale-${process.pid}-${newToken()}`;
-    try {
-      await fs.rename(this.lockPath, quarantine);
-    } catch (error) {
-      if (isErrno(error, "ENOENT")) return true;
-      throw error;
-    }
-    try {
-      await fs.rm(quarantine, { recursive: true });
-    } catch {
-      // error-policy:J6 renamed stale lock no longer blocks the authority.
-    }
-    return true;
+    });
   }
 
   private async acquireLock(): Promise<LockOwner> {
@@ -567,13 +714,22 @@ export class FileMessageInteractionSessionStore
     const startedAt = performance.now();
     while (performance.now() - startedAt <= this.lockTimeoutMs) {
       const now = this.clock();
-      let createdLock = false;
       try {
         await fs.mkdir(this.lockPath, { mode: 0o700 });
-        createdLock = true;
+      } catch (error) {
+        if (!isErrno(error, "EEXIST")) throw error;
+        await this.recoverStaleLock(now);
+        await delay(this.pollMs);
+        continue;
+      }
+
+      const created = await fs.lstat(this.lockPath);
+      const lockIdentity = this.lockIdentity(created);
+      try {
         const owner: LockOwner = {
           pid: process.pid,
           processIdentity: await this.readProcessIdentity(process.pid),
+          lockIdentity,
           token: newToken(),
           createdAt: now,
           expiresAt: now + this.staleLockMs,
@@ -589,17 +745,11 @@ export class FileMessageInteractionSessionStore
         await fs.rename(ownerTemp, path.join(this.lockPath, "owner.json"));
         return owner;
       } catch (error) {
-        if (createdLock) {
-          try {
-            await fs.rm(this.lockPath, { recursive: true });
-          } catch {
-            // error-policy:J6 failed lock construction is already fatal; cleanup
-            // must not replace its originating filesystem error.
-          }
-        }
-        if (!isErrno(error, "EEXIST")) throw error;
-        await this.recoverStaleLock(now);
-        await delay(this.pollMs);
+        // A construction failure may race a hard-ceiling recovery of the
+        // unpublished owner. Retain its identity quarantine so delayed cleanup
+        // cannot detach a successor generation.
+        await this.retireObservedLock(lockIdentity, async () => true);
+        throw error;
       }
     }
     return storeError(
@@ -609,14 +759,30 @@ export class FileMessageInteractionSessionStore
   }
 
   private async releaseLock(owner: LockOwner): Promise<void> {
-    const current = await this.readLockOwner();
-    if (!current || current.token !== owner.token) {
-      storeError(
-        "INTERACTION_STORE_LOCK_LOST",
-        "Interaction store lock ownership changed.",
-      );
+    await this.lockRaceHooks.beforeReleaseRetire?.();
+    const startedAt = performance.now();
+    while (performance.now() - startedAt <= this.lockTimeoutMs) {
+      if (
+        await this.retireObservedLock(owner.lockIdentity, async () => {
+          const current = await this.readLockOwner();
+          return Boolean(current && current.token === owner.token);
+        })
+      ) {
+        return;
+      }
+      const currentDirectory = await existsLstat(this.lockPath);
+      if (
+        !currentDirectory ||
+        this.lockIdentity(currentDirectory) !== owner.lockIdentity
+      ) {
+        break;
+      }
+      await delay(this.pollMs);
     }
-    await fs.rm(this.lockPath, { recursive: true });
+    storeError(
+      "INTERACTION_STORE_LOCK_LOST",
+      "Interaction store lock ownership changed.",
+    );
   }
 
   private async writeAndSync(filePath: string, value: unknown): Promise<void> {

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -11,12 +11,14 @@ import {
   applyMessageInteractionClaim,
   applyMessageInteractionCommit,
   applyMessageInteractionCompletion,
+  applyMessageInteractionReconciliation,
   applyMessageInteractionRevocation,
   ElizaError,
   type MessageInteractionClaimContext,
   type MessageInteractionClaimResult,
   type MessageInteractionCommitContext,
   type MessageInteractionCompleteContext,
+  type MessageInteractionReconcileContext,
   type MessageInteractionSession,
   type MessageInteractionSessionStore,
 } from "@elizaos/core";
@@ -28,6 +30,7 @@ interface SessionFile {
 
 interface LockOwner {
   pid: number;
+  processIdentity: string | null;
   token: string;
   createdAt: number;
   expiresAt: number;
@@ -187,8 +190,11 @@ export interface FileMessageInteractionSessionStoreOptions {
   fileName?: string;
   lockTimeoutMs?: number;
   staleLockMs?: number;
+  /** Absolute recovery ceiling for platforms that cannot qualify a PID. */
+  hardStaleLockMs?: number;
   pollMs?: number;
   retentionMs?: number;
+  committedRetentionMs?: number;
   maxStoreBytes?: number;
   maxSessions?: number;
   clock?: () => number;
@@ -253,8 +259,10 @@ export class FileMessageInteractionSessionStore
   private readonly lockPath: string;
   private readonly lockTimeoutMs: number;
   private readonly staleLockMs: number;
+  private readonly hardStaleLockMs: number;
   private readonly pollMs: number;
   private readonly retentionMs: number;
+  private readonly committedRetentionMs: number;
   private readonly maxStoreBytes: number;
   private readonly maxSessions: number;
   private readonly clock: () => number;
@@ -290,10 +298,20 @@ export class FileMessageInteractionSessionStore
       "staleLockMs",
       1,
     );
+    this.hardStaleLockMs = safeInteger(
+      options.hardStaleLockMs ?? Math.max(this.staleLockMs * 10, 300_000),
+      "hardStaleLockMs",
+      this.staleLockMs,
+    );
     this.pollMs = safeInteger(options.pollMs ?? 10, "pollMs", 1);
     this.retentionMs = safeInteger(
       options.retentionMs ?? 7 * 24 * 60 * 60 * 1_000,
       "retentionMs",
+      0,
+    );
+    this.committedRetentionMs = safeInteger(
+      options.committedRetentionMs ?? 30 * 24 * 60 * 60 * 1_000,
+      "committedRetentionMs",
       0,
     );
     this.maxStoreBytes = safeInteger(
@@ -391,6 +409,31 @@ export class FileMessageInteractionSessionStore
     }
   }
 
+  private async readProcessIdentity(pid: number): Promise<string | null> {
+    if (process.platform !== "linux" || !this.processAlive(pid)) return null;
+    try {
+      const [bootId, stat] = await Promise.all([
+        fs.readFile("/proc/sys/kernel/random/boot_id", "utf8"),
+        fs.readFile(`/proc/${pid}/stat`, "utf8"),
+      ]);
+      const commandEnd = stat.lastIndexOf(")");
+      if (commandEnd < 0) return null;
+      const fieldsAfterCommand = stat
+        .slice(commandEnd + 2)
+        .trim()
+        .split(/\s+/);
+      const startTimeTicks = fieldsAfterCommand[19];
+      if (!startTimeTicks || !bootId.trim()) return null;
+      return `${bootId.trim()}:${startTimeTicks}`;
+    } catch (error) {
+      if (isErrno(error, "ENOENT") || isErrno(error, "ESRCH")) return null;
+      // error-policy:J4 Process identity is an optional strengthening signal;
+      // PID liveness plus the absolute recovery ceiling remains authoritative.
+      if (isErrno(error, "EACCES") || isErrno(error, "EPERM")) return null;
+      throw error;
+    }
+  }
+
   private async readLockOwner(): Promise<LockOwner | null> {
     try {
       const ownerPath = path.join(this.lockPath, "owner.json");
@@ -405,6 +448,13 @@ export class FileMessageInteractionSessionStore
         storeError(
           "UNSAFE_INTERACTION_STORE_LOCK",
           "Interaction store lock owner file is unsafe.",
+          {
+            isFile: entry.isFile(),
+            isSymbolicLink: entry.isSymbolicLink(),
+            linkCount: entry.nlink,
+            mode: entry.mode & 0o777,
+            size: entry.size,
+          },
         );
       }
       const handle = await fs.open(
@@ -432,13 +482,18 @@ export class FileMessageInteractionSessionStore
       const value = JSON.parse(raw) as Partial<LockOwner>;
       if (
         !Number.isSafeInteger(value.pid) ||
+        (value.processIdentity !== null &&
+          typeof value.processIdentity !== "string") ||
         typeof value.token !== "string" ||
         !Number.isSafeInteger(value.createdAt) ||
         !Number.isSafeInteger(value.expiresAt)
       ) {
         return null;
       }
-      return value as LockOwner;
+      return {
+        ...(value as LockOwner),
+        processIdentity: value.processIdentity ?? null,
+      };
     } catch (error) {
       if (isErrno(error, "ENOENT")) {
         // error-policy:J4 a creator may exist before its owner file is durable.
@@ -463,9 +518,34 @@ export class FileMessageInteractionSessionStore
       );
     }
     const owner = await this.readLockOwner();
-    const stale = owner
-      ? owner.expiresAt <= now && !this.processAlive(owner.pid)
-      : lockStat.mtimeMs + this.staleLockMs <= now;
+    let stale: boolean;
+    if (!owner) {
+      // A creator publishes owner.json only after the lease is fully synced.
+      // Without an owner identity there is no safe PID-liveness decision, so
+      // incomplete or malformed locks use the same absolute recovery ceiling
+      // as an unqualified legacy owner instead of the short lease interval.
+      stale = lockStat.mtimeMs + this.hardStaleLockMs <= now;
+    } else if (owner.expiresAt > now) {
+      stale = false;
+    } else {
+      const live = this.processAlive(owner.pid);
+      const currentIdentity = live
+        ? await this.readProcessIdentity(owner.pid)
+        : null;
+      const reusedPid = Boolean(
+        live &&
+          owner.processIdentity &&
+          currentIdentity &&
+          owner.processIdentity !== currentIdentity,
+      );
+      const generationQualified = Boolean(
+        owner.processIdentity && currentIdentity,
+      );
+      stale =
+        !live ||
+        reusedPid ||
+        (!generationQualified && owner.createdAt + this.hardStaleLockMs <= now);
+    }
     if (!stale) return false;
     const quarantine = `${this.lockPath}.stale-${process.pid}-${newToken()}`;
     try {
@@ -493,11 +573,20 @@ export class FileMessageInteractionSessionStore
         createdLock = true;
         const owner: LockOwner = {
           pid: process.pid,
+          processIdentity: await this.readProcessIdentity(process.pid),
           token: newToken(),
           createdAt: now,
           expiresAt: now + this.staleLockMs,
         };
-        await this.writeAndSync(path.join(this.lockPath, "owner.json"), owner);
+        const ownerTemp = path.join(
+          this.lockPath,
+          `.owner-${process.pid}-${owner.token}.tmp`,
+        );
+        await this.writeAndSync(ownerTemp, owner);
+        // Publish only the complete, synced lease. Contenders may inspect the
+        // lock directory immediately after mkdir and must never mistake an
+        // empty or partially written owner file for hostile state.
+        await fs.rename(ownerTemp, path.join(this.lockPath, "owner.json"));
         return owner;
       } catch (error) {
         if (createdLock) {
@@ -651,11 +740,14 @@ export class FileMessageInteractionSessionStore
   private prune(document: SessionFile, now: number): number {
     let deleted = 0;
     for (const [reference, session] of Object.entries(document.sessions)) {
-      if (
-        Date.parse(session.expiresAt) + this.retentionMs <= now &&
-        session.consume.state !== "committed" &&
-        session.consume.state !== "completed"
-      ) {
+      const collectAt =
+        session.consume.state === "completed"
+          ? Date.parse(session.consume.completedAt) + this.retentionMs
+          : session.consume.state === "committed"
+            ? Date.parse(session.consume.committedAt) +
+              this.committedRetentionMs
+            : Date.parse(session.expiresAt) + this.retentionMs;
+      if (collectAt <= now) {
         delete document.sessions[reference];
         deleted += 1;
       }
@@ -704,17 +796,44 @@ export class FileMessageInteractionSessionStore
     operation: (document: SessionFile) => T | Promise<T>,
   ): Promise<T> {
     const owner = await this.acquireLock();
+    let result: T | undefined;
+    let operationError: unknown;
     try {
       await this.assertDirectoryIdentity();
       const document = await this.readFile();
       this.prune(document, this.clock());
-      const result = await operation(document);
+      result = await operation(document);
       await this.assertDirectoryIdentity();
       await this.writeFile(document);
-      return result;
-    } finally {
-      await this.releaseLock(owner);
+    } catch (error) {
+      operationError = error;
     }
+    let releaseError: unknown;
+    try {
+      await this.releaseLock(owner);
+    } catch (error) {
+      releaseError = error;
+    }
+    if (operationError && releaseError) {
+      // error-policy:J2 Preserve the transaction failure as the cause when lock
+      // teardown also fails, instead of replacing the useful error.
+      throw new ElizaError(
+        "Interaction transaction failed and lock ownership was lost.",
+        {
+          code: "INTERACTION_STORE_TRANSACTION_AND_RELEASE_FAILED",
+          cause: operationError,
+          context: {
+            releaseError:
+              releaseError instanceof Error
+                ? releaseError.message
+                : String(releaseError),
+          },
+        },
+      );
+    }
+    if (operationError) throw operationError;
+    if (releaseError) throw releaseError;
+    return result as T;
   }
 
   async create(session: MessageInteractionSession): Promise<void> {
@@ -769,6 +888,41 @@ export class FileMessageInteractionSessionStore
     });
   }
 
+  async listCommitted(args: {
+    committedBefore: number;
+    limit: number;
+  }): Promise<MessageInteractionSession[]> {
+    safeInteger(args.committedBefore, "committedBefore", 0);
+    safeInteger(args.limit, "limit", 1);
+    await this.initialize();
+    const document = await this.readFile();
+    return Object.values(document.sessions)
+      .filter(
+        (session) =>
+          session.consume.state === "committed" &&
+          Date.parse(session.consume.committedAt) <= args.committedBefore,
+      )
+      .sort((a, b) => a.reference.localeCompare(b.reference))
+      .slice(0, args.limit)
+      .map((session) => structuredClone(session));
+  }
+
+  async reconcileCommitted(
+    context: MessageInteractionReconcileContext,
+  ): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const completed = applyMessageInteractionReconciliation(current, context);
+      document.sessions[context.reference] = structuredClone(completed);
+      return completed;
+    });
+  }
+
   async commitIfClaimed(
     context: MessageInteractionCommitContext,
   ): Promise<MessageInteractionSession> {
@@ -812,11 +966,13 @@ export class FileMessageInteractionSessionStore
     return this.transaction((document) => {
       let deleted = 0;
       for (const [reference, session] of Object.entries(document.sessions)) {
-        if (
-          Date.parse(session.expiresAt) <= before &&
-          session.consume.state !== "committed" &&
-          session.consume.state !== "completed"
-        ) {
+        const terminalAt =
+          session.consume.state === "completed"
+            ? Date.parse(session.consume.completedAt)
+            : session.consume.state === "committed"
+              ? Date.parse(session.consume.committedAt)
+              : Date.parse(session.expiresAt);
+        if (terminalAt <= before) {
           delete document.sessions[reference];
           deleted += 1;
         }

--- a/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
+++ b/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
@@ -1,0 +1,21 @@
+# First-party interaction capability baseline
+
+This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.
+
+| Connector | Account | Target | Block delivery | Callback bytes | Attachments |
+| --- | --- | --- | --- | ---: | --- |
+| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |
+| gmail | <account> | email:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| google-chat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| imessage | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| instagram | <account> | thread:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| matrix | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| slack | <account> | channel:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |
+| wechat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| whatsapp | <account> | phone:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| x | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+
+## Explicit exclusions
+
+- plugin-signal: Signal is intentionally unsupported and throws SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE; it registers no message connector.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -64,10 +64,8 @@ a malformed block is left as plain text, never a broken control.
 - `toPlainTextFallback(block, { resolveUrl })` → concise prose for text-only
   transports such as SMS/iMessage, where there is no native control surface.
 - `encodeReplyCallback(value, { maxBytes })` / `decodeCallback(data)` —
-  callback codec that defaults to Telegram's 64-byte `callback_data` limit.
-  Connectors with a larger native budget, such as Discord custom IDs, pass their
-  own limit. Returns null when the answer is too big → caller links out or
-  accepts a free-text reply.
+  legacy presentation codec. Its decoded value is untrusted input and grants no
+  authority. New state-changing controls use the durable session protocol below.
 - `normalizeContentInteractions(content)` — attach parsed blocks to
   `Content.interactions` **without** mutating `text` (so the dashboard's own
   segment renderer keeps interleaving). `stripInteractionMarkers(text)` for prose.
@@ -75,6 +73,41 @@ a malformed block is left as plain text, never a broken control.
 Types: `InteractionBlock` (`FormInteraction | ChoiceInteraction |
 FollowupsInteraction | TaskInteraction | SecretInteraction`) in
 `@elizaos/core` `types/interactions`. `Content.interactions?: InteractionBlock[]`.
+
+## Negotiated delivery and durable callbacks
+
+`ConnectorInteractionCapabilityProfile` is the canonical, versioned capability
+description for one connector account and one target. `MessageConnector`
+implementations resolve it from `(target, delivery context)`; renderers select
+native, signed-hosted, conversational, or sensitive-request delivery from the
+profile rather than branching on a provider name. Every block kind is required,
+unsupported primitives use zero limits, and supported primitives use positive
+limits. `negotiateInteractionDelivery` enforces counts, UTF-8 byte budgets,
+callback size, attachment MIME and byte limits, edit windows, threads, and URL
+limits before selecting a mode. The generated `CAPABILITY_MATRIX.md` is the
+reviewable golden contract and its test fails when a registered first-party
+message connector is omitted.
+
+State-changing controls use `MessageInteractionSessionAuthority`. The wire value
+is only `is1:<128-bit opaque reference>`; it contains no answer, identity,
+authorization, credential, or signature. The durable record binds the actor,
+audience, agent, connector account, room, source message, response schema,
+authorization decision, expiry, effect, and stable replay key. A store performs
+atomic `pending → claimed → completed` transitions and retains the effect receipt.
+The executor must apply the replay key as its effect idempotency key, allowing a
+claim to resume after a crash without repeating the effect. Revocation after
+render, expiry, mismatched context, response tampering, stale claims, and a
+different replay key all fail closed.
+
+`InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
+processes. The agent host's `FileMessageInteractionSessionStore` is durable and
+cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
+commit and a stale-owner-aware lock. Multi-host deployments must implement the
+same store interface with a transactional database and idempotent effect/outbox
+boundary; the JSON store does not claim distributed exactly-once semantics.
+
+Secrets and OAuth values never enter these response records. A `secret` block
+can only negotiate `sensitive-request`, and ordinary forms reject secret fields.
 
 ## Per-surface rendering matrix
 
@@ -152,9 +185,12 @@ mounts `SensitiveRequestBlock` itself for the secret/OAuth card.
 
 ## Adding a new surface
 
-Implement one function: `parseInteractionBlocks(content.text)` → for each block
-`toNeutralLayout(block, { resolveUrl })` → map `NeutralButton.callbackData`/`.url`
-to the platform's button primitive; send `cleanedText` as the body. For the
-round-trip, decode the platform's callback payload with `decodeCallback` and
-re-inject `value` as an inbound user message. ~60 lines; see
-`plugin-telegram/src/interactions.ts` and `plugin-discord/interactions.ts`.
+Register the connector's mechanically verified capability template, resolve a
+concrete profile for each account/target, and render the mode returned by
+`negotiateInteractionDelivery`. For state-changing callbacks, create a durable
+session and place only its opaque callback reference in the native control. On
+receipt, pass the connector-authenticated actor/account/room/message context to
+the session authority and execute the retained typed effect with its replay key.
+Conversational fallback must explain the accepted reply shape; signed-hosted
+fallback must use a short-lived authenticated URL; secret/OAuth input must use
+the sensitive-request service.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -99,6 +99,16 @@ claim to resume after a crash without repeating the effect. Revocation after
 render, expiry, mismatched context, response tampering, stale claims, and a
 different replay key all fail closed.
 
+Connector plugins access that authority through the registered
+`MessageInteractionHost` service. `prepare` accepts the resolved profile plus
+trusted bindings, authorization, and effect, but returns only the block,
+negotiated delivery, opaque callback, expiry, and profile id needed to render.
+`consume` accepts connector-authenticated bindings and the provider's inbound
+event id, then dispatches through a host-registered effect handler using that id
+as the idempotency key. Its retained receipt carries the provider receipt,
+canonical inbound event id, audit id, and app-state result. Connectors must not
+construct their own authority, store, or effect dispatcher.
+
 `InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
 processes. The agent host's `FileMessageInteractionSessionStore` is durable and
 cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
@@ -186,11 +196,11 @@ mounts `SensitiveRequestBlock` itself for the secret/OAuth card.
 ## Adding a new surface
 
 Register the connector's mechanically verified capability template, resolve a
-concrete profile for each account/target, and render the mode returned by
-`negotiateInteractionDelivery`. For state-changing callbacks, create a durable
-session and place only its opaque callback reference in the native control. On
-receipt, pass the connector-authenticated actor/account/room/message context to
-the session authority and execute the retained typed effect with its replay key.
+concrete profile for each account/target, and ask the registered
+`MessageInteractionHost` to prepare the delivery. Place only its opaque callback
+reference in the native control. On receipt, pass the connector-authenticated
+actor/account/room/message context and provider event receipt back to the host;
+the host owns authorization, replay, effect dispatch, and durable receipts.
 Conversational fallback must explain the accepted reply shape; signed-hosted
 fallback must use a short-lived authenticated URL; secret/OAuth input must use
 the sensitive-request service.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -93,11 +93,13 @@ is only `is1:<128-bit opaque reference>`; it contains no answer, identity,
 authorization, credential, or signature. The durable record binds the actor,
 audience, agent, connector account, room, source message, response schema,
 authorization decision, expiry, effect, and stable replay key. A store performs
-atomic `pending → claimed → completed` transitions and retains the effect receipt.
-The executor must apply the replay key as its effect idempotency key, allowing a
-claim to resume after a crash without repeating the effect. Revocation after
-render, expiry, mismatched context, response tampering, stale claims, and a
-different replay key all fail closed.
+atomic `pending → claimed → committed → completed` transitions and retains the
+effect receipt. Reservation claims may expire before commitment. Once committed,
+the host may cross the external effect boundary, but an outcome lost to a crash
+remains permanently ambiguous: it is never transferred, retried, revoked as if
+cancellation succeeded, or garbage-collected. Revocation after render, expiry,
+mismatched context, response tampering, stale claims, and a different replay key
+all fail closed.
 
 Connector plugins access that authority through the registered
 `MessageInteractionHost` service. `prepare` accepts the resolved profile plus

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -119,8 +119,10 @@ construct their own authority, store, or effect dispatcher.
 `InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
 processes. The agent host's `FileMessageInteractionSessionStore` is durable and
 cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
-commit and a boot/process-generation-qualified stale-owner lock with an absolute
-recovery ceiling. Multi-host deployments must implement the
+commit and a boot/process-generation-qualified stale-owner lock whose atomic,
+shared transition marker prevents retirement from detaching a fresh successor.
+Unpublished owners have an absolute recovery ceiling; unqualified live PIDs
+fail closed. Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.
 

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -84,7 +84,10 @@ profile rather than branching on a provider name. Every block kind is required,
 unsupported primitives use zero limits, and supported primitives use positive
 limits. `negotiateInteractionDelivery` enforces counts, UTF-8 byte budgets,
 callback size, attachment MIME and byte limits, edit windows, threads, and URL
-limits before selecting a mode. The generated `CAPABILITY_MATRIX.md` is the
+limits before selecting a mode. Conversational delivery rejects a canonical
+payload that cannot fit intact; it never delegates truncation to a renderer.
+Signed-hosted delivery additionally requires a host-owned verifier to approve
+the HTTPS URL's authority and signature. The generated `CAPABILITY_MATRIX.md` is the
 reviewable golden contract and its test fails when a registered first-party
 message connector is omitted.
 
@@ -96,8 +99,10 @@ authorization decision, expiry, effect, and stable replay key. A store performs
 atomic `pending → claimed → committed → completed` transitions and retains the
 effect receipt. Reservation claims may expire before commitment. Once committed,
 the host may cross the external effect boundary, but an outcome lost to a crash
-remains permanently ambiguous: it is never transferred, retried, revoked as if
-cancellation succeeded, or garbage-collected. Revocation after render, expiry,
+remains ambiguous: it is never transferred, retried, or revoked as if
+cancellation succeeded. Stores expose committed rows and accept verified
+reconciliation receipts without re-executing the effect; bounded adapters may
+expire unreconciled records after their documented operator window. Revocation after render, expiry,
 mismatched context, response tampering, stale claims, and a different replay key
 all fail closed.
 
@@ -114,7 +119,8 @@ construct their own authority, store, or effect dispatcher.
 `InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
 processes. The agent host's `FileMessageInteractionSessionStore` is durable and
 cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
-commit and a stale-owner-aware lock. Multi-host deployments must implement the
+commit and a boot/process-generation-qualified stale-owner lock with an absolute
+recovery ceiling. Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.
 

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -43,10 +43,18 @@ export interface PrepareMessageInteractionRequest {
 export interface PreparedMessageInteraction {
 	block: InteractionBlock;
 	delivery: NegotiatedInteractionDelivery;
+	/** Present only after negotiation validates a signed-hosted delivery URL. */
+	hostedUrl?: string;
 	callbackData: string;
 	expiresAt: string;
 	profileId: string;
 }
+
+/** Bindings a connector can authenticate from an inbound provider event. */
+export type AuthenticatedMessageInteractionBindings = Omit<
+	MessageInteractionBindings,
+	"sourceMessageId"
+>;
 
 export interface MessageInteractionProviderReceipt {
 	source: string;
@@ -95,7 +103,7 @@ export type MessageInteractionHostConsumeOutcome =
 
 export interface ConsumeMessageInteractionRequest {
 	callbackData: string;
-	bindings: MessageInteractionBindings;
+	bindings: AuthenticatedMessageInteractionBindings;
 	response?: MessageInteractionResponse;
 	providerReceipt: MessageInteractionProviderReceipt;
 }

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -1,0 +1,141 @@
+/**
+ * Defines the host-owned interaction coordinator consumed by connector plugins.
+ * Connectors render prepared deliveries and submit authenticated inbound events;
+ * they never construct a second session authority or execute effects directly.
+ */
+
+import { ElizaError } from "../../errors";
+import type { InteractionBlock } from "../../types/interactions";
+import type { IAgentRuntime } from "../../types/runtime";
+import type {
+	ConnectorInteractionCapabilityProfile,
+	InteractionNegotiationContext,
+	NegotiatedInteractionDelivery,
+} from "./profiles";
+import type {
+	MessageInteractionAuthorizationDecision,
+	MessageInteractionBindings,
+	MessageInteractionEffect,
+	MessageInteractionPurpose,
+	MessageInteractionResponse,
+	MessageInteractionSession,
+} from "./sessions";
+
+export const MESSAGE_INTERACTION_HOST_SERVICE =
+	"message_interaction_host" as const;
+
+export interface PrepareMessageInteractionRequest {
+	block: InteractionBlock;
+	profile: ConnectorInteractionCapabilityProfile;
+	bindings: MessageInteractionBindings;
+	purpose: MessageInteractionPurpose;
+	negotiationContext?: InteractionNegotiationContext;
+	presetResponse?: MessageInteractionResponse;
+	authorization: Omit<
+		MessageInteractionAuthorizationDecision,
+		"state" | "revokedAt"
+	>;
+	effect: MessageInteractionEffect;
+	expiresAt: string;
+}
+
+/** Safe subset a connector needs to render; retained authority is omitted. */
+export interface PreparedMessageInteraction {
+	block: InteractionBlock;
+	delivery: NegotiatedInteractionDelivery;
+	callbackData: string;
+	expiresAt: string;
+	profileId: string;
+}
+
+export interface MessageInteractionProviderReceipt {
+	source: string;
+	accountId: string;
+	inboundEventId: string;
+	receivedAt: string;
+}
+
+export interface MessageInteractionHostEffectResult {
+	receiptId: string;
+	canonicalInboundEventId: string;
+	auditId: string;
+	appStateResult: Readonly<Record<string, string | number | boolean | null>>;
+	result: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+export interface MessageInteractionHostEffectHandler {
+	execute(args: {
+		idempotencyKey: string;
+		effect: MessageInteractionEffect;
+		response: MessageInteractionResponse;
+		session: MessageInteractionSession;
+		providerReceipt: MessageInteractionProviderReceipt;
+	}): Promise<MessageInteractionHostEffectResult>;
+}
+
+export interface MessageInteractionHostReceipt {
+	receiptId: string;
+	idempotencyKey: string;
+	status: "completed";
+	completedAt: string;
+	canonicalInboundEventId: string;
+	providerReceipt: MessageInteractionProviderReceipt;
+	auditId: string;
+	appStateResult: Readonly<Record<string, string | number | boolean | null>>;
+	result: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+export type MessageInteractionHostConsumeOutcome =
+	| {
+			status: "completed" | "replay";
+			receipt: MessageInteractionHostReceipt;
+	  }
+	| { status: "in_progress" }
+	| { status: "denied"; code: string; message: string };
+
+export interface ConsumeMessageInteractionRequest {
+	callbackData: string;
+	bindings: MessageInteractionBindings;
+	response?: MessageInteractionResponse;
+	providerReceipt: MessageInteractionProviderReceipt;
+}
+
+export interface MessageInteractionHost {
+	prepare(
+		request: PrepareMessageInteractionRequest,
+	): Promise<PreparedMessageInteraction>;
+	consume(
+		request: ConsumeMessageInteractionRequest,
+	): Promise<MessageInteractionHostConsumeOutcome>;
+	revoke(request: {
+		reference: string;
+		decisionId: string;
+		now?: number;
+	}): Promise<MessageInteractionSession>;
+	get(reference: string): Promise<MessageInteractionSession | null>;
+	registerEffectHandler(
+		kind: string,
+		handler: MessageInteractionHostEffectHandler,
+	): () => void;
+}
+
+/** Resolve the one host authority. Absence is an explicit unavailable state. */
+export function resolveMessageInteractionHost(
+	runtime: IAgentRuntime,
+): MessageInteractionHost | null {
+	const service = runtime.getService(MESSAGE_INTERACTION_HOST_SERVICE);
+	if (!service) return null;
+	const candidate = service as unknown as Partial<MessageInteractionHost>;
+	if (
+		typeof candidate.prepare !== "function" ||
+		typeof candidate.consume !== "function" ||
+		typeof candidate.revoke !== "function" ||
+		typeof candidate.get !== "function" ||
+		typeof candidate.registerEffectHandler !== "function"
+	) {
+		throw new ElizaError("Registered interaction host is malformed.", {
+			code: "INVALID_MESSAGE_INTERACTION_HOST_SERVICE",
+		});
+	}
+	return candidate as MessageInteractionHost;
+}

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -99,7 +99,7 @@ export type MessageInteractionHostConsumeOutcome =
 			receipt: MessageInteractionHostReceipt;
 	  }
 	| { status: "in_progress" }
-	| { status: "denied"; code: string; message: string };
+	| { status: "denied" | "unavailable"; code: string; message: string };
 
 export interface ConsumeMessageInteractionRequest {
 	callbackData: string;

--- a/packages/core/src/messaging/interactions/index.ts
+++ b/packages/core/src/messaging/interactions/index.ts
@@ -13,4 +13,7 @@ export * from "./dashboard-markers";
 export * from "./layout";
 export * from "./normalize";
 export * from "./parse";
+export * from "./profile-catalog";
+export * from "./profiles";
 export * from "./serialize";
+export * from "./sessions";

--- a/packages/core/src/messaging/interactions/index.ts
+++ b/packages/core/src/messaging/interactions/index.ts
@@ -10,6 +10,7 @@
 
 export * from "./callback";
 export * from "./dashboard-markers";
+export * from "./host";
 export * from "./layout";
 export * from "./normalize";
 export * from "./parse";

--- a/packages/core/src/messaging/interactions/profile-catalog.ts
+++ b/packages/core/src/messaging/interactions/profile-catalog.ts
@@ -1,0 +1,271 @@
+/**
+ * Publishes conservative capability families and the mechanically audited
+ * first-party connector handoff list. Runtime negotiation uses materialized
+ * account/target profiles, never this source-name catalog.
+ */
+
+import {
+	createConnectorInteractionCapabilityProfile,
+	type InteractionProfileTemplate,
+	renderInteractionCapabilityMatrix,
+} from "./profiles";
+
+const TTL = 15 * 60 * 1_000;
+
+export const CONVERSATIONAL_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	templateId: "conversational-v1",
+	blocks: {
+		choice: {
+			modes: ["conversational", "signed-hosted"],
+			maxSessionTtlMs: TTL,
+		},
+		form: { modes: ["conversational", "signed-hosted"], maxSessionTtlMs: TTL },
+		followups: { modes: ["conversational"], maxSessionTtlMs: TTL },
+		task: {
+			modes: ["signed-hosted", "conversational"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+		secret: { modes: ["sensitive-request"], maxSessionTtlMs: TTL },
+	},
+	limits: {
+		buttons: {
+			supported: false,
+			maxPerRow: 0,
+			maxPerMessage: 0,
+			maxLabelBytes: 0,
+			maxCallbackBytes: 0,
+		},
+		lists: {
+			supported: false,
+			maxItems: 0,
+			maxLabelBytes: 0,
+			maxDescriptionBytes: 0,
+		},
+		modals: { supported: false, maxFields: 0, maxTitleBytes: 0 },
+		forms: { supported: false, maxFields: 0, maxOptionsPerField: 0 },
+		links: { supported: true, maxUrlBytes: 2_048 },
+		edits: { supported: false, windowMs: null },
+		threads: { supported: false, maxTitleBytes: 0 },
+		text: { maxMessageBytes: 4_000 },
+		attachments: {
+			supported: false,
+			maxCount: 0,
+			maxBytesEach: 0,
+			mimeTypes: [],
+		},
+	},
+	nonSecretFallbacks: ["conversational", "signed-hosted"],
+};
+
+export const BUTTON_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...CONVERSATIONAL_INTERACTION_PROFILE,
+	templateId: "button-native-v1",
+	blocks: {
+		...CONVERSATIONAL_INTERACTION_PROFILE.blocks,
+		choice: {
+			modes: ["native", "conversational", "signed-hosted"],
+			maxSessionTtlMs: TTL,
+		},
+		followups: { modes: ["native", "conversational"], maxSessionTtlMs: TTL },
+		task: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+	},
+	limits: {
+		...CONVERSATIONAL_INTERACTION_PROFILE.limits,
+		buttons: {
+			supported: true,
+			maxPerRow: 5,
+			maxPerMessage: 25,
+			maxLabelBytes: 80,
+			maxCallbackBytes: 64,
+		},
+		links: { supported: true, maxUrlBytes: 2_048 },
+		text: { maxMessageBytes: 4_000 },
+	},
+	nonSecretFallbacks: ["native", "conversational", "signed-hosted"],
+};
+
+export const RICH_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...BUTTON_INTERACTION_PROFILE,
+	templateId: "rich-native-v1",
+	blocks: {
+		choice: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: TTL,
+		},
+		form: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: TTL,
+		},
+		followups: { modes: ["native", "conversational"], maxSessionTtlMs: TTL },
+		task: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+		secret: { modes: ["sensitive-request"], maxSessionTtlMs: TTL },
+	},
+	limits: {
+		buttons: {
+			supported: true,
+			maxPerRow: 8,
+			maxPerMessage: 100,
+			maxLabelBytes: 256,
+			maxCallbackBytes: 256,
+		},
+		lists: {
+			supported: true,
+			maxItems: 100,
+			maxLabelBytes: 256,
+			maxDescriptionBytes: 1_024,
+		},
+		modals: { supported: true, maxFields: 20, maxTitleBytes: 256 },
+		forms: { supported: true, maxFields: 20, maxOptionsPerField: 100 },
+		links: { supported: true, maxUrlBytes: 8_192 },
+		edits: { supported: true, windowMs: null },
+		threads: { supported: true, maxTitleBytes: 256 },
+		text: { maxMessageBytes: 1_000_000 },
+		attachments: {
+			supported: true,
+			maxCount: 20,
+			maxBytesEach: 100_000_000,
+			mimeTypes: ["*/*"],
+		},
+	},
+	nonSecretFallbacks: ["native", "signed-hosted", "conversational"],
+};
+
+export type FirstPartyInteractionProfileFamily =
+	| "button-native"
+	| "conversational";
+
+export interface FirstPartyInteractionConnectorAuditEntry {
+	plugin: string;
+	source: string;
+	targetKind: string;
+	profileFamily: FirstPartyInteractionProfileFamily;
+	note: string;
+}
+
+/**
+ * Production `registerMessageConnector` declarations as of this contract.
+ * #24288 replaces conservative families with live adapter declarations.
+ */
+export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
+	{
+		plugin: "plugin-discord",
+		source: "discord",
+		targetKind: "channel",
+		profileFamily: "button-native",
+		note: "native buttons already exist",
+	},
+	{
+		plugin: "plugin-google-workspace",
+		source: "gmail",
+		targetKind: "email",
+		profileFamily: "conversational",
+		note: "email target",
+	},
+	{
+		plugin: "plugin-google-workspace",
+		source: "google-chat",
+		targetKind: "room",
+		profileFamily: "conversational",
+		note: "chat spaces and threads",
+	},
+	{
+		plugin: "plugin-imessage",
+		source: "imessage",
+		targetKind: "user",
+		profileFamily: "conversational",
+		note: "text and attachment transport",
+	},
+	{
+		plugin: "plugin-instagram",
+		source: "instagram",
+		targetKind: "thread",
+		profileFamily: "conversational",
+		note: "existing DM threads",
+	},
+	{
+		plugin: "plugin-matrix",
+		source: "matrix",
+		targetKind: "room",
+		profileFamily: "conversational",
+		note: "rooms and threads",
+	},
+	{
+		plugin: "plugin-slack",
+		source: "slack",
+		targetKind: "channel",
+		profileFamily: "conversational",
+		note: "channels, threads, users",
+	},
+	{
+		plugin: "plugin-telegram",
+		source: "telegram",
+		targetKind: "room",
+		profileFamily: "button-native",
+		note: "inline keyboard already exists",
+	},
+	{
+		plugin: "plugin-wechat",
+		source: "wechat",
+		targetKind: "room",
+		profileFamily: "conversational",
+		note: "users and groups",
+	},
+	{
+		plugin: "plugin-whatsapp",
+		source: "whatsapp",
+		targetKind: "phone",
+		profileFamily: "conversational",
+		note: "Cloud API messages",
+	},
+	{
+		plugin: "plugin-x",
+		source: "x",
+		targetKind: "user",
+		profileFamily: "conversational",
+		note: "direct messages only; posts are separate",
+	},
+] as const satisfies readonly FirstPartyInteractionConnectorAuditEntry[];
+
+/** Deliberate non-registration that the audit must keep visible. */
+export const FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS = [
+	{
+		plugin: "plugin-signal",
+		reason:
+			"Signal is intentionally unsupported and throws SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE; it registers no message connector.",
+	},
+] as const;
+
+/** Deterministic handoff artifact for connector implementers and reviewers. */
+export function renderFirstPartyInteractionCapabilityMatrix(): string {
+	const profiles = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) =>
+		createConnectorInteractionCapabilityProfile({
+			template:
+				entry.profileFamily === "button-native"
+					? BUTTON_INTERACTION_PROFILE
+					: CONVERSATIONAL_INTERACTION_PROFILE,
+			source: entry.source,
+			accountId: "<account>",
+			targetKind: entry.targetKind,
+			targetId: "<target>",
+		}),
+	);
+	return [
+		"# First-party interaction capability baseline",
+		"",
+		"This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.",
+		"",
+		renderInteractionCapabilityMatrix(profiles),
+		"",
+		"## Explicit exclusions",
+		"",
+		...FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS.map(
+			(entry) => `- ${entry.plugin}: ${entry.reason}`,
+		),
+	].join("\n");
+}

--- a/packages/core/src/messaging/interactions/profile-catalog.ts
+++ b/packages/core/src/messaging/interactions/profile-catalog.ts
@@ -142,6 +142,7 @@ export type FirstPartyInteractionProfileFamily =
 
 export interface FirstPartyInteractionConnectorAuditEntry {
 	plugin: string;
+	registrationSite: string;
 	source: string;
 	targetKind: string;
 	profileFamily: FirstPartyInteractionProfileFamily;
@@ -155,6 +156,7 @@ export interface FirstPartyInteractionConnectorAuditEntry {
 export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-discord",
+		registrationSite: "plugin-discord/service.ts",
 		source: "discord",
 		targetKind: "channel",
 		profileFamily: "button-native",
@@ -162,6 +164,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-google-workspace",
+		registrationSite: "plugin-google-workspace/src/chat/service.ts",
 		source: "gmail",
 		targetKind: "email",
 		profileFamily: "conversational",
@@ -169,6 +172,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-google-workspace",
+		registrationSite: "plugin-google-workspace/src/chat/service.ts",
 		source: "google-chat",
 		targetKind: "room",
 		profileFamily: "conversational",
@@ -176,6 +180,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-imessage",
+		registrationSite: "plugin-imessage/src/service.ts",
 		source: "imessage",
 		targetKind: "user",
 		profileFamily: "conversational",
@@ -183,6 +188,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-instagram",
+		registrationSite: "plugin-instagram/src/service.ts",
 		source: "instagram",
 		targetKind: "thread",
 		profileFamily: "conversational",
@@ -190,6 +196,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-matrix",
+		registrationSite: "plugin-matrix/src/service.ts",
 		source: "matrix",
 		targetKind: "room",
 		profileFamily: "conversational",
@@ -197,6 +204,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-slack",
+		registrationSite: "plugin-slack/src/service.ts",
 		source: "slack",
 		targetKind: "channel",
 		profileFamily: "conversational",
@@ -204,6 +212,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-telegram",
+		registrationSite: "plugin-telegram/src/service.ts",
 		source: "telegram",
 		targetKind: "room",
 		profileFamily: "button-native",
@@ -211,6 +220,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-wechat",
+		registrationSite: "plugin-wechat/src/index.ts",
 		source: "wechat",
 		targetKind: "room",
 		profileFamily: "conversational",
@@ -218,6 +228,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-whatsapp",
+		registrationSite: "plugin-whatsapp/src/runtime-service.ts",
 		source: "whatsapp",
 		targetKind: "phone",
 		profileFamily: "conversational",
@@ -225,6 +236,7 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	},
 	{
 		plugin: "plugin-x",
+		registrationSite: "plugin-x/src/services/x.service.ts",
 		source: "x",
 		targetKind: "user",
 		profileFamily: "conversational",

--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Filesystem-backed audit proving the first-party profile matrix covers every
+ * production message-connector registration and remains byte-deterministic.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT,
+	FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS,
+	renderFirstPartyInteractionCapabilityMatrix,
+} from "./profile-catalog";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../../../..");
+
+async function sourceFiles(directory: string): Promise<string[]> {
+	const files: string[] = [];
+	for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+		if (
+			entry.name === "node_modules" ||
+			entry.name === "dist" ||
+			entry.name === "__tests__" ||
+			entry.name === "test" ||
+			entry.name.includes(".test.")
+		)
+			continue;
+		const fullPath = path.join(directory, entry.name);
+		if (entry.isDirectory()) files.push(...(await sourceFiles(fullPath)));
+		else if (entry.isFile() && entry.name.endsWith(".ts")) files.push(fullPath);
+	}
+	return files;
+}
+
+async function productionRegistrationPlugins(): Promise<string[]> {
+	const pluginsRoot = path.join(repositoryRoot, "plugins");
+	const found: string[] = [];
+	for (const entry of await fs.readdir(pluginsRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory() || !entry.name.startsWith("plugin-")) continue;
+		const files = await sourceFiles(path.join(pluginsRoot, entry.name));
+		for (const file of files) {
+			if (
+				(await fs.readFile(file, "utf8")).includes("registerMessageConnector")
+			) {
+				found.push(entry.name);
+				break;
+			}
+		}
+	}
+	return found.sort();
+}
+
+describe("first-party interaction capability matrix", () => {
+	it("covers every production message connector plugin root", async () => {
+		const declared = [
+			...new Set(
+				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.plugin),
+			),
+		].sort();
+		expect(await productionRegistrationPlugins()).toEqual(declared);
+	});
+
+	it("keeps deliberate unsupported connectors visible and unregistered", async () => {
+		expect(FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS).toContainEqual(
+			expect.objectContaining({ plugin: "plugin-signal" }),
+		);
+		const files = await sourceFiles(
+			path.join(repositoryRoot, "plugins/plugin-signal"),
+		);
+		const combined = (
+			await Promise.all(files.map((file) => fs.readFile(file, "utf8")))
+		).join("\n");
+		expect(combined).not.toContain("registerMessageConnector");
+		expect(combined).toContain("SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE");
+	});
+
+	it("matches the committed reviewer-readable golden artifact", async () => {
+		const golden = await fs.readFile(
+			path.join(import.meta.dirname, "CAPABILITY_MATRIX.md"),
+			"utf8",
+		);
+		expect(`${renderFirstPartyInteractionCapabilityMatrix()}\n`).toBe(golden);
+	});
+});

--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -27,37 +27,48 @@ async function sourceFiles(directory: string): Promise<string[]> {
 			continue;
 		const fullPath = path.join(directory, entry.name);
 		if (entry.isDirectory()) files.push(...(await sourceFiles(fullPath)));
-		else if (entry.isFile() && entry.name.endsWith(".ts")) files.push(fullPath);
+		else if (entry.isFile() && /[.](?:[cm]?[jt]sx?)$/.test(entry.name))
+			files.push(fullPath);
 	}
 	return files;
 }
 
-async function productionRegistrationPlugins(): Promise<string[]> {
+async function productionRegistrationSites(): Promise<
+	Array<{ site: string; registrations: number }>
+> {
 	const pluginsRoot = path.join(repositoryRoot, "plugins");
-	const found: string[] = [];
+	const found: Array<{ site: string; registrations: number }> = [];
 	for (const entry of await fs.readdir(pluginsRoot, { withFileTypes: true })) {
 		if (!entry.isDirectory() || !entry.name.startsWith("plugin-")) continue;
 		const files = await sourceFiles(path.join(pluginsRoot, entry.name));
 		for (const file of files) {
-			if (
-				(await fs.readFile(file, "utf8")).includes("registerMessageConnector")
-			) {
-				found.push(entry.name);
-				break;
+			const source = await fs.readFile(file, "utf8");
+			const registrations = source.match(
+				/\bregisterMessageConnector\s*\(/g,
+			)?.length;
+			if (registrations) {
+				found.push({
+					site: path.relative(pluginsRoot, file),
+					registrations,
+				});
 			}
 		}
 	}
-	return found.sort();
+	return found.sort((a, b) => a.site.localeCompare(b.site));
 }
 
 describe("first-party interaction capability matrix", () => {
-	it("covers every production message connector plugin root", async () => {
+	it("covers every production registration site and invocation", async () => {
 		const declared = [
 			...new Set(
-				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.plugin),
+				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map(
+					(entry) => entry.registrationSite,
+				),
 			),
-		].sort();
-		expect(await productionRegistrationPlugins()).toEqual(declared);
+		]
+			.sort()
+			.map((site) => ({ site, registrations: 1 }));
+		expect(await productionRegistrationSites()).toEqual(declared);
 	});
 
 	it("keeps deliberate unsupported connectors visible and unregistered", async () => {

--- a/packages/core/src/messaging/interactions/profiles.ts
+++ b/packages/core/src/messaging/interactions/profiles.ts
@@ -1,0 +1,720 @@
+/**
+ * Defines the provider-neutral capability profile negotiated for one concrete
+ * connector account and target. Rendering code consumes this profile directly;
+ * connector names are deliberately absent from the runtime decision path.
+ */
+
+import { ElizaError } from "../../errors";
+import type {
+	InteractionBlock,
+	InteractionKind,
+} from "../../types/interactions";
+import { stringToUuid } from "../../utils";
+import { stableStringify } from "../../utils/deterministic";
+
+export const INTERACTION_PROFILE_VERSION = 1 as const;
+export const INTERACTION_BLOCK_KINDS = [
+	"choice",
+	"form",
+	"followups",
+	"task",
+	"secret",
+] as const satisfies readonly InteractionKind[];
+
+export type InteractionDeliveryMode =
+	| "native"
+	| "conversational"
+	| "signed-hosted"
+	| "sensitive-request";
+
+const INTERACTION_DELIVERY_MODES = new Set<InteractionDeliveryMode>([
+	"native",
+	"conversational",
+	"signed-hosted",
+	"sensitive-request",
+]);
+
+export interface InteractionPrimitiveLimits {
+	buttons: {
+		supported: boolean;
+		maxPerRow: number;
+		maxPerMessage: number;
+		maxLabelBytes: number;
+		maxCallbackBytes: number;
+	};
+	lists: {
+		supported: boolean;
+		maxItems: number;
+		maxLabelBytes: number;
+		maxDescriptionBytes: number;
+	};
+	modals: {
+		supported: boolean;
+		maxFields: number;
+		maxTitleBytes: number;
+	};
+	forms: {
+		supported: boolean;
+		maxFields: number;
+		maxOptionsPerField: number;
+	};
+	links: {
+		supported: boolean;
+		maxUrlBytes: number;
+	};
+	edits: {
+		supported: boolean;
+		windowMs: number | null;
+	};
+	threads: {
+		supported: boolean;
+		maxTitleBytes: number;
+	};
+	text: {
+		maxMessageBytes: number;
+	};
+	attachments: {
+		supported: boolean;
+		maxCount: number;
+		maxBytesEach: number;
+		mimeTypes: readonly string[];
+	};
+}
+
+export interface InteractionBlockCapability {
+	modes: readonly InteractionDeliveryMode[];
+	/** Maximum lifetime for a callback rendered from this block. */
+	maxSessionTtlMs: number;
+}
+
+export interface ConnectorInteractionCapabilityProfile {
+	profileVersion: typeof INTERACTION_PROFILE_VERSION;
+	profileId: string;
+	connector: { source: string; accountId: string };
+	target: { kind: string; id: string };
+	blocks: Record<InteractionKind, InteractionBlockCapability>;
+	limits: InteractionPrimitiveLimits;
+	/** Ordered, actionable degradation paths for non-secret input. */
+	nonSecretFallbacks: readonly Exclude<
+		InteractionDeliveryMode,
+		"sensitive-request"
+	>[];
+	/** Secret and OAuth collection is never allowed through ordinary chat data. */
+	sensitiveFallback: "sensitive-request";
+}
+
+export interface InteractionProfileTemplate {
+	templateId: string;
+	blocks: Record<InteractionKind, InteractionBlockCapability>;
+	limits: InteractionPrimitiveLimits;
+	nonSecretFallbacks: ConnectorInteractionCapabilityProfile["nonSecretFallbacks"];
+}
+
+function positiveInteger(value: number, path: string): void {
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new ElizaError(`${path} must be a positive safe integer.`, {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { path, value },
+		});
+	}
+}
+
+function supportedLimit(supported: boolean, value: number, path: string): void {
+	if (supported) {
+		positiveInteger(value, path);
+		return;
+	}
+	if (value !== 0) {
+		throw new ElizaError(`${path} must be zero when unsupported.`, {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { path, value },
+		});
+	}
+}
+
+function nonEmpty(value: string, path: string): string {
+	const normalized = value.trim();
+	if (!normalized) {
+		throw new ElizaError(`${path} must not be blank.`, {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { path },
+		});
+	}
+	return normalized;
+}
+
+/** Validate and defensively copy one complete per-account/target profile. */
+export function normalizeConnectorInteractionCapabilityProfile(
+	profile: ConnectorInteractionCapabilityProfile,
+): ConnectorInteractionCapabilityProfile {
+	if (profile.profileVersion !== INTERACTION_PROFILE_VERSION) {
+		throw new ElizaError("Unsupported interaction profile version.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { profileVersion: profile.profileVersion },
+		});
+	}
+	for (const kind of INTERACTION_BLOCK_KINDS) {
+		const capability = profile.blocks[kind];
+		if (!capability || capability.modes.length === 0) {
+			throw new ElizaError(`Interaction profile omits ${kind}.`, {
+				code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+				context: { kind },
+			});
+		}
+		if (
+			capability.modes.some((mode) => !INTERACTION_DELIVERY_MODES.has(mode))
+		) {
+			throw new ElizaError(`Interaction profile has an unknown ${kind} mode.`, {
+				code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+				context: { kind },
+			});
+		}
+		positiveInteger(
+			capability.maxSessionTtlMs,
+			`blocks.${kind}.maxSessionTtlMs`,
+		);
+		if (new Set(capability.modes).size !== capability.modes.length) {
+			throw new ElizaError(`Interaction profile repeats a ${kind} mode.`, {
+				code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+				context: { kind },
+			});
+		}
+		if (
+			kind === "secret" &&
+			(capability.modes.length !== 1 ||
+				capability.modes[0] !== "sensitive-request")
+		) {
+			throw new ElizaError(
+				"Secret interactions must use only the sensitive-request flow.",
+				{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE", context: { kind } },
+			);
+		}
+		if (kind !== "secret" && capability.modes.includes("sensitive-request")) {
+			throw new ElizaError(
+				"Ordinary interaction blocks cannot use the sensitive-request mode.",
+				{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE", context: { kind } },
+			);
+		}
+	}
+	const limits = profile.limits;
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxPerRow,
+		"limits.buttons.maxPerRow",
+	);
+	if (
+		limits.buttons.supported &&
+		limits.buttons.maxPerRow > limits.buttons.maxPerMessage
+	) {
+		throw new ElizaError(
+			"Button row limit cannot exceed the message button limit.",
+			{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE" },
+		);
+	}
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxPerMessage,
+		"limits.buttons.maxPerMessage",
+	);
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxLabelBytes,
+		"limits.buttons.maxLabelBytes",
+	);
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxCallbackBytes,
+		"limits.buttons.maxCallbackBytes",
+	);
+	supportedLimit(
+		limits.lists.supported,
+		limits.lists.maxItems,
+		"limits.lists.maxItems",
+	);
+	supportedLimit(
+		limits.lists.supported,
+		limits.lists.maxLabelBytes,
+		"limits.lists.maxLabelBytes",
+	);
+	supportedLimit(
+		limits.lists.supported,
+		limits.lists.maxDescriptionBytes,
+		"limits.lists.maxDescriptionBytes",
+	);
+	supportedLimit(
+		limits.modals.supported,
+		limits.modals.maxFields,
+		"limits.modals.maxFields",
+	);
+	supportedLimit(
+		limits.modals.supported,
+		limits.modals.maxTitleBytes,
+		"limits.modals.maxTitleBytes",
+	);
+	supportedLimit(
+		limits.forms.supported,
+		limits.forms.maxFields,
+		"limits.forms.maxFields",
+	);
+	supportedLimit(
+		limits.forms.supported,
+		limits.forms.maxOptionsPerField,
+		"limits.forms.maxOptionsPerField",
+	);
+	supportedLimit(
+		limits.links.supported,
+		limits.links.maxUrlBytes,
+		"limits.links.maxUrlBytes",
+	);
+	if (
+		limits.edits.windowMs !== null &&
+		(!Number.isSafeInteger(limits.edits.windowMs) || limits.edits.windowMs < 1)
+	) {
+		throw new ElizaError("limits.edits.windowMs is invalid.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (!limits.edits.supported && limits.edits.windowMs !== null) {
+		throw new ElizaError("Unsupported edits must not declare a time window.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	supportedLimit(
+		limits.threads.supported,
+		limits.threads.maxTitleBytes,
+		"limits.threads.maxTitleBytes",
+	);
+	positiveInteger(limits.text.maxMessageBytes, "limits.text.maxMessageBytes");
+	supportedLimit(
+		limits.attachments.supported,
+		limits.attachments.maxCount,
+		"limits.attachments.maxCount",
+	);
+	supportedLimit(
+		limits.attachments.supported,
+		limits.attachments.maxBytesEach,
+		"limits.attachments.maxBytesEach",
+	);
+	if (
+		!limits.attachments.supported &&
+		limits.attachments.mimeTypes.length > 0
+	) {
+		throw new ElizaError("Unsupported attachments cannot declare MIME types.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.choice.modes.includes("native") &&
+		!limits.buttons.supported &&
+		!limits.lists.supported
+	) {
+		throw new ElizaError("Native choices require buttons or lists.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.followups.modes.includes("native") &&
+		!limits.buttons.supported
+	) {
+		throw new ElizaError("Native followups require buttons.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.form.modes.includes("native") &&
+		(!limits.forms.supported || !limits.modals.supported)
+	) {
+		throw new ElizaError("Native forms require form and modal primitives.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.task.modes.includes("native") &&
+		!limits.links.supported &&
+		!limits.threads.supported
+	) {
+		throw new ElizaError("Native tasks require links or threads.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (profile.nonSecretFallbacks.length === 0) {
+		throw new ElizaError("A non-secret fallback is required.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		new Set(profile.nonSecretFallbacks).size !==
+			profile.nonSecretFallbacks.length ||
+		profile.nonSecretFallbacks.some(
+			(mode) => !INTERACTION_DELIVERY_MODES.has(mode),
+		)
+	) {
+		throw new ElizaError(
+			"Non-secret interaction fallbacks must be unique known modes.",
+			{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE" },
+		);
+	}
+	for (const kind of INTERACTION_BLOCK_KINDS) {
+		if (kind === "secret") continue;
+		if (
+			profile.blocks[kind].modes.some(
+				(mode) =>
+					mode === "sensitive-request" ||
+					!profile.nonSecretFallbacks.includes(mode),
+			)
+		) {
+			throw new ElizaError(
+				`${kind} declares a mode missing from non-secret fallbacks.`,
+				{
+					code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+					context: { kind },
+				},
+			);
+		}
+	}
+	return structuredClone({
+		...profile,
+		profileId: nonEmpty(profile.profileId, "profileId"),
+		connector: {
+			source: nonEmpty(profile.connector.source, "connector.source"),
+			accountId: nonEmpty(profile.connector.accountId, "connector.accountId"),
+		},
+		target: {
+			kind: nonEmpty(profile.target.kind, "target.kind"),
+			id: nonEmpty(profile.target.id, "target.id"),
+		},
+	});
+}
+
+/** Materialize a template for exactly one connector account and target. */
+export function createConnectorInteractionCapabilityProfile(args: {
+	template: InteractionProfileTemplate;
+	source: string;
+	accountId: string;
+	targetKind: string;
+	targetId: string;
+}): ConnectorInteractionCapabilityProfile {
+	const templateId = nonEmpty(args.template.templateId, "template.templateId");
+	const source = nonEmpty(args.source, "connector.source");
+	const accountId = nonEmpty(args.accountId, "connector.accountId");
+	const targetKind = nonEmpty(args.targetKind, "target.kind");
+	const targetId = nonEmpty(args.targetId, "target.id");
+	return normalizeConnectorInteractionCapabilityProfile({
+		profileVersion: INTERACTION_PROFILE_VERSION,
+		profileId: `ip1:${stringToUuid(`${INTERACTION_PROFILE_VERSION}:${templateId}:${source}:${accountId}:${targetKind}:${targetId}`)}`,
+		connector: { source, accountId },
+		target: { kind: targetKind, id: targetId },
+		blocks: args.template.blocks,
+		limits: args.template.limits,
+		nonSecretFallbacks: args.template.nonSecretFallbacks,
+		sensitiveFallback: "sensitive-request",
+	});
+}
+
+export interface NegotiatedInteractionDelivery {
+	mode: InteractionDeliveryMode;
+	reason: "preferred" | "native-limit" | "native-unavailable" | "sensitive";
+	limitations: readonly string[];
+}
+
+export interface InteractionNegotiationContext {
+	callbackBytes?: number;
+	buttonsPerRow?: number;
+	signedHostedUrl?: string;
+	requiresEdit?: boolean;
+	sourceMessageCreatedAt?: number;
+	now?: number;
+	requiresThread?: boolean;
+}
+
+const OPAQUE_CALLBACK_WIRE_BYTES = 36;
+
+function utf8Bytes(value: string | undefined): number {
+	return value ? new TextEncoder().encode(value).length : 0;
+}
+
+function nativeBlockLimitations(
+	block: InteractionBlock,
+	profile: ConnectorInteractionCapabilityProfile,
+	context: InteractionNegotiationContext,
+): string[] {
+	const issues: string[] = [];
+	const { limits } = profile;
+	switch (block.kind) {
+		case "choice": {
+			const buttonIssues: string[] = [];
+			if (limits.buttons.supported) {
+				if (block.options.length > limits.buttons.maxPerMessage)
+					buttonIssues.push("option count");
+				if ((context.buttonsPerRow ?? 1) > limits.buttons.maxPerRow)
+					buttonIssues.push("button row count");
+				if (
+					limits.buttons.maxCallbackBytes <
+					(context.callbackBytes ?? OPAQUE_CALLBACK_WIRE_BYTES)
+				)
+					buttonIssues.push("opaque callback bytes");
+				if (
+					block.options.some(
+						(option) => utf8Bytes(option.label) > limits.buttons.maxLabelBytes,
+					)
+				)
+					buttonIssues.push("option label bytes");
+			}
+			const listIssues: string[] = [];
+			if (limits.lists.supported) {
+				if (block.options.length > limits.lists.maxItems)
+					listIssues.push("option count");
+				if (
+					block.options.some(
+						(option) => utf8Bytes(option.label) > limits.lists.maxLabelBytes,
+					)
+				)
+					listIssues.push("option label bytes");
+				if (
+					block.options.some(
+						(option) =>
+							utf8Bytes(option.description) > limits.lists.maxDescriptionBytes,
+					)
+				)
+					listIssues.push("option description bytes");
+			}
+			if (!limits.buttons.supported && !limits.lists.supported)
+				issues.push("no native choice primitive");
+			else if (
+				(!limits.buttons.supported || buttonIssues.length > 0) &&
+				(!limits.lists.supported || listIssues.length > 0)
+			)
+				issues.push(...buttonIssues, ...listIssues);
+			break;
+		}
+		case "followups": {
+			if (!limits.buttons.supported) issues.push("no native button primitive");
+			if (block.options.length > limits.buttons.maxPerMessage)
+				issues.push("option count");
+			if ((context.buttonsPerRow ?? 1) > limits.buttons.maxPerRow)
+				issues.push("button row count");
+			if (
+				limits.buttons.maxCallbackBytes <
+				(context.callbackBytes ?? OPAQUE_CALLBACK_WIRE_BYTES)
+			)
+				issues.push("opaque callback bytes");
+			if (
+				block.options.some(
+					(option) => utf8Bytes(option.label) > limits.buttons.maxLabelBytes,
+				)
+			)
+				issues.push("option label bytes");
+			break;
+		}
+		case "form": {
+			if (!limits.forms.supported || !limits.modals.supported)
+				issues.push("no native form/modal primitive");
+			if (
+				block.fields.length > limits.forms.maxFields ||
+				block.fields.length > limits.modals.maxFields
+			)
+				issues.push("field count");
+			if (utf8Bytes(block.title) > limits.modals.maxTitleBytes)
+				issues.push("modal title bytes");
+			const attachmentFields = block.fields.filter(
+				(field) => field.type === "file" || field.type === "image",
+			);
+			if (attachmentFields.length > limits.attachments.maxCount)
+				issues.push("attachment count");
+			for (const field of block.fields) {
+				if (field.type === "secret") issues.push("secret field");
+				if ((field.options?.length ?? 0) > limits.forms.maxOptionsPerField)
+					issues.push("field option count");
+				if (field.type === "file" || field.type === "image") {
+					if (!limits.attachments.supported)
+						issues.push("attachments unsupported");
+					if ((field.maxBytes ?? 0) > limits.attachments.maxBytesEach)
+						issues.push("attachment bytes");
+					if (
+						field.mimeTypes?.some(
+							(mime) =>
+								!limits.attachments.mimeTypes.includes("*/*") &&
+								!limits.attachments.mimeTypes.includes(mime),
+						)
+					)
+						issues.push("attachment MIME type");
+				}
+			}
+			break;
+		}
+		case "task": {
+			if (!limits.links.supported && !limits.threads.supported)
+				issues.push("no link or thread primitive");
+			if (
+				limits.links.supported &&
+				!limits.threads.supported &&
+				!context.signedHostedUrl
+			)
+				issues.push("task URL unavailable");
+			if (
+				limits.links.supported &&
+				!limits.threads.supported &&
+				context.signedHostedUrl &&
+				utf8Bytes(context.signedHostedUrl) > limits.links.maxUrlBytes
+			)
+				issues.push("link URL bytes");
+			if (
+				limits.threads.supported &&
+				utf8Bytes(block.title) > limits.threads.maxTitleBytes
+			)
+				issues.push("thread title bytes");
+			break;
+		}
+		case "secret":
+			issues.push("sensitive request required");
+	}
+	if (context.requiresThread && !limits.threads.supported)
+		issues.push("threads unsupported");
+	if (context.requiresEdit) {
+		if (!limits.edits.supported) issues.push("edits unsupported");
+		else if (
+			limits.edits.windowMs !== null &&
+			(context.sourceMessageCreatedAt === undefined ||
+				context.now === undefined)
+		)
+			issues.push("edit window unknown");
+		else if (
+			limits.edits.windowMs !== null &&
+			context.sourceMessageCreatedAt !== undefined &&
+			context.now !== undefined &&
+			context.now - context.sourceMessageCreatedAt > limits.edits.windowMs
+		)
+			issues.push("edit window expired");
+	}
+	const visible = JSON.stringify(block);
+	if (utf8Bytes(visible) > limits.text.maxMessageBytes)
+		issues.push("message bytes");
+	return [...new Set(issues)].sort();
+}
+
+function signedHostedLimitations(
+	profile: ConnectorInteractionCapabilityProfile,
+	context: InteractionNegotiationContext,
+): string[] {
+	if (!profile.limits.links.supported) return ["links unsupported"];
+	if (!context.signedHostedUrl) return ["signed hosted URL unavailable"];
+	if (utf8Bytes(context.signedHostedUrl) > profile.limits.links.maxUrlBytes)
+		return ["link URL bytes"];
+	return [];
+}
+
+/** Select a layout solely from negotiated capability and present payload size. */
+export function negotiateInteractionDelivery(
+	block: InteractionBlock,
+	profileValue: ConnectorInteractionCapabilityProfile,
+	context: InteractionNegotiationContext = {},
+): NegotiatedInteractionDelivery {
+	const profile = normalizeConnectorInteractionCapabilityProfile(profileValue);
+	if (block.kind === "secret") {
+		return { mode: "sensitive-request", reason: "sensitive", limitations: [] };
+	}
+	if (
+		block.kind === "form" &&
+		block.fields.some((field) => field.type === "secret")
+	) {
+		throw new ElizaError(
+			"Secret fields cannot use an ordinary interaction form.",
+			{ code: "INTERACTION_SENSITIVE_FLOW_REQUIRED" },
+		);
+	}
+	const modes = profile.blocks[block.kind].modes;
+	const limitations = nativeBlockLimitations(block, profile, context);
+	const fallbackLimitations = new Set(limitations);
+	for (const mode of modes) {
+		if (mode === "native") {
+			if (limitations.length === 0) {
+				return { mode, reason: "preferred", limitations };
+			}
+			continue;
+		}
+		if (mode === "signed-hosted") {
+			const hostedIssues = signedHostedLimitations(profile, context);
+			if (hostedIssues.length === 0) {
+				return {
+					mode,
+					reason: modes.includes("native")
+						? "native-limit"
+						: "native-unavailable",
+					limitations,
+				};
+			}
+			for (const issue of hostedIssues) fallbackLimitations.add(issue);
+			continue;
+		}
+		if (mode !== "sensitive-request") {
+			return {
+				mode,
+				reason: modes.includes("native")
+					? "native-limit"
+					: "native-unavailable",
+				limitations: [...fallbackLimitations].sort(),
+			};
+		}
+	}
+	throw new ElizaError("No safe interaction delivery mode was negotiated.", {
+		code: "INTERACTION_DELIVERY_UNAVAILABLE",
+		context: { kind: block.kind, profileId: profile.profileId },
+	});
+}
+
+/** Rejects profile-ID collisions whose immutable account/target body differs. */
+export class ConnectorInteractionProfileRegistry {
+	private readonly profiles = new Map<
+		string,
+		{ fingerprint: string; profile: ConnectorInteractionCapabilityProfile }
+	>();
+
+	register(
+		value: ConnectorInteractionCapabilityProfile,
+	): ConnectorInteractionCapabilityProfile {
+		const profile = normalizeConnectorInteractionCapabilityProfile(value);
+		const fingerprint = stableStringify(profile);
+		const existing = this.profiles.get(profile.profileId);
+		if (existing && existing.fingerprint !== fingerprint) {
+			throw new ElizaError(
+				"Interaction profile ID collides with a different account or target profile.",
+				{
+					code: "INTERACTION_PROFILE_ID_COLLISION",
+					context: { profileId: profile.profileId },
+				},
+			);
+		}
+		if (!existing)
+			this.profiles.set(profile.profileId, { fingerprint, profile });
+		return structuredClone(profile);
+	}
+
+	get(profileId: string): ConnectorInteractionCapabilityProfile | null {
+		const entry = this.profiles.get(profileId);
+		return entry ? structuredClone(entry.profile) : null;
+	}
+}
+
+/** Deterministic reviewer-facing matrix; callers decide where to persist it. */
+export function renderInteractionCapabilityMatrix(
+	profiles: readonly ConnectorInteractionCapabilityProfile[],
+): string {
+	const rows = [...profiles]
+		.map(normalizeConnectorInteractionCapabilityProfile)
+		.sort((a, b) =>
+			`${a.connector.source}\0${a.connector.accountId}\0${a.target.kind}\0${a.target.id}`.localeCompare(
+				`${b.connector.source}\0${b.connector.accountId}\0${b.target.kind}\0${b.target.id}`,
+			),
+		)
+		.map((profile) => {
+			const modes = INTERACTION_BLOCK_KINDS.map(
+				(kind) => `${kind}:${profile.blocks[kind].modes.join("→")}`,
+			).join("<br>");
+			return `| ${profile.connector.source} | ${profile.connector.accountId} | ${profile.target.kind}:${profile.target.id} | ${modes} | ${profile.limits.buttons.maxCallbackBytes} | ${profile.limits.attachments.supported ? `${profile.limits.attachments.maxCount} × ${profile.limits.attachments.maxBytesEach}` : "none"} |`;
+		});
+	return [
+		"| Connector | Account | Target | Block delivery | Callback bytes | Attachments |",
+		"| --- | --- | --- | --- | ---: | --- |",
+		...rows,
+	].join("\n");
+}

--- a/packages/core/src/messaging/interactions/profiles.ts
+++ b/packages/core/src/messaging/interactions/profiles.ts
@@ -421,6 +421,8 @@ export interface InteractionNegotiationContext {
 	callbackBytes?: number;
 	buttonsPerRow?: number;
 	signedHostedUrl?: string;
+	/** True only after the owning host verifies this URL's signature and authority. */
+	signedHostedUrlVerified?: boolean;
 	requiresEdit?: boolean;
 	sourceMessageCreatedAt?: number;
 	now?: number;
@@ -586,10 +588,19 @@ function nativeBlockLimitations(
 		)
 			issues.push("edit window expired");
 	}
-	const visible = JSON.stringify(block);
-	if (utf8Bytes(visible) > limits.text.maxMessageBytes)
-		issues.push("message bytes");
 	return [...new Set(issues)].sort();
+}
+
+function conversationalBlockLimitations(
+	block: InteractionBlock,
+	profile: ConnectorInteractionCapabilityProfile,
+): string[] {
+	// Conversational renderers receive the complete canonical block. Bounding its
+	// deterministic wire representation proves they never have to truncate an
+	// accepted payload to fit the connector's message limit.
+	return utf8Bytes(stableStringify(block)) > profile.limits.text.maxMessageBytes
+		? ["message bytes"]
+		: [];
 }
 
 function signedHostedLimitations(
@@ -598,6 +609,20 @@ function signedHostedLimitations(
 ): string[] {
 	if (!profile.limits.links.supported) return ["links unsupported"];
 	if (!context.signedHostedUrl) return ["signed hosted URL unavailable"];
+	if (!context.signedHostedUrlVerified) return ["signed hosted URL unverified"];
+	try {
+		const parsed = new URL(context.signedHostedUrl);
+		if (
+			parsed.protocol !== "https:" ||
+			parsed.username ||
+			parsed.password ||
+			parsed.hash
+		)
+			return ["signed hosted URL unsafe"];
+	} catch {
+		// error-policy:J3 malformed URLs are explicit negotiation failures.
+		return ["signed hosted URL unsafe"];
+	}
 	if (utf8Bytes(context.signedHostedUrl) > profile.limits.links.maxUrlBytes)
 		return ["link URL bytes"];
 	return [];
@@ -646,7 +671,16 @@ export function negotiateInteractionDelivery(
 			for (const issue of hostedIssues) fallbackLimitations.add(issue);
 			continue;
 		}
-		if (mode !== "sensitive-request") {
+		if (mode === "conversational") {
+			const conversationalIssues = conversationalBlockLimitations(
+				block,
+				profile,
+			);
+			if (conversationalIssues.length > 0) {
+				for (const issue of conversationalIssues)
+					fallbackLimitations.add(issue);
+				continue;
+			}
 			return {
 				mode,
 				reason: modes.includes("native")
@@ -658,7 +692,11 @@ export function negotiateInteractionDelivery(
 	}
 	throw new ElizaError("No safe interaction delivery mode was negotiated.", {
 		code: "INTERACTION_DELIVERY_UNAVAILABLE",
-		context: { kind: block.kind, profileId: profile.profileId },
+		context: {
+			kind: block.kind,
+			profileId: profile.profileId,
+			limitations: [...fallbackLimitations].sort(),
+		},
 	});
 }
 

--- a/packages/core/src/messaging/interactions/session-authority.test.ts
+++ b/packages/core/src/messaging/interactions/session-authority.test.ts
@@ -64,7 +64,7 @@ function receipt(key: string): MessageInteractionReceipt {
 		receiptId: `receipt-${key}`,
 		idempotencyKey: key,
 		status: "completed",
-		completedAt: "2026-08-21T00:00:01.000Z",
+		completedAt: "2026-08-21T00:00:00.000Z",
 		result: { accepted: true },
 	};
 }
@@ -347,7 +347,7 @@ describe("message interaction session authority", () => {
 		expect(execute).toHaveBeenCalledTimes(1);
 	});
 
-	it("resumes a crash window with one idempotent effect and completes the receipt", async () => {
+	it("fails closed after an effect succeeds but its durable completion is lost", async () => {
 		let now = Date.parse("2026-08-21T00:00:00.000Z");
 		const backing = new InMemoryMessageInteractionSessionStore();
 		let failCompletion = true;
@@ -356,6 +356,7 @@ describe("message interaction session authority", () => {
 			create: backing.create.bind(backing),
 			get: backing.get.bind(backing),
 			claimIfCurrent: backing.claimIfCurrent.bind(backing),
+			commitIfClaimed: backing.commitIfClaimed.bind(backing),
 			revokeAuthorization: backing.revokeAuthorization.bind(backing),
 			deleteExpired: backing.deleteExpired.bind(backing),
 			completeIfClaimed: async (context) => {
@@ -399,9 +400,148 @@ describe("message interaction session authority", () => {
 				replayKey: "replay-a",
 				executor,
 			}),
-		).toEqual(receipt("replay-a"));
+		).toEqual({ status: "in_progress" });
 		expect(physicalEffects).toBe(1);
 	});
+
+	it("fences an expired worker before effect commit and refuses revocation after commit", async () => {
+		let now = Date.parse("2026-08-21T00:00:00.000Z");
+		const store = new InMemoryMessageInteractionSessionStore();
+		const { authority, callbackData, session } = await created({
+			store,
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		const claim = await store.claimIfCurrent({
+			...bindings,
+			reference: session.reference,
+			replayKey: "replay-a",
+			claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			now,
+			claimTtlMs: 100,
+		});
+		expect(claim.status).toBe("acquired");
+		now += 101;
+		const replacement = await store.claimIfCurrent({
+			...bindings,
+			reference: session.reference,
+			replayKey: "replay-a",
+			claimId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			now,
+			claimTtlMs: 100,
+		});
+		expect(replacement.status).toBe("resumed");
+		await expect(
+			store.commitIfClaimed({
+				reference: session.reference,
+				claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				replayKey: "replay-a",
+				now,
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_STALE_CLAIM" });
+		await store.commitIfClaimed({
+			reference: session.reference,
+			claimId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			replayKey: "replay-a",
+			now,
+		});
+		await expect(
+			store.revokeAuthorization({
+				reference: session.reference,
+				decisionId: "decision-a",
+				now,
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_EFFECT_COMMITTED" });
+		let effects = 0;
+		expect(
+			await authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: {
+					execute: async () => {
+						effects += 1;
+						return receipt("replay-a");
+					},
+				},
+			}),
+		).toEqual({ status: "in_progress" });
+		expect(effects).toBe(0);
+	});
+
+	it.each(["reacquire", "revoke"] as const)(
+		"never calls the old worker effect when %s wins before durable commit",
+		async (winner) => {
+			let now = Date.parse("2026-08-21T00:00:00.000Z");
+			const backing = new InMemoryMessageInteractionSessionStore();
+			let enterCommit: () => void = () => undefined;
+			const commitEntered = new Promise<void>((resolve) => {
+				enterCommit = resolve;
+			});
+			let releaseCommit: () => void = () => undefined;
+			const commitBarrier = new Promise<void>((resolve) => {
+				releaseCommit = resolve;
+			});
+			const store: MessageInteractionSessionStore = {
+				create: backing.create.bind(backing),
+				get: backing.get.bind(backing),
+				claimIfCurrent: backing.claimIfCurrent.bind(backing),
+				commitIfClaimed: async (context) => {
+					enterCommit();
+					await commitBarrier;
+					return backing.commitIfClaimed(context);
+				},
+				completeIfClaimed: backing.completeIfClaimed.bind(backing),
+				revokeAuthorization: backing.revokeAuthorization.bind(backing),
+				deleteExpired: backing.deleteExpired.bind(backing),
+			};
+			const { authority, callbackData, session } = await created({
+				store,
+				clock: () => now,
+				preset: { value: "approve" },
+			});
+			let effects = 0;
+			const oldWorker = authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: {
+					execute: async () => {
+						effects += 1;
+						return receipt("replay-a");
+					},
+				},
+			});
+			await commitEntered;
+			if (winner === "reacquire") {
+				now += 101;
+				expect(
+					await backing.claimIfCurrent({
+						...bindings,
+						reference: session.reference,
+						replayKey: "replay-a",
+						claimId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						now,
+						claimTtlMs: 100,
+					}),
+				).toMatchObject({ status: "resumed" });
+			} else {
+				await backing.revokeAuthorization({
+					reference: session.reference,
+					decisionId: "decision-a",
+					now,
+				});
+			}
+			releaseCommit();
+			await expect(oldWorker).rejects.toMatchObject({
+				code:
+					winner === "reacquire"
+						? "MESSAGE_INTERACTION_STALE_CLAIM"
+						: "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+			});
+			expect(effects).toBe(0);
+		},
+	);
 
 	it("denies tamper, expiry, and revocation after render", async () => {
 		let now = Date.parse("2026-08-21T00:00:00.000Z");

--- a/packages/core/src/messaging/interactions/session-authority.test.ts
+++ b/packages/core/src/messaging/interactions/session-authority.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Deterministic contract coverage for negotiated profiles and the durable
+ * message-interaction claim/execute/receipt state machine. No model is mocked.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+	ChoiceInteraction,
+	FormInteraction,
+} from "../../types/interactions";
+import {
+	BUTTON_INTERACTION_PROFILE,
+	CONVERSATIONAL_INTERACTION_PROFILE,
+	RICH_INTERACTION_PROFILE,
+} from "./profile-catalog";
+import {
+	ConnectorInteractionProfileRegistry,
+	createConnectorInteractionCapabilityProfile,
+	negotiateInteractionDelivery,
+	normalizeConnectorInteractionCapabilityProfile,
+} from "./profiles";
+import {
+	createOpaqueMessageInteractionReference,
+	decodeMessageInteractionCallback,
+	encodeMessageInteractionCallback,
+	InMemoryMessageInteractionSessionStore,
+	type MessageInteractionEffectExecutor,
+	type MessageInteractionReceipt,
+	MessageInteractionSessionAuthority,
+	type MessageInteractionSessionStore,
+} from "./sessions";
+
+const choice: ChoiceInteraction = {
+	kind: "choice",
+	id: "approve-1",
+	scope: "approval",
+	options: [
+		{ value: "approve", label: "Approve" },
+		{ value: "deny", label: "Deny" },
+	],
+};
+
+function profile(template = BUTTON_INTERACTION_PROFILE) {
+	return createConnectorInteractionCapabilityProfile({
+		template,
+		source: "connector",
+		accountId: "account-a",
+		targetKind: "room",
+		targetId: "room-a",
+	});
+}
+
+const bindings = {
+	actorId: "actor-a",
+	audience: { kind: "room", id: "room-a" },
+	agentId: "agent-a",
+	connector: { source: "connector", accountId: "account-a" },
+	roomId: "room-a",
+	sourceMessageId: "message-a",
+};
+
+function receipt(key: string): MessageInteractionReceipt {
+	return {
+		receiptId: `receipt-${key}`,
+		idempotencyKey: key,
+		status: "completed",
+		completedAt: "2026-08-21T00:00:01.000Z",
+		result: { accepted: true },
+	};
+}
+
+async function created(options?: {
+	store?: MessageInteractionSessionStore;
+	clock?: () => number;
+	preset?: { value: string };
+}) {
+	const store = options?.store ?? new InMemoryMessageInteractionSessionStore();
+	const authority = new MessageInteractionSessionAuthority(store, {
+		clock: options?.clock ?? (() => Date.parse("2026-08-21T00:00:00.000Z")),
+		referenceFactory: () => "0123456789abcdef0123456789abcdef",
+		claimTtlMs: 100,
+	});
+	const result = await authority.create({
+		block: choice,
+		profile: profile(),
+		bindings,
+		purpose: "approval",
+		flow: "native",
+		...(options?.preset ? { presetResponse: options.preset } : {}),
+		authorization: {
+			decisionId: "decision-a",
+			policyRevision: "policy-7",
+			decidedAt: "2026-08-20T23:59:59.000Z",
+		},
+		effect: { kind: "approve_operation", metadata: { operationId: "op-a" } },
+		expiresAt: "2026-08-21T00:10:00.000Z",
+	});
+	return { authority, store, ...result };
+}
+
+describe("connector interaction profiles", () => {
+	it("binds IDs to account and target and rejects conflicting registry collisions", () => {
+		const a = profile();
+		const b = createConnectorInteractionCapabilityProfile({
+			template: BUTTON_INTERACTION_PROFILE,
+			source: "connector",
+			accountId: "account-b",
+			targetKind: "room",
+			targetId: "room-a",
+		});
+		expect(a.profileId).not.toBe(b.profileId);
+		const registry = new ConnectorInteractionProfileRegistry();
+		registry.register(a);
+		expect(() =>
+			registry.register({ ...b, profileId: a.profileId }),
+		).toThrowError(/ID collides/);
+	});
+
+	it("requires zero limits for unsupported primitives", () => {
+		const invalid = structuredClone(
+			profile(CONVERSATIONAL_INTERACTION_PROFILE),
+		);
+		invalid.limits.modals.maxFields = 1;
+		expect(() =>
+			normalizeConnectorInteractionCapabilityProfile(invalid),
+		).toThrowError(/must be zero/);
+	});
+
+	it("uses UTF-8 byte and opaque callback limits before native delivery", () => {
+		const constrained = structuredClone(profile());
+		constrained.limits.buttons.maxLabelBytes = 7;
+		const unicodeChoice = {
+			...choice,
+			options: [{ value: "ok", label: "✅✅✅" }],
+		};
+		expect(
+			negotiateInteractionDelivery(unicodeChoice, constrained),
+		).toMatchObject({
+			mode: "conversational",
+			reason: "native-limit",
+			limitations: ["option label bytes"],
+		});
+		constrained.limits.buttons.maxLabelBytes = 80;
+		constrained.limits.buttons.maxCallbackBytes = 35;
+		expect(
+			negotiateInteractionDelivery(choice, constrained).limitations,
+		).toContain("opaque callback bytes");
+	});
+
+	it("checks hosted URL, thread, edit, attachment and form limits", () => {
+		const form: FormInteraction = {
+			kind: "form",
+			id: "upload",
+			title: "資料を提出",
+			fields: [
+				{
+					name: "file",
+					type: "file",
+					maxBytes: 101_000_000,
+					mimeTypes: ["application/pdf"],
+				},
+			],
+		};
+		const rich = profile(RICH_INTERACTION_PROFILE);
+		const result = negotiateInteractionDelivery(form, rich, {
+			signedHostedUrl: `https://example.test/${"a".repeat(8_200)}`,
+			requiresEdit: true,
+			requiresThread: true,
+			now: 2_000,
+			sourceMessageCreatedAt: 1_000,
+		});
+		expect(result.limitations).toEqual(["attachment bytes", "link URL bytes"]);
+	});
+
+	it("does not apply a hosted-fallback URL limit to a fitting native block", () => {
+		expect(
+			negotiateInteractionDelivery(choice, profile(), {
+				signedHostedUrl: `https://example.test/${"x".repeat(3_000)}`,
+			}),
+		).toMatchObject({ mode: "native", limitations: [] });
+	});
+});
+
+describe("message interaction session authority", () => {
+	it("property: accepts only canonical opaque callback references", () => {
+		let state = 0x24_287;
+		const nextByte = () => {
+			state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+			return state & 0xff;
+		};
+		for (let sample = 0; sample < 256; sample += 1) {
+			const reference = createOpaqueMessageInteractionReference((size) =>
+				Uint8Array.from({ length: size }, nextByte),
+			);
+			const callback = encodeMessageInteractionCallback(reference);
+			expect(decodeMessageInteractionCallback(callback)).toBe(reference);
+			for (const mutated of [
+				callback.toUpperCase(),
+				`${callback}0`,
+				callback.slice(0, -1),
+				callback.replace("is1:", "is2:"),
+			]) {
+				expect(decodeMessageInteractionCallback(mutated)).toBeNull();
+			}
+		}
+	});
+
+	it("puts only a short opaque reference in callback data", async () => {
+		const { callbackData, session } = await created({
+			preset: { value: "approve" },
+		});
+		expect(callbackData).toBe("is1:0123456789abcdef0123456789abcdef");
+		expect(decodeMessageInteractionCallback(callbackData)).toBe(
+			session.reference,
+		);
+		expect(callbackData).not.toContain("approve");
+		expect(callbackData).not.toContain("account-a");
+	});
+
+	it("rejects a requested native flow when the concrete block exceeds limits", async () => {
+		const authority = new MessageInteractionSessionAuthority(
+			new InMemoryMessageInteractionSessionStore(),
+			{ clock: () => Date.parse("2026-08-21T00:00:00.000Z") },
+		);
+		await expect(
+			authority.create({
+				block: {
+					...choice,
+					options: [{ value: "large", label: "x".repeat(81) }],
+				},
+				profile: profile(),
+				bindings,
+				purpose: "approval",
+				flow: "native",
+				authorization: {
+					decisionId: "decision-a",
+					policyRevision: "policy-a",
+					decidedAt: "2026-08-20T23:59:00.000Z",
+				},
+				effect: { kind: "approve" },
+				expiresAt: "2026-08-21T00:05:00.000Z",
+			}),
+		).rejects.toMatchObject({
+			code: "INTERACTION_FLOW_NOT_NEGOTIATED",
+			context: expect.objectContaining({
+				negotiated: "conversational",
+				limitations: ["option label bytes"],
+			}),
+		});
+	});
+
+	it("binds profile text byte limits into custom responses", async () => {
+		const store = new InMemoryMessageInteractionSessionStore();
+		const authority = new MessageInteractionSessionAuthority(store, {
+			clock: () => Date.parse("2026-08-21T00:00:00.000Z"),
+			referenceFactory: () => "0123456789abcdef0123456789abcdef",
+		});
+		const result = await authority.create({
+			block: { ...choice, allowCustom: true },
+			profile: profile(),
+			bindings,
+			purpose: "choice",
+			flow: "native",
+			authorization: {
+				decisionId: "decision-a",
+				policyRevision: "policy-a",
+				decidedAt: "2026-08-20T23:59:00.000Z",
+			},
+			effect: { kind: "choose" },
+			expiresAt: "2026-08-21T00:05:00.000Z",
+		});
+		await expect(
+			authority.consume({
+				callbackData: result.callbackData,
+				bindings,
+				replayKey: "replay-a",
+				response: { value: "✅".repeat(1_334) },
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "INVALID_MESSAGE_INTERACTION_RESPONSE" });
+	});
+
+	it.each([
+		["actor", { actorId: "actor-b" }],
+		["audience", { audience: { kind: "room", id: "room-b" } }],
+		["agent", { agentId: "agent-b" }],
+		["account", { connector: { source: "connector", accountId: "account-b" } }],
+		["room", { roomId: "room-b" }],
+		["source message", { sourceMessageId: "message-b" }],
+	])("denies cross-%s callbacks", async (_name, override) => {
+		const { authority, callbackData } = await created({
+			preset: { value: "approve" },
+		});
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings: { ...bindings, ...override },
+				replayKey: "replay-a",
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_BINDING_MISMATCH" });
+	});
+
+	it("atomically admits one concurrent effect and replays its retained receipt", async () => {
+		const { authority, callbackData } = await created({
+			preset: { value: "approve" },
+		});
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const execute = vi.fn(async () => {
+			await gate;
+			return receipt("replay-a");
+		});
+		const executor = { execute };
+		const first = authority.consume({
+			callbackData,
+			bindings,
+			replayKey: "replay-a",
+			executor,
+		});
+		await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+		const contenders = await Promise.all(
+			Array.from({ length: 20 }, () =>
+				authority.consume({
+					callbackData,
+					bindings,
+					replayKey: "replay-a",
+					executor,
+				}),
+			),
+		);
+		expect(contenders).toEqual(
+			Array.from({ length: 20 }, () => ({ status: "in_progress" })),
+		);
+		release();
+		expect(await first).toEqual(receipt("replay-a"));
+		expect(
+			await authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).toEqual(receipt("replay-a"));
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it("resumes a crash window with one idempotent effect and completes the receipt", async () => {
+		let now = Date.parse("2026-08-21T00:00:00.000Z");
+		const backing = new InMemoryMessageInteractionSessionStore();
+		let failCompletion = true;
+		const crashingStore: MessageInteractionSessionStore = {
+			...backing,
+			create: backing.create.bind(backing),
+			get: backing.get.bind(backing),
+			claimIfCurrent: backing.claimIfCurrent.bind(backing),
+			revokeAuthorization: backing.revokeAuthorization.bind(backing),
+			deleteExpired: backing.deleteExpired.bind(backing),
+			completeIfClaimed: async (context) => {
+				if (failCompletion) {
+					failCompletion = false;
+					throw new Error("simulated crash after effect");
+				}
+				return backing.completeIfClaimed(context);
+			},
+		};
+		const { authority, callbackData } = await created({
+			store: crashingStore,
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		const effects = new Map<string, MessageInteractionReceipt>();
+		let physicalEffects = 0;
+		const executor: MessageInteractionEffectExecutor = {
+			execute: async ({ idempotencyKey }) => {
+				const prior = effects.get(idempotencyKey);
+				if (prior) return prior;
+				physicalEffects += 1;
+				const value = receipt(idempotencyKey);
+				effects.set(idempotencyKey, value);
+				return value;
+			},
+		};
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).rejects.toThrow("simulated crash");
+		now += 101;
+		expect(
+			await authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).toEqual(receipt("replay-a"));
+		expect(physicalEffects).toBe(1);
+	});
+
+	it("denies tamper, expiry, and revocation after render", async () => {
+		let now = Date.parse("2026-08-21T00:00:00.000Z");
+		const { authority, store, callbackData, session } = await created({
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				response: { value: "deny" },
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_TAMPERED" });
+		await store.revokeAuthorization({
+			reference: session.reference,
+			decisionId: "decision-a",
+			now,
+		});
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({
+			code: "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+		});
+
+		const second = await created({
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		now = Date.parse("2026-08-21T00:10:00.000Z");
+		await expect(
+			second.authority.consume({
+				callbackData: second.callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_EXPIRED" });
+	});
+
+	it("forbids secrets in ordinary forms and effect metadata", async () => {
+		const authority = new MessageInteractionSessionAuthority(
+			new InMemoryMessageInteractionSessionStore(),
+			{ clock: () => Date.parse("2026-08-21T00:00:00.000Z") },
+		);
+		const secretForm: FormInteraction = {
+			kind: "form",
+			id: "bad",
+			fields: [{ name: "apiKey", type: "secret" }],
+		};
+		await expect(
+			authority.create({
+				block: secretForm,
+				profile: profile(RICH_INTERACTION_PROFILE),
+				bindings,
+				purpose: "auth",
+				flow: "native",
+				authorization: {
+					decisionId: "d",
+					policyRevision: "p",
+					decidedAt: "2026-08-20T23:59:00.000Z",
+				},
+				effect: { kind: "setup", metadata: { apiKey: "secret-value" } },
+				expiresAt: "2026-08-21T00:05:00.000Z",
+			}),
+		).rejects.toMatchObject({ code: "INTERACTION_SENSITIVE_FLOW_REQUIRED" });
+	});
+});

--- a/packages/core/src/messaging/interactions/session-authority.test.ts
+++ b/packages/core/src/messaging/interactions/session-authority.test.ts
@@ -164,6 +164,7 @@ describe("connector interaction profiles", () => {
 		const rich = profile(RICH_INTERACTION_PROFILE);
 		const result = negotiateInteractionDelivery(form, rich, {
 			signedHostedUrl: `https://example.test/${"a".repeat(8_200)}`,
+			signedHostedUrlVerified: true,
 			requiresEdit: true,
 			requiresThread: true,
 			now: 2_000,
@@ -178,6 +179,44 @@ describe("connector interaction profiles", () => {
 				signedHostedUrl: `https://example.test/${"x".repeat(3_000)}`,
 			}),
 		).toMatchObject({ mode: "native", limitations: [] });
+	});
+
+	it("rejects an oversized conversational payload instead of delegating truncation", () => {
+		const constrained = structuredClone(
+			profile(CONVERSATIONAL_INTERACTION_PROFILE),
+		);
+		constrained.limits.text.maxMessageBytes = 64;
+		expect(() =>
+			negotiateInteractionDelivery(
+				{ ...choice, options: [{ value: "v", label: "✅".repeat(80) }] },
+				constrained,
+			),
+		).toThrowError(
+			expect.objectContaining({
+				code: "INTERACTION_DELIVERY_UNAVAILABLE",
+				context: expect.objectContaining({
+					limitations: expect.arrayContaining(["message bytes"]),
+				}),
+			}),
+		);
+	});
+
+	it("requires host verification before accepting a signed hosted URL", () => {
+		const signedOnly = structuredClone(profile(RICH_INTERACTION_PROFILE));
+		signedOnly.blocks.choice.modes = ["signed-hosted"];
+		expect(() =>
+			negotiateInteractionDelivery(choice, signedOnly, {
+				signedHostedUrl: "https://example.test/form/a",
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "INTERACTION_DELIVERY_UNAVAILABLE" }),
+		);
+		expect(
+			negotiateInteractionDelivery(choice, signedOnly, {
+				signedHostedUrl: "https://example.test/form/a",
+				signedHostedUrlVerified: true,
+			}),
+		).toMatchObject({ mode: "signed-hosted" });
 	});
 });
 
@@ -347,6 +386,29 @@ describe("message interaction session authority", () => {
 		expect(execute).toHaveBeenCalledTimes(1);
 	});
 
+	it("reports replay from the atomic claim outcome", async () => {
+		const { authority, callbackData } = await created({
+			preset: { value: "approve" },
+		});
+		const executor = { execute: async () => receipt("replay-a") };
+		await expect(
+			authority.consumeWithOutcome({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).resolves.toMatchObject({ status: "completed" });
+		await expect(
+			authority.consumeWithOutcome({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).resolves.toMatchObject({ status: "replay" });
+	});
+
 	it("fails closed after an effect succeeds but its durable completion is lost", async () => {
 		let now = Date.parse("2026-08-21T00:00:00.000Z");
 		const backing = new InMemoryMessageInteractionSessionStore();
@@ -357,6 +419,8 @@ describe("message interaction session authority", () => {
 			get: backing.get.bind(backing),
 			claimIfCurrent: backing.claimIfCurrent.bind(backing),
 			commitIfClaimed: backing.commitIfClaimed.bind(backing),
+			listCommitted: backing.listCommitted.bind(backing),
+			reconcileCommitted: backing.reconcileCommitted.bind(backing),
 			revokeAuthorization: backing.revokeAuthorization.bind(backing),
 			deleteExpired: backing.deleteExpired.bind(backing),
 			completeIfClaimed: async (context) => {
@@ -492,6 +556,8 @@ describe("message interaction session authority", () => {
 					return backing.commitIfClaimed(context);
 				},
 				completeIfClaimed: backing.completeIfClaimed.bind(backing),
+				listCommitted: backing.listCommitted.bind(backing),
+				reconcileCommitted: backing.reconcileCommitted.bind(backing),
 				revokeAuthorization: backing.revokeAuthorization.bind(backing),
 				deleteExpired: backing.deleteExpired.bind(backing),
 			};

--- a/packages/core/src/messaging/interactions/sessions.ts
+++ b/packages/core/src/messaging/interactions/sessions.ts
@@ -108,12 +108,23 @@ export type MessageInteractionConsumeState =
 			attempt: number;
 	  }
 	| {
+			state: "committed";
+			claimId: string;
+			replayKey: string;
+			responseDigest: string;
+			response: MessageInteractionResponse;
+			claimedAt: string;
+			committedAt: string;
+			attempt: number;
+	  }
+	| {
 			state: "completed";
 			claimId: string;
 			replayKey: string;
 			responseDigest: string;
 			response: MessageInteractionResponse;
 			claimedAt: string;
+			committedAt: string;
 			completedAt: string;
 			attempt: number;
 			receipt: MessageInteractionReceipt;
@@ -172,6 +183,13 @@ export interface MessageInteractionCompleteContext {
 	now: number;
 }
 
+export interface MessageInteractionCommitContext {
+	reference: string;
+	claimId: string;
+	replayKey: string;
+	now: number;
+}
+
 /**
  * Storage transaction boundary. Implementations must make every method atomic;
  * a distributed implementation maps these operations to one row transaction.
@@ -182,6 +200,9 @@ export interface MessageInteractionSessionStore {
 	claimIfCurrent(
 		context: MessageInteractionClaimContext,
 	): Promise<MessageInteractionClaimResult>;
+	commitIfClaimed(
+		context: MessageInteractionCommitContext,
+	): Promise<MessageInteractionSession>;
 	completeIfClaimed(
 		context: MessageInteractionCompleteContext,
 	): Promise<MessageInteractionSession>;
@@ -195,8 +216,8 @@ export interface MessageInteractionSessionStore {
 
 export interface MessageInteractionEffectExecutor {
 	/**
-	 * Must be idempotent for idempotencyKey. A retry after a crash may invoke this
-	 * again; it must return the original effect receipt without repeating effect.
+	 * Executes only after the host durably commits the replay key. A crash after
+	 * commit is permanently ambiguous and is never automatically re-executed.
 	 */
 	execute(args: {
 		idempotencyKey: string;
@@ -225,13 +246,25 @@ function requiredText(value: string, path: string): string {
 }
 
 function validClock(value: number): number {
-	if (!Number.isSafeInteger(value) || value < 0) {
+	if (
+		!Number.isSafeInteger(value) ||
+		value < 0 ||
+		value > 8_640_000_000_000_000
+	) {
 		return fail(
 			"INVALID_MESSAGE_INTERACTION_CLOCK",
 			"Trusted clock is invalid.",
 		);
 	}
 	return value;
+}
+
+function parseCanonicalIso(value: string): number {
+	const parsed = Date.parse(value);
+	if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+		return Number.NaN;
+	}
+	return parsed;
 }
 
 function hex(bytes: Uint8Array): string {
@@ -497,6 +530,7 @@ export function validateMessageInteractionResponse(
 function assertCurrentContext(
 	session: MessageInteractionSession,
 	context: MessageInteractionClaimContext,
+	options: { requireActive: boolean } = { requireActive: true },
 ): MessageInteractionResponse {
 	const suppliedBindings: MessageInteractionBindings = {
 		actorId: context.actorId,
@@ -513,13 +547,13 @@ function assertCurrentContext(
 			{ reference: session.reference },
 		);
 	}
-	if (session.authorization.state !== "active") {
+	if (options.requireActive && session.authorization.state !== "active") {
 		return fail(
 			"MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
 			"Interaction authorization was revoked after render.",
 		);
 	}
-	if (Date.parse(session.expiresAt) <= context.now) {
+	if (options.requireActive && Date.parse(session.expiresAt) <= context.now) {
 		return fail("MESSAGE_INTERACTION_EXPIRED", "Interaction session expired.");
 	}
 	const response = session.presetResponse ?? context.response;
@@ -559,7 +593,17 @@ export function applyMessageInteractionClaim(
 			"Interaction claim lease must be a positive safe integer.",
 		);
 	}
-	const response = assertCurrentContext(session, context);
+	if (context.claimTtlMs > 8_640_000_000_000_000 - context.now) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_CLAIM_TTL",
+			"Interaction claim lease exceeds the supported clock range.",
+		);
+	}
+	const response = assertCurrentContext(session, context, {
+		requireActive:
+			session.consume.state !== "committed" &&
+			session.consume.state !== "completed",
+	});
 	const digest = responseDigest(response);
 	if (session.consume.state === "completed") {
 		if (
@@ -572,6 +616,18 @@ export function applyMessageInteractionClaim(
 			);
 		}
 		return { status: "replay", session, receipt: session.consume.receipt };
+	}
+	if (session.consume.state === "committed") {
+		if (
+			session.consume.replayKey !== context.replayKey ||
+			session.consume.responseDigest !== digest
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_ALREADY_COMMITTED",
+				"Interaction already committed a different response.",
+			);
+		}
+		return { status: "in_progress", session };
 	}
 	if (session.consume.state === "claimed") {
 		if (
@@ -626,11 +682,14 @@ export function applyMessageInteractionCompletion(
 	requiredText(context.claimId, "claimId");
 	requiredText(context.replayKey, "replayKey");
 	requiredText(context.receipt.receiptId, "receipt.receiptId");
-	const receiptCompletedAt = Date.parse(context.receipt.completedAt);
-	if (!Number.isFinite(receiptCompletedAt)) {
+	const receiptCompletedAt = parseCanonicalIso(context.receipt.completedAt);
+	if (
+		!Number.isFinite(receiptCompletedAt) ||
+		receiptCompletedAt > context.now
+	) {
 		return fail(
 			"INVALID_MESSAGE_INTERACTION_RECEIPT",
-			"Effect receipt has an invalid completion time.",
+			"Effect receipt has an invalid or future completion time.",
 		);
 	}
 	if (session.consume.state === "completed") {
@@ -645,7 +704,7 @@ export function applyMessageInteractionCompletion(
 		);
 	}
 	if (
-		session.consume.state !== "claimed" ||
+		session.consume.state !== "committed" ||
 		session.consume.claimId !== context.claimId ||
 		session.consume.replayKey !== context.replayKey
 	) {
@@ -670,9 +729,48 @@ export function applyMessageInteractionCompletion(
 		responseDigest: session.consume.responseDigest,
 		response: session.consume.response,
 		claimedAt: session.consume.claimedAt,
+		committedAt: session.consume.committedAt,
 		completedAt: new Date(context.now).toISOString(),
 		attempt: session.consume.attempt,
 		receipt: structuredClone(context.receipt),
+	};
+	session.revision += 1;
+	return session;
+}
+
+/** Durably linearize one effect before crossing the external side-effect boundary. */
+export function applyMessageInteractionCommit(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionCommitContext,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	validClock(context.now);
+	if (
+		session.reference !== context.reference ||
+		session.consume.state !== "claimed" ||
+		session.consume.claimId !== context.claimId ||
+		session.consume.replayKey !== context.replayKey
+	) {
+		return fail(
+			"MESSAGE_INTERACTION_STALE_CLAIM",
+			"Interaction effect commitment does not own the current claim.",
+		);
+	}
+	if (session.authorization.state !== "active") {
+		return fail(
+			"MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+			"Interaction authorization was revoked before effect commitment.",
+		);
+	}
+	session.consume = {
+		state: "committed",
+		claimId: session.consume.claimId,
+		replayKey: session.consume.replayKey,
+		responseDigest: session.consume.responseDigest,
+		response: session.consume.response,
+		claimedAt: session.consume.claimedAt,
+		committedAt: new Date(context.now).toISOString(),
+		attempt: session.consume.attempt,
 	};
 	session.revision += 1;
 	return session;
@@ -691,6 +789,12 @@ export function applyMessageInteractionRevocation(
 		);
 	}
 	if (session.authorization.state === "revoked") return session;
+	if (session.consume.state === "committed") {
+		return fail(
+			"MESSAGE_INTERACTION_EFFECT_COMMITTED",
+			"Interaction revocation is pending an already committed effect outcome.",
+		);
+	}
 	session.authorization = {
 		...session.authorization,
 		state: "revoked",
@@ -771,6 +875,22 @@ export class InMemoryMessageInteractionSessionStore
 		});
 	}
 
+	async commitIfClaimed(
+		context: MessageInteractionCommitContext,
+	): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const committed = applyMessageInteractionCommit(current, context);
+			this.sessions.set(context.reference, cloneSession(committed));
+			return committed;
+		});
+	}
+
 	async revokeAuthorization(args: {
 		reference: string;
 		decisionId: string;
@@ -798,7 +918,11 @@ export class InMemoryMessageInteractionSessionStore
 		return this.atomic(() => {
 			let deleted = 0;
 			for (const [reference, session] of this.sessions) {
-				if (Date.parse(session.expiresAt) <= before) {
+				if (
+					Date.parse(session.expiresAt) <= before &&
+					session.consume.state !== "committed" &&
+					session.consume.state !== "completed"
+				) {
 					this.sessions.delete(reference);
 					deleted += 1;
 				}
@@ -851,7 +975,7 @@ export class MessageInteractionSessionAuthority {
 				"MESSAGE_INTERACTION_PROFILE_BINDING_MISMATCH",
 				"Capability profile belongs to another account or target.",
 			);
-		const expiry = Date.parse(args.expiresAt);
+		const expiry = parseCanonicalIso(args.expiresAt);
 		if (
 			!Number.isFinite(expiry) ||
 			expiry <= now ||
@@ -926,7 +1050,9 @@ export class MessageInteractionSessionAuthority {
 			consume: { state: "pending" },
 			revision: 0,
 		};
-		const authorizationTime = Date.parse(session.authorization.decidedAt);
+		const authorizationTime = parseCanonicalIso(
+			session.authorization.decidedAt,
+		);
 		if (!Number.isFinite(authorizationTime) || authorizationTime > now) {
 			return fail(
 				"INVALID_MESSAGE_INTERACTION_AUTHORIZATION",
@@ -993,11 +1119,22 @@ export class MessageInteractionSessionAuthority {
 				"MESSAGE_INTERACTION_STORE_PROTOCOL",
 				"Store returned an unclaimed session.",
 			);
+		const committed = await this.store.commitIfClaimed({
+			reference,
+			claimId: claim.session.consume.claimId,
+			replayKey,
+			now: this.now(),
+		});
+		if (committed.consume.state !== "committed")
+			return fail(
+				"MESSAGE_INTERACTION_STORE_PROTOCOL",
+				"Store did not retain the effect commitment.",
+			);
 		const receipt = await args.executor.execute({
 			idempotencyKey: replayKey,
-			effect: claim.session.effect,
-			response: claim.session.consume.response,
-			session: claim.session,
+			effect: committed.effect,
+			response: committed.consume.response,
+			session: committed,
 		});
 		const completed = await this.store.completeIfClaimed({
 			reference,

--- a/packages/core/src/messaging/interactions/sessions.ts
+++ b/packages/core/src/messaging/interactions/sessions.ts
@@ -1,0 +1,1016 @@
+/**
+ * Owns durable message-interaction sessions and their exactly-once execution
+ * protocol. The authority binds callbacks to trusted context, while storage
+ * implementations provide atomic claim/complete/revoke transitions.
+ */
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ElizaError } from "../../errors";
+import type {
+	InteractionBlock,
+	InteractionField,
+	InteractionKind,
+} from "../../types/interactions";
+import { stableStringify } from "../../utils/deterministic";
+import type {
+	ConnectorInteractionCapabilityProfile,
+	InteractionNegotiationContext,
+} from "./profiles";
+import {
+	negotiateInteractionDelivery,
+	normalizeConnectorInteractionCapabilityProfile,
+} from "./profiles";
+
+export const MESSAGE_INTERACTION_SESSION_VERSION = 1 as const;
+export const MESSAGE_INTERACTION_CALLBACK_PREFIX = "is1:";
+export const MESSAGE_INTERACTION_CALLBACK_BYTES = 36;
+
+export type MessageInteractionPurpose =
+	| "choice"
+	| "form"
+	| "approval"
+	| "setup"
+	| "auth"
+	| "task"
+	| "file"
+	| "followup";
+
+export type MessageInteractionFlow =
+	| "native"
+	| "conversational"
+	| "signed-hosted"
+	| "sensitive-request";
+
+export interface MessageInteractionBindings {
+	actorId: string;
+	audience: { kind: string; id: string };
+	agentId: string;
+	connector: { source: string; accountId: string };
+	roomId: string;
+	sourceMessageId: string;
+}
+
+export type MessageInteractionResponseScalar = string | number | boolean;
+
+export interface MessageInteractionAttachmentResponse {
+	mediaUrl: string;
+	mimeType: string;
+	bytes: number;
+}
+
+export type MessageInteractionResponseValue =
+	| MessageInteractionResponseScalar
+	| MessageInteractionAttachmentResponse;
+
+export type MessageInteractionResponse = Record<
+	string,
+	MessageInteractionResponseValue
+>;
+
+export interface MessageInteractionResponseField {
+	name: string;
+	type: InteractionField["type"] | "acknowledgement";
+	required: boolean;
+	options?: readonly string[];
+	maxBytes?: number;
+	mimeTypes?: readonly string[];
+}
+
+export interface MessageInteractionResponseSchema {
+	fields: readonly MessageInteractionResponseField[];
+	additionalFields: false;
+}
+
+export interface MessageInteractionAuthorizationDecision {
+	decisionId: string;
+	policyRevision: string;
+	decidedAt: string;
+	state: "active" | "revoked";
+	revokedAt: string | null;
+}
+
+export interface MessageInteractionEffect {
+	kind: string;
+	/** Non-secret operation metadata. Credentials and submitted secrets are forbidden. */
+	metadata?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export type MessageInteractionConsumeState =
+	| { state: "pending" }
+	| {
+			state: "claimed";
+			claimId: string;
+			replayKey: string;
+			responseDigest: string;
+			response: MessageInteractionResponse;
+			claimedAt: string;
+			claimExpiresAt: string;
+			attempt: number;
+	  }
+	| {
+			state: "completed";
+			claimId: string;
+			replayKey: string;
+			responseDigest: string;
+			response: MessageInteractionResponse;
+			claimedAt: string;
+			completedAt: string;
+			attempt: number;
+			receipt: MessageInteractionReceipt;
+	  };
+
+export interface MessageInteractionSession {
+	sessionVersion: typeof MESSAGE_INTERACTION_SESSION_VERSION;
+	reference: string;
+	purpose: MessageInteractionPurpose;
+	blockKind: InteractionKind;
+	flow: MessageInteractionFlow;
+	profileId: string;
+	bindings: MessageInteractionBindings;
+	responseSchema: MessageInteractionResponseSchema;
+	presetResponse: MessageInteractionResponse | null;
+	authorization: MessageInteractionAuthorizationDecision;
+	effect: MessageInteractionEffect;
+	createdAt: string;
+	expiresAt: string;
+	consume: MessageInteractionConsumeState;
+	revision: number;
+}
+
+export interface MessageInteractionReceipt {
+	receiptId: string;
+	idempotencyKey: string;
+	status: "completed";
+	completedAt: string;
+	result: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+export interface MessageInteractionClaimContext
+	extends MessageInteractionBindings {
+	reference: string;
+	replayKey: string;
+	response?: MessageInteractionResponse;
+	claimId: string;
+	now: number;
+	claimTtlMs: number;
+}
+
+export type MessageInteractionClaimResult =
+	| { status: "acquired" | "resumed"; session: MessageInteractionSession }
+	| { status: "in_progress"; session: MessageInteractionSession }
+	| {
+			status: "replay";
+			session: MessageInteractionSession;
+			receipt: MessageInteractionReceipt;
+	  };
+
+export interface MessageInteractionCompleteContext {
+	reference: string;
+	claimId: string;
+	replayKey: string;
+	receipt: MessageInteractionReceipt;
+	now: number;
+}
+
+/**
+ * Storage transaction boundary. Implementations must make every method atomic;
+ * a distributed implementation maps these operations to one row transaction.
+ */
+export interface MessageInteractionSessionStore {
+	create(session: MessageInteractionSession): Promise<void>;
+	get(reference: string): Promise<MessageInteractionSession | null>;
+	claimIfCurrent(
+		context: MessageInteractionClaimContext,
+	): Promise<MessageInteractionClaimResult>;
+	completeIfClaimed(
+		context: MessageInteractionCompleteContext,
+	): Promise<MessageInteractionSession>;
+	revokeAuthorization(args: {
+		reference: string;
+		decisionId: string;
+		now: number;
+	}): Promise<MessageInteractionSession>;
+	deleteExpired(before: number): Promise<number>;
+}
+
+export interface MessageInteractionEffectExecutor {
+	/**
+	 * Must be idempotent for idempotencyKey. A retry after a crash may invoke this
+	 * again; it must return the original effect receipt without repeating effect.
+	 */
+	execute(args: {
+		idempotencyKey: string;
+		effect: MessageInteractionEffect;
+		response: MessageInteractionResponse;
+		session: MessageInteractionSession;
+	}): Promise<MessageInteractionReceipt>;
+}
+
+function fail(
+	code: string,
+	message: string,
+	context?: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, { code, context });
+}
+
+function requiredText(value: string, path: string): string {
+	const normalized = value.trim();
+	if (!normalized || new TextEncoder().encode(normalized).length > 512) {
+		return fail("INVALID_MESSAGE_INTERACTION_SESSION", `${path} is invalid.`, {
+			path,
+		});
+	}
+	return normalized;
+}
+
+function validClock(value: number): number {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_CLOCK",
+			"Trusted clock is invalid.",
+		);
+	}
+	return value;
+}
+
+function hex(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+		"",
+	);
+}
+
+function responseDigest(response: MessageInteractionResponse): string {
+	return hex(
+		sha256(
+			new TextEncoder().encode(
+				`elizaos:message-interaction-response:v1\n${stableStringify(response)}`,
+			),
+		),
+	);
+}
+
+function sameBindings(
+	a: MessageInteractionBindings,
+	b: MessageInteractionBindings,
+): boolean {
+	return stableStringify(a) === stableStringify(b);
+}
+
+function cloneSession(
+	session: MessageInteractionSession,
+): MessageInteractionSession {
+	return structuredClone(session);
+}
+
+/** Create a short opaque callback reference with no embedded authority or data. */
+export function createOpaqueMessageInteractionReference(
+	random: (size: number) => Uint8Array = (size) => {
+		const bytes = new Uint8Array(new ArrayBuffer(size));
+		globalThis.crypto.getRandomValues(bytes);
+		return bytes;
+	},
+): string {
+	return hex(random(16));
+}
+
+export function encodeMessageInteractionCallback(reference: string): string {
+	if (!/^[a-f0-9]{32}$/.test(reference)) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_REFERENCE",
+			"Interaction reference must be a 128-bit opaque token.",
+		);
+	}
+	return `${MESSAGE_INTERACTION_CALLBACK_PREFIX}${reference}`;
+}
+
+export function decodeMessageInteractionCallback(
+	value: unknown,
+): string | null {
+	if (typeof value !== "string" || !/^is1:[a-f0-9]{32}$/.test(value)) {
+		return null;
+	}
+	return value.slice(MESSAGE_INTERACTION_CALLBACK_PREFIX.length);
+}
+
+function schemaField(
+	field: InteractionField,
+	maxTextResponseBytes?: number,
+): MessageInteractionResponseField {
+	const maxBytes =
+		field.type === "text" ||
+		field.type === "select" ||
+		field.type === "date" ||
+		field.type === "time" ||
+		field.type === "datetime"
+			? Math.min(
+					field.maxBytes ?? Number.POSITIVE_INFINITY,
+					maxTextResponseBytes ?? Number.POSITIVE_INFINITY,
+				)
+			: field.maxBytes;
+	return {
+		name: field.name,
+		type: field.type,
+		required: field.required === true,
+		...(field.options
+			? { options: field.options.map((option) => option.value) }
+			: {}),
+		...(Number.isFinite(maxBytes) ? { maxBytes } : {}),
+		...(field.mimeTypes ? { mimeTypes: [...field.mimeTypes] } : {}),
+	};
+}
+
+/** Derive the exact accepted response shape from the canonical block. */
+export function responseSchemaForInteraction(
+	block: InteractionBlock,
+	options: { maxTextResponseBytes?: number } = {},
+): MessageInteractionResponseSchema {
+	switch (block.kind) {
+		case "choice":
+			return {
+				fields: [
+					{
+						name: "value",
+						type: "text",
+						required: true,
+						...(options.maxTextResponseBytes
+							? { maxBytes: options.maxTextResponseBytes }
+							: {}),
+						...(block.allowCustom
+							? {}
+							: { options: block.options.map((option) => option.value) }),
+					},
+				],
+				additionalFields: false,
+			};
+		case "form":
+			if (block.fields.some((field) => field.type === "secret")) {
+				return fail(
+					"INTERACTION_SENSITIVE_FLOW_REQUIRED",
+					"Secret fields cannot be persisted in message interaction sessions.",
+				);
+			}
+			return {
+				fields: block.fields.map((field) =>
+					schemaField(field, options.maxTextResponseBytes),
+				),
+				additionalFields: false,
+			};
+		case "followups":
+			return {
+				fields: [
+					{
+						name: "value",
+						type: "text",
+						required: true,
+						...(options.maxTextResponseBytes
+							? { maxBytes: options.maxTextResponseBytes }
+							: {}),
+						options: block.options.map((option) => option.payload),
+					},
+				],
+				additionalFields: false,
+			};
+		case "task":
+		case "secret":
+			return {
+				fields: [
+					{ name: "acknowledged", type: "acknowledgement", required: true },
+				],
+				additionalFields: false,
+			};
+	}
+}
+
+function validateAttachment(
+	value: MessageInteractionResponseValue,
+	field: MessageInteractionResponseField,
+): void {
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		!("mediaUrl" in value) ||
+		!("mimeType" in value) ||
+		!("bytes" in value)
+	) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} must be a media reference.`,
+		);
+	}
+	const attachment = value as MessageInteractionAttachmentResponse;
+	if (!/^\/api\/media\/[a-f0-9]{64}\.[a-z0-9]+$/.test(attachment.mediaUrl)) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} has an invalid media capability URL.`,
+		);
+	}
+	if (
+		!Number.isSafeInteger(attachment.bytes) ||
+		attachment.bytes < 0 ||
+		(field.maxBytes !== undefined && attachment.bytes > field.maxBytes)
+	) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} exceeds its byte limit.`,
+		);
+	}
+	if (field.mimeTypes && !field.mimeTypes.includes(attachment.mimeType)) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} has an unsupported MIME type.`,
+		);
+	}
+}
+
+export function validateMessageInteractionResponse(
+	value: MessageInteractionResponse,
+	schema: MessageInteractionResponseSchema,
+): MessageInteractionResponse {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			"Interaction response must be an object.",
+		);
+	}
+	const allowed = new Map(schema.fields.map((field) => [field.name, field]));
+	for (const key of Object.keys(value)) {
+		if (!allowed.has(key)) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`Unexpected interaction response field: ${key}.`,
+			);
+		}
+	}
+	for (const field of schema.fields) {
+		const responseValue = value[field.name];
+		if (responseValue === undefined) {
+			if (field.required)
+				return fail(
+					"INVALID_MESSAGE_INTERACTION_RESPONSE",
+					`Missing interaction response field: ${field.name}.`,
+				);
+			continue;
+		}
+		if (field.type === "file" || field.type === "image") {
+			validateAttachment(responseValue, field);
+			continue;
+		}
+		if (field.type === "checkbox" || field.type === "acknowledgement") {
+			if (typeof responseValue !== "boolean")
+				return fail(
+					"INVALID_MESSAGE_INTERACTION_RESPONSE",
+					`${field.name} must be boolean.`,
+				);
+		} else if (field.type === "number") {
+			if (typeof responseValue !== "number" || !Number.isFinite(responseValue))
+				return fail(
+					"INVALID_MESSAGE_INTERACTION_RESPONSE",
+					`${field.name} must be a finite number.`,
+				);
+		} else if (typeof responseValue !== "string") {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`${field.name} must be text.`,
+			);
+		}
+		if (
+			typeof responseValue === "string" &&
+			field.maxBytes !== undefined &&
+			new TextEncoder().encode(responseValue).length > field.maxBytes
+		) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`${field.name} exceeds its UTF-8 byte limit.`,
+			);
+		}
+		if (field.options && !field.options.includes(String(responseValue))) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`${field.name} is not an allowed option.`,
+			);
+		}
+	}
+	return structuredClone(value);
+}
+
+function assertCurrentContext(
+	session: MessageInteractionSession,
+	context: MessageInteractionClaimContext,
+): MessageInteractionResponse {
+	const suppliedBindings: MessageInteractionBindings = {
+		actorId: context.actorId,
+		audience: context.audience,
+		agentId: context.agentId,
+		connector: context.connector,
+		roomId: context.roomId,
+		sourceMessageId: context.sourceMessageId,
+	};
+	if (!sameBindings(session.bindings, suppliedBindings)) {
+		return fail(
+			"MESSAGE_INTERACTION_BINDING_MISMATCH",
+			"Interaction callback belongs to another actor, audience, agent, account, room, or source message.",
+			{ reference: session.reference },
+		);
+	}
+	if (session.authorization.state !== "active") {
+		return fail(
+			"MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+			"Interaction authorization was revoked after render.",
+		);
+	}
+	if (Date.parse(session.expiresAt) <= context.now) {
+		return fail("MESSAGE_INTERACTION_EXPIRED", "Interaction session expired.");
+	}
+	const response = session.presetResponse ?? context.response;
+	if (!response) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			"Interaction response is required.",
+		);
+	}
+	if (session.presetResponse && context.response) {
+		return fail(
+			"MESSAGE_INTERACTION_TAMPERED",
+			"Preset callbacks cannot override their stored response.",
+		);
+	}
+	return validateMessageInteractionResponse(response, session.responseSchema);
+}
+
+/** Pure atomic-transition helper shared by memory, file, and database stores. */
+export function applyMessageInteractionClaim(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionClaimContext,
+): MessageInteractionClaimResult {
+	const session = cloneSession(sessionValue);
+	validClock(context.now);
+	if (context.reference !== session.reference) {
+		return fail(
+			"MESSAGE_INTERACTION_REFERENCE_MISMATCH",
+			"Interaction claim reference does not match the stored session.",
+		);
+	}
+	requiredText(context.replayKey, "replayKey");
+	requiredText(context.claimId, "claimId");
+	if (!Number.isSafeInteger(context.claimTtlMs) || context.claimTtlMs < 1) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_CLAIM_TTL",
+			"Interaction claim lease must be a positive safe integer.",
+		);
+	}
+	const response = assertCurrentContext(session, context);
+	const digest = responseDigest(response);
+	if (session.consume.state === "completed") {
+		if (
+			session.consume.replayKey !== context.replayKey ||
+			session.consume.responseDigest !== digest
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_ALREADY_CONSUMED",
+				"Interaction was already consumed by another response.",
+			);
+		}
+		return { status: "replay", session, receipt: session.consume.receipt };
+	}
+	if (session.consume.state === "claimed") {
+		if (
+			session.consume.replayKey !== context.replayKey ||
+			session.consume.responseDigest !== digest
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_ALREADY_CLAIMED",
+				"Interaction is claimed by another response.",
+			);
+		}
+		if (Date.parse(session.consume.claimExpiresAt) > context.now) {
+			return { status: "in_progress", session };
+		}
+		session.consume = {
+			...session.consume,
+			state: "claimed",
+			claimId: context.claimId,
+			claimedAt: new Date(context.now).toISOString(),
+			claimExpiresAt: new Date(context.now + context.claimTtlMs).toISOString(),
+			attempt: session.consume.attempt + 1,
+		};
+		session.revision += 1;
+		return { status: "resumed", session };
+	}
+	session.consume = {
+		state: "claimed",
+		claimId: context.claimId,
+		replayKey: context.replayKey,
+		responseDigest: digest,
+		response,
+		claimedAt: new Date(context.now).toISOString(),
+		claimExpiresAt: new Date(context.now + context.claimTtlMs).toISOString(),
+		attempt: 1,
+	};
+	session.revision += 1;
+	return { status: "acquired", session };
+}
+
+export function applyMessageInteractionCompletion(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionCompleteContext,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	validClock(context.now);
+	if (context.reference !== session.reference) {
+		return fail(
+			"MESSAGE_INTERACTION_REFERENCE_MISMATCH",
+			"Interaction completion reference does not match the stored session.",
+		);
+	}
+	requiredText(context.claimId, "claimId");
+	requiredText(context.replayKey, "replayKey");
+	requiredText(context.receipt.receiptId, "receipt.receiptId");
+	const receiptCompletedAt = Date.parse(context.receipt.completedAt);
+	if (!Number.isFinite(receiptCompletedAt)) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RECEIPT",
+			"Effect receipt has an invalid completion time.",
+		);
+	}
+	if (session.consume.state === "completed") {
+		if (
+			session.consume.replayKey === context.replayKey &&
+			session.consume.receipt.idempotencyKey === context.receipt.idempotencyKey
+		)
+			return session;
+		return fail(
+			"MESSAGE_INTERACTION_ALREADY_CONSUMED",
+			"A different effect already completed this interaction.",
+		);
+	}
+	if (
+		session.consume.state !== "claimed" ||
+		session.consume.claimId !== context.claimId ||
+		session.consume.replayKey !== context.replayKey
+	) {
+		return fail(
+			"MESSAGE_INTERACTION_STALE_CLAIM",
+			"Interaction completion does not own the current claim.",
+		);
+	}
+	if (
+		context.receipt.idempotencyKey !== context.replayKey ||
+		context.receipt.status !== "completed"
+	) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RECEIPT",
+			"Effect receipt does not bind the replay key.",
+		);
+	}
+	session.consume = {
+		state: "completed",
+		claimId: session.consume.claimId,
+		replayKey: session.consume.replayKey,
+		responseDigest: session.consume.responseDigest,
+		response: session.consume.response,
+		claimedAt: session.consume.claimedAt,
+		completedAt: new Date(context.now).toISOString(),
+		attempt: session.consume.attempt,
+		receipt: structuredClone(context.receipt),
+	};
+	session.revision += 1;
+	return session;
+}
+
+export function applyMessageInteractionRevocation(
+	sessionValue: MessageInteractionSession,
+	decisionId: string,
+	now: number,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	if (session.authorization.decisionId !== decisionId) {
+		return fail(
+			"MESSAGE_INTERACTION_AUTHORIZATION_MISMATCH",
+			"Authorization decision does not match this session.",
+		);
+	}
+	if (session.authorization.state === "revoked") return session;
+	session.authorization = {
+		...session.authorization,
+		state: "revoked",
+		revokedAt: new Date(validClock(now)).toISOString(),
+	};
+	session.revision += 1;
+	return session;
+}
+
+/** Process-local reference store used by deterministic tests and embedded hosts. */
+export class InMemoryMessageInteractionSessionStore
+	implements MessageInteractionSessionStore
+{
+	private readonly sessions = new Map<string, MessageInteractionSession>();
+	private queue: Promise<void> = Promise.resolve();
+
+	private async atomic<T>(operation: () => T | Promise<T>): Promise<T> {
+		let release: () => void = () => undefined;
+		const previous = this.queue;
+		this.queue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await operation();
+		} finally {
+			release();
+		}
+	}
+
+	async create(session: MessageInteractionSession): Promise<void> {
+		await this.atomic(() => {
+			if (this.sessions.has(session.reference))
+				return fail(
+					"MESSAGE_INTERACTION_REFERENCE_COLLISION",
+					"Interaction reference already exists.",
+				);
+			this.sessions.set(session.reference, cloneSession(session));
+		});
+	}
+
+	async get(reference: string): Promise<MessageInteractionSession | null> {
+		return this.atomic(() => {
+			const session = this.sessions.get(reference);
+			return session ? cloneSession(session) : null;
+		});
+	}
+
+	async claimIfCurrent(
+		context: MessageInteractionClaimContext,
+	): Promise<MessageInteractionClaimResult> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const result = applyMessageInteractionClaim(current, context);
+			this.sessions.set(context.reference, cloneSession(result.session));
+			return result;
+		});
+	}
+
+	async completeIfClaimed(
+		context: MessageInteractionCompleteContext,
+	): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const completed = applyMessageInteractionCompletion(current, context);
+			this.sessions.set(context.reference, cloneSession(completed));
+			return completed;
+		});
+	}
+
+	async revokeAuthorization(args: {
+		reference: string;
+		decisionId: string;
+		now: number;
+	}): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(args.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const revoked = applyMessageInteractionRevocation(
+				current,
+				args.decisionId,
+				args.now,
+			);
+			this.sessions.set(args.reference, cloneSession(revoked));
+			return revoked;
+		});
+	}
+
+	async deleteExpired(before: number): Promise<number> {
+		validClock(before);
+		return this.atomic(() => {
+			let deleted = 0;
+			for (const [reference, session] of this.sessions) {
+				if (Date.parse(session.expiresAt) <= before) {
+					this.sessions.delete(reference);
+					deleted += 1;
+				}
+			}
+			return deleted;
+		});
+	}
+}
+
+export class MessageInteractionSessionAuthority {
+	constructor(
+		private readonly store: MessageInteractionSessionStore,
+		private readonly options: {
+			clock?: () => number;
+			referenceFactory?: () => string;
+			claimTtlMs?: number;
+		} = {},
+	) {}
+
+	private now(): number {
+		return validClock(this.options.clock?.() ?? Date.now());
+	}
+
+	async create(args: {
+		block: InteractionBlock;
+		profile: ConnectorInteractionCapabilityProfile;
+		bindings: MessageInteractionBindings;
+		purpose: MessageInteractionPurpose;
+		flow: MessageInteractionFlow;
+		negotiationContext?: InteractionNegotiationContext;
+		presetResponse?: MessageInteractionResponse;
+		authorization: Omit<
+			MessageInteractionAuthorizationDecision,
+			"state" | "revokedAt"
+		>;
+		effect: MessageInteractionEffect;
+		expiresAt: string;
+	}): Promise<{ session: MessageInteractionSession; callbackData: string }> {
+		const now = this.now();
+		const profile = normalizeConnectorInteractionCapabilityProfile(
+			args.profile,
+		);
+		if (
+			profile.connector.source !== args.bindings.connector.source ||
+			profile.connector.accountId !== args.bindings.connector.accountId ||
+			profile.target.kind !== args.bindings.audience.kind ||
+			profile.target.id !== args.bindings.audience.id
+		)
+			return fail(
+				"MESSAGE_INTERACTION_PROFILE_BINDING_MISMATCH",
+				"Capability profile belongs to another account or target.",
+			);
+		const expiry = Date.parse(args.expiresAt);
+		if (
+			!Number.isFinite(expiry) ||
+			expiry <= now ||
+			expiry - now > profile.blocks[args.block.kind].maxSessionTtlMs
+		) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_EXPIRY",
+				"Interaction expiry exceeds negotiated capability.",
+			);
+		}
+		if (args.block.kind === "secret" && args.flow !== "sensitive-request") {
+			return fail(
+				"INTERACTION_SENSITIVE_FLOW_REQUIRED",
+				"Secret/OAuth interactions require the sensitive-request flow.",
+			);
+		}
+		if (args.block.kind !== "secret" && args.flow === "sensitive-request") {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_FLOW",
+				"Ordinary interactions cannot use the sensitive-request flow.",
+			);
+		}
+		const delivery = negotiateInteractionDelivery(args.block, profile, {
+			...args.negotiationContext,
+			callbackBytes: MESSAGE_INTERACTION_CALLBACK_BYTES,
+		});
+		if (delivery.mode !== args.flow) {
+			return fail(
+				"INTERACTION_FLOW_NOT_NEGOTIATED",
+				"Interaction flow does not match the negotiated delivery for this payload.",
+				{
+					requested: args.flow,
+					negotiated: delivery.mode,
+					limitations: delivery.limitations,
+				},
+			);
+		}
+		if (args.purpose === "auth" && args.block.kind !== "secret") {
+			return fail(
+				"INTERACTION_SENSITIVE_FLOW_REQUIRED",
+				"Authentication input must use a dedicated sensitive request.",
+			);
+		}
+		const reference =
+			this.options.referenceFactory?.() ??
+			createOpaqueMessageInteractionReference();
+		encodeMessageInteractionCallback(reference);
+		const schema = responseSchemaForInteraction(args.block, {
+			maxTextResponseBytes: profile.limits.text.maxMessageBytes,
+		});
+		const presetResponse = args.presetResponse
+			? validateMessageInteractionResponse(args.presetResponse, schema)
+			: null;
+		const session: MessageInteractionSession = {
+			sessionVersion: MESSAGE_INTERACTION_SESSION_VERSION,
+			reference,
+			purpose: args.purpose,
+			blockKind: args.block.kind,
+			flow: args.flow,
+			profileId: profile.profileId,
+			bindings: structuredClone(args.bindings),
+			responseSchema: schema,
+			presetResponse,
+			authorization: {
+				...args.authorization,
+				state: "active",
+				revokedAt: null,
+			},
+			effect: structuredClone(args.effect),
+			createdAt: new Date(now).toISOString(),
+			expiresAt: new Date(expiry).toISOString(),
+			consume: { state: "pending" },
+			revision: 0,
+		};
+		const authorizationTime = Date.parse(session.authorization.decidedAt);
+		if (!Number.isFinite(authorizationTime) || authorizationTime > now) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_AUTHORIZATION",
+				"Authorization decision time is invalid.",
+			);
+		}
+		for (const [path, value] of Object.entries({
+			...session.bindings,
+			audienceKind: session.bindings.audience.kind,
+			audienceId: session.bindings.audience.id,
+			connectorSource: session.bindings.connector.source,
+			connectorAccountId: session.bindings.connector.accountId,
+			authorizationDecisionId: session.authorization.decisionId,
+			policyRevision: session.authorization.policyRevision,
+			effectKind: session.effect.kind,
+		}))
+			if (typeof value === "string") requiredText(value, path);
+		if (
+			/secret|token|password|oauth.*code|api.?key/i.test(
+				stableStringify(session.effect.metadata ?? {}),
+			)
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+				"Interaction effect metadata appears to contain secret material.",
+			);
+		}
+		await this.store.create(session);
+		return {
+			session: cloneSession(session),
+			callbackData: encodeMessageInteractionCallback(reference),
+		};
+	}
+
+	async consume(args: {
+		callbackData: string;
+		bindings: MessageInteractionBindings;
+		replayKey: string;
+		response?: MessageInteractionResponse;
+		executor: MessageInteractionEffectExecutor;
+	}): Promise<MessageInteractionReceipt | { status: "in_progress" }> {
+		const reference = decodeMessageInteractionCallback(args.callbackData);
+		if (!reference)
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_REFERENCE",
+				"Callback is not an opaque interaction reference.",
+			);
+		const now = this.now();
+		const replayKey = requiredText(args.replayKey, "replayKey");
+		const claimId = createOpaqueMessageInteractionReference();
+		const claim = await this.store.claimIfCurrent({
+			...args.bindings,
+			reference,
+			replayKey,
+			response: args.response,
+			claimId,
+			now,
+			claimTtlMs: this.options.claimTtlMs ?? 30_000,
+		});
+		if (claim.status === "replay") return claim.receipt;
+		if (claim.status === "in_progress") return { status: "in_progress" };
+		if (claim.session.consume.state !== "claimed")
+			return fail(
+				"MESSAGE_INTERACTION_STORE_PROTOCOL",
+				"Store returned an unclaimed session.",
+			);
+		const receipt = await args.executor.execute({
+			idempotencyKey: replayKey,
+			effect: claim.session.effect,
+			response: claim.session.consume.response,
+			session: claim.session,
+		});
+		const completed = await this.store.completeIfClaimed({
+			reference,
+			claimId: claim.session.consume.claimId,
+			replayKey,
+			receipt,
+			now: this.now(),
+		});
+		if (completed.consume.state !== "completed")
+			return fail(
+				"MESSAGE_INTERACTION_STORE_PROTOCOL",
+				"Store did not retain the completion receipt.",
+			);
+		return completed.consume.receipt;
+	}
+}

--- a/packages/core/src/messaging/interactions/sessions.ts
+++ b/packages/core/src/messaging/interactions/sessions.ts
@@ -190,6 +190,13 @@ export interface MessageInteractionCommitContext {
 	now: number;
 }
 
+export interface MessageInteractionReconcileContext {
+	reference: string;
+	replayKey: string;
+	receipt: MessageInteractionReceipt;
+	now: number;
+}
+
 /**
  * Storage transaction boundary. Implementations must make every method atomic;
  * a distributed implementation maps these operations to one row transaction.
@@ -205,6 +212,15 @@ export interface MessageInteractionSessionStore {
 	): Promise<MessageInteractionSession>;
 	completeIfClaimed(
 		context: MessageInteractionCompleteContext,
+	): Promise<MessageInteractionSession>;
+	/** Discover committed outcomes that require provider/outbox reconciliation. */
+	listCommitted(args: {
+		committedBefore: number;
+		limit: number;
+	}): Promise<MessageInteractionSession[]>;
+	/** Retain a verified external outcome without re-executing its effect. */
+	reconcileCommitted(
+		context: MessageInteractionReconcileContext,
 	): Promise<MessageInteractionSession>;
 	revokeAuthorization(args: {
 		reference: string;
@@ -226,6 +242,10 @@ export interface MessageInteractionEffectExecutor {
 		session: MessageInteractionSession;
 	}): Promise<MessageInteractionReceipt>;
 }
+
+export type MessageInteractionAuthorityConsumeOutcome =
+	| { status: "completed" | "replay"; receipt: MessageInteractionReceipt }
+	| { status: "in_progress" };
 
 function fail(
 	code: string,
@@ -738,6 +758,29 @@ export function applyMessageInteractionCompletion(
 	return session;
 }
 
+export function applyMessageInteractionReconciliation(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionReconcileContext,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	if (session.consume.state !== "committed") {
+		return fail(
+			"MESSAGE_INTERACTION_NOT_COMMITTED",
+			"Only a committed ambiguous interaction can be reconciled.",
+		);
+	}
+	if (session.consume.replayKey !== context.replayKey) {
+		return fail(
+			"MESSAGE_INTERACTION_REPLAY_KEY_MISMATCH",
+			"Reconciliation receipt belongs to another replay key.",
+		);
+	}
+	return applyMessageInteractionCompletion(session, {
+		...context,
+		claimId: session.consume.claimId,
+	});
+}
+
 /** Durably linearize one effect before crossing the external side-effect boundary. */
 export function applyMessageInteractionCommit(
 	sessionValue: MessageInteractionSession,
@@ -875,6 +918,46 @@ export class InMemoryMessageInteractionSessionStore
 		});
 	}
 
+	async listCommitted(args: {
+		committedBefore: number;
+		limit: number;
+	}): Promise<MessageInteractionSession[]> {
+		validClock(args.committedBefore);
+		if (!Number.isSafeInteger(args.limit) || args.limit < 1) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RECONCILIATION_LIMIT",
+				"Reconciliation limit must be a positive safe integer.",
+			);
+		}
+		return this.atomic(() =>
+			[...this.sessions.values()]
+				.filter(
+					(session) =>
+						session.consume.state === "committed" &&
+						Date.parse(session.consume.committedAt) <= args.committedBefore,
+				)
+				.sort((a, b) => a.reference.localeCompare(b.reference))
+				.slice(0, args.limit)
+				.map(cloneSession),
+		);
+	}
+
+	async reconcileCommitted(
+		context: MessageInteractionReconcileContext,
+	): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const completed = applyMessageInteractionReconciliation(current, context);
+			this.sessions.set(context.reference, cloneSession(completed));
+			return completed;
+		});
+	}
+
 	async commitIfClaimed(
 		context: MessageInteractionCommitContext,
 	): Promise<MessageInteractionSession> {
@@ -918,11 +1001,13 @@ export class InMemoryMessageInteractionSessionStore
 		return this.atomic(() => {
 			let deleted = 0;
 			for (const [reference, session] of this.sessions) {
-				if (
-					Date.parse(session.expiresAt) <= before &&
-					session.consume.state !== "committed" &&
-					session.consume.state !== "completed"
-				) {
+				const terminalAt =
+					session.consume.state === "completed"
+						? Date.parse(session.consume.completedAt)
+						: session.consume.state === "committed"
+							? Date.parse(session.consume.committedAt)
+							: Date.parse(session.expiresAt);
+				if (terminalAt <= before) {
 					this.sessions.delete(reference);
 					deleted += 1;
 				}
@@ -1087,13 +1172,13 @@ export class MessageInteractionSessionAuthority {
 		};
 	}
 
-	async consume(args: {
+	private async consumeOutcome(args: {
 		callbackData: string;
 		bindings: MessageInteractionBindings;
 		replayKey: string;
 		response?: MessageInteractionResponse;
 		executor: MessageInteractionEffectExecutor;
-	}): Promise<MessageInteractionReceipt | { status: "in_progress" }> {
+	}): Promise<MessageInteractionAuthorityConsumeOutcome> {
 		const reference = decodeMessageInteractionCallback(args.callbackData);
 		if (!reference)
 			return fail(
@@ -1112,7 +1197,9 @@ export class MessageInteractionSessionAuthority {
 			now,
 			claimTtlMs: this.options.claimTtlMs ?? 30_000,
 		});
-		if (claim.status === "replay") return claim.receipt;
+		if (claim.status === "replay") {
+			return { status: "replay", receipt: claim.receipt };
+		}
 		if (claim.status === "in_progress") return { status: "in_progress" };
 		if (claim.session.consume.state !== "claimed")
 			return fail(
@@ -1148,6 +1235,29 @@ export class MessageInteractionSessionAuthority {
 				"MESSAGE_INTERACTION_STORE_PROTOCOL",
 				"Store did not retain the completion receipt.",
 			);
-		return completed.consume.receipt;
+		return { status: "completed", receipt: completed.consume.receipt };
+	}
+
+	/** Return the atomic claim disposition together with any retained receipt. */
+	async consumeWithOutcome(args: {
+		callbackData: string;
+		bindings: MessageInteractionBindings;
+		replayKey: string;
+		response?: MessageInteractionResponse;
+		executor: MessageInteractionEffectExecutor;
+	}): Promise<MessageInteractionAuthorityConsumeOutcome> {
+		return this.consumeOutcome(args);
+	}
+
+	/** Backward-compatible receipt API for callers that do not classify replay. */
+	async consume(args: {
+		callbackData: string;
+		bindings: MessageInteractionBindings;
+		replayKey: string;
+		response?: MessageInteractionResponse;
+		executor: MessageInteractionEffectExecutor;
+	}): Promise<MessageInteractionReceipt | { status: "in_progress" }> {
+		const outcome = await this.consumeOutcome(args);
+		return outcome.status === "in_progress" ? outcome : outcome.receipt;
 	}
 }

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -7,6 +7,7 @@
  */
 import type { ReportedError } from "../errors";
 import type { Logger } from "../logger";
+import type { ConnectorInteractionCapabilityProfile } from "../messaging/interactions/profiles";
 import type { ContextRegistry } from "../runtime/context-registry";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";
@@ -381,6 +382,13 @@ export interface MessageConnector {
 	description?: string;
 	contexts: AgentContext[];
 	metadata?: Metadata;
+	/** Resolve the negotiated interaction contract for this exact account/target. */
+	resolveInteractionProfile?: (
+		target: TargetInfo,
+		context: MessageConnectorQueryContext,
+	) =>
+		| Promise<ConnectorInteractionCapabilityProfile>
+		| ConnectorInteractionCapabilityProfile;
 	resolveTargets?: (
 		query: string,
 		context: MessageConnectorQueryContext,


### PR DESCRIPTION
# Relates to

Closes #24287. Contract handoff for #24288.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] The public core contract, registered host authority, real filesystem store, and focused tests are implemented.
- [x] Known repository-baseline failures are recorded without presenting them as success.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a8aa79511f5ea9b4b72a76394f1f2f7196bde49b`; zero conflicts.
- [x] Exact reviewed head: `af82262f6a55b402a21b470273c5377d08a532aa`.

# Risks

Medium. This adds a public connector capability resolver and durable authorization/dispatch boundary. A bad connector profile conservatively degrades presentation but cannot grant callback authority. The bundled JSON adapter is intentionally single-host; multi-host deployments must supply a transactional store and idempotent effect/outbox implementation.

# What this PR does

- Defines one versioned, immutable capability profile per concrete connector account/target and negotiates native, conversational, signed-hosted, or sensitive delivery from typed capability and payload size.
- Adds durable sessions binding actor, audience, agent, connector account, room, source message, response schema and byte limits, authorization revision, expiry, effect, lease state, replay key, and retained receipt.
- Uses opaque callback references containing no answers, authorization, credentials, trusted bindings, or effects.
- Adds the registered `MessageInteractionHost` authority. Render preparation returns only the renderer-safe block, negotiated delivery, callback, expiry, profile ID, and an already-validated signed-hosted URL when selected. Canonical consume accepts restart-safe connector-authenticated actor/audience/agent/account/room bindings plus the provider receipt, while the original source-message binding remains host-retained, claims by provider inbound event ID, invokes only a host-owned effect handler, and persists the app-state result and audit receipt.
- Enforces fail-closed expiry, revocation, cross-actor/room/account/agent denial, provider mismatch/collision denial, receipt validation, replay, and crash/lease recovery.
- Implements a hardened single-host file adapter with 0600 files, no-follow and directory identity checks, same-filesystem atomic replace/fsync, cross-process locking and liveness recovery, corruption failure, and retention GC.
- Commits a deterministic capability matrix covering all production `registerMessageConnector` roots; Signal remains an explicit unsupported exclusion.

# Testing

Reviewer entry points:

1. `packages/agent/src/services/message-interaction-host.test.ts`
2. `packages/core/src/messaging/interactions/session-authority.test.ts`
3. `packages/agent/src/services/message-interaction-session-store.test.ts`
4. `packages/core/src/messaging/interactions/profile-matrix.test.ts`
5. `packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md`

Results at the exact head:

- Core interaction suite: 3 files, 104 tests passed.
- Agent host + store suites: 10 host tests and 10 file-store tests passed, including renderer-safe preparation, authenticated binding denial, expiry, revocation, completed replay exactly once, provider mismatch/collision, missing-handler lease recovery, cross-agent denial, secret-receipt rejection, resolver validation, 0600 persistence, independent-process contention, symlink denial, stale-lock recovery, and retention GC.
- `packages/core`: typecheck passed; Node/browser/edge/testing/declaration/package-consumer build passed.
- `packages/agent`: `build:dist` passed.
- Direct Biome check on changed TypeScript files passed.
- `bun run check:agents-claude`: 160 tracked pairs passed.

# Evidence Gate

<!-- evidence-head:af82262f6a55b402a21b470273c5377d08a532aa -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this lane provides the core/host authority; connector rendering is #24288.
<!-- evidence-row:backend-logs -->
- [x] Deterministic host/store test output exercises the registered prepare/consume/dispatch lifecycle and real 0600 filesystem artifacts; commands and counts are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or planning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [capability matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24363-CAPABILITY_MATRIX.md), whose content is unchanged by the host-authority commit; the exact-head matrix tests pass.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Known gaps / failures

- Deep review still holds this draft: conversational payload limits, atomic replay classification, complete registration-site inventory, PID-reuse-safe stale-lock ownership, and bounded reconciliation/retention for committed outcomes remain unresolved.

- Root `bun run verify` remains blocked by the repository i18n baseline outside this diff.
- Agent `bun run typecheck` traverses the workspace graph but reports existing missing optional dependencies plus Signal/OpenCode baseline errors; no diagnostic references a changed file. This PR therefore does not claim agent typecheck success.
- The file-backed service is a real single-host implementation. Distributed deployments still need a transactional implementation of the public store contract.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-goal-14-15/universal-interactions]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->


