### PR TITLE
fix(telegram): use inbound entity ids for slash-command auth

### DIFF
--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -82,6 +82,8 @@ const { getConnectorCommands } = pluginCommandsMock;
 
 const TELEGRAM_COMMAND_NAME = /^[a-z0-9_]{1,32}$/;
 
+const OWNER_ENTITY_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
 function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
   const cache = new Map<string, unknown>();
   return {
@@ -93,6 +95,23 @@ function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
       return true;
     }),
     character: { name: "TestAgent" },
+  } as unknown as IAgentRuntime;
+}
+
+function ownerEntity(telegramUserId: string) {
+  return {
+    id: OWNER_ENTITY_ID,
+    names: ["owner"],
+    metadata: { telegram: { userId: telegramUserId } },
+  };
+}
+
+function makeOwnerRuntime(
+  getEntityById: ReturnType<typeof vi.fn>,
+): IAgentRuntime {
+  return {
+    ...makeRuntime({ ELIZA_ADMIN_ENTITY_ID: OWNER_ENTITY_ID }),
+    getEntityById,
   } as unknown as IAgentRuntime;
 }
 
@@ -141,6 +160,7 @@ function registerHandlers(
 beforeEach(() => {
   hasRoleAccess.mockReset();
   hasRoleAccess.mockResolvedValue(true);
+  pluginCommandsMock.resolveCommand.mockClear();
 });
 
 describe("buildTelegramCommandDescriptors", () => {
@@ -258,7 +278,13 @@ describe("registerTelegramCommandHandlers", () => {
     const { ctx } = makeCtx("/stop");
     await stopHandler?.(ctx);
 
-    expect(handleMessage).toHaveBeenCalledWith(ctx, { forceReply: true });
+    expect(handleMessage).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        forceReply: true,
+        entityId: expect.any(String),
+      }),
+    );
   });
 
   it("wires navigate handlers to reply with an app destination", async () => {
@@ -408,8 +434,14 @@ describe("auth gating", () => {
     const { ctx } = makeCtx("/restart");
     await restartHandler?.(ctx);
 
-    // Owner access → command routes to the agent.
-    expect(handleMessage).toHaveBeenCalledWith(ctx, { forceReply: true });
+    // Owner access → command routes to the agent with the bound actor snapshot.
+    expect(handleMessage).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        forceReply: true,
+        entityId: expect.any(String),
+      }),
+    );
   });
 
   it("consults both the OWNER and ADMIN roles when resolving the sender", async () => {
@@ -453,6 +485,71 @@ describe("auth gating", () => {
       entityId?: string;
     };
     expect(memory.entityId).toBe(createUniqueUuid(rt, "acct-a:4242"));
+  });
+
+  it("resolves a configured owner through the entity store, not the UUID fallback", async () => {
+    const getEntityById = vi.fn(async () => ownerEntity("4242"));
+    const rt = makeOwnerRuntime(getEntityById);
+    const { ctx } = makeCtx("/whoami");
+    await resolveTelegramSenderAuth(ctx, rt, "default");
+    const memory = hasRoleAccess.mock.calls[0]?.[1] as {
+      entityId?: string;
+    };
+    expect(memory.entityId).toBe(OWNER_ENTITY_ID);
+    expect(memory.entityId).not.toBe(createUniqueUuid(rt, "default:4242"));
+    expect(getEntityById).toHaveBeenCalledWith(OWNER_ENTITY_ID);
+  });
+
+  it("binds the authorized entity through dispatch when the pairing snapshot changes", async () => {
+    const getEntityById = vi
+      .fn()
+      .mockResolvedValueOnce(ownerEntity("4242"))
+      .mockResolvedValueOnce(ownerEntity("9999"));
+    const rt = makeOwnerRuntime(getEntityById);
+    const { manager } = makeMessageManager();
+    const { handlers } = registerHandlers(rt, manager);
+    const thinkHandler = handlers.get("think");
+    expect(thinkHandler).toBeDefined();
+    const { ctx, reply } = makeCtx("/think high");
+
+    await thinkHandler?.(ctx);
+
+    const authorizedMemory = hasRoleAccess.mock.calls[0]?.[1] as
+      | { entityId?: string }
+      | undefined;
+    const dispatchedMemory = pluginCommandsMock.resolveCommand.mock
+      .calls[0]?.[1] as { entityId?: string } | undefined;
+    const authorizedEntity = authorizedMemory?.entityId;
+    const dispatchedEntity = dispatchedMemory?.entityId;
+    const identityCalls = [authorizedEntity, dispatchedEntity];
+
+    expect(authorizedEntity).toBe(OWNER_ENTITY_ID);
+    expect(dispatchedEntity).toBe(authorizedEntity);
+    expect(dispatchedEntity).not.toBe(createUniqueUuid(rt, "default:4242"));
+    expect(getEntityById).toHaveBeenCalledTimes(1);
+    expect(identityCalls).toEqual([OWNER_ENTITY_ID, OWNER_ENTITY_ID]);
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the bound authorized entity to pipeline dispatch without a second lookup", async () => {
+    const getEntityById = vi
+      .fn()
+      .mockResolvedValueOnce(ownerEntity("4242"))
+      .mockResolvedValueOnce(ownerEntity("9999"));
+    const rt = makeOwnerRuntime(getEntityById);
+    const { manager, handleMessage } = makeMessageManager();
+    const { handlers } = registerHandlers(rt, manager);
+    const stopHandler = handlers.get("stop");
+    expect(stopHandler).toBeDefined();
+    const { ctx } = makeCtx("/stop");
+
+    await stopHandler?.(ctx);
+
+    expect(getEntityById).toHaveBeenCalledTimes(1);
+    expect(handleMessage).toHaveBeenCalledWith(ctx, {
+      forceReply: true,
+      entityId: OWNER_ENTITY_ID,
+    });
   });
 });
 

--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -4,7 +4,7 @@
  * per command (never clobbering `eliza_pair`), and role-gated dispatch. Runtime
  * and `hasRoleAccess` are mocked.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { createUniqueUuid, type IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // The connector bridge gates auth via the agent role model (`hasRoleAccess`).
@@ -73,7 +73,9 @@ import {
   buildTelegramCommandDescriptors,
   registerTelegramCommandHandlers,
   resolveTelegramEmbedUrl,
+  resolveTelegramSenderAuth,
 } from "./command-registration";
+import { resolveTelegramRuntimeEntityId } from "./identity";
 import type { MessageManager } from "./messageManager";
 
 const { getConnectorCommands } = pluginCommandsMock;
@@ -422,6 +424,35 @@ describe("auth gating", () => {
     const requestedRoles = hasRoleAccess.mock.calls.map((call) => call[2]);
     expect(requestedRoles).toContain("OWNER");
     expect(requestedRoles).toContain("ADMIN");
+  });
+
+  it("resolves default-account sender entity ids the same way inbound messages do", async () => {
+    hasRoleAccess.mockResolvedValue(true);
+    const rt = makeRuntime();
+    const { ctx } = makeCtx("/whoami");
+    await resolveTelegramSenderAuth(ctx, rt, "default");
+    const memory = hasRoleAccess.mock.calls[0]?.[1] as {
+      entityId?: string;
+    };
+    const expected = await resolveTelegramRuntimeEntityId(
+      rt,
+      "default",
+      "4242",
+    );
+    expect(memory.entityId).toBe(expected);
+    expect(memory.entityId).toBe(createUniqueUuid(rt, "default:4242"));
+    expect(memory.entityId).not.toBe(createUniqueUuid(rt, "4242"));
+  });
+
+  it("keeps non-default account sender ids on the historical account:user seed", async () => {
+    hasRoleAccess.mockResolvedValue(true);
+    const rt = makeRuntime();
+    const { ctx } = makeCtx("/whoami");
+    await resolveTelegramSenderAuth(ctx, rt, "acct-a");
+    const memory = hasRoleAccess.mock.calls[0]?.[1] as {
+      entityId?: string;
+    };
+    expect(memory.entityId).toBe(createUniqueUuid(rt, "acct-a:4242"));
   });
 });
 

--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -407,6 +407,33 @@ describe("Telegram Mini App launch command", () => {
 });
 
 describe("auth gating", () => {
+  it("fails visibly and without dispatch when canonical identity storage rejects", async () => {
+    const identityError = new Error("identity database unavailable");
+    const reportError = vi.fn();
+    const rt = {
+      ...makeOwnerRuntime(vi.fn(async () => Promise.reject(identityError))),
+      reportError,
+    } as unknown as IAgentRuntime;
+    const { manager, handleMessage } = makeMessageManager();
+    const { handlers } = registerHandlers(rt, manager);
+    const restartHandler = handlers.get("restart");
+    expect(restartHandler).toBeDefined();
+    const { ctx, reply } = makeCtx("/restart");
+
+    await restartHandler?.(ctx);
+
+    expect(reply).toHaveBeenCalledWith(
+      "Could not verify your identity. Try again.",
+    );
+    expect(hasRoleAccess).not.toHaveBeenCalled();
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledWith(
+      "telegram:command-identity",
+      identityError,
+      { accountId: "default", telegramUserId: "4242" },
+    );
+  });
+
   it("refuses a requiresAuth command when the sender is not an owner", async () => {
     hasRoleAccess.mockResolvedValue(false);
     const { manager, handleMessage } = makeMessageManager();

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -28,9 +28,11 @@
  * Auth gating: `requiresAuth` / `requiresElevated` commands are gated at the
  * connector boundary using the agent's role model (`hasRoleAccess`) — the same
  * mechanism every surface uses. The Telegram sender is mapped to a runtime
- * entity through `resolveTelegramRuntimeEntityId` (matching inbound
- * `handleMessage`), and a command is refused with a clear reply when the
- * sender is not an owner (for `requiresAuth`) or admin (for `requiresElevated`).
+ * entity once through `resolveTelegramRuntimeEntityId` (matching inbound
+ * `handleMessage`); that snapshot is bound through authorization and dispatch
+ * so a pairing change cannot authorize A and execute as B. A command is
+ * refused with a clear reply when the sender is not an owner (for
+ * `requiresAuth`) or admin (for `requiresElevated`).
  *
  * A matched `bot.command` handler never calls `next()`, so the catch-all
  * message handler registered in `service.ts` does not also process command
@@ -84,6 +86,15 @@ export function truncateTelegramCommandReply(reply: string): string {
 const TELEGRAM_SURFACE = "telegram";
 const DEFAULT_ACCOUNT_ID = "default";
 const TELEGRAM_EMBED_COMMAND = "app";
+
+/**
+ * Sender trust plus the runtime entity used to decide it. Authorization and
+ * dispatch must share this snapshot: a second identity lookup can observe a
+ * different pairing and run a privileged command as a different actor.
+ */
+export type TelegramSenderAuth = ConnectorSenderAuth & {
+  entityId?: UUID;
+};
 
 /** A catalog command projected onto Telegram's native command surface. */
 export interface TelegramCommandDescriptor {
@@ -210,12 +221,14 @@ export function resolveTelegramEmbedUrl(runtime: IAgentRuntime): string | null {
  * Telegram user id is mapped through `resolveTelegramRuntimeEntityId`
  * (matching inbound `handleMessage`), so role resolution reads the
  * canonical-owner / world-role state the inbound pipeline established.
+ * The resolved entity is returned with the auth result and must be reused
+ * for dispatch — never looked up again after the role check awaits.
  */
 export async function resolveTelegramSenderAuth(
   ctx: Context,
   runtime: IAgentRuntime,
   accountId: string,
-): Promise<ConnectorSenderAuth> {
+): Promise<TelegramSenderAuth> {
   const fromId = ctx.from?.id;
   const chatId = ctx.chat?.id;
   if (fromId === undefined || chatId === undefined) {
@@ -249,7 +262,12 @@ export async function resolveTelegramSenderAuth(
 
   const senderName =
     ctx.from?.username ?? ctx.from?.first_name ?? String(fromId);
-  return { isAuthorized: isOwner, isElevated: isAdmin, senderName };
+  return {
+    isAuthorized: isOwner,
+    isElevated: isAdmin,
+    senderName,
+    entityId,
+  };
 }
 
 /**
@@ -264,16 +282,12 @@ async function dispatchAgentCommand(
   messageManager: MessageManager,
   accountId: string,
   descriptor: TelegramCommandDescriptor,
-  sender: ConnectorSenderAuth,
+  sender: TelegramSenderAuth,
 ): Promise<void> {
   const fromId = ctx.from?.id;
   const chatId = ctx.chat?.id;
-  if (fromId !== undefined && chatId !== undefined) {
-    const entityId = await resolveTelegramRuntimeEntityId(
-      runtime,
-      accountId,
-      String(fromId),
-    );
+  const entityId = sender.entityId;
+  if (fromId !== undefined && chatId !== undefined && entityId) {
     const roomId = createUniqueUuid(
       runtime,
       scopedTelegramKey(String(chatId), accountId),
@@ -300,7 +314,10 @@ async function dispatchAgentCommand(
     }
   }
 
-  await messageManager.handleMessage(ctx, { forceReply: true });
+  await messageManager.handleMessage(ctx, {
+    forceReply: true,
+    ...(entityId ? { entityId } : {}),
+  });
   logger.debug(
     {
       src: "plugin:telegram",

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -28,9 +28,9 @@
  * Auth gating: `requiresAuth` / `requiresElevated` commands are gated at the
  * connector boundary using the agent's role model (`hasRoleAccess`) — the same
  * mechanism every surface uses. The Telegram sender is mapped to a runtime
- * entity (matching `MessageManager`'s account-scoped id), and a command is
- * refused with a clear reply when the sender is not an owner (for
- * `requiresAuth`) or admin (for `requiresElevated`).
+ * entity through `resolveTelegramRuntimeEntityId` (matching inbound
+ * `handleMessage`), and a command is refused with a clear reply when the
+ * sender is not an owner (for `requiresAuth`) or admin (for `requiresElevated`).
  *
  * A matched `bot.command` handler never calls `next()`, so the catch-all
  * message handler registered in `service.ts` does not also process command
@@ -56,6 +56,7 @@ import {
   resolveSettingsSection,
 } from "@elizaos/plugin-commands";
 import type { Context, Telegraf } from "telegraf";
+import { resolveTelegramRuntimeEntityId } from "./identity";
 import type { MessageManager } from "./messageManager";
 
 /**
@@ -95,9 +96,9 @@ export interface TelegramCommandDescriptor {
 }
 
 /**
- * Account-scoped key matching `MessageManager.scopedTelegramKey`, so the entity
- * id this bridge derives for role resolution is the same id the inbound message
- * pipeline assigns to the sender.
+ * Account-scoped key matching `MessageManager.scopedTelegramKey` for rooms and
+ * chats. Sender entity ids go through `resolveTelegramRuntimeEntityId` instead
+ * so slash-command auth uses the same UUID inbound messages persist.
  */
 function scopedTelegramKey(key: string, accountId: string): string {
   return accountId === DEFAULT_ACCOUNT_ID ? key : `${accountId}:${key}`;
@@ -206,9 +207,9 @@ export function resolveTelegramEmbedUrl(runtime: IAgentRuntime): string | null {
  * Resolve the Telegram sender's trust level using the agent's role model — the
  * same `hasRoleAccess` check every surface runs. OWNER access satisfies
  * `requiresAuth`; ADMIN access satisfies `requiresElevated`. The sender's
- * Telegram user id is mapped through the account-scoped `createUniqueUuid`
- * (matching `MessageManager`), so role resolution reads the canonical-owner /
- * world-role state the inbound pipeline established.
+ * Telegram user id is mapped through `resolveTelegramRuntimeEntityId`
+ * (matching inbound `handleMessage`), so role resolution reads the
+ * canonical-owner / world-role state the inbound pipeline established.
  */
 export async function resolveTelegramSenderAuth(
   ctx: Context,
@@ -222,10 +223,11 @@ export async function resolveTelegramSenderAuth(
     return { isAuthorized: false, isElevated: false };
   }
 
-  const entityId = createUniqueUuid(
+  const entityId = await resolveTelegramRuntimeEntityId(
     runtime,
-    scopedTelegramKey(String(fromId), accountId),
-  ) as UUID;
+    accountId,
+    String(fromId),
+  );
   const roomId = createUniqueUuid(
     runtime,
     scopedTelegramKey(String(chatId), accountId),
@@ -267,10 +269,11 @@ async function dispatchAgentCommand(
   const fromId = ctx.from?.id;
   const chatId = ctx.chat?.id;
   if (fromId !== undefined && chatId !== undefined) {
-    const entityId = createUniqueUuid(
+    const entityId = await resolveTelegramRuntimeEntityId(
       runtime,
-      scopedTelegramKey(String(fromId), accountId),
-    ) as UUID;
+      accountId,
+      String(fromId),
+    );
     const roomId = createUniqueUuid(
       runtime,
       scopedTelegramKey(String(chatId), accountId),

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -271,6 +271,42 @@ export async function resolveTelegramSenderAuth(
 }
 
 /**
+ * Translate a fallible canonical-identity lookup at the Telegram command
+ * boundary. Commands must fail closed with a visible response instead of
+ * disappearing into the bot-wide error handler when durable identity storage
+ * is unavailable.
+ */
+async function resolveTelegramSenderAuthOrReply(
+  ctx: Context,
+  runtime: IAgentRuntime,
+  accountId: string,
+): Promise<TelegramSenderAuth | null> {
+  try {
+    return await resolveTelegramSenderAuth(ctx, runtime, accountId);
+  } catch (error) {
+    // error-policy:J4 identity storage failure is an explicit unavailable
+    // response; authorization and dispatch remain fail closed.
+    runtime.reportError("telegram:command-identity", error, {
+      accountId,
+      telegramUserId:
+        ctx.from?.id === undefined ? undefined : String(ctx.from.id),
+    });
+    logger.error(
+      {
+        src: "plugin:telegram",
+        agentId: runtime.agentId,
+        accountId,
+        telegramUserId: ctx.from?.id,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Telegram command identity lookup failed",
+    );
+    await ctx.reply("Could not verify your identity. Try again.");
+    return null;
+  }
+}
+
+/**
  * Run an agent-target command. Deterministic commands
  * (help/status/think/model/reset/…) resolve via `resolveCommand` and answer
  * locally. Pipeline-owned commands route the command message through the agent
@@ -345,7 +381,12 @@ function buildCommandHandler(
   const { command } = descriptor;
 
   return async (ctx: Context) => {
-    const sender = await resolveTelegramSenderAuth(ctx, runtime, accountId);
+    const sender = await resolveTelegramSenderAuthOrReply(
+      ctx,
+      runtime,
+      accountId,
+    );
+    if (!sender) return;
     const gate = gateConnectorCommandByName(
       runtime.agentId,
       command.name,
@@ -398,7 +439,12 @@ function registerTelegramEmbedCommand(
   accountId: string,
 ): void {
   bot.command(TELEGRAM_EMBED_COMMAND, async (ctx) => {
-    const sender = await resolveTelegramSenderAuth(ctx, runtime, accountId);
+    const sender = await resolveTelegramSenderAuthOrReply(
+      ctx,
+      runtime,
+      accountId,
+    );
+    if (!sender) return;
     if (!sender.isAuthorized && !sender.isElevated) {
       await ctx.reply(
         "Opening the Eliza app from Telegram requires OWNER or ADMIN access.",

--- a/plugins/plugin-telegram/src/identity.test.ts
+++ b/plugins/plugin-telegram/src/identity.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Sender entity-id resolution. Proves inbound messages, slash-command auth,
+ * and callback/reaction paths share one UUID, including the default account
+ * whose old `scopedTelegramKey` omitted the `default:` prefix.
+ */
+import { createUniqueUuid, type IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { resolveTelegramRuntimeEntityId } from "./identity";
+
+function runtime(): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    getSetting: () => undefined,
+  } as unknown as IAgentRuntime;
+}
+
+describe("resolveTelegramRuntimeEntityId", () => {
+  it("seeds the default account as default:<telegramUserId>, not the bare id", async () => {
+    const rt = runtime();
+    const inbound = await resolveTelegramRuntimeEntityId(rt, "default", "4242");
+    expect(inbound).toBe(createUniqueUuid(rt, "default:4242"));
+    expect(inbound).not.toBe(createUniqueUuid(rt, "4242"));
+  });
+
+  it("keeps non-default account seeds identical to the historical scoped key", async () => {
+    const rt = runtime();
+    const accounts = ["acct-a", "bot-2", "other"];
+    for (const accountId of accounts) {
+      const resolved = await resolveTelegramRuntimeEntityId(
+        rt,
+        accountId,
+        "555001",
+      );
+      expect(resolved).toBe(createUniqueUuid(rt, `${accountId}:555001`));
+    }
+  });
+});

--- a/plugins/plugin-telegram/src/identity.test.ts
+++ b/plugins/plugin-telegram/src/identity.test.ts
@@ -1,16 +1,37 @@
 /**
  * Sender entity-id resolution. Proves inbound messages, slash-command auth,
  * and callback/reaction paths share one UUID, including the default account
- * whose old `scopedTelegramKey` omitted the `default:` prefix.
+ * whose old `scopedTelegramKey` omitted the `default:` prefix, the configured
+ * canonical-owner store path, and fail-closed `getEntityById` errors.
  */
 import { createUniqueUuid, type IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveTelegramRuntimeEntityId } from "./identity";
+
+// The shared vitest setup stubs `getConfiguredOwnerEntityIds` to `[]`, which
+// would hide the canonical-owner store path this file exists to cover.
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return { ...actual };
+});
+
+const OWNER_ENTITY_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
 function runtime(): IAgentRuntime {
   return {
     agentId: "agent-1",
     getSetting: () => undefined,
+  } as unknown as IAgentRuntime;
+}
+
+function ownerRuntime(
+  getEntityById?: IAgentRuntime["getEntityById"],
+): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    getSetting: (key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY_ID : undefined,
+    ...(getEntityById ? { getEntityById } : {}),
   } as unknown as IAgentRuntime;
 }
 
@@ -33,5 +54,52 @@ describe("resolveTelegramRuntimeEntityId", () => {
       );
       expect(resolved).toBe(createUniqueUuid(rt, `${accountId}:555001`));
     }
+  });
+
+  it("returns the configured owner entity when Telegram metadata matches", async () => {
+    const getEntityById = vi.fn(async () => ({
+      id: OWNER_ENTITY_ID,
+      names: ["owner"],
+      metadata: { telegram: { userId: "4242" } },
+    }));
+    const rt = ownerRuntime(getEntityById);
+    await expect(
+      resolveTelegramRuntimeEntityId(rt, "default", "4242"),
+    ).resolves.toBe(OWNER_ENTITY_ID);
+    expect(getEntityById).toHaveBeenCalledWith(OWNER_ENTITY_ID);
+    expect(OWNER_ENTITY_ID).not.toBe(createUniqueUuid(rt, "default:4242"));
+  });
+
+  it("falls back to the connector UUID when the configured owner is unpaired", async () => {
+    const getEntityById = vi.fn(async () => ({
+      id: OWNER_ENTITY_ID,
+      names: ["owner"],
+      metadata: { telegram: { userId: "9999" } },
+    }));
+    const rt = ownerRuntime(getEntityById);
+    await expect(
+      resolveTelegramRuntimeEntityId(rt, "default", "4242"),
+    ).resolves.toBe(createUniqueUuid(rt, "default:4242"));
+  });
+
+  it("throws TELEGRAM_IDENTITY_NOT_READY when getEntityById is absent", async () => {
+    const rt = ownerRuntime();
+    await expect(
+      resolveTelegramRuntimeEntityId(rt, "default", "4242"),
+    ).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "TELEGRAM_IDENTITY_NOT_READY",
+    });
+  });
+
+  it("propagates getEntityById storage failure", async () => {
+    const rt = ownerRuntime(
+      vi.fn(async () => {
+        throw new Error("disk full");
+      }),
+    );
+    await expect(
+      resolveTelegramRuntimeEntityId(rt, "default", "4242"),
+    ).rejects.toThrow("disk full");
   });
 });

--- a/plugins/plugin-telegram/src/messageManager.callback-identity.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.callback-identity.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Callback-query identity failure. Proves a configured-owner
+ * `getEntityById` miss or storage error is acknowledged to Telegram with a
+ * user-visible alert instead of leaving the button spinner running, and that
+ * the turn is not dispatched. Real core identity resolution; Telegraf is mocked.
+ */
+import { encodeReplyCallback, type IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "./messageManager";
+
+// The shared vitest setup stubs `getConfiguredOwnerEntityIds` to `[]`, which
+// would hide the canonical-owner store path this file exists to cover.
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return { ...actual };
+});
+
+const OWNER_ENTITY_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+function makeCallbackManager(runtimeOverrides: Record<string, unknown> = {}) {
+  const handleMessage = vi.fn(async () => undefined);
+  const ensureConnection = vi.fn(async () => undefined);
+  const reportError = vi.fn();
+  const runtime = {
+    agentId: "agent-1",
+    messageService: { handleMessage },
+    ensureConnection,
+    reportError,
+    getSetting: (key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY_ID : undefined,
+    ...runtimeOverrides,
+  };
+  const bot = { telegram: { sendMessage: vi.fn(), sendChatAction: vi.fn() } };
+  return {
+    manager: new MessageManager(
+      bot as never,
+      runtime as unknown as IAgentRuntime,
+    ),
+    handleMessage,
+    ensureConnection,
+    reportError,
+    runtime,
+  };
+}
+
+function callbackCtx() {
+  const data = encodeReplyCallback("continue");
+  if (!data) {
+    throw new Error("encodeReplyCallback returned null");
+  }
+  return {
+    callbackQuery: {
+      id: "cbq-identity",
+      data,
+      message: {
+        message_id: 77,
+        chat: { id: 123, type: "private" },
+        date: 1_700_000_000,
+      },
+    },
+    from: {
+      id: 42,
+      first_name: "Ada",
+      username: "ada",
+      is_bot: false,
+    },
+    chat: { id: 123, type: "private" },
+    answerCbQuery: vi.fn(async () => undefined),
+  };
+}
+
+describe("handleCallbackQuery identity failure", () => {
+  it("acknowledges and fails closed when getEntityById rejects", async () => {
+    const getEntityById = vi.fn(async () => {
+      throw new Error("store unavailable");
+    });
+    const { manager, handleMessage, reportError } = makeCallbackManager({
+      getEntityById,
+    });
+    const ctx = callbackCtx();
+
+    await expect(
+      manager.handleCallbackQuery(ctx as never),
+    ).resolves.toBeUndefined();
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(ctx.answerCbQuery).toHaveBeenCalledWith(
+      "Could not verify your identity. Try again.",
+      { show_alert: true },
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "telegram:callback-identity",
+      expect.objectContaining({ message: "store unavailable" }),
+      expect.objectContaining({
+        telegramUserId: "42",
+      }),
+    );
+  });
+
+  it("acknowledges and fails closed when getEntityById is absent", async () => {
+    const { manager, handleMessage, reportError } = makeCallbackManager();
+    const ctx = callbackCtx();
+
+    await expect(
+      manager.handleCallbackQuery(ctx as never),
+    ).resolves.toBeUndefined();
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(ctx.answerCbQuery).toHaveBeenCalledWith(
+      "Could not verify your identity. Try again.",
+      { show_alert: true },
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "telegram:callback-identity",
+      expect.objectContaining({ code: "TELEGRAM_IDENTITY_NOT_READY" }),
+      expect.objectContaining({
+        telegramUserId: "42",
+      }),
+    );
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.edit-react.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.edit-react.test.ts
@@ -4,8 +4,14 @@
  * that edits one status message, and computer-use approval callback parsing.
  * Telegraf send/edit calls are mocked.
  */
-import { type Content, encodeReplyCallback, type Memory } from "@elizaos/core";
+import {
+  type Content,
+  createUniqueUuid,
+  encodeReplyCallback,
+  type Memory,
+} from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveTelegramRuntimeEntityId } from "./identity";
 import {
   createTelegramCompactProgressCallback,
   MessageManager,
@@ -299,6 +305,49 @@ describe("Telegram computer-use approval callbacks (#8912)", () => {
     expect(messageId).toBe(88);
     expect(inlineId).toBeUndefined();
     expect(text).toContain("Step 2: click");
+  });
+
+  it("stamps callback-query turns with the inbound message entity id", async () => {
+    const data = encodeReplyCallback("continue");
+    expect(data).not.toBeNull();
+    const answerCbQuery = vi.fn(async () => undefined);
+    const seen: string[] = [];
+    const messageService = {
+      handleMessage: vi.fn(async (_runtime: unknown, memory: Memory) => {
+        seen.push(memory.entityId);
+      }),
+    };
+    const env = makeManager({ messageService });
+
+    await env.manager.handleCallbackQuery({
+      callbackQuery: {
+        id: "cbq-entity",
+        data,
+        message: {
+          message_id: 77,
+          chat: { id: 123, type: "private" },
+          date: 1_700_000_000,
+        },
+      },
+      from: {
+        id: 42,
+        first_name: "Ada",
+        username: "ada",
+        is_bot: false,
+      },
+      chat: { id: 123, type: "private" },
+      telegram: { sendMessage: env.sendMessage },
+      answerCbQuery,
+    } as never);
+
+    const expected = await resolveTelegramRuntimeEntityId(
+      env.runtime as never,
+      "default",
+      "42",
+    );
+    expect(seen).toEqual([expected]);
+    expect(expected).toBe(createUniqueUuid(env.runtime as never, "default:42"));
+    expect(expected).not.toBe(createUniqueUuid(env.runtime as never, "42"));
   });
 });
 

--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -772,6 +772,57 @@ describe("MessageManager malformed payload handling", () => {
     expect(runtime.setCache).not.toHaveBeenCalled();
   });
 
+  it("uses a bound slash-command entity id instead of looking identity up again", async () => {
+    const boundEntityId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const getEntityById = vi.fn(async () => {
+      throw new Error("identity store must not be consulted for a bound actor");
+    });
+    const cache = new Map<string, unknown>();
+    const ensureConnection = vi.fn(async () => undefined);
+    const createMemory = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      ensureConnection,
+      createMemory,
+      getEntityById,
+      getCache: vi.fn(async (key: string) => cache.get(key)),
+      setCache: vi.fn(async (key: string, value: unknown) => {
+        cache.set(key, value);
+        return true;
+      }),
+      getSetting: vi.fn(() => undefined),
+    } as unknown as IAgentRuntime;
+    const manager = new MessageManager({ telegram: {} } as never, runtime);
+
+    await manager.handleMessage(
+      {
+        from: {
+          id: 42,
+          first_name: "Ada",
+          username: "ada",
+          is_bot: false,
+        },
+        chat: { id: 123, type: "private", first_name: "Ada" },
+        message: {
+          message_id: 99,
+          date: 1_700_000_000,
+          text: "/stop",
+          chat: { id: 123, type: "private", first_name: "Ada" },
+        },
+      } as never,
+      { entityId: boundEntityId },
+    );
+
+    expect(getEntityById).not.toHaveBeenCalled();
+    expect(ensureConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: boundEntityId }),
+    );
+    expect(createMemory).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: boundEntityId }),
+      "messages",
+    );
+  });
+
   it("fails observably when passive inbound persistence fails", async () => {
     const createMemory = vi.fn(async () => {
       throw new Error("database unavailable");

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1446,11 +1446,13 @@ export class MessageManager {
    *   through the agent and force a reply, bypassing the TELEGRAM_AUTO_REPLY gate.
    *   Used for explicit slash-command invocations where the user intent to get a
    *   response is unambiguous.
+   * @param {UUID} [options.entityId] - Actor already resolved for this turn
+   *   (slash-command auth). When set, identity is not looked up again.
    * @returns {Promise<void>}
    */
   public async handleMessage(
     ctx: Context,
-    options?: { forceReply?: boolean },
+    options?: { forceReply?: boolean; entityId?: UUID },
   ): Promise<void> {
     if (!ctx.message || !ctx.from) {
       return;
@@ -1460,11 +1462,13 @@ export class MessageManager {
 
     try {
       const telegramUserId = ctx.from.id.toString();
-      const entityId = await resolveTelegramRuntimeEntityId(
-        this.runtime,
-        this.accountId,
-        telegramUserId,
-      );
+      const entityId =
+        options?.entityId ??
+        (await resolveTelegramRuntimeEntityId(
+          this.runtime,
+          this.accountId,
+          telegramUserId,
+        ));
 
       const threadId =
         "is_topic_message" in message && message.is_topic_message
@@ -1882,11 +1886,40 @@ export class MessageManager {
     const sourceMessage = query.message;
     const chat = sourceMessage.chat as Chat;
     const telegramUserId = ctx.from.id.toString();
-    const entityId = await resolveTelegramRuntimeEntityId(
-      this.runtime,
-      this.accountId,
-      telegramUserId,
-    );
+    let entityId: UUID;
+    try {
+      entityId = await resolveTelegramRuntimeEntityId(
+        this.runtime,
+        this.accountId,
+        telegramUserId,
+      );
+    } catch (error) {
+      // error-policy:J4 identity store failure is a user-visible unavailable
+      // state: fail closed, acknowledge so Telegram clears the spinner, then
+      // report. Do not throw before answerCbQuery — the service catch only logs.
+      try {
+        await ctx.answerCbQuery("Could not verify your identity. Try again.", {
+          show_alert: true,
+        });
+      } catch {
+        // error-policy:J6 best-effort: a stale callback may already have expired
+      }
+      this.runtime.reportError("telegram:callback-identity", error, {
+        accountId: this.accountId,
+        telegramUserId,
+      });
+      logger.error(
+        {
+          src: "plugin:telegram",
+          agentId: this.runtime.agentId,
+          accountId: this.accountId,
+          telegramUserId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Telegram callback identity lookup failed",
+      );
+      return;
+    }
 
     const threadId =
       "is_topic_message" in sourceMessage && sourceMessage.is_topic_message

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -1882,10 +1882,11 @@ export class MessageManager {
     const sourceMessage = query.message;
     const chat = sourceMessage.chat as Chat;
     const telegramUserId = ctx.from.id.toString();
-    const entityId = createUniqueUuid(
+    const entityId = await resolveTelegramRuntimeEntityId(
       this.runtime,
-      this.scopedTelegramKey(telegramUserId),
-    ) as UUID;
+      this.accountId,
+      telegramUserId,
+    );
 
     const threadId =
       "is_topic_message" in sourceMessage && sourceMessage.is_topic_message
@@ -2238,10 +2239,11 @@ export class MessageManager {
       firstReaction.type === "emoji" ? firstReaction.emoji : firstReaction.type;
 
     try {
-      const entityId = createUniqueUuid(
+      const entityId = await resolveTelegramRuntimeEntityId(
         this.runtime,
-        this.scopedTelegramKey(ctx.from.id.toString()),
-      ) as UUID;
+        this.accountId,
+        ctx.from.id.toString(),
+      );
       const roomId = createUniqueUuid(
         this.runtime,
         this.scopedTelegramKey(ctx.chat.id.toString()),


### PR DESCRIPTION
Closes #24477.

This is independently motivated from already-filed #24468 / #24465 (`fix/telegram-forum-text-thread-id`, forum topic text thread id). Two other independently motivated `plugins/plugin-telegram/src/messageManager.ts` defects are being filed separately with their own new test files: `fix/telegram-media-caption-limit` (Bot API 1024-unit caption clamp) and `fix/telegram-send-swallows-failure` (`sendMessage` returning `[]` on Bot API failure). Overlap on this one file is expected; they are not a stack and must not be combined.

# Relates to

Closes #24477.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`a40cc65d3f16`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a40cc65d3f16`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin tests and the plugin suite are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Default-account slash-command auth, callback queries, and reactions now seed the same entity id inbound `handleMessage` already used (`default:<telegramUserId>`). Non-default accounts already used `${accountId}:${telegramUserId}` on both paths and stay byte-identical. Room ids stay on `scopedTelegramKey` so DM rooms do not move.

Roles already stored under the old default-account ghost UUID (`createUniqueUuid(runtime, telegramUserId)`) will not follow the sender. That UUID was never the inbound entity; inbound memories already used `default:<id>`.

# Background

## What does this PR do?

Makes default-account slash-command auth, callback queries, and reactions use the inbound entity id (`resolveTelegramRuntimeEntityId`) instead of `scopedTelegramKey`'s unprefixed seed. On origin those two seeds produced different UUIDs (`e881c2dc-…` vs `f3cac183-…` for telegram user `42`), so `hasRoleAccess` on `/restart` did not see the OWNER role written against the inbound entity.

## What kind of change is this?

Bug fix (non-breaking). Fail-closed identity split: owner commands looked up a ghost UUID and were denied. Not privilege escalation.

## Why are we doing this? Any context or related work?

`handleMessage` uses the resolver. Slash-command auth, callbacks, and reactions used `scopedTelegramKey`. On the default account those are different UUIDs. Nothing throws; the command handler replies with a clean authorization denial.

Sibling, not a stack: #24468 already occupies `messageManager.ts` for the forum-topic text path.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/identity.test.ts`, `command-registration.test.ts` (default-account sender entity ids), and `messageManager.edit-react.test.ts` (callback-query turns).

## Detailed testing steps

Automated tests:

```
cd plugins/plugin-telegram
bun run test src/identity.test.ts src/command-registration.test.ts src/messageManager.edit-react.test.ts
# Test Files  3 passed (3)
# Tests  36 passed (36)
```

Load-bearing revert (copy-aside origin production files under the new tests): 2 failed | 32 skipped (34). Restore the fix: 2 passed | 32 skipped (34).

Over-rejection: corpus of `acct-a`, `bot-2`, `other` with user `555001` stays byte-identical. The `acct-a` command-auth test pins that.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:614244bebdb16476066b237b70c6fe0fc38dd93c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. The failure is a UUID split between inbound seed `default:42` and command-auth seed `42`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] [exact-head validation: 86 tests, typecheck, lint, build, diff and guide parity](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24478-validation-614244be.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - not driven against a live paired owner Telegram account. Tests drive real `createUniqueUuid` + `resolveTelegramRuntimeEntityId` + `resolveTelegramSenderAuth` / `handleCallbackQuery`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no throw, no UI. Focused vitest at `d66ac961707928219a0ad229772806bd50de68ba`: 3 files / 36 tests passed.

Load-bearing revert under the new tests:

```
FAIL  command-registration.test.ts > ... default-account sender entity ids
AssertionError: expected 'f3cac183-…' to be 'e881c2dc-…'

FAIL  messageManager.edit-react.test.ts > ... callback-query turns
AssertionError: expected [ 'f3cac183-90e4-0775-be57-5d54e97695fe' ]
to deeply equal [ 'e881c2dc-16a1-025a-aebc-a7d27b3d89c0' ]
Tests  2 failed | 32 skipped (34)
```

Restore the fix: `Tests  2 passed | 32 skipped (34)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Not driven against a live paired owner Telegram account. Proof is real `createUniqueUuid` + real `resolveTelegramRuntimeEntityId` + real `resolveTelegramSenderAuth` / `handleCallbackQuery`.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- Full plugin suite: **255 passed / 4 failed (259)**. The 4 failures are `src/messageConnector.test.ts` (`initializeBot` spy) and reproduce on an unmodified control. Not caused by this change.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Typecheck unique error messages vs control: added=0. `bunx biome check --write` on the five changed files: clean.
- Roles already stored under the old default-account ghost UUID (`createUniqueUuid(runtime, telegramUserId)`) will not follow the sender. That UUID was never the inbound entity; inbound memories already used `default:<id>`.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-telegram-entity-seed]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N5MF0CR7K16V40A2X88EKP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T16:42:31.820Z","completed_at":"2026-08-22T16:45:10.025Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T16:42:32.193Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"18e5a7bd91e4c2ecf7214e2eef8d0c0a5becc3e98db6d52a035a30d92105b349","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"033bf55f-c2fe-4153-9402-af20c691eb57","object_id":"sha256:18e5a7bd91e4c2ecf7214e2eef8d0c0a5becc3e98db6d52a035a30d92105b349","sha256":"18e5a7bd91e4c2ecf7214e2eef8d0c0a5becc3e98db6d52a035a30d92105b349"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"OXYCzaWkJcOcFvbGfWb6ner6CMo1Sf7dXe0L7Jlsob-FdhUx1bcuXnflXfNEfFpxQGiprQpn279FsQa7aIM2Bg"}} -->

