### PR TITLE
fix(gateway-webhook): validate the Blooio signature timestamp before the replay check

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
@@ -89,6 +89,40 @@ describe("blooio verifyWebhook", () => {
     expect(ok).toBe(true);
   });
 
+  test("rejects a malformed timestamp instead of skipping the replay window", async () => {
+    // `parseInt("")` is NaN, and every comparison against NaN is false, so
+    // `Math.abs(now - timestamp) > TOLERANCE` did not reject — the replay-window
+    // check silently fell through for any non-numeric `t=`.
+    const body = inboundPayload();
+    const hmac = crypto
+      .createHmac("sha256", SECRET)
+      .update(`NaN.${body}`)
+      .digest("hex");
+    const ok = await blooioAdapter.verifyWebhook(
+      makeRequest(`t=,v1=${hmac}`),
+      body,
+      makeConfig(),
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("rejects a prefix-parsed timestamp rather than the value the sender signed", async () => {
+    // `parseInt("<ts>junk")` yields <ts>, so a mutated header still produced the
+    // signed payload the sender authenticated.
+    const body = inboundPayload();
+    const timestamp = Math.floor(Date.now() / 1000);
+    const hmac = crypto
+      .createHmac("sha256", SECRET)
+      .update(`${timestamp}.${body}`)
+      .digest("hex");
+    const ok = await blooioAdapter.verifyWebhook(
+      makeRequest(`t=${timestamp}junk,v1=${hmac}`),
+      body,
+      makeConfig(),
+    );
+    expect(ok).toBe(false);
+  });
+
   test("accepts a delivery signed 200s ago (inside Blooio's documented 300s window)", async () => {
     // Bidirectional: fails against the previous 120s tolerance, which dropped
     // legitimately retried deliveries.
@@ -179,23 +213,13 @@ describe("blooio extractEvent", () => {
 
     expect(event).not.toBeNull();
     expect(event?.messageId).toBe("msg_v4_abc123");
-    expect(event?.chatId).toBe("chat_abc123");
-    expect(event?.chatType).toBe("private");
+    expect(event?.chatId).toBe("+15551234567");
     expect(event?.senderId).toBe("+15551234567");
     expect(event?.channelId).toBe("ch_abc123");
     expect(event?.channelType).toBe("blooio");
     expect(event?.protocol).toBe("imessage");
     expect(event?.text).toBe("hey from v4");
-    expect(event?.providerSentAtMs).toBe(1_786_244_262_331);
     expect(event?.rawPayload).toEqual(JSON.parse(body));
-  });
-
-  test("normalizes a legacy v2 epoch-seconds timestamp for ingress timing", async () => {
-    const event = await blooioAdapter.extractEvent(
-      inboundPayload({ timestamp: 1_786_244_262 }),
-    );
-
-    expect(event?.providerSentAtMs).toBe(1_786_244_262_000);
   });
 
   test("uses the v4 contact identity when sender is absent", async () => {
@@ -233,21 +257,11 @@ describe("blooio extractEvent", () => {
     expect(event).toBeNull();
   });
 
-  test("preserves group thread and participant identity", async () => {
+  test("skips group messages", async () => {
     const event = await blooioAdapter.extractEvent(
-      v4InboundPayload({
-        chat_id: "chat_group_123",
-        is_group: true,
-        group: { group_id: "grp_123", member_count: 4 },
-        reply_to_message_id: "msg_eliza_previous",
-      }),
+      inboundPayload({ is_group: true }),
     );
-    expect(event).toMatchObject({
-      chatId: "chat_group_123",
-      chatType: "group",
-      senderId: "+15551234567",
-      replyToMessageId: "msg_eliza_previous",
-    });
+    expect(event).toBeNull();
   });
 
   test("skips non message.received events", async () => {
@@ -389,15 +403,12 @@ describe("blooio sendReply", () => {
   }
 
   test("pins a v4 reply to the exact inbound WhatsApp channel", async () => {
-    let captured: { url: string; body: Record<string, unknown> } | null = null;
+    let body: Record<string, unknown> = {};
     globalThis.fetch = (async (
-      url: string | URL | Request,
+      _url: string | URL | Request,
       init?: RequestInit,
     ) => {
-      captured = {
-        url: String(url),
-        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
-      };
+      body = JSON.parse(String(init?.body));
       return Response.json({ id: "out_whatsapp_1" });
     }) as typeof fetch;
 
@@ -405,45 +416,16 @@ describe("blooio sendReply", () => {
       makeConfig(),
       {
         ...chatEvent,
-        chatId: "chat_whatsapp_123",
         channelId: "ch_whatsapp_123",
         channelType: "whatsapp_business",
         protocol: "whatsapp",
       },
       "hi",
     );
-    expect(captured).toEqual({
-      url: "https://api.blooio.com/v4/chats/chat_whatsapp_123/messages",
-      body: { text: "hi" },
-    });
-  });
-
-  test("replies to a group through its existing provider chat", async () => {
-    let captured: { url: string; body: Record<string, unknown> } | null = null;
-    globalThis.fetch = (async (
-      url: string | URL | Request,
-      init?: RequestInit,
-    ) => {
-      captured = {
-        url: String(url),
-        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
-      };
-      return Response.json({ id: "out_group_1" });
-    }) as typeof fetch;
-
-    await blooioAdapter.sendReply(
-      makeConfig(),
-      {
-        ...chatEvent,
-        chatId: "chat_group_123",
-        chatType: "group",
-      },
-      "hello group",
-    );
-
-    expect(captured).toEqual({
-      url: "https://api.blooio.com/v4/chats/chat_group_123/messages",
-      body: { text: "hello group" },
+    expect(body).toEqual({
+      to: "+15551234567",
+      from: "ch_whatsapp_123",
+      text: "hi",
     });
   });
 
@@ -502,63 +484,6 @@ describe("blooio sendTypingIndicator", () => {
     await expect(
       blooioAdapter.sendTypingIndicator(makeConfig(), chatEvent),
     ).resolves.toBeUndefined();
-  });
-
-  test("uses v4 chat-scoped read and typing actions", async () => {
-    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
-    globalThis.fetch = (async (
-      input: string | URL | Request,
-      init?: RequestInit,
-    ) => {
-      calls.push({
-        url: String(input),
-        method: init?.method ?? "GET",
-        ...(init?.body
-          ? { body: JSON.parse(String(init.body)) as unknown }
-          : {}),
-      });
-      return Response.json({ data: { state: "started" } });
-    }) as typeof fetch;
-
-    await blooioAdapter.sendTypingIndicator(makeConfig(), {
-      ...chatEvent,
-      chatId: "chat_group_123",
-      chatType: "group",
-    });
-
-    expect(calls).toEqual([
-      {
-        url: "https://api.blooio.com/v4/chats/chat_group_123/read",
-        method: "POST",
-      },
-      {
-        url: "https://api.blooio.com/v4/chats/chat_group_123/typing",
-        method: "POST",
-        body: { state: "started" },
-      },
-    ]);
-  });
-
-  test("stops a v4 chat typing indicator after the turn", async () => {
-    let captured: { url: string; method: string } | null = null;
-    globalThis.fetch = (async (
-      input: string | URL | Request,
-      init?: RequestInit,
-    ) => {
-      captured = { url: String(input), method: init?.method ?? "GET" };
-      return new Response(null, { status: 200 });
-    }) as typeof fetch;
-
-    await blooioAdapter.stopTypingIndicator?.(makeConfig(), {
-      ...chatEvent,
-      chatId: "chat_group_123",
-      chatType: "group",
-    });
-
-    expect(captured).toEqual({
-      url: "https://api.blooio.com/v4/chats/chat_group_123/typing",
-      method: "DELETE",
-    });
   });
 
   test("does nothing without an API key", async () => {

--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
@@ -213,13 +213,23 @@ describe("blooio extractEvent", () => {
 
     expect(event).not.toBeNull();
     expect(event?.messageId).toBe("msg_v4_abc123");
-    expect(event?.chatId).toBe("+15551234567");
+    expect(event?.chatId).toBe("chat_abc123");
+    expect(event?.chatType).toBe("private");
     expect(event?.senderId).toBe("+15551234567");
     expect(event?.channelId).toBe("ch_abc123");
     expect(event?.channelType).toBe("blooio");
     expect(event?.protocol).toBe("imessage");
     expect(event?.text).toBe("hey from v4");
+    expect(event?.providerSentAtMs).toBe(1_786_244_262_331);
     expect(event?.rawPayload).toEqual(JSON.parse(body));
+  });
+
+  test("normalizes a legacy v2 epoch-seconds timestamp for ingress timing", async () => {
+    const event = await blooioAdapter.extractEvent(
+      inboundPayload({ timestamp: 1_786_244_262 }),
+    );
+
+    expect(event?.providerSentAtMs).toBe(1_786_244_262_000);
   });
 
   test("uses the v4 contact identity when sender is absent", async () => {
@@ -257,11 +267,21 @@ describe("blooio extractEvent", () => {
     expect(event).toBeNull();
   });
 
-  test("skips group messages", async () => {
+  test("preserves group thread and participant identity", async () => {
     const event = await blooioAdapter.extractEvent(
-      inboundPayload({ is_group: true }),
+      v4InboundPayload({
+        chat_id: "chat_group_123",
+        is_group: true,
+        group: { group_id: "grp_123", member_count: 4 },
+        reply_to_message_id: "msg_eliza_previous",
+      }),
     );
-    expect(event).toBeNull();
+    expect(event).toMatchObject({
+      chatId: "chat_group_123",
+      chatType: "group",
+      senderId: "+15551234567",
+      replyToMessageId: "msg_eliza_previous",
+    });
   });
 
   test("skips non message.received events", async () => {
@@ -403,12 +423,15 @@ describe("blooio sendReply", () => {
   }
 
   test("pins a v4 reply to the exact inbound WhatsApp channel", async () => {
-    let body: Record<string, unknown> = {};
+    let captured: { url: string; body: Record<string, unknown> } | null = null;
     globalThis.fetch = (async (
-      _url: string | URL | Request,
+      url: string | URL | Request,
       init?: RequestInit,
     ) => {
-      body = JSON.parse(String(init?.body));
+      captured = {
+        url: String(url),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      };
       return Response.json({ id: "out_whatsapp_1" });
     }) as typeof fetch;
 
@@ -416,16 +439,45 @@ describe("blooio sendReply", () => {
       makeConfig(),
       {
         ...chatEvent,
+        chatId: "chat_whatsapp_123",
         channelId: "ch_whatsapp_123",
         channelType: "whatsapp_business",
         protocol: "whatsapp",
       },
       "hi",
     );
-    expect(body).toEqual({
-      to: "+15551234567",
-      from: "ch_whatsapp_123",
-      text: "hi",
+    expect(captured).toEqual({
+      url: "https://api.blooio.com/v4/chats/chat_whatsapp_123/messages",
+      body: { text: "hi" },
+    });
+  });
+
+  test("replies to a group through its existing provider chat", async () => {
+    let captured: { url: string; body: Record<string, unknown> } | null = null;
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = {
+        url: String(url),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      };
+      return Response.json({ id: "out_group_1" });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendReply(
+      makeConfig(),
+      {
+        ...chatEvent,
+        chatId: "chat_group_123",
+        chatType: "group",
+      },
+      "hello group",
+    );
+
+    expect(captured).toEqual({
+      url: "https://api.blooio.com/v4/chats/chat_group_123/messages",
+      body: { text: "hello group" },
     });
   });
 
@@ -484,6 +536,63 @@ describe("blooio sendTypingIndicator", () => {
     await expect(
       blooioAdapter.sendTypingIndicator(makeConfig(), chatEvent),
     ).resolves.toBeUndefined();
+  });
+
+  test("uses v4 chat-scoped read and typing actions", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      calls.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        ...(init?.body
+          ? { body: JSON.parse(String(init.body)) as unknown }
+          : {}),
+      });
+      return Response.json({ data: { state: "started" } });
+    }) as typeof fetch;
+
+    await blooioAdapter.sendTypingIndicator(makeConfig(), {
+      ...chatEvent,
+      chatId: "chat_group_123",
+      chatType: "group",
+    });
+
+    expect(calls).toEqual([
+      {
+        url: "https://api.blooio.com/v4/chats/chat_group_123/read",
+        method: "POST",
+      },
+      {
+        url: "https://api.blooio.com/v4/chats/chat_group_123/typing",
+        method: "POST",
+        body: { state: "started" },
+      },
+    ]);
+  });
+
+  test("stops a v4 chat typing indicator after the turn", async () => {
+    let captured: { url: string; method: string } | null = null;
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      captured = { url: String(input), method: init?.method ?? "GET" };
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    await blooioAdapter.stopTypingIndicator?.(makeConfig(), {
+      ...chatEvent,
+      chatId: "chat_group_123",
+      chatType: "group",
+    });
+
+    expect(captured).toEqual({
+      url: "https://api.blooio.com/v4/chats/chat_group_123/typing",
+      method: "DELETE",
+    });
   });
 
   test("does nothing without an API key", async () => {

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -234,7 +234,16 @@ async function verifySignature(
     const signaturePart = parts.find((p) => p.startsWith("v1="));
     if (!timestampPart || !signaturePart) return false;
 
-    const timestamp = parseInt(timestampPart.substring(2), 10);
+    // Validate the timestamp before comparing it. `parseInt` returns NaN for a
+    // malformed `t=` value, and every comparison against NaN is false — so the
+    // replay-window check below would not reject, it would silently fall
+    // through. `parseInt` also accepts a numeric prefix ("1234567890abc"), which
+    // is not the value the sender signed.
+    const rawTimestamp = timestampPart.substring(2);
+    const timestamp = /^\d+$/.test(rawTimestamp)
+      ? Number(rawTimestamp)
+      : Number.NaN;
+    if (!Number.isSafeInteger(timestamp)) return false;
     const expectedSignature = signaturePart.substring(3);
 
     const now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
# Relates to

No separate issue — the defect is described in full below. Reported through the normal PR flow rather than a security advisory because, as scoped below, this is **not** an authentication bypass.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the current `origin/develop` tree, so it applies with zero conflicts.
- [x] Focused and full-package tests plus scoped lint (repository-pinned Biome 2.5.8) were run; results are quoted below. Root `bun run verify` was not run green: `develop` currently carries unrelated `@elizaos/agent` Biome formatter diagnostics, the same blocker recorded in #24174.
- [x] A reviewer can confirm the change from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Exact unrelated blocker documented above.

# Risks

Low. The tolerance window and signed-payload construction are unchanged; only a malformed `t=` component is now rejected instead of silently skipping the replay check.

# Background

## What does this PR do?

The Blooio webhook verifier parses the `t=` component with `parseInt` and compares it without validating it:

```ts
const timestamp = parseInt(timestampPart.substring(2), 10);
const now = Math.floor(Date.now() / 1000);
if (Math.abs(now - timestamp) > SIGNATURE_TOLERANCE_SECONDS) return false;
```

For any non-numeric `t=`, `parseInt` returns `NaN` — and **every comparison against NaN is false**. So `Math.abs(now - NaN) > 300` is `false`, the guard does not reject, and the replay window is skipped entirely. Verified directly:

```
"1234567890abc"  parseInt=1234567890  tolerance rejects? true
""               parseInt=NaN         tolerance rejects? false
"abc"            parseInt=NaN         tolerance rejects? false
```

`parseInt` also accepts a numeric prefix, so a mutated `t=<ts>junk` header reconstructs the same `${timestamp}.${rawBody}` the sender signed and still verifies — the header is not byte-faithful to what was authenticated.

## Scope — stated plainly

The HMAC check still gates every delivery, so this is **not an authentication bypass**: a caller without the secret cannot forge a signature. What is broken is the **replay-window control failing open**, and the timestamp being reconstructed rather than validated. That is defense-in-depth silently doing nothing, which is worth closing on its own terms — but I did not want the framing overstated.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with the mutation block below: against unmodified source, a delivery with an empty `t=` is accepted.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `blooio-adapter.test.ts` | 34 passed |
| full gateway-webhook lane | **181 passed across 23 files** |
| `biome check` (pinned 2.5.8, both files) | clean |

**Drift note:** the verifier region is unchanged upstream, so the defect is live. The suite was executed against the local revision (upstream differs in unrelated v4/group `extractEvent` coverage) and the shipped file is `develop`'s revision with a **byte-identical hunk**, verified by diff.

Mutation resistance — reverting only the source change and keeping the tests:

```
(fail) rejects a malformed timestamp instead of skipping the replay window
(fail) rejects a prefix-parsed timestamp rather than the value the sender signed
32 pass, 2 fail
```

The existing fresh-delivery and 200s-old-delivery tests pass in **both** directions, so the tolerance window is unchanged.

# Evidence Gate

<!-- evidence-head:b067ea374b152b75745f15373ba435169bfc6187 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only change to a webhook signature verifier, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only change to a webhook signature verifier, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is whether verifyWebhook accepts or rejects a delivery, asserted directly in the tests below`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the adapter's public verifyWebhook is called directly by the suite quoted below`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider or action path is involved in signature verification`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the observable output is the boolean verification result, asserted in the tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - the change has no rendered visual surface`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a numeric-input validation sweep of `packages/cloud`.
- Independent verification, the NaN fail-open analysis, the explicit scoping of what is and is not affected, and the mutation proof by Claude Code (`claude-opus-5`).
