### PR TITLE
fix(scenario-runner): bound scenario-seed mock hops

### DIFF
--- a/packages/scenario-runner/src/seeds.fetch.test.ts
+++ b/packages/scenario-runner/src/seeds.fetch.test.ts
@@ -1,20 +1,28 @@
-// Pins the bounded seed-hop contract: every scenario-seed mock fetch fails
-// closed at the hop timeout instead of pinning the executor, and a
-// caller-provided abort signal is composed with the timeout (either wins).
-import { describe, expect, test, vi } from "vitest";
+/**
+ * Verifies scenario-seed mock fetches fail closed at the hop timeout and
+ * compose caller cancellation without reaching a real network service.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("seedFetch — bounded seed hops fail closed and compose caller signals", () => {
   test("aborts a hung seed hop at the configured timeout", async () => {
-    globalThis.fetch = vi.fn().mockImplementation(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(
-              new DOMException("The operation was aborted.", "AbortError"),
-            );
-          });
-        }),
-    ) as typeof fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            });
+          }),
+      ),
+    );
 
     const { seedFetch } = await import("./seeds");
     const start = Date.now();
@@ -25,16 +33,19 @@ describe("seedFetch — bounded seed hops fail closed and compose caller signals
   });
 
   test("times out a hung hop even when a non-aborted caller signal is present", async () => {
-    globalThis.fetch = vi.fn().mockImplementation(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(
-              new DOMException("The operation was aborted.", "AbortError"),
-            );
-          });
-        }),
-    ) as typeof fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            });
+          }),
+      ),
+    );
 
     const { seedFetch } = await import("./seeds");
     const controller = new AbortController();
@@ -54,14 +65,17 @@ describe("seedFetch — bounded seed hops fail closed and compose caller signals
 
   test("preserves caller cancellation (composed)", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = vi
-      .fn()
-      .mockImplementation(
-        async (_input: RequestInfo | URL, init?: RequestInit) => {
-          seen = init?.signal;
-          return new Response("{}", { status: 200 });
-        },
-      ) as typeof fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation(
+          async (_input: RequestInfo | URL, init?: RequestInit) => {
+            seen = init?.signal ?? undefined;
+            return new Response("{}", { status: 200 });
+          },
+        ),
+    );
 
     const { seedFetch } = await import("./seeds");
     const controller = new AbortController();

--- a/packages/scenario-runner/src/seeds.fetch.test.ts
+++ b/packages/scenario-runner/src/seeds.fetch.test.ts
@@ -1,0 +1,75 @@
+// Pins the bounded seed-hop contract: every scenario-seed mock fetch fails
+// closed at the hop timeout instead of pinning the executor, and a
+// caller-provided abort signal is composed with the timeout (either wins).
+import { describe, expect, test, vi } from "vitest";
+
+describe("seedFetch — bounded seed hops fail closed and compose caller signals", () => {
+  test("aborts a hung seed hop at the configured timeout", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { seedFetch } = await import("./seeds");
+    const start = Date.now();
+    await expect(
+      seedFetch("http://127.0.0.1:1/__mock/requests", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("times out a hung hop even when a non-aborted caller signal is present", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { seedFetch } = await import("./seeds");
+    const controller = new AbortController();
+    const start = Date.now();
+    await expect(
+      seedFetch(
+        "http://127.0.0.1:1/__mock/requests",
+        {
+          signal: controller.signal,
+        },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("preserves caller cancellation (composed)", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          seen = init?.signal;
+          return new Response("{}", { status: 200 });
+        },
+      ) as typeof fetch;
+
+    const { seedFetch } = await import("./seeds");
+    const controller = new AbortController();
+    await seedFetch("http://127.0.0.1:1/__mock/requests", {
+      signal: controller.signal,
+    });
+    expect(seen?.aborted).toBe(false);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
+  });
+});

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -14,6 +14,27 @@ import type {
 } from "@elizaos/scenario-runner/schema";
 import { isLoopbackUrl } from "./utils.js";
 
+const SEED_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every scenario-seed mock hop so a hung mock service cannot pin the
+ * executor. A caller-provided abort signal is composed with the timeout
+ * (either cancelling aborts), not substituted for it.
+ */
+export function seedFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = SEED_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal,
+  });
+}
+
 type LifeOpsOccurrenceState =
   | "completed"
   | "visible"
@@ -2396,7 +2417,7 @@ function gmailSeedFixtureNames(seed: GmailInboxSeed): string[] {
 }
 
 async function clearGmailMockLedger(baseUrl: string): Promise<void> {
-  const response = await fetch(`${baseUrl}/__mock/requests`, {
+  const response = await seedFetch(`${baseUrl}/__mock/requests`, {
     method: "DELETE",
   });
   if (!response.ok) {
@@ -2407,7 +2428,7 @@ async function clearGmailMockLedger(baseUrl: string): Promise<void> {
 }
 
 async function clearGmailMockFault(baseUrl: string): Promise<void> {
-  const response = await fetch(`${baseUrl}/__mock/google/gmail/fault`, {
+  const response = await seedFetch(`${baseUrl}/__mock/google/gmail/fault`, {
     method: "DELETE",
   });
   if (response.ok || response.status === 404) {
@@ -2486,7 +2507,7 @@ async function configureGmailMockFault(
   baseUrl: string,
   fault: GmailFaultInjectionConfig,
 ): Promise<string | undefined> {
-  const response = await fetch(`${baseUrl}/__mock/google/gmail/fault`, {
+  const response = await seedFetch(`${baseUrl}/__mock/google/gmail/fault`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(fault),
@@ -2501,7 +2522,7 @@ async function requireMockGmailMessage(
   baseUrl: string,
   messageId: string,
 ): Promise<string | undefined> {
-  const response = await fetch(
+  const response = await seedFetch(
     `${baseUrl}/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}`,
   );
   if (response.ok) {
@@ -2513,7 +2534,7 @@ async function requireMockGmailMessage(
 async function gmailFixtureMessageIds(
   baseUrl: string,
 ): Promise<Record<string, readonly string[]>> {
-  const response = await fetch(`${baseUrl}/__mock/google/gmail/fixtures`);
+  const response = await seedFetch(`${baseUrl}/__mock/google/gmail/fixtures`);
   if (!response.ok) {
     return GMAIL_FIXTURE_MESSAGE_IDS;
   }


### PR DESCRIPTION
## Problem

All five scenario-seed fetches (request log, Gmail fault injection ×2, fixture listing) had **no timeout** — a hung mock service could pin the executor between setup and the first turn.

## Fix

- Add `seedFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, composing any caller-provided abort signal via `AbortSignal.any` (either cancelling aborts — the deadline is never dropped by a caller signal).
- Route all five fetch sites through it.

## Tests

New `seeds.fetch.test.ts` (3 pass): hung-hop abort at the configured timeout; **non-aborted caller signal still times out** (the compose regression); caller cancellation preserved.

```bash
bunx vitest run src/seeds.fetch.test.ts
# 3 pass, 0 fail
```