### PR TITLE
fix(core): confine findEntityByName to room and relationship candidates

### DIFF
--- a/packages/core/src/entities.find-entity-by-name.test.ts
+++ b/packages/core/src/entities.find-entity-by-name.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Behavioral tests for `findEntityByName` candidate confinement. Drives the
+ * production resolver through its real runtime seams (`getEntitiesForRoom`,
+ * `getRelationships`, `getEntityById`, `useModel`). Deterministic TEXT_SMALL
+ * results — no live model.
+ */
+import { describe, expect, it } from "vitest";
+import { findEntityByName } from "./entities";
+import { createMockRuntime } from "./testing/mock-runtime";
+import type {
+	Component,
+	Entity,
+	IAgentRuntime,
+	Memory,
+	Relationship,
+	State,
+	UUID,
+} from "./types";
+
+const AGENT = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const SENDER = "00000000-0000-0000-0000-0000000000s1" as UUID;
+const ALICE = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const BOB = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const STRANGER = "00000000-0000-0000-0000-0000000000ff" as UUID;
+const ROOM = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const GUEST_SOURCE = "00000000-0000-0000-0000-0000000000g1" as UUID;
+
+function entity(
+	id: UUID,
+	names: string[],
+	components: Component[] = [],
+): Entity {
+	return {
+		id,
+		agentId: AGENT,
+		names,
+		components,
+		metadata: {},
+	};
+}
+
+function component(
+	entityId: UUID,
+	sourceEntityId: UUID,
+	data: Record<string, string>,
+): Component {
+	return {
+		id: `${entityId}-comp` as UUID,
+		entityId,
+		agentId: AGENT,
+		roomId: ROOM,
+		worldId: "00000000-0000-0000-0000-0000000000w1" as UUID,
+		sourceEntityId,
+		type: "discord",
+		createdAt: 1,
+		data,
+	};
+}
+
+function message(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000m1" as UUID,
+		roomId: ROOM,
+		entityId: SENDER,
+		agentId: AGENT,
+		content: { text: "tell them hi" },
+		createdAt: 1,
+	} as Memory;
+}
+
+function state(): State {
+	return {
+		values: {},
+		data: { room: { id: ROOM, name: "room", worldId: null } },
+		text: "",
+	};
+}
+
+function runtimeWith(options: {
+	roomEntities: Entity[];
+	byId?: Record<string, Entity>;
+	relationships?: Relationship[];
+	modelResult: unknown;
+}): IAgentRuntime {
+	const byId = { ...(options.byId ?? {}) };
+	for (const roomEntity of options.roomEntities) {
+		if (roomEntity.id && byId[roomEntity.id] === undefined) {
+			byId[roomEntity.id] = roomEntity;
+		}
+	}
+	return createMockRuntime({
+		agentId: AGENT,
+		getEntitiesForRoom: (async () =>
+			options.roomEntities) as IAgentRuntime["getEntitiesForRoom"],
+		getEntityById: (async (id: UUID) =>
+			byId[id] ?? null) as IAgentRuntime["getEntityById"],
+		getRelationships: (async () =>
+			options.relationships ?? []) as IAgentRuntime["getRelationships"],
+		getMemories: (async () => []) as IAgentRuntime["getMemories"],
+		useModel: (async () => options.modelResult) as IAgentRuntime["useModel"],
+	});
+}
+
+describe("findEntityByName candidate confinement", () => {
+	it("does not return an EXACT_MATCH entity outside the room and relationship set", async () => {
+		const stranger = entity(STRANGER, ["Stranger"]);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [entity(ALICE, ["Alice"]), entity(BOB, ["Bob"])],
+				byId: { [STRANGER]: stranger },
+				modelResult: {
+					type: "EXACT_MATCH",
+					entityId: STRANGER,
+					matches: [],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved?.id).not.toBe(STRANGER);
+		expect(resolved).toBeNull();
+	});
+
+	it("still returns an EXACT_MATCH that is a room participant", async () => {
+		const alice = entity(ALICE, ["Alice"]);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [alice, entity(BOB, ["Bob"])],
+				modelResult: {
+					type: "EXACT_MATCH",
+					entityId: ALICE,
+					matches: [{ name: "Alice", reason: "id in room list" }],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved?.id).toBe(ALICE);
+	});
+
+	it("still returns an EXACT_MATCH that is relationship-backed but not in the room", async () => {
+		const friend = entity(STRANGER, ["Friend"]);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [entity(ALICE, ["Alice"]), entity(BOB, ["Bob"])],
+				byId: { [STRANGER]: friend },
+				relationships: [
+					{
+						id: "00000000-0000-0000-0000-0000000000r1" as UUID,
+						sourceEntityId: SENDER,
+						targetEntityId: STRANGER,
+						agentId: AGENT,
+						tags: ["knows"],
+						createdAt: 1,
+					} as Relationship,
+				],
+				modelResult: {
+					type: "EXACT_MATCH",
+					entityId: STRANGER,
+					matches: [],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved?.id).toBe(STRANGER);
+	});
+
+	it("does not treat a guest handle on a relationship copy as a match after room trust filtering", async () => {
+		const leaked = component(ALICE, GUEST_SOURCE, { handle: "secret-handle" });
+		const roomAlice = entity(ALICE, ["Alice"], [leaked]);
+		const relationshipAlice = entity(ALICE, ["Alice"], [leaked]);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [roomAlice, entity(BOB, ["Bob"])],
+				byId: { [ALICE]: relationshipAlice },
+				relationships: [
+					{
+						id: "00000000-0000-0000-0000-0000000000r2" as UUID,
+						sourceEntityId: SENDER,
+						targetEntityId: ALICE,
+						agentId: AGENT,
+						tags: ["knows"],
+						createdAt: 1,
+					} as Relationship,
+				],
+				modelResult: {
+					type: "NAME_MATCH",
+					entityId: null,
+					matches: [{ name: "secret-handle", reason: "handle in message" }],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved).toBeNull();
+	});
+
+	it("does not resolve type UNKNOWN to a room member whose handle is a substring of the model JSON", async () => {
+		const casey = entity(
+			ALICE,
+			["Casey"],
+			[component(ALICE, AGENT, { username: "unknown" })],
+		);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [casey, entity(BOB, ["Drew"])],
+				modelResult: { type: "UNKNOWN", entityId: null, matches: [] },
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved).toBeNull();
+	});
+
+	it("still matches an honest username on a trusted (agent-authored) component", async () => {
+		const alice = entity(
+			ALICE,
+			["Alice"],
+			[component(ALICE, AGENT, { username: "alice" })],
+		);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [alice, entity(BOB, ["Bob"])],
+				modelResult: {
+					type: "USERNAME_MATCH",
+					entityId: null,
+					matches: [{ name: "@alice", reason: "mentioned handle" }],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved?.id).toBe(ALICE);
+	});
+
+	it("still returns the sole room candidate when model JSON is unparseable", async () => {
+		const alice = entity(ALICE, ["Alice"]);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [alice],
+				modelResult: "not-json",
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved?.id).toBe(ALICE);
+	});
+
+	it("does not mutate components on the adapter-returned room entity", async () => {
+		const leaked = component(ALICE, GUEST_SOURCE, { handle: "secret-handle" });
+		const roomAlice = entity(ALICE, ["Alice"], [leaked]);
+		await findEntityByName(
+			runtimeWith({
+				roomEntities: [roomAlice, entity(BOB, ["Bob"])],
+				modelResult: {
+					type: "NAME_MATCH",
+					entityId: null,
+					matches: [{ name: "Alice", reason: "name in room" }],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(roomAlice.components).toEqual([leaked]);
+	});
+
+	it("still resolves an exact handle that appears only in the match reason", async () => {
+		const alice = entity(
+			ALICE,
+			["Alice"],
+			[component(ALICE, AGENT, { handle: "alice" })],
+		);
+		const resolved = await findEntityByName(
+			runtimeWith({
+				roomEntities: [alice, entity(BOB, ["Bob"])],
+				modelResult: {
+					type: "USERNAME_MATCH",
+					entityId: null,
+					matches: [{ name: "the user", reason: "alice" }],
+				},
+			}),
+			message(),
+			state(),
+		);
+
+		expect(resolved?.id).toBe(ALICE);
+	});
+
+	it("returns byte-identical ids for a corpus of previously valid room EXACT_MATCH values", async () => {
+		const roomEntities = Array.from({ length: 24 }, (_, index) =>
+			entity(
+				`00000000-0000-0000-0000-${String(index + 1).padStart(12, "0")}` as UUID,
+				[`Person-${index + 1}`],
+			),
+		);
+		const ids: Array<string | null> = [];
+		for (const candidate of roomEntities) {
+			const resolved = await findEntityByName(
+				runtimeWith({
+					roomEntities,
+					modelResult: {
+						type: "EXACT_MATCH",
+						entityId: candidate.id,
+						matches: [{ name: candidate.names[0], reason: "room member" }],
+					},
+				}),
+				message(),
+				state(),
+			);
+			ids.push(resolved?.id ?? null);
+		}
+
+		expect(ids).toEqual(roomEntities.map((candidate) => candidate.id));
+	});
+});

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -14,6 +14,9 @@
  * (getRoom / getWorld / getEntitiesForRoom / getRelationships / useModel) and
  * imports roles.ts lazily to avoid a cycle with createUniqueUuid.
  * Nested LLM `{ match: … }` unwraps are bounded in `entity-matches.ts`.
+ * `findEntityByName` only returns a room participant or a relationship-backed
+ * entity, and only after the same component-trust filter; an EXACT_MATCH id
+ * that is merely present in the entity store is not enough.
  */
 import {
 	type EntityMatch,
@@ -90,6 +93,65 @@ export async function resolveTrustedComponentSourceIds(
 		}),
 	);
 	return trusted;
+}
+
+function isTrustedComponentSource(
+	sourceEntityId: string | undefined,
+	messageEntityId: UUID,
+	agentId: UUID,
+	trustedSourceIds: Set<string>,
+): boolean {
+	if (sourceEntityId === messageEntityId) return true;
+	if (sourceEntityId && trustedSourceIds.has(sourceEntityId)) return true;
+	if (sourceEntityId === agentId) return true;
+	return false;
+}
+
+/**
+ * Return a shallow copy whose components are restricted to the sender, the
+ * agent, or a source whose resolved role is ADMIN-or-higher. Never mutates
+ * the adapter-returned entity; those objects can be cached by callers.
+ */
+async function withTrustedComponents(
+	runtime: IAgentRuntime,
+	world: World | null,
+	entity: Entity,
+	messageEntityId: UUID,
+): Promise<Entity> {
+	if (!entity.components) {
+		return { ...entity };
+	}
+	const trustedSourceIds = await resolveTrustedComponentSourceIds(
+		runtime,
+		world,
+		entity.components,
+	);
+	return {
+		...entity,
+		components: entity.components.filter((component) =>
+			isTrustedComponentSource(
+				component.sourceEntityId,
+				messageEntityId,
+				runtime.agentId,
+				trustedSourceIds,
+			),
+		),
+	};
+}
+
+function dedupeEntitiesById(entities: Entity[]): Entity[] {
+	const seen = new Set<string>();
+	const result: Entity[] = [];
+	for (const entity of entities) {
+		if (!entity.id) {
+			result.push(entity);
+			continue;
+		}
+		if (seen.has(entity.id)) continue;
+		seen.add(entity.id);
+		result.push(entity);
+	}
+	return result;
 }
 
 interface ParsedResolution {
@@ -289,29 +351,9 @@ export async function findEntityByName(
 	const entitiesInRoom = await runtime.getEntitiesForRoom(room.id, true);
 
 	const filteredEntities = await Promise.all(
-		entitiesInRoom.map(async (entity) => {
-			if (!entity.components) return entity;
-
-			const trustedSourceIds = await resolveTrustedComponentSourceIds(
-				runtime,
-				world,
-				entity.components,
-			);
-
-			entity.components = entity.components.filter((component) => {
-				if (component.sourceEntityId === message.entityId) return true;
-				if (
-					component.sourceEntityId &&
-					trustedSourceIds.has(component.sourceEntityId)
-				) {
-					return true;
-				}
-				if (component.sourceEntityId === runtime.agentId) return true;
-				return false;
-			});
-
-			return entity;
-		}),
+		entitiesInRoom.map((entity) =>
+			withTrustedComponents(runtime, world, entity, message.entityId),
+		),
 	);
 
 	const relationships = await runtime.getRelationships({
@@ -324,14 +366,20 @@ export async function findEntityByName(
 				rel.sourceEntityId === message.entityId
 					? rel.targetEntityId
 					: rel.sourceEntityId;
-			return runtime.getEntityById(entityId);
+			const related = await runtime.getEntityById(entityId);
+			if (!related) return null;
+			return withTrustedComponents(runtime, world, related, message.entityId);
 		}),
 	);
 
-	const allEntities = [
+	const allEntities = dedupeEntitiesById([
 		...filteredEntities,
 		...relationshipEntities.filter((e): e is Entity => e !== null),
-	];
+	]);
+	const candidateById = new Map<string, Entity>();
+	for (const entity of allEntities) {
+		if (entity.id) candidateById.set(entity.id, entity);
+	}
 
 	const interactionData = await getRecentInteractions(
 		runtime,
@@ -373,27 +421,9 @@ export async function findEntityByName(
 	}
 
 	if (resolution.type === "EXACT_MATCH" && resolution.entityId) {
-		const entity = await runtime.getEntityById(resolution.entityId as UUID);
-		if (entity) {
-			if (entity.components) {
-				const trustedSourceIds = await resolveTrustedComponentSourceIds(
-					runtime,
-					world,
-					entity.components,
-				);
-				entity.components = entity.components.filter((component) => {
-					if (component.sourceEntityId === message.entityId) return true;
-					if (
-						component.sourceEntityId &&
-						trustedSourceIds.has(component.sourceEntityId)
-					) {
-						return true;
-					}
-					if (component.sourceEntityId === runtime.agentId) return true;
-					return false;
-				});
-			}
-			return entity;
+		const exact = candidateById.get(resolution.entityId);
+		if (exact) {
+			return exact;
 		}
 	}
 
@@ -419,7 +449,6 @@ export async function findEntityByName(
 		const strippedUsernames = new Set<string>();
 		const normalizedHandles = new Set<string>();
 		const strippedHandles = new Set<string>();
-		const fallbackTokens: string[] = [];
 		for (const component of entity.components ?? []) {
 			const username =
 				typeof component.data?.username === "string"
@@ -428,7 +457,6 @@ export async function findEntityByName(
 			if (username) {
 				normalizedUsernames.add(normalize(username));
 				strippedUsernames.add(stripAt(username));
-				fallbackTokens.push(normalize(username));
 			}
 
 			const handle =
@@ -436,14 +464,8 @@ export async function findEntityByName(
 					? component.data.handle
 					: undefined;
 			if (handle) {
-				const normalizedHandle = normalize(handle);
-				normalizedHandles.add(normalizedHandle);
+				normalizedHandles.add(normalize(handle));
 				strippedHandles.add(stripAt(handle));
-				fallbackTokens.push(normalizedHandle);
-				const handleNoAt = handle.replace(/^@+/, "");
-				if (handleNoAt) {
-					fallbackTokens.push(normalize(handleNoAt));
-				}
 			}
 		}
 
@@ -455,51 +477,51 @@ export async function findEntityByName(
 			strippedUsernames,
 			normalizedHandles,
 			strippedHandles,
-			fallbackTokens,
 		};
 	});
 
-	const firstMatch = matchesArray[0];
-	if (matchesArray.length > 0 && firstMatch && firstMatch.name) {
-		const matchName = normalize(firstMatch.name);
-		const matchKey = stripAt(firstMatch.name);
-
-		const matchingEntity = indexedEntities.find((entry) => {
-			if (
+	const tokenMatches = (
+		raw: string | undefined,
+	): (typeof indexedEntities)[number] | undefined => {
+		if (!raw) return undefined;
+		const matchName = normalize(raw);
+		const matchKey = stripAt(raw);
+		if (!matchName) return undefined;
+		return indexedEntities.find(
+			(entry) =>
 				entry.strippedNames.has(matchKey) ||
 				entry.normalizedNames.has(matchName) ||
 				entry.strippedUsernames.has(matchKey) ||
 				entry.normalizedUsernames.has(matchName) ||
 				entry.strippedHandles.has(matchKey) ||
-				entry.normalizedHandles.has(matchName)
-			) {
-				return true;
-			}
-			return false;
-		})?.entity;
+				entry.normalizedHandles.has(matchName),
+		);
+	};
 
-		if (matchingEntity) {
-			if (resolution.type === "RELATIONSHIP_MATCH") {
-				const interactionInfo = interactionData.find(
-					(d) => d.entity.id === matchingEntity.id,
-				);
-				if (interactionInfo && interactionInfo.count > 0) {
-					return matchingEntity;
-				}
-			} else {
-				return matchingEntity;
-			}
-		}
+	const acceptMatch = (candidate: Entity | undefined): Entity | null => {
+		if (!candidate) return null;
+		if (resolution.type !== "RELATIONSHIP_MATCH") return candidate;
+		const interactionInfo = interactionData.find(
+			(d) => d.entity.id === candidate.id,
+		);
+		if (interactionInfo && interactionInfo.count > 0) return candidate;
+		return null;
+	};
+
+	const firstMatch = matchesArray[0];
+	if (matchesArray.length > 0 && firstMatch && firstMatch.name) {
+		const accepted = acceptMatch(tokenMatches(firstMatch.name)?.entity);
+		if (accepted) return accepted;
 	}
 
-	// Fallback: if parsing failed to produce a usable match list, try to detect
-	// usernames/handles mentioned in the raw model output.
-	const resultLower = JSON.stringify(result).toLowerCase();
-	const fallbackEntity = indexedEntities.find((entry) =>
-		entry.fallbackTokens.some((token) => resultLower.includes(token)),
-	)?.entity;
-	if (fallbackEntity) {
-		return fallbackEntity;
+	// Exact token match against remaining match names/reasons only. Never scan
+	// JSON.stringify of the model result: that treats schema keys ("matches",
+	// "unknown", "type") as handles.
+	for (const match of matchesArray) {
+		const acceptedName = acceptMatch(tokenMatches(match.name)?.entity);
+		if (acceptedName) return acceptedName;
+		const acceptedReason = acceptMatch(tokenMatches(match.reason)?.entity);
+		if (acceptedReason) return acceptedReason;
 	}
 
 	// Heuristic fallback: if the model indicates a name/username match but we


### PR DESCRIPTION
# Relates to

Closes #24454.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with a concrete unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Branched from `origin/develop` `@ a40cc65d3f16`.
- [ ] `bun run verify` is the full workspace gate. Not run here (narrow core
      change). Focused vitest + `tsc --noEmit` + biome on the touched files
      were run at `8c813c8c22f669ec09e9564c4fcd6571b0847004`. Hosted CI does
      not run on fork-contributor PRs.

# Risks

Low–medium. Resolver now refuses EXACT_MATCH ids that are not in the room or
the sender's relationship set, and stops substring-matching model JSON. Honest
room EXACT_MATCH, relationship-backed EXACT_MATCH, username/handle match, and
the documented sole-candidate heuristic are preserved (6 of 10 tests passed on
unmodified origin; 24-member EXACT_MATCH corpus ids identical). A model that
hallucinated a store UUID of someone not in the room will now fall through to
null instead of sending/updating that person.

# Background

## What does this PR do?

Confines `findEntityByName` to the trust-filtered room ∪ relationship candidate
set. EXACT_MATCH no longer calls `getEntityById` on a model-supplied UUID.
Relationship copies go through the same component-trust filter as room copies
and are deduped by id (room copy first). Adapter-returned entities are copied
instead of mutated in place. Name/reason matching is exact token membership,
not `JSON.stringify(result).includes(token)`.

## What kind of change is this?

Bug fix (non-breaking for previously valid room/relationship resolutions).

## Why are we doing this?

MESSAGE `op=send` treats an `"entity"` reason as a vetted recipient. Origin
`findEntityByName` could hand it a stranger. CONTACT `op=update` writes
components onto whatever entity the resolver returned. Nothing throws.

# Documentation changes needed?

No project-docs change. The module header now states the candidate-set
invariant that MESSAGE already documented.

# Testing

## Where should a reviewer start?

`packages/core/src/entities.find-entity-by-name.test.ts` — drives the
production `findEntityByName` through `getEntitiesForRoom` / `getRelationships`
/ `getEntityById` / `useModel`.

## Detailed testing steps

```
bunx vitest run --config packages/core/vitest.config.ts \
  packages/core/src/entities.find-entity-by-name.test.ts \
  packages/core/src/entity-matches.test.ts \
  packages/core/src/entities.trusted-components.test.ts \
  packages/core/src/__tests__/entities-format.test.ts
```

At HEAD `8c813c8c22f669ec09e9564c4fcd6571b0847004`: Test Files 4 passed, Tests 28 passed.

# Evidence Gate

<!-- evidence-head:8c813c8c22f669ec09e9564c4fcd6571b0847004 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface; identity resolver in `@elizaos/core`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface; identity resolver in `@elizaos/core`.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI surface; identity resolver in `@elizaos/core`.
<!-- evidence-row:backend-logs -->
- [x] Origin vitest of the production module (byte-identical `entities.ts`):
```
FAIL  does not return an EXACT_MATCH entity outside the room and relationship set
AssertionError: expected '00000000-0000-0000-0000-0000000000ff' not to be '00000000-0000-0000-0000-0000000000ff'
FAIL  does not treat a guest handle on a relationship copy as a match after room trust filtering
AssertionError: expected { … } to be null  (received Alice with handle secret-handle)
FAIL  does not resolve type UNKNOWN to a room member whose handle is a substring of the model JSON
AssertionError: expected { … } to be null  (received Casey username unknown)
FAIL  does not mutate components on the adapter-returned room entity
AssertionError: expected [] to deeply equal [ { handle: "secret-handle" } ]
Tests  4 failed | 6 passed (10)
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend / browser path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - TEXT_SMALL is a runtime seam; the defect is post-parse handling of
      the already-structured JSON. The tests supply that JSON through `useModel`.
<!-- evidence-row:domain-artifacts -->
- [x] Load-bearing revert (copy-aside of `entities.ts`; never stash):
      origin `4 failed | 6 passed`; restored fix `10 passed`.
      Focused suite at HEAD: `Test Files  4 passed (4) / Tests  28 passed (28)`.
      Typecheck error sets origin vs branch: both `tsc --noEmit` exit 0,
      identical empty outputs, zero added errors.
      `bunx biome check` on the two changed files: clean.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no live model call. The production `useModel` seam is driven with the
JSON object the resolver already accepts (`responseFormat: json_object`).

## Origin reproduction

`packages/core/src/entities.ts` was byte-identical to `origin/develop` before
the branch (`git show origin/develop:packages/core/src/entities.ts | diff - <path>`
empty). Branched from `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`.

The three failing cases above are the origin measurement of the production
function. The 6 tests that passed on origin are the previously-valid corpus:
room EXACT_MATCH, relationship-backed EXACT_MATCH, honest `@alice` username
match, sole-candidate on unparseable JSON, exact handle in the match reason,
and a 24-member room EXACT_MATCH id corpus (byte-identical ids).

## Containment

`findEntityByName` returns a wrong `Entity` (or mutates the adapter copy) and
does **not** throw.

Wrapping catch at MESSAGE `handleSend`: there is a confirmation gate
(`isUnvettedDirectUserCandidate`), but it returns false immediately when
`entityId` is UUID-like (`message.ts` ~2553). Every entity id is a UUID, so
the gate never runs. The `"entity"` reason is documented as vetted *because*
"findEntityByName only surfaces room/relationship entities" — origin does not.
A catch cannot un-return the stranger.

Wrapping catch at CONTACT `handleUpdateComponent`: `if (!entity?.id) return
fail(...)`. A wrong entity with an id is written. The fail path is only null.

This is not an unhandled-rejection crash claim. `process-guards.ts` makes
unhandled rejections non-fatal on run/serve/start. The defect is a wrong
success value.

## Known gaps

- Did not run full `bun run verify` (workspace-wide). Focused vitest + tsc +
  biome only.
- Hosted CI does not run on this fork-contributor PR; do not read a missing
  check as a pass.
- Did not drive a live Discord/Telegram send of the stranger path; the send
  candidate construction in `collectEntityCandidates` was read and the UUID
  short-circuit was confirmed in source, then the resolver itself was driven.
- `getEntityDetails` still last-write-wins component objects via
  `Object.assign` before a dead merge loop. Left alone: different function,
  and merging it into this PR would mix units.
- In-memory `getEntityById` does not attach components; the relationship-copy
  leak is the SQL-shaped seam (join components). The test supplies that seam
  through `getEntityById`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-entities-mine]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N10Y4Q7GMYM2GF2G0NHKZY","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T15:21:57.655Z","completed_at":"2026-08-22T15:33:24.275Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T15:21:58.004Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e85c3139dbbd7a68b1feac581412bda17a6cb31ffaf6ab72b3b2e1c7471af6d9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7e3ffb87-58c0-435e-b5a4-0c91518d5e87","object_id":"sha256:e85c3139dbbd7a68b1feac581412bda17a6cb31ffaf6ab72b3b2e1c7471af6d9","sha256":"e85c3139dbbd7a68b1feac581412bda17a6cb31ffaf6ab72b3b2e1c7471af6d9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"rkjXkI2ZcBBE0USWndecBrsf2Tp-Zb-A0X61xEffVyhPczU07fmqC4Mqe15h3TWayUYCym8qEiM7-AjAjLZQBQ"}} -->
