### PR TITLE
fix(core): serialize secret-driven plugin activation

### DIFF
--- a/packages/core/src/features/secrets/services/plugin-activator.test.ts
+++ b/packages/core/src/features/secrets/services/plugin-activator.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Deterministic unit coverage for secret-driven plugin activation concurrency.
+ * A mocked SecretsService controls readiness while the real activator service
+ * runs its interval and secret-change entrypoints under fake timers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createMockRuntime,
+	MOCK_AGENT_ID,
+} from "../../../testing/mock-runtime.ts";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import type { SecretChangeCallback, SecretContext } from "../types.ts";
+import {
+	PluginActivatorService,
+	type PluginWithSecrets,
+} from "./plugin-activator.ts";
+import type { SecretsService } from "./secrets.ts";
+
+const PLUGIN: PluginWithSecrets = {
+	name: "concurrency-test-plugin",
+	description: "Exercises secret-driven activation concurrency.",
+	requiredSecrets: {
+		TOKEN: {
+			description: "Test token",
+			type: "token",
+			required: true,
+		},
+	},
+};
+
+const GLOBAL_CONTEXT: SecretContext = {
+	level: "global",
+	agentId: MOCK_AGENT_ID,
+	requesterId: MOCK_AGENT_ID,
+};
+
+interface ActivatorHarness {
+	emitSecretChange: () => Promise<void>;
+	reportError: ReturnType<typeof vi.fn>;
+	service: PluginActivatorService;
+}
+
+async function createHarness(
+	getMissingSecrets: (keys: string[]) => Promise<string[]>,
+): Promise<ActivatorHarness> {
+	let secretChangeCallback: SecretChangeCallback | undefined;
+	const secretsService = {
+		checkPluginRequirements: vi.fn(async () => ({
+			ready: false,
+			missingRequired: ["TOKEN"],
+			missingOptional: [],
+			invalid: [],
+		})),
+		getMissingSecrets: vi.fn(getMissingSecrets),
+		onAnySecretChanged: vi.fn((callback: SecretChangeCallback) => {
+			secretChangeCallback = callback;
+			return () => undefined;
+		}),
+	} satisfies Pick<
+		SecretsService,
+		"checkPluginRequirements" | "getMissingSecrets" | "onAnySecretChanged"
+	>;
+	const reportError = vi.fn();
+	const runtime = createMockRuntime({
+		getService: (() =>
+			secretsService as SecretsService) as IAgentRuntime["getService"],
+		reportError,
+	});
+	const service = await PluginActivatorService.start(runtime, {
+		enableAutoActivation: true,
+		pollingIntervalMs: 1,
+	});
+
+	return {
+		service,
+		reportError,
+		emitSecretChange: async () => {
+			if (!secretChangeCallback) {
+				throw new Error("Secret-change callback was not registered");
+			}
+			await secretChangeCallback("TOKEN", "ready", GLOBAL_CONTEXT);
+		},
+	};
+}
+
+describe("PluginActivatorService concurrency", () => {
+	let activeService: PluginActivatorService | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(async () => {
+		await activeService?.stop();
+		activeService = undefined;
+		vi.useRealTimers();
+	});
+
+	it("joins polling and secret-change activation into one attempt", async () => {
+		let releaseActivation: (() => void) | undefined;
+		const activationGate = new Promise<void>((resolve) => {
+			releaseActivation = resolve;
+		});
+		let markActivationStarted: (() => void) | undefined;
+		const activationStarted = new Promise<void>((resolve) => {
+			markActivationStarted = resolve;
+		});
+		const activation = vi.fn(async () => {
+			markActivationStarted?.();
+			await activationGate;
+		});
+		const harness = await createHarness(async () => []);
+		activeService = harness.service;
+
+		expect(await harness.service.registerPlugin(PLUGIN, activation)).toBe(
+			false,
+		);
+		const secretChange = harness.emitSecretChange();
+		await activationStarted;
+
+		await vi.advanceTimersByTimeAsync(5);
+		expect(activation).toHaveBeenCalledTimes(1);
+
+		releaseActivation?.();
+		await secretChange;
+		await vi.advanceTimersByTimeAsync(0);
+		expect(harness.service.isActivated(PLUGIN.name)).toBe(true);
+	});
+
+	it("serializes polls, reports failures, and retries activation", async () => {
+		let releaseFirstPoll: ((missing: string[]) => void) | undefined;
+		const firstPoll = new Promise<string[]>((resolve) => {
+			releaseFirstPoll = resolve;
+		});
+		const pollFailure = new Error("secret lookup unavailable");
+		let pollCalls = 0;
+		let concurrentPolls = 0;
+		let maxConcurrentPolls = 0;
+		const getMissingSecrets = vi.fn(async () => {
+			pollCalls += 1;
+			concurrentPolls += 1;
+			maxConcurrentPolls = Math.max(maxConcurrentPolls, concurrentPolls);
+			try {
+				if (pollCalls === 1) return await firstPoll;
+				if (pollCalls === 2) throw pollFailure;
+				return [];
+			} finally {
+				concurrentPolls -= 1;
+			}
+		});
+		const activationFailure = new Error("plugin startup failed");
+		const activation = vi
+			.fn<() => Promise<void>>()
+			.mockRejectedValueOnce(activationFailure)
+			.mockResolvedValueOnce(undefined);
+		const harness = await createHarness(getMissingSecrets);
+		activeService = harness.service;
+		expect(await harness.service.registerPlugin(PLUGIN, activation)).toBe(
+			false,
+		);
+
+		await vi.advanceTimersByTimeAsync(1);
+		await vi.advanceTimersByTimeAsync(5);
+		expect(getMissingSecrets).toHaveBeenCalledTimes(1);
+		expect(maxConcurrentPolls).toBe(1);
+
+		releaseFirstPoll?.(["TOKEN"]);
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(harness.reportError).toHaveBeenCalledWith(
+			"PluginActivator.poll",
+			pollFailure,
+		);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(activation).toHaveBeenCalledTimes(1);
+		expect(harness.service.isPending(PLUGIN.name)).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(activation).toHaveBeenCalledTimes(2);
+		expect(harness.service.isActivated(PLUGIN.name)).toBe(true);
+		expect(maxConcurrentPolls).toBe(1);
+	});
+});

--- a/packages/core/src/features/secrets/services/plugin-activator.ts
+++ b/packages/core/src/features/secrets/services/plugin-activator.ts
@@ -84,6 +84,8 @@ export class PluginActivatorService extends Service {
 	private activatedPlugins: Set<string> = new Set();
 	private pluginSecretMapping: Map<string, Set<string>> = new Map();
 	private pollingInterval: ReturnType<typeof setInterval> | null = null;
+	private activePoll: Promise<void> | null = null;
+	private activationPromises: Map<string, Promise<boolean>> = new Map();
 	private unsubscribeSecretChanges: (() => void) | null = null;
 
 	/** Registered plugins with their callbacks */
@@ -234,6 +236,11 @@ export class PluginActivatorService extends Service {
 			this.unsubscribeSecretChanges = null;
 		}
 
+		if (this.activePoll) {
+			await this.activePoll;
+		}
+		await Promise.allSettled(this.activationPromises.values());
+
 		this.pendingPlugins.clear();
 		this.activatedPlugins.clear();
 		this.pluginSecretMapping.clear();
@@ -356,7 +363,36 @@ export class PluginActivatorService extends Service {
 	/**
 	 * Activate a plugin
 	 */
-	private async activatePlugin(
+	private activatePlugin(
+		pluginId: string,
+		plugin: PluginWithSecrets,
+		callback?: () => Promise<void>,
+	): Promise<boolean> {
+		const existingActivation = this.activationPromises.get(pluginId);
+		if (existingActivation) {
+			return existingActivation;
+		}
+
+		if (this.activatedPlugins.has(pluginId)) {
+			return Promise.resolve(true);
+		}
+
+		// Defer the callback until after the promise is registered so concurrent
+		// activation requests see and join this attempt.
+		const work = Promise.resolve().then(() =>
+			this.performPluginActivation(pluginId, plugin, callback),
+		);
+		const activation = work.finally(() => {
+			if (this.activationPromises.get(pluginId) === activation) {
+				this.activationPromises.delete(pluginId);
+			}
+		});
+		this.activationPromises.set(pluginId, activation);
+		return activation;
+	}
+
+	/** Execute the single activation attempt owned by activatePlugin. */
+	private async performPluginActivation(
 		pluginId: string,
 		plugin: PluginWithSecrets,
 		callback?: () => Promise<void>,
@@ -523,6 +559,9 @@ export class PluginActivatorService extends Service {
 
 				// Check if all required secrets are now available
 				const missing = await this.getMissingSecrets(pending.requiredSecrets);
+				if (this.pendingPlugins.get(pluginId) !== pending) {
+					continue;
+				}
 				if (missing.length === 0) {
 					logger.info(
 						`[PluginActivator] All secrets available for ${pluginId}, activating`,
@@ -654,13 +693,38 @@ export class PluginActivatorService extends Service {
 			return;
 		}
 
-		this.pollingInterval = setInterval(async () => {
-			await this.checkPendingPlugins();
+		this.pollingInterval = setInterval(() => {
+			this.pollPendingPlugins();
 		}, this.activatorConfig.pollingIntervalMs);
 
 		logger.debug(
 			`[PluginActivator] Started polling every ${this.activatorConfig.pollingIntervalMs}ms`,
 		);
+	}
+
+	/** Start one observed poll without overlapping a still-running cycle. */
+	private pollPendingPlugins(): void {
+		if (this.activePoll) {
+			return;
+		}
+
+		const poll = this.checkPendingPlugins()
+			.catch((error) => {
+				// error-policy:J7 Poll failures are reported without terminating the
+				// recurring activation loop; the next interval may retry.
+				const errorMessage =
+					error instanceof Error ? error.message : String(error);
+				logger.error(
+					`[PluginActivator] Pending plugin poll failed: ${errorMessage}`,
+				);
+				this.runtime.reportError("PluginActivator.poll", error);
+			})
+			.finally(() => {
+				if (this.activePoll === poll) {
+					this.activePoll = null;
+				}
+			});
+		this.activePoll = poll;
 	}
 
 	/**
@@ -688,6 +752,9 @@ export class PluginActivatorService extends Service {
 
 			// Check if secrets are now available
 			const missing = await this.getMissingSecrets(pending.requiredSecrets);
+			if (this.pendingPlugins.get(pluginId) !== pending) {
+				continue;
+			}
 			if (missing.length === 0) {
 				logger.info(`[PluginActivator] Secrets now available for ${pluginId}`);
 				await pending.callback();


### PR DESCRIPTION
# Relates to

Fixes #24429.

The issue was opened after the independently reproduced implementation to repair
the missing acceptance record. At the pre-work duplicate check, no issue, PR,
public branch, or open-PR file overlap was found. The post-hoc timing is disclosed
in #24429 rather than represented as issue-first work.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic before/after evidence and focused regression below.

# Sync with develop

- [x] Based on current `origin/develop` at `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact blocker is documented in
      **Known gaps / failures** below.

# Risks

Low to medium. The change is confined to the opt-in `PluginActivatorService` lifecycle. It serializes activation per plugin, prevents overlapping polling, reports poll failures, and drains in-flight work during shutdown. The main behavioral change is that concurrent requests for the same plugin now join one activation attempt instead of running duplicate callbacks.

# Background

## What does this PR do?

`PluginActivatorService` previously used an async `setInterval` without an in-flight guard. If secret lookup or activation took longer than the interval, a later tick could observe the same pending plugin and invoke its activation callback concurrently. A rejected interval promise was also unobserved.

This PR:

- gives each plugin one in-flight activation promise so concurrent triggers join the same attempt;
- keeps a failed plugin pending so a later trigger can retry it;
- prevents overlapping polling and reports poll failures through `runtime.reportError`;
- revalidates pending identity after awaited secret lookup; and
- makes `stop()` wait for active polling and activation before clearing state.

The exact pre-fix source reproduced two concurrent activation callbacks while the first callback was blocked:

```json
{"activationCalls":2,"duplicateActivationObserved":true,"reportedErrors":[]}
```

The same deterministic harness against this head produced exactly one callback:

```json
{"activationCalls":1,"callsWhileBlocked":1,"exactlyOnce":true,"reports":[]}
```

## What kind of change is this?

Bug fix (non-breaking concurrency and lifecycle correction in a core service).

## Why are we doing this? Any context or related work?

Duplicate activation can repeat connector or service registration and can leak an unhandled polling rejection. The current repository does not expose a default in-tree caller of `PluginActivatorService.registerPlugin`, so this PR does **not** claim a demonstrated shipped-product incident. It fixes the observable contract of this opt-in core service API and adds regression coverage at that boundary.

# Documentation changes needed?

No public configuration or user-facing contract changes. The service-level behavior is covered by focused tests.

# Testing

## Where should a reviewer start?

1. `packages/core/src/features/secrets/services/plugin-activator.test.ts`
2. `activatePlugin`, `startPolling`, and `stop` in `packages/core/src/features/secrets/services/plugin-activator.ts`

## Detailed testing steps

Actual local checks on exact head `79524d413b56c54355eafa332a686469fb9cb322`:

```text
pnpm dlx vitest@4.1.10 run --config <temporary boundary-stub config> --reporter=verbose
Result: 1 test file passed; 2/2 tests passed; 155 ms.

Biome 2.5.8 check on both changed files
Result: passed.

git diff --check
Result: passed.
```

The focused Vitest run imported the real changed service and tests while stubbing only logger/type/service collaborator boundaries because this checkout has no monorepo dependency tree. It is service-level regression proof, not a full package/runtime run.

With workspace dependencies installed, reviewers/CI can run:

```bash
bun test packages/core/src/features/secrets/services/plugin-activator.test.ts
bun run verify
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:79524d413b56c54355eafa332a686469fb9cb322 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a non-visual core service concurrency change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no default in-tree runtime caller was found; deterministic service-level before/after output is included above, without claiming end-to-end execution.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or surface is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, provider, or LLM behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this change creates no DB row, memory, task, wallet output, or generated file.
<!-- evidence-row:ocr-review -->
- [x] N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior is changed.

## Backend + frontend logs

Backend: N/A for end-to-end logs because no default in-tree caller of this opt-in service API was found. The deterministic service-level before/after observations and focused regression result are included under **Background** and **Testing**.

Frontend: N/A - no frontend code or behavior is changed.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior is changed.

## Known gaps / failures

- Root `bun install` and `bun run verify` were not run. Bun is unavailable, Node is 24.2.0 rather than the repository-pinned 24.15.0, the checkout has no workspace dependency tree, and only about 2.1 GiB of disk headroom was available. Full package typecheck/build and repository verification remain for CI.
- The focused Vitest run used a temporary boundary-stub config and is not equivalent to a full package or AgentRuntime test.
- No default in-repo consumer of `PluginActivatorService.registerPlugin` was found, so this PR makes no shipped-product or end-to-end activation claim.
- The deterministic harnesses are local evidence and are not committed artifacts; the committed regression test captures the same overlap and recovery behavior.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [gg100-plugin-activator-single-flight]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0MGMKS9SBWZRYH9NGXWPTHS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T10:35:36.617Z","completed_at":"2026-08-22T11:02:48.445Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T10:35:37.642Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a7448c301b279ce7db1aa0556a9b187d747ecc12edbe4565e31781424a13de65","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e8dcaa60-5524-4c15-aed3-0b090be170f6","object_id":"sha256:a7448c301b279ce7db1aa0556a9b187d747ecc12edbe4565e31781424a13de65","sha256":"a7448c301b279ce7db1aa0556a9b187d747ecc12edbe4565e31781424a13de65"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAatQrQQOBV1qI24oLVWUHaqCa3midtkIIl7dGI5D4PLw","device_key_id":"8c4c510f91f2352c8081224eca4aa2f34a7fb521b00e0f5afba88b4cc93b0d1b","device_signature":"1HfdIKvAWid-KoDGBfC2qP07-fuO_GuyK8m5nHjV4-J8cEKng5_npQDC_J8V-ca9E_sdCpOOejtuud5oKwGACQ"}} -->
