### PR TITLE
fix(shared): drain in-flight sandbox heartbeat before unregister

### DIFF
--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -35,12 +35,33 @@ const recorded: Recorded[] = [];
 const store = new Map<string, string>();
 let failNextFetch = false;
 let nextPipelineResponse: unknown = null;
+let nextPipelineDelay: {
+  started: () => void;
+  wait: Promise<void>;
+} | null = null;
+
+function delayNextPipeline(): {
+  started: Promise<void>;
+  release: () => void;
+} {
+  let markStarted: () => void = () => {};
+  let release: () => void = () => {};
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  nextPipelineDelay = { started: markStarted, wait };
+  return { started, release };
+}
 
 function installFetch(): void {
   recorded.length = 0;
   store.clear();
   failNextFetch = false;
   nextPipelineResponse = null;
+  nextPipelineDelay = null;
   global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     if (failNextFetch) {
       failNextFetch = false;
@@ -51,6 +72,12 @@ function installFetch(): void {
     recorded.push({ url, body });
 
     if (url.endsWith("/pipeline")) {
+      const delay = nextPipelineDelay;
+      if (delay) {
+        nextPipelineDelay = null;
+        delay.started();
+        await delay.wait;
+      }
       if (nextPipelineResponse !== null) {
         return {
           ok: true,
@@ -201,6 +228,101 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
 
     reg.stopHeartbeat();
+  });
+
+  it("does not overlap heartbeat refreshes when a tick is still in flight", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    recorded.length = 0;
+
+    const delayed = delayNextPipeline();
+    reg.startHeartbeat(30_000);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+
+    delayed.release();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(2);
+
+    reg.stopHeartbeat();
+  });
+
+  it("unregister() drains an in-flight heartbeat before deleting its keys", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    recorded.length = 0;
+
+    const delayed = delayNextPipeline();
+    reg.startHeartbeat(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+
+    const unregistering = reg.unregister();
+    await Promise.resolve();
+    expect(
+      recorded.some(
+        (request) => Array.isArray(request.body) && request.body[0] === "EVAL",
+      ),
+    ).toBe(false);
+
+    delayed.release();
+    await unregistering;
+    expect(store.has("agent:char-123:server")).toBe(false);
+    expect(store.has("server:sandbox-abc:url")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+  });
+
+  it("unregister() falls back within the shutdown margin without deleting keys", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    recorded.length = 0;
+
+    const delayed = delayNextPipeline();
+    reg.startHeartbeat(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+
+    const unregistering = reg.unregister();
+    const outcome = unregistering.then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    let settled = false;
+    const observed = outcome.then((result) => {
+      settled = true;
+      return result;
+    });
+
+    // The dev supervisor allows 15s while runtime service teardown may use
+    // 13s. Registry cleanup must settle well inside the remaining 2s margin.
+    await vi.advanceTimersByTimeAsync(999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(observed).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
+    });
+
+    expect(
+      recorded.some(
+        (request) => Array.isArray(request.body) && request.body[0] === "EVAL",
+      ),
+    ).toBe(false);
+    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
+    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+
+    delayed.release();
+    await vi.advanceTimersByTimeAsync(0);
   });
 
   it("stopHeartbeat() halts the timer", async () => {

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -32,6 +32,12 @@ import { ElizaError, logger } from "@elizaos/core";
 
 /** Hard cap on a single TCP register/refresh round-trip. */
 const REGISTRY_TCP_TIMEOUT_MS = 10_000;
+/**
+ * Maximum graceful-shutdown wait before falling back to Redis key expiry.
+ * Runtime service teardown may use 13s of the dev supervisor's 15s ceiling,
+ * so registry cleanup must leave that path enough headroom to finish.
+ */
+const REGISTRY_HEARTBEAT_DRAIN_TIMEOUT_MS = 1_000;
 const MAX_REGISTRY_TCP_BYTES = 1_048_576;
 
 function formatErr(err: unknown): string {
@@ -80,6 +86,7 @@ export interface SandboxRegistryConfig {
 
 export class SandboxRegistry {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatInFlight: Promise<void> | null = null;
   private readonly tcp: boolean;
 
   constructor(private readonly config: SandboxRegistryConfig) {
@@ -98,6 +105,32 @@ export class SandboxRegistry {
   }
 
   async unregister(): Promise<void> {
+    this.stopHeartbeat();
+    const heartbeat = this.heartbeatInFlight;
+    if (heartbeat) {
+      let drainTimer: ReturnType<typeof setTimeout> | null = null;
+      try {
+        await Promise.race([
+          heartbeat,
+          new Promise<never>((_resolve, reject) => {
+            drainTimer = setTimeout(() => {
+              reject(
+                new ElizaError(
+                  "Timed out draining sandbox registry heartbeat; routing keys will expire through their TTL",
+                  { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
+                ),
+              );
+            }, REGISTRY_HEARTBEAT_DRAIN_TIMEOUT_MS);
+            if (typeof drainTimer === "object" && "unref" in drainTimer) {
+              drainTimer.unref();
+            }
+          }),
+        ]);
+      } finally {
+        if (drainTimer !== null) clearTimeout(drainTimer);
+      }
+    }
+
     const { serverName, serverUrl, agentId } = this.config;
     const serverUrlKey = `server:${serverName}:url`;
     const agentServerKey = `agent:${agentId}:server`;
@@ -126,11 +159,7 @@ export class SandboxRegistry {
     if (this.heartbeatTimer) return;
 
     this.heartbeatTimer = setInterval(() => {
-      void this.refresh().catch((err) => {
-        logger.warn(
-          `[sandbox-registry] Heartbeat refresh failed: ${formatErr(err)}`,
-        );
-      });
+      this.runHeartbeat();
     }, intervalMs);
 
     if (
@@ -146,6 +175,25 @@ export class SandboxRegistry {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }
+  }
+
+  private runHeartbeat(): void {
+    if (this.heartbeatInFlight) return;
+
+    const heartbeat = this.refresh()
+      .catch((err) => {
+        // error-policy:J7 a transient heartbeat failure is warned without
+        // terminating the recurring liveness loop; the next tick retries.
+        logger.warn(
+          `[sandbox-registry] Heartbeat refresh failed: ${formatErr(err)}`,
+        );
+      })
+      .finally(() => {
+        if (this.heartbeatInFlight === heartbeat) {
+          this.heartbeatInFlight = null;
+        }
+      });
+    this.heartbeatInFlight = heartbeat;
   }
 
   /**


### PR DESCRIPTION
# Relates to

Closes #24470.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      Windows CRLF blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the
      exact-head and mutation evidence below.

# Sync with develop

- [x] Rebased without conflicts onto `origin/develop@5abed3bccf5d20f7d86883fce20622d6b44266d3`; after the push, `develop` advanced to `f98226ef6ba016be6022a3b9358f13c2c61457c2` through unrelated cloud/scenario commits that touch neither changed file.
- [x] `bun run verify` was run post-sync; the exact unrelated blocker is documented in **Known gaps / failures**.

# Risks

Low-to-medium lifecycle risk, limited to graceful sandbox-registry shutdown:

- `unregister()` now waits for an active heartbeat before deleting its owned routing keys.
- The wait is capped at 1 second, leaving 1 second of margin between the runtime's 13-second service-stop allowance and the dev supervisor's 15-second hard ceiling. If the heartbeat remains stalled, unregister rejects before `EVAL`; existing teardown handlers warn and continue while Redis TTL expiry removes the route.
- A late REST completion after that timeout can renew the TTL, so the timeout guarantee is bounded shutdown with TTL fallback, not immediate route removal.
- Registration payloads, Redis key shapes, TTLs, and both REST/TCP transports are unchanged.

# Background

## What does this PR do?

- Coalesces heartbeat ticks so a slow Redis refresh cannot overlap later ticks.
- Tracks the handled in-flight heartbeat promise.
- Makes `unregister()` stop future ticks, drain an active heartbeat, and only then run the existing atomic compare-and-delete.
- Adds a bounded drain fallback so an unresponsive REST request cannot hang process teardown forever.
- Adds deterministic ordering, single-flight, and timeout regressions.

## What kind of change is this?

Bug fix (non-breaking lifecycle reliability change).

# Documentation changes needed?

No project documentation change is required. The lifecycle contract and timeout fallback are documented inline and covered by focused tests.

# Testing

## Where should a reviewer start?

Start with `SandboxRegistry.unregister()` and `runHeartbeat()` in `packages/shared/src/sandbox-registry.ts`, then the three new deferred-pipeline tests in `packages/shared/src/sandbox-registry.test.ts`.

## Detailed testing steps

Pinned toolchain: Node `24.15.0`, Bun `1.3.14`.

- `bun x vitest run --config packages/shared/vitest.config.ts packages/shared/src/sandbox-registry.test.ts --coverage.enabled=false` — 23/23 passed.
- `bun run --cwd packages/shared test` — 167 files, 2,225 tests passed.
- `bun run --cwd packages/shared typecheck` — passed.
- `node packages/scripts/run-turbo.mjs run build --filter=@elizaos/shared --concurrency=4 --cache=local:rw --output-logs=errors-only` — 4/4 tasks passed.
- `bunx @biomejs/biome check packages/shared/src/sandbox-registry.ts packages/shared/src/sandbox-registry.test.ts` — passed.
- Mutation proof: restoring the old fire-and-forget heartbeat behavior makes all three new regressions fail (overlap count 4 instead of 1, early `EVAL`, and no bounded timeout rejection).
- `git diff --check origin/develop...HEAD` — passed.
- `bun run verify` — preflight checks passed, then the workspace lint/typecheck phase stopped after 18 successful tasks because eight untouched UI CSS files were checked out with CRLF on Windows; exact paths are listed below.

# Evidence Gate

Evidence matches commit `51274fef29c38c5dc4c6e2ca8d736097787000fd`.
<!-- evidence-head:51274fef29c38c5dc4c6e2ca8d736097787000fd -->

This is a backend-only shared registry lifecycle change; it has no rendered UI surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - Backend-only lifecycle change; no UI surface exists to capture before.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Backend-only lifecycle change; no UI surface exists to capture after.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - No user-facing flow or rendered interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head backend verification transcript
<details>
<summary>Focused sandbox-registry test output</summary>

```json
{"timestamp":"2026-08-23T01:30:17+09:00","level":"INFO","message":"HEAD 51274fef29c38c5dc4c6e2ca8d736097787000fd focused Vitest completed: Test Files 1 passed (1)."}
{"timestamp":"2026-08-23T01:30:17+09:00","level":"INFO","message":"HEAD 51274fef29c38c5dc4c6e2ca8d736097787000fd focused Vitest completed: Tests 23 passed (23)."}
{"level":"INFO","message":"Filtered @elizaos/shared production build completed: Tasks 4 successful, 4 total; Cached 0; Time 30.782s."}
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code, request, or state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model, prompt, provider, action, or agent reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head deterministic lifecycle regression artifact
<details>
<summary>Observed routing-key lifecycle invariants</summary>

```text
Single-flight: a held heartbeat plus three later ticks produced 1 REST pipeline request; the next tick after settlement produced request 2.
Drain ordering: EVAL before the held heartbeat settled was false; after settlement, unregister completed and both owned routing keys were absent.
Shutdown bound: unregister remained pending at 999 ms, rejected at 1,000 ms with SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT, issued no EVAL, and preserved the keys for TTL expiry.
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No model, prompt, provider, action, or agent behavior changed.

## Backend + frontend logs

Backend exact-head transcript:

```text
HEAD 51274fef29c38c5dc4c6e2ca8d736097787000fd
Node v24.15.0
Bun 1.3.14
Test Files  1 passed (1)
Tests       23 passed (23)

Full @elizaos/shared suite:
Test Files  167 passed (167)
Tests       2225 passed (2225)
```

Frontend: N/A - No frontend code or network flow changed.

## Domain artifacts

The deferred REST-pipeline tests exercise the production `SandboxRegistry` while controlling Redis completion order and inspecting the resulting routing-key store:

```text
fixed: pending ticks -> 1 pipeline request; next tick after settlement -> 2
fixed: EVAL before heartbeat settlement -> false
fixed: store after settled heartbeat + unregister -> both routing keys absent
fixed: stalled heartbeat pending at 999ms; after 1s -> SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT
fixed: EVAL on timeout -> false; existing routing keys preserved for TTL fallback

mutation (old lifecycle):
overlap test -> expected 1 pipeline request, received 4
ordering test -> EVAL observed before pending heartbeat settled
timeout test -> unregister resolved instead of rejecting with the bounded fallback
```

## Screenshots (before / after) + video walkthrough

N/A - Backend-only shared registry lifecycle change with no rendered visual surface.

## Audio / voice walkthrough

N/A - No voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- [PR Static Smoke run 32585074869](https://github.com/elizaOS/eliza/actions/runs/32585074869/job/97060110601) completed 175 tasks successfully, then failed only in unchanged `plugins/plugin-documents/src/routes.ts:1077` and `:1079`: TypeScript reports that `directGrantEntityIds` is not present on every `MemoryMetadata` union member. This PR changes only the two sandbox-registry files; the package typecheck reproduces unchanged against the base, and current `develop@f98226ef6b` still has the same affected code. Upstream PR [#24426](https://github.com/elizaOS/eliza/pull/24426) contains the exact union-narrowing fix and its Static Smoke check is green.
- `bun run verify` on the final head passed its preflight checks, then stopped in the workspace lint/typecheck phase after 18 successful tasks because Biome rejected CRLF line endings in eight untouched files: `packages/ui/src/cloud-ui/index.css`, `packages/ui/src/styles/base.css`, `packages/ui/src/styles/brand-gold.css`, `packages/ui/src/styles/electrobun-mac-window-drag.css`, `packages/ui/src/styles/shadcn-utilities.css`, `packages/ui/src/styles/styles.css`, `packages/ui/src/styles/tailwind-theme.css`, and `packages/ui/src/styles/theme.css`. None are changed by this PR. Both changed TypeScript files pass the same pinned Biome version directly.
- One repeat full shared-suite invocation hit a transient Windows `EPERM` while an unrelated routing-preference test atomically renamed a temp file. The exact-blob full run passed 2,225/2,225, and the failed test passed 9/9 immediately when rerun in isolation.
- No production Upstash credentials were used. The shutdown interleaving is deterministic through the test REST transport; the same focused suite also exercises the native Redis transport over a real local TCP socket.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r-codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza"} -->
