### PR TITLE
fix(computeruse): reject malformed browser tab IDs

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/browser-tab-id-policy.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-tab-id-policy.test.ts
@@ -40,6 +40,7 @@ describe("normalizeBrowserTabId", () => {
     "0x1",
     "1junk",
     (Number.MAX_SAFE_INTEGER + 1).toString(),
+    -0,
     -1,
     1.5,
     Number.NaN,

--- a/plugins/plugin-computeruse/src/__tests__/browser-tab-id-policy.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/browser-tab-id-policy.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Browser tab IDs are positional decimal indices. These tests exercise the
+ * shared service/platform policy and the two destructive platform exports
+ * without launching Puppeteer.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { closeBrowserTab, switchBrowserTab } from "../platform/browser.js";
+import {
+  INVALID_BROWSER_TAB_ID_MESSAGE,
+  InvalidBrowserTabIdError,
+  normalizeBrowserTabId,
+} from "../security/browser-tab-id-policy.js";
+
+describe("normalizeBrowserTabId", () => {
+  it.each([
+    ["0", "0"],
+    ["1", "1"],
+    [Number.MAX_SAFE_INTEGER.toString(), Number.MAX_SAFE_INTEGER.toString()],
+    [0, "0"],
+    [1, "1"],
+    [Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER.toString()],
+  ])("normalizes canonical tab ID %j", (input, expected) => {
+    expect(normalizeBrowserTabId(input)).toBe(expected);
+  });
+
+  it.each([
+    undefined,
+    null,
+    "",
+    " ",
+    " 1 ",
+    "+1",
+    "-0",
+    "-1",
+    "01",
+    "1.0",
+    "1e1",
+    "0x1",
+    "1junk",
+    (Number.MAX_SAFE_INTEGER + 1).toString(),
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+    {},
+  ])("rejects malformed tab ID %j", (input) => {
+    expect(() => normalizeBrowserTabId(input)).toThrow(
+      InvalidBrowserTabIdError,
+    );
+    expect(() => normalizeBrowserTabId(input)).toThrow(
+      INVALID_BROWSER_TAB_ID_MESSAGE,
+    );
+  });
+
+  it("uses the repository's typed domain error contract", () => {
+    let thrown: unknown;
+    try {
+      normalizeBrowserTabId("1junk");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect(thrown).toMatchObject({
+      name: "InvalidBrowserTabIdError",
+      code: "COMPUTER_USE_BROWSER_TAB_ID_INVALID",
+    });
+  });
+});
+
+describe("browser tab platform boundaries", () => {
+  it.each([
+    ["close", closeBrowserTab],
+    ["switch", switchBrowserTab],
+  ] as const)(
+    "rejects a malformed ID before attempting to %s a tab",
+    async (_, action) => {
+      await expect(action("1junk")).rejects.toThrow(InvalidBrowserTabIdError);
+    },
+  );
+});

--- a/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
@@ -168,6 +168,32 @@ describe("ComputerUseService browser command dispatch", () => {
     expect(browser.switchBrowserTab).toHaveBeenCalledWith("0");
   });
 
+  it.each([
+    ["tabId", { tabId: "auto" }],
+    ["index", { index: -1 }],
+    ["tab_index", { tab_index: 1.5 }],
+  ] as const)(
+    "ignores a malformed %s alias for an unrelated browser action",
+    async (_, strayAlias) => {
+      vi.mocked(browser.navigateBrowser).mockClear();
+
+      const result = await service.executeBrowserAction({
+        action: "navigate",
+        url: "https://example.com/ignored-tab-alias",
+        ...strayAlias,
+      });
+
+      expect(result).toMatchObject({ success: true });
+      expect(result).not.toHaveProperty(
+        "error",
+        INVALID_BROWSER_TAB_ID_MESSAGE,
+      );
+      expect(browser.navigateBrowser).toHaveBeenCalledWith(
+        "https://example.com/ignored-tab-alias",
+      );
+    },
+  );
+
   it("rejects malformed close/switch tab IDs before adapter dispatch", async () => {
     const cases = [
       {
@@ -180,21 +206,29 @@ describe("ComputerUseService browser command dispatch", () => {
         tabId: "1.5",
         adapter: browser.switchBrowserTab,
       },
+      {
+        action: "close_tab" as const,
+        index: -1,
+        adapter: browser.closeBrowserTab,
+      },
+      {
+        action: "switch_tab" as const,
+        tab_index: 1.5,
+        adapter: browser.switchBrowserTab,
+      },
     ];
 
     for (const testCase of cases) {
-      vi.mocked(testCase.adapter).mockClear();
+      const { adapter, ...params } = testCase;
+      vi.mocked(adapter).mockClear();
 
-      const result = await service.executeBrowserAction({
-        action: testCase.action,
-        tabId: testCase.tabId,
-      });
+      const result = await service.executeBrowserAction(params);
 
       expect(result).toEqual({
         success: false,
         error: INVALID_BROWSER_TAB_ID_MESSAGE,
       });
-      expect(testCase.adapter).not.toHaveBeenCalled();
+      expect(adapter).not.toHaveBeenCalled();
       expect(service.getRecentActions().at(-1)).toMatchObject({
         action: `browser_${testCase.action}`,
         params: { action: testCase.action },
@@ -203,7 +237,29 @@ describe("ComputerUseService browser command dispatch", () => {
       expect(service.getRecentActions().at(-1)?.params).not.toHaveProperty(
         "tabId",
       );
+      expect(service.getRecentActions().at(-1)?.params).not.toHaveProperty(
+        "index",
+      );
+      expect(service.getRecentActions().at(-1)?.params).not.toHaveProperty(
+        "tab_index",
+      );
     }
+  });
+
+  it("does not fall back from a malformed tabId to a valid numeric alias", async () => {
+    vi.mocked(browser.closeBrowserTab).mockClear();
+
+    const result = await service.executeBrowserAction({
+      action: "close_tab",
+      tabId: "1junk",
+      index: 1,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: INVALID_BROWSER_TAB_ID_MESSAGE,
+    });
+    expect(browser.closeBrowserTab).not.toHaveBeenCalled();
   });
 
   it("rejects a malformed tab ID through command routing", async () => {

--- a/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import * as browser from "../platform/browser.js";
+import { INVALID_BROWSER_TAB_ID_MESSAGE } from "../security/browser-tab-id-policy.js";
 import { MAX_COMPUTER_USE_PLAIN_DATA_CHARS } from "../services/computer-use-plain-data.js";
 
 vi.mock("../platform/browser.js", () => {
@@ -147,6 +148,81 @@ describe("ComputerUseService browser command dispatch", () => {
       error: "Computer-use snapshot exceeds the plain-data walk budget",
     });
     expect(result).not.toHaveProperty("content");
+  });
+
+  it("normalizes numeric close/switch tab aliases before dispatch", async () => {
+    vi.mocked(browser.closeBrowserTab).mockClear();
+    vi.mocked(browser.switchBrowserTab).mockClear();
+
+    expect(
+      await service.executeBrowserAction({ action: "close_tab", index: 1 }),
+    ).toMatchObject({ success: true });
+    expect(browser.closeBrowserTab).toHaveBeenCalledWith("1");
+
+    expect(
+      await service.executeBrowserAction({
+        action: "switch_tab",
+        tab_index: 0,
+      }),
+    ).toMatchObject({ success: true });
+    expect(browser.switchBrowserTab).toHaveBeenCalledWith("0");
+  });
+
+  it("rejects malformed close/switch tab IDs before adapter dispatch", async () => {
+    const cases = [
+      {
+        action: "close_tab" as const,
+        tabId: "1junk",
+        adapter: browser.closeBrowserTab,
+      },
+      {
+        action: "switch_tab" as const,
+        tabId: "1.5",
+        adapter: browser.switchBrowserTab,
+      },
+    ];
+
+    for (const testCase of cases) {
+      vi.mocked(testCase.adapter).mockClear();
+
+      const result = await service.executeBrowserAction({
+        action: testCase.action,
+        tabId: testCase.tabId,
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: INVALID_BROWSER_TAB_ID_MESSAGE,
+      });
+      expect(testCase.adapter).not.toHaveBeenCalled();
+      expect(service.getRecentActions().at(-1)).toMatchObject({
+        action: `browser_${testCase.action}`,
+        params: { action: testCase.action },
+        success: false,
+      });
+      expect(service.getRecentActions().at(-1)?.params).not.toHaveProperty(
+        "tabId",
+      );
+    }
+  });
+
+  it("rejects a malformed tab ID through command routing", async () => {
+    vi.mocked(browser.switchBrowserTab).mockClear();
+
+    const result = await service.executeCommand("browser_switch_tab", {
+      tabId: "1e1",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: INVALID_BROWSER_TAB_ID_MESSAGE,
+    });
+    expect(browser.switchBrowserTab).not.toHaveBeenCalled();
+    expect(service.getRecentActions().at(-1)).toMatchObject({
+      action: "browser_switch_tab",
+      params: { action: "switch_tab" },
+      success: false,
+    });
   });
 
   it.each(["file:///etc/passwd", "https://user:password@example.com/private"])(

--- a/plugins/plugin-computeruse/src/platform/browser.ts
+++ b/plugins/plugin-computeruse/src/platform/browser.ts
@@ -17,6 +17,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
 import { assertBrowserExecuteAllowed } from "../security/browser-script-policy.js";
+import { normalizeBrowserTabId } from "../security/browser-tab-id-policy.js";
 import { assertHttpBrowserUrl } from "../security/browser-url-policy.js";
 import type {
   BrowserInfo,
@@ -569,11 +570,12 @@ export async function openBrowserTab(url?: string): Promise<BrowserTab> {
 }
 
 export async function closeBrowserTab(tabId: string): Promise<void> {
+  const normalizedTabId = normalizeBrowserTabId(tabId);
   if (!browser) throw new Error("Browser not open.");
   const pages = await browser.pages();
-  const idx = Number.parseInt(tabId, 10);
+  const idx = Number(normalizedTabId);
   const page = pages[idx];
-  if (!page) throw new Error(`Tab ${tabId} not found.`);
+  if (!page) throw new Error(`Tab ${normalizedTabId} not found.`);
   if (page === activePage) {
     // Switch to another tab before closing
     activePage = pages.find((p) => p !== page) ?? null;
@@ -582,11 +584,12 @@ export async function closeBrowserTab(tabId: string): Promise<void> {
 }
 
 export async function switchBrowserTab(tabId: string): Promise<BrowserState> {
+  const normalizedTabId = normalizeBrowserTabId(tabId);
   if (!browser) throw new Error("Browser not open.");
   const pages = await browser.pages();
-  const idx = Number.parseInt(tabId, 10);
+  const idx = Number(normalizedTabId);
   const page = pages[idx];
-  if (!page) throw new Error(`Tab ${tabId} not found.`);
+  if (!page) throw new Error(`Tab ${normalizedTabId} not found.`);
   activePage = page;
   await page.bringToFront();
   return {

--- a/plugins/plugin-computeruse/src/security/browser-tab-id-policy.ts
+++ b/plugins/plugin-computeruse/src/security/browser-tab-id-policy.ts
@@ -1,0 +1,36 @@
+/**
+ * Canonical browser-tab identifier policy for Computer Use.
+ *
+ * The Puppeteer adapter publishes dense zero-based page indices as decimal
+ * strings. Close/switch are destructive enough that prefix parsing (for
+ * example, treating `1junk` as tab 1) must fail closed at every entry point.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+const CANONICAL_BROWSER_TAB_ID = /^(?:0|[1-9]\d*)$/u;
+
+export const INVALID_BROWSER_TAB_ID_MESSAGE =
+  "Computer-use browser tab ID must be a canonical non-negative safe integer.";
+
+export class InvalidBrowserTabIdError extends ElizaError {
+  override readonly name = "InvalidBrowserTabIdError";
+
+  constructor() {
+    super(INVALID_BROWSER_TAB_ID_MESSAGE, {
+      code: "COMPUTER_USE_BROWSER_TAB_ID_INVALID",
+    });
+  }
+}
+
+export function normalizeBrowserTabId(raw: unknown): string {
+  const candidate = typeof raw === "number" ? String(raw) : raw;
+  if (
+    typeof candidate !== "string" ||
+    !CANONICAL_BROWSER_TAB_ID.test(candidate) ||
+    !Number.isSafeInteger(Number(candidate))
+  ) {
+    throw new InvalidBrowserTabIdError();
+  }
+  return candidate;
+}

--- a/plugins/plugin-computeruse/src/security/browser-tab-id-policy.ts
+++ b/plugins/plugin-computeruse/src/security/browser-tab-id-policy.ts
@@ -24,6 +24,11 @@ export class InvalidBrowserTabIdError extends ElizaError {
 }
 
 export function normalizeBrowserTabId(raw: unknown): string {
+  // String(-0) is "0", so reject the noncanonical numeric spelling before
+  // converting numbers to the decimal representation used by the adapter.
+  if (typeof raw === "number" && Object.is(raw, -0)) {
+    throw new InvalidBrowserTabIdError();
+  }
   const candidate = typeof raw === "number" ? String(raw) : raw;
   if (
     typeof candidate !== "string" ||

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -1798,17 +1798,22 @@ export class ComputerUseService extends Service {
   private normalizeBrowserActionParams(
     params: BrowserActionParams,
   ): BrowserActionParams {
+    const action = this.normalizeBrowserAction(params.action);
     const tabIdCandidate = params.tabId ?? params.index ?? params.tab_index;
+    const validatesTabId = action === "close_tab" || action === "switch_tab";
+    let tabId: string | undefined;
+    if (tabIdCandidate !== undefined) {
+      tabId = validatesTabId
+        ? normalizeBrowserTabId(tabIdCandidate)
+        : String(tabIdCandidate);
+    }
     return {
       ...params,
       ...(params.url === undefined
         ? {}
         : { url: assertHttpBrowserUrl(params.url) }),
-      tabId:
-        tabIdCandidate !== undefined
-          ? normalizeBrowserTabId(tabIdCandidate)
-          : undefined,
-      action: this.normalizeBrowserAction(params.action),
+      tabId,
+      action,
     };
   }
 

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -124,6 +124,7 @@ import {
   type ScreenStateChange,
   ScreenStateStore,
 } from "../scene/screen-state.js";
+import { normalizeBrowserTabId } from "../security/browser-tab-id-policy.js";
 import { assertHttpBrowserUrl } from "../security/browser-url-policy.js";
 import { ComputerUseSessionManager } from "../sessions/session-manager.js";
 import type {
@@ -1063,8 +1064,8 @@ export class ComputerUseService extends Service {
     try {
       params = this.normalizeBrowserActionParams(rawParams);
     } catch (error) {
-      // error-policy:J1 action boundary — reject an invalid navigation target
-      // before its raw value reaches action history or the approval queue.
+      // error-policy:J1 action boundary — reject invalid browser targets before
+      // their raw values reach action history or the approval queue.
       const rejectedEntry = this.createEntry(`browser_${action}`, { action });
       return this.failEntry(rejectedEntry, {
         success: false,
@@ -1803,7 +1804,10 @@ export class ComputerUseService extends Service {
       ...(params.url === undefined
         ? {}
         : { url: assertHttpBrowserUrl(params.url) }),
-      tabId: tabIdCandidate !== undefined ? String(tabIdCandidate) : undefined,
+      tabId:
+        tabIdCandidate !== undefined
+          ? normalizeBrowserTabId(tabIdCandidate)
+          : undefined,
       action: this.normalizeBrowserAction(params.action),
     };
   }


### PR DESCRIPTION
# Relates to

Closes #24442

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets develop and is rebased onto the latest origin/develop
      with zero conflicts (git fetch origin && git rebase origin/develop).
- [x] A frozen filtered install plus exact focused and package checks were run
      after sync; hosted affected-closure verification is linked below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@5714a3d84f3a08f2390d39facb234ea5d84b83ac:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto origin/develop@cefa6f81d846bb320ed98592fae9a424718cacd7;
      zero conflicts.
- [x] Post-sync verification is recorded below, including exact unrelated local
      blockers.

# Risks

Low. Only close/switch reject noncanonical tab identifiers instead of prefix
parsing them into a different real tab. Non-tab browser actions retain their
prior behavior: stray tabId/index/tab_index fields do not block navigation,
click, type, screenshot, or other unrelated actions. Canonical decimal IDs and
numeric aliases are unchanged, valid out-of-range IDs retain the existing
"Tab <id> not found." behavior, and numeric -0 now fails consistently with the
string "-0". A caller relying on unsupported forms such as "01" or "1junk" for
close/switch will now receive a structured failure.

# Background

## What does this PR do?

- Adds one canonical non-negative safe-integer policy for browser tab IDs.
- Applies it only to close/switch at the service normalization boundary and
  again at the direct Puppeteer close/switch exports.
- Preserves existing permissiveness for stray tab aliases on unrelated actions.
- Rejects suffixes, fractions, exponents, signs, leading zeroes, hex spellings,
  negative/nonfinite numbers, and unsafe integers before adapter access.
- Keeps malformed raw IDs out of approval inputs and failed action history.
- Adds real service-routing and platform-boundary regression coverage.

## What kind of change is this?

Bug fix (non-breaking, fail-closed input validation).

# Documentation changes needed?

No documentation change is needed. Browser tab listings already publish
canonical zero-based decimal IDs; this change makes close/switch enforce that
existing representation.

# Testing

## Where should a reviewer start?

- plugins/plugin-computeruse/src/security/browser-tab-id-policy.ts
- plugins/plugin-computeruse/src/platform/browser.ts
- plugins/plugin-computeruse/src/services/computer-use-service.ts
- plugins/plugin-computeruse/src/__tests__/browser-tab-id-policy.test.ts
- plugins/plugin-computeruse/src/__tests__/service-browser-routing.test.ts

## Detailed testing steps

- `bun install --force --frozen-lockfile --ignore-scripts --omit peer
  --backend=copyfile --filter '@elizaos/plugin-computeruse'` — passed with the
  exact Windows optional binaries from the frozen lock.
- Focused policy/routing suites — 2 files, 43/43 tests passed on the exact head
  with Node 24.15.0 and Bun 1.3.14.
- Adversarial all-actions-validation plus numeric-`-0` coercion mutation —
  4 failed / 39 passed; restored exact head — 43/43 passed.
- Computer Use lint — 235 files checked, clean.
- Computer Use typecheck — passed.
- Computer Use production/declaration build — passed; Vite views build passed
  via `bun x --bun vite build --config vite.config.views.ts`.
- Changed-file Biome 2.5.8 check — all five PR files clean.
- `git diff --check origin/develop..HEAD` — passed.
- Final rebase range-diff — both PR commits patch-equivalent; zero conflicts.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:1bd3df9314bfd5e68b693384991739776b1c628e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface is changed by this browser input-policy fix.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface is changed by this browser input-policy fix.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no visual user flow or rendered surface to record.
<!-- evidence-row:backend-logs -->
- [x] Exact-head service and production platform-boundary output is included
      below.

  <details>
  <summary>Malformed tab-ID boundary output</summary>

      closeBrowserTab("1junk") -> InvalidBrowserTabIdError
        code=COMPUTER_USE_BROWSER_TAB_ID_INVALID
      switchBrowserTab("1junk") -> InvalidBrowserTabIdError
        code=COMPUTER_USE_BROWSER_TAB_ID_INVALID
      executeBrowserAction({ action: "close_tab", index: -1 })
        -> { success: false, error: "Computer-use browser tab ID must be a canonical non-negative safe integer." }
        adapter calls=0; stored params={ action: "close_tab" }
      executeBrowserAction({ action: "navigate", tabId/index/tab_index: malformed })
        -> success=true for all three aliases; navigate adapter called once each
      executeCommand("browser_switch_tab", { tabId: "1e1" })
        -> same structured failure; adapter calls=0

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or state path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider, model, planning, or action-selection behavior
      changes; this validates an already-selected browser target.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head policy matrix and mutation artifact are included below.

  <details>
  <summary>Policy matrix and mutation result</summary>

      accepted: "0" -> "0"; 1 -> "1"
      rejected with COMPUTER_USE_BROWSER_TAB_ID_INVALID:
        "1junk", "1.5", "1e1", "01", numeric -0, 9007199254740992
      unrelated navigate with malformed tabId/index/tab_index: dispatched
      direct close/switch boundary: both rejected before browser access
      mutation all-actions validation + numeric -0 coercion: 4 failed / 39 passed
      restored exact head: 43 passed / 43

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or UI surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM, prompt, provider, planner, or action-selection behavior changes.

## Backend + frontend logs

The exact-head direct production-boundary and service-routing results are
embedded in the backend evidence row. Frontend logs are inapplicable because no
frontend path changes.

## Screenshots (before / after) + video walkthrough

N/A - browser target validation only; no rendered UI.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

- The entire Computer Use package suite and root `bun run verify` were not
  rerun on this exact head. The maintainer-requested focused suites, package
  typecheck/build/lint, and failure-sensitive mutation proof passed locally;
  refreshed affected-closure CI is running at
  https://github.com/elizaOS/eliza/actions/runs/32598267825.
- The standalone pinned Bun zip contains `bun.exe` but no `bunx.exe` alias, so
  the production/declaration build and the equivalent views command were run
  separately. Both passed; hosted CI exercises the repository's normal Bun
  command environment.
- No Chromium session was launched. Malformed IDs are rejected before browser
  access, which is exercised directly at both production exports; the service
  routing test mocks only the CDP adapter while running normalization, history,
  command routing, and error projection for real.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: N/A - no exception requested
- Validated origin/develop SHA: N/A - no exception requested
- Live ruleset readback and named bypass eligibility:
  N/A - no exception requested
- Queued or failing checks and run URLs: N/A - no exception requested
- Infrastructure-only or unrelated-failure proof: N/A - no exception requested
- Exact-head commands, exit status, and artifacts: N/A - no exception requested
- Exact-head security, secret-scan, and provenance results:
  N/A - no exception requested
- Conflict-free and affected-path failure attestation:
  N/A - no exception requested
- Independent approving reviewer: N/A - no exception requested
- Bypass authorizer: N/A - no exception requested
- Merge method: N/A - no exception requested
- Rollback owner: N/A - no exception requested
- Post-merge develop validation: N/A - no exception requested

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5714a3d84f3a08f2390d39facb234ea5d84b83ac:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [implementation-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5714a3d84f3a08f2390d39facb234ea5d84b83ac:packages/skills/skills/contribute-to-eliza"} -->