### PR TITLE
fix(scenario-runner): bound executor lifeops/Google-mock hops

### DIFF
--- a/packages/scenario-runner/src/executor.fetch.test.ts
+++ b/packages/scenario-runner/src/executor.fetch.test.ts
@@ -1,19 +1,28 @@
-// Pins the bounded executor-hop contract: lifeops API + Google mock fetches
-// fail closed at the hop timeout, composing a caller signal with the deadline.
-import { describe, expect, test, vi } from "vitest";
+/**
+ * Verifies lifeops and Google-mock executor fetches fail closed at their hop
+ * timeout and compose caller cancellation without reaching a real service.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("executorFetch — bounded executor hops fail closed and compose caller signals", () => {
   test("aborts a hung executor hop at the configured timeout", async () => {
-    globalThis.fetch = vi.fn().mockImplementation(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(
-              new DOMException("The operation was aborted.", "AbortError"),
-            );
-          });
-        }),
-    ) as typeof fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            });
+          }),
+      ),
+    );
 
     const { executorFetch } = await import("./executor");
     const start = Date.now();
@@ -28,16 +37,19 @@ describe("executorFetch — bounded executor hops fail closed and compose caller
   });
 
   test("times out a hung hop even when a non-aborted caller signal is present", async () => {
-    globalThis.fetch = vi.fn().mockImplementation(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(
-              new DOMException("The operation was aborted.", "AbortError"),
-            );
-          });
-        }),
-    ) as typeof fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            });
+          }),
+      ),
+    );
 
     const { executorFetch } = await import("./executor");
     const controller = new AbortController();
@@ -57,14 +69,17 @@ describe("executorFetch — bounded executor hops fail closed and compose caller
 
   test("preserves caller cancellation (composed)", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = vi
-      .fn()
-      .mockImplementation(
-        async (_input: RequestInfo | URL, init?: RequestInit) => {
-          seen = init?.signal;
-          return new Response("{}", { status: 200 });
-        },
-      ) as typeof fetch;
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation(
+          async (_input: RequestInfo | URL, init?: RequestInit) => {
+            seen = init?.signal ?? undefined;
+            return new Response("{}", { status: 200 });
+          },
+        ),
+    );
 
     const { executorFetch } = await import("./executor");
     const controller = new AbortController();

--- a/packages/scenario-runner/src/executor.fetch.test.ts
+++ b/packages/scenario-runner/src/executor.fetch.test.ts
@@ -1,0 +1,78 @@
+// Pins the bounded executor-hop contract: lifeops API + Google mock fetches
+// fail closed at the hop timeout, composing a caller signal with the deadline.
+import { describe, expect, test, vi } from "vitest";
+
+describe("executorFetch — bounded executor hops fail closed and compose caller signals", () => {
+  test("aborts a hung executor hop at the configured timeout", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { executorFetch } = await import("./executor");
+    const start = Date.now();
+    await expect(
+      executorFetch(
+        "http://127.0.0.1:1/api/lifeops/definitions",
+        undefined,
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("times out a hung hop even when a non-aborted caller signal is present", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { executorFetch } = await import("./executor");
+    const controller = new AbortController();
+    const start = Date.now();
+    await expect(
+      executorFetch(
+        "http://127.0.0.1:1/api/lifeops/definitions",
+        {
+          signal: controller.signal,
+        },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("preserves caller cancellation (composed)", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          seen = init?.signal;
+          return new Response("{}", { status: 200 });
+        },
+      ) as typeof fetch;
+
+    const { executorFetch } = await import("./executor");
+    const controller = new AbortController();
+    await executorFetch("http://127.0.0.1:1/api/lifeops/definitions", {
+      signal: controller.signal,
+    });
+    expect(seen?.aborted).toBe(false);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
+  });
+});

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -72,6 +72,7 @@ import type {
   ScenarioReport,
 } from "./types.ts";
 import { isLoopbackUrl, toRecord } from "./utils.js";
+import { executeVoiceTurn, voiceTurnAssertionFailures } from "./voice-turn.ts";
 
 const EXECUTOR_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -93,8 +94,6 @@ export function executorFetch(
       : timeoutSignal,
   });
 }
-
-import { executeVoiceTurn, voiceTurnAssertionFailures } from "./voice-turn.ts";
 
 export interface ExecutorOptions {
   providerName: string;

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -72,6 +72,28 @@ import type {
   ScenarioReport,
 } from "./types.ts";
 import { isLoopbackUrl, toRecord } from "./utils.js";
+
+const EXECUTOR_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every executor hop (lifeops API + Google mock) so a hung service
+ * cannot pin a scenario run. A caller-provided abort signal is composed with
+ * the timeout (either cancelling aborts), not substituted for it.
+ */
+export function executorFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = EXECUTOR_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal,
+  });
+}
+
 import { executeVoiceTurn, voiceTurnAssertionFailures } from "./voice-turn.ts";
 
 export interface ExecutorOptions {
@@ -1139,7 +1161,7 @@ async function lookupDefinitionIdByTitle(args: {
   if (cached) {
     return cached;
   }
-  const response = await fetch(
+  const response = await executorFetch(
     `${args.apiServer.baseUrl}/api/lifeops/definitions`,
   );
   const body = await response.json();
@@ -1172,7 +1194,7 @@ async function lookupOccurrenceIdByTitle(args: {
   if (cached) {
     return cached;
   }
-  const response = await fetch(
+  const response = await executorFetch(
     `${args.apiServer.baseUrl}/api/lifeops/overview`,
   );
   const body = await response.json();
@@ -1451,7 +1473,7 @@ async function deleteMockGmailDrafts(): Promise<string | undefined> {
   if (!isLoopbackUrl(baseUrl)) {
     return "gmailDeleteDrafts cleanup requires ELIZA_MOCK_GOOGLE_BASE to point at the loopback Google mock";
   }
-  const response = await fetch(`${baseUrl}/gmail/v1/users/me/drafts`);
+  const response = await executorFetch(`${baseUrl}/gmail/v1/users/me/drafts`);
   if (!response.ok) {
     return `gmailDeleteDrafts list failed with HTTP ${response.status}`;
   }
@@ -1465,7 +1487,7 @@ async function deleteMockGmailDrafts(): Promise<string | undefined> {
     if (typeof id !== "string" || id.length === 0) {
       continue;
     }
-    const deleteResponse = await fetch(
+    const deleteResponse = await executorFetch(
       `${baseUrl}/gmail/v1/users/me/drafts/${encodeURIComponent(id)}`,
       { method: "DELETE" },
     );


### PR DESCRIPTION
## Problem

The executor's lifeops-definitions and Gmail mock fetches had **no timeout** — a hung service could pin a scenario run indefinitely.

## Fix

- Add `executorFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, composing any caller-provided abort signal via `AbortSignal.any` (either cancelling aborts).
- Route the four unbounded fetch sites through it (the turn-scoped `api()` hop keeps its existing `withTimeout` wrapper).

## Tests

New `executor.fetch.test.ts` (3 pass): hung-hop abort; **non-aborted caller signal still times out** (compose regression); caller cancellation preserved.

```bash
bunx vitest run src/executor.fetch.test.ts
# 3 pass, 0 fail
```