### PR TITLE
feat(orchestrator): durable task service — per-lane verification, user-interrupt durability, canonical content

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -17,7 +17,11 @@
  * @module services/orchestrator-task-service
  */
 
-import { randomUUID } from "node:crypto";
+import {
+  boundedContentView,
+  orchestratorContentRef,
+} from "./durable-content.js";
+import { createHash, randomUUID } from "node:crypto";
 import {
   appendFile,
   mkdir,
@@ -27,7 +31,7 @@ import {
   stat,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import {
   ElizaError,
   getTrajectoryContext,
@@ -37,12 +41,20 @@ import {
   resolveStateDir,
   resolveTrajectoryGate,
   rollUpTrajectoryUsage,
+  runWithStreamingContext,
+  runWithTrajectoryContext,
   Service,
   TRACE_ENV,
   type TrajectoryUsageRollup,
   toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
+  withStandaloneTrajectory,
 } from "@elizaos/core";
+import {
+  AGENT_VOICED_METADATA,
+  phraseForUser,
+} from "../voice/phrase-for-user.js";
 import {
   detectTaskType,
   generateDefaultAcceptanceCriteria,
@@ -59,6 +71,7 @@ import {
   type SerializableSpawnOpts,
 } from "./admission-queue.js";
 import { assignAgentName } from "./agent-name-assignment.js";
+import { resolveAppDeployConfig } from "./app-deploy-guidance.js";
 import {
   extractWriteLedger,
   verifyClaimedFiles,
@@ -101,6 +114,11 @@ import {
   getCuratedCodingMemoryService,
   renderInjectedCodingNotes,
 } from "./curated-coding-memory.js";
+import {
+  detectFabricatedInput,
+  type InputBaseline,
+  readTargetsFromTask,
+} from "./fabricated-input.js";
 import {
   buildAutoVerifyCorrection,
   LLM_GOAL_VERIFIER_NAME,
@@ -203,10 +221,12 @@ import {
   collectFsObservedFiles,
   deriveRouteMappedUrls,
   detectCheckSurfaces,
+  enumerateWorkdirCandidates,
   mineCandidatePaths,
   probeMappedUrls,
   readFsVerifiedContents,
 } from "./quick-app-evidence.js";
+import { requestVoiceKeyForMeta } from "./router-loop-guard.js";
 import {
   readSmithersDurableRunLink,
   runDurableTask,
@@ -229,6 +249,7 @@ import {
   type SpawnResult,
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
+import { userTaskFromInitialTask } from "./user-task-text.js";
 import {
   WAVE_SUPERVISOR_SERVICE_TYPE,
   WaveConcurrencyCapError,
@@ -307,7 +328,8 @@ function configuredDefaultAgentType(runtime: {
   // Fall back to process.env. runtime.getSetting reads character
   // settings/secrets, not raw env, so a deployment that configures the default
   // agent purely via an env var (e.g. ELIZA_ACP_DEFAULT_AGENT=codex on a
-  // container) would otherwise be ignored. This mirrors the env resolution the
+  // container) would otherwise be ignored and the spawn would fall through to
+  // the default elizaos adapter. This mirrors the env resolution the
   // spawn-workdir path already does.
   for (const key of ["ELIZA_ACP_DEFAULT_AGENT", "ELIZA_DEFAULT_AGENT_TYPE"]) {
     const raw = process.env[key];
@@ -320,6 +342,10 @@ function configuredDefaultAgentType(runtime: {
  *  read-only execution verifier (#8898), distinct from the text judge's
  *  `llm-goal-verifier`, so the validation event's origin is unambiguous. */
 const INDEPENDENT_ACP_VERIFIER_NAME = "independent-acp-verifier";
+
+/** Cap on child trajectories ingested per task_complete (#13775) so a runaway
+ *  sub-agent can't flood the task doc; the store's MAX_ARTIFACTS also clamps. */
+const MAX_CHILD_TRAJECTORY_ARTIFACTS = 20;
 
 /** Default retention window for per-task child-trajectory dirs under the state
  *  dir (#14109). A per-task `<stateDir>/orchestrator/child-trajectories/<taskId>`
@@ -576,6 +602,82 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+/** Non-empty plain string or undefined. Mirrors the router's metadata reads so
+ * the request-voice key carried through task metadata is shape-compatible. */
+function pickPlainString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+/**
+ * Sub-agent-router serviceType, mirrored as a literal (not imported from
+ * sub-agent-router.ts) so this module keeps no dependency edge on the router
+ * module. Kept in sync with `SubAgentRouter.serviceType`.
+ */
+const SUB_AGENT_ROUTER_SERVICE_TYPE = "ACPX_SUB_AGENT_ROUTER";
+
+/**
+ * Structural view of the router's request-voice ledger. Resolved via
+ * `runtime.getService` and typeof-guarded per method so this service compiles
+ * and behaves identically whether or not the router (or its ledger API) is
+ * present — absence always fails OPEN to today's behavior.
+ */
+type RequestVoiceLedgerRouter = {
+  claimRequestTerminal?: (
+    key: string,
+    sessionId: string,
+    kind: string,
+    provisional: boolean,
+  ) => unknown;
+};
+
+/**
+ * Interpret a `claimRequestTerminal` result. Only an EXPLICIT denial
+ * suppresses the park notice; every other shape (granted, superseded, or an
+ * unrecognized return) sends as today so a ledger drift can only ever cost the
+ * dedupe, never silence the notice.
+ */
+function terminalClaimDenied(result: unknown): boolean {
+  if (result === false || result === "denied") return true;
+  if (isRecord(result)) {
+    return result.granted === false && result.superseded !== true;
+  }
+  return false;
+}
+
+/**
+ * FALLBACK notice for an auto-verify give-up — used verbatim only when the
+ * model-phrased line (see `notifyVerifyEscalation`) is unavailable, so it must
+ * carry every fact the phrased path is given. Deliberately honest about the
+ * split state: the WORK may be fine (it often is — the live regression was a
+ * served, working page) while VERIFICATION could not confirm it. Never leaks
+ * internal ids; caps the missing list so a long verifier dump stays readable.
+ * Sentence case: this is Eliza's voice, not nubilio's lowercase register.
+ */
+export function composeVerifyEscalationNotice(
+  title: string,
+  details: { attempts: number; summary: string; missing: string[] },
+): string {
+  const label = title.trim() || "the coding task";
+  const summaryText = details.summary.trim().toLowerCase();
+  const missing = details.missing
+    .filter((item) => item.trim().length > 0)
+    // The caller often passes the same residual line as both summary and
+    // missing; repeating it verbatim read like a stutter (live 2026-08-18:
+    // "Completion residuals found: 6 uncommitted path(s)… Couldn't confirm:
+    // 6 uncommitted path(s)…").
+    .filter((item) => !summaryText.includes(item.trim().toLowerCase()))
+    .slice(0, 3);
+  const missingLine =
+    missing.length > 0 ? ` Couldn't confirm: ${missing.join("; ")}.` : "";
+  return (
+    `⚠️ ${label}: automatic verification gave up after ${details.attempts} attempts, so it's waiting on you. ` +
+    `${details.summary.trim()}${details.summary.trim().endsWith(".") ? "" : "."}${missingLine} ` +
+    `The work itself may still be fine — check the result, then tell me to accept it or what to fix.`
+  );
+}
+
 /** Parse a positive-integer setting value, falling back to `fallback` when the
  * value is absent, non-numeric, or ≤ 0. Used for the admission-queue tunables. */
 function parsePositiveIntSetting(
@@ -592,6 +694,27 @@ function str(value: unknown): string | undefined {
 
 function num(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function withoutInterruptStamp(
+  metadata: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(metadata)) return undefined;
+  const { interruptReason: _r, interruptedAt: _a, ...rest } = metadata;
+  return rest;
+}
+
+/** The task was stopped by the user (not the stuck-task reaper): a late
+ * attach or completion must not resurrect it. Stamped by interruptTask. */
+function userInterrupted(task: {
+  status: string;
+  metadata?: unknown;
+}): boolean {
+  if (task.status !== "interrupted") return false;
+  const reason = isRecord(task.metadata)
+    ? task.metadata.interruptReason
+    : undefined;
+  return typeof reason === "string" && reason.startsWith("user");
 }
 
 /**
@@ -620,8 +743,11 @@ function readAttemptReflections(
   return out;
 }
 
-function normalizeTaskText(text: string): string {
-  return toWellFormedUnicode(text);
+function truncate(text: string, max = 2000): string {
+  const wellFormed = toWellFormedUnicode(text);
+  return wellFormed.length > max
+    ? `${truncateWellFormed(wellFormed, max)}…`
+    : wellFormed;
 }
 
 /**
@@ -716,7 +842,11 @@ export function residualsOrchestratorOwnedArtifacts(
   session: Pick<OrchestratorTaskSession, "sessionId" | "metadata"> | undefined,
 ): OrchestratorOwnedArtifact[] {
   if (!session) return [];
-  const live = acp?.getOrchestratorOwnedArtifacts(session.sessionId) ?? [];
+  // Optional METHOD call, not just optional receiver: transports (and test
+  // fakes) that predate the artifact registry lack the method entirely, and
+  // the bare call turned the whole auto-verify pass into a silent no-verdict
+  // failure ("acp?.getOrchestratorOwnedArtifacts is not a function").
+  const live = acp?.getOrchestratorOwnedArtifacts?.(session.sessionId) ?? [];
   return live.length > 0
     ? live
     : readOwnedArtifactsFromMetadata(session.metadata);
@@ -737,7 +867,10 @@ export function residualsSpawnBaseline(
   session: Pick<OrchestratorTaskSession, "metadata"> | undefined,
 ): Pick<
   CompletionResidualsInput,
-  "baselineDirtyPaths" | "baselineUntrackedPaths" | "sharedRouteWorkdir"
+  | "baselineDirtyPaths"
+  | "baselineUntrackedPaths"
+  | "sharedRouteWorkdir"
+  | "gitIndexFile"
 > {
   const meta = session?.metadata;
   if (!isRecord(meta)) return {};
@@ -755,7 +888,12 @@ export function residualsSpawnBaseline(
     typeof meta.workdirRouteId === "string" &&
     meta.workdirRouteId.trim().length > 0 &&
     meta[ACP_METADATA_ISOLATED_WORKDIR] !== true;
+  const gitIndexFile =
+    typeof meta.gitIndexFile === "string" && meta.gitIndexFile.trim()
+      ? meta.gitIndexFile
+      : undefined;
   return {
+    ...(gitIndexFile ? { gitIndexFile } : {}),
     ...(baselineDirtyPaths.length > 0 ? { baselineDirtyPaths } : {}),
     ...(baselineUntrackedPaths.length > 0 ? { baselineUntrackedPaths } : {}),
     ...(sharedRouteWorkdir ? { sharedRouteWorkdir: true } : {}),
@@ -834,7 +972,7 @@ function eventExcerpt(
 ): string {
   const data =
     Object.keys(event.data).length > 0
-      ? `\nData: ${normalizeTaskText(JSON.stringify(event.data))}`
+      ? `\nData: ${truncate(JSON.stringify(event.data), 1200)}`
       : "";
   return `Event ${event.id} (${event.eventType}): ${event.summary}${data}`;
 }
@@ -853,7 +991,7 @@ function retryInstruction(
     lines.push(
       "",
       `Source message ${source.id} (${source.senderKind}/${source.direction}):`,
-      normalizeTaskText(source.content),
+      truncate(source.content),
     );
   }
   return lines.join("\n");
@@ -882,7 +1020,7 @@ function withPlanRevisionContext(
     `Revision: ${revision.id}`,
   ];
   if (revision.editSummary) lines.push(`Summary: ${revision.editSummary}`);
-  lines.push(`Plan: ${normalizeTaskText(JSON.stringify(revision.plan))}`);
+  lines.push(`Plan: ${truncate(JSON.stringify(revision.plan), 2000)}`);
   return lines.join("\n");
 }
 
@@ -954,21 +1092,21 @@ function describeEvent(event: string, data: unknown): string {
       return `Running ${title}`;
     }
     case "message":
-      return normalizeTaskText(str(record.text) ?? "Sub-agent message");
+      return truncate(str(record.text) ?? "Sub-agent message", 160);
     case "reasoning":
-      return normalizeTaskText(str(record.text) ?? "Sub-agent reasoning");
+      return truncate(str(record.text) ?? "Sub-agent reasoning", 160);
     case "plan": {
       const count = Array.isArray(record.entries) ? record.entries.length : 0;
       return `Updated plan — ${count} item${count === 1 ? "" : "s"}`;
     }
     case "blocked":
-      return normalizeTaskText(str(record.message) ?? "Blocked on input");
+      return truncate(str(record.message) ?? "Blocked on input", 160);
     case "login_required":
       return "Sub-agent requires authentication";
     case "task_complete":
       return "Sub-agent reported completion (pending validation)";
     case "error":
-      return normalizeTaskText(str(record.message) ?? "Sub-agent error");
+      return truncate(str(record.message) ?? "Sub-agent error", 160);
     case "stopped":
       return "Sub-agent stopped";
     case "reconnected":
@@ -1007,6 +1145,14 @@ function activeSessionNames(
     .filter((label): label is string => label.length > 0);
 }
 
+const IN_FLIGHT_TASK_STATUSES: ReadonlySet<OrchestratorTaskStatus> = new Set([
+  "open",
+  "active",
+  "validating",
+]);
+const TERMINAL_OR_INTERRUPTED_TASK_STATUSES: ReadonlySet<OrchestratorTaskStatus> =
+  new Set(["interrupted", "done", "failed", "archived"]);
+
 export class OrchestratorTaskService extends Service {
   static serviceType = "ORCHESTRATOR_TASK_SERVICE";
 
@@ -1026,6 +1172,10 @@ export class OrchestratorTaskService extends Service {
   // from two sites for one turn; without this guard both runs read the same
   // attempt counter across the model `await` and double-send a correction.
   private readonly autoVerifyInFlight = new Set<string>();
+  // Lock-free fast signal of a user stop: the write lock can be held for a
+  // whole verify lap (judge model call + corrective send), and the stop must
+  // gate those long paths BEFORE the serialized status write lands.
+  private readonly pendingUserInterrupts = new Set<string>();
 
   /** Per-task async mutex serializing the two completion-metadata writers
    * (autoVerifyCompletion and validateTask). Both replace `task.metadata`
@@ -1169,13 +1319,22 @@ export class OrchestratorTaskService extends Service {
   private subscribeToAcp(acp: AcpService): void {
     this.unsubscribe = acp.onSessionEvent(
       (sessionId, event, data, sessionSnapshot, turnId) => {
-        void this.onSessionEvent(
-          sessionId,
-          event,
-          data,
-          sessionSnapshot,
-          turnId,
-        );
+        // Durable-task work (verification, coaching laps, respawns) is owned
+        // by the task, not by whichever user turn the event happened to fire
+        // inside. A native-transport prompt completes within the spawning
+        // turn's async context, so after the user cancelled that turn every
+        // verifier model call died "Turn aborted: user requested stop", each
+        // counting as a failed attempt until the task was parked (live
+        // 2026-08-22). Detach the ambient turn context at the entry.
+        runWithStreamingContext(undefined, () => {
+          void this.onSessionEvent(
+            sessionId,
+            event,
+            data,
+            sessionSnapshot,
+            turnId,
+          );
+        });
       },
     );
   }
@@ -1503,6 +1662,25 @@ export class OrchestratorTaskService extends Service {
     }
   }
 
+  /** Mark a completed session's durable Smithers run link terminal in BOTH
+   *  stores (and supersede stale sibling copies), so boot recovery stops
+   *  "resuming" finished work. No-op for sessions without a link or whose
+   *  link is already terminal. */
+  private async completeSmithersRunLink(sessionId: string): Promise<void> {
+    const acp = this.acp();
+    if (!acp || typeof acp.getSession !== "function") return;
+    const session = await acp.getSession(sessionId);
+    const link = readSmithersDurableRunLink(session?.metadata);
+    if (!link || link.state === "completed" || link.state === "superseded") {
+      return;
+    }
+    await this.syncSmithersRunCopies(
+      acp,
+      { ...link, state: "completed" },
+      sessionId,
+    );
+  }
+
   private async syncSmithersRunCopies(
     acp: AcpService,
     activeLink: SmithersDurableRunLink,
@@ -1723,7 +1901,7 @@ export class OrchestratorTaskService extends Service {
           {
             status: "completed",
             taskDelivered: true,
-            completionSummary: summary,
+            completionSummary: summary ? truncate(summary) : undefined,
             stoppedAt: Date.now(),
           },
           taskId,
@@ -1745,7 +1923,46 @@ export class OrchestratorTaskService extends Service {
             { taskId, sessionId },
           );
         }
-        await this.advanceTaskStatus(taskId, "completion_reported");
+        // Atomic with the interrupt: the check and the status advance sit
+        // under the task's write lock, so a stop landing between them cannot
+        // be overwritten by interrupted + completion_reported → validating.
+        const completionAccepted = await this.withTaskWriteLock(
+          taskId,
+          async () => {
+            const completedDoc = await this.store.getTask(taskId);
+            if (
+              completedDoc &&
+              (userInterrupted(completedDoc.task) ||
+                this.pendingUserInterrupts.has(taskId))
+            ) {
+              return false;
+            }
+            await this.advanceTaskStatus(taskId, "completion_reported");
+            return true;
+          },
+        );
+        if (!completionAccepted) {
+          // The user cancelled; the stopped child's final turn still reports
+          // a completion. `interrupted + completion_reported → validating`
+          // would verify and relay "it's ready" for a build the user stopped.
+          await this.store.addEvent({
+            id: randomUUID(),
+            taskId,
+            sessionId,
+            eventType: "completion_after_interrupt",
+            summary:
+              "Completion reported after the user stopped the task; not verified or relayed.",
+            data: { reason: "user_interrupt" },
+            timestamp: Date.now(),
+            createdAt: nowIso(),
+          });
+          this.log("info", "completion after user interrupt: ignored", {
+            taskId,
+            sessionId,
+          });
+          this.emitChange(taskId);
+          break;
+        }
         // Cross-surface arbitration for the digest emitter: stamp this
         // completion on the supervisor BEFORE its next tick, so the room's
         // status digest yields to the completion relay the router posts for
@@ -1767,19 +1984,84 @@ export class OrchestratorTaskService extends Service {
         // bare event summary. Fire-and-forget so the event-bridge write path
         // stays fast; the verifier gates itself on the flag + criteria presence,
         // and evidence assembly never throws into this path.
-        const { evidence: completionEvidence, bundle: completionBundle } =
-          await this.buildCompletionEvidence(taskId, sessionId, summary ?? "");
+        // Evidence is assembled AFTER the submit settles (below): built here
+        // it froze a pre-push snapshot, and verify attempt 1 judged "no PR,
+        // no diff" against a task whose PR opened seconds later (live
+        // 2026-08-20, SUPPORT.md run).
         // Thread the RAW final message (record.response) through alongside the
         // reworded evidence bundle: the #8895 CompletionEnvelope lives verbatim in
         // the sub-agent's last message, not in the prose evidence, so the structural
         // parser must see the original text.
-        void this.autoVerifyCompletion(
-          taskId,
-          sessionId,
-          completionEvidence,
-          summary ?? "",
-          completionBundle,
-        );
+        // These continuations run in the child-completion event's async
+        // context, which can still carry the SPAWN turn's trajectory step —
+        // closed minutes ago by then. Model calls made here were rejected as
+        // late captures (live 2026-08-19: purpose=action age=75s). Detach to
+        // a fresh standalone trajectory, keeping only the traceId correlation.
+        const inheritedTraceId = getTrajectoryContext()?.traceId;
+        const detachedContext = inheritedTraceId
+          ? { traceId: inheritedTraceId }
+          : undefined;
+        // Auto-submit for provisioned-repo tasks: children run behind the
+        // isolated git wrapper and cannot push, BY DESIGN — the orchestrator
+        // owns credentials. Without this, every "…and open a PR" repo ask
+        // ended with committed-but-unpushed work and a human had to finish
+        // the last leg (live 2026-08-17: two hello-validation runs).
+        //
+        // ORDER IS LOAD-BEARING: verification runs AFTER the submit settles.
+        // Fired independently, the residuals gate snapshotted the workspace
+        // BEFORE the submit's commit+push landed and parked a task whose PR
+        // was already open ("5 uncommitted paths; 1 commit not pushed" beside
+        // a live PR link, live 2026-08-20 FAQ run). A submit failure still
+        // verifies — the gate then reports the genuinely-unpushed state.
+        const submitSettled = Promise.resolve(
+          runWithTrajectoryContext(detachedContext, () =>
+            withStandaloneTrajectory(
+              this.runtime,
+              {
+                source: "orchestrator-task-submit",
+                metadata: { taskId, sessionId },
+              },
+              () => this.autoSubmitProvisionedWorkspace(taskId, sessionId),
+            ),
+          ),
+        ).catch(() => undefined);
+        void submitSettled.then(async () => {
+          const { evidence: completionEvidence, bundle: completionBundle } =
+            await this.buildCompletionEvidence(
+              taskId,
+              sessionId,
+              summary ?? "",
+            );
+          return runWithTrajectoryContext(detachedContext, () =>
+            withStandaloneTrajectory(
+              this.runtime,
+              {
+                source: "orchestrator-task-verify",
+                metadata: { taskId, sessionId },
+              },
+              () =>
+                this.autoVerifyCompletion(
+                  taskId,
+                  sessionId,
+                  completionEvidence,
+                  summary ?? "",
+                  completionBundle,
+                ),
+            ),
+          );
+        });
+        // Terminalize the durable Smithers link. The original run path never
+        // wrote state:"completed" (only the boot-recovery path did), so every
+        // normally-completed task carried a pending/running link forever and
+        // earned a pointless boot "recovery" that re-ran the finished task
+        // against the user — and a recovery that failed (e.g. a reclaimed
+        // workspace) retried on every subsequent boot (live 2026-08-18).
+        void this.completeSmithersRunLink(sessionId).catch((err) => {
+          this.log("warn", "smithers link terminalization failed", {
+            sessionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
         break;
       }
       case "error": {
@@ -2172,7 +2454,7 @@ export class OrchestratorTaskService extends Service {
    * flag is ALWAYS set explicitly ("1"/"0") so the broad ELIZA_ env forwarding
    * in AcpService never leaks the parent's value ambiguously.
    */
-  private buildChildTraceEnv(taskId: string): Record<string, string> {
+  buildChildTraceEnv(taskId: string): Record<string, string> {
     const ctx = getTrajectoryContext();
     const env: Record<string, string> = {
       [TRACE_ENV.TRACE_ID]: ctx?.traceId ?? randomUUID(),
@@ -2239,7 +2521,10 @@ export class OrchestratorTaskService extends Service {
     const freshFiles = files.filter((path) => !existingArtifactPaths.has(path));
     if (freshFiles.length === 0) return [];
 
-    // Newest first while retaining every genuinely new trajectory.
+    // Newest first, capped so a runaway child can't flood the task doc; the
+    // store's MAX_ARTIFACTS also clamps. Cap applies to genuinely-new files only
+    // so a large already-ingested backlog can't starve fresh trajectories out of
+    // the window.
     const withMtime = await Promise.all(
       freshFiles.map(async (path) => ({
         path,
@@ -2247,10 +2532,11 @@ export class OrchestratorTaskService extends Service {
       })),
     );
     withMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    const capped = withMtime.slice(0, MAX_CHILD_TRAJECTORY_ARTIFACTS);
 
     const session = (await this.store.findSession(sessionId, taskId))?.session;
     const ingested: string[] = [];
-    for (const { path } of withMtime) {
+    for (const { path } of capped) {
       // The recorder names files `<trajectoryId>.json`.
       const trajectoryId = basename(path, ".json");
       await this.store.addArtifact({
@@ -2378,6 +2664,10 @@ export class OrchestratorTaskService extends Service {
     fallbackSummary: string,
   ): Promise<CompletionEvidenceBundle> {
     const summary = fallbackSummary.trim();
+    const taskDocForPr = await this.store.getTask(taskId);
+    const pullRequestUrl =
+      str(taskDocForPr?.task.metadata?.prUrl) ??
+      str(taskDocForPr?.task.metadata?.autoSubmittedPrUrl);
     const empty: CompletionEvidenceBundle = {
       summary,
       verifiedUrls: [],
@@ -2454,7 +2744,7 @@ export class OrchestratorTaskService extends Service {
     // to the judge (a sub-agent could otherwise pass by writing "deployed to
     // https://…"). They are surfaced separately as `mentionedUrls`.
     const verifiedUrls = [
-      ...new Set(this.metadataVerifiedUrls(doc, sessionId)),
+      ...new Set(await this.metadataVerifiedUrls(doc, sessionId)),
     ];
     const verifiedSet = new Set(verifiedUrls);
     const mentionedUrls = [
@@ -2501,25 +2791,16 @@ export class OrchestratorTaskService extends Service {
         candidatePaths: [
           ...(changeSet?.changedFiles ?? []),
           ...mineCandidatePaths([summary, ...subAgentReplies]),
+          // Workers that end with an empty final reply leave nothing to mine;
+          // direct enumeration nominates what is actually in the workdir and
+          // the mtime gate below decides what counts (live 2026-08-19 parks).
+          ...enumerateWorkdirCandidates(reportingSession.workdir),
         ],
-        sessionStartedAt: reportingSession.registeredAt,
+        sessionStartedAt: await this.fsObservationFloor(
+          doc,
+          reportingSession.registeredAt,
+        ),
       });
-      if (fsVerifiedFiles.length > 0 && verifiedUrls.length === 0) {
-        const routeMeta = isRecord(reportingSession.metadata)
-          ? reportingSession.metadata.workdirRoute
-          : undefined;
-        const urlMappings =
-          isRecord(routeMeta) && Array.isArray(routeMeta.urlMappings)
-            ? (routeMeta.urlMappings as {
-                urlPrefix: string;
-                localPath: string;
-              }[])
-            : undefined;
-        const probed = await probeMappedUrls(
-          deriveRouteMappedUrls(fsVerifiedFiles, urlMappings),
-        );
-        verifiedUrls.push(...probed);
-      }
     }
 
     // Which check classes the verified deliverable can actually RUN —
@@ -2528,13 +2809,80 @@ export class OrchestratorTaskService extends Service {
       ...(ledgerVerdict.ledgerObserved ? ledgerVerdict.verifiedClaims : []),
       ...fsVerifiedFiles,
     ];
+    // The route's public URL is probed from whatever deliverable files are
+    // verified — ledger or fs. It used to live inside the ledger-less recovery
+    // branch only, so an adapter WITH a ledger (eliza-code once it mirrored
+    // its FILE writes) never had its served page probed: the verifier then
+    // demanded a non-loopback URL for a page that was live and parked the
+    // build after three laps (live 2026-08-22, quotes-page).
+    if (
+      reportingSession?.workdir &&
+      surfaceFiles.length > 0 &&
+      verifiedUrls.length === 0
+    ) {
+      const routeMeta = isRecord(reportingSession.metadata)
+        ? reportingSession.metadata.workdirRoute
+        : undefined;
+      const urlMappings =
+        isRecord(routeMeta) && Array.isArray(routeMeta.urlMappings)
+          ? (routeMeta.urlMappings as {
+              urlPrefix: string;
+              localPath: string;
+            }[])
+          : undefined;
+      const candidateUrls = deriveRouteMappedUrls(surfaceFiles, urlMappings);
+      // Assigned-slug workdirs carry no route metadata, so the mapped set
+      // is empty and criteria like "a reachable URL renders the page"
+      // starve on a build that IS served (live 2026-08-19: quote-generator
+      // parked for "no reachable URL"). The deploy config alone determines
+      // the URL for a workdir directly under the apps dir.
+      if (candidateUrls.length === 0) {
+        const deploy = resolveAppDeployConfig();
+        if (
+          deploy.target === "custom" &&
+          deploy.customAppsDir &&
+          deploy.customBaseUrl &&
+          dirname(resolvePath(reportingSession.workdir)) ===
+            resolvePath(deploy.customAppsDir)
+        ) {
+          candidateUrls.push(
+            `${deploy.customBaseUrl.replace(/\/+$/, "")}/apps/${basename(reportingSession.workdir)}/`,
+          );
+        }
+      }
+      const probed = await probeMappedUrls(candidateUrls);
+      verifiedUrls.push(...probed);
+    }
     const checkSurfaces =
       reportingSession?.workdir && surfaceFiles.length > 0
         ? detectCheckSurfaces(reportingSession.workdir, surfaceFiles)
         : undefined;
 
+    let runOutput: string | undefined;
+    try {
+      const acpForOutput = this.acp();
+      // The judge's RUN OUTPUT section is a bounded VIEW of the durable
+      // session transcript, not the record itself: read a generous tail and
+      // mark a partial view with its continuation reference so "the diff is
+      // truncated" never reads as "the content is gone" (#24262 close-out).
+      const rawRunOutput =
+        (await acpForOutput?.getSessionOutput?.(sessionId, 2_000))?.trim() ||
+        undefined;
+      runOutput = rawRunOutput
+        ? boundedContentView(
+            rawRunOutput,
+            16_000,
+            orchestratorContentRef("session-output", sessionId),
+          ).view
+        : undefined;
+    } catch {
+      // error-policy:J4 output capture is evidence enrichment; absence just
+      // leaves the section out.
+    }
     return {
       summary,
+      ...(runOutput ? { runOutput } : {}),
+      ...(pullRequestUrl ? { pullRequestUrl } : {}),
       diffSummary,
       toolOutput,
       verifiedUrls,
@@ -2547,11 +2895,15 @@ export class OrchestratorTaskService extends Service {
         : {}),
       ...(fsVerifiedFiles.length > 0 ? { fsVerifiedFiles } : {}),
       ...(checkSurfaces ? { checkSurfaces } : {}),
-      ...(fsVerifiedFiles.length > 0 && reportingSession?.workdir
+      // Every verified deliverable file's real text — ledger-verified too.
+      // With only the 3 KB diff excerpt to go on, the judge failed a served
+      // 123-line page twice for "the truncated diff hides the JavaScript"
+      // and each lane spent a coaching lap on it (live 2026-08-22).
+      ...(surfaceFiles.length > 0 && reportingSession?.workdir
         ? (() => {
             const fsVerifiedFileContents = readFsVerifiedContents(
               reportingSession.workdir,
-              fsVerifiedFiles,
+              [...new Set(surfaceFiles)],
             );
             return fsVerifiedFileContents.length > 0
               ? { fsVerifiedFileContents }
@@ -2593,15 +2945,26 @@ export class OrchestratorTaskService extends Service {
     return signals;
   }
 
-  /** URLs the router stamped as verified onto the task or session metadata
-   *  (`subAgentVerifiedUrls`), separate from URLs mined out of free text. */
-  private metadataVerifiedUrls(
+  /** URLs the router stamped as verified (`subAgentVerifiedUrls`), separate
+   *  from URLs mined out of free text. The router patches the LIVE ACP
+   *  session's metadata at task_complete; the store row is a spawn-time copy,
+   *  so it is consulted alongside the task record, never instead of the live
+   *  session. */
+  private async metadataVerifiedUrls(
     doc: OrchestratorTaskDocument,
     sessionId: string,
-  ): string[] {
+  ): Promise<string[]> {
     const out: string[] = [];
     const session = doc.sessions.find((row) => row.sessionId === sessionId);
-    for (const meta of [doc.task.metadata, session?.metadata]) {
+    let liveMetadata: Record<string, unknown> | undefined;
+    try {
+      const live = await this.acp()?.getSession(sessionId);
+      liveMetadata = isRecord(live?.metadata) ? live.metadata : undefined;
+    } catch {
+      // error-policy:J4 the live session may already be torn down; the
+      // persisted copies below still count.
+    }
+    for (const meta of [doc.task.metadata, session?.metadata, liveMetadata]) {
       const raw = meta?.subAgentVerifiedUrls;
       if (!Array.isArray(raw)) continue;
       for (const entry of raw) {
@@ -2782,9 +3145,36 @@ export class OrchestratorTaskService extends Service {
    * lets a resume/rerun spawn self-heal a task the stuck-task reaper
    * interrupted while the spawn was still in flight.
    */
+  /** Stamp the reason for a SYSTEM-initiated interrupt (reaper, stop-failure
+   * fallback). Overwrites any stale user stamp from a prior life so
+   * userInterrupted() reflects THIS interrupt — a leftover "user_interrupt"
+   * made a reaper interrupt sticky (no attach self-heal). */
+  private async stampSystemInterrupt(
+    taskId: string,
+    reason: string,
+  ): Promise<void> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc || doc.task.status !== "interrupted") return;
+    await this.store.updateTask(taskId, {
+      metadata: {
+        ...(doc.task.metadata ?? {}),
+        interruptReason: reason,
+        interruptedAt: nowIso(),
+      },
+    });
+  }
+
   private async advanceTaskLiveness(taskId: string): Promise<void> {
     const doc = await this.store.getTask(taskId);
     if (!doc || doc.task.paused) return;
+    if (userInterrupted(doc.task)) {
+      // The user stopped this task; only an explicit restart/reopen revives
+      // it. The session is indexed, the create path stops it on return.
+      this.log("info", "attach on a user-interrupted task: not resurrecting", {
+        taskId,
+      });
+      return;
+    }
     await this.advanceTaskStatus(
       taskId,
       doc.task.status === "interrupted" ? "restarted" : "session_active",
@@ -2836,6 +3226,16 @@ export class OrchestratorTaskService extends Service {
     if (!doc) return;
     if (doc.task.paused) return;
     if (TERMINAL_TASK_STATUSES.has(doc.task.status)) return;
+    if (userInterrupted(doc.task)) {
+      // The user stopped this task; the dying session's error must not fire
+      // `retrying` — interrupted → retrying → active resurrected the build
+      // and re-armed verification with the stamp still on it.
+      this.log("info", "session error on a user-interrupted task: ignored", {
+        taskId,
+        sessionId,
+      });
+      return;
+    }
 
     // Scope the budget to the current run: an operator `restartTask` stamps a
     // budget epoch, and sessions spawned before it (a prior failed run's dead
@@ -3082,6 +3482,32 @@ export class OrchestratorTaskService extends Service {
     this.emitChange(taskId);
   }
 
+  /** Floor for mtime-gated fs evidence: the reporting session's start, or —
+   * for a task continuing finished work in the predecessor's workdir
+   * (`parentTaskId` lineage) — the lineage root's earliest session start. The
+   * deliverable a successor builds on predates the successor session by
+   * construction; gating on its own start hid the script it re-ran and the
+   * judge saw only a bare output (live 2026-08-21: "banana" failed for "no
+   * evidence that a script file exists"). */
+  private async fsObservationFloor(
+    doc: OrchestratorTaskDocument,
+    sessionStartedAt: number,
+  ): Promise<number> {
+    let floor = sessionStartedAt;
+    let parentId = doc.task.parentTaskId;
+    for (let depth = 0; parentId && depth < 8; depth++) {
+      const parent = await this.store.getTask(parentId);
+      if (!parent) break;
+      const starts = [
+        new Date(parent.task.createdAt).getTime(),
+        ...parent.sessions.map((session) => session.registeredAt),
+      ].filter((value) => Number.isFinite(value));
+      floor = Math.min(floor, ...starts);
+      parentId = parent.task.parentTaskId;
+    }
+    return floor;
+  }
+
   /** Read-only lookup of the durable task record backing a session, for
    * consumers outside the service (the completion evaluator's
    * verification-aware framing) that must not receive the full document. */
@@ -3106,7 +3532,27 @@ export class OrchestratorTaskService extends Service {
   // ---- lifecycle ---------------------------------------------------------
 
   async createTask(input: CreateTaskInput): Promise<TaskThreadDetailDto> {
-    const bound = this.bindProject(input);
+    const inputText = `${input.goal}\n${input.originalRequest ?? ""}`;
+    const inputBaselines: InputBaseline[] = [];
+    for (const requestedPath of readTargetsFromTask(inputText)) {
+      const path = resolvePath(input.workdir ?? process.cwd(), requestedPath);
+      try {
+        const bytes = await readFile(path);
+        inputBaselines.push({
+          path,
+          existed: true,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+        });
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") inputBaselines.push({ path, existed: false });
+        else throw error;
+      }
+    }
+    const bound = this.bindProject({
+      ...input,
+      metadata: { ...input.metadata, inputBaselines },
+    });
     const doc = await this.store.createTask(
       await this.withDefaultAcceptanceCriteria(bound),
     );
@@ -3178,7 +3624,7 @@ export class OrchestratorTaskService extends Service {
 
     const hint = this.taskTypeHintFor(input);
     const generated = await generateDefaultAcceptanceCriteria(
-      input.goal,
+      `${input.goal}\n${input.originalRequest ?? ""}`,
       hint,
       this.runtime,
     );
@@ -3204,7 +3650,24 @@ export class OrchestratorTaskService extends Service {
     input: CreateTaskInput,
   ): OrchestratorTaskType | undefined {
     switch (input.kind) {
-      case "coding":
+      case "coding": {
+        // "coding" is the planner's default label for EVERY spawn, not a
+        // verification judgment — honoring it on a page-build ask resurrects
+        // the diff-summary criterion no slug-dir app can satisfy (live
+        // 2026-08-19: "make me a lil unit converter page" parked on "the
+        // change is summarized in the diff"). Let goal-text detection decide;
+        // it returns "coding" anyway for genuine repo work.
+        // The planner's goal often drops the user's phrasing ("memory match
+        // game" for "make me a lil memory match game page"), so detect on
+        // both texts (live 2026-08-19: coding criteria — typecheck/lint —
+        // parked a served page whose guidance forbids those very checks).
+        const detected = detectTaskType(
+          `${input.goal}\n${input.originalRequest ?? ""}`,
+        );
+        return detected === "app-build" || detected === "script-run"
+          ? detected
+          : "coding";
+      }
       case "view-create":
       case "app-build":
       case "deploy":
@@ -3253,6 +3716,581 @@ export class OrchestratorTaskService extends Service {
    * read from the task record metadata stamped at create time. Returns null when
    * the task has no origin room (e.g. an API-created task with no chat).
    */
+  /**
+   * PR-intent gate for {@link autoSubmitProvisionedWorkspace}: submit only
+   * when the user actually asked for a pull/merge request. A repo task
+   * without PR intent ("fix the bug in <repo>") keeps its commits local for
+   * the user to review. Matched against the durable goal + original request.
+   */
+  static wantsPullRequest(text: string): boolean {
+    // Negation-aware: "just commit it locally, no pr needed" matched the bare
+    // \bpr\b token and auto-submit opened the PR the user explicitly declined
+    // (live 2026-08-18, battery probe). Strip negated PR mentions (a negation
+    // word within a short bounded gap of the PR token) first; whatever PR
+    // mention survives is a genuine ask.
+    const withoutNegated = text.replace(
+      /\b(?:no|without|skip|don'?t|do not|never|not)\b(?:\s+\w+){0,3}?\s*(?:pr|pull[- ]?request|merge[- ]?request)s?\b/gi,
+      " ",
+    );
+    return /\b(?:pull[- ]request|merge[- ]request|\bpr\b|open (?:a |the )?pr\b)/i.test(
+      withoutNegated,
+    );
+  }
+
+  /**
+   * Push a provisioned-repo session's committed branch and open the PR the
+   * request asked for. Children commit behind the isolated git wrapper and
+   * cannot push (by design — the orchestrator owns credentials), so this is
+   * the completion leg of every "…and open a PR" repo task. Fire-and-forget
+   * from the task_complete bridge; every failure is loud in the log but never
+   * breaks the event path. The `autoSubmittedAt` metadata stamp makes it
+   * once-per-task (a verify re-engage's second task_complete must not race a
+   * second PR).
+   */
+  private async autoSubmitProvisionedWorkspace(
+    taskId: string,
+    sessionId: string,
+  ): Promise<void> {
+    try {
+      const doc = await this.store.getTask(taskId);
+      if (!doc) return;
+      const alreadySubmitted = Boolean(doc.task.metadata?.autoSubmittedAt);
+      const session = doc.sessions.find((s) => s.sessionId === sessionId);
+      const acp = this.acp();
+      const liveMeta = acp
+        ? (await acp.getSession(sessionId))?.metadata
+        : undefined;
+      const workspaceId =
+        (typeof liveMeta?.provisionedWorkspaceId === "string"
+          ? liveMeta.provisionedWorkspaceId
+          : undefined) ??
+        (typeof session?.metadata?.provisionedWorkspaceId === "string"
+          ? (session.metadata.provisionedWorkspaceId as string)
+          : undefined);
+      if (!workspaceId) return;
+      const intentText = `${doc.task.goal ?? ""} ${doc.task.originalRequest ?? ""}`;
+      if (!OrchestratorTaskService.wantsPullRequest(intentText)) return;
+      const workspaceService = getCodingWorkspaceService(this.runtime);
+      if (!workspaceService) return;
+      const workspace = workspaceService.getWorkspace(workspaceId);
+      if (!workspace) {
+        if (alreadySubmitted) {
+          await this.store
+            .addEvent({
+              id: randomUUID(),
+              taskId,
+              sessionId,
+              eventType: "corrective_push_failed",
+              summary: `Corrective-lap push skipped: workspace ${workspaceId} is no longer registered.`,
+              data: {},
+              timestamp: Date.now(),
+              createdAt: nowIso(),
+            })
+            .catch(() => undefined);
+        }
+        return;
+      }
+      if (alreadySubmitted) {
+        // Sync leg for corrective laps: each verify-failed round makes the
+        // child commit more work, but the full submit is claim-once — the
+        // early return left every later commit UNPUSHED, so the residuals
+        // gate flagged "commits not pushed" forever and parked a task whose
+        // PR was already open (live 2026-08-20: three laps in 36s, GLOSSARY
+        // run). Push pending commits to the registered branch and let the
+        // next verify see the true state.
+        const { execFile: execSync } = await import("node:child_process");
+        const syncGit = (args: string[]) =>
+          new Promise<string>((resolve, reject) =>
+            execSync(
+              "git",
+              ["-C", workspace.path, ...args],
+              { timeout: 30_000 },
+              (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
+            ),
+          );
+        try {
+          const unpushed = await syncGit(["rev-list", "@{u}..HEAD"]).catch(
+            () => "",
+          );
+          if (unpushed) {
+            // The naked `git push` here failed "Repository not found" — the
+            // service process has no ambient git credentials; the workspace
+            // service's push injects the GitHub token (same leg the original
+            // submit used). The registered branch was already pointed at the
+            // child's exec branch by that first submit.
+            await workspaceService.push(workspaceId);
+            await this.store.addEvent({
+              id: randomUUID(),
+              taskId,
+              sessionId,
+              eventType: "corrective_push",
+              summary: "Pushed corrective-lap commits to the PR branch.",
+              data: {},
+              timestamp: Date.now(),
+              createdAt: nowIso(),
+            });
+          }
+        } catch (err) {
+          // error-policy:J6 best-effort sync; the residuals gate reports the
+          // still-unpushed truth and the corrective loop continues. Recorded
+          // as a task event because plugin logs are not surfaced on this
+          // deployment — a silent bail here cost three debugging laps.
+          await this.store
+            .addEvent({
+              id: randomUUID(),
+              taskId,
+              sessionId,
+              eventType: "corrective_push_failed",
+              summary: `Corrective-lap push failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+              data: {},
+              timestamp: Date.now(),
+              createdAt: nowIso(),
+            })
+            .catch(() => undefined);
+        }
+        return;
+      }
+      // Claim before the slow work so a redelivered task_complete cannot race
+      // a duplicate submit.
+      await this.store.updateTask(taskId, {
+        metadata: { ...doc.task.metadata, autoSubmittedAt: nowIso() },
+      });
+      // The ACP git wrapper commits on its own exec branch; the workspace
+      // service pushes/PRs its REGISTERED branch. Point the registered branch
+      // at the child's actual work first, or the PR is opened from a branch
+      // with no commits (live: push landed the exec branch, createPR 422'd).
+      const { execFile } = await import("node:child_process");
+      const gitIn = (args: string[]) =>
+        new Promise<void>((resolve, reject) =>
+          execFile(
+            "git",
+            ["-C", workspace.path, ...args],
+            { timeout: 30_000 },
+            (err) => (err ? reject(err) : resolve()),
+          ),
+        );
+      const gitOut = (args: string[]) =>
+        new Promise<string>((resolve, reject) =>
+          execFile(
+            "git",
+            ["-C", workspace.path, ...args],
+            { timeout: 30_000 },
+            (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
+          ),
+        );
+      // task_complete can fire while the child is still writing its final
+      // commit (live 2026-08-18: README edited but uncommitted, three
+      // empty-diff gate blocks in a row). Wait — bounded — for actual new
+      // commits before submitting: poll while the tree is dirty or the
+      // session is still live; give up loudly when neither.
+      const baseCommit = await gitOut(["rev-parse", "origin/HEAD"]).catch(() =>
+        gitOut(["rev-parse", "origin/main"]).catch(() => ""),
+      );
+      const waitDeadline = Date.now() + 5 * 60_000;
+      for (;;) {
+        const head = await gitOut(["rev-parse", "HEAD"]).catch(() => "");
+        if (head && head !== baseCommit) break;
+        const dirty = await gitOut(["status", "--porcelain"]).catch(() => "");
+        const live = acp ? await acp.getSession(sessionId) : undefined;
+        const sessionActive =
+          live !== undefined &&
+          live !== null &&
+          !["stopped", "errored", "completed"].includes(live.status);
+        if (Date.now() > waitDeadline || (!dirty && !sessionActive)) {
+          throw new Error(
+            "auto-submit found no new commits in the provisioned workspace (child finished without committing)",
+          );
+        }
+        await new Promise((r) => setTimeout(r, 10_000));
+      }
+      // checkout -B: moves (or creates) the registered branch at the child's
+      // HEAD and checks it out in one step — including when the registered
+      // branch IS the currently checked-out branch, where `branch -f` refuses
+      // ("cannot force update the checked-out branch", live 2026-08-18).
+      await gitIn(["checkout", "-B", workspace.branch, "HEAD"]);
+      await workspaceService.push(workspaceId, { setUpstream: true });
+      // PR title/body must not carry the chat connector envelope — the raw
+      // originalRequest embeds "[Discord #channel | server] @user (ts):" plus
+      // platform mention ids, and a PR on a public repo publishes it (live
+      // 2026-08-18, sandbox PR #4). Use the planner-authored goal/title,
+      // stripped of any envelope prefix, mention tokens, and the trailing
+      // "and open a PR"-style instruction.
+      const scrubChatEnvelope = (value: string): string =>
+        value
+          .replace(
+            /^\[[^\]\n]{0,120}\]\s*@?[\w.-]*\s*\([^)\n]{0,60}\)\s*:\s*/u,
+            "",
+          )
+          .replace(/<@!?\d+>/g, "")
+          .replace(/\s+/g, " ")
+          .trim();
+      const rawTitle = doc.task.title || doc.task.goal || workspace.branch;
+      const canonicalPrTitle =
+        scrubChatEnvelope(rawTitle)
+          .replace(
+            /[\s,.]*(?:and\s+)?(?:then\s+)?(?:open|put\s+up|submit|raise|file)\s+(?:a\s+|the\s+)?(?:pr|pull[- ]?request)\b.*$/iu,
+            "",
+          )
+          .trim() || workspace.branch;
+      // GitHub enforces a bounded title field. Preserve the canonical value in
+      // task metadata and derive the provider payload explicitly.
+      const providerPrTitle = canonicalPrTitle.slice(0, 120);
+      const canonicalPrBody = scrubChatEnvelope(doc.task.goal ?? rawTitle);
+      const pr = await workspaceService.createPR(workspaceId, {
+        title: providerPrTitle,
+        body: `${canonicalPrBody}\n\n🤖 Automated submit by the coding orchestrator on task completion.`,
+      });
+      await this.store.updateTask(taskId, {
+        metadata: {
+          ...(((await this.store.getTask(taskId))?.task.metadata ??
+            {}) as Record<string, unknown>),
+          autoSubmittedPrUrl: pr.url,
+          canonicalPrTitle,
+          providerPrTitle,
+          canonicalPrBody,
+          // Canonical PR fields: the verifier's evidence, the ground-truth
+          // check, and the chat task widget all read `prUrl` — the submit
+          // writing only its own key left the judge insisting "no pull
+          // request was opened" while its OWN submit's PR sat open (live
+          // 2026-08-20: three verify attempts on TESTING.md, all failed on
+          // exactly that).
+          prUrl: pr.url,
+          ...(typeof (pr as { number?: unknown }).number === "number"
+            ? { prNumber: (pr as { number?: number }).number }
+            : {}),
+        },
+      });
+      this.log("info", "auto-submitted provisioned workspace", {
+        taskId,
+        sessionId,
+        workspaceId,
+        prUrl: pr.url,
+      });
+      // Tell the user where their PR is — model-phrased, factual fallback.
+      const origin = await this.getTaskOriginTarget(taskId);
+      const send = (
+        this.runtime as IAgentRuntime & {
+          sendMessageToTarget?: (
+            target: { source: string; roomId?: UUID },
+            content: { text: string; source: string },
+          ) => Promise<unknown>;
+        }
+      ).sendMessageToTarget;
+      if (origin && typeof send === "function") {
+        const { text } = await phraseForUser(
+          this.runtime,
+          {
+            intent: "notify",
+            facts: {
+              what: "branch pushed and pull request opened",
+              branch: workspace.branch,
+              prUrl: pr.url,
+            },
+            mustInclude: [pr.url],
+            mustNotClaim: ["merged", "reviewed"],
+          },
+          `pushed ${workspace.branch} and opened the pull request: ${pr.url}`,
+        );
+        await send(
+          { source: origin.source, roomId: origin.roomId as UUID },
+          { text, source: origin.source, ...AGENT_VOICED_METADATA },
+        );
+      }
+    } catch (error) {
+      // error-policy:J7 auto-submit is fire-and-forget from the event bridge;
+      // failure is loud here and the user still gets the completion relay.
+      // Flatten newlines: the pretty transport truncates a warn message at
+      // the first newline, which swallowed the diff-gate's reason list.
+      const submitError = (
+        error instanceof Error ? error.message : String(error)
+      ).replace(/\s*\n\s*/g, " | ");
+      this.log(
+        "warn",
+        `auto-submit of provisioned workspace failed (task=${taskId} session=${sessionId}): ${submitError}`,
+        { taskId, sessionId, error: submitError },
+      );
+      // Re-arm: a failed submit must not permanently claim the once-per-task
+      // stamp — a later genuine task_complete (verify re-engage, retry)
+      // deserves another attempt.
+      try {
+        const latest = await this.store.getTask(taskId);
+        if (latest?.task.metadata?.autoSubmittedAt) {
+          const { autoSubmittedAt: _dropped, ...rest } = latest.task
+            .metadata as Record<string, unknown>;
+          await this.store.updateTask(taskId, { metadata: rest });
+        }
+      } catch {
+        // error-policy:J6 best-effort re-arm; the warn above already reported the submit failure
+      }
+    }
+  }
+
+  /**
+   * Post the one-time "verification gave up, task parked for you" notice to
+   * the task's origin room. Best-effort at every step (no origin, no send
+   * handler, or a delivery failure must never break the escalation itself —
+   * the park already happened); the `verifyEscalationNotifiedAt` metadata
+   * stamp makes the notice once-per-task.
+   */
+  /**
+   * Corrective success notice: when a task promotes to `done` AFTER the room
+   * heard a failure-ish relay (a retry ran, or verification re-engaged the
+   * worker), the user's last impression is "failed" and the pass verdict is
+   * otherwise silent (live 2026-08-19: "it stopped before it finished …" was
+   * the final message on a task that verified done a minute later). Once per
+   * task; factual text takes the normal voice pass on delivery.
+   */
+  private async notifyVerifyRecovery(taskId: string): Promise<void> {
+    try {
+      const doc = await this.store.getTask(taskId);
+      if (!doc || doc.task.metadata?.verifyRecoveryNotifiedAt) return;
+      const reflections = readAttemptReflections(
+        doc.task.metadata ?? undefined,
+      );
+      const sawRetry = doc.sessions.some((session) => {
+        const meta = session.metadata as Record<string, unknown> | undefined;
+        return typeof meta?.retryCount === "number" && meta.retryCount > 0;
+      });
+      if (reflections.length === 0 && !sawRetry) return;
+      const origin = await this.getTaskOriginTarget(taskId);
+      if (!origin) return;
+      const send = (
+        this.runtime as IAgentRuntime & {
+          sendMessageToTarget?: (
+            target: { source: string; roomId?: UUID },
+            content: { text: string; source: string },
+          ) => Promise<unknown>;
+        }
+      ).sendMessageToTarget;
+      if (typeof send !== "function") return;
+      // Same request-terminal claim as the park notice: the task_complete
+      // relay and this notice raced and BOTH delivered ("…every criterion
+      // passed. live at <url>" followed 27s later by "it's all set. you can
+      // find…", live 2026-08-19). Whichever claims first is the single
+      // completion message; denial gags the other. Ledger absent → fail-open.
+      const router = this.runtime.getService?.(
+        SUB_AGENT_ROUTER_SERVICE_TYPE,
+      ) as RequestVoiceLedgerRouter | null;
+      let suppressed = false;
+      if (typeof router?.claimRequestTerminal === "function") {
+        const requestKey =
+          requestVoiceKeyForMeta({
+            ...(doc.task.metadata ?? {}),
+            taskId,
+          }) ?? `task:${taskId}`;
+        try {
+          suppressed = terminalClaimDenied(
+            router.claimRequestTerminal(requestKey, taskId, "completed", false),
+          );
+        } catch {
+          // error-policy:J4 ledger failure degrades to sending (dedupe lost,
+          // never the notice).
+          suppressed = false;
+        }
+      }
+      await this.store.updateTask(taskId, {
+        metadata: {
+          ...doc.task.metadata,
+          verifyRecoveryNotifiedAt: nowIso(),
+        },
+      });
+      if (suppressed) return;
+      const label = doc.task.title.trim() || "the coding task";
+      const deploy = resolveAppDeployConfig();
+      const workdir = doc.sessions.at(-1)?.workdir;
+      const url =
+        deploy.target === "custom" &&
+        deploy.customAppsDir &&
+        deploy.customBaseUrl &&
+        workdir &&
+        dirname(workdir) === deploy.customAppsDir.replace(/\/+$/, "")
+          ? `${deploy.customBaseUrl.replace(/\/+$/, "")}/apps/${basename(workdir)}/`
+          : undefined;
+      const text = sawRetry
+        ? `${label} recovered: the earlier failure was retried and every acceptance criterion now verifies.${url ? ` Live at ${url}` : ""}`
+        : `${label} is verified done — every acceptance criterion passes.${url ? ` Live at ${url}` : ""}`;
+      await send(
+        { source: origin.source, roomId: origin.roomId },
+        { text, source: origin.source },
+      );
+    } catch (err) {
+      // error-policy:J7 a missed courtesy notice must not affect the verdict.
+      this.runtime.reportError?.(
+        "OrchestratorTaskService.notifyVerifyRecovery",
+        err,
+        { taskId },
+      );
+    }
+  }
+
+  private async notifyVerifyEscalation(
+    taskId: string,
+    details: {
+      attempts: number;
+      summary: string;
+      missing: string[];
+      sessionId?: string;
+      verifier?: string;
+    },
+  ): Promise<void> {
+    try {
+      const doc = await this.store.getTask(taskId);
+      if (!doc) return;
+      // One notice per LANE, not per task: the second lane to park was
+      // silent (its relay already dropped, the task-level stamp set by the
+      // first lane's notice), so half the build vanished without a word.
+      const laneScoped =
+        details.sessionId &&
+        this.laneScope(doc, details.sessionId).laneSessionIds.length > 1;
+      const laneNotices = isRecord(doc.task.metadata?.laneVerifyNoticeAt)
+        ? (doc.task.metadata.laneVerifyNoticeAt as Record<string, unknown>)
+        : {};
+      if (
+        laneScoped
+          ? details.sessionId && laneNotices[details.sessionId]
+          : doc.task.metadata?.verifyEscalationNotifiedAt
+      ) {
+        return;
+      }
+      const origin = await this.getTaskOriginTarget(taskId);
+      if (!origin) return;
+      const send = (
+        this.runtime as IAgentRuntime & {
+          sendMessageToTarget?: (
+            target: { source: string; roomId?: UUID },
+            content: { text: string; source: string; agentVoiced?: boolean },
+          ) => Promise<unknown>;
+        }
+      ).sendMessageToTarget;
+      if (typeof send !== "function") return;
+      // Request-level dedupe: a verify-driven respawn can double the TASK
+      // record for one user request lineage, so the once-per-task
+      // verifyEscalationNotifiedAt stamp alone still allowed two park notices.
+      // Claim the request's terminal slot on the router's voice ledger, keyed
+      // by the SAME canonical ladder the router keys its session terminal
+      // claims with (requestVoiceKeyForMeta: spawnRootMessageId ??
+      // originConnectorMessageId ?? messageId ?? task:<id>, plus the fan-out
+      // part suffix). The parking session's OWN metadata is preferred — it is
+      // exactly what the router keyed that session's claims on, so the park
+      // supersedes its provisional result and lane-scoped parts resolve; the
+      // task-level projection covers restart parks whose session is already
+      // gone. Denied → a sibling task already parked this request lineage:
+      // stamp (so this task never re-tries) but do not send. Router
+      // absent/disabled/no method → send as today (fail-open; the per-task
+      // stamp remains the durable backstop).
+      let suppressed = false;
+      const router = this.runtime.getService?.(
+        SUB_AGENT_ROUTER_SERVICE_TYPE,
+      ) as RequestVoiceLedgerRouter | null;
+      if (typeof router?.claimRequestTerminal === "function") {
+        let sessionVoiceMeta: Record<string, unknown> | undefined;
+        if (details.sessionId) {
+          try {
+            const live = await this.acp()?.getSession(details.sessionId);
+            sessionVoiceMeta = live?.metadata as
+              | Record<string, unknown>
+              | undefined;
+          } catch {
+            // error-policy:J4 session metadata lookup failure degrades to the
+            // task-level key projection below (today's behavior).
+            sessionVoiceMeta = undefined;
+          }
+        }
+        const requestKey =
+          requestVoiceKeyForMeta({
+            ...(doc.task.metadata ?? {}),
+            ...(sessionVoiceMeta ?? {}),
+            taskId,
+          }) ?? `task:${taskId}`;
+        try {
+          suppressed = terminalClaimDenied(
+            router.claimRequestTerminal(
+              requestKey,
+              details.sessionId ?? taskId,
+              "parked",
+              false,
+            ),
+          );
+        } catch (claimErr) {
+          // error-policy:J4 ledger claim failure degrades to sending the
+          // notice (fail-open) — the dedupe is lost, never the notice.
+          this.log("warn", "verify-escalation ledger claim failed", {
+            taskId,
+            error:
+              claimErr instanceof Error ? claimErr.message : String(claimErr),
+          });
+          suppressed = false;
+        }
+      }
+      await this.store.updateTask(taskId, {
+        metadata: {
+          ...doc.task.metadata,
+          verifyEscalationNotifiedAt: nowIso(),
+          ...(laneScoped && details.sessionId
+            ? {
+                laneVerifyNoticeAt: {
+                  ...laneNotices,
+                  [details.sessionId]: nowIso(),
+                },
+              }
+            : {}),
+        },
+      });
+      if (suppressed) return;
+      // Model-phrased park notice (owner directive: user-facing text is
+      // LLM-written). Runs AFTER the terminal claim + stamp above
+      // (claim-before-phrase), so model latency cannot double the notice.
+      // composeVerifyEscalationNotice remains the factual fallback.
+      const label = doc.task.title.trim() || "the coding task";
+      const missing = details.missing
+        .filter((item) => item.trim().length > 0)
+        .slice(0, 3);
+      const fabricatedInput = details.verifier === "fabricated-input-ledger";
+      const { text } = await phraseForUser(
+        this.runtime,
+        {
+          intent: "warn",
+          facts: {
+            title: label,
+            attempts: details.attempts,
+            summary: details.summary,
+            ...(missing.length > 0 ? { couldNotConfirm: missing } : {}),
+            // User-facing state, not the internal status name: "parked"
+            // read as jargon in the room ("The page is parked", live
+            // 2026-08-22).
+            waitingOnYouNow: true,
+            // A manufactured input means the output is NOT to be trusted —
+            // "the work may still be fine" would soften a fabrication
+            // (live 2026-08-22: "though the output looks right").
+            ...(fabricatedInput
+              ? { outputIsFabricated: true, realInputMissingHere: true }
+              : { workMayStillBeFine: true }),
+            userShouldCheckThenAcceptOrSayWhatToFix: true,
+          },
+          mustInclude: [label],
+          mustNotClaim: [
+            "the work was confirmed good",
+            "the task was abandoned",
+            ...(fabricatedInput ? ["the output is correct or usable"] : []),
+          ],
+        },
+        composeVerifyEscalationNotice(doc.task.title, details),
+      );
+      await send(
+        { source: origin.source, roomId: origin.roomId as UUID },
+        { text, source: origin.source, ...AGENT_VOICED_METADATA },
+      );
+    } catch (err) {
+      // error-policy:J7 escalation notice is best-effort; the park must stand even when the room notice cannot be delivered
+      this.log("warn", "verify-escalation notice delivery failed", {
+        taskId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   async getTaskOriginTarget(
     taskId: string,
   ): Promise<{ roomId: string; source: string; worldId?: string } | null> {
@@ -3417,6 +4455,7 @@ export class OrchestratorTaskService extends Service {
       status,
       archivedAt: null,
       closedAt: null,
+      metadata: withoutInterruptStamp(doc.task.metadata),
     });
     return this.getTask(taskId);
   }
@@ -3488,9 +4527,10 @@ export class OrchestratorTaskService extends Service {
       verifier?: string;
       humanOverride?: boolean;
     },
+    sessionId?: string,
   ): Promise<TaskThreadDetailDto | null> {
     return this.withTaskWriteLock(taskId, () =>
-      this.validateTaskLocked(taskId, result),
+      this.validateTaskLocked(taskId, result, sessionId),
     );
   }
 
@@ -3504,10 +4544,114 @@ export class OrchestratorTaskService extends Service {
       verifier?: string;
       humanOverride?: boolean;
     },
+    sessionId?: string,
   ): Promise<TaskThreadDetailDto | null> {
-    const doc = await this.store.getTask(taskId);
+    let doc = await this.store.getTask(taskId);
     if (!doc) return null;
-    const from = doc.task.status;
+    let from = doc.task.status;
+    // A multi-lane task sits on ONE status: a sibling lane's failed verdict
+    // moved it to active — or its park moved it to waiting_on_user — while
+    // this lane's verdict was still queued. The lane's completion already
+    // reported; re-enter validating for it (a parked sibling's park is
+    // restored by the all-verdicts branch below).
+    if (
+      sessionId &&
+      (from === "active" || from === "waiting_on_user") &&
+      this.laneScope(doc, sessionId).laneSessionIds.length > 1
+    ) {
+      await this.store.updateTask(taskId, { status: "validating" });
+      doc = (await this.store.getTask(taskId)) ?? doc;
+      from = doc.task.status;
+    }
+    // A passing LANE of a multi-lane task: record the lane verdict, release
+    // that lane's relay, and keep the task open until every lane has passed
+    // — promoting to `done` on the first lane closed the task under its
+    // siblings (their completions found a done task and verified nothing).
+    if (result.passed && !result.humanOverride && sessionId) {
+      const { laneSessionIds } = this.laneScope(doc, sessionId);
+      if (laneSessionIds.length > 1) {
+        const verdicts = {
+          ...(isRecord(doc.task.metadata?.laneVerdicts)
+            ? (doc.task.metadata.laneVerdicts as Record<string, string>)
+            : {}),
+          [sessionId]: "passed",
+        };
+        // Pending lanes have NO verdict; a parked lane (at the attempt cap)
+        // has one and is not awaited — a sibling's pass used to leave the
+        // task `validating` forever over a parked lane.
+        const remaining = laneSessionIds.filter((id) => !verdicts[id]);
+        const parked = laneSessionIds.filter((id) => verdicts[id] === "parked");
+        if (remaining.length === 0 && parked.length > 0) {
+          await this.store.addEvent({
+            id: randomUUID(),
+            taskId,
+            sessionId,
+            eventType: "lane_validation_passed",
+            summary: `${result.summary ?? "Lane verified."} (${parked.length} lane(s) parked for the user; task stays parked)`,
+            data: {
+              evidence: result.evidence ?? "",
+              verifier: result.verifier ?? "orchestrator",
+              parkedLanes: parked,
+            },
+            timestamp: Date.now(),
+            createdAt: nowIso(),
+          });
+          await this.store.updateTask(taskId, {
+            metadata: { ...(doc.task.metadata ?? {}), laneVerdicts: verdicts },
+          });
+          // Back to the park the sibling's completion lifted it out of.
+          await this.advanceTaskStatus(taskId, "awaiting_user");
+          (
+            this.runtime.getService("ACPX_SUB_AGENT_ROUTER") as {
+              releaseDeferredCompletionRelay?: (
+                taskId: string,
+                verdict: "passed" | "failed",
+                sessionId?: string,
+              ) => void;
+            } | null
+          )?.releaseDeferredCompletionRelay?.(taskId, "passed", sessionId);
+          this.emitChange(taskId);
+          return this.getTask(taskId);
+        }
+        if (remaining.length > 0) {
+          await this.store.addEvent({
+            id: randomUUID(),
+            taskId,
+            sessionId,
+            eventType: "lane_validation_passed",
+            summary: `${result.summary ?? "Lane verified."} (${laneSessionIds.length - remaining.length}/${laneSessionIds.length} lanes verified)`,
+            data: {
+              evidence: result.evidence ?? "",
+              verifier: result.verifier ?? "orchestrator",
+              remainingLanes: remaining,
+            },
+            timestamp: Date.now(),
+            createdAt: nowIso(),
+          });
+          // The task STAYS validating: a sibling lane's verification may be
+          // queued behind this lock and bails on any other status (live
+          // 2026-08-22: flipping to active here silently skipped the second
+          // lane's verdict and its relay rode the 5-minute timeout).
+          await this.store.updateTask(taskId, {
+            metadata: { ...(doc.task.metadata ?? {}), laneVerdicts: verdicts },
+          });
+          (
+            this.runtime.getService("ACPX_SUB_AGENT_ROUTER") as {
+              releaseDeferredCompletionRelay?: (
+                taskId: string,
+                verdict: "passed" | "failed",
+                sessionId?: string,
+              ) => void;
+            } | null
+          )?.releaseDeferredCompletionRelay?.(taskId, "passed", sessionId);
+          this.emitChange(taskId);
+          return this.getTask(taskId);
+        }
+        await this.store.updateTask(taskId, {
+          metadata: { ...(doc.task.metadata ?? {}), laneVerdicts: verdicts },
+        });
+      }
+    }
     if (!result.humanOverride && from !== "validating") {
       throw new Error("Task must be validating before validation can finish");
     }
@@ -3613,6 +4757,17 @@ export class OrchestratorTaskService extends Service {
         },
       });
       this.emitChange(taskId);
+      // Scoped to this lane: a sibling lane's held "it's ready" must survive
+      // this lane's failure (unscoped release dropped every lane's relay).
+      (
+        this.runtime.getService("ACPX_SUB_AGENT_ROUTER") as {
+          releaseDeferredCompletionRelay?: (
+            taskId: string,
+            verdict: "passed" | "failed",
+            sessionId?: string,
+          ) => void;
+        } | null
+      )?.releaseDeferredCompletionRelay?.(taskId, "failed", sessionId);
       throw new ElizaError(
         `Ground-truth verification blocks validation: ${groundTruth.summary}`,
         {
@@ -3641,6 +4796,22 @@ export class OrchestratorTaskService extends Service {
       disclosedRisks.length > 0
         ? `${evidence}\nWorker-disclosed residual risks: ${disclosedRisks.join("; ")}`
         : evidence;
+    // Release (or drop) the router's deferred completion relay the moment the
+    // verdict is durable: passed → the held "it's ready" posts, failed → the
+    // retry loop / park notice owns all further messaging (the whiplash this
+    // kills: "all set" followed two minutes later by a park, live 2026-08-20).
+    const relayRouter = this.runtime.getService("ACPX_SUB_AGENT_ROUTER") as {
+      releaseDeferredCompletionRelay?: (
+        taskId: string,
+        verdict: "passed" | "failed",
+        sessionId?: string,
+      ) => void;
+    } | null;
+    relayRouter?.releaseDeferredCompletionRelay?.(
+      taskId,
+      result.passed ? "passed" : "failed",
+      sessionId,
+    );
     await this.store.addEvent({
       id: randomUUID(),
       taskId,
@@ -3684,6 +4855,14 @@ export class OrchestratorTaskService extends Service {
     // but must never reuse a stale verdict left in task metadata.
     if (next === "done" && groundTruth?.status === "verified") {
       await this.harvestCuratedCodingMemory(taskId);
+    }
+    if (next === "done" && !result.humanOverride) {
+      // Human overrides are operator bookkeeping, not recoveries — notifying
+      // on them flooded the channel with eight false "recovered" lines when a
+      // parked backlog was swept (live 2026-08-19).
+      // error-policy:J5 fire-and-forget courtesy notice; failures are reported
+      // inside notifyVerifyRecovery itself.
+      void this.notifyVerifyRecovery(taskId);
     }
     return this.getTask(taskId);
   }
@@ -3823,10 +5002,14 @@ export class OrchestratorTaskService extends Service {
     evidenceBundle?: CompletionEvidenceBundle,
   ): Promise<void> {
     if (!shouldAutoVerifyGoal()) return;
-    // Re-entrancy guard: drop a second overlapping run for the same task (the
-    // check-then-act across the model `await` would otherwise double-count).
-    if (this.autoVerifyInFlight.has(taskId)) return;
-    this.autoVerifyInFlight.add(taskId);
+    // Re-entrancy guard per LANE: a second overlapping run for the same
+    // session is dropped (the check-then-act across the model `await` would
+    // double-count), but a sibling lane of the same task must still verify —
+    // keyed per task it was dropped outright, no verdict, and its relay rode
+    // the 5-minute timeout (live 2026-08-22). The write lock serializes them.
+    const inFlightKey = `${taskId}\u0000${sessionId}`;
+    if (this.autoVerifyInFlight.has(inFlightKey)) return;
+    this.autoVerifyInFlight.add(inFlightKey);
     try {
       // Serialized against validateTask: both replace task.metadata wholesale.
       await this.withTaskWriteLock(taskId, () =>
@@ -3847,7 +5030,7 @@ export class OrchestratorTaskService extends Service {
         error: err instanceof Error ? err.message : String(err),
       });
     } finally {
-      this.autoVerifyInFlight.delete(taskId);
+      this.autoVerifyInFlight.delete(inFlightKey);
     }
   }
 
@@ -3863,11 +5046,67 @@ export class OrchestratorTaskService extends Service {
     {
       let doc = await this.store.getTask(taskId);
       if (!doc) return;
-      // Only act on the state the task_complete event just produced. A human or
-      // the manual auto-validate route may have already moved it on.
-      if (doc.task.status !== "validating") return;
-      const attempts = num(doc.task.metadata?.autoVerifyAttempts);
+      // Only act on the state the task_complete event just produced. A human
+      // or the manual auto-validate route may have already moved it on. A
+      // multi-lane sibling may have flipped it meanwhile — failed (active) or
+      // parked (waiting_on_user) — while THIS lane's verification was queued
+      // behind the write lock; its verdict must still land (a dropped lane
+      // stranded the task with no verdict and its relay rode the timeout).
+      const laneScopeNow = this.laneScope(doc, sessionId);
+      const verdictsNow = isRecord(doc.task.metadata?.laneVerdicts)
+        ? (doc.task.metadata.laneVerdicts as Record<string, unknown>)
+        : {};
+      const pendingMultiLane =
+        laneScopeNow.laneSessionIds.length > 1 && !verdictsNow[sessionId];
+      if (
+        doc.task.status !== "validating" &&
+        !(
+          (doc.task.status === "active" ||
+            doc.task.status === "waiting_on_user") &&
+          pendingMultiLane
+        )
+      ) {
+        return;
+      }
+      const attempts = this.laneAutoVerifyAttempts(doc, sessionId);
       const parse = parseCompletionEnvelope(rawCompletion);
+
+      // A manufactured input is never a pass and never coached further: the
+      // only honest outcome is to tell the user the real input is not here.
+      const sessionLedgerEvents = doc.events.filter(
+        (event) => event.sessionId === sessionId,
+      );
+      const fabricated = detectFabricatedInput(
+        `${doc.task.goal}\n${doc.task.originalRequest ?? ""}`,
+        [...extractWriteLedger(sessionLedgerEvents).verified],
+        this.extractToolSignals(sessionLedgerEvents)
+          .map((signal) => signal.source)
+          .filter((source): source is string => typeof source === "string"),
+        Array.isArray(doc.task.metadata?.inputBaselines)
+          ? (doc.task.metadata.inputBaselines as InputBaseline[])
+          : [],
+      );
+      if (fabricated) {
+        const summary = `The sub-agent manufactured the input it was asked to read (wrote ${basename(fabricated.wrote)} itself) instead of reading ${fabricated.target}, which does not exist here.`;
+        this.log("warn", "fabricated input detected; parking", {
+          taskId,
+          sessionId,
+          ...fabricated,
+        });
+        await this.reEngageOrEscalate({
+          taskId,
+          sessionId,
+          correction: "",
+          eventType: "auto_verify_failed",
+          verifier: "fabricated-input-ledger",
+          summary,
+          missing: doc.task.acceptanceCriteria.filter((criterion) =>
+            /\b(?:output|result)\b/i.test(criterion),
+          ),
+          attempt: MAX_AUTO_VERIFY_ATTEMPTS,
+        });
+        return;
+      }
 
       // 0. Deterministic residuals gate — BEFORE the criteria check and any
       // model spend, so even a criteria-free task with a git workspace cannot
@@ -3972,7 +5211,14 @@ export class OrchestratorTaskService extends Service {
         const workspace = getCodingWorkspaceService(this.runtime);
         const groundTruth = await verifyGroundTruth(
           {
-            completion: rawCompletion,
+            // The child cannot push or open PRs — its verbatim completion
+            // never carries the URL, so a raw-completion-only check reported
+            // "no pull request was claimed" while the orchestrator's own
+            // submit had the PR open (live 2026-08-20, ROADMAP run). Join the
+            // recorded PR exactly like verifyGroundTruthForValidation does.
+            completion: [rawCompletion, str(doc.task.metadata?.prUrl)]
+              .filter(Boolean)
+              .join("\n"),
             claimedFiles: changeSet?.changedFiles ?? [],
             requirePullRequest: groundTruthRequiresPullRequest(
               (key) => this.runtime.getSetting(key),
@@ -4006,12 +5252,16 @@ export class OrchestratorTaskService extends Service {
         }
         if (groundTruth.hardFail) {
           const failureEvidence = renderGroundTruthEvidence(groundTruth);
-          await this.validateTaskLocked(taskId, {
-            passed: false,
-            summary: groundTruth.summary,
-            evidence: failureEvidence,
-            verifier: "ground-truth-verifier",
-          });
+          await this.validateTaskLocked(
+            taskId,
+            {
+              passed: false,
+              summary: groundTruth.summary,
+              evidence: failureEvidence,
+              verifier: "ground-truth-verifier",
+            },
+            sessionId,
+          );
           await this.reEngageOrEscalate({
             taskId,
             sessionId,
@@ -4193,12 +5443,16 @@ export class OrchestratorTaskService extends Service {
         const explicitContract =
           doc.task.metadata.acceptanceCriteriaOrigin === "caller";
         if (detVerdict.allMet && explicitContract) {
-          await this.validateTaskLocked(taskId, {
-            passed: true,
-            summary: `All ${acceptanceCriteria.length} criteria deterministically verified from the write ledger, probed URLs, and captured output.`,
-            evidence: renderDeterministicVerdict(detVerdict),
-            verifier: DETERMINISTIC_LEDGER_VERIFIER_NAME,
-          });
+          await this.validateTaskLocked(
+            taskId,
+            {
+              passed: true,
+              summary: `All ${acceptanceCriteria.length} criteria deterministically verified from the write ledger, probed URLs, and captured output.`,
+              evidence: renderDeterministicVerdict(detVerdict),
+              verifier: DETERMINISTIC_LEDGER_VERIFIER_NAME,
+            },
+            sessionId,
+          );
           this.emitChange(taskId);
           return;
         }
@@ -4263,12 +5517,16 @@ export class OrchestratorTaskService extends Service {
           ]
             .filter(Boolean)
             .join("\n");
-          await this.validateTaskLocked(taskId, {
-            passed: false,
-            summary: independent.summary,
-            evidence: blockEvidence,
-            verifier: INDEPENDENT_ACP_VERIFIER_NAME,
-          });
+          await this.validateTaskLocked(
+            taskId,
+            {
+              passed: false,
+              summary: independent.summary,
+              evidence: blockEvidence,
+              verifier: INDEPENDENT_ACP_VERIFIER_NAME,
+            },
+            sessionId,
+          );
           const missing = [
             ...independent.unmet,
             ...independent.failedCommands.map((c) => `command failed: ${c}`),
@@ -4292,10 +5550,22 @@ export class OrchestratorTaskService extends Service {
       }
 
       // 4. Text judge (fallback for non-code / criteria-light tasks).
+      const { laneTask } = this.laneScope(doc, sessionId);
+      // The judge must see the user's own words: the planner's goal is often
+      // a bare title ("Lucky Numbers Script"), and a child that printed six
+      // numbers in 1-49 for "3 random lucky numbers between 1 and 50" passed
+      // because nothing in the goal said 3 or 50 (live 2026-08-22).
+      const request = doc.task.originalRequest?.trim();
+      const goalWithRequest =
+        request && request !== doc.task.goal
+          ? `${doc.task.goal}\n\nThe user's request, verbatim (the deliverable must match its specifics — counts, ranges, names, formats): ${request}`
+          : doc.task.goal;
       const verdict = await verifyGoalCompletion(
         this.runtime,
         {
-          goal: doc.task.goal,
+          goal: laneTask
+            ? `${goalWithRequest}\n\nThis completion is for ONE lane of a multi-lane task. Judge ONLY this lane's deliverable: ${laneTask}\nSibling lanes are verified separately; their absence from the evidence is not a gap.`
+            : goalWithRequest,
           acceptanceCriteria,
           completionEvidence: evidence,
         },
@@ -4309,12 +5579,16 @@ export class OrchestratorTaskService extends Service {
       );
 
       if (verdict.passed) {
-        await this.validateTaskLocked(taskId, {
-          passed: true,
-          summary: verdict.summary,
-          evidence: verdict.rawResponse || evidence,
-          verifier: LLM_GOAL_VERIFIER_NAME,
-        });
+        await this.validateTaskLocked(
+          taskId,
+          {
+            passed: true,
+            summary: verdict.summary,
+            evidence: verdict.rawResponse || evidence,
+            verifier: LLM_GOAL_VERIFIER_NAME,
+          },
+          sessionId,
+        );
         // Notify live subscribers (SSE/UI) — this is a fire-and-forget hook with
         // no HTTP response to refresh the client, so emitChange is the only
         // signal that the task left `validating`. Every other branch emits too.
@@ -4339,6 +5613,22 @@ export class OrchestratorTaskService extends Service {
         attempt: attempts,
       });
     }
+  }
+
+  /** Prior failed-verdict count for THIS lane: lane-keyed on a multi-lane
+   * task, the task-level counter otherwise. */
+  private laneAutoVerifyAttempts(
+    doc: OrchestratorTaskDocument,
+    sessionId: string,
+  ): number {
+    const metadata = doc.task.metadata;
+    if (this.laneScope(doc, sessionId).laneSessionIds.length > 1) {
+      const byLane = isRecord(metadata?.laneAutoVerifyAttempts)
+        ? (metadata.laneAutoVerifyAttempts as Record<string, unknown>)
+        : {};
+      return num(byLane[sessionId]);
+    }
+    return num(metadata?.autoVerifyAttempts);
   }
 
   /**
@@ -4374,6 +5664,45 @@ export class OrchestratorTaskService extends Service {
       missing,
       attempt,
     } = args;
+    // This lane's completion is judged failed either way: drop its held
+    // relay FIRST, on every path out of here. Left armed, the router's
+    // 5-minute fallback released it as "passed" mid-coaching-lap and the
+    // original failed completion posted as ready.
+    (
+      this.runtime.getService("ACPX_SUB_AGENT_ROUTER") as {
+        releaseDeferredCompletionRelay?: (
+          taskId: string,
+          verdict: "passed" | "failed",
+          sessionId?: string,
+        ) => void;
+      } | null
+    )?.releaseDeferredCompletionRelay?.(taskId, "failed", sessionId);
+    const doc = await this.store.getTask(taskId);
+    if (!doc) {
+      // The task was deleted concurrently (e.g. the user cancelled during
+      // auto-verify). Bail: there is nothing to re-engage, and writing partial
+      // metadata back with `...doc?.task.metadata` spreading to `{}` would
+      // clobber the completion envelope this very re-read exists to preserve.
+      return;
+    }
+    if (
+      TERMINAL_OR_INTERRUPTED_TASK_STATUSES.has(doc.task.status) ||
+      this.pendingUserInterrupts.has(taskId)
+    ) {
+      // The user cancelled (or an operator closed the task) while the judge
+      // was running: a corrective re-prompt would reactivate the stopped
+      // worker and resume the build the user just stopped; a park notice
+      // would announce a build nobody is waiting for. The pending flag covers
+      // the stop still queued behind THIS verify lap's write lock.
+      this.log("info", "skipping re-engage: task no longer in flight", {
+        taskId,
+        sessionId,
+        status: doc.task.status,
+        verifier,
+      });
+      return;
+    }
+    const multiLane = this.laneScope(doc, sessionId).laneSessionIds.length > 1;
     if (attempt >= MAX_AUTO_VERIFY_ATTEMPTS) {
       // Stop the loop: park for a human rather than re-prompting forever.
       await this.store.addEvent({
@@ -4386,30 +5715,81 @@ export class OrchestratorTaskService extends Service {
         timestamp: Date.now(),
         createdAt: nowIso(),
       });
+      if (multiLane) {
+        // Per-lane park verdict: the sibling's pass must not close the task
+        // over this lane, and must restore the park when it is the last one.
+        const parkedDoc = (await this.store.getTask(taskId)) ?? doc;
+        await this.store.updateTask(taskId, {
+          metadata: {
+            ...(parkedDoc.task.metadata ?? {}),
+            laneVerdicts: {
+              ...(isRecord(parkedDoc.task.metadata?.laneVerdicts)
+                ? (parkedDoc.task.metadata.laneVerdicts as Record<
+                    string,
+                    string
+                  >)
+                : {}),
+              [sessionId]: "parked",
+            },
+          },
+        });
+      }
       await this.advanceTaskStatus(taskId, "awaiting_user");
+      // Stamp the park time as durable task metadata. The forwarder's
+      // waiting_on_user gate discriminates VERIFY parks (drop forwards; the
+      // worker is done listening) from question/login parks (keep forwarding
+      // so the user's answer reaches the blocked session) on this stamp —
+      // verifyEscalationNotifiedAt alone is unreliable because
+      // notifyVerifyEscalation early-returns before stamping when the task
+      // has no origin room or no send handler.
+      await this.stampVerifyParkedAt(taskId);
+      // The park must be VISIBLE: the completion relay already promised the
+      // user "I'll flag if verification fails" — parking silently breaks that
+      // promise and strands the task (live: canon-clock sat waiting_on_user
+      // with a served, working page and the user never heard why). One notice
+      // per task (metadata-stamped) so a redelivered task_complete at the
+      // attempt cap cannot re-spam the room.
+      await this.notifyVerifyEscalation(taskId, {
+        attempts: attempt,
+        summary,
+        missing,
+        sessionId,
+        verifier,
+      });
       this.emitChange(taskId);
       return;
     }
     // Persist the bumped attempt counter + a reflexion post-mortem first, so a
     // redelivered task_complete can't double-count and the next respawn (#8899)
-    // can replay the gap. Re-read the doc so an upstream metadata write in this
-    // same pass (e.g. the valid-envelope stamp) is preserved.
-    const doc = await this.store.getTask(taskId);
-    if (!doc) {
-      // The task was deleted concurrently (e.g. the user cancelled during
-      // auto-verify). Bail: there is nothing to re-engage, and writing partial
-      // metadata back with `...doc?.task.metadata` spreading to `{}` would
-      // clobber the completion envelope this very re-read exists to preserve.
-      return;
-    }
+    // can replay the gap. `doc` was re-read above so an upstream metadata
+    // write in this same pass (e.g. the valid-envelope stamp) is preserved.
     const attemptReflections = [
       ...readAttemptReflections(doc.task.metadata),
       { attempt: attempt + 1, missing, summary },
     ];
+    // Lane-keyed budget: three failures of lane A must not park lane B on
+    // its first. The task-level counter stays the max for single-lane
+    // readers and the UI.
+    const laneAttempts = {
+      ...(isRecord(doc.task.metadata?.laneAutoVerifyAttempts)
+        ? (doc.task.metadata.laneAutoVerifyAttempts as Record<string, number>)
+        : {}),
+      [sessionId]: attempt + 1,
+    };
+    const laneVerdicts = isRecord(doc.task.metadata?.laneVerdicts)
+      ? { ...(doc.task.metadata.laneVerdicts as Record<string, string>) }
+      : {};
+    // A coached lane is pending again: its next completion re-verifies.
+    delete laneVerdicts[sessionId];
     await this.store.updateTask(taskId, {
       metadata: {
         ...doc.task.metadata,
-        autoVerifyAttempts: attempt + 1,
+        autoVerifyAttempts: Math.max(
+          num(doc.task.metadata?.autoVerifyAttempts),
+          attempt + 1,
+        ),
+        laneAutoVerifyAttempts: laneAttempts,
+        laneVerdicts,
         attemptReflections,
       },
     });
@@ -4462,8 +5842,35 @@ export class OrchestratorTaskService extends Service {
         createdAt: nowIso(),
       });
       await this.advanceTaskStatus(taskId, "awaiting_user");
+      // Same forwarder discriminator as the at-cap park above: this branch
+      // parks too (the corrective send failed), so it must carry the stamp.
+      await this.stampVerifyParkedAt(taskId);
     }
     this.emitChange(taskId);
+  }
+
+  /** Merge `verifyParkedAt` into the task metadata (re-read then write, same
+   * pattern as the attempt-counter persist above, so concurrent metadata
+   * writes in this pass are preserved). Best-effort: a failed stamp costs the
+   * forwarder gate's discriminator, never the park itself. */
+  private async stampVerifyParkedAt(taskId: string): Promise<void> {
+    try {
+      const doc = await this.store.getTask(taskId);
+      if (!doc) return;
+      await this.store.updateTask(taskId, {
+        metadata: {
+          ...doc.task.metadata,
+          verifyParkedAt: nowIso(),
+        },
+      });
+    } catch (err) {
+      // error-policy:J6 best-effort park-time stamp; the park (status write)
+      // already stands and the forwarder fails open without the stamp.
+      this.log("warn", "verifyParkedAt stamp failed", {
+        taskId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**
@@ -4549,7 +5956,7 @@ export class OrchestratorTaskService extends Service {
         : 0;
     const spawn = await acp.spawnSession({
       // Undefined defers to acp-service's defaultAgent (eliza-code on the
-      // native transport); opencode is opt-in via explicit settings only.
+      // native transport).
       agentType: configuredDefaultAgentType(this.runtime),
       workdir,
       initialTask: prompt,
@@ -4699,7 +6106,7 @@ export class OrchestratorTaskService extends Service {
     } else {
       // No active coding agent — auto-spawn one to work on the message so
       // messaging the orchestrator "just works" (parity with claude/codex):
-      // the default framework (opencode + Cerebras) into a per-task workdir.
+      // the default framework (eliza-code) into a per-task workdir.
       try {
         await this.spawnAgentForTask(taskId, {
           task: content,
@@ -4989,6 +6396,7 @@ export class OrchestratorTaskService extends Service {
       archivedAt: null,
       closedAt: null,
       status: nextTaskStatus(current.task.status, "restarted"),
+      metadata: withoutInterruptStamp(current.task.metadata),
     });
     return this.getTask(taskId);
   }
@@ -5318,8 +6726,7 @@ export class OrchestratorTaskService extends Service {
         // undefined and spawnSession resolves acp-service's `defaultAgent`
         // (eliza-code under the native transport) — the single source of
         // truth, so an unconfigured host dogfoods eliza-code rather than a
-        // vendored CLI. opencode remains available only as an explicit
-        // selection (settings/routing/request).
+        // vendored CLI.
         agentType: framework,
         workdir,
         initialTask: goalPrompt,
@@ -5353,6 +6760,28 @@ export class OrchestratorTaskService extends Service {
           // Carried so a child this sub-agent spawns can compute its own depth
           // (parent depth + 1) and the nesting guard above can enforce the cap.
           nestingDepth,
+          // Carry the originating request's voice key onto EVERY (re)spawn for
+          // this task — verify re-engage fresh workers and queue-head dispatch
+          // included — so the router's request-level ack/terminal ledger sees
+          // one key per user request across the whole session lineage. Stamped
+          // into task metadata at create time; absent for pre-stamp tasks
+          // (degraded mode: per-session dedupe only).
+          ...(pickPlainString(doc.task.metadata?.spawnRootMessageId)
+            ? {
+                spawnRootMessageId: pickPlainString(
+                  doc.task.metadata?.spawnRootMessageId,
+                ),
+              }
+            : {}),
+          // Carry the fan-out part with it: a lane task's respawns must keep
+          // claiming the SAME per-lane voice slot, never the whole request's.
+          ...(pickPlainString(doc.task.metadata?.requestVoicePart)
+            ? {
+                requestVoicePart: pickPlainString(
+                  doc.task.metadata?.requestVoicePart,
+                ),
+              }
+            : {}),
         },
       });
     } catch (err) {
@@ -5734,6 +7163,150 @@ export class OrchestratorTaskService extends Service {
     return true;
   }
 
+  /** Lane fan-out scope for one reporting session. A create that split the
+   * ask into lanes ("two pages: a coin flip page and a dice roll page") runs
+   * N sessions under ONE task record; each session carries `requestVoicePart`
+   * (`part:N`). Verification judged every lane against the WHOLE goal —
+   * the first lane to finish was failed for "the dice roll page is missing"
+   * and coached to build its sibling (live 2026-08-22). */
+  private laneScope(
+    doc: OrchestratorTaskDocument,
+    sessionId: string,
+  ): { laneTask?: string; laneSessionIds: string[] } {
+    const part = (session: OrchestratorTaskSession): string | undefined => {
+      const raw = session.metadata?.requestVoicePart;
+      return typeof raw === "string" && /^part:\d+$/.test(raw)
+        ? raw
+        : undefined;
+    };
+    const laneSessions = doc.sessions.filter((session) => part(session));
+    const parts = new Set(laneSessions.map((session) => part(session)));
+    if (parts.size < 2) return { laneSessionIds: [] };
+    const reporting = doc.sessions.find(
+      (session) => session.sessionId === sessionId,
+    );
+    const laneTask = reporting
+      ? userTaskFromInitialTask(reporting.originalTask ?? "")
+      : "";
+    // One session id per part — the LATEST session of each lane (respawns
+    // replace their predecessor).
+    const latestByPart = new Map<string, OrchestratorTaskSession>();
+    for (const session of laneSessions) {
+      const key = part(session) as string;
+      const current = latestByPart.get(key);
+      if (!current || session.registeredAt >= current.registeredAt) {
+        latestByPart.set(key, session);
+      }
+    }
+    return {
+      ...(laneTask ? { laneTask } : {}),
+      laneSessionIds: [...latestByPart.values()].map((s) => s.sessionId),
+    };
+  }
+
+  /** Operator/user stop of the whole task: the wave launches no further lane,
+   * respawns and verify laps stop, and the task reads `interrupted` instead of
+   * lingering active. Sessions are stopped by the caller (interrupt path);
+   * this records the task-level decision. Live 2026-08-22: "actually stop,
+   * cancel that build" hard-stopped the running lane, then the remaining
+   * three phase lanes launched and ran to verification anyway. */
+  async interruptTask(taskId: string, reason: string): Promise<boolean> {
+    // Serialized against the verifier: its validating→active retry and this
+    // interrupt both write status, and the verdict writer must observe
+    // `interrupted` before it re-prompts the worker. The pending flag is the
+    // lock-free fast path: a verify lap already holding the lock checks it
+    // before its corrective send, so the stop takes effect immediately even
+    // while this call queues (live: the re-prompt beat the queued interrupt).
+    if (reason.startsWith("user")) this.pendingUserInterrupts.add(taskId);
+    try {
+      return await this.withTaskWriteLock(taskId, () =>
+        this.interruptTaskLocked(taskId, reason),
+      );
+    } finally {
+      this.pendingUserInterrupts.delete(taskId);
+    }
+  }
+
+  private async interruptTaskLocked(
+    taskId: string,
+    reason: string,
+  ): Promise<boolean> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc || TERMINAL_OR_INTERRUPTED_TASK_STATUSES.has(doc.task.status)) {
+      return false;
+    }
+    // A paused task freezes advanceTaskStatus; a user stop overrides the
+    // pause (reporting success while leaving it active planted a stale
+    // stamp on a live task).
+    if (doc.task.paused) {
+      await this.store.updateTask(taskId, { paused: false });
+    }
+    // A task cancelled while parked in the admission queue must not dispatch
+    // when a slot frees (the drain skipped only done/failed/archived and
+    // launched the cancelled build).
+    await this.dequeueAdmission(taskId);
+    await this.advanceTaskStatus(taskId, "interrupted");
+    // Durable reason: advanceTaskLiveness self-heals a REAPER interrupt on
+    // the next attach (restarted), but a user stop must stick — a lane whose
+    // spawn returned after the cancel was attaching and resurrecting the
+    // task to active.
+    await this.store.updateTask(taskId, {
+      metadata: {
+        ...(doc.task.metadata ?? {}),
+        interruptReason: reason,
+        interruptedAt: nowIso(),
+      },
+    });
+    await this.store.addEvent({
+      id: randomUUID(),
+      taskId,
+      eventType: "task_interrupted",
+      summary: `Task interrupted (${reason}); no further lanes or verification laps run.`,
+      data: { reason },
+      timestamp: Date.now(),
+      createdAt: new Date().toISOString(),
+    });
+    this.emitChange(taskId);
+    // A completion relay deferred until the verdict would otherwise fire on
+    // its timeout, five minutes after the user cancelled the build.
+    (
+      this.runtime.getService("ACPX_SUB_AGENT_ROUTER") as {
+        releaseDeferredCompletionRelay?: (
+          taskId: string,
+          verdict: "passed" | "failed",
+        ) => void;
+      } | null
+    )?.releaseDeferredCompletionRelay?.(taskId, "failed");
+    return true;
+  }
+
+  /** Interrupt every in-flight task of a room. The cancel that lands while a
+   * spawn is still in flight finds NO session to stop (live 2026-08-22,
+   * pong: "No matching task found." and the build completed anyway); the
+   * durable task already exists, and the spawn path honors `interrupted`
+   * when it returns. Parked (waiting_on_user) tasks are not in flight. */
+  async interruptInFlightTasksForRoom(
+    roomId: string,
+    reason: string,
+    ownerUserId?: string,
+  ): Promise<string[]> {
+    const titles: string[] = [];
+    const records = await this.store.listTasks({ includeArchived: false });
+    for (const record of records) {
+      if (!IN_FLIGHT_TASK_STATUSES.has(record.status)) continue;
+      const doc = await this.store.getTask(record.id);
+      if (!doc) continue;
+      if (doc.task.roomId !== roomId && doc.task.taskRoomId !== roomId) {
+        continue;
+      }
+      if (ownerUserId && doc.task.ownerUserId !== ownerUserId) continue;
+      if (await this.interruptTask(record.id, reason)) {
+        titles.push(doc.task.title);
+      }
+    }
+    return titles;
+  }
+
   async stopTaskAgent(taskId: string, sessionId: string): Promise<boolean> {
     const doc = await this.store.getTask(taskId);
     if (!doc) return false;
@@ -5748,8 +7321,20 @@ export class OrchestratorTaskService extends Service {
       // — `done → interrupted` has no table edge, so this is a legal no-op there
       // and only interrupts a genuinely non-terminal task.
       await this.advanceTaskStatus(taskId, "interrupted");
+      await this.stampSystemInterrupt(taskId, "session_stop_failed");
       throw new Error("ACP service unavailable; cannot stop active session");
     }
+    // Stamp BEFORE stopping (same contract as every other administrative
+    // stop): an unstamped teardown defeats the router's and the swarm
+    // coordinator's noise suppression — the killed child then narrates
+    // "stopped before completion" and its dying lane reports "launch failed"
+    // (live 2026-08-20, bmi-calculator follow-up).
+    await markSessionAdministrativelyStopped(
+      acp,
+      sessionId,
+      "task_stop",
+      (msg) => this.log("warn", msg, { taskId, sessionId }),
+    );
     try {
       // Mark the stop administrative BEFORE stopping so the swarm
       // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
@@ -5781,6 +7366,7 @@ export class OrchestratorTaskService extends Service {
       !after.sessions.some((s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status))
     ) {
       await this.advanceTaskStatus(taskId, "interrupted");
+      await this.stampSystemInterrupt(taskId, "session_stop_failed");
       this.emitChange(taskId);
     }
     return true;
@@ -5994,9 +7580,9 @@ export class OrchestratorTaskService extends Service {
     const active = doc.sessions.filter(
       (s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status),
     );
-    if (active.length === 0) return;
     const acp = this.acp();
     if (!acp) {
+      if (active.length === 0) return;
       await Promise.all(
         active.map((session) =>
           this.store.updateSession(session.sessionId, {
@@ -6005,13 +7591,53 @@ export class OrchestratorTaskService extends Service {
         ),
       );
       await this.advanceTaskStatus(doc.task.id, "interrupted");
+      await this.stampSystemInterrupt(doc.task.id, "session_stop_failed");
       throw new RecoveryConflictError(
         "ACP service unavailable; cannot stop active sessions",
       );
     }
+    // ACP-truth widening: the event bridge marks the task-side row
+    // `completed` on task_complete while the keepAliveAfterComplete ACP
+    // session sits `ready` — so a task-row-only scan skipped the stop and the
+    // session survived archive/delete still room-bound, absorbing later live
+    // room messages under the dead task's label (the contamination survivor).
+    // Also stop any of this task's sessions that are still LIVE at the ACP
+    // layer, even when the row is already terminal.
+    let liveAcpSessionIds: ReadonlySet<string> = new Set<string>();
+    try {
+      const acpSessions = await Promise.resolve(acp.listSessions());
+      liveAcpSessionIds = new Set(
+        acpSessions
+          .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status))
+          .map((s) => s.id),
+      );
+    } catch (err) {
+      // error-policy:J4 listSessions unavailable degrades to the task-row-only
+      // scan (today's behavior) — never blocks the lifecycle stop.
+      this.log("warn", "stopActiveSessions listSessions failed", {
+        taskId: doc.task.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    const toStop = doc.sessions.filter(
+      (s) =>
+        !TERMINAL_TASK_SESSION_STATUSES.has(s.status) ||
+        liveAcpSessionIds.has(s.sessionId),
+    );
+    if (toStop.length === 0) return;
     const failures: Array<{ sessionId: string; error: string }> = [];
     await Promise.all(
-      active.map(async (session) => {
+      toStop.map(async (session) => {
+        // Mark the stop as administrative BEFORE stopping, so the swarm
+        // coordinator's `stopped` synthesis recognizes it as lifecycle
+        // plumbing and does not post "stopped before completion" for a stop
+        // the lifecycle itself caused.
+        await markSessionAdministrativelyStopped(
+          acp,
+          session.sessionId,
+          "task_lifecycle",
+          (msg) => this.log("warn", msg, { taskId: doc.task.id }),
+        );
         try {
           // Mark the stop administrative BEFORE stopping so the swarm
           // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
@@ -6022,19 +7648,39 @@ export class OrchestratorTaskService extends Service {
           );
           await acp.stopSession(session.sessionId);
         } catch (err) {
+          const error = err instanceof Error ? err.message : String(err);
+          // A session the transport no longer knows is DE FACTO dead — its
+          // record was retention-swept or the subprocess is long gone.
+          // Fail-closing here trapped tasks forever: one transient stop
+          // failure marked the row stop_failed, the ACP record aged out, and
+          // every later archive 500'd on "Failed to stop 1 active session"
+          // (live 2026-08-20, metronome ghost). Not-found terminalizes.
+          if (/not found|no session|unknown session/i.test(error)) {
+            await this.store.updateSession(session.sessionId, {
+              status: "stopped",
+              stoppedAt: Date.now(),
+            });
+            return;
+          }
           // error-policy:J1 collect per-session stop failures; the loop throws a
           // structured RecoveryConflictError afterward when any session failed.
-          const error = err instanceof Error ? err.message : String(err);
           failures.push({ sessionId: session.sessionId, error });
-          await this.store.updateSession(session.sessionId, {
-            status: "stop_failed",
-          });
+          if (!TERMINAL_TASK_SESSION_STATUSES.has(session.status)) {
+            await this.store.updateSession(session.sessionId, {
+              status: "stop_failed",
+            });
+          }
           return;
         }
-        await this.store.updateSession(session.sessionId, {
-          status: "stopped",
-          stoppedAt: Date.now(),
-        });
+        // A row already terminal on the task side (`completed` — delivered)
+        // keeps its status: rewriting it to `stopped` would erase the
+        // delivered outcome the UI shows.
+        if (!TERMINAL_TASK_SESSION_STATUSES.has(session.status)) {
+          await this.store.updateSession(session.sessionId, {
+            status: "stopped",
+            stoppedAt: Date.now(),
+          });
+        }
       }),
     );
     if (failures.length > 0) {
@@ -6042,6 +7688,7 @@ export class OrchestratorTaskService extends Service {
       // must not regress to `interrupted`; the table makes that a legal no-op
       // while still interrupting a non-terminal one.
       await this.advanceTaskStatus(doc.task.id, "interrupted");
+      await this.stampSystemInterrupt(doc.task.id, "session_stop_failed");
       throw new RecoveryConflictError(
         `Failed to stop ${failures.length} active session${
           failures.length === 1 ? "" : "s"
@@ -6155,6 +7802,7 @@ export class OrchestratorTaskService extends Service {
           createdAt: nowIso(),
         });
         await this.advanceTaskStatus(record.id, "interrupted");
+        await this.stampSystemInterrupt(record.id, "stalled_reaped");
         this.emitChange(record.id);
         this.log("info", "stuck task reaped to interrupted", {
           taskId: record.id,
@@ -6470,7 +8118,7 @@ export class OrchestratorTaskService extends Service {
         waveSupervisor?.release(head.taskId);
         continue;
       }
-      if (TERMINAL_TASK_STATUSES.has(doc.task.status)) {
+      if (TERMINAL_OR_INTERRUPTED_TASK_STATUSES.has(doc.task.status)) {
         waveSupervisor?.release(head.taskId);
         await this.writeAdmission(head.taskId, null);
         continue;

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
@@ -184,12 +184,12 @@ function pathSegment(value: string, fallback: string): string {
 
 /** Resolve the tenant-isolated SQLite file for a durable coding task. */
 export function resolveTaskDbPath(tenantId: string, taskId: string): string {
-  if (tenantId.trim().length === 0) {
+  if (typeof tenantId !== "string" || tenantId.trim().length === 0) {
     throw new ElizaError("Smithers task tenant id is required", {
       code: "SMITHERS_TASK_TENANT_REQUIRED",
     });
   }
-  if (taskId.trim().length === 0) {
+  if (typeof taskId !== "string" || taskId.trim().length === 0) {
     throw new ElizaError("Smithers task id is required", {
       code: "SMITHERS_TASK_ID_REQUIRED",
       context: { tenantId },


### PR DESCRIPTION
Part 4 of the split series closing out #24262 — the durable task service.

cc @lalalune

## Scope — OrchestratorTaskService: lifecycle, verification, canonical content

**Durable content**
- Canonical PR content (`canonicalPrTitle`/`providerPrTitle`/`canonicalPrBody`) persisted on task metadata; the provider payload is derived explicitly at the one hard GitHub bound (from the #24262 repair, kept intact).
- The judge's RUN OUTPUT evidence section is a 16K bounded view of a 2000-chunk durable-transcript tail with a continuation reference (was: last 120 in-memory chunks, silently).
- The judge reads every verified deliverable file IN FULL (FS-VERIFIED FILE CONTENTS covers ledger-verified files too) — with only a 3KB diff excerpt, a served 123-line page failed three coaching laps per lane for "the truncated diff hides the JavaScript" (live).
- `attemptReflections` uncapped; input baselines captured pre-execution (SHA-256) for the fabricated-input verdict.

**Per-lane verification** (multi-deliverable fan-outs)
- `laneVerdicts` / `laneAutoVerifyAttempts`: verify budgets, parks, and park notices are lane-scoped; a failed lane drops only ITS deferred relay; a sibling's pass over a parked lane restores the park; a lane verified while the task sits parked re-enters validating (no stranding).

**User-interrupt durability** (a stop must stick)
- `interruptTask` runs under the task write lock, stamps a durable `interruptReason`, dequeues the admission record (a build cancelled while queued no longer launches when a slot frees), unpauses paused tasks, and owner-scopes room-wide interrupts (repair semantics).
- A session error on a user-interrupted task no longer fires `retrying` (interrupted → active resurrected the cancelled build); a trailing `task_complete` records `completion_after_interrupt` and is neither verified nor relayed (check+advance atomic under the lock); `pendingUserInterrupts` gates a verify lap already holding the lock so the corrective re-prompt is skipped; system interrupts restamp the reason so a stale user stamp can't make a reaper interrupt sticky.

Every failure mode above was reproduced live on the nubilio deployment or by adversarial-review agents against the real service before being fixed; regression tests included.

## Stack
Base: `feat/coding-agent-split-3-acp-service`. Next: 5-router-relays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
