### PR TITLE
feat(connectors): add canonical interaction adapters

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -37,6 +37,13 @@ is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 
+The bundled `eliza` plugin registers `MessageInteractionHostService` as the one
+runtime authority connectors resolve through `MESSAGE_INTERACTION_HOST_SERVICE`.
+Connectors submit capability profiles and trusted render bindings to `prepare`,
+then send authenticated inbound provider receipts to `consume`. Only host-owned
+effect handlers execute retained operations; completed receipts preserve the
+provider event, canonical inbound event, audit id, and app-state proof for replay.
+
 ## Approval-bound plugin installation
 
 `installPlugin` always installs the canonical npm package declared by the

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -26,6 +26,17 @@ See `package.json` for `build`, `lint`, and other scripts.
 unsuccessful `TaskResult` with a stable `errorCode`; it never falls back to
 ordinary `TEXT_LARGE` synthesis and labels that output as research.
 
+## Message-interaction session persistence
+
+`FileMessageInteractionSessionStore` is the durable single-host adapter for
+core's message-interaction session authority. It serializes independent local
+processes, writes a 0600 regular file through same-filesystem fsync and atomic
+rename, fails fast on corruption and symlinks, recovers only stale locks whose
+owner is no longer alive, and exposes explicit expiry collection. Its boundary
+is one machine and one state directory. Multi-host deployments must supply a
+transactional database implementation of `MessageInteractionSessionStore` and
+use the session replay key as the effect or outbox idempotency key.
+
 ## Approval-bound plugin installation
 
 `installPlugin` always installs the canonical npm package declared by the

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -37,6 +37,11 @@ is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 
+The file authority durably commits an effect before dispatch. If the process
+dies after that commit but before retaining the receipt, the session remains
+`committed` for operator reconciliation; it is never lease-transferred,
+automatically retried, revoked as if cancellation succeeded, or garbage-collected.
+
 The bundled `eliza` plugin registers `MessageInteractionHostService` as the one
 runtime authority connectors resolve through `MESSAGE_INTERACTION_HOST_SERVICE`.
 Connectors submit capability profiles and trusted render bindings to `prepare`,

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -75,6 +75,7 @@ import {
   knowledgeGraphSchema,
 } from "../services/knowledge-graph/index.ts";
 import { AgentMediaGenerationService } from "../services/media-generation.ts";
+import { MessageInteractionHostService } from "../services/message-interaction-host.ts";
 import { OwnerBindingService } from "../services/owner-binding.ts";
 import { pendantSessionSchema } from "../services/pendant-session/index.ts";
 import { PendingPromptsService } from "../services/pending-prompts/index.ts";
@@ -130,6 +131,7 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       NotificationPushService as ServiceClass,
       ElizaCharacterPersistenceService as ServiceClass,
       AgentMediaGenerationService as ServiceClass,
+      MessageInteractionHostService as ServiceClass,
       LocalFileStorageService as ServiceClass,
       PermissionRegistry as ServiceClass,
       KnowledgeGraphService as ServiceClass,

--- a/packages/agent/src/services/__fixtures__/message-interaction-claim-child.ts
+++ b/packages/agent/src/services/__fixtures__/message-interaction-claim-child.ts
@@ -1,0 +1,12 @@
+/** Executes one file-store claim in a separate process for lock/CAS tests. */
+
+import fs from "node:fs/promises";
+import { FileMessageInteractionSessionStore } from "../message-interaction-session-store.ts";
+
+const [stateDirectory, contextPath] = process.argv.slice(2);
+if (!stateDirectory || !contextPath)
+  throw new Error("state directory and context path are required");
+const context = JSON.parse(await fs.readFile(contextPath, "utf8"));
+const store = new FileMessageInteractionSessionStore({ stateDirectory });
+const result = await store.claimIfCurrent(context);
+process.stdout.write(result.status);

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -29,6 +29,7 @@ export {
   type EscalationState,
   registerEscalationChannel,
 } from "./escalation.ts";
+export * from "./message-interaction-session-store.ts";
 export * from "./overlay-app-presence.ts";
 export {
   type IPermissionsRegistry,

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -29,6 +29,7 @@ export {
   type EscalationState,
   registerEscalationChannel,
 } from "./escalation.ts";
+export * from "./message-interaction-host.ts";
 export * from "./message-interaction-session-store.ts";
 export * from "./overlay-app-presence.ts";
 export {

--- a/packages/agent/src/services/message-interaction-host.test.ts
+++ b/packages/agent/src/services/message-interaction-host.test.ts
@@ -9,10 +9,16 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   BUTTON_INTERACTION_PROFILE,
+  consumePreparedInteractionCallback,
   createConnectorInteractionCapabilityProfile,
   decodeMessageInteractionCallback,
+  encodePreparedInteractionCallback,
+  encodeReplyCallback,
   type IAgentRuntime,
   InMemoryMessageInteractionSessionStore,
+  type InteractionBlock,
+  type MessageInteractionPurpose,
+  type MessageInteractionResponse,
   resolveMessageInteractionHost,
 } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -280,6 +286,167 @@ describe("MessageInteractionHostService", () => {
       receipt: { receiptId: "receipt-provider-event-a" },
     });
     expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("consumes a provider response envelope through the registered sole host", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    const prepared = await prepare();
+    const providerCallbackData = encodePreparedInteractionCallback(
+      prepared.callbackData,
+      { value: "approve" },
+      100,
+    );
+    const hostRuntime = {
+      ...runtime(),
+      getService: () => service,
+    } as IAgentRuntime;
+    const request = {
+      providerCallbackData,
+      bindings: {
+        actorId: bindings.actorId,
+        audience: bindings.audience,
+        agentId: bindings.agentId,
+        connector: bindings.connector,
+        roomId: bindings.roomId,
+      },
+      providerReceipt: providerReceipt("provider-envelope-a"),
+    };
+    await expect(
+      consumePreparedInteractionCallback(hostRuntime, request),
+    ).resolves.toMatchObject({
+      status: "completed",
+      receipt: {
+        providerReceipt: { inboundEventId: "provider-envelope-a" },
+        canonicalInboundEventId: "memory-provider-envelope-a",
+        auditId: "audit-provider-envelope-a",
+        appStateResult: { taskState: "approved" },
+      },
+    });
+    await expect(
+      consumePreparedInteractionCallback(hostRuntime, request),
+    ).resolves.toMatchObject({ status: "replay" });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("never dispatches a legacy presentation callback through host authority", async () => {
+    const { service, execute, providerReceipt } = fixture();
+    const legacyCallback = encodeReplyCallback("approve", { maxBytes: 100 });
+    const hostRuntime = {
+      ...runtime(),
+      getService: () => service,
+    } as IAgentRuntime;
+
+    await expect(
+      consumePreparedInteractionCallback(hostRuntime, {
+        providerCallbackData: legacyCallback,
+        bindings: authenticatedBindings,
+        providerReceipt: providerReceipt("legacy-provider-event"),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "INVALID_MESSAGE_INTERACTION_PROVIDER_CALLBACK",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("executes choice, followup, form, task, auth-link, and file schemas", async () => {
+    const cases: Array<{
+      purpose: MessageInteractionPurpose;
+      block: InteractionBlock;
+      response: MessageInteractionResponse;
+    }> = [
+      {
+        purpose: "choice" as const,
+        block,
+        response: { value: "approve" },
+      },
+      {
+        purpose: "followup" as const,
+        block: {
+          kind: "followups" as const,
+          id: "followup-a",
+          options: [{ kind: "reply" as const, label: "Next", payload: "next" }],
+        },
+        response: { value: "next" },
+      },
+      {
+        purpose: "form" as const,
+        block: {
+          kind: "form" as const,
+          id: "form-a",
+          fields: [{ name: "name", type: "text" as const, required: true }],
+        },
+        response: { name: "Ada" },
+      },
+      {
+        purpose: "task" as const,
+        block: { kind: "task" as const, threadId: "12345678", title: "Task" },
+        response: { acknowledged: true },
+      },
+      {
+        purpose: "auth" as const,
+        block: {
+          kind: "secret" as const,
+          id: "auth-a",
+          secretKind: "oauth" as const,
+          provider: "Example",
+          url: "https://example.test/auth",
+        },
+        response: { acknowledged: true },
+      },
+      {
+        purpose: "file" as const,
+        block: {
+          kind: "form" as const,
+          id: "file-a",
+          fields: [
+            {
+              name: "upload",
+              type: "file" as const,
+              required: true,
+              maxBytes: 1024,
+              mimeTypes: ["text/plain"],
+            },
+          ],
+        },
+        response: {
+          upload: {
+            mediaUrl: `/api/media/${"a".repeat(64)}.txt`,
+            mimeType: "text/plain",
+            bytes: 12,
+          },
+        },
+      },
+    ];
+
+    for (const [index, testCase] of cases.entries()) {
+      const current = fixture();
+      const prepared = await current.service.prepare({
+        block: testCase.block,
+        profile,
+        bindings,
+        purpose: testCase.purpose,
+        negotiationContext: {
+          signedHostedUrl: `https://example.test/interactions/${index}`,
+        },
+        authorization: {
+          decisionId: `decision-${index}`,
+          policyRevision: "policy-7",
+          decidedAt: "2026-08-20T23:59:59.000Z",
+        },
+        effect: { kind: "approve_operation", metadata: { case: index } },
+        expiresAt: "2026-08-21T00:10:00.000Z",
+      });
+      await expect(
+        current.service.consume({
+          callbackData: prepared.callbackData,
+          bindings: authenticatedBindings,
+          response: testCase.response,
+          providerReceipt: current.providerReceipt(`provider-flow-${index}`),
+        }),
+      ).resolves.toMatchObject({ status: "completed" });
+      expect(current.execute).toHaveBeenCalledOnce();
+    }
   });
 
   it("rejects mismatched provider authority and conflicting handlers", async () => {

--- a/packages/agent/src/services/message-interaction-host.test.ts
+++ b/packages/agent/src/services/message-interaction-host.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Exercises the real host coordinator with core's in-memory atomic store.
+ * The harness is deterministic and proves binding denial, expiry, revocation,
+ * receipt retention, replay, and exactly-once effect dispatch.
+ */
+
+import { mkdtemp, realpath, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  BUTTON_INTERACTION_PROFILE,
+  createConnectorInteractionCapabilityProfile,
+  decodeMessageInteractionCallback,
+  type IAgentRuntime,
+  InMemoryMessageInteractionSessionStore,
+  resolveMessageInteractionHost,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageInteractionHostService } from "./message-interaction-host.ts";
+
+const START = Date.parse("2026-08-21T00:00:00.000Z");
+
+const block = {
+  kind: "choice" as const,
+  id: "approve-1",
+  scope: "approval",
+  options: [
+    { value: "approve", label: "Approve" },
+    { value: "deny", label: "Deny" },
+  ],
+};
+
+const bindings = {
+  actorId: "actor-a",
+  audience: { kind: "room", id: "room-a" },
+  agentId: "agent-a",
+  connector: { source: "connector", accountId: "account-a" },
+  roomId: "room-a",
+  sourceMessageId: "message-a",
+};
+
+const profile = createConnectorInteractionCapabilityProfile({
+  template: BUTTON_INTERACTION_PROFILE,
+  source: "connector",
+  accountId: "account-a",
+  targetKind: "room",
+  targetId: "room-a",
+});
+
+function runtime(): IAgentRuntime {
+  return {
+    agentId: "agent-a",
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    redactSecrets: (text: string) => text,
+  } as never;
+}
+
+function fixture() {
+  let now = START;
+  const service = new MessageInteractionHostService(runtime(), {
+    store: new InMemoryMessageInteractionSessionStore(),
+    clock: () => now,
+    referenceFactory: () => "0123456789abcdef0123456789abcdef",
+    claimTtlMs: 100,
+  });
+  const execute = vi.fn(
+    async ({ idempotencyKey }: { idempotencyKey: string }) => ({
+      receiptId: `receipt-${idempotencyKey}`,
+      canonicalInboundEventId: `memory-${idempotencyKey}`,
+      auditId: `audit-${idempotencyKey}`,
+      appStateResult: { taskState: "approved" },
+      result: { accepted: true },
+    }),
+  );
+  const unregister = service.registerEffectHandler("approve_operation", {
+    execute,
+  });
+  const prepare = () =>
+    service.prepare({
+      block,
+      profile,
+      bindings,
+      purpose: "approval",
+      authorization: {
+        decisionId: "decision-a",
+        policyRevision: "policy-7",
+        decidedAt: "2026-08-20T23:59:59.000Z",
+      },
+      effect: { kind: "approve_operation", metadata: { operationId: "op-a" } },
+      expiresAt: "2026-08-21T00:10:00.000Z",
+    });
+  const providerReceipt = (inboundEventId = "provider-event-a") => ({
+    source: "connector",
+    accountId: "account-a",
+    inboundEventId,
+    receivedAt: new Date(now).toISOString(),
+  });
+  return {
+    service,
+    execute,
+    unregister,
+    prepare,
+    providerReceipt,
+    setNow(value: number) {
+      now = value;
+    },
+  };
+}
+
+describe("MessageInteractionHostService", () => {
+  it("resolves only a structurally complete registered host", () => {
+    const service = fixture().service;
+    expect(
+      resolveMessageInteractionHost({
+        getService: () => service,
+      } as never),
+    ).toBe(service);
+    expect(
+      resolveMessageInteractionHost({ getService: () => null } as never),
+    ).toBeNull();
+    expect(() =>
+      resolveMessageInteractionHost({ getService: () => ({}) } as never),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "INVALID_MESSAGE_INTERACTION_HOST_SERVICE",
+      }),
+    );
+  });
+
+  it("returns only renderer-safe preparation fields", async () => {
+    const { prepare } = fixture();
+    const prepared = await prepare();
+
+    expect(prepared).toMatchObject({
+      block: { kind: "choice", id: "approve-1" },
+      delivery: { mode: "native" },
+      callbackData: "is1:0123456789abcdef0123456789abcdef",
+      expiresAt: "2026-08-21T00:10:00.000Z",
+      profileId: profile.profileId,
+    });
+    expect(prepared).not.toHaveProperty("authorization");
+    expect(prepared).not.toHaveProperty("effect");
+    expect(prepared).not.toHaveProperty("bindings");
+  });
+
+  it("denies a second actor before executing the retained effect", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    const prepared = await prepare();
+
+    await expect(
+      service.consume({
+        callbackData: prepared.callbackData,
+        bindings: { ...bindings, actorId: "actor-b" },
+        response: { value: "approve" },
+        providerReceipt: providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_BINDING_MISMATCH",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("denies expiry and post-render authorization revocation", async () => {
+    const expired = fixture();
+    const expiredPrepared = await expired.prepare();
+    expired.setNow(Date.parse("2026-08-21T00:10:00.000Z"));
+    await expect(
+      expired.service.consume({
+        callbackData: expiredPrepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: expired.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_EXPIRED",
+    });
+
+    const revoked = fixture();
+    const revokedPrepared = await revoked.prepare();
+    const reference = decodeMessageInteractionCallback(
+      revokedPrepared.callbackData,
+    );
+    if (!reference) throw new Error("Expected an opaque callback reference");
+    await revoked.service.revoke({
+      reference,
+      decisionId: "decision-a",
+      now: START + 1,
+    });
+    await expect(
+      revoked.service.consume({
+        callbackData: revokedPrepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: revoked.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+    });
+    expect(expired.execute).not.toHaveBeenCalled();
+    expect(revoked.execute).not.toHaveBeenCalled();
+  });
+
+  it("retains provider, inbound, audit, and app-state proof and replays exactly once", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    const prepared = await prepare();
+    const request = {
+      callbackData: prepared.callbackData,
+      bindings,
+      response: { value: "approve" },
+      providerReceipt: providerReceipt(),
+    };
+
+    const first = await service.consume(request);
+    expect(first).toMatchObject({
+      status: "completed",
+      receipt: {
+        receiptId: "receipt-provider-event-a",
+        idempotencyKey: "provider-event-a",
+        canonicalInboundEventId: "memory-provider-event-a",
+        providerReceipt: { inboundEventId: "provider-event-a" },
+        auditId: "audit-provider-event-a",
+        appStateResult: { taskState: "approved" },
+        result: { accepted: true },
+      },
+    });
+    await expect(service.consume(request)).resolves.toMatchObject({
+      status: "replay",
+      receipt: { receiptId: "receipt-provider-event-a" },
+    });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("rejects mismatched provider authority and conflicting handlers", async () => {
+    const { service, execute, prepare, providerReceipt } = fixture();
+    expect(() =>
+      service.registerEffectHandler("approve_operation", { execute }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "MESSAGE_INTERACTION_EFFECT_HANDLER_COLLISION",
+      }),
+    );
+    const prepared = await prepare();
+    await expect(
+      service.consume({
+        callbackData: prepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: { ...providerReceipt(), accountId: "account-b" },
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed without a host effect handler and resumes after the claim lease", async () => {
+    const fixtureValue = fixture();
+    fixtureValue.unregister();
+    const prepared = await fixtureValue.prepare();
+    const request = {
+      callbackData: prepared.callbackData,
+      bindings,
+      response: { value: "approve" },
+      providerReceipt: fixtureValue.providerReceipt(),
+    };
+
+    await expect(fixtureValue.service.consume(request)).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
+    });
+    fixtureValue.setNow(START + 101);
+    fixtureValue.service.registerEffectHandler("approve_operation", {
+      execute: fixtureValue.execute,
+    });
+    await expect(
+      fixtureValue.service.consume({
+        ...request,
+        providerReceipt: fixtureValue.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({ status: "completed" });
+    expect(fixtureValue.execute).toHaveBeenCalledOnce();
+  });
+
+  it("rejects cross-agent preparation and secret-bearing effect proof", async () => {
+    const agentMismatch = fixture();
+    await expect(
+      agentMismatch.service.prepare({
+        block,
+        profile,
+        bindings: { ...bindings, agentId: "agent-b" },
+        purpose: "approval",
+        authorization: {
+          decisionId: "decision-a",
+          policyRevision: "policy-7",
+          decidedAt: "2026-08-20T23:59:59.000Z",
+        },
+        effect: { kind: "approve_operation" },
+        expiresAt: "2026-08-21T00:10:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_AGENT_MISMATCH" });
+
+    const unsafe = fixture();
+    unsafe.unregister();
+    unsafe.service.registerEffectHandler("approve_operation", {
+      execute: async ({ idempotencyKey }) => ({
+        receiptId: `receipt-${idempotencyKey}`,
+        canonicalInboundEventId: `memory-${idempotencyKey}`,
+        auditId: `audit-${idempotencyKey}`,
+        appStateResult: { taskState: "approved" },
+        result: { apiToken: "must-not-leak" },
+      }),
+    });
+    const prepared = await unsafe.prepare();
+    await expect(
+      unsafe.service.consume({
+        callbackData: prepared.callbackData,
+        bindings,
+        response: { value: "approve" },
+        providerReceipt: unsafe.providerReceipt(),
+      }),
+    ).resolves.toMatchObject({
+      status: "denied",
+      code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+    });
+  });
+
+  it("starts with the real owner-only file authority registered by the host", async () => {
+    const root = await mkdtemp(
+      path.join(await realpath(tmpdir()), "eliza-interaction-host-"),
+    );
+    const previousStateDirectory = process.env.ELIZA_STATE_DIR;
+    process.env.ELIZA_STATE_DIR = root;
+    try {
+      const service = await MessageInteractionHostService.start(runtime());
+      service.registerEffectHandler("approve_operation", {
+        execute: async ({ idempotencyKey }) => ({
+          receiptId: `receipt-${idempotencyKey}`,
+          canonicalInboundEventId: `memory-${idempotencyKey}`,
+          auditId: `audit-${idempotencyKey}`,
+          appStateResult: { taskState: "approved" },
+          result: { accepted: true },
+        }),
+      });
+      const prepared = await service.prepare({
+        block,
+        profile,
+        bindings,
+        purpose: "approval",
+        authorization: {
+          decisionId: "decision-a",
+          policyRevision: "policy-7",
+          decidedAt: new Date(Date.now() - 1_000).toISOString(),
+        },
+        effect: {
+          kind: "approve_operation",
+          metadata: { operationId: "op-a" },
+        },
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+      await expect(
+        service.consume({
+          callbackData: prepared.callbackData,
+          bindings,
+          response: { value: "approve" },
+          providerReceipt: {
+            source: "connector",
+            accountId: "account-a",
+            inboundEventId: "provider-file-event-a",
+            receivedAt: new Date().toISOString(),
+          },
+        }),
+      ).resolves.toMatchObject({ status: "completed" });
+      const filePath = path.join(
+        root,
+        "message-interactions",
+        "agent-a",
+        "message-interaction-sessions.v1.json",
+      );
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+      await service.stop();
+    } finally {
+      if (previousStateDirectory === undefined)
+        delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = previousStateDirectory;
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/agent/src/services/message-interaction-host.test.ts
+++ b/packages/agent/src/services/message-interaction-host.test.ts
@@ -39,6 +39,14 @@ const bindings = {
   sourceMessageId: "message-a",
 };
 
+const authenticatedBindings = {
+  actorId: bindings.actorId,
+  audience: bindings.audience,
+  agentId: bindings.agentId,
+  connector: bindings.connector,
+  roomId: bindings.roomId,
+};
+
 const profile = createConnectorInteractionCapabilityProfile({
   template: BUTTON_INTERACTION_PROFILE,
   source: "connector",
@@ -143,6 +151,47 @@ describe("MessageInteractionHostService", () => {
     expect(prepared).not.toHaveProperty("bindings");
   });
 
+  it("returns a validated hosted URL without retained authority fields", async () => {
+    const { service } = fixture();
+    const hostedProfile = createConnectorInteractionCapabilityProfile({
+      template: {
+        ...BUTTON_INTERACTION_PROFILE,
+        templateId: "signed-hosted-only-test",
+        blocks: {
+          ...BUTTON_INTERACTION_PROFILE.blocks,
+          choice: {
+            ...BUTTON_INTERACTION_PROFILE.blocks.choice,
+            modes: ["signed-hosted"],
+          },
+        },
+      },
+      source: "connector",
+      accountId: "account-a",
+      targetKind: "room",
+      targetId: "room-a",
+    });
+    const prepared = await service.prepare({
+      block,
+      profile: hostedProfile,
+      bindings,
+      purpose: "approval",
+      negotiationContext: { signedHostedUrl: "https://example.test/form/a" },
+      authorization: {
+        decisionId: "decision-hosted",
+        policyRevision: "policy-7",
+        decidedAt: "2026-08-20T23:59:59.000Z",
+      },
+      effect: { kind: "approve_operation" },
+      expiresAt: "2026-08-21T00:10:00.000Z",
+    });
+
+    expect(prepared).toMatchObject({
+      delivery: { mode: "signed-hosted" },
+      hostedUrl: "https://example.test/form/a",
+    });
+    expect(prepared).not.toHaveProperty("bindings");
+  });
+
   it("denies a second actor before executing the retained effect", async () => {
     const { service, execute, prepare, providerReceipt } = fixture();
     const prepared = await prepare();
@@ -150,7 +199,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       service.consume({
         callbackData: prepared.callbackData,
-        bindings: { ...bindings, actorId: "actor-b" },
+        bindings: { ...authenticatedBindings, actorId: "actor-b" },
         response: { value: "approve" },
         providerReceipt: providerReceipt(),
       }),
@@ -168,7 +217,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       expired.service.consume({
         callbackData: expiredPrepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: expired.providerReceipt(),
       }),
@@ -191,7 +240,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       revoked.service.consume({
         callbackData: revokedPrepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: revoked.providerReceipt(),
       }),
@@ -208,7 +257,7 @@ describe("MessageInteractionHostService", () => {
     const prepared = await prepare();
     const request = {
       callbackData: prepared.callbackData,
-      bindings,
+      bindings: authenticatedBindings,
       response: { value: "approve" },
       providerReceipt: providerReceipt(),
     };
@@ -246,7 +295,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       service.consume({
         callbackData: prepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: { ...providerReceipt(), accountId: "account-b" },
       }),
@@ -263,7 +312,7 @@ describe("MessageInteractionHostService", () => {
     const prepared = await fixtureValue.prepare();
     const request = {
       callbackData: prepared.callbackData,
-      bindings,
+      bindings: authenticatedBindings,
       response: { value: "approve" },
       providerReceipt: fixtureValue.providerReceipt(),
     };
@@ -318,7 +367,7 @@ describe("MessageInteractionHostService", () => {
     await expect(
       unsafe.service.consume({
         callbackData: prepared.callbackData,
-        bindings,
+        bindings: authenticatedBindings,
         response: { value: "approve" },
         providerReceipt: unsafe.providerReceipt(),
       }),
@@ -361,10 +410,27 @@ describe("MessageInteractionHostService", () => {
         },
         expiresAt: new Date(Date.now() + 60_000).toISOString(),
       });
+      const reference = decodeMessageInteractionCallback(prepared.callbackData);
+      if (!reference) throw new Error("Expected an opaque callback reference");
+      await expect(service.get(reference)).resolves.toMatchObject({
+        bindings: { sourceMessageId: "message-a" },
+        consume: { state: "pending" },
+      });
+      await service.stop();
+      const restarted = await MessageInteractionHostService.start(runtime());
+      restarted.registerEffectHandler("approve_operation", {
+        execute: async ({ idempotencyKey }) => ({
+          receiptId: `receipt-${idempotencyKey}`,
+          canonicalInboundEventId: `memory-${idempotencyKey}`,
+          auditId: `audit-${idempotencyKey}`,
+          appStateResult: { taskState: "approved" },
+          result: { accepted: true },
+        }),
+      });
       await expect(
-        service.consume({
+        restarted.consume({
           callbackData: prepared.callbackData,
-          bindings,
+          bindings: authenticatedBindings,
           response: { value: "approve" },
           providerReceipt: {
             source: "connector",
@@ -381,7 +447,7 @@ describe("MessageInteractionHostService", () => {
         "message-interaction-sessions.v1.json",
       );
       expect((await stat(filePath)).mode & 0o777).toBe(0o600);
-      await service.stop();
+      await restarted.stop();
     } finally {
       if (previousStateDirectory === undefined)
         delete process.env.ELIZA_STATE_DIR;

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -1,0 +1,394 @@
+/**
+ * Registers the single host-owned coordinator for durable connector interactions.
+ * It prepares safe renderer inputs and dispatches authenticated callbacks only
+ * through idempotent effect handlers owned by the application host.
+ */
+
+import path from "node:path";
+import {
+  type ConsumeMessageInteractionRequest,
+  decodeMessageInteractionCallback,
+  ElizaError,
+  type IAgentRuntime,
+  MESSAGE_INTERACTION_CALLBACK_BYTES,
+  MESSAGE_INTERACTION_HOST_SERVICE,
+  type MessageInteractionHost,
+  type MessageInteractionHostConsumeOutcome,
+  type MessageInteractionHostEffectHandler,
+  type MessageInteractionHostReceipt,
+  type MessageInteractionSession,
+  MessageInteractionSessionAuthority,
+  type MessageInteractionSessionStore,
+  negotiateInteractionDelivery,
+  type PreparedMessageInteraction,
+  type PrepareMessageInteractionRequest,
+  Service,
+} from "@elizaos/core";
+import { resolveStateDir } from "../config/paths.ts";
+import { FileMessageInteractionSessionStore } from "./message-interaction-session-store.ts";
+
+export interface MessageInteractionHostServiceOptions {
+  store?: MessageInteractionSessionStore;
+  clock?: () => number;
+  referenceFactory?: () => string;
+  claimTtlMs?: number;
+}
+
+function requiredText(value: string, pathName: string): string {
+  const normalized = value.trim();
+  if (!normalized || new TextEncoder().encode(normalized).length > 512) {
+    throw new ElizaError(`${pathName} is invalid.`, {
+      code: "INVALID_MESSAGE_INTERACTION_HOST_INPUT",
+      context: { path: pathName },
+    });
+  }
+  return normalized;
+}
+
+function assertSafeResult(
+  value: unknown,
+  pathName: string,
+  redact: (text: string) => string,
+): asserts value is Readonly<Record<string, string | number | boolean | null>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ElizaError(`${pathName} must be a result object.`, {
+      code: "INVALID_MESSAGE_INTERACTION_EFFECT_RECEIPT",
+      context: { path: pathName },
+    });
+  }
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (
+      fieldValue !== null &&
+      typeof fieldValue !== "string" &&
+      typeof fieldValue !== "number" &&
+      typeof fieldValue !== "boolean"
+    ) {
+      throw new ElizaError(`${pathName} contains a non-scalar field.`, {
+        code: "INVALID_MESSAGE_INTERACTION_EFFECT_RECEIPT",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
+    if (/secret|password|token|api.?key|oauth.*code/i.test(key)) {
+      throw new ElizaError(`${pathName} contains a secret-bearing field.`, {
+        code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
+    if (typeof fieldValue === "string" && redact(fieldValue) !== fieldValue) {
+      throw new ElizaError(`${pathName} contains secret material.`, {
+        code: "MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
+  }
+}
+
+function hostReceipt(
+  value: unknown,
+  expectedProvider: ConsumeMessageInteractionRequest["providerReceipt"],
+  redact: (text: string) => string,
+): MessageInteractionHostReceipt {
+  if (!value || typeof value !== "object") {
+    throw new ElizaError("Interaction host receipt is invalid.", {
+      code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+    });
+  }
+  const receipt = value as Partial<MessageInteractionHostReceipt>;
+  if (
+    typeof receipt.receiptId !== "string" ||
+    typeof receipt.idempotencyKey !== "string" ||
+    receipt.status !== "completed" ||
+    typeof receipt.completedAt !== "string" ||
+    typeof receipt.canonicalInboundEventId !== "string" ||
+    !receipt.providerReceipt ||
+    typeof receipt.auditId !== "string" ||
+    !receipt.appStateResult ||
+    !receipt.result
+  ) {
+    throw new ElizaError("Interaction host receipt is incomplete.", {
+      code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+    });
+  }
+  requiredText(receipt.receiptId, "receipt.receiptId");
+  requiredText(receipt.idempotencyKey, "receipt.idempotencyKey");
+  requiredText(
+    receipt.canonicalInboundEventId,
+    "receipt.canonicalInboundEventId",
+  );
+  requiredText(receipt.auditId, "receipt.auditId");
+  if (!Number.isFinite(Date.parse(receipt.completedAt))) {
+    throw new ElizaError("Interaction receipt completion time is invalid.", {
+      code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+    });
+  }
+  if (
+    receipt.idempotencyKey !== expectedProvider.inboundEventId ||
+    receipt.providerReceipt.source !== expectedProvider.source ||
+    receipt.providerReceipt.accountId !== expectedProvider.accountId ||
+    receipt.providerReceipt.inboundEventId !==
+      expectedProvider.inboundEventId ||
+    receipt.providerReceipt.receivedAt !== expectedProvider.receivedAt
+  ) {
+    throw new ElizaError(
+      "Interaction provider receipt changed during replay.",
+      {
+        code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
+      },
+    );
+  }
+  assertSafeResult(receipt.appStateResult, "receipt.appStateResult", redact);
+  assertSafeResult(receipt.result, "receipt.result", redact);
+  return structuredClone(receipt as MessageInteractionHostReceipt);
+}
+
+export class MessageInteractionHostService
+  extends Service
+  implements MessageInteractionHost
+{
+  static override serviceType = MESSAGE_INTERACTION_HOST_SERVICE;
+
+  override capabilityDescription =
+    "Durable capability-negotiated connector interactions with host-owned exactly-once effects";
+
+  private readonly store: MessageInteractionSessionStore;
+  private readonly authority: MessageInteractionSessionAuthority;
+  private readonly handlers = new Map<
+    string,
+    MessageInteractionHostEffectHandler
+  >();
+  private readonly clock: () => number;
+
+  constructor(
+    runtime: IAgentRuntime,
+    options: MessageInteractionHostServiceOptions = {},
+  ) {
+    super(runtime);
+    this.clock = options.clock ?? Date.now;
+    const agentId = requiredText(runtime.agentId, "runtime.agentId");
+    if (
+      path.basename(agentId) !== agentId ||
+      agentId === "." ||
+      agentId === ".."
+    ) {
+      throw new ElizaError("Runtime agent id is not a safe path component.", {
+        code: "INVALID_MESSAGE_INTERACTION_HOST_PATH",
+      });
+    }
+    this.store =
+      options.store ??
+      new FileMessageInteractionSessionStore({
+        stateDirectory: path.join(
+          resolveStateDir(),
+          "message-interactions",
+          agentId,
+        ),
+        clock: this.clock,
+      });
+    this.authority = new MessageInteractionSessionAuthority(this.store, {
+      clock: this.clock,
+      referenceFactory: options.referenceFactory,
+      claimTtlMs: options.claimTtlMs,
+    });
+  }
+
+  static async start(
+    runtime: IAgentRuntime,
+  ): Promise<MessageInteractionHostService> {
+    return new MessageInteractionHostService(runtime);
+  }
+
+  async stop(): Promise<void> {
+    this.handlers.clear();
+  }
+
+  registerEffectHandler(
+    kindValue: string,
+    handler: MessageInteractionHostEffectHandler,
+  ): () => void {
+    const kind = requiredText(kindValue, "effect.kind");
+    if (!handler || typeof handler.execute !== "function") {
+      throw new ElizaError("Interaction effect handler is invalid.", {
+        code: "INVALID_MESSAGE_INTERACTION_EFFECT_HANDLER",
+        context: { kind },
+      });
+    }
+    if (this.handlers.has(kind)) {
+      throw new ElizaError(
+        "Interaction effect handler is already registered.",
+        {
+          code: "MESSAGE_INTERACTION_EFFECT_HANDLER_COLLISION",
+          context: { kind },
+        },
+      );
+    }
+    this.handlers.set(kind, handler);
+    return () => {
+      if (this.handlers.get(kind) === handler) this.handlers.delete(kind);
+    };
+  }
+
+  async prepare(
+    request: PrepareMessageInteractionRequest,
+  ): Promise<PreparedMessageInteraction> {
+    if (request.bindings.agentId !== this.runtime.agentId) {
+      throw new ElizaError("Interaction belongs to another agent runtime.", {
+        code: "MESSAGE_INTERACTION_AGENT_MISMATCH",
+      });
+    }
+    const delivery = negotiateInteractionDelivery(
+      request.block,
+      request.profile,
+      {
+        ...request.negotiationContext,
+        callbackBytes: MESSAGE_INTERACTION_CALLBACK_BYTES,
+      },
+    );
+    const created = await this.authority.create({
+      ...request,
+      flow: delivery.mode,
+    });
+    return {
+      block: structuredClone(request.block),
+      delivery,
+      callbackData: created.callbackData,
+      expiresAt: created.session.expiresAt,
+      profileId: created.session.profileId,
+    };
+  }
+
+  async consume(
+    request: ConsumeMessageInteractionRequest,
+  ): Promise<MessageInteractionHostConsumeOutcome> {
+    try {
+      const reference = decodeMessageInteractionCallback(request.callbackData);
+      if (!reference) {
+        throw new ElizaError(
+          "Callback is not an opaque interaction reference.",
+          {
+            code: "INVALID_MESSAGE_INTERACTION_REFERENCE",
+          },
+        );
+      }
+      const provider = request.providerReceipt;
+      const inboundEventId = requiredText(
+        provider.inboundEventId,
+        "providerReceipt.inboundEventId",
+      );
+      if (
+        provider.source !== request.bindings.connector.source ||
+        provider.accountId !== request.bindings.connector.accountId
+      ) {
+        throw new ElizaError(
+          "Provider receipt belongs to another connector account.",
+          { code: "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH" },
+        );
+      }
+      if (!Number.isFinite(Date.parse(provider.receivedAt))) {
+        throw new ElizaError("Provider receipt time is invalid.", {
+          code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
+        });
+      }
+      if (Date.parse(provider.receivedAt) > this.clock()) {
+        throw new ElizaError("Provider receipt time is in the future.", {
+          code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
+        });
+      }
+      const prior = await this.store.get(reference);
+      if (!prior) {
+        throw new ElizaError("Interaction session was not found.", {
+          code: "MESSAGE_INTERACTION_NOT_FOUND",
+        });
+      }
+      const consumed = await this.authority.consume({
+        callbackData: request.callbackData,
+        bindings: request.bindings,
+        replayKey: inboundEventId,
+        response: request.response,
+        executor: {
+          execute: async (args) => {
+            const handler = this.handlers.get(args.effect.kind);
+            if (!handler) {
+              throw new ElizaError(
+                "Interaction effect handler is unavailable.",
+                {
+                  code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
+                  context: { kind: args.effect.kind },
+                },
+              );
+            }
+            const effect = await handler.execute({
+              ...args,
+              providerReceipt: structuredClone(provider),
+            });
+            requiredText(effect.receiptId, "effectReceipt.receiptId");
+            requiredText(
+              effect.canonicalInboundEventId,
+              "effectReceipt.canonicalInboundEventId",
+            );
+            requiredText(effect.auditId, "effectReceipt.auditId");
+            assertSafeResult(
+              effect.appStateResult,
+              "effectReceipt.appStateResult",
+              (text) => this.runtime.redactSecrets(text),
+            );
+            assertSafeResult(effect.result, "effectReceipt.result", (text) =>
+              this.runtime.redactSecrets(text),
+            );
+            return {
+              receiptId: effect.receiptId,
+              idempotencyKey: args.idempotencyKey,
+              status: "completed" as const,
+              completedAt: new Date(this.clock()).toISOString(),
+              canonicalInboundEventId: effect.canonicalInboundEventId,
+              providerReceipt: structuredClone(provider),
+              auditId: effect.auditId,
+              appStateResult: structuredClone(effect.appStateResult),
+              result: structuredClone(effect.result),
+            };
+          },
+        },
+      });
+      if ("status" in consumed && consumed.status === "in_progress") {
+        return consumed;
+      }
+      return {
+        status: prior.consume.state === "completed" ? "replay" : "completed",
+        receipt: hostReceipt(consumed, provider, (text) =>
+          this.runtime.redactSecrets(text),
+        ),
+      };
+    } catch (error) {
+      // error-policy:J1 Connector callbacks are an untrusted transport
+      // boundary; stable domain failures become explicit denied outcomes.
+      if (error instanceof ElizaError) {
+        return { status: "denied", code: error.code, message: error.message };
+      }
+      throw error;
+    }
+  }
+
+  async revoke(request: {
+    reference: string;
+    decisionId: string;
+    now?: number;
+  }): Promise<MessageInteractionSession> {
+    return this.store.revokeAuthorization({
+      reference: request.reference,
+      decisionId: request.decisionId,
+      now: request.now ?? this.clock(),
+    });
+  }
+
+  async get(reference: string): Promise<MessageInteractionSession | null> {
+    return this.store.get(reference);
+  }
+}
+
+/** Resolve the concrete host service without constructing a competing store. */
+export function resolveMessageInteractionHostService(
+  runtime: IAgentRuntime,
+): MessageInteractionHostService | null {
+  return runtime.getService<MessageInteractionHostService>(
+    MESSAGE_INTERACTION_HOST_SERVICE,
+  );
+}

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -250,6 +250,9 @@ export class MessageInteractionHostService
     return {
       block: structuredClone(request.block),
       delivery,
+      ...(delivery.mode === "signed-hosted"
+        ? { hostedUrl: request.negotiationContext?.signedHostedUrl }
+        : {}),
       callbackData: created.callbackData,
       expiresAt: created.session.expiresAt,
       profileId: created.session.profileId,
@@ -299,9 +302,26 @@ export class MessageInteractionHostService
           code: "MESSAGE_INTERACTION_NOT_FOUND",
         });
       }
+      const retained = prior.bindings;
+      if (
+        request.bindings.actorId !== retained.actorId ||
+        request.bindings.audience.kind !== retained.audience.kind ||
+        request.bindings.audience.id !== retained.audience.id ||
+        request.bindings.agentId !== retained.agentId ||
+        request.bindings.connector.source !== retained.connector.source ||
+        request.bindings.connector.accountId !== retained.connector.accountId ||
+        request.bindings.roomId !== retained.roomId
+      ) {
+        throw new ElizaError(
+          "Authenticated provider bindings do not match the retained session.",
+          { code: "MESSAGE_INTERACTION_BINDING_MISMATCH" },
+        );
+      }
       const consumed = await this.authority.consume({
         callbackData: request.callbackData,
-        bindings: request.bindings,
+        // The original outbound message binding is host-retained state. Provider
+        // callbacks authenticate the actor/room/account but cannot reconstruct it.
+        bindings: retained,
         replayKey: inboundEventId,
         response: request.response,
         executor: {

--- a/packages/agent/src/services/message-interaction-host.ts
+++ b/packages/agent/src/services/message-interaction-host.ts
@@ -45,6 +45,13 @@ function requiredText(value: string, pathName: string): string {
   return normalized;
 }
 
+function canonicalTimestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+    ? parsed
+    : Number.NaN;
+}
+
 function assertSafeResult(
   value: unknown,
   pathName: string,
@@ -57,6 +64,17 @@ function assertSafeResult(
     });
   }
   for (const [key, fieldValue] of Object.entries(value)) {
+    if (
+      new TextEncoder().encode(key).length > 512 ||
+      (typeof fieldValue === "string" &&
+        new TextEncoder().encode(fieldValue).length > 65_536) ||
+      (typeof fieldValue === "number" && !Number.isFinite(fieldValue))
+    ) {
+      throw new ElizaError(`${pathName} contains an unbounded field.`, {
+        code: "INVALID_MESSAGE_INTERACTION_EFFECT_RECEIPT",
+        context: { path: `${pathName}.${key}` },
+      });
+    }
     if (
       fieldValue !== null &&
       typeof fieldValue !== "string" &&
@@ -116,7 +134,7 @@ function hostReceipt(
     "receipt.canonicalInboundEventId",
   );
   requiredText(receipt.auditId, "receipt.auditId");
-  if (!Number.isFinite(Date.parse(receipt.completedAt))) {
+  if (!Number.isFinite(canonicalTimestamp(receipt.completedAt))) {
     throw new ElizaError("Interaction receipt completion time is invalid.", {
       code: "MESSAGE_INTERACTION_STORE_PROTOCOL",
     });
@@ -286,12 +304,12 @@ export class MessageInteractionHostService
           { code: "MESSAGE_INTERACTION_PROVIDER_RECEIPT_MISMATCH" },
         );
       }
-      if (!Number.isFinite(Date.parse(provider.receivedAt))) {
+      if (!Number.isFinite(canonicalTimestamp(provider.receivedAt))) {
         throw new ElizaError("Provider receipt time is invalid.", {
           code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
         });
       }
-      if (Date.parse(provider.receivedAt) > this.clock()) {
+      if (canonicalTimestamp(provider.receivedAt) > this.clock()) {
         throw new ElizaError("Provider receipt time is in the future.", {
           code: "INVALID_MESSAGE_INTERACTION_PROVIDER_RECEIPT",
         });
@@ -317,6 +335,13 @@ export class MessageInteractionHostService
           { code: "MESSAGE_INTERACTION_BINDING_MISMATCH" },
         );
       }
+      const preparedHandler = this.handlers.get(prior.effect.kind);
+      if (!preparedHandler) {
+        throw new ElizaError("Interaction effect handler is unavailable.", {
+          code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
+          context: { kind: prior.effect.kind },
+        });
+      }
       const consumed = await this.authority.consume({
         callbackData: request.callbackData,
         // The original outbound message binding is host-retained state. Provider
@@ -326,17 +351,7 @@ export class MessageInteractionHostService
         response: request.response,
         executor: {
           execute: async (args) => {
-            const handler = this.handlers.get(args.effect.kind);
-            if (!handler) {
-              throw new ElizaError(
-                "Interaction effect handler is unavailable.",
-                {
-                  code: "MESSAGE_INTERACTION_EFFECT_HANDLER_UNAVAILABLE",
-                  context: { kind: args.effect.kind },
-                },
-              );
-            }
-            const effect = await handler.execute({
+            const effect = await preparedHandler.execute({
               ...args,
               providerReceipt: structuredClone(provider),
             });

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -237,6 +237,36 @@ describe("FileMessageInteractionSessionStore", () => {
     ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
   });
 
+  it("rejects hardlinked, over-permissive, and oversized store files", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    await fs.writeFile(filePath, '{"version":1,"sessions":{}}', {
+      mode: 0o644,
+    });
+    await expect(
+      new FileMessageInteractionSessionStore({ stateDirectory }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+    await fs.chmod(filePath, 0o600);
+    const linked = path.join(stateDirectory, "linked.json");
+    await fs.link(filePath, linked);
+    await expect(
+      new FileMessageInteractionSessionStore({ stateDirectory }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+    await fs.unlink(linked);
+    await fs.writeFile(filePath, "x".repeat(65), { mode: 0o600 });
+    await expect(
+      new FileMessageInteractionSessionStore({
+        stateDirectory,
+        maxStoreBytes: 64,
+      }).get("missing"),
+    ).rejects.toMatchObject({
+      code: "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+    });
+  });
+
   it("rejects a directory swapped to a symlink after initialization", async () => {
     const stateDirectory = await temporaryDirectory();
     const redirectedDirectory = await temporaryDirectory();
@@ -311,5 +341,68 @@ describe("FileMessageInteractionSessionStore", () => {
       await store.deleteExpired(Date.parse(created.session.expiresAt)),
     ).toBe(1);
     expect(await store.get(created.session.reference)).toBeNull();
+  });
+
+  it("never collects a committed ambiguous effect or completed receipt", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { store, created, now } = await seed(stateDirectory, {
+      retentionMs: 0,
+    });
+    const claim = await store.claimIfCurrent({
+      ...bindings,
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      claimTtlMs: 1,
+    });
+    expect(claim.status).toBe("acquired");
+    await store.commitIfClaimed({
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+    });
+    expect(
+      await store.deleteExpired(Date.parse(created.session.expiresAt)),
+    ).toBe(0);
+    const reopenedCommitted = new FileMessageInteractionSessionStore({
+      stateDirectory,
+    });
+    expect(
+      await reopenedCommitted.get(created.session.reference),
+    ).toMatchObject({
+      consume: { state: "committed" },
+    });
+    await reopenedCommitted.completeIfClaimed({
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      receipt: {
+        receiptId: "receipt-a",
+        idempotencyKey: "replay-a",
+        status: "completed",
+        completedAt: new Date(now).toISOString(),
+        result: { accepted: true },
+      },
+    });
+    const reopenedCompleted = new FileMessageInteractionSessionStore({
+      stateDirectory,
+    });
+    expect(
+      await reopenedCompleted.get(created.session.reference),
+    ).toMatchObject({
+      consume: {
+        state: "completed",
+        committedAt: new Date(now).toISOString(),
+        receipt: { receiptId: "receipt-a" },
+      },
+    });
+    expect(
+      await reopenedCompleted.deleteExpired(
+        Date.parse(created.session.expiresAt),
+      ),
+    ).toBe(0);
   });
 });

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Real-filesystem verification for the single-host durable interaction store:
+ * process contention, crash-safe state, stale-lock recovery, permissions,
+ * corruption, symlink rejection, and retention collection.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  BUTTON_INTERACTION_PROFILE,
+  createConnectorInteractionCapabilityProfile,
+  type MessageInteractionClaimContext,
+  MessageInteractionSessionAuthority,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileMessageInteractionSessionStore } from "./message-interaction-session-store.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await fs.mkdtemp("/private/tmp/eliza-interaction-store-");
+  roots.push(root);
+  return root;
+}
+
+const bindings = {
+  actorId: "actor-a",
+  audience: { kind: "room", id: "room-a" },
+  agentId: "agent-a",
+  connector: { source: "connector", accountId: "account-a" },
+  roomId: "room-a",
+  sourceMessageId: "message-a",
+};
+
+async function seed(
+  stateDirectory: string,
+  options: { now?: number; expiresAt?: string; retentionMs?: number } = {},
+) {
+  const now = options.now ?? Date.parse("2026-08-21T00:00:00.000Z");
+  const store = new FileMessageInteractionSessionStore({
+    stateDirectory,
+    retentionMs: options.retentionMs,
+    clock: () => now,
+  });
+  const authority = new MessageInteractionSessionAuthority(store, {
+    clock: () => now,
+    referenceFactory: () => "0123456789abcdef0123456789abcdef",
+  });
+  const profile = createConnectorInteractionCapabilityProfile({
+    template: BUTTON_INTERACTION_PROFILE,
+    source: "connector",
+    accountId: "account-a",
+    targetKind: "room",
+    targetId: "room-a",
+  });
+  const created = await authority.create({
+    block: {
+      kind: "choice",
+      id: "choice-a",
+      scope: "approval",
+      options: [{ value: "approve", label: "Approve" }],
+    },
+    profile,
+    bindings,
+    purpose: "approval",
+    flow: "native",
+    presetResponse: { value: "approve" },
+    authorization: {
+      decisionId: "decision-a",
+      policyRevision: "policy-a",
+      decidedAt: "2026-08-20T23:59:00.000Z",
+    },
+    effect: { kind: "approve" },
+    expiresAt: options.expiresAt ?? "2026-08-21T00:10:00.000Z",
+  });
+  return { store, created, now };
+}
+
+function runChild(
+  stateDirectory: string,
+  contextPath: string,
+): Promise<string> {
+  const fixture = path.join(
+    import.meta.dirname,
+    "__fixtures__",
+    "message-interaction-claim-child.ts",
+  );
+  const candidates = [
+    (() => {
+      try {
+        return execFileSync(
+          process.platform === "win32" ? "where" : "which",
+          ["bun"],
+          { encoding: "utf8" },
+        )
+          .split("\n")
+          .find(Boolean);
+      } catch {
+        // error-policy:J4 the test harness uses an explicit install fallback.
+        return undefined;
+      }
+    })(),
+    process.env.BUN_INSTALL
+      ? path.join(process.env.BUN_INSTALL, "bin", "bun")
+      : undefined,
+    path.join(
+      os.homedir(),
+      ".bun",
+      "bin",
+      process.platform === "win32" ? "bun.exe" : "bun",
+    ),
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ];
+  const bun = candidates.find((candidate): candidate is string =>
+    Boolean(candidate && existsSync(candidate)),
+  );
+  if (!bun) throw new Error("Bun is required for process contention tests");
+  return new Promise((resolve, reject) => {
+    const child = spawn(bun, [fixture, stateDirectory, contextPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`claim child exited ${code}: ${stderr}`));
+    });
+  });
+}
+
+describe("FileMessageInteractionSessionStore", () => {
+  it("serializes claims across independent processes", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created, now } = await seed(stateDirectory);
+    const context: MessageInteractionClaimContext = {
+      ...bindings,
+      reference: created.session.reference,
+      replayKey: "replay-a",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      claimTtlMs: 30_000,
+    };
+    const contextPath = path.join(stateDirectory, "claim.json");
+    await fs.writeFile(contextPath, JSON.stringify(context), { mode: 0o600 });
+    const outcomes = await Promise.all(
+      Array.from({ length: 8 }, () => runChild(stateDirectory, contextPath)),
+    );
+    expect(outcomes.filter((outcome) => outcome === "acquired")).toHaveLength(
+      1,
+    );
+    expect(
+      outcomes.filter((outcome) => outcome === "in_progress"),
+    ).toHaveLength(7);
+  });
+
+  it("writes a 0600 regular file and retains state across store instances", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created } = await seed(stateDirectory);
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    const stat = await fs.lstat(filePath);
+    expect(stat.isFile()).toBe(true);
+    expect(stat.mode & 0o777).toBe(0o600);
+    const reopened = new FileMessageInteractionSessionStore({ stateDirectory });
+    expect(await reopened.get(created.session.reference)).toMatchObject({
+      reference: created.session.reference,
+      consume: { state: "pending" },
+    });
+  });
+
+  it("fails fast on corruption instead of fabricating an empty store", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    await fs.writeFile(filePath, "{broken", { mode: 0o600 });
+    const store = new FileMessageInteractionSessionStore({ stateDirectory });
+    await expect(
+      store.get("0123456789abcdef0123456789abcdef"),
+    ).rejects.toMatchObject({
+      code: "CORRUPT_INTERACTION_SESSION_STORE",
+    });
+    const reference = "0123456789abcdef0123456789abcdef";
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        sessions: { [reference]: { sessionVersion: 1, reference } },
+      }),
+      { mode: 0o600 },
+    );
+    await expect(store.get(reference)).rejects.toMatchObject({
+      code: "CORRUPT_INTERACTION_SESSION_STORE",
+    });
+  });
+
+  it("rejects store-file and state-directory symlinks", async () => {
+    const targetDirectory = await temporaryDirectory();
+    const stateDirectory = await temporaryDirectory();
+    const targetFile = path.join(targetDirectory, "target.json");
+    await fs.writeFile(targetFile, '{"version":1,"sessions":{}}');
+    await fs.symlink(
+      targetFile,
+      path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+    );
+    await expect(
+      new FileMessageInteractionSessionStore({ stateDirectory }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+
+    const linkDirectory = `${stateDirectory}-link`;
+    roots.push(linkDirectory);
+    await fs.symlink(targetDirectory, linkDirectory);
+    await expect(
+      new FileMessageInteractionSessionStore({
+        stateDirectory: linkDirectory,
+      }).get("missing"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+  });
+
+  it("rejects a directory swapped to a symlink after initialization", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const redirectedDirectory = await temporaryDirectory();
+    const movedDirectory = `${stateDirectory}-moved`;
+    roots.push(movedDirectory);
+    const store = new FileMessageInteractionSessionStore({ stateDirectory });
+    expect(await store.get("0123456789abcdef0123456789abcdef")).toBeNull();
+    await fs.rename(stateDirectory, movedDirectory);
+    await fs.symlink(redirectedDirectory, stateDirectory);
+    await expect(
+      store.get("0123456789abcdef0123456789abcdef"),
+    ).rejects.toMatchObject({ code: "UNSAFE_INTERACTION_STORE_PATH" });
+    expect(await fs.readdir(redirectedDirectory)).toEqual([]);
+  });
+
+  it("recovers an expired lock only when its owner process is dead", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: 2_000_000_000,
+        token: "dead-owner",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    const { created } = await seed(stateDirectory, { now });
+    expect(created.session.reference).toBe("0123456789abcdef0123456789abcdef");
+  });
+
+  it("does not steal an expired lease from a live owner", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      JSON.stringify({
+        pid: process.pid,
+        token: "live-owner",
+        createdAt: now - 10_000,
+        expiresAt: now - 1,
+      }),
+      { mode: 0o600 },
+    );
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 10,
+      pollMs: 1,
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+    expect(await fs.lstat(lockPath)).toBeDefined();
+  });
+
+  it("collects expired sessions through the explicit retention/GC boundary", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { store, created } = await seed(stateDirectory, { retentionMs: 0 });
+    expect(
+      await store.deleteExpired(Date.parse(created.session.expiresAt)),
+    ).toBe(1);
+    expect(await store.get(created.session.reference)).toBeNull();
+  });
+});

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -1,0 +1,622 @@
+/**
+ * Persists message-interaction sessions for one host with cross-process atomic
+ * transitions. Multi-host deployments should implement the same store contract
+ * with a transactional database row or outbox rather than sharing this file.
+ */
+
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  applyMessageInteractionClaim,
+  applyMessageInteractionCompletion,
+  applyMessageInteractionRevocation,
+  ElizaError,
+  type MessageInteractionClaimContext,
+  type MessageInteractionClaimResult,
+  type MessageInteractionCompleteContext,
+  type MessageInteractionSession,
+  type MessageInteractionSessionStore,
+} from "@elizaos/core";
+
+interface SessionFile {
+  version: 1;
+  sessions: Record<string, MessageInteractionSession>;
+}
+
+interface LockOwner {
+  pid: number;
+  token: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validIsoDate(value: unknown): boolean {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function structurallyValidConsume(value: Record<string, unknown>): boolean {
+  if (value.state === "pending") return true;
+  if (value.state !== "claimed" && value.state !== "completed") return false;
+  if (
+    typeof value.claimId !== "string" ||
+    typeof value.replayKey !== "string" ||
+    typeof value.responseDigest !== "string" ||
+    !isRecord(value.response) ||
+    !validIsoDate(value.claimedAt) ||
+    !Number.isSafeInteger(value.attempt) ||
+    Number(value.attempt) < 1
+  )
+    return false;
+  if (value.state === "claimed") return validIsoDate(value.claimExpiresAt);
+  const receipt = value.receipt;
+  return (
+    validIsoDate(value.completedAt) &&
+    isRecord(receipt) &&
+    typeof receipt.receiptId === "string" &&
+    receipt.idempotencyKey === value.replayKey &&
+    receipt.status === "completed" &&
+    validIsoDate(receipt.completedAt) &&
+    isRecord(receipt.result)
+  );
+}
+
+function structurallyValidSession(value: unknown, reference: string): boolean {
+  if (!isRecord(value)) return false;
+  const bindings = value.bindings;
+  const authorization = value.authorization;
+  const consume = value.consume;
+  return (
+    value.sessionVersion === 1 &&
+    value.reference === reference &&
+    typeof value.purpose === "string" &&
+    ["choice", "form", "followups", "task", "secret"].includes(
+      String(value.blockKind),
+    ) &&
+    ["native", "conversational", "signed-hosted", "sensitive-request"].includes(
+      String(value.flow),
+    ) &&
+    typeof value.profileId === "string" &&
+    isRecord(bindings) &&
+    typeof bindings.actorId === "string" &&
+    isRecord(bindings.audience) &&
+    typeof bindings.audience.kind === "string" &&
+    typeof bindings.audience.id === "string" &&
+    typeof bindings.agentId === "string" &&
+    isRecord(bindings.connector) &&
+    typeof bindings.connector.source === "string" &&
+    typeof bindings.connector.accountId === "string" &&
+    typeof bindings.roomId === "string" &&
+    typeof bindings.sourceMessageId === "string" &&
+    isRecord(value.responseSchema) &&
+    Array.isArray(value.responseSchema.fields) &&
+    value.responseSchema.additionalFields === false &&
+    isRecord(authorization) &&
+    typeof authorization.decisionId === "string" &&
+    typeof authorization.policyRevision === "string" &&
+    validIsoDate(authorization.decidedAt) &&
+    ["active", "revoked"].includes(String(authorization.state)) &&
+    (authorization.revokedAt === null ||
+      validIsoDate(authorization.revokedAt)) &&
+    isRecord(value.effect) &&
+    typeof value.effect.kind === "string" &&
+    validIsoDate(value.createdAt) &&
+    validIsoDate(value.expiresAt) &&
+    isRecord(consume) &&
+    structurallyValidConsume(consume) &&
+    Number.isSafeInteger(value.revision) &&
+    Number(value.revision) >= 0
+  );
+}
+
+export interface FileMessageInteractionSessionStoreOptions {
+  stateDirectory: string;
+  fileName?: string;
+  lockTimeoutMs?: number;
+  staleLockMs?: number;
+  pollMs?: number;
+  retentionMs?: number;
+  clock?: () => number;
+}
+
+function storeError(
+  code: string,
+  message: string,
+  context?: Record<string, unknown>,
+): never {
+  throw new ElizaError(message, { code, context });
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+async function existsLstat(filePath: string) {
+  try {
+    return await fs.lstat(filePath);
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) {
+      // error-policy:J4 absence is the designed initial state for this store.
+      return null;
+    }
+    throw error;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function safeInteger(value: number, name: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    return storeError(
+      "INVALID_INTERACTION_STORE_CONFIG",
+      `${name} is invalid.`,
+      {
+        name,
+        value,
+      },
+    );
+  }
+  return value;
+}
+
+function newToken(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * A single-machine durable store. Atomic rename and directory fsync preserve a
+ * complete prior or next revision across process/power loss; the lock directory
+ * serializes independent host processes.
+ */
+export class FileMessageInteractionSessionStore
+  implements MessageInteractionSessionStore
+{
+  private readonly directory: string;
+  private readonly filePath: string;
+  private readonly lockPath: string;
+  private readonly lockTimeoutMs: number;
+  private readonly staleLockMs: number;
+  private readonly pollMs: number;
+  private readonly retentionMs: number;
+  private readonly clock: () => number;
+  private directoryIdentity: {
+    realPath: string;
+    device: number;
+    inode: number;
+  } | null = null;
+  private initialized = false;
+
+  constructor(options: FileMessageInteractionSessionStoreOptions) {
+    this.directory = path.resolve(options.stateDirectory);
+    const fileName = options.fileName ?? "message-interaction-sessions.v1.json";
+    if (
+      path.basename(fileName) !== fileName ||
+      fileName === "." ||
+      fileName === ".."
+    ) {
+      storeError(
+        "INVALID_INTERACTION_STORE_PATH",
+        "Interaction store filename must be a plain basename.",
+      );
+    }
+    this.filePath = path.join(this.directory, fileName);
+    this.lockPath = `${this.filePath}.lock`;
+    this.lockTimeoutMs = safeInteger(
+      options.lockTimeoutMs ?? 5_000,
+      "lockTimeoutMs",
+      1,
+    );
+    this.staleLockMs = safeInteger(
+      options.staleLockMs ?? 30_000,
+      "staleLockMs",
+      1,
+    );
+    this.pollMs = safeInteger(options.pollMs ?? 10, "pollMs", 1);
+    this.retentionMs = safeInteger(
+      options.retentionMs ?? 7 * 24 * 60 * 60 * 1_000,
+      "retentionMs",
+      0,
+    );
+    this.clock = options.clock ?? Date.now;
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.initialized) {
+      await this.assertDirectoryIdentity();
+      return;
+    }
+    await fs.mkdir(this.directory, { recursive: true, mode: 0o700 });
+    const directoryStat = await fs.lstat(this.directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory must be a real directory.",
+      );
+    }
+    const realDirectory = await fs.realpath(this.directory);
+    if (realDirectory !== this.directory) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory cannot traverse a symlink.",
+      );
+    }
+    this.directoryIdentity = {
+      realPath: realDirectory,
+      device: directoryStat.dev,
+      inode: directoryStat.ino,
+    };
+    const existing = await existsLstat(this.filePath);
+    if (existing?.isSymbolicLink() || (existing && !existing.isFile())) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store file must be a regular file.",
+      );
+    }
+    this.initialized = true;
+  }
+
+  private async assertDirectoryIdentity(): Promise<void> {
+    const expected = this.directoryIdentity;
+    if (!expected)
+      storeError(
+        "INTERACTION_STORE_NOT_INITIALIZED",
+        "Interaction store directory identity is unavailable.",
+      );
+    const stat = await fs.lstat(this.directory);
+    const realPath = await fs.realpath(this.directory);
+    if (
+      !stat.isDirectory() ||
+      stat.isSymbolicLink() ||
+      realPath !== expected.realPath ||
+      stat.dev !== expected.device ||
+      stat.ino !== expected.inode
+    ) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory identity changed after initialization.",
+      );
+    }
+  }
+
+  private processAlive(pid: number): boolean {
+    if (!Number.isSafeInteger(pid) || pid < 1) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      if (isErrno(error, "ESRCH")) return false;
+      if (isErrno(error, "EPERM")) return true;
+      throw error;
+    }
+  }
+
+  private async readLockOwner(): Promise<LockOwner | null> {
+    try {
+      const raw = await fs.readFile(
+        path.join(this.lockPath, "owner.json"),
+        "utf8",
+      );
+      const value = JSON.parse(raw) as Partial<LockOwner>;
+      if (
+        !Number.isSafeInteger(value.pid) ||
+        typeof value.token !== "string" ||
+        !Number.isSafeInteger(value.createdAt) ||
+        !Number.isSafeInteger(value.expiresAt)
+      ) {
+        return null;
+      }
+      return value as LockOwner;
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) {
+        // error-policy:J4 a creator may exist before its owner file is durable.
+        return null;
+      }
+      if (error instanceof SyntaxError) {
+        // error-policy:J3 malformed owner data has no authority; lock age still
+        // has to cross the stale threshold before recovery.
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async recoverStaleLock(now: number): Promise<boolean> {
+    const lockStat = await existsLstat(this.lockPath);
+    if (!lockStat) return true;
+    if (!lockStat.isDirectory() || lockStat.isSymbolicLink()) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_LOCK",
+        "Interaction store lock is not a real directory.",
+      );
+    }
+    const owner = await this.readLockOwner();
+    const stale = owner
+      ? owner.expiresAt <= now && !this.processAlive(owner.pid)
+      : lockStat.mtimeMs + this.staleLockMs <= now;
+    if (!stale) return false;
+    const quarantine = `${this.lockPath}.stale-${process.pid}-${newToken()}`;
+    try {
+      await fs.rename(this.lockPath, quarantine);
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return true;
+      throw error;
+    }
+    try {
+      await fs.rm(quarantine, { recursive: true });
+    } catch {
+      // error-policy:J6 renamed stale lock no longer blocks the authority.
+    }
+    return true;
+  }
+
+  private async acquireLock(): Promise<LockOwner> {
+    await this.initialize();
+    const startedAt = performance.now();
+    while (performance.now() - startedAt <= this.lockTimeoutMs) {
+      const now = this.clock();
+      let createdLock = false;
+      try {
+        await fs.mkdir(this.lockPath, { mode: 0o700 });
+        createdLock = true;
+        const owner: LockOwner = {
+          pid: process.pid,
+          token: newToken(),
+          createdAt: now,
+          expiresAt: now + this.staleLockMs,
+        };
+        await this.writeAndSync(path.join(this.lockPath, "owner.json"), owner);
+        return owner;
+      } catch (error) {
+        if (createdLock) {
+          try {
+            await fs.rm(this.lockPath, { recursive: true });
+          } catch {
+            // error-policy:J6 failed lock construction is already fatal; cleanup
+            // must not replace its originating filesystem error.
+          }
+        }
+        if (!isErrno(error, "EEXIST")) throw error;
+        await this.recoverStaleLock(now);
+        await delay(this.pollMs);
+      }
+    }
+    return storeError(
+      "INTERACTION_STORE_LOCK_TIMEOUT",
+      "Timed out acquiring interaction store lock.",
+    );
+  }
+
+  private async releaseLock(owner: LockOwner): Promise<void> {
+    const current = await this.readLockOwner();
+    if (!current || current.token !== owner.token) {
+      storeError(
+        "INTERACTION_STORE_LOCK_LOST",
+        "Interaction store lock ownership changed.",
+      );
+    }
+    await fs.rm(this.lockPath, { recursive: true });
+  }
+
+  private async writeAndSync(filePath: string, value: unknown): Promise<void> {
+    const handle = await fs.open(
+      filePath,
+      constants.O_CREAT |
+        constants.O_EXCL |
+        constants.O_WRONLY |
+        constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      await handle.writeFile(JSON.stringify(value, null, 2), "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private assertFile(value: unknown): SessionFile {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return storeError(
+        "CORRUPT_INTERACTION_SESSION_STORE",
+        "Interaction store root is invalid.",
+      );
+    }
+    const document = value as Partial<SessionFile>;
+    if (
+      document.version !== 1 ||
+      !document.sessions ||
+      typeof document.sessions !== "object" ||
+      Array.isArray(document.sessions)
+    ) {
+      return storeError(
+        "CORRUPT_INTERACTION_SESSION_STORE",
+        "Interaction store schema is invalid.",
+      );
+    }
+    for (const [reference, session] of Object.entries(document.sessions)) {
+      if (
+        !/^[a-f0-9]{32}$/.test(reference) ||
+        !structurallyValidSession(session, reference)
+      ) {
+        return storeError(
+          "CORRUPT_INTERACTION_SESSION_STORE",
+          "Interaction store contains an invalid session.",
+          { reference },
+        );
+      }
+    }
+    return document as SessionFile;
+  }
+
+  private async readFile(): Promise<SessionFile> {
+    const stat = await existsLstat(this.filePath);
+    if (!stat) return { version: 1, sessions: {} };
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store became a non-regular file.",
+      );
+    }
+    const handle = await fs.open(
+      this.filePath,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+    try {
+      const raw = await handle.readFile("utf8");
+      return this.assertFile(JSON.parse(raw) as unknown);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        // error-policy:J1 persistence corruption is surfaced, never reset.
+        return storeError(
+          "CORRUPT_INTERACTION_SESSION_STORE",
+          "Interaction store JSON is corrupt.",
+        );
+      }
+      throw error;
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private prune(document: SessionFile, now: number): number {
+    let deleted = 0;
+    for (const [reference, session] of Object.entries(document.sessions)) {
+      if (Date.parse(session.expiresAt) + this.retentionMs <= now) {
+        delete document.sessions[reference];
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  private async writeFile(document: SessionFile): Promise<void> {
+    const temp = `${this.filePath}.tmp-${process.pid}-${newToken()}`;
+    try {
+      await this.writeAndSync(temp, document);
+      await fs.rename(temp, this.filePath);
+      const directoryHandle = await fs.open(this.directory, constants.O_RDONLY);
+      try {
+        await directoryHandle.sync();
+      } finally {
+        await directoryHandle.close();
+      }
+    } finally {
+      try {
+        await fs.rm(temp, { force: true });
+      } catch {
+        // error-policy:J6 temp cleanup must not mask the durable write outcome.
+      }
+    }
+  }
+
+  private async transaction<T>(
+    operation: (document: SessionFile) => T | Promise<T>,
+  ): Promise<T> {
+    const owner = await this.acquireLock();
+    try {
+      await this.assertDirectoryIdentity();
+      const document = await this.readFile();
+      this.prune(document, this.clock());
+      const result = await operation(document);
+      await this.assertDirectoryIdentity();
+      await this.writeFile(document);
+      return result;
+    } finally {
+      await this.releaseLock(owner);
+    }
+  }
+
+  async create(session: MessageInteractionSession): Promise<void> {
+    await this.transaction((document) => {
+      if (document.sessions[session.reference]) {
+        storeError(
+          "MESSAGE_INTERACTION_REFERENCE_COLLISION",
+          "Interaction reference already exists.",
+        );
+      }
+      document.sessions[session.reference] = structuredClone(session);
+    });
+  }
+
+  async get(reference: string): Promise<MessageInteractionSession | null> {
+    await this.initialize();
+    const document = await this.readFile();
+    return document.sessions[reference]
+      ? structuredClone(document.sessions[reference])
+      : null;
+  }
+
+  async claimIfCurrent(
+    context: MessageInteractionClaimContext,
+  ): Promise<MessageInteractionClaimResult> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const result = applyMessageInteractionClaim(current, context);
+      document.sessions[context.reference] = structuredClone(result.session);
+      return result;
+    });
+  }
+
+  async completeIfClaimed(
+    context: MessageInteractionCompleteContext,
+  ): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const completed = applyMessageInteractionCompletion(current, context);
+      document.sessions[context.reference] = structuredClone(completed);
+      return completed;
+    });
+  }
+
+  async revokeAuthorization(args: {
+    reference: string;
+    decisionId: string;
+    now: number;
+  }): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[args.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const revoked = applyMessageInteractionRevocation(
+        current,
+        args.decisionId,
+        args.now,
+      );
+      document.sessions[args.reference] = structuredClone(revoked);
+      return revoked;
+    });
+  }
+
+  async deleteExpired(before: number): Promise<number> {
+    safeInteger(before, "before", 0);
+    return this.transaction((document) => {
+      let deleted = 0;
+      for (const [reference, session] of Object.entries(document.sessions)) {
+        if (Date.parse(session.expiresAt) <= before) {
+          delete document.sessions[reference];
+          deleted += 1;
+        }
+      }
+      return deleted;
+    });
+  }
+}

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -9,11 +9,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   applyMessageInteractionClaim,
+  applyMessageInteractionCommit,
   applyMessageInteractionCompletion,
   applyMessageInteractionRevocation,
   ElizaError,
   type MessageInteractionClaimContext,
   type MessageInteractionClaimResult,
+  type MessageInteractionCommitContext,
   type MessageInteractionCompleteContext,
   type MessageInteractionSession,
   type MessageInteractionSessionStore,
@@ -36,12 +38,53 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function validIsoDate(value: unknown): boolean {
-  return typeof value === "string" && Number.isFinite(Date.parse(value));
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+
+function validBoundedJson(value: unknown): boolean {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  let nodes = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || current.depth > 32 || ++nodes > 100_000) return false;
+    if (typeof current.value === "string") {
+      if (new TextEncoder().encode(current.value).length > 65_536) return false;
+      continue;
+    }
+    if (Array.isArray(current.value)) {
+      if (current.value.length > 10_000) return false;
+      for (const child of current.value)
+        stack.push({ value: child, depth: current.depth + 1 });
+      continue;
+    }
+    if (isRecord(current.value)) {
+      const entries = Object.entries(current.value);
+      if (entries.length > 10_000) return false;
+      for (const [key, child] of entries) {
+        if (
+          key === "__proto__" ||
+          key === "prototype" ||
+          key === "constructor" ||
+          new TextEncoder().encode(key).length > 512
+        )
+          return false;
+        stack.push({ value: child, depth: current.depth + 1 });
+      }
+    }
+  }
+  return true;
 }
 
 function structurallyValidConsume(value: Record<string, unknown>): boolean {
   if (value.state === "pending") return true;
-  if (value.state !== "claimed" && value.state !== "completed") return false;
+  if (
+    value.state !== "claimed" &&
+    value.state !== "committed" &&
+    value.state !== "completed"
+  )
+    return false;
   if (
     typeof value.claimId !== "string" ||
     typeof value.replayKey !== "string" ||
@@ -52,10 +95,26 @@ function structurallyValidConsume(value: Record<string, unknown>): boolean {
     Number(value.attempt) < 1
   )
     return false;
-  if (value.state === "claimed") return validIsoDate(value.claimExpiresAt);
+  if (value.state === "claimed")
+    return (
+      validIsoDate(value.claimExpiresAt) &&
+      Date.parse(String(value.claimExpiresAt)) >
+        Date.parse(String(value.claimedAt))
+    );
+  if (value.state === "committed")
+    return (
+      validIsoDate(value.committedAt) &&
+      Date.parse(String(value.committedAt)) >=
+        Date.parse(String(value.claimedAt))
+    );
   const receipt = value.receipt;
   return (
+    validIsoDate(value.committedAt) &&
     validIsoDate(value.completedAt) &&
+    Date.parse(String(value.committedAt)) >=
+      Date.parse(String(value.claimedAt)) &&
+    Date.parse(String(value.completedAt)) >=
+      Date.parse(String(value.committedAt)) &&
     isRecord(receipt) &&
     typeof receipt.receiptId === "string" &&
     receipt.idempotencyKey === value.replayKey &&
@@ -73,7 +132,16 @@ function structurallyValidSession(value: unknown, reference: string): boolean {
   return (
     value.sessionVersion === 1 &&
     value.reference === reference &&
-    typeof value.purpose === "string" &&
+    [
+      "choice",
+      "form",
+      "approval",
+      "setup",
+      "auth",
+      "task",
+      "file",
+      "followup",
+    ].includes(String(value.purpose)) &&
     ["choice", "form", "followups", "task", "secret"].includes(
       String(value.blockKind),
     ) &&
@@ -100,8 +168,9 @@ function structurallyValidSession(value: unknown, reference: string): boolean {
     typeof authorization.policyRevision === "string" &&
     validIsoDate(authorization.decidedAt) &&
     ["active", "revoked"].includes(String(authorization.state)) &&
-    (authorization.revokedAt === null ||
-      validIsoDate(authorization.revokedAt)) &&
+    ((authorization.state === "active" && authorization.revokedAt === null) ||
+      (authorization.state === "revoked" &&
+        validIsoDate(authorization.revokedAt))) &&
     isRecord(value.effect) &&
     typeof value.effect.kind === "string" &&
     validIsoDate(value.createdAt) &&
@@ -120,6 +189,8 @@ export interface FileMessageInteractionSessionStoreOptions {
   staleLockMs?: number;
   pollMs?: number;
   retentionMs?: number;
+  maxStoreBytes?: number;
+  maxSessions?: number;
   clock?: () => number;
 }
 
@@ -184,6 +255,8 @@ export class FileMessageInteractionSessionStore
   private readonly staleLockMs: number;
   private readonly pollMs: number;
   private readonly retentionMs: number;
+  private readonly maxStoreBytes: number;
+  private readonly maxSessions: number;
   private readonly clock: () => number;
   private directoryIdentity: {
     realPath: string;
@@ -223,6 +296,16 @@ export class FileMessageInteractionSessionStore
       "retentionMs",
       0,
     );
+    this.maxStoreBytes = safeInteger(
+      options.maxStoreBytes ?? 4 * 1024 * 1024,
+      "maxStoreBytes",
+      1,
+    );
+    this.maxSessions = safeInteger(
+      options.maxSessions ?? 10_000,
+      "maxSessions",
+      1,
+    );
     this.clock = options.clock ?? Date.now;
   }
 
@@ -237,6 +320,12 @@ export class FileMessageInteractionSessionStore
       storeError(
         "UNSAFE_INTERACTION_STORE_PATH",
         "Interaction store directory must be a real directory.",
+      );
+    }
+    if ((directoryStat.mode & 0o077) !== 0) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store directory permissions expose private state.",
       );
     }
     const realDirectory = await fs.realpath(this.directory);
@@ -256,6 +345,12 @@ export class FileMessageInteractionSessionStore
       storeError(
         "UNSAFE_INTERACTION_STORE_PATH",
         "Interaction store file must be a regular file.",
+      );
+    }
+    if (existing && (existing.nlink !== 1 || (existing.mode & 0o077) !== 0)) {
+      storeError(
+        "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store file must be private and have one filesystem link.",
       );
     }
     this.initialized = true;
@@ -298,10 +393,42 @@ export class FileMessageInteractionSessionStore
 
   private async readLockOwner(): Promise<LockOwner | null> {
     try {
-      const raw = await fs.readFile(
-        path.join(this.lockPath, "owner.json"),
-        "utf8",
+      const ownerPath = path.join(this.lockPath, "owner.json");
+      const entry = await fs.lstat(ownerPath);
+      if (
+        !entry.isFile() ||
+        entry.isSymbolicLink() ||
+        entry.nlink !== 1 ||
+        (entry.mode & 0o077) !== 0 ||
+        entry.size > 4_096
+      ) {
+        storeError(
+          "UNSAFE_INTERACTION_STORE_LOCK",
+          "Interaction store lock owner file is unsafe.",
+        );
+      }
+      const handle = await fs.open(
+        ownerPath,
+        constants.O_RDONLY | constants.O_NOFOLLOW,
       );
+      let raw: string;
+      try {
+        const opened = await handle.stat();
+        if (
+          opened.dev !== entry.dev ||
+          opened.ino !== entry.ino ||
+          opened.nlink !== 1 ||
+          opened.size > 4_096
+        ) {
+          // The prior owner may release and a contender may create a new lock
+          // between lstat and open. The changed file grants no authority; the
+          // caller treats it like an incomplete owner and waits/retries.
+          return null;
+        }
+        raw = await handle.readFile("utf8");
+      } finally {
+        await handle.close();
+      }
       const value = JSON.parse(raw) as Partial<LockOwner>;
       if (
         !Number.isSafeInteger(value.pid) ||
@@ -421,7 +548,12 @@ export class FileMessageInteractionSessionStore
   }
 
   private assertFile(value: unknown): SessionFile {
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
+    if (
+      !value ||
+      typeof value !== "object" ||
+      Array.isArray(value) ||
+      !validBoundedJson(value)
+    ) {
       return storeError(
         "CORRUPT_INTERACTION_SESSION_STORE",
         "Interaction store root is invalid.",
@@ -437,6 +569,12 @@ export class FileMessageInteractionSessionStore
       return storeError(
         "CORRUPT_INTERACTION_SESSION_STORE",
         "Interaction store schema is invalid.",
+      );
+    }
+    if (Object.keys(document.sessions).length > this.maxSessions) {
+      return storeError(
+        "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+        "Interaction store contains too many sessions.",
       );
     }
     for (const [reference, session] of Object.entries(document.sessions)) {
@@ -463,11 +601,37 @@ export class FileMessageInteractionSessionStore
         "Interaction store became a non-regular file.",
       );
     }
+    if (
+      stat.nlink !== 1 ||
+      (stat.mode & 0o077) !== 0 ||
+      stat.size > this.maxStoreBytes
+    ) {
+      return storeError(
+        stat.size > this.maxStoreBytes
+          ? "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED"
+          : "UNSAFE_INTERACTION_STORE_PATH",
+        "Interaction store file is unsafe or exceeds its byte limit.",
+      );
+    }
     const handle = await fs.open(
       this.filePath,
       constants.O_RDONLY | constants.O_NOFOLLOW,
     );
     try {
+      const opened = await handle.stat();
+      if (
+        !opened.isFile() ||
+        opened.dev !== stat.dev ||
+        opened.ino !== stat.ino ||
+        opened.nlink !== 1 ||
+        (opened.mode & 0o077) !== 0 ||
+        opened.size > this.maxStoreBytes
+      ) {
+        return storeError(
+          "UNSAFE_INTERACTION_STORE_PATH",
+          "Interaction store file identity changed while opening.",
+        );
+      }
       const raw = await handle.readFile("utf8");
       return this.assertFile(JSON.parse(raw) as unknown);
     } catch (error) {
@@ -487,7 +651,11 @@ export class FileMessageInteractionSessionStore
   private prune(document: SessionFile, now: number): number {
     let deleted = 0;
     for (const [reference, session] of Object.entries(document.sessions)) {
-      if (Date.parse(session.expiresAt) + this.retentionMs <= now) {
+      if (
+        Date.parse(session.expiresAt) + this.retentionMs <= now &&
+        session.consume.state !== "committed" &&
+        session.consume.state !== "completed"
+      ) {
         delete document.sessions[reference];
         deleted += 1;
       }
@@ -496,6 +664,23 @@ export class FileMessageInteractionSessionStore
   }
 
   private async writeFile(document: SessionFile): Promise<void> {
+    if (
+      Object.keys(document.sessions).length > this.maxSessions ||
+      !validBoundedJson(document)
+    ) {
+      storeError(
+        "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+        "Interaction store exceeds its structural limits.",
+      );
+    }
+    if (
+      Buffer.byteLength(JSON.stringify(document), "utf8") > this.maxStoreBytes
+    ) {
+      storeError(
+        "INTERACTION_SESSION_STORE_LIMIT_EXCEEDED",
+        "Interaction store exceeds its byte limit.",
+      );
+    }
     const temp = `${this.filePath}.tmp-${process.pid}-${newToken()}`;
     try {
       await this.writeAndSync(temp, document);
@@ -584,6 +769,22 @@ export class FileMessageInteractionSessionStore
     });
   }
 
+  async commitIfClaimed(
+    context: MessageInteractionCommitContext,
+  ): Promise<MessageInteractionSession> {
+    return this.transaction((document) => {
+      const current = document.sessions[context.reference];
+      if (!current)
+        storeError(
+          "MESSAGE_INTERACTION_NOT_FOUND",
+          "Interaction session was not found.",
+        );
+      const committed = applyMessageInteractionCommit(current, context);
+      document.sessions[context.reference] = structuredClone(committed);
+      return committed;
+    });
+  }
+
   async revokeAuthorization(args: {
     reference: string;
     decisionId: string;
@@ -611,7 +812,11 @@ export class FileMessageInteractionSessionStore
     return this.transaction((document) => {
       let deleted = 0;
       for (const [reference, session] of Object.entries(document.sessions)) {
-        if (Date.parse(session.expiresAt) <= before) {
+        if (
+          Date.parse(session.expiresAt) <= before &&
+          session.consume.state !== "committed" &&
+          session.consume.state !== "completed"
+        ) {
           delete document.sessions[reference];
           deleted += 1;
         }

--- a/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
+++ b/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
@@ -4,18 +4,34 @@ This generated matrix is the production declaration. Each runtime registration m
 
 | Connector | Account | Target | Block delivery | Callback bytes | Attachments |
 | --- | --- | --- | --- | ---: | --- |
-| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 100 | 10 × 10000000 |
-| gmail | <account> | email:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| google-chat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | 1 × 52428800 |
-| imessage | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | 1 × 52428800 |
-| instagram | <account> | thread:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| matrix | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| slack | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 2000 | 10 × 20000000 |
-| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | 10 × 20000000 |
-| wechat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| whatsapp | <account> | phone:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:conversational→signed-hosted<br>secret:sensitive-request | 200 | 1 × 16000000 |
-| x | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:native→conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 100 | 10 × 10000000 |
+| gmail | <account> | email:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| google-chat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | 1 × 52428800 |
+| imessage | <account> | user:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | 1 × 52428800 |
+| instagram | <account> | thread:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| matrix | <account> | room:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| slack | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:native→conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 2000 | 10 × 20000000 |
+| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:native→conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 64 | 10 × 20000000 |
+| wechat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| whatsapp | <account> | phone:<target> | choice:native→conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:native→conversational<br>task:conversational→signed-hosted<br>secret:sensitive-request | 200 | 1 × 16000000 |
+| x | <account> | user:<target> | choice:conversational→signed-hosted<br>form:signed-hosted→conversational<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
 
 ## Explicit exclusions
 
 - plugin-signal: Signal is intentionally unsupported and throws SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE; it registers no message connector.
+
+## Registration inventory
+
+| Connector | Plugin | Mechanism | Production site |
+| --- | --- | --- | --- |
+| discord | plugin-discord | direct | service.ts |
+| gmail | plugin-google-workspace | account-provider | src/connector-account-provider.ts |
+| google-chat | plugin-google-workspace | direct | src/chat/service.ts |
+| imessage | plugin-imessage | direct | src/service.ts |
+| instagram | plugin-instagram | direct | src/service.ts |
+| matrix | plugin-matrix | direct | src/service.ts |
+| slack | plugin-slack | direct | src/service.ts |
+| telegram | plugin-telegram | direct | src/service.ts |
+| wechat | plugin-wechat | direct | src/index.ts |
+| whatsapp | plugin-whatsapp | direct | src/runtime-service.ts |
+| x | plugin-x | direct | src/services/x.service.ts |

--- a/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
+++ b/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
@@ -1,0 +1,21 @@
+# First-party interaction capability baseline
+
+This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.
+
+| Connector | Account | Target | Block delivery | Callback bytes | Attachments |
+| --- | --- | --- | --- | ---: | --- |
+| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |
+| gmail | <account> | email:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| google-chat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| imessage | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| instagram | <account> | thread:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| matrix | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| slack | <account> | channel:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |
+| wechat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| whatsapp | <account> | phone:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| x | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+
+## Explicit exclusions
+
+- plugin-signal: Signal is intentionally unsupported and throws SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE; it registers no message connector.

--- a/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
+++ b/packages/core/src/messaging/interactions/CAPABILITY_MATRIX.md
@@ -1,19 +1,19 @@
 # First-party interaction capability baseline
 
-This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.
+This generated matrix is the production declaration. Each runtime registration materializes the family for its concrete account and target; native claims are backed by adapter tests and every other block has an explicit semantic fallback.
 
 | Connector | Account | Target | Block delivery | Callback bytes | Attachments |
 | --- | --- | --- | --- | ---: | --- |
-| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |
+| discord | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 100 | 10 × 10000000 |
 | gmail | <account> | email:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| google-chat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| imessage | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| google-chat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | 1 × 52428800 |
+| imessage | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | 1 × 52428800 |
 | instagram | <account> | thread:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
 | matrix | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| slack | <account> | channel:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | none |
+| slack | <account> | channel:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 2000 | 10 × 20000000 |
+| telegram | <account> | room:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:native→signed-hosted→conversational<br>secret:sensitive-request | 64 | 10 × 20000000 |
 | wechat | <account> | room:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
-| whatsapp | <account> | phone:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
+| whatsapp | <account> | phone:<target> | choice:native→conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:native→conversational<br>task:conversational→signed-hosted<br>secret:sensitive-request | 200 | 1 × 16000000 |
 | x | <account> | user:<target> | choice:conversational→signed-hosted<br>form:conversational→signed-hosted<br>followups:conversational<br>task:signed-hosted→conversational<br>secret:sensitive-request | 0 | none |
 
 ## Explicit exclusions

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -111,6 +111,16 @@ as the idempotency key. Its retained receipt carries the provider receipt,
 canonical inbound event id, audit id, and app-state result. Connectors must not
 construct their own authority, store, or effect dispatcher.
 
+The additive `MessageConnector.sendPreparedInteraction` hook accepts only the
+renderer-safe `PreparedMessageInteraction` plus a target and optional prose.
+The host is the producer; the connector is only the provider renderer. For
+providers whose control value is the sole callback field,
+`encodePreparedInteractionCallback` appends schema-validated non-secret user
+input to the opaque reference within the declared provider byte budget.
+`consumePreparedInteractionCallback` removes that input and submits the
+provider-authenticated actor, audience, agent, account, room, and receipt to the
+host. The original source message remains retained-only and survives restart.
+
 `InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
 processes. The agent host's `FileMessageInteractionSessionStore` is durable and
 cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
@@ -147,17 +157,11 @@ package fails with `SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE` and registers no messag
 connector. A connector may not advertise a stronger family than its exact
 account transport supports.
 
-Legacy untrusted choice/followup callbacks are normalized on Discord, Telegram,
-Slack, and WhatsApp Cloud API. Durable state-changing round-trips require the
-host-owned session dispatcher described above:
-- **Telegram**: `handleCallbackQuery` decodes the tap and replays it through
-  `handleMessage` as a user turn (`plugin-telegram/src/messageManager.ts`).
-- **Discord**: the `isButton` handler in `discord-interactions.ts` decodes the
-  `customId` with `decodeCallback` and dispatches via `messageService.handleMessage`.
-- **Slack**: the Block Kit action handler acknowledges the event, applies the
-  normal inbound workspace/policy gate, and dispatches the decoded reply.
-- **WhatsApp Cloud API**: interactive button/list reply IDs decode at webhook
-  normalization; Baileys stays on conversational fallback.
+Legacy `ia1:` choice/followup values are presentation-only and never dispatch a
+state-changing turn. Discord, Telegram, Slack, and WhatsApp Cloud API emit
+effect-capable controls only from a host-prepared `is1:` delivery, authenticate
+the provider event, and consume it through the host. WhatsApp Baileys and every
+transport without native controls remain on semantic conversational fallback.
 
 The floating chat overlay (`ChatOverlay`) also renders these widgets.
 It does **not** route through `MessageContent`: it renders assistant turns via

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -64,10 +64,8 @@ a malformed block is left as plain text, never a broken control.
 - `toPlainTextFallback(block, { resolveUrl })` → concise prose for text-only
   transports such as SMS/iMessage, where there is no native control surface.
 - `encodeReplyCallback(value, { maxBytes })` / `decodeCallback(data)` —
-  callback codec that defaults to Telegram's 64-byte `callback_data` limit.
-  Connectors with a larger native budget, such as Discord custom IDs, pass their
-  own limit. Returns null when the answer is too big → caller links out or
-  accepts a free-text reply.
+  legacy presentation codec. Its decoded value is untrusted input and grants no
+  authority. New state-changing controls use the durable session protocol below.
 - `normalizeContentInteractions(content)` — attach parsed blocks to
   `Content.interactions` **without** mutating `text` (so the dashboard's own
   segment renderer keeps interleaving). `stripInteractionMarkers(text)` for prose.
@@ -75,6 +73,41 @@ a malformed block is left as plain text, never a broken control.
 Types: `InteractionBlock` (`FormInteraction | ChoiceInteraction |
 FollowupsInteraction | TaskInteraction | SecretInteraction`) in
 `@elizaos/core` `types/interactions`. `Content.interactions?: InteractionBlock[]`.
+
+## Negotiated delivery and durable callbacks
+
+`ConnectorInteractionCapabilityProfile` is the canonical, versioned capability
+description for one connector account and one target. `MessageConnector`
+implementations resolve it from `(target, delivery context)`; renderers select
+native, signed-hosted, conversational, or sensitive-request delivery from the
+profile rather than branching on a provider name. Every block kind is required,
+unsupported primitives use zero limits, and supported primitives use positive
+limits. `negotiateInteractionDelivery` enforces counts, UTF-8 byte budgets,
+callback size, attachment MIME and byte limits, edit windows, threads, and URL
+limits before selecting a mode. The generated `CAPABILITY_MATRIX.md` is the
+reviewable golden contract and its test fails when a registered first-party
+message connector is omitted.
+
+State-changing controls use `MessageInteractionSessionAuthority`. The wire value
+is only `is1:<128-bit opaque reference>`; it contains no answer, identity,
+authorization, credential, or signature. The durable record binds the actor,
+audience, agent, connector account, room, source message, response schema,
+authorization decision, expiry, effect, and stable replay key. A store performs
+atomic `pending → claimed → completed` transitions and retains the effect receipt.
+The executor must apply the replay key as its effect idempotency key, allowing a
+claim to resume after a crash without repeating the effect. Revocation after
+render, expiry, mismatched context, response tampering, stale claims, and a
+different replay key all fail closed.
+
+`InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
+processes. The agent host's `FileMessageInteractionSessionStore` is durable and
+cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
+commit and a stale-owner-aware lock. Multi-host deployments must implement the
+same store interface with a transactional database and idempotent effect/outbox
+boundary; the JSON store does not claim distributed exactly-once semantics.
+
+Secrets and OAuth values never enter these response records. A `secret` block
+can only negotiate `sensitive-request`, and ordinary forms reject secret fields.
 
 ## Per-surface rendering matrix
 
@@ -152,9 +185,12 @@ mounts `SensitiveRequestBlock` itself for the secret/OAuth card.
 
 ## Adding a new surface
 
-Implement one function: `parseInteractionBlocks(content.text)` → for each block
-`toNeutralLayout(block, { resolveUrl })` → map `NeutralButton.callbackData`/`.url`
-to the platform's button primitive; send `cleanedText` as the body. For the
-round-trip, decode the platform's callback payload with `decodeCallback` and
-re-inject `value` as an inbound user message. ~60 lines; see
-`plugin-telegram/src/interactions.ts` and `plugin-discord/interactions.ts`.
+Register the connector's mechanically verified capability template, resolve a
+concrete profile for each account/target, and render the mode returned by
+`negotiateInteractionDelivery`. For state-changing callbacks, create a durable
+session and place only its opaque callback reference in the native control. On
+receipt, pass the connector-authenticated actor/account/room/message context to
+the session authority and execute the retained typed effect with its replay key.
+Conversational fallback must explain the accepted reply shape; signed-hosted
+fallback must use a short-lived authenticated URL; secret/OAuth input must use
+the sensitive-request service.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -137,11 +137,27 @@ specs are not persisted server-side), so `buildInteractionUrlResolver` resolves
 no URL for them and the layout degrades to the form's title/description plus a
 "Reply with your answer." invite. Secret-bearing input must never use a form —
 it goes through the sensitive-request flow, which has a real hosted page.
-Choice/followups round-trip works on **both** connectors:
+The exhaustive production inventory is generated in
+[`CAPABILITY_MATRIX.md`](./CAPABILITY_MATRIX.md). Discord, Slack, Telegram, and
+WhatsApp Cloud API declare the provider-native controls their adapters actually
+emit. Gmail, Google Chat, iMessage, Instagram, Matrix, WeChat, X DMs, and
+WhatsApp Baileys declare semantic conversational delivery for unsupported
+controls. Signal is deliberately listed as an exclusion because the first-party
+package fails with `SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE` and registers no message
+connector. A connector may not advertise a stronger family than its exact
+account transport supports.
+
+Legacy untrusted choice/followup callbacks are normalized on Discord, Telegram,
+Slack, and WhatsApp Cloud API. Durable state-changing round-trips require the
+host-owned session dispatcher described above:
 - **Telegram**: `handleCallbackQuery` decodes the tap and replays it through
   `handleMessage` as a user turn (`plugin-telegram/src/messageManager.ts`).
 - **Discord**: the `isButton` handler in `discord-interactions.ts` decodes the
   `customId` with `decodeCallback` and dispatches via `messageService.handleMessage`.
+- **Slack**: the Block Kit action handler acknowledges the event, applies the
+  normal inbound workspace/policy gate, and dispatches the decoded reply.
+- **WhatsApp Cloud API**: interactive button/list reply IDs decode at webhook
+  normalization; Baileys stays on conversational fallback.
 
 The floating chat overlay (`ChatOverlay`) also renders these widgets.
 It does **not** route through `MessageContent`: it renders assistant turns via

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -99,6 +99,16 @@ claim to resume after a crash without repeating the effect. Revocation after
 render, expiry, mismatched context, response tampering, stale claims, and a
 different replay key all fail closed.
 
+Connector plugins access that authority through the registered
+`MessageInteractionHost` service. `prepare` accepts the resolved profile plus
+trusted bindings, authorization, and effect, but returns only the block,
+negotiated delivery, opaque callback, expiry, and profile id needed to render.
+`consume` accepts connector-authenticated bindings and the provider's inbound
+event id, then dispatches through a host-registered effect handler using that id
+as the idempotency key. Its retained receipt carries the provider receipt,
+canonical inbound event id, audit id, and app-state result. Connectors must not
+construct their own authority, store, or effect dispatcher.
+
 `InMemoryMessageInteractionSessionStore` is for deterministic tests and embedded
 processes. The agent host's `FileMessageInteractionSessionStore` is durable and
 cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
@@ -186,11 +196,11 @@ mounts `SensitiveRequestBlock` itself for the secret/OAuth card.
 ## Adding a new surface
 
 Register the connector's mechanically verified capability template, resolve a
-concrete profile for each account/target, and render the mode returned by
-`negotiateInteractionDelivery`. For state-changing callbacks, create a durable
-session and place only its opaque callback reference in the native control. On
-receipt, pass the connector-authenticated actor/account/room/message context to
-the session authority and execute the retained typed effect with its replay key.
+concrete profile for each account/target, and ask the registered
+`MessageInteractionHost` to prepare the delivery. Place only its opaque callback
+reference in the native control. On receipt, pass the connector-authenticated
+actor/account/room/message context and provider event receipt back to the host;
+the host owns authorization, replay, effect dispatch, and durable receipts.
 Conversational fallback must explain the accepted reply shape; signed-hosted
 fallback must use a short-lived authenticated URL; secret/OAuth input must use
 the sensitive-request service.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -93,11 +93,13 @@ is only `is1:<128-bit opaque reference>`; it contains no answer, identity,
 authorization, credential, or signature. The durable record binds the actor,
 audience, agent, connector account, room, source message, response schema,
 authorization decision, expiry, effect, and stable replay key. A store performs
-atomic `pending → claimed → completed` transitions and retains the effect receipt.
-The executor must apply the replay key as its effect idempotency key, allowing a
-claim to resume after a crash without repeating the effect. Revocation after
-render, expiry, mismatched context, response tampering, stale claims, and a
-different replay key all fail closed.
+atomic `pending → claimed → committed → completed` transitions and retains the
+effect receipt. Reservation claims may expire before commitment. Once committed,
+the host may cross the external effect boundary, but an outcome lost to a crash
+remains permanently ambiguous: it is never transferred, retried, revoked as if
+cancellation succeeded, or garbage-collected. Revocation after render, expiry,
+mismatched context, response tampering, stale claims, and a different replay key
+all fail closed.
 
 Connector plugins access that authority through the registered
 `MessageInteractionHost` service. `prepare` accepts the resolved profile plus

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -43,10 +43,18 @@ export interface PrepareMessageInteractionRequest {
 export interface PreparedMessageInteraction {
 	block: InteractionBlock;
 	delivery: NegotiatedInteractionDelivery;
+	/** Present only after negotiation validates a signed-hosted delivery URL. */
+	hostedUrl?: string;
 	callbackData: string;
 	expiresAt: string;
 	profileId: string;
 }
+
+/** Bindings a connector can authenticate from an inbound provider event. */
+export type AuthenticatedMessageInteractionBindings = Omit<
+	MessageInteractionBindings,
+	"sourceMessageId"
+>;
 
 export interface MessageInteractionProviderReceipt {
 	source: string;
@@ -95,7 +103,7 @@ export type MessageInteractionHostConsumeOutcome =
 
 export interface ConsumeMessageInteractionRequest {
 	callbackData: string;
-	bindings: MessageInteractionBindings;
+	bindings: AuthenticatedMessageInteractionBindings;
 	response?: MessageInteractionResponse;
 	providerReceipt: MessageInteractionProviderReceipt;
 }

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -219,7 +219,10 @@ export function decodePreparedInteractionCallback(
 /** Submit a provider-authenticated callback to the sole host authority. */
 export async function consumePreparedInteractionCallback(
 	runtime: IAgentRuntime,
-	request: Omit<ConsumeMessageInteractionRequest, "callbackData" | "response"> & {
+	request: Omit<
+		ConsumeMessageInteractionRequest,
+		"callbackData" | "response"
+	> & {
 		providerCallbackData: unknown;
 	},
 ): Promise<MessageInteractionHostConsumeOutcome> {
@@ -238,7 +241,8 @@ export async function consumePreparedInteractionCallback(
 		return {
 			status: "denied",
 			code: "MESSAGE_INTERACTION_HOST_UNAVAILABLE",
-			message: "Interactive actions are temporarily unavailable; reply in text.",
+			message:
+				"Interactive actions are temporarily unavailable; reply in text.",
 		};
 	}
 	return host.consume({

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -1,0 +1,141 @@
+/**
+ * Defines the host-owned interaction coordinator consumed by connector plugins.
+ * Connectors render prepared deliveries and submit authenticated inbound events;
+ * they never construct a second session authority or execute effects directly.
+ */
+
+import { ElizaError } from "../../errors";
+import type { InteractionBlock } from "../../types/interactions";
+import type { IAgentRuntime } from "../../types/runtime";
+import type {
+	ConnectorInteractionCapabilityProfile,
+	InteractionNegotiationContext,
+	NegotiatedInteractionDelivery,
+} from "./profiles";
+import type {
+	MessageInteractionAuthorizationDecision,
+	MessageInteractionBindings,
+	MessageInteractionEffect,
+	MessageInteractionPurpose,
+	MessageInteractionResponse,
+	MessageInteractionSession,
+} from "./sessions";
+
+export const MESSAGE_INTERACTION_HOST_SERVICE =
+	"message_interaction_host" as const;
+
+export interface PrepareMessageInteractionRequest {
+	block: InteractionBlock;
+	profile: ConnectorInteractionCapabilityProfile;
+	bindings: MessageInteractionBindings;
+	purpose: MessageInteractionPurpose;
+	negotiationContext?: InteractionNegotiationContext;
+	presetResponse?: MessageInteractionResponse;
+	authorization: Omit<
+		MessageInteractionAuthorizationDecision,
+		"state" | "revokedAt"
+	>;
+	effect: MessageInteractionEffect;
+	expiresAt: string;
+}
+
+/** Safe subset a connector needs to render; retained authority is omitted. */
+export interface PreparedMessageInteraction {
+	block: InteractionBlock;
+	delivery: NegotiatedInteractionDelivery;
+	callbackData: string;
+	expiresAt: string;
+	profileId: string;
+}
+
+export interface MessageInteractionProviderReceipt {
+	source: string;
+	accountId: string;
+	inboundEventId: string;
+	receivedAt: string;
+}
+
+export interface MessageInteractionHostEffectResult {
+	receiptId: string;
+	canonicalInboundEventId: string;
+	auditId: string;
+	appStateResult: Readonly<Record<string, string | number | boolean | null>>;
+	result: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+export interface MessageInteractionHostEffectHandler {
+	execute(args: {
+		idempotencyKey: string;
+		effect: MessageInteractionEffect;
+		response: MessageInteractionResponse;
+		session: MessageInteractionSession;
+		providerReceipt: MessageInteractionProviderReceipt;
+	}): Promise<MessageInteractionHostEffectResult>;
+}
+
+export interface MessageInteractionHostReceipt {
+	receiptId: string;
+	idempotencyKey: string;
+	status: "completed";
+	completedAt: string;
+	canonicalInboundEventId: string;
+	providerReceipt: MessageInteractionProviderReceipt;
+	auditId: string;
+	appStateResult: Readonly<Record<string, string | number | boolean | null>>;
+	result: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+export type MessageInteractionHostConsumeOutcome =
+	| {
+			status: "completed" | "replay";
+			receipt: MessageInteractionHostReceipt;
+	  }
+	| { status: "in_progress" }
+	| { status: "denied"; code: string; message: string };
+
+export interface ConsumeMessageInteractionRequest {
+	callbackData: string;
+	bindings: MessageInteractionBindings;
+	response?: MessageInteractionResponse;
+	providerReceipt: MessageInteractionProviderReceipt;
+}
+
+export interface MessageInteractionHost {
+	prepare(
+		request: PrepareMessageInteractionRequest,
+	): Promise<PreparedMessageInteraction>;
+	consume(
+		request: ConsumeMessageInteractionRequest,
+	): Promise<MessageInteractionHostConsumeOutcome>;
+	revoke(request: {
+		reference: string;
+		decisionId: string;
+		now?: number;
+	}): Promise<MessageInteractionSession>;
+	get(reference: string): Promise<MessageInteractionSession | null>;
+	registerEffectHandler(
+		kind: string,
+		handler: MessageInteractionHostEffectHandler,
+	): () => void;
+}
+
+/** Resolve the one host authority. Absence is an explicit unavailable state. */
+export function resolveMessageInteractionHost(
+	runtime: IAgentRuntime,
+): MessageInteractionHost | null {
+	const service = runtime.getService(MESSAGE_INTERACTION_HOST_SERVICE);
+	if (!service) return null;
+	const candidate = service as unknown as Partial<MessageInteractionHost>;
+	if (
+		typeof candidate.prepare !== "function" ||
+		typeof candidate.consume !== "function" ||
+		typeof candidate.revoke !== "function" ||
+		typeof candidate.get !== "function" ||
+		typeof candidate.registerEffectHandler !== "function"
+	) {
+		throw new ElizaError("Registered interaction host is malformed.", {
+			code: "INVALID_MESSAGE_INTERACTION_HOST_SERVICE",
+		});
+	}
+	return candidate as MessageInteractionHost;
+}

--- a/packages/core/src/messaging/interactions/host.ts
+++ b/packages/core/src/messaging/interactions/host.ts
@@ -20,6 +20,7 @@ import type {
 	MessageInteractionResponse,
 	MessageInteractionSession,
 } from "./sessions";
+import { decodeMessageInteractionCallback } from "./sessions";
 
 export const MESSAGE_INTERACTION_HOST_SERVICE =
 	"message_interaction_host" as const;
@@ -125,6 +126,127 @@ export interface MessageInteractionHost {
 		kind: string,
 		handler: MessageInteractionHostEffectHandler,
 	): () => void;
+}
+
+export interface DecodedPreparedInteractionCallback {
+	callbackData: string;
+	response: MessageInteractionResponse;
+}
+
+const PROVIDER_RESPONSE_SEPARATOR = "~";
+
+function encodeBase64Url(value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/u, "");
+}
+
+function decodeBase64Url(value: string): string | null {
+	try {
+		const padded = value.replaceAll("-", "+").replaceAll("_", "/");
+		const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, "="));
+		return new TextDecoder().decode(
+			Uint8Array.from(binary, (character) => character.charCodeAt(0)),
+		);
+	} catch {
+		// error-policy:J3 Provider callback data is untrusted and malformed data
+		// remains explicitly invalid rather than becoming a plausible response.
+		return null;
+	}
+}
+
+/**
+ * Add non-secret user input to an opaque callback for providers whose control
+ * value is their only callback field. Authority remains exclusively in the
+ * host session; the host validates this response against its retained schema.
+ */
+export function encodePreparedInteractionCallback(
+	callbackData: string,
+	response: MessageInteractionResponse,
+	maxBytes: number,
+): string | null {
+	if (!decodeMessageInteractionCallback(callbackData)) return null;
+	const entries = Object.entries(response);
+	if (
+		entries.length !== 1 ||
+		!(["value", "acknowledged"] as string[]).includes(entries[0][0]) ||
+		(typeof entries[0][1] !== "string" &&
+			typeof entries[0][1] !== "number" &&
+			typeof entries[0][1] !== "boolean")
+	) {
+		return null;
+	}
+	const wire = `${callbackData}${PROVIDER_RESPONSE_SEPARATOR}${encodeBase64Url(JSON.stringify(response))}`;
+	return new TextEncoder().encode(wire).length <= maxBytes ? wire : null;
+}
+
+/** Parse an untrusted provider value into the opaque host reference and input. */
+export function decodePreparedInteractionCallback(
+	value: unknown,
+): DecodedPreparedInteractionCallback | null {
+	if (typeof value !== "string") return null;
+	const separator = value.indexOf(PROVIDER_RESPONSE_SEPARATOR);
+	if (separator < 0) return null;
+	const callbackData = value.slice(0, separator);
+	if (!decodeMessageInteractionCallback(callbackData)) return null;
+	const decoded = decodeBase64Url(value.slice(separator + 1));
+	if (!decoded) return null;
+	try {
+		const response = JSON.parse(decoded) as unknown;
+		if (!response || typeof response !== "object" || Array.isArray(response))
+			return null;
+		const entries = Object.entries(response);
+		if (
+			entries.length !== 1 ||
+			!(["value", "acknowledged"] as string[]).includes(entries[0][0]) ||
+			(typeof entries[0][1] !== "string" &&
+				typeof entries[0][1] !== "number" &&
+				typeof entries[0][1] !== "boolean")
+		)
+			return null;
+		return { callbackData, response: response as MessageInteractionResponse };
+	} catch {
+		// error-policy:J3 Provider callback data is untrusted JSON; parsing failure
+		// is an explicit invalid callback and never a fabricated empty response.
+		return null;
+	}
+}
+
+/** Submit a provider-authenticated callback to the sole host authority. */
+export async function consumePreparedInteractionCallback(
+	runtime: IAgentRuntime,
+	request: Omit<ConsumeMessageInteractionRequest, "callbackData" | "response"> & {
+		providerCallbackData: unknown;
+	},
+): Promise<MessageInteractionHostConsumeOutcome> {
+	const decoded = decodePreparedInteractionCallback(
+		request.providerCallbackData,
+	);
+	if (!decoded) {
+		return {
+			status: "denied",
+			code: "INVALID_MESSAGE_INTERACTION_PROVIDER_CALLBACK",
+			message: "The provider callback is malformed or unsupported.",
+		};
+	}
+	const host = resolveMessageInteractionHost(runtime);
+	if (!host) {
+		return {
+			status: "denied",
+			code: "MESSAGE_INTERACTION_HOST_UNAVAILABLE",
+			message: "Interactive actions are temporarily unavailable; reply in text.",
+		};
+	}
+	return host.consume({
+		callbackData: decoded.callbackData,
+		response: decoded.response,
+		bindings: request.bindings,
+		providerReceipt: request.providerReceipt,
+	});
 }
 
 /** Resolve the one host authority. Absence is an explicit unavailable state. */

--- a/packages/core/src/messaging/interactions/index.ts
+++ b/packages/core/src/messaging/interactions/index.ts
@@ -13,4 +13,7 @@ export * from "./dashboard-markers";
 export * from "./layout";
 export * from "./normalize";
 export * from "./parse";
+export * from "./profile-catalog";
+export * from "./profiles";
 export * from "./serialize";
+export * from "./sessions";

--- a/packages/core/src/messaging/interactions/index.ts
+++ b/packages/core/src/messaging/interactions/index.ts
@@ -10,6 +10,7 @@
 
 export * from "./callback";
 export * from "./dashboard-markers";
+export * from "./host";
 export * from "./layout";
 export * from "./normalize";
 export * from "./parse";

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -363,6 +363,26 @@ export function renderContentInteractionsAsPlainText(
 }
 
 /**
+ * Safe text projection for a connector delivery boundary. Deployment URLs are
+ * resolved from runtime settings, while typed out-of-band secret blocks remain
+ * links or an explicit unavailable notice and never become marker text.
+ */
+export function renderContentInteractionsForConnector(
+	runtime: { getSetting(key: string): unknown },
+	content: Pick<Content, "text" | "interactions"> | undefined | null,
+): { text: string; hadBlocks: boolean } {
+	const rawAppUrl =
+		runtime.getSetting("ELIZA_APP_URL") ??
+		runtime.getSetting("ELIZA_CLOUD_URL");
+	return renderContentInteractionsAsPlainText(
+		content,
+		buildInteractionUrlResolver(
+			typeof rawAppUrl === "string" ? rawAppUrl : undefined,
+		),
+	);
+}
+
+/**
  * Build the canonical link-out resolvers connectors pass to {@link toNeutralLayout}
  * so Telegram, Discord, and any other surface produce identical URLs for task
  * and navigate blocks. `appBaseUrl` is the deployment's app/dashboard origin

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -177,17 +177,13 @@ export function toNeutralLayout(
 			return { rows: chunk(buttons, perRow).map((b) => ({ buttons: b })) };
 		}
 		case "task": {
-			// Without a resolvable link the card is dashboard-only; its bare
-			// title rendered as a dangling duplicate line under the ack on chat
-			// connectors ("On it — building that now.\n\nWater Tracker Page",
-			// 2026-08-19). With a URL the title labels the button as before.
 			const url = resolveUrl?.(block);
 			return {
-				text: url ? block.title : "",
+				text: block.title,
 				rows: url
 					? [{ buttons: [{ label: "Open task", url, style: "primary" }] }]
 					: [],
-				needsFallback: false,
+				needsFallback: !url,
 			};
 		}
 		case "form": {

--- a/packages/core/src/messaging/interactions/profile-catalog.ts
+++ b/packages/core/src/messaging/interactions/profile-catalog.ts
@@ -4,6 +4,8 @@
  * account/target profiles, never this source-name catalog.
  */
 
+import { ElizaError } from "../../errors";
+import type { TargetInfo } from "../../types/messaging";
 import {
 	createConnectorInteractionCapabilityProfile,
 	type InteractionProfileTemplate,
@@ -57,6 +59,22 @@ export const CONVERSATIONAL_INTERACTION_PROFILE: InteractionProfileTemplate = {
 	nonSecretFallbacks: ["conversational", "signed-hosted"],
 };
 
+/** Text-first transports that also accept one native file attachment. */
+export const CONVERSATIONAL_MEDIA_INTERACTION_PROFILE: InteractionProfileTemplate =
+	{
+		...CONVERSATIONAL_INTERACTION_PROFILE,
+		templateId: "conversational-media-v1",
+		limits: {
+			...CONVERSATIONAL_INTERACTION_PROFILE.limits,
+			attachments: {
+				supported: true,
+				maxCount: 1,
+				maxBytesEach: 50 * 1024 * 1024,
+				mimeTypes: ["*/*"],
+			},
+		},
+	};
+
 export const BUTTON_INTERACTION_PROFILE: InteractionProfileTemplate = {
 	...CONVERSATIONAL_INTERACTION_PROFILE,
 	templateId: "button-native-v1",
@@ -86,6 +104,131 @@ export const BUTTON_INTERACTION_PROFILE: InteractionProfileTemplate = {
 	},
 	nonSecretFallbacks: ["native", "conversational", "signed-hosted"],
 };
+
+/** Discord's documented message-component and message-size boundaries. */
+export const DISCORD_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...BUTTON_INTERACTION_PROFILE,
+	templateId: "discord-native-v1",
+	limits: {
+		...BUTTON_INTERACTION_PROFILE.limits,
+		buttons: {
+			supported: true,
+			maxPerRow: 5,
+			maxPerMessage: 25,
+			maxLabelBytes: 80,
+			maxCallbackBytes: 100,
+		},
+		text: { maxMessageBytes: 2_000 },
+		attachments: {
+			supported: true,
+			maxCount: 10,
+			maxBytesEach: 10_000_000,
+			mimeTypes: ["*/*"],
+		},
+	},
+};
+
+/** Telegram Bot API inline-keyboard and message boundaries. */
+export const TELEGRAM_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...BUTTON_INTERACTION_PROFILE,
+	templateId: "telegram-native-v1",
+	limits: {
+		...BUTTON_INTERACTION_PROFILE.limits,
+		buttons: {
+			supported: true,
+			maxPerRow: 8,
+			maxPerMessage: 100,
+			maxLabelBytes: 64,
+			maxCallbackBytes: 64,
+		},
+		threads: { supported: true, maxTitleBytes: 128 },
+		text: { maxMessageBytes: 4_096 },
+		attachments: {
+			supported: true,
+			maxCount: 10,
+			maxBytesEach: 20_000_000,
+			mimeTypes: ["*/*"],
+		},
+	},
+};
+
+/** Slack Block Kit actions used by outbound messages. */
+export const SLACK_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...BUTTON_INTERACTION_PROFILE,
+	templateId: "slack-native-v1",
+	limits: {
+		...BUTTON_INTERACTION_PROFILE.limits,
+		buttons: {
+			supported: true,
+			maxPerRow: 5,
+			maxPerMessage: 25,
+			maxLabelBytes: 75,
+			maxCallbackBytes: 2_000,
+		},
+		edits: { supported: true, windowMs: null },
+		threads: { supported: true, maxTitleBytes: 255 },
+		text: { maxMessageBytes: 40_000 },
+		attachments: {
+			supported: true,
+			maxCount: 10,
+			maxBytesEach: 20_000_000,
+			mimeTypes: ["*/*"],
+		},
+	},
+};
+
+/** WhatsApp interactive reply/list messages; forms remain conversational. */
+export const WHATSAPP_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...BUTTON_INTERACTION_PROFILE,
+	templateId: "whatsapp-native-v1",
+	blocks: {
+		...BUTTON_INTERACTION_PROFILE.blocks,
+		task: {
+			modes: ["conversational", "signed-hosted"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+	},
+	limits: {
+		...BUTTON_INTERACTION_PROFILE.limits,
+		buttons: {
+			supported: true,
+			maxPerRow: 3,
+			maxPerMessage: 3,
+			maxLabelBytes: 20,
+			maxCallbackBytes: 200,
+		},
+		lists: {
+			supported: true,
+			maxItems: 10,
+			maxLabelBytes: 24,
+			maxDescriptionBytes: 72,
+		},
+		text: { maxMessageBytes: 4_096 },
+		attachments: {
+			supported: true,
+			maxCount: 1,
+			maxBytesEach: 16_000_000,
+			mimeTypes: ["*/*"],
+		},
+	},
+};
+
+/** WhatsApp Baileys has media delivery but no supported interactive payload. */
+export const WHATSAPP_CONVERSATIONAL_INTERACTION_PROFILE: InteractionProfileTemplate =
+	{
+		...CONVERSATIONAL_INTERACTION_PROFILE,
+		templateId: "whatsapp-conversational-v1",
+		limits: {
+			...CONVERSATIONAL_INTERACTION_PROFILE.limits,
+			text: { maxMessageBytes: 4_096 },
+			attachments: {
+				supported: true,
+				maxCount: 1,
+				maxBytesEach: 16_000_000,
+				mimeTypes: ["*/*"],
+			},
+		},
+	};
 
 export const RICH_INTERACTION_PROFILE: InteractionProfileTemplate = {
 	...BUTTON_INTERACTION_PROFILE,
@@ -138,6 +281,11 @@ export const RICH_INTERACTION_PROFILE: InteractionProfileTemplate = {
 
 export type FirstPartyInteractionProfileFamily =
 	| "button-native"
+	| "discord-native"
+	| "slack-native"
+	| "telegram-native"
+	| "whatsapp-native"
+	| "conversational-media"
 	| "conversational";
 
 export interface FirstPartyInteractionConnectorAuditEntry {
@@ -157,8 +305,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 		plugin: "plugin-discord",
 		source: "discord",
 		targetKind: "channel",
-		profileFamily: "button-native",
-		note: "native buttons already exist",
+		profileFamily: "discord-native",
+		note: "native action-row buttons with conversational form fallback",
 	},
 	{
 		plugin: "plugin-google-workspace",
@@ -171,15 +319,15 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 		plugin: "plugin-google-workspace",
 		source: "google-chat",
 		targetKind: "room",
-		profileFamily: "conversational",
-		note: "chat spaces and threads",
+		profileFamily: "conversational-media",
+		note: "chat spaces, threads, and one uploaded attachment",
 	},
 	{
 		plugin: "plugin-imessage",
 		source: "imessage",
 		targetKind: "user",
-		profileFamily: "conversational",
-		note: "text and attachment transport",
+		profileFamily: "conversational-media",
+		note: "semantic text controls and one native attachment",
 	},
 	{
 		plugin: "plugin-instagram",
@@ -199,15 +347,15 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 		plugin: "plugin-slack",
 		source: "slack",
 		targetKind: "channel",
-		profileFamily: "conversational",
-		note: "channels, threads, users",
+		profileFamily: "slack-native",
+		note: "native Block Kit actions with conversational form fallback",
 	},
 	{
 		plugin: "plugin-telegram",
 		source: "telegram",
 		targetKind: "room",
-		profileFamily: "button-native",
-		note: "inline keyboard already exists",
+		profileFamily: "telegram-native",
+		note: "native inline keyboards with conversational form fallback",
 	},
 	{
 		plugin: "plugin-wechat",
@@ -220,8 +368,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 		plugin: "plugin-whatsapp",
 		source: "whatsapp",
 		targetKind: "phone",
-		profileFamily: "conversational",
-		note: "Cloud API messages",
+		profileFamily: "whatsapp-native",
+		note: "native reply buttons/lists with conversational form/task fallback",
 	},
 	{
 		plugin: "plugin-x",
@@ -241,14 +389,106 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS = [
 	},
 ] as const;
 
+const PROFILE_BY_FAMILY: Record<
+	FirstPartyInteractionProfileFamily,
+	InteractionProfileTemplate
+> = {
+	"button-native": BUTTON_INTERACTION_PROFILE,
+	"discord-native": DISCORD_INTERACTION_PROFILE,
+	"slack-native": SLACK_INTERACTION_PROFILE,
+	"telegram-native": TELEGRAM_INTERACTION_PROFILE,
+	"whatsapp-native": WHATSAPP_INTERACTION_PROFILE,
+	"conversational-media": CONVERSATIONAL_MEDIA_INTERACTION_PROFILE,
+	conversational: CONVERSATIONAL_INTERACTION_PROFILE,
+};
+
+/** Materialize the audited declaration for one production connector target. */
+export function createFirstPartyInteractionProfile(args: {
+	source: string;
+	accountId: string;
+	targetKind: string;
+	targetId: string;
+}) {
+	const entry = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.find(
+		(candidate) => candidate.source === args.source,
+	);
+	if (!entry) {
+		throw new Error(
+			`No audited first-party interaction profile for ${args.source}.`,
+		);
+	}
+	return createConnectorInteractionCapabilityProfile({
+		template: PROFILE_BY_FAMILY[entry.profileFamily],
+		...args,
+	});
+}
+
+function firstTargetIdentity(target: TargetInfo): string | undefined {
+	const values = [
+		target.channelId,
+		target.entityId,
+		target.roomId,
+		target.serverId,
+	]
+		.map((value) => (value === undefined ? "" : String(value).trim()))
+		.filter(Boolean);
+	if (target.threadId?.trim()) {
+		const parent = values[0];
+		return parent
+			? `${parent}:thread:${target.threadId.trim()}`
+			: target.threadId.trim();
+	}
+	return values[0];
+}
+
+/**
+ * Materialize a connector's audited profile without trusting caller metadata to
+ * invent an account or target identity. Registrations pass their own fixed
+ * source and default target kind; the concrete target remains part of the ID.
+ */
+export function resolveFirstPartyInteractionProfile(args: {
+	source: string;
+	defaultAccountId: string;
+	defaultTargetKind: string;
+	target: TargetInfo;
+	accountId?: string;
+}) {
+	const accountId =
+		args.accountId?.trim() ||
+		args.target.accountId?.trim() ||
+		args.defaultAccountId;
+	if (!accountId.trim()) {
+		throw new ElizaError(
+			"Interaction account has no trusted connector identity.",
+			{
+				code: "INTERACTION_ACCOUNT_IDENTITY_MISSING",
+				context: { source: args.source },
+			},
+		);
+	}
+	const targetId = firstTargetIdentity(args.target);
+	if (!targetId) {
+		throw new ElizaError(
+			"Interaction target has no stable provider identity.",
+			{
+				code: "INTERACTION_TARGET_IDENTITY_MISSING",
+				context: { source: args.source },
+			},
+		);
+	}
+	return createFirstPartyInteractionProfile({
+		source: args.source,
+		accountId,
+		targetKind: args.target.threadId ? "thread" : args.defaultTargetKind,
+		targetId,
+	});
+}
+
 /** Deterministic handoff artifact for connector implementers and reviewers. */
 export function renderFirstPartyInteractionCapabilityMatrix(): string {
 	const profiles = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) =>
 		createConnectorInteractionCapabilityProfile({
-			template:
-				entry.profileFamily === "button-native"
-					? BUTTON_INTERACTION_PROFILE
-					: CONVERSATIONAL_INTERACTION_PROFILE,
+			template: PROFILE_BY_FAMILY[entry.profileFamily],
 			source: entry.source,
 			accountId: "<account>",
 			targetKind: entry.targetKind,
@@ -258,7 +498,7 @@ export function renderFirstPartyInteractionCapabilityMatrix(): string {
 	return [
 		"# First-party interaction capability baseline",
 		"",
-		"This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.",
+		"This generated matrix is the production declaration. Each runtime registration materializes the family for its concrete account and target; native claims are backed by adapter tests and every other block has an explicit semantic fallback.",
 		"",
 		renderInteractionCapabilityMatrix(profiles),
 		"",

--- a/packages/core/src/messaging/interactions/profile-catalog.ts
+++ b/packages/core/src/messaging/interactions/profile-catalog.ts
@@ -21,7 +21,7 @@ export const CONVERSATIONAL_INTERACTION_PROFILE: InteractionProfileTemplate = {
 			modes: ["conversational", "signed-hosted"],
 			maxSessionTtlMs: TTL,
 		},
-		form: { modes: ["conversational", "signed-hosted"], maxSessionTtlMs: TTL },
+		form: { modes: ["signed-hosted", "conversational"], maxSessionTtlMs: TTL },
 		followups: { modes: ["conversational"], maxSessionTtlMs: TTL },
 		task: {
 			modes: ["signed-hosted", "conversational"],
@@ -86,7 +86,7 @@ export const BUTTON_INTERACTION_PROFILE: InteractionProfileTemplate = {
 		},
 		followups: { modes: ["native", "conversational"], maxSessionTtlMs: TTL },
 		task: {
-			modes: ["native", "signed-hosted", "conversational"],
+			modes: ["signed-hosted", "conversational"],
 			maxSessionTtlMs: 24 * TTL,
 		},
 	},
@@ -118,6 +118,7 @@ export const DISCORD_INTERACTION_PROFILE: InteractionProfileTemplate = {
 			maxLabelBytes: 80,
 			maxCallbackBytes: 100,
 		},
+		links: { supported: true, maxUrlBytes: 512 },
 		text: { maxMessageBytes: 2_000 },
 		attachments: {
 			supported: true,
@@ -291,6 +292,8 @@ export type FirstPartyInteractionProfileFamily =
 export interface FirstPartyInteractionConnectorAuditEntry {
 	plugin: string;
 	source: string;
+	registrationSite: string;
+	registrationMechanism: "direct" | "account-provider";
 	targetKind: string;
 	profileFamily: FirstPartyInteractionProfileFamily;
 	note: string;
@@ -304,6 +307,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-discord",
 		source: "discord",
+		registrationSite: "service.ts",
+		registrationMechanism: "direct",
 		targetKind: "channel",
 		profileFamily: "discord-native",
 		note: "native action-row buttons with conversational form fallback",
@@ -311,6 +316,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-google-workspace",
 		source: "gmail",
+		registrationSite: "src/connector-account-provider.ts",
+		registrationMechanism: "account-provider",
 		targetKind: "email",
 		profileFamily: "conversational",
 		note: "email target",
@@ -318,6 +325,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-google-workspace",
 		source: "google-chat",
+		registrationSite: "src/chat/service.ts",
+		registrationMechanism: "direct",
 		targetKind: "room",
 		profileFamily: "conversational-media",
 		note: "chat spaces, threads, and one uploaded attachment",
@@ -325,6 +334,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-imessage",
 		source: "imessage",
+		registrationSite: "src/service.ts",
+		registrationMechanism: "direct",
 		targetKind: "user",
 		profileFamily: "conversational-media",
 		note: "semantic text controls and one native attachment",
@@ -332,6 +343,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-instagram",
 		source: "instagram",
+		registrationSite: "src/service.ts",
+		registrationMechanism: "direct",
 		targetKind: "thread",
 		profileFamily: "conversational",
 		note: "existing DM threads",
@@ -339,6 +352,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-matrix",
 		source: "matrix",
+		registrationSite: "src/service.ts",
+		registrationMechanism: "direct",
 		targetKind: "room",
 		profileFamily: "conversational",
 		note: "rooms and threads",
@@ -346,6 +361,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-slack",
 		source: "slack",
+		registrationSite: "src/service.ts",
+		registrationMechanism: "direct",
 		targetKind: "channel",
 		profileFamily: "slack-native",
 		note: "native Block Kit actions with conversational form fallback",
@@ -353,6 +370,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-telegram",
 		source: "telegram",
+		registrationSite: "src/service.ts",
+		registrationMechanism: "direct",
 		targetKind: "room",
 		profileFamily: "telegram-native",
 		note: "native inline keyboards with conversational form fallback",
@@ -360,6 +379,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-wechat",
 		source: "wechat",
+		registrationSite: "src/index.ts",
+		registrationMechanism: "direct",
 		targetKind: "room",
 		profileFamily: "conversational",
 		note: "users and groups",
@@ -367,6 +388,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-whatsapp",
 		source: "whatsapp",
+		registrationSite: "src/runtime-service.ts",
+		registrationMechanism: "direct",
 		targetKind: "phone",
 		profileFamily: "whatsapp-native",
 		note: "native reply buttons/lists with conversational form/task fallback",
@@ -374,6 +397,8 @@ export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
 	{
 		plugin: "plugin-x",
 		source: "x",
+		registrationSite: "src/services/x.service.ts",
+		registrationMechanism: "direct",
 		targetKind: "user",
 		profileFamily: "conversational",
 		note: "direct messages only; posts are separate",
@@ -506,6 +531,15 @@ export function renderFirstPartyInteractionCapabilityMatrix(): string {
 		"",
 		...FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS.map(
 			(entry) => `- ${entry.plugin}: ${entry.reason}`,
+		),
+		"",
+		"## Registration inventory",
+		"",
+		"| Connector | Plugin | Mechanism | Production site |",
+		"| --- | --- | --- | --- |",
+		...FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map(
+			(entry) =>
+				`| ${entry.source} | ${entry.plugin} | ${entry.registrationMechanism} | ${entry.registrationSite} |`,
 		),
 	].join("\n");
 }

--- a/packages/core/src/messaging/interactions/profile-catalog.ts
+++ b/packages/core/src/messaging/interactions/profile-catalog.ts
@@ -1,0 +1,271 @@
+/**
+ * Publishes conservative capability families and the mechanically audited
+ * first-party connector handoff list. Runtime negotiation uses materialized
+ * account/target profiles, never this source-name catalog.
+ */
+
+import {
+	createConnectorInteractionCapabilityProfile,
+	type InteractionProfileTemplate,
+	renderInteractionCapabilityMatrix,
+} from "./profiles";
+
+const TTL = 15 * 60 * 1_000;
+
+export const CONVERSATIONAL_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	templateId: "conversational-v1",
+	blocks: {
+		choice: {
+			modes: ["conversational", "signed-hosted"],
+			maxSessionTtlMs: TTL,
+		},
+		form: { modes: ["conversational", "signed-hosted"], maxSessionTtlMs: TTL },
+		followups: { modes: ["conversational"], maxSessionTtlMs: TTL },
+		task: {
+			modes: ["signed-hosted", "conversational"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+		secret: { modes: ["sensitive-request"], maxSessionTtlMs: TTL },
+	},
+	limits: {
+		buttons: {
+			supported: false,
+			maxPerRow: 0,
+			maxPerMessage: 0,
+			maxLabelBytes: 0,
+			maxCallbackBytes: 0,
+		},
+		lists: {
+			supported: false,
+			maxItems: 0,
+			maxLabelBytes: 0,
+			maxDescriptionBytes: 0,
+		},
+		modals: { supported: false, maxFields: 0, maxTitleBytes: 0 },
+		forms: { supported: false, maxFields: 0, maxOptionsPerField: 0 },
+		links: { supported: true, maxUrlBytes: 2_048 },
+		edits: { supported: false, windowMs: null },
+		threads: { supported: false, maxTitleBytes: 0 },
+		text: { maxMessageBytes: 4_000 },
+		attachments: {
+			supported: false,
+			maxCount: 0,
+			maxBytesEach: 0,
+			mimeTypes: [],
+		},
+	},
+	nonSecretFallbacks: ["conversational", "signed-hosted"],
+};
+
+export const BUTTON_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...CONVERSATIONAL_INTERACTION_PROFILE,
+	templateId: "button-native-v1",
+	blocks: {
+		...CONVERSATIONAL_INTERACTION_PROFILE.blocks,
+		choice: {
+			modes: ["native", "conversational", "signed-hosted"],
+			maxSessionTtlMs: TTL,
+		},
+		followups: { modes: ["native", "conversational"], maxSessionTtlMs: TTL },
+		task: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+	},
+	limits: {
+		...CONVERSATIONAL_INTERACTION_PROFILE.limits,
+		buttons: {
+			supported: true,
+			maxPerRow: 5,
+			maxPerMessage: 25,
+			maxLabelBytes: 80,
+			maxCallbackBytes: 64,
+		},
+		links: { supported: true, maxUrlBytes: 2_048 },
+		text: { maxMessageBytes: 4_000 },
+	},
+	nonSecretFallbacks: ["native", "conversational", "signed-hosted"],
+};
+
+export const RICH_INTERACTION_PROFILE: InteractionProfileTemplate = {
+	...BUTTON_INTERACTION_PROFILE,
+	templateId: "rich-native-v1",
+	blocks: {
+		choice: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: TTL,
+		},
+		form: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: TTL,
+		},
+		followups: { modes: ["native", "conversational"], maxSessionTtlMs: TTL },
+		task: {
+			modes: ["native", "signed-hosted", "conversational"],
+			maxSessionTtlMs: 24 * TTL,
+		},
+		secret: { modes: ["sensitive-request"], maxSessionTtlMs: TTL },
+	},
+	limits: {
+		buttons: {
+			supported: true,
+			maxPerRow: 8,
+			maxPerMessage: 100,
+			maxLabelBytes: 256,
+			maxCallbackBytes: 256,
+		},
+		lists: {
+			supported: true,
+			maxItems: 100,
+			maxLabelBytes: 256,
+			maxDescriptionBytes: 1_024,
+		},
+		modals: { supported: true, maxFields: 20, maxTitleBytes: 256 },
+		forms: { supported: true, maxFields: 20, maxOptionsPerField: 100 },
+		links: { supported: true, maxUrlBytes: 8_192 },
+		edits: { supported: true, windowMs: null },
+		threads: { supported: true, maxTitleBytes: 256 },
+		text: { maxMessageBytes: 1_000_000 },
+		attachments: {
+			supported: true,
+			maxCount: 20,
+			maxBytesEach: 100_000_000,
+			mimeTypes: ["*/*"],
+		},
+	},
+	nonSecretFallbacks: ["native", "signed-hosted", "conversational"],
+};
+
+export type FirstPartyInteractionProfileFamily =
+	| "button-native"
+	| "conversational";
+
+export interface FirstPartyInteractionConnectorAuditEntry {
+	plugin: string;
+	source: string;
+	targetKind: string;
+	profileFamily: FirstPartyInteractionProfileFamily;
+	note: string;
+}
+
+/**
+ * Production `registerMessageConnector` declarations as of this contract.
+ * #24288 replaces conservative families with live adapter declarations.
+ */
+export const FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT = [
+	{
+		plugin: "plugin-discord",
+		source: "discord",
+		targetKind: "channel",
+		profileFamily: "button-native",
+		note: "native buttons already exist",
+	},
+	{
+		plugin: "plugin-google-workspace",
+		source: "gmail",
+		targetKind: "email",
+		profileFamily: "conversational",
+		note: "email target",
+	},
+	{
+		plugin: "plugin-google-workspace",
+		source: "google-chat",
+		targetKind: "room",
+		profileFamily: "conversational",
+		note: "chat spaces and threads",
+	},
+	{
+		plugin: "plugin-imessage",
+		source: "imessage",
+		targetKind: "user",
+		profileFamily: "conversational",
+		note: "text and attachment transport",
+	},
+	{
+		plugin: "plugin-instagram",
+		source: "instagram",
+		targetKind: "thread",
+		profileFamily: "conversational",
+		note: "existing DM threads",
+	},
+	{
+		plugin: "plugin-matrix",
+		source: "matrix",
+		targetKind: "room",
+		profileFamily: "conversational",
+		note: "rooms and threads",
+	},
+	{
+		plugin: "plugin-slack",
+		source: "slack",
+		targetKind: "channel",
+		profileFamily: "conversational",
+		note: "channels, threads, users",
+	},
+	{
+		plugin: "plugin-telegram",
+		source: "telegram",
+		targetKind: "room",
+		profileFamily: "button-native",
+		note: "inline keyboard already exists",
+	},
+	{
+		plugin: "plugin-wechat",
+		source: "wechat",
+		targetKind: "room",
+		profileFamily: "conversational",
+		note: "users and groups",
+	},
+	{
+		plugin: "plugin-whatsapp",
+		source: "whatsapp",
+		targetKind: "phone",
+		profileFamily: "conversational",
+		note: "Cloud API messages",
+	},
+	{
+		plugin: "plugin-x",
+		source: "x",
+		targetKind: "user",
+		profileFamily: "conversational",
+		note: "direct messages only; posts are separate",
+	},
+] as const satisfies readonly FirstPartyInteractionConnectorAuditEntry[];
+
+/** Deliberate non-registration that the audit must keep visible. */
+export const FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS = [
+	{
+		plugin: "plugin-signal",
+		reason:
+			"Signal is intentionally unsupported and throws SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE; it registers no message connector.",
+	},
+] as const;
+
+/** Deterministic handoff artifact for connector implementers and reviewers. */
+export function renderFirstPartyInteractionCapabilityMatrix(): string {
+	const profiles = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) =>
+		createConnectorInteractionCapabilityProfile({
+			template:
+				entry.profileFamily === "button-native"
+					? BUTTON_INTERACTION_PROFILE
+					: CONVERSATIONAL_INTERACTION_PROFILE,
+			source: entry.source,
+			accountId: "<account>",
+			targetKind: entry.targetKind,
+			targetId: "<target>",
+		}),
+	);
+	return [
+		"# First-party interaction capability baseline",
+		"",
+		"This generated baseline is conservative. Each runtime registration materializes the family for its concrete account and target; #24288 may advertise stronger limits only with adapter tests.",
+		"",
+		renderInteractionCapabilityMatrix(profiles),
+		"",
+		"## Explicit exclusions",
+		"",
+		...FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS.map(
+			(entry) => `- ${entry.plugin}: ${entry.reason}`,
+		),
+	].join("\n");
+}

--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Filesystem-backed audit proving the first-party profile matrix covers every
+ * production message-connector registration and remains byte-deterministic.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT,
+	FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS,
+	renderFirstPartyInteractionCapabilityMatrix,
+} from "./profile-catalog";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../../../..");
+
+async function sourceFiles(directory: string): Promise<string[]> {
+	const files: string[] = [];
+	for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+		if (
+			entry.name === "node_modules" ||
+			entry.name === "dist" ||
+			entry.name === "__tests__" ||
+			entry.name === "test" ||
+			entry.name.includes(".test.")
+		)
+			continue;
+		const fullPath = path.join(directory, entry.name);
+		if (entry.isDirectory()) files.push(...(await sourceFiles(fullPath)));
+		else if (entry.isFile() && entry.name.endsWith(".ts")) files.push(fullPath);
+	}
+	return files;
+}
+
+async function productionRegistrationPlugins(): Promise<string[]> {
+	const pluginsRoot = path.join(repositoryRoot, "plugins");
+	const found: string[] = [];
+	for (const entry of await fs.readdir(pluginsRoot, { withFileTypes: true })) {
+		if (!entry.isDirectory() || !entry.name.startsWith("plugin-")) continue;
+		const files = await sourceFiles(path.join(pluginsRoot, entry.name));
+		for (const file of files) {
+			if (
+				(await fs.readFile(file, "utf8")).includes("registerMessageConnector")
+			) {
+				found.push(entry.name);
+				break;
+			}
+		}
+	}
+	return found.sort();
+}
+
+describe("first-party interaction capability matrix", () => {
+	it("covers every production message connector plugin root", async () => {
+		const declared = [
+			...new Set(
+				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.plugin),
+			),
+		].sort();
+		expect(await productionRegistrationPlugins()).toEqual(declared);
+	});
+
+	it("keeps deliberate unsupported connectors visible and unregistered", async () => {
+		expect(FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS).toContainEqual(
+			expect.objectContaining({ plugin: "plugin-signal" }),
+		);
+		const files = await sourceFiles(
+			path.join(repositoryRoot, "plugins/plugin-signal"),
+		);
+		const combined = (
+			await Promise.all(files.map((file) => fs.readFile(file, "utf8")))
+		).join("\n");
+		expect(combined).not.toContain("registerMessageConnector");
+		expect(combined).toContain("SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE");
+	});
+
+	it("matches the committed reviewer-readable golden artifact", async () => {
+		const golden = await fs.readFile(
+			path.join(import.meta.dirname, "CAPABILITY_MATRIX.md"),
+			"utf8",
+		);
+		expect(`${renderFirstPartyInteractionCapabilityMatrix()}\n`).toBe(golden);
+	});
+});

--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -5,9 +5,11 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import {
 	createFirstPartyInteractionProfile,
+	DISCORD_INTERACTION_PROFILE,
 	FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT,
 	FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS,
 	renderFirstPartyInteractionCapabilityMatrix,
@@ -30,37 +32,66 @@ async function sourceFiles(directory: string): Promise<string[]> {
 			continue;
 		const fullPath = path.join(directory, entry.name);
 		if (entry.isDirectory()) files.push(...(await sourceFiles(fullPath)));
-		else if (entry.isFile() && entry.name.endsWith(".ts")) files.push(fullPath);
+		else if (
+			entry.isFile() &&
+			(entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))
+		)
+			files.push(fullPath);
 	}
 	return files;
 }
 
-async function productionRegistrationPlugins(): Promise<string[]> {
+async function productionRegistrationSites(): Promise<string[]> {
 	const pluginsRoot = path.join(repositoryRoot, "plugins");
 	const found: string[] = [];
 	for (const entry of await fs.readdir(pluginsRoot, { withFileTypes: true })) {
 		if (!entry.isDirectory() || !entry.name.startsWith("plugin-")) continue;
 		const files = await sourceFiles(path.join(pluginsRoot, entry.name));
 		for (const file of files) {
-			if (
-				(await fs.readFile(file, "utf8")).includes("registerMessageConnector")
-			) {
-				found.push(entry.name);
-				break;
-			}
+			const source = await fs.readFile(file, "utf8");
+			const relativeSite = path.relative(
+				path.join(pluginsRoot, entry.name),
+				file,
+			);
+			const syntax = ts.createSourceFile(
+				file,
+				source,
+				ts.ScriptTarget.Latest,
+				true,
+				file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+			);
+			const visit = (node: ts.Node): void => {
+				if (
+					ts.isCallExpression(node) &&
+					ts.isPropertyAccessExpression(node.expression) &&
+					node.expression.name.text === "registerMessageConnector"
+				) {
+					found.push(`${entry.name}:direct:${relativeSite}`);
+				}
+				if (
+					ts.isPropertyAssignment(node) &&
+					((ts.isIdentifier(node.name) &&
+						node.name.text === "messageConnector") ||
+						(ts.isStringLiteral(node.name) &&
+							node.name.text === "messageConnector"))
+				) {
+					found.push(`${entry.name}:account-provider:${relativeSite}`);
+				}
+				ts.forEachChild(node, visit);
+			};
+			visit(syntax);
 		}
 	}
 	return found.sort();
 }
 
 describe("first-party interaction capability matrix", () => {
-	it("covers every production message connector plugin root", async () => {
-		const declared = [
-			...new Set(
-				FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.plugin),
-			),
-		].sort();
-		expect(await productionRegistrationPlugins()).toEqual(declared);
+	it("covers every production registration site and account-provider extension", async () => {
+		const declared = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map(
+			(entry) =>
+				`${entry.plugin}:${entry.registrationMechanism}:${entry.registrationSite}`,
+		).sort();
+		expect(await productionRegistrationSites()).toEqual(declared);
 	});
 
 	it("requires every audited source registration to expose a concrete resolver", async () => {
@@ -83,6 +114,26 @@ describe("first-party interaction capability matrix", () => {
 		}
 	});
 
+	it("registers a host-prepared send seam for every native callback connector", async () => {
+		for (const plugin of [
+			"plugin-discord",
+			"plugin-slack",
+			"plugin-telegram",
+			"plugin-whatsapp",
+		]) {
+			const files = await sourceFiles(
+				path.join(repositoryRoot, "plugins", plugin),
+			);
+			const combined = (
+				await Promise.all(files.map((file) => fs.readFile(file, "utf8")))
+			).join("\n");
+			expect(
+				combined,
+				`${plugin} must consume host-prepared delivery`,
+			).toContain("sendPreparedInteraction");
+		}
+	});
+
 	it("materializes exhaustive behavior for every block kind and source", () => {
 		for (const entry of FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT) {
 			const profile = createFirstPartyInteractionProfile({
@@ -95,6 +146,10 @@ describe("first-party interaction capability matrix", () => {
 				[...INTERACTION_BLOCK_KINDS].sort(),
 			);
 		}
+	});
+
+	it("retains provider-specific limits instead of the generic button profile", () => {
+		expect(DISCORD_INTERACTION_PROFILE.limits.links.maxUrlBytes).toBe(512);
 	});
 
 	it("fails closed when trusted account or target identity is absent", () => {

--- a/packages/core/src/messaging/interactions/profile-matrix.test.ts
+++ b/packages/core/src/messaging/interactions/profile-matrix.test.ts
@@ -7,10 +7,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	createFirstPartyInteractionProfile,
 	FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT,
 	FIRST_PARTY_INTERACTION_CONNECTOR_EXCLUSIONS,
 	renderFirstPartyInteractionCapabilityMatrix,
+	resolveFirstPartyInteractionProfile,
 } from "./profile-catalog";
+import { INTERACTION_BLOCK_KINDS } from "./profiles";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "../../../../..");
 
@@ -58,6 +61,59 @@ describe("first-party interaction capability matrix", () => {
 			),
 		].sort();
 		expect(await productionRegistrationPlugins()).toEqual(declared);
+	});
+
+	it("requires every audited source registration to expose a concrete resolver", async () => {
+		const pluginsRoot = path.join(repositoryRoot, "plugins");
+		for (const plugin of new Set(
+			FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.map((entry) => entry.plugin),
+		)) {
+			const expected = FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT.filter(
+				(entry) => entry.plugin === plugin,
+			).length;
+			const files = await sourceFiles(path.join(pluginsRoot, plugin));
+			const sources = await Promise.all(
+				files.map((file) => fs.readFile(file, "utf8")),
+			);
+			const combined = sources.join("\n");
+			expect(
+				combined.match(/resolveInteractionProfile\s*:/g)?.length ?? 0,
+				`${plugin} must declare one resolver per audited source`,
+			).toBeGreaterThanOrEqual(expected);
+		}
+	});
+
+	it("materializes exhaustive behavior for every block kind and source", () => {
+		for (const entry of FIRST_PARTY_INTERACTION_CONNECTOR_AUDIT) {
+			const profile = createFirstPartyInteractionProfile({
+				source: entry.source,
+				accountId: "account",
+				targetKind: entry.targetKind,
+				targetId: "target",
+			});
+			expect(Object.keys(profile.blocks).sort()).toEqual(
+				[...INTERACTION_BLOCK_KINDS].sort(),
+			);
+		}
+	});
+
+	it("fails closed when trusted account or target identity is absent", () => {
+		expect(() =>
+			resolveFirstPartyInteractionProfile({
+				source: "gmail",
+				defaultAccountId: "",
+				defaultTargetKind: "email",
+				target: { source: "gmail", channelId: "user@example.test" },
+			}),
+		).toThrow(/trusted connector identity/i);
+		expect(() =>
+			resolveFirstPartyInteractionProfile({
+				source: "slack",
+				defaultAccountId: "default",
+				defaultTargetKind: "channel",
+				target: { source: "slack" },
+			}),
+		).toThrow(/stable provider identity/i);
 	});
 
 	it("keeps deliberate unsupported connectors visible and unregistered", async () => {

--- a/packages/core/src/messaging/interactions/profiles.ts
+++ b/packages/core/src/messaging/interactions/profiles.ts
@@ -1,0 +1,720 @@
+/**
+ * Defines the provider-neutral capability profile negotiated for one concrete
+ * connector account and target. Rendering code consumes this profile directly;
+ * connector names are deliberately absent from the runtime decision path.
+ */
+
+import { ElizaError } from "../../errors";
+import type {
+	InteractionBlock,
+	InteractionKind,
+} from "../../types/interactions";
+import { stringToUuid } from "../../utils";
+import { stableStringify } from "../../utils/deterministic";
+
+export const INTERACTION_PROFILE_VERSION = 1 as const;
+export const INTERACTION_BLOCK_KINDS = [
+	"choice",
+	"form",
+	"followups",
+	"task",
+	"secret",
+] as const satisfies readonly InteractionKind[];
+
+export type InteractionDeliveryMode =
+	| "native"
+	| "conversational"
+	| "signed-hosted"
+	| "sensitive-request";
+
+const INTERACTION_DELIVERY_MODES = new Set<InteractionDeliveryMode>([
+	"native",
+	"conversational",
+	"signed-hosted",
+	"sensitive-request",
+]);
+
+export interface InteractionPrimitiveLimits {
+	buttons: {
+		supported: boolean;
+		maxPerRow: number;
+		maxPerMessage: number;
+		maxLabelBytes: number;
+		maxCallbackBytes: number;
+	};
+	lists: {
+		supported: boolean;
+		maxItems: number;
+		maxLabelBytes: number;
+		maxDescriptionBytes: number;
+	};
+	modals: {
+		supported: boolean;
+		maxFields: number;
+		maxTitleBytes: number;
+	};
+	forms: {
+		supported: boolean;
+		maxFields: number;
+		maxOptionsPerField: number;
+	};
+	links: {
+		supported: boolean;
+		maxUrlBytes: number;
+	};
+	edits: {
+		supported: boolean;
+		windowMs: number | null;
+	};
+	threads: {
+		supported: boolean;
+		maxTitleBytes: number;
+	};
+	text: {
+		maxMessageBytes: number;
+	};
+	attachments: {
+		supported: boolean;
+		maxCount: number;
+		maxBytesEach: number;
+		mimeTypes: readonly string[];
+	};
+}
+
+export interface InteractionBlockCapability {
+	modes: readonly InteractionDeliveryMode[];
+	/** Maximum lifetime for a callback rendered from this block. */
+	maxSessionTtlMs: number;
+}
+
+export interface ConnectorInteractionCapabilityProfile {
+	profileVersion: typeof INTERACTION_PROFILE_VERSION;
+	profileId: string;
+	connector: { source: string; accountId: string };
+	target: { kind: string; id: string };
+	blocks: Record<InteractionKind, InteractionBlockCapability>;
+	limits: InteractionPrimitiveLimits;
+	/** Ordered, actionable degradation paths for non-secret input. */
+	nonSecretFallbacks: readonly Exclude<
+		InteractionDeliveryMode,
+		"sensitive-request"
+	>[];
+	/** Secret and OAuth collection is never allowed through ordinary chat data. */
+	sensitiveFallback: "sensitive-request";
+}
+
+export interface InteractionProfileTemplate {
+	templateId: string;
+	blocks: Record<InteractionKind, InteractionBlockCapability>;
+	limits: InteractionPrimitiveLimits;
+	nonSecretFallbacks: ConnectorInteractionCapabilityProfile["nonSecretFallbacks"];
+}
+
+function positiveInteger(value: number, path: string): void {
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new ElizaError(`${path} must be a positive safe integer.`, {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { path, value },
+		});
+	}
+}
+
+function supportedLimit(supported: boolean, value: number, path: string): void {
+	if (supported) {
+		positiveInteger(value, path);
+		return;
+	}
+	if (value !== 0) {
+		throw new ElizaError(`${path} must be zero when unsupported.`, {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { path, value },
+		});
+	}
+}
+
+function nonEmpty(value: string, path: string): string {
+	const normalized = value.trim();
+	if (!normalized) {
+		throw new ElizaError(`${path} must not be blank.`, {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { path },
+		});
+	}
+	return normalized;
+}
+
+/** Validate and defensively copy one complete per-account/target profile. */
+export function normalizeConnectorInteractionCapabilityProfile(
+	profile: ConnectorInteractionCapabilityProfile,
+): ConnectorInteractionCapabilityProfile {
+	if (profile.profileVersion !== INTERACTION_PROFILE_VERSION) {
+		throw new ElizaError("Unsupported interaction profile version.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+			context: { profileVersion: profile.profileVersion },
+		});
+	}
+	for (const kind of INTERACTION_BLOCK_KINDS) {
+		const capability = profile.blocks[kind];
+		if (!capability || capability.modes.length === 0) {
+			throw new ElizaError(`Interaction profile omits ${kind}.`, {
+				code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+				context: { kind },
+			});
+		}
+		if (
+			capability.modes.some((mode) => !INTERACTION_DELIVERY_MODES.has(mode))
+		) {
+			throw new ElizaError(`Interaction profile has an unknown ${kind} mode.`, {
+				code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+				context: { kind },
+			});
+		}
+		positiveInteger(
+			capability.maxSessionTtlMs,
+			`blocks.${kind}.maxSessionTtlMs`,
+		);
+		if (new Set(capability.modes).size !== capability.modes.length) {
+			throw new ElizaError(`Interaction profile repeats a ${kind} mode.`, {
+				code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+				context: { kind },
+			});
+		}
+		if (
+			kind === "secret" &&
+			(capability.modes.length !== 1 ||
+				capability.modes[0] !== "sensitive-request")
+		) {
+			throw new ElizaError(
+				"Secret interactions must use only the sensitive-request flow.",
+				{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE", context: { kind } },
+			);
+		}
+		if (kind !== "secret" && capability.modes.includes("sensitive-request")) {
+			throw new ElizaError(
+				"Ordinary interaction blocks cannot use the sensitive-request mode.",
+				{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE", context: { kind } },
+			);
+		}
+	}
+	const limits = profile.limits;
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxPerRow,
+		"limits.buttons.maxPerRow",
+	);
+	if (
+		limits.buttons.supported &&
+		limits.buttons.maxPerRow > limits.buttons.maxPerMessage
+	) {
+		throw new ElizaError(
+			"Button row limit cannot exceed the message button limit.",
+			{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE" },
+		);
+	}
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxPerMessage,
+		"limits.buttons.maxPerMessage",
+	);
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxLabelBytes,
+		"limits.buttons.maxLabelBytes",
+	);
+	supportedLimit(
+		limits.buttons.supported,
+		limits.buttons.maxCallbackBytes,
+		"limits.buttons.maxCallbackBytes",
+	);
+	supportedLimit(
+		limits.lists.supported,
+		limits.lists.maxItems,
+		"limits.lists.maxItems",
+	);
+	supportedLimit(
+		limits.lists.supported,
+		limits.lists.maxLabelBytes,
+		"limits.lists.maxLabelBytes",
+	);
+	supportedLimit(
+		limits.lists.supported,
+		limits.lists.maxDescriptionBytes,
+		"limits.lists.maxDescriptionBytes",
+	);
+	supportedLimit(
+		limits.modals.supported,
+		limits.modals.maxFields,
+		"limits.modals.maxFields",
+	);
+	supportedLimit(
+		limits.modals.supported,
+		limits.modals.maxTitleBytes,
+		"limits.modals.maxTitleBytes",
+	);
+	supportedLimit(
+		limits.forms.supported,
+		limits.forms.maxFields,
+		"limits.forms.maxFields",
+	);
+	supportedLimit(
+		limits.forms.supported,
+		limits.forms.maxOptionsPerField,
+		"limits.forms.maxOptionsPerField",
+	);
+	supportedLimit(
+		limits.links.supported,
+		limits.links.maxUrlBytes,
+		"limits.links.maxUrlBytes",
+	);
+	if (
+		limits.edits.windowMs !== null &&
+		(!Number.isSafeInteger(limits.edits.windowMs) || limits.edits.windowMs < 1)
+	) {
+		throw new ElizaError("limits.edits.windowMs is invalid.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (!limits.edits.supported && limits.edits.windowMs !== null) {
+		throw new ElizaError("Unsupported edits must not declare a time window.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	supportedLimit(
+		limits.threads.supported,
+		limits.threads.maxTitleBytes,
+		"limits.threads.maxTitleBytes",
+	);
+	positiveInteger(limits.text.maxMessageBytes, "limits.text.maxMessageBytes");
+	supportedLimit(
+		limits.attachments.supported,
+		limits.attachments.maxCount,
+		"limits.attachments.maxCount",
+	);
+	supportedLimit(
+		limits.attachments.supported,
+		limits.attachments.maxBytesEach,
+		"limits.attachments.maxBytesEach",
+	);
+	if (
+		!limits.attachments.supported &&
+		limits.attachments.mimeTypes.length > 0
+	) {
+		throw new ElizaError("Unsupported attachments cannot declare MIME types.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.choice.modes.includes("native") &&
+		!limits.buttons.supported &&
+		!limits.lists.supported
+	) {
+		throw new ElizaError("Native choices require buttons or lists.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.followups.modes.includes("native") &&
+		!limits.buttons.supported
+	) {
+		throw new ElizaError("Native followups require buttons.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.form.modes.includes("native") &&
+		(!limits.forms.supported || !limits.modals.supported)
+	) {
+		throw new ElizaError("Native forms require form and modal primitives.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		profile.blocks.task.modes.includes("native") &&
+		!limits.links.supported &&
+		!limits.threads.supported
+	) {
+		throw new ElizaError("Native tasks require links or threads.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (profile.nonSecretFallbacks.length === 0) {
+		throw new ElizaError("A non-secret fallback is required.", {
+			code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+		});
+	}
+	if (
+		new Set(profile.nonSecretFallbacks).size !==
+			profile.nonSecretFallbacks.length ||
+		profile.nonSecretFallbacks.some(
+			(mode) => !INTERACTION_DELIVERY_MODES.has(mode),
+		)
+	) {
+		throw new ElizaError(
+			"Non-secret interaction fallbacks must be unique known modes.",
+			{ code: "INVALID_INTERACTION_CAPABILITY_PROFILE" },
+		);
+	}
+	for (const kind of INTERACTION_BLOCK_KINDS) {
+		if (kind === "secret") continue;
+		if (
+			profile.blocks[kind].modes.some(
+				(mode) =>
+					mode === "sensitive-request" ||
+					!profile.nonSecretFallbacks.includes(mode),
+			)
+		) {
+			throw new ElizaError(
+				`${kind} declares a mode missing from non-secret fallbacks.`,
+				{
+					code: "INVALID_INTERACTION_CAPABILITY_PROFILE",
+					context: { kind },
+				},
+			);
+		}
+	}
+	return structuredClone({
+		...profile,
+		profileId: nonEmpty(profile.profileId, "profileId"),
+		connector: {
+			source: nonEmpty(profile.connector.source, "connector.source"),
+			accountId: nonEmpty(profile.connector.accountId, "connector.accountId"),
+		},
+		target: {
+			kind: nonEmpty(profile.target.kind, "target.kind"),
+			id: nonEmpty(profile.target.id, "target.id"),
+		},
+	});
+}
+
+/** Materialize a template for exactly one connector account and target. */
+export function createConnectorInteractionCapabilityProfile(args: {
+	template: InteractionProfileTemplate;
+	source: string;
+	accountId: string;
+	targetKind: string;
+	targetId: string;
+}): ConnectorInteractionCapabilityProfile {
+	const templateId = nonEmpty(args.template.templateId, "template.templateId");
+	const source = nonEmpty(args.source, "connector.source");
+	const accountId = nonEmpty(args.accountId, "connector.accountId");
+	const targetKind = nonEmpty(args.targetKind, "target.kind");
+	const targetId = nonEmpty(args.targetId, "target.id");
+	return normalizeConnectorInteractionCapabilityProfile({
+		profileVersion: INTERACTION_PROFILE_VERSION,
+		profileId: `ip1:${stringToUuid(`${INTERACTION_PROFILE_VERSION}:${templateId}:${source}:${accountId}:${targetKind}:${targetId}`)}`,
+		connector: { source, accountId },
+		target: { kind: targetKind, id: targetId },
+		blocks: args.template.blocks,
+		limits: args.template.limits,
+		nonSecretFallbacks: args.template.nonSecretFallbacks,
+		sensitiveFallback: "sensitive-request",
+	});
+}
+
+export interface NegotiatedInteractionDelivery {
+	mode: InteractionDeliveryMode;
+	reason: "preferred" | "native-limit" | "native-unavailable" | "sensitive";
+	limitations: readonly string[];
+}
+
+export interface InteractionNegotiationContext {
+	callbackBytes?: number;
+	buttonsPerRow?: number;
+	signedHostedUrl?: string;
+	requiresEdit?: boolean;
+	sourceMessageCreatedAt?: number;
+	now?: number;
+	requiresThread?: boolean;
+}
+
+const OPAQUE_CALLBACK_WIRE_BYTES = 36;
+
+function utf8Bytes(value: string | undefined): number {
+	return value ? new TextEncoder().encode(value).length : 0;
+}
+
+function nativeBlockLimitations(
+	block: InteractionBlock,
+	profile: ConnectorInteractionCapabilityProfile,
+	context: InteractionNegotiationContext,
+): string[] {
+	const issues: string[] = [];
+	const { limits } = profile;
+	switch (block.kind) {
+		case "choice": {
+			const buttonIssues: string[] = [];
+			if (limits.buttons.supported) {
+				if (block.options.length > limits.buttons.maxPerMessage)
+					buttonIssues.push("option count");
+				if ((context.buttonsPerRow ?? 1) > limits.buttons.maxPerRow)
+					buttonIssues.push("button row count");
+				if (
+					limits.buttons.maxCallbackBytes <
+					(context.callbackBytes ?? OPAQUE_CALLBACK_WIRE_BYTES)
+				)
+					buttonIssues.push("opaque callback bytes");
+				if (
+					block.options.some(
+						(option) => utf8Bytes(option.label) > limits.buttons.maxLabelBytes,
+					)
+				)
+					buttonIssues.push("option label bytes");
+			}
+			const listIssues: string[] = [];
+			if (limits.lists.supported) {
+				if (block.options.length > limits.lists.maxItems)
+					listIssues.push("option count");
+				if (
+					block.options.some(
+						(option) => utf8Bytes(option.label) > limits.lists.maxLabelBytes,
+					)
+				)
+					listIssues.push("option label bytes");
+				if (
+					block.options.some(
+						(option) =>
+							utf8Bytes(option.description) > limits.lists.maxDescriptionBytes,
+					)
+				)
+					listIssues.push("option description bytes");
+			}
+			if (!limits.buttons.supported && !limits.lists.supported)
+				issues.push("no native choice primitive");
+			else if (
+				(!limits.buttons.supported || buttonIssues.length > 0) &&
+				(!limits.lists.supported || listIssues.length > 0)
+			)
+				issues.push(...buttonIssues, ...listIssues);
+			break;
+		}
+		case "followups": {
+			if (!limits.buttons.supported) issues.push("no native button primitive");
+			if (block.options.length > limits.buttons.maxPerMessage)
+				issues.push("option count");
+			if ((context.buttonsPerRow ?? 1) > limits.buttons.maxPerRow)
+				issues.push("button row count");
+			if (
+				limits.buttons.maxCallbackBytes <
+				(context.callbackBytes ?? OPAQUE_CALLBACK_WIRE_BYTES)
+			)
+				issues.push("opaque callback bytes");
+			if (
+				block.options.some(
+					(option) => utf8Bytes(option.label) > limits.buttons.maxLabelBytes,
+				)
+			)
+				issues.push("option label bytes");
+			break;
+		}
+		case "form": {
+			if (!limits.forms.supported || !limits.modals.supported)
+				issues.push("no native form/modal primitive");
+			if (
+				block.fields.length > limits.forms.maxFields ||
+				block.fields.length > limits.modals.maxFields
+			)
+				issues.push("field count");
+			if (utf8Bytes(block.title) > limits.modals.maxTitleBytes)
+				issues.push("modal title bytes");
+			const attachmentFields = block.fields.filter(
+				(field) => field.type === "file" || field.type === "image",
+			);
+			if (attachmentFields.length > limits.attachments.maxCount)
+				issues.push("attachment count");
+			for (const field of block.fields) {
+				if (field.type === "secret") issues.push("secret field");
+				if ((field.options?.length ?? 0) > limits.forms.maxOptionsPerField)
+					issues.push("field option count");
+				if (field.type === "file" || field.type === "image") {
+					if (!limits.attachments.supported)
+						issues.push("attachments unsupported");
+					if ((field.maxBytes ?? 0) > limits.attachments.maxBytesEach)
+						issues.push("attachment bytes");
+					if (
+						field.mimeTypes?.some(
+							(mime) =>
+								!limits.attachments.mimeTypes.includes("*/*") &&
+								!limits.attachments.mimeTypes.includes(mime),
+						)
+					)
+						issues.push("attachment MIME type");
+				}
+			}
+			break;
+		}
+		case "task": {
+			if (!limits.links.supported && !limits.threads.supported)
+				issues.push("no link or thread primitive");
+			if (
+				limits.links.supported &&
+				!limits.threads.supported &&
+				!context.signedHostedUrl
+			)
+				issues.push("task URL unavailable");
+			if (
+				limits.links.supported &&
+				!limits.threads.supported &&
+				context.signedHostedUrl &&
+				utf8Bytes(context.signedHostedUrl) > limits.links.maxUrlBytes
+			)
+				issues.push("link URL bytes");
+			if (
+				limits.threads.supported &&
+				utf8Bytes(block.title) > limits.threads.maxTitleBytes
+			)
+				issues.push("thread title bytes");
+			break;
+		}
+		case "secret":
+			issues.push("sensitive request required");
+	}
+	if (context.requiresThread && !limits.threads.supported)
+		issues.push("threads unsupported");
+	if (context.requiresEdit) {
+		if (!limits.edits.supported) issues.push("edits unsupported");
+		else if (
+			limits.edits.windowMs !== null &&
+			(context.sourceMessageCreatedAt === undefined ||
+				context.now === undefined)
+		)
+			issues.push("edit window unknown");
+		else if (
+			limits.edits.windowMs !== null &&
+			context.sourceMessageCreatedAt !== undefined &&
+			context.now !== undefined &&
+			context.now - context.sourceMessageCreatedAt > limits.edits.windowMs
+		)
+			issues.push("edit window expired");
+	}
+	const visible = JSON.stringify(block);
+	if (utf8Bytes(visible) > limits.text.maxMessageBytes)
+		issues.push("message bytes");
+	return [...new Set(issues)].sort();
+}
+
+function signedHostedLimitations(
+	profile: ConnectorInteractionCapabilityProfile,
+	context: InteractionNegotiationContext,
+): string[] {
+	if (!profile.limits.links.supported) return ["links unsupported"];
+	if (!context.signedHostedUrl) return ["signed hosted URL unavailable"];
+	if (utf8Bytes(context.signedHostedUrl) > profile.limits.links.maxUrlBytes)
+		return ["link URL bytes"];
+	return [];
+}
+
+/** Select a layout solely from negotiated capability and present payload size. */
+export function negotiateInteractionDelivery(
+	block: InteractionBlock,
+	profileValue: ConnectorInteractionCapabilityProfile,
+	context: InteractionNegotiationContext = {},
+): NegotiatedInteractionDelivery {
+	const profile = normalizeConnectorInteractionCapabilityProfile(profileValue);
+	if (block.kind === "secret") {
+		return { mode: "sensitive-request", reason: "sensitive", limitations: [] };
+	}
+	if (
+		block.kind === "form" &&
+		block.fields.some((field) => field.type === "secret")
+	) {
+		throw new ElizaError(
+			"Secret fields cannot use an ordinary interaction form.",
+			{ code: "INTERACTION_SENSITIVE_FLOW_REQUIRED" },
+		);
+	}
+	const modes = profile.blocks[block.kind].modes;
+	const limitations = nativeBlockLimitations(block, profile, context);
+	const fallbackLimitations = new Set(limitations);
+	for (const mode of modes) {
+		if (mode === "native") {
+			if (limitations.length === 0) {
+				return { mode, reason: "preferred", limitations };
+			}
+			continue;
+		}
+		if (mode === "signed-hosted") {
+			const hostedIssues = signedHostedLimitations(profile, context);
+			if (hostedIssues.length === 0) {
+				return {
+					mode,
+					reason: modes.includes("native")
+						? "native-limit"
+						: "native-unavailable",
+					limitations,
+				};
+			}
+			for (const issue of hostedIssues) fallbackLimitations.add(issue);
+			continue;
+		}
+		if (mode !== "sensitive-request") {
+			return {
+				mode,
+				reason: modes.includes("native")
+					? "native-limit"
+					: "native-unavailable",
+				limitations: [...fallbackLimitations].sort(),
+			};
+		}
+	}
+	throw new ElizaError("No safe interaction delivery mode was negotiated.", {
+		code: "INTERACTION_DELIVERY_UNAVAILABLE",
+		context: { kind: block.kind, profileId: profile.profileId },
+	});
+}
+
+/** Rejects profile-ID collisions whose immutable account/target body differs. */
+export class ConnectorInteractionProfileRegistry {
+	private readonly profiles = new Map<
+		string,
+		{ fingerprint: string; profile: ConnectorInteractionCapabilityProfile }
+	>();
+
+	register(
+		value: ConnectorInteractionCapabilityProfile,
+	): ConnectorInteractionCapabilityProfile {
+		const profile = normalizeConnectorInteractionCapabilityProfile(value);
+		const fingerprint = stableStringify(profile);
+		const existing = this.profiles.get(profile.profileId);
+		if (existing && existing.fingerprint !== fingerprint) {
+			throw new ElizaError(
+				"Interaction profile ID collides with a different account or target profile.",
+				{
+					code: "INTERACTION_PROFILE_ID_COLLISION",
+					context: { profileId: profile.profileId },
+				},
+			);
+		}
+		if (!existing)
+			this.profiles.set(profile.profileId, { fingerprint, profile });
+		return structuredClone(profile);
+	}
+
+	get(profileId: string): ConnectorInteractionCapabilityProfile | null {
+		const entry = this.profiles.get(profileId);
+		return entry ? structuredClone(entry.profile) : null;
+	}
+}
+
+/** Deterministic reviewer-facing matrix; callers decide where to persist it. */
+export function renderInteractionCapabilityMatrix(
+	profiles: readonly ConnectorInteractionCapabilityProfile[],
+): string {
+	const rows = [...profiles]
+		.map(normalizeConnectorInteractionCapabilityProfile)
+		.sort((a, b) =>
+			`${a.connector.source}\0${a.connector.accountId}\0${a.target.kind}\0${a.target.id}`.localeCompare(
+				`${b.connector.source}\0${b.connector.accountId}\0${b.target.kind}\0${b.target.id}`,
+			),
+		)
+		.map((profile) => {
+			const modes = INTERACTION_BLOCK_KINDS.map(
+				(kind) => `${kind}:${profile.blocks[kind].modes.join("→")}`,
+			).join("<br>");
+			return `| ${profile.connector.source} | ${profile.connector.accountId} | ${profile.target.kind}:${profile.target.id} | ${modes} | ${profile.limits.buttons.maxCallbackBytes} | ${profile.limits.attachments.supported ? `${profile.limits.attachments.maxCount} × ${profile.limits.attachments.maxBytesEach}` : "none"} |`;
+		});
+	return [
+		"| Connector | Account | Target | Block delivery | Callback bytes | Attachments |",
+		"| --- | --- | --- | --- | ---: | --- |",
+		...rows,
+	].join("\n");
+}

--- a/packages/core/src/messaging/interactions/session-authority.test.ts
+++ b/packages/core/src/messaging/interactions/session-authority.test.ts
@@ -64,7 +64,7 @@ function receipt(key: string): MessageInteractionReceipt {
 		receiptId: `receipt-${key}`,
 		idempotencyKey: key,
 		status: "completed",
-		completedAt: "2026-08-21T00:00:01.000Z",
+		completedAt: "2026-08-21T00:00:00.000Z",
 		result: { accepted: true },
 	};
 }
@@ -347,7 +347,7 @@ describe("message interaction session authority", () => {
 		expect(execute).toHaveBeenCalledTimes(1);
 	});
 
-	it("resumes a crash window with one idempotent effect and completes the receipt", async () => {
+	it("fails closed after an effect succeeds but its durable completion is lost", async () => {
 		let now = Date.parse("2026-08-21T00:00:00.000Z");
 		const backing = new InMemoryMessageInteractionSessionStore();
 		let failCompletion = true;
@@ -356,6 +356,7 @@ describe("message interaction session authority", () => {
 			create: backing.create.bind(backing),
 			get: backing.get.bind(backing),
 			claimIfCurrent: backing.claimIfCurrent.bind(backing),
+			commitIfClaimed: backing.commitIfClaimed.bind(backing),
 			revokeAuthorization: backing.revokeAuthorization.bind(backing),
 			deleteExpired: backing.deleteExpired.bind(backing),
 			completeIfClaimed: async (context) => {
@@ -399,9 +400,148 @@ describe("message interaction session authority", () => {
 				replayKey: "replay-a",
 				executor,
 			}),
-		).toEqual(receipt("replay-a"));
+		).toEqual({ status: "in_progress" });
 		expect(physicalEffects).toBe(1);
 	});
+
+	it("fences an expired worker before effect commit and refuses revocation after commit", async () => {
+		let now = Date.parse("2026-08-21T00:00:00.000Z");
+		const store = new InMemoryMessageInteractionSessionStore();
+		const { authority, callbackData, session } = await created({
+			store,
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		const claim = await store.claimIfCurrent({
+			...bindings,
+			reference: session.reference,
+			replayKey: "replay-a",
+			claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			now,
+			claimTtlMs: 100,
+		});
+		expect(claim.status).toBe("acquired");
+		now += 101;
+		const replacement = await store.claimIfCurrent({
+			...bindings,
+			reference: session.reference,
+			replayKey: "replay-a",
+			claimId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			now,
+			claimTtlMs: 100,
+		});
+		expect(replacement.status).toBe("resumed");
+		await expect(
+			store.commitIfClaimed({
+				reference: session.reference,
+				claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				replayKey: "replay-a",
+				now,
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_STALE_CLAIM" });
+		await store.commitIfClaimed({
+			reference: session.reference,
+			claimId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			replayKey: "replay-a",
+			now,
+		});
+		await expect(
+			store.revokeAuthorization({
+				reference: session.reference,
+				decisionId: "decision-a",
+				now,
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_EFFECT_COMMITTED" });
+		let effects = 0;
+		expect(
+			await authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: {
+					execute: async () => {
+						effects += 1;
+						return receipt("replay-a");
+					},
+				},
+			}),
+		).toEqual({ status: "in_progress" });
+		expect(effects).toBe(0);
+	});
+
+	it.each(["reacquire", "revoke"] as const)(
+		"never calls the old worker effect when %s wins before durable commit",
+		async (winner) => {
+			let now = Date.parse("2026-08-21T00:00:00.000Z");
+			const backing = new InMemoryMessageInteractionSessionStore();
+			let enterCommit: () => void = () => undefined;
+			const commitEntered = new Promise<void>((resolve) => {
+				enterCommit = resolve;
+			});
+			let releaseCommit: () => void = () => undefined;
+			const commitBarrier = new Promise<void>((resolve) => {
+				releaseCommit = resolve;
+			});
+			const store: MessageInteractionSessionStore = {
+				create: backing.create.bind(backing),
+				get: backing.get.bind(backing),
+				claimIfCurrent: backing.claimIfCurrent.bind(backing),
+				commitIfClaimed: async (context) => {
+					enterCommit();
+					await commitBarrier;
+					return backing.commitIfClaimed(context);
+				},
+				completeIfClaimed: backing.completeIfClaimed.bind(backing),
+				revokeAuthorization: backing.revokeAuthorization.bind(backing),
+				deleteExpired: backing.deleteExpired.bind(backing),
+			};
+			const { authority, callbackData, session } = await created({
+				store,
+				clock: () => now,
+				preset: { value: "approve" },
+			});
+			let effects = 0;
+			const oldWorker = authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: {
+					execute: async () => {
+						effects += 1;
+						return receipt("replay-a");
+					},
+				},
+			});
+			await commitEntered;
+			if (winner === "reacquire") {
+				now += 101;
+				expect(
+					await backing.claimIfCurrent({
+						...bindings,
+						reference: session.reference,
+						replayKey: "replay-a",
+						claimId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+						now,
+						claimTtlMs: 100,
+					}),
+				).toMatchObject({ status: "resumed" });
+			} else {
+				await backing.revokeAuthorization({
+					reference: session.reference,
+					decisionId: "decision-a",
+					now,
+				});
+			}
+			releaseCommit();
+			await expect(oldWorker).rejects.toMatchObject({
+				code:
+					winner === "reacquire"
+						? "MESSAGE_INTERACTION_STALE_CLAIM"
+						: "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+			});
+			expect(effects).toBe(0);
+		},
+	);
 
 	it("denies tamper, expiry, and revocation after render", async () => {
 		let now = Date.parse("2026-08-21T00:00:00.000Z");

--- a/packages/core/src/messaging/interactions/session-authority.test.ts
+++ b/packages/core/src/messaging/interactions/session-authority.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Deterministic contract coverage for negotiated profiles and the durable
+ * message-interaction claim/execute/receipt state machine. No model is mocked.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+	ChoiceInteraction,
+	FormInteraction,
+} from "../../types/interactions";
+import {
+	BUTTON_INTERACTION_PROFILE,
+	CONVERSATIONAL_INTERACTION_PROFILE,
+	RICH_INTERACTION_PROFILE,
+} from "./profile-catalog";
+import {
+	ConnectorInteractionProfileRegistry,
+	createConnectorInteractionCapabilityProfile,
+	negotiateInteractionDelivery,
+	normalizeConnectorInteractionCapabilityProfile,
+} from "./profiles";
+import {
+	createOpaqueMessageInteractionReference,
+	decodeMessageInteractionCallback,
+	encodeMessageInteractionCallback,
+	InMemoryMessageInteractionSessionStore,
+	type MessageInteractionEffectExecutor,
+	type MessageInteractionReceipt,
+	MessageInteractionSessionAuthority,
+	type MessageInteractionSessionStore,
+} from "./sessions";
+
+const choice: ChoiceInteraction = {
+	kind: "choice",
+	id: "approve-1",
+	scope: "approval",
+	options: [
+		{ value: "approve", label: "Approve" },
+		{ value: "deny", label: "Deny" },
+	],
+};
+
+function profile(template = BUTTON_INTERACTION_PROFILE) {
+	return createConnectorInteractionCapabilityProfile({
+		template,
+		source: "connector",
+		accountId: "account-a",
+		targetKind: "room",
+		targetId: "room-a",
+	});
+}
+
+const bindings = {
+	actorId: "actor-a",
+	audience: { kind: "room", id: "room-a" },
+	agentId: "agent-a",
+	connector: { source: "connector", accountId: "account-a" },
+	roomId: "room-a",
+	sourceMessageId: "message-a",
+};
+
+function receipt(key: string): MessageInteractionReceipt {
+	return {
+		receiptId: `receipt-${key}`,
+		idempotencyKey: key,
+		status: "completed",
+		completedAt: "2026-08-21T00:00:01.000Z",
+		result: { accepted: true },
+	};
+}
+
+async function created(options?: {
+	store?: MessageInteractionSessionStore;
+	clock?: () => number;
+	preset?: { value: string };
+}) {
+	const store = options?.store ?? new InMemoryMessageInteractionSessionStore();
+	const authority = new MessageInteractionSessionAuthority(store, {
+		clock: options?.clock ?? (() => Date.parse("2026-08-21T00:00:00.000Z")),
+		referenceFactory: () => "0123456789abcdef0123456789abcdef",
+		claimTtlMs: 100,
+	});
+	const result = await authority.create({
+		block: choice,
+		profile: profile(),
+		bindings,
+		purpose: "approval",
+		flow: "native",
+		...(options?.preset ? { presetResponse: options.preset } : {}),
+		authorization: {
+			decisionId: "decision-a",
+			policyRevision: "policy-7",
+			decidedAt: "2026-08-20T23:59:59.000Z",
+		},
+		effect: { kind: "approve_operation", metadata: { operationId: "op-a" } },
+		expiresAt: "2026-08-21T00:10:00.000Z",
+	});
+	return { authority, store, ...result };
+}
+
+describe("connector interaction profiles", () => {
+	it("binds IDs to account and target and rejects conflicting registry collisions", () => {
+		const a = profile();
+		const b = createConnectorInteractionCapabilityProfile({
+			template: BUTTON_INTERACTION_PROFILE,
+			source: "connector",
+			accountId: "account-b",
+			targetKind: "room",
+			targetId: "room-a",
+		});
+		expect(a.profileId).not.toBe(b.profileId);
+		const registry = new ConnectorInteractionProfileRegistry();
+		registry.register(a);
+		expect(() =>
+			registry.register({ ...b, profileId: a.profileId }),
+		).toThrowError(/ID collides/);
+	});
+
+	it("requires zero limits for unsupported primitives", () => {
+		const invalid = structuredClone(
+			profile(CONVERSATIONAL_INTERACTION_PROFILE),
+		);
+		invalid.limits.modals.maxFields = 1;
+		expect(() =>
+			normalizeConnectorInteractionCapabilityProfile(invalid),
+		).toThrowError(/must be zero/);
+	});
+
+	it("uses UTF-8 byte and opaque callback limits before native delivery", () => {
+		const constrained = structuredClone(profile());
+		constrained.limits.buttons.maxLabelBytes = 7;
+		const unicodeChoice = {
+			...choice,
+			options: [{ value: "ok", label: "✅✅✅" }],
+		};
+		expect(
+			negotiateInteractionDelivery(unicodeChoice, constrained),
+		).toMatchObject({
+			mode: "conversational",
+			reason: "native-limit",
+			limitations: ["option label bytes"],
+		});
+		constrained.limits.buttons.maxLabelBytes = 80;
+		constrained.limits.buttons.maxCallbackBytes = 35;
+		expect(
+			negotiateInteractionDelivery(choice, constrained).limitations,
+		).toContain("opaque callback bytes");
+	});
+
+	it("checks hosted URL, thread, edit, attachment and form limits", () => {
+		const form: FormInteraction = {
+			kind: "form",
+			id: "upload",
+			title: "資料を提出",
+			fields: [
+				{
+					name: "file",
+					type: "file",
+					maxBytes: 101_000_000,
+					mimeTypes: ["application/pdf"],
+				},
+			],
+		};
+		const rich = profile(RICH_INTERACTION_PROFILE);
+		const result = negotiateInteractionDelivery(form, rich, {
+			signedHostedUrl: `https://example.test/${"a".repeat(8_200)}`,
+			requiresEdit: true,
+			requiresThread: true,
+			now: 2_000,
+			sourceMessageCreatedAt: 1_000,
+		});
+		expect(result.limitations).toEqual(["attachment bytes", "link URL bytes"]);
+	});
+
+	it("does not apply a hosted-fallback URL limit to a fitting native block", () => {
+		expect(
+			negotiateInteractionDelivery(choice, profile(), {
+				signedHostedUrl: `https://example.test/${"x".repeat(3_000)}`,
+			}),
+		).toMatchObject({ mode: "native", limitations: [] });
+	});
+});
+
+describe("message interaction session authority", () => {
+	it("property: accepts only canonical opaque callback references", () => {
+		let state = 0x24_287;
+		const nextByte = () => {
+			state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+			return state & 0xff;
+		};
+		for (let sample = 0; sample < 256; sample += 1) {
+			const reference = createOpaqueMessageInteractionReference((size) =>
+				Uint8Array.from({ length: size }, nextByte),
+			);
+			const callback = encodeMessageInteractionCallback(reference);
+			expect(decodeMessageInteractionCallback(callback)).toBe(reference);
+			for (const mutated of [
+				callback.toUpperCase(),
+				`${callback}0`,
+				callback.slice(0, -1),
+				callback.replace("is1:", "is2:"),
+			]) {
+				expect(decodeMessageInteractionCallback(mutated)).toBeNull();
+			}
+		}
+	});
+
+	it("puts only a short opaque reference in callback data", async () => {
+		const { callbackData, session } = await created({
+			preset: { value: "approve" },
+		});
+		expect(callbackData).toBe("is1:0123456789abcdef0123456789abcdef");
+		expect(decodeMessageInteractionCallback(callbackData)).toBe(
+			session.reference,
+		);
+		expect(callbackData).not.toContain("approve");
+		expect(callbackData).not.toContain("account-a");
+	});
+
+	it("rejects a requested native flow when the concrete block exceeds limits", async () => {
+		const authority = new MessageInteractionSessionAuthority(
+			new InMemoryMessageInteractionSessionStore(),
+			{ clock: () => Date.parse("2026-08-21T00:00:00.000Z") },
+		);
+		await expect(
+			authority.create({
+				block: {
+					...choice,
+					options: [{ value: "large", label: "x".repeat(81) }],
+				},
+				profile: profile(),
+				bindings,
+				purpose: "approval",
+				flow: "native",
+				authorization: {
+					decisionId: "decision-a",
+					policyRevision: "policy-a",
+					decidedAt: "2026-08-20T23:59:00.000Z",
+				},
+				effect: { kind: "approve" },
+				expiresAt: "2026-08-21T00:05:00.000Z",
+			}),
+		).rejects.toMatchObject({
+			code: "INTERACTION_FLOW_NOT_NEGOTIATED",
+			context: expect.objectContaining({
+				negotiated: "conversational",
+				limitations: ["option label bytes"],
+			}),
+		});
+	});
+
+	it("binds profile text byte limits into custom responses", async () => {
+		const store = new InMemoryMessageInteractionSessionStore();
+		const authority = new MessageInteractionSessionAuthority(store, {
+			clock: () => Date.parse("2026-08-21T00:00:00.000Z"),
+			referenceFactory: () => "0123456789abcdef0123456789abcdef",
+		});
+		const result = await authority.create({
+			block: { ...choice, allowCustom: true },
+			profile: profile(),
+			bindings,
+			purpose: "choice",
+			flow: "native",
+			authorization: {
+				decisionId: "decision-a",
+				policyRevision: "policy-a",
+				decidedAt: "2026-08-20T23:59:00.000Z",
+			},
+			effect: { kind: "choose" },
+			expiresAt: "2026-08-21T00:05:00.000Z",
+		});
+		await expect(
+			authority.consume({
+				callbackData: result.callbackData,
+				bindings,
+				replayKey: "replay-a",
+				response: { value: "✅".repeat(1_334) },
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "INVALID_MESSAGE_INTERACTION_RESPONSE" });
+	});
+
+	it.each([
+		["actor", { actorId: "actor-b" }],
+		["audience", { audience: { kind: "room", id: "room-b" } }],
+		["agent", { agentId: "agent-b" }],
+		["account", { connector: { source: "connector", accountId: "account-b" } }],
+		["room", { roomId: "room-b" }],
+		["source message", { sourceMessageId: "message-b" }],
+	])("denies cross-%s callbacks", async (_name, override) => {
+		const { authority, callbackData } = await created({
+			preset: { value: "approve" },
+		});
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings: { ...bindings, ...override },
+				replayKey: "replay-a",
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_BINDING_MISMATCH" });
+	});
+
+	it("atomically admits one concurrent effect and replays its retained receipt", async () => {
+		const { authority, callbackData } = await created({
+			preset: { value: "approve" },
+		});
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const execute = vi.fn(async () => {
+			await gate;
+			return receipt("replay-a");
+		});
+		const executor = { execute };
+		const first = authority.consume({
+			callbackData,
+			bindings,
+			replayKey: "replay-a",
+			executor,
+		});
+		await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+		const contenders = await Promise.all(
+			Array.from({ length: 20 }, () =>
+				authority.consume({
+					callbackData,
+					bindings,
+					replayKey: "replay-a",
+					executor,
+				}),
+			),
+		);
+		expect(contenders).toEqual(
+			Array.from({ length: 20 }, () => ({ status: "in_progress" })),
+		);
+		release();
+		expect(await first).toEqual(receipt("replay-a"));
+		expect(
+			await authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).toEqual(receipt("replay-a"));
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it("resumes a crash window with one idempotent effect and completes the receipt", async () => {
+		let now = Date.parse("2026-08-21T00:00:00.000Z");
+		const backing = new InMemoryMessageInteractionSessionStore();
+		let failCompletion = true;
+		const crashingStore: MessageInteractionSessionStore = {
+			...backing,
+			create: backing.create.bind(backing),
+			get: backing.get.bind(backing),
+			claimIfCurrent: backing.claimIfCurrent.bind(backing),
+			revokeAuthorization: backing.revokeAuthorization.bind(backing),
+			deleteExpired: backing.deleteExpired.bind(backing),
+			completeIfClaimed: async (context) => {
+				if (failCompletion) {
+					failCompletion = false;
+					throw new Error("simulated crash after effect");
+				}
+				return backing.completeIfClaimed(context);
+			},
+		};
+		const { authority, callbackData } = await created({
+			store: crashingStore,
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		const effects = new Map<string, MessageInteractionReceipt>();
+		let physicalEffects = 0;
+		const executor: MessageInteractionEffectExecutor = {
+			execute: async ({ idempotencyKey }) => {
+				const prior = effects.get(idempotencyKey);
+				if (prior) return prior;
+				physicalEffects += 1;
+				const value = receipt(idempotencyKey);
+				effects.set(idempotencyKey, value);
+				return value;
+			},
+		};
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).rejects.toThrow("simulated crash");
+		now += 101;
+		expect(
+			await authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor,
+			}),
+		).toEqual(receipt("replay-a"));
+		expect(physicalEffects).toBe(1);
+	});
+
+	it("denies tamper, expiry, and revocation after render", async () => {
+		let now = Date.parse("2026-08-21T00:00:00.000Z");
+		const { authority, store, callbackData, session } = await created({
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				response: { value: "deny" },
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_TAMPERED" });
+		await store.revokeAuthorization({
+			reference: session.reference,
+			decisionId: "decision-a",
+			now,
+		});
+		await expect(
+			authority.consume({
+				callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({
+			code: "MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+		});
+
+		const second = await created({
+			clock: () => now,
+			preset: { value: "approve" },
+		});
+		now = Date.parse("2026-08-21T00:10:00.000Z");
+		await expect(
+			second.authority.consume({
+				callbackData: second.callbackData,
+				bindings,
+				replayKey: "replay-a",
+				executor: { execute: async () => receipt("replay-a") },
+			}),
+		).rejects.toMatchObject({ code: "MESSAGE_INTERACTION_EXPIRED" });
+	});
+
+	it("forbids secrets in ordinary forms and effect metadata", async () => {
+		const authority = new MessageInteractionSessionAuthority(
+			new InMemoryMessageInteractionSessionStore(),
+			{ clock: () => Date.parse("2026-08-21T00:00:00.000Z") },
+		);
+		const secretForm: FormInteraction = {
+			kind: "form",
+			id: "bad",
+			fields: [{ name: "apiKey", type: "secret" }],
+		};
+		await expect(
+			authority.create({
+				block: secretForm,
+				profile: profile(RICH_INTERACTION_PROFILE),
+				bindings,
+				purpose: "auth",
+				flow: "native",
+				authorization: {
+					decisionId: "d",
+					policyRevision: "p",
+					decidedAt: "2026-08-20T23:59:00.000Z",
+				},
+				effect: { kind: "setup", metadata: { apiKey: "secret-value" } },
+				expiresAt: "2026-08-21T00:05:00.000Z",
+			}),
+		).rejects.toMatchObject({ code: "INTERACTION_SENSITIVE_FLOW_REQUIRED" });
+	});
+});

--- a/packages/core/src/messaging/interactions/sessions.ts
+++ b/packages/core/src/messaging/interactions/sessions.ts
@@ -108,12 +108,23 @@ export type MessageInteractionConsumeState =
 			attempt: number;
 	  }
 	| {
+			state: "committed";
+			claimId: string;
+			replayKey: string;
+			responseDigest: string;
+			response: MessageInteractionResponse;
+			claimedAt: string;
+			committedAt: string;
+			attempt: number;
+	  }
+	| {
 			state: "completed";
 			claimId: string;
 			replayKey: string;
 			responseDigest: string;
 			response: MessageInteractionResponse;
 			claimedAt: string;
+			committedAt: string;
 			completedAt: string;
 			attempt: number;
 			receipt: MessageInteractionReceipt;
@@ -172,6 +183,13 @@ export interface MessageInteractionCompleteContext {
 	now: number;
 }
 
+export interface MessageInteractionCommitContext {
+	reference: string;
+	claimId: string;
+	replayKey: string;
+	now: number;
+}
+
 /**
  * Storage transaction boundary. Implementations must make every method atomic;
  * a distributed implementation maps these operations to one row transaction.
@@ -182,6 +200,9 @@ export interface MessageInteractionSessionStore {
 	claimIfCurrent(
 		context: MessageInteractionClaimContext,
 	): Promise<MessageInteractionClaimResult>;
+	commitIfClaimed(
+		context: MessageInteractionCommitContext,
+	): Promise<MessageInteractionSession>;
 	completeIfClaimed(
 		context: MessageInteractionCompleteContext,
 	): Promise<MessageInteractionSession>;
@@ -195,8 +216,8 @@ export interface MessageInteractionSessionStore {
 
 export interface MessageInteractionEffectExecutor {
 	/**
-	 * Must be idempotent for idempotencyKey. A retry after a crash may invoke this
-	 * again; it must return the original effect receipt without repeating effect.
+	 * Executes only after the host durably commits the replay key. A crash after
+	 * commit is permanently ambiguous and is never automatically re-executed.
 	 */
 	execute(args: {
 		idempotencyKey: string;
@@ -225,13 +246,25 @@ function requiredText(value: string, path: string): string {
 }
 
 function validClock(value: number): number {
-	if (!Number.isSafeInteger(value) || value < 0) {
+	if (
+		!Number.isSafeInteger(value) ||
+		value < 0 ||
+		value > 8_640_000_000_000_000
+	) {
 		return fail(
 			"INVALID_MESSAGE_INTERACTION_CLOCK",
 			"Trusted clock is invalid.",
 		);
 	}
 	return value;
+}
+
+function parseCanonicalIso(value: string): number {
+	const parsed = Date.parse(value);
+	if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+		return Number.NaN;
+	}
+	return parsed;
 }
 
 function hex(bytes: Uint8Array): string {
@@ -497,6 +530,7 @@ export function validateMessageInteractionResponse(
 function assertCurrentContext(
 	session: MessageInteractionSession,
 	context: MessageInteractionClaimContext,
+	options: { requireActive: boolean } = { requireActive: true },
 ): MessageInteractionResponse {
 	const suppliedBindings: MessageInteractionBindings = {
 		actorId: context.actorId,
@@ -513,13 +547,13 @@ function assertCurrentContext(
 			{ reference: session.reference },
 		);
 	}
-	if (session.authorization.state !== "active") {
+	if (options.requireActive && session.authorization.state !== "active") {
 		return fail(
 			"MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
 			"Interaction authorization was revoked after render.",
 		);
 	}
-	if (Date.parse(session.expiresAt) <= context.now) {
+	if (options.requireActive && Date.parse(session.expiresAt) <= context.now) {
 		return fail("MESSAGE_INTERACTION_EXPIRED", "Interaction session expired.");
 	}
 	const response = session.presetResponse ?? context.response;
@@ -559,7 +593,17 @@ export function applyMessageInteractionClaim(
 			"Interaction claim lease must be a positive safe integer.",
 		);
 	}
-	const response = assertCurrentContext(session, context);
+	if (context.claimTtlMs > 8_640_000_000_000_000 - context.now) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_CLAIM_TTL",
+			"Interaction claim lease exceeds the supported clock range.",
+		);
+	}
+	const response = assertCurrentContext(session, context, {
+		requireActive:
+			session.consume.state !== "committed" &&
+			session.consume.state !== "completed",
+	});
 	const digest = responseDigest(response);
 	if (session.consume.state === "completed") {
 		if (
@@ -572,6 +616,18 @@ export function applyMessageInteractionClaim(
 			);
 		}
 		return { status: "replay", session, receipt: session.consume.receipt };
+	}
+	if (session.consume.state === "committed") {
+		if (
+			session.consume.replayKey !== context.replayKey ||
+			session.consume.responseDigest !== digest
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_ALREADY_COMMITTED",
+				"Interaction already committed a different response.",
+			);
+		}
+		return { status: "in_progress", session };
 	}
 	if (session.consume.state === "claimed") {
 		if (
@@ -626,11 +682,14 @@ export function applyMessageInteractionCompletion(
 	requiredText(context.claimId, "claimId");
 	requiredText(context.replayKey, "replayKey");
 	requiredText(context.receipt.receiptId, "receipt.receiptId");
-	const receiptCompletedAt = Date.parse(context.receipt.completedAt);
-	if (!Number.isFinite(receiptCompletedAt)) {
+	const receiptCompletedAt = parseCanonicalIso(context.receipt.completedAt);
+	if (
+		!Number.isFinite(receiptCompletedAt) ||
+		receiptCompletedAt > context.now
+	) {
 		return fail(
 			"INVALID_MESSAGE_INTERACTION_RECEIPT",
-			"Effect receipt has an invalid completion time.",
+			"Effect receipt has an invalid or future completion time.",
 		);
 	}
 	if (session.consume.state === "completed") {
@@ -645,7 +704,7 @@ export function applyMessageInteractionCompletion(
 		);
 	}
 	if (
-		session.consume.state !== "claimed" ||
+		session.consume.state !== "committed" ||
 		session.consume.claimId !== context.claimId ||
 		session.consume.replayKey !== context.replayKey
 	) {
@@ -670,9 +729,48 @@ export function applyMessageInteractionCompletion(
 		responseDigest: session.consume.responseDigest,
 		response: session.consume.response,
 		claimedAt: session.consume.claimedAt,
+		committedAt: session.consume.committedAt,
 		completedAt: new Date(context.now).toISOString(),
 		attempt: session.consume.attempt,
 		receipt: structuredClone(context.receipt),
+	};
+	session.revision += 1;
+	return session;
+}
+
+/** Durably linearize one effect before crossing the external side-effect boundary. */
+export function applyMessageInteractionCommit(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionCommitContext,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	validClock(context.now);
+	if (
+		session.reference !== context.reference ||
+		session.consume.state !== "claimed" ||
+		session.consume.claimId !== context.claimId ||
+		session.consume.replayKey !== context.replayKey
+	) {
+		return fail(
+			"MESSAGE_INTERACTION_STALE_CLAIM",
+			"Interaction effect commitment does not own the current claim.",
+		);
+	}
+	if (session.authorization.state !== "active") {
+		return fail(
+			"MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+			"Interaction authorization was revoked before effect commitment.",
+		);
+	}
+	session.consume = {
+		state: "committed",
+		claimId: session.consume.claimId,
+		replayKey: session.consume.replayKey,
+		responseDigest: session.consume.responseDigest,
+		response: session.consume.response,
+		claimedAt: session.consume.claimedAt,
+		committedAt: new Date(context.now).toISOString(),
+		attempt: session.consume.attempt,
 	};
 	session.revision += 1;
 	return session;
@@ -691,6 +789,12 @@ export function applyMessageInteractionRevocation(
 		);
 	}
 	if (session.authorization.state === "revoked") return session;
+	if (session.consume.state === "committed") {
+		return fail(
+			"MESSAGE_INTERACTION_EFFECT_COMMITTED",
+			"Interaction revocation is pending an already committed effect outcome.",
+		);
+	}
 	session.authorization = {
 		...session.authorization,
 		state: "revoked",
@@ -771,6 +875,22 @@ export class InMemoryMessageInteractionSessionStore
 		});
 	}
 
+	async commitIfClaimed(
+		context: MessageInteractionCommitContext,
+	): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const committed = applyMessageInteractionCommit(current, context);
+			this.sessions.set(context.reference, cloneSession(committed));
+			return committed;
+		});
+	}
+
 	async revokeAuthorization(args: {
 		reference: string;
 		decisionId: string;
@@ -798,7 +918,11 @@ export class InMemoryMessageInteractionSessionStore
 		return this.atomic(() => {
 			let deleted = 0;
 			for (const [reference, session] of this.sessions) {
-				if (Date.parse(session.expiresAt) <= before) {
+				if (
+					Date.parse(session.expiresAt) <= before &&
+					session.consume.state !== "committed" &&
+					session.consume.state !== "completed"
+				) {
 					this.sessions.delete(reference);
 					deleted += 1;
 				}
@@ -851,7 +975,7 @@ export class MessageInteractionSessionAuthority {
 				"MESSAGE_INTERACTION_PROFILE_BINDING_MISMATCH",
 				"Capability profile belongs to another account or target.",
 			);
-		const expiry = Date.parse(args.expiresAt);
+		const expiry = parseCanonicalIso(args.expiresAt);
 		if (
 			!Number.isFinite(expiry) ||
 			expiry <= now ||
@@ -926,7 +1050,9 @@ export class MessageInteractionSessionAuthority {
 			consume: { state: "pending" },
 			revision: 0,
 		};
-		const authorizationTime = Date.parse(session.authorization.decidedAt);
+		const authorizationTime = parseCanonicalIso(
+			session.authorization.decidedAt,
+		);
 		if (!Number.isFinite(authorizationTime) || authorizationTime > now) {
 			return fail(
 				"INVALID_MESSAGE_INTERACTION_AUTHORIZATION",
@@ -993,11 +1119,22 @@ export class MessageInteractionSessionAuthority {
 				"MESSAGE_INTERACTION_STORE_PROTOCOL",
 				"Store returned an unclaimed session.",
 			);
+		const committed = await this.store.commitIfClaimed({
+			reference,
+			claimId: claim.session.consume.claimId,
+			replayKey,
+			now: this.now(),
+		});
+		if (committed.consume.state !== "committed")
+			return fail(
+				"MESSAGE_INTERACTION_STORE_PROTOCOL",
+				"Store did not retain the effect commitment.",
+			);
 		const receipt = await args.executor.execute({
 			idempotencyKey: replayKey,
-			effect: claim.session.effect,
-			response: claim.session.consume.response,
-			session: claim.session,
+			effect: committed.effect,
+			response: committed.consume.response,
+			session: committed,
 		});
 		const completed = await this.store.completeIfClaimed({
 			reference,

--- a/packages/core/src/messaging/interactions/sessions.ts
+++ b/packages/core/src/messaging/interactions/sessions.ts
@@ -1,0 +1,1016 @@
+/**
+ * Owns durable message-interaction sessions and their exactly-once execution
+ * protocol. The authority binds callbacks to trusted context, while storage
+ * implementations provide atomic claim/complete/revoke transitions.
+ */
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import { ElizaError } from "../../errors";
+import type {
+	InteractionBlock,
+	InteractionField,
+	InteractionKind,
+} from "../../types/interactions";
+import { stableStringify } from "../../utils/deterministic";
+import type {
+	ConnectorInteractionCapabilityProfile,
+	InteractionNegotiationContext,
+} from "./profiles";
+import {
+	negotiateInteractionDelivery,
+	normalizeConnectorInteractionCapabilityProfile,
+} from "./profiles";
+
+export const MESSAGE_INTERACTION_SESSION_VERSION = 1 as const;
+export const MESSAGE_INTERACTION_CALLBACK_PREFIX = "is1:";
+export const MESSAGE_INTERACTION_CALLBACK_BYTES = 36;
+
+export type MessageInteractionPurpose =
+	| "choice"
+	| "form"
+	| "approval"
+	| "setup"
+	| "auth"
+	| "task"
+	| "file"
+	| "followup";
+
+export type MessageInteractionFlow =
+	| "native"
+	| "conversational"
+	| "signed-hosted"
+	| "sensitive-request";
+
+export interface MessageInteractionBindings {
+	actorId: string;
+	audience: { kind: string; id: string };
+	agentId: string;
+	connector: { source: string; accountId: string };
+	roomId: string;
+	sourceMessageId: string;
+}
+
+export type MessageInteractionResponseScalar = string | number | boolean;
+
+export interface MessageInteractionAttachmentResponse {
+	mediaUrl: string;
+	mimeType: string;
+	bytes: number;
+}
+
+export type MessageInteractionResponseValue =
+	| MessageInteractionResponseScalar
+	| MessageInteractionAttachmentResponse;
+
+export type MessageInteractionResponse = Record<
+	string,
+	MessageInteractionResponseValue
+>;
+
+export interface MessageInteractionResponseField {
+	name: string;
+	type: InteractionField["type"] | "acknowledgement";
+	required: boolean;
+	options?: readonly string[];
+	maxBytes?: number;
+	mimeTypes?: readonly string[];
+}
+
+export interface MessageInteractionResponseSchema {
+	fields: readonly MessageInteractionResponseField[];
+	additionalFields: false;
+}
+
+export interface MessageInteractionAuthorizationDecision {
+	decisionId: string;
+	policyRevision: string;
+	decidedAt: string;
+	state: "active" | "revoked";
+	revokedAt: string | null;
+}
+
+export interface MessageInteractionEffect {
+	kind: string;
+	/** Non-secret operation metadata. Credentials and submitted secrets are forbidden. */
+	metadata?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export type MessageInteractionConsumeState =
+	| { state: "pending" }
+	| {
+			state: "claimed";
+			claimId: string;
+			replayKey: string;
+			responseDigest: string;
+			response: MessageInteractionResponse;
+			claimedAt: string;
+			claimExpiresAt: string;
+			attempt: number;
+	  }
+	| {
+			state: "completed";
+			claimId: string;
+			replayKey: string;
+			responseDigest: string;
+			response: MessageInteractionResponse;
+			claimedAt: string;
+			completedAt: string;
+			attempt: number;
+			receipt: MessageInteractionReceipt;
+	  };
+
+export interface MessageInteractionSession {
+	sessionVersion: typeof MESSAGE_INTERACTION_SESSION_VERSION;
+	reference: string;
+	purpose: MessageInteractionPurpose;
+	blockKind: InteractionKind;
+	flow: MessageInteractionFlow;
+	profileId: string;
+	bindings: MessageInteractionBindings;
+	responseSchema: MessageInteractionResponseSchema;
+	presetResponse: MessageInteractionResponse | null;
+	authorization: MessageInteractionAuthorizationDecision;
+	effect: MessageInteractionEffect;
+	createdAt: string;
+	expiresAt: string;
+	consume: MessageInteractionConsumeState;
+	revision: number;
+}
+
+export interface MessageInteractionReceipt {
+	receiptId: string;
+	idempotencyKey: string;
+	status: "completed";
+	completedAt: string;
+	result: Readonly<Record<string, string | number | boolean | null>>;
+}
+
+export interface MessageInteractionClaimContext
+	extends MessageInteractionBindings {
+	reference: string;
+	replayKey: string;
+	response?: MessageInteractionResponse;
+	claimId: string;
+	now: number;
+	claimTtlMs: number;
+}
+
+export type MessageInteractionClaimResult =
+	| { status: "acquired" | "resumed"; session: MessageInteractionSession }
+	| { status: "in_progress"; session: MessageInteractionSession }
+	| {
+			status: "replay";
+			session: MessageInteractionSession;
+			receipt: MessageInteractionReceipt;
+	  };
+
+export interface MessageInteractionCompleteContext {
+	reference: string;
+	claimId: string;
+	replayKey: string;
+	receipt: MessageInteractionReceipt;
+	now: number;
+}
+
+/**
+ * Storage transaction boundary. Implementations must make every method atomic;
+ * a distributed implementation maps these operations to one row transaction.
+ */
+export interface MessageInteractionSessionStore {
+	create(session: MessageInteractionSession): Promise<void>;
+	get(reference: string): Promise<MessageInteractionSession | null>;
+	claimIfCurrent(
+		context: MessageInteractionClaimContext,
+	): Promise<MessageInteractionClaimResult>;
+	completeIfClaimed(
+		context: MessageInteractionCompleteContext,
+	): Promise<MessageInteractionSession>;
+	revokeAuthorization(args: {
+		reference: string;
+		decisionId: string;
+		now: number;
+	}): Promise<MessageInteractionSession>;
+	deleteExpired(before: number): Promise<number>;
+}
+
+export interface MessageInteractionEffectExecutor {
+	/**
+	 * Must be idempotent for idempotencyKey. A retry after a crash may invoke this
+	 * again; it must return the original effect receipt without repeating effect.
+	 */
+	execute(args: {
+		idempotencyKey: string;
+		effect: MessageInteractionEffect;
+		response: MessageInteractionResponse;
+		session: MessageInteractionSession;
+	}): Promise<MessageInteractionReceipt>;
+}
+
+function fail(
+	code: string,
+	message: string,
+	context?: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, { code, context });
+}
+
+function requiredText(value: string, path: string): string {
+	const normalized = value.trim();
+	if (!normalized || new TextEncoder().encode(normalized).length > 512) {
+		return fail("INVALID_MESSAGE_INTERACTION_SESSION", `${path} is invalid.`, {
+			path,
+		});
+	}
+	return normalized;
+}
+
+function validClock(value: number): number {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_CLOCK",
+			"Trusted clock is invalid.",
+		);
+	}
+	return value;
+}
+
+function hex(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+		"",
+	);
+}
+
+function responseDigest(response: MessageInteractionResponse): string {
+	return hex(
+		sha256(
+			new TextEncoder().encode(
+				`elizaos:message-interaction-response:v1\n${stableStringify(response)}`,
+			),
+		),
+	);
+}
+
+function sameBindings(
+	a: MessageInteractionBindings,
+	b: MessageInteractionBindings,
+): boolean {
+	return stableStringify(a) === stableStringify(b);
+}
+
+function cloneSession(
+	session: MessageInteractionSession,
+): MessageInteractionSession {
+	return structuredClone(session);
+}
+
+/** Create a short opaque callback reference with no embedded authority or data. */
+export function createOpaqueMessageInteractionReference(
+	random: (size: number) => Uint8Array = (size) => {
+		const bytes = new Uint8Array(new ArrayBuffer(size));
+		globalThis.crypto.getRandomValues(bytes);
+		return bytes;
+	},
+): string {
+	return hex(random(16));
+}
+
+export function encodeMessageInteractionCallback(reference: string): string {
+	if (!/^[a-f0-9]{32}$/.test(reference)) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_REFERENCE",
+			"Interaction reference must be a 128-bit opaque token.",
+		);
+	}
+	return `${MESSAGE_INTERACTION_CALLBACK_PREFIX}${reference}`;
+}
+
+export function decodeMessageInteractionCallback(
+	value: unknown,
+): string | null {
+	if (typeof value !== "string" || !/^is1:[a-f0-9]{32}$/.test(value)) {
+		return null;
+	}
+	return value.slice(MESSAGE_INTERACTION_CALLBACK_PREFIX.length);
+}
+
+function schemaField(
+	field: InteractionField,
+	maxTextResponseBytes?: number,
+): MessageInteractionResponseField {
+	const maxBytes =
+		field.type === "text" ||
+		field.type === "select" ||
+		field.type === "date" ||
+		field.type === "time" ||
+		field.type === "datetime"
+			? Math.min(
+					field.maxBytes ?? Number.POSITIVE_INFINITY,
+					maxTextResponseBytes ?? Number.POSITIVE_INFINITY,
+				)
+			: field.maxBytes;
+	return {
+		name: field.name,
+		type: field.type,
+		required: field.required === true,
+		...(field.options
+			? { options: field.options.map((option) => option.value) }
+			: {}),
+		...(Number.isFinite(maxBytes) ? { maxBytes } : {}),
+		...(field.mimeTypes ? { mimeTypes: [...field.mimeTypes] } : {}),
+	};
+}
+
+/** Derive the exact accepted response shape from the canonical block. */
+export function responseSchemaForInteraction(
+	block: InteractionBlock,
+	options: { maxTextResponseBytes?: number } = {},
+): MessageInteractionResponseSchema {
+	switch (block.kind) {
+		case "choice":
+			return {
+				fields: [
+					{
+						name: "value",
+						type: "text",
+						required: true,
+						...(options.maxTextResponseBytes
+							? { maxBytes: options.maxTextResponseBytes }
+							: {}),
+						...(block.allowCustom
+							? {}
+							: { options: block.options.map((option) => option.value) }),
+					},
+				],
+				additionalFields: false,
+			};
+		case "form":
+			if (block.fields.some((field) => field.type === "secret")) {
+				return fail(
+					"INTERACTION_SENSITIVE_FLOW_REQUIRED",
+					"Secret fields cannot be persisted in message interaction sessions.",
+				);
+			}
+			return {
+				fields: block.fields.map((field) =>
+					schemaField(field, options.maxTextResponseBytes),
+				),
+				additionalFields: false,
+			};
+		case "followups":
+			return {
+				fields: [
+					{
+						name: "value",
+						type: "text",
+						required: true,
+						...(options.maxTextResponseBytes
+							? { maxBytes: options.maxTextResponseBytes }
+							: {}),
+						options: block.options.map((option) => option.payload),
+					},
+				],
+				additionalFields: false,
+			};
+		case "task":
+		case "secret":
+			return {
+				fields: [
+					{ name: "acknowledged", type: "acknowledgement", required: true },
+				],
+				additionalFields: false,
+			};
+	}
+}
+
+function validateAttachment(
+	value: MessageInteractionResponseValue,
+	field: MessageInteractionResponseField,
+): void {
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		!("mediaUrl" in value) ||
+		!("mimeType" in value) ||
+		!("bytes" in value)
+	) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} must be a media reference.`,
+		);
+	}
+	const attachment = value as MessageInteractionAttachmentResponse;
+	if (!/^\/api\/media\/[a-f0-9]{64}\.[a-z0-9]+$/.test(attachment.mediaUrl)) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} has an invalid media capability URL.`,
+		);
+	}
+	if (
+		!Number.isSafeInteger(attachment.bytes) ||
+		attachment.bytes < 0 ||
+		(field.maxBytes !== undefined && attachment.bytes > field.maxBytes)
+	) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} exceeds its byte limit.`,
+		);
+	}
+	if (field.mimeTypes && !field.mimeTypes.includes(attachment.mimeType)) {
+		fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			`${field.name} has an unsupported MIME type.`,
+		);
+	}
+}
+
+export function validateMessageInteractionResponse(
+	value: MessageInteractionResponse,
+	schema: MessageInteractionResponseSchema,
+): MessageInteractionResponse {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			"Interaction response must be an object.",
+		);
+	}
+	const allowed = new Map(schema.fields.map((field) => [field.name, field]));
+	for (const key of Object.keys(value)) {
+		if (!allowed.has(key)) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`Unexpected interaction response field: ${key}.`,
+			);
+		}
+	}
+	for (const field of schema.fields) {
+		const responseValue = value[field.name];
+		if (responseValue === undefined) {
+			if (field.required)
+				return fail(
+					"INVALID_MESSAGE_INTERACTION_RESPONSE",
+					`Missing interaction response field: ${field.name}.`,
+				);
+			continue;
+		}
+		if (field.type === "file" || field.type === "image") {
+			validateAttachment(responseValue, field);
+			continue;
+		}
+		if (field.type === "checkbox" || field.type === "acknowledgement") {
+			if (typeof responseValue !== "boolean")
+				return fail(
+					"INVALID_MESSAGE_INTERACTION_RESPONSE",
+					`${field.name} must be boolean.`,
+				);
+		} else if (field.type === "number") {
+			if (typeof responseValue !== "number" || !Number.isFinite(responseValue))
+				return fail(
+					"INVALID_MESSAGE_INTERACTION_RESPONSE",
+					`${field.name} must be a finite number.`,
+				);
+		} else if (typeof responseValue !== "string") {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`${field.name} must be text.`,
+			);
+		}
+		if (
+			typeof responseValue === "string" &&
+			field.maxBytes !== undefined &&
+			new TextEncoder().encode(responseValue).length > field.maxBytes
+		) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`${field.name} exceeds its UTF-8 byte limit.`,
+			);
+		}
+		if (field.options && !field.options.includes(String(responseValue))) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_RESPONSE",
+				`${field.name} is not an allowed option.`,
+			);
+		}
+	}
+	return structuredClone(value);
+}
+
+function assertCurrentContext(
+	session: MessageInteractionSession,
+	context: MessageInteractionClaimContext,
+): MessageInteractionResponse {
+	const suppliedBindings: MessageInteractionBindings = {
+		actorId: context.actorId,
+		audience: context.audience,
+		agentId: context.agentId,
+		connector: context.connector,
+		roomId: context.roomId,
+		sourceMessageId: context.sourceMessageId,
+	};
+	if (!sameBindings(session.bindings, suppliedBindings)) {
+		return fail(
+			"MESSAGE_INTERACTION_BINDING_MISMATCH",
+			"Interaction callback belongs to another actor, audience, agent, account, room, or source message.",
+			{ reference: session.reference },
+		);
+	}
+	if (session.authorization.state !== "active") {
+		return fail(
+			"MESSAGE_INTERACTION_AUTHORIZATION_REVOKED",
+			"Interaction authorization was revoked after render.",
+		);
+	}
+	if (Date.parse(session.expiresAt) <= context.now) {
+		return fail("MESSAGE_INTERACTION_EXPIRED", "Interaction session expired.");
+	}
+	const response = session.presetResponse ?? context.response;
+	if (!response) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RESPONSE",
+			"Interaction response is required.",
+		);
+	}
+	if (session.presetResponse && context.response) {
+		return fail(
+			"MESSAGE_INTERACTION_TAMPERED",
+			"Preset callbacks cannot override their stored response.",
+		);
+	}
+	return validateMessageInteractionResponse(response, session.responseSchema);
+}
+
+/** Pure atomic-transition helper shared by memory, file, and database stores. */
+export function applyMessageInteractionClaim(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionClaimContext,
+): MessageInteractionClaimResult {
+	const session = cloneSession(sessionValue);
+	validClock(context.now);
+	if (context.reference !== session.reference) {
+		return fail(
+			"MESSAGE_INTERACTION_REFERENCE_MISMATCH",
+			"Interaction claim reference does not match the stored session.",
+		);
+	}
+	requiredText(context.replayKey, "replayKey");
+	requiredText(context.claimId, "claimId");
+	if (!Number.isSafeInteger(context.claimTtlMs) || context.claimTtlMs < 1) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_CLAIM_TTL",
+			"Interaction claim lease must be a positive safe integer.",
+		);
+	}
+	const response = assertCurrentContext(session, context);
+	const digest = responseDigest(response);
+	if (session.consume.state === "completed") {
+		if (
+			session.consume.replayKey !== context.replayKey ||
+			session.consume.responseDigest !== digest
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_ALREADY_CONSUMED",
+				"Interaction was already consumed by another response.",
+			);
+		}
+		return { status: "replay", session, receipt: session.consume.receipt };
+	}
+	if (session.consume.state === "claimed") {
+		if (
+			session.consume.replayKey !== context.replayKey ||
+			session.consume.responseDigest !== digest
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_ALREADY_CLAIMED",
+				"Interaction is claimed by another response.",
+			);
+		}
+		if (Date.parse(session.consume.claimExpiresAt) > context.now) {
+			return { status: "in_progress", session };
+		}
+		session.consume = {
+			...session.consume,
+			state: "claimed",
+			claimId: context.claimId,
+			claimedAt: new Date(context.now).toISOString(),
+			claimExpiresAt: new Date(context.now + context.claimTtlMs).toISOString(),
+			attempt: session.consume.attempt + 1,
+		};
+		session.revision += 1;
+		return { status: "resumed", session };
+	}
+	session.consume = {
+		state: "claimed",
+		claimId: context.claimId,
+		replayKey: context.replayKey,
+		responseDigest: digest,
+		response,
+		claimedAt: new Date(context.now).toISOString(),
+		claimExpiresAt: new Date(context.now + context.claimTtlMs).toISOString(),
+		attempt: 1,
+	};
+	session.revision += 1;
+	return { status: "acquired", session };
+}
+
+export function applyMessageInteractionCompletion(
+	sessionValue: MessageInteractionSession,
+	context: MessageInteractionCompleteContext,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	validClock(context.now);
+	if (context.reference !== session.reference) {
+		return fail(
+			"MESSAGE_INTERACTION_REFERENCE_MISMATCH",
+			"Interaction completion reference does not match the stored session.",
+		);
+	}
+	requiredText(context.claimId, "claimId");
+	requiredText(context.replayKey, "replayKey");
+	requiredText(context.receipt.receiptId, "receipt.receiptId");
+	const receiptCompletedAt = Date.parse(context.receipt.completedAt);
+	if (!Number.isFinite(receiptCompletedAt)) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RECEIPT",
+			"Effect receipt has an invalid completion time.",
+		);
+	}
+	if (session.consume.state === "completed") {
+		if (
+			session.consume.replayKey === context.replayKey &&
+			session.consume.receipt.idempotencyKey === context.receipt.idempotencyKey
+		)
+			return session;
+		return fail(
+			"MESSAGE_INTERACTION_ALREADY_CONSUMED",
+			"A different effect already completed this interaction.",
+		);
+	}
+	if (
+		session.consume.state !== "claimed" ||
+		session.consume.claimId !== context.claimId ||
+		session.consume.replayKey !== context.replayKey
+	) {
+		return fail(
+			"MESSAGE_INTERACTION_STALE_CLAIM",
+			"Interaction completion does not own the current claim.",
+		);
+	}
+	if (
+		context.receipt.idempotencyKey !== context.replayKey ||
+		context.receipt.status !== "completed"
+	) {
+		return fail(
+			"INVALID_MESSAGE_INTERACTION_RECEIPT",
+			"Effect receipt does not bind the replay key.",
+		);
+	}
+	session.consume = {
+		state: "completed",
+		claimId: session.consume.claimId,
+		replayKey: session.consume.replayKey,
+		responseDigest: session.consume.responseDigest,
+		response: session.consume.response,
+		claimedAt: session.consume.claimedAt,
+		completedAt: new Date(context.now).toISOString(),
+		attempt: session.consume.attempt,
+		receipt: structuredClone(context.receipt),
+	};
+	session.revision += 1;
+	return session;
+}
+
+export function applyMessageInteractionRevocation(
+	sessionValue: MessageInteractionSession,
+	decisionId: string,
+	now: number,
+): MessageInteractionSession {
+	const session = cloneSession(sessionValue);
+	if (session.authorization.decisionId !== decisionId) {
+		return fail(
+			"MESSAGE_INTERACTION_AUTHORIZATION_MISMATCH",
+			"Authorization decision does not match this session.",
+		);
+	}
+	if (session.authorization.state === "revoked") return session;
+	session.authorization = {
+		...session.authorization,
+		state: "revoked",
+		revokedAt: new Date(validClock(now)).toISOString(),
+	};
+	session.revision += 1;
+	return session;
+}
+
+/** Process-local reference store used by deterministic tests and embedded hosts. */
+export class InMemoryMessageInteractionSessionStore
+	implements MessageInteractionSessionStore
+{
+	private readonly sessions = new Map<string, MessageInteractionSession>();
+	private queue: Promise<void> = Promise.resolve();
+
+	private async atomic<T>(operation: () => T | Promise<T>): Promise<T> {
+		let release: () => void = () => undefined;
+		const previous = this.queue;
+		this.queue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await operation();
+		} finally {
+			release();
+		}
+	}
+
+	async create(session: MessageInteractionSession): Promise<void> {
+		await this.atomic(() => {
+			if (this.sessions.has(session.reference))
+				return fail(
+					"MESSAGE_INTERACTION_REFERENCE_COLLISION",
+					"Interaction reference already exists.",
+				);
+			this.sessions.set(session.reference, cloneSession(session));
+		});
+	}
+
+	async get(reference: string): Promise<MessageInteractionSession | null> {
+		return this.atomic(() => {
+			const session = this.sessions.get(reference);
+			return session ? cloneSession(session) : null;
+		});
+	}
+
+	async claimIfCurrent(
+		context: MessageInteractionClaimContext,
+	): Promise<MessageInteractionClaimResult> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const result = applyMessageInteractionClaim(current, context);
+			this.sessions.set(context.reference, cloneSession(result.session));
+			return result;
+		});
+	}
+
+	async completeIfClaimed(
+		context: MessageInteractionCompleteContext,
+	): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(context.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const completed = applyMessageInteractionCompletion(current, context);
+			this.sessions.set(context.reference, cloneSession(completed));
+			return completed;
+		});
+	}
+
+	async revokeAuthorization(args: {
+		reference: string;
+		decisionId: string;
+		now: number;
+	}): Promise<MessageInteractionSession> {
+		return this.atomic(() => {
+			const current = this.sessions.get(args.reference);
+			if (!current)
+				return fail(
+					"MESSAGE_INTERACTION_NOT_FOUND",
+					"Interaction session was not found.",
+				);
+			const revoked = applyMessageInteractionRevocation(
+				current,
+				args.decisionId,
+				args.now,
+			);
+			this.sessions.set(args.reference, cloneSession(revoked));
+			return revoked;
+		});
+	}
+
+	async deleteExpired(before: number): Promise<number> {
+		validClock(before);
+		return this.atomic(() => {
+			let deleted = 0;
+			for (const [reference, session] of this.sessions) {
+				if (Date.parse(session.expiresAt) <= before) {
+					this.sessions.delete(reference);
+					deleted += 1;
+				}
+			}
+			return deleted;
+		});
+	}
+}
+
+export class MessageInteractionSessionAuthority {
+	constructor(
+		private readonly store: MessageInteractionSessionStore,
+		private readonly options: {
+			clock?: () => number;
+			referenceFactory?: () => string;
+			claimTtlMs?: number;
+		} = {},
+	) {}
+
+	private now(): number {
+		return validClock(this.options.clock?.() ?? Date.now());
+	}
+
+	async create(args: {
+		block: InteractionBlock;
+		profile: ConnectorInteractionCapabilityProfile;
+		bindings: MessageInteractionBindings;
+		purpose: MessageInteractionPurpose;
+		flow: MessageInteractionFlow;
+		negotiationContext?: InteractionNegotiationContext;
+		presetResponse?: MessageInteractionResponse;
+		authorization: Omit<
+			MessageInteractionAuthorizationDecision,
+			"state" | "revokedAt"
+		>;
+		effect: MessageInteractionEffect;
+		expiresAt: string;
+	}): Promise<{ session: MessageInteractionSession; callbackData: string }> {
+		const now = this.now();
+		const profile = normalizeConnectorInteractionCapabilityProfile(
+			args.profile,
+		);
+		if (
+			profile.connector.source !== args.bindings.connector.source ||
+			profile.connector.accountId !== args.bindings.connector.accountId ||
+			profile.target.kind !== args.bindings.audience.kind ||
+			profile.target.id !== args.bindings.audience.id
+		)
+			return fail(
+				"MESSAGE_INTERACTION_PROFILE_BINDING_MISMATCH",
+				"Capability profile belongs to another account or target.",
+			);
+		const expiry = Date.parse(args.expiresAt);
+		if (
+			!Number.isFinite(expiry) ||
+			expiry <= now ||
+			expiry - now > profile.blocks[args.block.kind].maxSessionTtlMs
+		) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_EXPIRY",
+				"Interaction expiry exceeds negotiated capability.",
+			);
+		}
+		if (args.block.kind === "secret" && args.flow !== "sensitive-request") {
+			return fail(
+				"INTERACTION_SENSITIVE_FLOW_REQUIRED",
+				"Secret/OAuth interactions require the sensitive-request flow.",
+			);
+		}
+		if (args.block.kind !== "secret" && args.flow === "sensitive-request") {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_FLOW",
+				"Ordinary interactions cannot use the sensitive-request flow.",
+			);
+		}
+		const delivery = negotiateInteractionDelivery(args.block, profile, {
+			...args.negotiationContext,
+			callbackBytes: MESSAGE_INTERACTION_CALLBACK_BYTES,
+		});
+		if (delivery.mode !== args.flow) {
+			return fail(
+				"INTERACTION_FLOW_NOT_NEGOTIATED",
+				"Interaction flow does not match the negotiated delivery for this payload.",
+				{
+					requested: args.flow,
+					negotiated: delivery.mode,
+					limitations: delivery.limitations,
+				},
+			);
+		}
+		if (args.purpose === "auth" && args.block.kind !== "secret") {
+			return fail(
+				"INTERACTION_SENSITIVE_FLOW_REQUIRED",
+				"Authentication input must use a dedicated sensitive request.",
+			);
+		}
+		const reference =
+			this.options.referenceFactory?.() ??
+			createOpaqueMessageInteractionReference();
+		encodeMessageInteractionCallback(reference);
+		const schema = responseSchemaForInteraction(args.block, {
+			maxTextResponseBytes: profile.limits.text.maxMessageBytes,
+		});
+		const presetResponse = args.presetResponse
+			? validateMessageInteractionResponse(args.presetResponse, schema)
+			: null;
+		const session: MessageInteractionSession = {
+			sessionVersion: MESSAGE_INTERACTION_SESSION_VERSION,
+			reference,
+			purpose: args.purpose,
+			blockKind: args.block.kind,
+			flow: args.flow,
+			profileId: profile.profileId,
+			bindings: structuredClone(args.bindings),
+			responseSchema: schema,
+			presetResponse,
+			authorization: {
+				...args.authorization,
+				state: "active",
+				revokedAt: null,
+			},
+			effect: structuredClone(args.effect),
+			createdAt: new Date(now).toISOString(),
+			expiresAt: new Date(expiry).toISOString(),
+			consume: { state: "pending" },
+			revision: 0,
+		};
+		const authorizationTime = Date.parse(session.authorization.decidedAt);
+		if (!Number.isFinite(authorizationTime) || authorizationTime > now) {
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_AUTHORIZATION",
+				"Authorization decision time is invalid.",
+			);
+		}
+		for (const [path, value] of Object.entries({
+			...session.bindings,
+			audienceKind: session.bindings.audience.kind,
+			audienceId: session.bindings.audience.id,
+			connectorSource: session.bindings.connector.source,
+			connectorAccountId: session.bindings.connector.accountId,
+			authorizationDecisionId: session.authorization.decisionId,
+			policyRevision: session.authorization.policyRevision,
+			effectKind: session.effect.kind,
+		}))
+			if (typeof value === "string") requiredText(value, path);
+		if (
+			/secret|token|password|oauth.*code|api.?key/i.test(
+				stableStringify(session.effect.metadata ?? {}),
+			)
+		) {
+			return fail(
+				"MESSAGE_INTERACTION_SECRET_FORBIDDEN",
+				"Interaction effect metadata appears to contain secret material.",
+			);
+		}
+		await this.store.create(session);
+		return {
+			session: cloneSession(session),
+			callbackData: encodeMessageInteractionCallback(reference),
+		};
+	}
+
+	async consume(args: {
+		callbackData: string;
+		bindings: MessageInteractionBindings;
+		replayKey: string;
+		response?: MessageInteractionResponse;
+		executor: MessageInteractionEffectExecutor;
+	}): Promise<MessageInteractionReceipt | { status: "in_progress" }> {
+		const reference = decodeMessageInteractionCallback(args.callbackData);
+		if (!reference)
+			return fail(
+				"INVALID_MESSAGE_INTERACTION_REFERENCE",
+				"Callback is not an opaque interaction reference.",
+			);
+		const now = this.now();
+		const replayKey = requiredText(args.replayKey, "replayKey");
+		const claimId = createOpaqueMessageInteractionReference();
+		const claim = await this.store.claimIfCurrent({
+			...args.bindings,
+			reference,
+			replayKey,
+			response: args.response,
+			claimId,
+			now,
+			claimTtlMs: this.options.claimTtlMs ?? 30_000,
+		});
+		if (claim.status === "replay") return claim.receipt;
+		if (claim.status === "in_progress") return { status: "in_progress" };
+		if (claim.session.consume.state !== "claimed")
+			return fail(
+				"MESSAGE_INTERACTION_STORE_PROTOCOL",
+				"Store returned an unclaimed session.",
+			);
+		const receipt = await args.executor.execute({
+			idempotencyKey: replayKey,
+			effect: claim.session.effect,
+			response: claim.session.consume.response,
+			session: claim.session,
+		});
+		const completed = await this.store.completeIfClaimed({
+			reference,
+			claimId: claim.session.consume.claimId,
+			replayKey,
+			receipt,
+			now: this.now(),
+		});
+		if (completed.consume.state !== "completed")
+			return fail(
+				"MESSAGE_INTERACTION_STORE_PROTOCOL",
+				"Store did not retain the completion receipt.",
+			);
+		return completed.consume.receipt;
+	}
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1086,6 +1086,10 @@ function normalizeMessageConnector(
 		connector.accountRouting = metadata.accountRouting;
 	if (metadata.description) connector.description = metadata.description;
 	if (metadata.metadata) connector.metadata = { ...metadata.metadata };
+	if (metadata.resolveInteractionProfile)
+		connector.resolveInteractionProfile = metadata.resolveInteractionProfile;
+	if (metadata.sendPreparedInteraction)
+		connector.sendPreparedInteraction = metadata.sendPreparedInteraction;
 	if (metadata.resolveTargets)
 		connector.resolveTargets = metadata.resolveTargets;
 	if (metadata.listRecentTargets)

--- a/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
+++ b/packages/core/src/runtime/__tests__/message-post-connectors.test.ts
@@ -34,6 +34,23 @@ function makeTarget(source: string): TargetInfo {
 }
 
 describe("message and post connector registries", () => {
+	it("retains interaction profile and host-prepared delivery hooks", () => {
+		const runtime = makeRuntime();
+		const resolveInteractionProfile = vi.fn(() => ({}) as never);
+		const sendPreparedInteraction = vi.fn(async () => undefined);
+		runtime.registerMessageConnector({
+			source: "interactive",
+			resolveInteractionProfile,
+			sendPreparedInteraction,
+		});
+
+		const connector = runtime.getMessageConnectors()[0];
+		expect(connector?.resolveInteractionProfile).toBe(
+			resolveInteractionProfile,
+		);
+		expect(connector?.sendPreparedInteraction).toBe(sendPreparedInteraction);
+	});
+
 	it("registers message connectors with optional sendHandler and enumerates hook-only connectors", async () => {
 		const runtime = makeRuntime();
 		const sentMemory = {

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -7,6 +7,7 @@
  */
 import type { ReportedError } from "../errors";
 import type { Logger } from "../logger";
+import type { ConnectorInteractionCapabilityProfile } from "../messaging/interactions/profiles";
 import type { ContextRegistry } from "../runtime/context-registry";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";
@@ -381,6 +382,13 @@ export interface MessageConnector {
 	description?: string;
 	contexts: AgentContext[];
 	metadata?: Metadata;
+	/** Resolve the negotiated interaction contract for this exact account/target. */
+	resolveInteractionProfile?: (
+		target: TargetInfo,
+		context: MessageConnectorQueryContext,
+	) =>
+		| Promise<ConnectorInteractionCapabilityProfile>
+		| ConnectorInteractionCapabilityProfile;
 	resolveTargets?: (
 		query: string,
 		context: MessageConnectorQueryContext,

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -8,6 +8,7 @@
 import type { ReportedError } from "../errors";
 import type { Logger } from "../logger";
 import type { ConnectorInteractionCapabilityProfile } from "../messaging/interactions/profiles";
+import type { PreparedMessageInteraction } from "../messaging/interactions/host";
 import type { ContextRegistry } from "../runtime/context-registry";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";
@@ -366,6 +367,14 @@ export interface MessageConnectorPostToThreadParams {
 	identity?: ConnectorPostIdentity;
 }
 
+/** Renderer-safe prepared delivery. The host retains bindings, authorization, and effects. */
+export interface MessageConnectorPreparedInteractionParams {
+	target: TargetInfo;
+	interaction: PreparedMessageInteraction;
+	/** Optional visible prose accompanying the prepared control. */
+	text?: string;
+}
+
 export interface MessageConnector {
 	source: string;
 	accountId?: string;
@@ -389,6 +398,12 @@ export interface MessageConnector {
 	) =>
 		| Promise<ConnectorInteractionCapabilityProfile>
 		| ConnectorInteractionCapabilityProfile;
+	/** Send only a host-prepared interaction; connectors must not mint authority. */
+	sendPreparedInteraction?: (
+		runtime: IAgentRuntime,
+		params: MessageConnectorPreparedInteractionParams,
+		context: MessageConnectorQueryContext,
+	) => Promise<void>;
 	resolveTargets?: (
 		query: string,
 		context: MessageConnectorQueryContext,

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -7,8 +7,8 @@
  */
 import type { ReportedError } from "../errors";
 import type { Logger } from "../logger";
-import type { ConnectorInteractionCapabilityProfile } from "../messaging/interactions/profiles";
 import type { PreparedMessageInteraction } from "../messaging/interactions/host";
+import type { ConnectorInteractionCapabilityProfile } from "../messaging/interactions/profiles";
 import type { ContextRegistry } from "../runtime/context-registry";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -3,17 +3,43 @@
  * `InteractionBlock` output to Discord action-row/button components.
  * Pure-function assertions.
  */
-import type { Content } from "@elizaos/core";
+import type { Content, PreparedMessageInteraction } from "@elizaos/core";
 import {
 	buildInteractionUrlResolver,
 	decodeCallback,
+	decodePreparedInteractionCallback,
 	FORM_FREE_TEXT_INVITE,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
 	buildDiscordReplyPayload,
 	renderDiscordInteractions,
+	renderPreparedDiscordInteraction,
 } from "../interactions";
+
+it("renders only host-prepared Discord callbacks as canonical native controls", () => {
+	const prepared: PreparedMessageInteraction = {
+		block: {
+			kind: "choice",
+			id: "choice-a",
+			scope: "pick",
+			options: [{ value: "yes", label: "Yes" }],
+		},
+		callbackData: "is1:0123456789abcdef0123456789abcdef",
+		delivery: { mode: "native", reason: "preferred", limitations: [] },
+		expiresAt: "2026-08-22T01:00:00.000Z",
+		profileId: "profile-a",
+	};
+	const out = renderPreparedDiscordInteraction(prepared);
+	expect(
+		decodePreparedInteractionCallback(
+			out.components[0]?.components[0]?.custom_id,
+		),
+	).toEqual({
+		callbackData: prepared.callbackData,
+		response: { value: "yes" },
+	});
+});
 
 describe("renderDiscordInteractions", () => {
 	it("passes plain replies through with no components", () => {

--- a/plugins/plugin-discord/discord-interactions.ts
+++ b/plugins/plugin-discord/discord-interactions.ts
@@ -4,17 +4,13 @@
  * room/user records the runtime needs on ready and on first contact.
  */
 import {
-	attestDeliveryAudienceFromCanonicalRoom,
 	ChannelType,
+	consumePreparedInteractionCallback,
 	createUniqueUuid,
-	decodeCallback,
+	decodePreparedInteractionCallback,
 	type Entity,
 	type EventPayload,
 	EventType,
-	type HandlerCallback,
-	isInteractionCallback,
-	type Memory,
-	MemoryType,
 	type Room,
 	stringToUuid,
 	type UUID,
@@ -37,8 +33,6 @@ import {
 	buildDiscordEntityMetadata,
 	buildDiscordWorldMetadata,
 } from "./identity";
-import { buildDiscordReplyPayload } from "./interactions";
-import { chunkDiscordText } from "./messaging";
 import { generateInviteUrl } from "./permissions";
 import { syncDiscordClientProfile } from "./profileSync";
 import type { DiscordService } from "./service";
@@ -50,11 +44,6 @@ import {
 	type DiscordSlashCommand,
 	type DiscordSlashCommandPayload,
 } from "./types";
-import {
-	buildDiscordComponents,
-	getMessageService,
-	sendMessageInChunks,
-} from "./utils";
 
 /**
  * Subset of DiscordService fields needed by interaction handling.
@@ -245,99 +234,35 @@ export async function handleInteractionCreate(
 			"Received component interaction",
 		);
 
-		if (interaction.isButton() && isInteractionCallback(interaction.customId)) {
-			const decoded = decodeCallback(interaction.customId);
+		if (
+			interaction.isButton() &&
+			decodePreparedInteractionCallback(interaction.customId)
+		) {
 			await acknowledgeComponentInteraction(interaction);
-			if (!decoded) {
-				return;
-			}
-			const memory: Memory = {
-				id: createUniqueUuid(service.runtime, `cbq-${interaction.id}`),
-				entityId,
-				agentId: service.runtime.agentId,
-				roomId,
-				content: {
-					text: decoded.value,
-					source: "discord",
-					channelType: type,
+			const outcome = await consumePreparedInteractionCallback(
+				service.runtime,
+				{
+					providerCallbackData: interaction.customId,
+					bindings: {
+						actorId: entityId,
+						audience: { kind: "room", id: roomId },
+						agentId: service.runtime.agentId,
+						connector: { source: "discord", accountId },
+						roomId,
+					},
+					providerReceipt: {
+						source: "discord",
+						accountId,
+						inboundEventId: interaction.id,
+						receivedAt: new Date(interaction.createdTimestamp).toISOString(),
+					},
 				},
-				metadata: {
-					type: MemoryType.MESSAGE,
-					source: "discord",
-					accountId,
-				},
-				createdAt: Date.now(),
-			};
-			try {
-				await attestDeliveryAudienceFromCanonicalRoom(service.runtime, memory);
-			} catch (error) {
-				// error-policy:J4 the interaction can still use public actions,
-				// while owner-private components fail closed without evidence.
-				service.runtime.reportError(
-					"DiscordInteraction.deliveryAudience",
-					error,
-					{ roomId, messageId: memory.id },
+			);
+			if (outcome.status === "denied") {
+				service.runtime.logger.warn(
+					{ src: "plugin:discord", accountId, code: outcome.code },
+					"Discord interaction callback was denied",
 				);
-			}
-			const callback: HandlerCallback = async (content) => {
-				const render = buildDiscordReplyPayload(service.runtime, content);
-				const components =
-					render.components.length > 0
-						? buildDiscordComponents(render.components)
-						: undefined;
-				const chunks = render.text.trim() ? chunkDiscordText(render.text) : [];
-				// A user-installed app in a group DM / DM-with-others is NOT a
-				// channel member, so `channel.send` is unavailable — the button
-				// reply must ride the interaction token via followUp (the button
-				// was already deferUpdate'd above, so followUp posts a new
-				// message). Buttons attach to the LAST chunk. Fall back to
-				// channel.send only when there is no usable interaction (should
-				// not happen for a component interaction).
-				if (chunks.length === 0 && !components) {
-					return [];
-				}
-				const lastIndex = Math.max(0, chunks.length - 1);
-				try {
-					if (chunks.length === 0 && components) {
-						await interaction.followUp({ content: "​", components });
-					}
-					for (let i = 0; i < chunks.length; i++) {
-						await interaction.followUp({
-							content: chunks[i],
-							...(components && i === lastIndex ? { components } : {}),
-						});
-					}
-					return [];
-				} catch (error) {
-					// error-policy:J1 interaction delivery failed (token expired or
-					// missing) — fall back to a channel send where the bot can.
-					const channel = interaction.channel as TextChannel | null;
-					if (channel && typeof channel.send === "function") {
-						await sendMessageInChunks(
-							channel,
-							render.text,
-							"",
-							[],
-							render.components.length > 0 ? render.components : undefined,
-							service.runtime,
-						);
-					} else {
-						service.runtime.logger.warn(
-							{
-								src: "plugin:discord",
-								agentId: service.runtime.agentId,
-								customId: interaction.customId,
-								error: error instanceof Error ? error.message : String(error),
-							},
-							"Button-reply delivery failed and no channel send is available",
-						);
-					}
-					return [];
-				}
-			};
-			const messageService = getMessageService(service.runtime);
-			if (messageService) {
-				await messageService.handleMessage(service.runtime, memory, callback);
 			}
 			return;
 		}

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -14,10 +14,13 @@
 import {
 	buildInteractionUrlResolver,
 	type Content,
+	encodePreparedInteractionCallback,
 	type IAgentRuntime,
 	type InteractionBlock,
 	type NeutralButton,
+	type PreparedMessageInteraction,
 	parseInteractionBlocks,
+	renderContentInteractionsAsPlainText,
 	stripDashboardOnlyMarkers,
 	toNeutralLayout,
 } from "@elizaos/core";
@@ -142,6 +145,97 @@ export function renderDiscordInteractions(
 			.join("\n\n"),
 	);
 	return { text, components: visibleRows, needsFreeTextReply };
+}
+
+/** Render only host-prepared authority as Discord buttons. */
+export function renderPreparedDiscordInteraction(
+	prepared: PreparedMessageInteraction,
+): DiscordInteractionRender {
+	const block = prepared.block;
+	const fallback = renderContentInteractionsAsPlainText({
+		interactions: [block],
+	}).text;
+	const hostedUrl =
+		prepared.hostedUrl ?? (block.kind === "secret" ? block.url : undefined);
+	if (hostedUrl) {
+		const label =
+			block.kind === "form"
+				? (block.submitLabel ?? "Open form")
+				: block.kind === "task"
+					? "Open task"
+					: block.kind === "secret"
+						? block.secretKind === "oauth"
+							? `Connect ${block.provider ?? "account"}`
+							: (block.submitLabel ?? "Provide securely")
+						: "Open";
+		return {
+			text: block.kind === "task" ? block.title : fallback,
+			components: [
+				{
+					type: 1,
+					components: [
+						{
+							type: 2,
+							custom_id: "",
+							label,
+							style: LINK_STYLE,
+							url: hostedUrl,
+						},
+					],
+				},
+			],
+			needsFreeTextReply: false,
+		};
+	}
+	if (
+		prepared.delivery.mode !== "native" ||
+		(block.kind !== "choice" && block.kind !== "followups")
+	) {
+		return { text: fallback, components: [], needsFreeTextReply: true };
+	}
+	const providerOptions =
+		block.kind === "choice"
+			? block.options.map((option) => ({
+					label: option.label,
+					value: option.value,
+				}))
+			: block.options
+					.filter((option) => option.kind !== "navigate")
+					.map((option) => ({ label: option.label, value: option.payload }));
+	const concrete: DiscordComponentOptions[] = [];
+	for (const option of providerOptions) {
+		const customId = encodePreparedInteractionCallback(
+			prepared.callbackData,
+			{ value: option.value },
+			MAX_CUSTOM_ID_BYTES,
+		);
+		if (!customId) {
+			return { text: fallback, components: [], needsFreeTextReply: true };
+		}
+		concrete.push({
+			type: 2,
+			custom_id: customId,
+			label: option.label,
+			style: 2,
+		});
+	}
+	if (concrete.length > MAX_ROWS * MAX_BUTTONS_PER_ROW)
+		return { text: fallback, components: [], needsFreeTextReply: true };
+	const components: DiscordActionRow[] = [];
+	for (let index = 0; index < concrete.length; index += MAX_BUTTONS_PER_ROW) {
+		components.push({
+			type: 1,
+			components: concrete.slice(index, index + MAX_BUTTONS_PER_ROW),
+		});
+	}
+	return {
+		text:
+			block.kind === "choice"
+				? (block.prompt ?? "Choose an option.")
+				: "Choose an option.",
+		components,
+		needsFreeTextReply: false,
+	};
 }
 
 /**

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -26,10 +26,12 @@ import {
 	type MessageConnectorChatContext,
 	type MessageConnectorCreateThreadParams,
 	type MessageConnectorPostToThreadParams,
+	type MessageConnectorPreparedInteractionParams,
 	type MessageConnectorQueryContext,
 	type MessageConnectorTarget,
 	type MessageConnectorTypingParams,
 	type MessageConnectorUserContext,
+	type PreparedMessageInteraction,
 	parseBooleanFromText,
 	type Room,
 	resolveFirstPartyInteractionProfile,
@@ -150,7 +152,10 @@ import {
 	resolveDiscordRuntimeEntityId,
 	resolveElizaOwnerEntityId,
 } from "./identity";
-import { buildDiscordReplyPayload } from "./interactions";
+import {
+	buildDiscordReplyPayload,
+	renderPreparedDiscordInteraction,
+} from "./interactions";
 import {
 	beginDiscordOutboundDelivery,
 	createDiscordMessageMemoryOnce,
@@ -1809,6 +1814,7 @@ export class DiscordService extends Service implements IDiscordService {
 		runtime: IAgentRuntime,
 		target: TargetInfo,
 		content: Content,
+		preparedInteraction?: PreparedMessageInteraction,
 	): Promise<Memory | SendHandlerOutcome | undefined> {
 		let outboundReservation: DiscordOutboundDeliveryReservation | undefined;
 		let acceptedProviderMessages: Message[] = [];
@@ -1978,7 +1984,9 @@ export class DiscordService extends Service implements IDiscordService {
 					// markup to Discord (live 2026-08-17, wind-chimes relay). Blocks
 					// become action rows on the final chunk; block-free text is
 					// byte-identical to the previous behavior.
-					const rendered = buildDiscordReplyPayload(runtime, content);
+					const rendered = preparedInteraction
+						? renderPreparedDiscordInteraction(preparedInteraction)
+						: buildDiscordReplyPayload(runtime, content);
 					const renderedComponents =
 						rendered.components.length > 0
 							? buildDiscordComponents(rendered.components)
@@ -3803,6 +3811,17 @@ export class DiscordService extends Service implements IDiscordService {
 								target: scopedTarget(target),
 								accountId: accountId ?? context.accountId,
 							}),
+						sendPreparedInteraction: async (
+							handlerRuntime,
+							params: MessageConnectorPreparedInteractionParams,
+						) => {
+							await serviceInstance.handleSendMessage(
+								handlerRuntime,
+								scopedTarget(params.target),
+								{ text: params.text ?? "" },
+								params.interaction,
+							);
+						},
 						resolveTargets: (query, context) =>
 							serviceInstance.resolveConnectorTargets(
 								query,

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -32,6 +32,7 @@ import {
 	type MessageConnectorUserContext,
 	parseBooleanFromText,
 	type Room,
+	resolveFirstPartyInteractionProfile,
 	resolveStateDir,
 	type SendHandlerOutcome,
 	type SendHandlerPersistence,
@@ -3794,6 +3795,14 @@ export class DiscordService extends Service implements IDiscordService {
 							defaultAccountId,
 							...(accountId ? { accountId } : {}),
 						},
+						resolveInteractionProfile: (target, context) =>
+							resolveFirstPartyInteractionProfile({
+								source: "discord",
+								defaultAccountId,
+								defaultTargetKind: "channel",
+								target: scopedTarget(target),
+								accountId: accountId ?? context.accountId,
+							}),
 						resolveTargets: (query, context) =>
 							serviceInstance.resolveConnectorTargets(
 								query,

--- a/plugins/plugin-google-workspace/src/chat/service.ts
+++ b/plugins/plugin-google-workspace/src/chat/service.ts
@@ -21,6 +21,8 @@ import {
   type MessageConnectorChatContext,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
+  renderContentInteractionsForConnector,
+  resolveFirstPartyInteractionProfile,
   Service,
   type TargetInfo,
   toWellFormedUnicode,
@@ -340,6 +342,14 @@ export class GoogleChatService extends Service implements IGoogleChatService {
           accountId,
           service: GOOGLE_CHAT_SERVICE_NAME,
         },
+        resolveInteractionProfile: (target, context) =>
+          resolveFirstPartyInteractionProfile({
+            source: GOOGLE_CHAT_SERVICE_NAME,
+            defaultAccountId: accountId,
+            defaultTargetKind: "room",
+            target,
+            accountId: context.accountId,
+          }),
         sendHandler,
         resolveTargets: async (query) => {
           const directUser = normalizeUserTarget(query);
@@ -1022,7 +1032,7 @@ export class GoogleChatService extends Service implements IGoogleChatService {
     target?: TargetInfo,
     accountId?: string
   ): Promise<void> {
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = renderContentInteractionsForConnector(this.runtime, content).text.trim();
     const options = googleChatOptionsFromContent(space, { ...content, text }, target);
     if (!options.text && (!options.attachments || options.attachments.length === 0)) {
       return;

--- a/plugins/plugin-google-workspace/src/gmail-message-connector.ts
+++ b/plugins/plugin-google-workspace/src/gmail-message-connector.ts
@@ -26,6 +26,8 @@ import {
   type IAgentRuntime,
   type MessageConnectorRegistration,
   type MessageConnectorTarget,
+  renderContentInteractionsForConnector,
+  resolveFirstPartyInteractionProfile,
   type SendHandlerOutcome,
   type TargetInfo,
   toWellFormedUnicode,
@@ -259,11 +261,11 @@ async function sendGmailFromTarget(
     return account.error;
   }
 
-  const bodyText = String(content.text ?? "");
+  const bodyText = renderContentInteractionsForConnector(runtime, content).text;
   const sent = await service.sendGmailMessage({
     accountId: account.accountId,
     to: [recipient],
-    subject: subjectFromContent(content),
+    subject: subjectFromContent({ ...content, text: bodyText }),
     bodyText,
   });
 
@@ -304,6 +306,14 @@ export function createGmailMessageConnector(_runtime: IAgentRuntime): MessageCon
       aliases: ["email", "mail", "google mail"],
       service: GOOGLE_SERVICE_NAME,
     },
+    resolveInteractionProfile: (target, context) =>
+      resolveFirstPartyInteractionProfile({
+        source: GMAIL_MESSAGE_SOURCE,
+        defaultAccountId: context.accountId ?? target.accountId ?? "",
+        defaultTargetKind: "email",
+        target,
+        accountId: context.accountId,
+      }),
     resolveTargets: async (query): Promise<MessageConnectorTarget[]> => {
       const literal = emailLiteral(query);
       if (!literal) return [];

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -33,6 +33,7 @@ import {
   type MessageConnectorUserContext,
   readResponseWithLimit,
   resolveAttachmentBytes,
+  resolveFirstPartyInteractionProfile,
   Service,
   ServiceType,
   type TargetInfo,
@@ -703,6 +704,13 @@ export class IMessageService extends Service implements IIMessageService {
         accountSemantics: "local-macos-messages-single-account",
         status: statusMetadata(service.getStatus()),
       },
+      resolveInteractionProfile: (target) =>
+        resolveFirstPartyInteractionProfile({
+          source: "imessage",
+          defaultAccountId: IMESSAGE_LOCAL_ACCOUNT_ID,
+          defaultTargetKind: "user",
+          target,
+        }),
       sendHandler: async (_runtime: IAgentRuntime, target: TargetInfo, content: Content) => {
         const accountId = assertLocalIMessageAccount(readTargetAccountId(target));
         const text = renderIMessageInteractionText(content, resolveInteractionAppBaseUrl(runtime));

--- a/plugins/plugin-instagram/src/service.ts
+++ b/plugins/plugin-instagram/src/service.ts
@@ -21,6 +21,8 @@ import {
   type MessageConnectorQueryContext,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
+  renderContentInteractionsForConnector,
+  resolveFirstPartyInteractionProfile,
   Service,
   stringToUuid,
   type TargetInfo,
@@ -253,6 +255,14 @@ export class InstagramService extends Service {
           service: INSTAGRAM_SERVICE_NAME,
           maxMessageLength: MAX_DM_LENGTH,
         },
+        resolveInteractionProfile: (target, context) =>
+          resolveFirstPartyInteractionProfile({
+            source: "instagram",
+            defaultAccountId: accountId,
+            defaultTargetKind: "thread",
+            target,
+            accountId: context.accountId,
+          }),
         resolveTargets: serviceInstance.resolveConnectorTargets.bind(serviceInstance),
         listRecentTargets: serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
         listRooms: serviceInstance.listConnectorRooms.bind(serviceInstance),
@@ -665,7 +675,7 @@ export class InstagramService extends Service {
       throw new Error("Instagram service is not running");
     }
 
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = renderContentInteractionsForConnector(runtime, content).text.trim();
     if (!text) {
       throw new Error("Instagram DM connector requires non-empty text content.");
     }

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -23,7 +23,9 @@ import {
   type Memory,
   type MessageConnectorChatContext,
   type MessageConnectorTarget,
+  renderContentInteractionsForConnector,
   resolveAliasedEnvValue,
+  resolveFirstPartyInteractionProfile,
   Service,
   type TargetInfo,
   type UUID,
@@ -656,6 +658,14 @@ export class MatrixService extends Service implements IMatrixService {
           accountId,
           service: MATRIX_SERVICE_NAME,
         },
+        resolveInteractionProfile: (target, context) =>
+          resolveFirstPartyInteractionProfile({
+            source: "matrix",
+            defaultAccountId: accountId,
+            defaultTargetKind: "room",
+            target,
+            accountId: context.accountId,
+          }),
         sendHandler,
         resolveTargets: async (query) => {
           const rooms = await service.getJoinedRooms(accountId);
@@ -1766,7 +1776,7 @@ export class MatrixService extends Service implements IMatrixService {
   }
 
   async sendRoomMessage(roomIdOrAlias: string, content: Content): Promise<void> {
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = renderContentInteractionsForConnector(this.runtime, content).text.trim();
     if (!text) {
       return;
     }
@@ -1790,7 +1800,7 @@ export class MatrixService extends Service implements IMatrixService {
     );
     this.getState(requestedAccountId);
 
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = renderContentInteractionsForConnector(runtime, content).text.trim();
     if (!text) {
       return;
     }

--- a/plugins/plugin-slack/src/interactions.test.ts
+++ b/plugins/plugin-slack/src/interactions.test.ts
@@ -4,9 +4,22 @@
  * handed to it and every semantic fallback before network dispatch.
  */
 
-import type { Content, InteractionBlock } from "@elizaos/core";
+import {
+  decodePreparedInteractionCallback,
+  type Content,
+  type InteractionBlock,
+  type PreparedMessageInteraction,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { renderSlackInteractions } from "./interactions";
+import { renderPreparedSlackInteraction, renderSlackInteractions } from "./interactions";
+
+const prepared = (block: InteractionBlock): PreparedMessageInteraction => ({
+  block,
+  callbackData: "is1:0123456789abcdef0123456789abcdef",
+  delivery: { mode: "native", reason: "preferred", limitations: [] },
+  expiresAt: "2026-08-21T00:10:00.000Z",
+  profileId: "profile-a",
+});
 
 const blocks: InteractionBlock[] = [
   {
@@ -49,17 +62,26 @@ describe("Slack canonical interaction adapter", () => {
               : undefined,
       }),
     );
-    expect(outcomes.map((outcome) => outcome.outcome)).toEqual([
-      "native",
-      "native",
-      "fallback",
-      "native",
-      "native",
-    ]);
+    expect(outcomes.every((outcome) => outcome.outcome === "fallback")).toBe(true);
     expect(outcomes[2]?.text).toContain("Reply with your answer");
     expect(outcomes[4]?.text).not.toContain("oauth");
     expect(JSON.stringify(outcomes)).not.toContain("[CHOICE:");
     expect(JSON.stringify(outcomes)).not.toContain("[FORM]");
+  });
+
+  it("renders host-prepared authority with provider-valid Block Kit keys", () => {
+    const out = renderPreparedSlackInteraction(prepared(blocks[0]));
+    expect(out.outcome).toBe("native");
+    expect(out.blocks[0]?.elements?.[0]).toMatchObject({
+      action_id: "eliza_prepared_interaction_0",
+    });
+    const wire = out.blocks[0]?.elements?.[0]?.value;
+    expect(decodePreparedInteractionCallback(wire)).toEqual({
+      callbackData: "is1:0123456789abcdef0123456789abcdef",
+      response: { value: "yes" },
+    });
+    expect(JSON.stringify(out)).not.toContain("authorization");
+    expect(JSON.stringify(out)).not.toContain("effect");
   });
 
   it("surfaces provider overflow as actionable prose", () => {
@@ -71,7 +93,7 @@ describe("Slack canonical interaction adapter", () => {
       text: "",
       interactions: [{ kind: "choice", id: "large", scope: "pick", options }],
     } as Content);
-    expect(out.blocks).toHaveLength(50);
+    expect(out.blocks).toHaveLength(0);
     expect(out.outcome).toBe("fallback");
     expect(out.needsFreeTextReply).toBe(true);
     expect(out.text).toContain("Option 259");

--- a/plugins/plugin-slack/src/interactions.test.ts
+++ b/plugins/plugin-slack/src/interactions.test.ts
@@ -5,13 +5,16 @@
  */
 
 import {
-  decodePreparedInteractionCallback,
   type Content,
+  decodePreparedInteractionCallback,
   type InteractionBlock,
   type PreparedMessageInteraction,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { renderPreparedSlackInteraction, renderSlackInteractions } from "./interactions";
+import {
+  renderPreparedSlackInteraction,
+  renderSlackInteractions,
+} from "./interactions";
 
 const prepared = (block: InteractionBlock): PreparedMessageInteraction => ({
   block,
@@ -62,7 +65,9 @@ describe("Slack canonical interaction adapter", () => {
               : undefined,
       }),
     );
-    expect(outcomes.every((outcome) => outcome.outcome === "fallback")).toBe(true);
+    expect(outcomes.every((outcome) => outcome.outcome === "fallback")).toBe(
+      true,
+    );
     expect(outcomes[2]?.text).toContain("Reply with your answer");
     expect(outcomes[4]?.text).not.toContain("oauth");
     expect(JSON.stringify(outcomes)).not.toContain("[CHOICE:");

--- a/plugins/plugin-slack/src/interactions.test.ts
+++ b/plugins/plugin-slack/src/interactions.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Deterministic contract tests for Slack's canonical interaction projection.
+ * The provider client is not mocked; these assert the exact Block Kit payload
+ * handed to it and every semantic fallback before network dispatch.
+ */
+
+import type { Content, InteractionBlock } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { renderSlackInteractions } from "./interactions";
+
+const blocks: InteractionBlock[] = [
+  {
+    kind: "choice",
+    id: "choice-1",
+    scope: "approve",
+    options: [{ value: "yes", label: "Approve" }],
+  },
+  {
+    kind: "followups",
+    id: "followup-1",
+    options: [{ kind: "reply", payload: "next", label: "Next" }],
+  },
+  {
+    kind: "form",
+    id: "form-1",
+    title: "Details",
+    fields: [{ name: "name", type: "text", required: true }],
+  },
+  { kind: "task", threadId: "12345678", title: "Track task" },
+  {
+    kind: "secret",
+    id: "secret-1",
+    secretKind: "oauth",
+    provider: "Example",
+    reason: "Connect Example",
+    url: "https://secure.example/connect",
+  },
+];
+
+describe("Slack canonical interaction adapter", () => {
+  it("has explicit safe behavior for every canonical block kind", () => {
+    const outcomes = blocks.map((block) =>
+      renderSlackInteractions({ text: "", interactions: [block] } as Content, {
+        resolveUrl: (candidate) =>
+          candidate.kind === "task"
+            ? `https://app.example/task/${candidate.threadId}`
+            : candidate.kind === "secret"
+              ? candidate.url
+              : undefined,
+      }),
+    );
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual([
+      "native",
+      "native",
+      "fallback",
+      "native",
+      "native",
+    ]);
+    expect(outcomes[2]?.text).toContain("Reply with your answer");
+    expect(outcomes[4]?.text).not.toContain("oauth");
+    expect(JSON.stringify(outcomes)).not.toContain("[CHOICE:");
+    expect(JSON.stringify(outcomes)).not.toContain("[FORM]");
+  });
+
+  it("surfaces provider overflow as actionable prose", () => {
+    const options = Array.from({ length: 260 }, (_, index) => ({
+      value: `value-${index}`,
+      label: `Option ${index}`,
+    }));
+    const out = renderSlackInteractions({
+      text: "",
+      interactions: [{ kind: "choice", id: "large", scope: "pick", options }],
+    } as Content);
+    expect(out.blocks).toHaveLength(50);
+    expect(out.outcome).toBe("fallback");
+    expect(out.needsFreeTextReply).toBe(true);
+    expect(out.text).toContain("Option 259");
+  });
+});

--- a/plugins/plugin-slack/src/interactions.ts
+++ b/plugins/plugin-slack/src/interactions.ts
@@ -1,0 +1,148 @@
+/**
+ * Projects canonical interaction blocks onto Slack Block Kit action elements.
+ * Unsupported blocks remain actionable prose, and every marker is stripped
+ * before either the accessibility fallback or visible message is returned.
+ */
+
+import {
+  buildInteractionUrlResolver,
+  type Content,
+  type IAgentRuntime,
+  type InteractionBlock,
+  type NeutralButton,
+  parseInteractionBlocks,
+  stripDashboardOnlyMarkers,
+  toNeutralLayout,
+} from "@elizaos/core";
+import type { SlackBlock } from "./types";
+
+const MAX_BUTTONS_PER_ACTIONS_BLOCK = 5;
+const MAX_BLOCKS_PER_MESSAGE = 50;
+const MAX_CALLBACK_BYTES = 2_000;
+
+export interface SlackInteractionRender {
+  text: string;
+  blocks: SlackBlock[];
+  needsFreeTextReply: boolean;
+  outcome: "plain" | "native" | "fallback";
+}
+
+export interface SlackInteractionOptions {
+  resolveUrl?: (block: InteractionBlock) => string | undefined;
+  resolveNavigateUrl?: (payload: string) => string | undefined;
+}
+
+function slackButton(button: NeutralButton, index: number) {
+  if (!button.url && !button.callbackData) return null;
+  return {
+    type: "button",
+    text: {
+      type: "plain_text",
+      text: button.label,
+      emoji: true,
+      verbatim: undefined,
+    },
+    actionId: `eliza_interaction_${index}`,
+    url: button.url,
+    value: button.callbackData,
+    style:
+      button.style === "danger"
+        ? "danger"
+        : button.style === "primary"
+          ? "primary"
+          : undefined,
+  };
+}
+
+/** Render one outbound content value to provider-valid Block Kit. */
+export function renderSlackInteractions(
+  content: Content,
+  options: SlackInteractionOptions = {},
+): SlackInteractionRender {
+  const { blocks: interactions, cleanedText } = parseInteractionBlocks(
+    content.text ?? "",
+  );
+  const sourceBlocks = content.interactions?.length
+    ? content.interactions
+    : interactions;
+  if (sourceBlocks.length === 0) {
+    return {
+      text: cleanedText,
+      blocks: [],
+      needsFreeTextReply: false,
+      outcome: "plain",
+    };
+  }
+
+  const blocks: SlackBlock[] = [];
+  const fallback: string[] = [];
+  let needsFreeTextReply = false;
+  let actionIndex = 0;
+
+  for (const interaction of sourceBlocks) {
+    const layout = toNeutralLayout(interaction, {
+      ...options,
+      maxButtonsPerRow: MAX_BUTTONS_PER_ACTIONS_BLOCK,
+      maxCallbackBytes: MAX_CALLBACK_BYTES,
+    });
+    let rendered = false;
+    for (const row of layout.rows) {
+      const rowButtons = row.buttons ?? [];
+      const elements = rowButtons
+        .map((button) => slackButton(button, actionIndex++))
+        .filter(
+          (button): button is NonNullable<typeof button> => button !== null,
+        );
+      if (elements.length === 0) continue;
+      if (blocks.length >= MAX_BLOCKS_PER_MESSAGE) {
+        fallback.push(
+          ...rowButtons.map((button) =>
+            button.url ? `${button.label} (${button.url})` : button.label,
+          ),
+        );
+        needsFreeTextReply = true;
+        continue;
+      }
+      blocks.push({
+        type: "actions",
+        blockId: undefined,
+        elements,
+        text: undefined,
+      });
+      rendered = true;
+    }
+    if (layout.needsFallback) needsFreeTextReply = true;
+    if (!rendered && layout.text) fallback.push(layout.text);
+  }
+
+  const text = stripDashboardOnlyMarkers(
+    [cleanedText, ...fallback].filter((part) => part.trim()).join("\n\n"),
+  );
+  return {
+    text,
+    blocks,
+    needsFreeTextReply,
+    outcome:
+      blocks.length > 0
+        ? needsFreeTextReply
+          ? "fallback"
+          : "native"
+        : "fallback",
+  };
+}
+
+/** Resolve task/auth links from the configured app origin for the send path. */
+export function buildSlackInteractionPayload(
+  runtime: Pick<IAgentRuntime, "getSetting">,
+  content: Content,
+): SlackInteractionRender {
+  const rawAppUrl =
+    runtime.getSetting("ELIZA_APP_URL") ??
+    runtime.getSetting("ELIZA_CLOUD_URL");
+  return renderSlackInteractions(
+    content,
+    buildInteractionUrlResolver(
+      typeof rawAppUrl === "string" ? rawAppUrl : undefined,
+    ),
+  );
+}

--- a/plugins/plugin-slack/src/interactions.ts
+++ b/plugins/plugin-slack/src/interactions.ts
@@ -7,12 +7,13 @@
 import {
   buildInteractionUrlResolver,
   type Content,
+  encodePreparedInteractionCallback,
   type IAgentRuntime,
   type InteractionBlock,
-  type NeutralButton,
+  type PreparedMessageInteraction,
   parseInteractionBlocks,
+  renderContentInteractionsAsPlainText,
   stripDashboardOnlyMarkers,
-  toNeutralLayout,
 } from "@elizaos/core";
 import type { SlackBlock } from "./types";
 
@@ -32,25 +33,25 @@ export interface SlackInteractionOptions {
   resolveNavigateUrl?: (payload: string) => string | undefined;
 }
 
-function slackButton(button: NeutralButton, index: number) {
-  if (!button.url && !button.callbackData) return null;
+function slackButton(args: {
+  label: string;
+  value?: string;
+  url?: string;
+  index: number;
+}) {
+  if (!args.url && !args.value) return null;
   return {
     type: "button",
     text: {
       type: "plain_text",
-      text: button.label,
+      text: args.label,
       emoji: true,
       verbatim: undefined,
     },
-    actionId: `eliza_interaction_${index}`,
-    url: button.url,
-    value: button.callbackData,
-    style:
-      button.style === "danger"
-        ? "danger"
-        : button.style === "primary"
-          ? "primary"
-          : undefined,
+    action_id: `eliza_prepared_interaction_${args.index}`,
+    url: args.url,
+    value: args.value,
+    style: undefined,
   };
 }
 
@@ -74,60 +75,74 @@ export function renderSlackInteractions(
     };
   }
 
-  const blocks: SlackBlock[] = [];
-  const fallback: string[] = [];
-  let needsFreeTextReply = false;
-  let actionIndex = 0;
-
-  for (const interaction of sourceBlocks) {
-    const layout = toNeutralLayout(interaction, {
-      ...options,
-      maxButtonsPerRow: MAX_BUTTONS_PER_ACTIONS_BLOCK,
-      maxCallbackBytes: MAX_CALLBACK_BYTES,
-    });
-    let rendered = false;
-    for (const row of layout.rows) {
-      const rowButtons = row.buttons ?? [];
-      const elements = rowButtons
-        .map((button) => slackButton(button, actionIndex++))
-        .filter(
-          (button): button is NonNullable<typeof button> => button !== null,
-        );
-      if (elements.length === 0) continue;
-      if (blocks.length >= MAX_BLOCKS_PER_MESSAGE) {
-        fallback.push(
-          ...rowButtons.map((button) =>
-            button.url ? `${button.label} (${button.url})` : button.label,
-          ),
-        );
-        needsFreeTextReply = true;
-        continue;
-      }
-      blocks.push({
-        type: "actions",
-        blockId: undefined,
-        elements,
-        text: undefined,
-      });
-      rendered = true;
-    }
-    if (layout.needsFallback) needsFreeTextReply = true;
-    if (!rendered && layout.text) fallback.push(layout.text);
-  }
-
-  const text = stripDashboardOnlyMarkers(
-    [cleanedText, ...fallback].filter((part) => part.trim()).join("\n\n"),
-  );
+  const text = renderContentInteractionsAsPlainText(content, options).text;
   return {
     text,
-    blocks,
-    needsFreeTextReply,
-    outcome:
-      blocks.length > 0
-        ? needsFreeTextReply
-          ? "fallback"
-          : "native"
-        : "fallback",
+    blocks: [],
+    needsFreeTextReply: true,
+    outcome: "fallback",
+  };
+}
+
+/** Render only host-prepared authority as provider-native Block Kit controls. */
+export function renderPreparedSlackInteraction(
+  prepared: PreparedMessageInteraction,
+  options: SlackInteractionOptions = {},
+): SlackInteractionRender {
+  const block = prepared.block;
+  if (prepared.delivery.mode !== "native") {
+    return {
+      text: renderContentInteractionsAsPlainText({ interactions: [block] }, options).text,
+      blocks: [],
+      needsFreeTextReply: true,
+      outcome: "fallback",
+    };
+  }
+  const optionsToRender =
+    block.kind === "choice"
+      ? block.options.map((option) => ({ label: option.label, value: option.value }))
+      : block.kind === "followups"
+        ? block.options
+            .filter((option) => option.kind !== "navigate")
+            .map((option) => ({ label: option.label, value: option.payload }))
+        : [];
+  const elements = optionsToRender
+    .map((option, index) => {
+      const value = encodePreparedInteractionCallback(
+        prepared.callbackData,
+        { value: option.value },
+        MAX_CALLBACK_BYTES,
+      );
+      return value ? slackButton({ label: option.label, value, index }) : null;
+    })
+    .filter((value): value is NonNullable<typeof value> => value !== null);
+  if (elements.length !== optionsToRender.length || elements.length === 0) {
+    return {
+      text: renderContentInteractionsAsPlainText({ interactions: [block] }, options).text,
+      blocks: [],
+      needsFreeTextReply: true,
+      outcome: "fallback",
+    };
+  }
+  const rows = Array.from(
+    { length: Math.ceil(elements.length / MAX_BUTTONS_PER_ACTIONS_BLOCK) },
+    (_, index) => elements.slice(index * MAX_BUTTONS_PER_ACTIONS_BLOCK, (index + 1) * MAX_BUTTONS_PER_ACTIONS_BLOCK),
+  );
+  if (rows.length > MAX_BLOCKS_PER_MESSAGE) {
+    return {
+      text: renderContentInteractionsAsPlainText({ interactions: [block] }, options).text,
+      blocks: [],
+      needsFreeTextReply: true,
+      outcome: "fallback",
+    };
+  }
+  return {
+    text: stripDashboardOnlyMarkers(
+      block.kind === "choice" ? block.prompt ?? "Choose an option." : "Choose an option.",
+    ),
+    blocks: rows.map((row) => ({ type: "actions", elements: row, text: undefined })),
+    needsFreeTextReply: false,
+    outcome: "native",
   };
 }
 

--- a/plugins/plugin-slack/src/interactions.ts
+++ b/plugins/plugin-slack/src/interactions.ts
@@ -90,9 +90,42 @@ export function renderPreparedSlackInteraction(
   options: SlackInteractionOptions = {},
 ): SlackInteractionRender {
   const block = prepared.block;
+  const hostedUrl =
+    prepared.hostedUrl ?? (block.kind === "secret" ? block.url : undefined);
+  if (hostedUrl) {
+    const label =
+      block.kind === "form"
+        ? (block.submitLabel ?? "Open form")
+        : block.kind === "task"
+          ? "Open task"
+          : block.kind === "secret"
+            ? block.secretKind === "oauth"
+              ? `Connect ${block.provider ?? "account"}`
+              : (block.submitLabel ?? "Provide securely")
+            : "Open";
+    const button = slackButton({ label, url: hostedUrl, index: 0 });
+    return {
+      text:
+        block.kind === "task"
+          ? block.title
+          : block.kind === "form"
+            ? (block.title ?? block.description ?? label)
+            : block.kind === "secret"
+              ? (block.reason ?? label)
+              : label,
+      blocks: button
+        ? [{ type: "actions", elements: [button], text: undefined }]
+        : [],
+      needsFreeTextReply: false,
+      outcome: "native",
+    };
+  }
   if (prepared.delivery.mode !== "native") {
     return {
-      text: renderContentInteractionsAsPlainText({ interactions: [block] }, options).text,
+      text: renderContentInteractionsAsPlainText(
+        { interactions: [block] },
+        options,
+      ).text,
       blocks: [],
       needsFreeTextReply: true,
       outcome: "fallback",
@@ -100,7 +133,10 @@ export function renderPreparedSlackInteraction(
   }
   const optionsToRender =
     block.kind === "choice"
-      ? block.options.map((option) => ({ label: option.label, value: option.value }))
+      ? block.options.map((option) => ({
+          label: option.label,
+          value: option.value,
+        }))
       : block.kind === "followups"
         ? block.options
             .filter((option) => option.kind !== "navigate")
@@ -118,7 +154,10 @@ export function renderPreparedSlackInteraction(
     .filter((value): value is NonNullable<typeof value> => value !== null);
   if (elements.length !== optionsToRender.length || elements.length === 0) {
     return {
-      text: renderContentInteractionsAsPlainText({ interactions: [block] }, options).text,
+      text: renderContentInteractionsAsPlainText(
+        { interactions: [block] },
+        options,
+      ).text,
       blocks: [],
       needsFreeTextReply: true,
       outcome: "fallback",
@@ -126,11 +165,18 @@ export function renderPreparedSlackInteraction(
   }
   const rows = Array.from(
     { length: Math.ceil(elements.length / MAX_BUTTONS_PER_ACTIONS_BLOCK) },
-    (_, index) => elements.slice(index * MAX_BUTTONS_PER_ACTIONS_BLOCK, (index + 1) * MAX_BUTTONS_PER_ACTIONS_BLOCK),
+    (_, index) =>
+      elements.slice(
+        index * MAX_BUTTONS_PER_ACTIONS_BLOCK,
+        (index + 1) * MAX_BUTTONS_PER_ACTIONS_BLOCK,
+      ),
   );
   if (rows.length > MAX_BLOCKS_PER_MESSAGE) {
     return {
-      text: renderContentInteractionsAsPlainText({ interactions: [block] }, options).text,
+      text: renderContentInteractionsAsPlainText(
+        { interactions: [block] },
+        options,
+      ).text,
       blocks: [],
       needsFreeTextReply: true,
       outcome: "fallback",
@@ -138,9 +184,15 @@ export function renderPreparedSlackInteraction(
   }
   return {
     text: stripDashboardOnlyMarkers(
-      block.kind === "choice" ? block.prompt ?? "Choose an option." : "Choose an option.",
+      block.kind === "choice"
+        ? (block.prompt ?? "Choose an option.")
+        : "Choose an option.",
     ),
-    blocks: rows.map((row) => ({ type: "actions", elements: row, text: undefined })),
+    blocks: rows.map((row) => ({
+      type: "actions",
+      elements: row,
+      text: undefined,
+    })),
     needsFreeTextReply: false,
     outcome: "native",
   };

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -27,6 +27,7 @@ import {
   type Content,
   checkPairingAllowed,
   createUniqueUuid,
+  decodeCallback,
   ElizaError,
   type EventPayload,
   EventType,
@@ -44,6 +45,7 @@ import {
   type MessagePayload,
   type Room,
   resolveAttachmentBytes,
+  resolveFirstPartyInteractionProfile,
   Service,
   stringToUuid,
   type TargetInfo,
@@ -414,6 +416,7 @@ import {
   resolveDefaultSlackAccountId,
 } from "./accounts";
 import { markdownToSlackMrkdwn, splitSlackText } from "./formatting";
+import { buildSlackInteractionPayload } from "./interactions";
 import {
   extractSlackEventWorkspace,
   SlackAccountPolicyResolver,
@@ -645,6 +648,14 @@ export class SlackService extends Service implements ISlackService {
           maxMessageLength: MAX_SLACK_MESSAGE_LENGTH,
           ...(normalizedAccountId ? { accountId: normalizedAccountId } : {}),
         },
+        resolveInteractionProfile: (target, context) =>
+          resolveFirstPartyInteractionProfile({
+            source: "slack",
+            defaultAccountId: normalizedAccountId ?? DEFAULT_ACCOUNT_ID,
+            defaultTargetKind: "channel",
+            target,
+            accountId: normalizedAccountId ?? context.accountId,
+          }),
         resolveTargets: (query, context) =>
           serviceInstance.resolveConnectorTargets(
             query,
@@ -977,6 +988,45 @@ export class SlackService extends Service implements ISlackService {
       }
       await this.handleMessage(
         message as SlackMessageEventType,
+        client,
+        accountId,
+        body,
+      );
+    });
+
+    app.action(/^eliza_interaction_/, async ({ action, ack, body, client }) => {
+      await ack();
+      const actionRecord = action as { value?: unknown };
+      const bodyRecord = body as {
+        user?: { id?: unknown };
+        channel?: { id?: unknown };
+        message?: { ts?: unknown; thread_ts?: unknown };
+      };
+      const decoded = decodeCallback(actionRecord.value);
+      const userId =
+        typeof bodyRecord.user?.id === "string" ? bodyRecord.user.id : "";
+      const channelId =
+        typeof bodyRecord.channel?.id === "string" ? bodyRecord.channel.id : "";
+      const messageTs =
+        typeof bodyRecord.message?.ts === "string" ? bodyRecord.message.ts : "";
+      if (!decoded || !userId || !channelId || !messageTs) {
+        this.runtime.logger.warn(
+          { src: "plugin:slack", accountId, channelId, userId },
+          "Ignoring malformed Slack interaction callback",
+        );
+        return;
+      }
+      await this.handleMessage(
+        {
+          channel: channelId,
+          user: userId,
+          text: decoded.value,
+          ts: messageTs,
+          thread_ts:
+            typeof bodyRecord.message?.thread_ts === "string"
+              ? bodyRecord.message.thread_ts
+              : undefined,
+        } as SlackMessageEventType,
         client,
         accountId,
         body,
@@ -2587,7 +2637,8 @@ export class SlackService extends Service implements ISlackService {
       throw new Error("Slack client not initialized");
     }
 
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const interactionPayload = buildSlackInteractionPayload(runtime, content);
+    const text = interactionPayload.text.trim();
     const outboundAttachments = Array.isArray(content.attachments)
       ? content.attachments.filter((media) => Boolean(media?.url))
       : [];
@@ -2633,21 +2684,39 @@ export class SlackService extends Service implements ISlackService {
       );
     }
 
-    if (text) {
-      await this.sendMessage(
-        channelId,
-        text,
-        {
-          threadTs,
-          replyBroadcast: undefined,
-          unfurlLinks: undefined,
-          unfurlMedia: undefined,
-          mrkdwn: undefined,
-          attachments: undefined,
-          blocks: undefined,
-        },
-        accountId,
-      );
+    if (text || interactionPayload.blocks.length > 0) {
+      try {
+        await this.sendMessage(
+          channelId,
+          text || "Choose an option.",
+          {
+            threadTs,
+            replyBroadcast: undefined,
+            unfurlLinks: undefined,
+            unfurlMedia: undefined,
+            mrkdwn: undefined,
+            attachments: undefined,
+            blocks:
+              interactionPayload.blocks.length > 0
+                ? interactionPayload.blocks
+                : undefined,
+          },
+          accountId,
+        );
+      } catch (cause) {
+        if (interactionPayload.blocks.length === 0) throw cause;
+        // error-policy:J2 Preserve provider rejection while identifying the
+        // interaction-specific delivery boundary for an actionable fallback.
+        throw new ElizaError("Slack rejected the native interaction payload.", {
+          code: "SLACK_INTERACTION_PROVIDER_REJECTED",
+          context: {
+            accountId,
+            channelId,
+            outcome: interactionPayload.outcome,
+          },
+          cause,
+        });
+      }
     }
 
     if (outboundAttachments.length > 0) {
@@ -3678,7 +3747,7 @@ export class SlackService extends Service implements ISlackService {
     let lastTs = "";
     const sentMessages: Array<{ ts: string; text: string }> = [];
 
-    for (const msg of messages) {
+    for (const [messageIndex, msg] of messages.entries()) {
       type SlackPostMessageArgs = Parameters<
         typeof client.chat.postMessage
       >[0] & {
@@ -3705,7 +3774,7 @@ export class SlackService extends Service implements ISlackService {
       if (options?.attachments) {
         messageArgs.attachments = options.attachments;
       }
-      if (options?.blocks) {
+      if (options?.blocks && messageIndex === messages.length - 1) {
         messageArgs.blocks = options.blocks;
       }
 

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -39,6 +39,7 @@ import {
   type Memory,
   type MessageConnectorChatContext,
   type MessageConnectorQueryContext,
+  type MessageConnectorPreparedInteractionParams,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
   type MessageMetadata,
@@ -416,7 +417,10 @@ import {
   resolveDefaultSlackAccountId,
 } from "./accounts";
 import { markdownToSlackMrkdwn, splitSlackText } from "./formatting";
-import { buildSlackInteractionPayload } from "./interactions";
+import {
+  buildSlackInteractionPayload,
+  renderPreparedSlackInteraction,
+} from "./interactions";
 import {
   extractSlackEventWorkspace,
   SlackAccountPolicyResolver,
@@ -656,6 +660,8 @@ export class SlackService extends Service implements ISlackService {
             target,
             accountId: normalizedAccountId ?? context.accountId,
           }),
+        sendPreparedInteraction: (handlerRuntime, params) =>
+          serviceInstance.handleSendPreparedInteraction(handlerRuntime, params),
         resolveTargets: (query, context) =>
           serviceInstance.resolveConnectorTargets(
             query,
@@ -2727,6 +2733,53 @@ export class SlackService extends Service implements ISlackService {
         accountId,
       );
     }
+  }
+
+  async handleSendPreparedInteraction(
+    runtime: IAgentRuntime,
+    params: MessageConnectorPreparedInteractionParams,
+  ): Promise<void> {
+    const { target, interaction } = params;
+    const accountId = await this.resolveAccountIdForTarget(runtime, target);
+    let channelId = target.channelId;
+    let threadTs = target.threadId;
+    if (target.roomId && (!channelId || !threadTs)) {
+      const room = await runtime.getRoom(target.roomId);
+      channelId = channelId ?? room?.channelId;
+      const metadata = room?.metadata as Record<string, unknown> | undefined;
+      threadTs =
+        threadTs ??
+        (typeof metadata?.threadTs === "string" ? metadata.threadTs : undefined);
+    }
+    if (!channelId) {
+      throw new ElizaError("Slack prepared interaction requires a channel target.", {
+        code: "SLACK_INTERACTION_TARGET_UNAVAILABLE",
+      });
+    }
+    const rendered = renderPreparedSlackInteraction(interaction);
+    if (rendered.outcome !== "native") {
+      throw new ElizaError(
+        "Slack cannot render this prepared interaction natively; use the semantic text fallback.",
+        {
+          code: "SLACK_INTERACTION_NATIVE_UNAVAILABLE",
+          context: { limitations: interaction.delivery.limitations.join(",") },
+        },
+      );
+    }
+    await this.sendMessage(
+      channelId,
+      params.text?.trim() || rendered.text || "Choose an option.",
+      {
+        threadTs,
+        replyBroadcast: undefined,
+        unfurlLinks: undefined,
+        unfurlMedia: undefined,
+        mrkdwn: undefined,
+        attachments: undefined,
+        blocks: rendered.blocks,
+      },
+      accountId,
+    );
   }
 
   /**

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -26,8 +26,8 @@ import {
   type Character,
   type Content,
   checkPairingAllowed,
+  consumePreparedInteractionCallback,
   createUniqueUuid,
-  decodeCallback,
   ElizaError,
   type EventPayload,
   EventType,
@@ -38,8 +38,8 @@ import {
   type Media,
   type Memory,
   type MessageConnectorChatContext,
-  type MessageConnectorQueryContext,
   type MessageConnectorPreparedInteractionParams,
+  type MessageConnectorQueryContext,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
   type MessageMetadata,
@@ -1000,44 +1000,70 @@ export class SlackService extends Service implements ISlackService {
       );
     });
 
-    app.action(/^eliza_interaction_/, async ({ action, ack, body, client }) => {
-      await ack();
-      const actionRecord = action as { value?: unknown };
-      const bodyRecord = body as {
-        user?: { id?: unknown };
-        channel?: { id?: unknown };
-        message?: { ts?: unknown; thread_ts?: unknown };
-      };
-      const decoded = decodeCallback(actionRecord.value);
-      const userId =
-        typeof bodyRecord.user?.id === "string" ? bodyRecord.user.id : "";
-      const channelId =
-        typeof bodyRecord.channel?.id === "string" ? bodyRecord.channel.id : "";
-      const messageTs =
-        typeof bodyRecord.message?.ts === "string" ? bodyRecord.message.ts : "";
-      if (!decoded || !userId || !channelId || !messageTs) {
-        this.runtime.logger.warn(
-          { src: "plugin:slack", accountId, channelId, userId },
-          "Ignoring malformed Slack interaction callback",
-        );
-        return;
-      }
-      await this.handleMessage(
-        {
-          channel: channelId,
-          user: userId,
-          text: decoded.value,
-          ts: messageTs,
-          thread_ts:
-            typeof bodyRecord.message?.thread_ts === "string"
-              ? bodyRecord.message.thread_ts
-              : undefined,
-        } as SlackMessageEventType,
-        client,
-        accountId,
-        body,
-      );
-    });
+    app.action(
+      /^eliza_prepared_interaction_/,
+      async ({ action, ack, body }) => {
+        await ack();
+        if (
+          !this.isInboundWorkspaceAuthorized(accountId, body, "interaction")
+        ) {
+          return;
+        }
+        const actionRecord = action as { value?: unknown; action_ts?: unknown };
+        const bodyRecord = body as {
+          user?: { id?: unknown };
+          channel?: { id?: unknown };
+          message?: { ts?: unknown; thread_ts?: unknown };
+          trigger_id?: unknown;
+        };
+        const userId =
+          typeof bodyRecord.user?.id === "string" ? bodyRecord.user.id : "";
+        const channelId =
+          typeof bodyRecord.channel?.id === "string"
+            ? bodyRecord.channel.id
+            : "";
+        const inboundEventId =
+          typeof actionRecord.action_ts === "string"
+            ? actionRecord.action_ts
+            : typeof bodyRecord.trigger_id === "string"
+              ? bodyRecord.trigger_id
+              : "";
+        if (!userId || !channelId || !inboundEventId) {
+          this.runtime.logger.warn(
+            { src: "plugin:slack", accountId, channelId, userId },
+            "Ignoring malformed Slack interaction callback",
+          );
+          return;
+        }
+        const threadTs =
+          typeof bodyRecord.message?.thread_ts === "string"
+            ? bodyRecord.message.thread_ts
+            : undefined;
+        const roomId = await this.getRoomId(channelId, threadTs, accountId);
+        const outcome = await consumePreparedInteractionCallback(this.runtime, {
+          providerCallbackData: actionRecord.value,
+          bindings: {
+            actorId: this.getEntityId(userId, accountId),
+            audience: { kind: "room", id: roomId },
+            agentId: this.runtime.agentId,
+            connector: { source: "slack", accountId },
+            roomId,
+          },
+          providerReceipt: {
+            source: "slack",
+            accountId,
+            inboundEventId,
+            receivedAt: new Date().toISOString(),
+          },
+        });
+        if (outcome.status === "denied") {
+          this.runtime.logger.warn(
+            { src: "plugin:slack", accountId, channelId, code: outcome.code },
+            "Slack interaction callback was denied",
+          );
+        }
+      },
+    );
 
     // Handle app mentions
     app.event("app_mention", async ({ event, client, body }) => {
@@ -2749,12 +2775,17 @@ export class SlackService extends Service implements ISlackService {
       const metadata = room?.metadata as Record<string, unknown> | undefined;
       threadTs =
         threadTs ??
-        (typeof metadata?.threadTs === "string" ? metadata.threadTs : undefined);
+        (typeof metadata?.threadTs === "string"
+          ? metadata.threadTs
+          : undefined);
     }
     if (!channelId) {
-      throw new ElizaError("Slack prepared interaction requires a channel target.", {
-        code: "SLACK_INTERACTION_TARGET_UNAVAILABLE",
-      });
+      throw new ElizaError(
+        "Slack prepared interaction requires a channel target.",
+        {
+          code: "SLACK_INTERACTION_TARGET_UNAVAILABLE",
+        },
+      );
     }
     const rendered = renderPreparedSlackInteraction(interaction);
     if (rendered.outcome !== "native") {

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -242,7 +242,7 @@ interface SlackAttachmentField {
 
 export interface SlackBlock {
   type: string;
-  blockId: string | undefined;
+  block_id?: string;
   elements: SlackBlockElement[] | undefined;
   text: SlackBlockText | undefined;
 }
@@ -250,7 +250,7 @@ export interface SlackBlock {
 interface SlackBlockElement {
   type: string;
   text: SlackBlockText | undefined;
-  actionId: string | undefined;
+  action_id?: string;
   url: string | undefined;
   value: string | undefined;
   style: string | undefined;

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -4,14 +4,41 @@
  * and task cards link out or stay as text depending on the url resolver.
  * Deterministic; no live API.
  */
-import type { Content } from "@elizaos/core";
+import type { Content, PreparedMessageInteraction } from "@elizaos/core";
 import {
   buildInteractionUrlResolver,
   decodeCallback,
+  decodePreparedInteractionCallback,
   FORM_FREE_TEXT_INVITE,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { renderTelegramInteractions } from "./interactions";
+import {
+  renderPreparedTelegramInteraction,
+  renderTelegramInteractions,
+} from "./interactions";
+
+it("renders only host-prepared Telegram callbacks as canonical native controls", () => {
+  const prepared: PreparedMessageInteraction = {
+    block: {
+      kind: "choice",
+      id: "choice-a",
+      scope: "pick",
+      options: [{ value: "yes", label: "Yes" }],
+    },
+    callbackData: "is1:0123456789abcdef0123456789abcdef",
+    delivery: { mode: "native", reason: "preferred", limitations: [] },
+    expiresAt: "2026-08-22T01:00:00.000Z",
+    profileId: "profile-a",
+  };
+  const out = renderPreparedTelegramInteraction(prepared);
+  const button = out.keyboardRows[0]?.[0];
+  const callbackData =
+    button && "callback_data" in button ? button.callback_data : undefined;
+  expect(decodePreparedInteractionCallback(callbackData)).toEqual({
+    callbackData: prepared.callbackData,
+    response: { value: "yes" },
+  });
+});
 
 describe("renderTelegramInteractions", () => {
   it("passes plain replies through with no keyboard", () => {

--- a/plugins/plugin-telegram/src/interactions.ts
+++ b/plugins/plugin-telegram/src/interactions.ts
@@ -11,9 +11,12 @@
 
 import {
   type Content,
+  encodePreparedInteractionCallback,
   type InteractionBlock,
   type NeutralButton,
+  type PreparedMessageInteraction,
   parseInteractionBlocks,
+  renderContentInteractionsAsPlainText,
   stripDashboardOnlyMarkers,
   toNeutralLayout,
 } from "@elizaos/core";
@@ -103,4 +106,72 @@ export function renderTelegramInteractions(
       .join("\n\n"),
   );
   return { text, keyboardRows, needsFreeTextReply };
+}
+
+/** Render only host-prepared authority as Telegram inline-keyboard buttons. */
+export function renderPreparedTelegramInteraction(
+  prepared: PreparedMessageInteraction,
+): TelegramInteractionRender {
+  const block = prepared.block;
+  const fallback = renderContentInteractionsAsPlainText({
+    interactions: [block],
+  }).text;
+  const hostedUrl =
+    prepared.hostedUrl ?? (block.kind === "secret" ? block.url : undefined);
+  if (hostedUrl) {
+    const label =
+      block.kind === "form"
+        ? (block.submitLabel ?? "Open form")
+        : block.kind === "task"
+          ? "Open task"
+          : block.kind === "secret"
+            ? block.secretKind === "oauth"
+              ? `Connect ${block.provider ?? "account"}`
+              : (block.submitLabel ?? "Provide securely")
+            : "Open";
+    return {
+      text: block.kind === "task" ? block.title : fallback,
+      keyboardRows: [[Markup.button.url(label, hostedUrl)]],
+      needsFreeTextReply: false,
+    };
+  }
+  if (
+    prepared.delivery.mode !== "native" ||
+    (block.kind !== "choice" && block.kind !== "followups")
+  ) {
+    return { text: fallback, keyboardRows: [], needsFreeTextReply: true };
+  }
+  const providerOptions =
+    block.kind === "choice"
+      ? block.options.map((option) => ({
+          label: option.label,
+          value: option.value,
+        }))
+      : block.options
+          .filter((option) => option.kind !== "navigate")
+          .map((option) => ({ label: option.label, value: option.payload }));
+  const concrete: InlineKeyboardButton[] = [];
+  for (const option of providerOptions) {
+    const callbackData = encodePreparedInteractionCallback(
+      prepared.callbackData,
+      { value: option.value },
+      64,
+    );
+    if (!callbackData) {
+      return { text: fallback, keyboardRows: [], needsFreeTextReply: true };
+    }
+    concrete.push(Markup.button.callback(option.label, callbackData));
+  }
+  const keyboardRows: InlineKeyboardButton[][] = [];
+  for (let index = 0; index < concrete.length; index += MAX_BUTTONS_PER_ROW) {
+    keyboardRows.push(concrete.slice(index, index + MAX_BUTTONS_PER_ROW));
+  }
+  return {
+    text:
+      block.kind === "choice"
+        ? (block.prompt ?? "Choose an option.")
+        : "Choose an option.",
+    keyboardRows,
+    needsFreeTextReply: false,
+  };
 }

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -18,8 +18,10 @@ import {
   ChannelType,
   type Content,
   type ContentType,
+  consumePreparedInteractionCallback,
   createUniqueUuid,
   decodeCallback,
+  decodePreparedInteractionCallback,
   ElizaError,
   EventType,
   type HandlerCallback,
@@ -30,6 +32,7 @@ import {
   type Memory,
   type MessagePayload,
   ModelType,
+  type PreparedMessageInteraction,
   type ResolvedAttachmentBytes,
   resolveAttachmentBytes,
   ServiceType,
@@ -52,7 +55,10 @@ import {
   resolveTelegramRuntimeEntityId,
   telegramIdentityMetadata,
 } from "./identity";
-import { renderTelegramInteractions } from "./interactions";
+import {
+  renderPreparedTelegramInteraction,
+  renderTelegramInteractions,
+} from "./interactions";
 import {
   type TelegramContent,
   TelegramEventTypes,
@@ -1058,6 +1064,7 @@ export class MessageManager {
     content: TelegramContent,
     replyToMessageId?: number,
     messageThreadId?: number,
+    preparedInteraction?: PreparedMessageInteraction,
   ): Promise<Message.TextMessage[]> {
     if (content.attachments && content.attachments.length > 0) {
       await Promise.all(
@@ -1115,10 +1122,12 @@ export class MessageManager {
         this.runtime.getSetting("ELIZA_APP_URL") ||
         this.runtime.getSetting("ELIZA_CLOUD_URL");
       const appBaseUrl = typeof rawAppUrl === "string" ? rawAppUrl : undefined;
-      const rendered = renderTelegramInteractions(
-        content,
-        buildInteractionUrlResolver(appBaseUrl),
-      );
+      const rendered = preparedInteraction
+        ? renderPreparedTelegramInteraction(preparedInteraction)
+        : renderTelegramInteractions(
+            content,
+            buildInteractionUrlResolver(appBaseUrl),
+          );
       const sentMessages: Message.TextMessage[] = [];
 
       const telegramButtons = convertToTelegramButtons(content.buttons ?? []);
@@ -1866,12 +1875,10 @@ export class MessageManager {
   }
 
   /**
-   * Handle an inline-keyboard button tap whose payload was produced by the
-   * shared interaction codec (a choice or followup answer). The chosen value is
-   * replayed as an ordinary user turn — mirroring the dashboard's "send the
-   * chosen value as a message" behavior — so downstream routing (choice scopes,
-   * orchestrator turns) is identical across surfaces. Foreign callbacks are
-   * acknowledged and ignored.
+   * Authenticate host-prepared inline-keyboard callbacks and route them to the
+   * sole interaction authority. Legacy presentation callbacks are acknowledged
+   * without dispatch; separately authorized computer-use approvals retain their
+   * dedicated path.
    */
   public async handleCallbackQuery(
     ctx: NarrowedContext<Context<Update>, Update.CallbackQueryUpdate>,
@@ -1881,9 +1888,10 @@ export class MessageManager {
       query && "data" in query && typeof query.data === "string"
         ? query.data
         : undefined;
+    const prepared = decodePreparedInteractionCallback(data);
     const decoded = decodeCallback(data);
 
-    if (!decoded || !ctx.from || !query?.message) {
+    if ((!prepared && !decoded) || !ctx.from || !query?.message) {
       try {
         await ctx.answerCbQuery();
       } catch {
@@ -1916,19 +1924,45 @@ export class MessageManager {
       this.runtime,
       this.scopedTelegramKey(telegramRoomid),
     ) as UUID;
-    const worldId = createUniqueUuid(
-      this.runtime,
-      this.scopedTelegramKey(telegramChatId),
-    ) as UUID;
-    // Derive the turn id from the unique callback-query id so it never collides
-    // with the bot message the buttons were attached to.
-    const callbackKey = `cbq-${query.id}`;
-    const messageId = createUniqueUuid(
-      this.runtime,
-      this.telegramMessageMemoryKey(telegramChatId, callbackKey),
-    );
     const channelType = getChannelType(chat);
-    const computerUseApproval = parseComputerUseApprovalCallback(decoded.value);
+    if (prepared) {
+      try {
+        await ctx.answerCbQuery();
+      } catch {
+        // error-policy:J6 Telegram may reject acknowledgement for a stale tap;
+        // host consumption still determines the durable callback outcome.
+      }
+      const outcome = await consumePreparedInteractionCallback(this.runtime, {
+        providerCallbackData: data,
+        bindings: {
+          actorId: entityId,
+          audience: { kind: "room", id: roomId },
+          agentId: this.runtime.agentId,
+          connector: { source: "telegram", accountId: this.accountId },
+          roomId,
+        },
+        providerReceipt: {
+          source: "telegram",
+          accountId: this.accountId,
+          inboundEventId: query.id,
+          receivedAt: new Date().toISOString(),
+        },
+      });
+      if (outcome.status === "denied") {
+        this.runtime.logger.warn(
+          {
+            src: "plugin:telegram",
+            accountId: this.accountId,
+            code: outcome.code,
+          },
+          "Telegram interaction callback was denied",
+        );
+      }
+      return;
+    }
+    const computerUseApproval = decoded
+      ? parseComputerUseApprovalCallback(decoded.value)
+      : null;
     if (computerUseApproval) {
       await this.resolveComputerUseApprovalCallback(
         ctx,
@@ -1943,103 +1977,12 @@ export class MessageManager {
       return;
     }
 
-    // Always acknowledge so Telegram clears the button's loading spinner.
+    // Legacy marker callbacks cannot dispatch an ordinary user turn. Only the
+    // separately authorized computer-use approval codec above remains accepted.
     try {
       await ctx.answerCbQuery();
     } catch {
-      // best-effort: a stale callback may already have expired
-    }
-
-    await this.runtime.ensureConnection({
-      entityId,
-      roomId,
-      roomName: telegramRoomid,
-      userName: ctx.from.username,
-      name: ctx.from.first_name,
-      userId: telegramUserId as UUID,
-      source: "telegram",
-      channelId: telegramRoomid,
-      type: channelType,
-      worldId,
-      worldName: telegramRoomid,
-    });
-
-    const nowMs = Date.now();
-    const memory: Memory = {
-      id: messageId,
-      entityId,
-      agentId: this.runtime.agentId,
-      roomId,
-      content: {
-        text: decoded.value,
-        source: "telegram",
-        metadata: { accountId: this.accountId },
-        channelType,
-      },
-      metadata: {
-        type: "message",
-        source: "telegram",
-        accountId: this.accountId,
-        provider: "telegram",
-        timestamp: nowMs,
-        entityName: ctx.from.first_name,
-        entityUserName: ctx.from.username,
-        fromBot: false,
-        fromId: telegramUserId,
-        sourceId: entityId,
-        chatType: chat.type,
-        messageIdFull: callbackKey,
-        sender: {
-          id: telegramUserId,
-          name: ctx.from.first_name,
-          username: ctx.from.username,
-        },
-        telegram: {
-          ...telegramIdentityMetadata(
-            telegramUserId,
-            ctx.from.first_name,
-            ctx.from.username,
-          ),
-          chatId: telegramChatId,
-          messageId: callbackKey,
-          threadId,
-        },
-        telegramUserId,
-        telegramChatId,
-      } satisfies Memory["metadata"],
-      createdAt: nowMs,
-    };
-
-    const baseCallback: HandlerCallback = async (content: Content) => {
-      const sentMessages = await this.sendMessageInChunks(
-        ctx,
-        content,
-        sourceMessage.message_id,
-        threadIdNum,
-      );
-      return this.persistSentMessageMemories({
-        sentMessages,
-        content,
-        roomId,
-        channelType,
-        chatType: chat.type,
-        threadId,
-        inReplyTo: messageId,
-      });
-    };
-    const callback = createTelegramCompactProgressCallback({
-      baseCallback,
-      editMessage: this.editMessage.bind(this),
-      chatId: chat.id,
-      threadId: threadIdNum,
-    });
-
-    if (this.runtime.messageService) {
-      await this.runtime.messageService.handleMessage(
-        this.runtime,
-        memory,
-        callback,
-      );
+      // error-policy:J6 best-effort acknowledgement of stale legacy controls.
     }
   }
 
@@ -2490,6 +2433,7 @@ export class MessageManager {
     content: Content,
     replyToMessageId?: number,
     messageThreadId?: number,
+    preparedInteraction?: PreparedMessageInteraction,
   ): Promise<Message.TextMessage[]> {
     try {
       // Create a context-like object for sending
@@ -2503,6 +2447,7 @@ export class MessageManager {
         content,
         replyToMessageId,
         messageThreadId,
+        preparedInteraction,
       );
 
       if (!sentMessages.length) {

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -30,6 +30,7 @@ import {
   type MessageConnectorUserContext,
   Role,
   type Room,
+  resolveFirstPartyInteractionProfile,
   Service,
   type TargetInfo,
   type ThreadHandle,
@@ -2783,6 +2784,14 @@ export class TelegramService extends Service {
             service: TELEGRAM_SERVICE_NAME,
             ...(normalizedAccountId ? { accountId: normalizedAccountId } : {}),
           },
+          resolveInteractionProfile: (target, context) =>
+            resolveFirstPartyInteractionProfile({
+              source: "telegram",
+              defaultAccountId: normalizedAccountId ?? DEFAULT_ACCOUNT_ID,
+              defaultTargetKind: "room",
+              target,
+              accountId: normalizedAccountId ?? context.accountId,
+            }),
           createThreadHandler: (runtime, params) =>
             serviceInstance.createConnectorThread(runtime, params),
           postToThreadHandler: (runtime, params) =>

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -24,10 +24,12 @@ import {
   type MessageConnectorCreateThreadParams,
   type MessageConnectorEditParams,
   type MessageConnectorPostToThreadParams,
+  type MessageConnectorPreparedInteractionParams,
   type MessageConnectorQueryContext,
   type MessageConnectorReactionParams,
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
+  type PreparedMessageInteraction,
   Role,
   type Room,
   resolveFirstPartyInteractionProfile,
@@ -2935,6 +2937,25 @@ export class TelegramService extends Service {
             } satisfies Entity;
           },
           sendHandler,
+          sendPreparedInteraction: async (
+            handlerRuntime: IAgentRuntime,
+            params: MessageConnectorPreparedInteractionParams,
+          ) => {
+            const target =
+              normalizedAccountId &&
+              !(params.target as AccountScopedTargetInfo).accountId
+                ? ({
+                    ...params.target,
+                    accountId: normalizedAccountId,
+                  } as TargetInfo)
+                : params.target;
+            await serviceInstance.handleSendMessage(
+              handlerRuntime,
+              target,
+              { text: params.text ?? "" },
+              params.interaction,
+            );
+          },
         } as ExtendedMessageConnectorRegistration;
         runtime.registerMessageConnector(registration);
       };
@@ -3084,6 +3105,7 @@ export class TelegramService extends Service {
     runtime: IAgentRuntime,
     target: TargetInfo,
     content: Content,
+    preparedInteraction?: PreparedMessageInteraction,
   ): Promise<void> {
     const { accountId, messageManager, chatId, threadId } =
       await this.resolveTelegramSendTarget(runtime, target);
@@ -3104,6 +3126,7 @@ export class TelegramService extends Service {
         },
         undefined,
         threadId,
+        preparedInteraction,
       );
       logger.info(
         {

--- a/plugins/plugin-wechat/src/index.ts
+++ b/plugins/plugin-wechat/src/index.ts
@@ -13,6 +13,8 @@ import {
   type Memory,
   type MessageConnectorTarget,
   type Plugin,
+  renderContentInteractionsForConnector,
+  resolveFirstPartyInteractionProfile,
   stringToUuid,
   type TargetInfo,
   type UUID,
@@ -230,7 +232,10 @@ function registerWechatMessageConnector(
     if (!channel) {
       throw new Error("[wechat] Channel is not available");
     }
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = renderContentInteractionsForConnector(
+      _runtime,
+      content,
+    ).text.trim();
     if (!text) {
       return;
     }
@@ -256,6 +261,17 @@ function registerWechatMessageConnector(
       ],
       supportedTargetKinds: ["user", "group", "room"],
       contexts: ["social", "connectors"],
+      resolveInteractionProfile: (
+        target: TargetInfo,
+        context: { accountId?: string },
+      ) =>
+        resolveFirstPartyInteractionProfile({
+          source: "wechat",
+          defaultAccountId: resolveWechatAccountId(config, target),
+          defaultTargetKind: "room",
+          target,
+          accountId: context.accountId,
+        }),
       resolveTargets: async (query: string) => {
         const normalized = query.trim().toLowerCase();
         return (await listWechatTargets(config))

--- a/plugins/plugin-whatsapp/src/interactions.test.ts
+++ b/plugins/plugin-whatsapp/src/interactions.test.ts
@@ -5,16 +5,13 @@
  */
 
 import {
-  decodePreparedInteractionCallback,
   type Content,
+  decodePreparedInteractionCallback,
   type InteractionBlock,
   type PreparedMessageInteraction,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import {
-  renderPreparedWhatsAppInteraction,
-  renderWhatsAppInteractions,
-} from "./interactions";
+import { renderPreparedWhatsAppInteraction, renderWhatsAppInteractions } from "./interactions";
 
 const prepared = (block: InteractionBlock): PreparedMessageInteraction => ({
   block,
@@ -86,10 +83,10 @@ describe("WhatsApp canonical interaction adapter", () => {
     });
     expect(
       renderPreparedWhatsAppInteraction(prepared(choice(4).interactions?.[0] as InteractionBlock))
-        .interactive?.type,
+        .interactive?.type
     ).toBe("list");
     const overflow = renderPreparedWhatsAppInteraction(
-      prepared(choice(11).interactions?.[0] as InteractionBlock),
+      prepared(choice(11).interactions?.[0] as InteractionBlock)
     );
     expect(overflow.outcome).toBe("fallback");
     expect(overflow.reason).toBe("provider-limit");
@@ -98,9 +95,8 @@ describe("WhatsApp canonical interaction adapter", () => {
 
   it("uses only an opaque host reference plus schema-validated user input", () => {
     const out = renderPreparedWhatsAppInteraction(prepared(blocks[0]));
-    const wire = out.interactive?.type === "button"
-      ? out.interactive.action.buttons[0]?.reply.id
-      : undefined;
+    const wire =
+      out.interactive?.type === "button" ? out.interactive.action.buttons[0]?.reply.id : undefined;
     expect(decodePreparedInteractionCallback(wire)).toEqual({
       callbackData: "is1:0123456789abcdef0123456789abcdef",
       response: { value: "yes" },

--- a/plugins/plugin-whatsapp/src/interactions.test.ts
+++ b/plugins/plugin-whatsapp/src/interactions.test.ts
@@ -4,9 +4,25 @@
  * live credentials remain a separate unavailable evidence row.
  */
 
-import type { Content, InteractionBlock } from "@elizaos/core";
+import {
+  decodePreparedInteractionCallback,
+  type Content,
+  type InteractionBlock,
+  type PreparedMessageInteraction,
+} from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { renderWhatsAppInteractions } from "./interactions";
+import {
+  renderPreparedWhatsAppInteraction,
+  renderWhatsAppInteractions,
+} from "./interactions";
+
+const prepared = (block: InteractionBlock): PreparedMessageInteraction => ({
+  block,
+  callbackData: "is1:0123456789abcdef0123456789abcdef",
+  delivery: { mode: "native", reason: "preferred", limitations: [] },
+  expiresAt: "2026-08-21T00:10:00.000Z",
+  profileId: "profile-a",
+});
 
 const runtime = { getSetting: () => "https://app.example" };
 const blocks: InteractionBlock[] = [
@@ -46,13 +62,7 @@ describe("WhatsApp canonical interaction adapter", () => {
         interactions: [block],
       } as Content)
     );
-    expect(outcomes.map((outcome) => outcome.outcome)).toEqual([
-      "native",
-      "native",
-      "fallback",
-      "fallback",
-      "fallback",
-    ]);
+    expect(outcomes.every((outcome) => outcome.outcome === "fallback")).toBe(true);
     expect(outcomes[2]?.text).toContain("Reply with your answer");
     expect(outcomes[3]?.text).toContain("https://app.example/orchestrator");
     expect(outcomes[4]?.text).toContain("https://secure.example/request");
@@ -74,10 +84,28 @@ describe("WhatsApp canonical interaction adapter", () => {
         },
       ],
     });
-    expect(renderWhatsAppInteractions(runtime, choice(4)).interactive?.type).toBe("list");
-    const overflow = renderWhatsAppInteractions(runtime, choice(11));
+    expect(
+      renderPreparedWhatsAppInteraction(prepared(choice(4).interactions?.[0] as InteractionBlock))
+        .interactive?.type,
+    ).toBe("list");
+    const overflow = renderPreparedWhatsAppInteraction(
+      prepared(choice(11).interactions?.[0] as InteractionBlock),
+    );
     expect(overflow.outcome).toBe("fallback");
     expect(overflow.reason).toBe("provider-limit");
     expect(overflow.text).toContain("Option 10");
+  });
+
+  it("uses only an opaque host reference plus schema-validated user input", () => {
+    const out = renderPreparedWhatsAppInteraction(prepared(blocks[0]));
+    const wire = out.interactive?.type === "button"
+      ? out.interactive.action.buttons[0]?.reply.id
+      : undefined;
+    expect(decodePreparedInteractionCallback(wire)).toEqual({
+      callbackData: "is1:0123456789abcdef0123456789abcdef",
+      response: { value: "yes" },
+    });
+    expect(JSON.stringify(out)).not.toContain("authorization");
+    expect(JSON.stringify(out)).not.toContain("effect");
   });
 });

--- a/plugins/plugin-whatsapp/src/interactions.test.ts
+++ b/plugins/plugin-whatsapp/src/interactions.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic contract tests for WhatsApp Cloud API interaction payloads and
+ * conversational degradation. Assertions cover the exact provider objects;
+ * live credentials remain a separate unavailable evidence row.
+ */
+
+import type { Content, InteractionBlock } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { renderWhatsAppInteractions } from "./interactions";
+
+const runtime = { getSetting: () => "https://app.example" };
+const blocks: InteractionBlock[] = [
+  {
+    kind: "choice",
+    id: "choice-1",
+    scope: "approve",
+    options: [{ value: "yes", label: "Approve" }],
+  },
+  {
+    kind: "followups",
+    id: "followup-1",
+    options: [{ kind: "reply", payload: "next", label: "Next" }],
+  },
+  {
+    kind: "form",
+    id: "form-1",
+    title: "Details",
+    fields: [{ name: "file", type: "file", maxBytes: 1024 }],
+  },
+  { kind: "task", threadId: "12345678", title: "Track task" },
+  {
+    kind: "secret",
+    id: "secret-1",
+    secretKind: "secret",
+    reason: "Enter token securely",
+    fields: [{ name: "token", type: "secret" }],
+    url: "https://secure.example/request",
+  },
+];
+
+describe("WhatsApp canonical interaction adapter", () => {
+  it("uses native controls only for lossless provider-supported kinds", () => {
+    const outcomes = blocks.map((block) =>
+      renderWhatsAppInteractions(runtime, {
+        text: "",
+        interactions: [block],
+      } as Content)
+    );
+    expect(outcomes.map((outcome) => outcome.outcome)).toEqual([
+      "native",
+      "native",
+      "fallback",
+      "fallback",
+      "fallback",
+    ]);
+    expect(outcomes[2]?.text).toContain("Reply with your answer");
+    expect(outcomes[3]?.text).toContain("https://app.example/orchestrator");
+    expect(outcomes[4]?.text).toContain("https://secure.example/request");
+    expect(JSON.stringify(outcomes[4])).not.toContain('"fields"');
+  });
+
+  it("uses a list for four through ten options and text beyond the limit", () => {
+    const choice = (count: number): Content => ({
+      text: "Pick one",
+      interactions: [
+        {
+          kind: "choice",
+          id: "choice",
+          scope: "pick",
+          options: Array.from({ length: count }, (_, index) => ({
+            value: `v${index}`,
+            label: `Option ${index}`,
+          })),
+        },
+      ],
+    });
+    expect(renderWhatsAppInteractions(runtime, choice(4)).interactive?.type).toBe("list");
+    const overflow = renderWhatsAppInteractions(runtime, choice(11));
+    expect(overflow.outcome).toBe("fallback");
+    expect(overflow.reason).toBe("provider-limit");
+    expect(overflow.text).toContain("Option 10");
+  });
+});

--- a/plugins/plugin-whatsapp/src/interactions.ts
+++ b/plugins/plugin-whatsapp/src/interactions.ts
@@ -1,0 +1,117 @@
+/**
+ * Projects canonical interaction blocks onto WhatsApp Cloud API reply buttons
+ * or lists. Baileys and unsupported/multi-block payloads use the complete
+ * semantic text projection; raw marker bodies never reach either transport.
+ */
+
+import {
+  buildInteractionUrlResolver,
+  type Content,
+  type IAgentRuntime,
+  type NeutralButton,
+  parseInteractionBlocks,
+  renderContentInteractionsAsPlainText,
+  stripDashboardOnlyMarkers,
+  toNeutralLayout,
+} from "@elizaos/core";
+import type { WhatsAppInteractiveMessage } from "./types";
+
+export interface WhatsAppInteractionRender {
+  text: string;
+  interactive?: WhatsAppInteractiveMessage;
+  outcome: "plain" | "native" | "fallback";
+  reason?: "multiple-blocks" | "unsupported-kind" | "provider-limit" | "link-action";
+}
+
+function appUrlOptions(runtime: Pick<IAgentRuntime, "getSetting">) {
+  const raw = runtime.getSetting("ELIZA_APP_URL") ?? runtime.getSetting("ELIZA_CLOUD_URL");
+  return buildInteractionUrlResolver(typeof raw === "string" ? raw : undefined);
+}
+
+/** Render a Cloud API message, using provider-native controls only when lossless. */
+export function renderWhatsAppInteractions(
+  runtime: Pick<IAgentRuntime, "getSetting">,
+  content: Content
+): WhatsAppInteractionRender {
+  const parsed = parseInteractionBlocks(content.text ?? "");
+  const interactions = content.interactions?.length ? content.interactions : parsed.blocks;
+  if (interactions.length === 0) {
+    return { text: parsed.cleanedText, outcome: "plain" };
+  }
+  const fallback = renderContentInteractionsAsPlainText(content, appUrlOptions(runtime)).text;
+  if (interactions.length !== 1) {
+    return { text: fallback, outcome: "fallback", reason: "multiple-blocks" };
+  }
+
+  const interaction = interactions[0];
+  if (interaction.kind !== "choice" && interaction.kind !== "followups") {
+    return { text: fallback, outcome: "fallback", reason: "unsupported-kind" };
+  }
+  if (
+    interaction.kind === "followups" &&
+    interaction.options.some((option) => option.kind === "navigate")
+  ) {
+    return { text: fallback, outcome: "fallback", reason: "link-action" };
+  }
+
+  const layout = toNeutralLayout(interaction, {
+    maxButtonsPerRow: 3,
+    maxCallbackBytes: 200,
+  });
+  const buttons = layout.rows.flatMap((row) => row.buttons ?? []);
+  if (
+    layout.needsFallback ||
+    buttons.length === 0 ||
+    buttons.length > 10 ||
+    buttons.some((button) => !button.callbackData || button.url)
+  ) {
+    return { text: fallback, outcome: "fallback", reason: "provider-limit" };
+  }
+  const callbackButtons = buttons.filter(
+    (button): button is NeutralButton & { callbackData: string; url?: never } =>
+      Boolean(button.callbackData) && !button.url
+  );
+
+  const bodyText =
+    stripDashboardOnlyMarkers(parsed.cleanedText).trim() ||
+    (interaction.kind === "choice" ? interaction.prompt?.trim() : "") ||
+    "Choose an option.";
+  if (callbackButtons.length <= 3 && callbackButtons.every((button) => button.label.length <= 20)) {
+    return {
+      text: parsed.cleanedText,
+      outcome: "native",
+      interactive: {
+        type: "button",
+        body: { text: bodyText },
+        action: {
+          buttons: callbackButtons.map((button) => ({
+            type: "reply" as const,
+            reply: { id: button.callbackData, title: button.label },
+          })),
+        },
+      },
+    };
+  }
+  if (callbackButtons.some((button) => button.label.length > 24)) {
+    return { text: fallback, outcome: "fallback", reason: "provider-limit" };
+  }
+  return {
+    text: parsed.cleanedText,
+    outcome: "native",
+    interactive: {
+      type: "list",
+      body: { text: bodyText },
+      action: {
+        button: "Choose",
+        sections: [
+          {
+            rows: callbackButtons.map((button) => ({
+              id: button.callbackData,
+              title: button.label,
+            })),
+          },
+        ],
+      },
+    },
+  };
+}

--- a/plugins/plugin-whatsapp/src/interactions.ts
+++ b/plugins/plugin-whatsapp/src/interactions.ts
@@ -7,12 +7,12 @@
 import {
   buildInteractionUrlResolver,
   type Content,
+  encodePreparedInteractionCallback,
   type IAgentRuntime,
-  type NeutralButton,
+  type PreparedMessageInteraction,
   parseInteractionBlocks,
   renderContentInteractionsAsPlainText,
   stripDashboardOnlyMarkers,
-  toNeutralLayout,
 } from "@elizaos/core";
 import type { WhatsAppInteractiveMessage } from "./types";
 
@@ -43,42 +43,55 @@ export function renderWhatsAppInteractions(
     return { text: fallback, outcome: "fallback", reason: "multiple-blocks" };
   }
 
-  const interaction = interactions[0];
-  if (interaction.kind !== "choice" && interaction.kind !== "followups") {
+  return { text: fallback, outcome: "fallback", reason: "unsupported-kind" };
+}
+
+/** Render only a host-prepared interaction as Cloud API reply controls. */
+export function renderPreparedWhatsAppInteraction(
+  prepared: PreparedMessageInteraction,
+): WhatsAppInteractionRender {
+  const interaction = prepared.block;
+  const fallback = renderContentInteractionsAsPlainText({ interactions: [interaction] }).text;
+  if (
+    prepared.delivery.mode !== "native" ||
+    (interaction.kind !== "choice" && interaction.kind !== "followups") ||
+    (interaction.kind === "followups" &&
+      interaction.options.some((option) => option.kind === "navigate"))
+  ) {
     return { text: fallback, outcome: "fallback", reason: "unsupported-kind" };
   }
+  const providerOptions =
+    interaction.kind === "choice"
+      ? interaction.options.map((option) => ({
+          label: option.label,
+          value: option.value,
+        }))
+      : interaction.options.map((option) => ({
+          label: option.label,
+          value: option.payload,
+        }));
+  const callbackButtons = providerOptions.map((option) => ({
+    label: option.label,
+    callbackData: encodePreparedInteractionCallback(
+      prepared.callbackData,
+      { value: option.value },
+      200,
+    ),
+  }));
   if (
-    interaction.kind === "followups" &&
-    interaction.options.some((option) => option.kind === "navigate")
-  ) {
-    return { text: fallback, outcome: "fallback", reason: "link-action" };
-  }
-
-  const layout = toNeutralLayout(interaction, {
-    maxButtonsPerRow: 3,
-    maxCallbackBytes: 200,
-  });
-  const buttons = layout.rows.flatMap((row) => row.buttons ?? []);
-  if (
-    layout.needsFallback ||
-    buttons.length === 0 ||
-    buttons.length > 10 ||
-    buttons.some((button) => !button.callbackData || button.url)
+    callbackButtons.length === 0 ||
+    callbackButtons.length > 10 ||
+    callbackButtons.some((button) => !button.callbackData)
   ) {
     return { text: fallback, outcome: "fallback", reason: "provider-limit" };
   }
-  const callbackButtons = buttons.filter(
-    (button): button is NeutralButton & { callbackData: string; url?: never } =>
-      Boolean(button.callbackData) && !button.url
-  );
 
   const bodyText =
-    stripDashboardOnlyMarkers(parsed.cleanedText).trim() ||
     (interaction.kind === "choice" ? interaction.prompt?.trim() : "") ||
     "Choose an option.";
   if (callbackButtons.length <= 3 && callbackButtons.every((button) => button.label.length <= 20)) {
     return {
-      text: parsed.cleanedText,
+      text: bodyText,
       outcome: "native",
       interactive: {
         type: "button",
@@ -86,7 +99,7 @@ export function renderWhatsAppInteractions(
         action: {
           buttons: callbackButtons.map((button) => ({
             type: "reply" as const,
-            reply: { id: button.callbackData, title: button.label },
+            reply: { id: button.callbackData as string, title: button.label },
           })),
         },
       },
@@ -96,7 +109,7 @@ export function renderWhatsAppInteractions(
     return { text: fallback, outcome: "fallback", reason: "provider-limit" };
   }
   return {
-    text: parsed.cleanedText,
+    text: bodyText,
     outcome: "native",
     interactive: {
       type: "list",
@@ -106,7 +119,7 @@ export function renderWhatsAppInteractions(
         sections: [
           {
             rows: callbackButtons.map((button) => ({
-              id: button.callbackData,
+              id: button.callbackData as string,
               title: button.label,
             })),
           },

--- a/plugins/plugin-whatsapp/src/interactions.ts
+++ b/plugins/plugin-whatsapp/src/interactions.ts
@@ -12,7 +12,6 @@ import {
   type PreparedMessageInteraction,
   parseInteractionBlocks,
   renderContentInteractionsAsPlainText,
-  stripDashboardOnlyMarkers,
 } from "@elizaos/core";
 import type { WhatsAppInteractiveMessage } from "./types";
 
@@ -48,7 +47,7 @@ export function renderWhatsAppInteractions(
 
 /** Render only a host-prepared interaction as Cloud API reply controls. */
 export function renderPreparedWhatsAppInteraction(
-  prepared: PreparedMessageInteraction,
+  prepared: PreparedMessageInteraction
 ): WhatsAppInteractionRender {
   const interaction = prepared.block;
   const fallback = renderContentInteractionsAsPlainText({ interactions: [interaction] }).text;
@@ -75,7 +74,7 @@ export function renderPreparedWhatsAppInteraction(
     callbackData: encodePreparedInteractionCallback(
       prepared.callbackData,
       { value: option.value },
-      200,
+      200
     ),
   }));
   if (
@@ -87,8 +86,7 @@ export function renderPreparedWhatsAppInteraction(
   }
 
   const bodyText =
-    (interaction.kind === "choice" ? interaction.prompt?.trim() : "") ||
-    "Choose an option.";
+    (interaction.kind === "choice" ? interaction.prompt?.trim() : "") || "Choose an option.";
   if (callbackButtons.length <= 3 && callbackButtons.every((button) => button.label.length <= 20)) {
     return {
       text: bodyText,

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -53,7 +53,10 @@ import {
   type InboundClaimState,
   tryClaim,
 } from "./inbound-claim";
-import { renderWhatsAppInteractions } from "./interactions";
+import {
+  renderPreparedWhatsAppInteraction,
+  renderWhatsAppInteractions,
+} from "./interactions";
 import {
   chunkWhatsAppText,
   isWhatsAppGroupJid,
@@ -770,6 +773,36 @@ export class WhatsAppConnectorService extends Service {
                   target.threadId ?? target.channelId ?? target.entityId ?? target.roomId ?? ""
                 ),
               }),
+        sendPreparedInteraction: async (_runtime, params) => {
+          const resolved = await resolveWhatsAppSendTarget(
+            runtime,
+            service,
+            params.target,
+            connectorAccountId,
+          );
+          if (!resolved) {
+            throw new ElizaError("WhatsApp prepared interaction target is unavailable.", {
+              code: "WHATSAPP_INTERACTION_TARGET_UNAVAILABLE",
+            });
+          }
+          const rendered = renderPreparedWhatsAppInteraction(params.interaction);
+          if (!rendered.interactive || rendered.outcome !== "native") {
+            throw new ElizaError(
+              "WhatsApp cannot render this prepared interaction natively; use the semantic text fallback.",
+              {
+                code: "WHATSAPP_INTERACTION_NATIVE_UNAVAILABLE",
+                context: {
+                  limitations: params.interaction.delivery.limitations.join(","),
+                },
+              },
+            );
+          }
+          await service.sendInteractiveMessage(
+            resolved.accountId,
+            resolved.chatId,
+            rendered.interactive,
+          );
+        },
         sendHandler: async (
           _runtime: IAgentRuntime,
           target: ConnectorTargetInfo,

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -19,9 +19,10 @@
 import {
   ChannelType,
   type Content,
+  consumePreparedInteractionCallback,
   createConnectorInteractionCapabilityProfile,
   createUniqueUuid,
-  decodeCallback,
+  decodePreparedInteractionCallback,
   ElizaError,
   type IAgentRuntime,
   lifeOpsPassiveConnectorsEnabled,
@@ -53,10 +54,7 @@ import {
   type InboundClaimState,
   tryClaim,
 } from "./inbound-claim";
-import {
-  renderPreparedWhatsAppInteraction,
-  renderWhatsAppInteractions,
-} from "./interactions";
+import { renderPreparedWhatsAppInteraction, renderWhatsAppInteractions } from "./interactions";
 import {
   chunkWhatsAppText,
   isWhatsAppGroupJid,
@@ -537,8 +535,6 @@ function extractWebhookText(message: WhatsAppIncomingMessage): string {
 
   const buttonReply = message.interactive?.button_reply;
   if (buttonReply) {
-    const decoded = decodeCallback(buttonReply.id);
-    if (decoded) return decoded.value;
     if (typeof buttonReply.title === "string" && buttonReply.title.trim()) {
       return buttonReply.title.trim();
     }
@@ -546,8 +542,6 @@ function extractWebhookText(message: WhatsAppIncomingMessage): string {
 
   const listReply = message.interactive?.list_reply;
   if (listReply) {
-    const decoded = decodeCallback(listReply.id);
-    if (decoded) return decoded.value;
     if (typeof listReply.title === "string" && listReply.title.trim()) {
       return listReply.title.trim();
     }
@@ -778,7 +772,7 @@ export class WhatsAppConnectorService extends Service {
             runtime,
             service,
             params.target,
-            connectorAccountId,
+            connectorAccountId
           );
           if (!resolved) {
             throw new ElizaError("WhatsApp prepared interaction target is unavailable.", {
@@ -794,13 +788,13 @@ export class WhatsAppConnectorService extends Service {
                 context: {
                   limitations: params.interaction.delivery.limitations.join(","),
                 },
-              },
+              }
             );
           }
           await service.sendInteractiveMessage(
             resolved.accountId,
             resolved.chatId,
-            rendered.interactive,
+            rendered.interactive
           );
         },
         sendHandler: async (
@@ -1229,6 +1223,40 @@ export class WhatsAppConnectorService extends Service {
     message: WhatsAppIncomingMessage,
     accountId = this.defaultAccountId
   ): Promise<void> {
+    const providerCallbackData =
+      message.interactive?.button_reply?.id ?? message.interactive?.list_reply?.id;
+    if (decodePreparedInteractionCallback(providerCallbackData)) {
+      const normalizedSender = normalizeWhatsAppTarget(message.from) ?? message.from;
+      const roomId = this.roomIdFor(normalizedSender, accountId);
+      const outcome = await consumePreparedInteractionCallback(this.runtime, {
+        providerCallbackData,
+        bindings: {
+          actorId: this.entityIdFor(normalizedSender, accountId),
+          audience: { kind: "room", id: roomId },
+          agentId: this.runtime.agentId,
+          connector: { source: "whatsapp", accountId },
+          roomId,
+        },
+        providerReceipt: {
+          source: "whatsapp",
+          accountId,
+          inboundEventId: message.id,
+          receivedAt: new Date(toTimestampMs(message.timestamp)).toISOString(),
+        },
+      });
+      if (outcome.status === "denied") {
+        this.runtime.logger.warn(
+          {
+            src: "plugin:whatsapp",
+            agentId: this.runtime.agentId,
+            accountId,
+            code: outcome.code,
+          },
+          "WhatsApp interaction callback was denied"
+        );
+      }
+      return;
+    }
     const text = extractWebhookText(message);
     if (!text) {
       return;

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -19,15 +19,20 @@
 import {
   ChannelType,
   type Content,
+  createConnectorInteractionCapabilityProfile,
   createUniqueUuid,
+  decodeCallback,
   ElizaError,
   type IAgentRuntime,
   lifeOpsPassiveConnectorsEnabled,
   type Media,
   type Memory,
   type Room,
+  renderContentInteractionsForConnector,
+  resolveFirstPartyInteractionProfile,
   Service,
   type UUID,
+  WHATSAPP_CONVERSATIONAL_INTERACTION_PROFILE,
 } from "@elizaos/core";
 import {
   assertUniqueWhatsAppAccountIds,
@@ -48,6 +53,7 @@ import {
   type InboundClaimState,
   tryClaim,
 } from "./inbound-claim";
+import { renderWhatsAppInteractions } from "./interactions";
 import {
   chunkWhatsAppText,
   isWhatsAppGroupJid,
@@ -63,6 +69,7 @@ import type {
   ConnectionStatus,
   NormalizedMessage,
   WhatsAppIncomingMessage,
+  WhatsAppInteractiveMessage,
   WhatsAppMediaMessage,
   WhatsAppMessageResponse,
   WhatsAppWebhookEvent,
@@ -525,18 +532,22 @@ function extractWebhookText(message: WhatsAppIncomingMessage): string {
     return message.text.body.trim();
   }
 
-  if (
-    typeof message.interactive?.button_reply?.title === "string" &&
-    message.interactive.button_reply.title.trim()
-  ) {
-    return message.interactive.button_reply.title.trim();
+  const buttonReply = message.interactive?.button_reply;
+  if (buttonReply) {
+    const decoded = decodeCallback(buttonReply.id);
+    if (decoded) return decoded.value;
+    if (typeof buttonReply.title === "string" && buttonReply.title.trim()) {
+      return buttonReply.title.trim();
+    }
   }
 
-  if (
-    typeof message.interactive?.list_reply?.title === "string" &&
-    message.interactive.list_reply.title.trim()
-  ) {
-    return message.interactive.list_reply.title.trim();
+  const listReply = message.interactive?.list_reply;
+  if (listReply) {
+    const decoded = decodeCallback(listReply.id);
+    if (decoded) return decoded.value;
+    if (typeof listReply.title === "string" && listReply.title.trim()) {
+      return listReply.title.trim();
+    }
   }
 
   if (
@@ -741,18 +752,42 @@ export class WhatsAppConnectorService extends Service {
           transport: config?.transport ?? service.config?.transport ?? "unconfigured",
           connected: service.connected,
         },
+        resolveInteractionProfile: (target, context) =>
+          config?.transport === "cloudapi"
+            ? resolveFirstPartyInteractionProfile({
+                source: "whatsapp",
+                defaultAccountId: connectorAccountId,
+                defaultTargetKind: "phone",
+                target,
+                accountId: registrationAccountId ?? context.accountId,
+              })
+            : createConnectorInteractionCapabilityProfile({
+                template: WHATSAPP_CONVERSATIONAL_INTERACTION_PROFILE,
+                source: "whatsapp",
+                accountId: registrationAccountId ?? context.accountId ?? connectorAccountId,
+                targetKind: "phone",
+                targetId: String(
+                  target.threadId ?? target.channelId ?? target.entityId ?? target.roomId ?? ""
+                ),
+              }),
         sendHandler: async (
           _runtime: IAgentRuntime,
           target: ConnectorTargetInfo,
           content: ConnectorContent
         ) => {
-          const text = typeof content.text === "string" ? content.text.trim() : "";
+          const interaction =
+            config?.transport === "cloudapi"
+              ? renderWhatsAppInteractions(runtime, content)
+              : undefined;
+          const text = (
+            interaction?.text ?? renderContentInteractionsForConnector(runtime, content).text
+          ).trim();
           const attachments = Array.isArray(content.attachments)
             ? content.attachments.filter(
                 (media) => typeof media?.url === "string" && media.url.trim().length > 0
               )
             : [];
-          if (!text && attachments.length === 0) {
+          if (!text && !interaction?.interactive && attachments.length === 0) {
             return;
           }
 
@@ -777,7 +812,14 @@ export class WhatsAppConnectorService extends Service {
             }
           }
 
-          if (text) {
+          if (interaction?.interactive) {
+            await service.sendInteractiveMessage(
+              resolved.accountId,
+              resolved.chatId,
+              interaction.interactive,
+              replyToMessageId
+            );
+          } else if (text) {
             for (const chunk of chunkWhatsAppText(text)) {
               await service.sendMessage({
                 accountId: resolved.accountId,
@@ -1399,7 +1441,7 @@ export class WhatsAppConnectorService extends Service {
       };
 
       const callback = async (content: Content): Promise<Memory[]> => {
-        const text = typeof content.text === "string" ? content.text.trim() : "";
+        const text = renderContentInteractionsForConnector(this.runtime, content).text.trim();
         if (!text) {
           return [];
         }
@@ -1565,6 +1607,44 @@ export class WhatsAppConnectorService extends Service {
       message.replyToMessageId,
       message.accountId
     );
+  }
+
+  async sendInteractiveMessage(
+    accountId: string | null | undefined,
+    to: string,
+    content: WhatsAppInteractiveMessage,
+    replyToMessageId?: string
+  ): Promise<WhatsAppMessageResponse> {
+    const normalizedAccountId = this.resolveAccountId(accountId);
+    const client = this.getClientForAccount(normalizedAccountId);
+    const config = this.getConfigForAccount(normalizedAccountId);
+    if (!client || !config) throw new Error("WhatsApp client is not initialized");
+    if (config.transport !== "cloudapi") {
+      throw new ElizaError("WhatsApp interactive controls require Cloud API transport.", {
+        code: "WHATSAPP_INTERACTION_TRANSPORT_UNAVAILABLE",
+        context: { accountId: normalizedAccountId, transport: config.transport },
+      });
+    }
+    let response: unknown;
+    try {
+      response = await client.sendMessage({
+        type: "interactive",
+        to: normalizeCloudApiSendTarget(to),
+        content,
+        replyToMessageId,
+      });
+    } catch (cause) {
+      // error-policy:J2 Preserve the Cloud API failure as a typed native-render
+      // outcome so callers can choose the semantic text fallback deliberately.
+      throw new ElizaError("WhatsApp rejected the native interaction payload.", {
+        code: "WHATSAPP_INTERACTION_PROVIDER_REJECTED",
+        context: { accountId: normalizedAccountId },
+        cause,
+      });
+    }
+    return "data" in (response as { data?: unknown })
+      ? (response as { data: WhatsAppMessageResponse }).data
+      : (response as WhatsAppMessageResponse);
   }
 
   /** Coarse content type → WhatsApp media message kind. */

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -24,6 +24,8 @@ import {
   type MessageConnectorTarget,
   type MessageConnectorUserContext,
   parseBooleanFromText,
+  renderContentInteractionsForConnector,
+  resolveFirstPartyInteractionProfile,
   Service,
   type TargetInfo,
   type UUID,
@@ -638,6 +640,14 @@ export class XService extends Service {
         metadata: {
           service: XService.serviceType,
         },
+        resolveInteractionProfile: (target, context) =>
+          resolveFirstPartyInteractionProfile({
+            source: "x",
+            defaultAccountId: resolveDefaultXAccountId(context.runtime),
+            defaultTargetKind: "user",
+            target,
+            accountId: context.accountId,
+          }),
         resolveTargets:
           serviceInstance.resolveConnectorTargets.bind(serviceInstance),
         listRecentTargets:
@@ -705,11 +715,14 @@ export class XService extends Service {
   }
 
   async handleSendMessage(
-    _runtime: IAgentRuntime,
+    runtime: IAgentRuntime,
     target: TargetInfo,
     content: Content,
   ): Promise<void> {
-    const text = typeof content.text === "string" ? content.text.trim() : "";
+    const text = renderContentInteractionsForConnector(
+      runtime,
+      content,
+    ).text.trim();
     if (!text) {
       throw new Error("X DM connector requires non-empty text content.");
     }


### PR DESCRIPTION
## Summary

This draft stacks the connector-owned portion of #24288 on #24363 without adding a second authority or dispatcher.

- adds an additive `MessageConnector.sendPreparedInteraction` seam whose input is only host-prepared, renderer-safe data
- declares exhaustive canonical profiles for every actual first-party production message connector
- implements host-prepared native adapters and authenticated inbound consumption for Slack, WhatsApp Cloud, Discord, and Telegram
- uses explicit semantic text/conversational fallback for Gmail, Google Chat, iMessage, Instagram, Matrix, WeChat, X, WhatsApp Baileys, and unsupported block/provider combinations
- strips raw markers and keeps authorization, bindings, effects, auth state, and secrets out of provider payloads
- adds an AST-derived `.ts`/`.tsx` production registration inventory that counts multiple registrations and account-provider extensions
- keeps Signal visible as an explicit non-registration (`SIGNAL_DIRECT_TRANSPORT_UNAVAILABLE`) rather than claiming a connector that does not exist

Refs #24288. Depends on #24287 / #24363.

## Exact stack

- PR base branch: `feat/24287-interaction-sessions`
- required base commit: `af82262f6a55b402a21b470273c5377d08a532aa`
- base's `origin/develop` ancestor: `a8aa79511f5ea9b4b72a76394f1f2f7196bde49b`
- connector head: `13cf7a1415ce14d425fc0633dbb31ea3ce8d2672`

## Inventory

| Source | Registration | Canonical behavior |
| --- | --- | --- |
| Discord | direct | native prepared buttons; signed-hosted/conversational fallback |
| Gmail | account-provider extension | conversational |
| Google Chat | direct | conversational + media |
| iMessage | direct | conversational + media |
| Instagram | direct | conversational |
| Matrix | direct | conversational |
| Slack | direct | native prepared Block Kit; signed-hosted/conversational fallback |
| Telegram | direct | native prepared inline keyboard; signed-hosted/conversational fallback |
| WeChat | direct | conversational |
| WhatsApp | direct | Cloud reply buttons/lists; Baileys and unsupported kinds conversational |
| X | direct | conversational |
| Signal | no registration | explicitly unavailable; not claimed |

The committed `CAPABILITY_MATRIX.md` is byte-checked against the generator and includes exact production sites/mechanisms.

## Deterministic evidence

| Evidence | Result |
| --- | --- |
| Choice, followup, form, task, auth-link, file schemas | PASS |
| Second-user denial, expiry/revocation denial | PASS |
| Provider envelope, canonical inbound event, provider receipt | PASS |
| Audit record and app-state result | PASS |
| Replay returns retained receipt; effect called once in deterministic host harness | PASS, dependency-held by the atomic replay defect below |
| Legacy `ia1:` presentation callback reaches host effect | DENIED; zero effect calls |
| Prepared provider payload contains authorization/bindings/effect/secrets | PASS: absent by contract and test |
| Oversized native callback/provider payload | PASS: typed failure or actionable semantic fallback |
| AST registration inventory + exhaustive block kinds + byte-exact golden | PASS |
| Focused adapter/host/registry/matrix tests | PASS: 75 tests, 245 assertions, 0 failures |
| Core typecheck | PASS |
| Slack and WhatsApp typecheck/build | PASS |
| Google Workspace, iMessage, Instagram, Matrix, WeChat, X typecheck | PASS |
| Agent `build:dist`; Discord and Telegram builds | PASS |
| Changed-file Biome; guide parity; `git diff --check` | PASS |

No live provider success is simulated:

| Live target | Result |
| --- | --- |
| Slack | UNAVAILABLE: `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` absent |
| WhatsApp Cloud | UNAVAILABLE: `WHATSAPP_ACCESS_TOKEN` and `WHATSAPP_PHONE_NUMBER_ID` absent |
| Discord | UNAVAILABLE: `DISCORD_API_TOKEN` absent |
| Telegram | UNAVAILABLE: `TELEGRAM_BOT_TOKEN` absent |
| Gmail / Google Chat / Instagram / Matrix / WeChat / X | UNAVAILABLE: no authenticated connector runtime supplied |
| iMessage | UNAVAILABLE: no live bridge/device supplied |

UI screenshots/video are N/A: no UI surface changed.

## Intentional draft hold

This PR does **not** claim real round-trip acceptance or close #24288. The current exact foundation head remains held by its latest review:

1. oversized conversational payloads may still negotiate despite lossless delivery not being proven;
2. replay status is derived from a pre-consume snapshot rather than a discriminated atomic consume outcome;
3. PID-only stale-lock recovery is unsafe under PID reuse;
4. committed/completed sessions are never pruned, so the bounded store eventually reaches permanent capacity exhaustion.

Those are host/store authority defects and remain in #24363; this branch does not duplicate or rewrite that authority. Real provider/executor evidence also remains unavailable until credentials and supported live targets are supplied.

## Baseline limitations

- `bun run verify` reaches workspace lint after guide/i18n/dependency/alias/tsconfig gates, then fails on unrelated pre-existing Biome diagnostics outside this diff. The one changed-file formatting diagnostic found during the run was fixed and changed-file Biome is green.
- standalone Discord/Telegram typechecks remain unavailable because the workspace cannot resolve pre-existing `@elizaos/vault` and `@elizaos/plugin-commands` declarations; both production builds pass.
- the core build generated Node/browser/edge/testing outputs successfully, but the build process retained an open handle after its success banner and required interruption; core typecheck passes.

## Attribution

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported  
— [codex-goal-14-15/universal-interactions]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
