### PR TITLE
fix(plugin-discord): do not drop body when smart-split returns a mixed array

### DIFF
--- a/plugins/plugin-discord/__tests__/smart-split-message.test.ts
+++ b/plugins/plugin-discord/__tests__/smart-split-message.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `smartSplitMessage` must not silently drop body text when the model returns
+ * a mixed valid/over-limit array. The real function is driven; `useModel` is
+ * the network seam.
+ */
+import type { IAgentRuntime, ModelTypeName } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	MAX_MESSAGE_LENGTH,
+	needsSmartSplit,
+	smartSplitMessage,
+	splitMessage,
+} from "../utils";
+
+function makeRuntime(
+	modelReply: string,
+): IAgentRuntime & { useModel: ReturnType<typeof vi.fn> } {
+	const useModel = vi.fn(async (_type: ModelTypeName, _opts: unknown) => {
+		return modelReply;
+	});
+	return {
+		agentId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+		useModel,
+	} as unknown as IAgentRuntime & { useModel: ReturnType<typeof vi.fn> };
+}
+
+const LONG_A = "A".repeat(1000);
+const LONG_B = "B".repeat(1000);
+const SOURCE = `${LONG_A}\n${LONG_B}`;
+
+describe("smartSplitMessage", () => {
+	it("selects the long-unbreakable-line path for this source", () => {
+		expect(SOURCE.length).toBeGreaterThan(MAX_MESSAGE_LENGTH);
+		expect(needsSmartSplit(SOURCE)).toBe(true);
+	});
+
+	it("falls back to a complete splitMessage when one model chunk is over the cap", async () => {
+		const overlong = `${LONG_B}${"C".repeat(MAX_MESSAGE_LENGTH)}`;
+		const runtime = makeRuntime(JSON.stringify([LONG_A, overlong]));
+
+		const chunks = await smartSplitMessage(runtime, SOURCE, MAX_MESSAGE_LENGTH);
+
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+		expect(chunks.join("")).toContain(LONG_A);
+		expect(chunks.join("")).toContain(LONG_B);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(MAX_MESSAGE_LENGTH);
+		}
+		expect(chunks).toEqual(splitMessage(SOURCE, MAX_MESSAGE_LENGTH));
+	});
+
+	it("keeps a complete in-limit model split", async () => {
+		const runtime = makeRuntime(JSON.stringify([LONG_A, LONG_B]));
+		const chunks = await smartSplitMessage(runtime, SOURCE, MAX_MESSAGE_LENGTH);
+		expect(chunks).toEqual([LONG_A, LONG_B]);
+	});
+
+	it("falls back when the model returns no usable array", async () => {
+		const runtime = makeRuntime("not-json");
+		const chunks = await smartSplitMessage(runtime, SOURCE, MAX_MESSAGE_LENGTH);
+		expect(chunks).toEqual(splitMessage(SOURCE, MAX_MESSAGE_LENGTH));
+	});
+
+	it("does not change under-limit text", async () => {
+		const runtime = makeRuntime("[]");
+		const chunks = await smartSplitMessage(
+			runtime,
+			"hello",
+			MAX_MESSAGE_LENGTH,
+		);
+		expect(chunks).toEqual(["hello"]);
+		expect(runtime.useModel).not.toHaveBeenCalled();
+	});
+
+	it("keeps a three-chunk in-limit model split of an over-cap source", async () => {
+		const a = "A".repeat(700);
+		const b = "B".repeat(700);
+		const c = "C".repeat(700);
+		const source = `${a}\n${b}\n${c}`;
+		expect(source.length).toBeGreaterThan(MAX_MESSAGE_LENGTH);
+		const runtime = makeRuntime(JSON.stringify([a, b, c]));
+		const chunks = await smartSplitMessage(runtime, source, MAX_MESSAGE_LENGTH);
+		expect(chunks).toEqual([a, b, c]);
+	});
+});

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -817,19 +817,21 @@ Return format:
 
 		const parsed = parseJsonArrayFromText(response);
 		if (Array.isArray(parsed)) {
-			const validChunks = parsed.filter(
-				(chunk: unknown): chunk is string =>
-					typeof chunk === "string" &&
-					chunk.trim().length > 0 &&
-					chunk.length <= maxLength,
-			);
+			const allValid =
+				parsed.length > 0 &&
+				parsed.every(
+					(chunk: unknown): chunk is string =>
+						typeof chunk === "string" &&
+						chunk.trim().length > 0 &&
+						chunk.length <= maxLength,
+				);
 
-			if (validChunks.length > 0) {
-				return validChunks;
+			if (allValid) {
+				return parsed;
 			}
 
 			runtime.logger.debug(
-				"Smart split returned empty or invalid chunks, falling back to simple split",
+				"Smart split returned empty, mixed, or over-limit chunks, falling back to simple split",
 			);
 		}
 	} catch (error) {


### PR DESCRIPTION
# Relates to

Closes #24510.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`5abed3bccf5d20f7d86883fce20622d6b44266d3`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` at `5abed3bccf5d20f7d86883fce20622d6b44266d3`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin tests are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Mixed over-limit model arrays fall back to a complete `splitMessage` of the full source. Previously-valid inputs stay the same (under-limit `"hello"`, complete in-limit model splits, three in-limit chunks, non-JSON → `splitMessage(source)`). `splitMessage` surrogate path is unchanged.

# Background

## What does this PR do?

Stops `smartSplitMessage` from returning a truncated chunk list when the model JSON contains a mix of in-limit strings and one over-cap sibling. Origin filtered to the in-limit subset and treated that as success, so Discord sent the prefix and the rest of the body was dropped.

## What kind of change is this?

Bug fix (non-breaking). Incomplete chunk list → full-source `splitMessage` fallback.

## Why are we doing this? Any context or related work?

`sendMessageInChunks` is the guild outbound path. A non-empty truncated list looks like a successful send. Coordination then treats the turn as delivered and will not retry the missing suffix.

Independently motivated from `fix/discord-voice-speaking-listeners` (`voice.ts`). Different file; do not combine.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-discord/__tests__/smart-split-message.test.ts` — mixed over-limit array on the real `smartSplitMessage`.

## Detailed testing steps

Automated tests:

```
bun run --cwd plugins/plugin-discord test __tests__/smart-split-message.test.ts __tests__/messaging-chunk-surrogate.test.ts
# Test Files  2 passed (2)
# Tests  10 passed (10)
```

Load-bearing revert (copy-aside origin `utils.ts` under the new tests): 1 failed | 4 passed (5). Restore the fix: 6 passed (6). The sixth test is the three-chunk over-rejection case.

Over-rejection: under-limit `"hello"`; complete in-limit `[LONG_A, LONG_B]`; three in-limit chunks of an over-cap source; non-JSON → `splitMessage(source)`; 4 `splitMessage` surrogate tests passed on origin and on the branch.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:2c64477f9129b97abe6baeff7dc161e15d5161e7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is a truncated chunk list from `smartSplitMessage`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime server logs. Origin vitest on the real `smartSplitMessage` showed mixed model array `[LONG_A, overlong]` returning only `LONG_A`; `chunks.join("")` did not contain `LONG_B`. Outer send catch never ran. Focused suite transcript is in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - `useModel` is the network seam only. The defect is the post-parse filter, not model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - not driven against a live Discord 2000-char reject or a live model `TEXT_SMALL` split.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change. `useModel` returns a JSON string fixture.

## Backend + frontend logs

N/A - no UI. Focused vitest at `2c64477f9129b97abe6baeff7dc161e15d5161e7`: 2 files / 10 tests passed.

Load-bearing revert under the new tests:

```
FAIL  smartSplitMessage > falls back to a complete splitMessage when one model chunk is over the cap
AssertionError: expected 'AAA…' to contain 'BBB…'
Test Files  1 failed (1)
Tests  1 failed | 4 passed (5)
```

Restore the fix: `Test Files  1 passed (1)` / `Tests  6 passed (6)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Not driven against a live Discord 2000-char reject or a live model `TEXT_SMALL` split. The mixed-array case is the filter bug; a well-formed complete model split is still accepted.
- `sendMessageInChunks` still swallows a **later** `channel.send` throw after some chunks succeeded (returns the partial `sentMessages`). `messages.ts` already records `partially_delivered` via the observer when that happens. Not changed here — different mechanism, and coordination intentionally treats a delivered first chunk as the edge so a crash sweeper does not double-reply.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Package `tsc --noEmit` vs the speaking worktree: 104 shared errors, 0 unique. Hits on `utils.ts`: none. Unique messages added: 0.
- `bunx biome check --write` on the two files: clean on second pass.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-discord-smartsplit-20260822]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N6JJ1Y3H6EZHE4QYQA9ARM","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T16:58:57.982Z","completed_at":"2026-08-22T16:59:59.530Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T16:58:58.597Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3a5ff2b5a6c506b748a301a12a57c85c2d5b713ec5844bff91247fece42d14b2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c52ae139-c4a4-41af-a208-d981ddb9dd16","object_id":"sha256:3a5ff2b5a6c506b748a301a12a57c85c2d5b713ec5844bff91247fece42d14b2","sha256":"3a5ff2b5a6c506b748a301a12a57c85c2d5b713ec5844bff91247fece42d14b2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"J-BMIhDCoRqqdP9vAZKioxuIxzvG59gB0kyOz-GDMKVyPB8Xg7Lbjf8CnNGjJErmUkkbzl3QdjZUCxQxRZIqDw"}} -->
