### PR TITLE
fix(agent): register plugin-signal in the optional-plugin import table

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -174,6 +174,7 @@ const optionalPluginSpecifiers = {
   cloud: "@elizaos/plugin-elizacloud",
   imessage: "@elizaos/plugin-imessage",
   mcp: "@elizaos/plugin-mcp",
+  signal: "@elizaos/plugin-signal",
   whatsapp: "@elizaos/plugin-whatsapp",
   workflow: "@elizaos/plugin-workflow",
 } as const;
@@ -184,6 +185,7 @@ const optionalPluginImports = {
   cloud: () => importOptionalPlugin(optionalPluginSpecifiers.cloud),
   imessage: () => importOptionalPlugin(optionalPluginSpecifiers.imessage),
   mcp: () => importOptionalPlugin(optionalPluginSpecifiers.mcp),
+  signal: () => importOptionalPlugin(optionalPluginSpecifiers.signal),
   whatsapp: () => importOptionalPlugin(optionalPluginSpecifiers.whatsapp),
   workflow: () => importOptionalPlugin(optionalPluginSpecifiers.workflow),
 };


### PR DESCRIPTION
develop's `@elizaos/app-core#typecheck` currently fails on every PR: `server.ts:2556` calls `getOptionalPluginApi("signal")` (for `applySignalQrOverride`) but `signal` was never added to `optionalPluginSpecifiers`/`optionalPluginImports` (TS2345). Two-line registration; `@elizaos/plugin-signal` exists in the workspace.

Sibling CI-unblocker to #24426 (ui format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)