### PR TITLE
fix(vault): harden native secure storage and recovery UX

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/auth-bridge.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/auth-bridge.test.ts
@@ -8,6 +8,7 @@ import {
   loadPersistedSession,
   resolveAuthDir,
   resolveSessionPath,
+  resolveShortSocketDir,
 } from "./auth-bridge";
 
 vi.mock("../logger", () => ({
@@ -64,5 +65,11 @@ describe("desktop auth bridge", () => {
     expect(loadPersistedSession(env, () => 1_700_000_000_000)).toBeNull();
 
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("uses a private child directory for short macOS bootstrap sockets", () => {
+    expect(resolveShortSocketDir("/private/var/tmp", 501)).toBe(
+      "/private/var/tmp/eza-dx",
+    );
   });
 });

--- a/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
+++ b/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
@@ -135,6 +135,21 @@ export function resolveSocketDir(env: NodeJS.ProcessEnv = process.env): string {
   return path.join(resolveStateDir(env), "sockets");
 }
 
+/**
+ * macOS limits Unix-domain socket paths to roughly 100 bytes. When a branded
+ * or QA state directory is too long, keep the socket in a private child of the
+ * process temp directory instead of chmodding Apple's shared temp root.
+ */
+export function resolveShortSocketDir(
+  tempRoot: string = os.tmpdir(),
+  uid: number | undefined = typeof process.getuid === "function"
+    ? process.getuid()
+    : undefined,
+): string {
+  const owner = uid === undefined ? "user" : uid.toString(36);
+  return path.join(tempRoot, `eza-${owner}`);
+}
+
 // ── Persisted-session round-trip ─────────────────────────────────────────────
 
 /**
@@ -268,7 +283,7 @@ function openBootstrapSocket(
     process.platform === "darwin" &&
     path.join(socketDir, socketName).length > 100
   ) {
-    socketDir = os.tmpdir();
+    socketDir = resolveShortSocketDir();
     socketName = `mda-${crypto.randomBytes(4).toString("hex")}.sock`;
   }
   fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });

--- a/packages/app-core/scripts/mas-smoke.mjs
+++ b/packages/app-core/scripts/mas-smoke.mjs
@@ -16,8 +16,10 @@
  *     app-sandbox + cs.inherit + `allow-jit` only — JIT is scoped to this
  *     one binary because Bun's macOS runtime imports Apple's JIT
  *     write-protection APIs.
- *   - Every other nested Mach-O gets `mas-child.entitlements`: app-sandbox
- *     + cs.inherit, no JIT, no library-validation bypass, no unsigned-exec.
+ *   - Executable child Mach-Os get `mas-child.entitlements`: app-sandbox +
+ *     cs.inherit, no JIT, no library-validation bypass, no unsigned-exec.
+ *     Apple codesign may omit entitlement blobs from non-executable dynamic
+ *     libraries; those remain signed and are still checked for forbidden keys.
  *
  * Usage:
  *   node mas-smoke.mjs --app=path/to/Built.app
@@ -299,10 +301,22 @@ function assertBunHelperEntitlements(machoPath, ents, collector) {
 }
 
 function assertChildEntitlements(machoPath, ents, collector) {
-  collector.failTrue(machoPath, "com.apple.security.inherit", ents);
+  if (!mayOmitChildEntitlements(machoPath) || ents.size > 0) {
+    collector.failTrue(machoPath, "com.apple.security.inherit", ents);
+  }
   for (const key of CHILD_FORBIDDEN_KEYS) {
     collector.failForbidden(machoPath, key, ents);
   }
+}
+
+/**
+ * `codesign --entitlements` does not retain an entitlement blob on ordinary
+ * dynamic libraries even when the signer supplies one. Only those known
+ * non-executable library forms may therefore report an empty entitlement map;
+ * helpers and other executable Mach-Os must still carry `cs.inherit`.
+ */
+function mayOmitChildEntitlements(machoPath) {
+  return /\.(?:dylib|so|node)$/i.test(machoPath);
 }
 
 function tailSandboxLog(appPath) {
@@ -447,6 +461,7 @@ export {
   findMachOFiles,
   isMachO,
   isParentMainExecutable,
+  mayOmitChildEntitlements,
   PARENT_FORBIDDEN_KEYS,
   PARENT_REQUIRED_TRUE_KEYS,
   parseEntitlementsPlist,

--- a/packages/app-core/scripts/mas-smoke.test.mjs
+++ b/packages/app-core/scripts/mas-smoke.test.mjs
@@ -28,6 +28,7 @@ import { resolveElizaWorkspaceRootFromImportMeta } from "./lib/repo-root.mjs";
 import {
   findMachOFiles,
   isMachO,
+  mayOmitChildEntitlements,
   parseEntitlementsPlist,
   walkBundleFiles,
 } from "./mas-smoke.mjs";
@@ -152,6 +153,14 @@ test("parseEntitlementsPlist decodes XML entities in keys and string values", ()
   const ents = parseEntitlementsPlist(xml);
   assert.equal(ents.has("com.apple.foo&bar"), true);
   assert.equal(ents.get("com.apple.foo&bar"), 'a "quoted" & thing');
+});
+
+test("only non-executable dynamic libraries may omit child entitlements", () => {
+  assert.equal(mayOmitChildEntitlements("libNativeWrapper.dylib"), true);
+  assert.equal(mayOmitChildEntitlements("keyring.darwin-arm64.node"), true);
+  assert.equal(mayOmitChildEntitlements("libhelper.so"), true);
+  assert.equal(mayOmitChildEntitlements("Contents/MacOS/bspatch"), false);
+  assert.equal(mayOmitChildEntitlements("Contents/MacOS/zig-zstd"), false);
 });
 
 // Bytes for a 64-bit little-endian Mach-O magic (0xfeedfacf in big-endian wire order).

--- a/packages/app-core/scripts/mobile/ios-pods.mjs
+++ b/packages/app-core/scripts/mobile/ios-pods.mjs
@@ -190,6 +190,10 @@ export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
     iosPods: [{ name: "ElizaosCapacitorScreencapture", kind: "custom" }],
   },
   {
+    packageName: "@elizaos/capacitor-secure-store",
+    iosPods: [{ name: "ElizaosCapacitorSecureStore", kind: "custom" }],
+  },
+  {
     packageName: "@elizaos/capacitor-swabble",
     iosPods: [{ name: "ElizaosCapacitorSwabble", kind: "custom" }],
   },

--- a/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
@@ -50,6 +50,9 @@ it("keeps the existing iOS custom pod include gates", () => {
   expect(defaultPods.get("ElizaosCapacitorBrowserSurface")).toBe(
     "@elizaos/capacitor-browser-surface",
   );
+  expect(defaultPods.get("ElizaosCapacitorSecureStore")).toBe(
+    "@elizaos/capacitor-secure-store",
+  );
   expect(defaultPods.has("ElizaosCapacitorBunRuntime")).toBe(false);
   expect(defaultPods.has("ElizaosCapacitorMobileAgentBridge")).toBe(false);
   expect(defaultPods.has("LlamaCpp")).toBe(false);
@@ -67,6 +70,9 @@ it("keeps the existing iOS custom pod include gates", () => {
     "@elizaos/capacitor-bun-runtime",
   );
   expect(appStorePods.get("ElizaBunEngine")).toBe("@elizaos/bun-ios-runtime");
+  expect(appStorePods.get("ElizaosCapacitorSecureStore")).toBe(
+    "@elizaos/capacitor-secure-store",
+  );
   expect(appStorePods.has("ElizaosCapacitorMobileAgentBridge")).toBe(false);
   expect(appStorePods.has("LlamaCpp")).toBe(false);
 

--- a/packages/app-core/src/alias-env-reads.13422.test.ts
+++ b/packages/app-core/src/alias-env-reads.13422.test.ts
@@ -168,19 +168,18 @@ describe("steward credentials load (ELIZA_STATE_DIR)", () => {
     );
   }
 
-  it("reads persisted credentials from a branded MILADY_STATE_DIR", async () => {
+  it("honors a branded MILADY_STATE_DIR while failing closed without protected storage", async () => {
     const dir = makeTempDir();
     writeCredentials(dir);
     process.env.MILADY_STATE_DIR = dir;
 
-    const creds = await loadStewardCredentials({
-      secureStore: unavailableSecureStore,
-    });
-
-    expect(creds).not.toBeNull();
-    expect(creds?.apiUrl).toBe("https://steward.milady.test");
-    expect(creds?.tenantId).toBe("tenant-milady");
-    expect(creds?.agentId).toBe("agent-milady");
+    await expect(
+      loadStewardCredentials({
+        secureStore: unavailableSecureStore,
+      }),
+    ).rejects.toThrow(
+      "platform secure store is unavailable; plaintext Steward credentials were retained for recovery",
+    );
     expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
   });
 

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -84,6 +84,12 @@ export const DESKTOP_VIEW_WINDOWS: readonly DesktopViewWindow[] = [
     path: "/settings",
   },
   {
+    id: "vault",
+    label: "Vault",
+    labelKey: "desktop.views.vault",
+    path: "/vault",
+  },
+  {
     id: "background",
     label: "Background",
     labelKey: "desktop.views.background",

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -84,12 +84,6 @@ export const DESKTOP_VIEW_WINDOWS: readonly DesktopViewWindow[] = [
     path: "/settings",
   },
   {
-    id: "vault",
-    label: "Vault",
-    labelKey: "desktop.views.vault",
-    path: "/vault",
-  },
-  {
     id: "background",
     label: "Background",
     labelKey: "desktop.views.background",

--- a/packages/app-core/src/security/platform-secure-store-node.test.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveBundledKeyringPath } from "./platform-secure-store-node";
+import {
+  createNodePlatformSecureStore,
+  resolveBundledKeyringPath,
+} from "./platform-secure-store-node";
 
 const source = readFileSync(
   new URL("./platform-secure-store-node.ts", import.meta.url),
@@ -158,5 +161,147 @@ describe("desktop platform secure-store boundary", () => {
     expect(source).toContain("linuxSecretServiceSessionReachable()");
     expect(source).toContain("process.env.DBUS_SESSION_BUS_ADDRESS");
     expect(source).toContain('path.join(runtimeDir, "bus")');
+  });
+});
+
+describe("platform secure-store behavioral outcomes", () => {
+  it("verifies native set, read, delete, and idempotent absence", async () => {
+    const values = new Map<string, string>();
+    class FakeAsyncEntry {
+      constructor(
+        _service: string,
+        private readonly account: string,
+      ) {}
+
+      async getPassword(): Promise<string | null> {
+        return values.get(this.account) ?? null;
+      }
+
+      async setPassword(value: string): Promise<void> {
+        values.set(this.account, value);
+      }
+
+      async deleteCredential(): Promise<void> {
+        if (!values.delete(this.account)) throw new Error("entry not found");
+      }
+    }
+    const store = createNodePlatformSecureStore({
+      platform: "darwin",
+      loadNativeKeyring: async () =>
+        ({
+          AsyncEntry: FakeAsyncEntry,
+        }) as unknown as typeof import("@napi-rs/keyring"),
+    });
+
+    await expect(
+      store.set("test-vault", "session.steward_token", "ephemeral-value"),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      store.get("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, value: "ephemeral-value" });
+    await expect(
+      store.delete("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, deleted: true });
+    await expect(
+      store.delete("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, deleted: false });
+  });
+
+  it("propagates native denied deletion without removing the credential", async () => {
+    class DeniedAsyncEntry {
+      async getPassword(): Promise<string> {
+        return "retained-value";
+      }
+      async setPassword(): Promise<void> {}
+      async deleteCredential(): Promise<void> {
+        throw new Error("access denied");
+      }
+    }
+    const store = createNodePlatformSecureStore({
+      platform: "darwin",
+      loadNativeKeyring: async () =>
+        ({
+          AsyncEntry: DeniedAsyncEntry,
+        }) as unknown as typeof import("@napi-rs/keyring"),
+    });
+
+    await expect(
+      store.delete("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: false, reason: "denied" });
+    await expect(
+      store.get("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, value: "retained-value" });
+  });
+
+  it("rejects native write success that cannot be read back exactly", async () => {
+    class UnverifiedAsyncEntry {
+      async getPassword(): Promise<null> {
+        return null;
+      }
+      async setPassword(): Promise<void> {}
+      async deleteCredential(): Promise<void> {}
+    }
+    const store = createNodePlatformSecureStore({
+      platform: "darwin",
+      loadNativeKeyring: async () =>
+        ({
+          AsyncEntry: UnverifiedAsyncEntry,
+        }) as unknown as typeof import("@napi-rs/keyring"),
+    });
+
+    await expect(
+      store.set("test-vault", "session.steward_token", "ephemeral-value"),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "error",
+      message: "Native credential store write could not be verified.",
+    });
+  });
+
+  it("distinguishes Linux not-found from consequential clear failure", async () => {
+    const values = new Map<string, string>();
+    let clearMode: "success" | "missing" | "denied" = "missing";
+    const store = createNodePlatformSecureStore({
+      platform: "linux",
+      secretToolAvailable: async () => true,
+      secretServiceReachable: () => true,
+      storeSecretTool: async (args, value) => {
+        values.set(args.at(-1) ?? "", value);
+      },
+      runSecretTool: async (_executable, args) => {
+        const account = args.at(-1) ?? "";
+        if (args[0] === "lookup") {
+          const value = values.get(account);
+          if (value === undefined) {
+            throw Object.assign(new Error("missing"), { code: 1, stderr: "" });
+          }
+          return { stdout: value, stderr: "" };
+        }
+        if (clearMode === "missing") {
+          throw Object.assign(new Error("missing"), { code: 1, stderr: "" });
+        }
+        if (clearMode === "denied") throw new Error("access denied");
+        values.delete(account);
+        return { stdout: "", stderr: "" };
+      },
+    });
+
+    await expect(
+      store.delete("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, deleted: false });
+
+    await store.set("test-vault", "session.steward_token", "retained-value");
+    clearMode = "denied";
+    await expect(
+      store.delete("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: false, reason: "denied" });
+    await expect(
+      store.get("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, value: "retained-value" });
+
+    clearMode = "success";
+    await expect(
+      store.delete("test-vault", "session.steward_token"),
+    ).resolves.toEqual({ ok: true, deleted: true });
   });
 });

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -27,6 +27,33 @@ import type {
 const execFileAsync = promisify(execFile);
 const LINUX_SECRET_WIRE_PREFIX = "eliza-v1:";
 
+type NativeKeyringLoader = () => Promise<typeof import("@napi-rs/keyring")>;
+type SecretToolCommandRunner = (
+  executable: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr?: string }>;
+type SecretToolStoreRunner = (
+  args: string[],
+  secretLine: string,
+) => Promise<void>;
+
+interface NodePlatformSecureStoreOptions {
+  platform?: NodeJS.Platform;
+  loadNativeKeyring?: NativeKeyringLoader;
+  runSecretTool?: SecretToolCommandRunner;
+  storeSecretTool?: SecretToolStoreRunner;
+  secretToolAvailable?: () => Promise<boolean>;
+  secretServiceReachable?: () => boolean;
+}
+
+async function runSecretTool(
+  executable: string,
+  args: string[],
+): Promise<{ stdout: string; stderr?: string }> {
+  const result = await execFileAsync(executable, args, { encoding: "utf8" });
+  return { stdout: String(result.stdout), stderr: String(result.stderr) };
+}
+
 function encodeLinuxSecret(value: string): string {
   return `${LINUX_SECRET_WIRE_PREFIX}${Buffer.from(value, "utf8").toString("base64url")}`;
 }
@@ -264,11 +291,14 @@ function loadNativeKeyring(): Promise<NativeKeyringModule> {
 }
 
 class NativeKeyringPlatformSecureStore implements PlatformSecureStore {
-  constructor(readonly backend: PlatformSecureStoreBackend) {}
+  constructor(
+    readonly backend: PlatformSecureStoreBackend,
+    private readonly keyringLoader: NativeKeyringLoader = loadNativeKeyring,
+  ) {}
 
   async isAvailable(): Promise<boolean> {
     try {
-      await loadNativeKeyring();
+      await this.keyringLoader();
       return true;
     } catch {
       // error-policy:J4 native Keychain binding unavailable (probe)
@@ -282,7 +312,7 @@ class NativeKeyringPlatformSecureStore implements PlatformSecureStore {
   ): Promise<SecureStoreGetResult> {
     const account = keychainAccountForSecretKind(vaultId, kind);
     try {
-      const { AsyncEntry } = await loadNativeKeyring();
+      const { AsyncEntry } = await this.keyringLoader();
       const value = await new AsyncEntry(
         ELIZA_AGENT_VAULT_SERVICE,
         account,
@@ -303,10 +333,17 @@ class NativeKeyringPlatformSecureStore implements PlatformSecureStore {
   ): Promise<SecureStoreSetResult> {
     const account = keychainAccountForSecretKind(vaultId, kind);
     try {
-      const { AsyncEntry } = await loadNativeKeyring();
-      await new AsyncEntry(ELIZA_AGENT_VAULT_SERVICE, account).setPassword(
-        value,
-      );
+      const { AsyncEntry } = await this.keyringLoader();
+      const entry = new AsyncEntry(ELIZA_AGENT_VAULT_SERVICE, account);
+      await entry.setPassword(value);
+      const verified = await entry.getPassword();
+      if (verified !== value) {
+        return {
+          ok: false,
+          reason: "error",
+          message: "Native credential store write could not be verified.",
+        };
+      }
       return { ok: true };
     } catch (err: unknown) {
       return nativeStoreReason(err);
@@ -319,7 +356,7 @@ class NativeKeyringPlatformSecureStore implements PlatformSecureStore {
   ): Promise<SecureStoreDeleteResult> {
     const account = keychainAccountForSecretKind(vaultId, kind);
     try {
-      const { AsyncEntry } = await loadNativeKeyring();
+      const { AsyncEntry } = await this.keyringLoader();
       await new AsyncEntry(
         ELIZA_AGENT_VAULT_SERVICE,
         account,
@@ -362,8 +399,15 @@ class NativeKeyringPlatformSecureStore implements PlatformSecureStore {
 class LinuxSecretToolPlatformSecureStore implements PlatformSecureStore {
   readonly backend: PlatformSecureStoreBackend = "linux_secret_service";
 
+  constructor(
+    private readonly commandRunner: SecretToolCommandRunner = runSecretTool,
+    private readonly storeRunner: SecretToolStoreRunner = secretToolStoreWithStdin,
+    private readonly available: () => Promise<boolean> = secretToolOnPath,
+    private readonly sessionReachable: () => boolean = linuxSecretServiceSessionReachable,
+  ) {}
+
   async isAvailable(): Promise<boolean> {
-    return (await secretToolOnPath()) && linuxSecretServiceSessionReachable();
+    return (await this.available()) && this.sessionReachable();
   }
 
   private account(vaultId: string, kind: SecureStoreSecretKind): string {
@@ -376,11 +420,13 @@ class LinuxSecretToolPlatformSecureStore implements PlatformSecureStore {
   ): Promise<SecureStoreGetResult> {
     const account = this.account(vaultId, kind);
     try {
-      const { stdout } = await execFileAsync(
-        "secret-tool",
-        ["lookup", "service", ELIZA_AGENT_VAULT_SERVICE, "account", account],
-        { encoding: "utf8" },
-      );
+      const { stdout } = await this.commandRunner("secret-tool", [
+        "lookup",
+        "service",
+        ELIZA_AGENT_VAULT_SERVICE,
+        "account",
+        account,
+      ]);
       const value = stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout;
       return decodeLinuxSecret(value);
     } catch (err: unknown) {
@@ -404,7 +450,7 @@ class LinuxSecretToolPlatformSecureStore implements PlatformSecureStore {
   ): Promise<SecureStoreSetResult> {
     const account = this.account(vaultId, kind);
     try {
-      await secretToolStoreWithStdin(
+      await this.storeRunner(
         [
           "store",
           "--label=Eliza agent wallet",
@@ -415,6 +461,14 @@ class LinuxSecretToolPlatformSecureStore implements PlatformSecureStore {
         ],
         encodeLinuxSecret(value),
       );
+      const verified = await this.get(vaultId, kind);
+      if (!verified.ok || verified.value !== value) {
+        return {
+          ok: false,
+          reason: "error",
+          message: "Native credential store write could not be verified.",
+        };
+      }
       return { ok: true };
     } catch (err: unknown) {
       return nativeStoreReason(err);
@@ -427,7 +481,7 @@ class LinuxSecretToolPlatformSecureStore implements PlatformSecureStore {
   ): Promise<SecureStoreDeleteResult> {
     const account = this.account(vaultId, kind);
     try {
-      await execFileAsync("secret-tool", [
+      await this.commandRunner("secret-tool", [
         "clear",
         "service",
         ELIZA_AGENT_VAULT_SERVICE,
@@ -481,15 +535,29 @@ class NonePlatformSecureStore implements PlatformSecureStore {
  * Node-side factory: macOS Keychain, Linux `secret-tool`, or the explicit
  * unavailable backend on platforms without an OS credential-store adapter.
  */
-export function createNodePlatformSecureStore(): PlatformSecureStore {
-  if (isDarwin()) {
-    return new NativeKeyringPlatformSecureStore("macos_keychain");
+export function createNodePlatformSecureStore(
+  options: NodePlatformSecureStoreOptions = {},
+): PlatformSecureStore {
+  const platform = options.platform ?? process.platform;
+  if (platform === "darwin") {
+    return new NativeKeyringPlatformSecureStore(
+      "macos_keychain",
+      options.loadNativeKeyring,
+    );
   }
-  if (isWindows()) {
-    return new NativeKeyringPlatformSecureStore("windows_credential_manager");
+  if (platform === "win32") {
+    return new NativeKeyringPlatformSecureStore(
+      "windows_credential_manager",
+      options.loadNativeKeyring,
+    );
   }
-  if (isLinux()) {
-    return new LinuxSecretToolPlatformSecureStore();
+  if (platform === "linux") {
+    return new LinuxSecretToolPlatformSecureStore(
+      options.runSecretTool,
+      options.storeSecretTool,
+      options.secretToolAvailable,
+      options.secretServiceReachable,
+    );
   }
   return new NonePlatformSecureStore();
 }

--- a/packages/app-core/src/services/steward-credentials.test.ts
+++ b/packages/app-core/src/services/steward-credentials.test.ts
@@ -2,8 +2,9 @@
  * Unit tests for `saveStewardCredentials` / `loadStewardCredentials`: verifies
  * steward secrets (apiKey, agentToken) land in the PlatformSecureStore rather
  * than the plaintext metadata file, that legacy plaintext secrets are migrated
- * and scrubbed on load, and that scrubbing still happens when the secure store
- * is unavailable. Uses an in-memory secure store and a temp `ELIZA_STATE_DIR`.
+ * and scrubbed only after exact read-back, and that plaintext is retained for
+ * recovery when secure storage is unavailable. Uses an in-memory secure store
+ * and a temp `ELIZA_STATE_DIR`.
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -143,7 +144,7 @@ describe("steward credentials", () => {
     expect(raw).not.toContain("legacy-agent-token");
   });
 
-  it("scrubs legacy plaintext secrets even when secure store is unavailable", async () => {
+  it("retains legacy plaintext for recovery when secure store is unavailable", async () => {
     const secureStore = new MemorySecureStore(false);
     fs.writeFileSync(
       credentialsPath(stateDir),
@@ -161,17 +162,56 @@ describe("steward credentials", () => {
       { mode: 0o600 },
     );
 
-    const loaded = await loadStewardCredentials({ secureStore });
-
-    expect(loaded).toMatchObject({
-      apiUrl: "https://legacy.local",
-      tenantId: "tenant-legacy",
-      agentId: "agent-legacy",
-      apiKey: "",
-      agentToken: "",
-    });
+    await expect(loadStewardCredentials({ secureStore })).rejects.toThrow(
+      /retained for recovery/,
+    );
     const raw = fs.readFileSync(credentialsPath(stateDir), "utf8");
-    expect(raw).not.toContain("legacy-api-key");
-    expect(raw).not.toContain("legacy-agent-token");
+    expect(raw).toContain("legacy-api-key");
+    expect(raw).toContain("legacy-agent-token");
+  });
+
+  it("retains legacy plaintext when native success cannot be read back", async () => {
+    const secureStore = new MemorySecureStore();
+    secureStore.set = async () => ({ ok: true });
+    fs.writeFileSync(
+      credentialsPath(stateDir),
+      JSON.stringify(
+        {
+          apiUrl: "https://legacy.local",
+          tenantId: "tenant-legacy",
+          agentId: "agent-legacy",
+          apiKey: "legacy-api-key",
+          agentToken: "legacy-agent-token",
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+
+    await expect(loadStewardCredentials({ secureStore })).rejects.toThrow(
+      /could not verify/,
+    );
+    const raw = fs.readFileSync(credentialsPath(stateDir), "utf8");
+    expect(raw).toContain("legacy-api-key");
+    expect(raw).toContain("legacy-agent-token");
+  });
+
+  it("rejects a new save when secure storage is unavailable", async () => {
+    const secureStore = new MemorySecureStore(false);
+
+    await expect(
+      saveStewardCredentials(
+        {
+          apiUrl: "https://steward.local",
+          tenantId: "tenant-1",
+          agentId: "agent-1",
+          apiKey: "tenant-api-key",
+          agentToken: "agent-token",
+        },
+        { secureStore },
+      ),
+    ).rejects.toThrow(/were not persisted/);
+    expect(fs.existsSync(credentialsPath(stateDir))).toBe(false);
   });
 });

--- a/packages/app-core/src/services/steward-credentials.test.ts
+++ b/packages/app-core/src/services/steward-credentials.test.ts
@@ -214,4 +214,74 @@ describe("steward credentials", () => {
     ).rejects.toThrow(/were not persisted/);
     expect(fs.existsSync(credentialsPath(stateDir))).toBe(false);
   });
+
+  it("restores the complete prior credential set after a partial save failure", async () => {
+    const secureStore = new MemorySecureStore();
+    await saveStewardCredentials(
+      {
+        apiUrl: "https://old.steward.local",
+        tenantId: "old-tenant",
+        agentId: "old-agent",
+        apiKey: "old-api-key",
+        agentToken: "old-agent-token",
+      },
+      { secureStore },
+    );
+    const originalSet = secureStore.set.bind(secureStore);
+    let writes = 0;
+    secureStore.set = async (vaultId, kind, value) => {
+      writes += 1;
+      if (writes === 3) return { ok: false, reason: "denied" };
+      return originalSet(vaultId, kind, value);
+    };
+
+    await expect(
+      saveStewardCredentials(
+        {
+          apiUrl: "https://new.steward.local",
+          tenantId: "new-tenant",
+          agentId: "new-agent",
+          apiKey: "new-api-key",
+          agentToken: "new-agent-token",
+        },
+        { secureStore },
+      ),
+    ).rejects.toThrow(/prior values were restored/);
+
+    const loaded = await loadStewardCredentials({ secureStore });
+    expect(loaded).toMatchObject({
+      apiUrl: "https://old.steward.local",
+      tenantId: "old-tenant",
+      agentId: "old-agent",
+      apiKey: "old-api-key",
+      agentToken: "old-agent-token",
+    });
+  });
+
+  it("clears optional secrets instead of leaving stale prior values", async () => {
+    const secureStore = new MemorySecureStore();
+    await saveStewardCredentials(
+      {
+        apiUrl: "https://steward.local",
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        apiKey: "old-api-key",
+        agentToken: "old-agent-token",
+      },
+      { secureStore },
+    );
+    await saveStewardCredentials(
+      {
+        apiUrl: "https://steward.local",
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        apiKey: "",
+        agentToken: "",
+      },
+      { secureStore },
+    );
+
+    const loaded = await loadStewardCredentials({ secureStore });
+    expect(loaded).toMatchObject({ apiKey: "", agentToken: "" });
+  });
 });

--- a/packages/app-core/src/services/steward-credentials.ts
+++ b/packages/app-core/src/services/steward-credentials.ts
@@ -143,9 +143,23 @@ async function writeStewardSecret(
   vaultId: string,
   field: StewardCredentialSecretField,
   value: string,
+  clearEmpty = false,
 ): Promise<void> {
   const trimmed = value.trim();
-  if (!trimmed) return;
+  if (!trimmed) {
+    if (!clearEmpty) return;
+    const removed = await store.delete(vaultId, STEWARD_SECRET_KINDS[field]);
+    if (!removed.ok) {
+      throw new Error(
+        `secure store rejected clearing ${field}: ${removed.message ?? removed.reason}`,
+      );
+    }
+    const verified = await store.get(vaultId, STEWARD_SECRET_KINDS[field]);
+    if (verified.ok || verified.reason !== "not_found") {
+      throw new Error(`secure store could not verify clearing ${field}`);
+    }
+    return;
+  }
   const result = await store.set(vaultId, STEWARD_SECRET_KINDS[field], trimmed);
   if (!result.ok) {
     throw new Error(
@@ -157,6 +171,56 @@ async function writeStewardSecret(
     throw new Error(
       `secure store could not verify ${field}; plaintext credentials were retained for recovery`,
     );
+  }
+}
+
+async function snapshotStewardSecrets(
+  store: PlatformSecureStore,
+  vaultId: string,
+): Promise<Map<StewardCredentialSecretField, string | null>> {
+  const snapshot = new Map<StewardCredentialSecretField, string | null>();
+  for (const field of Object.keys(
+    STEWARD_SECRET_KINDS,
+  ) as StewardCredentialSecretField[]) {
+    const result = await store.get(vaultId, STEWARD_SECRET_KINDS[field]);
+    if (result.ok) {
+      snapshot.set(field, result.value);
+    } else if (result.reason === "not_found") {
+      snapshot.set(field, null);
+    } else {
+      throw new Error(`secure store could not snapshot ${field}`);
+    }
+  }
+  return snapshot;
+}
+
+async function restoreStewardSecrets(
+  store: PlatformSecureStore,
+  vaultId: string,
+  snapshot: ReadonlyMap<StewardCredentialSecretField, string | null>,
+  attempted: readonly StewardCredentialSecretField[],
+): Promise<void> {
+  for (const field of [...attempted].reverse()) {
+    const previous = snapshot.get(field) ?? null;
+    if (previous === null) {
+      const removed = await store.delete(vaultId, STEWARD_SECRET_KINDS[field]);
+      if (!removed.ok) throw new Error(`rollback could not clear ${field}`);
+      const verified = await store.get(vaultId, STEWARD_SECRET_KINDS[field]);
+      if (verified.ok || verified.reason !== "not_found") {
+        throw new Error(`rollback could not verify clearing ${field}`);
+      }
+      continue;
+    }
+    const restored = await store.set(
+      vaultId,
+      STEWARD_SECRET_KINDS[field],
+      previous,
+    );
+    if (!restored.ok) throw new Error(`rollback could not restore ${field}`);
+    const verified = await store.get(vaultId, STEWARD_SECRET_KINDS[field]);
+    if (!verified.ok || verified.value !== previous) {
+      throw new Error(`rollback could not verify restoring ${field}`);
+    }
   }
 }
 
@@ -268,13 +332,34 @@ export async function saveStewardCredentials(
     );
   }
   const vaultId = deriveStewardVaultId();
-  await Promise.all(
-    (Object.keys(STEWARD_SECRET_KINDS) as StewardCredentialSecretField[]).map(
-      (field) => writeStewardSecret(store, vaultId, field, credentials[field]),
-    ),
-  );
-
-  writeCredentialsMetadata(credentials);
+  const snapshot = await snapshotStewardSecrets(store, vaultId);
+  const attempted: StewardCredentialSecretField[] = [];
+  try {
+    for (const field of Object.keys(
+      STEWARD_SECRET_KINDS,
+    ) as StewardCredentialSecretField[]) {
+      attempted.push(field);
+      await writeStewardSecret(store, vaultId, field, credentials[field], true);
+    }
+    writeCredentialsMetadata(credentials);
+  } catch (cause) {
+    try {
+      await restoreStewardSecrets(store, vaultId, snapshot, attempted);
+    } catch (rollbackCause) {
+      // error-policy:J2 report both failures without including credential data.
+      throw new Error(
+        `Steward credential save failed and rollback was incomplete: ${rollbackCause instanceof Error ? rollbackCause.message : String(rollbackCause)}`,
+        { cause },
+      );
+    }
+    // error-policy:J2 preserve the original secure-store or metadata failure.
+    throw new Error(
+      "Steward credential save failed; prior values were restored",
+      {
+        cause,
+      },
+    );
+  }
 }
 
 /**

--- a/packages/app-core/src/services/steward-credentials.ts
+++ b/packages/app-core/src/services/steward-credentials.ts
@@ -152,6 +152,12 @@ async function writeStewardSecret(
       `secure store rejected ${field}: ${result.message ?? result.reason}`,
     );
   }
+  const verified = await store.get(vaultId, STEWARD_SECRET_KINDS[field]);
+  if (!verified.ok || verified.value.trim() !== trimmed) {
+    throw new Error(
+      `secure store could not verify ${field}; plaintext credentials were retained for recovery`,
+    );
+  }
 }
 
 async function migrateLegacyFileSecrets(
@@ -227,7 +233,9 @@ export async function loadStewardCredentials(
   }
 
   if (hasLegacySecrets) {
-    writeCredentialsMetadata(parsed);
+    throw new Error(
+      "platform secure store is unavailable; plaintext Steward credentials were retained for recovery",
+    );
   }
 
   const apiUrl = parsed.apiUrl || null;
@@ -254,15 +262,17 @@ export async function saveStewardCredentials(
   options: StewardCredentialPersistenceOptions = {},
 ): Promise<void> {
   const store = createStewardSecureStore(options);
-  if (await store.isAvailable()) {
-    const vaultId = deriveStewardVaultId();
-    await Promise.all(
-      (Object.keys(STEWARD_SECRET_KINDS) as StewardCredentialSecretField[]).map(
-        (field) =>
-          writeStewardSecret(store, vaultId, field, credentials[field]),
-      ),
+  if (!(await store.isAvailable())) {
+    throw new Error(
+      "platform secure store is unavailable; Steward credentials were not persisted",
     );
   }
+  const vaultId = deriveStewardVaultId();
+  await Promise.all(
+    (Object.keys(STEWARD_SECRET_KINDS) as StewardCredentialSecretField[]).map(
+      (field) => writeStewardSecret(store, vaultId, field, credentials[field]),
+    ),
+  );
 
   writeCredentialsMetadata(credentials);
 }

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -78,6 +78,24 @@ describe("App standalone chat-overlay wiring", () => {
     );
   });
 
+  it("keeps native auxiliary app windows free of duplicate chat overlays", () => {
+    expect(APP_TSX).toContain("isAppWindowRoute,");
+    expect(APP_TSX).toContain(
+      "const isAuxiliaryAppWindow = isAppWindowRoute();",
+    );
+    expect(APP_TSX).toContain("{!isAuxiliaryAppWindow ? (");
+
+    const auxiliaryGuard = APP_TSX.slice(
+      APP_TSX.indexOf("{!isAuxiliaryAppWindow ? ("),
+      APP_TSX.indexOf("<PermissionPrimingOverlay />"),
+    );
+    expect(auxiliaryGuard).toContain("<ChatOverlayMount");
+    expect(auxiliaryGuard).toContain("<FirstRunConductorMount");
+    expect(auxiliaryGuard).toContain("<ModelStatusConductorMount />");
+    expect(auxiliaryGuard).toContain("<BootRecoveryConductorMount />");
+    expect(auxiliaryGuard).toContain("<TutorialConductorMount />");
+  });
+
   it("opens the packaged desktop pill into the shared mobile chat composer", () => {
     const overlayShell = APP_TSX.slice(
       APP_TSX.indexOf("function ChatOverlayShell({"),
@@ -197,7 +215,10 @@ describe("App standalone chat-overlay wiring", () => {
     // persistent ambient overlay as its composer.
     expect(CHATVIEW_TSX).toContain("hideComposer");
     expect(APP_TSX).toContain("<ChatOverlayMount");
-    expect(APP_TSX).toContain("floats over EVERY view, including the /chat");
+    expect(APP_TSX).toContain(
+      "Chat overlay (ChatOverlay) — one ambient glass conversation in the",
+    );
+    expect(APP_TSX).toContain("primary shell.");
     // The composer swaps mic→send once there's a draft (one trailing control).
     expect(OVERLAY_TSX).toContain("hasDraft");
     expect(OVERLAY_TSX).toContain("(hasDraft || hasImages) && !recording");

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -161,6 +161,7 @@ import {
   getAppSlugFromPath,
   getWindowNavigationPath,
   isAospShellEnabled,
+  isAppWindowRoute,
   isRouteRootPath,
   NATIVE_OS_VIEW_IDS,
   pathForTab,
@@ -2361,6 +2362,7 @@ function AppContent() {
     t: s.t,
   }));
   const isPopout = useIsPopout();
+  const isAuxiliaryAppWindow = isAppWindowRoute();
   const shellMode = useShellMode();
   // Register the developer-only sandboxed-iframe consumer once at boot (#14180),
   // so the level has a shipped, navigable first-party view. Idempotent.
@@ -3389,46 +3391,44 @@ function AppContent() {
           tab !== "apps" &&
           tab !== "views" && <GameViewOverlay />}
         {/*
-          Chat overlay (ChatOverlay) — one ambient glass
-          conversation (the app's single active conversation via
-          useShellController) that floats over EVERY view, including the /chat
-          route (whose base is now just ambient space). It survives tab/view
-          changes because it renders here in the persistent sibling region, and
-          is pointer-events-none except its own composer/messages, so the view
-          behind stays live.
+          Chat overlay (ChatOverlay) — one ambient glass conversation in the
+          primary shell. Native auxiliary app windows (`?appWindow=1`) are
+          dedicated workspaces; mounting another onboarding-pinned overlay in
+          each of them occludes their controls and duplicates the headless chat
+          conductors already owned by the primary/chat-overlay window.
         */}
-        <ChatOverlayMount
-          releaseFirstRunToFull={firstRunChatRelease.releasePending}
-          onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
-          onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}
-          firstRunMountEpoch={firstRunChatRelease.mountEpoch}
-        />
-        {/* In-chat first-run conductor (headless) — while firstRunComplete is
-            false it seeds the onboarding greeting + choices into the SAME live
-            transcript the overlay renders and routes first-run picks to the
-            headless finish use case. Renders null. */}
-        <FirstRunConductorMount
-          onFirstRunTranscriptMounted={
-            firstRunChatRelease.recordMountedTranscript
-          }
-          firstRunMountEpoch={firstRunChatRelease.mountEpoch}
-          firstRunAuthorityEpoch={firstRunChatRelease.authorityEpoch}
-        />
-        {/* In-chat model-status card (headless) — while the local text model is
-            downloading/loading/missing/errored it seeds ONE live status turn
-            with cancel / switch-to-cloud / retry controls. Renders null. */}
-        <ModelStatusConductorMount />
-        {/* In-chat boot-recovery card (headless) — a stalled boot or a failed
-            dedicated-agent handoff seeds ONE live turn with re-log-in /
-            try-again / retry-setup controls; the transcript is the only boot
-            status surface (no floating banner). Renders null. */}
-        <BootRecoveryConductorMount />
-        {/* In-chat tutorial conductor (headless) — while the tour is active it
-            seeds one conversational turn per step into the SAME live transcript
-            the overlay renders, narrates through the real voice engine, and
-            auto-advances on the user's real actions. No locks, no spotlight:
-            the user can ignore it freely. */}
-        <TutorialConductorMount />
+        {!isAuxiliaryAppWindow ? (
+          <>
+            <ChatOverlayMount
+              releaseFirstRunToFull={firstRunChatRelease.releasePending}
+              onFirstRunReleaseHandled={firstRunChatRelease.acknowledgeRelease}
+              onFirstRunChatMounted={firstRunChatRelease.recordMountedOverlay}
+              firstRunMountEpoch={firstRunChatRelease.mountEpoch}
+            />
+            {/* In-chat first-run conductor (headless) — while firstRunComplete
+                is false it seeds the onboarding greeting + choices into the
+                SAME live transcript the overlay renders and routes first-run
+                picks to the headless finish use case. Renders null. */}
+            <FirstRunConductorMount
+              onFirstRunTranscriptMounted={
+                firstRunChatRelease.recordMountedTranscript
+              }
+              firstRunMountEpoch={firstRunChatRelease.mountEpoch}
+              firstRunAuthorityEpoch={firstRunChatRelease.authorityEpoch}
+            />
+            {/* In-chat model-status card (headless) — while the local text
+                model is downloading/loading/missing/errored it seeds ONE live
+                status turn with cancel / switch-to-cloud / retry controls. */}
+            <ModelStatusConductorMount />
+            {/* In-chat boot-recovery card (headless) — a stalled boot or a
+                failed dedicated-agent handoff seeds ONE live turn with
+                re-log-in / try-again / retry-setup controls. */}
+            <BootRecoveryConductorMount />
+            {/* In-chat tutorial conductor (headless) — narrates one live
+                transcript turn per step in the primary conversation only. */}
+            <TutorialConductorMount />
+          </>
+        ) : null}
         {/* Post-login permission priming: a one-time soft-ask modal that walks
             the user through the platform's onboarding permission set (voice,
             location, notifications) BEFORE any OS prompt. Self-gates on

--- a/packages/ui/src/components/settings/VaultInventoryPanel.security-findings.test.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.security-findings.test.tsx
@@ -111,7 +111,6 @@ describe("VaultInventoryPanel connector security findings", () => {
   });
 
   it("retains the row and reports recovery when secure deletion is rejected", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
     clientMocks.rawRequest.mockResolvedValueOnce({ ok: false, status: 503 });
     const onChanged = vi.fn();
     render(
@@ -130,9 +129,70 @@ describe("VaultInventoryPanel connector security findings", () => {
     );
 
     fireEvent.click(screen.getByLabelText("Delete Test provider"));
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(clientMocks.rawRequest).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByLabelText("Permanently delete Test provider"));
     expect(await screen.findByText(/credential was retained/i)).toBeTruthy();
     expect(screen.getByTestId("vault-entry-row-TEST_API_KEY")).toBeTruthy();
     expect(onChanged).not.toHaveBeenCalled();
+    expect(clientMocks.rawRequest).toHaveBeenCalledWith(
+      "/api/secrets/inventory/TEST_API_KEY",
+      { method: "DELETE" },
+      { allowNonOk: true, timeoutMs: 30_000 },
+    );
+  });
+
+  it("keeps deletion in-app and lets the owner cancel without a request", () => {
+    render(
+      <VaultInventoryPanel
+        entries={[
+          {
+            key: "TEST_API_KEY",
+            category: "provider",
+            label: "Test provider",
+            hasProfiles: false,
+            kind: "secret",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Delete Test provider"));
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    fireEvent.click(screen.getByLabelText("Cancel deleting Test provider"));
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(clientMocks.rawRequest).not.toHaveBeenCalled();
+  });
+
+  it("gives a first native secure write the extended Keychain budget", async () => {
+    clientMocks.rawRequest.mockResolvedValueOnce({ ok: true, status: 200 });
+    const onChanged = vi.fn();
+    const { container } = render(
+      <VaultInventoryPanel entries={[]} onChanged={onChanged} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add secret" }));
+    fireEvent.change(screen.getByPlaceholderText("OPENROUTER_API_KEY"), {
+      target: { value: "SYNTHETIC_QA_KEY" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("OpenRouter"), {
+      target: { value: "Synthetic QA" },
+    });
+    const password = container.querySelector<HTMLInputElement>(
+      'input[type="password"]',
+    );
+    expect(password).toBeTruthy();
+    fireEvent.change(password as HTMLInputElement, {
+      target: { value: "disposable-test-only" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save secret" }));
+
+    await waitFor(() => expect(onChanged).toHaveBeenCalledTimes(1));
+    expect(clientMocks.rawRequest).toHaveBeenCalledWith(
+      "/api/secrets/inventory/SYNTHETIC_QA_KEY",
+      expect.objectContaining({ method: "PUT" }),
+      { allowNonOk: true, timeoutMs: 30_000 },
+    );
   });
 });
 

--- a/packages/ui/src/components/settings/VaultInventoryPanel.security-findings.test.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.security-findings.test.tsx
@@ -4,9 +4,23 @@
  * @vitest-environment jsdom
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VaultInventoryPanel } from "./VaultInventoryPanel";
+
+const clientMocks = vi.hoisted(() => ({
+  rawRequest: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({
+  client: clientMocks,
+}));
 
 vi.mock("../../agent-surface", () => ({
   useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
@@ -19,7 +33,14 @@ vi.mock("../../state/TranslationContext.hooks", () => ({
   }),
 }));
 
-afterEach(cleanup);
+beforeEach(() => {
+  clientMocks.rawRequest.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("VaultInventoryPanel connector security findings", () => {
   it("shows non-revealing credential locations outside encrypted Vault storage", () => {
@@ -45,6 +66,73 @@ describe("VaultInventoryPanel connector security findings", () => {
     expect(screen.getByText("Telegram Personal session")).toBeTruthy();
     expect(screen.getByText(/outside encrypted Vault storage/)).toBeTruthy();
     expect(screen.queryByText(/session-secret/)).toBeNull();
+  });
+
+  it("reveals only on demand and hides on focus loss without exposing values in errors", async () => {
+    clientMocks.rawRequest.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        value: "opaque-test-value",
+        source: "vault",
+      }),
+    });
+    render(
+      <VaultInventoryPanel
+        entries={[
+          {
+            key: "TEST_API_KEY",
+            category: "provider",
+            label: "Test provider",
+            hasProfiles: false,
+            kind: "secret",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("opaque-test-value")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Reveal Test provider"));
+    expect(await screen.findByText("opaque-test-value")).toBeTruthy();
+    expect(
+      screen.getByLabelText("Temporarily revealed value for Test provider"),
+    ).toBeTruthy();
+
+    fireEvent(window, new Event("blur"));
+    await waitFor(() => {
+      expect(screen.queryByText("opaque-test-value")).toBeNull();
+    });
+
+    clientMocks.rawRequest.mockResolvedValueOnce({ ok: false, status: 423 });
+    fireEvent.click(screen.getByLabelText("Reveal Test provider"));
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/unlock the system credential store/i);
+    expect(alert.textContent).not.toContain("opaque-test-value");
+  });
+
+  it("retains the row and reports recovery when secure deletion is rejected", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    clientMocks.rawRequest.mockResolvedValueOnce({ ok: false, status: 503 });
+    const onChanged = vi.fn();
+    render(
+      <VaultInventoryPanel
+        entries={[
+          {
+            key: "TEST_API_KEY",
+            category: "provider",
+            label: "Test provider",
+            hasProfiles: false,
+            kind: "secret",
+          },
+        ]}
+        onChanged={onChanged}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Delete Test provider"));
+    expect(await screen.findByText(/credential was retained/i)).toBeTruthy();
+    expect(screen.getByTestId("vault-entry-row-TEST_API_KEY")).toBeTruthy();
+    expect(onChanged).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/settings/VaultInventoryPanel.security-findings.test.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.security-findings.test.tsx
@@ -110,7 +110,7 @@ describe("VaultInventoryPanel connector security findings", () => {
     expect(alert.textContent).not.toContain("opaque-test-value");
   });
 
-  it("retains the row and reports recovery when secure deletion is rejected", async () => {
+  it("retains the row and reports a truthful recovery check when secure deletion is rejected", async () => {
     clientMocks.rawRequest.mockResolvedValueOnce({ ok: false, status: 503 });
     const onChanged = vi.fn();
     render(
@@ -132,7 +132,9 @@ describe("VaultInventoryPanel connector security findings", () => {
     expect(screen.getByRole("alertdialog")).toBeTruthy();
     expect(clientMocks.rawRequest).not.toHaveBeenCalled();
     fireEvent.click(screen.getByLabelText("Permanently delete Test provider"));
-    expect(await screen.findByText(/credential was retained/i)).toBeTruthy();
+    expect(
+      await screen.findByText(/refresh the Vault to confirm/i),
+    ).toBeTruthy();
     expect(screen.getByTestId("vault-entry-row-TEST_API_KEY")).toBeTruthy();
     expect(onChanged).not.toHaveBeenCalled();
     expect(clientMocks.rawRequest).toHaveBeenCalledWith(

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -124,6 +124,12 @@ const CATEGORY_INPUT_OPTIONS: Array<{
   },
 ];
 
+// The first native Keychain operation in a newly signed or freshly installed
+// app can take longer than the generic API budget while macOS initializes the
+// credential-store process. Keep the request alive long enough to avoid an
+// ambiguous "failed" UI after the secure write has actually committed.
+const VAULT_NATIVE_OPERATION_TIMEOUT_MS = 30_000;
+
 // ── Public component ───────────────────────────────────────────────
 
 export interface VaultInventoryPanelProps {
@@ -443,6 +449,7 @@ const EntryRow = memo(function EntryRow({
   const [revealError, setRevealError] = useState<string | null>(null);
   const [revealing, setRevealing] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
   const { ref: revealRef, agentProps: revealAgentProps } =
@@ -504,7 +511,10 @@ const EntryRow = memo(function EntryRow({
       const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
         undefined,
-        { allowNonOk: true },
+        {
+          allowNonOk: true,
+          timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+        },
       );
       if (!res.ok) {
         setRevealError(
@@ -546,17 +556,16 @@ const EntryRow = memo(function EntryRow({
   }, [revealed]);
 
   const onDelete = useCallback(async () => {
-    const confirmed = window.confirm(
-      `Delete "${entry.label}"? This drops the value, every profile, and the metadata.`,
-    );
-    if (!confirmed) return;
     setDeleting(true);
     setRevealError(null);
     try {
       const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
         { method: "DELETE" },
-        { allowNonOk: true },
+        {
+          allowNonOk: true,
+          timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+        },
       );
       if (!res.ok) {
         setRevealError(
@@ -565,6 +574,7 @@ const EntryRow = memo(function EntryRow({
         return;
       }
       setRevealed(null);
+      setConfirmingDelete(false);
       onChanged();
     } catch {
       // error-policy:J1 deletion failures retain the row and surface a
@@ -575,7 +585,7 @@ const EntryRow = memo(function EntryRow({
     } finally {
       setDeleting(false);
     }
-  }, [entry.key, entry.label, onChanged]);
+  }, [entry.key, onChanged]);
 
   const profileCount = entry.profiles?.length ?? 0;
 
@@ -649,7 +659,11 @@ const EntryRow = memo(function EntryRow({
           variant="ghost"
           size="sm"
           className="h-7 w-7 shrink-0 rounded-sm p-0 text-muted hover:text-danger"
-          onClick={() => void onDelete()}
+          onClick={() => {
+            setRevealed(null);
+            setRevealError(null);
+            setConfirmingDelete(true);
+          }}
           disabled={deleting}
           aria-label={`Delete ${entry.label}`}
         >
@@ -660,6 +674,63 @@ const EntryRow = memo(function EntryRow({
           )}
         </Button>
       </div>
+
+      {confirmingDelete && (
+        <div
+          role="alertdialog"
+          aria-labelledby={`vault-delete-title-${entry.key}`}
+          aria-describedby={`vault-delete-description-${entry.key}`}
+          className="mt-1.5 rounded-sm border border-danger/40 bg-danger/5 p-2"
+        >
+          <p
+            id={`vault-delete-title-${entry.key}`}
+            className="text-xs font-medium text-txt"
+          >
+            Delete {entry.label}?
+          </p>
+          <p
+            id={`vault-delete-description-${entry.key}`}
+            className="mt-0.5 text-2xs text-muted"
+          >
+            This permanently removes the value, every profile, and its metadata
+            from this Vault.
+          </p>
+          <div className="mt-2 flex flex-wrap justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 rounded-sm px-2 text-xs"
+              onClick={() => setConfirmingDelete(false)}
+              disabled={deleting}
+              aria-label={`Cancel deleting ${entry.label}`}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              className="h-7 rounded-sm px-2 text-xs"
+              onClick={() => void onDelete()}
+              disabled={deleting}
+              aria-label={`Permanently delete ${entry.label}`}
+            >
+              {deleting ? (
+                <>
+                  <Loader2
+                    className="mr-1 h-3.5 w-3.5 animate-spin"
+                    aria-hidden
+                  />
+                  Deleting…
+                </>
+              ) : (
+                "Delete permanently"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
 
       {revealed && (
         <fieldset
@@ -730,6 +801,10 @@ function ProfilesPanel({
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [migrating, setMigrating] = useState(false);
+  const [pendingProfileDelete, setPendingProfileDelete] = useState<
+    string | null
+  >(null);
+  const [deletingProfile, setDeletingProfile] = useState<string | null>(null);
 
   const profiles = entry.profiles ?? [];
   const hasProfiles = profiles.length > 0;
@@ -814,7 +889,10 @@ function ProfilesPanel({
             value: newValue,
           }),
         },
-        { allowNonOk: true },
+        {
+          allowNonOk: true,
+          timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+        },
       );
       setSubmitting(false);
       if (!res.ok) {
@@ -839,7 +917,10 @@ function ProfilesPanel({
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ profileId }),
         },
-        { allowNonOk: true },
+        {
+          allowNonOk: true,
+          timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+        },
       );
       if (res.ok) onChanged();
     },
@@ -848,14 +929,32 @@ function ProfilesPanel({
 
   const onDelete = useCallback(
     async (profileId: string) => {
-      const confirmed = window.confirm(`Delete profile "${profileId}"?`);
-      if (!confirmed) return;
-      const res = await client.rawRequest(
-        `/api/secrets/inventory/${encodeURIComponent(entry.key)}/profiles/${encodeURIComponent(profileId)}`,
-        { method: "DELETE" },
-        { allowNonOk: true },
-      );
-      if (res.ok) onChanged();
+      setDeletingProfile(profileId);
+      setErr(null);
+      try {
+        const res = await client.rawRequest(
+          `/api/secrets/inventory/${encodeURIComponent(entry.key)}/profiles/${encodeURIComponent(profileId)}`,
+          { method: "DELETE" },
+          {
+            allowNonOk: true,
+            timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+          },
+        );
+        if (!res.ok) {
+          setErr(
+            `Profile delete failed (HTTP ${res.status}). The credential was retained; unlock secure storage and retry.`,
+          );
+          return;
+        }
+        setPendingProfileDelete(null);
+        onChanged();
+      } catch {
+        setErr(
+          "Profile delete failed. The credential was retained; unlock secure storage and retry.",
+        );
+      } finally {
+        setDeletingProfile(null);
+      }
     },
     [entry.key, onChanged],
   );
@@ -870,7 +969,10 @@ function ProfilesPanel({
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ key: entry.key }),
       },
-      { allowNonOk: true },
+      {
+        allowNonOk: true,
+        timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+      },
     );
     setMigrating(false);
     if (!res.ok) {
@@ -968,8 +1070,15 @@ function ProfilesPanel({
               profileLabel={p.label}
               active={entry.activeProfile === p.id}
               highlight={highlightProfileId === p.id}
+              confirmingDelete={pendingProfileDelete === p.id}
+              deleting={deletingProfile === p.id}
               onActivate={() => void onActivate(p.id)}
-              onDelete={() => void onDelete(p.id)}
+              onRequestDelete={() => {
+                setErr(null);
+                setPendingProfileDelete(p.id);
+              }}
+              onCancelDelete={() => setPendingProfileDelete(null)}
+              onConfirmDelete={() => void onDelete(p.id)}
             />
           ))}
         </ul>
@@ -1083,8 +1192,12 @@ interface ProfileRowProps {
   profileLabel: string;
   active: boolean;
   highlight: boolean;
+  confirmingDelete: boolean;
+  deleting: boolean;
   onActivate: () => void;
-  onDelete: () => void;
+  onRequestDelete: () => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: () => void;
 }
 
 const ProfileRow = memo(
@@ -1094,8 +1207,12 @@ const ProfileRow = memo(
     profileLabel,
     active,
     highlight,
+    confirmingDelete,
+    deleting,
     onActivate,
-    onDelete,
+    onRequestDelete,
+    onCancelDelete,
+    onConfirmDelete,
   }: ProfileRowProps) {
     const { t } = useTranslation();
     const { ref: activateRef, agentProps: activateAgentProps } =
@@ -1113,52 +1230,92 @@ const ProfileRow = memo(
         role: "button",
         label: `Delete profile ${profileLabel}`,
         group: "vault-profiles",
-        onActivate: onDelete,
+        onActivate: onRequestDelete,
       });
     return (
-      <li
-        className={`flex items-center gap-2 rounded-sm px-1.5 py-1 text-xs ${highlight ? " " : ""}`}
-      >
-        <Input
-          ref={activateRef}
-          {...activateAgentProps}
-          type="radio"
-          name={`active-${entryKey}`}
-          checked={active}
-          onChange={onActivate}
-          className="h-3 w-3 cursor-pointer border-border p-0 accent-accent"
-          aria-current={active ? "true" : undefined}
-          aria-label={t("vaultinventory.profiles.makeActive", {
-            label: profileLabel,
-            defaultValue: "Make {{label}} active",
-          })}
-        />
-        <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-txt">{profileLabel}</p>
-          <p className="truncate font-mono text-2xs text-muted">{profileId}</p>
-        </div>
-        {active && (
-          <span className="shrink-0 inline-flex items-center gap-0.5 rounded-full border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-2xs font-medium text-accent">
-            <CheckCircle2 className="h-3 w-3" aria-hidden />{" "}
-            {t("vaultinventory.profiles.active", {
-              defaultValue: "Active",
+      <li className={`rounded-sm px-1.5 py-1 text-xs ${highlight ? " " : ""}`}>
+        <div className="flex items-center gap-2">
+          <Input
+            ref={activateRef}
+            {...activateAgentProps}
+            type="radio"
+            name={`active-${entryKey}`}
+            checked={active}
+            onChange={onActivate}
+            className="h-3 w-3 cursor-pointer border-border p-0 accent-accent"
+            aria-current={active ? "true" : undefined}
+            aria-label={t("vaultinventory.profiles.makeActive", {
+              label: profileLabel,
+              defaultValue: "Make {{label}} active",
             })}
-          </span>
+          />
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-medium text-txt">{profileLabel}</p>
+            <p className="truncate font-mono text-2xs text-muted">
+              {profileId}
+            </p>
+          </div>
+          {active && (
+            <span className="inline-flex shrink-0 items-center gap-0.5 rounded-full border border-accent/40 bg-accent/10 px-1.5 py-0.5 text-2xs font-medium text-accent">
+              <CheckCircle2 className="h-3 w-3" aria-hidden />{" "}
+              {t("vaultinventory.profiles.active", {
+                defaultValue: "Active",
+              })}
+            </span>
+          )}
+          <Button
+            ref={deleteRef}
+            {...deleteAgentProps}
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 shrink-0 rounded-sm p-0 text-muted hover:text-danger"
+            aria-label={t("vaultinventory.profiles.deleteProfile", {
+              label: profileLabel,
+              defaultValue: "Delete profile {{label}}",
+            })}
+            onClick={onRequestDelete}
+            disabled={deleting}
+          >
+            {deleting ? (
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+            ) : (
+              <Trash2 className="h-3 w-3" aria-hidden />
+            )}
+          </Button>
+        </div>
+        {confirmingDelete && (
+          <div
+            role="alertdialog"
+            aria-label={`Delete profile ${profileLabel}?`}
+            className="mt-1.5 rounded-sm border border-danger/40 bg-danger/5 p-2"
+          >
+            <p className="text-2xs text-muted">
+              Permanently delete this profile and its stored value?
+            </p>
+            <div className="mt-2 flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 rounded-sm px-2 text-2xs"
+                onClick={onCancelDelete}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                className="h-6 rounded-sm px-2 text-2xs"
+                onClick={onConfirmDelete}
+                disabled={deleting}
+              >
+                Delete permanently
+              </Button>
+            </div>
+          </div>
         )}
-        <Button
-          ref={deleteRef}
-          {...deleteAgentProps}
-          variant="ghost"
-          size="sm"
-          className="h-6 w-6 shrink-0 rounded-sm p-0 text-muted hover:text-danger"
-          aria-label={t("vaultinventory.profiles.deleteProfile", {
-            label: profileLabel,
-            defaultValue: "Delete profile {{label}}",
-          })}
-          onClick={onDelete}
-        >
-          <Trash2 className="h-3 w-3" aria-hidden />
-        </Button>
       </li>
     );
   },
@@ -1169,7 +1326,9 @@ const ProfileRow = memo(
     prev.profileId === next.profileId &&
     prev.profileLabel === next.profileLabel &&
     prev.active === next.active &&
-    prev.highlight === next.highlight,
+    prev.highlight === next.highlight &&
+    prev.confirmingDelete === next.confirmingDelete &&
+    prev.deleting === next.deleting,
 );
 
 // ── Add-secret form ────────────────────────────────────────────────
@@ -1274,7 +1433,10 @@ function AddSecretForm({
               category,
             }),
           },
-          { allowNonOk: true },
+          {
+            allowNonOk: true,
+            timeoutMs: VAULT_NATIVE_OPERATION_TIMEOUT_MS,
+          },
         );
         if (!res.ok) {
           setErr(`Secret save failed (HTTP ${res.status}).`);

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -522,12 +522,18 @@ const EntryRow = memo(function EntryRow({
         );
         return;
       }
-      const body = (await res.json()) as {
-        value: string;
-        source: string;
-        profileId?: string;
-      };
-      setRevealed(body);
+      const body: unknown = await res.json();
+      if (
+        typeof body !== "object" ||
+        body === null ||
+        typeof (body as { value?: unknown }).value !== "string" ||
+        typeof (body as { source?: unknown }).source !== "string"
+      ) {
+        throw new Error("invalid reveal response");
+      }
+      setRevealed(
+        body as { value: string; source: string; profileId?: string },
+      );
     } catch {
       // error-policy:J1 the row exposes a redacted recovery message; transport
       // and native errors can contain sensitive identifiers and stay out of UI.
@@ -569,7 +575,7 @@ const EntryRow = memo(function EntryRow({
       );
       if (!res.ok) {
         setRevealError(
-          `Delete failed (HTTP ${res.status}). The credential was retained; unlock the system credential store and retry.`,
+          `Delete failed (HTTP ${res.status}). Refresh the Vault to confirm whether the credential remains, then unlock secure storage and retry if needed.`,
         );
         return;
       }
@@ -580,7 +586,7 @@ const EntryRow = memo(function EntryRow({
       // error-policy:J1 deletion failures retain the row and surface a
       // redacted, retryable state instead of claiming the credential is gone.
       setRevealError(
-        "Delete failed. The credential was retained; unlock the system credential store and retry.",
+        "Delete could not be confirmed. Refresh the Vault to check whether the credential remains, then unlock secure storage and retry if needed.",
       );
     } finally {
       setDeleting(false);
@@ -942,7 +948,7 @@ function ProfilesPanel({
         );
         if (!res.ok) {
           setErr(
-            `Profile delete failed (HTTP ${res.status}). The credential was retained; unlock secure storage and retry.`,
+            `Profile delete failed (HTTP ${res.status}). Refresh the Vault to confirm whether the profile remains, then unlock secure storage and retry if needed.`,
           );
           return;
         }
@@ -950,7 +956,7 @@ function ProfilesPanel({
         onChanged();
       } catch {
         setErr(
-          "Profile delete failed. The credential was retained; unlock secure storage and retry.",
+          "Profile deletion could not be confirmed. Refresh the Vault to check whether the profile remains, then unlock secure storage and retry if needed.",
         );
       } finally {
         setDeletingProfile(null);
@@ -1446,7 +1452,9 @@ function AddSecretForm({
       } catch {
         // error-policy:J1 retain the entered value only inside this password
         // field for retry; native/transport details remain redacted.
-        setErr("Secret save failed. Unlock secure storage and try again.");
+        setErr(
+          "Secret save could not be confirmed. Refresh the Vault before retrying to avoid replacing a value that may already be stored.",
+        );
       } finally {
         setSubmitting(false);
       }

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -19,7 +19,7 @@
  * the Vault modal via `onJumpToRouting`.
  *
  * Hard rule: revealed values never persist in component state past the
- * 10-second auto-hide window.
+ * 10-second auto-hide window or while the app is backgrounded.
  */
 
 import {
@@ -442,6 +442,7 @@ const EntryRow = memo(function EntryRow({
   } | null>(null);
   const [revealError, setRevealError] = useState<string | null>(null);
   const [revealing, setRevealing] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
   const { ref: revealRef, agentProps: revealAgentProps } =
@@ -482,38 +483,65 @@ const EntryRow = memo(function EntryRow({
   // Auto-hide the revealed value after 10 seconds.
   useEffect(() => {
     if (!revealed) return;
-    const id = setTimeout(() => setRevealed(null), 10_000);
-    return () => clearTimeout(id);
+    const hideRevealedValue = () => setRevealed(null);
+    const hideWhenBackgrounded = () => {
+      if (document.visibilityState === "hidden") hideRevealedValue();
+    };
+    const id = setTimeout(hideRevealedValue, 10_000);
+    window.addEventListener("blur", hideRevealedValue);
+    document.addEventListener("visibilitychange", hideWhenBackgrounded);
+    return () => {
+      clearTimeout(id);
+      window.removeEventListener("blur", hideRevealedValue);
+      document.removeEventListener("visibilitychange", hideWhenBackgrounded);
+    };
   }, [revealed]);
 
   const reveal = useCallback(async () => {
     setRevealing(true);
     setRevealError(null);
-    const res = await client.rawRequest(
-      `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
-      undefined,
-      { allowNonOk: true },
-    );
-    if (!res.ok) {
-      setRevealError(`HTTP ${res.status}`);
+    try {
+      const res = await client.rawRequest(
+        `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
+        undefined,
+        { allowNonOk: true },
+      );
+      if (!res.ok) {
+        setRevealError(
+          `Reveal failed (HTTP ${res.status}). Unlock the system credential store and try again.`,
+        );
+        return;
+      }
+      const body = (await res.json()) as {
+        value: string;
+        source: string;
+        profileId?: string;
+      };
+      setRevealed(body);
+    } catch {
+      // error-policy:J1 the row exposes a redacted recovery message; transport
+      // and native errors can contain sensitive identifiers and stay out of UI.
+      setRevealError(
+        "Reveal failed. Unlock the system credential store and try again.",
+      );
+    } finally {
       setRevealing(false);
-      return;
     }
-    const body = (await res.json()) as {
-      value: string;
-      source: string;
-      profileId?: string;
-    };
-    setRevealed(body);
-    setRevealing(false);
   }, [entry.key]);
 
   const hide = useCallback(() => setRevealed(null), []);
 
   const copy = useCallback(async () => {
     if (!revealed) return;
-    if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      if (typeof navigator === "undefined" || !navigator.clipboard) {
+        throw new Error("clipboard unavailable");
+      }
       await navigator.clipboard.writeText(revealed.value);
+    } catch {
+      // error-policy:J1 clipboard failures are recoverable and the message is
+      // deliberately value-free; the user can retry while reveal is active.
+      setRevealError("Copy failed. Check clipboard permission and try again.");
     }
   }, [revealed]);
 
@@ -522,12 +550,31 @@ const EntryRow = memo(function EntryRow({
       `Delete "${entry.label}"? This drops the value, every profile, and the metadata.`,
     );
     if (!confirmed) return;
-    const res = await client.rawRequest(
-      `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
-      { method: "DELETE" },
-      { allowNonOk: true },
-    );
-    if (res.ok) onChanged();
+    setDeleting(true);
+    setRevealError(null);
+    try {
+      const res = await client.rawRequest(
+        `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
+        { method: "DELETE" },
+        { allowNonOk: true },
+      );
+      if (!res.ok) {
+        setRevealError(
+          `Delete failed (HTTP ${res.status}). The credential was retained; unlock the system credential store and retry.`,
+        );
+        return;
+      }
+      setRevealed(null);
+      onChanged();
+    } catch {
+      // error-policy:J1 deletion failures retain the row and surface a
+      // redacted, retryable state instead of claiming the credential is gone.
+      setRevealError(
+        "Delete failed. The credential was retained; unlock the system credential store and retry.",
+      );
+    } finally {
+      setDeleting(false);
+    }
   }, [entry.key, entry.label, onChanged]);
 
   const profileCount = entry.profiles?.length ?? 0;
@@ -538,7 +585,7 @@ const EntryRow = memo(function EntryRow({
       data-testid={`vault-entry-row-${entry.key}`}
       className="rounded-sm px-2 py-1.5 hover:bg-bg-muted/30"
     >
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
         <Button
           variant="ghost"
           size="sm"
@@ -580,7 +627,7 @@ const EntryRow = memo(function EntryRow({
             ) : (
               <Eye className="h-3.5 w-3.5" aria-hidden />
             )}
-            Reveal
+            <span className="hidden sm:inline">Reveal</span>
           </Button>
         ) : (
           <Button
@@ -593,7 +640,7 @@ const EntryRow = memo(function EntryRow({
             aria-label={`Hide ${entry.label}`}
           >
             <EyeOff className="h-3.5 w-3.5" aria-hidden />
-            Hide
+            <span className="hidden sm:inline">Hide</span>
           </Button>
         )}
         <Button
@@ -603,15 +650,21 @@ const EntryRow = memo(function EntryRow({
           size="sm"
           className="h-7 w-7 shrink-0 rounded-sm p-0 text-muted hover:text-danger"
           onClick={() => void onDelete()}
+          disabled={deleting}
           aria-label={`Delete ${entry.label}`}
         >
-          <Trash2 className="h-3.5 w-3.5" aria-hidden />
+          {deleting ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          ) : (
+            <Trash2 className="h-3.5 w-3.5" aria-hidden />
+          )}
         </Button>
       </div>
 
       {revealed && (
-        <div
+        <fieldset
           data-testid={`vault-revealed-${entry.key}`}
+          aria-label={`Temporarily revealed value for ${entry.label}`}
           className="mt-1.5 flex items-center gap-2 rounded-sm border border-border/50 bg-bg/40 p-2"
         >
           <code className="flex-1 truncate font-mono text-2xs text-txt">
@@ -632,11 +685,16 @@ const EntryRow = memo(function EntryRow({
             <Copy className="h-3 w-3" aria-hidden />{" "}
             {t("vaultinventory.copy", { defaultValue: "Copy" })}
           </Button>
-        </div>
+          <span className="sr-only">
+            This value hides after ten seconds or when the app loses focus.
+          </span>
+        </fieldset>
       )}
 
       {revealError && (
-        <p className="mt-1 text-2xs text-danger">{revealError}</p>
+        <p className="mt-1 text-2xs text-danger" role="alert">
+          {revealError}
+        </p>
       )}
 
       {expanded && (
@@ -1203,26 +1261,33 @@ function AddSecretForm({
       if (!key.trim() || !value) return;
       setSubmitting(true);
       setErr(null);
-      const res = await client.rawRequest(
-        `/api/secrets/inventory/${encodeURIComponent(key.trim())}`,
-        {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            value,
-            ...(label.trim() ? { label: label.trim() } : {}),
-            ...(providerId.trim() ? { providerId: providerId.trim() } : {}),
-            category,
-          }),
-        },
-        { allowNonOk: true },
-      );
-      setSubmitting(false);
-      if (!res.ok) {
-        setErr(`HTTP ${res.status}`);
-        return;
+      try {
+        const res = await client.rawRequest(
+          `/api/secrets/inventory/${encodeURIComponent(key.trim())}`,
+          {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              value,
+              ...(label.trim() ? { label: label.trim() } : {}),
+              ...(providerId.trim() ? { providerId: providerId.trim() } : {}),
+              category,
+            }),
+          },
+          { allowNonOk: true },
+        );
+        if (!res.ok) {
+          setErr(`Secret save failed (HTTP ${res.status}).`);
+          return;
+        }
+        onSaved();
+      } catch {
+        // error-policy:J1 retain the entered value only inside this password
+        // field for retry; native/transport details remain redacted.
+        setErr("Secret save failed. Unlock secure storage and try again.");
+      } finally {
+        setSubmitting(false);
       }
-      onSaved();
     },
     [category, key, label, providerId, value, onSaved],
   );

--- a/packages/vault/src/master-key.ts
+++ b/packages/vault/src/master-key.ts
@@ -421,7 +421,13 @@ export function loadDefaultMasterKeySync(opts: OsKeychainOptions = {}): Buffer {
       return key;
     }
     const created = generateMasterKey();
-    entry.setPassword(created.toString("base64"));
+    const encoded = created.toString("base64");
+    entry.setPassword(encoded);
+    if (entry.getPassword() !== encoded) {
+      throw new MasterKeyUnavailableError(
+        `OS keychain write could not be verified (${service}/${account})`,
+      );
+    }
     return created;
   } catch (keychainError) {
     if (passphrase) {
@@ -507,12 +513,16 @@ export function osKeychainMasterKey(
         return buf;
       }
       const created = generateMasterKey();
+      const encoded = created.toString("base64");
       try {
-        entry.setPassword(created.toString("base64"));
+        entry.setPassword(encoded);
+        if (entry.getPassword() !== encoded) {
+          throw new Error("exact read-back mismatch");
+        }
       } catch (err) {
         // error-policy:J2 context-adding rethrow — a freshly-generated key that
-        // cannot be persisted must fail loudly; returning it un-stored would
-        // mint a new key on every boot and orphan prior ciphertext.
+        // cannot be persisted and read back exactly must fail loudly; returning
+        // it un-stored would mint a new key on every boot and orphan ciphertext.
         throw new MasterKeyUnavailableError(
           `OS keychain write failed (${service}/${account}): ${
             err instanceof Error ? err.message : String(err)

--- a/plugins/plugin-native-secure-store/ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
+++ b/plugins/plugin-native-secure-store/ios/Sources/SecureStorePlugin/SecureStorePlugin.swift
@@ -70,25 +70,47 @@ public class ElizaSecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
             add.merge(attributes) { _, replacement in replacement }
             status = SecItemAdd(add as CFDictionary, nil)
         }
-        if status == errSecSuccess {
-            call.resolve(["ok": true])
-        } else {
+        guard status == errSecSuccess else {
             call.resolve(statusResult(status))
+            return
         }
+
+        var verificationQuery = query
+        verificationQuery[kSecReturnData as String] = kCFBooleanTrue
+        verificationQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+        var storedItem: CFTypeRef?
+        let verificationStatus = SecItemCopyMatching(verificationQuery as CFDictionary, &storedItem)
+        guard verificationStatus == errSecSuccess else {
+            call.resolve(statusResult(verificationStatus))
+            return
+        }
+        guard let storedData = storedItem as? Data, storedData == valueData else {
+            call.resolve(errorResult("native_error", "Apple Keychain write could not be verified."))
+            return
+        }
+        call.resolve(["ok": true])
     }
 
     @objc func remove(_ call: CAPPluginCall) {
         guard let key = validatedKey(call) else { return }
         let status = SecItemDelete(baseQuery(key) as CFDictionary)
-        if status == errSecSuccess {
-            call.resolve(["ok": true, "deleted": true])
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            call.resolve(statusResult(status))
             return
         }
-        if status == errSecItemNotFound {
-            call.resolve(["ok": true, "deleted": false])
+
+        var verificationQuery = baseQuery(key)
+        verificationQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+        let verificationStatus = SecItemCopyMatching(verificationQuery as CFDictionary, nil)
+        if verificationStatus == errSecItemNotFound {
+            call.resolve(["ok": true, "deleted": status == errSecSuccess])
             return
         }
-        call.resolve(statusResult(status))
+        if verificationStatus == errSecSuccess {
+            call.resolve(errorResult("native_error", "Apple Keychain deletion could not be verified."))
+            return
+        }
+        call.resolve(statusResult(verificationStatus))
     }
 
     @objc func status(_ call: CAPPluginCall) {

--- a/plugins/plugin-native-secure-store/src/swift-bridge-contract.test.ts
+++ b/plugins/plugin-native-secure-store/src/swift-bridge-contract.test.ts
@@ -39,6 +39,14 @@ describe("Apple secure-store bridge contract", () => {
     );
   });
 
+  it("verifies an exact Keychain read-back before reporting a write", () => {
+    expect(source).toContain(
+      "SecItemCopyMatching(verificationQuery as CFDictionary, &storedItem)",
+    );
+    expect(source).toContain("storedData == valueData");
+    expect(source).toContain("Apple Keychain write could not be verified.");
+  });
+
   it("allowlists accounts and never accepts an arbitrary service", () => {
     for (const key of [
       "session.device_auth",
@@ -53,9 +61,23 @@ describe("Apple secure-store bridge contract", () => {
     expect(source).toContain("!value.isEmpty");
   });
 
-  it("distinguishes deleted and already-absent items", () => {
-    expect(source).toContain('["ok": true, "deleted": true]');
-    expect(source).toContain('["ok": true, "deleted": false]');
+  it("distinguishes deletion outcomes only after verifying absence", () => {
+    expect(source).toContain(
+      "SecItemCopyMatching(verificationQuery as CFDictionary, nil)",
+    );
+    expect(source).toContain(
+      '["ok": true, "deleted": status == errSecSuccess]',
+    );
+    expect(source).toContain("Apple Keychain deletion could not be verified.");
+  });
+
+  it("maps locked, unavailable, authentication, and cancellation outcomes", () => {
+    expect(source).toContain("errSecInteractionNotAllowed");
+    expect(source).toContain("errSecAuthFailed");
+    expect(source).toContain("errSecUserCanceled");
+    expect(source).toContain("errSecNotAvailable");
+    expect(source).toContain('errorResult("denied"');
+    expect(source).toContain('errorResult("unavailable"');
   });
 
   it("does not grant Keychain Sharing to the app or its extensions", () => {


### PR DESCRIPTION
## Summary

- require exact native secure-store write read-back and verified deletion
- preserve recoverable legacy credentials until protected migration is proven
- harden Vault recovery, reveal, auto-hide, destructive confirmation, and redacted retry states
- ship the allowlisted iOS secure-store plugin and tighten MAS artifact verification
- register Vault desktop catalogs and keep auxiliary windows free of the chat overlay

## Verification

- Vault: 208 tests; native secure store: 13 tests
- focused app-core: 46 tests; Electrobun menu/auth bridge: 17 tests
- UI auxiliary/Vault security: 23 tests; MAS verifier: 15 tests; mobile manifest: 3 tests
- exact macOS direct/store artifacts pass codesign checks and store MAS smoke
- exact iOS Simulator and unsigned generic-device audits pass with zero findings
- exact isolated macOS Computer Use acceptance passes metadata, reveal/auto-hide, delete-cancel, restart persistence, and auxiliary-window isolation

## Manual gates

- signed physical-iPhone Keychain lifecycle acceptance
- Apple distribution signing, notarization, and TestFlight
- review, merge, and deployment
