### PR TITLE
fix(app-core): bound Steward sidecar wallet-setup hops

### DIFF
--- a/packages/app-core/src/services/steward-sidecar/wallet-setup.fetch.test.ts
+++ b/packages/app-core/src/services/steward-sidecar/wallet-setup.fetch.test.ts
@@ -1,0 +1,74 @@
+// Pins the bounded Steward sidecar contract: every API hop fails closed at
+// the hop timeout, composing a caller signal with the deadline (either wins).
+import { describe, expect, test, vi } from "vitest";
+
+describe("stewardFetch — bounded Steward hops fail closed and compose caller signals", () => {
+  test("aborts a hung Steward hop at the configured timeout", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { stewardFetch } = await import("./wallet-setup");
+    const start = Date.now();
+    await expect(
+      stewardFetch("http://127.0.0.1:1/agents/x/token", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("times out a hung hop even when a non-aborted caller signal is present", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { stewardFetch } = await import("./wallet-setup");
+    const controller = new AbortController();
+    const start = Date.now();
+    await expect(
+      stewardFetch(
+        "http://127.0.0.1:1/agents/x/token",
+        {
+          signal: controller.signal,
+        },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("preserves caller cancellation (composed)", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          seen = init?.signal;
+          return new Response("{}", { status: 200 });
+        },
+      ) as typeof fetch;
+
+    const { stewardFetch } = await import("./wallet-setup");
+    const controller = new AbortController();
+    await stewardFetch("http://127.0.0.1:1/agents/x/token", {
+      signal: controller.signal,
+    });
+    expect(seen?.aborted).toBe(false);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
+  });
+});

--- a/packages/app-core/src/services/steward-sidecar/wallet-setup.fetch.test.ts
+++ b/packages/app-core/src/services/steward-sidecar/wallet-setup.fetch.test.ts
@@ -1,6 +1,17 @@
-// Pins the bounded Steward sidecar contract: every API hop fails closed at
-// the hop timeout, composing a caller signal with the deadline (either wins).
-import { describe, expect, test, vi } from "vitest";
+/**
+ * Pins the bounded Steward sidecar contract: every API hop fails closed at the
+ * hop timeout, composing a caller signal with the deadline so either one
+ * aborts the request. The harness stubs `globalThis.fetch` with a hung or
+ * immediate responder and restores the original between tests; the module
+ * under test is the real `stewardFetch`.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("stewardFetch — bounded Steward hops fail closed and compose caller signals", () => {
   test("aborts a hung Steward hop at the configured timeout", async () => {
@@ -13,7 +24,7 @@ describe("stewardFetch — bounded Steward hops fail closed and compose caller s
             );
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const { stewardFetch } = await import("./wallet-setup");
     const start = Date.now();
@@ -33,7 +44,7 @@ describe("stewardFetch — bounded Steward hops fail closed and compose caller s
             );
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const { stewardFetch } = await import("./wallet-setup");
     const controller = new AbortController();
@@ -57,10 +68,10 @@ describe("stewardFetch — bounded Steward hops fail closed and compose caller s
       .fn()
       .mockImplementation(
         async (_input: RequestInfo | URL, init?: RequestInit) => {
-          seen = init?.signal;
+          seen = init?.signal ?? undefined;
           return new Response("{}", { status: 200 });
         },
-      ) as typeof fetch;
+      ) as unknown as typeof fetch;
 
     const { stewardFetch } = await import("./wallet-setup");
     const controller = new AbortController();

--- a/packages/app-core/src/services/steward-sidecar/wallet-setup.ts
+++ b/packages/app-core/src/services/steward-sidecar/wallet-setup.ts
@@ -7,6 +7,19 @@ import * as path from "node:path";
 import { ElizaError, logger } from "@elizaos/core";
 import { fingerprintRandomToken, generateApiKey } from "./helpers";
 
+import type {
+  StewardCredentialCheckpoint,
+  StewardCredentials,
+  StewardSidecarStatus,
+} from "./types";
+import {
+  CREDENTIALS_FILE,
+  DEFAULT_AGENT_ID,
+  DEFAULT_AGENT_NAME,
+  DEFAULT_TENANT_ID,
+  DEFAULT_TENANT_NAME,
+} from "./types";
+
 const STEWARD_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
@@ -27,19 +40,6 @@ export function stewardFetch(
       : timeoutSignal,
   });
 }
-
-import type {
-  StewardCredentialCheckpoint,
-  StewardCredentials,
-  StewardSidecarStatus,
-} from "./types";
-import {
-  CREDENTIALS_FILE,
-  DEFAULT_AGENT_ID,
-  DEFAULT_AGENT_NAME,
-  DEFAULT_TENANT_ID,
-  DEFAULT_TENANT_NAME,
-} from "./types";
 
 /**
  * Ensure wallet is set up: verify existing wallet or perform first-launch setup.

--- a/packages/app-core/src/services/steward-sidecar/wallet-setup.ts
+++ b/packages/app-core/src/services/steward-sidecar/wallet-setup.ts
@@ -6,6 +6,28 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { ElizaError, logger } from "@elizaos/core";
 import { fingerprintRandomToken, generateApiKey } from "./helpers";
+
+const STEWARD_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Steward sidecar API hop so a hung sidecar cannot pin
+ * first-launch wallet setup. A caller-provided abort signal is composed with
+ * the timeout (either cancelling aborts), not substituted for it.
+ */
+export function stewardFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = STEWARD_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal,
+  });
+}
+
 import type {
   StewardCredentialCheckpoint,
   StewardCredentials,
@@ -77,7 +99,7 @@ async function requestAgentToken(
   credentials: StewardCredentialCheckpoint,
   apiBase: string,
 ): Promise<string> {
-  const tokenResponse = await fetch(
+  const tokenResponse = await stewardFetch(
     `${apiBase}/agents/${credentials.agentId}/token`,
     {
       method: "POST",
@@ -177,12 +199,15 @@ async function verifyExistingWallet(
   updateStatus: (partial: Partial<StewardSidecarStatus>) => void,
 ): Promise<void> {
   try {
-    const response = await fetch(`${apiBase}/agents/${credentials.agentId}`, {
-      headers: {
-        "X-Steward-Tenant": credentials.tenantId,
-        "X-Steward-Key": credentials.tenantApiKey,
+    const response = await stewardFetch(
+      `${apiBase}/agents/${credentials.agentId}`,
+      {
+        headers: {
+          "X-Steward-Tenant": credentials.tenantId,
+          "X-Steward-Key": credentials.tenantApiKey,
+        },
       },
-    });
+    );
 
     if (response.ok) {
       const result = (await response.json()) as {
@@ -219,7 +244,7 @@ async function performFirstLaunchSetup(
 
   // 1. Create tenant
   const tenantApiKey = generateApiKey();
-  const tenantResponse = await fetch(`${apiBase}/tenants`, {
+  const tenantResponse = await stewardFetch(`${apiBase}/tenants`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -237,7 +262,7 @@ async function performFirstLaunchSetup(
   }
 
   // 2. Create agent with wallet
-  const agentResponse = await fetch(`${apiBase}/agents`, {
+  const agentResponse = await stewardFetch(`${apiBase}/agents`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Problem

All four Steward API fetches (agent token, agent verify, tenant create, agent create) had **no timeout** — a hung sidecar could pin first-launch wallet setup indefinitely.

## Fix

- Add `stewardFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, composing any caller-provided abort signal via `AbortSignal.any` (either cancelling aborts).
- Route all four fetch sites through it.

## Tests

New `wallet-setup.fetch.test.ts` (3 pass): hung-hop abort; **non-aborted caller signal still times out** (compose regression); caller cancellation preserved.

```bash
bunx vitest run steward-sidecar/wallet-setup.fetch
# 3 pass, 0 fail
```