### PR TITLE
fix(voice): deliver APP launch browser handoffs

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1049,6 +1049,48 @@ describe("voice-session WS lifecycle", () => {
     expect(JSON.stringify(client.controlFrames)).not.toContain("not-forwarded");
   });
 
+  test("forwards a terminal APP launch through the originating Session turn trace", async () => {
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      fetchImpl: makeCanonicalChunkFetch(["Opened Demo."], {
+        actionResults: [
+          {
+            actionName: "APP",
+            success: true,
+            values: {
+              mode: "launch",
+              viewId: "browser",
+              viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+            },
+          },
+        ],
+      }),
+    });
+
+    const ink = FakeInkSocket.instances.at(-1)!;
+    ink.emitTurn("turn.start");
+    ink.emitTurn("turn.end", "launch demo");
+    await flush();
+    await flush();
+
+    const firstText = client.controlFrames.find(
+      (frame) => frame.t === "llm_first_text",
+    );
+    const navigation = client.controlFrames.filter(
+      (frame) => frame.t === "navigate_view",
+    );
+    expect(firstText).toBeDefined();
+    expect(navigation).toEqual([
+      {
+        t: "navigate_view",
+        viewId: "browser",
+        viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+        traceId: firstText?.traceId,
+      },
+    ]);
+  });
+
   test("prewarms Eliza tenancy context when the live session starts", async () => {
     let prewarmCalls = 0;
     const client = new FakeClientSocket();

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -31,6 +31,27 @@ function sseResponse(
   });
 }
 
+async function streamTerminalActionResult(actionResult: Record<string, unknown>) {
+  const fetchImpl = (async () =>
+    sseResponse([
+      `event: done\ndata: ${JSON.stringify({ actionResults: [actionResult] })}\n\n`,
+    ])) as unknown as typeof fetch;
+  return streamElizaConversation(
+    {
+      endpoint: "http://x",
+      authorization: "Bearer s",
+      model: "m",
+      transcript: "launch demo",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      traceId: "trace-app-navigation",
+      signal: new AbortController().signal,
+      fetchImpl,
+    },
+    () => {},
+  );
+}
+
 describe("eliza sse bridge", () => {
   test("decodes delta.content tokens and completes on [DONE]", async () => {
     const deltas: string[] = [];
@@ -758,6 +779,56 @@ describe("eliza sse bridge", () => {
         subview: "recent",
       },
     });
+  });
+
+  test("returns a successful APP launch handoff addressed to Browser", async () => {
+    await expect(
+      streamTerminalActionResult({
+        actionName: "APP",
+        success: true,
+        values: {
+          mode: "launch",
+          viewId: "browser",
+          viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+          subview: "preview",
+        },
+      }),
+    ).resolves.toEqual({
+      completed: true,
+      aborted: false,
+      viewHandoff: {
+        viewId: "browser",
+        viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+        subview: "preview",
+      },
+    });
+  });
+
+  test("rejects failed, wrong-mode, and non-Browser APP handoffs", async () => {
+    const rejected = [
+      {
+        actionName: "APP",
+        success: false,
+        values: { mode: "launch", viewId: "browser", viewPath: "/browser" },
+      },
+      {
+        actionName: "APP",
+        success: true,
+        values: { mode: "stop", viewId: "browser", viewPath: "/browser" },
+      },
+      {
+        actionName: "APP",
+        success: true,
+        values: { mode: "launch", viewId: "wallet", viewPath: "/wallet" },
+      },
+    ];
+
+    for (const actionResult of rejected) {
+      await expect(streamTerminalActionResult(actionResult)).resolves.toEqual({
+        completed: true,
+        aborted: false,
+      });
+    }
   });
 
   test("does not promote failed or malformed terminal action results", async () => {

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -650,12 +650,17 @@ function extractViewHandoff(payload: string): ElizaVoiceViewHandoff | null {
         : typeof data?.actionName === "string"
           ? data.actionName
           : null;
-    if (actionName?.toUpperCase() !== "VIEWS" || !isRecord(candidate.values)) {
+    if (!isRecord(candidate.values)) {
       continue;
     }
+    const normalizedActionName = actionName?.toUpperCase();
     const mode = readBoundedString(candidate.values.mode)?.toLowerCase();
     const viewId = readBoundedString(candidate.values.viewId);
-    if ((mode !== "show" && mode !== "open") || !viewId) continue;
+    if (!viewId) continue;
+    const isViewsHandoff = normalizedActionName === "VIEWS" && (mode === "show" || mode === "open");
+    const isAppBrowserHandoff =
+      normalizedActionName === "APP" && mode === "launch" && viewId === "browser";
+    if (!isViewsHandoff && !isAppBrowserHandoff) continue;
     const viewPath = readBoundedString(candidate.values.viewPath);
     const subview = readBoundedString(candidate.values.subview);
     return {


### PR DESCRIPTION
Closes #24359

## Summary

- accept successful terminal `APP` + `launch` handoffs only when addressed to the canonical `browser` view
- preserve the existing bounded `viewPath` and `subview` contract and reject failed, wrong-mode, and non-browser APP results
- prove the resulting `navigate_view` frame stays on the originating voice Session turn trace

## Verification

- `bun run --cwd packages/cloud/shared test -- src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts --no-coverage` — 28 passed
- `bun test packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts --timeout 120000 --reporter=dots --coverage-reporter=lcov` — 66 passed
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` — passed
- `git diff --check origin/develop...HEAD` — passed

## Exact tested revision

- head: `a7cbbfef146107dd87ac80e507979a627e35074f`
- merge-base: `df736d7730057b7c5ef88a37b421ffc352608be2`

## Explicit hold

- package-wide cloud-shared typecheck is locally environment-blocked in this sparse worktree by the incomplete shared dependency install (unrelated missing declared modules such as `@types/pg`, `drizzle-kit`, `uuid`, `ai`, and `viem`); hosted exact-head CI remains required. The focused extractor and full WS lifecycle suites above both pass.