### PR TITLE
fix(core): clear every room message instead of the first in-memory page

### DIFF
--- a/packages/core/src/services/message.clear-channel.test.ts
+++ b/packages/core/src/services/message.clear-channel.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Drives the real {@link DefaultMessageService.clearChannel} against a real
+ * {@link AgentRuntime} + {@link InMemoryDatabaseAdapter}. Origin getMemoriesByRoomIds
+ * defaulted limit to 20, so a 25-message room left 5 rows after a successful
+ * clear. The bulk deleteAllMemories path must empty the room regardless of that
+ * default.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter.ts";
+import { AgentRuntime } from "../runtime.ts";
+import type { Character, UUID } from "../types";
+import { DefaultMessageService } from "./message.ts";
+
+const ROOM_ID = "20000000-0000-0000-0000-0000000000aa" as UUID;
+const ENTITY_ID = "10000000-0000-0000-0000-0000000000aa" as UUID;
+
+async function seededRuntime(count: number): Promise<{
+	runtime: AgentRuntime;
+	adapter: InMemoryDatabaseAdapter;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		character: { name: "ClearChannelAgent", bio: "test" } as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	const memories = Array.from({ length: count }, (_, index) => ({
+		memory: {
+			id: `30000000-0000-0000-0000-0000000000${String(index).padStart(2, "0")}` as UUID,
+			entityId: ENTITY_ID,
+			agentId: runtime.agentId,
+			roomId: ROOM_ID,
+			content: { text: `msg ${index}` },
+			createdAt: index,
+		},
+		tableName: "messages",
+	}));
+	await adapter.createMemories(memories);
+	return { runtime, adapter };
+}
+
+describe("DefaultMessageService.clearChannel", () => {
+	it("deletes every message in a room larger than the in-memory default page", async () => {
+		const { runtime, adapter } = await seededRuntime(25);
+		const before = await adapter.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+		});
+		expect(before).toHaveLength(25);
+
+		await new DefaultMessageService().clearChannel(
+			runtime,
+			ROOM_ID,
+			"chan-repro",
+		);
+
+		const remaining = await adapter.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+		});
+		expect(remaining).toHaveLength(0);
+	});
+
+	it("is a no-op on an already empty room", async () => {
+		const { runtime, adapter } = await seededRuntime(0);
+		await new DefaultMessageService().clearChannel(
+			runtime,
+			ROOM_ID,
+			"chan-empty",
+		);
+		const remaining = await adapter.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+		});
+		expect(remaining).toHaveLength(0);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -15638,44 +15638,24 @@ export class DefaultMessageService implements IMessageService {
 			"Clearing message memories from channel",
 		);
 
-		// Get all message memories for this room
-		const memories = await runtime.getMemoriesByRoomIds({
-			tableName: "messages",
+		// Bulk room delete — do not snapshot via getMemoriesByRoomIds. The
+		// in-memory adapter defaults that read to 20 rows, so a successful
+		// per-id loop left the rest of the channel intact. deleteAllMemories
+		// is the adapter contract for "this room, this table, all rows".
+		const totalCount = await runtime.countMemories({
 			roomIds: [roomId],
+			tableName: "messages",
+			unique: false,
 		});
-
-		runtime.logger.debug(
-			{ src: "service:message", channelId, count: memories.length },
-			"Found message memories to delete",
-		);
-
-		const messageIds: UUID[] = [];
-		for (const memory of memories) {
-			if (!memory.id) {
-				throw new ElizaError(
-					"Cannot clear a channel containing a message memory without an ID",
-					{
-						code: "CHANNEL_MESSAGE_ID_MISSING",
-						context: { roomId, channelId },
-					},
-				);
-			}
-			messageIds.push(memory.id);
-		}
-
-		let deletedCount = 0;
-		for (const messageId of messageIds) {
-			await runtime.deleteMemory(messageId);
-			deletedCount++;
-		}
+		await runtime.deleteAllMemories([roomId], "messages");
 
 		runtime.logger.info(
 			{
 				src: "service:message",
 				agentId: runtime.agentId,
 				channelId,
-				deletedCount,
-				totalCount: memories.length,
+				deletedCount: totalCount,
+				totalCount,
 			},
 			"Cleared message memories from channel",
 		);


### PR DESCRIPTION
Closes #24463.


Fixes #24463

## The defect

`DefaultMessageService.clearChannel` listed room messages with `getMemoriesByRoomIds` and no `limit`, then deleted those ids one by one.

`InMemoryDatabaseAdapter.getMemoriesByRoomIds` defaults `limit` to 20. plugin-sql does not. On the fallback adapter a 25-message room deletes 20, leaves 5, and logs a successful clear.

## Containment check (why a wrapping catch does not cover this)

There is no catch on this method. It returns after deleting a prefix of the room. The leftover rows are a missing cleanup. Callers treat a resolved promise as an empty channel.

## The fix

Call `runtime.deleteAllMemories([roomId], "messages")` — the existing bulk contract — after counting for the log. Do not snapshot through the paged read.

## Evidence

### 1. Origin reproduction on unmodified code

`packages/core/src/services/message.ts` was byte-identical to `origin/develop` (`a40cc65d3f161b307d6ba70fe6d89f1130b785eb`):

```
BYTE_IDENTICAL
```

Real DefaultMessageService + AgentRuntime + InMemoryDatabaseAdapter:

```
D2 clearChannel remaining= 5 of 25 (origin default getMemoriesByRoomIds limit 20 → leftover 5)
```

Committed test on origin: `expected length 0 but got 5`. `Tests  1 failed | 1 passed (2)`.

### 2. No over-rejection

Empty room remains a no-op (`2 passed` includes that case). `getMemoriesByRoomIds` default is unchanged, so other callers of that read are byte-identical.

### 3. Load-bearing revert (copy-aside)

Origin source under the new tests: `1 failed | 1 passed`. Restored fix: `2 passed`.

### 4. Committed tests actually run

```
$ bun run --cwd packages/core test -- src/services/message.clear-channel.test.ts
Test Files  1 passed (1)
Tests  2 passed (2)
```

### 5. Typecheck vs untouched control

packages/core tsc: control 0, branch 0, **zero added**.

### 6. Biome

clean on both changed files.

# Risks

Low. Uses the existing bulk delete. plugin-sql already implements `deleteAllMemories` including embeddings.

# Background

## What does this PR do?

Clears a channel with `deleteAllMemories` instead of a paged snapshot.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/core/src/services/message.clear-channel.test.ts`

## Detailed testing steps

```
bun run --cwd packages/core test -- src/services/message.clear-channel.test.ts
```

# Evidence Gate

<!-- evidence-head:b1c10c430a432251c2dc0f8b01dfb507214e2e11 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; message-store cleanup only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; message-store cleanup only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface; message-store cleanup only.
<!-- evidence-row:backend-logs -->
- [x] Origin run of the real service:

<details>
<summary>origin clearChannel output</summary>

```
INFO D2 clearChannel remaining= 5 of 25 (origin default getMemoriesByRoomIds limit 20)
INFO committed tests on origin: Test Files 1 failed; Tests 1 failed | 1 passed (2)
INFO after fix: Test Files 1 passed; Tests 2 passed (2)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model call.
<!-- evidence-row:domain-artifacts -->
- [x] In-process message rows from the real adapter:

<details>
<summary>origin leftover rows</summary>

```
INFO seeded 25 message rows in one room via createMemories
INFO after origin clearChannel getMemories returned 5 leftover rows
INFO after fix getMemories returned 0 leftover rows
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model call.

# Known gaps / failures

- Did not run `bun run verify`.
- Did not photograph plugin-sql `deleteAllMemories` against live Postgres in this session.
- Hosted CI does **not** run on fork PRs from ss251.

# Sync with develop

- [x] Branched from current `origin/develop` `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`.
- [ ] `bun run verify` not run; focused tests + typecheck + biome recorded above.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-core-memory-clear]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N249VBVKKG6HQQSTVKZZP6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T15:41:16.523Z","completed_at":"2026-08-22T15:43:20.871Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T15:41:16.874Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d0776c41cfc33be47634fdbf0e1700b5954ecb858d92d1693a342f33f3c813e6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b0a6edb1-89e4-412d-9991-9b03213f7116","object_id":"sha256:d0776c41cfc33be47634fdbf0e1700b5954ecb858d92d1693a342f33f3c813e6","sha256":"d0776c41cfc33be47634fdbf0e1700b5954ecb858d92d1693a342f33f3c813e6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"WjYshyVBrqCQCPonO20ZLt-TcYB0wwyCFwpcGsRGWW9MseyAJyAyEIwQF8JYcXcvbse-HX_m-JuItGsDC04SCw"}} -->
