### PR TITLE
fix(ui): route Cloud requests through desktop transport

### DIFF
--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -6,7 +6,7 @@
  * load-bearing guarantee: the WEB path stays same-origin-only and throws
  * `CROSS_ORIGIN_API_URL` on any cross-origin absolute URL, while native /
  * Electrobun resolves to the single allowlisted Eliza Cloud API host and rides
- * `CapacitorHttp` — but ONLY that one host (every other cross-origin target
+ * the desktop HTTP bridge — but ONLY that one host (every other cross-origin target
  * still throws, even on native). `@capacitor/core` is doubled to toggle native.
  */
 
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const capacitorState = vi.hoisted(() => ({ isNative: false }));
 const capacitorMocks = vi.hoisted(() => ({ request: vi.fn() }));
+const desktopTransportMocks = vi.hoisted(() => ({ request: vi.fn() }));
 
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
@@ -22,6 +23,14 @@ vi.mock("@capacitor/core", () => ({
   CapacitorHttp: {
     request: capacitorMocks.request,
   },
+}));
+
+vi.mock("../../api/desktop-http-transport", () => ({
+  desktopHttpTransportForUrl: (url: string) =>
+    (window as unknown as { __electrobunWindowId?: number })
+      .__electrobunWindowId && url.startsWith("https://api.eliza.app/")
+      ? { request: desktopTransportMocks.request }
+      : null,
 }));
 
 import {
@@ -74,6 +83,7 @@ describe("cloud api-client transport bridge", () => {
     capacitorState.isNative = false;
     setElectrobun(false);
     capacitorMocks.request.mockReset();
+    desktopTransportMocks.request.mockReset();
     window.localStorage.setItem(STEWARD_TOKEN_KEY, STEWARD_TOKEN);
   });
 
@@ -241,22 +251,30 @@ describe("cloud api-client transport bridge", () => {
       setElectrobun(true);
     });
 
-    it("resolves to the Cloud API base and rides CapacitorHttp", async () => {
-      capacitorMocks.request.mockResolvedValue({
-        status: 200,
-        data: { apps: [] },
-        headers: {},
-      });
+    it("resolves to the Cloud API base and rides the desktop HTTP bridge", async () => {
+      desktopTransportMocks.request.mockResolvedValue(
+        new Response(JSON.stringify({ apps: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
       const fetchSpy = vi.spyOn(globalThis, "fetch");
 
       const result = await api<{ apps: unknown[] }>("/api/v1/apps");
 
       expect(result).toEqual({ apps: [] });
       expect(fetchSpy).not.toHaveBeenCalled();
-      expect(capacitorMocks.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: "https://api.eliza.app/api/v1/apps",
-        }),
+      expect(capacitorMocks.request).not.toHaveBeenCalled();
+      expect(desktopTransportMocks.request).toHaveBeenCalledWith(
+        "https://api.eliza.app/api/v1/apps",
+        expect.objectContaining({ body: null }),
+        undefined,
+      );
+      const requestInit = desktopTransportMocks.request.mock.calls[0]?.[1] as
+        | RequestInit
+        | undefined;
+      expect(new Headers(requestInit?.headers).get("Authorization")).toBe(
+        `Bearer ${STEWARD_TOKEN}`,
       );
     });
 

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -32,6 +32,7 @@ import {
   readStoredStewardToken,
   STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
+import { desktopHttpTransportForUrl } from "../../api/desktop-http-transport";
 import {
   DEFAULT_DIRECT_CLOUD_API_BASE_URL,
   resolveDirectCloudAuthApiBase,
@@ -225,7 +226,7 @@ export async function readCloudBearerToken(): Promise<string | null> {
 }
 
 // ---------------------------------------------------------------------------
-// Native/Electrobun transport — routes the resolved Cloud API request through
+// Capacitor transport — routes the resolved Cloud API request through
 // `CapacitorHttp` (bypassing the WebView CORS sandbox) and re-wraps the result
 // as a standard `Response`, so the shared payload/error handling below is
 // identical to the web `fetch` path.
@@ -414,21 +415,29 @@ export async function apiFetch(
   const requestBody =
     json !== undefined ? JSON.stringify(json) : (body ?? null);
 
-  // Native/Electrobun: ride `CapacitorHttp` so the request leaves the WebView
-  // sandbox and reaches the allowlisted Cloud API host. Web: the original
-  // same-origin `fetch` path, byte-for-byte unchanged.
-  const res = isNativeCloudRuntime()
-    ? await nativeApiFetch(url, {
-        method: rest.method,
-        headers,
-        body: requestBody,
-      })
-    : await fetch(url, {
-        ...rest,
-        credentials: "include",
-        headers,
-        body: requestBody,
-      });
+  // Electrobun has its own main-process HTTP bridge; CapacitorHttp is not
+  // installed in the macOS shell and otherwise falls back to a CORS-blocked
+  // WKWebView request. Capacitor keeps its native plugin, while web retains the
+  // original same-origin fetch path.
+  const desktopTransport = desktopHttpTransportForUrl(url);
+  const res = desktopTransport
+    ? await desktopTransport.request(
+        url,
+        { ...rest, headers, body: requestBody },
+        undefined,
+      )
+    : Capacitor.isNativePlatform()
+      ? await nativeApiFetch(url, {
+          method: rest.method,
+          headers,
+          body: requestBody,
+        })
+      : await fetch(url, {
+          ...rest,
+          credentials: "include",
+          headers,
+          body: requestBody,
+        });
 
   if (!res.ok) {
     // A 401 on an authed call means our session was rejected (token revoked or


### PR DESCRIPTION
# Relates to

Operator-requested extraction from `feat/cloud-settings-panel`; no separate issue.

- [x] Targets `develop` and is rebased onto latest `origin/develop` with zero conflicts.
- [ ] `bun install` was run after sync; full `bun run verify` was not run because this is a two-file split with focused package verification recorded below.
- [x] The deterministic transport test proves the changed request path without requiring rendered UI.

# Sync with develop

- [x] Rebased onto `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`; zero conflicts.
- [ ] Full `bun run verify` not run; focused affected-package checks pass.

# Risks

Low. The change only selects the existing allowlisted desktop HTTP bridge for Electrobun Cloud URLs. Web remains on same-origin `fetch`; Capacitor remains on `CapacitorHttp`. Regression risk is transport selection or header/body forwarding, covered by the existing 21-case contract suite.

# Background

## What does this PR do?

Routes Electrobun Cloud API requests through the existing main-process desktop HTTP transport. The desktop shell does not install `CapacitorHttp`; its fallback would otherwise execute in WKWebView and be blocked by CORS.

The split contains only:

- `packages/ui/src/cloud/lib/api-client.ts`
- `packages/ui/src/cloud/lib/api-client.test.ts`

It contains no NuPhy or Cloud Settings panel code.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects an internal platform transport choice without changing a public API.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/lib/api-client.test.ts`, especially the Electrobun runtime case.

## Detailed testing steps

- `bun install` — pass
- `bun run --cwd packages/ui test --run src/cloud/lib/api-client.test.ts` — pass, 21 tests
- `bun run --cwd plugins/plugin-native-secure-store build` — pass, required UI typecheck dependency
- `bun run --cwd packages/ui typecheck` — pass
- `bunx biome check packages/ui/src/cloud/lib/api-client.ts packages/ui/src/cloud/lib/api-client.test.ts` — pass
- `git diff --check` — pass

# Evidence Gate

<!-- evidence-head:896d9ffa1d7eec5983b156d0ab1cf07dda4de067 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visible user flow changes; this is transport-layer routing.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - deterministic transport test directly asserts the request URL, auth header, body, and selected bridge.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts are produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

N/A - deterministic unit coverage is the applicable evidence for this internal transport-selection change.

## Screenshots (before / after) + video walkthrough

N/A - no `.tsx`, CSS, SVG, layout, copy, or other rendered UI changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- Full `bun run verify` was not run for this isolated two-file extraction; focused affected-package tests, typecheck, and Biome checks pass.
- The first direct UI typecheck attempt reported missing built workspace dependencies. After building the declared `@elizaos/capacitor-secure-store` dependency, the unchanged command passed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
