### PR TITLE
fix(core): reject unusable memory extraction intervals

### DIFF
--- a/packages/core/src/features/advanced-memory/services/memory-service.test.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.test.ts
@@ -53,3 +53,77 @@ describe("MemoryService extraction checkpoints", () => {
 		expect(getCache).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("MemoryService extraction interval configuration", () => {
+	const DEFAULT_INTERVAL = 10;
+
+	/** Initialize a service with MEMORY_EXTRACTION_INTERVAL set to `raw`. */
+	async function intervalFor(raw: string): Promise<number> {
+		const runtime = createMockRuntime({
+			getCache: vi.fn<IAgentRuntime["getCache"]>(async () => 0),
+			setCache: vi.fn(async () => true),
+			getSetting: (key: string) =>
+				key === "MEMORY_EXTRACTION_INTERVAL" ? raw : undefined,
+			// No storage backend: initialize() resolves config either way, and
+			// these assertions are about the config value, not the provider.
+			hasService: () => false,
+			getService: () => null,
+		});
+		const service = new MemoryService(runtime);
+		await service.initialize(runtime);
+		return (
+			service as unknown as {
+				memoryConfig: { longTermExtractionInterval: number };
+			}
+		).memoryConfig.longTermExtractionInterval;
+	}
+
+	it("ignores a fractional interval that would truncate to a zero divisor", async () => {
+		// parseInt("0.5") is 0, and shouldRunExtraction computes
+		//   Math.floor(count / interval) * interval
+		// so the checkpoint became NaN. Every comparison against NaN is false,
+		// so extraction silently never ran again.
+		await expect(intervalFor("0.5")).resolves.toBe(DEFAULT_INTERVAL);
+	});
+
+	it("ignores a negative interval that would run extraction every message", async () => {
+		// A negative divisor makes the checkpoint exceed the last one on nearly
+		// every call — the mirror failure of the zero case.
+		await expect(intervalFor("-5")).resolves.toBe(DEFAULT_INTERVAL);
+	});
+
+	it("ignores a trailing-garbage interval", async () => {
+		// parseInt("30junk") is 30 — a cadence three times the default, taken
+		// as deliberate configuration.
+		await expect(intervalFor("30junk")).resolves.toBe(DEFAULT_INTERVAL);
+	});
+
+	it("ignores an interval beyond the safe integer range", async () => {
+		await expect(intervalFor("9007199254740993")).resolves.toBe(
+			DEFAULT_INTERVAL,
+		);
+	});
+
+	it("still honours a clean interval, including a signed one", async () => {
+		await expect(intervalFor("50")).resolves.toBe(50);
+		// `parseInt` accepted "+50"; rejecting it would be a regression.
+		await expect(intervalFor("+50")).resolves.toBe(50);
+	});
+
+	it("keeps extraction running on a valid interval", async () => {
+		// End-to-end: the resolved interval still drives shouldRunExtraction.
+		const runtime = createMockRuntime({
+			getCache: vi.fn<IAgentRuntime["getCache"]>(async () => 0),
+			setCache: vi.fn(async () => true),
+			getSetting: (key: string) =>
+				key === "MEMORY_EXTRACTION_INTERVAL" ? "50" : undefined,
+			hasService: () => false,
+			getService: () => null,
+		});
+		const service = new MemoryService(runtime);
+		await service.initialize(runtime);
+		await expect(
+			service.shouldRunExtraction(ENTITY_ID, ROOM_ID, 100),
+		).resolves.toBe(true);
+	});
+});

--- a/packages/core/src/features/advanced-memory/services/memory-service.test.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.test.ts
@@ -1,5 +1,6 @@
 /** Verifies extraction checkpoints distinguish an absent value from cache I/O failure. */
 import { describe, expect, it, vi } from "vitest";
+import { logger } from "../../../logger.ts";
 import { createMockRuntime } from "../../../testing/mock-runtime.ts";
 import type { UUID } from "../../../types/primitives.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";
@@ -58,7 +59,7 @@ describe("MemoryService extraction interval configuration", () => {
 	const DEFAULT_INTERVAL = 10;
 
 	/** Initialize a service with MEMORY_EXTRACTION_INTERVAL set to `raw`. */
-	async function intervalFor(raw: string): Promise<number> {
+	async function intervalFor(raw: string | number | boolean): Promise<number> {
 		const runtime = createMockRuntime({
 			getCache: vi.fn<IAgentRuntime["getCache"]>(async () => 0),
 			setCache: vi.fn(async () => true),
@@ -102,6 +103,16 @@ describe("MemoryService extraction interval configuration", () => {
 		await expect(intervalFor("9007199254740993")).resolves.toBe(
 			DEFAULT_INTERVAL,
 		);
+	});
+
+	it("warns and keeps the default for a defined numeric zero", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+		await expect(intervalFor(0)).resolves.toBe(DEFAULT_INTERVAL);
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining('MEMORY_EXTRACTION_INTERVAL="0"'),
+		);
+		warn.mockRestore();
 	});
 
 	it("still honours a clean interval, including a signed one", async () => {

--- a/packages/core/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.ts
@@ -226,7 +226,11 @@ export class MemoryService extends Service {
 		}
 
 		const extractionInterval = runtime.getSetting("MEMORY_EXTRACTION_INTERVAL");
-		if (extractionInterval) {
+		if (
+			extractionInterval !== undefined &&
+			extractionInterval !== null &&
+			extractionInterval !== ""
+		) {
 			// This value is a DIVISOR in shouldRunExtraction:
 			//   Math.floor(currentMessageCount / interval) * interval
 			// `Number.parseInt` truncates, so "0.5" became 0 and the checkpoint
@@ -245,7 +249,6 @@ export class MemoryService extends Service {
 				);
 			}
 		}
-
 
 		const configuredModelType = resolveConfiguredTextGenerationModelType(
 			runtime.getSetting("MEMORY_SUMMARY_MODEL_TYPE") ??

--- a/packages/core/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.ts
@@ -227,11 +227,25 @@ export class MemoryService extends Service {
 
 		const extractionInterval = runtime.getSetting("MEMORY_EXTRACTION_INTERVAL");
 		if (extractionInterval) {
-			this.memoryConfig.longTermExtractionInterval = Number.parseInt(
-				String(extractionInterval),
-				10,
-			);
+			// This value is a DIVISOR in shouldRunExtraction:
+			//   Math.floor(currentMessageCount / interval) * interval
+			// `Number.parseInt` truncates, so "0.5" became 0 and the checkpoint
+			// became NaN — and every comparison against NaN is false, so
+			// extraction silently never ran again. A negative value is the
+			// mirror failure: the checkpoint always exceeds the last one, so it
+			// runs on every message. Only a positive whole number is usable;
+			// anything else keeps the documented default.
+			const raw = String(extractionInterval).trim();
+			const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+			if (Number.isSafeInteger(parsed) && parsed > 0) {
+				this.memoryConfig.longTermExtractionInterval = parsed;
+			} else {
+				logger.warn(
+					`[MemoryService] ignoring MEMORY_EXTRACTION_INTERVAL=${JSON.stringify(String(extractionInterval))}; expected a positive whole number, keeping ${this.memoryConfig.longTermExtractionInterval}`,
+				);
+			}
 		}
+
 
 		const configuredModelType = resolveConfiguredTextGenerationModelType(
 			runtime.getSetting("MEMORY_SUMMARY_MODEL_TYPE") ??


### PR DESCRIPTION
Relates to #24511. Supersedes #24432 because that fork branch cannot be updated past workflow changes with the available OAuth scope.

This preserves the reviewed implementation and follow-up repair from original author @Svector-anu on current `develop`, with no workflow-file delta. Explicit malformed, non-positive, or unsafe `MEMORY_EXTRACTION_INTERVAL` values retain the documented default and emit an operator warning; valid whole positive values drive extraction checkpoints. Defined falsey values such as numeric `0` are validated rather than silently bypassed.

Verification on exact head `553d0f0e62`:

- changed files are tree-identical to the previously tested merged feature tree
- focused Vitest: 10/10 passed
- `packages/core` typecheck passed
- changed-file Biome passed
- `git diff --check` passed
- no `.github/workflows` delta

Evidence: screenshots/video/frontend/backend/LLM/domain artifacts are N/A because this is a server-side configuration parser and timer-divisor guard with no rendered UI or external integration. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation by @Svector-anu in #24432; follow-up validation/harness repair and current-base migration by Codex.