### PR TITLE
fix(agent): re-arm memory watchdog after restart failures

### DIFF
--- a/packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
+++ b/packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
@@ -2,8 +2,9 @@
  * Unit coverage for the memory watchdog: env enable-flag parsing, config
  * defaults/floors, and the tick/start/stop state machine that requests a clean
  * restart after sustained over-threshold RSS (debounced on transient dips,
- * one-shot, never process.exit). Deterministic — RSS is read from a mutable
- * holder, timers are faked, and restart/log are spies.
+ * single-flight with failure recovery, one-shot after success, never
+ * process.exit). Deterministic — RSS is read from a mutable holder, timers are
+ * faked, and restart/log are spies.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -15,6 +16,25 @@ import {
 } from "../memory-watchdog.ts";
 
 const MB = 1024 * 1024;
+
+function deferredRestart(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 /** Build watchdog deps whose RSS is read from a mutable holder, with spy log/restart. */
 function makeDeps(rssMbHolder: { value: number }): {
@@ -160,6 +180,128 @@ describe("createMemoryWatchdog.tick", () => {
     expect(wd.tick()).toBe(true);
     for (let i = 0; i < 5; i += 1) expect(wd.tick()).toBe(false);
     expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms immediately when the restart handler throws synchronously", () => {
+    const rss = { value: 2000 };
+    const { deps, restart, warn } = makeDeps(rss);
+    const failure = new Error("restart bootstrap failed");
+    restart
+      .mockImplementationOnce(() => {
+        throw failure;
+      })
+      .mockImplementationOnce(() => undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    expect(wd.tick()).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: failure }),
+      expect.stringMatching(/\[MemoryWatchdog].*failed.*re-armed/i),
+    );
+  });
+
+  it("stays latched until an asynchronous restart rejection is observed", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart, warn } = makeDeps(rss);
+    const pending = deferredRestart();
+    const failure = new Error("restart rejected");
+    restart
+      .mockReturnValueOnce(pending.promise)
+      .mockImplementationOnce(() => undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    expect(wd.tick()).toBe(false);
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    pending.reject(failure);
+    await flushMicrotasks();
+
+    expect(wd.tick()).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: failure }),
+      expect.stringMatching(/\[MemoryWatchdog].*failed.*re-armed/i),
+    );
+  });
+
+  it("retries after rejection without rebuilding the sustained window", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    const pending = deferredRestart();
+    restart
+      .mockReturnValueOnce(pending.promise)
+      .mockImplementationOnce(() => undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 3 }), deps);
+
+    expect(wd.tick()).toBe(false);
+    expect(wd.tick()).toBe(false);
+    expect(wd.tick()).toBe(true);
+
+    pending.reject(new Error("restart rejected"));
+    await flushMicrotasks();
+
+    expect(wd.tick()).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps at most one restart request in flight", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    const pending = deferredRestart();
+    restart.mockReturnValue(pending.promise);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    for (let index = 0; index < 5; index += 1) {
+      expect(wd.tick()).toBe(false);
+    }
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    pending.resolve();
+    await flushMicrotasks();
+    expect(wd.tick()).toBe(false);
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("remains one-shot after an asynchronous restart request fulfills", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    restart.mockResolvedValue(undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    await flushMicrotasks();
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(wd.tick()).toBe(false);
+    }
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("consumes rejected restart promises without leaking unhandledRejection", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    const pending = deferredRestart();
+    restart.mockReturnValue(pending.promise);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      expect(wd.tick()).toBe(true);
+      pending.reject(new Error("restart rejected"));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 });
 

--- a/packages/agent/src/runtime/memory-watchdog.ts
+++ b/packages/agent/src/runtime/memory-watchdog.ts
@@ -128,9 +128,17 @@ export function createMemoryWatchdog(
   let triggered = false;
   let timer: ReturnType<typeof setInterval> | null = null;
 
+  const rearmAfterRestartFailure = (error: unknown, reason: string): void => {
+    triggered = false;
+    deps.log.warn(
+      { error, reason },
+      "[MemoryWatchdog] clean restart request failed; watchdog re-armed",
+    );
+  };
+
   const tick = (): boolean => {
-    // One-shot: once a restart is requested, stop sampling/acting. The supervisor
-    // owns what happens next; re-requesting would spam the handler.
+    // A pending or successful restart request is one-shot. Failure re-arms this
+    // latch so an unsafe process can try the supervisor again on a later tick.
     if (triggered) return false;
 
     const rss = deps.readRssBytes();
@@ -150,7 +158,19 @@ export function createMemoryWatchdog(
     deps.log.warn(
       `[MemoryWatchdog] ${reason} — requesting clean restart via supervisor`,
     );
-    void deps.requestRestart(reason);
+    try {
+      void Promise.resolve(deps.requestRestart(reason)).catch(
+        (error: unknown) => {
+          // error-policy:J7 the rejected restart request is observed here so the
+          // watchdog can keep protecting a process that remains over threshold.
+          rearmAfterRestartFailure(error, reason);
+        },
+      );
+    } catch (error) {
+      // error-policy:J7 a synchronous handler failure must not kill the watchdog
+      // timer or permanently suppress later clean-restart attempts.
+      rearmAfterRestartFailure(error, reason);
+    }
     return true;
   };
 


### PR DESCRIPTION
# Relates to

Fixes #24450.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated baseline blockers are recorded below.
- [x] A reviewer can confirm the changed behavior from the exact-head test and mutation transcripts below.

# Sync with develop

- [x] Based on current `origin/develop` (`a40cc65d3f161b307d6ba70fe6d89f1130b785eb`); zero conflicts.
- [x] `bun run verify` was run at the exact PR head; its unrelated `packages/ui` lint blocker is documented under **Known gaps / failures**.

# Risks

Low. The watchdog now retries only when the restart callback throws or rejects. While RSS remains above the threshold, a persistently failing restart callback can therefore be retried once per watchdog interval and emit one warning per failed attempt; this is deliberate so a transient restart-bootstrap failure cannot permanently disable recovery. Pending and fulfilled restart requests remain single-flight and one-shot.

# Background

## What does this PR do?

The memory watchdog previously latched its one-shot `triggered` flag before requesting a clean restart. If that callback threw synchronously or returned a rejected promise, the latch never cleared, so a live process under sustained memory pressure would never try again.

This change observes both failure modes, emits a structured warning, and re-arms the watchdog without discarding the already-satisfied sustained-memory window. It still latches before invocation to prevent re-entrant or concurrent requests, and a successful request remains one-shot.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects internal failure handling without changing configuration or public APIs.

# Testing

## Where should a reviewer start?

- `packages/agent/src/runtime/memory-watchdog.ts`
- `packages/agent/src/runtime/__tests__/memory-watchdog.test.ts`

## Detailed testing steps

Using Node `24.15.0`, Bun `1.3.14`, and exact head `b6e54c22d7e5bfdff4ad170dd9c0023d9439d6a4`:

```bash
ELIZA_SKIP_LOCAL_UPSTREAMS=1 bun x vitest run \
  --config packages/agent/vitest.config.ts \
  packages/agent/src/runtime/__tests__/memory-watchdog.test.ts \
  --coverage.enabled=false

bun x biome check \
  packages/agent/src/runtime/memory-watchdog.ts \
  packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
```

The focused suite covers synchronous throws, asynchronous rejections, immediate retry with the sustained count preserved, pending single-flight behavior, fulfilled one-shot behavior, structured warnings, and suppression of leaked `unhandledRejection` events.

# Evidence Gate

Evidence matches the exact commit reviewed. This marker is refreshed from the live PR head by `scripts/pr-evidence.mjs rows` after the push.
<!-- evidence-head:b6e54c22d7e5bfdff4ad170dd9c0023d9439d6a4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only watchdog state-machine change with no rendered UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only watchdog state-machine change with no rendered UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic backend failure-handling change has no interactive user flow

<!-- evidence-row:backend-logs -->
- [x] Exact-head watchdog execution transcript:
  <details><summary>Focused test and mutation proof</summary>

  ```text
  HEAD b6e54c22d7e5bfdff4ad170dd9c0023d9439d6a4
  Node v24.15.0; Bun 1.3.14; Vitest 4.1.10
  RUN packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
  Test Files  1 passed (1)
  Tests       18 passed (18)
  Duration    7.29s
  Mutation proof: temporarily restored the unguarded requestRestart call.
  Targeted synchronous-throw regression then failed with "restart bootstrap failed" (exit 1).
  The guarded implementation was restored; the exact-head suite returned to 18/18 passing.
  Biome: Checked 2 files. No fixes applied.
  Agent dependency graph build: 54/54 tasks successful.
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, response, or browser state changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no action, provider, prompt, model, or LLM behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - watchdog control-flow fix produces no database, memory, wallet, file, or audio artifact

<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only TypeScript change has no rendered visual text

# Evidence Details

## Real LLM-call trajectory

N/A - no action, provider, prompt, model, or LLM behavior changes.

## Backend + frontend logs

The exact-head backend execution transcript is inline in the evidence row above. Frontend logs are N/A because no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - this change has no rendered or interactive surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- `bun install --frozen-lockfile --ignore-scripts --backend=copyfile`: passed (6,865 packages).
- Agent dependency graph build (`bun run build:server -- --env-mode=loose`): passed, 54/54 tasks.
- Focused watchdog suite: passed, 18/18 tests.
- Targeted Biome check and `git diff --check`: passed.
- `packages/agent` lint: passed; it printed only pre-existing warnings in unrelated wallet, character-history, and owner-name test files.
- `packages/agent` typecheck reached only current-`develop` errors outside this diff: `src/api/server.ts` signal literal typing, E2B `opencode` runner tests, and cloud shared users resolving `@elizaos/plugin-todos/edge`.
- The complete isolated agent test lane executed 514/514 batches. The watchdog batch passed; 34 unrelated current-`develop` batches failed in existing areas including `opencode`, `@elizaos/core/testing` resolution, Windows symlink/permission behavior, public-route expectations, attachment disclosure expectations, and Windows transcript/temp paths.
- Exact-head `bun run verify` passed repository contracts through the affected-path audits, then stopped in unchanged `@elizaos/ui#lint:check` files (including `packages/ui/src/cloud-ui/index.css` and `login-page.same-origin.test.tsx`) due existing formatting/CRLF drift. No changed file appeared in the failure.
- Independent review found no correctness, race, error-policy, logger-typing, test-coverage, or scope issues.

These baseline failures are outside the two-file watchdog diff and do not affect the focused exact-head proof.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza"} -->

