### PR TITLE
fix(telegram): throw when outbound send or reaction reply fails

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -1085,3 +1085,94 @@ describe("MessageManager typing-indicator resilience", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("MessageManager.sendMessage transport failure", () => {
+  const corpus = [
+    "hello",
+    "Sure! Step 1 - done.",
+    "**bold** and _italic_",
+    "🦊",
+    "a".repeat(64),
+  ] as const;
+
+  function managerForSend(
+    sendMessage: ReturnType<typeof vi.fn>,
+    runtimeExtras: Record<string, unknown> = {},
+  ) {
+    return new MessageManager(
+      {
+        telegram: {
+          sendMessage,
+          sendChatAction: vi.fn(async () => undefined),
+        },
+      } as never,
+      {
+        agentId: "agent-1",
+        getSetting: () => undefined,
+        createMemory: vi.fn(async () => true),
+        emitEvent: vi.fn(),
+        ...runtimeExtras,
+      } as never,
+    );
+  }
+
+  it("throws instead of returning an empty array when Telegram rejects the send (403)", async () => {
+    const sendMessage = vi.fn(async () => {
+      throw {
+        response: {
+          error_code: 403,
+          description: "Forbidden: bot was blocked by the user",
+        },
+      };
+    });
+    const manager = managerForSend(sendMessage);
+
+    await expect(
+      manager.sendMessage(4242, { text: "hello from connector" }),
+    ).rejects.toMatchObject({
+      code: "TELEGRAM_OUTBOUND_SEND_FAILED",
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("still returns [] when there is nothing textual to send", async () => {
+    const sendMessage = vi.fn();
+    const manager = managerForSend(sendMessage);
+    const sent = await manager.sendMessage(4242, { text: "   " });
+    expect(sent).toEqual([]);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps previously accepted corpus sends byte-identical on the wire", async () => {
+    const sentBodies: string[] = [];
+    const sendMessage = vi.fn(async (chatId: number | string, text: string) => {
+      sentBodies.push(text);
+      return {
+        message_id: sentBodies.length,
+        date: 1_700_000_000,
+        text,
+        chat: { id: chatId, type: "private" },
+      };
+    });
+    const manager = managerForSend(sendMessage);
+
+    for (const text of corpus) {
+      const sent = await manager.sendMessage(7, { text });
+      expect(sent.length).toBeGreaterThan(0);
+    }
+    expect(sentBodies).toHaveLength(corpus.length);
+  });
+});
+
+describe("MessageManager reaction reply transport failure", () => {
+  it("does not report an empty successful turn when ctx.reply fails", async () => {
+    const { callback, reply } = await captureReactionCallback();
+    reply.mockRejectedValueOnce(new Error("Forbidden: bot was blocked"));
+
+    await expect(
+      callback({ text: "thanks for the reaction" }),
+    ).rejects.toMatchObject({
+      code: "TELEGRAM_REACTION_REPLY_FAILED",
+    });
+  });
+});

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -2360,7 +2360,15 @@ export class MessageManager {
             },
             "Error in reaction callback",
           );
-          return [];
+          // error-policy:J2 A failed reaction reply is not an empty successful
+          // turn; the inbound message callback already rethrows this way.
+          throw error instanceof ElizaError
+            ? error
+            : new ElizaError("Telegram reaction reply failed", {
+                code: "TELEGRAM_REACTION_REPLY_FAILED",
+                cause: error,
+                context: { accountId: this.accountId, roomId },
+              });
         }
       };
 
@@ -2483,7 +2491,12 @@ export class MessageManager {
    * @param {number | string} chatId - The Telegram chat ID to send the message to
    * @param {Content} content - The content to send
    * @param {number} [replyToMessageId] - Optional message ID to reply to
-   * @returns {Promise<Message.TextMessage[]>} The sent messages
+   * @returns {Promise<Message.TextMessage[]>} The sent messages. An empty
+   *   array means there was nothing to send (attachments-only or blank text),
+   *   not that Telegram rejected the send.
+   * @throws {ElizaError} `TELEGRAM_OUTBOUND_SEND_FAILED` when the Bot API
+   *   rejects the send; `TELEGRAM_OUTBOUND_PERSIST_FAILED` when Telegram
+   *   accepted the send but local memory/event evidence could not be written.
    */
   public async sendMessage(
     chatId: number | string,
@@ -2491,6 +2504,7 @@ export class MessageManager {
     replyToMessageId?: number,
     messageThreadId?: number,
   ): Promise<Message.TextMessage[]> {
+    let sentMessages: Message.TextMessage[];
     try {
       // Create a context-like object for sending
       const ctx = {
@@ -2498,17 +2512,43 @@ export class MessageManager {
         telegram: this.bot.telegram,
       };
 
-      const sentMessages = await this.sendMessageInChunks(
+      sentMessages = await this.sendMessageInChunks(
         ctx as Context,
         content,
         replyToMessageId,
         messageThreadId,
       );
+    } catch (error) {
+      logger.error(
+        {
+          src: "plugin:telegram",
+          agentId: this.runtime.agentId,
+          chatId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Error sending message to Telegram",
+      );
+      // error-policy:J2 Transport failure must not collapse to the same empty
+      // array `sendMessageInChunks` returns when there is nothing to send.
+      // `TelegramService.handleSendMessage` only rethrows if we throw here;
+      // returning [] made a 403/400 look like a successful no-op send.
+      throw error instanceof ElizaError
+        ? error
+        : new ElizaError("Telegram outbound send failed", {
+            code: "TELEGRAM_OUTBOUND_SEND_FAILED",
+            cause: error,
+            context: {
+              accountId: this.accountId,
+              chatId: String(chatId),
+            },
+          });
+    }
 
-      if (!sentMessages.length) {
-        return [];
-      }
+    if (!sentMessages.length) {
+      return [];
+    }
 
+    try {
       // Create group ID
       const roomKey = messageThreadId
         ? `${chatId.toString()}-${messageThreadId}`
@@ -2624,9 +2664,28 @@ export class MessageManager {
           chatId,
           error: error instanceof Error ? error.message : String(error),
         },
-        "Error sending message to Telegram",
+        "Error persisting a Telegram message that the Bot API already accepted",
       );
-      return [];
+      // error-policy:J2 Local persist/event failure after Telegram accepted the
+      // send. Returning [] would look like "nothing sent" and invite a retry
+      // that duplicates the visible message; rethrow with the provider ids in
+      // context so the connector boundary can fail without claiming silence.
+      throw error instanceof ElizaError
+        ? error
+        : new ElizaError(
+            "Telegram accepted the send but local delivery evidence failed",
+            {
+              code: "TELEGRAM_OUTBOUND_PERSIST_FAILED",
+              cause: error,
+              context: {
+                accountId: this.accountId,
+                chatId: String(chatId),
+                providerMessageIds: sentMessages.map((message) =>
+                  message.message_id.toString(),
+                ),
+              },
+            },
+          );
     }
   }
 }


### PR DESCRIPTION
Closes #24483.

This is independently motivated from already-filed #24468 / #24465 (`fix/telegram-forum-text-thread-id`), #24477 / #24478 (`fix/telegram-default-entity-seed`), and #24479 / #24481 (`fix/telegram-media-caption-limit`). They share `plugins/plugin-telegram/src/messageManager.ts`; each has its own new or extended test file. Overlap on this one file is expected; they are not a stack and must not be combined.

# Relates to

Closes #24483.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`a40cc65d3f16`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a40cc65d3f16`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin tests and the plugin suite are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Transport failures on the public `sendMessage` path and reaction-reply callbacks now throw instead of returning `[]`. Blank text still returns `[]` without calling the Bot API. Previously-valid sends (hello, markdown punctuation, `**bold** and _italic_`, 🦊, 64× `a`) still produce non-empty arrays.

Persist-after-send (`createMemory` throw after Telegram 200) now throws `TELEGRAM_OUTBOUND_PERSIST_FAILED` with `providerMessageIds` in context. A naive retry could duplicate. Callers should treat that code as do-not-retry; this PR does not wire `SendHandlerOutcome`.

# Background

## What does this PR do?

Makes `MessageManager.sendMessage` and the reaction-reply callback throw when the Bot API rejects the send, instead of returning `[]` (the same shape as a successful empty send). `handleSendMessage` currently logs `"Message sent"` after `[]` because nothing is thrown.

## What kind of change is this?

Bug fix (non-breaking). Fail-open success on a 403 becomes a throw.

## Why are we doing this? Any context or related work?

The inbound reply callback already rethrows (`TELEGRAM_REPLY_DELIVERY_FAILED`). Only this public outbound path swallowed. `service.ts` `sendHandler` is unchanged (#24051 occupies that file); scheduled dispatch will still see `inspectSendHandlerResult` → `unknown` on success. This PR only makes **failures throw**.

Sibling occupancy on `messageManager.ts` (#24468, #24478, #24481) is expected and independently motivated.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/messageManager.test.ts` — transport-failure cases on `sendMessage` and reaction reply.

## Detailed testing steps

Automated tests:

```
cd plugins/plugin-telegram
bun run test src/messageManager.test.ts
# Test Files  1 passed (1)
# Tests  37 passed (37)
```

Load-bearing revert (copy-aside origin `messageManager.ts` under the new tests): 2 failed | 35 skipped (37). Restore the fix: 2 passed | 35 skipped (37).

Over-rejection: previously-valid sends still produce non-empty arrays. Blank text still returns `[]` without calling the Bot API (pinned). `sendMessageInChunks` 403 test is unchanged (still rejects).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:8bf4fcb710eec3059849688a02b8b4cc69a59f30 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is `sendMessage` resolving to `[]` on a 403.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] Origin: promise resolved `[]` instead of rejecting on 403 / `ctx.reply` failure. Outer `handleSendMessage` catch never runs; it logs `"Message sent"`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - not driven against a live Bot API 403. The 403 object shape matches Telegraf's `{ response: { error_code } }`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `8bf4fcb710eec3059849688a02b8b4cc69a59f30`: 1 file / 37 tests passed.

Load-bearing revert under the new tests:

```
FAIL  MessageManager.sendMessage transport failure > throws instead of returning an empty array when Telegram rejects the send (403)
AssertionError: promise resolved "[]" instead of rejecting

FAIL  MessageManager reaction reply transport failure > does not report an empty successful turn when ctx.reply fails
AssertionError: promise resolved "[]" instead of rejecting
Tests  2 failed | 35 skipped (37)
```

Restore the fix: `Tests  2 passed | 35 skipped (37)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Did **not** change `service.ts` `sendHandler` (still returns `undefined` after a successful send). #24051 occupies that file. Scheduled dispatch will still see `inspectSendHandlerResult` → `unknown` on success. This PR only makes **failures throw** so they are not confused with `[]`.
- Persist-after-send (`createMemory` throw after Telegram 200) now throws `TELEGRAM_OUTBOUND_PERSIST_FAILED` with `providerMessageIds` in context. A naive retry could duplicate. Callers should treat that code as do-not-retry; this PR does not wire `SendHandlerOutcome`.
- Not driven against a live Bot API 403 (no bot token in this seat). The 403 object shape matches Telegraf's `{ response: { error_code } }`, and origin already tests that shape on `sendMessageInChunks`.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- Full plugin suite: **254 passed / 4 failed (258)**. Same `messageConnector.test.ts` failures exist on an unmodified control. Two `interactions.test.ts` failures on this worktree are missing generated `@elizaos/core` i18n data (pass on a checkout that has `packages/core/src/i18n/generated`). Not introduced by this change.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Typecheck unique error messages vs control: added=0. `bunx biome check --write` on the two files: clean.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-telegram-send]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N1MWY10JD3M7D0MY8K75DZ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T15:32:51.778Z","completed_at":"2026-08-22T15:38:27.599Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T15:32:52.884Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c1cb8d5c9e12fb3d8f5acb5034c5165ae82188b724e6b19b1e61eecf09f3bdd3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0847200c-5935-43b3-a0c1-14c9685346fc","object_id":"sha256:c1cb8d5c9e12fb3d8f5acb5034c5165ae82188b724e6b19b1e61eecf09f3bdd3","sha256":"c1cb8d5c9e12fb3d8f5acb5034c5165ae82188b724e6b19b1e61eecf09f3bdd3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"F4SC_F2yYAbf0SPm_QjHYB_DtCjQUCCO6kAiynjAhxboRvcB7UoiBLx2QVKejint5kROOpMcJ16hnaqlFrjoDQ"}} -->
