### PR TITLE
fix(cloud): bound Blooio adapter API hops

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
@@ -1,0 +1,74 @@
+// Pins the bounded Blooio adapter contract: every API hop fails closed at the
+// hop timeout, composing a caller signal with the deadline (either wins).
+import { describe, expect, test, vi } from "vitest";
+
+describe("blooioFetch — bounded Blooio hops fail closed and compose caller signals", () => {
+  test("aborts a hung Blooio hop at the configured timeout", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { blooioFetch } = await import("./blooio");
+    const start = Date.now();
+    await expect(
+      blooioFetch("https://api.blooio.com/v4/messages", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("times out a hung hop even when a non-aborted caller signal is present", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { blooioFetch } = await import("./blooio");
+    const controller = new AbortController();
+    const start = Date.now();
+    await expect(
+      blooioFetch(
+        "https://api.blooio.com/v4/messages",
+        {
+          signal: controller.signal,
+        },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("preserves caller cancellation (composed)", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          seen = init?.signal;
+          return new Response("{}", { status: 200 });
+        },
+      ) as typeof fetch;
+
+    const { blooioFetch } = await import("./blooio");
+    const controller = new AbortController();
+    await blooioFetch("https://api.blooio.com/v4/messages", {
+      signal: controller.signal,
+    });
+    expect(seen?.aborted).toBe(false);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
@@ -1,6 +1,15 @@
-// Pins the bounded Blooio adapter contract: every API hop fails closed at the
-// hop timeout, composing a caller signal with the deadline (either wins).
-import { describe, expect, test, vi } from "vitest";
+/**
+ * Pins the bounded Blooio adapter contract with a stubbed global fetch: every
+ * API hop fails closed at its hop timeout, and a caller signal is composed with
+ * that deadline so whichever aborts first cancels the request.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("blooioFetch — bounded Blooio hops fail closed and compose caller signals", () => {
   test("aborts a hung Blooio hop at the configured timeout", async () => {
@@ -13,7 +22,7 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
             );
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const { blooioFetch } = await import("./blooio");
     const start = Date.now();
@@ -33,7 +42,7 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
             );
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const { blooioFetch } = await import("./blooio");
     const controller = new AbortController();
@@ -57,10 +66,10 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
       .fn()
       .mockImplementation(
         async (_input: RequestInfo | URL, init?: RequestInit) => {
-          seen = init?.signal;
+          seen = init?.signal ?? undefined;
           return new Response("{}", { status: 200 });
         },
-      ) as typeof fetch;
+      ) as unknown as typeof fetch;
 
     const { blooioFetch } = await import("./blooio");
     const controller = new AbortController();

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -7,6 +7,27 @@ import { z } from "zod";
 import { logger } from "../logger";
 import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 
+const BLOOIO_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Blooio API hop so a hung gateway cannot pin the adapter. A
+ * caller-provided abort signal is composed with the timeout (either cancelling
+ * aborts), not substituted for it.
+ */
+export function blooioFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = BLOOIO_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal,
+  });
+}
+
 const BLOOIO_V2_API_BASE = "https://api.blooio.com/v2/api";
 const BLOOIO_V4_MESSAGES_URL = "https://api.blooio.com/v4/messages";
 const BLOOIO_V4_CHATS_URL = "https://api.blooio.com/v4/chats";
@@ -174,7 +195,7 @@ async function sendBlooioMessage(
     if (from) body.from = from;
   }
 
-  const response = await fetch(url, {
+  const response = await blooioFetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -391,8 +412,8 @@ export const blooioAdapter: PlatformAdapter = {
       if (/^chat_/i.test(event.chatId)) {
         const chatBase = `${BLOOIO_V4_CHATS_URL}/${encodeURIComponent(event.chatId)}`;
         const [read, typing] = await Promise.all([
-          fetch(`${chatBase}/read`, { method: "POST", headers }),
-          fetch(`${chatBase}/typing`, {
+          blooioFetch(`${chatBase}/read`, { method: "POST", headers }),
+          blooioFetch(`${chatBase}/typing`, {
             method: "POST",
             headers,
             body: JSON.stringify({ state: "started" }),
@@ -407,7 +428,7 @@ export const blooioAdapter: PlatformAdapter = {
       } else {
         const url = `${BLOOIO_V2_API_BASE}/chats/${encodeURIComponent(event.chatId)}/read`;
         if (config.fromNumber) headers["X-From-Number"] = config.fromNumber;
-        const response = await fetch(url, { method: "POST", headers });
+        const response = await blooioFetch(url, { method: "POST", headers });
         if (!response.ok) {
           throw new BlooioApiResponseError(
             response.status,
@@ -428,7 +449,7 @@ export const blooioAdapter: PlatformAdapter = {
   async stopTypingIndicator(config, event): Promise<void> {
     if (!config.apiKey || !/^chat_/i.test(event.chatId)) return;
     try {
-      const response = await fetch(
+      const response = await blooioFetch(
         `${BLOOIO_V4_CHATS_URL}/${encodeURIComponent(event.chatId)}/typing`,
         {
           method: "DELETE",


### PR DESCRIPTION
## Problem

All five Blooio fetches (send message, chat read/typing, stop typing) had **no timeout** — a hung gateway could pin the webhook adapter indefinitely.

## Fix

- Add `blooioFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, composing any caller-provided abort signal via `AbortSignal.any` (either cancelling aborts).
- Route all five fetch sites through it.

## Tests

New `blooio.fetch.test.ts` (3 pass): hung-hop abort; **non-aborted caller signal still times out** (compose regression); caller cancellation preserved.

```bash
bun test --isolate src/adapters/blooio.fetch.test.ts
# 3 pass, 0 fail
```