### PR TITLE
fix(core): implement in-memory vector recall and reclaim stale embeddings

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
@@ -161,6 +161,33 @@ describe("InMemoryDatabaseAdapter.searchMemories", () => {
 		});
 		expect(results).toEqual([]);
 	});
+
+	it("uses the SQL-compatible default threshold while preserving an explicit zero", async () => {
+		const belowDefault = offAxis(2);
+		const adapter = await seed([
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "below default" },
+				embedding: belowDefault,
+			},
+		]);
+
+		expect(
+			await adapter.searchMemories({
+				tableName: "memories",
+				embedding: onAxis(),
+			}),
+		).toEqual([]);
+		expect(
+			await adapter.searchMemories({
+				tableName: "memories",
+				embedding: onAxis(),
+				match_threshold: 0,
+			}),
+		).toMatchObject([{ content: { text: "below default" } }]);
+	});
 });
 
 describe("InMemoryDatabaseAdapter.clearEmbeddingsOutsideActiveDimension", () => {

--- a/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Drives the real {@link InMemoryDatabaseAdapter} searchMemories / embedding-
+ * reclaim path with no stand-in for the adapter. Pins the plugin-sql contract:
+ * scope eligibility is applied before the top-K cut, mixed-width vectors are
+ * skipped rather than scored, and clearEmbeddingsOutsideActiveDimension
+ * actually strips stale-width embeddings so a later search cannot rank them.
+ */
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { Memory, UUID } from "../types";
+import { InMemoryDatabaseAdapter } from "./inMemoryAdapter.ts";
+
+const DIM = 4;
+
+function onAxis(dimension = DIM): number[] {
+	const embedding = Array.from({ length: dimension }, () => 0);
+	embedding[0] = 1;
+	return embedding;
+}
+
+function offAxis(tilt: number, dimension = DIM): number[] {
+	const embedding = Array.from({ length: dimension }, () => 0);
+	embedding[0] = 1;
+	embedding[1] = tilt;
+	const norm = Math.hypot(1, tilt);
+	return embedding.map((value) => value / norm);
+}
+
+describe("InMemoryDatabaseAdapter.searchMemories", () => {
+	const agentId = randomUUID() as UUID;
+	const roomA = randomUUID() as UUID;
+	const roomB = randomUUID() as UUID;
+	const worldA = randomUUID() as UUID;
+	const worldB = randomUUID() as UUID;
+	const entityA = randomUUID() as UUID;
+	const entityB = randomUUID() as UUID;
+
+	async function seed(
+		memories: Memory[],
+		tableName = "memories",
+	): Promise<InMemoryDatabaseAdapter> {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		await adapter.createMemories(
+			memories.map((memory) => ({ memory, tableName })),
+		);
+		return adapter;
+	}
+
+	it("returns the in-room top-K even when a larger off-room corpus holds closer vectors", async () => {
+		const crowd: Memory[] = Array.from({ length: 20 }, (_, i) => ({
+			entityId: entityB,
+			roomId: roomB,
+			agentId,
+			content: { text: `crowd ${i}` },
+			embedding: onAxis(),
+		}));
+		const inRoom: Memory[] = Array.from({ length: 5 }, (_, i) => ({
+			entityId: entityA,
+			roomId: roomA,
+			agentId,
+			content: { text: `roomA ${i}` },
+			embedding: offAxis(0.05 + i * 0.01),
+		}));
+		const adapter = await seed([...crowd, ...inRoom]);
+
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(),
+			match_threshold: 0,
+			count: 3,
+			roomId: roomA,
+		});
+
+		expect(results).toHaveLength(3);
+		for (const memory of results) {
+			expect(memory.roomId).toBe(roomA);
+		}
+		expect(results[0]?.content.text).toBe("roomA 0");
+		const similarities = results.map((memory) => memory.similarity ?? 0);
+		expect(similarities[0]).toBeGreaterThanOrEqual(similarities[1] ?? 0);
+		expect(similarities[1]).toBeGreaterThanOrEqual(similarities[2] ?? 0);
+	});
+
+	it("honors worldId scope past a crowd of closer out-of-world vectors", async () => {
+		const crowd: Memory[] = Array.from({ length: 15 }, (_, i) => ({
+			entityId: entityB,
+			roomId: roomB,
+			worldId: worldB,
+			agentId,
+			content: { text: `world crowd ${i}` },
+			embedding: onAxis(),
+		}));
+		const inWorld: Memory[] = Array.from({ length: 4 }, (_, i) => ({
+			entityId: entityA,
+			roomId: roomA,
+			worldId: worldA,
+			agentId,
+			content: { text: `worldA ${i}` },
+			embedding: offAxis(0.05 + i * 0.01),
+		}));
+		const adapter = await seed([...crowd, ...inWorld]);
+
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(),
+			match_threshold: 0,
+			count: 4,
+			worldId: worldA,
+		});
+
+		expect(results).toHaveLength(4);
+		for (const memory of results) {
+			expect(memory.worldId).toBe(worldA);
+		}
+	});
+
+	it("skips mixed-width vectors instead of ranking them against the query", async () => {
+		const adapter = await seed([
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "active width" },
+				embedding: onAxis(4),
+			},
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "stale width" },
+				embedding: onAxis(1536),
+			},
+		]);
+
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(4),
+			match_threshold: 0,
+			count: 10,
+		});
+
+		expect(results.map((memory) => memory.content.text)).toEqual([
+			"active width",
+		]);
+	});
+
+	it("returns an empty list when no memory has an embedding", async () => {
+		const adapter = await seed([
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "no vector" },
+			},
+		]);
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(),
+			count: 10,
+		});
+		expect(results).toEqual([]);
+	});
+});
+
+describe("InMemoryDatabaseAdapter.clearEmbeddingsOutsideActiveDimension", () => {
+	it("strips old-width vectors so they cannot occupy later search results", async () => {
+		const agentId = randomUUID() as UUID;
+		const entityId = randomUUID() as UUID;
+		const roomId = randomUUID() as UUID;
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		await adapter.ensureEmbeddingDimension(1536);
+		const stale: Memory = {
+			id: randomUUID() as UUID,
+			agentId,
+			entityId,
+			roomId,
+			content: { text: "old cloud embedding" },
+			embedding: onAxis(1536),
+		};
+		const [staleId] = await adapter.createMemories([
+			{ memory: stale, tableName: "memories" },
+		]);
+
+		await adapter.ensureEmbeddingDimension(4);
+		expect(await adapter.clearEmbeddingsOutsideActiveDimension()).toEqual([
+			staleId,
+		]);
+
+		const reclaimed = await adapter.getMemoriesByIds([staleId]);
+		expect(reclaimed[0]?.embedding).toBeUndefined();
+
+		const fresh: Memory = {
+			id: randomUUID() as UUID,
+			agentId,
+			entityId,
+			roomId,
+			content: { text: "active local embedding" },
+			embedding: onAxis(4),
+		};
+		const [freshId] = await adapter.createMemories([
+			{ memory: fresh, tableName: "memories" },
+		]);
+
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(4),
+			match_threshold: 0,
+			limit: 10,
+		});
+		expect(results.map((memory) => memory.id)).toEqual([freshId]);
+		expect(await adapter.clearEmbeddingsOutsideActiveDimension()).toEqual([]);
+	});
+});

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1447,7 +1447,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			accessContext: params.accessContext,
 		});
 		const limit = params.count ?? params.limit ?? 10;
-		const threshold = params.match_threshold;
+		const threshold = params.match_threshold ?? 0.5;
 		const scored: Memory[] = [];
 		for (const memory of candidates) {
 			if (!Array.isArray(memory.embedding) || memory.embedding.length === 0) {
@@ -1457,7 +1457,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			if (similarity < 0) {
 				continue;
 			}
-			if (threshold && similarity < threshold) {
+			if (similarity < threshold) {
 				continue;
 			}
 			scored.push({ ...memory, similarity });

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -132,6 +132,36 @@ function memoryMatchesMetadata(
 	return true;
 }
 
+/**
+ * Cosine similarity for in-process vector recall. Returns -1 when the vectors
+ * cannot be compared (empty, mixed width, or non-finite components) so a search
+ * can skip them instead of inventing a score. Matches the document-fragment
+ * in-memory twin.
+ */
+function cosineSimilarity(left: number[], right: number[]): number {
+	if (left.length !== right.length || left.length === 0) return -1;
+	let dot = 0;
+	let leftMagnitude = 0;
+	let rightMagnitude = 0;
+	for (let index = 0; index < left.length; index++) {
+		const leftValue = left[index];
+		const rightValue = right[index];
+		if (
+			typeof leftValue !== "number" ||
+			typeof rightValue !== "number" ||
+			!Number.isFinite(leftValue) ||
+			!Number.isFinite(rightValue)
+		) {
+			return -1;
+		}
+		dot += leftValue * rightValue;
+		leftMagnitude += leftValue * leftValue;
+		rightMagnitude += rightValue * rightValue;
+	}
+	if (leftMagnitude === 0 || rightMagnitude === 0) return -1;
+	return dot / (Math.sqrt(leftMagnitude) * Math.sqrt(rightMagnitude));
+}
+
 function connectorAccountKey(params: {
 	agentId: UUID;
 	provider: string;
@@ -287,6 +317,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	private memoriesById = new Map<string, Memory>();
 	private memoriesByRoom = new Map<string, Memory[]>();
 	private cache = new Map<string, string>();
+	/** Width last passed to {@link ensureEmbeddingDimension}; used to reclaim stale vectors. */
+	private embeddingDimension: number | undefined;
 
 	private participantsByRoom = new Map<string, Set<string>>();
 	private roomsByParticipant = new Map<string, Set<string>>();
@@ -489,14 +521,34 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		return Array.from(this.agents.values());
 	}
 
-	async ensureEmbeddingDimension(_dimension: number): Promise<void> {
-		// In-memory vectors are not schema-bound, so there is no dimension migration to apply.
+	async ensureEmbeddingDimension(dimension: number): Promise<void> {
+		this.embeddingDimension = dimension;
 	}
 
 	async clearEmbeddingsOutsideActiveDimension(): Promise<UUID[]> {
-		// In-memory vectors are not schema-bound to a fixed-width column, so there
-		// is no stale-dimension row to reclaim.
-		return [];
+		if (
+			this.embeddingDimension === undefined ||
+			!Number.isFinite(this.embeddingDimension) ||
+			this.embeddingDimension <= 0
+		) {
+			return [];
+		}
+		const active = this.embeddingDimension;
+		const reclaimed: UUID[] = [];
+		for (const memory of this.memoriesById.values()) {
+			if (!Array.isArray(memory.embedding) || memory.embedding.length === 0) {
+				continue;
+			}
+			if (memory.embedding.length === active) {
+				continue;
+			}
+			if (!memory.id) {
+				continue;
+			}
+			delete memory.embedding;
+			reclaimed.push(memory.id);
+		}
+		return reclaimed;
 	}
 
 	async transaction<T>(
@@ -1369,7 +1421,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		this.logs = this.logs.filter((l) => !idSet.has(String(l.id)));
 	}
 
-	async searchMemories(_params: {
+	async searchMemories(params: {
 		tableName: string;
 		embedding: number[];
 		match_threshold?: number;
@@ -1382,7 +1434,38 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		entityId?: UUID;
 		accessContext?: AccessContext;
 	}): Promise<Memory[]> {
-		return [];
+		// Scope eligibility first, then the top-K cut — the plugin-sql contract.
+		// A global top-K followed by a post-hoc room/world/entity filter silently
+		// drops eligible matches whenever closer out-of-scope vectors outnumber
+		// the candidate pool.
+		const candidates = await this.getMemories({
+			tableName: params.tableName,
+			roomId: params.roomId,
+			worldId: params.worldId,
+			entityId: params.entityId,
+			unique: params.unique,
+			accessContext: params.accessContext,
+		});
+		const limit = params.count ?? params.limit ?? 10;
+		const threshold = params.match_threshold;
+		const scored: Memory[] = [];
+		for (const memory of candidates) {
+			if (!Array.isArray(memory.embedding) || memory.embedding.length === 0) {
+				continue;
+			}
+			const similarity = cosineSimilarity(memory.embedding, params.embedding);
+			if (similarity < 0) {
+				continue;
+			}
+			if (threshold && similarity < threshold) {
+				continue;
+			}
+			scored.push({ ...memory, similarity });
+		}
+		scored.sort(
+			(left, right) => (right.similarity ?? -1) - (left.similarity ?? -1),
+		);
+		return scored.slice(0, limit);
 	}
 
 	// Batch memory methods


### PR DESCRIPTION
Closes #24460.


Fixes #24460

## The defect

`InMemoryDatabaseAdapter.searchMemories` always returned `[]`. `clearEmbeddingsOutsideActiveDimension` always returned `[]`.

`AgentRuntime.searchMemories` delegates here. The fallback adapter is what `initialize()` installs when `ALLOW_NO_DATABASE` is set (ephemeral / serverless / tests). The file header claims a full `IDatabaseAdapter` surface kept honest against plugin-sql. Keyword `searchMessages` on the same class is implemented; vector `searchMemories` was not.

## Containment check (why a wrapping catch does not cover this)

There is **no throw**. `runtime.searchMemories` receives `[]` and returns it (or BM25-reranks the empty list). No `error-policy:J*` on this method. Wrong value passes through unchanged.

The reclaim no-op is a missing side effect: `ensureEmbeddingDimension` on the runtime calls `clearEmbeddingsOutsideActiveDimension` and re-embeds the returned ids. Origin always reports none, so stale-width vectors stay on the row.

## The fix

- Exact cosine scan of **scope-eligible** memories, then top-K (`count ?? limit ?? 10`). Same "scope before the cut" contract as plugin-sql / plugin-inmemorydb.
- Mixed-width or non-finite vectors score as incomparable and are skipped.
- `ensureEmbeddingDimension` stores the active width; `clearEmbeddingsOutsideActiveDimension` deletes embeddings whose length differs and returns those ids.

## Evidence

All measurements are execution output.

### 1. Origin reproduction on unmodified code

`packages/core/src/database/inMemoryAdapter.ts` was byte-identical to `origin/develop` (`a40cc65d3f161b307d6ba70fe6d89f1130b785eb`) before the branch:

```
$ git show origin/develop:packages/core/src/database/inMemoryAdapter.ts | diff - packages/core/src/database/inMemoryAdapter.ts
BYTE_IDENTICAL
```

Real module, real `createMemories` / `searchMemories` / `clearEmbeddingsOutsideActiveDimension`:

```
D1 searchMemories in-room top-3 length= 0 ids= []
D1b clearEmbeddingsOutsideActiveDimension reclaimed= [] expected staleId= da6a9381-a611-4f55-9a36-e0b63e242a14
```

Committed tests on that origin file:

```
Test Files  1 failed (1)
Tests  4 failed | 1 passed (5)
```

### 2. No over-rejection

The one origin-passing case (no embeddings → `[]`) still passes. Existing adapter files `inMemoryAdapter.count-memories-metadata.test.ts`, `inMemoryAdapter.project-memory-scope.test.ts`, `inMemoryAdapter.secure-random.test.ts`: **16 passed**. `inMemoryAdapter.message-search.test.ts` has 1 failure on **origin as well** (entityId filter); not introduced here.

### 3. Load-bearing revert (copy-aside, never stash)

Origin source under the new tests:

```
Test Files  1 failed (1)
Tests  4 failed | 1 passed (5)
```

Restored fix:

```
Test Files  1 passed (1)
Tests  5 passed (5)
```

### 4. Committed tests actually run

```
$ bun run --cwd packages/core test -- src/database/inMemoryAdapter.search-memories.test.ts
Test Files  1 passed (1)
Tests  5 passed (5)
```

### 5. Typecheck vs untouched control

packages/core `tsc --noEmit`: control **0** errors, branch **0** errors, **zero added**.

### 6. Biome

`bunx biome check packages/core/src/database/inMemoryAdapter.ts packages/core/src/database/inMemoryAdapter.search-memories.test.ts` — clean.

# Risks

Low. Fallback adapter only. SQL / plugin-inmemorydb paths unchanged.

# Background

## What does this PR do?

Implements in-process vector recall and stale-width reclaim on the core in-memory adapter.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No. Adapter header already claimed the full surface.

# Testing

## Where should a reviewer start?

`packages/core/src/database/inMemoryAdapter.search-memories.test.ts`

## Detailed testing steps

```
bun run --cwd packages/core test -- src/database/inMemoryAdapter.search-memories.test.ts
```

# Evidence Gate

<!-- evidence-head:411b7236a0b210302adaa2ee6d56bd5bac5d6f1e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; adapter recall only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; adapter recall only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface; adapter recall only.
<!-- evidence-row:backend-logs -->
- [x] Origin run of the real adapter:

<details>
<summary>origin adapter output</summary>

```
INFO D1 searchMemories in-room top-3 length= 0 ids= []
INFO D1b clearEmbeddingsOutsideActiveDimension reclaimed= [] expected staleId present
INFO committed tests on origin adapter: Test Files 1 failed; Tests 4 failed | 1 passed (5)
INFO after fix: Test Files 1 passed; Tests 5 passed (5)
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model call; canned vectors only.
<!-- evidence-row:domain-artifacts -->
- [x] In-process memory rows from the real adapter:

<details>
<summary>origin recall rows</summary>

```
INFO seeded 20 out-of-room exact matches plus 5 in-room near matches
INFO searchMemories room-scoped count=3 returned length=0
INFO after fix the same seed returns 3 in-room rows ordered by similarity
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model call.

# Known gaps / failures

- Did not run `bun run verify`. Focused tests + package typecheck + biome.
- Did not drive plugin-sql. That adapter already searches.
- Hosted CI does **not** run on fork PRs from ss251. Do not read a missing check as a pass.
- `inMemoryAdapter.message-search.test.ts` entityId case fails on origin; left untouched.

# Sync with develop

- [x] Branched from current `origin/develop` `a40cc65d3f161b307d6ba70fe6d89f1130b785eb`; zero conflicts.
- [ ] `bun run verify` not run; focused package tests + typecheck + biome recorded above.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-core-memory]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N10FMFDHQGGDWE3VHTP4WR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T15:21:42.799Z","completed_at":"2026-08-22T15:37:38.720Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T15:21:43.153Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"74eb42ff810aedbebe63b564c76f6bdf1fc4190bf6bf5719226e4b7233b2d8cd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7caa8284-89f9-4ae0-a9e0-1b2f78489f52","object_id":"sha256:74eb42ff810aedbebe63b564c76f6bdf1fc4190bf6bf5719226e4b7233b2d8cd","sha256":"74eb42ff810aedbebe63b564c76f6bdf1fc4190bf6bf5719226e4b7233b2d8cd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"U79YJ06Yzex22bAktt4R-wPmX-DJeRpBVUUF2913hKiJJ6-8WdYQXrtVPoJ7-E5oFG4LHv90K1Lfsu0Kfp2oAw"}} -->


## Attribution and replacement

This organization branch preserves the contribution from @ss251 / #24461, rebased onto current develop and repaired from independent review. The fork branch could not be updated because the maintainer OAuth token lacks workflow-file scope.
