### PR TITLE
feat(orchestrator): foundation modules — durable-content views, routing shapes, verification helpers

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -7,17 +7,25 @@
 
 import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { parseJsonObjectResponse } from "./json-model-output.js";
-import { stripInventedArtifactCriteria } from "./producible-evidence.js";
+import {
+  stripInventedArtifactCriteria,
+  stripUncollectableEvidenceCriteria,
+} from "./producible-evidence.js";
 
 /** Coarse task classification driving which template set is applied. */
 export type OrchestratorTaskType =
   | "coding"
+  | "script-run"
   | "view-create"
   | "app-build"
   | "deploy";
 
 /** Lower bound the issue calls for: a generated set always has ≥3 criteria. */
 const MIN_CRITERIA = 3;
+/** Upper bound so the verifier prompt stays cheap and focused. */
+const MAX_CRITERIA = 5;
+/** Per-criterion length cap so a runaway model line can't bloat the record. */
+const MAX_CRITERION_CHARS = 240;
 /** A goal shorter than this is treated as trivial — no criteria generated. */
 const MIN_GOAL_CHARS = 8;
 
@@ -53,6 +61,16 @@ export const DEFAULT_CRITERIA_TEMPLATES: Readonly<
     "the deliverable file exists in the workdir",
     "the page serves the requested content",
   ],
+  // One-shot "write a script and run it" asks: the deliverable is the RUN
+  // OUTPUT, not a maintained codebase. The coding template's lint/test-suite
+  // demands parked a two-tool write+run task whose script worked on the first
+  // try (live 2026-08-20: prime-numbers ask, three verify attempts burned on
+  // "a test suite passes").
+  "script-run": [
+    "the script file exists in the workdir",
+    "the script runs to completion without errors",
+    "the captured run output contains the requested result",
+  ],
   "view-create": [
     "a Plugin.views entry is declared with a viewKind",
     "the view appears in /api/views",
@@ -78,6 +96,16 @@ export function shouldRequireGoalContract(): boolean {
 
 /** Keyword groups feeding {@link detectTaskType}. Ordered most-specific-first
  *  so a goal that matches several groups gets the narrower classification. */
+// "write/make a <lang> script … and run it" (or "run it for me"): a compute
+// deliverable judged by its output. A creation verb directly before the
+// script noun also qualifies — "write me a python script that picks a random
+// dinner idea" is the same one-shot deliverable even without a run verb, and
+// classifying it coding parked a working script on invented lint/test-suite
+// criteria (live 2026-08-20). "add a build script to package.json" stays
+// coding: "add" is not a creation-of-deliverable verb here.
+const SCRIPT_RUN_RE =
+  /\b(?:script|one[- ]?liner)\b[\s\S]{0,80}\b(?:run|execute)\b|\b(?:run|execute)\b[\s\S]{0,40}\bscript\b|\b(?:write|make|create)\b(?:\s+\w+){0,4}?\s+(?:script|one[- ]?liner)\b/i;
+
 const VIEW_RE =
   /\b(view|views|viewkind|widget|dashboard\s+(?:card|panel|tile)|render\s+a\s+view)\b/i;
 const DEPLOY_RE =
@@ -90,21 +118,32 @@ const DEPLOY_RE =
 // intervening words so canonical phrasing like "build an app" and
 // "create a checklist app" classifies correctly (a bare `build\s+a\s+app` never
 // matches grammatical English and silently regressed those to coding).
+// The trailing alternative catches verb-less goals that are just a noun
+// phrase ending in page/site ("quote generator page" — the planner's task
+// title became the goal and classified coding, resurrecting the diff-summary
+// criterion on a slug-dir app, live 2026-08-19).
 const APP_BUILD_RE =
-  /\b(website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|(?:build|create|make)\s+an?\s+(?:\w+[ -]){0,2}(?:site|page|app|application)\b)/i;
+  /\b(website|web\s*site|web\s?page|landing\s+page|web\s+app|webapp|frontend\s+app|(?:build|create|make)\s+(?:me\s+)?an?\s+(?:[\w'-]+[ -]){0,5}(?:site|page|app|application)\b|^[\w'’-]+(?:\s+[\w'’-]+){0,5}\s+(?:page|site|webpage)\s*$)/im;
 
 /**
  * Classify a task from its goal text. Defaults to `coding` — the safest
  * superset, since every other type extends or specializes the coding checks.
  * Pure and deterministic so the static path is fully testable without a model.
  */
+// File names and paths are not intent: "/etc/nubs-deploy-settings.yaml"
+// classified a read-a-config script as a DEPLOY task (deploy criteria, two
+// lanes, live 2026-08-22). Strip path-like tokens before the keyword groups.
+const PATH_TOKEN_RE =
+  /(?:(?:\/|~\/|\.\/|[A-Za-z]:\\)[\w.\\/-]+)|\b[\w-]+\.(?:ya?ml|json|csv|tsv|txt|toml|ini|cfg|conf|xml|env|log|md|db|sqlite3?|py|js|ts|sh|html|css)\b/gi;
+
 export function detectTaskType(goal: string): OrchestratorTaskType {
-  const text = (goal ?? "").trim();
+  const text = (goal ?? "").replace(PATH_TOKEN_RE, " ").trim();
   if (text.length === 0) return "coding";
   // View creation is the most specific signal — check it first.
   if (VIEW_RE.test(text)) return "view-create";
   if (DEPLOY_RE.test(text)) return "deploy";
   if (APP_BUILD_RE.test(text)) return "app-build";
+  if (SCRIPT_RUN_RE.test(text)) return "script-run";
   return "coding";
 }
 
@@ -114,7 +153,8 @@ export function isNonTrivialGoal(goal: string): boolean {
   return (goal ?? "").trim().length >= MIN_GOAL_CHARS;
 }
 
-/** Normalize and de-dupe a candidate criteria list, topping up from the static fallback when the model
+/** Normalize, de-dupe, length-cap and bound a candidate criteria list to the
+ *  [MIN, MAX] window, topping up from the static fallback when the model
  *  returned too few usable lines. Always returns ≥{@link MIN_CRITERIA} when the
  *  fallback set itself has that many. */
 function normalizeCriteria(
@@ -124,20 +164,23 @@ function normalizeCriteria(
   const seen = new Set<string>();
   const out: string[] = [];
   const push = (raw: string): void => {
-    const trimmed = raw.trim();
+    const trimmed = raw.trim().slice(0, MAX_CRITERION_CHARS).trim();
     if (trimmed.length === 0) return;
     const key = trimmed.toLowerCase();
     if (seen.has(key)) return;
     seen.add(key);
     out.push(trimmed);
   };
-  for (const candidate of candidates) push(candidate);
+  for (const candidate of candidates) {
+    if (out.length >= MAX_CRITERIA) break;
+    push(candidate);
+  }
   // Top up to the minimum from the static fallback if the model was stingy.
   for (const item of fallback) {
     if (out.length >= MIN_CRITERIA) break;
     push(item);
   }
-  return out;
+  return out.slice(0, MAX_CRITERIA);
 }
 
 /**
@@ -175,7 +218,7 @@ function buildRefinePrompt(
     template.map((c, i) => `${i + 1}. ${c}`).join("\n"),
     "",
     'Respond with a SINGLE JSON object and nothing else, no markdown fences. Schema: { "criteria": ["<criterion>", "<criterion>", ...] }',
-    `Return at least ${MIN_CRITERIA} criteria.`,
+    `Return between ${MIN_CRITERIA} and ${MAX_CRITERIA} criteria.`,
   ].join("\n");
 }
 
@@ -214,6 +257,18 @@ export async function generateDefaultAcceptanceCriteria(
   const type = taskTypeHint ?? detectTaskType(goal);
   const fallback = [...DEFAULT_CRITERIA_TEMPLATES[type]];
 
+  // Static app builds keep the deterministic serve-focused template with NO
+  // model refine: every refine pass invented runtime-behavior demands in new
+  // phrasings ("browser console shows zero errors", "interaction updates the
+  // DOM", "timer changes its value") that no headless pipeline can evidence,
+  // and each parked a live, working page (2026-08-19, four distinct parks).
+  // The template criteria — reachable URL, files on disk, served content —
+  // are exactly what the evidence pipeline can prove.
+  if (type === "app-build") return fallback;
+  // Same purity rule for script-run: refinement re-invents the lint/test-suite
+  // demands the template exists to avoid.
+  if (type === "script-run") return fallback;
+
   if (!runtime || typeof runtime.useModel !== "function") return fallback;
 
   try {
@@ -230,7 +285,10 @@ export async function generateDefaultAcceptanceCriteria(
     // The prompt forbids invented paths, but the filter is the enforcement:
     // a criterion pinning a path the goal never named is unsatisfiable by
     // design (#20794), so it is dropped and the template tops the set back up.
-    const producible = stripInventedArtifactCriteria(candidates, goal).kept;
+    const producible = stripUncollectableEvidenceCriteria(
+      stripInventedArtifactCriteria(candidates, goal).kept,
+      type,
+    ).kept;
     const refined = normalizeCriteria(producible, fallback);
     return refined.length >= MIN_CRITERIA ? refined : fallback;
   } catch {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -235,9 +235,9 @@ export class NativeAcpClient {
           version: "2.0.0",
         },
       },
-      // The first opencode spawn compiles its TS tree and installs the provider
-      // npm package (e.g. @ai-sdk/cerebras), which can exceed the 300s default.
-      // Honor the configured session timeout for the handshake too.
+      // A slow first spawn (toolchain compile, provider npm install) can
+      // exceed the 300s default. Honor the configured session timeout for the
+      // handshake too.
       this.opts.timeoutMs && this.opts.timeoutMs > 0
         ? this.opts.timeoutMs
         : DEFAULT_TIMEOUT_MS,

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -26,6 +26,7 @@
  * @module services/app-deploy-guidance
  */
 
+import { detectTaskType } from "./acceptance-criteria.js";
 import { readConfigEnvKey } from "./config-env.js";
 import { APP_DEPLOY_TASK_RE } from "./skill-recommender.js";
 import {
@@ -180,6 +181,7 @@ function customHostGuidance(
   config: AppDeployConfig,
   _task?: string,
   monetized?: boolean,
+  assignedAppDir?: string,
 ): string {
   const dir = config.customAppsDir ?? "";
   const base = config.customBaseUrl ?? "";
@@ -200,7 +202,16 @@ function customHostGuidance(
     "--- Publishing web apps (custom host) ---",
     "If (and only if) your task is to build OR edit a web app, page, or site for the operator — not a script, CLI, library, or backend service — publish it to the operator's configured static host:",
     `- Published apps are plain static files under \`${dir}/<slug>/\` (index.html plus any css/js — there is NO per-app build step), served live at \`${base}/apps/<slug>/\`.`,
-    `- To CREATE a new app: pick a fresh, short kebab-case \`<slug>\`, write the files into \`${dir}/<slug>/\`, then open \`${base}/apps/<slug>/\` to confirm it works and report that URL.`,
+    // A server-assigned dir removes the child's slug choice entirely: a
+    // self-picked slug overwrote an existing app (live 2026-08-19).
+    assignedAppDir
+      ? `- To CREATE the app: your assigned app folder is \`${assignedAppDir}/\` — write index.html (plus css/js) directly there and NOWHERE else under \`${dir}/\`; it serves at \`${base}/apps/${assignedAppDir.split("/").pop()}/\` — open that URL to confirm and report it.`
+      : `- To CREATE a new app: pick a fresh, short kebab-case \`<slug>\` that is NOT an existing folder under \`${dir}/\`, write the files into \`${dir}/<slug>/\`, then open \`${base}/apps/<slug>/\` to confirm it works and report that URL. Never overwrite an existing app folder you did not create.`,
+    // Children self-imposed `eslint`/`tsc` checks on plain browser scripts;
+    // with no lint/ts config in the app dir those exit 1, the child's planner
+    // ends on a failed tool step, and a finished page reports as a failed
+    // task (live 2026-08-19: every first attempt "failed" this way).
+    "- Verify a static app by reading the files back and fetching its served URL. There is NO build, lint, or typecheck step: do not run eslint, tsc, npm, or bun for these plain static apps — a failing check you invented is not a task failure.",
     `- To EDIT an existing app: the \`<slug>\` is the app's existing folder name under \`${dir}/\` — read its files there, modify them in place, then re-open \`${base}/apps/<slug>/\` to confirm. Do not create a new slug for an edit.`,
     monetizeLine,
   ];
@@ -294,7 +305,7 @@ function extractViewPluginSourceDir(task: string): string | undefined {
 export function augmentTaskWithDeployGuidance(
   task: string,
   config?: AppDeployConfig,
-  opts?: { monetized?: boolean; cloudAppId?: string },
+  opts?: { monetized?: boolean; cloudAppId?: string; assignedAppDir?: string },
 ): string {
   // Idempotent: if a deploy block is already present, no-op.
   if (
@@ -304,6 +315,30 @@ export function augmentTaskWithDeployGuidance(
     task.includes("--- Publishing web apps")
   ) {
     return task;
+  }
+  // Script deliverables never get the web-publishing contract. The section's
+  // own "If (and only if) your task is to build OR edit a web app … not a
+  // script" conditional is routinely ignored at small-model scale: a python
+  // script ask produced an unrequested "Dinner Picker" web app, and a
+  // run-the-script follow-up produced a JavaScript rewrite inside the apps
+  // dir (both live 2026-08-20). detectTaskType is the same deterministic
+  // classifier the acceptance-criteria contract uses.
+  if (detectTaskType(task) === "script-run" && !isAppBuildTask(task)) {
+    return [
+      task.trimEnd(),
+      "",
+      "--- Script tasks ---",
+      "The deliverable is the script and its run output. Verify by executing the script and capturing its stdout.",
+      // Children self-imposed mypy/flake8 on scratch workspaces with no venv;
+      // the failed check led the completion as a task failure while the
+      // script itself ran clean (live 2026-08-21, 2 of 4 runs).
+      "Do not run linters, type checkers, or test frameworks (mypy, flake8, eslint, tsc, pytest) unless the workspace already has them installed and configured — a failing check you introduced is not a task failure.",
+      // A missing input got replaced by a hand-written stand-in and a made-up
+      // value shipped as the answer (live 2026-08-22). The honest result of a
+      // script whose input is absent IS the error.
+      "If a file, endpoint, or dataset the task names does not exist or cannot be reached from here, report that as the result — never create a stand-in for it or change the script to read something else.",
+      "End your final message with the captured run output.",
+    ].join("\n");
   }
   const resolved = config ?? resolveAppDeployConfig();
   // The planner's monetization judgment (model intent, not a keyword match).
@@ -329,7 +364,12 @@ export function augmentTaskWithDeployGuidance(
     // A custom-host app only touches Cloud when it is monetized (it registers
     // for billing); only then does an existing-app binding apply.
     const boundLine = monetized ? existingCloudAppLine(opts?.cloudAppId) : "";
-    const custom = customHostGuidance(resolved, task, monetized);
+    const custom = customHostGuidance(
+      resolved,
+      task,
+      monetized,
+      opts?.assignedAppDir,
+    );
     const block = boundLine ? `${custom}\n${boundLine}` : custom;
     return `${task.trimEnd()}\n\n${block}`;
   }

--- a/plugins/plugin-agent-orchestrator/src/services/ask-shapes.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ask-shapes.ts
@@ -1,0 +1,20 @@
+/** Shapes of a user ask the orchestrator routes on structurally. */
+
+/** "also …", "add … to it", "make it …": an instruction about work already
+ *  under way, not a new deliverable. */
+export const FOLLOW_UP_SHAPE_RE =
+  /^\s*(?:oh\s+|and\s+)?(?:also|plus|btw|additionally)\b|\b(?:to|on|in|for|into)\s+(?:it|that|the\s+(?:page|app|site|script))\b|\bmake\s+it\b|\bit\s+(?:too|as\s+well)\b/i;
+
+/** "make me a page …", "another script …": a new deliverable, even when the
+ *  sentence also says "on it" / "run it". */
+export const NEW_DELIVERABLE_RE =
+  /\b(?:make|build|create|write|spin\s+up)\s+(?:me\s+)?(?:a|an|another|new|two|three|\d+)\b[^.!?\n]{0,40}\b(?:pages?|apps?|sites?|scripts?|games?|tools?|widgets?)\b/i;
+
+export function looksLikeNewDeliverableAsk(text: string): boolean {
+  return NEW_DELIVERABLE_RE.test(text);
+}
+
+/** "like that", "of it", "than this": the sentence leans on prior work even
+ *  when it names a new deliverable. */
+export const ANAPHOR_RE =
+  /\b(?:like|of|for|than|as|to)\s+(?:it|that|this)\b|\bthe\s+(?:last|previous|earlier)\s+one\b/i;

--- a/plugins/plugin-agent-orchestrator/src/services/asked-output-deliverable.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/asked-output-deliverable.test.ts
@@ -1,0 +1,93 @@
+/** Unit tests for extractAskedOutputDeliverable — the verbatim relay of a
+ *  short plain child response when the user's ask requested output/results.
+ *  Deterministic, no runtime. */
+import { describe, expect, it } from "vitest";
+import { extractAskedOutputDeliverable } from "./sub-agent-router.js";
+
+describe("extractAskedOutputDeliverable", () => {
+  it("relays a short plain response for an output ask", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "Tonight's dinner idea is: Homemade Pizza" },
+        "run the dinner picker script and show me the output",
+      ),
+    ).toBe("Tonight's dinner idea is: Homemade Pizza");
+  });
+
+  it("returns undefined when the ask does not request output", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "done, the page is live" },
+        "make me a lil recipe box page",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty response", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "   " },
+        "run it and print the result",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("treats a run-it-again ask as an output ask", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "Fun fact: Venus rotates backwards." },
+        "nice, run it again i want another fact",
+      ),
+    ).toBe("Fun fact: Venus rotates backwards.");
+  });
+
+  it("matches the what-is-the-output phrasing", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { finalText: "42" },
+        "what's the output of the script?",
+      ),
+    ).toBe("42");
+  });
+
+  it("falls back to the summarized path for an oversized response", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "x".repeat(65_536) },
+        "run it and show me the output",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+import { lastProofBlockOutput } from "./sub-agent-router.js";
+
+describe("lastProofBlockOutput", () => {
+  it("pulls the stdout of the last $-command fence", () => {
+    const resp = [
+      "- [x] the script exists — proof:",
+      "```bash",
+      "$ ls /w",
+      "space_facts.py",
+      "```",
+      "```bash",
+      "$ python3 /w/space_facts.py",
+      "The sun makes up 99.86% of the mass in our solar system.",
+      "```",
+    ].join("\n");
+    expect(lastProofBlockOutput(resp)).toBe(
+      "The sun makes up 99.86% of the mass in our solar system.",
+    );
+  });
+
+  it("skips truncated blocks and oversized outputs", () => {
+    expect(lastProofBlockOutput("```bash\n$ ls\n...\n```")).toBeUndefined();
+    expect(
+      lastProofBlockOutput(`\`\`\`bash\n$ run\n${"x".repeat(500)}\n\`\`\``),
+    ).toBeUndefined();
+  });
+
+  it("ignores fences without command lines", () => {
+    expect(lastProofBlockOutput("```\njust code\n```")).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -99,6 +99,18 @@ export interface ToolOutputEvidence {
 export interface CompletionEvidenceBundle {
   /** The sub-agent's reported result — the fallback/final-reply text. */
   summary: string;
+  /** Tail of the session's captured raw output (tool stdout the transport
+   *  recorded). Script-run criteria are judged by what the run PRINTED; the
+   *  classified tool buckets miss plain interpreter output, and the judge
+   *  rejected a correct prime-numbers run as "no execution logs provided"
+   *  (live 2026-08-20). */
+  runOutput?: string;
+  /** Pull request the ORCHESTRATOR's auto-submit opened for this task. The
+   *  child cannot push or open PRs by design, so its narration never carries
+   *  the URL — without this field the judge kept failing "no pull request
+   *  was opened" against tasks whose PR its own submit had already opened
+   *  (live 2026-08-20: TESTING.md and STYLE.md, three attempts each). */
+  pullRequestUrl?: string;
   /** Human-readable git diff summary (diffstat + changed files + capped diff)
    *  captured at completion, if any. */
   diffSummary?: string;
@@ -224,6 +236,20 @@ export function classifyToolOutput(
   };
   const seen = new Set<string>();
   for (const signal of signals) {
+    // A `[tool output: …]…[/tool output]` envelope IS tool output by
+    // construction — no marker heuristics needed. Without this, a script's
+    // plain stdout (bare numbers) matched no build/test line shape and the
+    // judge failed a correct run for "missing actual shell output"
+    // (live 2026-08-19: squares.py printed 1..36, task marked failed).
+    for (const match of signal.text.matchAll(
+      /\[tool output:[^\]]*\]([\s\S]*?)\[\/tool output\]/g,
+    )) {
+      const inner = (match[1] ?? "").trim().slice(0, 2_000);
+      if (inner && !seen.has(inner)) {
+        seen.add(inner);
+        buckets.raw.push(inner);
+      }
+    }
     const lines = extractToolLines(signal.text, seen);
     if (lines.length === 0) continue;
     const haystack = `${signal.source ?? ""}\n${signal.text}`;
@@ -400,6 +426,28 @@ export function buildCompletionEvidenceString(
 ): string {
   const sections: string[] = [];
   let hasRicherSection = false;
+
+  const runOutput = bundle.runOutput?.trim();
+  if (runOutput) {
+    sections.push(
+      [
+        "## RUN OUTPUT (raw session output captured by the orchestrator)",
+        runOutput,
+      ].join("\n"),
+    );
+    hasRicherSection = true;
+  }
+
+  const pr = bundle.pullRequestUrl?.trim();
+  if (pr) {
+    sections.push(
+      [
+        "## PULL REQUEST (opened by the orchestrator's auto-submit; the sub-agent cannot push or open PRs itself)",
+        pr,
+      ].join("\n"),
+    );
+    hasRicherSection = true;
+  }
 
   const diff = bundle.diffSummary?.trim();
   if (diff) {

--- a/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
@@ -127,6 +127,14 @@ export interface CompletionResidualsInput {
    * pre-existing churn was not produced by this run. Tracked modifications
    * only — untracked exemptions come from `baselineUntrackedPaths`. */
   baselineDirtyPaths?: readonly string[];
+  /** The session's ISOLATED git index (the ACP wrapper's GIT_INDEX_FILE).
+   *  Wrapper-managed workspaces commit exclusively through it, so the REAL
+   *  index stays frozen at clone state forever — a plain `git status` then
+   *  reports every wrapper-committed file as staged-deleted + untracked and
+   *  the gate parks finished work on phantom dirt (live 2026-08-20: the same
+   *  "5 uncommitted path(s)" on four consecutive PR tasks whose branches
+   *  were clean). When set, the git legs run against this index. */
+  gitIndexFile?: string;
   /** Untracked paths already present when the reporting session spawned
    * (session metadata `codingBaselineUntracked`, captured by
    * `AcpService.spawnSession` from `git status --porcelain` `??` lines). A
@@ -161,13 +169,20 @@ interface GitProbe {
   stderr: string;
 }
 
-function runGit(workdir: string, args: string[]): GitProbe {
+function runGit(
+  workdir: string,
+  args: string[],
+  gitIndexFile?: string,
+): GitProbe {
   const result = spawnSync("git", args, {
     cwd: workdir,
     timeout: GIT_TIMEOUT_MS,
     maxBuffer: GIT_MAX_BUFFER,
     windowsHide: true,
     encoding: "utf8",
+    ...(gitIndexFile
+      ? { env: { ...process.env, GIT_INDEX_FILE: gitIndexFile } }
+      : {}),
   });
   return {
     ok: result.status === 0,
@@ -396,7 +411,11 @@ export async function collectCompletionResiduals(
     // the persisted snapshot so the skip is visible, never a silent pass.
     gitLegsSkipped = "shared_route_workdir";
   } else if (workdir !== undefined) {
-    const status = runGit(workdir, ["status", "--porcelain"]);
+    const status = runGit(
+      workdir,
+      ["status", "--porcelain"],
+      input.gitIndexFile,
+    );
     if (!status.ok) {
       return unverifiable(
         "git_failed",

--- a/plugins/plugin-agent-orchestrator/src/services/durable-content.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/durable-content.ts
@@ -1,0 +1,123 @@
+/**
+ * Durable complete content with bounded model views (#24262 close-out).
+ *
+ * The contract, from the review that closed the original orchestration PR:
+ * canonical content is persisted IN FULL; every capped string handed to a
+ * model prompt or a chat surface is a VIEW derived from that durable content,
+ * and a partial view carries a continuation reference so the reader — model
+ * or human — can recover the remainder instead of losing it.
+ *
+ * Two conventions compose here:
+ * - `canonical<Thing>` / `provider<Thing>` metadata keys (introduced by the
+ *   auto-submit PR title repair): the canonical value is stored untruncated;
+ *   a provider-bounded payload is derived explicitly, named, and stored next
+ *   to it so the derivation is auditable.
+ * - {@link ContentReference} / {@link ReadView} from @elizaos/core (#24305):
+ *   the source-neutral progressive-read envelope. Views produced here use
+ *   the `tool-result` kind with orchestrator-owned opaque refs; the owning
+ *   HTTP surfaces resolve continuations:
+ *     `acpx-session-output:<sessionId>`  → GET /api/coding-agents/:id/output
+ *     `acpx-task:<taskId>`               → GET /api/orchestrator/tasks/:id
+ *     `acpx-task-meta:<taskId>:<key>`    → task metadata key on the same route
+ */
+import { createHash } from "node:crypto";
+import type {
+  ContentReference,
+  ReadCompleteness,
+  ReadView,
+} from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+export interface BoundedContentView {
+  /** The bounded text. Partial views end with a one-line continuation
+   *  marker naming the reference. */
+  view: string;
+  /** True when `view` carries less than the full content. */
+  truncated: boolean;
+  /** The progressive-read envelope for a partial view; absent when the
+   *  content fit whole. */
+  read?: ReadView;
+}
+
+/** An orchestrator-owned content reference (opaque, model-safe). */
+export function orchestratorContentRef(
+  scope: "session-output" | "task" | "task-meta",
+  id: string,
+  key?: string,
+): ContentReference {
+  const ref = [`acpx-${scope}`, id, ...(key ? [key] : [])]
+    .join(":")
+    // The core contract requires OPAQUE_REFERENCE_PATTERN-safe tokens.
+    .replace(/[^A-Za-z0-9._:~-]/gu, "~");
+  return { kind: "tool-result", ref: ref.slice(0, 256) };
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/**
+ * Derive a bounded view of durable content. NEVER call this on content that
+ * is not persisted in full somewhere the reference can reach — the marker
+ * promises the remainder is recoverable, and a false promise is worse than a
+ * silent cut.
+ */
+export function boundedContentView(
+  full: string,
+  budgetChars: number,
+  reference: ContentReference,
+  opts: { completeness?: ReadCompleteness } = {},
+): BoundedContentView {
+  const wellFormed = toWellFormedUnicode(full);
+  if (wellFormed.length <= budgetChars) {
+    return { view: wellFormed, truncated: false };
+  }
+  const marker = `\n… [view of ${budgetChars} of ${wellFormed.length} chars — full content: ${reference.ref}]`;
+  const headBudget = Math.max(0, budgetChars - marker.length);
+  const head = truncateWellFormed(wellFormed, headBudget).trimEnd();
+  return {
+    view: `${head}${marker}`,
+    truncated: true,
+    read: {
+      reference,
+      slice: {
+        range: {
+          unit: "byte",
+          start: 0,
+          end: Buffer.byteLength(head, "utf8"),
+          total: Buffer.byteLength(wellFormed, "utf8"),
+        },
+        hasPrevious: false,
+        hasMore: true,
+        nextOffset: Buffer.byteLength(head, "utf8"),
+        completeness: opts.completeness ?? "partial-recoverable",
+        sliceSha256: sha256(head),
+        sourceSha256: sha256(wellFormed),
+      },
+    },
+  };
+}
+
+/**
+ * Canonical/provider pair for a value a downstream surface hard-bounds
+ * (GitHub title, Discord message, room name, served slug). The canonical
+ * value is what gets persisted; the provider value is what gets sent.
+ */
+export interface CanonicalProviderPair {
+  canonical: string;
+  provider: string;
+  truncated: boolean;
+}
+
+export function canonicalProviderPair(
+  canonical: string,
+  providerLimit: number,
+): CanonicalProviderPair {
+  const wellFormed = toWellFormedUnicode(canonical);
+  const provider = truncateWellFormed(wellFormed, providerLimit);
+  return {
+    canonical: wellFormed,
+    provider,
+    truncated: provider.length < wellFormed.length,
+  };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/fabricated-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/fabricated-input.ts
@@ -1,0 +1,111 @@
+/**
+ * Detects a sub-agent that manufactured the input it was told to consume.
+ * Under verify coaching ("prove the run output contains the result"), a weak
+ * coding model that could not find `/etc/nubs-secret-config.yaml` wrote its
+ * own `nubs-secret-config.yaml` with `version: 1.2.3`, pointed the script at
+ * it, and the judge passed "1.2.3" to the user (live 2026-08-22). The task's
+ * read targets are compared against the session's write ledger and shell
+ * redirections by normalized path. Filename similarity is not evidence: two
+ * different directories commonly contain the same configuration filename.
+ */
+
+const FILE_TOKEN =
+  "((?:\\/|~\\/|\\.\\/|[A-Za-z]:\\\\)?[\\w.\\\\/-]*[\\w-]\\.(?:ya?ml|json|csv|tsv|txt|toml|ini|cfg|conf|xml|env|log|md|db|sqlite3?|parquet|xlsx?))\\b";
+const READ_VERBS =
+  "read|reads|reading|parse|parses|parsing|load|loads|loading|open|opens|opening|fetch|fetches|consume|consumes|from";
+const WRITE_VERBS =
+  "write|writes|save|saves|output|outputs|export|exports|store|stores|create|creates|generate|generates|produce|produces|emit|emits";
+/** Up to 60 chars on one line that never cross a verb of the other class. */
+const window = (blocked: string) => `(?:(?!\\b(?:${blocked})\\b)[^\\n]){0,60}?`;
+const READ_TARGET_RE = new RegExp(
+  `\\b(?:${READ_VERBS})\\b${window(WRITE_VERBS)}${FILE_TOKEN}`,
+  "gi",
+);
+/** Files the task tells the worker to PRODUCE — never read targets. */
+const WRITE_TARGET_RE = new RegExp(
+  `\\b(?:${WRITE_VERBS})\\b${window(READ_VERBS)}${FILE_TOKEN}`,
+  "gi",
+);
+
+const SHELL_WRITE_TARGET_RE =
+  /(?:>>?|\btee\s+(?:-a\s+)?)\s*["']?([^\s"'|;&]+)/g;
+
+export interface FabricatedInput {
+  /** The file the task said to read (as written in the task). */
+  target: string;
+  /** The file the sub-agent wrote in its place. */
+  wrote: string;
+}
+
+export interface InputBaseline {
+  path: string;
+  existed: boolean;
+  sha256?: string;
+}
+
+function normalizedPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+/g, "/").toLowerCase();
+}
+
+/** File-like tokens the task text asks the worker to READ. */
+export function readTargetsFromTask(text: string): string[] {
+  const produced = new Set<string>();
+  for (const match of text.matchAll(WRITE_TARGET_RE)) {
+    const target = match[1]?.trim();
+    if (target) produced.add(target.toLowerCase());
+  }
+  const out: string[] = [];
+  for (const match of text.matchAll(READ_TARGET_RE)) {
+    const target = match[1]?.trim();
+    if (
+      target &&
+      !produced.has(target.toLowerCase()) &&
+      !out.includes(target)
+    ) {
+      out.push(target);
+    }
+  }
+  return out;
+}
+
+/** Paths a shell command line writes to via redirection or tee. */
+export function shellWriteTargets(command: string): string[] {
+  const out: string[] = [];
+  for (const match of command.matchAll(SHELL_WRITE_TARGET_RE)) {
+    const target = match[1];
+    if (target && target !== "/dev/null" && !out.includes(target)) {
+      out.push(target);
+    }
+  }
+  return out;
+}
+
+export function detectFabricatedInput(
+  taskText: string,
+  writtenPaths: readonly string[],
+  shellCommands: readonly string[],
+  baselines: readonly InputBaseline[],
+): FabricatedInput | undefined {
+  const targets = readTargetsFromTask(taskText);
+  if (targets.length === 0) return undefined;
+  const writes = [
+    ...writtenPaths,
+    ...shellCommands.flatMap((command) => shellWriteTargets(command)),
+  ];
+  for (const target of targets) {
+    const normalizedTarget = normalizedPath(target);
+    if (!normalizedTarget) continue;
+    const baseline = baselines.find(
+      (entry) => normalizedPath(entry.path) === normalizedTarget,
+    );
+    // A write is only fabrication evidence when the requested input was
+    // captured as absent before execution. Missing baseline is unknown, not a
+    // guilty verdict; an existing file may legitimately be rewritten.
+    if (!baseline || baseline.existed) continue;
+    const wrote = writes.find(
+      (path) => normalizedPath(path) === normalizedTarget,
+    );
+    if (wrote) return { target, wrote };
+  }
+  return undefined;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/follow-up-origin.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/follow-up-origin.ts
@@ -1,0 +1,135 @@
+/**
+ * A follow-up delivered into a LIVE session re-keys that session's voice.
+ *
+ * The router's request-voice ledger keys every relay on the session's origin
+ * message (spawnRootMessageId). A follow-up ("also give it a dark mode
+ * toggle") delivered to the same session produces a second task_complete
+ * under the SAME key, which the ledger denies as a duplicate terminal — the
+ * user heard "queued" and never heard "done" (live 2026-08-22, countdown
+ * timer's dark-mode toggle).
+ *
+ * The follow-up's own message id is noted on the session when it is queued
+ * and activated when it is actually delivered (direct send, idle flush, or
+ * room forward), so the completion that answers it claims the follow-up's
+ * slot. Stamping is best-effort metadata: a failure never blocks delivery.
+ */
+import type { Memory } from "@elizaos/core";
+
+export const FOLLOW_UP_ORIGIN_KEY = "followUpOriginMessageId";
+export const PENDING_FOLLOW_UP_ORIGIN_KEY = "pendingFollowUpOriginMessageId";
+
+type SessionLike = { metadata?: Record<string, unknown> | null } | null;
+
+export interface FollowUpOriginService {
+  getSession(
+    sessionId: string,
+  ): Promise<SessionLike | undefined> | SessionLike | undefined;
+  updateSessionMetadata?(
+    sessionId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void>;
+}
+
+function plain(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** The connector message id of a room message (the same ladder the TASKS
+ *  spawn paths use for the origin key), falling back to the memory id. */
+export function originMessageIdFor(message: Memory): string | undefined {
+  const content = record(message.content) ?? {};
+  const contentMetadata = record(content.metadata);
+  const messageMetadata = record(message.metadata);
+  const discordMetadata = record(messageMetadata?.discord);
+  return (
+    plain(contentMetadata?.originConnectorMessageId) ??
+    plain(contentMetadata?.replyToExternalMessageId) ??
+    plain(messageMetadata?.messageIdFull) ??
+    plain(messageMetadata?.discordMessageId) ??
+    plain(discordMetadata?.messageId) ??
+    plain(message.id)
+  );
+}
+
+async function metadataOf(
+  service: FollowUpOriginService,
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const session = await Promise.resolve(service.getSession(sessionId));
+    return record(session?.metadata) ?? {};
+  } catch {
+    // error-policy:J4 best-effort read; an unreadable session stamps nothing
+    return {};
+  }
+}
+
+async function patch(
+  service: FollowUpOriginService,
+  sessionId: string,
+  values: Record<string, unknown>,
+): Promise<void> {
+  if (typeof service.updateSessionMetadata !== "function") return;
+  try {
+    await service.updateSessionMetadata(sessionId, values);
+  } catch {
+    // error-policy:J4 voice re-keying is metadata; delivery proceeds without it
+  }
+}
+
+export async function readFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+): Promise<string | undefined> {
+  return plain((await metadataOf(service, sessionId))[FOLLOW_UP_ORIGIN_KEY]);
+}
+
+/** The follow-up is QUEUED (session busy): remember its origin for the
+ *  flush that delivers it. The in-flight turn keeps the current key. */
+export async function notePendingFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+  originMessageId: string | undefined,
+): Promise<void> {
+  if (!originMessageId) return;
+  await patch(service, sessionId, {
+    [PENDING_FOLLOW_UP_ORIGIN_KEY]: originMessageId,
+  });
+}
+
+/** The follow-up is being DELIVERED: its origin becomes the session's voice
+ *  key. With no explicit id, the pending (queued) origin is promoted. */
+export async function activateFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+  originMessageId?: string,
+): Promise<void> {
+  const id =
+    originMessageId ??
+    plain((await metadataOf(service, sessionId))[PENDING_FOLLOW_UP_ORIGIN_KEY]);
+  if (!id) return;
+  await patch(service, sessionId, {
+    [FOLLOW_UP_ORIGIN_KEY]: id,
+    [PENDING_FOLLOW_UP_ORIGIN_KEY]: "",
+  });
+}
+
+/** A direct send lost the race to a busy session and was queued instead:
+ *  hand the voice back to the in-flight turn and park the origin as pending. */
+export async function restoreFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+  previousActive: string | undefined,
+  pendingId: string | undefined,
+): Promise<void> {
+  await patch(service, sessionId, {
+    [FOLLOW_UP_ORIGIN_KEY]: previousActive ?? "",
+    [PENDING_FOLLOW_UP_ORIGIN_KEY]: pendingId ?? "",
+  });
+}

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -40,6 +40,7 @@ import {
   ModelType,
   type RecordedStage,
   toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import type { EvidenceCapabilities } from "./producible-evidence.js";
 
@@ -240,6 +241,11 @@ export function buildAutoVerifyCorrection(
     "",
     ...closing,
     "",
+    // Integrity clause on every stage: the pressure to "prove" a criterion
+    // must never become pressure to fake it (live 2026-08-22: a missing
+    // config file was replaced by a hand-written one and "1.2.3" shipped).
+    "Integrity: never manufacture the inputs, fixtures, files, data, or endpoints the task says to read, fetch, or operate on, and never quietly change the task to something easier to satisfy a criterion. If the real input does not exist or cannot be reached from here, say so explicitly and stop — an honest blocker is the correct report; a faked pass is a failure.",
+    "",
     buildEvidenceChecklist(missing, caps),
   ];
   return lines.join("\n");
@@ -340,6 +346,7 @@ export function buildVerificationPrompt(input: GoalVerificationInput): string {
     "- If the evidence is silent on a criterion, or only describes intent / future work, that criterion FAILS.",
     "- If the evidence contains a failure marker (a non-zero exit, a failing/red test line, an error/traceback, a loopback-only URL where a public one is required) relevant to a criterion, that criterion FAILS.",
     "- Do not give the benefit of the doubt. When in doubt, mark it missing.",
+    "- A criterion satisfied by inputs the sub-agent MANUFACTURED ITSELF FAILS: if the evidence shows it created or wrote the very file, config, dataset, or endpoint the task said to READ / FETCH / USE (or rewrote the program to consume a stand-in it made), the output is fabricated — mark the output criterion missing and say so in the summary.",
     "",
     "Respond with a SINGLE JSON object and nothing else. Do not wrap it in ```. Schema:",
     '{ "passed": <true|false>, "summary": "<one sentence under 200 chars>", "missing": ["<criterion text that was NOT proven>", ...] }',
@@ -430,6 +437,36 @@ export function parseJudgeResponse(
  * Pure with respect to filesystem and network state — the only side effect
  * is one `runtime.useModel` call.
  */
+/**
+ * Verifier model call with one bounded retry when the call died to a TURN
+ * ABORT. A user's "cancel my coding tasks" aborts every in-flight turn in the
+ * room — including this background verification of an ALREADY-DELIVERED build
+ * — and the abort then burned a verify attempt and parked a working page
+ * (live 2026-08-19). The abort is transient (the aborting turn ends in
+ * seconds); one delayed retry answers it. Any other failure propagates.
+ */
+async function verifierModelCallWithAbortRetry(
+  runtime: IAgentRuntime,
+  prompt: string,
+): Promise<string> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+        stopSequences: [],
+      });
+      return typeof result === "string" ? result : String(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (attempt === 0 && /\bTurn aborted\b/i.test(message)) {
+        await new Promise((resolve) => setTimeout(resolve, 8_000));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 export async function verifyGoalCompletion(
   runtime: IAgentRuntime,
   input: GoalVerificationInput,
@@ -455,18 +492,14 @@ export async function verifyGoalCompletion(
   const startedAt = Date.now();
   let raw: string;
   try {
-    const result = await runtime.useModel(ModelType.TEXT_SMALL, {
-      prompt,
-      stopSequences: [],
-    });
-    raw = typeof result === "string" ? result : String(result);
+    raw = await verifierModelCallWithAbortRetry(runtime, prompt);
   } catch (err) {
     // error-policy:J1 boundary translation — a failed verifier model call
     // becomes a structured fail verdict naming the error, never a fake pass.
     const detail = err instanceof Error ? err.message : String(err);
     return {
       passed: false,
-      summary: `Verifier model call failed: ${toWellFormedUnicode(detail)}`,
+      summary: `Verifier model call failed: ${truncateWellFormed(toWellFormedUnicode(detail), 200)}`,
       missing: [...input.acceptanceCriteria],
       rawResponse: "",
     };

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -6,8 +6,8 @@
  * `/api/orchestrator/*` route — must pass its raw text through one of these
  * builders. Centralising the envelope is what makes worker behaviour
  * consistent: the same goal, acceptance criteria, room wiring, capability
- * fence, and completion contract reach Claude, Codex, OpenCode, ElizaOS, and
- * Pi Agent regardless of entry point. The wording is the formalised version of
+ * fence, and completion contract reach Claude, Codex, ElizaOS, and Pi Agent
+ * regardless of entry point. The wording is the formalised version of
  * the swarm-coordination block that `TASKS_SPAWN_AGENT` already emits.
  *
  * @module services/goal-prompt

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -7,8 +7,8 @@
  * IGNORED (ambient chatter not meant for this agent).
  *
  * Eliza participants already have this faculty: the core `shouldRespond`
- * evaluator (RESPOND / IGNORE / STOP). Coding sub-agents (Claude Code, Codex,
- * OpenCode) have no such gate — left alone, every keystroke in the room is
+ * evaluator (RESPOND / IGNORE / STOP). Coding sub-agents (Claude Code, Codex)
+ * have no such gate — left alone, every keystroke in the room is
  * injected into a running turn, derailing it. This module gives them an
  * equivalent structural decision, and threads an Eliza participant's
  * `shouldRespond` verdict through unchanged when one is supplied.
@@ -34,7 +34,7 @@ export interface InterruptionDecision {
 export interface InterruptionInput {
   /** The incoming user message text. */
   text: string;
-  /** Sub-agent framework: claude / codex / opencode / elizaos / … */
+  /** Sub-agent framework: claude / codex / elizaos / … */
   agentType: string;
   /** True when the sub-agent is mid-turn (ACP status `busy`). */
   sessionBusy: boolean;

--- a/plugins/plugin-agent-orchestrator/src/services/loopback-urls.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/loopback-urls.ts
@@ -1,0 +1,28 @@
+/**
+ * Loopback URL redaction for user-facing sub-agent text. A coding child
+ * verifies its page on the supervisor's loopback port and narrates that URL;
+ * chat must never carry it (it is unreachable for the user and names an
+ * internal port). Shared by the router narration and the completion
+ * evaluator's delivery funnel.
+ */
+
+const LOOPBACK_URL_PATTERN =
+  /https?:\/\/(?:localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[?::1\]?)(?::\d{1,5})?(?:\/[^\s)<>"`]*)?/gi;
+
+export function redactLoopbackUrls(text: string): string {
+  if (!text) return text;
+  LOOPBACK_URL_PATTERN.lastIndex = 0;
+  if (!LOOPBACK_URL_PATTERN.test(text)) return text;
+  LOOPBACK_URL_PATTERN.lastIndex = 0;
+  const stripped = text
+    .replace(LOOPBACK_URL_PATTERN, "")
+    .replace(/[ \t]+\n/g, "\n");
+  // Drop lines that became orphan punctuation after the URL was removed
+  // (e.g. "- " or "* " markdown list bullets pointing at nothing).
+  return stripped
+    .split("\n")
+    .filter((line) => !/^[-*\s]*[:>→\->]?[\s]*$/.test(line) || line === "")
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/plugins/plugin-agent-orchestrator/src/services/model-gateway.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/model-gateway.ts
@@ -6,12 +6,13 @@
  * process env, per config-env conventions). In gateway mode a spawned
  * sub-agent's env points `OPENAI_BASE_URL` (Codex CLI) and
  * `ANTHROPIC_BASE_URL` (Claude Code via claude-agent-acp) at the gateway,
- * with the gateway token injected as the api-key env for both paths. OpenCode
- * routes through the gateway too: in gateway mode `buildOpencodeSpawnConfig`
- * (opencode-config.ts) builds a gateway-pointed provider config instead of
- * embedding a raw provider key into `OPENCODE_CONFIG_CONTENT`. Raw provider
- * credentials are actively excluded — deleted before the token is assigned,
- * and any composite env value still embedding a raw key is dropped whole —
+ * with the gateway token injected as the api-key env for both paths. The
+ * eliza-code backend routes through the gateway via the same two vars: its
+ * model-provider resolution prefers `OPENAI_BASE_URL`/`OPENAI_API_KEY` over
+ * the `ELIZA_CODE_*` fallbacks, so the env rewrite alone covers it. Raw
+ * provider credentials are actively excluded — deleted before the token is
+ * assigned, and any composite env value still embedding a raw key is dropped
+ * whole —
  * so a sub-agent env dump contains no raw provider credential.
  * With either var unset the child env is byte-identical to non-gateway
  * behavior.
@@ -37,7 +38,7 @@ export const MODEL_GATEWAY_TOKEN_KEY = "ELIZA_MODEL_GATEWAY_TOKEN";
  * credential `AcpService.buildEnv` merge paths can carry into a child env:
  * - `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `CEREBRAS_API_KEY` — on the
  *   host-env forwarding allowlist (`shouldForwardEnv`).
- * - `ELIZA_E2E_CEREBRAS_API_KEY` — raw provider
+ * - `ELIZA_CODE_API_KEY` / `ELIZA_E2E_CEREBRAS_API_KEY` — raw provider
  *   keys forwarded via the broad `ELIZA_` prefix rule.
  * - `CLAUDE_CODE_OAUTH_TOKEN` — injected by multi-account selection
  *   (`selectCodingAccount` envPatch) for linked Claude subscriptions.
@@ -52,6 +53,7 @@ export const MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS = [
   "ANTHROPIC_API_KEY",
   "CODEX_API_KEY",
   "CEREBRAS_API_KEY",
+  "ELIZA_CODE_API_KEY",
   "ELIZA_E2E_CEREBRAS_API_KEY",
   "CLAUDE_CODE_OAUTH_TOKEN",
 ] as const;
@@ -97,11 +99,10 @@ const MODEL_GATEWAY_ENV_PREFIX = "ELIZA_MODEL_GATEWAY_";
  * The invariant is "no raw provider key VALUE anywhere in the child env",
  * not "the named keys are absent" — so after deleting the named keys, any
  * remaining env var whose value embeds one of their raw values (a composite
- * carrier, e.g. a JSON config blob like `OPENCODE_CONFIG_CONTENT`) is
+ * carrier, e.g. a JSON config blob assembled by an earlier merge step) is
  * dropped whole. Fail closed: a misconfigured child beats a leaked key.
- * (The opencode path never trips this in practice — in gateway mode
- * `buildOpencodeSpawnConfig` builds a gateway-pointed config with no raw
- * key; this sweep is the backstop for future merge steps.)
+ * No current merge step builds such a blob; this sweep is the backstop for
+ * future ones.
  */
 export function applyModelGatewayEnv(
   env: NodeJS.ProcessEnv,

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -77,6 +77,53 @@ export interface InventedArtifactFilterResult {
   dropped: string[];
 }
 
+/** Evidence classes no orchestrator pipeline can collect: the verifier judges
+ *  from workdir files, tool stdout, git changesets, and HTTP probes — never a
+ *  live browser session or a human eyeball. A generated criterion demanding
+ *  one of these is unsatisfiable by design and parks working deliverables
+ *  (live 2026-08-19: "Browser console shows zero JavaScript errors during a
+ *  complete work-to-break cycle" parked a built, served pomodoro page). */
+const UNCOLLECTABLE_EVIDENCE_RE =
+  /\b(?:browser\s+console|devtools|dev\s+tools|console\s+logs?\s+(?:show|prove|confirm)|screenshots?|screen\s+recording|visually\s+(?:verify|confirm|inspect)|manual(?:ly)?\s+(?:test|verify|confirm|inspect)|user\s+confirms?|lighthouse|cross-browser|no\s+(?:js|javascript)\s+(?:errors?|warnings?)\s+in\s+the\s+(?:browser|console)|(?:interact(?:ion|ing)?|click(?:ing|s)?|tapping|hover(?:ing)?)\s+(?:with\s+)?(?:a\s+|the\s+)?\w*\s*(?:trigger|button|element).{0,40}\b(?:DOM|display|updates?|renders?)|updates?\s+the\s+(?:displayed|rendered)|\bin\s+the\s+DOM\b|visual(?:ly)?\s+(?:evidence|representation|verification|confirm)|renders?\s+(?:correctly|properly|the\s+\w+\s+correctly))/i;
+
+/** Criteria classes unsatisfiable for STATIC APP builds specifically: slug-dir
+ *  pages have no git pipeline, so "summarized in the diff" can never be
+ *  evidenced (live 2026-08-19: quote-generator parked on it), and runtime DOM
+ *  behavior is only provable in a browser the verifier does not have. */
+/** Report-shaped criteria demand a NARRATIVE (a summary/description of the
+ *  changes) rather than a property of the deliverable itself. They are
+ *  unsatisfiable as acceptance criteria for EVERY task type — the verifier
+ *  ends up grading the sub-agent's prose, and an under-narrated but working
+ *  build parks ("the diff summarizes the specific style and theme changes",
+ *  live 2026-08-20 dark-mode edit). Checkable diff-content criteria ("the
+ *  diff shows a toggle element added") survive. */
+const REPORT_SHAPED_CRITERION_RE =
+  /\b(?:diff\s+summariz|summar(?:y|ize[sd]?|izing)\s+(?:of|in)?\s*the\s+(?:diff|changes?|work)|provide[sd]?\s+a\s+summary|describe[sd]?\s+the\s+changes?\b)/i;
+
+const APP_BUILD_UNSATISFIABLE_RE =
+  /\b(?:diff\s+summar|summar\w*\s+in\s+the\s+diff|the\s+diff\b|git\s+diff|changeset|commit\s+message)/i;
+
+/**
+ * Drop generated criteria whose proof would require evidence the pipeline
+ * cannot produce (browser runtime state, human inspection). Deterministic
+ * template criteria never trip this; only model-refined text does.
+ */
+export function stripUncollectableEvidenceCriteria(
+  criteria: readonly string[],
+  taskType?: string,
+): InventedArtifactFilterResult {
+  const kept: string[] = [];
+  const dropped: string[] = [];
+  for (const criterion of criteria) {
+    const uncollectable =
+      UNCOLLECTABLE_EVIDENCE_RE.test(criterion) ||
+      REPORT_SHAPED_CRITERION_RE.test(criterion) ||
+      (taskType === "app-build" && APP_BUILD_UNSATISFIABLE_RE.test(criterion));
+    (uncollectable ? dropped : kept).push(criterion);
+  }
+  return { kept, dropped };
+}
+
 /**
  * Drop generated criteria that pin a concrete path/filename absent from the
  * request. The worker legitimately chooses its own layout when the request

--- a/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
@@ -37,6 +37,52 @@ export function mineCandidatePaths(texts: readonly string[]): string[] {
   return [...out];
 }
 
+const ENUMERATE_MAX_DEPTH = 3;
+const ENUMERATE_MAX_ENTRIES = 64;
+/** Orchestration plumbing written into the workdir for the child — never the
+ *  deliverable, so never candidate evidence. */
+const ENUMERATE_SKIP = new Set(["AGENTS.md", "CLAUDE.md", "node_modules"]);
+
+/**
+ * Enumerate the session workdir directly as a candidate source. A worker that
+ * ends its run with an empty final reply leaves NOTHING to mine claims from,
+ * and a working build then parks with "no evidence" (live 2026-08-19: built
+ * dice-roller page reported as ghosted + parked). Enumeration only nominates
+ * candidates; collectFsObservedFiles still applies the mtime-after-start gate
+ * before anything counts as evidence.
+ */
+export function enumerateWorkdirCandidates(workdir: string): string[] {
+  const root = path.resolve(workdir);
+  const out: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    if (depth > ENUMERATE_MAX_DEPTH || out.length >= ENUMERATE_MAX_ENTRIES) {
+      return;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      // error-policy:J3 an unreadable directory nominates no candidates; the
+      // claim-mining sources still apply.
+      return;
+    }
+    for (const entry of entries) {
+      if (out.length >= ENUMERATE_MAX_ENTRIES) return;
+      if (entry.name.startsWith(".") || ENUMERATE_SKIP.has(entry.name)) {
+        continue;
+      }
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute, depth + 1);
+      } else if (entry.isFile()) {
+        out.push(path.relative(root, absolute));
+      }
+    }
+  };
+  walk(root, 0);
+  return out.sort();
+}
+
 export interface FsObservedFilesInput {
   workdir: string;
   candidatePaths: readonly string[];

--- a/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
@@ -44,6 +44,31 @@ export const DEFAULT_STATE_LOST_RESPAWN_CAP = stateLostRespawnCapFor(
 );
 
 /**
+ * Per-request voice ledger entry: which session posted the single spawn ack
+ * for this user request, and which session holds its single user-facing
+ * terminal. `finalized` distinguishes a provisional result (a `task_complete`
+ * claimed before verification settles — supersedable exactly once by a park
+ * notice) from a settled terminal.
+ *
+ * Finality is not absolute for a `failure` holder: its narration explicitly
+ * invites the planner to retry ("spawn a fresh session"), so a later GENUINE
+ * `result` supersedes it (`claim_request_terminal`), and an admitted respawn
+ * for the same request clears it outright (`respawn_admitted`) so the new
+ * generation regains the request's voice. Without those two escapes a
+ * transient error permanently gagged the key and the invited retry's real
+ * success was eaten (live defect).
+ */
+export interface RequestVoiceEntry {
+  readonly ackSessionId?: string;
+  readonly terminal?: {
+    readonly holderSessionId: string;
+    readonly kind: "result" | "parked" | "failure";
+    readonly provisional: boolean;
+    readonly finalized: boolean;
+  };
+}
+
+/**
  * The complete loop-guard state. Every field is treated as immutable: the
  * reducer never mutates the input, it returns a fresh state with copied
  * collections.
@@ -61,6 +86,16 @@ export interface RouterLoopState {
   readonly stateLostCapNotified: ReadonlySet<string>;
   /** Completion lineage key → the first session that claimed its post slot. */
   readonly completionFirstPostedSession: ReadonlyMap<string, string>;
+  /**
+   * Request key (stable per USER coding request, across sessions AND
+   * respawns — see `requestVoiceKeyForMeta`) → its voice ledger entry. The
+   * lineage/completion slots above are per session generation; a task-service
+   * respawn mints a new session and a new lineage, so every generation's
+   * completion passed those guards and relayed. This slot is the broader
+   * invariant: ≤1 ack and ≤1 terminal per request, one sanctioned
+   * provisional-result → parked supersede.
+   */
+  readonly requestVoice: ReadonlyMap<string, RequestVoiceEntry>;
 }
 
 /** One incoming loop-guard signal, derived from a classified ACP event. */
@@ -88,7 +123,31 @@ export type RouterLoopEvent =
    */
   | { type: "rollback_round_trip"; sessionId: string; expectedCount: number }
   /** Claim the post slot for a completion lineage, for `sessionId`. */
-  | { type: "claim_completion"; completionKey: string; sessionId: string };
+  | { type: "claim_completion"; completionKey: string; sessionId: string }
+  /** Claim the single spawn-ack slot for a user request, for `sessionId`. */
+  | { type: "claim_request_ack"; requestKey: string; sessionId: string }
+  /**
+   * Claim the single user-facing terminal slot for a user request. A
+   * `provisional` claim (a `task_complete` before verification settles) may be
+   * superseded exactly once by a `parked` claim; everything else is
+   * first-writer-wins.
+   */
+  | {
+      type: "claim_request_terminal";
+      requestKey: string;
+      sessionId: string;
+      kind: "result" | "parked" | "failure";
+      provisional: boolean;
+    }
+  /**
+   * A NEW spawn was admitted for this request (verify-driven or planner-driven
+   * retry). A `failure` terminal held by an earlier generation is cleared so
+   * the retry regains the request's voice — its progress/questions un-mute and
+   * its eventual terminal claims a fresh slot. `result`/`parked` holders are
+   * untouched (the request genuinely concluded), as is the ack slot (one spawn
+   * ack per request stands across every generation).
+   */
+  | { type: "respawn_admitted"; requestKey: string };
 
 /** What the service should do for a given event. */
 export type RouterLoopDecision =
@@ -113,7 +172,19 @@ export type RouterLoopDecision =
   /** This session holds the completion slot (newly, or a same-session re-claim): post. */
   | { kind: "claimed" }
   /** A different session already holds the slot: suppress this duplicate. */
-  | { kind: "already_claimed" };
+  | { kind: "already_claimed" }
+  /** The request's ack slot was free and is now held by this session: post the ack. */
+  | { kind: "ack_granted" }
+  /** An ack already posted for this request: suppress this duplicate ack. */
+  | { kind: "ack_already_posted" }
+  /** The request's terminal slot was free and is now held by this session: post. */
+  | { kind: "terminal_granted" }
+  /** A sanctioned supersede (provisional result → park, or failure → genuine result): post. */
+  | { kind: "terminal_granted_supersede" }
+  /** A terminal already holds this request's voice: suppress (holderKind for logging). */
+  | { kind: "terminal_denied"; holderKind: "result" | "parked" | "failure" }
+  /** An admitted respawn cleared the request's failure terminal: the voice is live again. */
+  | { kind: "voice_reset" };
 
 export interface RouterLoopTransition {
   readonly state: RouterLoopState;
@@ -138,7 +209,63 @@ export function createRouterLoopState(opts?: {
     stateLostRespawnCounts: new Map(),
     stateLostCapNotified: new Set(),
     completionFirstPostedSession: new Map(),
+    requestVoice: new Map(),
   };
+}
+
+const UUID_KEY_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function pickKeyString(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim() || undefined : undefined;
+}
+
+/** Separator between the request-root base key and a fan-out part suffix.
+ * NUL cannot appear in message ids, uuids, or minted part labels, so composed
+ * keys can never collide with a bare base key (same trick as the per-origin
+ * cap's `spawnOriginKeyFor`). */
+const REQUEST_VOICE_PART_SEP = "\0";
+
+/**
+ * The canonical request-voice key ladder, read from a session's (or task's)
+ * metadata. The BASE mirrors `spawnRootIdFromMeta` (sub-agent-router.ts) —
+ * `spawnRootMessageId ?? originConnectorMessageId ?? messageId(uuid)` — plus a
+ * `task:<taskId>` fallback so task-service-spawned sessions (no connector
+ * message at all) and `notifyVerifyEscalation`'s task-level projection resolve
+ * the SAME key. Returns null when nothing stable exists; callers must fail
+ * open (no gating) on null.
+ *
+ * `requestVoicePart` scopes the key WITHIN one user request: a deliberate
+ * multi-part fan-out (lane plan with several lanes, a multi-part TASKS create)
+ * stamps a distinct part per lane/part at spawn time, so genuinely parallel
+ * lanes each own their own ack/terminal slot instead of the first lane's
+ * terminal gagging the rest. The part is INHERITED verbatim by every respawn
+ * of the same logical lane (task-metadata carry, router synthetic-inbound
+ * re-stamp), never re-minted, so respawn-shares-key still holds per lane.
+ * Sessions without a part (single-task requests, pre-stamp sessions) keep the
+ * bare base key — the original ledger behavior.
+ */
+export function requestVoiceKeyForMeta(
+  meta: Record<string, unknown> | undefined,
+): string | null {
+  if (!meta) return null;
+  // A follow-up delivered into the live session re-keys its voice: the
+  // completion answering "also give it a dark mode toggle" is THAT message's
+  // terminal, not a duplicate of the original build's (live 2026-08-22: the
+  // dark-mode completion was terminal_denied and never posted).
+  const direct =
+    pickKeyString(meta.followUpOriginMessageId) ??
+    pickKeyString(meta.spawnRootMessageId) ??
+    pickKeyString(meta.originConnectorMessageId);
+  const messageId = pickKeyString(meta.messageId);
+  const taskId = pickKeyString(meta.taskId);
+  const base =
+    direct ??
+    (messageId && UUID_KEY_RE.test(messageId) ? messageId : undefined) ??
+    (taskId ? `task:${taskId}` : undefined);
+  if (!base) return null;
+  const part = pickKeyString(meta.requestVoicePart);
+  return part ? `${base}${REQUEST_VOICE_PART_SEP}${part}` : base;
 }
 
 /** Copy a map, set a key, and FIFO-evict down to the bound. */
@@ -332,6 +459,112 @@ export function routerLoopTransition(
       return {
         state: { ...state, completionFirstPostedSession },
         decision: { kind: "claimed" },
+      };
+    }
+
+    case "claim_request_ack": {
+      // Synchronous CAS like claim_completion: no await between get and set,
+      // so the TOCTOU window is closed by construction.
+      const entry = state.requestVoice.get(event.requestKey);
+      if (entry?.ackSessionId !== undefined) {
+        return { state, decision: { kind: "ack_already_posted" } };
+      }
+      const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+        ...entry,
+        ackSessionId: event.sessionId,
+      });
+      return {
+        state: { ...state, requestVoice },
+        decision: { kind: "ack_granted" },
+      };
+    }
+
+    case "claim_request_terminal": {
+      const entry = state.requestVoice.get(event.requestKey);
+      const held = entry?.terminal;
+      if (held === undefined) {
+        // Empty slot: first terminal wins. A provisional claim (task_complete
+        // before verification settles) stays supersedable; anything else is
+        // final immediately.
+        const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+          ...entry,
+          terminal: {
+            holderSessionId: event.sessionId,
+            kind: event.kind,
+            provisional: event.provisional,
+            finalized: !event.provisional,
+          },
+        });
+        return {
+          state: { ...state, requestVoice },
+          decision: { kind: "terminal_granted" },
+        };
+      }
+      if (held.provisional && !held.finalized && event.kind === "parked") {
+        // The ONE sanctioned correction: a provisional result is superseded by
+        // the honest park notice, exactly once — the slot finalizes here so a
+        // second park (respawn doubled the task) is denied.
+        const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+          ...entry,
+          terminal: {
+            holderSessionId: event.sessionId,
+            kind: "parked",
+            provisional: event.provisional,
+            finalized: true,
+          },
+        });
+        return {
+          state: { ...state, requestVoice },
+          decision: { kind: "terminal_granted_supersede" },
+        };
+      }
+      if (held.kind === "failure" && event.kind === "result") {
+        // A failure narration invites the planner to retry, so its finality
+        // binds only against duplicate failures and redundant parks — never
+        // against the GENUINE success it asked for. Without this supersede the
+        // invited retry's task_complete was terminal_denied and the user was
+        // left with the stale error (live defect). The new holder is the
+        // standard supersedable-provisional result when `provisional`, so the
+        // one sanctioned parked correction above still applies to it.
+        const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+          ...entry,
+          terminal: {
+            holderSessionId: event.sessionId,
+            kind: "result",
+            provisional: event.provisional,
+            finalized: !event.provisional,
+          },
+        });
+        return {
+          state: { ...state, requestVoice },
+          decision: { kind: "terminal_granted_supersede" },
+        };
+      }
+      return {
+        state,
+        decision: { kind: "terminal_denied", holderKind: held.kind },
+      };
+    }
+
+    case "respawn_admitted": {
+      const entry = state.requestVoice.get(event.requestKey);
+      if (entry?.terminal?.kind !== "failure") {
+        // Nothing to revive: empty slot, or a result/parked terminal that an
+        // admitted respawn must not disturb (the request genuinely concluded).
+        return { state, decision: { kind: "noop" } };
+      }
+      // Drop ONLY the failure terminal. The ack slot survives — the request
+      // was ack'd once and the retry must not re-ack — and the fresh slot
+      // means the retry's terminal claims `terminal_granted` normally, with
+      // every downstream `finalized` gate (progress mute, question gate)
+      // released for the new generation.
+      const { terminal: _cleared, ...rest } = entry;
+      const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+        ...rest,
+      });
+      return {
+        state: { ...state, requestVoice },
+        decision: { kind: "voice_reset" },
       };
     }
 

--- a/plugins/plugin-agent-orchestrator/src/services/session-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-store.ts
@@ -427,6 +427,20 @@ export class InMemorySessionStore implements SessionStore {
     await this.writes.enqueue(() => this.applyUpdateLocked(id, patch));
   }
 
+  async mergeMetadata(
+    id: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    // Read+merge+write inside ONE queued op — see the SessionStore contract.
+    await this.writes.enqueue(async () => {
+      const current = this.sessions.get(id);
+      if (!current) return;
+      await this.applyUpdateLocked(id, {
+        metadata: { ...(current.metadata ?? {}), ...patch },
+      });
+    });
+  }
+
   async updateStatus(
     id: string,
     status: SessionStatus,
@@ -763,6 +777,24 @@ export class RuntimeDbSessionStore implements SessionStore {
 
   async update(id: string, patch: Partial<SessionInfo>): Promise<void> {
     await this.writes.enqueue(() => this.applyUpdateLocked(id, patch));
+  }
+
+  async mergeMetadata(
+    id: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    // Read+merge+write inside ONE queued op — see the SessionStore contract.
+    await this.writes.enqueue(async () => {
+      await this.ensureInitialized();
+      const current = await this.getOne(
+        "SELECT * FROM acp_sessions WHERE id = ?",
+        [id],
+      );
+      if (!current) return;
+      await this.applyUpdateLocked(id, {
+        metadata: { ...(current.metadata ?? {}), ...patch },
+      });
+    });
   }
 
   async updateStatus(

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -40,8 +40,11 @@ export const APP_BUILD_TASK_RE =
 // regex's `tool`/`page`/`portfolio`/`widget` nouns false-positive). The skill
 // recommender tolerates over-matching (it only suggests a skill); the spawn-
 // time deploy injection rewrites the task contract, so it uses this gate.
+// Bare "page"/"site" belong in the noun list: "Build a simple, aesthetically
+// pleasing moon phase page" matched nothing, so the build ran in a scratch
+// workspace with no served URL and verification parked it (live 2026-08-19).
 export const APP_DEPLOY_TASK_RE =
-  /\b(build|create|make|ship|deploy|generate|design)\b(?:(?!\b(?:article|blog|post|cli|command[-\s]?line|library|package|script|extension|bot|plugin)\b)[\s\S]){0,120}\b(web\s?app|webapp|web\s?site|website|web\s?page|webpage|landing\s?page|home\s?page|dashboard|micro\s?site|website|app)\b/i;
+  /\b(build|create|make|ship|deploy|generate|design)\b(?:(?!\b(?:article|blog|post|cli|command[-\s]?line|library|package|script|extension|bot|plugin)\b)[\s\S]){0,120}\b(web\s?app|webapp|web\s?site|website|web\s?page|webpage|landing\s?page|home\s?page|dashboard|micro\s?site|page|site|app)\b/i;
 // Tokens shorter than this carry no signal — they show up in nearly every
 // task description and would inflate every skill's score equally.
 const MIN_TOKEN_LENGTH = 4;

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -22,10 +22,6 @@ const DENY_ENV_PATTERNS = [
   // including through customCredentials. Registry push uses the dedicated
   // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.
   /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT|GH_PAT)$/i,
-  // OpenCode's spawn config is runtime-built (buildOpencodeAcpEnv overwrites it
-  // AFTER this filter runs). A caller- or host-supplied value would let the
-  // spawner inject arbitrary provider config into the child, so it is denied at
-  // both intake paths.
 ];
 
 /**
@@ -43,7 +39,7 @@ export function isDeniedSubAgentEnvKey(key: string): boolean {
  * Matched case-insensitively (see `shouldForwardEnv`): the repo runtime is Bun,
  * and Bun on Windows reports these with native casing — `Path`, not `PATH` —
  * so a case-sensitive check would forward NONE of them, leaving the child with
- * no search path (the opencode shim then fails with "'bun' is not recognized").
+ * no search path (a spawned CLI then fails with "'bun' is not recognized").
  * Includes the Windows essentials cmd.exe + Bun + the agent's config/cache
  * resolution rely on, alongside the POSIX names.
  */

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -1,7 +1,7 @@
 /**
  * Self-contained operating manual scaffolded into a spawned sub-agent's
- * workspace so every backend (claude reads CLAUDE.md, codex reads AGENTS.md,
- * opencode reads both) receives the same eliza-context + non-interactive
+ * workspace so every backend (claude reads CLAUDE.md, codex reads AGENTS.md)
+ * receives the same eliza-context + non-interactive
  * directive regardless of where the spawn cwd lands. The ACP spawn path injects
  * nothing but the task string, so without this a sub-agent in a bare/scratch
  * cwd gets zero orientation — codex in particular ("expected identity files are

--- a/plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts
@@ -15,7 +15,7 @@
  * file — which outlives the session — can never leak the model key the
  * sub-agent echoed to stdout.
  */
-import { appendFile, mkdir, rename, stat } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rename, stat } from "node:fs/promises";
 import { join } from "node:path";
 import {
   isTrajectoryRecordingEnabled,
@@ -74,6 +74,73 @@ export async function appendSubagentStdout(
   });
   await appendFile(path, `${record}\n`, "utf8");
   return path;
+}
+
+/** One decoded chunk window read back from the durable log. */
+export interface SubagentStdoutWindow {
+  /** Concatenated chunk text for the requested window. */
+  text: string;
+  /** Zero-based index of the first chunk in the window. */
+  offset: number;
+  /** Total chunks currently in the log (current generation only). */
+  totalChunks: number;
+  /** True when chunks exist after the window (continuation available). */
+  hasMore: boolean;
+  /** True when a rotated `.1` generation exists — older content was
+   *  discarded from THIS reader's view but may survive in that file. */
+  rotated: boolean;
+}
+
+/**
+ * Read a window of the durable per-session stdout log — the continuation
+ * resolver for `acpx-session-output:<sessionId>` content references. Chunk
+ * indexed (one NDJSON record per captured chunk); a negative `offset` counts
+ * from the end (tail semantics). Returns undefined when no log exists (
+ * recording disabled, or the session never wrote output).
+ */
+export async function readSubagentStdout(
+  sessionId: string,
+  opts: { offset?: number; limit?: number } = {},
+): Promise<SubagentStdoutWindow | undefined> {
+  const path = subagentStdoutLogPath(sessionId);
+  const raw = await readFile(path, "utf8").catch(
+    (err: NodeJS.ErrnoException) => {
+      // error-policy:J3 ENOENT is the explicit "no durable log" signal the
+      // caller branches on; any other read failure is a real fault.
+      if (err?.code === "ENOENT") return undefined;
+      throw err;
+    },
+  );
+  if (raw === undefined) return undefined;
+  const rotated = await stat(`${path}.1`).then(
+    () => true,
+    () => false,
+  );
+  const chunks: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const record = JSON.parse(line) as { text?: unknown };
+      if (typeof record.text === "string") chunks.push(record.text);
+    } catch {
+      // error-policy:J3 a torn tail line (crash mid-append) is expected in an
+      // append-only log; skip it rather than fail the whole read.
+    }
+  }
+  const limit = Math.max(1, Math.min(opts.limit ?? 200, 10_000));
+  const requested = opts.offset ?? -limit;
+  const start =
+    requested < 0
+      ? Math.max(0, chunks.length + requested)
+      : Math.min(requested, chunks.length);
+  const window = chunks.slice(start, start + limit);
+  return {
+    text: window.join(""),
+    offset: start,
+    totalChunks: chunks.length,
+    hasMore: start + window.length < chunks.length,
+    rotated,
+  };
 }
 
 // A session id flows in from ACP and could in principle contain path separators;

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -404,6 +404,13 @@ function normalizeTaskAgentAdapterForModelPrefs(
     case "elizaos":
     case "eliza-os":
     case "eliza":
+    case "eliza-code":
+    case "eliza code":
+    // "opencode" is a retired backend name; legacy task records naming it
+    // resolve to the eliza-code (elizaos) adapter.
+    case "opencode":
+    case "open-code":
+    case "open code":
       return "elizaos";
     case "pi-agent":
     case "pi agent":
@@ -717,6 +724,12 @@ async function computeTaskAgentFrameworkState(
     configuredSubscriptionProvider === "openai-codex" ||
     configuredSubscriptionProvider === "openai-subscription" ||
     hasCodexApiKey(runtime);
+  // eliza-code (elizaos) is the BYO default when no provider-specific key
+  // prefers Claude/Codex. Claude/Codex only become preferred when their key
+  // path is set; an uninstalled framework's availabilityScore of -100 keeps it
+  // out of the running.
+  const providerPrefersByoDefault =
+    !providerPrefersClaude && !providerPrefersCodex;
   const explicitDefault = safeGetSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE")
     ?.toLowerCase()
     .trim();
@@ -793,7 +806,13 @@ async function computeTaskAgentFrameworkState(
       framework.id === "elizaos" || framework.id === "pi-agent"
         ? explicitDefault === framework.id
           ? 18
-          : 0
+          : // eliza-code is the BYO default when no provider key prefers
+            // claude/codex.
+            framework.id === "elizaos" && providerPrefersByoDefault
+            ? framework.authReady
+              ? 18
+              : 6
+            : 0
         : providerPrefersClaude && framework.id === "claude"
           ? framework.subscriptionReady
             ? 18
@@ -997,6 +1016,12 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
     configuredSubscriptionProvider === "openai-codex" ||
     configuredSubscriptionProvider === "openai-subscription" ||
     hasCodexApiKey(runtime);
+  // eliza-code (elizaos) is the BYO default when no provider-specific key
+  // prefers Claude/Codex. Claude/Codex only become preferred when their key
+  // path is set; an uninstalled framework's availabilityScore of -100 keeps it
+  // out of the running.
+  const providerPrefersByoDefault =
+    !providerPrefersClaude && !providerPrefersCodex;
   const explicitDefault = safeGetSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE")
     ?.toLowerCase()
     .trim();
@@ -1008,7 +1033,13 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
       framework.id === "elizaos" || framework.id === "pi-agent"
         ? explicitDefault === framework.id
           ? 18
-          : 0
+          : // eliza-code is the BYO default when no provider key prefers
+            // claude/codex.
+            framework.id === "elizaos" && providerPrefersByoDefault
+            ? framework.authReady
+              ? 18
+              : 6
+            : 0
         : providerPrefersClaude && framework.id === "claude"
           ? framework.subscriptionReady
             ? 18

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -8,6 +8,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { resolveAppDeployConfig } from "./app-deploy-guidance.js";
 import { readConfigEnvKey } from "./config-env.js";
 
 export const KNOWN_ADAPTER_TYPES = new Set([
@@ -26,6 +27,13 @@ export function normalizeTaskAgentAdapter(
     case "elizaos":
     case "eliza-os":
     case "eliza":
+    case "eliza-code":
+    case "eliza code":
+    // "opencode" is a retired backend name; requests naming it route to the
+    // eliza-code (elizaos) adapter.
+    case "opencode":
+    case "open-code":
+    case "open code":
       return "elizaos";
     case "pi-agent":
     case "pi agent":
@@ -93,12 +101,77 @@ export function resolvePinnedAdapter(
   return KNOWN_ADAPTER_TYPES.has(raw) ? raw : undefined;
 }
 
+/** Directories a build must never land in by planner invention: the home
+ *  directory itself, any ancestor of a configured route's workdir (the
+ *  projects folder that holds real repos), and the runtime's own checkout. */
+function isProtectedLocation(
+  runtime: IAgentRuntime | undefined,
+  workdir: string,
+): boolean {
+  const resolved = path.resolve(workdir);
+  const home = path.resolve(os.homedir());
+  if (resolved === home) return true;
+  const cwdRoot = path.resolve(process.cwd());
+  if (resolved === cwdRoot || cwdRoot.startsWith(`${resolved}${path.sep}`)) {
+    return true;
+  }
+  for (const route of configuredWorkdirRoutes(runtime)) {
+    const routeDir = path.resolve(expandHomePath(route.workdir));
+    if (
+      routeDir !== resolved &&
+      routeDir.startsWith(`${resolved}${path.sep}`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Whether an explicit existing workdir has a reason to be honored: it sits
+ *  inside a configured route tree or the published-apps dir, the user named
+ *  it (path or last segment) in the request or task text, or it is the
+ *  workdir of a session the orchestrator knows (a finished lane being
+ *  continued). Anything else is a planner-invented path. */
+function explicitWorkdirIsGrounded(
+  runtime: IAgentRuntime | undefined,
+  workdir: string,
+  userRequest: string,
+  task: string,
+  knownWorkdirs: readonly string[],
+): boolean {
+  const resolved = path.resolve(workdir);
+  if (resolveRouteForWorkdir(runtime, resolved)) return true;
+  const deploy = resolveAppDeployConfig();
+  if (
+    deploy.target === "custom" &&
+    deploy.customAppsDir &&
+    resolved.startsWith(`${path.resolve(deploy.customAppsDir)}${path.sep}`)
+  ) {
+    return true;
+  }
+  const mentioned = `${userRequest}\n${task}`;
+  const base = path.basename(resolved);
+  if (
+    mentioned.toLowerCase().includes(resolved.toLowerCase()) ||
+    mentioned.toLowerCase().includes(workdir.toLowerCase()) ||
+    (base.length >= 3 && containsPhrase(mentioned, base))
+  ) {
+    return true;
+  }
+  return knownWorkdirs.some((known) => path.resolve(known) === resolved);
+}
+
 export function resolveSpawnWorkdir(
   runtime: IAgentRuntime | undefined,
   task: string,
   userRequest: string,
   explicitWorkdir: string | undefined,
-  opts: { lockWorkdir?: boolean } = {},
+  opts: {
+    lockWorkdir?: boolean;
+    /** Workdirs of sessions the orchestrator knows (a finished lane being
+     *  continued); the caller resolves them because session listing is async. */
+    knownWorkdirs?: readonly string[];
+  } = {},
 ): { workdir: string; route?: ResolvedWorkdirRoute; isolate?: boolean } {
   const expandedExplicit = explicitWorkdir
     ? expandHomePath(explicitWorkdir)
@@ -127,6 +200,31 @@ export function resolveSpawnWorkdir(
   const detected = resolveWorkdirByConvention(runtime, task, userRequest);
   if (detected) return withContainedRoute({ workdir: detected });
   const fallback = resolveDefaultSpawnWorkdir(runtime);
+  if (
+    expandedExplicit &&
+    fs.existsSync(expandedExplicit) &&
+    isProtectedLocation(runtime, expandedExplicit) &&
+    !explicitWorkdirIsGrounded(
+      runtime,
+      expandedExplicit,
+      userRequest,
+      task,
+      opts.knownWorkdirs ?? [],
+    )
+  ) {
+    // The planner fills `workdir` on every create ("/home/milady/<label>",
+    // live 2026-08-22 on every build). An existing scratch dir stays trusted
+    // (the established contract), but a PROTECTED location — the home dir,
+    // the parent of a configured route, the agent's own checkout — that
+    // nothing grounds (not a route tree, not named by the user, not a known
+    // lane's dir) would land a fresh build in an unrelated real directory.
+    logger.warn(
+      `[workdir-routes] Planner workdir is a protected location nothing grounds; ignoring it: ${expandedExplicit} — falling back to ${fallback.workdir}`,
+    );
+    return fallback.isolate
+      ? { workdir: fallback.workdir, isolate: true }
+      : { workdir: fallback.workdir };
+  }
   if (expandedExplicit && fs.existsSync(expandedExplicit)) {
     if (
       fallback.isolate &&
@@ -140,6 +238,25 @@ export function resolveSpawnWorkdir(
     return withContainedRoute({ workdir: expandedExplicit });
   }
   if (expandedExplicit) {
+    // A nonexistent explicit workdir directly under the configured published-
+    // apps dir is the PLANNER DOING THE RIGHT THING — naming the fresh slug
+    // dir for a new app. Rejecting it dropped the build into a scratch
+    // workspace with no served URL and verification parked a working page
+    // (live 2026-08-19: …/data/apps/moon-phase-page). Create and use it.
+    const deploy = resolveAppDeployConfig();
+    if (
+      deploy.target === "custom" &&
+      deploy.customAppsDir &&
+      path.dirname(path.resolve(expandedExplicit)) ===
+        path.resolve(deploy.customAppsDir)
+    ) {
+      try {
+        fs.mkdirSync(expandedExplicit, { recursive: true });
+        return withContainedRoute({ workdir: expandedExplicit });
+      } catch {
+        // error-policy:J4 mkdir failure falls through to the scratch fallback.
+      }
+    }
     logger.warn(
       `[workdir-routes] Planner workdir does not exist, ignoring it: ${expandedExplicit} — falling back to ${fallback.workdir}`,
     );

--- a/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
@@ -31,6 +31,10 @@ import {
   requireConfirmedSendHandlerDelivery,
   Service,
 } from "@elizaos/core";
+import {
+  AGENT_VOICED_METADATA,
+  phraseForUser,
+} from "../voice/phrase-for-user.js";
 import { getSessionSpendUsd, readSpendCapUsd } from "./spend-allowance.js";
 import { TERMINAL_SESSION_STATUSES } from "./types.js";
 
@@ -170,13 +174,17 @@ function sessionLabel(metadata: Record<string, unknown> | undefined): string {
   return typeof label === "string" && label.trim() ? label : "A sub-agent";
 }
 
-/** Deterministic warning text for the originating room. */
+/** Deterministic FALLBACK warning text for the originating room — used verbatim
+ * only when the model-phrased line (see `postCapWarning`) is unavailable.
+ * Minimal facts only (label, count/limit, percent, what the user can do); no
+ * internal action names or mechanism vocabulary — the module's own
+ * banned-vocab contract would reject equivalent model output. */
 export function composeCapWarning(warning: CapWarning, label: string): string {
   const pct = Math.round(warning.ratio * 100);
   if (warning.kind === "round-trip") {
-    return `⚠️ ${label} is at ${warning.count}/${warning.limit} round-trips (${pct}%) — risk of a runaway loop. Consider stopping it (STOP_AGENT) or redirecting it (SEND_TO_AGENT) before it force-stops.`;
+    return `${label} is at ${warning.count}/${warning.limit} check-ins (${pct}%) and may be stuck in a loop — you can stop it or redirect it.`;
   }
-  return `⚠️ ${label} has spent $${warning.count.toFixed(2)} of its $${warning.limit.toFixed(2)} budget (${pct}%) — approaching the spend cap. Consider stopping or redirecting it.`;
+  return `${label} has spent $${warning.count.toFixed(2)} of its $${warning.limit.toFixed(2)} budget (${pct}%) — you can stop it or redirect it.`;
 }
 
 interface AcpServiceLike {
@@ -189,6 +197,23 @@ interface AcpServiceLike {
     }>
   >;
   sendToSession(sessionId: string, input: string): Promise<unknown>;
+}
+
+/** Durable-task statuses that mean the session is actually WORKING — the only
+ * states where a stall is a defect worth grilling. `waiting_on_user`,
+ * `blocked`, and `validating` sessions are idle BY DESIGN (gated on the user,
+ * an external dependency, or the verifier) and a status-check prompt cannot
+ * unblock any of them — it just burns a turn and produces noise. */
+const GRILLABLE_TASK_STATUSES = new Set(["open", "active"]);
+
+/** Read-only task view the stall gate needs from ORCHESTRATOR_TASK_SERVICE. */
+interface TaskStatusSourceLike {
+  listTasks(filter?: Record<string, unknown>): Promise<
+    Array<{
+      status: string;
+      latestSessionId: string | null;
+    }>
+  >;
 }
 
 /** Read-only round-trip accounting exposed by the SubAgentRouter. */
@@ -210,8 +235,19 @@ export class TaskWatchdogService extends Service {
     "Detects stalled (idle) sub-agent sessions and prods them, and warns the originating room when a session approaches its round-trip or spend cap.";
 
   private timer: ReturnType<typeof setInterval> | undefined;
-  /** Session ids already prodded this stall, so we grill once (not every tick). */
+  /**
+   * Session ids already prodded, kept for the SESSION'S LIFETIME (dropped only
+   * when the session leaves the active list). The previous recover-then-regrill
+   * reset made the prod loop self-sustaining: the grill starts a fresh ACP
+   * turn, the turn's reply resets `lastActivityAt` ("recovered"), recovery
+   * cleared the prodded flag, and one stall threshold later the same session
+   * was grilled again — a ~4-minute nag loop whose status babble relayed to
+   * the user's room indefinitely (live 2026-08-17 01:01–01:21Z). "Prods each
+   * ONCE" now means once per session, exactly as documented.
+   */
   private readonly prodded = new Set<string>();
+  /** Sessions stalled as of the last tick (provider surface only). */
+  private currentlyStalled = new Set<string>();
   /** `${kind}:${sessionId}` already warned this approach, so we warn once per
    * threshold crossing (cleared when the ratio drops back under the threshold). */
   private readonly warned = new Set<string>();
@@ -255,7 +291,7 @@ export class TaskWatchdogService extends Service {
 
   /** Session ids currently considered stalled (for the ACTIVE_SUB_AGENTS provider). */
   getStalledSessionIds(): string[] {
-    return [...this.prodded];
+    return [...this.currentlyStalled];
   }
 
   /** Sessions currently approaching a cap (for the ACTIVE_SUB_AGENTS provider). */
@@ -281,16 +317,34 @@ export class TaskWatchdogService extends Service {
       lastActivityMs: s.lastActivityAt?.getTime?.() ?? 0,
     }));
     const stalled = detectStalledSessions(views, nowMs, this.stallMs());
-    const stalledIds = new Set(stalled.map((s) => s.id));
+    this.currentlyStalled = new Set(stalled.map((s) => s.id));
 
-    // Clear the prodded flag for sessions that recovered or ended, so a future
-    // stall re-grills.
+    // The prod memo lives as long as the session does: drop only ids that are
+    // no longer in the session list at all. Recovery does NOT re-arm the grill
+    // — the grill itself manufactures "recovery" (its reply resets activity),
+    // which is exactly the loop this memo exists to break.
+    const liveIds = new Set(views.map((v) => v.id));
     for (const id of [...this.prodded]) {
-      if (!stalledIds.has(id)) this.prodded.delete(id);
+      if (!liveIds.has(id)) this.prodded.delete(id);
     }
 
+    const taskStatusBySession = await this.taskStatusBySession();
     for (const s of stalled) {
-      if (this.prodded.has(s.id)) continue; // already prodded this stall
+      if (this.prodded.has(s.id)) continue; // one grill per session lifetime
+      // A stall is only worth grilling while the durable task is actually
+      // WORKING. User-gated / blocked / validating tasks idle by design; a
+      // status check cannot unblock them. Sessions with no resolvable task
+      // record fail open (grilled once) — an ad-hoc session can still wedge.
+      const taskStatus = taskStatusBySession.get(s.id);
+      if (
+        taskStatus !== undefined &&
+        !GRILLABLE_TASK_STATUSES.has(taskStatus)
+      ) {
+        logger.debug(
+          `[TaskWatchdogService] session ${s.id} idle but its task is ${taskStatus} — not grilling`,
+        );
+        continue;
+      }
       this.prodded.add(s.id);
       try {
         await acp.sendToSession(s.id, STALL_GRILL_PROMPT);
@@ -313,6 +367,33 @@ export class TaskWatchdogService extends Service {
 
     await this.checkCapWarnings(sessions);
     return stalled;
+  }
+
+  /**
+   * Best-effort map of ACP session id → durable task status via the task
+   * service's latest-session linkage. Any failure (service absent, store
+   * error) yields an empty map so the stall gate FAILS OPEN — a wedged
+   * session must still get its one grill even when task state is unreadable.
+   */
+  private async taskStatusBySession(): Promise<Map<string, string>> {
+    const map = new Map<string, string>();
+    try {
+      const tasks = this.runtime.getService<Service & TaskStatusSourceLike>(
+        "ORCHESTRATOR_TASK_SERVICE",
+      );
+      if (!tasks || typeof tasks.listTasks !== "function") return map;
+      for (const task of await tasks.listTasks({})) {
+        if (task.latestSessionId) map.set(task.latestSessionId, task.status);
+      }
+    } catch (error) {
+      // error-policy:J7 stall gating is advisory; an unreadable task store must not stop the watchdog tick
+      logger.debug(
+        `[TaskWatchdogService] task-status lookup failed; grilling ungated: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return map;
   }
 
   /**
@@ -386,11 +467,43 @@ export class TaskWatchdogService extends Service {
     if (typeof send !== "function") return;
     const origin = resolveOrigin(metadata);
     if (!origin) return; // no chat origin — nothing to warn into
-    const text = composeCapWarning(warning, sessionLabel(metadata));
+    // Model-phrased warning (owner directive: user-facing text is LLM-written).
+    // The caller has already claimed the `warned` slot synchronously, so the
+    // model latency here cannot double the warning. composeCapWarning stays the
+    // factual fallback when the model is unavailable.
+    const label = sessionLabel(metadata);
+    const { text } = await phraseForUser(
+      this.runtime,
+      {
+        intent: "warn",
+        facts: {
+          label,
+          kind: warning.kind,
+          count:
+            warning.kind === "spend"
+              ? `$${warning.count.toFixed(2)}`
+              : warning.count,
+          limit:
+            warning.kind === "spend"
+              ? `$${warning.limit.toFixed(2)}`
+              : warning.limit,
+          percentUsed: Math.round(warning.ratio * 100),
+          suggestStopOrRedirect: true,
+        },
+        mustInclude: [label],
+      },
+      composeCapWarning(warning, label),
+      // The memo serves cached text WITHOUT re-validating facts, so the key
+      // must pin every fact the text embeds (label via mustInclude, counts in
+      // prose) — a kind-only key would replay another session's numbers.
+      {
+        cacheKey: `capwarn:${warning.kind}:${label}:${warning.count}/${warning.limit}`,
+      },
+    );
     requireConfirmedSendHandlerDelivery(
       await send(
         { source: origin.source, roomId: origin.roomId },
-        { text, source: origin.source },
+        { text, source: origin.source, ...AGENT_VOICED_METADATA },
       ),
     );
     logger.info(
@@ -407,5 +520,6 @@ export class TaskWatchdogService extends Service {
     }
     this.prodded.clear();
     this.warned.clear();
+    this.currentlyStalled.clear();
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -269,6 +269,13 @@ export interface SessionStore {
   }): Promise<SessionInfo | null>;
   list(filter?: SessionFilter): Promise<SessionInfo[]>;
   update(id: string, patch: Partial<SessionInfo>): Promise<void>;
+  /** Atomically merge a metadata patch (read+merge+write inside the store's
+   *  write queue). The naive get→merge→update in AcpService lost patches to
+   *  concurrent writers — the admin-stop stamp NEVER survived a racing
+   *  lastChangeSet merge, so every stop narrated as an unexplained death
+   *  (live 2026-08-20). Optional so external store impls keep compiling; the
+   *  service falls back to the racy path when absent. */
+  mergeMetadata?(id: string, patch: Record<string, unknown>): Promise<void>;
   updateStatus(
     id: string,
     status: SessionStatus,

--- a/plugins/plugin-agent-orchestrator/src/services/user-task-text.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/user-task-text.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts the user's verbatim request from an augmented child prompt. The
+ * spawn path wraps the user task in injected sections ("--- Swarm
+ * Coordination ---", "--- Publishing web apps (custom host) ---", ...) with
+ * the verbatim ask between the "--- User Task ---" marker and the NEXT
+ * section header. Slicing only from the marker to end-of-string drags every
+ * trailing guidance section into successor tasks — a redirected follow-up
+ * then derives its title, slug, and workdir from guidance prose (live
+ * 2026-08-20: successor titled "elizaos --- Publishing web apps (custom
+ * host) ---..." with a matching junk app dir).
+ */
+export const USER_TASK_MARKER = "--- User Task ---";
+
+const SECTION_HEADER_RE = /^--- .+? ---$/m;
+
+export function userTaskFromInitialTask(raw: string | undefined): string {
+  if (!raw) return "";
+  const at = raw.lastIndexOf(USER_TASK_MARKER);
+  if (at < 0) return raw.trim();
+  const after = raw.slice(at + USER_TASK_MARKER.length);
+  const next = after.search(SECTION_HEADER_RE);
+  return (next >= 0 ? after.slice(0, next) : after).trim();
+}

--- a/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
@@ -960,6 +960,25 @@ export class WaveSupervisor extends Service {
       providerPolicy: terminalLane.providerPolicy ?? undefined,
       metadata: {
         ...spec.metadata,
+        // The refill continues the SAME user-request lineage as the lane it
+        // replaces: carry the request-voice keys so the router's ack/terminal
+        // ledger and the park-notice dedupe (notifyVerifyEscalation) keep
+        // matching across the replacement task record instead of degrading to
+        // a fresh task:<id> key (which re-opened the double-park window).
+        ...(nonEmptyString(terminalLane.metadata?.spawnRootMessageId)
+          ? {
+              spawnRootMessageId: nonEmptyString(
+                terminalLane.metadata?.spawnRootMessageId,
+              ),
+            }
+          : {}),
+        ...(nonEmptyString(terminalLane.metadata?.requestVoicePart)
+          ? {
+              requestVoicePart: nonEmptyString(
+                terminalLane.metadata?.requestVoicePart,
+              ),
+            }
+          : {}),
         [WAVE_ID_METADATA_KEY]: waveId,
         waveAttemptId: readWaveAttemptId(terminalLane.metadata),
         waveGoal,

--- a/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit coverage for the model-phrasing seam: the phrased happy path, every
+ * degrade-to-fallback edge (timeout, throw, empty, banned vocabulary,
+ * mustInclude miss, over-length), the machine-appendix byte contract, the
+ * voiced-send metadata shape, the LRU memo, and the pure prompt builder.
+ * Deterministic: fake runtime, mocked model, no network.
+ */
+
+import type { Character, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AGENT_VOICED_METADATA,
+  BANNED_MECHANISM_VOCAB_RE,
+  buildPhrasePrompt,
+  characterVoiceSlice,
+  phraseForUser,
+  validatePhrasedText,
+  withMachineAppendix,
+} from "./phrase-for-user.js";
+
+const CHARACTER: Character = {
+  name: "Eliza",
+  bio: ["A helpful runtime companion.", "Loves shipping."],
+  adjectives: ["warm", "direct"],
+  style: { chat: ["concise"], all: ["sentence case"] },
+} as Character;
+
+function makeRuntime(useModel: (...args: unknown[]) => unknown): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-0000000000aa",
+    character: CHARACTER,
+    getSetting: vi.fn(() => undefined),
+    useModel: vi.fn(useModel),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+const FRAME = {
+  intent: "confirm" as const,
+  facts: { createdCount: 2, titles: ["auth refactor", "docs pass"] },
+};
+
+describe("phraseForUser", () => {
+  it("returns the model's text on the phrased path", async () => {
+    const runtime = makeRuntime(async () => "Both tasks are underway.");
+    const out = await phraseForUser(runtime, FRAME, "Created 2 task agents.");
+    expect(out).toEqual({ text: "Both tasks are underway.", phrased: true });
+  });
+
+  it("times out to the fallback without throwing", async () => {
+    const runtime = makeRuntime(() => new Promise(() => {}));
+    const out = await phraseForUser(runtime, FRAME, "Created 2 task agents.", {
+      timeoutMs: 10,
+    });
+    expect(out).toEqual({ text: "Created 2 task agents.", phrased: false });
+  });
+
+  it("a model throw degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => {
+      throw new Error("provider down");
+    });
+    const out = await phraseForUser(runtime, FRAME, "Created 2 task agents.");
+    expect(out).toEqual({ text: "Created 2 task agents.", phrased: false });
+  });
+
+  it("a missing useModel degrades to the fallback (never throws)", async () => {
+    const runtime = {
+      agentId: "a",
+      character: CHARACTER,
+    } as unknown as IAgentRuntime;
+    const out = await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(out).toEqual({ text: "fallback facts", phrased: false });
+  });
+
+  it("empty model output degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => "   ");
+    const out = await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(out.phrased).toBe(false);
+  });
+
+  it("a mustInclude miss (case-sensitive) degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => "Opened issue #7 for you.");
+    const out = await phraseForUser(
+      runtime,
+      {
+        intent: "confirm",
+        facts: { number: 7 },
+        mustInclude: ["#7", "https://github.com/o/r/issues/7"],
+      },
+      "Created issue #7: https://github.com/o/r/issues/7",
+    );
+    expect(out.phrased).toBe(false);
+    expect(out.text).toContain("https://github.com/o/r/issues/7");
+  });
+
+  it("keeps model text that carries every mustInclude value verbatim", async () => {
+    const runtime = makeRuntime(
+      async () => "Done — issue #7 is up: https://github.com/o/r/issues/7",
+    );
+    const out = await phraseForUser(
+      runtime,
+      {
+        intent: "confirm",
+        facts: { number: 7 },
+        mustInclude: ["#7", "https://github.com/o/r/issues/7"],
+      },
+      "Created issue #7: https://github.com/o/r/issues/7",
+    );
+    expect(out.phrased).toBe(true);
+  });
+
+  it("banned internal-mechanism vocabulary degrades to the fallback", async () => {
+    for (const leak of [
+      "The session is running now.",
+      "I got a receipt for that.",
+      "The orchestrator kicked it off.",
+      "My planner scheduled it.",
+      "ACP is connected.",
+      "The callback fired.",
+      "Tracking uuid abc.",
+    ]) {
+      const runtime = makeRuntime(async () => leak);
+      const out = await phraseForUser(runtime, FRAME, "fallback facts");
+      expect(out, leak).toEqual({ text: "fallback facts", phrased: false });
+    }
+  });
+
+  it("over-length output degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => "x".repeat(500));
+    const out = await phraseForUser(runtime, FRAME, "fallback facts", {
+      maxChars: 320,
+    });
+    expect(out.phrased).toBe(false);
+  });
+
+  it("strips one pair of surrounding quotes before validating", async () => {
+    const runtime = makeRuntime(async () => '"Both tasks are underway."');
+    const out = await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(out).toEqual({ text: "Both tasks are underway.", phrased: true });
+  });
+
+  it("never makes a second model call for a failed frame", async () => {
+    const useModel = vi.fn(async () => "the session leaked");
+    const runtime = makeRuntime(useModel);
+    await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("memoizes repeated frames by cacheKey and skips the model on a hit", async () => {
+    const useModel = vi.fn(async () => "Heads up — nearly at the limit.");
+    const runtime = makeRuntime(useModel);
+    const first = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-1",
+    });
+    const second = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-1",
+    });
+    expect(first.phrased).toBe(true);
+    expect(second).toEqual(first);
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches fallbacks — the next call retries the model", async () => {
+    const useModel = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("down"))
+      .mockResolvedValueOnce("Back up and phrased.");
+    const runtime = makeRuntime(useModel);
+    const first = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-2",
+    });
+    const second = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-2",
+    });
+    expect(first.phrased).toBe(false);
+    expect(second).toEqual({ text: "Back up and phrased.", phrased: true });
+  });
+});
+
+describe("withMachineAppendix", () => {
+  it("keeps the appendix byte-identical below the prose", () => {
+    const appendix = `[TASK:abc-123]Fix the auth bug[/TASK]`;
+    const out = withMachineAppendix("On it.", appendix);
+    expect(out).toBe(`On it.\n\n${appendix}`);
+    expect(out.endsWith(appendix)).toBe(true);
+  });
+});
+
+describe("AGENT_VOICED_METADATA", () => {
+  it("is the exact spreadable voice-gate marker", () => {
+    expect(AGENT_VOICED_METADATA).toEqual({ agentVoiced: true });
+    expect({ text: "x", ...AGENT_VOICED_METADATA }).toMatchObject({
+      agentVoiced: true,
+    });
+  });
+});
+
+describe("buildPhrasePrompt / characterVoiceSlice", () => {
+  it("derives voice from the character (name, bio, deduped traits)", () => {
+    const slice = characterVoiceSlice(CHARACTER);
+    expect(slice).toContain("You are Eliza.");
+    expect(slice).toContain("A helpful runtime companion.");
+    expect(slice).toContain("Voice: warm, direct, concise, sentence case.");
+  });
+
+  it("carries facts, exact-inclusion quotes, forbidden claims, and rules", () => {
+    const prompt = buildPhrasePrompt(
+      CHARACTER,
+      {
+        intent: "fail",
+        facts: { launchedCount: 1, failedLabels: ["docs pass"] },
+        mustInclude: ["docs pass"],
+        mustNotClaim: ["everything launched"],
+      },
+      320,
+    );
+    expect(prompt).toContain("- launchedCount: 1");
+    expect(prompt).toContain("- failedLabels: docs pass");
+    expect(prompt).toContain('include exactly: "docs pass"');
+    expect(prompt).toContain("do not claim: everything launched");
+    expect(prompt).toContain("under 320 characters");
+    expect(prompt).toContain("Sentence case");
+  });
+});
+
+describe("validatePhrasedText", () => {
+  it("rejects banned vocab and accepts clean prose", () => {
+    const req = { intent: "notify" as const, facts: {} };
+    expect(validatePhrasedText("All done here.", req, 320)).toBe(true);
+    expect(validatePhrasedText("The receipt is in.", req, 320)).toBe(false);
+    expect(BANNED_MECHANISM_VOCAB_RE.test("reception desk")).toBe(false);
+    expect(BANNED_MECHANISM_VOCAB_RE.test("sessions")).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.ts
+++ b/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.ts
@@ -1,0 +1,327 @@
+/**
+ * Single model-phrasing seam for every user-visible line the orchestrator
+ * composes itself (acks, confirmations, warnings, denials). Callers hand over
+ * STRUCTURED FACTS plus a factual fallback string; ONE bounded TEXT_SMALL call
+ * phrases them in the configured character's own voice, and any failure —
+ * timeout, throw, empty output, or a post-validation violation — degrades to
+ * the caller's fallback. The module owns the one prompt builder (extracted
+ * from the spawn-ack generator so ack and confirmation voice cannot drift),
+ * the banned internal-mechanism vocabulary, and the exact-substring
+ * `mustInclude` receipt contract that keeps hashes/URLs riding verbatim.
+ *
+ * Machine-readable payloads (widgets, commit hashes, PR URLs) must never pass
+ * through the model: append them with `withMachineAppendix`, which bypasses
+ * phrasing entirely. Sends that carry already-phrased text spread
+ * `AGENT_VOICED_METADATA` so the core transport voice gate does not re-phrase.
+ */
+
+import { type Character, type IAgentRuntime, ModelType } from "@elizaos/core";
+
+export type PhraseIntent =
+  | "confirm"
+  | "refuse"
+  | "fail"
+  | "warn"
+  | "notify"
+  | "ask";
+
+export interface PhraseFacts {
+  intent: PhraseIntent;
+  facts: Record<string, string | number | boolean | string[] | undefined>;
+  /** Values that must appear in the output as exact, case-sensitive
+   * substrings (labels, issue numbers, paths). A miss falls back. */
+  mustInclude?: string[];
+  /** Claims the model is explicitly forbidden to make. */
+  mustNotClaim?: string[];
+}
+
+export interface PhraseOptions {
+  /** Model race budget in ms. Default 1200, env
+   * `ELIZA_ORCHESTRATOR_PHRASE_TIMEOUT_MS`. */
+  timeoutMs?: number;
+  /** Longest accepted output; anything longer falls back. Default 320. */
+  maxChars?: number;
+  /** Small LRU memo key for repeating frames (cap warnings, first-post) so a
+   * recurring identical frame does not re-bill a model call. */
+  cacheKey?: string;
+}
+
+/** Spread into send metadata so the core transport voice gate skips
+ * re-phrasing text this module already phrased. */
+export const AGENT_VOICED_METADATA: { agentVoiced: true } = {
+  agentVoiced: true,
+};
+
+/** Append a machine payload (widget block, commit hash, PR URL) below the
+ * prose. The appendix bypasses the model entirely and must ride byte-identical
+ * so downstream receipt/widget parsers keep binding. */
+export function withMachineAppendix(prose: string, appendix: string): string {
+  return `${prose}\n\n${appendix}`;
+}
+
+/** Internal-mechanism vocabulary that must never reach chat. Any hit in the
+ * model output falls back to the caller's factual string. */
+export const BANNED_MECHANISM_VOCAB_RE =
+  /\b(?:sessions?|acp|receipts?|callbacks?|uuids?|orchestrators?|planners?)\b/i;
+
+// 3.5s: at 1.2s the Cerebras round-trip lost the race often enough that the
+// canned fallbacks ("Created task agent.") leaked to normies as the COMMON
+// case (owner report 2026-08-19). Acks precede work measured in tens of
+// seconds; a few hundred extra ms of voice is the right trade.
+const DEFAULT_TIMEOUT_MS = 3_500;
+const DEFAULT_MAX_CHARS = 320;
+const FACT_VALUE_MAX_CHARS = 400;
+const CACHE_CAP = 32;
+
+/** Module-level LRU memo of successfully phrased frames, keyed by
+ * agentId + cacheKey (fallbacks are never cached so a transient model outage
+ * cannot pin the degraded string). */
+const phrasedCache = new Map<string, string>();
+
+const INTENT_FRAMES: Record<PhraseIntent, string> = {
+  confirm:
+    "You just did (or kicked off) something the user asked for. Confirm it plainly.",
+  refuse:
+    "You are declining to do what was asked. Say so plainly, and why, without apologizing at length.",
+  fail: "Something the user asked for did not work. Report the failure honestly — no excuses, no technical jargon.",
+  warn: "Warn the user about the situation the facts describe, so they can act on it.",
+  notify: "Give the user a brief factual status update.",
+  ask: "You need something from the user. Ask for it directly.",
+};
+
+/**
+ * The character-voice slice of the prompt — extracted verbatim from the spawn
+ * ack generator's system prompt so every phrased line (ack or confirmation)
+ * derives its voice from the SAME composition: name, up to three bio lines,
+ * up to eight deduped adjective/style traits. Pure + exported for tests.
+ */
+export function characterVoiceSlice(character: Character): string {
+  const name = (character.name ?? "").trim() || "the assistant";
+  const voiceParts: string[] = [];
+  const bio = (character.bio ?? []).map((b) => b.trim()).filter(Boolean);
+  if (bio.length > 0) voiceParts.push(bio.slice(0, 3).join(" "));
+  const traits = [
+    ...(character.adjectives ?? []),
+    ...(character.style?.chat ?? []),
+    ...(character.style?.all ?? []),
+  ]
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (traits.length > 0) {
+    voiceParts.push(`Voice: ${[...new Set(traits)].slice(0, 8).join(", ")}.`);
+  }
+  return [`You are ${name}.`, voiceParts.join(" ").trim()]
+    .filter((part) => part.length > 0)
+    .join(" ");
+}
+
+function clipFactValue(value: string): string {
+  return value.length > FACT_VALUE_MAX_CHARS
+    ? `${value.slice(0, FACT_VALUE_MAX_CHARS - 1)}…`
+    : value;
+}
+
+function factLines(facts: PhraseFacts["facts"]): string[] {
+  return Object.entries(facts)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => {
+      const rendered = Array.isArray(value)
+        ? value.map((item) => clipFactValue(String(item))).join(", ")
+        : clipFactValue(String(value));
+      return `- ${key}: ${rendered}`;
+    });
+}
+
+/**
+ * The ONE prompt this module ever sends: character voice slice + intent frame
+ * + compact fact list + exact-inclusion quotes + forbidden claims + standing
+ * rules. Pure + deterministic so it is unit-tested directly.
+ */
+export function buildPhrasePrompt(
+  character: Character,
+  req: PhraseFacts,
+  maxChars: number,
+): string {
+  const lines: string[] = [
+    characterVoiceSlice(character),
+    INTENT_FRAMES[req.intent],
+    "Write ONE short message to the user, in your own voice, based ONLY on these facts:",
+    ...factLines(req.facts),
+  ];
+  if (req.mustInclude && req.mustInclude.length > 0) {
+    lines.push(
+      "Include each of the following EXACTLY as written, character for character:",
+      ...req.mustInclude.map((value) => `- include exactly: "${value}"`),
+    );
+  }
+  if (req.mustNotClaim && req.mustNotClaim.length > 0) {
+    lines.push(
+      "Hard constraints — you must NOT claim any of the following:",
+      ...req.mustNotClaim.map((claim) => `- do not claim: ${claim}`),
+    );
+  }
+  lines.push(
+    "Standing rules:",
+    "- One short message only. Sentence case — not all-lowercase, not a headline.",
+    "- Write in the same language the user's own words in the facts are written in.",
+    "- Plain conversational text: no surrounding quotes, no markdown headers, no emoji, no preamble.",
+    "- Never mention internal machinery: no sessions, receipts, callbacks, ids, or agent plumbing.",
+    `- Keep it under ${maxChars} characters.`,
+    "Your message:",
+  );
+  return lines.filter((line) => line.length > 0).join("\n");
+}
+
+function phraseTimeoutMs(runtime: IAgentRuntime, opts?: PhraseOptions): number {
+  if (opts?.timeoutMs !== undefined && opts.timeoutMs > 0) {
+    return opts.timeoutMs;
+  }
+  const raw =
+    (typeof runtime.getSetting === "function"
+      ? (runtime.getSetting("ELIZA_ORCHESTRATOR_PHRASE_TIMEOUT_MS") as
+          | string
+          | undefined)
+      : undefined) ?? process.env.ELIZA_ORCHESTRATOR_PHRASE_TIMEOUT_MS;
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_MS;
+}
+
+/** Strip a single pair of surrounding quotes and collapse outer whitespace —
+ * the only sanitation applied before validation. */
+function tidyModelOutput(raw: string): string {
+  let text = raw.replace(/\r\n/g, "\n").trim();
+  const quotePairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["“", "”"],
+    ["‘", "’"],
+    ["`", "`"],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (
+      text.length >= open.length + close.length &&
+      text.startsWith(open) &&
+      text.endsWith(close)
+    ) {
+      text = text.slice(open.length, text.length - close.length).trim();
+      break;
+    }
+  }
+  return text;
+}
+
+/** Post-validation: the phrased text is only accepted when every mustInclude
+ * value appears as an exact case-sensitive substring (hashes/URLs), the
+ * banned-mechanism vocabulary is absent, and the length fits. */
+export function validatePhrasedText(
+  text: string,
+  req: PhraseFacts,
+  maxChars: number,
+): boolean {
+  if (!text) return false;
+  if (text.length > maxChars) return false;
+  if (BANNED_MECHANISM_VOCAB_RE.test(text)) return false;
+  for (const value of req.mustInclude ?? []) {
+    if (!text.includes(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Phrase structured facts as one user-visible message in the agent's voice.
+ * Single TEXT_SMALL call raced against the timeout; on ANY failure (error,
+ * timeout, empty, validation miss) returns the caller's fallback with
+ * `phrased: false`. Never throws, never retries, never makes a second model
+ * call. Fallback strings are the caller's responsibility and must already
+ * contain every mustInclude value — they are facts, not prose theater.
+ */
+export async function phraseForUser(
+  runtime: IAgentRuntime,
+  req: PhraseFacts,
+  fallback: string,
+  opts?: PhraseOptions,
+): Promise<{ text: string; phrased: boolean }> {
+  const maxChars = opts?.maxChars ?? DEFAULT_MAX_CHARS;
+  const cacheKey = opts?.cacheKey
+    ? `${String(runtime.agentId ?? "")}:${opts.cacheKey}`
+    : undefined;
+  try {
+    if (cacheKey) {
+      const hit = phrasedCache.get(cacheKey);
+      if (hit !== undefined) {
+        // LRU touch: re-insert as newest.
+        phrasedCache.delete(cacheKey);
+        phrasedCache.set(cacheKey, hit);
+        return { text: hit, phrased: true };
+      }
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), phraseTimeoutMs(runtime, opts));
+      (timer as { unref?: () => void }).unref?.();
+    });
+    // error-policy:J4 the phrased line is cosmetic voice over caller-owned
+    // facts; model rejection/timeout degrades to the factual fallback string,
+    // never fabricated data.
+    let callError: string | undefined;
+    const raw = await Promise.race([
+      Promise.resolve(
+        runtime.useModel(ModelType.TEXT_SMALL, {
+          system: buildPhrasePrompt(runtime.character, req, maxChars),
+          prompt: "Write the message now.",
+          maxTokens: 128,
+          temperature: 0.7,
+          // Formatting call: suppress hidden reasoning. A reasoning-effort pin
+          // (e.g. ELIZAOS_CLOUD_REASONING_EFFORT=high) burns the whole
+          // 128-token cap on hidden reasoning and returns EMPTY content on
+          // gemma-4-31b — every ack shipped the canned fallback for two days
+          // (live 2026-08-20). thinking:"off" maps to the model's suppression
+          // value in both the cloud and direct-Cerebras handlers.
+          providerOptions: { eliza: { thinking: "off" } },
+        }),
+      ).catch((err) => {
+        callError = err instanceof Error ? err.message : String(err);
+        return null;
+      }),
+      timeout,
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+    const text = typeof raw === "string" ? tidyModelOutput(raw) : "";
+    if (!validatePhrasedText(text, req, maxChars)) {
+      // WARN, not debug: the canned fallbacks kept reaching users while this
+      // deployment drops plugin debug logs entirely — the cause (timeout vs
+      // model error vs rejected output) was invisible for two days
+      // (2026-08-20). The error text is load-bearing diagnosis.
+      runtime.logger?.warn?.(
+        {
+          reason:
+            raw === null
+              ? callError
+                ? "model-error"
+                : "timeout"
+              : "validation-reject",
+          ...(callError ? { error: callError } : {}),
+          raw: typeof raw === "string" ? raw : String(raw),
+          rejected: text,
+          intent: req.intent,
+        },
+        "[phrase-for-user] fell back to canned text",
+      );
+      return { text: fallback, phrased: false };
+    }
+    if (cacheKey) {
+      phrasedCache.set(cacheKey, text);
+      while (phrasedCache.size > CACHE_CAP) {
+        const oldest = phrasedCache.keys().next().value;
+        if (oldest === undefined) break;
+        phrasedCache.delete(oldest);
+      }
+    }
+    return { text, phrased: true };
+  } catch {
+    // error-policy:J4 phrasing must never take the turn down; degrade to the
+    // caller's factual fallback.
+    return { text: fallback, phrased: false };
+  }
+}


### PR DESCRIPTION
Part 2 of the split series closing out #24262 (see part 1 for series context).

cc @lalalune

## Scope — orchestrator foundation modules (leaves only; no service/action integrators)

**The durable-content contract this series is built on** — `services/durable-content.ts`:
- `boundedContentView(full, budget, ref)`: every capped string handed to a model prompt or chat surface is a VIEW; a partial view ends with a continuation marker naming its reference and carries a core `ReadView` (`ContentReference`/`ReadSlice` from #24305) with sha256'd slice/source.
- `orchestratorContentRef(scope, id)`: opaque `acpx-*` tokens; resolvers are the orchestrator's own HTTP surfaces (`/api/coding-agents/:id/output`, `/api/orchestrator/tasks/:id`).
- `canonicalProviderPair`: the canonical/provider convention from the #24262 repair (`canonicalPrTitle`/`providerPrTitle`) as a reusable helper — canonical persisted in full, provider payload derived explicitly and auditable.
- `subagent-stdout-log.ts` gains `readSubagentStdout(sessionId, {offset, limit})` — the chunk-indexed continuation reader over the durable per-session transcript.

**Verification foundations**: fabricated-input detection with pre-run existence/SHA-256 `InputBaseline`s (a write is fabrication evidence only when the input was captured absent before execution) + read/write verb-window target selection; acceptance criteria, completion evidence (full FS-verified file contents for content criteria), residuals, ground-truth/independent/goal verifiers.

**Routing foundations**: `ask-shapes.ts` (follow-up vs new-deliverable vs anaphor shapes), `follow-up-origin.ts` (a delivered follow-up re-keys the session's voice so its completion posts — see part 5), workdir route grounding, framework/account/model-gateway selection (OpenCode-free, aligned with develop's removal).

All modules are leaves: nothing here imports the ACP service, task service, router, or actions. Tests included per module.

## Stack
Base: `feat/coding-agent-split-1-eliza-code-acp`. Next: 3-acp-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
