### PR TITLE
test(agent): cover workbench normalization helpers

### DIFF
--- a/packages/agent/src/api/__tests__/workbench-helpers.test.ts
+++ b/packages/agent/src/api/__tests__/workbench-helpers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Task } from "@elizaos/core";
+import {
+  asObject,
+  isWorkbenchTodoTask,
+  normalizeStringArray,
+  normalizeTags,
+  normalizeTaskId,
+  normalizeTimestamp,
+  parseNullableNumber,
+  readTaskCompleted,
+  readTaskMetadata,
+  toWorkbenchTask,
+  toWorkbenchTodo,
+} from "./workbench-helpers.ts";
+
+vi.mock("./runtime.ts", () => ({
+  readTriggerConfig: () => null,
+}));
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    name: "Task 1",
+    description: "desc",
+    tags: [],
+    metadata: {},
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  } as Task;
+}
+
+describe("asObject", () => {
+  it("accepts plain objects and rejects others", () => {
+    expect(asObject({ a: 1 })).toEqual({ a: 1 });
+    expect(asObject(null)).toBeNull();
+    expect(asObject([])).toBeNull();
+    expect(asObject(42)).toBeNull();
+  });
+});
+
+describe("normalizeStringArray", () => {
+  it("filters, trims, and drops empties", () => {
+    expect(normalizeStringArray([" a ", 5, "b", "", null])).toEqual(["a", "b"]);
+    expect(normalizeStringArray("not-array")).toEqual([]);
+  });
+});
+
+describe("normalizeTimestamp", () => {
+  it("accepts numbers, Dates, numeric strings, and date strings", () => {
+    expect(normalizeTimestamp(123)).toBe(123);
+    expect(normalizeTimestamp(new Date(456))).toBe(456);
+    expect(normalizeTimestamp("789")).toBe(789);
+    expect(normalizeTimestamp("2026-01-01T00:00:00Z")).toBe(Date.parse("2026-01-01T00:00:00Z"));
+  });
+  it("returns undefined for garbage", () => {
+    expect(normalizeTimestamp("nope")).toBeUndefined();
+    expect(normalizeTimestamp({})).toBeUndefined();
+  });
+});
+
+describe("parseNullableNumber", () => {
+  it("parses numbers and numeric strings, null for the rest", () => {
+    expect(parseNullableNumber(5)).toBe(5);
+    expect(parseNullableNumber("7")).toBe(7);
+    expect(parseNullableNumber(null)).toBeNull();
+    expect(parseNullableNumber("")).toBeNull();
+    expect(parseNullableNumber("x")).toBeNull();
+  });
+});
+
+describe("readTaskMetadata / normalizeTaskId", () => {
+  it("reads metadata safely and normalizes ids", () => {
+    expect(readTaskMetadata(task({ metadata: { a: 1 } }))).toEqual({ a: 1 });
+    expect(readTaskMetadata(task({ metadata: null as never }))).toEqual({});
+    expect(normalizeTaskId(task({ id: "x" }))).toBe("x");
+    expect(normalizeTaskId(task({ id: "  " }))).toBeNull();
+  });
+});
+
+describe("readTaskCompleted", () => {
+  it("checks metadata and nested todo metadata", () => {
+    expect(readTaskCompleted(task({ metadata: { isCompleted: true } }))).toBe(true);
+    expect(
+      readTaskCompleted(task({ metadata: { workbenchTodo: { isCompleted: true } } })),
+    ).toBe(true);
+    expect(readTaskCompleted(task())).toBe(false);
+  });
+});
+
+describe("isWorkbenchTodoTask", () => {
+  it("detects todo tags and todo metadata", () => {
+    expect(isWorkbenchTodoTask(task({ tags: ["workbench-todo"] }))).toBe(true);
+    expect(isWorkbenchTodoTask(task({ tags: ["todo"] }))).toBe(true);
+    expect(isWorkbenchTodoTask(task({ metadata: { todo: {} } }))).toBe(true);
+    expect(isWorkbenchTodoTask(task({ tags: ["other"] }))).toBe(false);
+  });
+});
+
+describe("toWorkbenchTodo", () => {
+  it("builds a todo view with defaults", () => {
+    const view = toWorkbenchTodo(task({ tags: ["todo"], name: "" }));
+    expect(view).not.toBeNull();
+    expect(view?.name).toBe("Todo");
+    expect(view?.priority).toBeNull();
+    expect(view?.type).toBe("task");
+  });
+
+  it("returns null for non-todo tasks", () => {
+    expect(toWorkbenchTodo(task({ tags: ["other"] }))).toBeNull();
+  });
+});
+
+describe("toWorkbenchTask", () => {
+  it("builds a task view for workbench-task tags", () => {
+    const view = toWorkbenchTask(task({ tags: ["workbench-task"] }));
+    expect(view?.id).toBe("t1");
+    expect(view?.updatedAt).toBe(1700000000000);
+  });
+
+  it("returns null without the task tag or for todo tasks", () => {
+    expect(toWorkbenchTask(task({ tags: ["other"] }))).toBeNull();
+    expect(toWorkbenchTask(task({ tags: ["workbench-task", "todo"] }))).toBeNull();
+  });
+});
+
+describe("normalizeTags", () => {
+  it("merges with required tags and dedupes", () => {
+    expect(normalizeTags(["a", "b"], ["b", " c "])).toEqual(["a", "b", "c"]);
+  });
+});

--- a/packages/agent/src/api/__tests__/workbench-helpers.test.ts
+++ b/packages/agent/src/api/__tests__/workbench-helpers.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+/**
+ * Verifies workbench task normalization helpers by importing the production
+ * API module while mocking only its runtime configuration dependency.
+ */
+
 import type { Task } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
 import {
   asObject,
   isWorkbenchTodoTask,
@@ -12,9 +17,9 @@ import {
   readTaskMetadata,
   toWorkbenchTask,
   toWorkbenchTodo,
-} from "./workbench-helpers.ts";
+} from "../workbench-helpers.ts";
 
-vi.mock("./runtime.ts", () => ({
+vi.mock("../runtime.ts", () => ({
   readTriggerConfig: () => null,
 }));
 
@@ -52,7 +57,9 @@ describe("normalizeTimestamp", () => {
     expect(normalizeTimestamp(123)).toBe(123);
     expect(normalizeTimestamp(new Date(456))).toBe(456);
     expect(normalizeTimestamp("789")).toBe(789);
-    expect(normalizeTimestamp("2026-01-01T00:00:00Z")).toBe(Date.parse("2026-01-01T00:00:00Z"));
+    expect(normalizeTimestamp("2026-01-01T00:00:00Z")).toBe(
+      Date.parse("2026-01-01T00:00:00Z"),
+    );
   });
   it("returns undefined for garbage", () => {
     expect(normalizeTimestamp("nope")).toBeUndefined();
@@ -81,9 +88,13 @@ describe("readTaskMetadata / normalizeTaskId", () => {
 
 describe("readTaskCompleted", () => {
   it("checks metadata and nested todo metadata", () => {
-    expect(readTaskCompleted(task({ metadata: { isCompleted: true } }))).toBe(true);
+    expect(readTaskCompleted(task({ metadata: { isCompleted: true } }))).toBe(
+      true,
+    );
     expect(
-      readTaskCompleted(task({ metadata: { workbenchTodo: { isCompleted: true } } })),
+      readTaskCompleted(
+        task({ metadata: { workbenchTodo: { isCompleted: true } } }),
+      ),
     ).toBe(true);
     expect(readTaskCompleted(task())).toBe(false);
   });
@@ -121,7 +132,9 @@ describe("toWorkbenchTask", () => {
 
   it("returns null without the task tag or for todo tasks", () => {
     expect(toWorkbenchTask(task({ tags: ["other"] }))).toBeNull();
-    expect(toWorkbenchTask(task({ tags: ["workbench-task", "todo"] }))).toBeNull();
+    expect(
+      toWorkbenchTask(task({ tags: ["workbench-task", "todo"] })),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Unit coverage for `packages/agent/src/api/workbench-helpers.ts`.

## Coverage (13 cases)

- `asObject`, `normalizeStringArray`, `normalizeTimestamp`, `parseNullableNumber`
- `readTaskMetadata`, `normalizeTaskId`, `readTaskCompleted`
- `isWorkbenchTodoTask`, `toWorkbenchTodo`, `toWorkbenchTask`
- `normalizeTags`

## Evidence

- `packages/agent/src/api/__tests__/workbench-helpers.test.ts`: **13 passed** (verified in isolation with vitest)

## Scope

Test-only; no production change.

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash

## Attribution and replacement

This organization branch preserves the contribution from @wwl-hub / #24474, rebased onto current develop and repaired from independent review. The fork branch could not be updated because the maintainer OAuth token lacks workflow-file scope.
