### PR TITLE
fix(ci): restore affected closure checks

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -174,6 +174,7 @@ const optionalPluginSpecifiers = {
   cloud: "@elizaos/plugin-elizacloud",
   imessage: "@elizaos/plugin-imessage",
   mcp: "@elizaos/plugin-mcp",
+  signal: "@elizaos/plugin-signal",
   whatsapp: "@elizaos/plugin-whatsapp",
   workflow: "@elizaos/plugin-workflow",
 } as const;
@@ -184,6 +185,7 @@ const optionalPluginImports = {
   cloud: () => importOptionalPlugin(optionalPluginSpecifiers.cloud),
   imessage: () => importOptionalPlugin(optionalPluginSpecifiers.imessage),
   mcp: () => importOptionalPlugin(optionalPluginSpecifiers.mcp),
+  signal: () => importOptionalPlugin(optionalPluginSpecifiers.signal),
   whatsapp: () => importOptionalPlugin(optionalPluginSpecifiers.whatsapp),
   workflow: () => importOptionalPlugin(optionalPluginSpecifiers.workflow),
 };

--- a/packages/agent/src/services/e2b-capability-router.coding-remote-runner.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.coding-remote-runner.test.ts
@@ -85,7 +85,7 @@ describe("E2B remote runner router with the Coding remote runner HTTP runner", (
       provider: "home",
       remoteHttpBaseUrl: REMOTE_RUNNER_URL,
       remoteHttpToken: REMOTE_RUNNER_TOKEN,
-      agentRunners: ["codex", "claude-code", "opencode"],
+      agentRunners: ["codex", "claude-code"],
       workdir: "/workspace",
       hostWorkspaceRoot: workspaceRoot,
       timeoutMs: 30_000,
@@ -168,7 +168,7 @@ describe("configured request timeout propagation (#23005 review findings)", () =
   it("aborts fs.list at the configured request timeout, not the 60s default", async () => {
     const service = makeService(100, true);
     const start = Date.now();
-    await expect(service.fs.list({})).rejects.toThrow(/aborted/i);
+    await expect(service.fs.list({})).rejects.toThrow(/timed out/i);
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
@@ -177,14 +177,14 @@ describe("configured request timeout propagation (#23005 review findings)", () =
     const start = Date.now();
     await expect(
       service.fs.writeText({ path: "/workspace/evidence.txt", text: "hi" }),
-    ).rejects.toThrow(/aborted/i);
+    ).rejects.toThrow(/timed out/i);
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
   it("aborts the remote runner health check at the configured request timeout", async () => {
     const service = makeService(100, false);
     const start = Date.now();
-    await expect(service.fs.list({})).rejects.toThrow(/aborted/i);
+    await expect(service.fs.list({})).rejects.toThrow(/timed out/i);
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 });

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -540,7 +540,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
       "https://cloud.example/remote-runner",
     );
     expect(config.remoteHttpToken).toBe("token");
-    expect(config.agentRunners).toEqual(["codex", "claude-code", "opencode"]);
+    expect(config.agentRunners).toEqual(["codex", "claude-code"]);
   });
 
   it("resolves Eliza Cloud API-backed provisioning settings", () => {
@@ -608,7 +608,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
       "https://www.elizacloud.ai/dashboard/app?homeRemoteRunnerSession=session-123",
     );
     expect(config.remoteHttpToken).toBe("token");
-    expect(config.agentRunners).toEqual(["codex", "claude-code", "opencode"]);
+    expect(config.agentRunners).toEqual(["codex", "claude-code"]);
   });
 
   it("rejects runner timeout settings that overflow the JavaScript timer range", () => {
@@ -767,7 +767,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
         remoteHttpBaseUrl: "http://home.local:2468",
         remoteAccessUrl:
           "https://www.elizacloud.ai/dashboard/app?homeRemoteRunnerSession=session-123",
-        agentRunners: ["codex", "opencode"],
+        agentRunners: ["codex"],
       }),
       new FakeFactory(),
     );
@@ -841,7 +841,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
             apiKey: undefined,
             remoteHttpBaseUrl: server.baseUrl,
             remoteHttpToken: "token",
-            agentRunners: ["codex", "claude-code", "opencode"],
+            agentRunners: ["codex", "claude-code"],
           }),
         );
 
@@ -1264,7 +1264,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
           apiKey: undefined,
           cloudApiBaseUrl: server.baseUrl,
           cloudApiToken: "cloud-key",
-          agentRunners: ["codex", "claude-code", "opencode"],
+          agentRunners: ["codex", "claude-code"],
         }),
       );
 
@@ -1295,7 +1295,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
           environmentVars: {
             HOST: "0.0.0.0",
             ELIZA_CODING_WORKSPACE: "/workspace",
-            ELIZA_SANDBOX_AGENT_RUNNERS: "codex,claude-code,opencode",
+            ELIZA_SANDBOX_AGENT_RUNNERS: "codex,claude-code",
           },
         },
       });

--- a/packages/app-core/platforms/electrobun/tsconfig.json
+++ b/packages/app-core/platforms/electrobun/tsconfig.json
@@ -37,6 +37,12 @@
       "@elizaos/capacitor-bun-runtime/*": [
         "../../../../plugins/plugin-native-bun-runtime/src/*"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
+      "@elizaos/capacitor-secure-store/*": [
+        "../../../../plugins/plugin-native-secure-store/src/*"
+      ],
       "@elizaos/core": ["../../../core/src/index.node.ts"],
       "@elizaos/core/atomic-json": ["../../../core/src/utils/atomic-json.ts"],
       "@elizaos/core/*": ["../../../core/src/*"],

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
@@ -115,9 +115,7 @@ it("keeps canonical app-host login on the current origin", async () => {
     </MemoryRouter>,
   );
 
-  expect(
-    await screen.findByRole("heading", { name: "Sign in" }),
-  ).toBeTruthy();
+  expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();
   expect(
     await screen.findByRole("button", { name: /Magic Link/i }),
   ).toBeTruthy();
@@ -135,9 +133,7 @@ it("keeps canonical staging app-host login on the current origin", async () => {
     </MemoryRouter>,
   );
 
-  expect(
-    await screen.findByRole("heading", { name: "Sign in" }),
-  ).toBeTruthy();
+  expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();
   expect(
     await screen.findByRole("button", { name: /Magic Link/i }),
   ).toBeTruthy();
@@ -155,9 +151,7 @@ it("normalizes a canonical app hostname before keeping login local", async () =>
     </MemoryRouter>,
   );
 
-  expect(
-    await screen.findByRole("heading", { name: "Sign in" }),
-  ).toBeTruthy();
+  expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();
   expect(
     await screen.findByRole("button", { name: /Magic Link/i }),
   ).toBeTruthy();

--- a/packages/ui/src/components/chat/widgets/maps-card.tsx
+++ b/packages/ui/src/components/chat/widgets/maps-card.tsx
@@ -89,10 +89,7 @@ function placeMapUris(place: MapsCardPlace): {
 function AttributionLine({ attribution }: { attribution: string | null }) {
   if (!attribution) return null;
   return (
-    <div
-      className="pt-0.5 text-3xs text-muted"
-      data-testid="maps-attribution"
-    >
+    <div className="pt-0.5 text-3xs text-muted" data-testid="maps-attribution">
       {attribution}
     </div>
   );


### PR DESCRIPTION
## Summary
- register the Signal optional-plugin literal importer
- map the Electrobun secure-store package to its actual workspace source
- format the two UI files currently failing the affected lint lane
- finish the OpenCode removal in stale agent tests and update timeout assertions to the current typed boundary message

Closes #24471

## Validation
- `bun test packages/agent/src/api/optional-plugin-fallback.test.ts packages/agent/src/runtime/optional-plugins.test.ts` (28 passed)
- `bun test packages/agent/src/services/e2b-capability-router.coding-remote-runner.test.ts packages/agent/src/services/e2b-capability-router.test.ts` (55 passed)
- `biome check` on all changed files
- `git diff --check`
- hosted affected-CI lint passed; rerun pending for affected typecheck/build

## Evidence
N/A: CI/type-resolution repair with no user-visible UI behavior change.
