### PR TITLE
fix(telegram): clamp media captions to the Bot API 1024-unit cap

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.outbound-media.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.outbound-media.test.ts
@@ -9,6 +9,9 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { MediaType, MessageManager } from "./messageManager";
 
+/** Telegram Bot API caption cap (photo/video/document/audio/animation). */
+const BOT_API_CAPTION_MAX = 1024;
+
 // Outbound media coverage for the Telegram connector (#8876): when the agent
 // sends a message that carries `Media` attachments, each attachment must be
 // dispatched through the matching Telegram API method (sendPhoto / sendVideo /
@@ -167,6 +170,57 @@ describe("Telegram connector outbound media", () => {
       "https://cdn.example.com/cat.png",
       { caption: "a cat", message_thread_id: 77 },
     );
+  });
+
+  it("keeps previously-valid captions at or under the Bot API cap unchanged", async () => {
+    const { manager, ctx, senders } = setup();
+    const corpus = [
+      "a cat",
+      "report",
+      "a".repeat(BOT_API_CAPTION_MAX),
+      "café 🦊",
+      "",
+    ];
+    for (const caption of corpus) {
+      senders.sendPhoto.mockClear();
+      await manager.sendMedia(
+        ctx,
+        "https://cdn.example.com/cat.png",
+        MediaType.PHOTO,
+        caption,
+      );
+      expect(senders.sendPhoto.mock.calls[0][2]?.caption).toBe(caption);
+    }
+  });
+
+  it("clamps an over-limit caption to 1024 well-formed units before send", async () => {
+    const { manager, ctx, senders } = setup();
+    const over = `${"a".repeat(BOT_API_CAPTION_MAX)}z`;
+    await manager.sendMedia(
+      ctx,
+      "https://cdn.example.com/cat.png",
+      MediaType.PHOTO,
+      over,
+    );
+    const sent = senders.sendPhoto.mock.calls[0][2]?.caption as string;
+    expect(sent.length).toBe(BOT_API_CAPTION_MAX);
+    expect(sent).toBe("a".repeat(BOT_API_CAPTION_MAX));
+    expect(sent.isWellFormed()).toBe(true);
+  });
+
+  it("does not split a trailing surrogate pair when clamping a caption", async () => {
+    const { manager, ctx, senders } = setup();
+    const over = `${"a".repeat(BOT_API_CAPTION_MAX - 1)}🦊`;
+    await manager.sendMedia(
+      ctx,
+      "https://cdn.example.com/cat.png",
+      MediaType.PHOTO,
+      over,
+    );
+    const sent = senders.sendPhoto.mock.calls[0][2]?.caption as string;
+    expect(sent.length).toBe(BOT_API_CAPTION_MAX - 1);
+    expect(sent).toBe("a".repeat(BOT_API_CAPTION_MAX - 1));
+    expect(sent.isWellFormed()).toBe(true);
   });
 
   it("routes local-file media through the active forum topic", async () => {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -159,6 +159,8 @@ async function resolveTelegramFileBytes(
 }
 
 const MAX_MESSAGE_LENGTH = 4096; // Telegram's max message length
+/** Bot API caption cap for photo/video/document/audio/animation sends. */
+export const TELEGRAM_CAPTION_MAX = 1024;
 const INTERACTION_ONLY_FALLBACK_TEXT = "Choose an option:";
 const ACTION_PROGRESS_SOURCE = "action_progress";
 const COMPUTER_USE_APPROVAL_CALLBACK_RE =
@@ -1322,8 +1324,15 @@ export class MessageManager {
       if (!ctx.chat) {
         throw new Error("sendMedia: ctx.chat is undefined");
       }
+      const captionForSend =
+        caption === undefined || caption.length === 0
+          ? caption
+          : truncateWellFormed(
+              toWellFormedUnicode(caption),
+              TELEGRAM_CAPTION_MAX,
+            );
       const sendOptions = {
-        caption,
+        caption: captionForSend,
         ...(messageThreadId !== undefined
           ? { message_thread_id: messageThreadId }
           : {}),


### PR DESCRIPTION
Closes #24479.

This is independently motivated from already-filed #24468 / #24465 (`fix/telegram-forum-text-thread-id`, forum topic text thread id) and #24477 / #24478 (`fix/telegram-default-entity-seed`, default-account slash-command UUID split). A third independently motivated `plugins/plugin-telegram/src/messageManager.ts` defect (`fix/telegram-send-swallows-failure`, `sendMessage` returning `[]` on Bot API failure) is being filed separately. Overlap on this one file is expected; each has its own new test file. They are not a stack and must not be combined.

# Relates to

Closes #24479.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`a40cc65d3f16`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a40cc65d3f16`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin tests and the plugin suite are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Over-limit media captions are clamped to 1024 well-formed UTF-16 units. Previously-valid captions at or under the cap (`a cat`, `report`, 1024 `a`s, `café 🦊`, `""`) stay byte-identical. Does not change `Promise.all` media-before-text ordering.

# Background

## What does this PR do?

Clamps `sendMedia` captions to the Telegram Bot API 1024 UTF-16-unit cap, without splitting a trailing surrogate pair. Vision descriptions from `processImage` routinely exceed 1024; origin passed them through, so a 400 aborted the whole reply including the agent's prose.

## What kind of change is this?

Bug fix (non-breaking).

## Why are we doing this? Any context or related work?

`sendMessageInChunks` sends all media via `Promise.all` before the text path. A caption 400 therefore drops the prose. The inbound J2 catch correctly maps that 400 to `TELEGRAM_REPLY_DELIVERY_FAILED`; it does not restore the text. Truncating the caption is the fix.

Sibling occupancy on `messageManager.ts` (#24468, #24478) is expected and independently motivated.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/messageManager.outbound-media.test.ts` (clamp + surrogate-pair) and the `sendMedia` caption extra in `messageManager.ts`.

## Detailed testing steps

Automated tests:

```
cd plugins/plugin-telegram
bun run test src/messageManager.outbound-media.test.ts src/messageManager.test.ts
# Test Files  2 passed (2)
# Tests  42 passed (42)
```

Load-bearing revert (copy-aside origin `messageManager.ts` under the new tests; cap is a literal 1024 in the test file): 2 failed | 1 passed | 6 skipped (9). Restore the fix: 3 passed | 6 skipped (9).

Over-rejection: corpus of 5 previously-valid captions origin vs branch **byte-identical** on `sendPhoto` extra.caption.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:d3eaea08d772c37eeaee285577cbf67846b4ef3a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is a Bot API caption length (1025 units → 400).
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] Origin sent 1025-unit captions. After the fix, 1024 well-formed units. The J2 catch sees a 400 and wraps `TELEGRAM_REPLY_DELIVERY_FAILED`; that does not restore the dropped prose.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - not driven against live Bot API `sendPhoto`. Proof is the extra object the real `sendMedia` passes to the Telegraf sender.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `d3eaea08d772c37eeaee285577cbf67846b4ef3a`: 2 files / 42 tests passed.

Load-bearing revert under the new tests:

```
FAIL  ... clamps an over-limit caption to 1024 well-formed units before send
FAIL  ... does not split a trailing surrogate pair when clamping a caption
AssertionError: expected 1025 to be 1023
Tests  2 failed | 1 passed | 6 skipped (9)
```

Restore the fix: `Tests  3 passed | 6 skipped (9)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Not driven against live Bot API `sendPhoto` (would 400 on 1025). Proof is the extra object the real `sendMedia` passes to the Telegraf sender, which is the Bot API payload.
- Did not change `Promise.all` to continue text after a non-caption media failure. That would be a different defect.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- Full plugin suite: **253 passed / 4 failed (257)**. The 4 failures are `src/messageConnector.test.ts` (`initializeBot` spy) and reproduce on an unmodified control. Not caused by this change.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Typecheck unique error messages vs control: added=0. `bunx biome check --write` on the two changed files: clean.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-telegram-caption]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N5Y2KPB3CDBAQ13T8R9DAB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T16:47:46.806Z","completed_at":"2026-08-22T16:49:51.316Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T16:47:47.735Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"511c3ca921c7d89ad254c46dfb81bec61421e6ab81c3ff3eff9951beb1368e4b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"85e4f778-2e1d-4d6b-962d-9a3df78f0f4f","object_id":"sha256:511c3ca921c7d89ad254c46dfb81bec61421e6ab81c3ff3eff9951beb1368e4b","sha256":"511c3ca921c7d89ad254c46dfb81bec61421e6ab81c3ff3eff9951beb1368e4b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"F_HV_JVkXQRa0iiHyy12chN1UAkD2CriFKgJsIcA5GezcqE-NYBppZr48KJufDlHSD9WYCrML6E0axmfZck5Ag"}} -->
