### PR TITLE
fix(desktop): bind Cloud login to personal agent

### DIFF
--- a/packages/ui/src/state/bind-direct-cloud-login.test.ts
+++ b/packages/ui/src/state/bind-direct-cloud-login.test.ts
@@ -1,0 +1,61 @@
+/** Verifies direct Cloud login becomes a durable personal-agent binding. */
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getActiveProfile } from "./agent-profiles";
+import { bindDirectCloudLoginToPersonalAgent } from "./bind-direct-cloud-login";
+import { loadPersistedActiveServer } from "./persistence";
+
+const PERSONAL_ID = "personal:00000000-0000-5000-8000-000000000001";
+const API_BASE =
+  "https://api.eliza.app/api/v1/eliza/agents/personal%3A00000000-0000-5000-8000-000000000001";
+
+describe("bindDirectCloudLoginToPersonalAgent", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("replaces a stale staging target and repoints the live client", async () => {
+    localStorage.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "cloud:old",
+        kind: "cloud",
+        label: "Staging",
+        apiBase: "https://api-staging.eliza.app/api/v1/eliza/agents/old",
+        accessToken: "stale",
+      }),
+    );
+    const client = {
+      getPersonalSharedEliza: vi.fn(async () => ({
+        personalElizaId: PERSONAL_ID,
+        activeAgentId: PERSONAL_ID,
+        agentName: "Eliza",
+        apiBase: API_BASE,
+        runtime: "shared" as const,
+      })),
+      setBaseUrl: vi.fn(),
+      setToken: vi.fn(),
+    };
+
+    await bindDirectCloudLoginToPersonalAgent({
+      client,
+      cloudApiBase: "https://api.eliza.app",
+      token: "production-token",
+    });
+
+    expect(loadPersistedActiveServer()).toMatchObject({
+      id: `cloud:${PERSONAL_ID}`,
+      apiBase: API_BASE,
+      accessToken: "production-token",
+      cloudRuntime: "shared",
+    });
+    expect(getActiveProfile()).toMatchObject({
+      cloudAgentId: PERSONAL_ID,
+      apiBase: API_BASE,
+      accessToken: "production-token",
+    });
+    expect(client.setBaseUrl).toHaveBeenCalledWith(API_BASE, {
+      persist: false,
+    });
+    expect(client.setToken).toHaveBeenCalledWith("production-token");
+  });
+});

--- a/packages/ui/src/state/bind-direct-cloud-login.ts
+++ b/packages/ui/src/state/bind-direct-cloud-login.ts
@@ -1,0 +1,63 @@
+/**
+ * Converts a direct Cloud account login into the durable personal-agent target
+ * used by desktop startup and chat routing.
+ */
+
+import { setStorageValue } from "../bridge/storage-bridge";
+import { upsertAndActivateAgentProfile } from "./agent-profiles";
+import {
+  createPersistedActiveServer,
+  savePersistedActiveServer,
+} from "./persistence";
+
+const ACTIVE_SERVER_STORAGE_KEY = "elizaos:active-server";
+
+interface DirectCloudBindingClient {
+  getPersonalSharedEliza(options: {
+    cloudApiBase: string;
+    authToken: string;
+  }): Promise<{
+    personalElizaId: string;
+    activeAgentId: string;
+    agentName: string;
+    apiBase: string;
+    runtime: "shared" | "dedicated";
+  }>;
+  setBaseUrl(base: string, options?: { persist?: boolean }): void;
+  setToken(token: string): void;
+}
+
+export async function bindDirectCloudLoginToPersonalAgent(options: {
+  client: DirectCloudBindingClient;
+  cloudApiBase: string;
+  token: string;
+}): Promise<void> {
+  const personal = await options.client.getPersonalSharedEliza({
+    cloudApiBase: options.cloudApiBase,
+    authToken: options.token,
+  });
+  const server = createPersistedActiveServer({
+    kind: "cloud",
+    id: `cloud:${personal.personalElizaId}`,
+    label: personal.agentName,
+    apiBase: personal.apiBase,
+    accessToken: options.token,
+    cloudRuntimeAgentId: personal.activeAgentId,
+    cloudRuntime: personal.runtime,
+  });
+  if (!server.apiBase || !savePersistedActiveServer(server)) {
+    throw new Error("The production Cloud agent target could not be saved.");
+  }
+  await setStorageValue(ACTIVE_SERVER_STORAGE_KEY, JSON.stringify(server));
+  upsertAndActivateAgentProfile({
+    kind: "cloud",
+    label: server.label,
+    cloudAgentId: personal.personalElizaId,
+    cloudRuntimeAgentId: personal.activeAgentId,
+    cloudRuntime: personal.runtime,
+    apiBase: server.apiBase,
+    accessToken: options.token,
+  });
+  options.client.setBaseUrl(server.apiBase, { persist: false });
+  options.client.setToken(options.token);
+}

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -53,6 +53,7 @@ import {
   yieldHttpAfterNativeMessageBox,
 } from "../utils";
 import { scrubPersistedAgentProfileTokens } from "./agent-profiles";
+import { bindDirectCloudLoginToPersonalAgent } from "./bind-direct-cloud-login";
 import {
   CLOUD_LOGIN_POPUP_NAME,
   navigateToSameTabCloudLogin,
@@ -1081,10 +1082,18 @@ export function useCloudState({
                   );
                   return;
                 }
-                client.setBaseUrl(authenticatedCloudApiBase, {
-                  persist: false,
-                });
-                client.setToken(poll.token);
+                if (isElectrobunRuntime()) {
+                  await bindDirectCloudLoginToPersonalAgent({
+                    client,
+                    cloudApiBase: authenticatedCloudApiBase,
+                    token: poll.token,
+                  });
+                } else {
+                  client.setBaseUrl(authenticatedCloudApiBase, {
+                    persist: false,
+                  });
+                  client.setToken(poll.token);
+                }
               }
 
               closePrePoppedWindow();


### PR DESCRIPTION
# Relates to

Operator-requested extraction from the Cloud settings branch. This PR is independent from #24457 and starts directly from `origin/develop`.

# Sync with develop

- [x] Targets `develop` and is based on `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`.
- [x] Zero conflicts.
- [x] `bun install --frozen-lockfile` completed.

# Risks

Medium. This changes the persisted active Cloud server/profile and the live API client target after successful direct Electrobun login. Web and mobile retain their existing behavior.

# Background

## What does this PR do?

After direct desktop Cloud authentication succeeds, it:

- resolves the user's personal shared or dedicated agent;
- persists that agent as the active Cloud server and active profile;
- writes the active-server record through the desktop storage bridge;
- repoints the live client to the agent API base and applies the authenticated token before login completes.

This PR contains no speculative-login cache changes, auth rate-limit ordering, runtime-mode injection, settings routing, or NuPhy UI work.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No. This repairs post-login routing for an existing desktop Cloud flow.

# Testing

## Where should a reviewer start?

- `packages/ui/src/state/bind-direct-cloud-login.ts`
- `packages/ui/src/state/bind-direct-cloud-login.test.ts`
- the direct-auth completion block in `packages/ui/src/state/useCloudState.ts`

## Detailed testing steps

1. Run `node packages/shared/scripts/generate-keywords.mjs`.
2. From `packages/ui`, run `bunx vitest run --config ./vitest.config.ts src/state/bind-direct-cloud-login.test.ts src/state/useCloudState.same-tab-login.test.tsx`.
3. Run Biome on the three changed files.

# Evidence Gate

<!-- evidence-head:7d57e707a5c9b99e333c1797addf5506033b33e4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI, CSS, or layout changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI, CSS, or layout changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI changes; live authenticated desktop login remains a maintainer verification step.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production credentials were used during this extraction.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no production credentials were used during this extraction.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the persisted active server and profile are asserted by the focused jsdom test; no production account data was written.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Known gaps / failures

Passing on exact head `7d57e707a5c9b99e333c1797addf5506033b33e4`:

- Biome: 3 changed files clean.
- Binding and surrounding direct-login hook Vitest: 18 tests passed across 2 files.

The UI package typecheck is blocked on current `develop` by missing private/prebuilt workspace modules, including `@elizaos/core/edge`, `@elizaos/cloud-routing`, and `@elizaos/capacitor-secure-store`. Full `bun run verify` was not claimed.

Live end-to-end desktop Cloud authentication was not repeated because it requires an authenticated production account. Maintainer verification should confirm Safari login returns to the installed Electrobun app and subsequent chat requests target the personal agent API base.

## Maintainer CI exception record

N/A - no exception requested.

## What if the user does not have a personal agent?

A separately provisioned agent is not required. Every authenticated Cloud account has an account-native personal Eliza identity. The backend derives its stable `personal:<uuid>` ID from the authenticated user and organization, so the default Shared runtime exists without an `agent_sandboxes` row and without provisioning paid compute during login.

After desktop authentication, `GET /api/v1/eliza/personal` resolves the active runtime:

- If the account has a healthy Dedicated target, it returns the stable personal identity together with that Dedicated agent ID and API base.
- Otherwise, it returns the deterministic rowless Shared personal identity, and the client builds the Shared agent API base from that ID.

The PR persists whichever runtime the backend returns and points the live client at it. A missing or malformed identity therefore indicates an authentication or backend-contract failure, not an ordinary new-user state. In that case the binding throws, the login poll retries up to its consecutive-error limit, and the desktop remains disconnected rather than reporting success against an unscoped Cloud API URL.
