### PR TITLE
fix(desktop): load packaged native keyring fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -344,7 +344,7 @@
         "@elizaos/skills": "workspace:*",
         "@elizaos/ui": "workspace:*",
         "@elizaos/vault": "workspace:*",
-        "@napi-rs/keyring": "^1.1.6",
+        "@napi-rs/keyring": "^1.3.0",
         "@node-rs/argon2": "^2.0.2",
         "@upstash/redis": "^1.37.0",
         "adm-zip": "^0.6.0",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -294,7 +294,7 @@
     "@elizaos/ui": "workspace:*",
     "@elizaos/vault": "workspace:*",
     "@node-rs/argon2": "^2.0.2",
-    "@napi-rs/keyring": "^1.1.6",
+    "@napi-rs/keyring": "^1.3.0",
     "@upstash/redis": "^1.37.0",
     "adm-zip": "^0.6.0",
     "chalk": "^6.0.0",

--- a/packages/app-core/src/security/platform-secure-store-node.test.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.test.ts
@@ -1,6 +1,9 @@
 /** Verifies desktop secure-store adapters and renderer boundary hardening. */
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveBundledKeyringPath } from "./platform-secure-store-node";
 
 const source = readFileSync(
   new URL("./platform-secure-store-node.ts", import.meta.url),
@@ -30,6 +33,49 @@ const subscriptionCredentialSource = readFileSync(
 );
 
 describe("desktop platform secure-store boundary", () => {
+  it("resolves one Bun-emitted native Keychain addon beside the entrypoint", () => {
+    const runtimeDir = mkdtempSync(path.join(os.tmpdir(), "eliza-keyring-"));
+    try {
+      const entrypoint = path.join(runtimeDir, "index.js");
+      const bindingPath = path.join(
+        runtimeDir,
+        "keyring.darwin-arm64-buildhash.node",
+      );
+      writeFileSync(entrypoint, "entrypoint");
+      writeFileSync(bindingPath, "binding");
+
+      expect(
+        resolveBundledKeyringPath({
+          arch: "arm64",
+          entrypoint,
+          platform: "darwin",
+        }),
+      ).toBe(bindingPath);
+    } finally {
+      rmSync(runtimeDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects ambiguous bundled native Keychain addons", () => {
+    const runtimeDir = mkdtempSync(path.join(os.tmpdir(), "eliza-keyring-"));
+    try {
+      const entrypoint = path.join(runtimeDir, "index.js");
+      writeFileSync(entrypoint, "entrypoint");
+      writeFileSync(path.join(runtimeDir, "keyring.darwin-arm64-a.node"), "a");
+      writeFileSync(path.join(runtimeDir, "keyring.darwin-arm64-b.node"), "b");
+
+      expect(
+        resolveBundledKeyringPath({
+          arch: "arm64",
+          entrypoint,
+          platform: "darwin",
+        }),
+      ).toBeNull();
+    } finally {
+      rmSync(runtimeDir, { force: true, recursive: true });
+    }
+  });
+
   it("uses the cross-platform native keyring binding and never launches the security CLI", () => {
     expect(source).toContain('import("@napi-rs/keyring")');
     expect(source).not.toContain('spawn("security"');

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -173,10 +173,93 @@ function nativeStoreReason(error: unknown): SecureStoreFailure {
   };
 }
 
-let nativeKeyringModule: Promise<typeof import("@napi-rs/keyring")> | undefined;
+interface NativeKeyringEntry {
+  deleteCredential(): Promise<void>;
+  getPassword(): Promise<string | null>;
+  setPassword(value: string): Promise<void>;
+}
 
-function loadNativeKeyring(): Promise<typeof import("@napi-rs/keyring")> {
-  nativeKeyringModule ??= import("@napi-rs/keyring");
+type NativeKeyringEntryConstructor = new (
+  service: string,
+  account: string,
+) => NativeKeyringEntry;
+
+interface NativeKeyringModule {
+  AsyncEntry: NativeKeyringEntryConstructor;
+}
+
+function isNativeKeyringModule(value: unknown): value is NativeKeyringModule {
+  if (typeof value !== "object" || value === null) return false;
+  return "AsyncEntry" in value && typeof value.AsyncEntry === "function";
+}
+
+export function resolveBundledKeyringPath(options: {
+  arch: string;
+  entrypoint: string | undefined;
+  platform: string;
+}): string | null {
+  if (!options.entrypoint) return null;
+  const runtimeDir = path.dirname(options.entrypoint);
+  const prefix = `keyring.${options.platform}-${options.arch}`;
+  try {
+    const matches = fs
+      .readdirSync(runtimeDir)
+      .filter(
+        (fileName) =>
+          fileName.startsWith(prefix) && path.extname(fileName) === ".node",
+      )
+      .sort();
+    if (matches.length !== 1) return null;
+    return path.join(runtimeDir, matches[0]);
+  } catch {
+    // error-policy:J3 the packaged runtime directory may not exist.
+    return null;
+  }
+}
+
+function loadBundledNativeKeyring(): NativeKeyringModule {
+  const bindingPath = resolveBundledKeyringPath({
+    arch: process.arch,
+    entrypoint: process.argv[1],
+    platform: process.platform,
+  });
+  if (!bindingPath) {
+    throw new Error("Bundled native Keychain binding was not found.");
+  }
+
+  const nativeModule: { exports: unknown } = { exports: {} };
+  process.dlopen(nativeModule, bindingPath);
+  if (!isNativeKeyringModule(nativeModule.exports)) {
+    throw new Error("Bundled native Keychain binding has invalid exports.");
+  }
+  return nativeModule.exports;
+}
+
+let nativeKeyringModule: Promise<NativeKeyringModule> | undefined;
+
+async function importNativeKeyring(): Promise<NativeKeyringModule> {
+  try {
+    const imported: unknown = await import("@napi-rs/keyring");
+    if (!isNativeKeyringModule(imported)) {
+      throw new Error("Native Keychain package has invalid exports.");
+    }
+    return imported;
+  } catch (importError) {
+    // error-policy:J2 Bun 1.3.13 can emit a native addon while its generated
+    // import.meta.require cannot load it. Load the validated packaged addon.
+    try {
+      return loadBundledNativeKeyring();
+    } catch (bundledError) {
+      throw new AggregateError(
+        [importError, bundledError],
+        "Native Keychain binding is unavailable.",
+      );
+    }
+  }
+}
+
+function loadNativeKeyring(): Promise<NativeKeyringModule> {
+  nativeKeyringModule ??= importNativeKeyring();
   return nativeKeyringModule;
 }
 


### PR DESCRIPTION
# Relates to

Requested split from the cloud settings branch. This PR contains only the packaged desktop keyring fallback.

- [x] Targets `develop` and is rebased onto `origin/develop` at `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`.
- [x] `bun install` and `bun run verify` were run after sync. The unrelated verify failure is recorded below.
- [x] The focused resolver tests demonstrate the changed contract.

# Risks

Low. The fallback runs only when the normal `@napi-rs/keyring` import fails. It accepts exactly one platform and architecture matched `.node` binding beside the packaged entrypoint and validates its exports before use.

# Background

## What does this PR do?

Packaged Bun desktop builds can emit the native keyring addon beside the entrypoint while the generated module loader fails to import it. This change locates that emitted addon, rejects missing or ambiguous matches, loads it through `process.dlopen`, validates the `AsyncEntry` export, and preserves both import failures in an `AggregateError`.

It also updates app-core's direct `@napi-rs/keyring` range to `^1.3.0`. No settings UI or NuPhy dependency is included.

## What kind of change is this?

Bug fix and dependency update.

# Documentation changes needed?

N/A - this changes an internal packaged-runtime fallback without changing a public API or user workflow.

# Testing

## Where should a reviewer start?

`packages/app-core/src/security/platform-secure-store-node.ts` and its focused test.

## Detailed testing steps

```bash
node packages/shared/scripts/generate-keywords.mjs
node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/src/security/platform-secure-store-node.test.ts
bunx @biomejs/biome check packages/app-core/src/security/platform-secure-store-node.ts packages/app-core/src/security/platform-secure-store-node.test.ts
```

Observed: 1 test file passed, 11 tests passed. Biome checked both files with no fixes.

# Evidence Gate

<!-- evidence-head:7a4cdbb39d7d2a0a20a6e50845b89050c54c76d2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - this PR changes packaged native module loading and does not add a backend request path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network request changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled task, wallet, generated file, audio, or other domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - no backend transport or frontend request path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- `bun run --cwd packages/app-core typecheck` is blocked in this clean worktree by unresolved optional/private workspace packages such as `@elizaos/plugin-app-control`, `@elizaos/plugin-scheduling`, and Capacitor packages. The errors do not reference either changed TypeScript file.
- `bun run verify` reached the workspace lint/typecheck stage and failed on pre-existing formatting errors in `packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx` and `packages/ui/src/components/chat/widgets/maps-card.tsx`. This PR does not touch `packages/ui`.
- A signed packaged macOS app was not rebuilt for this split. The deterministic tests cover selection and ambiguity rejection; hosted CI can exercise the complete packaging lane.

## Maintainer CI exception record

N/A - no exception requested.
