### PR TITLE
feat(orchestrator): ACP service — prompt watchdog, durable transcript fallback, output continuations

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -9,6 +9,7 @@
  * @module api/agent-routes
  */
 
+import { readSubagentStdout } from "../services/subagent-stdout-log.js";
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { access, readFile, realpath, rm } from "node:fs/promises";
@@ -16,6 +17,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import { logger } from "@elizaos/core";
+import { markSessionAdministrativelyStopped } from "../services/admin-stop-marker.js";
 import { assignAgentName } from "../services/agent-name-assignment.js";
 import { buildGoalFollowUp, buildGoalPrompt } from "../services/goal-prompt.js";
 import { isParentAgentBrokerWired } from "../services/parent-agent-broker.js";
@@ -431,7 +433,7 @@ export async function handleAgentRoutes(
       if (!agentType) {
         sendError(
           res,
-          "agentType query parameter required (claude, codex)",
+          "agentType query parameter required (claude, codex, elizaos)",
           400,
         );
         return true;
@@ -810,6 +812,14 @@ export async function handleAgentRoutes(
 
     try {
       const sessionId = stopMatch[1];
+      // A dashboard/API stop is administrative: this route already answers its
+      // caller with success JSON, so the terminal relay must not also post
+      // "<label> — stopped before completion." into the Discord origin room.
+      await markSessionAdministrativelyStopped(
+        ctx.acpService,
+        sessionId,
+        "api_stop",
+      );
       await ctx.acpService.stopSession(sessionId);
       sendJson(res, { success: true, sessionId });
     } catch (error) {
@@ -847,6 +857,37 @@ export async function handleAgentRoutes(
       return true;
     }
 
+    // Continuation semantics for durable session output (#24262 close-out):
+    // ?offset=<chunk>&limit=<n> windows the per-session durable stdout log —
+    // the resolver for `acpx-session-output:<sessionId>` content references.
+    // Without offset, the live-buffer tail keeps its existing shape.
+    const offsetRaw = url.searchParams.get("offset");
+    if (offsetRaw !== null) {
+      const offset = Number.parseInt(offsetRaw, 10);
+      if (!Number.isSafeInteger(offset)) {
+        sendError(res, "offset must be an integer chunk index", 400);
+        return true;
+      }
+      try {
+        const window = await readSubagentStdout(sessionId, {
+          offset,
+          limit: lines,
+        });
+        if (!window) {
+          sendError(res, "No durable output log for this session", 404);
+          return true;
+        }
+        sendJson(res, { sessionId, ...window });
+      } catch (error) {
+        // error-policy:J1 route boundary — service failure becomes a 500 response.
+        sendError(
+          res,
+          error instanceof Error ? error.message : "Failed to read output log",
+          500,
+        );
+      }
+      return true;
+    }
     try {
       const output = await ctx.acpService.getSessionOutput?.(sessionId, lines);
       sendJson(res, { sessionId, output });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -46,7 +46,10 @@ import {
 import { isAndroidMobile } from "@elizaos/shared";
 import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { NativeAcpClient } from "./acp-native-transport.js";
-import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
+import {
+  augmentTaskWithDeployGuidance,
+  resolveAppDeployConfig,
+} from "./app-deploy-guidance.js";
 import {
   CODEX_NO_LANDLOCK_SANDBOX_MODE_ENV,
   type CodexSandboxMode,
@@ -113,6 +116,7 @@ import {
   appendSubagentStdout,
   isSubagentStdoutLoggingEnabled,
   subagentStdoutLogPath,
+  readSubagentStdout,
 } from "./subagent-stdout-log.js";
 import { normalizeTaskAgentAdapter } from "./task-agent-routing.js";
 import {
@@ -445,7 +449,7 @@ const ACP_METADATA_GIT_INDEX_FILE = "gitIndexFile";
 const ACP_METADATA_GIT_INDEX_BASE_FILE = "gitIndexBaseFile";
 const ACP_METADATA_GIT_WRAPPER_DIR = "gitWrapperDir";
 const ACP_METADATA_SPAWN_MODEL = "spawnModel";
-const _MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
+const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const SESSION_GIT_WRAPPER_BODY = `const { spawn, spawnSync } = require("node:child_process");
 const { randomUUID } = require("node:crypto");
@@ -454,7 +458,17 @@ const path = require("node:path");
 const git = process.env.ACP_REAL_GIT || "git";
 const indexFile = process.env.ACP_GIT_INDEX_FILE;
 const baseline = process.env.ACP_GIT_BASELINE_SHA;
-if (indexFile) process.env.GIT_INDEX_FILE = indexFile;
+if (indexFile) {
+  process.env.GIT_INDEX_FILE = indexFile;
+  // Self-heal the index dir: scratch GC (or a corrective-lap reactivation)
+  // can remove ~/.acpx/git-indexes/<session>/ between turns, after which
+  // every git call exits 128 until someone recreates it — the child burned
+  // three failed steps rediscovering this by hand (live 2026-08-20,
+  // GLOSSARY corrective lap).
+  try {
+    fs.mkdirSync(path.dirname(indexFile), { recursive: true });
+  } catch {}
+}
 delete process.env.ACP_GIT_INDEX_FILE;
 delete process.env.ACP_GIT_BASELINE_SHA;
 delete process.env.ACP_REAL_GIT;
@@ -1500,6 +1514,23 @@ export class AcpService extends Service {
   // fall back to the legacy default-root predicate for backward cleanup.
   private async removeOwnedScratchWorkdir(session: SessionInfo): Promise<void> {
     if (!this.sessionOwnsIsolatedWorkdir(session)) return;
+    // A durable-task session's workspace OUTLIVES the session: verification,
+    // the residuals gate, and the corrective loop all inspect it after the
+    // post-completion stop. Reclaiming here failed the whole chain — the
+    // verifier found "no execution logs", the corrective re-send died on a
+    // missing workspace, and the user was asked whether they still wanted a
+    // result the child had already computed (live 2026-08-20, prime-numbers
+    // run). The orphan GC owns these dirs once the session record ages out.
+    if (session.metadata?.smithersDurableRun !== undefined) {
+      this.log(
+        "debug",
+        "scratch reclaim deferred to GC (durable-task session)",
+        {
+          sessionId: session.id,
+        },
+      );
+      return;
+    }
     const root = session.metadata?.[ACP_METADATA_WORKDIR_ROOT];
     if (
       typeof root === "string" &&
@@ -1628,10 +1659,11 @@ export class AcpService extends Service {
           } catch (err) {
             // error-policy:J6 best-effort GC; a locked/vanished dir is skipped so
             // the sweep continues and retries next boot.
-            this.log("warn", "scratch GC: failed to remove dir", {
-              path,
-              error: errorMessage(err),
-            });
+            this.log(
+              "warn",
+              `scratch GC: failed to remove dir ${path}: ${errorMessage(err)}`,
+              { path, error: errorMessage(err) },
+            );
           }
         }),
       );
@@ -1820,11 +1852,11 @@ export class AcpService extends Service {
 
   // The acpx transport persists session state as `<acpxSessionId>.json` under
   // <stateRoot>/sessions. The old probe checked `<acpxSessionId>.stream.ndjson`
-  // which NEVER exists for opencode/native sessions (verified: 0 such files on
-  // disk, only ses_*.json) — a permanent false-negative that made every healthy
+  // which NEVER exists for native sessions (verified: 0 such files on disk,
+  // only ses_*.json) — a permanent false-negative that made every healthy
   // session look "state lost", triggering a runaway "spawn a fresh sub-agent"
-  // respawn cascade AND spuriously throwing on the first real prompt to any
-  // opencode session. Probe the artifact the transport actually writes.
+  // respawn cascade AND spuriously throwing on the first real prompt to a
+  // session. Probe the artifact the transport actually writes.
   private acpxSessionStateFile(acpxSessionId: string): string {
     return join(this.acpxStateRoot(), "sessions", `${acpxSessionId}.json`);
   }
@@ -2044,10 +2076,25 @@ export class AcpService extends Service {
       // Re-attach it ONCE here, before the transport branch, so BOTH the native
       // and the CLI/acpx paths host the app and report a verified URL. No-op for
       // non-app tasks; applied only to the initial task, never to follow-up sends.
+      // When the spawn's workdir already IS a served app dir (slug placement
+      // by construction), name it in the guidance so the child never picks —
+      // and never collides with — a slug of its own.
+      const deployConfig = resolveAppDeployConfig();
+      const appsDirResolved = deployConfig.customAppsDir
+        ? resolve(deployConfig.customAppsDir)
+        : undefined;
+      const workdirResolved = resolve(session.workdir);
+      const assignedAppDir =
+        appsDirResolved &&
+        workdirResolved.startsWith(appsDirResolved + sep) &&
+        !workdirResolved.slice(appsDirResolved.length + 1).includes(sep)
+          ? workdirResolved
+          : undefined;
       const initialTask =
         opts.initialTask && opts.initialTask.trim().length > 0
           ? augmentTaskWithDeployGuidance(opts.initialTask, undefined, {
               monetized: opts.monetized,
+              assignedAppDir,
             })
           : opts.initialTask;
 
@@ -2091,14 +2138,7 @@ export class AcpService extends Service {
         timeoutMs: opts.timeoutMs,
         model: spawnModel,
       });
-      args.push(
-        ...this.agentCommandArgs(agentType, [
-          "sessions",
-          "new",
-          "--name",
-          name,
-        ]),
-      );
+      args.push(agentType, "sessions", "new", "--name", name);
       const result = await this.runAcpx({
         sessionId: id,
         sessionName: name,
@@ -2272,9 +2312,49 @@ export class AcpService extends Service {
       },
     };
     this.promptTurns.set(sessionId, turn);
+    // Whole-turn watchdog. The JSON-RPC request timer bounds only the
+    // session/prompt exchange; every await AROUND it (reconnect attach, lease
+    // mint, workspace build, store writes) was unbounded, and one hang held
+    // the busy flag forever — a queued follow-up wedged its session for 10+
+    // minutes with no child process and no error (live 2026-08-22,
+    // coin-flip-streak-counter). The inner timer is 5 min; +60s grace keeps
+    // the watchdog strictly a backstop, never the primary bound.
+    const watchdogMs =
+      (opts.timeoutMs ?? this.sessionTimeoutMs ?? 300_000) + 60_000;
+    let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
+    const watchdog = new Promise<never>((_, reject) => {
+      watchdogTimer = setTimeout(() => {
+        reject(
+          new ElizaError(
+            `ACP prompt turn exceeded ${watchdogMs}ms with no result; releasing the session`,
+            {
+              code: "ACP_PROMPT_TURN_WEDGED",
+              context: { sessionId, watchdogMs },
+            },
+          ),
+        );
+      }, watchdogMs);
+      watchdogTimer.unref?.();
+    });
     try {
-      return await this.sendPromptTurn(session, text, opts);
+      const turnRun = this.sendPromptTurn(session, text, opts);
+      // The abandoned turn may still settle later; observe its rejection so a
+      // late failure never surfaces as an unhandled rejection.
+      turnRun.catch(() => undefined);
+      return await Promise.race([turnRun, watchdog]);
+    } catch (err) {
+      if (err instanceof ElizaError && err.code === "ACP_PROMPT_TURN_WEDGED") {
+        // error-policy:J1 watchdog boundary — the wedge becomes a structured
+        // errored turn; the busy flag is released by the finally below.
+        await this.store
+          .updateStatus(sessionId, "errored", err.message)
+          .catch(() => undefined);
+        this.emitSessionEvent(sessionId, "error", { message: err.message });
+        this.nativePromptSessionIds.delete(sessionId);
+      }
+      throw err;
     } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
       if (this.promptTurns.get(sessionId)?.id === turn.id) {
         this.promptTurns.delete(sessionId);
       }
@@ -2347,13 +2427,12 @@ export class AcpService extends Service {
       model: promptModel,
     });
     args.push(
-      ...this.agentCommandArgs(session.agentType, [
-        "prompt",
-        "-s",
-        session.name ?? session.id,
-        "--",
-        text,
-      ]),
+      session.agentType,
+      "prompt",
+      "-s",
+      session.name ?? session.id,
+      "--",
+      text,
     );
 
     // The cli transport spawns a fresh subprocess per prompt, so re-inject the
@@ -2479,11 +2558,12 @@ export class AcpService extends Service {
       active.cancelled = true;
       this.terminateProcess(sessionId, active);
     } else {
-      const args = this.agentCommandArgs(session.agentType, [
+      const args = [
+        session.agentType,
         "cancel",
         "-s",
         session.name ?? session.id,
-      ]);
+      ];
       await this.runAcpx({
         sessionId,
         agentType: session.agentType,
@@ -2529,11 +2609,10 @@ export class AcpService extends Service {
       "json",
       "--cwd",
       session.workdir,
-      ...this.agentCommandArgs(session.agentType, [
-        "sessions",
-        "close",
-        session.name ?? session.id,
-      ]),
+      session.agentType,
+      "sessions",
+      "close",
+      session.name ?? session.id,
     ];
     try {
       await this.runAcpx({
@@ -2607,6 +2686,12 @@ export class AcpService extends Service {
     sessionId: string,
     patch: Record<string, unknown>,
   ): Promise<void> {
+    if (typeof this.store.mergeMetadata === "function") {
+      await this.store.mergeMetadata(sessionId, patch);
+      return;
+    }
+    // Racy fallback for stores without the atomic merge: a concurrent merge
+    // can clobber this patch (the admin-stop stamp was lost to exactly this).
     const session = await this.store.get(sessionId);
     if (!session) return;
     await this.store.update(sessionId, {
@@ -2620,6 +2705,56 @@ export class AcpService extends Service {
   // prompt at each one (background) so claude-agent-sdk reloads its stream
   // and picks the work back up without waiting for new user input. Mirrors
   // moltbot's recoverOrphanedSubagentSessions pattern.
+  /**
+   * Terminalize stored non-terminal NATIVE sessions from a previous process.
+   * Native ACP clients live only in process memory, so a restart orphans the
+   * row while its status stays "ready"/"busy" — and non-terminal rows hold
+   * worker slots forever (live 2026-08-19: 8/8 phantom "ready" sessions from
+   * the night's restarts blocked every spawn with a cap error). CLI-transport
+   * sessions are left alone: their acpx state survives on disk and feeds the
+   * orphan-resume and label-resume paths.
+   */
+  async sweepDeadNativeSessions(): Promise<number> {
+    let sessions: SessionInfo[];
+    try {
+      sessions = await this.store.list();
+    } catch (err) {
+      // error-policy:J7 sweep is boot hygiene; a store read failure is
+      // reported and the resume scan surfaces its own failure separately.
+      this.runtime.reportError("AcpService.sweepDeadNativeSessions", err, {
+        phase: "store.list",
+      });
+      return 0;
+    }
+    let swept = 0;
+    for (const session of sessions) {
+      if (!AcpService.isActiveSession(session)) continue;
+      if (sessionTransportMode(session, this.transportMode) !== "native") {
+        continue;
+      }
+      if (this.nativeClients.has(session.id)) continue;
+      try {
+        await this.store.updateStatus(
+          session.id,
+          "stopped",
+          "native session did not survive a runtime restart",
+        );
+        swept += 1;
+      } catch (err) {
+        // error-policy:J7 one unsweepable row must not abort the rest.
+        this.runtime.reportError("AcpService.sweepDeadNativeSessions", err, {
+          sessionId: session.id,
+        });
+      }
+    }
+    if (swept > 0) {
+      this.log("info", "swept dead native sessions from previous process", {
+        swept,
+      });
+    }
+    return swept;
+  }
+
   async resumeOrphanedBusySessions(): Promise<{
     resumed: number;
     skipped: number;
@@ -2870,7 +3005,18 @@ export class AcpService extends Service {
   }
 
   async getSessionOutput(sessionId: string, lines = 200): Promise<string> {
-    return (this.outputBuffers.get(sessionId) ?? []).slice(-lines).join("");
+    const buffered = this.outputBuffers.get(sessionId);
+    if (buffered && buffered.length > 0) {
+      return buffered.slice(-lines).join("");
+    }
+    // Closed sessions drop their in-memory buffer, but the durable per-session
+    // stdout log survives — a completion verifier or a late reader must not
+    // see "" for output that is durably on disk (#24262 close-out: bounded
+    // views read from durable complete content).
+    const durable = await readSubagentStdout(sessionId, {
+      limit: lines,
+    }).catch(() => undefined);
+    return durable?.text ?? "";
   }
 
   /** Output captured during the most recent prompt turn only. */
@@ -3544,6 +3690,19 @@ export class AcpService extends Service {
       });
       throw err;
     }
+    // A stopped session's scratch workdir may have been reclaimed by
+    // workspace GC; spawning into a missing cwd surfaces as a bare
+    // posix_spawn ENOENT on the agent command (live 2026-08-19), which reads
+    // as a broken install. Name the real condition instead.
+    if (!existsSync(session.workdir)) {
+      const message = `session workspace no longer exists (${session.workdir}); it was likely reclaimed after completion`;
+      await this.store.updateStatus(session.id, "errored", message);
+      this.emitSessionEvent(session.id, "error", { message });
+      throw new ElizaError(message, {
+        code: "ACP_SESSION_WORKSPACE_RECLAIMED",
+        context: { sessionId: session.id, workdir: session.workdir },
+      });
+    }
     const promptCredentials = await this.accountCredentialsForSession(session);
     const promptEnv: Record<string, string> = {
       ...(opts.env ?? {}),
@@ -3630,10 +3789,6 @@ export class AcpService extends Service {
     // close/closeSession failure must not abort the deletion.
     await client.closeSession(protocolSessionId).catch(() => undefined);
     await client.close().catch(() => undefined);
-  }
-
-  private agentCommandArgs(agentType: AgentType, args: string[]): string[] {
-    return [agentType, ...args];
   }
 
   private runAcpx(opts: RunOptions): Promise<RunResult> {
@@ -4014,7 +4169,7 @@ export class AcpService extends Service {
         this.emitSessionEvent(sessionId, "message", { text: content.text });
       }
       // agent_thought_chunk: the model's reasoning / chain-of-thought streams
-      // in the SAME payload shape as agent_message_chunk (opencode emits it for
+      // in the SAME payload shape as agent_message_chunk (adapters emit it for
       // `reasoning` parts). Forward the text as a dedicated `reasoning` event so
       // the UI can surface it, but do NOT add it to finalText/appendOutput:
       // reasoning is not the deliverable response, and folding it into the turn
@@ -4026,8 +4181,8 @@ export class AcpService extends Service {
       ) {
         this.emitSessionEvent(sessionId, "reasoning", { text: content.text });
       }
-      // plan: opencode emits the agent's checklist/plan list as a `plan` update with
-      // entries [{content, status, priority}] (driven by its todowrite tool).
+      // plan: an adapter emits the agent's checklist/plan list as a `plan` update
+      // with entries [{content, status, priority}] (driven by its todo tooling).
       // Forward a sanitized snapshot as a `plan` event so the task's currentPlan
       // can drive the plan/checklist dock. Validated at this boundary (raw -> typed);
       // an adapter that never emits a plan simply does not enter this branch.
@@ -4456,7 +4611,7 @@ export class AcpService extends Service {
     const metadata = { ...(session.metadata ?? {}), account: meta };
     session.metadata = metadata;
     try {
-      await this.store.update(session.id, { metadata });
+      await this.updateSessionMetadata(session.id, { account: meta });
     } catch (err) {
       // error-policy:J7 the failover credential is already resolved and must
       // reach the subprocess; a failed durable re-stamp only degrades the NEXT
@@ -5382,8 +5537,12 @@ function captureTerminalToolOutput(
   if (capturedToolOutputs.has(key)) return undefined;
   capturedToolOutputs.add(key);
   const wellFormed = toWellFormedUnicode(output);
+  const truncated =
+    wellFormed.length > MAX_CAPTURED_TOOL_OUTPUT_CHARS
+      ? `${truncateWellFormed(wellFormed, MAX_CAPTURED_TOOL_OUTPUT_CHARS)}\n[tool output truncated]`
+      : wellFormed;
   const title = toolCall.title?.trim() || "tool output";
-  return `[tool output: ${title}]\n${wellFormed}\n${TOOL_OUTPUT_END_MARKER}`;
+  return `[tool output: ${title}]\n${truncated}\n${TOOL_OUTPUT_END_MARKER}`;
 }
 
 // Exported for unit coverage of the exec-record one-liner path (issue #11578).


### PR DESCRIPTION
Part 3 of the split series closing out #24262.

cc @lalalune

## Scope — the ACP subprocess service + session output surface

- **Whole-turn prompt watchdog**: the JSON-RPC request timer bounds only the `session/prompt` exchange; every await around it (reconnect attach, lease mint, workspace build, store writes) was unbounded — one hang held the session busy forever (live: a queued follow-up wedged its session 12+ minutes with no child process and no error). `sendPrompt` now races the whole turn at inner-timeout+60s and releases the busy flag with a structured `ACP_PROMPT_TURN_WEDGED` errored turn.
- **Durable transcript fallback**: `getSessionOutput` for a closed session reads the durable per-session NDJSON transcript instead of returning "" (the in-memory buffer is deleted on close; the content is not gone).
- **Output continuations**: `GET /api/coding-agents/:id/output?offset=<chunk>&lines=<n>` windows the durable log — the resolver for `acpx-session-output:*` content references minted in part 2.
- Session lifecycle/auth/credential handling as carried from the #24262 repaired head (warm spawn claim, model leases, no-Landlock fail-closed Codex modes).

## Stack
Base: `feat/coding-agent-split-2-orchestrator-foundations`. Next: 4-task-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
