### PR TITLE
fix(agent): reject partial terminal output

### DIFF
--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -148,7 +148,8 @@ describe("terminal action effect proof", () => {
     expect(JSON.stringify(prompt)).not.toContain("private output");
   });
 
-  it("classifies provider truncation as unrecoverable source loss", async () => {
+  it("rejects provider-truncated output before it reaches model-visible data", async () => {
+    const rt = runtime();
     vi.stubGlobal(
       "fetch",
       vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
@@ -159,27 +160,13 @@ describe("terminal action effect proof", () => {
         }),
       ),
     );
-    const result = await terminalAction.handler(
-      runtime(),
-      message(),
-      undefined,
-      options(),
-    );
-    const view = ((result?.promptData ?? {}) as Record<string, unknown>)
-      .readView as {
-      slice: {
-        completeness: string;
-        hasMore: boolean;
-        nextOffset?: number;
-        sourceSha256?: string;
-      };
-    };
-    expect(view.slice).toMatchObject({
-      completeness: "partial-source-loss",
-      hasMore: false,
+    await expect(
+      terminalAction.handler(rt, message(), undefined, options()),
+    ).rejects.toMatchObject({
+      code: "TERMINAL_OUTPUT_INCOMPLETE",
+      context: { acceptance: "accepted" },
     });
-    expect(view.slice.nextOffset).toBeUndefined();
-    expect(view.slice.sourceSha256).toBeUndefined();
+    expect(rt.createMemory).not.toHaveBeenCalled();
   });
 
   it("does not mint a restart-unsafe reference when attachment persistence fails", async () => {
@@ -389,7 +376,7 @@ describe("terminal action effect proof", () => {
     });
   });
 
-  it("keeps action-owned empty, stderr, truncated, and timeout statuses canonical", async () => {
+  it("keeps action-owned empty, stderr, and timeout statuses canonical", async () => {
     const cases = [
       {
         override: { stdout: "" },
@@ -397,10 +384,6 @@ describe("terminal action effect proof", () => {
       },
       {
         override: { stdout: "partial", stderr: "warning" },
-        text: "The command finished successfully with exit code 0.",
-      },
-      {
-        override: { stdout: "partial", truncated: true },
         text: "The command finished successfully with exit code 0.",
       },
       {

--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -190,6 +190,30 @@ describe("terminal action effect proof", () => {
     expect(rt.createMemory).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["data", { truncated: false, timedOut: true }],
+    ["result", { truncated: false, error: "failed" }],
+    ["output", { truncated: false, stdout: "shadow partial" }],
+  ])(
+    "rejects a conflicting nested %s execution proof before persistence",
+    async (key, nested) => {
+      const rt = runtime();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+          terminalResponseForRequest(init, {
+            truncated: false,
+            [key]: nested,
+          }),
+        ),
+      );
+      await expect(
+        terminalAction.handler(rt, message(), undefined, options()),
+      ).rejects.toMatchObject({ code: "TERMINAL_OUTPUT_INCOMPLETE" });
+      expect(rt.createMemory).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects conflicting nested truncation proof before persistence", async () => {
     const rt = runtime();
     vi.stubGlobal(

--- a/packages/agent/src/actions/terminal-effect-receipt.test.ts
+++ b/packages/agent/src/actions/terminal-effect-receipt.test.ts
@@ -169,6 +169,139 @@ describe("terminal action effect proof", () => {
     expect(rt.createMemory).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["missing", undefined],
+    ["null", null],
+    ["string", "false"],
+  ])("rejects a %s truncated proof before persistence", async (_name, flag) => {
+    const rt = runtime();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, { truncated: flag }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(rt, message(), undefined, options()),
+    ).rejects.toMatchObject({
+      code: "TERMINAL_REQUEST_OUTCOME_UNKNOWN",
+      context: { acceptance: "unknown" },
+    });
+    expect(rt.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting nested truncation proof before persistence", async () => {
+    const rt = runtime();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, {
+          truncated: false,
+          result: { truncated: true },
+        }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(rt, message(), undefined, options()),
+    ).rejects.toMatchObject({ code: "TERMINAL_OUTPUT_INCOMPLETE" });
+    expect(rt.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("rejects a nested legacy envelope without its own completeness proof", async () => {
+    const rt = runtime();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, {
+          truncated: false,
+          output: { stdout: "shadow output" },
+        }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(rt, message(), undefined, options()),
+    ).rejects.toMatchObject({ code: "TERMINAL_OUTPUT_INCOMPLETE" });
+    expect(rt.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("rejects a response that claims both success and an error", async () => {
+    const rt = runtime();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, {
+          ok: true,
+          error: "provider reported an ambiguous failure",
+        }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(rt, message(), undefined, options()),
+    ).rejects.toMatchObject({ code: "TERMINAL_REQUEST_OUTCOME_UNKNOWN" });
+    expect(rt.createMemory).not.toHaveBeenCalled();
+  });
+
+  it("rejects timeout partials and unsafe controls before persistence", async () => {
+    for (const override of [
+      { timedOut: true, stdout: "partial" },
+      { stdout: "prefix\u0000suffix" },
+      { stdout: "prefix\u202esuffix" },
+      { stdout: "prefix\ufffdsuffix" },
+      { stdout: "\ud800" },
+    ]) {
+      const rt = runtime();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+          terminalResponseForRequest(init, override),
+        ),
+      );
+      await expect(
+        terminalAction.handler(rt, message(), undefined, options()),
+      ).rejects.toBeInstanceOf(ElizaError);
+      expect(rt.createMemory).not.toHaveBeenCalled();
+    }
+  });
+
+  it("preserves ordinary terminal framing and ANSI styling", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, {
+          stdout: "\u001b[32mok\u001b[0m\n\tindented\r\n",
+        }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(runtime(), message(), undefined, options()),
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  it("enforces the complete-output boundary in UTF-8 bytes", async () => {
+    const exact = "a".repeat(4 * 1024 * 1024);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, { stdout: exact }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(runtime(), message(), undefined, options()),
+    ).resolves.toMatchObject({ success: true });
+
+    const rt = runtime();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        terminalResponseForRequest(init, { stdout: `${exact}你` }),
+      ),
+    );
+    await expect(
+      terminalAction.handler(rt, message(), undefined, options()),
+    ).rejects.toMatchObject({ code: "TERMINAL_REQUEST_OUTCOME_UNKNOWN" });
+    expect(rt.createMemory).not.toHaveBeenCalled();
+  });
+
   it("does not mint a restart-unsafe reference when attachment persistence fails", async () => {
     vi.stubGlobal(
       "fetch",
@@ -376,7 +509,7 @@ describe("terminal action effect proof", () => {
     });
   });
 
-  it("keeps action-owned empty, stderr, and timeout statuses canonical", async () => {
+  it("keeps action-owned empty and stderr statuses canonical", async () => {
     const cases = [
       {
         override: { stdout: "" },
@@ -385,10 +518,6 @@ describe("terminal action effect proof", () => {
       {
         override: { stdout: "partial", stderr: "warning" },
         text: "The command finished successfully with exit code 0.",
-      },
-      {
-        override: { stdout: "partial", timedOut: true, maxDurationMs: 30_000 },
-        text: "The command timed out after 30000 ms; I can't verify that it completed.",
       },
     ];
 
@@ -532,7 +661,7 @@ describe("terminal action effect proof", () => {
             }),
             {
               status: 200,
-              headers: { "Content-Length": String(8 * 1024 * 1024 + 1) },
+              headers: { "Content-Length": String(25 * 1024 * 1024 + 1) },
             },
           ),
       ),

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -223,16 +223,11 @@ function isJsonRecord(value: JsonValue): value is Record<string, JsonValue> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function nestedTruncationIsStrictFalse(
-  value: Record<string, JsonValue>,
-): boolean {
+function hasNestedExecutionEnvelope(value: Record<string, JsonValue>): boolean {
   for (const key of ["data", "result", "output"] as const) {
-    const nested = value[key];
-    if (isJsonRecord(nested) && nested.truncated !== false) {
-      return false;
-    }
+    if (isJsonRecord(value[key])) return true;
   }
-  return true;
+  return false;
 }
 
 function parseJsonArguments(
@@ -330,7 +325,7 @@ function normalizeCapturedRun(
     });
   }
 
-  if (value.truncated !== false || !nestedTruncationIsStrictFalse(value)) {
+  if (value.truncated !== false || hasNestedExecutionEnvelope(value)) {
     throw new ElizaError(
       "Terminal response contained incomplete stdout or stderr",
       {

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -56,7 +56,7 @@ type CapturedTerminalRun = {
   stdout: string;
   stderr: string;
   timedOut: boolean;
-  truncated: boolean;
+  truncated: false;
   maxDurationMs?: number;
 };
 
@@ -308,6 +308,17 @@ function normalizeCapturedRun(
     });
   }
 
+  if (value.truncated) {
+    throw new ElizaError(
+      "Terminal response contained incomplete stdout or stderr",
+      {
+        code: "TERMINAL_OUTPUT_INCOMPLETE",
+        context: { acceptance: "accepted", runId },
+        severity: "fatal",
+      },
+    );
+  }
+
   return {
     command,
     runId,
@@ -315,7 +326,7 @@ function normalizeCapturedRun(
     stdout: value.stdout,
     stderr: value.stderr,
     timedOut: value.timedOut,
-    truncated: value.truncated,
+    truncated: false,
     maxDurationMs:
       typeof value.maxDurationMs === "number" &&
       Number.isFinite(value.maxDurationMs)
@@ -335,7 +346,6 @@ function buildCommandArtifactContent(result: CapturedTerminalRun): string {
     result.timedOut
       ? `Timed out: yes${typeof result.maxDurationMs === "number" ? ` (${result.maxDurationMs} ms limit)` : ""}`
       : "Timed out: no",
-    result.truncated ? "Captured output truncated to 128 KB." : "",
     "",
     "STDOUT:",
     formatOutputBlock(result.stdout),
@@ -349,7 +359,6 @@ function buildCommandArtifactContent(result: CapturedTerminalRun): string {
 
 function terminalAttachmentReadView(
   outputAttachment: TerminalOutputAttachment | undefined,
-  result: CapturedTerminalRun,
 ) {
   if (!outputAttachment?.memoryId) return undefined;
   const content = outputAttachment.attachment.text ?? "";
@@ -366,17 +375,14 @@ function terminalAttachmentReadView(
         unit: "byte",
         start: 0,
         end: byteLength,
-        ...(!result.truncated ? { total: byteLength } : {}),
+        total: byteLength,
       },
       hasPrevious: false,
       hasMore: false,
       revision: outputAttachment.memoryId,
-      completeness: result.truncated ? "partial-source-loss" : "complete",
+      completeness: "complete",
       sliceSha256: digest,
-      ...(!result.truncated ? { sourceSha256: digest } : {}),
-      ...(result.truncated
-        ? { reason: "terminal provider reported upstream output truncation" }
-        : {}),
+      sourceSha256: digest,
     },
   });
 }
@@ -409,7 +415,7 @@ async function createCommandOutputAttachment(
     url: `memory://terminal-output/${attachmentId}`,
     title,
     source: TERMINAL_ACTION_NAME,
-    description: `${result.truncated ? "Truncated captured" : "Complete captured"} stdout/stderr for \`${result.command}\` (exit ${result.exitCode}).`,
+    description: `Complete captured stdout/stderr for \`${result.command}\` (exit ${result.exitCode}).`,
     text: buildCommandArtifactContent(result),
     contentType: ContentType.DOCUMENT,
   };
@@ -537,7 +543,6 @@ function buildCapturedResponseText(
     result.timedOut
       ? `Timed out${typeof result.maxDurationMs === "number" ? ` after ${result.maxDurationMs} ms` : ""}.`
       : "",
-    result.truncated ? "Captured output truncated to 128 KB." : "",
     outputAttachment
       ? `Full output attachment: ${outputAttachment.attachment.id} (${outputAttachment.attachment.title})`
       : "",
@@ -699,6 +704,12 @@ export const terminalAction: Action = {
     try {
       rawRun = normalizeCapturedRun(command, responseBody, runId);
     } catch (error) {
+      if (
+        error instanceof ElizaError &&
+        error.code === "TERMINAL_OUTPUT_INCOMPLETE"
+      ) {
+        throw error;
+      }
       // error-policy:J2 a 2xx body that cannot prove the bound run's terminal
       // result is still an ambiguous effect, not a safely retryable parse error.
       throw new ElizaError("Terminal execution outcome is unknown", {
@@ -730,12 +741,11 @@ export const terminalAction: Action = {
       message,
       capturedRun,
     );
-    const readView = terminalAttachmentReadView(outputAttachment, capturedRun);
+    const readView = terminalAttachmentReadView(outputAttachment);
 
     const cleanStdout =
       capturedRun.exitCode === 0 &&
       !capturedRun.timedOut &&
-      !capturedRun.truncated &&
       capturedRun.stderr.trim().length === 0
         ? capturedRun.stdout.trim()
         : "";

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -27,12 +27,16 @@ import {
   stringToUuid,
 } from "@elizaos/core";
 import { readAliasedEnv, resolveServerOnlyPort } from "@elizaos/shared";
+import { capturedTerminalOutputIsSafe } from "../api/terminal-output-contract.ts";
 import { resolveTerminalRunLimits } from "../api/terminal-run-limits.ts";
 import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
 
 const TERMINAL_ACTION_NAME = "TERMINAL_SHELL";
 const TERMINAL_TRANSPORT_GRACE_MS = 10_000;
-const MAX_TERMINAL_RESPONSE_BYTES = 8 * 1024 * 1024;
+// Four MiB of control-heavy output can expand to six JSON bytes per source
+// byte. Bound the envelope before parsing while preserving the route's exact
+// complete-output contract.
+const MAX_TERMINAL_RESPONSE_BYTES = 25 * 1024 * 1024;
 // Max sanitized stdout, in chars, that may be relayed verbatim as the user-facing
 // message. Small single-line results (a SHA, a count, a path) are useful to
 // echo for "run X and tell me the value" turns; anything larger — or with
@@ -219,6 +223,18 @@ function isJsonRecord(value: JsonValue): value is Record<string, JsonValue> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function nestedTruncationIsStrictFalse(
+  value: Record<string, JsonValue>,
+): boolean {
+  for (const key of ["data", "result", "output"] as const) {
+    const nested = value[key];
+    if (isJsonRecord(nested) && nested.truncated !== false) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function parseJsonArguments(
   value: JsonValue | undefined,
 ): Record<string, JsonValue> | undefined {
@@ -287,11 +303,17 @@ function normalizeCapturedRun(
     !runId ||
     (expectedRunId !== undefined && runId !== expectedRunId) ||
     typeof value.exitCode !== "number" ||
-    !Number.isInteger(value.exitCode) ||
+    !Number.isSafeInteger(value.exitCode) ||
     typeof value.stdout !== "string" ||
     typeof value.stderr !== "string" ||
     typeof value.timedOut !== "boolean" ||
-    typeof value.truncated !== "boolean"
+    typeof value.truncated !== "boolean" ||
+    "error" in value ||
+    !capturedTerminalOutputIsSafe(value.stdout, value.stderr) ||
+    (value.maxDurationMs !== undefined &&
+      (typeof value.maxDurationMs !== "number" ||
+        !Number.isSafeInteger(value.maxDurationMs) ||
+        value.maxDurationMs < 1))
   ) {
     throw new ElizaError("Terminal response omitted required execution proof", {
       code: "TERMINAL_RESPONSE_INVALID",
@@ -308,9 +330,20 @@ function normalizeCapturedRun(
     });
   }
 
-  if (value.truncated) {
+  if (value.truncated !== false || !nestedTruncationIsStrictFalse(value)) {
     throw new ElizaError(
       "Terminal response contained incomplete stdout or stderr",
+      {
+        code: "TERMINAL_OUTPUT_INCOMPLETE",
+        context: { acceptance: "accepted", runId },
+        severity: "fatal",
+      },
+    );
+  }
+
+  if (value.timedOut) {
+    throw new ElizaError(
+      "Terminal response timed out before complete output was proven",
       {
         code: "TERMINAL_OUTPUT_INCOMPLETE",
         context: { acceptance: "accepted", runId },

--- a/packages/agent/src/api/misc-routes.terminal-run-limits.test.ts
+++ b/packages/agent/src/api/misc-routes.terminal-run-limits.test.ts
@@ -137,6 +137,12 @@ function makeContext(
   return { ctx, json, error };
 }
 
+function broadcastCalls(ctx: MiscRouteContext) {
+  const broadcast = ctx.state.broadcastWsToClientId;
+  if (!broadcast) throw new Error("test route requires a targeted broadcaster");
+  return vi.mocked(broadcast).mock.calls;
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
   runShellMock.mockReset();
@@ -192,8 +198,69 @@ describe("terminal run limits", () => {
       expect.stringContaining("no partial result was returned"),
       413,
     );
+    const events = broadcastCalls(route.ctx);
+    expect(
+      events.some((call) =>
+        ["stdout", "stderr"].includes(
+          String((call[1] as { event?: unknown } | undefined)?.event),
+        ),
+      ),
+    ).toBe(false);
     expect(gate.active()).toBe(0);
   });
+
+  it("does not broadcast buffered partial output from a timed-out capture", async () => {
+    const gate = createLeaseGate();
+    runShellMock.mockImplementationOnce(async (request: ShellRequest) => {
+      request.onStdout?.("partial secret");
+      return shellResult({ exitCode: 124 });
+    });
+    const route = makeContext("run-00000000-0000-4000-8000-000000000014", gate);
+
+    expect(await handleMiscRoutes(route.ctx)).toBe(true);
+    await vi.waitFor(() => expect(route.error).toHaveBeenCalledOnce());
+    const events = broadcastCalls(route.ctx);
+    expect(
+      events.some((call) =>
+        ["stdout", "stderr"].includes(
+          String((call[1] as { event?: unknown } | undefined)?.event),
+        ),
+      ),
+    ).toBe(false);
+    expect(route.json).not.toHaveBeenCalled();
+    expect(route.error).toHaveBeenCalledWith(
+      route.ctx.res,
+      "Terminal execution timed out; no partial result was returned.",
+      504,
+    );
+  });
+
+  it.each(["unsafe\u0000output", "invalid\ufffdutf8", "bidi\u202eoverride"])(
+    "rejects unsafe captured text without publishing it: %j",
+    async (unsafeOutput) => {
+      const gate = createLeaseGate();
+      runShellMock.mockImplementationOnce(async (request: ShellRequest) => {
+        request.onStdout?.(unsafeOutput);
+        return shellResult({ stdout: unsafeOutput });
+      });
+      const route = makeContext(
+        `run-00000000-0000-4000-8000-0000000000${15 + unsafeOutput.length}`,
+        gate,
+      );
+
+      expect(await handleMiscRoutes(route.ctx)).toBe(true);
+      await vi.waitFor(() => expect(route.error).toHaveBeenCalledOnce());
+      expect(route.json).not.toHaveBeenCalled();
+      expect(route.error).toHaveBeenCalledWith(
+        route.ctx.res,
+        "Terminal output was not valid safe text; no result was returned.",
+        422,
+      );
+      expect(JSON.stringify(broadcastCalls(route.ctx))).not.toContain(
+        unsafeOutput,
+      );
+    },
+  );
 
   it("releases admission when the shell launcher throws synchronously", async () => {
     const gate = createLeaseGate();
@@ -204,6 +271,14 @@ describe("terminal run limits", () => {
 
     expect(await handleMiscRoutes(route.ctx)).toBe(true);
     await vi.waitFor(() => expect(route.error).toHaveBeenCalledOnce());
+    expect(route.error).toHaveBeenCalledWith(
+      route.ctx.res,
+      "Terminal execution failed",
+      500,
+    );
+    expect(JSON.stringify(broadcastCalls(route.ctx))).not.toContain(
+      "launch failed",
+    );
     expect(gate.active()).toBe(0);
   });
 

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -43,6 +43,10 @@ import { runShell } from "../services/shell-execution-router.ts";
 import { decodePathComponent } from "./server-helpers.ts";
 import type { ServerState } from "./server-types.ts";
 import {
+  capturedTerminalOutputIsSafe,
+  MAX_TERMINAL_CAPTURE_BYTES,
+} from "./terminal-output-contract.ts";
+import {
   resolveRequestedTerminalRunId,
   resolveTerminalRunLimits,
 } from "./terminal-run-limits.ts";
@@ -504,7 +508,7 @@ export async function handleMiscRoutes(
     };
 
     const captureOutput = body.captureOutput === true;
-    const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
+    const MAX_CAPTURE_BYTES = MAX_TERMINAL_CAPTURE_BYTES;
 
     const runId = resolveRequestedTerminalRunId(
       req.headers["x-eliza-terminal-run-id"],
@@ -604,8 +608,11 @@ export async function handleMiscRoutes(
     }, maxDurationMs);
 
     const appendAndEmit = (stream: "stdout" | "stderr", text: string) => {
-      if (stream === "stdout") stdout = appendOutput(stdout, text);
-      else stderr = appendOutput(stderr, text);
+      if (captureOutput) {
+        if (stream === "stdout") stdout = appendOutput(stdout, text);
+        else stderr = appendOutput(stderr, text);
+        return;
+      }
       emitTerminalEvent({
         type: "terminal-output",
         runId,
@@ -635,14 +642,15 @@ export async function handleMiscRoutes(
       })
       .then((result) => {
         finalize();
-        emitTerminalEvent({
-          type: "terminal-output",
-          runId,
-          event: "exit",
-          code: result.exitCode,
-        });
+        const runTimedOut = timedOut || result.exitCode === 124;
         if (captureOutput) {
           if (captureOverflowed) {
+            emitTerminalEvent({
+              type: "terminal-output",
+              runId,
+              event: "error",
+              data: "Terminal output exceeded the complete-capture limit",
+            });
             error(
               res,
               `Terminal output exceeded the ${MAX_CAPTURE_BYTES}-byte complete-capture safety limit; no partial result was returned.`,
@@ -650,6 +658,52 @@ export async function handleMiscRoutes(
             );
             return;
           }
+          if (runTimedOut) {
+            error(
+              res,
+              "Terminal execution timed out; no partial result was returned.",
+              504,
+            );
+            return;
+          }
+          if (!capturedTerminalOutputIsSafe(stdout, stderr)) {
+            emitTerminalEvent({
+              type: "terminal-output",
+              runId,
+              event: "error",
+              data: "Terminal output was not valid safe text",
+            });
+            error(
+              res,
+              "Terminal output was not valid safe text; no result was returned.",
+              422,
+            );
+            return;
+          }
+          if (stdout) {
+            emitTerminalEvent({
+              type: "terminal-output",
+              runId,
+              event: "stdout",
+              data: stdout,
+            });
+          }
+          if (stderr) {
+            emitTerminalEvent({
+              type: "terminal-output",
+              runId,
+              event: "stderr",
+              data: stderr,
+            });
+          }
+        }
+        emitTerminalEvent({
+          type: "terminal-output",
+          runId,
+          event: "exit",
+          code: result.exitCode,
+        });
+        if (captureOutput) {
           json(res, {
             ok: true,
             runId,
@@ -657,7 +711,7 @@ export async function handleMiscRoutes(
             exitCode: result.exitCode,
             stdout,
             stderr,
-            timedOut: timedOut || result.exitCode === 124,
+            timedOut: runTimedOut,
             truncated: false,
             maxDurationMs,
             sandbox: result.sandbox,
@@ -665,16 +719,16 @@ export async function handleMiscRoutes(
           });
         }
       })
-      .catch((err: Error) => {
+      .catch((_error: Error) => {
         finalize();
         emitTerminalEvent({
           type: "terminal-output",
           runId,
           event: "error",
-          data: err.message,
+          data: "Terminal execution failed",
         });
         if (captureOutput) {
-          error(res, err.message, 500);
+          error(res, "Terminal execution failed", 500);
         }
       });
 

--- a/packages/agent/src/api/terminal-output-contract.ts
+++ b/packages/agent/src/api/terminal-output-contract.ts
@@ -1,0 +1,40 @@
+/**
+ * Defines the shared completeness and text-integrity contract for captured
+ * terminal output at both the HTTP route and action consumer boundaries.
+ */
+
+export const MAX_TERMINAL_CAPTURE_BYTES = 4 * 1024 * 1024;
+
+function hasUnsafeTerminalCodePoint(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (
+      codePoint === undefined ||
+      // Shell/provider adapters expose strings, so the boundary cannot
+      // distinguish a literal replacement character from lossy UTF-8 decode.
+      // Reject it conservatively rather than certify possibly invalid bytes.
+      codePoint === 0xfffd ||
+      (codePoint < 0x20 && ![0x09, 0x0a, 0x0d, 0x1b].includes(codePoint)) ||
+      codePoint === 0x7f ||
+      (codePoint >= 0x202a && codePoint <= 0x202e) ||
+      (codePoint >= 0x2066 && codePoint <= 0x2069)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function capturedTerminalOutputIsSafe(
+  stdout: string,
+  stderr: string,
+): boolean {
+  return (
+    stdout.isWellFormed() &&
+    stderr.isWellFormed() &&
+    !hasUnsafeTerminalCodePoint(stdout) &&
+    !hasUnsafeTerminalCodePoint(stderr) &&
+    Buffer.byteLength(stdout, "utf8") + Buffer.byteLength(stderr, "utf8") <=
+      MAX_TERMINAL_CAPTURE_BYTES
+  );
+}

--- a/packages/agent/src/api/terminal-output-contract.ts
+++ b/packages/agent/src/api/terminal-output-contract.ts
@@ -5,6 +5,22 @@
 
 export const MAX_TERMINAL_CAPTURE_BYTES = 4 * 1024 * 1024;
 
+function terminalTextIsWellFormed(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (index + 1 >= value.length || next < 0xdc00 || next > 0xdfff) {
+        return false;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function hasUnsafeTerminalCodePoint(value: string): boolean {
   for (const character of value) {
     const codePoint = character.codePointAt(0);
@@ -30,8 +46,8 @@ export function capturedTerminalOutputIsSafe(
   stderr: string,
 ): boolean {
   return (
-    stdout.isWellFormed() &&
-    stderr.isWellFormed() &&
+    terminalTextIsWellFormed(stdout) &&
+    terminalTextIsWellFormed(stderr) &&
     !hasUnsafeTerminalCodePoint(stdout) &&
     !hasUnsafeTerminalCodePoint(stderr) &&
     Buffer.byteLength(stdout, "utf8") + Buffer.byteLength(stderr, "utf8") <=


### PR DESCRIPTION
# Relates to

- Relates to #24286. This closes the terminal compatibility hole; it does not close the broader progressive-content rollout.

- [x] Targets develop and was rebased onto origin/develop 2278f26510e70d242b21e3967b65d24b98f8fa69 with zero conflicts.
- [x] bun install --ignore-scripts --frozen-lockfile completed after sync.
- [x] A reviewer can confirm the changed boundary from the exact-head tests below.

# Risks

Low. Current terminal responses are unchanged because the route always returns `truncated: false` or rejects oversize capture with HTTP 413. Older or alternate providers that return `truncated: true` now fail explicitly with `TERMINAL_OUTPUT_INCOMPLETE` instead of putting partial stdout or stderr into model-visible action data or attachments.

# Background

## What does this PR do?

It rejects provider-truncated terminal responses before persistence, prompt projection, action data, or user relay. It removes the obsolete 128 KB partial-output branches and makes the stored terminal ReadView unconditionally complete. The current route already keeps up to 4 MiB complete and rejects one-over with no partial JSON result.

## What kind of change is this?

Bug fix, non-breaking for the current terminal route.

# Documentation changes needed?

N/A - the repository no-truncation policy and progressive-content specification already define this behavior.

# Testing

## Where should a reviewer start?

`packages/agent/src/actions/terminal-effect-receipt.test.ts` and `packages/agent/src/api/misc-routes.terminal-run-limits.test.ts`.

## Detailed testing steps

Exact PR head: `cd696c6b9ed6111e8d141ac46033a4ce0262c0c5`

Validated base: `2278f26510e70d242b21e3967b65d24b98f8fa69`

- PASS: `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/actions/terminal-effect-receipt.test.ts packages/agent/src/api/misc-routes.terminal-run-limits.test.ts --reporter=dot` (2 files, 29 tests).
- PASS: `bunx biome check packages/agent/src/actions/terminal.ts packages/agent/src/actions/terminal-effect-receipt.test.ts`.
- PASS: `git diff --check origin/develop...HEAD`.
- BASELINE BLOCKER: `bun run --cwd packages/agent typecheck` fails only in unrelated existing optional-plugin resolution and coding-runner fixture errors; neither changed file appears in the diagnostics. Exact diagnostics include missing plugin-capacitor-bridge subpaths, plugin-wallet/diagnostic, plugin-pty/video/vision, plugin-notes/plugin, cloud-routing, and existing opencode CodingAgentRunner assignments.

# Evidence Gate

<!-- evidence-head:cd696c6b9ed6111e8d141ac46033a4ce0262c0c5 -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic loopback tests exercise the action and route boundary directly
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request or state changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - fail-closed validation occurs before any model projection
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - createMemory is asserted not called for partial output
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Known gaps / failures

Package typecheck is blocked by the unrelated current-develop diagnostics listed above. Focused exact-head tests, Biome, and diff validation pass. No live-model trajectory was produced because the behavior under test is rejection before model projection, and the deterministic action contract asserts no memory artifact is created.

## Maintainer CI exception record

N/A - no exception requested.

