### PR TITLE
fix(agent): validate connector metadata before provider effects

### DIFF
--- a/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
+++ b/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
@@ -14,12 +14,14 @@
  * side fails the same way on an adapter-supplied audit row, whose `metadata`
  * column no layer between the row and the redaction walk bounds.
  *
- * These tests pin the bounded behaviour: an over-budget write is rejected with
- * a 400, an over-budget stored value is still served with an explicit marker,
- * and honest nested metadata is untouched.
+ * These tests pin both bounded layers: route-walk failures and the stricter
+ * connector-storage projection are rejected with a 400 before provider
+ * callbacks run, an over-budget stored value is served with an explicit
+ * marker, and honest nested metadata is untouched.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  type ConnectorAccountPatch,
   getConnectorAccountManager,
   InMemoryDatabaseAdapter,
 } from "@elizaos/core";
@@ -36,6 +38,10 @@ const ACCOUNT_ID = "3a899cd0-170f-4b3e-932e-46ec68119b35";
 
 /** Comfortably past the V8 recursion limit for these frames. */
 const OVERFLOW_DEPTH = 60_000;
+/** One level beyond the connector-storage depth accepted by core. */
+const STORAGE_OVERFLOW_DEPTH = 17;
+/** Wide enough to exceed core's storage-node budget but not the route budget. */
+const STORAGE_OVERFLOW_WIDTH = 2_100;
 
 function deepChain(depth: number): Record<string, unknown> {
   const root: Record<string, unknown> = {};
@@ -47,6 +53,12 @@ function deepChain(depth: number): Record<string, unknown> {
   }
   cursor.leaf = "end";
   return root;
+}
+
+function wideObject(width: number): Record<string, unknown> {
+  return Object.fromEntries(
+    Array.from({ length: width }, (_, index) => [`field_${index}`, index]),
+  );
 }
 
 function createRuntime(adapter?: InMemoryDatabaseAdapter) {
@@ -100,6 +112,65 @@ async function newAdapter(): Promise<InMemoryDatabaseAdapter> {
 }
 
 describe("connector account metadata walk bounds (real route handler)", () => {
+  it("rejects storage-over-deep POST metadata before a provider create side effect", async () => {
+    const runtime = createRuntime(await newAdapter());
+    const manager = getConnectorAccountManager(runtime as never);
+    const createAccount = vi.fn(async (input: ConnectorAccountPatch) => input);
+    manager.registerProvider({ provider: PROVIDER, createAccount });
+    const pathname = `/api/connectors/${PROVIDER}/accounts`;
+    const { ctx, captured } = createContext(runtime, "POST", pathname, {
+      label: "deep-for-storage",
+      metadata: { root: deepChain(STORAGE_OVERFLOW_DEPTH) },
+    });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(createAccount).not.toHaveBeenCalled();
+  });
+
+  it("rejects storage-over-wide PATCH metadata before a provider patch side effect", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    await manager.upsertAccount(PROVIDER, {
+      id: ACCOUNT_ID,
+      provider: PROVIDER,
+      label: "user@example.com",
+      role: "OWNER",
+      accessGate: "open",
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: {},
+    } as never);
+    const patchAccount = vi.fn(
+      async (_accountId: string, patch: ConnectorAccountPatch) => patch,
+    );
+    manager.registerProvider({ provider: PROVIDER, patchAccount });
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${ACCOUNT_ID}`;
+    const { ctx, captured } = createContext(runtime, "PATCH", pathname, {
+      metadata: wideObject(STORAGE_OVERFLOW_WIDTH),
+    });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(patchAccount).not.toHaveBeenCalled();
+  });
+
   it("rejects an over-deep POST body with a 400 instead of escaping the handler", async () => {
     const runtime = createRuntime(await newAdapter());
     const pathname = `/api/connectors/${PROVIDER}/accounts`;

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -12,12 +12,15 @@
  */
 import type http from "node:http";
 import {
+  CONNECTOR_JSON_UNBOUNDED,
   type ConnectorAccount,
+  type ConnectorAccountJsonObject,
   type ConnectorAccountPatch,
   type ConnectorAccountPurpose,
   type ConnectorAccountRole,
   type ConnectorAccountStatus,
   type ConnectorOAuthFlow,
+  cloneConnectorJsonObject,
   DEFAULT_PRIVACY_LEVEL,
   ElizaError,
   getConnectorAccountManager,
@@ -364,8 +367,28 @@ function cleanMetadata(value: unknown): Metadata | undefined {
 
 function isUnboundedMetadataGraph(error: unknown): boolean {
   return (
-    error instanceof ElizaError && error.code === BLOCKED_OBJECT_GRAPH_UNBOUNDED
+    error instanceof ElizaError &&
+    (error.code === BLOCKED_OBJECT_GRAPH_UNBOUNDED ||
+      error.code === CONNECTOR_JSON_UNBOUNDED)
   );
+}
+
+/**
+ * Validate sanitized metadata against the stricter durable-storage projection
+ * before the manager can invoke a registered provider callback. The route
+ * walker intentionally has a looser budget, so relying on the adapter alone
+ * would allow a provider side effect before persistence rejects the patch.
+ */
+function validatePatchMetadataForStorage(
+  patch: ConnectorAccountPatch,
+): ConnectorAccountPatch {
+  if (patch.metadata === undefined) return patch;
+  return {
+    ...patch,
+    metadata: cloneConnectorJsonObject(
+      patch.metadata as ConnectorAccountJsonObject,
+    ),
+  };
 }
 
 function redactAuditMetadata(value: unknown): unknown {
@@ -758,12 +781,13 @@ export async function handleConnectorAccountRoutes(
       }
       let createPatch: ConnectorAccountPatch;
       try {
-        createPatch = accountPatchFromBody(parsed.data);
+        createPatch = validatePatchMetadataForStorage(
+          accountPatchFromBody(parsed.data),
+        );
       } catch (err) {
-        // error-policy:J1 route boundary — an over-budget caller body becomes a
-        // 400 rather than escaping the handler with no response written. Any
-        // other error is rethrown, so this narrows one shape rather than
-        // swallowing the class.
+        // error-policy:J1 route boundary — an over-budget caller body at either
+        // the route-walk or durable-storage budget becomes a 400 before any
+        // provider callback. Every other error is rethrown.
         if (!isUnboundedMetadataGraph(err)) throw err;
         error(res, UNBOUNDED_METADATA_MESSAGE, 400);
         return true;
@@ -812,11 +836,12 @@ export async function handleConnectorAccountRoutes(
         }
         let patch: ConnectorAccountPatch;
         try {
-          patch = accountPatchFromBody(parsed.data, existing.metadata);
+          patch = validatePatchMetadataForStorage(
+            accountPatchFromBody(parsed.data, existing.metadata),
+          );
         } catch (err) {
-          // error-policy:J1 route boundary — same translation as the POST path
-          // above; an over-budget patch body becomes a 400 and every other
-          // error is rethrown.
+          // error-policy:J1 route boundary — same pre-provider translation as
+          // the POST path above; every unrelated failure is rethrown.
           if (!isUnboundedMetadataGraph(err)) throw err;
           error(res, UNBOUNDED_METADATA_MESSAGE, 400);
           return true;


### PR DESCRIPTION
Clean restack of #24301 on current `develop`, preserving the contributor-authored patch and attribution after GitHub refused a maintainer update to the fork branch because its old history crosses a workflow file.

Closes the remaining provider-effect ordering gap in #23805: final sanitized/merged connector metadata is validated against the durable connector JSON bounds before any registered provider create/patch callback. Only typed bounded-graph failures translate to HTTP 400; unrelated provider/database failures propagate.

Verification at `5ac20953288a2e090dd86b060f75d92e61f96284`:
- focused real-handler/manager tests: 8/8 pass;
- changed-file Biome: pass;
- package build: pass;
- `git diff --check`: pass;
- independent review: source-go, stable patch identical to #24301.

Package typecheck reaches current-tree optional/generated plugin declaration gaps and unrelated existing typing; neither changed file is named. Hosted exact-head CI remains required.

<!-- evidence-head:5ac20953288a2e090dd86b060f75d92e61f96284 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only validation boundary.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only validation boundary.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered flow.
<!-- evidence-row:backend-logs -->
- [x] Focused real route/manager tests prove provider callbacks are not invoked for rejected metadata.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] In-memory durable account rows and provider callback spies inspected in focused tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual content.
