### PR TITLE
fix(cloud): narrow llm_first_text frame in voice ws-lifecycle test

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1075,18 +1075,20 @@ describe("voice-session WS lifecycle", () => {
     await flush();
 
     const firstText = client.controlFrames.find(
-      (frame) => frame.t === "llm_first_text",
+      (frame): frame is Extract<ServerControlFrame, { t: "llm_first_text" }> =>
+        frame.t === "llm_first_text",
     );
     const navigation = client.controlFrames.filter(
       (frame) => frame.t === "navigate_view",
     );
     expect(firstText).toBeDefined();
+    if (!firstText) throw new Error("expected an llm_first_text control frame");
     expect(navigation).toEqual([
       {
         t: "navigate_view",
         viewId: "browser",
         viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
-        traceId: firstText?.traceId,
+        traceId: firstText.traceId,
       },
     ]);
   });


### PR DESCRIPTION
@lalalune — unblocks the staging deploy train; PR CI is dead so this carries local receipts.

## What

#24376's new app-launch handoff test reads `traceId` off an un-narrowed `ServerControlFrame` union (`find` without a type guard), which fails `packages/cloud/api` typecheck:

```
v1/voice/session/__tests__/ws-lifecycle.test.ts(1089,9): error TS2769: No overload matches this call.
```

Every staging train since it merged fails at `Deploy API Worker` on this (latest: run 32560462635). Test-only change: narrow the `find` with `frame is Extract<ServerControlFrame, { t: "llm_first_text" }>` and throw-assert presence before use — preserves the trace-continuity assertion intent exactly.

## Receipts (local, PR CI dead)

- `bun run --cwd packages/cloud/api typecheck` → exit 0 (tsc --noEmit + worker-bundle dry-run)
- `bun test .../ws-lifecycle.test.ts` → 66 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)