### PR TITLE
fix(computeruse): keep Android trajectory errors Unicode-well-formed

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
@@ -10,9 +10,55 @@
 import { logger } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  type AndroidTrajectoryActionEvent,
   emitAndroidAction,
   emitAndroidAgentStep,
 } from "../mobile/android-trajectory.js";
+
+const ERROR_MESSAGE_MAX_CODE_UNITS = 256;
+const REPLACEMENT_CHARACTER = "�";
+
+function isWellFormed(text: string): boolean {
+  return (
+    (text as unknown as { isWellFormed?: () => boolean }).isWellFormed?.() ??
+    !/[\uD800-\uDFFF]/u.test(text)
+  );
+}
+
+function emitFailure(errorMessage?: string): {
+  event: AndroidTrajectoryActionEvent;
+  payload: AndroidTrajectoryActionEvent;
+  logged: Record<string, unknown>;
+} {
+  const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+  try {
+    const event: AndroidTrajectoryActionEvent = {
+      kind: "tap",
+      success: false,
+      errorCode: "accessibility_unavailable",
+      errorMessage,
+    };
+    const payload = emitAndroidAction(event);
+    const logged = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    return { event, payload, logged };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+function expectProjectedError(
+  input: string | undefined,
+  expected: string | undefined,
+): void {
+  const { event, payload, logged } = emitFailure(input);
+  expect(event.errorMessage).toBe(input);
+  expect(payload.errorMessage).toBe(expected);
+  expect(logged.errorMessage).toBe(expected);
+  if (expected !== undefined) {
+    expect(isWellFormed(expected)).toBe(true);
+    expect(expected.length).toBeLessThanOrEqual(ERROR_MESSAGE_MAX_CODE_UNITS);
+  }
+}
 
 describe("emitAndroidAction", () => {
   it("emits a structured `computeruse.android.action` log entry with platform=android", () => {
@@ -61,6 +107,69 @@ describe("emitAndroidAction", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it.each([
+    ["empty", "", ""],
+    ["short", "bridge 🧠 failed", "bridge 🧠 failed"],
+  ])("preserves a %s error projection", (_, input, expected) => {
+    expectProjectedError(input, expected);
+  });
+
+  it("keeps an absent error message absent", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      const event: AndroidTrajectoryActionEvent = {
+        kind: "tap",
+        success: false,
+        errorCode: "accessibility_unavailable",
+      };
+      const payload = emitAndroidAction(event);
+      const logged = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+
+      expect(Object.hasOwn(event, "errorMessage")).toBe(false);
+      expect(Object.hasOwn(payload, "errorMessage")).toBe(false);
+      expect(Object.hasOwn(logged, "errorMessage")).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("preserves an exact-cap astral error without truncating", () => {
+    const input = `${"a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS - 2)}🧠`;
+    expect(input.length).toBe(ERROR_MESSAGE_MAX_CODE_UNITS);
+    expectProjectedError(input, input);
+  });
+
+  it("caps a plain max+1 error at 256 code units", () => {
+    const input = "a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS + 1);
+    expectProjectedError(input, "a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS));
+  });
+
+  it("backs off when an astral pair crosses the cut", () => {
+    const input = `${"a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS - 1)}🧠z`;
+    expectProjectedError(input, "a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS - 1));
+  });
+
+  it.each([
+    ["lone high surrogate", "\uD83E"],
+    ["lone low surrogate", "\uDDE0"],
+  ])("normalizes a short %s", (_, lone) => {
+    expectProjectedError(
+      `left${lone}right`,
+      `left${REPLACEMENT_CHARACTER}right`,
+    );
+  });
+
+  it.each([
+    ["lone high surrogate", "\uD83E"],
+    ["lone low surrogate", "\uDDE0"],
+  ])("normalizes a long %s before truncating", (_, lone) => {
+    const input = `${"a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS - 1)}${lone}z`;
+    expectProjectedError(
+      input,
+      `${"a".repeat(ERROR_MESSAGE_MAX_CODE_UNITS - 1)}${REPLACEMENT_CHARACTER}`,
+    );
   });
 
   it("does not emit fields that were not supplied", () => {

--- a/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
+++ b/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
@@ -24,7 +24,7 @@
  * log-capture pipeline.
  */
 
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 export type AndroidActionKind =
   | "tap"
@@ -76,8 +76,11 @@ export function emitAndroidAction(
   event: AndroidTrajectoryActionEvent,
 ): AndroidTrajectoryActionEvent {
   const trimmed: AndroidTrajectoryActionEvent = { ...event };
-  if (trimmed.errorMessage) {
-    trimmed.errorMessage = trimmed.errorMessage.slice(0, MAX_ERROR_MSG);
+  if (typeof trimmed.errorMessage === "string") {
+    trimmed.errorMessage = truncateWellFormed(
+      toWellFormedUnicode(trimmed.errorMessage),
+      MAX_ERROR_MSG,
+    );
   }
   logger.info(
     {


### PR DESCRIPTION
# Relates to

Closes #23969  
Tracks #23245

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      local blockers are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@a40cc65d3f161b307d6ba70fe6d89f1130b785eb`; zero conflicts.
- [x] Post-sync verification is recorded below, including exact unrelated local
      blockers.

# Risks

Low. This only changes Android structured trajectory error projection. Supplied
lone surrogates now become U+FFFD, and an astral character crossing the
256-code-unit boundary causes truncation to back off by one code unit. The
caller-owned event remains unchanged; no action execution, UI, bridge protocol,
or public schema changes.

# Background

## What does this PR do?

- Normalizes supplied Android action `errorMessage` values with
  `toWellFormedUnicode`.
- Preserves the existing 256 UTF-16-code-unit ceiling with
  `truncateWellFormed` without splitting astral pairs.
- Keeps returned and structured-logger payloads identical.
- Adds real emitter/logger coverage for absent, empty, short, exact-cap,
  max+1, astral-boundary, and short/long lone-high/lone-low inputs.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; the package contract remains the same apart
from malformed Unicode being repaired before projection.

# Testing

## Where should a reviewer start?

- `plugins/plugin-computeruse/src/mobile/android-trajectory.ts`
- `plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts`

## Detailed testing steps

- `bun install --frozen-lockfile --ignore-scripts` — passed after final sync.
- Focused Android trajectory suite — 15/15 passed on the exact PR head.
- Raw `.slice(0, 256)` mutation — 5 failed / 10 passed; restored implementation
  — 15/15 passed.
- Computer Use lint — 233 files checked, clean.
- Computer Use typecheck — passed.
- Computer Use build, declarations, and views — passed.
- Full Computer Use package suite — 100/102 files passed; 915 tests passed,
  2 failed, 22 skipped. Both failures are unchanged Windows environment cases
  and are listed below.
- `git diff --check` — passed.
- `bun run verify` — invoked after final sync; it stopped at the unrelated sparse
  checkout blocker recorded below.

# Evidence Gate

<!-- evidence-head:b7c598bf101966bed508637e8105e4f8f9dcf32c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed by this structured logging fix.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed by this structured logging fix.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no visual user flow or rendered surface to record.
<!-- evidence-row:backend-logs -->
- [x] Exact-head production emitter/logger output is included below.

  <details>
  <summary>Android trajectory logger output</summary>

  ```json
  {"case":"astral-cut","evt":"computeruse.android.action","platform":"android","inputUnchanged":true,"returnedEqualsLogger":true,"codeUnits":255,"wellFormed":true,"tailCodePoints":["U+0061","U+0061","U+0061"]}
  {"case":"lone-high","evt":"computeruse.android.action","platform":"android","inputUnchanged":true,"returnedEqualsLogger":true,"codeUnits":256,"wellFormed":true,"tailCodePoints":["U+0061","U+0061","U+FFFD"]}
  {"case":"short","evt":"computeruse.android.action","platform":"android","inputUnchanged":true,"returnedEqualsLogger":true,"codeUnits":16,"wellFormed":true,"tailCodePoints":["U+006C","U+0065","U+0064"]}
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or state path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no planning, prompt, provider, model, or live-LLM behavior changes;
      this only sanitizes an already-produced error string.
<!-- evidence-row:domain-artifacts -->
- [x] Boundary and mutation artifacts are included below.

  <details>
  <summary>Unicode projection and mutation results</summary>

  ```text
  base@c8026f007fec1f6f74ad650022b4bfecaff914fc: inputUnits=258 projectedUnits=256 wellFormed=false tail=U+0061,U+D83E
  fixed@b7c598bf101966bed508637e8105e4f8f9dcf32c: astral-cut projectedUnits=255 wellFormed=true inputUnchanged=true returnedEqualsLogger=true
  fixed@b7c598bf101966bed508637e8105e4f8f9dcf32c: lone-high projectedUnits=256 wellFormed=true tail=U+FFFD inputUnchanged=true returnedEqualsLogger=true
  mutation raw-slice: 5 failed / 10 passed; restored implementation: 15 passed / 15
  ```
  </details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text or UI surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM, prompt, provider, planner, or action-selection behavior changes.

## Backend + frontend logs

The exact-head production emitter/logger transcript is embedded in the backend
evidence row. Frontend logs are inapplicable because no frontend path changes.

## Screenshots (before / after) + video walkthrough

N/A - structured Android trajectory data only; no rendered UI.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

- Full package suite: `src/scene/a11y-provider.error-policy.test.ts` cannot
  exercise Linux AT-SPI/Python semantics on this Windows host, and
  `src/__tests__/security-file-target.test.ts` cannot create a symlink without
  Windows developer/admin privileges (`EPERM`). Both files are byte-identical to
  `origin/develop`; neither overlaps this PR.
- Root `bun run verify` passed the AGENTS/CLAUDE identity check and then stopped
  in `check:biome-version` because this disk-saving sparse worktree intentionally
  does not materialize tracked `packages/app-core/biome.json`. The file exists on
  `origin/develop`; this is a local checkout constraint, not a branch change.
- No Android device or emulator run was performed. The changed path is a
  platform-independent TypeScript string projection exercised through the real
  emitter and structured logger; it does not invoke Android bridge/device APIs.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r/codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza"} -->

