### PR TITLE
fix(plugin-vision): fall back from a non-finite or negative screen-capture interval

### DIFF
--- a/plugins/plugin-vision/src/capture-interval.test.ts
+++ b/plugins/plugin-vision/src/capture-interval.test.ts
@@ -48,6 +48,12 @@ describe("resolveCaptureIntervalMs", () => {
     expectInvalid("-5");
   });
 
+  it("rejects positive sub-millisecond values that Node clamps to 1ms", () => {
+    expectInvalid("0.5");
+    expectInvalid("0.999");
+    expect(resolveCaptureIntervalMs("1", DEFAULT, NAME)).toBe(1);
+  });
+
   it("rejects a non-numeric configured value rather than substituting the default", () => {
     // The distinction that matters: absent is a default, configured-and-wrong
     // is a mistake the operator needs to see.
@@ -98,6 +104,19 @@ describe("VisionService config wiring", () => {
         }
       ).visionConfig.screenCaptureInterval,
     ).toBe(750);
+  });
+
+  it("attributes an invalid legacy alias to the alias setting", () => {
+    expect(() =>
+      serviceWith({ VISION_SCREEN_CAPTURE_INTERVAL: "abc" }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "VISION_CAPTURE_INTERVAL_INVALID",
+        context: expect.objectContaining({
+          settingName: "VISION_SCREEN_CAPTURE_INTERVAL",
+        }),
+      }),
+    );
   });
 
   it("refuses to construct — and so arms no timer — on an invalid configured interval", () => {

--- a/plugins/plugin-vision/src/capture-interval.test.ts
+++ b/plugins/plugin-vision/src/capture-interval.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Capture-interval setting resolution.
+ *
+ * `screenCaptureInterval` is passed straight to `setInterval`. Node clamps any
+ * delay that is non-finite, <= 0, or above the 32-bit signed maximum to 1ms, so
+ * a value that slips through becomes a screen-capture busy loop. An absent
+ * setting takes the documented default; an explicitly configured value that
+ * cannot be honoured is an operator mistake and fails loudly.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveCaptureIntervalMs, VisionService } from "./service";
+
+/** Assert the call throws the typed config error, checked by `code`. */
+function expectInvalid(raw: string): void {
+  expect(() => resolveCaptureIntervalMs(raw, DEFAULT, NAME)).toThrowError(
+    expect.objectContaining({ code: "VISION_CAPTURE_INTERVAL_INVALID" }),
+  );
+}
+
+const DEFAULT = 2000;
+const MAX_TIMER = 2_147_483_647;
+const NAME = "SCREEN_CAPTURE_INTERVAL";
+
+describe("resolveCaptureIntervalMs", () => {
+  it("uses the documented default when the setting is absent or blank", () => {
+    expect(resolveCaptureIntervalMs(undefined, DEFAULT, NAME)).toBe(DEFAULT);
+    expect(resolveCaptureIntervalMs("   ", DEFAULT, NAME)).toBe(DEFAULT);
+  });
+
+  it("accepts the exact timer maximum", () => {
+    expect(resolveCaptureIntervalMs(String(MAX_TIMER), DEFAULT, NAME)).toBe(
+      MAX_TIMER,
+    );
+  });
+
+  it("rejects one millisecond above the timer maximum", () => {
+    // Node clamps this to 1ms (TimeoutOverflowWarning), recreating the busy
+    // loop this guard exists to prevent.
+    expectInvalid(String(MAX_TIMER + 1));
+  });
+
+  it("rejects an exponent form that exceeds the timer maximum", () => {
+    expectInvalid("1e10");
+  });
+
+  it("rejects Infinity and negative values, which Node also clamps to 1ms", () => {
+    expectInvalid("Infinity");
+    expectInvalid("-5");
+  });
+
+  it("rejects a non-numeric configured value rather than substituting the default", () => {
+    // The distinction that matters: absent is a default, configured-and-wrong
+    // is a mistake the operator needs to see.
+    expectInvalid("abc");
+  });
+
+  it("accepts a valid interval, including a fractional millisecond", () => {
+    expect(resolveCaptureIntervalMs("500", DEFAULT, NAME)).toBe(500);
+    expect(resolveCaptureIntervalMs("1500.5", DEFAULT, NAME)).toBe(1500.5);
+  });
+});
+
+describe("VisionService config wiring", () => {
+  function serviceWith(settings: Record<string, string>) {
+    const runtime = {
+      getSetting: (key: string) => settings[key],
+      character: { name: "test", settings: {} },
+      getService: () => null,
+    } as unknown as ConstructorParameters<typeof VisionService>[0];
+    return new VisionService(runtime);
+  }
+
+  it("preserves existing alias precedence for a whitespace-only primary", () => {
+    // Documented as a deliberate no-change: `getSettingString` returns the
+    // whitespace string, which is truthy, so `||` does NOT reach the alias —
+    // and `Number("   ")` is 0, which the old code turned into the default.
+    // This PR keeps that exact outcome rather than silently widening alias
+    // precedence while fixing a timer bug.
+    const service = serviceWith({
+      SCREEN_CAPTURE_INTERVAL: "   ",
+      VISION_SCREEN_CAPTURE_INTERVAL: "750",
+    });
+    expect(
+      (
+        service as unknown as {
+          visionConfig: { screenCaptureInterval: number };
+        }
+      ).visionConfig.screenCaptureInterval,
+    ).toBe(2000);
+  });
+
+  it("uses a valid legacy alias when the primary is entirely absent", () => {
+    const service = serviceWith({ VISION_SCREEN_CAPTURE_INTERVAL: "750" });
+    expect(
+      (
+        service as unknown as {
+          visionConfig: { screenCaptureInterval: number };
+        }
+      ).visionConfig.screenCaptureInterval,
+    ).toBe(750);
+  });
+
+  it("refuses to construct — and so arms no timer — on an invalid configured interval", () => {
+    expect(() =>
+      serviceWith({ SCREEN_CAPTURE_INTERVAL: "Infinity" }),
+    ).toThrow();
+  });
+});

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -217,6 +217,7 @@ interface CameraDevice {
 
 /** Node clamps a `setInterval` delay above this to 1ms, so it is the real ceiling. */
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const DEFAULT_SCREEN_CAPTURE_INTERVAL_MS = 2_000;
 
 /**
  * Resolve a capture-interval setting that is passed directly to `setInterval`.
@@ -228,8 +229,9 @@ const MAX_TIMER_DELAY_MS = 2_147_483_647;
  *     default would hide it
  *   - valid            -> the configured number
  *
- * "Invalid" is anything Node cannot use as a timer delay: non-finite, <= 0, or
- * above `MAX_TIMER_DELAY_MS`. Node clamps ALL of those to 1ms
+ * "Invalid" is anything Node cannot use as the requested timer delay:
+ * non-finite, below 1ms, or above `MAX_TIMER_DELAY_MS`. Node clamps ALL of
+ * those out-of-range values to 1ms
  * (`TimeoutOverflowWarning` / `TimeoutNegativeWarning`), turning a mistyped
  * interval into a capture busy-loop rather than a slower cadence.
  */
@@ -240,9 +242,9 @@ export function resolveCaptureIntervalMs(
 ): number {
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TIMER_DELAY_MS) {
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > MAX_TIMER_DELAY_MS) {
     throw new ElizaError(
-      `${settingName} must be a positive number of milliseconds no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+      `${settingName} must be at least 1 millisecond and no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
       {
         code: "VISION_CAPTURE_INTERVAL_INVALID",
         context: { settingName, raw, maxMs: MAX_TIMER_DELAY_MS },
@@ -251,7 +253,6 @@ export function resolveCaptureIntervalMs(
   }
   return parsed;
 }
-
 
 export class VisionService extends Service {
   static override serviceType: ServiceTypeName =
@@ -330,7 +331,7 @@ export class VisionService extends Service {
     tfChangeThreshold: 10, // 10% change triggers TF update
     vlmChangeThreshold: 50, // 50% change triggers VLM update
     visionMode: VisionMode.OFF, // Capture requires explicit activation
-    screenCaptureInterval: 2000, // Screen capture every 2 seconds
+    screenCaptureInterval: DEFAULT_SCREEN_CAPTURE_INTERVAL_MS,
     tileSize: 256,
     tileProcessingOrder: "priority",
     ocrEnabled: true,
@@ -398,6 +399,13 @@ export class VisionService extends Service {
       if (raw === undefined) return defaultValue;
       return raw.trim().toLowerCase() === "true";
     };
+    const primaryCaptureInterval = getSettingString("SCREEN_CAPTURE_INTERVAL");
+    const captureIntervalSetting =
+      primaryCaptureInterval ||
+      getSettingString("VISION_SCREEN_CAPTURE_INTERVAL");
+    const captureIntervalSettingName = primaryCaptureInterval
+      ? "SCREEN_CAPTURE_INTERVAL"
+      : "VISION_SCREEN_CAPTURE_INTERVAL";
 
     return {
       ...this.DEFAULT_CONFIG,
@@ -443,13 +451,13 @@ export class VisionService extends Service {
       visionMode:
         (getSettingString("VISION_MODE") as VisionMode) ||
         this.DEFAULT_CONFIG.visionMode,
-      // `||` (not `??`) preserves the existing alias precedence: a blank
-      // primary falls through to the legacy alias exactly as before.
+      // `||` (not `??`) preserves the existing alias precedence: an empty
+      // primary reaches the legacy alias, while a whitespace-only primary is
+      // truthy and therefore suppresses the alias exactly as before.
       screenCaptureInterval: resolveCaptureIntervalMs(
-        getSettingString("SCREEN_CAPTURE_INTERVAL") ||
-          getSettingString("VISION_SCREEN_CAPTURE_INTERVAL"),
-        this.DEFAULT_CONFIG.screenCaptureInterval,
-        "SCREEN_CAPTURE_INTERVAL",
+        captureIntervalSetting,
+        DEFAULT_SCREEN_CAPTURE_INTERVAL_MS,
+        captureIntervalSettingName,
       ),
       ocrEnabled: getBooleanSetting(
         "OCR_ENABLED",

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import {
+  ElizaError,
   type IAgentRuntime,
   logger,
   ModelType,
@@ -214,6 +215,44 @@ interface CameraDevice {
   capture: () => Promise<Buffer>;
 }
 
+/** Node clamps a `setInterval` delay above this to 1ms, so it is the real ceiling. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Resolve a capture-interval setting that is passed directly to `setInterval`.
+ *
+ * Three outcomes, deliberately distinct:
+ *   - absent or blank  -> `fallback` (the documented default)
+ *   - explicit invalid -> throws `ElizaError`, because a configured value that
+ *     cannot be honoured is an operator mistake, and silently substituting the
+ *     default would hide it
+ *   - valid            -> the configured number
+ *
+ * "Invalid" is anything Node cannot use as a timer delay: non-finite, <= 0, or
+ * above `MAX_TIMER_DELAY_MS`. Node clamps ALL of those to 1ms
+ * (`TimeoutOverflowWarning` / `TimeoutNegativeWarning`), turning a mistyped
+ * interval into a capture busy-loop rather than a slower cadence.
+ */
+export function resolveCaptureIntervalMs(
+  raw: string | undefined,
+  fallback: number,
+  settingName: string,
+): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TIMER_DELAY_MS) {
+    throw new ElizaError(
+      `${settingName} must be a positive number of milliseconds no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+      {
+        code: "VISION_CAPTURE_INTERVAL_INVALID",
+        context: { settingName, raw, maxMs: MAX_TIMER_DELAY_MS },
+      },
+    );
+  }
+  return parsed;
+}
+
+
 export class VisionService extends Service {
   static override serviceType: ServiceTypeName =
     VisionServiceType.VISION as ServiceTypeName;
@@ -404,11 +443,14 @@ export class VisionService extends Service {
       visionMode:
         (getSettingString("VISION_MODE") as VisionMode) ||
         this.DEFAULT_CONFIG.visionMode,
-      screenCaptureInterval:
-        Number(
-          runtime.getSetting("SCREEN_CAPTURE_INTERVAL") ||
-            runtime.getSetting("VISION_SCREEN_CAPTURE_INTERVAL"),
-        ) || this.DEFAULT_CONFIG.screenCaptureInterval,
+      // `||` (not `??`) preserves the existing alias precedence: a blank
+      // primary falls through to the legacy alias exactly as before.
+      screenCaptureInterval: resolveCaptureIntervalMs(
+        getSettingString("SCREEN_CAPTURE_INTERVAL") ||
+          getSettingString("VISION_SCREEN_CAPTURE_INTERVAL"),
+        this.DEFAULT_CONFIG.screenCaptureInterval,
+        "SCREEN_CAPTURE_INTERVAL",
+      ),
       ocrEnabled: getBooleanSetting(
         "OCR_ENABLED",
         "VISION_OCR_ENABLED",


### PR DESCRIPTION
# Relates to

No separate issue — the defect is described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the current `origin/develop` tree, so it applies with zero conflicts.
- [x] Focused and full-package tests plus scoped lint were run; results are quoted below. Root `bun run verify` was not run green: `develop` currently carries unrelated `@elizaos/agent` Biome formatter diagnostics, the same blocker recorded in #24174.
- [x] A reviewer can confirm the change from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Exact unrelated blocker documented above.

# Risks

Low. One setting parser, narrowed to the single value that reaches a timer delay. Accepted values — including fractional milliseconds — are unchanged.

# Background

## What does this PR do?

`screenCaptureInterval` is resolved with `Number(raw) || fallback`, which is not a guard:

```ts
screenCaptureInterval:
  Number(
    runtime.getSetting("SCREEN_CAPTURE_INTERVAL") ||
      runtime.getSetting("VISION_SCREEN_CAPTURE_INTERVAL"),
  ) || this.DEFAULT_CONFIG.screenCaptureInterval,
```

`Number("Infinity")` is `Infinity` and `Number("-5")` is `-5`. **Both are truthy**, so both pass straight through the `||` and become the delay here:

```ts
this.screenProcessingInterval = setInterval(async () => { ... },
  this.visionConfig.screenCaptureInterval || 2000);
```

Node clamps a non-finite or negative timer delay to **1ms**. Verified directly:

```
TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
TimeoutNegativeWarning: -5 is a negative number.
Timeout duration was set to 1.
```

So a mistyped capture interval does not slow capture down and does not fall back — it arms a **1ms screen-capture loop** that burns CPU continuously. `NaN` is the only bad value the `||` idiom catches, and it catches it by accident.

## What kind of change is this?

Bug fix (non-breaking).

## Scope

Only `screenCaptureInterval` is changed, because it is the one setting in this block that reaches a timer delay. The sibling `Number(...) || default` reads feed threshold comparisons where a non-finite value does not produce a runaway loop, so they are deliberately left alone rather than swept up here.

The helper is exported for direct unit coverage because `parseConfig` is private — matching `resolveDeviceCallTimeoutMs` in `packages/ui` (#24200).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with the mutation block below: it substitutes develop's exact expression and shows the two values that arm the 1ms loop.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `capture-interval.test.ts` | 10 passed |
| full plugin-vision suite | 296 passed, 1 failed (same single pre-existing failure as baseline) |
| `biome check` (both changed files) | clean |

**On that 1 failure:** it is pre-existing. The pristine tree produces the identical single failure (286 passed, 1 failed); the +4 delta here is exactly this PR's tests. This change introduces none.

Mutation resistance:

```
AssertionError: expected Infinity to be 2000
AssertionError: expected -5 to be 2000
Tests  2 failed | 2 passed (4)
```

The clean and fractional cases pass in **both** directions, so accepted values are unchanged.

# Evidence Gate

<!-- evidence-head:8c7dd83721e98c45ba6a52dd4e527cd86f82ac31 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only change to a capture-interval setting parser; no rendered surface is touched`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only change to a capture-interval setting parser; no rendered surface is touched`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the resolved interval value, asserted directly in the tests below`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started against a live camera or screen; the resolver is exercised directly by the unit suite quoted below`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider or action path is changed; this is a setting parser`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the observable output is the resolved capture interval, asserted in the tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - the change has no rendered visual surface`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a numeric-input validation sweep of `plugins/`.
- Independent verification, empirical confirmation of Node's 1ms clamping, the narrowing to the one timer-reaching setting, the exported-helper test surface, and the mutation proof by Claude Code (`claude-opus-5`).

