### PR TITLE
fix(cloud): narrow voice trace frame in lifecycle test

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1081,12 +1081,15 @@ describe("voice-session WS lifecycle", () => {
       (frame) => frame.t === "navigate_view",
     );
     expect(firstText).toBeDefined();
+    if (!firstText) {
+      throw new Error("Expected an llm_first_text control frame");
+    }
     expect(navigation).toEqual([
       {
         t: "navigate_view",
         viewId: "browser",
         viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
-        traceId: firstText?.traceId,
+        traceId: firstText.traceId,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- narrow the asserted `llm_first_text` frame before reading its trace ID
- restore the Cloud API typecheck that blocks staging deployment

## Context
The forced staging deployment for merged PR #24411 failed in the mandatory `Deploy API Worker` verification gate because `firstText?.traceId` produced `string | undefined`. The runtime behavior is unchanged; this only makes the test assertion explicit to TypeScript.

## Verification
- `bun run build:core`
- `bun run --cwd packages/cloud/api typecheck`
- `git diff --check`

Failed deployment: https://github.com/elizaOS/eliza/actions/runs/32563295587