### PR TITLE
fix(core): completion relays ground their own effects; constant-snippet asks stay inline

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -717,15 +717,23 @@ describe("live routing regressions", () => {
 		for (const text of [
 			"write a python script that just prints nubs",
 			"make me a bash script that only says hello",
+			"write a script that just prints 42",
 		]) {
 			expect(
 				inferDirectCurrentRequestCandidateActions(actions, text),
 			).not.toContain("TASKS");
 		}
-		// A computed deliverable still gets built and run.
+		// A computed deliverable still gets built and run — the WHOLE printed
+		// object is scanned, so a path, a computed noun, or a computed
+		// continuation after "and"/"then" defeats the constant-snippet scope.
 		for (const text of [
 			"write me a python script that picks a random card from a deck and prints it",
 			"write a python script that prints the current bitcoin price",
+			"write a script that just prints the current bitcoin price",
+			"write a python script that just prints the contents of /etc/hosts",
+			"make a python script that only outputs the primes under a million",
+			"write a script that just prints hello and then fetches the weather",
+			"make a python script that just prints my ip address",
 		]) {
 			expect(inferDirectCurrentRequestCandidateActions(actions, text)).toEqual([
 				"TASKS",

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -4723,6 +4723,54 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("does not buffer an applied effect claim on a task_complete relay turn — the relay is the receipt", async () => {
+		// The inbound message IS a sub-agent task_complete relay: the child did
+		// and verified the work, so Stage 1's "applied" is grounded by the relay
+		// itself and the good reply must not be withheld behind the hedge
+		// (2026-08-22: a verified, live page shipped as "i'm not sure if that
+		// change actually went through").
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Relay the finished build to the user.",
+				contexts: ["simple"],
+				replyText: "The dice roller app is built and deployed.",
+				extra: { requiresTool: true, replyEffectStatus: "applied" },
+			}),
+			JSON.stringify({
+				thought: "Deliver the relayed completion.",
+				toolCalls: [],
+				messageToUser: "The dice roller app is built and deployed — enjoy.",
+			}),
+		]);
+		const earlyReply = vi.fn(async () => undefined);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text:
+					"[sub-agent: dice roller build (opencode) — task_complete]\n" +
+					"Done. The dice roller app is built and deployed.",
+				source: "sub_agent",
+				metadata: { subAgent: true },
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			onResponseHandlerEarlyReply: earlyReply,
+		});
+
+		expect(earlyReply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				text: "The dice roller app is built and deployed.",
+			}),
+		);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"The dice roller app is built and deployed — enjoy.",
+			);
+		}
+	});
+
 	it("does not let a rejected early completion claim hide the later receipt-grounded confirmation", async () => {
 		const canonicalText = "Done — the pickup reminder is scheduled.";
 		const observedAt = "2026-07-27T18:00:00.000Z";

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -1207,6 +1207,27 @@ describe("evaluatePlannedReplyEgress", () => {
 			}),
 		).toBe(false);
 	});
+
+	it("allows a completed-side-effect claim on a sub-agent completion relay turn", () => {
+		// The task_complete relay IS the effect receipt: the child did and
+		// verified the work, so the reply may state it without an action
+		// result of this turn. The same reply without the relay flag still
+		// fails closed.
+		const reply =
+			"the bmi calculator is ready for you. i've set up the `index.html` file to handle everything.";
+		expect(
+			evaluatePlannedReplyEgress({
+				reply,
+				actionResults: [],
+				actions: [],
+				completionRelay: true,
+			}).verdict,
+		).toBe("allow");
+		expect(
+			evaluatePlannedReplyEgress({ reply, actionResults: [], actions: [] })
+				.verdict,
+		).toBe("reject");
+	});
 });
 
 describe("tasks context recap/status routing vocabulary", () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2582,6 +2582,22 @@ function isSubAgentCompletionArtifact(memory: Memory): boolean {
 	return source === MESSAGE_SOURCE_SUB_AGENT && metadata?.subAgent === true;
 }
 
+/** The inbound turn is a sub-agent router relay of a finished lane
+ * (`task_complete`) — the ONLY sub-agent artifact whose reply may state the
+ * worker's applied effects as its own: that relay IS the effect receipt for
+ * the completed work it reports. A question, error, blocked or progress
+ * relay from the same router carries no finished work, so grounding stays
+ * strict for those. Keyed on the router's parsed status header — the
+ * authoritative relay classifier on this branch — never on untrusted body
+ * prose or side-channel metadata. */
+function isTaskCompleteRelayTurn(memory: Memory): boolean {
+	return (
+		isSubAgentCompletionArtifact(memory) &&
+		parseSubAgentTaskCompleteRelay(String(memory.content?.text ?? "")) !==
+			undefined
+	);
+}
+
 function looksLikePriorDialogueArtifact(text: string): boolean {
 	if (!text) return false;
 	return /^\s*\[(?:sub-agent|tool output|tool result|command output)\b/im.test(
@@ -3310,10 +3326,7 @@ function buildV5PlannerActionSurface(params: {
 	// of relaying the result). Protocol tools (REPLY/IGNORE/STOP) remain.
 	// Blocked/question/coordination relays keep the full surface — those turns
 	// may legitimately act (answer a child, coordinate a sibling).
-	if (
-		isSubAgentCompletionArtifact(params.message) &&
-		parseSubAgentTaskCompleteRelay(String(params.message.content?.text ?? ""))
-	) {
+	if (isTaskCompleteRelayTurn(params.message)) {
 		return {
 			exposedActionNames: new Set<string>(),
 			summary: {
@@ -4141,11 +4154,18 @@ export function evaluatePlannedReplyEgress(args: {
 	reply: string;
 	actionResults: readonly ActionResult[];
 	actions: readonly Action[];
+	/** The turn relays a sub-agent's verified completion (`task_complete`):
+	 *  that message is the effect receipt, so a completed-side-effect claim
+	 *  ("the page is ready") is grounded without an action of this turn.
+	 *  Without it a verified, live page shipped as "I couldn't verify that
+	 *  the requested change was completed" (2026-08-22). */
+	completionRelay?: boolean;
 }): PlannedReplyEgressDecision {
 	const reply = args.reply.trim();
 	if (!reply) return { verdict: "allow" };
 	if (replyClaimsCompletedSideEffect(reply)) {
 		if (
+			args.completionRelay === true ||
 			plannedReplyHasClaimGroundingReceipt({
 				kind: "completed_side_effect",
 				reply,
@@ -8601,8 +8621,14 @@ export async function runV5MessageRuntimeStage1(args: {
 				: undefined;
 		const prePatchStageOneReplyEffectStatus =
 			messageHandler.plan.replyEffectStatus;
+		// A sub-agent task_complete relay IS the effect receipt: the build it
+		// reports was done and verified by the child. Treating the relay's
+		// "applied" as ungrounded withheld the good reply and the planner
+		// shipped "i'm not sure if that change actually went through" for a
+		// verified, live page (2026-08-22, two-lane build).
 		const prePatchStageOneReplyIsUngroundedAppliedClaim =
-			prePatchStageOneReplyEffectStatus === "applied";
+			prePatchStageOneReplyEffectStatus === "applied" &&
+			!isTaskCompleteRelayTurn(args.message);
 		const responseHandlerEvaluation = fieldRunResult?.preempt
 			? {
 					activeEvaluators: [],
@@ -8761,6 +8787,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				reply,
 				actionResults: [],
 				actions: args.runtime.actions,
+				completionRelay: isTaskCompleteRelayTurn(args.message),
 			});
 			if (directReplyEgressDecision.verdict === "reject") {
 				reply = directReplyEgressDecision.fallbackReply;
@@ -8822,6 +8849,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				reply: earlyReplyText,
 				actionResults: [],
 				actions: args.runtime.actions,
+				completionRelay: isTaskCompleteRelayTurn(args.message),
 			});
 			if (earlyReplyEgressDecision.verdict === "reject") {
 				// Planning is still in progress, so an ungrounded completion claim
@@ -9763,6 +9791,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			reply: String(plannerResult.finalMessage ?? ""),
 			actionResults: egressActionResults,
 			actions: args.runtime.actions,
+			completionRelay: isTaskCompleteRelayTurn(args.message),
 		});
 		// A reply an action callback already delivered this turn (verbatim or as
 		// a strict superset) is a planner echo: the suppression below drops it, so
@@ -9950,6 +9979,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			reply: effectiveReplyText,
 			actionResults,
 			actions: args.runtime.actions,
+			completionRelay: isTaskCompleteRelayTurn(args.message),
 		});
 		if (finalReplyEgressDecision.verdict === "reject") {
 			effectiveReplyText = finalReplyEgressDecision.fallbackReply;
@@ -11157,6 +11187,29 @@ function looksLikeExplicitDelegationRequest(text: string): boolean {
 	);
 }
 
+const COMPUTED_OBJECT_RE =
+	/[\/\\:@]|https?:|\b(?:current|latest|live|today|now|price|prices|contents?|weather|time|date|random|primes?|fibonacci|under|between|from|of|in|at|each|every|all|list|first|last|largest|smallest|sum|count|number|result|output|value|api|file|url|env|variable|ip|address|size|length|temperature|stats?|status|usage|memory|disk|uptime|hostname|version|fetch(?:es|ed)?|read(?:s)?|calculat\w*|comput\w*)\b/iu;
+
+/** The object of "just prints X" is a constant when it is a quoted literal,
+ * a bare numeric literal, or a few bare words naming nothing computed. The
+ * WHOLE object is scanned — a computed continuation after "and"/"then"
+ * ("prints hello and then fetches the weather") is still a real program. */
+function isConstantPrintedObject(object: string): boolean {
+	const trimmed = object.trim().replace(/[.!?]+$/u, "");
+	if (!trimmed) return false;
+	if (/^(?:["'`“‘]).+/u.test(trimmed)) return true;
+	const head =
+		trimmed.split(/\s*(?:,|;|\band\b|\bthen\b|\bwhen\b|\bif\b)\s*/iu)[0] ?? "";
+	// "just prints 42" is a constant, not a computation.
+	if (/^(?:the\s+)?(?:number\s+)?\d+$/u.test(head)) {
+		return !COMPUTED_OBJECT_RE.test(trimmed.replace(/\d+/gu, ""));
+	}
+	const words = head.split(/\s+/u).filter(Boolean);
+	if (words.length === 0 || words.length > 4) return false;
+	if (/\d/u.test(trimmed)) return false;
+	return !COMPUTED_OBJECT_RE.test(trimmed);
+}
+
 function looksLikeInlineCodeSnippetRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	if (
@@ -11171,10 +11224,17 @@ function looksLikeInlineCodeSnippetRequest(text: string): boolean {
 	// it through a coding sub-agent spent a 27s build and the user never saw
 	// the one line (live 2026-08-22). Scoped by the just/only/simply marker so
 	// computed deliverables ("prints a random card") still get built and run.
-	const constantOutputScript =
-		/\b(?:script|program)\b[\s\S]{0,40}\b(?:just|only|simply)\s+(?:prints?|says?|outputs?|echo(?:es)?|displays?|returns?)\b/iu.test(
+	// The printed OBJECT must itself be constant: a quoted literal, or a few
+	// bare words with no path, URL, number or computed noun ("the current
+	// bitcoin price", "the contents of /etc/hosts", "the primes under a
+	// million" are real programs however the ask is phrased).
+	const constantOutputMatch =
+		/\b(?:script|program)\b[\s\S]{0,40}\b(?:just|only|simply)\s+(?:prints?|says?|outputs?|echo(?:es)?|displays?|returns?)\s+([^\n]{0,80})/iu.exec(
 			normalized,
 		);
+	const constantOutputScript =
+		constantOutputMatch !== null &&
+		isConstantPrintedObject(constantOutputMatch[1] ?? "");
 	const asksForSnippet =
 		constantOutputScript ||
 		/\b(?:write|give me|show me|generate|provide|create|make)\b[\s\S]{0,80}\b(?:code block|snippet|function|class|method|example|program|one[- ]?liner|hello world|fibonacci)\b/iu.test(
@@ -11583,6 +11643,12 @@ function enforceEffectGroundedVisibleContent(
 	runtime: Pick<IAgentRuntime, "logger">,
 	response: Content,
 	actionName?: string,
+	opts: {
+		/** The turn relays a sub-agent's verified `task_complete` — that relay
+		 *  is the effect receipt for "the page is ready" (2026-08-22: the gate
+		 *  replaced a verified live page with the unverified-effect line). */
+		completionRelay?: boolean;
+	} = {},
 ): Content {
 	const hasEffectDeliveryBinding =
 		getEffectDeliveryBinding(response) !== undefined;
@@ -11594,6 +11660,7 @@ function enforceEffectGroundedVisibleContent(
 	if (
 		effectDeliveryBindingInvalid ||
 		(typeof response.text === "string" &&
+			!opts.completionRelay &&
 			replyClaimsCompletedSideEffect(response.text) &&
 			!effectDeliveryBindingProvesApplication(response))
 	) {
@@ -11884,7 +11951,8 @@ export function wrapSingleTurnVisibleCallback(
 		Partial<Pick<IAgentRuntime, "character" | "useModel">> & {
 			getService?: IAgentRuntime["getService"];
 		},
-	message: Pick<Memory, "id" | "roomId" | "entityId">,
+	message: Pick<Memory, "id" | "roomId" | "entityId"> &
+		Partial<Pick<Memory, "content">>,
 	callback?: HandlerCallback,
 	recordDeliveredVisibleText?: (text: string) => void,
 ): HandlerCallback | undefined {
@@ -11981,6 +12049,7 @@ export function wrapSingleTurnVisibleCallback(
 			fullRuntime,
 			response,
 			actionName,
+			{ completionRelay: isTaskCompleteRelayTurn(message as Memory) },
 		);
 		if (typeof response?.text === "string" && response.text.trim()) {
 			if (nearDuplicateOfDeliveredThisTurn(response.text)) {
@@ -13660,6 +13729,8 @@ export class DefaultMessageService implements IMessageService {
 					earlyContent = enforceEffectGroundedVisibleContent(
 						runtime,
 						earlyContent,
+						undefined,
+						{ completionRelay: isTaskCompleteRelayTurn(message) },
 					);
 					earlyContent = await enforceTrustedDeliveryAudienceAtEgress(
 						runtime,
@@ -14209,6 +14280,8 @@ export class DefaultMessageService implements IMessageService {
 					deliverableResponseContent = enforceEffectGroundedVisibleContent(
 						runtime,
 						deliverableResponseContent,
+						undefined,
+						{ completionRelay: isTaskCompleteRelayTurn(message) },
 					);
 					deliverableResponseContent =
 						await enforceTrustedDeliveryAudienceAtEgress(


### PR DESCRIPTION
Independent core-runtime companion to the #24262 split series (no dependency on the orchestrator parts).

cc @lalalune

## Scope — packages/core message runtime

- **A completion relay is its own effect receipt**: when the inbound turn is a task_complete relay (keyed on core's own `parseSubAgentTaskCompleteRelay` header classifier), the planner's reply may state the worker's applied effects without tripping the effect-grounding gates — the egress/side-effect/delivery gates previously rewrote a verified build's reply into "i'm not sure that change went through" (live). Non-completion router relays (question/error/blocked) keep strict grounding.
- **Constant-snippet scope**: "write a script that just prints X" is an inline snippet only when X is actually constant (quoted literal, bare numeric, or a few bare words) — the printed OBJECT is scanned, so "just prints the current bitcoin price", "the contents of /etc/hosts", "the primes under a million", and computed continuations after "and then …" are real builds, while "just prints 42" stays inline.

Tests included for both; every behavior ran live on the nubilio deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
