### PR TITLE
fix(core): reject prefix-parsed EMBEDDING_DIMENSION and bound vector width

### DIFF
--- a/packages/core/src/__tests__/provisioning.test.ts
+++ b/packages/core/src/__tests__/provisioning.test.ts
@@ -79,6 +79,33 @@ describe("ensureEmbeddingDimension (core/provisioning.ts daemon-composition prob
 		expect(ensureDim).not.toHaveBeenCalled();
 	});
 
+	it("skips when EMBEDDING_DIMENSION contains trailing non-digit characters (prefix-parse)", async () => {
+		const { runtime, ensureDim } = makeRuntime({
+			hasModel: true,
+			embeddingDimension: "1536abc",
+		});
+		await ensureEmbeddingDimension(runtime);
+		expect(ensureDim).not.toHaveBeenCalled();
+	});
+
+	it("skips when EMBEDDING_DIMENSION is a non-integer float", async () => {
+		const { runtime, ensureDim } = makeRuntime({
+			hasModel: true,
+			embeddingDimension: "1536.9",
+		});
+		await ensureEmbeddingDimension(runtime);
+		expect(ensureDim).not.toHaveBeenCalled();
+	});
+
+	it("skips when EMBEDDING_DIMENSION exceeds maximum allowed dimension 16384", async () => {
+		const { runtime, ensureDim } = makeRuntime({
+			hasModel: true,
+			embeddingDimension: 20000,
+		});
+		await ensureEmbeddingDimension(runtime);
+		expect(ensureDim).not.toHaveBeenCalled();
+	});
+
 	it("skips when EMBEDDING_DIMENSION is <= 0", async () => {
 		const { runtime, ensureDim } = makeRuntime({
 			hasModel: true,

--- a/packages/core/src/provisioning.ts
+++ b/packages/core/src/provisioning.ts
@@ -201,16 +201,27 @@ export async function ensureEmbeddingDimension(
 	// and "no facts available" results. Accept both spellings. On conflict, PLURAL
 	// wins: the DB column must match the embedder's real output dimension, and the
 	// embedder reads the plural key — so it is the source of truth. Warn loudly.
-	const parseDim = (value: unknown): number =>
-		typeof value === "number"
-			? value
-			: typeof value === "string"
-				? parseInt(value, 10)
-				: NaN;
+	const MAX_EMBEDDING_DIMENSION = 16_384;
+	const parseDim = (value: unknown): number => {
+		if (typeof value === "number") {
+			return Number.isSafeInteger(value) ? value : NaN;
+		}
+		if (typeof value === "string") {
+			const trimmed = value.trim();
+			return /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : NaN;
+		}
+		return NaN;
+	};
 	const singular = parseDim(runtime.getSetting("EMBEDDING_DIMENSION"));
 	const plural = parseDim(runtime.getSetting("EMBEDDING_DIMENSIONS"));
-	const singularValid = Number.isFinite(singular) && singular > 0;
-	const pluralValid = Number.isFinite(plural) && plural > 0;
+	const singularValid =
+		Number.isSafeInteger(singular) &&
+		singular > 0 &&
+		singular <= MAX_EMBEDDING_DIMENSION;
+	const pluralValid =
+		Number.isSafeInteger(plural) &&
+		plural > 0 &&
+		plural <= MAX_EMBEDDING_DIMENSION;
 	if (singularValid && pluralValid && singular !== plural) {
 		logger.warn(
 			{ src: "provisioning", agentId: runtime.agentId, singular, plural },
@@ -222,8 +233,12 @@ export async function ensureEmbeddingDimension(
 	}
 	// Plural wins on conflict (embedder's actual output dimension); otherwise use
 	// whichever single key is valid.
-	const dimension = pluralValid ? plural : singular;
-	if (!Number.isFinite(dimension) || dimension <= 0) {
+	const dimension = pluralValid ? plural : singularValid ? singular : NaN;
+	if (
+		!Number.isSafeInteger(dimension) ||
+		dimension <= 0 ||
+		dimension > MAX_EMBEDDING_DIMENSION
+	) {
 		logger.debug(
 			{ src: "provisioning", agentId: runtime.agentId },
 			"EMBEDDING_DIMENSION / EMBEDDING_DIMENSIONS not set or invalid, skipping (set it in character settings to avoid LLM detection)",


### PR DESCRIPTION
## Summary
- Fix `packages/core/src/provisioning.ts:208` to reject prefix-parsed strings (e.g. `"1536abc"`, `"1536.9"`) and bound embedding dimension width (`1 <= dimension <= 16,384`) during agent provisioning.
- Add deterministic unit coverage via `packages/core/src/__tests__/provisioning.test.ts` verifying prefix-parse rejection, non-integer float rejection, and upper ceiling bounds.
Same class as approved #24431, #24193, #24199 — identical strict whole-string integer parsing pattern.

## Changes
| File | Change |
|------|--------|
| `packages/core/src/provisioning.ts` | Replace naive `parseInt` with `/^\d+$/.test(value.trim())` and `Number.isSafeInteger`, enforce `1 <= dimension <= 16,384` |
| `packages/core/src/__tests__/provisioning.test.ts` | Add test cases verifying prefix-parse rejection, float rejection, and dimension ceiling |

## Verification
- Rebased onto `origin/develop@a40cc65` — zero conflicts
- `bun --bun x @biomejs/biome check --write --unsafe` — target files clean (no fixes after --write on second run)
- `bun --bun x vitest run src/__tests__/provisioning.test.ts` — **12 passed, 0 failed**
- `git show 36b8364:packages/core/src/provisioning.ts` verifies strict integer parser + upper ceiling

## Evidence Gate
<!-- evidence-row:before-screenshots --> - [x] N/A - headless daemon provisioning logic, no UI
<!-- evidence-row:after-screenshots -->  - [x] N/A - same
<!-- evidence-row:walkthrough-video -->  - [x] N/A - no user flow; proven by unit tests
<!-- evidence-row:backend-logs -->       - [x] Real logs:
```log
vitest run src/__tests__/provisioning.test.ts
 Test Files  1 passed
      Tests  12 passed
 skips when EMBEDDING_DIMENSION contains trailing non-digit characters (prefix-parse)
 skips when EMBEDDING_DIMENSION is a non-integer float
 skips when EMBEDDING_DIMENSION exceeds maximum allowed dimension 16384
```
<!-- evidence-row:frontend-logs -->      - [x] N/A
<!-- evidence-row:llm-trajectory -->     - [x] N/A
<!-- evidence-row:domain-artifacts -->   - [x] Domain artifact = wiring, proven by tests
<!-- evidence-row:ocr-review -->         - [x] N/A

# Risks
Low — strict whole-string integer parsing and vector width boundary guard for agent DB column provisioning.

## Testing
### Where should a reviewer start?
`packages/core/src/provisioning.ts` (parseDim) and `packages/core/src/__tests__/provisioning.test.ts`.

### Detailed testing steps
- `bun --cwd packages/core vitest run src/__tests__/provisioning.test.ts` — expect 12 passed
- `bun biome check packages/core/src/provisioning.ts packages/core/src/__tests__/provisioning.test.ts` — expect `No fixes applied`