### PR TITLE
fix(cloud): bound WhatsApp Cloud API adapter hops

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
@@ -1,0 +1,78 @@
+// Pins the bounded WhatsApp adapter contract: every Cloud API hop fails
+// closed at the hop timeout, composing a caller signal with the deadline.
+import { describe, expect, test, vi } from "vitest";
+
+describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller signals", () => {
+  test("aborts a hung WhatsApp hop at the configured timeout", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { whatsappFetch } = await import("./whatsapp");
+    const start = Date.now();
+    await expect(
+      whatsappFetch(
+        "https://graph.facebook.com/v21.0/me/messages",
+        undefined,
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("times out a hung hop even when a non-aborted caller signal is present", async () => {
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const { whatsappFetch } = await import("./whatsapp");
+    const controller = new AbortController();
+    const start = Date.now();
+    await expect(
+      whatsappFetch(
+        "https://graph.facebook.com/v21.0/me/messages",
+        {
+          signal: controller.signal,
+        },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("preserves caller cancellation (composed)", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          seen = init?.signal;
+          return new Response("{}", { status: 200 });
+        },
+      ) as typeof fetch;
+
+    const { whatsappFetch } = await import("./whatsapp");
+    const controller = new AbortController();
+    await whatsappFetch("https://graph.facebook.com/v21.0/me/messages", {
+      signal: controller.signal,
+    });
+    expect(seen?.aborted).toBe(false);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
@@ -1,6 +1,17 @@
-// Pins the bounded WhatsApp adapter contract: every Cloud API hop fails
-// closed at the hop timeout, composing a caller signal with the deadline.
-import { describe, expect, test, vi } from "vitest";
+/**
+ * Pins the bounded WhatsApp adapter contract: every Cloud API hop fails closed
+ * at the hop timeout and composes a caller signal with that deadline. The
+ * harness stubs globalThis.fetch with a hung or immediate responder and
+ * restores the real implementation after each test so the stub cannot leak
+ * into other files sharing the worker.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
 
 describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller signals", () => {
   test("aborts a hung WhatsApp hop at the configured timeout", async () => {
@@ -13,7 +24,7 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
             );
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const { whatsappFetch } = await import("./whatsapp");
     const start = Date.now();
@@ -37,7 +48,7 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
             );
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const { whatsappFetch } = await import("./whatsapp");
     const controller = new AbortController();
@@ -56,7 +67,7 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
   });
 
   test("preserves caller cancellation (composed)", async () => {
-    let seen: AbortSignal | undefined;
+    let seen: AbortSignal | null | undefined;
     globalThis.fetch = vi
       .fn()
       .mockImplementation(
@@ -64,7 +75,7 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
           seen = init?.signal;
           return new Response("{}", { status: 200 });
         },
-      ) as typeof fetch;
+      ) as unknown as typeof fetch;
 
     const { whatsappFetch } = await import("./whatsapp");
     const controller = new AbortController();

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
@@ -4,6 +4,27 @@ import { z } from "zod";
 import { logger } from "../logger";
 import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
 
+const WHATSAPP_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every WhatsApp Cloud API hop so a hung gateway cannot pin the
+ * adapter. A caller-provided abort signal is composed with the timeout
+ * (either cancelling aborts), not substituted for it.
+ */
+export function whatsappFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = WHATSAPP_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal,
+  });
+}
+
 const WHATSAPP_API_BASE = "https://graph.facebook.com/v21.0";
 
 const WhatsAppWebhookMessageSchema = z.object({
@@ -154,7 +175,7 @@ export const whatsappAdapter: PlatformAdapter = {
     }
 
     const url = `${WHATSAPP_API_BASE}/${config.phoneNumberId}/messages`;
-    const response = await fetch(url, {
+    const response = await whatsappFetch(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${config.accessToken}`,
@@ -182,7 +203,7 @@ export const whatsappAdapter: PlatformAdapter = {
     if (!config.accessToken || !config.phoneNumberId) return;
     try {
       const url = `${WHATSAPP_API_BASE}/${config.phoneNumberId}/messages`;
-      await fetch(url, {
+      await whatsappFetch(url, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${config.accessToken}`,


### PR DESCRIPTION
## Problem

Both WhatsApp fetches (send reply, mark read) had **no timeout** — a hung gateway could pin the webhook adapter indefinitely.

## Fix

- Add `whatsappFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, composing any caller-provided abort signal via `AbortSignal.any` (either cancelling aborts).
- Route both fetch sites through it.

## Tests

New `whatsapp.fetch.test.ts` (3 pass): hung-hop abort; **non-aborted caller signal still times out** (compose regression); caller cancellation preserved.

```bash
bun test --isolate src/adapters/whatsapp.fetch.test.ts
# 3 pass, 0 fail
```