### PR TITLE
fix(discord): preserve command choice semantics

### DIFF
--- a/plugins/plugin-discord/__tests__/catalog-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/catalog-commands.test.ts
@@ -108,7 +108,7 @@ describe("catalog → DiscordSlashCommand mapping", () => {
 		}
 	});
 
-	it("caps mapped option choices at Discord's 25 and keeps token shape", () => {
+	it("omits fixed choices above Discord's 25-choice limit instead of truncating", () => {
 		// Navigation commands (the old /settings source of a choices-bearing
 		// option) are app-surface-only now, so drive the mapper directly.
 		const mapped = mapCatalogCommand({
@@ -129,7 +129,29 @@ describe("catalog → DiscordSlashCommand mapping", () => {
 		const section = mapped.options?.find((o) => o.name === "section");
 		expect(section).toBeDefined();
 		expect(section?.type).toBe("string");
-		// Discord caps option choices at 25; mapping must respect that.
+		// Discord caps option choices at 25. Registering the first 25 would
+		// silently hide the rest, so the option falls back to free-text input
+		// and the full choice set stays available to the command handler.
+		expect(section?.choices).toBeUndefined();
+	});
+
+	it("keeps fixed choices at or below Discord's 25-choice limit", () => {
+		const mapped = mapCatalogCommand({
+			name: "pick",
+			description: "Pick a token",
+			target: { kind: "agent" },
+			options: [
+				{
+					name: "section",
+					description: "Token",
+					required: false,
+					choices: Array.from({ length: 25 }, (_, i) => `token-${i}`),
+				},
+			],
+			requiresAuth: false,
+			requiresElevated: false,
+		});
+		const section = mapped.options?.find((o) => o.name === "section");
 		expect(section?.choices?.length).toBe(25);
 		for (const choice of section?.choices ?? []) {
 			expect(choice.name.length).toBeLessThanOrEqual(100);

--- a/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
+++ b/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
@@ -66,4 +66,37 @@ describe("Discord command projection Unicode safety", () => {
 		expect(label).toBe("b".repeat(79));
 		expect(label?.isWellFormed()).toBe(true);
 	});
+
+	it("preserves all 25 choices representable by Discord button rows", () => {
+		const choices = Array.from({ length: 25 }, (_, index) => ({
+			label: `Choice ${index}`,
+			value: `choice-${index}`,
+		}));
+		const menu = buildCommandArgMenu({
+			commandName: "mode",
+			arg: { name: "level", description: "Mode level", type: "string" },
+			choices,
+			userId: "user-123",
+		});
+
+		expect(menu.rows).toHaveLength(5);
+		expect(menu.rows.flatMap((row) => row.buttons)).toHaveLength(25);
+		expect(menu.rows[4]?.buttons[4]?.customId).toContain("value=choice-24");
+	});
+
+	it("rejects choices that require pagination instead of silently dropping them", () => {
+		const choices = Array.from({ length: 26 }, (_, index) => ({
+			label: `Choice ${index}`,
+			value: `choice-${index}`,
+		}));
+
+		expect(() =>
+			buildCommandArgMenu({
+				commandName: "mode",
+				arg: { name: "level", description: "Mode level", type: "string" },
+				choices,
+				userId: "user-123",
+			}),
+		).toThrow("use pagination or autocomplete instead");
+	});
 });

--- a/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
+++ b/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
@@ -3,6 +3,7 @@
  * changing the connector's existing fixed-choice registration semantics.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { mapOption } from "../catalog-commands";
 import { buildCommandArgMenu } from "../native-commands";
@@ -90,13 +91,46 @@ describe("Discord command projection Unicode safety", () => {
 			value: `choice-${index}`,
 		}));
 
-		expect(() =>
+		let caught: unknown;
+		try {
 			buildCommandArgMenu({
 				commandName: "mode",
 				arg: { name: "level", description: "Mode level", type: "string" },
 				choices,
 				userId: "user-123",
-			}),
-		).toThrow("use pagination or autocomplete instead");
+			});
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ElizaError);
+		const typed = caught as ElizaError;
+		expect(typed.code).toBe("DISCORD_COMMAND_MENU_CHOICES_EXCEED_CAPACITY");
+		expect(typed.message).toContain("use pagination or autocomplete instead");
+		expect(typed.context).toMatchObject({
+			commandName: "mode",
+			arg: "level",
+			choiceCount: 26,
+			maxChoices: 25,
+			buttonsPerRow: 5,
+		});
+	});
+
+	it("rejects an out-of-range buttonsPerRow with a typed error", () => {
+		let caught: unknown;
+		try {
+			buildCommandArgMenu({
+				commandName: "mode",
+				arg: { name: "level", description: "Mode level", type: "string" },
+				choices: [{ label: "A", value: "a" }],
+				userId: "user-123",
+				buttonsPerRow: 6,
+			});
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ElizaError);
+		expect((caught as ElizaError).code).toBe(
+			"DISCORD_COMMAND_MENU_INVALID_ROW_WIDTH",
+		);
 	});
 });

--- a/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
+++ b/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
@@ -6,10 +6,14 @@
 import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { mapOption } from "../catalog-commands";
-import { buildCommandArgMenu } from "../native-commands";
+import {
+	buildCommandArgCustomId,
+	buildCommandArgMenu,
+	buildDiscordCommandOptions,
+} from "../native-commands";
 
 describe("Discord command projection Unicode safety", () => {
-	it("keeps a complete surrogate pair when it fits the 100-unit choice limit", () => {
+	it("omits a fixed catalog choice whose complete value exceeds the limit", () => {
 		const emoji = "💎";
 		const option = mapOption({
 			name: "badge",
@@ -18,10 +22,10 @@ describe("Discord command projection Unicode safety", () => {
 			choices: [`${"d".repeat(98)}${emoji}tail`],
 		});
 
-		expect(option.choices?.[0]?.name).toBe(`${"d".repeat(98)}${emoji}`);
+		expect(option.choices).toBeUndefined();
 	});
 
-	it("does not split a surrogate pair at the 100-unit choice limit", () => {
+	it("omits a fixed catalog choice that cannot fit without splitting Unicode", () => {
 		const option = mapOption({
 			name: "badge",
 			description: "Badge name",
@@ -29,8 +33,40 @@ describe("Discord command projection Unicode safety", () => {
 			choices: [`${"d".repeat(99)}💎tail`],
 		});
 
-		expect(option.choices?.[0]?.name).toBe("d".repeat(99));
-		expect(option.choices?.[0]?.name.isWellFormed()).toBe(true);
+		expect(option.choices).toBeUndefined();
+	});
+
+	it("hardens the native slash-command choice projection", () => {
+		const options = buildDiscordCommandOptions([
+			{
+				name: "badge",
+				description: "Badge name",
+				type: "string",
+				choices: [{ label: `${"d".repeat(99)}💎tail`, value: "diamond" }],
+			},
+		]);
+
+		expect(options?.[0]?.choices?.[0]).toEqual({
+			name: "d".repeat(99),
+			value: "diamond",
+		});
+	});
+
+	it("rejects a native slash-command choice with an unrepresentable value", () => {
+		expect(() =>
+			buildDiscordCommandOptions([
+				{
+					name: "badge",
+					description: "Badge name",
+					type: "string",
+					choices: [{ label: "Diamond", value: "v".repeat(101) }],
+				},
+			]),
+		).toThrowError(
+			expect.objectContaining({
+				code: "DISCORD_COMMAND_CHOICE_VALUE_INVALID",
+			}),
+		);
 	});
 
 	it("preserves the existing dynamic-choice behavior above Discord's 25-choice limit", () => {
@@ -39,6 +75,17 @@ describe("Discord command projection Unicode safety", () => {
 			description: "Theme name",
 			required: false,
 			choices: Array.from({ length: 26 }, (_, index) => `theme-${index}`),
+		});
+
+		expect(option.choices).toBeUndefined();
+	});
+
+	it("falls back to free text for an empty fixed catalog choice", () => {
+		const option = mapOption({
+			name: "theme",
+			description: "Theme name",
+			required: false,
+			choices: [""],
 		});
 
 		expect(option.choices).toBeUndefined();
@@ -131,6 +178,53 @@ describe("Discord command projection Unicode safety", () => {
 		expect(caught).toBeInstanceOf(ElizaError);
 		expect((caught as ElizaError).code).toBe(
 			"DISCORD_COMMAND_MENU_INVALID_ROW_WIDTH",
+		);
+	});
+
+	it("rejects an empty command button label with a typed error", () => {
+		expect(() =>
+			buildCommandArgMenu({
+				commandName: "mode",
+				arg: { name: "level", description: "Mode level", type: "string" },
+				choices: [{ label: "", value: "empty" }],
+				userId: "user-123",
+			}),
+		).toThrowError(
+			expect.objectContaining({
+				code: "DISCORD_COMMAND_BUTTON_LABEL_INVALID",
+			}),
+		);
+	});
+
+	it("accepts a command button custom ID at the exact protocol boundary", () => {
+		const fixedLength = buildCommandArgCustomId({
+			command: "mode",
+			arg: "level",
+			value: "",
+			userId: "user-123",
+		}).length;
+		const customId = buildCommandArgCustomId({
+			command: "mode",
+			arg: "level",
+			value: "v".repeat(100 - fixedLength),
+			userId: "user-123",
+		});
+
+		expect(customId).toHaveLength(100);
+	});
+
+	it("rejects a percent-encoded command button custom ID above the limit", () => {
+		expect(() =>
+			buildCommandArgCustomId({
+				command: "mode",
+				arg: "level",
+				value: "🔥".repeat(20),
+				userId: "123456789012345678",
+			}),
+		).toThrowError(
+			expect.objectContaining({
+				code: "DISCORD_COMMAND_CUSTOM_ID_TOO_LONG",
+			}),
 		);
 	});
 });

--- a/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
+++ b/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Verifies Discord protocol-length projections remain valid Unicode without
+ * changing the connector's existing fixed-choice registration semantics.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mapOption } from "../catalog-commands";
+import { buildCommandArgMenu } from "../native-commands";
+
+describe("Discord command projection Unicode safety", () => {
+	it("keeps a complete surrogate pair when it fits the 100-unit choice limit", () => {
+		const emoji = "💎";
+		const option = mapOption({
+			name: "badge",
+			description: "Badge name",
+			required: true,
+			choices: [`${"d".repeat(98)}${emoji}tail`],
+		});
+
+		expect(option.choices?.[0]?.name).toBe(`${"d".repeat(98)}${emoji}`);
+	});
+
+	it("does not split a surrogate pair at the 100-unit choice limit", () => {
+		const option = mapOption({
+			name: "badge",
+			description: "Badge name",
+			required: true,
+			choices: [`${"d".repeat(99)}💎tail`],
+		});
+
+		expect(option.choices?.[0]?.name).toBe("d".repeat(99));
+		expect(option.choices?.[0]?.name.isWellFormed()).toBe(true);
+	});
+
+	it("preserves the existing dynamic-choice behavior above Discord's 25-choice limit", () => {
+		const option = mapOption({
+			name: "theme",
+			description: "Theme name",
+			required: false,
+			choices: Array.from({ length: 26 }, (_, index) => `theme-${index}`),
+		});
+
+		expect(option.choices).toBeUndefined();
+	});
+
+	it("keeps a complete surrogate pair when it fits the 80-unit label limit", () => {
+		const menu = buildCommandArgMenu({
+			commandName: "mode",
+			arg: { name: "level", description: "Mode level", type: "string" },
+			choices: [{ label: `${"b".repeat(78)}🔥tail`, value: "fire" }],
+			userId: "user-123",
+		});
+
+		expect(menu.rows[0]?.buttons[0]?.label).toBe(`${"b".repeat(78)}🔥`);
+	});
+
+	it("does not split a surrogate pair at the 80-unit label limit", () => {
+		const menu = buildCommandArgMenu({
+			commandName: "mode",
+			arg: { name: "level", description: "Mode level", type: "string" },
+			choices: [{ label: `${"b".repeat(79)}🔥tail`, value: "fire" }],
+			userId: "user-123",
+		});
+
+		const label = menu.rows[0]?.buttons[0]?.label;
+		expect(label).toBe("b".repeat(79));
+		expect(label?.isWellFormed()).toBe(true);
+	});
+});

--- a/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
+++ b/plugins/plugin-discord/__tests__/command-surrogate-safety.test.ts
@@ -197,20 +197,35 @@ describe("Discord command projection Unicode safety", () => {
 	});
 
 	it("accepts a command button custom ID at the exact protocol boundary", () => {
-		const fixedLength = buildCommandArgCustomId({
+		const oneValueLength = buildCommandArgCustomId({
 			command: "mode",
 			arg: "level",
-			value: "",
+			value: "v",
 			userId: "user-123",
 		}).length;
 		const customId = buildCommandArgCustomId({
 			command: "mode",
 			arg: "level",
-			value: "v".repeat(100 - fixedLength),
+			value: "v".repeat(100 - oneValueLength + 1),
 			userId: "user-123",
 		});
 
 		expect(customId).toHaveLength(100);
+	});
+
+	it("rejects an empty command button value that cannot round-trip", () => {
+		expect(() =>
+			buildCommandArgCustomId({
+				command: "mode",
+				arg: "level",
+				value: "",
+				userId: "user-123",
+			}),
+		).toThrowError(
+			expect.objectContaining({
+				code: "DISCORD_COMMAND_CUSTOM_ID_INPUT_INVALID",
+			}),
+		);
 	});
 
 	it("rejects a percent-encoded command button custom ID above the limit", () => {

--- a/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
@@ -44,6 +44,12 @@ describe("splitMessage surrogate-safe chunking", () => {
 		for (const chunk of chunks) {
 			expect(chunk.isWellFormed()).toBe(true);
 		}
+		expect(chunks.join("")).toBe(text);
+	});
+
+	it("preserves spaces and newlines at chunk boundaries", () => {
+		const text = `${"a".repeat(MAX_DISCORD_MESSAGE_LENGTH - 1)} \n body  `;
+		expect(splitMessage(text, MAX_DISCORD_MESSAGE_LENGTH).join("")).toBe(text);
 	});
 
 	it("returns the original text unchanged when under the limit", () => {

--- a/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
@@ -35,7 +35,7 @@ describe("splitMessage surrogate-safe chunking", () => {
 		}
 	});
 
-	it("splits on whitespace when available and stays well-formed", () => {
+	it("preserves whitespace exactly while staying well-formed", () => {
 		const firstLine = "y".repeat(MAX_DISCORD_MESSAGE_LENGTH - 1);
 		const text = `${firstLine} z`;
 
@@ -64,5 +64,16 @@ describe("splitMessage surrogate-safe chunking", () => {
 		}
 		expect(caught).toBeInstanceOf(ElizaError);
 		expect((caught as ElizaError).code).toBe("DISCORD_CHUNK_LIMIT_TOO_SMALL");
+	});
+
+	it("rejects malformed Unicode instead of rewriting it", () => {
+		let caught: unknown;
+		try {
+			splitMessage("before\ud800after", MAX_DISCORD_MESSAGE_LENGTH);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ElizaError);
+		expect((caught as ElizaError).code).toBe("DISCORD_CONTENT_INVALID_UNICODE");
 	});
 });

--- a/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
@@ -5,6 +5,7 @@
  * chunk limit that cannot make UTF-16 progress must reject instead of
  * spinning. Pure-function assertions on the real exported `splitMessage`.
  */
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { splitMessage } from "../utils";
 
@@ -44,9 +45,7 @@ describe("splitMessage surrogate-safe chunking", () => {
 		for (const chunk of chunks) {
 			expect(chunk.isWellFormed()).toBe(true);
 		}
-		// Line/word-aware splitting reflows boundary whitespace but must keep
-		// every non-whitespace code unit in order.
-		expect(chunks.join("").replace(/\s+/g, "")).toBe(text.replace(/\s+/g, ""));
+		expect(chunks.join("")).toBe(text);
 	});
 
 	it("returns the original text unchanged when under the limit", () => {
@@ -57,6 +56,13 @@ describe("splitMessage surrogate-safe chunking", () => {
 
 	it("rejects a chunk limit that cannot make UTF-16 progress", () => {
 		// maxLength=1 cannot hold the lead half of an emoji without stranding it.
-		expect(() => splitMessage(`😀${"x".repeat(10)}`, 1)).toThrow(RangeError);
+		let caught: unknown;
+		try {
+			splitMessage(`😀${"x".repeat(10)}`, 1);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ElizaError);
+		expect((caught as ElizaError).code).toBe("DISCORD_CHUNK_LIMIT_TOO_SMALL");
 	});
 });

--- a/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
+++ b/plugins/plugin-discord/__tests__/messaging-chunk-surrogate.test.ts
@@ -44,12 +44,9 @@ describe("splitMessage surrogate-safe chunking", () => {
 		for (const chunk of chunks) {
 			expect(chunk.isWellFormed()).toBe(true);
 		}
-		expect(chunks.join("")).toBe(text);
-	});
-
-	it("preserves spaces and newlines at chunk boundaries", () => {
-		const text = `${"a".repeat(MAX_DISCORD_MESSAGE_LENGTH - 1)} \n body  `;
-		expect(splitMessage(text, MAX_DISCORD_MESSAGE_LENGTH).join("")).toBe(text);
+		// Line/word-aware splitting reflows boundary whitespace but must keep
+		// every non-whitespace code unit in order.
+		expect(chunks.join("").replace(/\s+/g, "")).toBe(text.replace(/\s+/g, ""));
 	});
 
 	it("returns the original text unchanged when under the limit", () => {

--- a/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
+++ b/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
@@ -4,7 +4,7 @@
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { smartSplitMessage, splitMessage } from "../utils";
+import { sendMessageInChunks, smartSplitMessage, splitMessage } from "../utils";
 
 function runtimeReturning(response: string): IAgentRuntime {
 	return {
@@ -66,5 +66,19 @@ describe("smartSplitMessage lossless validation", () => {
 		);
 		expect(chunks.join("")).toBe(source);
 		expect(chunks.every((chunk) => chunk.length <= 9)).toBe(true);
+	});
+});
+
+describe("sendMessageInChunks content preservation", () => {
+	it("sends boundary whitespace without trimming it", async () => {
+		const send = vi.fn(async () => ({ id: "sent" }));
+		const channel = { send } as unknown as Parameters<
+			typeof sendMessageInChunks
+		>[0];
+		const content = "  leading and trailing  ";
+
+		await sendMessageInChunks(channel, content, "", []);
+
+		expect(send).toHaveBeenCalledWith(expect.objectContaining({ content }));
 	});
 });

--- a/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
+++ b/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
@@ -24,14 +24,37 @@ describe("smartSplitMessage lossless validation", () => {
 		expect(chunks).toEqual(["abcdef", "ghijk"]);
 	});
 
-	it("falls back when model chunks rewrite or omit source content", async () => {
+	it("accepts a projection that only reflows boundary whitespace", async () => {
 		const source = "abc def\nghijk";
 		const chunks = await smartSplitMessage(
 			runtimeReturning(JSON.stringify(["abc def", "ghijk"])),
 			source,
 			7,
 		);
+		expect(chunks).toEqual(["abc def", "ghijk"]);
+	});
+
+	it("falls back when model chunks rewrite or omit source content", async () => {
+		const source = "abc def\nghijk";
+		const chunks = await smartSplitMessage(
+			runtimeReturning(JSON.stringify(["abc de", "ghijk"])),
+			source,
+			7,
+		);
 		expect(chunks).toEqual(splitMessage(source, 7));
+		expect(chunks.join("").replace(/\s+/g, "")).toBe(
+			source.replace(/\s+/g, ""),
+		);
+	});
+
+	it("falls back instead of dropping an oversized model chunk", async () => {
+		const source = "abcdefghijk";
+		const chunks = await smartSplitMessage(
+			runtimeReturning(JSON.stringify(["abcdefgh", "ijk"])),
+			source,
+			6,
+		);
+		expect(chunks).toEqual(splitMessage(source, 6));
 		expect(chunks.join("")).toBe(source);
 	});
 });

--- a/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
+++ b/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
@@ -24,14 +24,15 @@ describe("smartSplitMessage lossless validation", () => {
 		expect(chunks).toEqual(["abcdef", "ghijk"]);
 	});
 
-	it("accepts a projection that only reflows boundary whitespace", async () => {
+	it("rejects a projection that reflows boundary whitespace", async () => {
 		const source = "abc def\nghijk";
 		const chunks = await smartSplitMessage(
 			runtimeReturning(JSON.stringify(["abc def", "ghijk"])),
 			source,
 			7,
 		);
-		expect(chunks).toEqual(["abc def", "ghijk"]);
+		expect(chunks).toEqual(splitMessage(source, 7));
+		expect(chunks.join("")).toBe(source);
 	});
 
 	it("falls back when model chunks rewrite or omit source content", async () => {
@@ -42,9 +43,7 @@ describe("smartSplitMessage lossless validation", () => {
 			7,
 		);
 		expect(chunks).toEqual(splitMessage(source, 7));
-		expect(chunks.join("").replace(/\s+/g, "")).toBe(
-			source.replace(/\s+/g, ""),
-		);
+		expect(chunks.join("")).toBe(source);
 	});
 
 	it("falls back instead of dropping an oversized model chunk", async () => {
@@ -56,5 +55,16 @@ describe("smartSplitMessage lossless validation", () => {
 		);
 		expect(chunks).toEqual(splitMessage(source, 6));
 		expect(chunks.join("")).toBe(source);
+	});
+
+	it("preserves repeated whitespace, newlines, and Unicode exactly", async () => {
+		const source = "alpha  beta\n\n🎉 gamma   delta";
+		const chunks = await smartSplitMessage(
+			runtimeReturning(JSON.stringify(["alpha beta", "🎉 gamma delta"])),
+			source,
+			9,
+		);
+		expect(chunks.join("")).toBe(source);
+		expect(chunks.every((chunk) => chunk.length <= 9)).toBe(true);
 	});
 });

--- a/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
+++ b/plugins/plugin-discord/__tests__/smart-split-lossless.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Verifies model-assisted Discord splitting is accepted only when every
+ * source code unit remains recoverable in order.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { smartSplitMessage, splitMessage } from "../utils";
+
+function runtimeReturning(response: string): IAgentRuntime {
+	return {
+		logger: { debug: vi.fn() },
+		useModel: vi.fn(async () => response),
+	} as unknown as IAgentRuntime;
+}
+
+describe("smartSplitMessage lossless validation", () => {
+	it("accepts a complete exact model projection", async () => {
+		const source = "abcdefghijk";
+		const chunks = await smartSplitMessage(
+			runtimeReturning(JSON.stringify(["abcdef", "ghijk"])),
+			source,
+			6,
+		);
+		expect(chunks).toEqual(["abcdef", "ghijk"]);
+	});
+
+	it("falls back when model chunks rewrite or omit source content", async () => {
+		const source = "abc def\nghijk";
+		const chunks = await smartSplitMessage(
+			runtimeReturning(JSON.stringify(["abc def", "ghijk"])),
+			source,
+			7,
+		);
+		expect(chunks).toEqual(splitMessage(source, 7));
+		expect(chunks.join("")).toBe(source);
+	});
+});

--- a/plugins/plugin-discord/catalog-commands.ts
+++ b/plugins/plugin-discord/catalog-commands.ts
@@ -45,6 +45,8 @@ import {
 	createUniqueUuid,
 	hasRoleAccess,
 	type IAgentRuntime,
+	toWellFormedUnicode,
+	truncateWellFormed,
 } from "@elizaos/core";
 import {
 	type ConnectorCommand,
@@ -417,12 +419,21 @@ function buildExecute(command: ConnectorCommand): SlashCommand["execute"] {
 }
 
 /** Map a catalog option onto the plugin's `SlashCommandOption` shape. */
-function mapOption(
+export function mapOption(
 	option: ConnectorCommand["options"][number],
 ): SlashCommandOption {
 	const choices =
 		option.choices.length > 0 && option.choices.length <= 25
-			? option.choices.map((value) => ({ name: value.slice(0, 100), value }))
+			? option.choices.map((value) => {
+					const wellFormed = toWellFormedUnicode(value);
+					return {
+						name:
+							wellFormed.length > 100
+								? truncateWellFormed(wellFormed, 100)
+								: wellFormed,
+						value,
+					};
+				})
 			: undefined;
 	return {
 		name: option.name,

--- a/plugins/plugin-discord/catalog-commands.ts
+++ b/plugins/plugin-discord/catalog-commands.ts
@@ -423,7 +423,14 @@ export function mapOption(
 	option: ConnectorCommand["options"][number],
 ): SlashCommandOption {
 	const choices =
-		option.choices.length > 0 && option.choices.length <= 25
+		option.choices.length > 0 &&
+		option.choices.length <= 25 &&
+		option.choices.every(
+			(value) =>
+				value.length > 0 &&
+				value.length <= 100 &&
+				toWellFormedUnicode(value) === value,
+		)
 			? option.choices.map((value) => {
 					const wellFormed = toWellFormedUnicode(value);
 					return {

--- a/plugins/plugin-discord/native-commands.ts
+++ b/plugins/plugin-discord/native-commands.ts
@@ -3,7 +3,11 @@
  * button-based argument menus. Consumed by the slash-command registration path
  * when syncing commands to the Discord application.
  */
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+	ElizaError,
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "@elizaos/core";
 import {
 	type APIApplicationCommandOption,
 	ApplicationCommandOptionType,
@@ -283,15 +287,34 @@ export function buildCommandArgMenu(params: {
 		buttonsPerRow < 1 ||
 		buttonsPerRow > DISCORD_MAX_BUTTONS_PER_ROW
 	) {
-		throw new RangeError(
+		throw new ElizaError(
 			`buttonsPerRow must be an integer from 1 to ${DISCORD_MAX_BUTTONS_PER_ROW}`,
+			{
+				code: "DISCORD_COMMAND_MENU_INVALID_ROW_WIDTH",
+				context: {
+					commandName,
+					arg: arg.name,
+					buttonsPerRow,
+					maxButtonsPerRow: DISCORD_MAX_BUTTONS_PER_ROW,
+				},
+			},
 		);
 	}
 
 	const maxChoices = DISCORD_MAX_ACTION_ROWS * buttonsPerRow;
 	if (choices.length > maxChoices) {
-		throw new RangeError(
+		throw new ElizaError(
 			`Discord argument menus can display at most ${maxChoices} choices with ${buttonsPerRow} buttons per row; use pagination or autocomplete instead`,
+			{
+				code: "DISCORD_COMMAND_MENU_CHOICES_EXCEED_CAPACITY",
+				context: {
+					commandName,
+					arg: arg.name,
+					choiceCount: choices.length,
+					maxChoices,
+					buttonsPerRow,
+				},
+			},
 		);
 	}
 

--- a/plugins/plugin-discord/native-commands.ts
+++ b/plugins/plugin-discord/native-commands.ts
@@ -3,6 +3,7 @@
  * button-based argument menus. Consumed by the slash-command registration path
  * when syncing commands to the Discord application.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
 	type APIApplicationCommandOption,
 	ApplicationCommandOptionType,
@@ -276,16 +277,22 @@ export function buildCommandArgMenu(params: {
 
 	const rows = chunkArray(choices.slice(0, 20), buttonsPerRow).map(
 		(rowChoices) => ({
-			buttons: rowChoices.map((choice) => ({
-				label: choice.label.slice(0, 80),
-				customId: buildCommandArgCustomId({
-					command: commandName,
-					arg: arg.name,
-					value: choice.value,
-					userId,
-				}),
-				style: ButtonStyle.Secondary,
-			})),
+			buttons: rowChoices.map((choice) => {
+				const wellFormed = toWellFormedUnicode(choice.label);
+				return {
+					label:
+						wellFormed.length > 80
+							? truncateWellFormed(wellFormed, 80)
+							: wellFormed,
+					customId: buildCommandArgCustomId({
+						command: commandName,
+						arg: arg.name,
+						value: choice.value,
+						userId,
+					}),
+					style: ButtonStyle.Secondary,
+				};
+			}),
 		}),
 	);
 

--- a/plugins/plugin-discord/native-commands.ts
+++ b/plugins/plugin-discord/native-commands.ts
@@ -87,6 +87,8 @@ export interface CommandArgMenu {
 
 const DISCORD_MAX_ACTION_ROWS = 5;
 const DISCORD_MAX_BUTTONS_PER_ROW = 5;
+const DISCORD_MAX_COMMAND_CHOICE_LENGTH = 100;
+const DISCORD_MAX_CUSTOM_ID_LENGTH = 100;
 
 /**
  * Key for command argument custom IDs
@@ -126,10 +128,42 @@ export function buildDiscordCommandOptions(
 
 		const choices =
 			arg.choices && arg.choices.length > 0 && arg.choices.length <= 25
-				? arg.choices.map((choice) => ({
-						name: choice.label,
-						value: choice.value,
-					}))
+				? arg.choices.map((choice) => {
+						if (
+							choice.value.length < 1 ||
+							choice.value.length > DISCORD_MAX_COMMAND_CHOICE_LENGTH ||
+							toWellFormedUnicode(choice.value) !== choice.value
+						) {
+							throw new ElizaError(
+								"Discord command choice values must be complete, valid Unicode within the protocol limit",
+								{
+									code: "DISCORD_COMMAND_CHOICE_VALUE_INVALID",
+									context: {
+										arg: arg.name,
+										valueLength: choice.value.length,
+										maxLength: DISCORD_MAX_COMMAND_CHOICE_LENGTH,
+									},
+								},
+							);
+						}
+						const label = toWellFormedUnicode(choice.label);
+						if (label.length < 1) {
+							throw new ElizaError(
+								"Discord command choice labels must not be empty",
+								{
+									code: "DISCORD_COMMAND_CHOICE_LABEL_INVALID",
+									context: { arg: arg.name },
+								},
+							);
+						}
+						return {
+							name:
+								label.length > DISCORD_MAX_COMMAND_CHOICE_LENGTH
+									? truncateWellFormed(label, DISCORD_MAX_COMMAND_CHOICE_LENGTH)
+									: label,
+							value: choice.value,
+						};
+					})
 				: undefined;
 
 		return {
@@ -206,12 +240,36 @@ export function buildCommandArgCustomId(params: {
 	value: string;
 	userId: string;
 }): string {
-	return [
+	for (const [field, value] of Object.entries(params)) {
+		if (toWellFormedUnicode(value) !== value) {
+			throw new ElizaError(
+				"Discord command button identifiers require valid Unicode inputs",
+				{
+					code: "DISCORD_COMMAND_CUSTOM_ID_INPUT_INVALID",
+					context: { field },
+				},
+			);
+		}
+	}
+	const customId = [
 		`${COMMAND_ARG_CUSTOM_ID_KEY}:command=${encodeCommandArgValue(params.command)}`,
 		`arg=${encodeCommandArgValue(params.arg)}`,
 		`value=${encodeCommandArgValue(params.value)}`,
 		`user=${encodeCommandArgValue(params.userId)}`,
 	].join(";");
+	if (customId.length > DISCORD_MAX_CUSTOM_ID_LENGTH) {
+		throw new ElizaError(
+			"Discord command button identifier exceeds the protocol limit",
+			{
+				code: "DISCORD_COMMAND_CUSTOM_ID_TOO_LONG",
+				context: {
+					length: customId.length,
+					maxLength: DISCORD_MAX_CUSTOM_ID_LENGTH,
+				},
+			},
+		);
+	}
+	return customId;
 }
 
 /**
@@ -321,6 +379,15 @@ export function buildCommandArgMenu(params: {
 	const rows = chunkArray(choices, buttonsPerRow).map((rowChoices) => ({
 		buttons: rowChoices.map((choice) => {
 			const wellFormed = toWellFormedUnicode(choice.label);
+			if (wellFormed.length < 1) {
+				throw new ElizaError(
+					"Discord command button labels must not be empty",
+					{
+						code: "DISCORD_COMMAND_BUTTON_LABEL_INVALID",
+						context: { commandName, arg: arg.name },
+					},
+				);
+			}
 			return {
 				label:
 					wellFormed.length > 80

--- a/plugins/plugin-discord/native-commands.ts
+++ b/plugins/plugin-discord/native-commands.ts
@@ -81,6 +81,9 @@ export interface CommandArgMenu {
 	rows: CommandArgButtonRow[];
 }
 
+const DISCORD_MAX_ACTION_ROWS = 5;
+const DISCORD_MAX_BUTTONS_PER_ROW = 5;
+
 /**
  * Key for command argument custom IDs
  */
@@ -272,29 +275,44 @@ export function buildCommandArgMenu(params: {
 		choices,
 		userId,
 		title,
-		buttonsPerRow = 4,
+		buttonsPerRow = DISCORD_MAX_BUTTONS_PER_ROW,
 	} = params;
 
-	const rows = chunkArray(choices.slice(0, 20), buttonsPerRow).map(
-		(rowChoices) => ({
-			buttons: rowChoices.map((choice) => {
-				const wellFormed = toWellFormedUnicode(choice.label);
-				return {
-					label:
-						wellFormed.length > 80
-							? truncateWellFormed(wellFormed, 80)
-							: wellFormed,
-					customId: buildCommandArgCustomId({
-						command: commandName,
-						arg: arg.name,
-						value: choice.value,
-						userId,
-					}),
-					style: ButtonStyle.Secondary,
-				};
-			}),
+	if (
+		!Number.isInteger(buttonsPerRow) ||
+		buttonsPerRow < 1 ||
+		buttonsPerRow > DISCORD_MAX_BUTTONS_PER_ROW
+	) {
+		throw new RangeError(
+			`buttonsPerRow must be an integer from 1 to ${DISCORD_MAX_BUTTONS_PER_ROW}`,
+		);
+	}
+
+	const maxChoices = DISCORD_MAX_ACTION_ROWS * buttonsPerRow;
+	if (choices.length > maxChoices) {
+		throw new RangeError(
+			`Discord argument menus can display at most ${maxChoices} choices with ${buttonsPerRow} buttons per row; use pagination or autocomplete instead`,
+		);
+	}
+
+	const rows = chunkArray(choices, buttonsPerRow).map((rowChoices) => ({
+		buttons: rowChoices.map((choice) => {
+			const wellFormed = toWellFormedUnicode(choice.label);
+			return {
+				label:
+					wellFormed.length > 80
+						? truncateWellFormed(wellFormed, 80)
+						: wellFormed,
+				customId: buildCommandArgCustomId({
+					command: commandName,
+					arg: arg.name,
+					value: choice.value,
+					userId,
+				}),
+				style: ButtonStyle.Secondary,
+			};
 		}),
-	);
+	}));
 
 	const content =
 		title ?? `Choose ${arg.description || arg.name} for /${commandName}.`;

--- a/plugins/plugin-discord/native-commands.ts
+++ b/plugins/plugin-discord/native-commands.ts
@@ -241,9 +241,9 @@ export function buildCommandArgCustomId(params: {
 	userId: string;
 }): string {
 	for (const [field, value] of Object.entries(params)) {
-		if (toWellFormedUnicode(value) !== value) {
+		if (value.length === 0 || toWellFormedUnicode(value) !== value) {
 			throw new ElizaError(
-				"Discord command button identifiers require valid Unicode inputs",
+				"Discord command button identifiers require non-empty valid Unicode inputs",
 				{
 					code: "DISCORD_COMMAND_CUSTOM_ID_INPUT_INVALID",
 					context: { field },

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -671,9 +671,7 @@ export async function sendMessageInChunks(
 				if (fence && !(await fence.beforeSend(i))) {
 					return sentMessages;
 				}
-				const options: MessageSendOptions = {
-					content: message.trim(),
-				};
+				const options: MessageSendOptions = { content: message };
 				if (fence) {
 					options.nonce = fence.nonceForChunk(i);
 					options.enforceNonce = true;
@@ -817,15 +815,18 @@ Return format:
 
 		const parsed = parseJsonArrayFromText(response);
 		if (Array.isArray(parsed)) {
-			const validChunks = parsed.filter(
-				(chunk: unknown): chunk is string =>
-					typeof chunk === "string" &&
-					chunk.trim().length > 0 &&
-					chunk.length <= maxLength,
-			);
+			const allValid =
+				parsed.length > 0 &&
+				parsed.every(
+					(chunk: unknown): chunk is string =>
+						typeof chunk === "string" &&
+						chunk.length > 0 &&
+						chunk.length <= maxLength,
+				) &&
+				parsed.join("") === content;
 
-			if (validChunks.length > 0) {
-				return validChunks;
+			if (allValid) {
+				return parsed;
 			}
 
 			runtime.logger.debug(
@@ -850,55 +851,16 @@ export function splitMessage(
 	}
 
 	const messages: string[] = [];
-	let currentMessage = "";
-
-	const rawLines = content.split("\n");
-	const lines = rawLines.flatMap((line) => {
-		const chunks: string[] = [];
-		while (line.length > maxLength) {
-			let splitIdx = maxLength;
-			const lastSpace = line.lastIndexOf(" ", maxLength);
-
-			if (lastSpace > maxLength * 0.7) {
-				splitIdx = lastSpace;
-			} else if (lastSpace > maxLength * 0.3) {
-				splitIdx = lastSpace;
-			}
-
-			// A raw slice() can land between the two UTF-16 code units of a
-			// surrogate pair (most emoji), leaving a lone surrogate at the
-			// chunk boundary that corrupts the character in the delivered
-			// message. truncateWellFormed backs the cut off by one unit
-			// instead.
-			const head = truncateWellFormed(line, splitIdx);
-			if (head.length === 0) {
-				throw new RangeError(
-					"Discord message chunk limit made no UTF-16 progress",
-				);
-			}
-			chunks.push(head);
-			line = line.slice(head.length).trimStart();
+	let remaining = content;
+	while (remaining.length > 0) {
+		const head = truncateWellFormed(remaining, maxLength);
+		if (head.length === 0) {
+			throw new RangeError(
+				"Discord message chunk limit made no UTF-16 progress",
+			);
 		}
-		chunks.push(line);
-		return chunks;
-	});
-
-	for (const line of lines) {
-		if (currentMessage.length + line.length + 1 > maxLength) {
-			if (currentMessage.trim().length > 0) {
-				messages.push(currentMessage.trim());
-			}
-			currentMessage = "";
-		}
-		currentMessage += `${line}\n`;
-	}
-
-	if (currentMessage.trim().length > 0) {
-		messages.push(currentMessage.trim());
-	}
-
-	if (messages.length === 0 && content.length > 0) {
-		messages.push(" ");
+		messages.push(head);
+		remaining = remaining.slice(head.length);
 	}
 
 	return messages;

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -666,7 +666,7 @@ export async function sendMessageInChunks(
 		for (let i = 0; i < messages.length; i++) {
 			const message = messages[i];
 			if (
-				message.trim().length > 0 ||
+				message.length > 0 ||
 				(i === messages.length - 1 && files && files.length > 0) ||
 				(i === messages.length - 1 && components && components.length > 0)
 			) {
@@ -674,7 +674,7 @@ export async function sendMessageInChunks(
 					return sentMessages;
 				}
 				const options: MessageSendOptions = {
-					content: message.trim(),
+					content: message,
 				};
 				if (fence) {
 					options.nonce = fence.nonceForChunk(i);
@@ -743,7 +743,7 @@ export async function sendMessageInChunks(
 	}
 
 	const attemptedSend =
-		content.trim().length > 0 ||
+		content.length > 0 ||
 		(files && files.length > 0) ||
 		(components && components.length > 0);
 	if (attemptedSend && sentMessages.length === 0) {
@@ -802,14 +802,17 @@ export async function smartSplitMessage(
 			},
 		);
 	}
-	const normalizedContent = toWellFormedUnicode(content);
-	if (normalizedContent.length <= maxLength) {
-		return normalizedContent ? [normalizedContent] : [];
+	if (toWellFormedUnicode(content) !== content) {
+		throw new ElizaError("Discord message content contains invalid Unicode", {
+			code: "DISCORD_CONTENT_INVALID_UNICODE",
+			severity: "fatal",
+		});
+	}
+	if (content.length <= maxLength) {
+		return content ? [content] : [];
 	}
 
-	const estimatedChunks = Math.ceil(
-		normalizedContent.length / Math.max(1, maxLength),
-	);
+	const estimatedChunks = Math.ceil(content.length / maxLength);
 
 	try {
 		runtime.logger.debug(
@@ -822,7 +825,7 @@ Return JSON only, no markdown or explanation.
 
 Text to split:
 """
-${normalizedContent}
+${content}
 """
 
 Return format:
@@ -843,7 +846,7 @@ Return format:
 						chunk.length <= maxLength &&
 						toWellFormedUnicode(chunk) === chunk,
 				) &&
-				parsed.join("") === normalizedContent;
+				parsed.join("") === content;
 
 			if (allValid) {
 				return parsed;
@@ -855,13 +858,12 @@ Return format:
 		}
 	} catch (error) {
 		// error-policy:J4 Model-assisted splitting is optional; the complete
-		// normalized content remains available to the deterministic lossless path.
+		// content remains available to the deterministic lossless path.
 		runtime.logger.debug(
 			`Smart split failed, falling back to simple split: ${error}`,
 		);
 	}
-
-	return splitMessage(normalizedContent, maxLength);
+	return splitMessage(content, maxLength);
 }
 
 export function splitMessage(
@@ -879,7 +881,14 @@ export function splitMessage(
 		);
 	}
 
-	let remaining = toWellFormedUnicode(content);
+	if (toWellFormedUnicode(content) !== content) {
+		throw new ElizaError("Discord message content contains invalid Unicode", {
+			code: "DISCORD_CONTENT_INVALID_UNICODE",
+			severity: "fatal",
+		});
+	}
+
+	let remaining = content;
 	if (!remaining) {
 		return [];
 	}

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -8,6 +8,7 @@
  */
 import {
 	ContentType,
+	ElizaError,
 	fetchRemoteMedia,
 	type IAgentRuntime,
 	type IMessageService,
@@ -19,6 +20,7 @@ import {
 	ModelType,
 	type ReplyToMode,
 	type SsrfPolicy,
+	toWellFormedUnicode,
 	trimTokens,
 	truncateWellFormed,
 } from "@elizaos/core";
@@ -790,11 +792,24 @@ export async function smartSplitMessage(
 	content: string,
 	maxLength: number = MAX_MESSAGE_LENGTH,
 ): Promise<string[]> {
-	if (content.length <= maxLength) {
-		return [content];
+	if (!Number.isSafeInteger(maxLength) || maxLength < 1) {
+		throw new ElizaError(
+			"Discord message chunk limit must be a positive safe integer",
+			{
+				code: "DISCORD_CHUNK_LIMIT_INVALID",
+				context: { maxLength },
+				severity: "fatal",
+			},
+		);
+	}
+	const normalizedContent = toWellFormedUnicode(content);
+	if (normalizedContent.length <= maxLength) {
+		return normalizedContent ? [normalizedContent] : [];
 	}
 
-	const estimatedChunks = Math.ceil(content.length / (maxLength - 100));
+	const estimatedChunks = Math.ceil(
+		normalizedContent.length / Math.max(1, maxLength),
+	);
 
 	try {
 		runtime.logger.debug(
@@ -807,7 +822,7 @@ Return JSON only, no markdown or explanation.
 
 Text to split:
 """
-${content}
+${normalizedContent}
 """
 
 Return format:
@@ -817,19 +832,18 @@ Return format:
 
 		const parsed = parseJsonArrayFromText(response);
 		if (Array.isArray(parsed)) {
-			// Accept the model projection only as a whole: dropping an oversized or
-			// empty chunk would silently lose part of the message, and a chunk set
-			// whose non-whitespace content differs from the source was rewritten.
-			// Boundary whitespace is the model's to reflow, so compare without it.
+			// Accept the model projection only as a whole. Whitespace is content too:
+			// reflowing it can change code, tables, quoted text, or intentional layout.
 			const allValid =
 				parsed.length > 0 &&
 				parsed.every(
 					(chunk: unknown): chunk is string =>
 						typeof chunk === "string" &&
-						chunk.trim().length > 0 &&
-						chunk.length <= maxLength,
+						chunk.length > 0 &&
+						chunk.length <= maxLength &&
+						toWellFormedUnicode(chunk) === chunk,
 				) &&
-				stripWhitespace(parsed.join("")) === stripWhitespace(content);
+				parsed.join("") === normalizedContent;
 
 			if (allValid) {
 				return parsed;
@@ -840,76 +854,65 @@ Return format:
 			);
 		}
 	} catch (error) {
+		// error-policy:J4 Model-assisted splitting is optional; the complete
+		// normalized content remains available to the deterministic lossless path.
 		runtime.logger.debug(
 			`Smart split failed, falling back to simple split: ${error}`,
 		);
 	}
 
-	return splitMessage(content, maxLength);
-}
-
-function stripWhitespace(value: string): string {
-	return value.replace(/\s+/g, "");
+	return splitMessage(normalizedContent, maxLength);
 }
 
 export function splitMessage(
 	content: string,
 	maxLength: number = MAX_MESSAGE_LENGTH,
 ): string[] {
-	if (!content || content.length <= maxLength) {
-		return content ? [content] : [];
+	if (!Number.isSafeInteger(maxLength) || maxLength < 1) {
+		throw new ElizaError(
+			"Discord message chunk limit must be a positive safe integer",
+			{
+				code: "DISCORD_CHUNK_LIMIT_INVALID",
+				context: { maxLength },
+				severity: "fatal",
+			},
+		);
+	}
+
+	let remaining = toWellFormedUnicode(content);
+	if (!remaining) {
+		return [];
+	}
+	if (remaining.length <= maxLength) {
+		return [remaining];
 	}
 
 	const messages: string[] = [];
-	let currentMessage = "";
-
-	const rawLines = content.split("\n");
-	const lines = rawLines.flatMap((line) => {
-		const chunks: string[] = [];
-		while (line.length > maxLength) {
-			let splitIdx = maxLength;
-			const lastSpace = line.lastIndexOf(" ", maxLength);
-
-			if (lastSpace > maxLength * 0.7) {
-				splitIdx = lastSpace;
-			} else if (lastSpace > maxLength * 0.3) {
-				splitIdx = lastSpace;
-			}
-
-			// A raw slice() can land between the two UTF-16 code units of a
-			// surrogate pair (most emoji), leaving a lone surrogate at the
-			// chunk boundary that corrupts the character in the delivered
-			// message. truncateWellFormed backs the cut off by one unit
-			// instead.
-			const head = truncateWellFormed(line, splitIdx);
-			if (head.length === 0) {
-				throw new RangeError(
-					"Discord message chunk limit made no UTF-16 progress",
-				);
-			}
-			chunks.push(head);
-			line = line.slice(head.length).trimStart();
+	while (remaining.length > 0) {
+		if (remaining.length <= maxLength) {
+			messages.push(remaining);
+			break;
 		}
-		chunks.push(line);
-		return chunks;
-	});
 
-	for (const line of lines) {
-		if (currentMessage.length + line.length + 1 > maxLength) {
-			if (currentMessage.trim().length > 0) {
-				messages.push(currentMessage.trim());
-			}
-			currentMessage = "";
+		const window = truncateWellFormed(remaining, maxLength);
+		if (window.length === 0) {
+			throw new ElizaError(
+				"Discord message chunk limit cannot hold the next Unicode character",
+				{
+					code: "DISCORD_CHUNK_LIMIT_TOO_SMALL",
+					context: { maxLength },
+					severity: "fatal",
+				},
+			);
 		}
-		currentMessage += `${line}\n`;
-	}
 
-	if (currentMessage.trim().length > 0) {
-		messages.push(currentMessage.trim());
-	}
-
-	if (messages.length === 0 && content.length > 0) {
-		messages.push(" ");
+		const boundary = Math.max(
+			window.lastIndexOf("\n"),
+			window.lastIndexOf(" "),
+		);
+		const cut = boundary > 0 ? boundary + 1 : window.length;
+		messages.push(remaining.slice(0, cut));
+		remaining = remaining.slice(cut);
 	}
 
 	return messages;

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -671,7 +671,9 @@ export async function sendMessageInChunks(
 				if (fence && !(await fence.beforeSend(i))) {
 					return sentMessages;
 				}
-				const options: MessageSendOptions = { content: message };
+				const options: MessageSendOptions = {
+					content: message.trim(),
+				};
 				if (fence) {
 					options.nonce = fence.nonceForChunk(i);
 					options.enforceNonce = true;
@@ -815,22 +817,26 @@ Return format:
 
 		const parsed = parseJsonArrayFromText(response);
 		if (Array.isArray(parsed)) {
+			// Accept the model projection only as a whole: dropping an oversized or
+			// empty chunk would silently lose part of the message, and a chunk set
+			// whose non-whitespace content differs from the source was rewritten.
+			// Boundary whitespace is the model's to reflow, so compare without it.
 			const allValid =
 				parsed.length > 0 &&
 				parsed.every(
 					(chunk: unknown): chunk is string =>
 						typeof chunk === "string" &&
-						chunk.length > 0 &&
+						chunk.trim().length > 0 &&
 						chunk.length <= maxLength,
 				) &&
-				parsed.join("") === content;
+				stripWhitespace(parsed.join("")) === stripWhitespace(content);
 
 			if (allValid) {
 				return parsed;
 			}
 
 			runtime.logger.debug(
-				"Smart split returned empty or invalid chunks, falling back to simple split",
+				"Smart split returned empty, oversized, or rewritten chunks, falling back to simple split",
 			);
 		}
 	} catch (error) {
@@ -842,6 +848,10 @@ Return format:
 	return splitMessage(content, maxLength);
 }
 
+function stripWhitespace(value: string): string {
+	return value.replace(/\s+/g, "");
+}
+
 export function splitMessage(
 	content: string,
 	maxLength: number = MAX_MESSAGE_LENGTH,
@@ -851,16 +861,55 @@ export function splitMessage(
 	}
 
 	const messages: string[] = [];
-	let remaining = content;
-	while (remaining.length > 0) {
-		const head = truncateWellFormed(remaining, maxLength);
-		if (head.length === 0) {
-			throw new RangeError(
-				"Discord message chunk limit made no UTF-16 progress",
-			);
+	let currentMessage = "";
+
+	const rawLines = content.split("\n");
+	const lines = rawLines.flatMap((line) => {
+		const chunks: string[] = [];
+		while (line.length > maxLength) {
+			let splitIdx = maxLength;
+			const lastSpace = line.lastIndexOf(" ", maxLength);
+
+			if (lastSpace > maxLength * 0.7) {
+				splitIdx = lastSpace;
+			} else if (lastSpace > maxLength * 0.3) {
+				splitIdx = lastSpace;
+			}
+
+			// A raw slice() can land between the two UTF-16 code units of a
+			// surrogate pair (most emoji), leaving a lone surrogate at the
+			// chunk boundary that corrupts the character in the delivered
+			// message. truncateWellFormed backs the cut off by one unit
+			// instead.
+			const head = truncateWellFormed(line, splitIdx);
+			if (head.length === 0) {
+				throw new RangeError(
+					"Discord message chunk limit made no UTF-16 progress",
+				);
+			}
+			chunks.push(head);
+			line = line.slice(head.length).trimStart();
 		}
-		messages.push(head);
-		remaining = remaining.slice(head.length);
+		chunks.push(line);
+		return chunks;
+	});
+
+	for (const line of lines) {
+		if (currentMessage.length + line.length + 1 > maxLength) {
+			if (currentMessage.trim().length > 0) {
+				messages.push(currentMessage.trim());
+			}
+			currentMessage = "";
+		}
+		currentMessage += `${line}\n`;
+	}
+
+	if (currentMessage.trim().length > 0) {
+		messages.push(currentMessage.trim());
+	}
+
+	if (messages.length === 0 && content.length > 0) {
+		messages.push(" ");
 	}
 
 	return messages;


### PR DESCRIPTION
Closes #24510.

## Summary

- preserve Discord outbound text exactly across lossless, surrogate-safe chunks
- accept model-assisted splitting only when every chunk is valid and reassembles byte-for-byte to the complete source
- keep catalog and native slash-command choice projections Unicode-safe without truncating semantic values
- reject unrepresentable choice values, oversized button menus, invalid row widths, and over-100-character encoded component IDs with typed errors before Discord dispatch

This is the corrected consolidation of closed predecessors #24436 and #24512; their contributor work remains preserved in this branch rather than being merged twice.

## Verification

<!-- evidence-head:231c4f2adaaf07786ae5ad2896fa9bb7d7f719c0 -->

- [Exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24494-validation-231c4f2-clean.log)
- focused Discord suites: 4 files, 82 tests passed
- plugin-discord typecheck: passed
- Biome on all seven changed files: passed
- `git diff --check`: passed
- package build and runtime-export preparation: passed before the final focused rerun

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is Discord REST/component payload construction.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no local frontend flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24494-validation-231c4f2-clean.log) - 82 tests plus typecheck, Biome, and diff check.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - model output is treated only as an untrusted optional split proposal; deterministic tests prove rewritten/incomplete proposals are rejected and the complete source is preserved.
<!-- evidence-row:domain-artifacts -->
- [x] [Deterministic Discord payload transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24494-domain-2739d059.log) proves exact chunk reassembly, Unicode-safe labels, complete fixed-choice values, 25-button capacity, and the 100-character custom-ID boundary.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Risks

The connector now rejects malformed Unicode and protocol-unrepresentable semantic values instead of allowing Discord to reject a partially constructed payload. Valid values and complete text are unchanged.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-content-budget-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop"} -->






