### PR TITLE
fix(desktop): restore persisted cloud runtime mode

### DIFF
--- a/packages/app-core/platforms/electrobun/src/api-base.test.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.test.ts
@@ -7,6 +7,7 @@ import {
   DESKTOP_LOCAL_AGENT_IPC_BASE,
   type PersistedDeployment,
   resolveCloudHostedAgentApiBase,
+  resolveDesktopRuntimeModeSignal,
   resolveDesktopRuntimeModeWithDeployment,
   resolveInitialApiBase,
   resolveLocalAgentIpcMode,
@@ -242,6 +243,38 @@ describe("readPersistedDeployment — eliza.json reader", () => {
   it("returns null for malformed JSON (fail-safe)", () => {
     const file = writeConfig("{ not valid json ");
     expect(readPersistedDeployment({ ELIZA_CONFIG_PATH: file })).toBeNull();
+  });
+});
+
+describe("resolveDesktopRuntimeModeSignal", () => {
+  it("returns cloud for the explicit runtime-mode flag", () => {
+    expect(
+      resolveDesktopRuntimeModeSignal({ ELIZA_DESKTOP_RUNTIME_MODE: "cloud" }),
+    ).toBe("cloud");
+  });
+
+  it("returns cloud for the cloud-only flag", () => {
+    expect(
+      resolveDesktopRuntimeModeSignal({ ELIZA_DESKTOP_CLOUD_ONLY: "1" }),
+    ).toBe("cloud");
+  });
+
+  it("returns cloud for a persisted cloud deployment", () => {
+    expect(
+      resolveDesktopRuntimeModeSignal(
+        {},
+        { runtime: "cloud", remoteApiBase: null },
+      ),
+    ).toBe("cloud");
+  });
+
+  it("does not infer cloud from a local deployment", () => {
+    expect(
+      resolveDesktopRuntimeModeSignal(
+        {},
+        { runtime: "local", remoteApiBase: null },
+      ),
+    ).toBeNull();
   });
 });
 

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -205,13 +205,17 @@ export function resolveDesktopRuntimeModeWithDeployment(
  * after sign-in; only its model sourcing and the renderer's first-run UI change.
  * Returns `null` (the default) when no cloud-only opt-in is present, so existing
  * desktop/mobile/web behavior is unchanged.
+ * A persisted cloud deployment is also honored so a selected cloud target
+ * survives subsequent desktop boots without requiring an environment flag.
  */
 export function resolveDesktopRuntimeModeSignal(
   env: Record<string, string | undefined>,
+  deployment?: PersistedDeployment | null,
 ): "cloud" | null {
   const explicit = env.ELIZA_DESKTOP_RUNTIME_MODE?.trim().toLowerCase();
   if (explicit === "cloud" || explicit === "elizacloud") return "cloud";
   if (isEnabledFlag(env.ELIZA_DESKTOP_CLOUD_ONLY)) return "cloud";
+  if (deployment?.runtime === "cloud") return "cloud";
   return null;
 }
 

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
@@ -119,6 +119,17 @@ describe("api-base-owner", () => {
     expect(injected).not.toContain("apiBase:");
   });
 
+  it("injects cloud-only runtime branding before an agent API base exists", () => {
+    process.env.ELIZA_DESKTOP_CLOUD_ONLY = "1";
+
+    const injected = injectIntoHtml("<html><head></head><body></body></html>");
+
+    expect(injected).toContain(
+      'window.__ELIZA_DESKTOP_RUNTIME_MODE__="cloud";',
+    );
+    expect(injected).not.toContain("apiBase:");
+  });
+
   it("marks a non-loopback current API base as an external desktop API base", () => {
     setCurrent("https://agent.example.com", "cloud-token");
 

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
@@ -35,6 +35,7 @@ import {
   resolveDesktopRuntimeMode,
   resolveDesktopRuntimeModeSignal,
 } from "../api-base";
+import { getPersistedDeployment } from "../persisted-deployment";
 import { getStartupTraceConfig } from "../startup-trace";
 
 interface ApiBaseSnapshot {
@@ -146,11 +147,19 @@ export function injectIntoHtml(html: string): string {
   const desktopTestBridgeInject = shouldInjectDesktopTestBridgeMarker()
     ? "window.__ELIZA_DESKTOP_TEST_BRIDGE_ENABLED__=true;"
     : "";
+  const runtimeModeSignal = resolveDesktopRuntimeModeSignal(
+    process.env,
+    getPersistedDeployment(),
+  );
+  const runtimeModeInject = runtimeModeSignal
+    ? `window.__ELIZA_DESKTOP_RUNTIME_MODE__=${safeJsonForHtml(runtimeModeSignal)};`
+    : "";
   if (
     !current.base &&
     !startupTraceInject &&
     !runtimeChooserTestInject &&
-    !desktopTestBridgeInject
+    !desktopTestBridgeInject &&
+    !runtimeModeInject
   )
     return html;
 
@@ -164,18 +173,14 @@ export function injectIntoHtml(html: string): string {
     // (shouldUseCloudOnlyBranding) resolves correctly at module-eval time. Only
     // injected when explicitly cloud, so the default desktop/web behavior is
     // unchanged.
-    const runtimeModeSignal = resolveDesktopRuntimeModeSignal(process.env);
-    const runtimeModeInject = runtimeModeSignal
-      ? `window.__ELIZA_DESKTOP_RUNTIME_MODE__=${safeJsonForHtml(runtimeModeSignal)};`
-      : "";
     const externalApiBase = resolveCurrentExternalApiBase();
     const externalApiBaseInject = externalApiBase
       ? `window.__ELIZA_DESKTOP_EXTERNAL_API_BASE__=${safeJsonForHtml(externalApiBase)};`
       : "";
-    apiBaseInject = `${runtimeModeInject}${externalApiBaseInject}${bootConfigInject}`;
+    apiBaseInject = `${externalApiBaseInject}${bootConfigInject}`;
   }
 
-  const script = `<script>${startupTraceInject}${runtimeChooserTestInject}${desktopTestBridgeInject}${apiBaseInject}</script>`;
+  const script = `<script>${startupTraceInject}${runtimeChooserTestInject}${desktopTestBridgeInject}${runtimeModeInject}${apiBaseInject}</script>`;
   if (html.includes("</head>")) {
     return html.replace("</head>", `${script}</head>`);
   }


### PR DESCRIPTION
## Summary
- restore cloud-only renderer mode from the persisted desktop deployment
- inject the cloud runtime signal before an agent API base exists
- preserve existing local/default desktop behavior

## Testing
- `bunx vitest run --config vitest.electrobun.config.ts src/api-base.test.ts src/lifecycle/api-base-owner.test.ts` (47 passed)
- `bunx @biomejs/biome check` on all four changed files
- `git diff --check`

## Evidence
- Screenshots: N/A - startup configuration signal only; no rendered UI changed in this PR
- Video: N/A - deterministic boot-injection tests cover the behavior
- Backend logs: N/A - no backend request path changed
- Frontend console/network logs: N/A - no renderer network path changed