### PR TITLE
fix(sql): persist task due time and entity ownership

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -636,6 +636,7 @@ export abstract class DatabaseAdapter<DB extends object = object>
 	 */
 	abstract getTasks(params: {
 		roomId?: UUID;
+		worldId?: UUID;
 		tags?: string[];
 		entityId?: UUID;
 		agentIds: UUID[];

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -79,6 +79,21 @@ export function validateQueryEntitiesPagination(params: {
 	}
 }
 
+/** Enforces the portable pagination contract for task-query boundaries. */
+export function validateTaskQueryPagination(params: {
+	limit?: number;
+	offset?: number;
+}): void {
+	for (const field of ["limit", "offset"] as const) {
+		const value = params[field];
+		if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) {
+			throw new RangeError(
+				`getTasks ${field} must be a non-negative safe integer`,
+			);
+		}
+	}
+}
+
 /**
  * Compares UUID-backed memory ids in the same order as PostgreSQL's `uuid`
  * type. PostgreSQL normalizes hexadecimal case before ordering, so in-memory
@@ -92,6 +107,19 @@ export function compareMemoryIds(left: string, right: string): number {
 	if (normalizedLeft < normalizedRight) return -1;
 	if (normalizedLeft > normalizedRight) return 1;
 	return 0;
+}
+
+/** Matches PostgreSQL's ascending `(created_at, id)` task-query order. */
+export function compareTasksForQuery(left: Task, right: Task): number {
+	const leftCreatedAt = left.createdAt;
+	const rightCreatedAt = right.createdAt;
+	if (leftCreatedAt === undefined && rightCreatedAt !== undefined) return 1;
+	if (leftCreatedAt !== undefined && rightCreatedAt === undefined) return -1;
+	if (leftCreatedAt !== undefined && rightCreatedAt !== undefined) {
+		if (leftCreatedAt < rightCreatedAt) return -1;
+		if (leftCreatedAt > rightCreatedAt) return 1;
+	}
+	return compareMemoryIds(String(left.id ?? ""), String(right.id ?? ""));
 }
 
 /**

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -2008,6 +2008,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 
 	async getTasks(params: {
 		roomId?: UUID;
+		worldId?: UUID;
 		tags?: string[];
 		entityId?: UUID;
 		agentIds: UUID[];
@@ -2018,6 +2019,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		const all = Array.from(this.tasks.values());
 		let filtered = all.filter((t) => {
 			if (params.roomId && t.roomId !== params.roomId) return false;
+			if (params.worldId && t.worldId !== params.worldId) return false;
 			if (params.entityId && t.entityId !== params.entityId) return false;
 			if (t.agentId == null || !params.agentIds.includes(t.agentId))
 				return false;

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -15,8 +15,10 @@
  */
 import {
 	compareMemoryIds,
+	compareTasksForQuery,
 	DatabaseAdapter,
 	validateQueryEntitiesPagination,
+	validateTaskQueryPagination,
 } from "../database";
 import { ElizaError } from "../errors";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
@@ -2015,6 +2017,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		limit?: number;
 		offset?: number;
 	}): Promise<Task[]> {
+		validateTaskQueryPagination(params);
 		if (params.agentIds.length === 0) return [];
 		const all = Array.from(this.tasks.values());
 		let filtered = all.filter((t) => {
@@ -2030,6 +2033,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			}
 			return true;
 		});
+
+		filtered.sort(compareTasksForQuery);
 
 		// Paginate to bound result size.
 		const offset = params.offset ?? 0;

--- a/packages/core/src/database/inMemoryTaskQuery.test.ts
+++ b/packages/core/src/database/inMemoryTaskQuery.test.ts
@@ -1,0 +1,69 @@
+/** Verifies the core in-memory adapter's portable task filter and pagination contract. */
+
+import { describe, expect, it } from "vitest";
+import type { Task, UUID } from "../types";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter";
+
+const AGENT_ID = "10000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_AGENT_ID = "10000000-0000-0000-0000-000000000002" as UUID;
+const WORLD_ID = "10000000-0000-0000-0000-000000000003" as UUID;
+
+function task(
+	id: UUID,
+	createdAt: number,
+	overrides: Partial<Task> = {},
+): Task {
+	return {
+		id,
+		agentId: AGENT_ID,
+		worldId: WORLD_ID,
+		name: id,
+		tags: ["queue", "task-query"],
+		createdAt,
+		...overrides,
+	};
+}
+
+describe("core in-memory task queries", () => {
+	it("filters authority and returns stable created-at/id pages", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const first = "10000000-0000-0000-0000-000000000010" as UUID;
+		const second = "10000000-0000-0000-0000-000000000011" as UUID;
+		const third = "10000000-0000-0000-0000-000000000012" as UUID;
+		await adapter.createTasks([
+			task(third, 20),
+			task(second, 10),
+			task(first, 10),
+			task("10000000-0000-0000-0000-000000000013" as UUID, 1, {
+				agentId: OTHER_AGENT_ID,
+			}),
+			task("10000000-0000-0000-0000-000000000014" as UUID, 1, {
+				agentId: undefined,
+			}),
+		]);
+
+		const query = {
+			agentIds: [AGENT_ID],
+			worldId: WORLD_ID,
+			tags: ["queue", "task-query"],
+		};
+		await expect(
+			adapter.getTasks({ ...query, limit: 2 }),
+		).resolves.toMatchObject([{ id: first }, { id: second }]);
+		await expect(
+			adapter.getTasks({ ...query, limit: 1, offset: 2 }),
+		).resolves.toMatchObject([{ id: third }]);
+		await expect(adapter.getTasks({ agentIds: [] })).resolves.toEqual([]);
+	});
+
+	it.each([
+		["negative limit", { limit: -1 }],
+		["fractional limit", { limit: 1.5 }],
+		["unsafe offset", { offset: Number.MAX_SAFE_INTEGER + 1 }],
+	])("rejects %s", async (_label, pagination) => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await expect(
+			adapter.getTasks({ agentIds: [AGENT_ID], ...pagination }),
+		).rejects.toThrow(/non-negative safe integer/u);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11808,8 +11808,11 @@ ${section_end}`;
 
 	async getTasks(params: {
 		roomId?: UUID;
+		worldId?: UUID;
 		tags?: string[];
 		entityId?: UUID;
+		limit?: number;
+		offset?: number;
 	}): Promise<Task[]> {
 		return this.adapter.getTasks({ ...params, agentIds: [this.agentId] });
 	}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -34,7 +34,10 @@ import {
 import { ensureConnection as ensureConnectionStandalone } from "./connection";
 import { registerConnectorSourceDefinitions } from "./connectors";
 import { deriveKnownSecrets } from "./constants/secrets";
-import { validateQueryEntitiesPagination } from "./database";
+import {
+	validateQueryEntitiesPagination,
+	validateTaskQueryPagination,
+} from "./database";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
 import { ElizaError, type ReportedError, toElizaError } from "./errors";
 import {
@@ -11814,6 +11817,7 @@ ${section_end}`;
 		limit?: number;
 		offset?: number;
 	}): Promise<Task[]> {
+		validateTaskQueryPagination(params);
 		return this.adapter.getTasks({ ...params, agentIds: [this.agentId] });
 	}
 	async getTasksByName(name: string): Promise<Task[]> {

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1618,6 +1618,7 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	 */
 	getTasks(params: {
 		roomId?: UUID;
+		worldId?: UUID;
 		tags?: string[];
 		entityId?: UUID;
 		/** Required. Only tasks with agentId in this array are returned. Single agent = [id]. WHY: multi-tenant safety; schema indexes by agent_id; daemon batches one getTasks(agentIds) for many agents. */

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -139,7 +139,8 @@ export interface Task {
 	metadata?: TaskMetadata;
 	createdAt?: number | bigint;
 	updatedAt?: number | bigint;
-	dueAt?: number | bigint;
+	/** Millisecond deadline; null explicitly clears a previously persisted deadline. */
+	dueAt?: number | bigint | null;
 	status?: TaskStatus;
 }
 

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -22,6 +22,7 @@ import {
   canRequesterManageDocumentDirectGrants,
   canRequesterMutateDocument,
   compareMemoryIds,
+  compareTasksForQuery,
   DatabaseAdapter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
   type DocumentCompareAndSwapParams,
@@ -70,6 +71,7 @@ import {
   validateDocumentDirectGrantEntityIds,
   validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination,
+  validateTaskQueryPagination,
   type World,
   withinCreatedAtWindow,
 } from "@elizaos/core";
@@ -1970,26 +1972,29 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
 
   async getTasks(params: {
     roomId?: UUID;
+    worldId?: UUID;
     tags?: string[];
     entityId?: UUID;
     agentIds: UUID[];
     limit?: number;
     offset?: number;
   }): Promise<Task[]> {
+    validateTaskQueryPagination(params);
+    if (params.agentIds.length === 0) return [];
     const agentSet = new Set(params.agentIds);
     let tasks = await this.storage.getWhere<Task>(COLLECTIONS.TASKS, (t) => {
       const taskAgentId = (t as Task & { agentId?: UUID }).agentId;
-      if (agentSet.size > 0 && taskAgentId !== undefined && !agentSet.has(taskAgentId)) {
-        return false;
-      }
+      if (taskAgentId === undefined || !agentSet.has(taskAgentId)) return false;
       if (params.roomId && t.roomId !== params.roomId) return false;
+      if (params.worldId && t.worldId !== params.worldId) return false;
       if (params.entityId && t.entityId !== params.entityId) return false;
       if (params.tags && params.tags.length > 0) {
         const tags = t.tags ?? [];
-        if (!params.tags.some((tag) => tags.includes(tag))) return false;
+        if (!params.tags.every((tag) => tags.includes(tag))) return false;
       }
       return true;
     });
+    tasks.sort(compareTasksForQuery);
     const offset = params.offset ?? 0;
     if (offset > 0) tasks = tasks.slice(offset);
     if (params.limit !== undefined) tasks = tasks.slice(0, params.limit);

--- a/plugins/plugin-inmemorydb/task-query.test.ts
+++ b/plugins/plugin-inmemorydb/task-query.test.ts
@@ -1,0 +1,69 @@
+/** Verifies plugin-inmemorydb matches the shared task authority, filter, and pagination contract. */
+
+import type { Task, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const AGENT_ID = "20000000-0000-0000-0000-000000000001" as UUID;
+const OTHER_AGENT_ID = "20000000-0000-0000-0000-000000000002" as UUID;
+const WORLD_ID = "20000000-0000-0000-0000-000000000003" as UUID;
+
+function task(id: UUID, createdAt: number, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    agentId: AGENT_ID,
+    worldId: WORLD_ID,
+    name: id,
+    tags: ["queue", "task-query"],
+    createdAt,
+    ...overrides,
+  };
+}
+
+describe("plugin-inmemorydb task queries", () => {
+  it("filters authority and returns stable created-at/id pages", async () => {
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+    await adapter.initialize();
+    const first = "20000000-0000-0000-0000-000000000010" as UUID;
+    const second = "20000000-0000-0000-0000-000000000011" as UUID;
+    const third = "20000000-0000-0000-0000-000000000012" as UUID;
+    await adapter.createTasks([
+      task(third, 20),
+      task(second, 10),
+      task(first, 10),
+      task("20000000-0000-0000-0000-000000000013" as UUID, 1, {
+        agentId: OTHER_AGENT_ID,
+      }),
+      task("20000000-0000-0000-0000-000000000014" as UUID, 1, {
+        agentId: undefined,
+      }),
+    ]);
+
+    const query = {
+      agentIds: [AGENT_ID],
+      worldId: WORLD_ID,
+      tags: ["queue", "task-query"],
+    };
+    await expect(adapter.getTasks({ ...query, limit: 2 })).resolves.toMatchObject([
+      { id: first },
+      { id: second },
+    ]);
+    await expect(adapter.getTasks({ ...query, limit: 1, offset: 2 })).resolves.toMatchObject([
+      { id: third },
+    ]);
+    await expect(adapter.getTasks({ agentIds: [] })).resolves.toEqual([]);
+  });
+
+  it.each([
+    ["negative limit", { limit: -1 }],
+    ["fractional limit", { limit: 1.5 }],
+    ["unsafe offset", { offset: Number.MAX_SAFE_INTEGER + 1 }],
+  ])("rejects %s", async (_label, pagination) => {
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+    await adapter.initialize();
+    await expect(adapter.getTasks({ agentIds: [AGENT_ID], ...pagination })).rejects.toThrow(
+      /non-negative safe integer/u
+    );
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
@@ -96,10 +96,14 @@ describe("Task Integration Tests", () => {
         status: "pending",
         scheduledAt: "2030-03-17T17:46:45.000Z",
       });
-      await expect(adapter.getTasks({ entityId: testEntityId })).resolves.toEqual([
-        expect.objectContaining({ id: taskId, entityId: testEntityId }),
-      ]);
-      await expect(adapter.getTasks({ entityId: uuidv4() as UUID })).resolves.toEqual([]);
+      await expect(
+        adapter.getTasks({ entityId: testEntityId, agentIds: [testAgentId] })
+      ).resolves.toEqual([expect.objectContaining({ id: taskId, entityId: testEntityId })]);
+      await expect(
+        adapter.getTasks({ entityId: uuidv4() as UUID, agentIds: [testAgentId] })
+      ).resolves.toEqual([]);
+      await expect(adapter.getTasks({ agentIds: [] })).resolves.toEqual([]);
+      await expect(adapter.getTasks({ agentIds: [uuidv4() as UUID] })).resolves.toEqual([]);
       await expect(
         adapter.createTask({
           ...task,
@@ -128,7 +132,7 @@ describe("Task Integration Tests", () => {
 
       const byId = await adapter.getTask(taskId);
       const byName = await adapter.getTasksByName("Drain Task");
-      const byQuery = await adapter.getTasks({ tags: ["queue"] });
+      const byQuery = await adapter.getTasks({ tags: ["queue"], agentIds: [testAgentId] });
 
       expect(byId?.agentId).toBe(testAgentId);
       expect(byName).toHaveLength(1);
@@ -158,6 +162,12 @@ describe("Task Integration Tests", () => {
           affinityKey: "preserved",
           scheduledAt: "2030-03-17T17:46:49.000Z",
         },
+      });
+
+      await adapter.updateTask(taskId, { dueAt: null });
+      await expect(adapter.getTask(taskId)).resolves.toMatchObject({
+        dueAt: undefined,
+        metadata: { status: "pending", affinityKey: "preserved" },
       });
 
       await adapter.updateTask(taskId, {
@@ -309,9 +319,27 @@ describe("Task Integration Tests", () => {
       const filteredTasks = await adapter.getTasks({
         roomId: roomId1,
         tags: ["urgent"],
+        agentIds: [testAgentId],
       });
       expect(filteredTasks.length).toBe(1);
       expect(filteredTasks[0].id).toBe(task1.id as UUID);
+      await expect(
+        adapter.getTasks({
+          roomId: roomId1,
+          worldId: testWorldId,
+          entityId: testEntityId,
+          tags: ["a"],
+          agentIds: [testAgentId],
+        })
+      ).resolves.toHaveLength(2);
+      await expect(
+        adapter.getTasks({ worldId: uuidv4() as UUID, agentIds: [testAgentId] })
+      ).resolves.toEqual([]);
+      const firstPage = await adapter.getTasks({ agentIds: [testAgentId], limit: 1 });
+      const secondPage = await adapter.getTasks({ agentIds: [testAgentId], limit: 1, offset: 1 });
+      expect(firstPage).toHaveLength(1);
+      expect(secondPage).toHaveLength(1);
+      expect(secondPage[0]?.id).not.toBe(firstPage[0]?.id);
     });
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
@@ -4,6 +4,7 @@
  * — no mocks.
  */
 import { ChannelType, type Entity, logger, type Room, type Task, type UUID } from "@elizaos/core";
+import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PgDatabaseAdapter } from "../../pg/adapter";
@@ -104,6 +105,12 @@ describe("Task Integration Tests", () => {
       ).resolves.toEqual([]);
       await expect(adapter.getTasks({ agentIds: [] })).resolves.toEqual([]);
       await expect(adapter.getTasks({ agentIds: [uuidv4() as UUID] })).resolves.toEqual([]);
+      await expect(adapter.getTasks({ agentIds: [testAgentId], limit: -1 })).rejects.toThrow(
+        /non-negative safe integer/u
+      );
+      await expect(adapter.getTasks({ agentIds: [testAgentId], offset: 0.5 })).rejects.toThrow(
+        /non-negative safe integer/u
+      );
       await expect(
         adapter.createTask({
           ...task,
@@ -240,6 +247,79 @@ describe("Task Integration Tests", () => {
       expect(["completed", "executing"]).toContain(stored?.metadata?.status);
     });
 
+    it("atomically composes concurrent due-time patches with metadata replacement and clear", async () => {
+      const taskId = uuidv4() as UUID;
+      await adapter.createTask({
+        id: taskId,
+        roomId: testRoomId,
+        worldId: testWorldId,
+        entityId: testEntityId,
+        name: "Concurrent timing",
+        metadata: { owner: "old", preserved: true },
+      });
+
+      await Promise.all([
+        adapter.updateTask(taskId, { dueAt: 1_900_000_011_000 }),
+        adapter.updateTask(taskId, { metadata: { owner: "replacement" } }),
+      ]);
+      const replaced = await adapter.getTask(taskId);
+      expect(replaced?.metadata?.owner).toBe("replacement");
+      expect(replaced?.metadata).not.toHaveProperty("preserved");
+      expect([undefined, 1_900_000_011_000]).toContain(replaced?.dueAt);
+
+      await adapter.updateTask(taskId, {
+        dueAt: 1_900_000_012_000,
+        metadata: { owner: "stable" },
+      });
+      await Promise.all([
+        adapter.updateTask(taskId, { dueAt: 1_900_000_013_000 }),
+        adapter.updateTask(taskId, { dueAt: null }),
+      ]);
+      const raced = await adapter.getTask(taskId);
+      expect(raced?.metadata?.owner).toBe("stable");
+      expect([undefined, 1_900_000_013_000]).toContain(raced?.dueAt);
+    });
+
+    it("returns only tasks authorized by the requested agent set", async () => {
+      const secondAgentId = uuidv4() as UUID;
+      const existingAgent = await adapter.getAgent(testAgentId);
+      if (!existingAgent) throw new Error("test agent must exist");
+      await adapter.createAgent({
+        ...existingAgent,
+        id: secondAgentId,
+        name: "Second task authority",
+      });
+      const firstTaskId = uuidv4() as UUID;
+      const secondTaskId = uuidv4() as UUID;
+      await adapter.createTask({
+        id: firstTaskId,
+        roomId: testRoomId,
+        worldId: testWorldId,
+        entityId: testEntityId,
+        name: "First authority",
+        metadata: {},
+      });
+      await (adapter.getDatabase() as DrizzleDatabase).insert(taskTable).values({
+        id: secondTaskId,
+        agentId: secondAgentId,
+        roomId: testRoomId,
+        worldId: testWorldId,
+        entityId: testEntityId,
+        name: "Second authority",
+        metadata: {},
+      });
+
+      await expect(adapter.getTasks({ agentIds: [testAgentId, secondAgentId] })).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: firstTaskId, agentId: testAgentId }),
+          expect.objectContaining({ id: secondTaskId, agentId: secondAgentId }),
+        ])
+      );
+      const firstOnly = await adapter.getTasks({ agentIds: [testAgentId] });
+      expect(firstOnly.map((task) => task.id)).toContain(firstTaskId);
+      expect(firstOnly.map((task) => task.id)).not.toContain(secondTaskId);
+    });
+
     it("should delete a task", async () => {
       const taskId = uuidv4() as UUID;
       const task: Task = {
@@ -281,7 +361,7 @@ describe("Task Integration Tests", () => {
       ]);
 
       const task1: Task = {
-        id: uuidv4() as UUID,
+        id: "30000000-0000-0000-0000-000000000011" as UUID,
         roomId: roomId1,
         worldId: testWorldId,
         entityId: testEntityId,
@@ -293,7 +373,7 @@ describe("Task Integration Tests", () => {
       await adapter.createTask(task1);
 
       const task2: Task = {
-        id: uuidv4() as UUID,
+        id: "30000000-0000-0000-0000-000000000010" as UUID,
         roomId: roomId1,
         worldId: testWorldId,
         entityId: testEntityId,
@@ -315,6 +395,19 @@ describe("Task Integration Tests", () => {
         metadata: {},
       };
       await adapter.createTask(task3);
+      const db = adapter.getDatabase() as DrizzleDatabase;
+      await db
+        .update(taskTable)
+        .set({ createdAt: new Date("2030-01-01T00:00:01.000Z") })
+        .where(eq(taskTable.id, task1.id as UUID));
+      await db
+        .update(taskTable)
+        .set({ createdAt: new Date("2030-01-01T00:00:01.000Z") })
+        .where(eq(taskTable.id, task2.id as UUID));
+      await db
+        .update(taskTable)
+        .set({ createdAt: new Date("2030-01-01T00:00:02.000Z") })
+        .where(eq(taskTable.id, task3.id as UUID));
 
       const filteredTasks = await adapter.getTasks({
         roomId: roomId1,
@@ -337,9 +430,8 @@ describe("Task Integration Tests", () => {
       ).resolves.toEqual([]);
       const firstPage = await adapter.getTasks({ agentIds: [testAgentId], limit: 1 });
       const secondPage = await adapter.getTasks({ agentIds: [testAgentId], limit: 1, offset: 1 });
-      expect(firstPage).toHaveLength(1);
-      expect(secondPage).toHaveLength(1);
-      expect(secondPage[0]?.id).not.toBe(firstPage[0]?.id);
+      expect(firstPage).toMatchObject([{ id: task2.id }]);
+      expect(secondPage).toMatchObject([{ id: task1.id }]);
     });
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
@@ -3,9 +3,9 @@
  * Postgres, if `POSTGRES_URL` is set) adapter via `createIsolatedTestDatabase`
  * — no mocks.
  */
-import { ChannelType, type Entity, type Room, type Task, type UUID } from "@elizaos/core";
+import { ChannelType, type Entity, logger, type Room, type Task, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PgDatabaseAdapter } from "../../pg/adapter";
 import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
 import { taskTable } from "../../schema";
@@ -79,6 +79,7 @@ describe("Task Integration Tests", () => {
         name: "Test Task",
         description: "A test task",
         tags: ["a", "b"],
+        dueAt: 1_900_000_005_000n,
         metadata: { status: "pending" },
       };
 
@@ -89,6 +90,26 @@ describe("Task Integration Tests", () => {
       expect(retrieved).not.toBeNull();
       expect(retrieved?.id).toBe(taskId);
       expect(retrieved?.agentId).toBe(testAgentId);
+      expect(retrieved?.entityId).toBe(testEntityId);
+      expect(retrieved?.dueAt).toBe(1_900_000_005_000);
+      expect(retrieved?.metadata).toMatchObject({
+        status: "pending",
+        scheduledAt: "2030-03-17T17:46:45.000Z",
+      });
+      await expect(adapter.getTasks({ entityId: testEntityId })).resolves.toEqual([
+        expect.objectContaining({ id: taskId, entityId: testEntityId }),
+      ]);
+      await expect(adapter.getTasks({ entityId: uuidv4() as UUID })).resolves.toEqual([]);
+      await expect(
+        adapter.createTask({
+          ...task,
+          id: uuidv4() as UUID,
+          dueAt: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+        })
+      ).rejects.toThrow("safe integer millisecond timestamp");
+      await expect(
+        adapter.createTask({ ...task, id: uuidv4() as UUID, dueAt: Number.NaN })
+      ).rejects.toThrow("safe integer millisecond timestamp");
     });
 
     it("returns agentId from task lookup APIs", async () => {
@@ -125,18 +146,59 @@ describe("Task Integration Tests", () => {
         name: "Original Task",
         description: "Original description",
         tags: ["a"],
-        metadata: { status: "pending" },
+        metadata: { status: "pending", affinityKey: "preserved" },
       };
       await adapter.createTask(originalTask);
 
+      await adapter.updateTask(taskId, { dueAt: 1_900_000_009_000 });
+      await expect(adapter.getTask(taskId)).resolves.toMatchObject({
+        dueAt: 1_900_000_009_000,
+        metadata: {
+          status: "pending",
+          affinityKey: "preserved",
+          scheduledAt: "2030-03-17T17:46:49.000Z",
+        },
+      });
+
       await adapter.updateTask(taskId, {
         description: "Updated Description",
+        dueAt: 1_900_000_010_000,
         metadata: { status: "completed" },
       });
 
       const retrieved = await adapter.getTask(taskId);
       expect(retrieved?.description).toBe("Updated Description");
-      expect(retrieved?.metadata).toEqual({ status: "completed" });
+      expect(retrieved?.dueAt).toBe(1_900_000_010_000);
+      expect(retrieved?.metadata).toEqual({
+        status: "completed",
+        scheduledAt: "2030-03-17T17:46:50.000Z",
+      });
+    });
+
+    it("does not retry malformed persisted task timing", async () => {
+      const taskId = uuidv4() as UUID;
+      await adapter.createTask({
+        id: taskId,
+        roomId: testRoomId,
+        worldId: testWorldId,
+        entityId: testEntityId,
+        name: "Malformed timing",
+        metadata: {},
+      });
+      await (adapter.getDatabase() as DrizzleDatabase)
+        .update(taskTable)
+        .set({ metadata: { scheduledAt: "not-a-date" } });
+
+      const warn = vi.spyOn(logger, "warn");
+      try {
+        await expect(adapter.getTask(taskId)).rejects.toThrow("ISO-8601");
+        expect(warn).not.toHaveBeenCalledWith(
+          expect.objectContaining({ src: "plugin:sql" }),
+          "Database operation failed, retrying"
+        );
+      } finally {
+        warn.mockRestore();
+      }
     });
 
     it("allows exactly one pending-task lifecycle transition", async () => {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -91,6 +91,7 @@ import {
   type World,
 } from "@elizaos/core";
 import { sanitizeJsonObject } from "./sanitize-json";
+import { readTaskDueAt, serializeTaskDueAt, TaskTimingValidationError } from "./stores/task-timing";
 
 function agentBioRowsFromDb(bio: unknown): string[] {
   if (bio == null) return [];
@@ -763,6 +764,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       try {
         return await operation();
       } catch (error) {
+        if (error instanceof TaskTimingValidationError) throw error;
         lastError = error as Error;
 
         if (attempt < this.maxRetries) {
@@ -5096,10 +5098,14 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     if (!task.worldId) {
       task = { ...task, worldId: this.agentId as UUID };
     }
+    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
     return this.withRetry(async () => {
       return this.withDatabase(async () => {
         const now = new Date();
-        const metadata = task.metadata || {};
+        const metadata: TaskMetadata = {
+          ...(task.metadata || {}),
+          ...(scheduledAt === undefined ? {} : { scheduledAt }),
+        };
 
         const values = {
           // Only include id when provided; otherwise let the DB use its
@@ -5110,6 +5116,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           description: task.description,
           roomId: task.roomId as UUID,
           worldId: task.worldId as UUID,
+          entityId: task.entityId as UUID,
           tags: task.tags,
           metadata: metadata,
           createdAt: now,
@@ -5143,6 +5150,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             and(
               eq(taskTable.agentId, this.agentId),
               ...(params.roomId ? [eq(taskTable.roomId, params.roomId)] : []),
+              ...(params.entityId ? [eq(taskTable.entityId, params.entityId)] : []),
               ...(params.tags && params.tags.length > 0
                 ? [
                     sql`${taskTable.tags} @> ARRAY[${sql.join(
@@ -5154,16 +5162,21 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             )
           );
 
-        return result.map((row) => ({
-          id: row.id as UUID,
-          agentId: row.agentId as UUID,
-          name: row.name,
-          description: row.description ?? "",
-          roomId: row.roomId as UUID,
-          worldId: row.worldId as UUID,
-          tags: row.tags || [],
-          metadata: row.metadata as TaskMetadata,
-        }));
+        return result.map((row) => {
+          const metadata = (row.metadata || {}) as TaskMetadata;
+          return {
+            id: row.id as UUID,
+            agentId: row.agentId as UUID,
+            name: row.name,
+            description: row.description ?? "",
+            roomId: row.roomId as UUID,
+            worldId: row.worldId as UUID,
+            entityId: row.entityId as UUID,
+            tags: row.tags || [],
+            dueAt: readTaskDueAt(metadata),
+            metadata,
+          };
+        });
       });
     });
   }
@@ -5181,16 +5194,21 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .from(taskTable)
           .where(and(eq(taskTable.name, name), eq(taskTable.agentId, this.agentId)));
 
-        return result.map((row) => ({
-          id: row.id as UUID,
-          agentId: row.agentId as UUID,
-          name: row.name,
-          description: row.description ?? "",
-          roomId: row.roomId as UUID,
-          worldId: row.worldId as UUID,
-          tags: row.tags || [],
-          metadata: (row.metadata || {}) as TaskMetadata,
-        }));
+        return result.map((row) => {
+          const metadata = (row.metadata || {}) as TaskMetadata;
+          return {
+            id: row.id as UUID,
+            agentId: row.agentId as UUID,
+            name: row.name,
+            description: row.description ?? "",
+            roomId: row.roomId as UUID,
+            worldId: row.worldId as UUID,
+            entityId: row.entityId as UUID,
+            tags: row.tags || [],
+            dueAt: readTaskDueAt(metadata),
+            metadata,
+          };
+        });
       });
     });
   }
@@ -5214,6 +5232,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         }
 
         const row = result[0];
+        const metadata = (row.metadata || {}) as TaskMetadata;
         return {
           id: row.id as UUID,
           agentId: row.agentId as UUID,
@@ -5221,8 +5240,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           description: row.description ?? "",
           roomId: row.roomId as UUID,
           worldId: row.worldId as UUID,
+          entityId: row.entityId as UUID,
           tags: row.tags || [],
-          metadata: (row.metadata || {}) as TaskMetadata,
+          dueAt: readTaskDueAt(metadata),
+          metadata,
         };
       });
     });
@@ -5235,6 +5256,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
    * @returns Promise resolving when the update is complete
    */
   async updateTask(id: UUID, task: Partial<Task>): Promise<void> {
+    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
     await this.withRetry(async () => {
       await this.withDatabase(async () => {
         const updateValues: Partial<typeof taskTable.$inferInsert> = {};
@@ -5244,9 +5266,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         if (task.description !== undefined) updateValues.description = task.description;
         if (task.roomId !== undefined) updateValues.roomId = task.roomId;
         if (task.worldId !== undefined) updateValues.worldId = task.worldId;
+        if (task.entityId !== undefined) updateValues.entityId = task.entityId;
         if (task.tags !== undefined) updateValues.tags = task.tags;
-        if (task.metadata !== undefined)
-          updateValues.metadata = task.metadata as typeof taskTable.$inferInsert.metadata;
+        if (task.metadata !== undefined) {
+          updateValues.metadata = {
+            ...task.metadata,
+            ...(scheduledAt === undefined ? {} : { scheduledAt }),
+          };
+        } else if (scheduledAt !== undefined) {
+          const dueAtPatch = JSON.stringify({ scheduledAt });
+          updateValues.metadata = sql`COALESCE(${taskTable.metadata}, '{}'::jsonb) || ${dueAtPatch}::jsonb`;
+        }
         // Handle createdAt if present in the task object (using type assertion for compatibility)
         const taskWithCreatedAt = task as {
           createdAt?: number | bigint | null;
@@ -5265,10 +5295,6 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         };
 
         // Handle metadata updates - just set it directly without merging
-        if (task.metadata !== undefined) {
-          dbUpdateValues.metadata = task.metadata;
-        }
-
         await this.db
           .update(taskTable)
           // createdAt is hella borked, number / Date

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -88,6 +88,7 @@ import {
   validateDocumentRequesterContext,
   validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination,
+  validateTaskQueryPagination,
   type World,
 } from "@elizaos/core";
 import { sanitizeJsonObject } from "./sanitize-json";
@@ -5145,6 +5146,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     limit?: number;
     offset?: number;
   }): Promise<Task[]> {
+    validateTaskQueryPagination(params);
     if (params.agentIds.length === 0) return [];
     return this.withRetry(async () => {
       return this.withDatabase(async () => {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -91,7 +91,12 @@ import {
   type World,
 } from "@elizaos/core";
 import { sanitizeJsonObject } from "./sanitize-json";
-import { readTaskDueAt, serializeTaskDueAt, TaskTimingValidationError } from "./stores/task-timing";
+import {
+  readTaskDueAt,
+  serializeTaskDueAt,
+  TaskTimingValidationError,
+  taskMetadataForWrite,
+} from "./stores/task-timing";
 
 function agentBioRowsFromDb(bio: unknown): string[] {
   if (bio == null) return [];
@@ -5098,15 +5103,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     if (!task.worldId) {
       task = { ...task, worldId: this.agentId as UUID };
     }
-    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
+    const metadata = taskMetadataForWrite(task.metadata, task.dueAt);
     return this.withRetry(async () => {
       return this.withDatabase(async () => {
         const now = new Date();
-        const metadata: TaskMetadata = {
-          ...(task.metadata || {}),
-          ...(scheduledAt === undefined ? {} : { scheduledAt }),
-        };
-
         const values = {
           // Only include id when provided; otherwise let the DB use its
           // gen_random_uuid() DEFAULT — passing undefined explicitly causes
@@ -5138,9 +5138,14 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
    */
   async getTasks(params: {
     roomId?: UUID;
+    worldId?: UUID;
     tags?: string[];
-    entityId?: UUID; // Added entityId parameter
+    entityId?: UUID;
+    agentIds: UUID[];
+    limit?: number;
+    offset?: number;
   }): Promise<Task[]> {
+    if (params.agentIds.length === 0) return [];
     return this.withRetry(async () => {
       return this.withDatabase(async () => {
         const result = await this.db
@@ -5148,8 +5153,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .from(taskTable)
           .where(
             and(
-              eq(taskTable.agentId, this.agentId),
+              inArray(taskTable.agentId, params.agentIds),
               ...(params.roomId ? [eq(taskTable.roomId, params.roomId)] : []),
+              ...(params.worldId ? [eq(taskTable.worldId, params.worldId)] : []),
               ...(params.entityId ? [eq(taskTable.entityId, params.entityId)] : []),
               ...(params.tags && params.tags.length > 0
                 ? [
@@ -5160,7 +5166,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
                   ]
                 : [])
             )
-          );
+          )
+          .orderBy(asc(taskTable.createdAt), asc(taskTable.id))
+          .limit(params.limit ?? Number.MAX_SAFE_INTEGER)
+          .offset(params.offset ?? 0);
 
         return result.map((row) => {
           const metadata = (row.metadata || {}) as TaskMetadata;
@@ -5256,7 +5265,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
    * @returns Promise resolving when the update is complete
    */
   async updateTask(id: UUID, task: Partial<Task>): Promise<void> {
-    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
+    const scheduledAt = task.dueAt == null ? undefined : serializeTaskDueAt(task.dueAt);
+    const replacementMetadata =
+      task.metadata === undefined ? undefined : taskMetadataForWrite(task.metadata, task.dueAt);
     await this.withRetry(async () => {
       await this.withDatabase(async () => {
         const updateValues: Partial<typeof taskTable.$inferInsert> = {};
@@ -5269,13 +5280,12 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         if (task.entityId !== undefined) updateValues.entityId = task.entityId;
         if (task.tags !== undefined) updateValues.tags = task.tags;
         if (task.metadata !== undefined) {
-          updateValues.metadata = {
-            ...task.metadata,
-            ...(scheduledAt === undefined ? {} : { scheduledAt }),
-          };
+          updateValues.metadata = replacementMetadata;
         } else if (scheduledAt !== undefined) {
           const dueAtPatch = JSON.stringify({ scheduledAt });
           updateValues.metadata = sql`COALESCE(${taskTable.metadata}, '{}'::jsonb) || ${dueAtPatch}::jsonb`;
+        } else if (task.dueAt === null) {
+          updateValues.metadata = sql`COALESCE(${taskTable.metadata}, '{}'::jsonb) - 'scheduledAt'`;
         }
         // Handle createdAt if present in the task object (using type assertion for compatibility)
         const taskWithCreatedAt = task as {
@@ -5311,7 +5321,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
    */
   async deleteTask(id: UUID): Promise<void> {
     return this.withDatabase(async () => {
-      await this.db.delete(taskTable).where(eq(taskTable.id, id));
+      await this.db
+        .delete(taskTable)
+        .where(and(eq(taskTable.id, id), eq(taskTable.agentId, this.agentId)));
     });
   }
 

--- a/plugins/plugin-sql/src/schema/tasks.ts
+++ b/plugins/plugin-sql/src/schema/tasks.ts
@@ -5,21 +5,30 @@
  * state.
  */
 import { sql } from "drizzle-orm";
-import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 
-export const taskTable = pgTable("tasks", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  name: text("name").notNull(),
-  description: text("description"),
-  roomId: uuid("room_id"),
-  worldId: uuid("world_id"),
-  entityId: uuid("entity_id"),
-  agentId: uuid("agent_id")
-    .notNull()
-    .references(() => agentTable.id, { onDelete: "cascade" }),
-  tags: text("tags").array().default(sql`'{}'::text[]`),
-  metadata: jsonb("metadata").default(sql`'{}'::jsonb`),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
-});
+export const taskTable = pgTable(
+  "tasks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    description: text("description"),
+    roomId: uuid("room_id"),
+    worldId: uuid("world_id"),
+    entityId: uuid("entity_id"),
+    agentId: uuid("agent_id")
+      .notNull()
+      .references(() => agentTable.id, { onDelete: "cascade" }),
+    tags: text("tags").array().default(sql`'{}'::text[]`),
+    metadata: jsonb("metadata").default(sql`'{}'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    index("tasks_agent_created_id_idx").on(table.agentId, table.createdAt, table.id),
+    index("tasks_agent_room_idx").on(table.agentId, table.roomId),
+    index("tasks_agent_world_idx").on(table.agentId, table.worldId),
+    index("tasks_agent_entity_idx").on(table.agentId, table.entityId),
+  ]
+);

--- a/plugins/plugin-sql/src/stores/task-timing.test.ts
+++ b/plugins/plugin-sql/src/stores/task-timing.test.ts
@@ -1,0 +1,27 @@
+/** Verifies exact and fail-closed task due-time conversion at the SQL persistence boundary. */
+
+import type { TaskMetadata } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { readTaskDueAt, serializeTaskDueAt } from "./task-timing";
+
+describe("SQL task timing", () => {
+  it("serializes safe bigint milliseconds as canonical ISO-8601", () => {
+    expect(serializeTaskDueAt(1_900_000_005_000n)).toBe("2030-03-17T17:46:45.000Z");
+    expect(readTaskDueAt({ scheduledAt: "2030-03-17T17:46:45.000Z" })).toBe(1_900_000_005_000);
+  });
+
+  it("reads a finite legacy numeric metadata value", () => {
+    const legacy = {
+      scheduledAt: 1_900_000_005_000,
+    } as unknown as TaskMetadata;
+    expect(readTaskDueAt(legacy)).toBe(1_900_000_005_000);
+  });
+
+  it("rejects lossy, out-of-range, and malformed values", () => {
+    expect(() => serializeTaskDueAt(Number.NaN)).toThrow("safe integer");
+    expect(() => serializeTaskDueAt(1.5)).toThrow("safe integer");
+    expect(() => serializeTaskDueAt(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow("safe integer");
+    expect(() => readTaskDueAt({ scheduledAt: "not-a-date" })).toThrow("ISO-8601");
+    expect(() => readTaskDueAt({ scheduledAt: "" })).toThrow("ISO-8601");
+  });
+});

--- a/plugins/plugin-sql/src/stores/task-timing.test.ts
+++ b/plugins/plugin-sql/src/stores/task-timing.test.ts
@@ -2,12 +2,14 @@
 
 import type { TaskMetadata } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { readTaskDueAt, serializeTaskDueAt } from "./task-timing";
+import { readTaskDueAt, serializeTaskDueAt, taskMetadataForWrite } from "./task-timing";
 
 describe("SQL task timing", () => {
   it("serializes safe bigint milliseconds as canonical ISO-8601", () => {
     expect(serializeTaskDueAt(1_900_000_005_000n)).toBe("2030-03-17T17:46:45.000Z");
     expect(readTaskDueAt({ scheduledAt: "2030-03-17T17:46:45.000Z" })).toBe(1_900_000_005_000);
+    expect(serializeTaskDueAt(-1)).toBe("1969-12-31T23:59:59.999Z");
+    expect(readTaskDueAt({ scheduledAt: "1969-12-31T23:59:59.999Z" })).toBe(-1);
   });
 
   it("reads a finite legacy numeric metadata value", () => {
@@ -17,11 +19,27 @@ describe("SQL task timing", () => {
     expect(readTaskDueAt(legacy)).toBe(1_900_000_005_000);
   });
 
+  it("distinguishes absent, set, and explicit-clear writes", () => {
+    expect(taskMetadataForWrite({ owner: "a" }, undefined)).toEqual({ owner: "a" });
+    expect(taskMetadataForWrite({ scheduledAt: "2030-03-17T17:46:45.000Z" }, null)).toEqual({});
+    expect(taskMetadataForWrite({ scheduledAt: "not-a-date" }, 0)).toEqual({
+      scheduledAt: "1970-01-01T00:00:00.000Z",
+    });
+    expect(() => taskMetadataForWrite({ scheduledAt: "March 17, 2030" }, undefined)).toThrow(
+      "ISO-8601"
+    );
+  });
+
   it("rejects lossy, out-of-range, and malformed values", () => {
     expect(() => serializeTaskDueAt(Number.NaN)).toThrow("safe integer");
     expect(() => serializeTaskDueAt(1.5)).toThrow("safe integer");
     expect(() => serializeTaskDueAt(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow("safe integer");
     expect(() => readTaskDueAt({ scheduledAt: "not-a-date" })).toThrow("ISO-8601");
     expect(() => readTaskDueAt({ scheduledAt: "" })).toThrow("ISO-8601");
+    expect(() => readTaskDueAt({ scheduledAt: "2030-03-17T17:46:45Z" })).toThrow("ISO-8601");
+    expect(() => readTaskDueAt({ scheduledAt: "2030-03-17 17:46:45.000Z" })).toThrow("ISO-8601");
+    expect(() => readTaskDueAt({ scheduledAt: "2030-03-17T09:46:45.000-08:00" })).toThrow(
+      "ISO-8601"
+    );
   });
 });

--- a/plugins/plugin-sql/src/stores/task-timing.ts
+++ b/plugins/plugin-sql/src/stores/task-timing.ts
@@ -1,0 +1,42 @@
+/** Converts the public task due-time field to and from its canonical SQL metadata representation. */
+
+import type { TaskMetadata } from "@elizaos/core";
+
+export class TaskTimingValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TaskTimingValidationError";
+  }
+}
+
+function safeTimestamp(value: number, label: string): number {
+  if (!Number.isSafeInteger(value)) {
+    throw new TaskTimingValidationError(`${label} must be a safe integer millisecond timestamp`);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new TaskTimingValidationError(`${label} is outside the supported date range`);
+  }
+  return value;
+}
+
+export function serializeTaskDueAt(dueAt: number | bigint): string {
+  const numeric = typeof dueAt === "bigint" ? Number(dueAt) : dueAt;
+  return new Date(safeTimestamp(numeric, "task dueAt")).toISOString();
+}
+
+export function readTaskDueAt(metadata: TaskMetadata): number | undefined {
+  const scheduledAt: unknown = metadata.scheduledAt;
+  if (scheduledAt === undefined) return undefined;
+  if (typeof scheduledAt === "number") {
+    return safeTimestamp(scheduledAt, "task metadata.scheduledAt");
+  }
+  if (typeof scheduledAt !== "string" || scheduledAt.trim().length === 0) {
+    throw new TaskTimingValidationError("task metadata.scheduledAt must be an ISO-8601 string");
+  }
+  const parsed = Date.parse(scheduledAt);
+  if (Number.isNaN(parsed)) {
+    throw new TaskTimingValidationError("task metadata.scheduledAt must be an ISO-8601 string");
+  }
+  return safeTimestamp(parsed, "task metadata.scheduledAt");
+}

--- a/plugins/plugin-sql/src/stores/task-timing.ts
+++ b/plugins/plugin-sql/src/stores/task-timing.ts
@@ -1,13 +1,14 @@
 /** Converts the public task due-time field to and from its canonical SQL metadata representation. */
 
-import type { TaskMetadata } from "@elizaos/core";
+import { ElizaError, type TaskMetadata } from "@elizaos/core";
 
-export class TaskTimingValidationError extends Error {
+export class TaskTimingValidationError extends ElizaError {
   constructor(message: string) {
-    super(message);
-    this.name = "TaskTimingValidationError";
+    super(message, { code: "TASK_TIMING_INVALID" });
   }
 }
+
+const CANONICAL_ISO_INSTANT = /^(?:\d{4}|[+-]\d{6})-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 function safeTimestamp(value: number, label: string): number {
   if (!Number.isSafeInteger(value)) {
@@ -21,8 +22,30 @@ function safeTimestamp(value: number, label: string): number {
 }
 
 export function serializeTaskDueAt(dueAt: number | bigint): string {
+  if (
+    typeof dueAt === "bigint" &&
+    (dueAt < BigInt(Number.MIN_SAFE_INTEGER) || dueAt > BigInt(Number.MAX_SAFE_INTEGER))
+  ) {
+    throw new TaskTimingValidationError("task dueAt must be a safe integer millisecond timestamp");
+  }
   const numeric = typeof dueAt === "bigint" ? Number(dueAt) : dueAt;
   return new Date(safeTimestamp(numeric, "task dueAt")).toISOString();
+}
+
+/** Build caller-authored metadata before retry admission, preserving explicit clear semantics. */
+export function taskMetadataForWrite(
+  metadata: TaskMetadata | undefined,
+  dueAt: number | bigint | null | undefined
+): TaskMetadata {
+  const result: TaskMetadata = { ...(metadata || {}) };
+  if (dueAt === null) {
+    delete result.scheduledAt;
+  } else if (dueAt !== undefined) {
+    result.scheduledAt = serializeTaskDueAt(dueAt);
+  } else {
+    readTaskDueAt(result);
+  }
+  return result;
 }
 
 export function readTaskDueAt(metadata: TaskMetadata): number | undefined {
@@ -34,9 +57,14 @@ export function readTaskDueAt(metadata: TaskMetadata): number | undefined {
   if (typeof scheduledAt !== "string" || scheduledAt.trim().length === 0) {
     throw new TaskTimingValidationError("task metadata.scheduledAt must be an ISO-8601 string");
   }
-  const parsed = Date.parse(scheduledAt);
-  if (Number.isNaN(parsed)) {
+  if (!CANONICAL_ISO_INSTANT.test(scheduledAt)) {
     throw new TaskTimingValidationError("task metadata.scheduledAt must be an ISO-8601 string");
   }
-  return safeTimestamp(parsed, "task metadata.scheduledAt");
+  const parsed = safeTimestamp(Date.parse(scheduledAt), "task metadata.scheduledAt");
+  if (new Date(parsed).toISOString() !== scheduledAt) {
+    throw new TaskTimingValidationError(
+      "task metadata.scheduledAt must be a canonical ISO-8601 instant"
+    );
+  }
+  return parsed;
 }

--- a/plugins/plugin-sql/src/stores/task.store.ts
+++ b/plugins/plugin-sql/src/stores/task.store.ts
@@ -3,6 +3,7 @@ import type { Task, TaskMetadata, UUID } from "@elizaos/core";
 import { and, eq, sql } from "drizzle-orm";
 import { taskTable } from "../schema/index";
 import type { DrizzleDatabase } from "../types";
+import { readTaskDueAt, serializeTaskDueAt } from "./task-timing";
 import type { Store, StoreContext } from "./types";
 
 export class TaskStore implements Store {
@@ -14,10 +15,14 @@ export class TaskStore implements Store {
 
   async create(task: Task): Promise<UUID> {
     if (!task.worldId) throw new Error("worldId is required");
+    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
 
     return this.ctx.withRetry(async () => {
       const now = new Date();
-      const metadata = task.metadata || {};
+      const metadata: TaskMetadata = {
+        ...(task.metadata || {}),
+        ...(scheduledAt === undefined ? {} : { scheduledAt }),
+      };
 
       const values = {
         id: task.id as UUID,
@@ -25,6 +30,7 @@ export class TaskStore implements Store {
         description: task.description,
         roomId: task.roomId as UUID,
         worldId: task.worldId as UUID,
+        entityId: task.entityId as UUID,
         tags: task.tags,
         metadata: metadata,
         createdAt: now,
@@ -46,6 +52,7 @@ export class TaskStore implements Store {
           and(
             eq(taskTable.agentId, this.ctx.agentId),
             ...(params.roomId ? [eq(taskTable.roomId, params.roomId)] : []),
+            ...(params.entityId ? [eq(taskTable.entityId, params.entityId)] : []),
             ...(params.tags && params.tags.length > 0
               ? [
                   sql`${taskTable.tags} @> ARRAY[${sql.join(
@@ -57,15 +64,20 @@ export class TaskStore implements Store {
           )
         );
 
-      return result.map((row) => ({
-        id: row.id as UUID,
-        name: row.name,
-        description: row.description ?? "",
-        roomId: row.roomId as UUID,
-        worldId: row.worldId as UUID,
-        tags: row.tags || [],
-        metadata: row.metadata as TaskMetadata,
-      }));
+      return result.map((row) => {
+        const metadata = (row.metadata || {}) as TaskMetadata;
+        return {
+          id: row.id as UUID,
+          name: row.name,
+          description: row.description ?? "",
+          roomId: row.roomId as UUID,
+          worldId: row.worldId as UUID,
+          entityId: row.entityId as UUID,
+          tags: row.tags || [],
+          dueAt: readTaskDueAt(metadata),
+          metadata,
+        };
+      });
     }, "TaskStore.getAll");
   }
 
@@ -76,15 +88,20 @@ export class TaskStore implements Store {
         .from(taskTable)
         .where(and(eq(taskTable.name, name), eq(taskTable.agentId, this.ctx.agentId)));
 
-      return result.map((row) => ({
-        id: row.id as UUID,
-        name: row.name,
-        description: row.description ?? "",
-        roomId: row.roomId as UUID,
-        worldId: row.worldId as UUID,
-        tags: row.tags || [],
-        metadata: (row.metadata || {}) as TaskMetadata,
-      }));
+      return result.map((row) => {
+        const metadata = (row.metadata || {}) as TaskMetadata;
+        return {
+          id: row.id as UUID,
+          name: row.name,
+          description: row.description ?? "",
+          roomId: row.roomId as UUID,
+          worldId: row.worldId as UUID,
+          entityId: row.entityId as UUID,
+          tags: row.tags || [],
+          dueAt: readTaskDueAt(metadata),
+          metadata,
+        };
+      });
     }, "TaskStore.getByName");
   }
 
@@ -99,19 +116,23 @@ export class TaskStore implements Store {
       if (result.length === 0) return null;
 
       const row = result[0];
+      const metadata = (row.metadata || {}) as TaskMetadata;
       return {
         id: row.id as UUID,
         name: row.name,
         description: row.description ?? "",
         roomId: row.roomId as UUID,
         worldId: row.worldId as UUID,
+        entityId: row.entityId as UUID,
         tags: row.tags || [],
-        metadata: (row.metadata || {}) as TaskMetadata,
+        dueAt: readTaskDueAt(metadata),
+        metadata,
       };
     }, "TaskStore.get");
   }
 
   async update(id: UUID, task: Partial<Task>): Promise<void> {
+    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
     return this.ctx.withRetry(async () => {
       const dbUpdateValues: Partial<typeof taskTable.$inferInsert> & { updatedAt: Date } = {
         updatedAt: new Date(),
@@ -121,8 +142,17 @@ export class TaskStore implements Store {
       if (task.description !== undefined) dbUpdateValues.description = task.description;
       if (task.roomId !== undefined) dbUpdateValues.roomId = task.roomId;
       if (task.worldId !== undefined) dbUpdateValues.worldId = task.worldId;
+      if (task.entityId !== undefined) dbUpdateValues.entityId = task.entityId;
       if (task.tags !== undefined) dbUpdateValues.tags = task.tags;
-      if (task.metadata !== undefined) dbUpdateValues.metadata = task.metadata;
+      if (task.metadata !== undefined) {
+        dbUpdateValues.metadata = {
+          ...task.metadata,
+          ...(scheduledAt === undefined ? {} : { scheduledAt }),
+        };
+      } else if (scheduledAt !== undefined) {
+        const dueAtPatch = JSON.stringify({ scheduledAt });
+        dbUpdateValues.metadata = sql`COALESCE(${taskTable.metadata}, '{}'::jsonb) || ${dueAtPatch}::jsonb`;
+      }
 
       await this.db
         .update(taskTable)

--- a/plugins/plugin-sql/src/stores/task.store.ts
+++ b/plugins/plugin-sql/src/stores/task.store.ts
@@ -3,7 +3,7 @@ import type { Task, TaskMetadata, UUID } from "@elizaos/core";
 import { and, eq, sql } from "drizzle-orm";
 import { taskTable } from "../schema/index";
 import type { DrizzleDatabase } from "../types";
-import { readTaskDueAt, serializeTaskDueAt } from "./task-timing";
+import { readTaskDueAt, serializeTaskDueAt, taskMetadataForWrite } from "./task-timing";
 import type { Store, StoreContext } from "./types";
 
 export class TaskStore implements Store {
@@ -15,14 +15,10 @@ export class TaskStore implements Store {
 
   async create(task: Task): Promise<UUID> {
     if (!task.worldId) throw new Error("worldId is required");
-    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
+    const metadata = taskMetadataForWrite(task.metadata, task.dueAt);
 
     return this.ctx.withRetry(async () => {
       const now = new Date();
-      const metadata: TaskMetadata = {
-        ...(task.metadata || {}),
-        ...(scheduledAt === undefined ? {} : { scheduledAt }),
-      };
 
       const values = {
         id: task.id as UUID,
@@ -43,7 +39,12 @@ export class TaskStore implements Store {
     }, "TaskStore.create");
   }
 
-  async getAll(params: { roomId?: UUID; tags?: string[]; entityId?: UUID }): Promise<Task[]> {
+  async getAll(params: {
+    roomId?: UUID;
+    worldId?: UUID;
+    tags?: string[];
+    entityId?: UUID;
+  }): Promise<Task[]> {
     return this.ctx.withRetry(async () => {
       const result = await this.db
         .select()
@@ -52,6 +53,7 @@ export class TaskStore implements Store {
           and(
             eq(taskTable.agentId, this.ctx.agentId),
             ...(params.roomId ? [eq(taskTable.roomId, params.roomId)] : []),
+            ...(params.worldId ? [eq(taskTable.worldId, params.worldId)] : []),
             ...(params.entityId ? [eq(taskTable.entityId, params.entityId)] : []),
             ...(params.tags && params.tags.length > 0
               ? [
@@ -132,7 +134,9 @@ export class TaskStore implements Store {
   }
 
   async update(id: UUID, task: Partial<Task>): Promise<void> {
-    const scheduledAt = task.dueAt === undefined ? undefined : serializeTaskDueAt(task.dueAt);
+    const scheduledAt = task.dueAt == null ? undefined : serializeTaskDueAt(task.dueAt);
+    const replacementMetadata =
+      task.metadata === undefined ? undefined : taskMetadataForWrite(task.metadata, task.dueAt);
     return this.ctx.withRetry(async () => {
       const dbUpdateValues: Partial<typeof taskTable.$inferInsert> & { updatedAt: Date } = {
         updatedAt: new Date(),
@@ -145,13 +149,12 @@ export class TaskStore implements Store {
       if (task.entityId !== undefined) dbUpdateValues.entityId = task.entityId;
       if (task.tags !== undefined) dbUpdateValues.tags = task.tags;
       if (task.metadata !== undefined) {
-        dbUpdateValues.metadata = {
-          ...task.metadata,
-          ...(scheduledAt === undefined ? {} : { scheduledAt }),
-        };
+        dbUpdateValues.metadata = replacementMetadata;
       } else if (scheduledAt !== undefined) {
         const dueAtPatch = JSON.stringify({ scheduledAt });
         dbUpdateValues.metadata = sql`COALESCE(${taskTable.metadata}, '{}'::jsonb) || ${dueAtPatch}::jsonb`;
+      } else if (task.dueAt === null) {
+        dbUpdateValues.metadata = sql`COALESCE(${taskTable.metadata}, '{}'::jsonb) - 'scheduledAt'`;
       }
 
       await this.db


### PR DESCRIPTION
Refs #24381
Prerequisite for #24344.

## Scope

- Preserve task `entityId` through SQL and enforce the public agent/entity/room/world/tag filter contract.
- Give every official adapter the same stable `(createdAt,id)` ordering and non-negative safe-integer limit/offset validation.
- Fail closed on an empty or mismatched multi-agent authority set; require all requested tags in both in-memory adapters.
- Scope direct deletes to the adapter agent and add PostgreSQL indexes for authoritative agent plus room/world/entity query shapes.
- Store due time as canonical ISO-8601 `metadata.scheduledAt`, round-trip exact safe-integer milliseconds, reject permissive `Date.parse` spellings, and treat malformed persisted timing as a typed permanent error.
- Give `dueAt` explicit absent/set/null-clear semantics. DueAt-only changes atomically patch or remove the reserved JSONB key; caller metadata replacement remains replacement.

## Exact-head evidence

- Head: `ce807da9951abb7aca1de043736a931f8f8930ba`
- Rebased base: `15fb0e6d2d97b70f5288913a4610da869fd33018`
- Core in-memory task query lane: 4/4 passed; core typecheck and build passed.
- plugin-inmemorydb task query lane: 4/4 passed; typecheck and build passed.
- Real PostgreSQL 17 + pgvector task/timing lane: 13/13 passed against an isolated Docker database. It covers canonical timing, malformed readback/no retry, stable pagination, multi-agent authority, and concurrent due-time set/metadata replacement/set-vs-clear behavior.
- Runtime migrations created `tasks_agent_created_id_idx`, `tasks_agent_room_idx`, `tasks_agent_world_idx`, and `tasks_agent_entity_idx` on PostgreSQL.
- After loading 10,000 task rows and running `ANALYZE`, `EXPLAIN (ANALYZE, BUFFERS)` used `tasks_agent_created_id_idx` for the ordered bounded agent query (20 rows in 0.031 ms in this local container).
- plugin-sql typecheck and build passed. Biome on all repaired files and `git diff --check` passed.

## Remaining hold

This stays draft until hosted exact-head validation completes and dependent composition PR #24393 is rebound to this repaired lineage. The prior PGlite-only and portable-adapter blockers are resolved.

## Evidence Gate

<!-- evidence-head:ce807da9951abb7aca1de043736a931f8f8930ba -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend persistence and adapter-contract change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend persistence and adapter-contract change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic storage/query behavior has no interactive UI flow
<!-- evidence-row:backend-logs -->
- [x] Exact-head real PostgreSQL migration, CRUD, authority, concurrency, and query-plan transcript recorded in the review
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, requests, or state changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, action-planner, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] PostgreSQL task rows, canonical `scheduledAt`, four runtime-created indexes, and inspected query plans
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed

