### PR TITLE
fix(desktop): restore shortcut after rejected replacement

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -709,6 +709,61 @@ describe("DesktopManager main window controls", () => {
     );
   });
 
+  it("restores the prior global shortcut when its replacement is rejected", async () => {
+    const manager = new DesktopManager();
+    const sendToWebview = vi.fn();
+    manager.setSendToWebview(sendToWebview);
+    electrobunMock.GlobalShortcut.register
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    await manager.registerShortcut({
+      id: "chat-overlay",
+      accelerator: "CommandOrControl+Shift+C",
+    });
+    await expect(
+      manager.registerShortcut({
+        id: "chat-overlay",
+        accelerator: "CommandOrControl+J",
+      }),
+    ).resolves.toEqual({ success: false });
+
+    expect(manager.pressRegisteredShortcut({ id: "chat-overlay" })).toBe(true);
+    expect(sendToWebview).toHaveBeenCalledWith("desktopShortcutPressed", {
+      id: "chat-overlay",
+      accelerator: "CommandOrControl+Shift+C",
+    });
+    await manager.unregisterShortcut({ id: "chat-overlay" });
+    expect(electrobunMock.GlobalShortcut.unregister).toHaveBeenLastCalledWith(
+      "CommandOrControl+Shift+C",
+    );
+  });
+
+  it("removes stale shortcut ownership when replacement and rollback both fail", async () => {
+    const manager = new DesktopManager();
+    electrobunMock.GlobalShortcut.register
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false);
+
+    await manager.registerShortcut({
+      id: "chat-overlay",
+      accelerator: "CommandOrControl+Shift+C",
+    });
+    await expect(
+      manager.registerShortcut({
+        id: "chat-overlay",
+        accelerator: "CommandOrControl+J",
+      }),
+    ).resolves.toEqual({ success: false });
+
+    expect(manager.pressRegisteredShortcut({ id: "chat-overlay" })).toBe(false);
+    electrobunMock.GlobalShortcut.unregister.mockClear();
+    await manager.unregisterShortcut({ id: "chat-overlay" });
+    expect(electrobunMock.GlobalShortcut.unregister).not.toHaveBeenCalled();
+  });
+
   it("presses a registered shortcut through the test seam", async () => {
     const manager = new DesktopManager();
     const sendToWebview = vi.fn();

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -941,27 +941,48 @@ export class DesktopManager {
   async registerShortcut(
     options: ShortcutOptions,
   ): Promise<{ success: boolean }> {
-    // Unregister existing shortcut with same id
-    if (this.shortcuts.has(options.id)) {
-      const existing = this.shortcuts.get(options.id);
-      if (existing) {
-        GlobalShortcut.unregister(existing.accelerator);
-      }
+    const existing = this.shortcuts.get(options.id);
+    if (existing?.accelerator === options.accelerator) {
+      return { success: true };
     }
 
-    try {
-      const registered = GlobalShortcut.register(options.accelerator, () => {
+    if (existing) GlobalShortcut.unregister(existing.accelerator);
+
+    const register = (shortcut: ShortcutOptions): boolean =>
+      GlobalShortcut.register(shortcut.accelerator, () => {
         this.send("desktopShortcutPressed", {
-          id: options.id,
-          accelerator: options.accelerator,
+          id: shortcut.id,
+          accelerator: shortcut.accelerator,
         });
-      });
-      if (registered === false) {
-        return { success: false };
-      }
+      }) !== false;
+
+    try {
+      if (!register(options))
+        throw new Error("The operating system rejected the shortcut");
       this.shortcuts.set(options.id, options);
       return { success: true };
-    } catch {
+    } catch (replacementError) {
+      if (!existing) return { success: false };
+
+      try {
+        if (!register(existing)) {
+          throw new Error("The operating system rejected shortcut rollback");
+        }
+        this.shortcuts.set(existing.id, existing);
+      } catch (rollbackError) {
+        // error-policy:J1 Native shortcut registration is the boundary; a failed
+        // rollback is reported and stale in-memory ownership is removed.
+        this.shortcuts.delete(existing.id);
+        logger.error(
+          `[Desktop] Failed to replace shortcut ${options.id} and restore ${existing.accelerator}: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+          {
+            replacementError:
+              replacementError instanceof Error
+                ? replacementError.message
+                : String(replacementError),
+          },
+        );
+      }
       return { success: false };
     }
   }


### PR DESCRIPTION
## Summary
- make unchanged shortcut registration idempotent
- roll back to the previous accelerator when macOS rejects a replacement
- clear stale shortcut ownership if both replacement and rollback fail

## Testing
- `node ../../../scripts/run-vitest.mjs run --config vitest.electrobun.config.ts src/native/desktop-window.test.ts` (33 passed)
- `bunx @biomejs/biome check src/native/desktop.ts src/native/desktop-window.test.ts`
- `git diff --check`

## Evidence
- Screenshots: N/A - native shortcut transaction has no changed rendered UI
- Video: N/A - deterministic native bridge tests cover replacement and rollback
- Backend logs: N/A - no backend path changed
- Frontend console/network logs: N/A - no renderer network path changed