### PR TITLE
fix(shared): ground mutable facts in traceable live results

### DIFF
--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -10,6 +10,8 @@ export type SharedRuntimePublicGrounding =
       provider: KeylessWebSearchProvider;
       text: string;
       observedAt: number;
+      /** Traceable public sources extracted from the successful tool receipt. */
+      sourceUrls?: string[];
       truncated: boolean;
     }
   | {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/__fixtures__/telegram-realtime-grounding-20260821.redacted.json
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/__fixtures__/telegram-realtime-grounding-20260821.redacted.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "surface": "Eliza Staging Telegram DM",
+  "observedDate": "2026-08-21",
+  "identityMarker": "AUTH-GATEWAY-REUSE-20260821-0101",
+  "identityReply": "ACCOUNT REUSE READY",
+  "redaction": "Provider user, chat, message, account, organization, and trace identifiers omitted.",
+  "turns": [
+    {
+      "role": "user",
+      "content": "what is btc price rn"
+    },
+    {
+      "role": "assistant",
+      "content": "Bitcoin is currently 63,800 USD according to TradingView"
+    },
+    {
+      "role": "user",
+      "content": "[correction that the quoted price was wrong]"
+    },
+    {
+      "role": "user",
+      "content": "check the web"
+    },
+    {
+      "role": "assistant",
+      "content": "[claimed search results and an article mentioning $117k, but named no site or URL]"
+    },
+    {
+      "role": "user",
+      "content": "[asked for the missing source]"
+    },
+    {
+      "role": "assistant",
+      "content": "[admitted no source had been specified, then degraded into punctuation-only replies]"
+    }
+  ],
+  "acceptanceMeaning": {
+    "proved": ["gateway delivery", "account reuse"],
+    "didNotProve": [
+      "live tool invocation",
+      "current-data factuality",
+      "source attribution",
+      "conversational recovery"
+    ]
+  }
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.realtime-grounding.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Pins the fail-closed boundary around mutable factual turns. The model may
+ * fabricate, omit attribution, or stay silent; only the server-owned public
+ * read can authorize the final Telegram-safe reply.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ActionResult } from "@elizaos/core/edge";
+
+let searchResult: ActionResult;
+let runtimeReply = "";
+let runtimeResponded = true;
+let capturedRuntimeInput: Record<string, unknown> | undefined;
+
+mock.module("../../providers/language-model", () => ({
+  hasLanguageModelProviderConfigured: () => true,
+}));
+
+mock.module("@elizaos/plugin-web-search/edge", () => ({
+  runWebSearchEdge: async () => searchResult,
+}));
+
+mock.module("./shared-eliza-runtime", () => ({
+  runSharedElizaRuntimeTurn: async (input: Record<string, unknown>) => {
+    capturedRuntimeInput = input;
+    const history = input.history as Array<{
+      role: "system" | "user" | "assistant";
+      content: string;
+    }>;
+    return {
+      reply: runtimeReply,
+      responded: runtimeResponded,
+      history: runtimeResponded
+        ? [
+            ...history,
+            { role: "user" as const, content: String(input.message) },
+            { role: "assistant" as const, content: runtimeReply },
+          ]
+        : [...history, { role: "user" as const, content: String(input.message) }],
+      model: String(input.model),
+      degraded: false,
+    };
+  },
+  runSharedElizaRuntimeTurnStream: async () => {
+    throw new Error("current-data turns must use the buffered verification boundary");
+  },
+}));
+
+const { runSharedAgentTurn, runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
+
+const character = { name: "Grounding Pin", system: "You are a test persona." };
+
+function groundedSearch(): ActionResult {
+  return {
+    success: true,
+    text: JSON.stringify({ symbol: "BTC", value: "70,000", currency: "USD" }),
+    data: {
+      actionName: "WEB_SEARCH",
+      query: "what is btc price rn",
+      provider: "parallel",
+      observedAt: Date.UTC(2026, 7, 21, 8, 30),
+      sourceUrls: ["https://example.com/markets/btc-usd"],
+      truncated: false,
+    },
+  };
+}
+
+beforeEach(() => {
+  searchResult = groundedSearch();
+  runtimeReply = "BTC is 70,000 USD. [[SOURCE_URL:https://example.com/markets/btc-usd]]";
+  runtimeResponded = true;
+  capturedRuntimeInput = undefined;
+});
+
+describe("runSharedAgentTurn realtime grounding", () => {
+  test("preflights current prices and returns a concise traceable source", async () => {
+    const result = await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "what is btc price rn",
+      execution: {
+        agentKey: "personal-shared:test",
+        roomKey: "telegram:test",
+        channel: { type: "DM", source: "telegram" },
+      },
+    });
+
+    expect(result.reply).toContain("BTC is 70,000 USD.");
+    expect(result.reply).toContain("Source: example.com");
+    expect(result.reply).toContain("https://example.com/markets/btc-usd");
+    expect(result.reply).toContain("parallel, checked 2026-08-21T08:30:00.000Z");
+    expect(result.actionResults).toEqual([searchResult]);
+    expect(capturedRuntimeInput?.preflightActionResults).toEqual([searchResult]);
+    if (!capturedRuntimeInput) throw new Error("runtime input was not captured");
+    expect((capturedRuntimeInput.character as { system: string }).system).toContain(
+      "Current-data grounding policy",
+    );
+  });
+
+  test("replaces a fabricated value and attribution with a safe answer", async () => {
+    runtimeReply = "Bitcoin is currently 63,800 USD according to TradingView.";
+    const result = await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "what is btc price rn",
+    });
+
+    expect(result.reply).not.toContain("63,800");
+    expect(result.reply).not.toContain("TradingView");
+    expect(result.reply).toContain("couldn’t safely verify a single current value");
+    expect(result.reply).toContain("Source provider: parallel");
+  });
+
+  test("fails closed when search has no traceable source", async () => {
+    searchResult = {
+      success: true,
+      text: "A result that does not name or link its source",
+      data: {
+        actionName: "WEB_SEARCH",
+        query: "weather today",
+        provider: "parallel",
+        observedAt: Date.now(),
+      },
+    };
+    runtimeReply = "It is 72 degrees according to WeatherNow.";
+    const result = await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "weather today",
+    });
+
+    expect(result.reply).toContain("can’t verify");
+    expect(result.reply).toContain("won’t guess");
+    expect(result.reply).not.toContain("72");
+    expect(result.reply).not.toContain("WeatherNow");
+    expect(result.actionResults?.[0]?.success).toBe(false);
+  });
+
+  test("turns model silence into useful correction recovery", async () => {
+    runtimeReply = "";
+    runtimeResponded = false;
+    const result = await runSharedAgentTurn({
+      character,
+      history: [
+        { role: "user", content: "what is btc price rn" },
+        { role: "assistant", content: "Bitcoin is 63,800 USD." },
+      ],
+      message: "wrong, check again",
+    });
+
+    expect(result.responded).toBe(true);
+    expect(result.reply).toContain("couldn’t safely verify a single current value");
+    expect(result.reply).not.toMatch(/^\?+$/u);
+  });
+
+  test("buffers current-data streaming so no unverified prefix escapes", async () => {
+    const result = await runSharedAgentTurnStream({
+      character,
+      history: [],
+      message: "latest ethereum price",
+    });
+    if (!result.parts) throw new Error("stream returned no parts");
+    const parts = [];
+    for await (const part of result.parts) parts.push(part);
+
+    expect(parts.map((part) => part.type)).toEqual(["text-delta", "finish"]);
+    expect(parts[0]?.text).toContain("Source: example.com");
+    expect(parts[1]?.text).toContain("Source: example.com");
+    expect(parts[1]?.type === "finish" ? parts[1].actionResults : undefined).toEqual([
+      searchResult,
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -30,6 +30,7 @@ import {
 } from "@elizaos/core/edge";
 import type { ScheduledTaskRunner, SharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { TodoStore } from "@elizaos/plugin-todos/edge";
+import { runWebSearchEdge } from "@elizaos/plugin-web-search/edge";
 import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-runtime-history";
 import type { MobilePushMessage } from "../../mobile-push/types";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
@@ -46,7 +47,14 @@ import {
   type SharedCapabilityWall,
 } from "./shared-capability-wall";
 import type { SharedMemoryStore } from "./shared-memory-store";
+import {
+  finalizeSharedRealtimeReply,
+  requireTraceableRealtimeSearch,
+  resolveSharedRealtimeRequirement,
+  sharedRealtimePromptPolicy,
+} from "./shared-realtime-grounding";
 import type { SharedRuntimeChannel } from "./shared-runtime-channel";
+import { sharedPublicWebGrounding } from "./shared-runtime-history-policy";
 import type {
   SharedProviderTimingReceipt,
   SharedRuntimeTimingReceipt,
@@ -311,6 +319,7 @@ function buildSharedRuntimeSystem(
   recallContext?: string,
   blockedCapabilities: SharedCapabilityWall[] = [],
   requiredAction?: "REMINDERS" | "TODO",
+  realtimeGrounding?: SharedRuntimePublicGrounding,
 ): string {
   const parts: string[] = [];
   const system = replaceNameTokens(character.system ?? "", character.name).trim();
@@ -340,6 +349,7 @@ function buildSharedRuntimeSystem(
         `- If the request is incomplete or cannot be applied, call ${requiredAction} anyway and use its grounded clarification or failure result; never invent success.`,
     );
   }
+  if (realtimeGrounding) parts.push(sharedRealtimePromptPolicy(realtimeGrounding));
   if (recallContext?.trim()) parts.push(recallContext.trim());
   return parts.join("\n\n") || `You are ${character.name}, a helpful assistant.`;
 }
@@ -494,6 +504,34 @@ export async function runSharedAgentTurn(
     };
   }
 
+  const realtimeRequirement = actionsEnabled
+    ? resolveSharedRealtimeRequirement(message, input.history)
+    : undefined;
+  let realtimeActionResults: ActionResult[] | undefined;
+  let realtimeGrounding: SharedRuntimePublicGrounding | undefined;
+  if (realtimeRequirement) {
+    let searchResult: ActionResult;
+    try {
+      searchResult = await runWebSearchEdge(realtimeRequirement.query);
+    } catch {
+      // error-policy:J4 current-data lookup failures become an explicit,
+      // visibly unavailable receipt; the model never receives fake success.
+      searchResult = {
+        success: false,
+        text: "Live public data is temporarily unavailable.",
+        error: "Live public data is temporarily unavailable.",
+        data: {
+          actionName: "WEB_SEARCH",
+          query: realtimeRequirement.query,
+          observedAt: Date.now(),
+        },
+      };
+    }
+    const traceableResult = requireTraceableRealtimeSearch(searchResult, realtimeRequirement.query);
+    realtimeActionResults = [traceableResult];
+    realtimeGrounding = sharedPublicWebGrounding(realtimeActionResults);
+  }
+
   let turn: RunSharedAgentTurnResult;
   try {
     const execution = resolveRuntimeExecution(input);
@@ -515,15 +553,24 @@ export async function runSharedAgentTurn(
             input.recallContext,
             capabilityWall ? [capabilityWall] : blockedSecondary,
             requiredAction,
+            realtimeGrounding,
           ),
         },
         execution,
         agentKey: execution.agentKey,
         model: modelId,
+        ...(realtimeGrounding ? { realtimeGrounding } : {}),
+        ...(realtimeActionResults ? { preflightActionResults: realtimeActionResults } : {}),
       }),
       capabilityWall,
       blockedSecondary,
     );
+    if (realtimeActionResults) {
+      const runtimeActionResults = (turn.actionResults ?? []).filter(
+        (result) => result.data?.actionName !== "WEB_SEARCH",
+      );
+      turn = { ...turn, actionResults: [...realtimeActionResults, ...runtimeActionResults] };
+    }
     if (requiredAction && !hasRequiredActionResult(turn, requiredAction)) {
       throw new Error(
         `Eliza Shared runtime completed an executable ${requiredAction} request without an action result`,
@@ -536,6 +583,31 @@ export async function runSharedAgentTurn(
       `[shared-runtime] AgentRuntime turn failed (agent=${input.character.name}, model=${modelId})`,
       { cause: error },
     );
+  }
+  if (realtimeRequirement) {
+    const groundedReply = finalizeSharedRealtimeReply(turn.reply, realtimeGrounding);
+    const history = [...turn.history];
+    let replaced = false;
+    for (let index = history.length - 1; index >= 0; index -= 1) {
+      if (history[index].role !== "assistant") continue;
+      history[index] = {
+        ...history[index],
+        content: groundedReply,
+        ...(realtimeGrounding ? { grounding: realtimeGrounding } : {}),
+      };
+      replaced = true;
+      break;
+    }
+    if (!replaced) {
+      history.push({
+        id: input.messageIds?.assistant,
+        role: "assistant",
+        content: groundedReply,
+        createdAt: Date.now(),
+        ...(realtimeGrounding ? { grounding: realtimeGrounding } : {}),
+      });
+    }
+    turn = { ...turn, reply: groundedReply, responded: true, history };
   }
   // The durable memory commit runs OUTSIDE the provider try/catch: its failure
   // is a storage fault on an already-landed reply and must not be re-labeled
@@ -576,6 +648,31 @@ export async function runSharedAgentTurnStream(
       history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
       model: "none",
       degraded: true,
+    };
+  }
+
+  // Current-data answers are buffered until their complete grounded reply has
+  // passed validation; streaming an unverified numeric claim cannot be undone.
+  if (actionsEnabled && resolveSharedRealtimeRequirement(message, input.history)) {
+    const turn = await runSharedAgentTurn(input);
+    const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
+      if (turn.reply) yield { type: "text-delta", text: turn.reply };
+      yield {
+        type: "finish",
+        text: turn.reply,
+        ...(turn.responded === false ? { responded: false } : {}),
+        ...(turn.usage ? { usage: turn.usage } : {}),
+        ...(turn.actionResults?.length ? { actionResults: turn.actionResults } : {}),
+        ...(turn.timing ? { timing: turn.timing } : {}),
+      };
+    })();
+    return {
+      model: turn.model,
+      degraded: turn.degraded,
+      reply: turn.reply,
+      history: turn.history,
+      ...(turn.actionResults?.length ? { actionResults: turn.actionResults } : {}),
+      parts,
     };
   }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -1095,13 +1095,13 @@ describe("Shared Eliza Workerd runtime", () => {
               role: "assistant",
               content:
                 call === 5
-                  ? "A new ElizaOS public release was announced today, according to the project news page."
+                  ? "A new ElizaOS public release was announced today. [[SOURCE_URL:https://elizaos.ai/news]]"
                   : JSON.stringify({
                       success: true,
                       decision: "FINISH",
                       thought: "Answer from the public result.",
                       messageToUser:
-                        "A new ElizaOS public release was announced today, according to the project news page.",
+                        "A new ElizaOS public release was announced today. [[SOURCE_URL:https://elizaos.ai/news]]",
                     }),
             },
             finish_reason: "stop",
@@ -1136,24 +1136,28 @@ describe("Shared Eliza Workerd runtime", () => {
       method: "tools/call",
       params: {
         name: "web_search",
-        arguments: { objective: "latest ElizaOS news" },
+        arguments: { objective: "What is the latest ElizaOS news?" },
       },
     });
-    expect(result.reply).toBe(
-      "A new ElizaOS public release was announced today, according to the project news page.",
-    );
-    expect(modelRequests).toHaveLength(3);
+    expect(result.reply).toStartWith("A new ElizaOS public release was announced today.");
+    expect(result.reply).toContain("Source: elizaos.ai — https://elizaos.ai/news");
+    expect(result.reply).toContain("parallel, checked ");
+    expect(
+      result.actionResults?.filter((action) => action.data?.actionName === "WEB_SEARCH"),
+    ).toHaveLength(1);
+    expect(modelRequests).toHaveLength(4);
     expect(result.usage).toMatchObject({
-      promptTokens: 120,
-      completionTokens: 36,
-      totalTokens: 156,
+      promptTokens: 170,
+      completionTokens: 50,
+      totalTokens: 220,
     });
     expect(result.history.at(-1)?.grounding).toEqual({
       kind: "web_search",
-      query: "latest ElizaOS news",
+      query: "What is the latest ElizaOS news?",
       provider: "parallel",
       text: "ElizaOS launched a new public release today. Source: https://elizaos.ai/news",
       observedAt: expect.any(Number),
+      sourceUrls: ["https://elizaos.ai/news"],
       truncated: false,
     });
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  type ActionResult,
   type AgentEventPayload,
   AgentEventService,
   type AgentNotification,
@@ -38,7 +39,11 @@ import {
 } from "@elizaos/core/edge";
 import { createSharedRemindersEdgePlugin } from "@elizaos/plugin-scheduling/edge";
 import { createTodosEdgePlugin } from "@elizaos/plugin-todos/edge";
-import { webSearchEdgeAction, webSearchEdgePlugin } from "@elizaos/plugin-web-search/edge";
+import {
+  createWebSearchEdgePlugin,
+  webSearchEdgeAction,
+  webSearchEdgePlugin,
+} from "@elizaos/plugin-web-search/edge";
 import type { AgentCapabilityTransport } from "@elizaos/shared";
 import {
   generateText,
@@ -48,6 +53,7 @@ import {
   streamText,
   type ToolSet,
 } from "ai";
+import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-runtime-history";
 import type { MobilePushMessage } from "../../mobile-push/types";
 import { getInteractiveCerebrasLanguageModel } from "../../providers/language-model";
 import { logger } from "../../utils/logger";
@@ -70,6 +76,7 @@ import {
 import {
   insertSharedRuntimeGroundingMessages,
   sharedPublicWebGrounding,
+  sharedRuntimeFreshGroundingProjectionMessages,
   sharedRuntimeGroundingProjectionMessages,
 } from "./shared-runtime-history-policy";
 import {
@@ -95,6 +102,10 @@ type SharedElizaRuntimeTurnInput = Omit<RunSharedAgentTurnInput, "execution"> & 
   execution: NonNullable<RunSharedAgentTurnInput["execution"]>;
   agentKey: string;
   model: string;
+  /** Server-executed current-turn public read, never transport supplied. */
+  realtimeGrounding?: SharedRuntimePublicGrounding;
+  /** Traceable action receipt for the server-executed public read. */
+  preflightActionResults?: ActionResult[];
 };
 
 interface SharedNotificationEventBus {
@@ -241,6 +252,7 @@ function createRuntime(options: {
   adapter: InMemoryDatabaseAdapter;
   character: RunSharedAgentTurnInput["character"];
   modelPlugin: Plugin;
+  webSearchPlugin?: Plugin;
   transport?: AgentCapabilityTransport;
   mediaPlugin?: Plugin;
   reminderPlugin?: Plugin;
@@ -277,7 +289,7 @@ function createRuntime(options: {
       options.modelPlugin,
       ...(!options.actionsEnabled ? [sharedSystemLifecyclePlugin] : []),
       ...(options.actionsEnabled ? [capabilityPlugin] : []),
-      ...(options.actionsEnabled ? [webSearchEdgePlugin] : []),
+      ...(options.actionsEnabled ? [options.webSearchPlugin ?? webSearchEdgePlugin] : []),
       ...(options.actionsEnabled && options.mediaPlugin ? [options.mediaPlugin] : []),
       ...(options.actionsEnabled && options.reminderPlugin ? [options.reminderPlugin] : []),
       ...(options.actionsEnabled && options.todoPlugin ? [options.todoPlugin] : []),
@@ -576,10 +588,12 @@ async function executeMeasuredSharedElizaRuntimeTurn(
   // The native tool-call projection may only reference a tool the current
   // request actually declares; otherwise the evidence is carried as data-only
   // transcript content so a strict provider cannot reject the whole request.
-  const persistedGroundingMessages = (declaresWebSearch: boolean): ModelMessage[] =>
-    sharedRuntimeGroundingProjectionMessages(input.history, input.message, groundingObservedAt, {
+  const persistedGroundingMessages = (declaresWebSearch: boolean): ModelMessage[] => [
+    ...sharedRuntimeGroundingProjectionMessages(input.history, input.message, groundingObservedAt, {
       nativeToolProjection: declaresWebSearch,
-    });
+    }),
+    ...sharedRuntimeFreshGroundingProjectionMessages(input.realtimeGrounding),
+  ];
 
   const modelHandler = async (
     _runtime: IAgentRuntime,
@@ -735,6 +749,9 @@ async function executeMeasuredSharedElizaRuntimeTurn(
   const incomingEntityId = actionsEnabled ? userEntityId : lifecycleEntityId;
   const authenticatedPersonalSharedUser =
     actionsEnabled && input.execution?.authenticatedPersonalSharedUser === true;
+  const preflightWebSearchResult = input.preflightActionResults?.find(
+    (result) => result.data?.actionName === "WEB_SEARCH",
+  );
   const runtime = createRuntime({
     agentKey: input.agentKey,
     agentId,
@@ -742,6 +759,11 @@ async function executeMeasuredSharedElizaRuntimeTurn(
     adapter,
     character: input.character,
     modelPlugin,
+    ...(preflightWebSearchResult
+      ? {
+          webSearchPlugin: createWebSearchEdgePlugin(async () => preflightWebSearchResult),
+        }
+      : {}),
     transport: sharedCapabilityTransportForSource(input.execution.channel.source),
     mediaPlugin,
     reminderPlugin,
@@ -947,6 +969,7 @@ async function executeMeasuredSharedElizaRuntimeTurn(
     // response. The callback receipt is still an actual user-visible delivery.
     if (!result?.didRespond && delivered.length === 0) {
       logSharedProviderSpans(input, inferenceTelemetry.summary, false);
+      const preflightActionResults = input.preflightActionResults ?? [];
       return {
         reply: "",
         responded: false,
@@ -959,12 +982,18 @@ async function executeMeasuredSharedElizaRuntimeTurn(
         model: input.model,
         degraded: false,
         usage,
+        ...(preflightActionResults.length ? { actionResults: preflightActionResults } : {}),
       };
     }
     if (!reply) {
       throw new Error("Eliza Shared runtime completed without a user-visible reply");
     }
     logSharedProviderSpans(input, inferenceTelemetry.summary, true);
+    const actionResults = [
+      ...(input.preflightActionResults ?? []),
+      ...(result.actionResults ?? []),
+    ];
+    const grounding = input.realtimeGrounding ?? sharedPublicWebGrounding(actionResults);
     return {
       reply,
       responded: true,
@@ -974,12 +1003,12 @@ async function executeMeasuredSharedElizaRuntimeTurn(
         reply,
         input.messageIds,
         input.messageRole,
-        sharedPublicWebGrounding(result.actionResults),
+        grounding,
       ),
       model: input.model,
       degraded: false,
       usage,
-      ...(result.actionResults?.length ? { actionResults: result.actionResults } : {}),
+      ...(actionResults.length ? { actionResults } : {}),
     };
   } finally {
     for (const [operation, cleanup] of [

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
@@ -1,0 +1,137 @@
+/** Deterministic adversarial coverage for Shared current-data grounding gates. */
+
+import { describe, expect, test } from "bun:test";
+import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-runtime-history";
+import {
+  finalizeSharedRealtimeReply,
+  requireTraceableRealtimeSearch,
+  resolveSharedRealtimeRequirement,
+  validateSharedRealtimeReply,
+} from "./shared-realtime-grounding";
+
+const observedAt = Date.UTC(2026, 7, 22, 7, 0, 0);
+const grounding: SharedRuntimePublicGrounding = {
+  kind: "web_search",
+  query: "what is btc price rn",
+  provider: "parallel",
+  observedAt,
+  sourceUrls: ["https://coin.example/bitcoin"],
+  text: JSON.stringify({
+    results: [
+      {
+        url: "https://coin.example/bitcoin",
+        title: "Bitcoin price",
+        excerpt: "Bitcoin is 77,357.93 USD at 07:00 UTC.",
+      },
+    ],
+  }),
+  truncated: false,
+};
+
+describe("Shared realtime request classification", () => {
+  for (const [message, domain] of [
+    ["what is btc price rn", "markets"],
+    ["weather in Austin", "weather"],
+    ["latest election news", "news"],
+    ["what's the Lakers score?", "sports"],
+    ["who is the current CEO of Example Corp?", "mutable_fact"],
+    ["check the web and give me a source", "explicit_verification"],
+  ] as const) {
+    test(`requires ${domain} grounding for ${message}`, () => {
+      expect(resolveSharedRealtimeRequirement(message, [])?.domain).toBe(domain);
+    });
+  }
+
+  test("does not force live lookup for static or explicitly historical facts", () => {
+    expect(resolveSharedRealtimeRequirement("What is Bitcoin?", [])).toBeUndefined();
+    expect(resolveSharedRealtimeRequirement("Explain proof of work", [])).toBeUndefined();
+    expect(resolveSharedRealtimeRequirement("Why did BTC move in 2017?", [])).toBeUndefined();
+  });
+
+  test("inherits a current-data requirement through correction and retry", () => {
+    const history = [
+      { role: "user" as const, content: "what is btc price rn" },
+      {
+        role: "assistant" as const,
+        content: "Bitcoin is currently 63,800 USD according to TradingView",
+      },
+    ];
+    expect(resolveSharedRealtimeRequirement("that's wrong, check again", history)).toMatchObject({
+      domain: "markets",
+      correction: true,
+    });
+    expect(resolveSharedRealtimeRequirement("check the web", history)?.query).toContain(
+      "what is btc price rn",
+    );
+  });
+});
+
+describe("Shared realtime receipts and Telegram-safe replies", () => {
+  test("rejects a successful search that has no traceable source", () => {
+    expect(
+      requireTraceableRealtimeSearch(
+        {
+          success: true,
+          text: "Bitcoin is 77,357.93 USD",
+          data: { actionName: "WEB_SEARCH", query: "BTC price", provider: "parallel" },
+        },
+        "BTC price",
+        observedAt,
+      ),
+    ).toMatchObject({
+      success: false,
+      data: { actionName: "WEB_SEARCH", query: "BTC price" },
+    });
+  });
+
+  test("accepts only values, currency, URLs, and attribution present in evidence", () => {
+    if (grounding.kind !== "web_search") throw new Error("fixture grounding must be available");
+    expect(
+      validateSharedRealtimeReply(
+        "Bitcoin is 77,357.93 USD. [[SOURCE_URL:https://coin.example/bitcoin]]",
+        grounding,
+      ),
+    ).toBe(true);
+    expect(validateSharedRealtimeReply("Bitcoin is 63,800 USD.", grounding)).toBe(false);
+    expect(
+      validateSharedRealtimeReply("Bitcoin is 77,357.93 USD according to TradingView.", grounding),
+    ).toBe(false);
+    expect(
+      validateSharedRealtimeReply(
+        "Bitcoin is 77,357.93 USD according to tradingview. [[SOURCE_URL:https://coin.example/bitcoin]]",
+        grounding,
+      ),
+    ).toBe(false);
+    expect(
+      validateSharedRealtimeReply(
+        "Bitcoin is 77,357.93 USD: https://forged.example/price",
+        grounding,
+      ),
+    ).toBe(false);
+    expect(validateSharedRealtimeReply("?", grounding)).toBe(false);
+  });
+
+  test("adds concise source, provider, and checked time for Telegram", () => {
+    const reply = finalizeSharedRealtimeReply(
+      "Bitcoin is 77,357.93 USD. [[SOURCE_URL:https://coin.example/bitcoin]]",
+      grounding,
+    );
+    expect(reply).toContain("Bitcoin is 77,357.93 USD.");
+    expect(reply).toContain("https://coin.example/bitcoin");
+    expect(reply).toContain("parallel");
+    expect(reply).toContain("2026-08-22T07:00:00.000Z");
+    expect(reply).not.toContain("[[SOURCE_URL:");
+  });
+
+  test("recovers honestly from unavailable tools and punctuation-only model output", () => {
+    const unavailable: SharedRuntimePublicGrounding = {
+      kind: "web_search_unavailable",
+      query: "weather now",
+      observedAt,
+    };
+    const reply = finalizeSharedRealtimeReply("?", unavailable);
+    expect(reply).toContain("can’t verify");
+    expect(reply).toContain("won’t guess");
+    expect(reply).not.toMatch(/\b\d[\d,.]*\b/u);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
@@ -1,0 +1,211 @@
+/**
+ * Enforces fresh public-read evidence for mutable factual claims in Shared.
+ * Classification is deterministic, while provider text remains untrusted data.
+ */
+
+import type { ActionResult } from "@elizaos/core/edge";
+import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-runtime-history";
+import type { SharedTurnMessage } from "./run-shared-agent-turn";
+
+export type SharedRealtimeDomain =
+  | "markets"
+  | "weather"
+  | "news"
+  | "sports"
+  | "mutable_fact"
+  | "explicit_verification";
+
+export interface SharedRealtimeRequirement {
+  domain: SharedRealtimeDomain;
+  query: string;
+  correction: boolean;
+}
+
+const FRESHNESS =
+  /\b(?:now|rn|right now|current|currently|today|tonight|latest|live|recent|recently|up[- ]?to[- ]?date|this (?:morning|afternoon|evening|week|month|year))\b/i;
+const EXPLICIT_VERIFICATION =
+  /\b(?:check|search|browse|look(?:ed)? up|verify|confirm|fact[- ]?check)(?:\s+(?:it|that|this|again|online|the))?(?:\s+(?:web|internet|source|sources|news))?\b|\b(?:source|sources|citation|citations|link|links)\??$/i;
+const CORRECTION =
+  /\b(?:wrong|incorrect|not right|made that up|hallucinat(?:e|ed|ion)|check again|try again|prove it|where did (?:that|you) (?:come|get) from)\b|^\s*\?+\s*$/i;
+const MARKETS =
+  /\b(?:price|quote|exchange rate|market cap|market price|stock|share price|crypto|cryptocurrency|bitcoin|btc|ethereum|eth|forex|bond yield|commodity|gold price|oil price)\b/i;
+const WEATHER = /\b(?:weather|forecast|temperature|rain|snow|wind|air quality|uv index)\b/i;
+const NEWS = /\b(?:news|headline|breaking|announcement|announced|release today|current events)\b/i;
+const SPORTS = /\b(?:score|standings|fixture|match result|game result|playoffs|season record)\b/i;
+const MUTABLE_FACT =
+  /\b(?:president|prime minister|governor|mayor|senator|representative|ceo|chief executive|officeholder|version|release version|availability|status|outage|traffic|flight status|schedule)\b/i;
+
+function classifyStandalone(text: string): SharedRealtimeDomain | undefined {
+  if (WEATHER.test(text)) return "weather";
+  if (
+    MARKETS.test(text) &&
+    (FRESHNESS.test(text) || /\b(?:price|quote|exchange rate)\b/i.test(text))
+  ) {
+    return "markets";
+  }
+  if (NEWS.test(text) && (FRESHNESS.test(text) || /\b(?:news|headline|breaking)\b/i.test(text))) {
+    return "news";
+  }
+  if (
+    SPORTS.test(text) &&
+    (FRESHNESS.test(text) || /\b(?:score|standings|fixture)\b/i.test(text))
+  ) {
+    return "sports";
+  }
+  if (
+    MUTABLE_FACT.test(text) &&
+    (FRESHNESS.test(text) || /^\s*(?:who|what|when|is|are)\b/i.test(text))
+  ) {
+    return "mutable_fact";
+  }
+  if (EXPLICIT_VERIFICATION.test(text)) return "explicit_verification";
+  return undefined;
+}
+
+/** Identifies current-data turns and terse corrections that inherit that need. */
+export function resolveSharedRealtimeRequirement(
+  message: string,
+  history: readonly SharedTurnMessage[],
+): SharedRealtimeRequirement | undefined {
+  const normalized = message.trim();
+  const direct = classifyStandalone(normalized);
+  const correction = CORRECTION.test(normalized);
+  if (direct && direct !== "explicit_verification") {
+    return { domain: direct, query: normalized, correction };
+  }
+  if (!correction && !EXPLICIT_VERIFICATION.test(normalized)) return undefined;
+  const prior = [...history]
+    .reverse()
+    .find((turn) => turn.role === "user" && classifyStandalone(turn.content));
+  if (!prior) return direct ? { domain: direct, query: normalized, correction } : undefined;
+  return {
+    domain: classifyStandalone(prior.content) ?? "explicit_verification",
+    query: `${prior.content}\n${normalized}\nVerify against current public sources.`,
+    correction: true,
+  };
+}
+
+function normalizedNumericTokens(value: string): Set<string> {
+  return new Set(
+    [...value.matchAll(/(?:[$€£¥]\s*)?\d[\d,]*(?:\.\d+)?%?/gu)].map((match) =>
+      match[0].toLowerCase().replace(/[\s,]/gu, ""),
+    ),
+  );
+}
+
+function replyUrls(value: string): string[] {
+  return [...value.matchAll(/https?:\/\/[^\s<>"'\]]+/gu)].map((match) =>
+    match[0].replace(/[),.;]+$/u, ""),
+  );
+}
+
+function selectedSourceUrl(
+  reply: string,
+  grounding: Extract<SharedRuntimePublicGrounding, { kind: "web_search" }>,
+): string | undefined {
+  const selected = reply.match(/\[\[SOURCE_URL:(https?:\/\/[^\]\s]+)\]\]/iu)?.[1];
+  if (!selected) return undefined;
+  return (grounding.sourceUrls ?? []).find(
+    (allowed) => allowed === selected || allowed === `${selected}/` || `${allowed}/` === selected,
+  );
+}
+
+function hostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./u, "");
+  } catch {
+    return "public source";
+  }
+}
+
+/** A successful current-data receipt must be attributable outside provider prose. */
+export function hasTraceableRealtimeGrounding(
+  grounding: SharedRuntimePublicGrounding | undefined,
+): grounding is Extract<SharedRuntimePublicGrounding, { kind: "web_search" }> & {
+  sourceUrls: [string, ...string[]];
+} {
+  return Boolean(
+    grounding?.kind === "web_search" && grounding.sourceUrls && grounding.sourceUrls.length > 0,
+  );
+}
+
+/** Converts a healthy-looking but source-free search into an explicit miss. */
+export function requireTraceableRealtimeSearch(
+  result: ActionResult,
+  query: string,
+  observedAt = Date.now(),
+): ActionResult {
+  const data = result.data && typeof result.data === "object" ? result.data : {};
+  if (
+    result.success === true &&
+    Array.isArray(data.sourceUrls) &&
+    data.sourceUrls.some((url) => typeof url === "string" && /^https?:\/\//u.test(url))
+  ) {
+    return result;
+  }
+  return {
+    success: false,
+    text: "Live public data is temporarily unavailable from a traceable source.",
+    error: "Live public data is temporarily unavailable from a traceable source.",
+    data: { actionName: "WEB_SEARCH", query, observedAt },
+  };
+}
+
+/** Rejects new numbers, currencies, URLs, and named attributions absent from evidence. */
+export function validateSharedRealtimeReply(
+  reply: string,
+  grounding: Extract<SharedRuntimePublicGrounding, { kind: "web_search" }>,
+): boolean {
+  const trimmed = reply.trim();
+  if (!trimmed || /^[\s?!.,-]{1,12}$/u.test(trimmed)) return false;
+  if (!selectedSourceUrl(trimmed, grounding)) return false;
+  const evidenceNumbers = normalizedNumericTokens(grounding.text);
+  for (const token of normalizedNumericTokens(trimmed)) {
+    if (!evidenceNumbers.has(token)) return false;
+  }
+  const evidenceCurrencies = new Set(
+    grounding.text.toUpperCase().match(/\b(?:USD|EUR|GBP|JPY|CAD|AUD|BTC|ETH)\b/gu) ?? [],
+  );
+  for (const currency of trimmed.toUpperCase().match(/\b(?:USD|EUR|GBP|JPY|CAD|AUD|BTC|ETH)\b/gu) ??
+    []) {
+    if (!evidenceCurrencies.has(currency)) return false;
+  }
+  const allowedUrls = new Set(grounding.sourceUrls ?? []);
+  for (const url of replyUrls(trimmed)) {
+    if (!allowedUrls.has(url) && !allowedUrls.has(`${url}/`)) return false;
+  }
+  for (const match of trimmed.matchAll(
+    /\b(?:according to|reported by)\s+([^,.;\n[][^,.;\n]{0,79})/giu,
+  )) {
+    if (!grounding.text.toLowerCase().includes(match[1].trim().toLowerCase())) return false;
+  }
+  return true;
+}
+
+/** Produces Telegram-safe attribution or an honest deterministic recovery. */
+export function finalizeSharedRealtimeReply(
+  reply: string,
+  grounding: SharedRuntimePublicGrounding | undefined,
+): string {
+  if (!hasTraceableRealtimeGrounding(grounding)) {
+    return "I can’t verify the current value from a traceable live source right now, so I won’t guess. Please try again shortly.";
+  }
+  const sourceUrl = selectedSourceUrl(reply, grounding);
+  if (!sourceUrl) {
+    return `I found live public results, but I couldn’t safely verify a single current value from them, so I won’t guess.\n\nSource provider: ${grounding.provider} (checked ${new Date(grounding.observedAt).toISOString()})`;
+  }
+  const checkedAt = new Date(grounding.observedAt).toISOString();
+  const source = `Source: ${hostname(sourceUrl)} — ${sourceUrl} (${grounding.provider}, checked ${checkedAt})`;
+  if (!validateSharedRealtimeReply(reply, grounding)) {
+    return `I found live public results, but I couldn’t safely verify a single current value from them, so I won’t guess.\n\n${source}`;
+  }
+  const answer = reply.replace(/\s*\[\[SOURCE_URL:https?:\/\/[^\]\s]+\]\]\s*/giu, " ").trim();
+  return `${answer}\n\n${source}`;
+}
+
+/** System-only policy; the actual provider result is injected as untrusted data. */
+export function sharedRealtimePromptPolicy(grounding: SharedRuntimePublicGrounding): string {
+  return grounding.kind === "web_search"
+    ? "Current-data grounding policy:\n- A live public read already ran for this turn. Use only its current-turn evidence for mutable factual claims.\n- Preserve its value, timestamp, units or currency, provider, and source URL. If sources conflict or omit the requested value, say so and do not guess.\n- End the draft with [[SOURCE_URL:https://exact-supporting-url]] using one URL from the supplied evidence that directly supports the claim; this marker is removed before delivery.\n- Never invent a search, article, source, attribution, or numeric value. Do not run a duplicate search unless the supplied receipt is explicitly unavailable."
+    : "Current-data grounding policy:\n- The required live public read failed or had no traceable source. Say you cannot verify the current value and do not provide a number, source, article, or claimed search result.\n- Recover conversationally from corrections; never answer with punctuation alone.";
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -43,6 +43,29 @@ const DEICTIC_GROUNDING_FOLLOW_UP =
   /\b(?:it|that|this|those|these|they|them|result|results|source|sources|find|found|finding|findings|corrected|correction)\b/i;
 export type SharedRuntimeHistoryMessageLike = SharedRuntimeHistoryMessage;
 
+function publicSourceUrls(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  const urls: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") return undefined;
+    try {
+      const parsed = new URL(item);
+      if (
+        (parsed.protocol !== "https:" && parsed.protocol !== "http:") ||
+        parsed.username ||
+        parsed.password
+      ) {
+        return undefined;
+      }
+      urls.push(parsed.toString());
+    } catch {
+      return undefined;
+    }
+  }
+  return urls;
+}
+
 /** Rejects malformed provenance while preserving every validated field. */
 export function parseSharedPublicWebGrounding(
   value: unknown,
@@ -75,13 +98,15 @@ export function parseSharedPublicWebGrounding(
   }
   const query = candidate.query.trim();
   const text = candidate.text.trim();
-  if (!query || !text) return undefined;
+  const sourceUrls = publicSourceUrls(candidate.sourceUrls);
+  if (!query || !text || (candidate.sourceUrls !== undefined && !sourceUrls)) return undefined;
   return {
     kind: "web_search",
     query,
     provider: candidate.provider,
     text,
     observedAt: candidate.observedAt,
+    ...(sourceUrls ? { sourceUrls } : {}),
     truncated: candidate.truncated,
   };
 }
@@ -97,6 +122,27 @@ export function encodeSharedPublicWebGrounding(value: SharedRuntimePublicGroundi
     instructionPolicy: "data_only",
     ...parsed,
   });
+}
+
+/** Projects a server-observed current-turn read as policy plus untrusted data. */
+export function sharedRuntimeFreshGroundingProjectionMessages(
+  value: SharedRuntimePublicGrounding | undefined,
+): ModelMessage[] {
+  const grounding = parseSharedPublicWebGrounding(value);
+  if (!grounding) return [];
+  const authority: ModelMessage = {
+    role: "system",
+    content: JSON.stringify({
+      type: "public_web_search_authority",
+      status: grounding.kind === "web_search" ? "available" : "unavailable",
+      policy: "current_turn_evidence_only",
+      observedAt: grounding.observedAt,
+      ...(grounding.kind === "web_search" ? { provider: grounding.provider } : {}),
+    }),
+  };
+  return grounding.kind === "web_search"
+    ? [authority, { role: "user", content: encodeSharedPublicWebGrounding(grounding) }]
+    : [authority];
 }
 
 /** Extracts only a successful Worker-safe public read for durable follow-up grounding. */
@@ -118,7 +164,11 @@ export function sharedPublicWebGrounding(
             query: data.query,
             provider: data.provider,
             text: record.text,
-            observedAt,
+            observedAt:
+              typeof data.observedAt === "number" && Number.isSafeInteger(data.observedAt)
+                ? data.observedAt
+                : observedAt,
+            sourceUrls: data.sourceUrls,
             truncated: data.truncated === true,
           })
         : parseSharedPublicWebGrounding({

--- a/plugins/plugin-web-search/src/edge.test.ts
+++ b/plugins/plugin-web-search/src/edge.test.ts
@@ -2,7 +2,12 @@
 
 import type { IAgentRuntime, Memory } from "@elizaos/core/edge";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { webSearchEdgeAction, webSearchEdgePlugin } from "./edge";
+import {
+    runWebSearchEdge,
+    webSearchEdgeAction,
+    webSearchEdgePlugin,
+    webSearchSourceUrls,
+} from "./edge";
 
 const ORIGINAL_FETCH = globalThis.fetch;
 
@@ -22,7 +27,19 @@ describe("webSearchEdgePlugin", () => {
                 jsonrpc: "2.0",
                 id: 1,
                 result: {
-                    content: [{ type: "text", text: "Current public result" }],
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({
+                                results: [
+                                    {
+                                        url: "https://example.com/current",
+                                        title: "Current public result",
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
                 },
             })
         ) as typeof fetch;
@@ -36,11 +53,47 @@ describe("webSearchEdgePlugin", () => {
 
         expect(result).toMatchObject({
             success: true,
-            text: "Current public result",
             data: {
                 actionName: "WEB_SEARCH",
                 provider: "parallel",
                 query: "current public result",
+                observedAt: expect.any(Number),
+                sourceUrls: ["https://example.com/current"],
+            },
+        });
+    });
+
+    it("extracts structured and prose source URLs without accepting credentials", () => {
+        expect(
+            webSearchSourceUrls(
+                `${JSON.stringify({ results: [{ url: "https://example.com/a" }] })}\n` +
+                    "Source: https://news.example.org/story). Ignore https://u:p@example.net/private"
+            )
+        ).toEqual(["https://example.com/a", "https://news.example.org/story"]);
+    });
+
+    it("exposes the same traceable receipt through the direct edge runner", async () => {
+        globalThis.fetch = vi.fn(async () =>
+            Response.json({
+                jsonrpc: "2.0",
+                id: 1,
+                result: {
+                    content: [
+                        {
+                            type: "text",
+                            text: '{"results":[{"url":"https://weather.example/current"}]}',
+                        },
+                    ],
+                },
+            })
+        ) as typeof fetch;
+
+        await expect(runWebSearchEdge("weather now")).resolves.toMatchObject({
+            success: true,
+            data: {
+                actionName: "WEB_SEARCH",
+                query: "weather now",
+                sourceUrls: ["https://weather.example/current"],
             },
         });
     });

--- a/plugins/plugin-web-search/src/edge.ts
+++ b/plugins/plugin-web-search/src/edge.ts
@@ -45,6 +45,44 @@ function readResultCount(parameters: Record<string, unknown>): number | undefine
     return Number.isFinite(parsed) && parsed > 0 ? Math.min(10, Math.floor(parsed)) : undefined;
 }
 
+/** Extracts traceable public HTTP sources without interpreting provider prose. */
+export function webSearchSourceUrls(text: string): string[] {
+    const urls = new Set<string>();
+    const add = (value: unknown): void => {
+        if (typeof value !== "string") return;
+        try {
+            const parsed = new URL(value.replace(/[),.;]+$/u, ""));
+            if (
+                (parsed.protocol === "https:" || parsed.protocol === "http:") &&
+                !parsed.username &&
+                !parsed.password
+            ) {
+                urls.add(parsed.toString());
+            }
+        } catch {
+            // error-policy:J3 malformed provider URLs are explicit non-sources.
+        }
+    };
+    const visit = (value: unknown): void => {
+        if (Array.isArray(value)) {
+            for (const item of value) visit(item);
+            return;
+        }
+        if (!value || typeof value !== "object") return;
+        for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+            if (key === "url" || key === "source_url" || key === "sourceUrl") add(item);
+            visit(item);
+        }
+    };
+    try {
+        visit(JSON.parse(text));
+    } catch {
+        // error-policy:J3 non-JSON providers fall through to URL extraction.
+    }
+    for (const match of text.matchAll(/https?:\/\/[^\s<>"']+/gu)) add(match[0]);
+    return [...urls];
+}
+
 async function fail(
     text: string,
     callback?: HandlerCallback,
@@ -59,59 +97,94 @@ async function fail(
     };
 }
 
-export const webSearchEdgeAction: Action = {
-    name: "WEB_SEARCH",
-    similes: ["SEARCH_WEB", "WEB_QUERY", "FIND_ONLINE", "SEARCH_INTERNET"],
-    tags: ["resource:web", "capability:read"],
-    contexts: ["general"],
-    roleGate: { minRole: "GUEST" },
-    description:
-        "Search the current public web for facts, news, recommendations, products, places, or other information that may have changed. Returns bounded source results for Eliza to answer from. This does not control a browser or access private accounts.",
-    parameters: [
-        {
-            name: "query",
-            description: "Specific public-web search query.",
-            required: true,
-            schema: { type: "string" },
+/** Runs the same public-read implementation used by the registered action. */
+export async function runWebSearchEdge(
+    query: string,
+    options: { numResults?: number } = {}
+): Promise<ActionResult> {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) return await fail("A web search query is required.");
+    const observedAt = Date.now();
+    const result = await searchKeylessWeb(normalizedQuery, {
+        resultCount: options.numResults,
+    });
+    if (!result) {
+        return await fail("Web search is temporarily unavailable.", undefined, normalizedQuery);
+    }
+    return {
+        success: true,
+        text: result.text,
+        data: {
+            actionName: "WEB_SEARCH",
+            query: normalizedQuery,
+            provider: result.provider,
+            observedAt,
+            sourceUrls: webSearchSourceUrls(result.text),
+            truncated: result.truncated,
+            value: result.text,
         },
-        {
-            name: "numResults",
-            description: "Optional result count, from 1 through 10.",
-            required: false,
-            schema: { type: "number" },
-        },
-    ],
-    validate: async () => true,
-    handler: async (
-        _runtime: IAgentRuntime,
-        _message: Memory,
-        _state?: State,
-        options?: unknown,
-        callback?: HandlerCallback
-    ): Promise<ActionResult> => {
-        const parameters = readParameters(options);
-        const query = readQuery(parameters);
-        if (!query) return await fail("A web search query is required.", callback);
+    };
+}
 
-        const result = await searchKeylessWeb(query, {
-            resultCount: readResultCount(parameters),
-        });
-        if (!result) {
-            return await fail("Web search is temporarily unavailable.", callback, query);
-        }
-        return {
-            success: true,
-            text: result.text,
-            data: {
-                actionName: "WEB_SEARCH",
-                query,
-                provider: result.provider,
-                truncated: result.truncated,
-                value: result.text,
+export type WebSearchEdgeRunner = (
+    query: string,
+    options?: { numResults?: number }
+) => Promise<ActionResult>;
+
+function createWebSearchEdgeAction(runner: WebSearchEdgeRunner): Action {
+    return {
+        name: "WEB_SEARCH",
+        similes: ["SEARCH_WEB", "WEB_QUERY", "FIND_ONLINE", "SEARCH_INTERNET"],
+        tags: ["resource:web", "capability:read"],
+        contexts: ["general"],
+        roleGate: { minRole: "GUEST" },
+        description:
+            "Search the current public web for facts, news, recommendations, products, places, or other information that may have changed. Returns bounded source results for Eliza to answer from. This does not control a browser or access private accounts.",
+        parameters: [
+            {
+                name: "query",
+                description: "Specific public-web search query.",
+                required: true,
+                schema: { type: "string" },
             },
-        };
-    },
-};
+            {
+                name: "numResults",
+                description: "Optional result count, from 1 through 10.",
+                required: false,
+                schema: { type: "number" },
+            },
+        ],
+        validate: async () => true,
+        handler: async (
+            _runtime: IAgentRuntime,
+            _message: Memory,
+            _state?: State,
+            options?: unknown,
+            callback?: HandlerCallback
+        ): Promise<ActionResult> => {
+            const parameters = readParameters(options);
+            const query = readQuery(parameters);
+            if (!query) return await fail("A web search query is required.", callback);
+
+            const result = await runner(query, {
+                numResults: readResultCount(parameters),
+            });
+            await callback?.({ text: result.text ?? "Web search is temporarily unavailable." });
+            return result;
+        },
+    };
+}
+
+export const webSearchEdgeAction: Action = createWebSearchEdgeAction(runWebSearchEdge);
+
+/** Creates an edge plugin whose runner may reuse a server-owned read receipt. */
+export function createWebSearchEdgePlugin(runner: WebSearchEdgeRunner = runWebSearchEdge): Plugin {
+    return {
+        name: "web-search-edge",
+        description: "Credential-free, public, read-only web search for edge runtimes.",
+        actions: [createWebSearchEdgeAction(runner)],
+    };
+}
 
 export const webSearchEdgePlugin: Plugin = {
     name: "web-search-edge",


### PR DESCRIPTION
## Incident

The staging Telegram Personal Shared agent answered a current BTC-price question with an invented value and TradingView attribution, later claimed untraceable search/article results, and degraded to punctuation-only replies after correction. The redacted acceptance transcript is retained as a fixture.

## Fix

- classify time-sensitive market, weather, news, sports, mutable-fact, and explicit-verification requests
- preflight a server-owned live public lookup and retain provider, checked time, and supporting source URLs
- require current-data replies to select an exact URL from the live receipt
- reject novel numbers, currency, URLs, and named attribution not present in the receipt
- fail closed when live verification is unavailable and recover usefully after correction
- buffer Telegram streaming until validation, then render a concise source/provider/timestamp line
- prevent duplicate external search calls while retaining one auditable action receipt

## Exact current candidate

- head: 8256364623c3b94a5111773d2e4fc8804a262e9e
- base: e40d0ae27296741bf75f663235cb4633d07b9d28
- tag: shared-agent-realtime-grounding-v4-20260822
- clean single-commit rebase; upstream scenario/core changes did not overlap this patch

## Proof

- focused grounding and edge receipt suites: 22 tests, 55 expectations, 0 failures
- adjacent history/error/memory/recall suites: 28 tests, 74 expectations, 0 failures
- genuine Shared Workerd runtime suite: 26 tests, 167 expectations, 0 failures
- Cloud Shared and web-search plugin typechecks green
- Biome clean across all 11 changed files; git diff check clean
- core build green: 59/59 tasks

## Staging

This is intentionally not deployed before normal review and merge. After merge, serialize one successor staging release, require matching Worker + Pages + routing source proof, align Railway gateway-webhook to that exact source, then run the approved bounded Telegram factual-grounding regression and remaining provider acceptance.

@lalalune please review the runtime/tool-receipt boundary and staging successor plan.