### PR TITLE
fix(voice): validate APP launch handoffs

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1091,6 +1091,56 @@ describe("voice-session WS lifecycle", () => {
     ]);
   });
 
+  test("does not forward ambiguous or non-canonical APP launch handoffs", async () => {
+    for (const actionResults of [
+      [
+        {
+          actionName: "APP",
+          success: true,
+          values: {
+            mode: "launch",
+            viewId: "browser",
+            viewPath: "/browser?browse=javascript%3Aalert(1)",
+          },
+        },
+      ],
+      [
+        {
+          actionName: "APP",
+          success: true,
+          values: {
+            mode: "launch",
+            viewId: "browser",
+            viewPath: "/browser?browse=https%3A%2F%2Fone.example",
+          },
+        },
+        {
+          actionName: "APP",
+          success: true,
+          values: {
+            mode: "launch",
+            viewId: "browser",
+            viewPath: "/browser?browse=https%3A%2F%2Ftwo.example",
+          },
+        },
+      ],
+    ]) {
+      const client = new FakeClientSocket();
+      await connectSession({
+        client,
+        fetchImpl: makeCanonicalChunkFetch(["Opened Demo."], { actionResults }),
+      });
+      const ink = FakeInkSocket.instances.at(-1)!;
+      ink.emitTurn("turn.start");
+      ink.emitTurn("turn.end", "launch demo");
+      await flush();
+      await flush();
+      expect(
+        client.controlFrames.filter((frame) => frame.t === "navigate_view"),
+      ).toEqual([]);
+    }
+  });
+
   test("prewarms Eliza tenancy context when the live session starts", async () => {
     let prewarmCalls = 0;
     const client = new FakeClientSocket();

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -32,9 +32,13 @@ function sseResponse(
 }
 
 async function streamTerminalActionResult(actionResult: Record<string, unknown>) {
+  return streamTerminalActionResults([actionResult]);
+}
+
+async function streamTerminalActionResults(actionResults: Record<string, unknown>[]) {
   const fetchImpl = (async () =>
     sseResponse([
-      `event: done\ndata: ${JSON.stringify({ actionResults: [actionResult] })}\n\n`,
+      `event: done\ndata: ${JSON.stringify({ actionResults })}\n\n`,
     ])) as unknown as typeof fetch;
   return streamElizaConversation(
     {
@@ -829,6 +833,66 @@ describe("eliza sse bridge", () => {
         aborted: false,
       });
     }
+  });
+
+  test("rejects non-canonical APP Browser paths and malformed terminal shapes", async () => {
+    const rejectedPaths = [
+      "/browser",
+      "/wallet?browse=https%3A%2F%2Fexample.com",
+      "/browser?browse=javascript%3Aalert(1)",
+      "/browser?browse=%2Fapi%2Fapps%2Flocal%2F..%2Fsecret",
+      "/browser?browse=%2F%2Fevil.example",
+      "/browser?browse=https%3A%2F%2Fuser%3Asecret%40example.com",
+      "/browser?browse=https%3A%2F%2Fexample.com&browse=https%3A%2F%2Fevil.example",
+      "/browser?browse=https%3A%2F%2Fexample.com%2F%250Ainject",
+      `/${"a".repeat(257)}`,
+    ];
+    for (const viewPath of rejectedPaths) {
+      await expect(
+        streamTerminalActionResult({
+          actionName: "APP",
+          success: true,
+          values: { mode: "launch", viewId: "browser", viewPath },
+        }),
+      ).resolves.toEqual({ completed: true, aborted: false });
+    }
+
+    await expect(
+      streamTerminalActionResult({
+        data: { actionName: "APP" },
+        success: true,
+        values: {
+          mode: "launch",
+          viewId: "browser",
+          viewPath: "/browser?browse=https%3A%2F%2Fexample.com",
+        },
+      }),
+    ).resolves.toEqual({ completed: true, aborted: false });
+  });
+
+  test("fails closed when a terminal frame contains multiple successful navigations", async () => {
+    await expect(
+      streamTerminalActionResults([
+        {
+          actionName: "APP",
+          success: true,
+          values: {
+            mode: "launch",
+            viewId: "browser",
+            viewPath: "/browser?browse=https%3A%2F%2Fone.example",
+          },
+        },
+        {
+          actionName: "APP",
+          success: true,
+          values: {
+            mode: "launch",
+            viewId: "browser",
+            viewPath: "/browser?browse=https%3A%2F%2Ftwo.example",
+          },
+        },
+      ]),
+    ).resolves.toEqual({ completed: true, aborted: false });
   });
 
   test("does not promote failed or malformed terminal action results", async () => {

--- a/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
+++ b/packages/cloud/shared/src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts
@@ -895,6 +895,27 @@ describe("eliza sse bridge", () => {
     ).resolves.toEqual({ completed: true, aborted: false });
   });
 
+  test("keeps the navigation handoff when non-navigation VIEWS modes share the frame", async () => {
+    await expect(
+      streamTerminalActionResults([
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: { mode: "create", viewId: "chat" },
+        },
+        {
+          actionName: "VIEWS",
+          success: true,
+          values: { mode: "show", viewId: "chat", viewPath: "/chat" },
+        },
+      ]),
+    ).resolves.toEqual({
+      completed: true,
+      aborted: false,
+      viewHandoff: { viewId: "chat", viewPath: "/chat" },
+    });
+  });
+
   test("does not promote failed or malformed terminal action results", async () => {
     const fetchImpl = (async () =>
       sseResponse([

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -640,42 +640,121 @@ function extractViewHandoff(payload: string): ElizaVoiceViewHandoff | null {
   }
   if (!isRecord(parsed) || !Array.isArray(parsed.actionResults)) return null;
 
+  let selected: ElizaVoiceViewHandoff | null = null;
+  let successfulNavigationResults = 0;
   for (let index = parsed.actionResults.length - 1; index >= 0; index--) {
     const candidate = parsed.actionResults[index];
     if (!isRecord(candidate) || candidate.success !== true) continue;
-    const data = isRecord(candidate.data) ? candidate.data : null;
-    const actionName =
-      typeof candidate.actionName === "string"
-        ? candidate.actionName
-        : typeof data?.actionName === "string"
-          ? data.actionName
-          : null;
+    const actionName = readBoundedString(candidate.actionName)?.toUpperCase();
+    if (actionName !== "VIEWS" && actionName !== "APP") continue;
+    successfulNavigationResults += 1;
+    // A terminal frame containing more than one successful navigation result
+    // has no authoritative ordering contract. Fail closed instead of choosing
+    // whichever array position an adapter happened to serialize last.
+    if (successfulNavigationResults > 1) return null;
     if (!isRecord(candidate.values)) {
       continue;
     }
-    const normalizedActionName = actionName?.toUpperCase();
     const mode = readBoundedString(candidate.values.mode)?.toLowerCase();
     const viewId = readBoundedString(candidate.values.viewId);
     if (!viewId) continue;
-    const isViewsHandoff = normalizedActionName === "VIEWS" && (mode === "show" || mode === "open");
-    const isAppBrowserHandoff =
-      normalizedActionName === "APP" && mode === "launch" && viewId === "browser";
+    const isViewsHandoff = actionName === "VIEWS" && (mode === "show" || mode === "open");
+    const isAppBrowserHandoff = actionName === "APP" && mode === "launch" && viewId === "browser";
     if (!isViewsHandoff && !isAppBrowserHandoff) continue;
     const viewPath = readBoundedString(candidate.values.viewPath);
     const subview = readBoundedString(candidate.values.subview);
-    return {
+    if (isAppBrowserHandoff && (!viewPath || !isCanonicalBrowserLaunchPath(viewPath))) {
+      continue;
+    }
+    selected = {
       viewId,
       ...(viewPath ? { viewPath } : {}),
       ...(subview ? { subview } : {}),
     };
   }
-  return null;
+  return selected;
 }
+
+const UNSAFE_HANDOFF_CHARACTERS = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u;
 
 function readBoundedString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const normalized = value.trim();
-  return normalized.length > 0 && normalized.length <= 256 ? normalized : null;
+  return normalized.length > 0 &&
+    normalized.length <= 256 &&
+    !UNSAFE_HANDOFF_CHARACTERS.test(normalized)
+    ? normalized
+    : null;
+}
+
+/** Validate the canonical path emitted by plugin-app-control, not a generic URL. */
+function isCanonicalBrowserLaunchPath(viewPath: string): boolean {
+  if (!viewPath.startsWith("/browser?") || /[^\x20-\x7e]/u.test(viewPath)) return false;
+  let browserUrl: URL;
+  try {
+    browserUrl = new URL(viewPath, "https://voice-handoff.invalid");
+  } catch (ignoredError) {
+    void ignoredError;
+    // error-policy:J3 malformed navigation metadata is an absent handoff.
+    return false;
+  }
+  const query = [...browserUrl.searchParams.entries()];
+  if (
+    browserUrl.origin !== "https://voice-handoff.invalid" ||
+    browserUrl.pathname !== "/browser" ||
+    browserUrl.hash !== "" ||
+    query.length !== 1 ||
+    query[0]?.[0] !== "browse"
+  ) {
+    return false;
+  }
+  const target = query[0]?.[1];
+  if (
+    !target ||
+    UNSAFE_HANDOFF_CHARACTERS.test(target) ||
+    target.includes("\\") ||
+    hasUnsafeHandoffEncoding(target)
+  ) {
+    return false;
+  }
+  try {
+    if (target.startsWith("/")) {
+      if (target.startsWith("//")) return false;
+      const relative = new URL(target, "https://app-launch.invalid");
+      return (
+        relative.origin === "https://app-launch.invalid" &&
+        relative.pathname.startsWith("/api/apps/local/")
+      );
+    }
+    const absolute = new URL(target);
+    return (
+      (absolute.protocol === "http:" || absolute.protocol === "https:") &&
+      absolute.username === "" &&
+      absolute.password === ""
+    );
+  } catch (ignoredError) {
+    void ignoredError;
+    // error-policy:J3 malformed embedded launch URLs are never delivered.
+    return false;
+  }
+}
+
+function hasUnsafeHandoffEncoding(value: string): boolean {
+  let decoded = value;
+  for (let depth = 0; depth < 2; depth++) {
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch (ignoredError) {
+      void ignoredError;
+      // error-policy:J3 non-canonical percent encoding is not navigation data.
+      return true;
+    }
+    if (UNSAFE_HANDOFF_CHARACTERS.test(next)) return true;
+    if (next === decoded) return false;
+    decoded = next;
+  }
+  return false;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -647,11 +647,6 @@ function extractViewHandoff(payload: string): ElizaVoiceViewHandoff | null {
     if (!isRecord(candidate) || candidate.success !== true) continue;
     const actionName = readBoundedString(candidate.actionName)?.toUpperCase();
     if (actionName !== "VIEWS" && actionName !== "APP") continue;
-    successfulNavigationResults += 1;
-    // A terminal frame containing more than one successful navigation result
-    // has no authoritative ordering contract. Fail closed instead of choosing
-    // whichever array position an adapter happened to serialize last.
-    if (successfulNavigationResults > 1) return null;
     if (!isRecord(candidate.values)) {
       continue;
     }
@@ -661,6 +656,11 @@ function extractViewHandoff(payload: string): ElizaVoiceViewHandoff | null {
     const isViewsHandoff = actionName === "VIEWS" && (mode === "show" || mode === "open");
     const isAppBrowserHandoff = actionName === "APP" && mode === "launch" && viewId === "browser";
     if (!isViewsHandoff && !isAppBrowserHandoff) continue;
+    successfulNavigationResults += 1;
+    // A terminal frame containing more than one successful navigation result
+    // has no authoritative ordering contract. Fail closed instead of choosing
+    // whichever array position an adapter happened to serialize last.
+    if (successfulNavigationResults > 1) return null;
     const viewPath = readBoundedString(candidate.values.viewPath);
     const subview = readBoundedString(candidate.values.subview);
     if (isAppBrowserHandoff && (!viewPath || !isCanonicalBrowserLaunchPath(viewPath))) {


### PR DESCRIPTION
Follow-up to #24359 and merged #24376.

## Summary

- validate APP terminal handoffs against the canonical `/browser?browse=` route contract instead of forwarding any bounded string
- allow only normalized `/api/apps/local/*` targets or credential-free HTTP(S) targets
- reject outer-route substitution, network paths, traversal, duplicate parameters, unsupported schemes, userinfo, control/bidi characters, malformed or control-bearing nested encoding, and oversized values
- reject terminal frames with multiple successful navigation results because their array ordering is not an authority contract
- require the authoritative top-level action name rather than accepting a nested `data.actionName` substitute
- preserve existing successful VIEWS show/open behavior and originating Voice Session stale-turn fencing

## Verification

- `bun run --cwd packages/cloud/shared test -- src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts --no-coverage` — 30 passed, 0 failed on the corrective patch
- scoped Biome over the three changed files — passed after rebasing
- `git diff --check origin/develop...HEAD` — passed
- the WS lifecycle suite at merged #24376 was 66/66; this follow-up adds an integration case proving unsafe/ambiguous APP results emit no `navigate_view`, but its post-rebase rerun is locally blocked by sparse-worktree dependency hydration (`@noble/hashes/sha2.js` after resolving earlier sparse imports). Hosted CI remains required for that added assertion.

## Exact evidence revision

- head: `dcc9798ca20cf9f0fffbc82faa6f132cff129246`
- base: `8940dea477afd71769c9050fc250a727b1c54dac`

## Scope

No client identity is invented and no new delivery channel is added. The existing Voice Session turn/session/agent/conversation headers and stale-callback fence remain the delivery authority; this change only narrows which terminal action result can become its single navigation frame.
