### PR TITLE
fix(cloud): bind staging OAuth callbacks to release origin

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -2378,6 +2378,7 @@ jobs:
             node packages/cloud/scripts/verify-steward-oauth-callbacks.mjs \
               --base-url "$served_url" \
               --callback-url "$served_url/login" \
+              --environment "$DEPLOY_ENVIRONMENT" \
               --tenant-id "$tenant_id"
           done
 

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -18,6 +18,9 @@ const CONFIG = {
   tenantId: "elizacloud-staging",
 };
 
+const STAGING_CALLBACK_BASE_URL =
+  "https://api-staging.eliza.app/steward";
+
 let providerStateSequence = 0;
 
 function providerDestination(
@@ -33,7 +36,7 @@ function providerDestination(
   destination.searchParams.set("state", state);
   destination.searchParams.set(
     "redirect_uri",
-    `${CONFIG.baseUrl}/steward/auth/oauth/${provider}/callback`,
+    `${STAGING_CALLBACK_BASE_URL}/auth/oauth/${provider}/callback`,
   );
   return destination.toString();
 }
@@ -183,7 +186,7 @@ describe("Steward OAuth callback deployment probe", () => {
         },
       ),
     ).rejects.toThrow(
-      "expected https://staging.eliza.app/steward/auth/oauth/discord/callback",
+      "expected https://api-staging.eliza.app/steward/auth/oauth/discord/callback",
     );
   });
 
@@ -217,7 +220,7 @@ describe("Steward OAuth callback deployment probe", () => {
           }),
       }),
     ).rejects.toThrow(
-      "expected https://staging.eliza.app/steward/auth/oauth/discord/callback",
+      "expected https://api-staging.eliza.app/steward/auth/oauth/discord/callback",
     );
   });
 

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -14,16 +14,18 @@ import {
 const CONFIG = {
   baseUrl: "https://staging.eliza.app",
   callbackUrl: "https://staging.eliza.app/login",
+  environment: "staging",
   tenantId: "elizacloud-staging",
 };
 
 function providerDestination(provider: "discord" | "google"): string {
   const destination = new URL(
     provider === "discord"
-      ? "https://discord.com/oauth2/authorize"
+      ? "https://discord.com/api/oauth2/authorize"
       : "https://accounts.google.com/o/oauth2/v2/auth",
   );
   destination.searchParams.set("client_id", "public");
+  destination.searchParams.set("state", "0123456789abcdef0123456789abcdef");
   destination.searchParams.set(
     "redirect_uri",
     `${CONFIG.baseUrl}/steward/auth/oauth/${provider}/callback`,
@@ -75,7 +77,7 @@ describe("Steward OAuth callback deployment probe", () => {
     ).rejects.toThrow("HTTP 400");
   });
 
-  test("rejects a redirect to a non-provider host", async () => {
+  test("rejects a redirect to a non-provider destination", async () => {
     await expect(
       verifyStewardOAuthCallbacks(CONFIG, {
         fetchImpl: async () =>
@@ -84,27 +86,64 @@ describe("Steward OAuth callback deployment probe", () => {
             headers: { Location: "https://attacker.example/collect" },
           }),
       }),
-    ).rejects.toThrow("unexpected provider host");
+    ).rejects.toThrow("unexpected provider destination");
   });
+
+  test.each([
+    "https://discord.com:8443/api/oauth2/authorize?state=0123456789abcdef0123456789abcdef",
+    "https://discord.com/oauth2/authorize?state=0123456789abcdef0123456789abcdef",
+    "https://user@discord.com/api/oauth2/authorize?state=0123456789abcdef0123456789abcdef",
+  ])("rejects a non-canonical provider URL %s", async (location) => {
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: location },
+          }),
+      }),
+    ).rejects.toThrow("unexpected provider destination");
+  });
+
+  test.each([
+    "https://discord.com/api/oauth2/authorize",
+    "https://discord.com/api/oauth2/authorize?state=predictable",
+  ])(
+    "rejects a missing or malformed provider state in %s",
+    async (location) => {
+      await expect(
+        verifyStewardOAuthCallbacks(CONFIG, {
+          fetchImpl: async () =>
+            new Response(null, {
+              status: 302,
+              headers: { Location: location },
+            }),
+        }),
+      ).rejects.toThrow("invalid provider state");
+    },
+  );
 
   test("rejects an upstream callback bound to another environment", async () => {
     await expect(
-      verifyStewardOAuthCallbacks(CONFIG, {
-        fetchImpl: async (input: string | URL | Request) => {
-          const provider = String(input).includes("/discord/")
-            ? "discord"
-            : "google";
-          const destination = new URL(providerDestination(provider));
-          destination.searchParams.set(
-            "redirect_uri",
-            `https://api.eliza.app/steward/auth/oauth/${provider}/callback`,
-          );
-          return new Response(null, {
-            status: 302,
-            headers: { Location: destination.toString() },
-          });
+      verifyStewardOAuthCallbacks(
+        { ...CONFIG, tenantId: "renamed-staging-tenant" },
+        {
+          fetchImpl: async (input: string | URL | Request) => {
+            const provider = String(input).includes("/discord/")
+              ? "discord"
+              : "google";
+            const destination = new URL(providerDestination(provider));
+            destination.searchParams.set(
+              "redirect_uri",
+              `https://api.eliza.app/steward/auth/oauth/${provider}/callback`,
+            );
+            return new Response(null, {
+              status: 302,
+              headers: { Location: destination.toString() },
+            });
+          },
         },
-      }),
+      ),
     ).rejects.toThrow(
       "expected https://staging.eliza.app/steward/auth/oauth/discord/callback",
     );
@@ -116,7 +155,10 @@ describe("Steward OAuth callback deployment probe", () => {
         fetchImpl: async () =>
           new Response(null, {
             status: 302,
-            headers: { Location: "https://discord.com/oauth2/authorize" },
+            headers: {
+              Location:
+                "https://discord.com/api/oauth2/authorize?state=0123456789abcdef0123456789abcdef",
+            },
           }),
       }),
     ).rejects.toThrow("used no redirect_uri");
@@ -124,8 +166,9 @@ describe("Steward OAuth callback deployment probe", () => {
 
   test("preserves the established production direct-callback contract", async () => {
     const productionConfig = {
-      baseUrl: "https://api.eliza.app",
+      baseUrl: "https://eliza.app",
       callbackUrl: "https://eliza.app/login",
+      environment: "production",
       tenantId: "elizacloud",
     };
     const results = await verifyStewardOAuthCallbacks(productionConfig, {
@@ -158,6 +201,8 @@ describe("Steward OAuth callback deployment probe", () => {
         "http://staging.eliza.app",
         "--callback-url",
         CONFIG.callbackUrl,
+        "--environment",
+        CONFIG.environment,
         "--tenant-id",
         CONFIG.tenantId,
       ]),
@@ -165,7 +210,61 @@ describe("Steward OAuth callback deployment probe", () => {
     expect(() => parseStewardCallbackProbeArgs([])).toThrow(
       "--base-url is required",
     );
+    expect(() =>
+      parseStewardCallbackProbeArgs([
+        "--base-url",
+        CONFIG.baseUrl,
+        "--callback-url",
+        CONFIG.callbackUrl,
+        "--environment",
+        "preview",
+        "--tenant-id",
+        CONFIG.tenantId,
+      ]),
+    ).toThrow("--environment must be staging or production");
   });
+
+  test("binds the browser callback to the probed release origin", () => {
+    expect(() =>
+      parseStewardCallbackProbeArgs([
+        "--base-url",
+        CONFIG.baseUrl,
+        "--callback-url",
+        "https://attacker.example/login",
+        "--environment",
+        CONFIG.environment,
+        "--tenant-id",
+        CONFIG.tenantId,
+      ]),
+    ).toThrow("--callback-url must use the --base-url origin");
+  });
+
+  test.each([
+    ["https://staging.eliza.app/path", CONFIG.callbackUrl],
+    [
+      CONFIG.baseUrl,
+      "https://staging.eliza.app/login?next=https://attacker.example",
+    ],
+    [CONFIG.baseUrl, "https://user@staging.eliza.app/login"],
+  ])(
+    "rejects non-canonical release URLs base=%s callback=%s",
+    (baseUrl, callbackUrl) => {
+      expect(() =>
+        parseStewardCallbackProbeArgs([
+          "--base-url",
+          baseUrl,
+          "--callback-url",
+          callbackUrl,
+          "--environment",
+          CONFIG.environment,
+          "--tenant-id",
+          CONFIG.tenantId,
+        ]),
+      ).toThrow(
+        /must be an HTTPS origin|must be the canonical HTTPS \/login URL/,
+      );
+    },
+  );
 });
 
 describe("Steward wallet-origin deployment probe", () => {
@@ -254,6 +353,8 @@ describe("Steward deployment probe CLI composition", () => {
     CONFIG.baseUrl,
     "--callback-url",
     CONFIG.callbackUrl,
+    "--environment",
+    CONFIG.environment,
     "--tenant-id",
     CONFIG.tenantId,
   ];

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -17,6 +17,20 @@ const CONFIG = {
   tenantId: "elizacloud-staging",
 };
 
+function providerDestination(provider: "discord" | "google"): string {
+  const destination = new URL(
+    provider === "discord"
+      ? "https://discord.com/oauth2/authorize"
+      : "https://accounts.google.com/o/oauth2/v2/auth",
+  );
+  destination.searchParams.set("client_id", "public");
+  destination.searchParams.set(
+    "redirect_uri",
+    `${CONFIG.baseUrl}/steward/auth/oauth/${provider}/callback`,
+  );
+  return destination.toString();
+}
+
 describe("Steward OAuth callback deployment probe", () => {
   test("proves both provider handoffs use the exact canonical callback", async () => {
     const requested: URL[] = [];
@@ -30,10 +44,7 @@ describe("Steward OAuth callback deployment probe", () => {
         return new Response(null, {
           status: 302,
           headers: {
-            Location:
-              provider === "discord"
-                ? "https://discord.com/oauth2/authorize?client_id=public"
-                : "https://accounts.google.com/o/oauth2/v2/auth?client_id=public",
+            Location: providerDestination(provider),
           },
         });
       },
@@ -74,6 +85,70 @@ describe("Steward OAuth callback deployment probe", () => {
           }),
       }),
     ).rejects.toThrow("unexpected provider host");
+  });
+
+  test("rejects an upstream callback bound to another environment", async () => {
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async (input: string | URL | Request) => {
+          const provider = String(input).includes("/discord/")
+            ? "discord"
+            : "google";
+          const destination = new URL(providerDestination(provider));
+          destination.searchParams.set(
+            "redirect_uri",
+            `https://api.eliza.app/steward/auth/oauth/${provider}/callback`,
+          );
+          return new Response(null, {
+            status: 302,
+            headers: { Location: destination.toString() },
+          });
+        },
+      }),
+    ).rejects.toThrow(
+      "expected https://staging.eliza.app/steward/auth/oauth/discord/callback",
+    );
+  });
+
+  test("rejects a provider redirect with no callback URI", async () => {
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: "https://discord.com/oauth2/authorize" },
+          }),
+      }),
+    ).rejects.toThrow("used no redirect_uri");
+  });
+
+  test("preserves the established production direct-callback contract", async () => {
+    const productionConfig = {
+      baseUrl: "https://api.eliza.app",
+      callbackUrl: "https://eliza.app/login",
+      tenantId: "elizacloud",
+    };
+    const results = await verifyStewardOAuthCallbacks(productionConfig, {
+      fetchImpl: async (input: string | URL | Request) => {
+        const provider = String(input).includes("/discord/")
+          ? "discord"
+          : "google";
+        const destination = new URL(providerDestination(provider));
+        destination.searchParams.set(
+          "redirect_uri",
+          `https://eliza.steward.fi/auth/oauth/${provider}/callback`,
+        );
+        return new Response(null, {
+          status: 302,
+          headers: { Location: destination.toString() },
+        });
+      },
+    });
+
+    expect(results).toEqual([
+      { provider: "discord", destinationHostname: "discord.com" },
+      { provider: "google", destinationHostname: "accounts.google.com" },
+    ]);
   });
 
   test("requires HTTPS and all three deployment-owned inputs", () => {
@@ -193,9 +268,9 @@ describe("Steward deployment probe CLI composition", () => {
         if (url.endsWith("/steward/auth/nonce")) {
           return Response.json({ nonce: "Tk9iR2buAPsSuxF0T" });
         }
-        const destination = url.includes("/discord/")
-          ? "https://discord.com/oauth2/authorize"
-          : "https://accounts.google.com/o/oauth2/v2/auth";
+        const destination = providerDestination(
+          url.includes("/discord/") ? "discord" : "google",
+        );
         return new Response(null, {
           status: 302,
           headers: { Location: destination },
@@ -221,9 +296,9 @@ describe("Steward deployment probe CLI composition", () => {
           if (url.endsWith("/steward/auth/nonce")) {
             return Response.json({ error: "origin rejected" }, { status: 400 });
           }
-          const destination = url.includes("/discord/")
-            ? "https://discord.com/oauth2/authorize"
-            : "https://accounts.google.com/o/oauth2/v2/auth";
+          const destination = providerDestination(
+            url.includes("/discord/") ? "discord" : "google",
+          );
           return new Response(null, {
             status: 302,
             headers: { Location: destination },

--- a/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-steward-oauth-callbacks.test.ts
@@ -18,14 +18,19 @@ const CONFIG = {
   tenantId: "elizacloud-staging",
 };
 
-function providerDestination(provider: "discord" | "google"): string {
+let providerStateSequence = 0;
+
+function providerDestination(
+  provider: "discord" | "google",
+  state = (++providerStateSequence).toString(16).padStart(32, "0"),
+): string {
   const destination = new URL(
     provider === "discord"
       ? "https://discord.com/api/oauth2/authorize"
       : "https://accounts.google.com/o/oauth2/v2/auth",
   );
   destination.searchParams.set("client_id", "public");
-  destination.searchParams.set("state", "0123456789abcdef0123456789abcdef");
+  destination.searchParams.set("state", state);
   destination.searchParams.set(
     "redirect_uri",
     `${CONFIG.baseUrl}/steward/auth/oauth/${provider}/callback`,
@@ -56,7 +61,7 @@ describe("Steward OAuth callback deployment probe", () => {
       { provider: "discord", destinationHostname: "discord.com" },
       { provider: "google", destinationHostname: "accounts.google.com" },
     ]);
-    expect(requested).toHaveLength(2);
+    expect(requested).toHaveLength(4);
     for (const url of requested) {
       expect(url.origin).toBe(CONFIG.baseUrl);
       expect(url.searchParams.get("tenant_id")).toBe(CONFIG.tenantId);
@@ -123,6 +128,39 @@ describe("Steward OAuth callback deployment probe", () => {
     },
   );
 
+  test("rejects a valid-looking provider state reused across launches", async () => {
+    const staticDestination = providerDestination(
+      "discord",
+      "0123456789abcdef0123456789abcdef",
+    );
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: staticDestination },
+          }),
+      }),
+    ).rejects.toThrow("reused provider state across independent launches");
+  });
+
+  test("rejects ambiguous duplicate provider state parameters", async () => {
+    const destination = new URL(providerDestination("discord"));
+    destination.searchParams.append(
+      "state",
+      "fedcba9876543210fedcba9876543210",
+    );
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: destination.toString() },
+          }),
+      }),
+    ).rejects.toThrow("invalid provider state");
+  });
+
   test("rejects an upstream callback bound to another environment", async () => {
     await expect(
       verifyStewardOAuthCallbacks(
@@ -164,6 +202,25 @@ describe("Steward OAuth callback deployment probe", () => {
     ).rejects.toThrow("used no redirect_uri");
   });
 
+  test("rejects ambiguous duplicate callback parameters", async () => {
+    const destination = new URL(providerDestination("discord"));
+    destination.searchParams.append(
+      "redirect_uri",
+      "https://attacker.example/oauth/callback",
+    );
+    await expect(
+      verifyStewardOAuthCallbacks(CONFIG, {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: destination.toString() },
+          }),
+      }),
+    ).rejects.toThrow(
+      "expected https://staging.eliza.app/steward/auth/oauth/discord/callback",
+    );
+  });
+
   test("preserves the established production direct-callback contract", async () => {
     const productionConfig = {
       baseUrl: "https://eliza.app",
@@ -193,6 +250,39 @@ describe("Steward OAuth callback deployment probe", () => {
       { provider: "google", destinationHostname: "accounts.google.com" },
     ]);
   });
+
+  test.each([undefined, "https://attacker.example/oauth/callback"])(
+    "rejects a production provider redirect with callback %s",
+    async (redirectUri) => {
+      const productionConfig = {
+        baseUrl: "https://eliza.app",
+        callbackUrl: "https://eliza.app/login",
+        environment: "production",
+        tenantId: "elizacloud",
+      };
+      await expect(
+        verifyStewardOAuthCallbacks(productionConfig, {
+          fetchImpl: async (input: string | URL | Request) => {
+            const provider = String(input).includes("/discord/")
+              ? "discord"
+              : "google";
+            const destination = new URL(providerDestination(provider));
+            if (redirectUri === undefined) {
+              destination.searchParams.delete("redirect_uri");
+            } else {
+              destination.searchParams.set("redirect_uri", redirectUri);
+            }
+            return new Response(null, {
+              status: 302,
+              headers: { Location: destination.toString() },
+            });
+          },
+        }),
+      ).rejects.toThrow(
+        `expected https://eliza.steward.fi/auth/oauth/discord/callback`,
+      );
+    },
+  );
 
   test("requires HTTPS and all three deployment-owned inputs", () => {
     expect(() =>
@@ -380,7 +470,7 @@ describe("Steward deployment probe CLI composition", () => {
       log: (message: string) => logs.push(message),
     });
 
-    expect(requested).toHaveLength(3);
+    expect(requested).toHaveLength(5);
     expect(requested.at(-1)).toBe(`${CONFIG.baseUrl}/steward/auth/nonce`);
     expect(logs).toEqual([
       "Verified discord canonical callback via discord.com.",

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -10,9 +10,18 @@ import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 const PROVIDER_DESTINATIONS = Object.freeze({
-  discord: "discord.com",
-  google: "accounts.google.com",
+  discord: {
+    origin: "https://discord.com",
+    pathname: "/api/oauth2/authorize",
+  },
+  google: {
+    origin: "https://accounts.google.com",
+    pathname: "/o/oauth2/v2/auth",
+  },
 });
+
+const DEPLOY_ENVIRONMENTS = new Set(["staging", "production"]);
+const OAUTH_STATE_PATTERN = /^[0-9a-f]{32}$/;
 
 // ERC-4361 defines a SIWE nonce as at least eight ASCII alphanumeric
 // characters. Steward shares this nonce across its SIWE and SIWS launch paths,
@@ -27,6 +36,15 @@ function requiredUrl(value, flag) {
     throw new Error(`${flag} must use https`);
   }
   return url;
+}
+
+function requiredEnvironment(value) {
+  const environment = value?.trim().toLowerCase();
+  if (!environment) throw new Error("--environment is required");
+  if (!DEPLOY_ENVIRONMENTS.has(environment)) {
+    throw new Error("--environment must be staging or production");
+  }
+  return environment;
 }
 
 export function parseStewardCallbackProbeArgs(argv) {
@@ -45,12 +63,35 @@ export function parseStewardCallbackProbeArgs(argv) {
     values.get("--callback-url"),
     "--callback-url",
   );
+  if (
+    baseUrl.username ||
+    baseUrl.password ||
+    baseUrl.pathname !== "/" ||
+    baseUrl.search ||
+    baseUrl.hash
+  ) {
+    throw new Error("--base-url must be an HTTPS origin");
+  }
+  if (
+    callbackUrl.username ||
+    callbackUrl.password ||
+    callbackUrl.pathname !== "/login" ||
+    callbackUrl.search ||
+    callbackUrl.hash
+  ) {
+    throw new Error("--callback-url must be the canonical HTTPS /login URL");
+  }
   const tenantId = values.get("--tenant-id")?.trim();
   if (!tenantId) throw new Error("--tenant-id is required");
+  const environment = requiredEnvironment(values.get("--environment"));
+  if (callbackUrl.origin !== baseUrl.origin) {
+    throw new Error("--callback-url must use the --base-url origin");
+  }
 
   return {
     baseUrl: baseUrl.origin,
     callbackUrl: callbackUrl.toString(),
+    environment,
     tenantId,
   };
 }
@@ -62,11 +103,11 @@ function pkceChallenge() {
 }
 
 export async function verifyStewardOAuthCallbacks(
-  { baseUrl, callbackUrl, tenantId },
+  { baseUrl, callbackUrl, environment, tenantId },
   { fetchImpl = fetch } = {},
 ) {
   const results = [];
-  for (const [provider, expectedHostname] of Object.entries(
+  for (const [provider, expectedDestination] of Object.entries(
     PROVIDER_DESTINATIONS,
   )) {
     const query = new URLSearchParams({
@@ -88,17 +129,26 @@ export async function verifyStewardOAuthCallbacks(
 
     const destination = new URL(location);
     if (
-      destination.protocol !== "https:" ||
-      destination.hostname !== expectedHostname
+      destination.origin !== expectedDestination.origin ||
+      destination.pathname !== expectedDestination.pathname ||
+      destination.username !== "" ||
+      destination.password !== "" ||
+      destination.hash !== ""
     ) {
       throw new Error(
-        `${provider} callback probe reached unexpected provider host ${destination.hostname}`,
+        `${provider} callback probe reached unexpected provider destination ${destination.origin}${destination.pathname}`,
+      );
+    }
+    const providerState = destination.searchParams.get("state");
+    if (!providerState || !OAUTH_STATE_PATTERN.test(providerState)) {
+      throw new Error(
+        `${provider} callback probe returned an invalid provider state`,
       );
     }
     // Staging owns a separate challenge store, so a provider callback that
     // escapes to the legacy production Steward host cannot consume its state.
     // Production keeps its established direct callback contract unchanged.
-    if (tenantId.toLowerCase().endsWith("-staging")) {
+    if (environment === "staging") {
       const expectedProviderCallback = `${baseUrl}/steward/auth/oauth/${encodeURIComponent(provider)}/callback`;
       const actualProviderCallback =
         destination.searchParams.get("redirect_uri");

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -8,8 +8,6 @@
 
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
-import { CANONICAL_STEWARD_UPSTREAM_URLS } from "./verify-steward-upstream-binding.mjs";
-
 const PROVIDER_DESTINATIONS = Object.freeze({
   discord: {
     origin: "https://discord.com",
@@ -19,6 +17,15 @@ const PROVIDER_DESTINATIONS = Object.freeze({
     origin: "https://accounts.google.com",
     pathname: "/o/oauth2/v2/auth",
   },
+});
+
+// Provider callbacks terminate on the public Steward API authority, not on
+// either browser host. Both staging browser hosts share the isolated staging
+// challenge store through api-staging.eliza.app; production retains the
+// established direct Steward callback.
+const CANONICAL_STEWARD_CALLBACK_BASE_URLS = Object.freeze({
+  staging: "https://api-staging.eliza.app/steward",
+  production: "https://eliza.steward.fi",
 });
 
 const DEPLOY_ENVIRONMENTS = new Set(["staging", "production"]);
@@ -156,13 +163,8 @@ export async function verifyStewardOAuthCallbacks(
       }
       launchStates.add(providerState);
 
-      // Staging terminates the provider callback at the release origin because
-      // its challenge store is isolated there. Production retains the
-      // established direct callback on the canonical Steward upstream.
-      const expectedProviderCallback =
-        deployEnvironment === "staging"
-          ? `${baseUrl}/steward/auth/oauth/${encodeURIComponent(provider)}/callback`
-          : `${CANONICAL_STEWARD_UPSTREAM_URLS.production}/auth/oauth/${encodeURIComponent(provider)}/callback`;
+      const callbackBaseUrl = CANONICAL_STEWARD_CALLBACK_BASE_URLS[deployEnvironment];
+      const expectedProviderCallback = `${callbackBaseUrl}/auth/oauth/${encodeURIComponent(provider)}/callback`;
       const providerCallbacks = destination.searchParams.getAll("redirect_uri");
       const actualProviderCallback = providerCallbacks[0];
       if (

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -95,6 +95,19 @@ export async function verifyStewardOAuthCallbacks(
         `${provider} callback probe reached unexpected provider host ${destination.hostname}`,
       );
     }
+    // Staging owns a separate challenge store, so a provider callback that
+    // escapes to the legacy production Steward host cannot consume its state.
+    // Production keeps its established direct callback contract unchanged.
+    if (tenantId.toLowerCase().endsWith("-staging")) {
+      const expectedProviderCallback = `${baseUrl}/steward/auth/oauth/${encodeURIComponent(provider)}/callback`;
+      const actualProviderCallback =
+        destination.searchParams.get("redirect_uri");
+      if (actualProviderCallback !== expectedProviderCallback) {
+        throw new Error(
+          `${provider} callback probe used ${actualProviderCallback ?? "no redirect_uri"}; expected ${expectedProviderCallback}`,
+        );
+      }
+    }
     results.push({ provider, destinationHostname: destination.hostname });
   }
   return results;

--- a/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
+++ b/packages/cloud/scripts/verify-steward-oauth-callbacks.mjs
@@ -8,6 +8,7 @@
 
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
+import { CANONICAL_STEWARD_UPSTREAM_URLS } from "./verify-steward-upstream-binding.mjs";
 
 const PROVIDER_DESTINATIONS = Object.freeze({
   discord: {
@@ -106,59 +107,82 @@ export async function verifyStewardOAuthCallbacks(
   { baseUrl, callbackUrl, environment, tenantId },
   { fetchImpl = fetch } = {},
 ) {
+  const deployEnvironment = requiredEnvironment(environment);
   const results = [];
   for (const [provider, expectedDestination] of Object.entries(
     PROVIDER_DESTINATIONS,
   )) {
-    const query = new URLSearchParams({
-      tenant_id: tenantId,
-      redirect_uri: callbackUrl,
-      code_challenge: pkceChallenge(),
-      code_challenge_method: "S256",
-      state: "canonical-callback-deploy-probe",
-    });
-    const endpoint = `${baseUrl}/steward/auth/oauth/${provider}/authorize?${query}`;
-    const response = await fetchImpl(endpoint, { redirect: "manual" });
-    const location = response.headers.get("location");
+    const launchStates = new Set();
+    for (let launch = 0; launch < 2; launch += 1) {
+      const query = new URLSearchParams({
+        tenant_id: tenantId,
+        redirect_uri: callbackUrl,
+        code_challenge: pkceChallenge(),
+        code_challenge_method: "S256",
+        state: "canonical-callback-deploy-probe",
+      });
+      const endpoint = `${baseUrl}/steward/auth/oauth/${provider}/authorize?${query}`;
+      const response = await fetchImpl(endpoint, { redirect: "manual" });
+      const location = response.headers.get("location");
 
-    if (response.status !== 302 || !location) {
-      throw new Error(
-        `${provider} callback probe returned HTTP ${response.status}; expected a provider redirect`,
-      );
-    }
+      if (response.status !== 302 || !location) {
+        throw new Error(
+          `${provider} callback probe returned HTTP ${response.status}; expected a provider redirect`,
+        );
+      }
 
-    const destination = new URL(location);
-    if (
-      destination.origin !== expectedDestination.origin ||
-      destination.pathname !== expectedDestination.pathname ||
-      destination.username !== "" ||
-      destination.password !== "" ||
-      destination.hash !== ""
-    ) {
-      throw new Error(
-        `${provider} callback probe reached unexpected provider destination ${destination.origin}${destination.pathname}`,
-      );
-    }
-    const providerState = destination.searchParams.get("state");
-    if (!providerState || !OAUTH_STATE_PATTERN.test(providerState)) {
-      throw new Error(
-        `${provider} callback probe returned an invalid provider state`,
-      );
-    }
-    // Staging owns a separate challenge store, so a provider callback that
-    // escapes to the legacy production Steward host cannot consume its state.
-    // Production keeps its established direct callback contract unchanged.
-    if (environment === "staging") {
-      const expectedProviderCallback = `${baseUrl}/steward/auth/oauth/${encodeURIComponent(provider)}/callback`;
-      const actualProviderCallback =
-        destination.searchParams.get("redirect_uri");
-      if (actualProviderCallback !== expectedProviderCallback) {
+      const destination = new URL(location);
+      if (
+        destination.origin !== expectedDestination.origin ||
+        destination.pathname !== expectedDestination.pathname ||
+        destination.username !== "" ||
+        destination.password !== "" ||
+        destination.hash !== ""
+      ) {
+        throw new Error(
+          `${provider} callback probe reached unexpected provider destination ${destination.origin}${destination.pathname}`,
+        );
+      }
+      const providerStates = destination.searchParams.getAll("state");
+      const providerState = providerStates[0];
+      if (
+        providerStates.length !== 1 ||
+        !providerState ||
+        !OAUTH_STATE_PATTERN.test(providerState)
+      ) {
+        throw new Error(
+          `${provider} callback probe returned an invalid provider state`,
+        );
+      }
+      launchStates.add(providerState);
+
+      // Staging terminates the provider callback at the release origin because
+      // its challenge store is isolated there. Production retains the
+      // established direct callback on the canonical Steward upstream.
+      const expectedProviderCallback =
+        deployEnvironment === "staging"
+          ? `${baseUrl}/steward/auth/oauth/${encodeURIComponent(provider)}/callback`
+          : `${CANONICAL_STEWARD_UPSTREAM_URLS.production}/auth/oauth/${encodeURIComponent(provider)}/callback`;
+      const providerCallbacks = destination.searchParams.getAll("redirect_uri");
+      const actualProviderCallback = providerCallbacks[0];
+      if (
+        providerCallbacks.length !== 1 ||
+        actualProviderCallback !== expectedProviderCallback
+      ) {
         throw new Error(
           `${provider} callback probe used ${actualProviderCallback ?? "no redirect_uri"}; expected ${expectedProviderCallback}`,
         );
       }
     }
-    results.push({ provider, destinationHostname: destination.hostname });
+    if (launchStates.size !== 2) {
+      throw new Error(
+        `${provider} callback probe reused provider state across independent launches`,
+      );
+    }
+    results.push({
+      provider,
+      destinationHostname: new URL(expectedDestination.origin).hostname,
+    });
   }
   return results;
 }


### PR DESCRIPTION
## Summary

- fail the Cloud release callback probe when a Steward provider redirect crosses environment callback authority
- bind the expected provider callback to the canonical staging API or established production Steward authority
- require exact provider authorization endpoints, fresh provider CSRF state, and exactly one `state` / `redirect_uri`
- reject non-canonical or cross-origin browser callback inputs

## Why

Staging owns a separate Steward challenge store. Its provider callbacks terminate at `https://api-staging.eliza.app/steward/auth/oauth/:provider/callback`, shared by both staging browser hosts. Production retains the established direct `https://eliza.steward.fi/auth/oauth/:provider/callback` contract. The verifier now proves the actual hosted contract instead of encoding a browser-origin callback that the deployed service never emits.

## Exact-head evidence

Validated head: `0604433df17e35c788de6bcd32faa9eaf2443ac6`
Validated base at review repair: `c97833f1c53332af08d53bbf0cc029ec05d1bb42`

- focused callback verifier: 33 pass, 0 fail, 57 expectations
- Biome over both changed script/test files: pass
- `git diff --check`: pass
- live nonmutating staging probes: `staging.eliza.app` and `cloud-staging.eliza.app` both passed Discord, Google, and wallet nonce checks
- live nonmutating production probes: `eliza.app` and `cloud.eliza.app` both passed Discord, Google, and wallet nonce checks
- provider redirects were not followed; no login/session/provider mutation occurred
- broader cloud deployment contract remains 21 pass / 1 unrelated pre-existing failure because current develop uses Wrangler 4.116.0 while that test still asserts 4.100.0

## Evidence matrix

- UI screenshots: N/A — no rendered UI change
- Video: N/A — no rendered UI change
- Browser console/network: N/A — deploy verifier and direct HTTP probes only
- Backend evidence: all four canonical served-host probes passed at exact head
- Production mutation: none; production probes stopped at provider redirects / public wallet nonce

## Rollback

Revert commit `0604433df17e35c788de6bcd32faa9eaf2443ac6` plus the earlier commits on this branch. No data, secret, provider, or deployment rollback is required.

Related operator/auth tracking: #18627 and #24390. @lalalune
