### PR TITLE
fix(auth): fail closed on malformed Steward providers

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -481,6 +481,7 @@ describe("thin Steward public path dispatch (#18049)", () => {
           google: false,
           discord: false,
           github: false,
+          twitter: false,
           oauth: [],
         },
       });
@@ -553,7 +554,12 @@ describe("thin Steward public path dispatch (#18049)", () => {
         data: {
           passkey: true,
           email: true,
+          siwe: false,
+          siws: false,
           google: false,
+          discord: false,
+          github: false,
+          twitter: false,
           oauth: [],
         },
       });

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -153,25 +153,133 @@ function resolveStewardUpstream(
   return null;
 }
 
-type ProvidersData = {
-  passkey?: boolean;
-  email?: boolean;
-  siwe?: boolean;
-  siws?: boolean;
-  google?: boolean;
-  discord?: boolean;
-  github?: boolean;
-  oauth?: string[];
+type ProvidersCaptcha = {
+  enabled?: boolean;
+  provider?: "turnstile" | "hcaptcha";
+  siteKey?: string;
+  requiredFor?: Array<"email_otp" | "sms_otp">;
   [key: string]: unknown;
 };
 
-type ProvidersBody = ProvidersData & {
-  ok?: boolean;
-  data?: ProvidersData;
+type ProvidersData = {
+  passkey: boolean;
+  email: boolean;
+  sms?: boolean;
+  whatsapp?: boolean;
+  totp?: boolean;
+  siwe: boolean;
+  siws: boolean;
+  google: boolean;
+  discord: boolean;
+  github: boolean;
+  twitter: boolean;
+  telegram?: boolean;
+  farcaster?: boolean;
+  linkedin?: boolean;
+  spotify?: boolean;
+  twitch?: boolean;
+  instagram?: boolean;
+  line?: boolean;
+  jwt?: boolean;
+  oidc?: string[];
+  captcha?: ProvidersCaptcha;
+  oauth: string[];
+  disabled?: string[];
+  [key: string]: unknown;
 };
+
+const REQUIRED_PROVIDER_BOOLEAN_FIELDS = [
+  "passkey",
+  "email",
+  "siwe",
+  "siws",
+  "google",
+  "discord",
+  "github",
+  "twitter",
+] as const;
+
+const OPTIONAL_PROVIDER_BOOLEAN_FIELDS = [
+  "sms",
+  "whatsapp",
+  "totp",
+  "telegram",
+  "farcaster",
+  "linkedin",
+  "spotify",
+  "twitch",
+  "instagram",
+  "line",
+  "jwt",
+] as const;
+
+const OPTIONAL_PROVIDER_STRING_ARRAY_FIELDS = ["oidc", "disabled"] as const;
+const CAPTCHA_PROVIDERS = new Set(["turnstile", "hcaptcha"]);
+const CAPTCHA_REQUIRED_FOR = new Set(["email_otp", "sms_otp"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === "string")
+  );
+}
+
+function isValidCaptcha(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (Object.hasOwn(value, "enabled") && typeof value.enabled !== "boolean") {
+    return false;
+  }
+  if (
+    Object.hasOwn(value, "provider") &&
+    (typeof value.provider !== "string" ||
+      !CAPTCHA_PROVIDERS.has(value.provider))
+  ) {
+    return false;
+  }
+  if (Object.hasOwn(value, "siteKey") && typeof value.siteKey !== "string") {
+    return false;
+  }
+  if (Object.hasOwn(value, "requiredFor")) {
+    if (!isStringArray(value.requiredFor)) return false;
+    if (!value.requiredFor.every((entry) => CAPTCHA_REQUIRED_FOR.has(entry))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isProvidersData(value: unknown): value is ProvidersData {
+  if (!isRecord(value)) return false;
+  if (
+    !REQUIRED_PROVIDER_BOOLEAN_FIELDS.every(
+      (field) =>
+        Object.hasOwn(value, field) && typeof value[field] === "boolean",
+    )
+  ) {
+    return false;
+  }
+  if (!Object.hasOwn(value, "oauth") || !isStringArray(value.oauth)) {
+    return false;
+  }
+  if (
+    !OPTIONAL_PROVIDER_BOOLEAN_FIELDS.every(
+      (field) =>
+        !Object.hasOwn(value, field) || typeof value[field] === "boolean",
+    )
+  ) {
+    return false;
+  }
+  if (
+    !OPTIONAL_PROVIDER_STRING_ARRAY_FIELDS.every(
+      (field) => !Object.hasOwn(value, field) || isStringArray(value[field]),
+    )
+  ) {
+    return false;
+  }
+  return !Object.hasOwn(value, "captcha") || isValidCaptcha(value.captcha);
 }
 
 function invalidProvidersResponse(): Response {
@@ -187,6 +295,14 @@ function invalidProvidersResponse(): Response {
       headers: { "cache-control": "no-store" },
     },
   );
+}
+
+function asHeadResponse(response: Response): Response {
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 function hasOAuthCreds(
@@ -335,28 +451,23 @@ async function patchProvidersResponse(
 ): Promise<Response> {
   if (!upstream.ok) return upstream;
   const contentType = upstream.headers.get("content-type") || "";
-  if (!contentType.includes("application/json")) return upstream;
-
-  let parsed: ProvidersBody;
-  try {
-    parsed = (await upstream.clone().json()) as ProvidersBody;
-  } catch {
-    return upstream;
-  }
-  if (!isRecord(parsed)) return invalidProvidersResponse();
-
-  const hasNestedData = Object.hasOwn(parsed, "data");
-  const providerData = hasNestedData ? parsed.data : parsed;
-  if (!isRecord(providerData)) return invalidProvidersResponse();
-  if (
-    Object.hasOwn(providerData, "oauth") &&
-    (!Array.isArray(providerData.oauth) ||
-      !providerData.oauth.every((provider) => typeof provider === "string"))
-  ) {
+  if (!contentType.includes("application/json")) {
     return invalidProvidersResponse();
   }
 
-  const oauth = new Set<string>(providerData.oauth ?? []);
+  let parsed: unknown;
+  try {
+    parsed = await upstream.clone().json();
+  } catch {
+    return invalidProvidersResponse();
+  }
+  if (!isRecord(parsed)) return invalidProvidersResponse();
+
+  const hasNestedData = !isProvidersData(parsed);
+  const providerData = hasNestedData ? parsed.data : parsed;
+  if (!isProvidersData(providerData)) return invalidProvidersResponse();
+
+  const oauth = new Set<string>(providerData.oauth);
   const patched: ProvidersData = { ...providerData };
 
   for (const provider of ["google", "discord", "github"] as const) {
@@ -378,13 +489,20 @@ async function patchProvidersResponse(
 
 export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   const url = new URL(c.req.url);
-  if (c.req.method === "GET" && isPublicStewardTenantConfigPath(url.pathname)) {
-    return c.json({ ok: true, data: PUBLIC_STEWARD_TENANT_CONFIG });
+  const requestMethod = c.req.method.toUpperCase();
+  const isReadMethod = requestMethod === "GET" || requestMethod === "HEAD";
+  const isProvidersRequest = isReadMethod && isAuthProvidersPath(url.pathname);
+
+  if (isReadMethod && isPublicStewardTenantConfigPath(url.pathname)) {
+    const response = c.json({ ok: true, data: PUBLIC_STEWARD_TENANT_CONFIG });
+    return requestMethod === "HEAD" ? asHeadResponse(response) : response;
   }
 
-  if (c.req.method === "GET" && isAuthProvidersPath(url.pathname)) {
+  if (isProvidersRequest) {
     const cached = readProvidersCache(c.env);
-    if (cached) return cached;
+    if (cached) {
+      return requestMethod === "HEAD" ? asHeadResponse(cached) : cached;
+    }
   }
 
   const upstream = resolveStewardUpstream(c.env, url);
@@ -411,7 +529,11 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   // the SPA. Without this, /auth/email/send (Magic Link) returns
   // `Request expiry header required` — see Steward
   // packages/api/src/middleware/{request-expiry,authorization-signature}.ts.
-  const method = c.req.method.toUpperCase();
+  // A HEAD discovery request must be validated against the same representation
+  // as GET. Fetch GET upstream, cache only the validated body, then strip the
+  // downstream body below; an upstream HEAD has no body to validate.
+  const method =
+    requestMethod === "HEAD" && isProvidersRequest ? "GET" : requestMethod;
   const isMutating = MUTATING_METHODS.has(method);
   const rawSecret = c.env.STEWARD_REQUEST_SIGNING_SECRET;
   const signingSecret =
@@ -510,9 +632,10 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
       502,
     );
   }
-  if (c.req.method === "GET" && isAuthProvidersPath(url.pathname)) {
+  if (isProvidersRequest) {
     const patched = await patchProvidersResponse(response, c.env);
-    return writeProvidersCache(patched, c.env);
+    const cached = await writeProvidersCache(patched, c.env);
+    return requestMethod === "HEAD" ? asHeadResponse(cached) : cached;
   }
   return response;
 };

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -1,4 +1,4 @@
-// Boots cloud API src steward embedded Worker infrastructure under Cloudflare runtime constraints.
+/** Proxies the embedded Steward API with signed mutations and bounded public discovery. */
 import type { MiddlewareHandler } from "hono";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -9,6 +9,12 @@ const REQUEST_TTL_SECONDS = 60;
 // packages/cloud/shared/src/lib/auth/steward-client.ts. Inlined so this module
 // (and the thin login path that loads it) does not pull the JWT/jose graph.
 const STEWARD_AUTH_UPSTREAM_TIMEOUT_MS = 25_000;
+const MAX_PROVIDERS_BODY_BYTES = 64 * 1024;
+const MAX_PROVIDERS_JSON_DEPTH = 16;
+const MAX_PROVIDERS_CONTAINER_ENTRIES = 256;
+const MAX_PROVIDERS_JSON_NODES = 2_048;
+const MAX_PROVIDERS_CACHE_ENTRIES = 8;
+const DANGEROUS_JSON_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
 function bytesToHex(bytes: Uint8Array): string {
   let out = "";
@@ -227,6 +233,124 @@ function isStringArray(value: unknown): value is string[] {
   );
 }
 
+async function readBoundedBody(response: Response): Promise<string | null> {
+  if (!response.body) return null;
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_PROVIDERS_BODY_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function parseProvidersJson(text: string): unknown {
+  let position = 0;
+  let nodes = 0;
+  const skipWhitespace = () => {
+    while (/\s/.test(text[position] ?? "")) position += 1;
+  };
+  const parseString = (): string => {
+    if (text[position] !== '"') throw new Error("expected JSON string");
+    const start = position++;
+    while (position < text.length) {
+      if (text[position] === "\\") {
+        position += 2;
+        continue;
+      }
+      if (text[position++] === '"') {
+        return JSON.parse(text.slice(start, position)) as string;
+      }
+    }
+    throw new Error("unterminated JSON string");
+  };
+  const parseValue = (depth: number): void => {
+    nodes += 1;
+    if (nodes > MAX_PROVIDERS_JSON_NODES || depth > MAX_PROVIDERS_JSON_DEPTH) {
+      throw new Error("provider JSON complexity exceeded");
+    }
+    skipWhitespace();
+    if (text[position] === "{") {
+      position += 1;
+      skipWhitespace();
+      const keys = new Set<string>();
+      let entries = 0;
+      if (text[position] === "}") {
+        position += 1;
+        return;
+      }
+      while (true) {
+        const key = parseString();
+        if (keys.has(key) || DANGEROUS_JSON_KEYS.has(key)) {
+          throw new Error("unsafe or duplicate provider JSON key");
+        }
+        keys.add(key);
+        entries += 1;
+        if (entries > MAX_PROVIDERS_CONTAINER_ENTRIES) {
+          throw new Error("provider object too large");
+        }
+        skipWhitespace();
+        if (text[position++] !== ":") throw new Error("expected colon");
+        parseValue(depth + 1);
+        skipWhitespace();
+        const separator = text[position++];
+        if (separator === "}") return;
+        if (separator !== ",") throw new Error("expected object separator");
+        skipWhitespace();
+      }
+    }
+    if (text[position] === "[") {
+      position += 1;
+      skipWhitespace();
+      let entries = 0;
+      if (text[position] === "]") {
+        position += 1;
+        return;
+      }
+      while (true) {
+        entries += 1;
+        if (entries > MAX_PROVIDERS_CONTAINER_ENTRIES) {
+          throw new Error("provider array too large");
+        }
+        parseValue(depth + 1);
+        skipWhitespace();
+        const separator = text[position++];
+        if (separator === "]") return;
+        if (separator !== ",") throw new Error("expected array separator");
+      }
+    }
+    if (text[position] === '"') {
+      parseString();
+      return;
+    }
+    const start = position;
+    while (position < text.length && !/[\s,\]}]/.test(text[position]))
+      position += 1;
+    JSON.parse(text.slice(start, position));
+  };
+  parseValue(0);
+  skipWhitespace();
+  if (position !== text.length) throw new Error("trailing JSON data");
+  return JSON.parse(text) as unknown;
+}
+
 function isValidCaptcha(value: unknown): boolean {
   if (!isRecord(value)) return false;
   if (Object.hasOwn(value, "enabled") && typeof value.enabled !== "boolean") {
@@ -352,10 +476,24 @@ type ProvidersCacheEntry = {
   deployCommit: string | null;
 };
 
-let providersResponseCache: ProvidersCacheEntry | null = null;
+const providersResponseCache = new Map<string, ProvidersCacheEntry>();
+const providersInflight = new Map<string, Promise<Response>>();
 
-function providersCacheKey(env: AppEnv["Bindings"]): string | null {
-  return env.ELIZA_DEPLOY_COMMIT?.trim() || null;
+async function providersCacheKey(
+  env: AppEnv["Bindings"],
+  requestUrl: URL,
+): Promise<string> {
+  const upstream = resolveStewardUpstream(env, requestUrl);
+  return sha256TextHex(
+    JSON.stringify({
+      upstream,
+      deployCommit: env.ELIZA_DEPLOY_COMMIT?.trim() || null,
+      tenantId: env.STEWARD_TENANT_ID?.trim() || null,
+      google: hasOAuthCreds(env, "google"),
+      discord: hasOAuthCreds(env, "discord"),
+      github: hasOAuthCreds(env, "github"),
+    }),
+  );
 }
 
 /**
@@ -369,12 +507,11 @@ export function providersCacheControlForAgeMs(ageMs: number): string {
   return `public, max-age=${maxAgeSec}`;
 }
 
-function readProvidersCache(env: AppEnv["Bindings"]): Response | null {
-  const entry = providersResponseCache;
+function readProvidersCache(key: string): Response | null {
+  const entry = providersResponseCache.get(key);
   if (!entry) return null;
   const now = Date.now();
   if (entry.expiresAt <= now) return null;
-  if (entry.deployCommit !== providersCacheKey(env)) return null;
   const ageMs = now - entry.fetchedAt;
   if (ageMs >= PROVIDERS_CACHE_TTL_MS) return null;
   return new Response(entry.body.slice(0), {
@@ -390,7 +527,7 @@ function readProvidersCache(env: AppEnv["Bindings"]): Response | null {
 
 async function writeProvidersCache(
   response: Response,
-  env: AppEnv["Bindings"],
+  key: string,
 ): Promise<Response> {
   if (!response.ok) return response;
   const contentType = response.headers.get("content-type") || "";
@@ -398,14 +535,23 @@ async function writeProvidersCache(
 
   const body = await response.clone().arrayBuffer();
   const fetchedAt = Date.now();
-  providersResponseCache = {
+  if (
+    !providersResponseCache.has(key) &&
+    providersResponseCache.size >= MAX_PROVIDERS_CACHE_ENTRIES
+  ) {
+    const oldest = [...providersResponseCache.entries()].sort(
+      ([, left], [, right]) => left.fetchedAt - right.fetchedAt,
+    )[0]?.[0];
+    if (oldest) providersResponseCache.delete(oldest);
+  }
+  providersResponseCache.set(key, {
     body,
     status: response.status,
     contentType,
     fetchedAt,
     expiresAt: fetchedAt + PROVIDERS_CACHE_TTL_MS,
-    deployCommit: providersCacheKey(env),
-  };
+    deployCommit: key,
+  });
 
   const headers = new Headers(response.headers);
   headers.set("cache-control", providersCacheControlForAgeMs(0));
@@ -419,14 +565,14 @@ async function writeProvidersCache(
 
 /** Test helper — clears the isolate providers cache between cases. */
 export function resetProvidersResponseCacheForTests(): void {
-  providersResponseCache = null;
+  providersResponseCache.clear();
+  providersInflight.clear();
 }
 
 /** Test helper — force the current isolate entry past its expiry. */
 export function expireProvidersResponseCacheForTests(): void {
-  if (providersResponseCache) {
-    providersResponseCache.expiresAt = Date.now() - 1;
-  }
+  for (const entry of providersResponseCache.values())
+    entry.expiresAt = Date.now() - 1;
 }
 
 /**
@@ -434,9 +580,10 @@ export function expireProvidersResponseCacheForTests(): void {
  * (positive = age the entry as if that many ms already elapsed).
  */
 export function ageProvidersResponseCacheForTests(deltaMs: number): void {
-  if (!providersResponseCache) return;
-  providersResponseCache.fetchedAt -= deltaMs;
-  providersResponseCache.expiresAt -= deltaMs;
+  for (const entry of providersResponseCache.values()) {
+    entry.fetchedAt -= deltaMs;
+    entry.expiresAt -= deltaMs;
+  }
 }
 
 /**
@@ -449,21 +596,38 @@ async function patchProvidersResponse(
   upstream: Response,
   env: AppEnv["Bindings"],
 ): Promise<Response> {
-  if (!upstream.ok) return upstream;
-  const contentType = upstream.headers.get("content-type") || "";
-  if (!contentType.includes("application/json")) {
+  if (!upstream.ok) return invalidProvidersResponse();
+  if (upstream.status !== 200) return invalidProvidersResponse();
+  const contentType = upstream.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== "application/json" && !contentType?.endsWith("+json")) {
     return invalidProvidersResponse();
   }
 
   let parsed: unknown;
   try {
-    parsed = await upstream.clone().json();
+    const text = await readBoundedBody(upstream);
+    if (text === null) return invalidProvidersResponse();
+    parsed = parseProvidersJson(text);
   } catch {
     return invalidProvidersResponse();
   }
   if (!isRecord(parsed)) return invalidProvidersResponse();
+  if (
+    parsed.ok !== true ||
+    Object.hasOwn(parsed, "error") ||
+    (Object.hasOwn(parsed, "success") && parsed.success !== true)
+  ) {
+    return invalidProvidersResponse();
+  }
 
   const hasNestedData = !isProvidersData(parsed);
+  if (hasNestedData && !Object.hasOwn(parsed, "data")) {
+    return invalidProvidersResponse();
+  }
   const providerData = hasNestedData ? parsed.data : parsed;
   if (!isProvidersData(providerData)) return invalidProvidersResponse();
 
@@ -483,7 +647,7 @@ async function patchProvidersResponse(
     : { ...parsed, ...patched };
   return Response.json(body, {
     status: upstream.status,
-    headers: upstream.headers,
+    headers: { "content-type": "application/json; charset=UTF-8" },
   });
 }
 
@@ -492,14 +656,17 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   const requestMethod = c.req.method.toUpperCase();
   const isReadMethod = requestMethod === "GET" || requestMethod === "HEAD";
   const isProvidersRequest = isReadMethod && isAuthProvidersPath(url.pathname);
+  const providerCacheKey = isProvidersRequest
+    ? await providersCacheKey(c.env, url)
+    : null;
 
   if (isReadMethod && isPublicStewardTenantConfigPath(url.pathname)) {
     const response = c.json({ ok: true, data: PUBLIC_STEWARD_TENANT_CONFIG });
     return requestMethod === "HEAD" ? asHeadResponse(response) : response;
   }
 
-  if (isProvidersRequest) {
-    const cached = readProvidersCache(c.env);
+  if (providerCacheKey) {
+    const cached = readProvidersCache(providerCacheKey);
     if (cached) {
       return requestMethod === "HEAD" ? asHeadResponse(cached) : cached;
     }
@@ -562,6 +729,21 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   // Strip the host header that Workers carries from the inbound request — the
   // upstream fetch sets its own.
   headers.delete("host");
+  if (isProvidersRequest) {
+    for (const name of [
+      "authorization",
+      "cookie",
+      "x-api-key",
+      "x-steward-key",
+      "x-steward-platform-key",
+      "x-steward-signer-id",
+      "x-steward-signer-secret",
+      "x-steward-key-quorum-id",
+      "x-steward-key-quorum-credentials",
+    ]) {
+      headers.delete(name);
+    }
+  }
 
   // Forward the real inbound origin so Steward's origin-gated auth checks pass.
   // Steward's SIWE/SIWS `GET /auth/nonce` rejects a request that carries
@@ -614,6 +796,45 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
     headers.set("x-steward-signature", `v1=${signature}`);
   }
 
+  if (isProvidersRequest && providerCacheKey) {
+    const existing = providersInflight.get(providerCacheKey);
+    if (existing) {
+      const shared = (await existing).clone();
+      return requestMethod === "HEAD" ? asHeadResponse(shared) : shared;
+    }
+    const load = (async () => {
+      let response: Response;
+      try {
+        response = await fetch(upstreamUrl.toString(), init);
+      } catch (error) {
+        logger.error("[embedded-steward] upstream transport failure", {
+          message: error instanceof Error ? error.message : String(error),
+          path: url.pathname,
+        });
+        return Response.json(
+          {
+            success: false,
+            error: "steward_upstream_unavailable",
+            code: "steward_upstream_unavailable",
+            message: "Steward upstream unavailable",
+          },
+          { status: 502, headers: { "cache-control": "no-store" } },
+        );
+      }
+      const patched = await patchProvidersResponse(response, c.env);
+      return writeProvidersCache(patched, providerCacheKey);
+    })();
+    providersInflight.set(providerCacheKey, load);
+    try {
+      const loaded = (await load).clone();
+      return requestMethod === "HEAD" ? asHeadResponse(loaded) : loaded;
+    } finally {
+      if (providersInflight.get(providerCacheKey) === load) {
+        providersInflight.delete(providerCacheKey);
+      }
+    }
+  }
+
   let response: Response;
   try {
     response = await fetch(upstreamUrl.toString(), init);
@@ -631,11 +852,6 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
       },
       502,
     );
-  }
-  if (isProvidersRequest) {
-    const patched = await patchProvidersResponse(response, c.env);
-    const cached = await writeProvidersCache(patched, c.env);
-    return requestMethod === "HEAD" ? asHeadResponse(cached) : cached;
   }
   return response;
 };

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -42,11 +42,10 @@ function stubFetch(
   globalThis.fetch = impl as unknown as typeof fetch;
 }
 
-function providersUpstreamResponse(
+function providersData(
   overrides: Record<string, unknown> = {},
-): Response {
-  return Response.json({
-    ok: true,
+): Record<string, unknown> {
+  return {
     passkey: true,
     email: true,
     siwe: false,
@@ -54,15 +53,42 @@ function providersUpstreamResponse(
     google: false,
     discord: false,
     github: false,
+    twitter: false,
     oauth: [],
     ...overrides,
-  });
+  };
+}
+
+function providersUpstreamResponse(
+  overrides: Record<string, unknown> = {},
+): Response {
+  return Response.json({ ok: true, ...providersData(overrides) });
 }
 
 beforeEach(() => {
   resetProvidersResponseCacheForTests();
   globalThis.fetch = originalFetch;
 });
+
+async function expectInvalidProvidersResponse(
+  upstreamResponse: Response,
+): Promise<void> {
+  stubFetch(async () => upstreamResponse);
+
+  const app = createStewardThinApp();
+  const response = await app.request(
+    "https://api.elizacloud.ai/steward/auth/providers",
+    { method: "GET" },
+    stewardEnv,
+  );
+
+  expect(response.status).toBe(502);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("x-eliza-providers-cache")).toBeNull();
+  await expect(response.json()).resolves.toMatchObject({
+    code: "steward_upstream_invalid_response",
+  });
+}
 
 describe("isThinStewardPublicPath", () => {
   test("matches only login-critical Steward GETs", () => {
@@ -193,6 +219,7 @@ describe("createStewardThinApp", () => {
       return providersUpstreamResponse({
         telegram: true,
         oauth: ["apple"],
+        futureProvider: { state: "preview" },
       });
     });
 
@@ -217,13 +244,109 @@ describe("createStewardThinApp", () => {
       passkey?: boolean;
       telegram?: boolean;
       oauth?: string[];
+      futureProvider?: unknown;
     };
     expect(body.ok).toBe(true);
     expect(body.passkey).toBe(true);
     expect(body.google).toBe(true);
     expect(body.telegram).toBe(true);
     expect(body.oauth).toEqual(["apple", "google"]);
+    expect(body.futureProvider).toEqual({ state: "preview" });
   });
+
+  test("preserves the legacy nested shape and unknown envelope/provider fields", async () => {
+    stubFetch(async () =>
+      Response.json({
+        ok: true,
+        requestVersion: 7,
+        data: providersData({
+          oauth: ["apple"],
+          sms: true,
+          oidc: ["workforce"],
+          disabled: ["line"],
+          captcha: {
+            enabled: true,
+            provider: "turnstile",
+            siteKey: "site-key",
+            requiredFor: ["email_otp", "sms_otp"],
+            futureCaptchaOption: "preserved",
+          },
+          futureProvider: { state: "preview" },
+        }),
+      }),
+    );
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    const body = (await response.json()) as {
+      ok?: boolean;
+      requestVersion?: number;
+      google?: boolean;
+      data?: {
+        google?: boolean;
+        oauth?: string[];
+        sms?: boolean;
+        oidc?: string[];
+        disabled?: string[];
+        captcha?: Record<string, unknown>;
+        futureProvider?: unknown;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.requestVersion).toBe(7);
+    expect(body.google).toBeUndefined();
+    expect(body.data?.google).toBe(true);
+    expect(body.data?.oauth).toEqual(["apple", "google"]);
+    expect(body.data?.sms).toBe(true);
+    expect(body.data?.oidc).toEqual(["workforce"]);
+    expect(body.data?.disabled).toEqual(["line"]);
+    expect(body.data?.captcha).toEqual({
+      enabled: true,
+      provider: "turnstile",
+      siteKey: "site-key",
+      requiredFor: ["email_otp", "sms_otp"],
+      futureCaptchaOption: "preserved",
+    });
+    expect(body.data?.futureProvider).toEqual({ state: "preview" });
+  });
+
+  test.each([
+    ["object", { requestVersion: 7 }],
+    ["null", null],
+  ])(
+    "preserves an unknown flat data field containing %s",
+    async (_case, data) => {
+      stubFetch(async () =>
+        providersUpstreamResponse({
+          data,
+          futureProvider: { state: "preview" },
+        }),
+      );
+
+      const app = createStewardThinApp();
+      const response = await app.request(
+        "https://api.elizacloud.ai/steward/auth/providers",
+        { method: "GET" },
+        stewardEnv,
+      );
+      const body = (await response.json()) as {
+        data?: unknown;
+        google?: boolean;
+        futureProvider?: unknown;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.data).toEqual(data);
+      expect(body.google).toBe(true);
+      expect(body.futureProvider).toEqual({ state: "preview" });
+    },
+  );
 
   test.each([true, false])(
     "preserves upstream Telegram provider state (%s) without inferring it from Eliza OAuth env",
@@ -247,26 +370,146 @@ describe("createStewardThinApp", () => {
   );
 
   test.each([
-    ["nested scalar provider data", { data: "telegram" }],
-    ["nested array provider data", { data: ["telegram"] }],
-    ["non-array oauth", { oauth: { google: true } }],
-    ["oauth entries with non-string values", { oauth: ["google", 42] }],
-  ])("fails closed on %s", async (_case, malformedProviders) => {
-    stubFetch(async () => providersUpstreamResponse(malformedProviders));
+    "passkey",
+    "email",
+    "siwe",
+    "siws",
+    "google",
+    "discord",
+    "github",
+    "twitter",
+    "oauth",
+  ])(
+    "fails closed when required provider field %s is missing",
+    async (field) => {
+      const body: Record<string, unknown> = {
+        ok: true,
+        ...providersData(),
+      };
+      delete body[field];
+      await expectInvalidProvidersResponse(Response.json(body));
+    },
+  );
+
+  test.each([
+    "passkey",
+    "email",
+    "siwe",
+    "siws",
+    "google",
+    "discord",
+    "github",
+    "twitter",
+  ])(
+    "fails closed when required provider boolean %s is malformed",
+    async (field) => {
+      await expectInvalidProvidersResponse(
+        providersUpstreamResponse({ [field]: "false" }),
+      );
+    },
+  );
+
+  test.each([
+    "sms",
+    "whatsapp",
+    "totp",
+    "telegram",
+    "farcaster",
+    "linkedin",
+    "spotify",
+    "twitch",
+    "instagram",
+    "line",
+    "jwt",
+  ])(
+    "fails closed when optional provider boolean %s is malformed",
+    async (field) => {
+      await expectInvalidProvidersResponse(
+        providersUpstreamResponse({ [field]: 1 }),
+      );
+    },
+  );
+
+  test.each([
+    ["oauth is not an array", { oauth: { google: true } }],
+    ["oauth contains a non-string", { oauth: ["google", 42] }],
+    ["oidc is not an array", { oidc: "corp" }],
+    ["oidc contains a non-string", { oidc: ["corp", false] }],
+    ["disabled is not an array", { disabled: null }],
+    ["disabled contains a non-string", { disabled: ["email", 7] }],
+  ])("fails closed when %s", async (_case, overrides) => {
+    await expectInvalidProvidersResponse(providersUpstreamResponse(overrides));
+  });
+
+  test.each([
+    ["captcha is null", null],
+    ["captcha is an array", []],
+    ["captcha enabled is not boolean", { enabled: "true" }],
+    ["captcha provider is not a string", { provider: 1 }],
+    ["captcha provider is unsupported", { provider: "recaptcha" }],
+    ["captcha siteKey is not a string", { siteKey: 123 }],
+    ["captcha requiredFor is not an array", { requiredFor: "email_otp" }],
+    [
+      "captcha requiredFor contains a non-string",
+      { requiredFor: ["email_otp", 1] },
+    ],
+    [
+      "captcha requiredFor contains an unsupported purpose",
+      { requiredFor: ["password"] },
+    ],
+  ])("fails closed when %s", async (_case, captcha) => {
+    await expectInvalidProvidersResponse(
+      providersUpstreamResponse({ captcha }),
+    );
+  });
+
+  test.each([
+    ["nested scalar provider data", "telegram"],
+    ["nested array provider data", ["telegram"]],
+    ["nested null provider data", null],
+  ])("fails closed on %s", async (_case, data) => {
+    await expectInvalidProvidersResponse(Response.json({ ok: true, data }));
+  });
+
+  test.each([
+    ["non-JSON content type", new Response("not json", { status: 200 })],
+    [
+      "malformed JSON body",
+      new Response("{", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ],
+  ])("fails closed on %s", async (_case, response) => {
+    await expectInvalidProvidersResponse(response);
+  });
+
+  test("does not cache a malformed provider response", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      return upstreamCalls === 1
+        ? providersUpstreamResponse({ passkey: "true" })
+        : providersUpstreamResponse();
+    });
 
     const app = createStewardThinApp();
-    const response = await app.request(
+    const first = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    const second = await app.request(
       "https://api.elizacloud.ai/steward/auth/providers",
       { method: "GET" },
       stewardEnv,
     );
 
-    expect(response.status).toBe(502);
-    expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(response.headers.get("x-eliza-providers-cache")).toBeNull();
-    await expect(response.json()).resolves.toMatchObject({
-      code: "steward_upstream_invalid_response",
-    });
+    expect(first.status).toBe(502);
+    expect(first.headers.get("cache-control")).toBe("no-store");
+    expect(second.status).toBe(200);
+    expect(second.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(upstreamCalls).toBe(2);
   });
 
   test("serves GET /steward/tenants/config without upstream and defaults no-store", async () => {
@@ -409,20 +652,62 @@ describe("createStewardThinApp", () => {
     expect(upstreamCalls).toBe(0);
   });
 
-  test("HEAD /steward/auth/providers is accepted by the thin shell", async () => {
-    stubFetch(async () => providersUpstreamResponse());
+  test("HEAD /steward/auth/providers validates GET upstream, strips the body, and primes the cache", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async (_input, init) => {
+      upstreamCalls += 1;
+      expect(init?.method).toBe("GET");
+      return providersUpstreamResponse();
+    });
 
     const app = createStewardThinApp();
-    const response = await app.request(
+    const head = await app.request(
       "https://api.elizacloud.ai/steward/auth/providers",
       { method: "HEAD" },
       stewardEnv,
     );
-
-    // Hono may answer HEAD via GET handler; either 200 or method-shaped success.
-    expect([200, 204].includes(response.status) || response.status < 500).toBe(
-      true,
+    const get = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
     );
+
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe("");
+    expect(head.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(get.status).toBe(200);
+    expect(get.headers.get("x-eliza-providers-cache")).toBe("hit");
+    expect(upstreamCalls).toBe(1);
+  });
+
+  test("HEAD /steward/auth/providers fails closed on malformed upstream and does not poison the cache", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      return upstreamCalls === 1
+        ? new Response("not json", { status: 200 })
+        : providersUpstreamResponse();
+    });
+
+    const app = createStewardThinApp();
+    const head = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "HEAD" },
+      stewardEnv,
+    );
+    const get = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+
+    expect(head.status).toBe(502);
+    expect(await head.text()).toBe("");
+    expect(head.headers.get("cache-control")).toBe("no-store");
+    expect(head.headers.get("x-eliza-providers-cache")).toBeNull();
+    expect(get.status).toBe(200);
+    expect(get.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(upstreamCalls).toBe(2);
   });
 
   test("proxies POST /steward/auth/email/send with signing headers", async () => {

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -484,6 +484,90 @@ describe("createStewardThinApp", () => {
     await expectInvalidProvidersResponse(response);
   });
 
+  test.each([
+    ["explicit unsuccessful flat envelope", { ok: false, ...providersData() }],
+    [
+      "conflicting success flag",
+      { ok: true, success: false, ...providersData() },
+    ],
+    ["nested envelope without ok:true", { data: providersData() }],
+    [
+      "successful envelope carrying an error",
+      { ok: true, error: "denied", ...providersData() },
+    ],
+  ])("fails closed on %s", async (_case, body) => {
+    await expectInvalidProvidersResponse(Response.json(body));
+  });
+
+  test.each([
+    [
+      "duplicate keys",
+      `{"ok":true,"passkey":true,"passkey":false,"email":true,"siwe":false,"siws":false,"google":false,"discord":false,"github":false,"twitter":false,"oauth":[]}`,
+    ],
+    [
+      "prototype keys",
+      `{"ok":true,"passkey":true,"email":true,"siwe":false,"siws":false,"google":false,"discord":false,"github":false,"twitter":false,"oauth":[],"__proto__":{}}`,
+    ],
+    [
+      "excessive depth",
+      JSON.stringify({
+        ok: true,
+        ...providersData(),
+        future: Array.from({ length: 18 }).reduce((value) => [value], true),
+      }),
+    ],
+    [
+      "oversize body",
+      JSON.stringify({
+        ok: true,
+        ...providersData(),
+        future: "x".repeat(70_000),
+      }),
+    ],
+  ])("rejects bounded JSON violation: %s", async (_case, body) => {
+    await expectInvalidProvidersResponse(
+      new Response(body, { headers: { "content-type": "application/json" } }),
+    );
+  });
+
+  test("strips request credentials and upstream private headers before public caching", async () => {
+    let sentHeaders: Headers | null = null;
+    stubFetch(async (_input, init) => {
+      sentHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ ok: true, ...providersData() }), {
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "session=secret",
+          "www-authenticate": "Bearer secret",
+          vary: "cookie, authorization",
+          "x-private-token": "secret",
+        },
+      });
+    });
+    const response = await createStewardThinApp().request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {
+        headers: {
+          authorization: "Bearer browser-secret",
+          cookie: "session=browser-secret",
+          "x-api-key": "browser-key",
+        },
+      },
+      stewardEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(sentHeaders).not.toBeNull();
+    const capturedHeaders = sentHeaders as Headers | null;
+    expect(capturedHeaders?.get("authorization")).toBeNull();
+    expect(capturedHeaders?.get("cookie")).toBeNull();
+    expect(capturedHeaders?.get("x-api-key")).toBeNull();
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("www-authenticate")).toBeNull();
+    expect(response.headers.get("vary")).toBeNull();
+    expect(response.headers.get("x-private-token")).toBeNull();
+  });
+
   test("does not cache a malformed provider response", async () => {
     let upstreamCalls = 0;
     stubFetch(async () => {
@@ -625,6 +709,130 @@ describe("createStewardThinApp", () => {
     expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
     expect(second.headers.get("x-eliza-providers-cache")).toBe("miss");
     expect(upstreamCalls).toBe(2);
+  });
+
+  test("isolates cache entries by tenant and OAuth representation inputs", async () => {
+    let upstreamCalls = 0;
+    stubFetch(async (_input, init) => {
+      upstreamCalls += 1;
+      const tenant = new Headers(init?.headers).get("x-steward-tenant");
+      return providersUpstreamResponse({ futureTenant: tenant });
+    });
+    const app = createStewardThinApp();
+    const envA = {
+      ...stewardEnv,
+      STEWARD_TENANT_ID: "tenant-a",
+    } as unknown as AppEnv["Bindings"];
+    const envB = {
+      ...stewardEnv,
+      STEWARD_TENANT_ID: "tenant-b",
+      GOOGLE_CLIENT_ID: undefined,
+      GOOGLE_CLIENT_SECRET: undefined,
+    } as unknown as AppEnv["Bindings"];
+    const first = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {},
+      envA,
+    );
+    const second = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {},
+      envB,
+    );
+
+    expect(first.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(second.headers.get("x-eliza-providers-cache")).toBe("miss");
+    expect(
+      ((await first.json()) as { futureTenant?: unknown }).futureTenant,
+    ).toBe("tenant-a");
+    expect(
+      ((await second.json()) as { futureTenant?: unknown }).futureTenant,
+    ).toBe("tenant-b");
+    expect(upstreamCalls).toBe(2);
+  });
+
+  test("a slow old cache generation cannot overwrite a faster new generation", async () => {
+    let releaseOld!: () => void;
+    const oldBarrier = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    let upstreamCalls = 0;
+    stubFetch(async (_input, init) => {
+      upstreamCalls += 1;
+      const tenant = new Headers(init?.headers).get("x-steward-tenant");
+      if (tenant === "tenant-old") await oldBarrier;
+      return providersUpstreamResponse({ futureTenant: tenant });
+    });
+    const app = createStewardThinApp();
+    const oldEnv = {
+      ...stewardEnv,
+      STEWARD_TENANT_ID: "tenant-old",
+    } as unknown as AppEnv["Bindings"];
+    const newEnv = {
+      ...stewardEnv,
+      STEWARD_TENANT_ID: "tenant-new",
+    } as unknown as AppEnv["Bindings"];
+    const oldRequest = app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {},
+      oldEnv,
+    );
+    const newResponse = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {},
+      newEnv,
+    );
+    releaseOld();
+    await oldRequest;
+    const newHit = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {},
+      newEnv,
+    );
+
+    expect(
+      ((await newResponse.json()) as { futureTenant?: unknown }).futureTenant,
+    ).toBe("tenant-new");
+    expect(newHit.headers.get("x-eliza-providers-cache")).toBe("hit");
+    expect(
+      ((await newHit.json()) as { futureTenant?: unknown }).futureTenant,
+    ).toBe("tenant-new");
+    expect(upstreamCalls).toBe(2);
+  });
+
+  test("singleflights concurrent HEAD and GET onto one validated representation", async () => {
+    let upstreamCalls = 0;
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    stubFetch(async () => {
+      upstreamCalls += 1;
+      await barrier;
+      return providersUpstreamResponse({ futureGeneration: "same" });
+    });
+    const app = createStewardThinApp();
+    const getPromise = app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      {},
+      stewardEnv,
+    );
+    const headPromise = app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "HEAD" },
+      stewardEnv,
+    );
+    await Promise.resolve();
+    release();
+    const [get, head] = await Promise.all([getPromise, headPromise]);
+
+    expect(upstreamCalls).toBe(1);
+    expect(get.status).toBe(200);
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe("");
+    expect(
+      ((await get.json()) as { futureGeneration?: unknown }).futureGeneration,
+    ).toBe("same");
   });
 
   test("fails closed in production when REDIS_RATE_LIMITING=true without Redis", async () => {


### PR DESCRIPTION
Closes #24341

## Decision

This issue is relevant, on mission, necessary, and fixes a real fail-open authentication-discovery boundary. The managed login proxy previously validated only the selected object and `oauth`, so missing required fields and wrong scalar types could be patched, cached, and returned as healthy provider availability.

## What changed

- validates the complete current Steward SDK discovery contract before patching or caching;
- requires passkey, email, SIWE, SIWS, Google, Discord, GitHub, Twitter, and OAuth with their declared types;
- validates optional provider booleans, OIDC/disabled arrays, and captcha types/enums;
- preserves unknown envelope, provider, captcha, and forward-compatible flat `data` fields;
- preserves current flat and legacy `{ ok, data }` response shapes;
- returns explicit `502 steward_upstream_invalid_response` with `Cache-Control: no-store` for malformed successful upstream responses;
- prevents malformed responses from entering the isolate/browser cache;
- makes HEAD discovery validate the same upstream GET representation, strip the downstream body, and prime only a validated cache entry.

## Exact-head verification

Head: `9a6d39c2ee41cf4ce12c50271da6533c5c4d7130`
Validated develop: `0b88074d1b2910d3045b67f0b40506a6e8fb62ed`

- independent exact-source review: APPROVE, no remaining P1/P2 findings;
- independent broader focused run: 129/129 tests, 605 assertions across thin Steward, Worker entry, and embedded signing;
- exact-current-head root run: 121/121 tests, 583 assertions across thin Steward and real Worker entry;
- scoped Biome on all three changed files: pass;
- `git diff --check`: pass;
- guide parity: 160/160 pairs pass;
- current Steward SDK contract independently compared at `packages/sdk/src/auth-types.ts` commit `201c1869d40ffca8a207a32a24eecc7eb6f24cd6`;
- rebase range-diff from independently approved head: exact equivalence.

Package typecheck reaches one untouched current-base missing workspace dependency (`@elizaos/plugin-doordash`) and reports no changed-file errors. Root `bun run verify` reaches the unchanged current-base i18n gate (nine missing English login/menu keys plus existing locale fallback debt); this PR touches no UI or locale file.

## Evidence boundary

No UI, model, device, provider credential, schema, billing, or deployment behavior changes. The real Worker entry is exercised in-process through its production dispatch boundary; hosted Static Smoke remains the final hosted acceptance gate.

<!-- evidence-head:9a6d39c2ee41cf4ce12c50271da6533c5c4d7130 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend authentication discovery validation only; no visible flow changed

<!-- evidence-row:backend-logs -->
- [x] [exact-head JUnit text report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24380-24341-tests.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the production Worker response and cache contract is exercised in the attached backend test report

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text changed

## Attribution

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex Desktop / multi-agent
Attribution status: self-reported
