### PR TITLE
fix(core): reject overlong posts without rewriting them

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -87,6 +87,10 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/sorted\s*\.slice\(0,\s*8\)/,
 		/room\.id\.slice\(0,\s*8\)/,
 	],
+	"packages/core/src/features/advanced-capabilities/actions/post.ts": [
+		/truncateWellFormed/,
+		/text\s*=\s*text\.slice\(/,
+	],
 	"packages/core/src/runtime/trajectory-recorder.ts": [
 		/resolveTrajectoryFieldCapBytes/,
 		/applyTrajectoryFieldCap/,

--- a/packages/core/src/features/advanced-capabilities/actions/post.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.test.ts
@@ -162,4 +162,47 @@ describe("POST trusted connector account routing", () => {
 		});
 		expect(postHandler).not.toHaveBeenCalled();
 	});
+
+	it("rejects an overlong post without truncating or dispatching it", async () => {
+		const postHandler = vi.fn(async () => undefined);
+		const runtime = {
+			agentId: "00000000-0000-0000-0000-000000000001",
+			logger: { debug() {}, info() {}, warn() {}, error() {} },
+			getPostConnectors: () => [
+				{
+					source: "bounded",
+					label: "Bounded feed",
+					capabilities: ["post"],
+					contexts: [],
+					contentShaping: { constraints: { maxLength: 12 } },
+					postHandler,
+				},
+			],
+		} as unknown as IAgentRuntime;
+		const message = {
+			id: "00000000-0000-0000-0000-0000000000aa",
+			roomId: "00000000-0000-0000-0000-0000000000bb",
+			entityId: "00000000-0000-0000-0000-0000000000cc",
+			agentId: runtime.agentId,
+			content: { text: "complete post with a required tail" },
+			createdAt: 1,
+		} as Memory;
+
+		const result = await postAction.handler(runtime, message, undefined, {
+			parameters: {
+				action: "send",
+				text: "complete post with a required tail",
+			},
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			data: {
+				error: "POST_CONTENT_TOO_LONG",
+				maxLength: 12,
+				actualLength: 34,
+			},
+		});
+		expect(postHandler).not.toHaveBeenCalled();
+	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/post.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.ts
@@ -26,10 +26,7 @@ import type {
 } from "../../../types/index.ts";
 import { ChannelType } from "../../../types/index.ts";
 import { hasActionContext } from "../../../utils/action-validation.ts";
-import {
-	toWellFormedUnicode,
-	truncateWellFormed,
-} from "../../../utils/well-formed.ts";
+import { toWellFormedUnicode } from "../../../utils/well-formed.ts";
 import { stringToUuid } from "../../../utils.ts";
 import {
 	boolParam,
@@ -200,16 +197,6 @@ function applyPostContentShaping(
 	const shaping = connector.contentShaping;
 	if (text && typeof shaping?.postProcess === "function") {
 		text = toWellFormedUnicode(shaping.postProcess(text));
-	}
-	const maxLength = shaping?.constraints?.maxLength;
-	if (
-		text &&
-		typeof maxLength === "number" &&
-		Number.isFinite(maxLength) &&
-		maxLength > 0 &&
-		text.length > maxLength
-	) {
-		text = truncateWellFormed(text, Math.max(0, Math.floor(maxLength)));
 	}
 	return text === content.text ? content : { ...content, text };
 }
@@ -399,6 +386,25 @@ async function handleSend(
 		selected.connector,
 		buildPostContent(params, selected.connector, message),
 	);
+	const maxLength = selected.connector.contentShaping?.constraints?.maxLength;
+	if (
+		typeof content.text === "string" &&
+		typeof maxLength === "number" &&
+		Number.isFinite(maxLength) &&
+		maxLength > 0 &&
+		content.text.length > maxLength
+	) {
+		return failure(
+			"send",
+			"POST_CONTENT_TOO_LONG",
+			`${selected.connector.label} accepts at most ${Math.floor(maxLength)} characters; the complete ${content.text.length}-character post was not sent.`,
+			{
+				source: selected.connector.source,
+				maxLength: Math.floor(maxLength),
+				actualLength: content.text.length,
+			},
+		);
+	}
 	if (!textParam(content.text) && !content.attachments?.length) {
 		return failure(
 			"send",


### PR DESCRIPTION
Progresses #24221. Follow-up to merged #24232 and the progressive-content contract in #24345.

## What changed

POST previously applied a connector `maxLength` by silently rewriting the model/user-authored post before dispatch. This patch preserves the complete value and fails before the connector effect with `POST_CONTENT_TOO_LONG`, including the connector limit and actual length. Nothing partial is dispatched.

The prompt-integrity source policy now prevents the truncation helper or an equivalent direct slice from returning to this action.

## Exact-head verification

Head: `3d88d7d6a0ad6bb8bf00d0f8bb6e3bd9fba7a013` on `origin/develop@5c1d3d604fdd0ce8a3ce7e95598c7407af14e0e3`.

- POST + prompt-integrity policy: 2 files / 12 tests passed after the final rebase;
- core typecheck passed on the immediately preceding equivalent patch head;
- changed-file Biome and `git diff --check` passed.

## Evidence

- UI screenshots/video: N/A — no rendered UI changed.
- Live-model trajectory: N/A — deterministic pre-dispatch admission is the changed contract.
- Domain evidence: regression proves an overlong complete value returns a typed failure and the connector handler is never called.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [prompt-truncation-audit]

<!-- evidence-head:3d88d7d6a0ad6bb8bf00d0f8bb6e3bd9fba7a013 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI flow changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic focused test output is summarized in the PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic pre-dispatch admission is the changed contract

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - regression proves typed rejection and zero connector dispatch

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text changed
