### PR TITLE
test: repair production coverage additions

### DIFF
--- a/packages/agent/src/api/__tests__/boundary-role-resolver.test.ts
+++ b/packages/agent/src/api/__tests__/boundary-role-resolver.test.ts
@@ -2,7 +2,10 @@
 
 import type http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BoundaryRoleAccess, TokenRoleResolver } from "../boundary-role-resolver.ts";
+import type {
+  BoundaryRoleAccess,
+  TokenRoleResolver,
+} from "../boundary-role-resolver.ts";
 import {
   clearTokenRoleResolvers,
   hasTokenRoleResolver,
@@ -54,7 +57,9 @@ describe("boundary-role resolver registry", () => {
     registerTokenRoleResolver(fakeResolver("r1", null));
     const expected = access({ principal: "winner" });
     registerTokenRoleResolver(fakeResolver("r2", expected));
-    registerTokenRoleResolver(fakeResolver("r3", access({ principal: "loser" })));
+    registerTokenRoleResolver(
+      fakeResolver("r3", access({ principal: "loser" })),
+    );
     const result = resolveRegisteredTokenRoleAccess(fakeReq());
     expect(result?.principal).toBe("winner");
   });
@@ -68,7 +73,9 @@ describe("boundary-role resolver registry", () => {
     registerTokenRoleResolver(fakeResolver("r1", access(), { throws: true }));
     const fallback = access({ principal: "fallback" });
     registerTokenRoleResolver(fakeResolver("r2", fallback));
-    expect(resolveRegisteredTokenRoleAccess(fakeReq())?.principal).toBe("fallback");
+    expect(resolveRegisteredTokenRoleAccess(fakeReq())?.principal).toBe(
+      "fallback",
+    );
   });
 
   it("re-registering the same id replaces the prior resolver", () => {
@@ -83,15 +90,15 @@ describe("boundary-role resolver registry", () => {
     );
     // A later re-registration owns the slot; unregistering the old instance
     // must not remove the new one.
-    registerTokenRoleResolver(fakeResolver("r1", access({ principal: "second" })));
+    registerTokenRoleResolver(
+      fakeResolver("r1", access({ principal: "second" })),
+    );
     unregister();
     expect(hasTokenRoleResolver("r1")).toBe(true);
   });
 
   it("unregister removes the only instance", () => {
-    const unregister = registerTokenRoleResolver(
-      fakeResolver("r1", access()),
-    );
+    const unregister = registerTokenRoleResolver(fakeResolver("r1", access()));
     unregister();
     expect(hasTokenRoleResolver("r1")).toBe(false);
   });
@@ -99,10 +106,10 @@ describe("boundary-role resolver registry", () => {
 
 describe("isRegisteredTokenRoleAuthorized", () => {
   it("authorizes admins unconditionally", () => {
-    registerTokenRoleResolver(
-      fakeResolver("r1", access({ isAdmin: true })),
-    );
-    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "GET", "/any/route")).toBe(true);
+    registerTokenRoleResolver(fakeResolver("r1", access({ isAdmin: true })));
+    expect(
+      isRegisteredTokenRoleAuthorized(fakeReq(), "GET", "/any/route"),
+    ).toBe(true);
   });
 
   it("checks route scope for non-admins", () => {
@@ -112,7 +119,9 @@ describe("isRegisteredTokenRoleAuthorized", () => {
     );
     expect(isRegisteredTokenRoleAuthorized(fakeReq(), "get", "/ok")).toBe(true);
     expect(inScope).toHaveBeenCalledWith("GET", "/ok");
-    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "POST", "/ok")).toBe(false);
+    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "POST", "/ok")).toBe(
+      false,
+    );
   });
 
   it("denies unrecognised requests", () => {

--- a/packages/agent/src/api/__tests__/boundary-role-resolver.test.ts
+++ b/packages/agent/src/api/__tests__/boundary-role-resolver.test.ts
@@ -1,0 +1,121 @@
+/** Verifies token role resolver registration, scope checks, and fail-closed authorization. */
+
+import type http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BoundaryRoleAccess, TokenRoleResolver } from "../boundary-role-resolver.ts";
+import {
+  clearTokenRoleResolvers,
+  hasTokenRoleResolver,
+  isRegisteredTokenRoleAuthorized,
+  registerTokenRoleResolver,
+  resolveRegisteredTokenRoleAccess,
+} from "../boundary-role-resolver.ts";
+
+function fakeResolver(
+  id: string,
+  access: BoundaryRoleAccess | null,
+  opts: { throws?: boolean } = {},
+): TokenRoleResolver {
+  return {
+    id,
+    resolve: () => {
+      if (opts.throws) throw new Error("boom");
+      return access;
+    },
+  };
+}
+
+function fakeReq(): http.IncomingMessage {
+  return {} as http.IncomingMessage;
+}
+
+const access = (
+  overrides: Partial<BoundaryRoleAccess> = {},
+): BoundaryRoleAccess => ({
+  providerId: "test",
+  worldRole: "USER",
+  principal: "p1",
+  isAdmin: false,
+  isRouteInScope: () => true,
+  claims: {},
+  ...overrides,
+});
+
+afterEach(() => clearTokenRoleResolvers());
+
+describe("boundary-role resolver registry", () => {
+  it("registers and detects a resolver", () => {
+    registerTokenRoleResolver(fakeResolver("r1", access()));
+    expect(hasTokenRoleResolver("r1")).toBe(true);
+    expect(hasTokenRoleResolver("missing")).toBe(false);
+  });
+
+  it("returns the first non-null access in registration order", () => {
+    registerTokenRoleResolver(fakeResolver("r1", null));
+    const expected = access({ principal: "winner" });
+    registerTokenRoleResolver(fakeResolver("r2", expected));
+    registerTokenRoleResolver(fakeResolver("r3", access({ principal: "loser" })));
+    const result = resolveRegisteredTokenRoleAccess(fakeReq());
+    expect(result?.principal).toBe("winner");
+  });
+
+  it("returns null when no resolver recognises the request", () => {
+    registerTokenRoleResolver(fakeResolver("r1", null));
+    expect(resolveRegisteredTokenRoleAccess(fakeReq())).toBeNull();
+  });
+
+  it("treats a throwing resolver as a non-match", () => {
+    registerTokenRoleResolver(fakeResolver("r1", access(), { throws: true }));
+    const fallback = access({ principal: "fallback" });
+    registerTokenRoleResolver(fakeResolver("r2", fallback));
+    expect(resolveRegisteredTokenRoleAccess(fakeReq())?.principal).toBe("fallback");
+  });
+
+  it("re-registering the same id replaces the prior resolver", () => {
+    registerTokenRoleResolver(fakeResolver("r1", access({ principal: "old" })));
+    registerTokenRoleResolver(fakeResolver("r1", access({ principal: "new" })));
+    expect(resolveRegisteredTokenRoleAccess(fakeReq())?.principal).toBe("new");
+  });
+
+  it("unregister only removes the same instance", () => {
+    const unregister = registerTokenRoleResolver(
+      fakeResolver("r1", access({ principal: "first" })),
+    );
+    // A later re-registration owns the slot; unregistering the old instance
+    // must not remove the new one.
+    registerTokenRoleResolver(fakeResolver("r1", access({ principal: "second" })));
+    unregister();
+    expect(hasTokenRoleResolver("r1")).toBe(true);
+  });
+
+  it("unregister removes the only instance", () => {
+    const unregister = registerTokenRoleResolver(
+      fakeResolver("r1", access()),
+    );
+    unregister();
+    expect(hasTokenRoleResolver("r1")).toBe(false);
+  });
+});
+
+describe("isRegisteredTokenRoleAuthorized", () => {
+  it("authorizes admins unconditionally", () => {
+    registerTokenRoleResolver(
+      fakeResolver("r1", access({ isAdmin: true })),
+    );
+    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "GET", "/any/route")).toBe(true);
+  });
+
+  it("checks route scope for non-admins", () => {
+    const inScope = vi.fn((m: string, p: string) => m === "GET" && p === "/ok");
+    registerTokenRoleResolver(
+      fakeResolver("r1", access({ isAdmin: false, isRouteInScope: inScope })),
+    );
+    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "get", "/ok")).toBe(true);
+    expect(inScope).toHaveBeenCalledWith("GET", "/ok");
+    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "POST", "/ok")).toBe(false);
+  });
+
+  it("denies unrecognised requests", () => {
+    expect(isRegisteredTokenRoleAuthorized(fakeReq(), "GET", "/x")).toBe(false);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/__tests__/rpc-parse-utils.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/rpc-parse-utils.test.ts
@@ -1,0 +1,93 @@
+/** Verifies the Electrobun RPC boundary's strict primitive and record parsers. */
+
+import { describe, expect, it } from "vitest";
+import {
+  finiteNumber,
+  hasBooleanFields,
+  isRecord,
+  nullableString,
+  optionalFiniteNumber,
+  optionalString,
+  parseStringArray,
+  requiredBoolean,
+  requiredString,
+} from "../rpc-parse-utils.ts";
+
+describe("isRecord", () => {
+  it("accepts plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+  it("rejects non-objects", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord("x")).toBe(false);
+    expect(isRecord(42)).toBe(false);
+  });
+});
+
+describe("finiteNumber", () => {
+  it("accepts finite numbers", () => {
+    expect(finiteNumber(3.14)).toBe(3.14);
+    expect(finiteNumber(0)).toBe(0);
+  });
+  it("rejects non-finite and non-numbers", () => {
+    expect(finiteNumber(NaN)).toBeNull();
+    expect(finiteNumber(Infinity)).toBeNull();
+    expect(finiteNumber("3")).toBeNull();
+  });
+});
+
+describe("nullableString", () => {
+  it("handles null, strings, and other types", () => {
+    expect(nullableString(null)).toBeNull();
+    expect(nullableString("hi")).toBe("hi");
+    expect(nullableString(42)).toBeUndefined();
+  });
+});
+
+describe("parseStringArray", () => {
+  it("parses homogeneous string arrays", () => {
+    expect(parseStringArray(["a", "b"])).toEqual(["a", "b"]);
+  });
+  it("returns null for non-arrays and mixed arrays", () => {
+    expect(parseStringArray("x")).toBeNull();
+    expect(parseStringArray(["a", 2])).toBeNull();
+    expect(parseStringArray([])).toEqual([]);
+  });
+});
+
+describe("optionalString", () => {
+  it("returns undefined for undefined, string for strings, false otherwise", () => {
+    expect(optionalString(undefined)).toBeUndefined();
+    expect(optionalString("ok")).toBe("ok");
+    expect(optionalString(5)).toBe(false);
+  });
+});
+
+describe("requiredString / requiredBoolean", () => {
+  it("extracts present fields and null for missing/wrong types", () => {
+    expect(requiredString({ name: "x" }, "name")).toBe("x");
+    expect(requiredString({ name: 5 }, "name")).toBeNull();
+    expect(requiredString({}, "name")).toBeNull();
+    expect(requiredBoolean({ flag: true }, "flag")).toBe(true);
+    expect(requiredBoolean({ flag: "yes" }, "flag")).toBeNull();
+  });
+});
+
+describe("hasBooleanFields", () => {
+  it("checks all keys are booleans", () => {
+    expect(hasBooleanFields({ a: true, b: false }, ["a", "b"])).toBe(true);
+    expect(hasBooleanFields({ a: true, b: 1 }, ["a", "b"])).toBe(false);
+    expect(hasBooleanFields({}, [])).toBe(true);
+  });
+});
+
+describe("optionalFiniteNumber", () => {
+  it("returns undefined for undefined, number for finite, false otherwise", () => {
+    expect(optionalFiniteNumber(undefined)).toBeUndefined();
+    expect(optionalFiniteNumber(2.5)).toBe(2.5);
+    expect(optionalFiniteNumber(NaN)).toBe(false);
+    expect(optionalFiniteNumber("2")).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/build-variant.test.ts
+++ b/packages/core/src/__tests__/build-variant.test.ts
@@ -1,0 +1,65 @@
+/** Verifies build-variant resolution and direct-download policy with a mocked environment reader. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetBuildVariantForTests,
+  getBuildVariant,
+  getDirectDownloadUrl,
+  isDirectBuild,
+  isStoreBuild,
+} from "../build-variant.ts";
+
+const envRead = vi.fn();
+
+vi.mock("../utils/read-env.ts", () => ({
+  readEnv: (...args: unknown[]) => envRead(...args),
+}));
+
+describe("build-variant resolution", () => {
+  beforeEach(() => {
+    _resetBuildVariantForTests();
+    envRead.mockReset();
+  });
+
+  afterEach(() => {
+    _resetBuildVariantForTests();
+  });
+
+  it("defaults to direct when ELIZA_BUILD_VARIANT is unset", () => {
+    envRead.mockReturnValue(undefined);
+    expect(getBuildVariant()).toBe("direct");
+    expect(isDirectBuild()).toBe(true);
+    expect(isStoreBuild()).toBe(false);
+  });
+
+  it("accepts the store variant", () => {
+    envRead.mockReturnValue("store");
+    expect(getBuildVariant()).toBe("store");
+    expect(isStoreBuild()).toBe(true);
+    expect(isDirectBuild()).toBe(false);
+  });
+
+  it("falls back to direct on unknown values", () => {
+    envRead.mockReturnValue("unknown-variant");
+    expect(getBuildVariant()).toBe("direct");
+  });
+
+  it("normalizes case and whitespace", () => {
+    envRead.mockReturnValue("  STORE  ");
+    expect(getBuildVariant()).toBe("store");
+  });
+
+  it("returns a stable download URL", () => {
+    expect(getDirectDownloadUrl()).toBe("https://eliza.so/download");
+  });
+
+  it("caches the resolved variant across calls", () => {
+    envRead.mockReturnValue("store");
+    expect(getBuildVariant()).toBe("store");
+    // After resolution, changing the env has no effect until reset.
+    envRead.mockReturnValue("direct");
+    expect(getBuildVariant()).toBe("store");
+    _resetBuildVariantForTests();
+    expect(getBuildVariant()).toBe("direct");
+  });
+});

--- a/packages/core/src/__tests__/build-variant.test.ts
+++ b/packages/core/src/__tests__/build-variant.test.ts
@@ -2,64 +2,64 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  _resetBuildVariantForTests,
-  getBuildVariant,
-  getDirectDownloadUrl,
-  isDirectBuild,
-  isStoreBuild,
+	_resetBuildVariantForTests,
+	getBuildVariant,
+	getDirectDownloadUrl,
+	isDirectBuild,
+	isStoreBuild,
 } from "../build-variant.ts";
 
 const envRead = vi.fn();
 
 vi.mock("../utils/read-env.ts", () => ({
-  readEnv: (...args: unknown[]) => envRead(...args),
+	readEnv: (...args: unknown[]) => envRead(...args),
 }));
 
 describe("build-variant resolution", () => {
-  beforeEach(() => {
-    _resetBuildVariantForTests();
-    envRead.mockReset();
-  });
+	beforeEach(() => {
+		_resetBuildVariantForTests();
+		envRead.mockReset();
+	});
 
-  afterEach(() => {
-    _resetBuildVariantForTests();
-  });
+	afterEach(() => {
+		_resetBuildVariantForTests();
+	});
 
-  it("defaults to direct when ELIZA_BUILD_VARIANT is unset", () => {
-    envRead.mockReturnValue(undefined);
-    expect(getBuildVariant()).toBe("direct");
-    expect(isDirectBuild()).toBe(true);
-    expect(isStoreBuild()).toBe(false);
-  });
+	it("defaults to direct when ELIZA_BUILD_VARIANT is unset", () => {
+		envRead.mockReturnValue(undefined);
+		expect(getBuildVariant()).toBe("direct");
+		expect(isDirectBuild()).toBe(true);
+		expect(isStoreBuild()).toBe(false);
+	});
 
-  it("accepts the store variant", () => {
-    envRead.mockReturnValue("store");
-    expect(getBuildVariant()).toBe("store");
-    expect(isStoreBuild()).toBe(true);
-    expect(isDirectBuild()).toBe(false);
-  });
+	it("accepts the store variant", () => {
+		envRead.mockReturnValue("store");
+		expect(getBuildVariant()).toBe("store");
+		expect(isStoreBuild()).toBe(true);
+		expect(isDirectBuild()).toBe(false);
+	});
 
-  it("falls back to direct on unknown values", () => {
-    envRead.mockReturnValue("unknown-variant");
-    expect(getBuildVariant()).toBe("direct");
-  });
+	it("falls back to direct on unknown values", () => {
+		envRead.mockReturnValue("unknown-variant");
+		expect(getBuildVariant()).toBe("direct");
+	});
 
-  it("normalizes case and whitespace", () => {
-    envRead.mockReturnValue("  STORE  ");
-    expect(getBuildVariant()).toBe("store");
-  });
+	it("normalizes case and whitespace", () => {
+		envRead.mockReturnValue("  STORE  ");
+		expect(getBuildVariant()).toBe("store");
+	});
 
-  it("returns a stable download URL", () => {
-    expect(getDirectDownloadUrl()).toBe("https://eliza.so/download");
-  });
+	it("returns a stable download URL", () => {
+		expect(getDirectDownloadUrl()).toBe("https://eliza.so/download");
+	});
 
-  it("caches the resolved variant across calls", () => {
-    envRead.mockReturnValue("store");
-    expect(getBuildVariant()).toBe("store");
-    // After resolution, changing the env has no effect until reset.
-    envRead.mockReturnValue("direct");
-    expect(getBuildVariant()).toBe("store");
-    _resetBuildVariantForTests();
-    expect(getBuildVariant()).toBe("direct");
-  });
+	it("caches the resolved variant across calls", () => {
+		envRead.mockReturnValue("store");
+		expect(getBuildVariant()).toBe("store");
+		// After resolution, changing the env has no effect until reset.
+		envRead.mockReturnValue("direct");
+		expect(getBuildVariant()).toBe("store");
+		_resetBuildVariantForTests();
+		expect(getBuildVariant()).toBe("direct");
+	});
 });

--- a/packages/core/src/testing/__tests__/deterministic-action-fixtures.test.ts
+++ b/packages/core/src/testing/__tests__/deterministic-action-fixtures.test.ts
@@ -1,0 +1,131 @@
+/** Tests deterministic action-route fixtures used by real scenario harnesses. */
+
+import { describe, expect, it } from "vitest";
+import { ModelType } from "../../types/model.ts";
+import {
+  actionSlug,
+  finalMessageUserText,
+  matchesScenarioInput,
+  registerStrictActionRouteFixtures,
+  stage1ResponseHandlerFixture,
+  strictActionRouteFixtures,
+} from "../deterministic-action-fixtures.ts";
+
+describe("finalMessageUserText", () => {
+  it("strips the message:user: marker", () => {
+    expect(finalMessageUserText("prefix message:user:\nHello there")).toBe(
+      "Hello there",
+    );
+  });
+
+  it("returns the input unchanged when no marker", () => {
+    expect(finalMessageUserText("plain text")).toBe("plain text");
+  });
+
+  it("extracts text after the external-content separator", () => {
+    const value =
+      "message:user:\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nignored\n---\nREAL USER TEXT\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
+    expect(finalMessageUserText(value)).toBe("REAL USER TEXT");
+  });
+
+  it("returns full envelope text when no separator", () => {
+    const value =
+      "message:user:\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\njust this\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
+    expect(finalMessageUserText(value)).toBe("just this");
+  });
+
+  it("trims the trailing provider boundary", () => {
+    const value = "message:user:\nBuy 10 apples\n\nevent: user_message";
+    expect(finalMessageUserText(value)).toBe("Buy 10 apples");
+  });
+});
+
+describe("matchesScenarioInput", () => {
+  it("compares normalized text exactly", () => {
+    const matcher = matchesScenarioInput("Buy apples");
+    expect(matcher("message:user:\nBuy apples")).toBe(true);
+    expect(matcher("message:user:\nBuy pears")).toBe(false);
+  });
+});
+
+describe("actionSlug", () => {
+  it("lowercases and hyphenates", () => {
+    expect(actionSlug("Send Email")).toBe("send-email");
+    expect(actionSlug("GET_BALANCE")).toBe("get-balance");
+    expect(actionSlug("simple")).toBe("simple");
+  });
+});
+
+describe("stage1ResponseHandlerFixture", () => {
+  it("routes to the candidate action", () => {
+    const fixture = stage1ResponseHandlerFixture({
+      actionName: "Check Balance",
+      args: {},
+      input: "what is my balance",
+    });
+    expect(fixture.match.modelType).toBe(ModelType.RESPONSE_HANDLER);
+    expect(fixture.match.toolName).toBe("HANDLE_RESPONSE");
+    expect(fixture.name).toContain("check-balance");
+  });
+
+  it("uses default context and reply when absent", () => {
+    const fixture = stage1ResponseHandlerFixture({
+      actionName: "X",
+      args: {},
+      input: "hi",
+    });
+    const response = fixture.response as { contexts: string[]; replyText: string };
+    expect(response.contexts).toEqual(["general"]);
+    expect(response.replyText).toBe("On it.");
+  });
+});
+
+describe("strictActionRouteFixtures", () => {
+  it("emits the stage1 + planner pair", () => {
+    const fixtures = strictActionRouteFixtures({
+      actionName: "SendEmail",
+      args: { to: "a@b.c" },
+      input: "email a",
+    });
+    expect(fixtures).toHaveLength(2);
+    expect(fixtures[0].match.modelType).toBe(ModelType.RESPONSE_HANDLER);
+    expect(fixtures[1].match.modelType).toBe(ModelType.ACTION_PLANNER);
+    const planner = fixtures[1].response as { toolCalls: { name: string }[] };
+    expect(planner.toolCalls[0].name).toBe("SendEmail");
+  });
+
+  it("passes arguments through to the tool call", () => {
+    const fixtures = strictActionRouteFixtures({
+      actionName: "GetBalance",
+      args: { address: "0x123" },
+      input: "balance please",
+    });
+    const planner = fixtures[1].response as { toolCalls: { arguments: unknown }[] };
+    expect(planner.toolCalls[0].arguments).toEqual({ address: "0x123" });
+  });
+});
+
+describe("registerStrictActionRouteFixtures", () => {
+  it("registers all fixtures onto the runtime bridge", () => {
+    const register = (() => {
+      const calls: unknown[][] = [];
+      return {
+        fn: (...f: unknown[]) => calls.push(f),
+        calls,
+      };
+    })();
+    const runtime = { scenarioModelFixtures: { register: register.fn } };
+    registerStrictActionRouteFixtures(runtime, [
+      { actionName: "A", args: {}, input: "a" },
+      { actionName: "B", args: {}, input: "b" },
+    ]);
+    expect(register.calls).toHaveLength(1);
+    expect(register.calls[0]).toHaveLength(4); // 2 specs × 2 fixtures
+  });
+
+  it("is a no-op when the runtime has no fixture bridge", () => {
+    expect(() =>
+      registerStrictActionRouteFixtures({}, [{ actionName: "A", args: {}, input: "a" }]),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/testing/__tests__/deterministic-action-fixtures.test.ts
+++ b/packages/core/src/testing/__tests__/deterministic-action-fixtures.test.ts
@@ -3,129 +3,136 @@
 import { describe, expect, it } from "vitest";
 import { ModelType } from "../../types/model.ts";
 import {
-  actionSlug,
-  finalMessageUserText,
-  matchesScenarioInput,
-  registerStrictActionRouteFixtures,
-  stage1ResponseHandlerFixture,
-  strictActionRouteFixtures,
+	actionSlug,
+	finalMessageUserText,
+	matchesScenarioInput,
+	registerStrictActionRouteFixtures,
+	stage1ResponseHandlerFixture,
+	strictActionRouteFixtures,
 } from "../deterministic-action-fixtures.ts";
 
 describe("finalMessageUserText", () => {
-  it("strips the message:user: marker", () => {
-    expect(finalMessageUserText("prefix message:user:\nHello there")).toBe(
-      "Hello there",
-    );
-  });
+	it("strips the message:user: marker", () => {
+		expect(finalMessageUserText("prefix message:user:\nHello there")).toBe(
+			"Hello there",
+		);
+	});
 
-  it("returns the input unchanged when no marker", () => {
-    expect(finalMessageUserText("plain text")).toBe("plain text");
-  });
+	it("returns the input unchanged when no marker", () => {
+		expect(finalMessageUserText("plain text")).toBe("plain text");
+	});
 
-  it("extracts text after the external-content separator", () => {
-    const value =
-      "message:user:\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nignored\n---\nREAL USER TEXT\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
-    expect(finalMessageUserText(value)).toBe("REAL USER TEXT");
-  });
+	it("extracts text after the external-content separator", () => {
+		const value =
+			"message:user:\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\nignored\n---\nREAL USER TEXT\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
+		expect(finalMessageUserText(value)).toBe("REAL USER TEXT");
+	});
 
-  it("returns full envelope text when no separator", () => {
-    const value =
-      "message:user:\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\njust this\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
-    expect(finalMessageUserText(value)).toBe("just this");
-  });
+	it("returns full envelope text when no separator", () => {
+		const value =
+			"message:user:\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\njust this\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>";
+		expect(finalMessageUserText(value)).toBe("just this");
+	});
 
-  it("trims the trailing provider boundary", () => {
-    const value = "message:user:\nBuy 10 apples\n\nevent: user_message";
-    expect(finalMessageUserText(value)).toBe("Buy 10 apples");
-  });
+	it("trims the trailing provider boundary", () => {
+		const value = "message:user:\nBuy 10 apples\n\nevent: user_message";
+		expect(finalMessageUserText(value)).toBe("Buy 10 apples");
+	});
 });
 
 describe("matchesScenarioInput", () => {
-  it("compares normalized text exactly", () => {
-    const matcher = matchesScenarioInput("Buy apples");
-    expect(matcher("message:user:\nBuy apples")).toBe(true);
-    expect(matcher("message:user:\nBuy pears")).toBe(false);
-  });
+	it("compares normalized text exactly", () => {
+		const matcher = matchesScenarioInput("Buy apples");
+		expect(matcher("message:user:\nBuy apples")).toBe(true);
+		expect(matcher("message:user:\nBuy pears")).toBe(false);
+	});
 });
 
 describe("actionSlug", () => {
-  it("lowercases and hyphenates", () => {
-    expect(actionSlug("Send Email")).toBe("send-email");
-    expect(actionSlug("GET_BALANCE")).toBe("get-balance");
-    expect(actionSlug("simple")).toBe("simple");
-  });
+	it("lowercases and hyphenates", () => {
+		expect(actionSlug("Send Email")).toBe("send-email");
+		expect(actionSlug("GET_BALANCE")).toBe("get-balance");
+		expect(actionSlug("simple")).toBe("simple");
+	});
 });
 
 describe("stage1ResponseHandlerFixture", () => {
-  it("routes to the candidate action", () => {
-    const fixture = stage1ResponseHandlerFixture({
-      actionName: "Check Balance",
-      args: {},
-      input: "what is my balance",
-    });
-    expect(fixture.match.modelType).toBe(ModelType.RESPONSE_HANDLER);
-    expect(fixture.match.toolName).toBe("HANDLE_RESPONSE");
-    expect(fixture.name).toContain("check-balance");
-  });
+	it("routes to the candidate action", () => {
+		const fixture = stage1ResponseHandlerFixture({
+			actionName: "Check Balance",
+			args: {},
+			input: "what is my balance",
+		});
+		expect(fixture.match.modelType).toBe(ModelType.RESPONSE_HANDLER);
+		expect(fixture.match.toolName).toBe("HANDLE_RESPONSE");
+		expect(fixture.name).toContain("check-balance");
+	});
 
-  it("uses default context and reply when absent", () => {
-    const fixture = stage1ResponseHandlerFixture({
-      actionName: "X",
-      args: {},
-      input: "hi",
-    });
-    const response = fixture.response as { contexts: string[]; replyText: string };
-    expect(response.contexts).toEqual(["general"]);
-    expect(response.replyText).toBe("On it.");
-  });
+	it("uses default context and reply when absent", () => {
+		const fixture = stage1ResponseHandlerFixture({
+			actionName: "X",
+			args: {},
+			input: "hi",
+		});
+		const response = fixture.response as {
+			contexts: string[];
+			replyText: string;
+		};
+		expect(response.contexts).toEqual(["general"]);
+		expect(response.replyText).toBe("On it.");
+	});
 });
 
 describe("strictActionRouteFixtures", () => {
-  it("emits the stage1 + planner pair", () => {
-    const fixtures = strictActionRouteFixtures({
-      actionName: "SendEmail",
-      args: { to: "a@b.c" },
-      input: "email a",
-    });
-    expect(fixtures).toHaveLength(2);
-    expect(fixtures[0].match.modelType).toBe(ModelType.RESPONSE_HANDLER);
-    expect(fixtures[1].match.modelType).toBe(ModelType.ACTION_PLANNER);
-    const planner = fixtures[1].response as { toolCalls: { name: string }[] };
-    expect(planner.toolCalls[0].name).toBe("SendEmail");
-  });
+	it("emits the stage1 + planner pair", () => {
+		const fixtures = strictActionRouteFixtures({
+			actionName: "SendEmail",
+			args: { to: "a@b.c" },
+			input: "email a",
+		});
+		expect(fixtures).toHaveLength(2);
+		expect(fixtures[0].match.modelType).toBe(ModelType.RESPONSE_HANDLER);
+		expect(fixtures[1].match.modelType).toBe(ModelType.ACTION_PLANNER);
+		const planner = fixtures[1].response as { toolCalls: { name: string }[] };
+		expect(planner.toolCalls[0].name).toBe("SendEmail");
+	});
 
-  it("passes arguments through to the tool call", () => {
-    const fixtures = strictActionRouteFixtures({
-      actionName: "GetBalance",
-      args: { address: "0x123" },
-      input: "balance please",
-    });
-    const planner = fixtures[1].response as { toolCalls: { arguments: unknown }[] };
-    expect(planner.toolCalls[0].arguments).toEqual({ address: "0x123" });
-  });
+	it("passes arguments through to the tool call", () => {
+		const fixtures = strictActionRouteFixtures({
+			actionName: "GetBalance",
+			args: { address: "0x123" },
+			input: "balance please",
+		});
+		const planner = fixtures[1].response as {
+			toolCalls: { arguments: unknown }[];
+		};
+		expect(planner.toolCalls[0].arguments).toEqual({ address: "0x123" });
+	});
 });
 
 describe("registerStrictActionRouteFixtures", () => {
-  it("registers all fixtures onto the runtime bridge", () => {
-    const register = (() => {
-      const calls: unknown[][] = [];
-      return {
-        fn: (...f: unknown[]) => calls.push(f),
-        calls,
-      };
-    })();
-    const runtime = { scenarioModelFixtures: { register: register.fn } };
-    registerStrictActionRouteFixtures(runtime, [
-      { actionName: "A", args: {}, input: "a" },
-      { actionName: "B", args: {}, input: "b" },
-    ]);
-    expect(register.calls).toHaveLength(1);
-    expect(register.calls[0]).toHaveLength(4); // 2 specs × 2 fixtures
-  });
+	it("registers all fixtures onto the runtime bridge", () => {
+		const register = (() => {
+			const calls: unknown[][] = [];
+			return {
+				fn: (...f: unknown[]) => calls.push(f),
+				calls,
+			};
+		})();
+		const runtime = { scenarioModelFixtures: { register: register.fn } };
+		registerStrictActionRouteFixtures(runtime, [
+			{ actionName: "A", args: {}, input: "a" },
+			{ actionName: "B", args: {}, input: "b" },
+		]);
+		expect(register.calls).toHaveLength(1);
+		expect(register.calls[0]).toHaveLength(4); // 2 specs × 2 fixtures
+	});
 
-  it("is a no-op when the runtime has no fixture bridge", () => {
-    expect(() =>
-      registerStrictActionRouteFixtures({}, [{ actionName: "A", args: {}, input: "a" }]),
-    ).not.toThrow();
-  });
+	it("is a no-op when the runtime has no fixture bridge", () => {
+		expect(() =>
+			registerStrictActionRouteFixtures({}, [
+				{ actionName: "A", args: {}, input: "a" },
+			]),
+		).not.toThrow();
+	});
 });

--- a/packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts
+++ b/packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts
@@ -1,6 +1,9 @@
 /** Exercises the real scenario effect-assertion helpers against captured action records. */
 
-import type { CapturedAction, ScenarioContext } from "@elizaos/scenario-runner/schema";
+import type {
+  CapturedAction,
+  ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
 import { describe, expect, it } from "vitest";
 import {
   callPayloadBlob,
@@ -37,13 +40,18 @@ describe("successfulActionData", () => {
   it("returns the first successful non-synthesized data payload", () => {
     const c = ctx([
       action({ actionName: "other" }),
-      action({ actionName: "target", result: { success: true, data: { value: 42 } } }),
+      action({
+        actionName: "target",
+        result: { success: true, data: { value: 42 } },
+      }),
     ]);
     expect(successfulActionData(c, "target")).toEqual({ value: 42 });
   });
 
   it("accepts multiple names", () => {
-    const c = ctx([action({ actionName: "b", result: { success: true, data: { x: 1 } } })]);
+    const c = ctx([
+      action({ actionName: "b", result: { success: true, data: { x: 1 } } }),
+    ]);
     expect(successfulActionData(c, ["a", "b"])).toEqual({ x: 1 });
   });
 
@@ -97,21 +105,25 @@ describe("callPayloadBlob", () => {
 describe("describeCalls", () => {
   it("summarizes calls and handles the empty case", () => {
     expect(describeCalls(ctx([]))).toBe("(no actions called)");
-    const c = ctx([action({ actionName: "go", result: { success: true, data: null } })]);
+    const c = ctx([
+      action({ actionName: "go", result: { success: true, data: null } }),
+    ]);
     expect(describeCalls(c)).toContain("go(success=true");
   });
 });
 
 describe("expectNoActionCalled", () => {
   it("returns undefined when no forbidden action fired", () => {
-    expect(expectNoActionCalled(ctx([action({ actionName: "ok" })]), ["bad"])).toBeUndefined();
+    expect(
+      expectNoActionCalled(ctx([action({ actionName: "ok" })]), ["bad"]),
+    ).toBeUndefined();
   });
 
   it("returns a failure message when a forbidden action fired", () => {
-    const message = expectNoActionCalled(
-      ctx([action({ actionName: "bad" })]),
-      ["bad", "worse"],
-    );
+    const message = expectNoActionCalled(ctx([action({ actionName: "bad" })]), [
+      "bad",
+      "worse",
+    ]);
     expect(message).toContain("expected none of");
     expect(message).toContain("bad");
   });

--- a/packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts
+++ b/packages/scenario-runner/src/scenario-assertions/__tests__/effect-assertions.test.ts
@@ -1,0 +1,118 @@
+/** Exercises the real scenario effect-assertion helpers against captured action records. */
+
+import type { CapturedAction, ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { describe, expect, it } from "vitest";
+import {
+  callPayloadBlob,
+  describeCalls,
+  expectNoActionCalled,
+  successfulActionData,
+  successfulCalls,
+  toRecord,
+} from "../effect-assertions.ts";
+
+function action(overrides: Partial<CapturedAction> = {}): CapturedAction {
+  return {
+    actionName: "test",
+    parameters: {},
+    result: { success: true, data: { ok: 1 } },
+    ...overrides,
+  } as CapturedAction;
+}
+
+function ctx(actions: CapturedAction[]): ScenarioContext {
+  return { actionsCalled: actions } as ScenarioContext;
+}
+
+describe("toRecord", () => {
+  it("accepts plain objects and rejects everything else", () => {
+    expect(toRecord({ a: 1 })).toEqual({ a: 1 });
+    expect(toRecord(null)).toBeNull();
+    expect(toRecord([])).toBeNull();
+    expect(toRecord("x")).toBeNull();
+  });
+});
+
+describe("successfulActionData", () => {
+  it("returns the first successful non-synthesized data payload", () => {
+    const c = ctx([
+      action({ actionName: "other" }),
+      action({ actionName: "target", result: { success: true, data: { value: 42 } } }),
+    ]);
+    expect(successfulActionData(c, "target")).toEqual({ value: 42 });
+  });
+
+  it("accepts multiple names", () => {
+    const c = ctx([action({ actionName: "b", result: { success: true, data: { x: 1 } } })]);
+    expect(successfulActionData(c, ["a", "b"])).toEqual({ x: 1 });
+  });
+
+  it("skips failed and synthesized replies", () => {
+    const c = ctx([
+      action({ actionName: "t", result: { success: false, data: { bad: 1 } } }),
+      action({
+        actionName: "t",
+        result: { success: true, data: { source: "synthesized-reply" } },
+      }),
+      action({ actionName: "t", result: { success: true, data: { good: 2 } } }),
+    ]);
+    expect(successfulActionData(c, "t")).toEqual({ good: 2 });
+  });
+
+  it("returns null when nothing qualifies", () => {
+    expect(successfulActionData(ctx([]), "missing")).toBeNull();
+  });
+});
+
+describe("successfulCalls", () => {
+  it("filters successful non-synthesized calls", () => {
+    const calls = [
+      action({ actionName: "t" }),
+      action({ actionName: "t", result: { success: false, data: null } }),
+      action({
+        actionName: "t",
+        result: { success: true, data: { source: "synthesized-reply" } },
+      }),
+    ];
+    expect(successfulCalls(ctx(calls), "t")).toHaveLength(1);
+  });
+});
+
+describe("callPayloadBlob", () => {
+  it("lowercases the JSON blob of matching calls", () => {
+    const c = ctx([
+      action({
+        actionName: "SendEmail",
+        parameters: { to: "A@B.C" },
+        result: { success: true, data: { id: "X" }, text: "SENT" },
+      }),
+    ]);
+    const blob = callPayloadBlob(c, "SendEmail");
+    expect(blob).toContain('"to":"a@b.c"');
+    expect(blob).toContain('"id":"x"');
+    expect(blob).toBe(blob.toLowerCase());
+  });
+});
+
+describe("describeCalls", () => {
+  it("summarizes calls and handles the empty case", () => {
+    expect(describeCalls(ctx([]))).toBe("(no actions called)");
+    const c = ctx([action({ actionName: "go", result: { success: true, data: null } })]);
+    expect(describeCalls(c)).toContain("go(success=true");
+  });
+});
+
+describe("expectNoActionCalled", () => {
+  it("returns undefined when no forbidden action fired", () => {
+    expect(expectNoActionCalled(ctx([action({ actionName: "ok" })]), ["bad"])).toBeUndefined();
+  });
+
+  it("returns a failure message when a forbidden action fired", () => {
+    const message = expectNoActionCalled(
+      ctx([action({ actionName: "bad" })]),
+      ["bad", "worse"],
+    );
+    expect(message).toContain("expected none of");
+    expect(message).toContain("bad");
+  });
+});

--- a/packages/shared/src/apps/__tests__/overlay-app-registry.test.ts
+++ b/packages/shared/src/apps/__tests__/overlay-app-registry.test.ts
@@ -1,0 +1,114 @@
+/** Exercises overlay app registration and platform availability with mocked host boundaries. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OverlayApp } from "../overlay-app-registry.ts";
+import {
+  getAllOverlayApps,
+  getAvailableOverlayApps,
+  getOverlayApp,
+  isAospAndroid,
+  isOverlayApp,
+  overlayAppToRegistryInfo,
+  registerOverlayApp,
+} from "../overlay-app-registry.ts";
+
+// Fake registry store: a plain module-level map.
+const store = new Map<string, unknown>();
+
+vi.mock("../../registry-host.js", () => ({
+  getUiRegistryStore: (_key: string, factory: () => unknown) => {
+    if (!store.has(_key)) store.set(_key, factory());
+    return store.get(_key);
+  },
+}));
+
+vi.mock("../../platform/aosp-user-agent.js", () => ({
+  userAgentHasElizaOSMarker: (ua: string) => ua.includes("ElizaOS/"),
+}));
+
+function fakeApp(name: string, overrides: Partial<OverlayApp> = {}): OverlayApp {
+  return {
+    name,
+    displayName: name,
+    description: `desc ${name}`,
+    category: "tools",
+    launch: () => Promise.resolve(),
+    icon: null,
+    ...overrides,
+  } as OverlayApp;
+}
+
+beforeEach(() => store.clear());
+afterEach(() => store.clear());
+
+describe("overlay-app registry", () => {
+  it("registers and looks up apps", () => {
+    registerOverlayApp(fakeApp("alpha"));
+    expect(getOverlayApp("alpha")?.displayName).toBe("alpha");
+    expect(isOverlayApp("alpha")).toBe(true);
+    expect(isOverlayApp("missing")).toBe(false);
+  });
+
+  it("lists all registered apps", () => {
+    registerOverlayApp(fakeApp("a"));
+    registerOverlayApp(fakeApp("b"));
+    expect(getAllOverlayApps().map((a) => a.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("overwrites on re-registration of the same name", () => {
+    registerOverlayApp(fakeApp("x", { displayName: "old" }));
+    registerOverlayApp(fakeApp("x", { displayName: "new" }));
+    expect(getAllOverlayApps()).toHaveLength(1);
+    expect(getOverlayApp("x")?.displayName).toBe("new");
+  });
+});
+
+describe("availability filtering", () => {
+  it("hides androidOnly apps on non-AOSP platforms", () => {
+    registerOverlayApp(fakeApp("normal"));
+    registerOverlayApp(fakeApp("priv", { androidOnly: true }));
+    const apps = getAvailableOverlayApps({ platform: "android", aospAndroid: false });
+    expect(apps.map((a) => a.name)).toEqual(["normal"]);
+  });
+
+  it("shows androidOnly apps on AOSP Android", () => {
+    registerOverlayApp(fakeApp("priv", { androidOnly: true }));
+    const apps = getAvailableOverlayApps({ platform: "android", aospAndroid: true });
+    expect(apps.map((a) => a.name)).toEqual(["priv"]);
+  });
+
+  it("accepts a plain platform string", () => {
+    registerOverlayApp(fakeApp("priv", { androidOnly: true }));
+    const apps = getAvailableOverlayApps("android");
+    expect(apps).toHaveLength(0);
+  });
+
+  it("detects AOSP from user agent", () => {
+    expect(
+      isAospAndroid({ platform: "android", userAgent: "Mozilla ElizaOS/1.2.3" }),
+    ).toBe(true);
+    expect(
+      isAospAndroid({ platform: "android", userAgent: "Mozilla plain" }),
+    ).toBe(false);
+    expect(isAospAndroid({ platform: "web" })).toBe(false);
+  });
+});
+
+describe("registry info conversion", () => {
+  it("maps overlay app fields into RegistryAppInfo", () => {
+    const app = fakeApp("calc", {
+      heroImage: "https://x/hero.png",
+    });
+    const info = overlayAppToRegistryInfo(app);
+    expect(info.name).toBe("calc");
+    expect(info.launchType).toBe("overlay");
+    expect(info.heroImage).toBe("https://x/hero.png");
+    expect(info.supports.v2).toBe(true);
+    expect(info.npm.package).toBe("calc");
+  });
+
+  it("defaults heroImage to null", () => {
+    const info = overlayAppToRegistryInfo(fakeApp("plain"));
+    expect(info.heroImage).toBeNull();
+  });
+});

--- a/packages/shared/src/apps/__tests__/overlay-app-registry.test.ts
+++ b/packages/shared/src/apps/__tests__/overlay-app-registry.test.ts
@@ -26,7 +26,10 @@ vi.mock("../../platform/aosp-user-agent.js", () => ({
   userAgentHasElizaOSMarker: (ua: string) => ua.includes("ElizaOS/"),
 }));
 
-function fakeApp(name: string, overrides: Partial<OverlayApp> = {}): OverlayApp {
+function fakeApp(
+  name: string,
+  overrides: Partial<OverlayApp> = {},
+): OverlayApp {
   return {
     name,
     displayName: name,
@@ -52,7 +55,11 @@ describe("overlay-app registry", () => {
   it("lists all registered apps", () => {
     registerOverlayApp(fakeApp("a"));
     registerOverlayApp(fakeApp("b"));
-    expect(getAllOverlayApps().map((a) => a.name).sort()).toEqual(["a", "b"]);
+    expect(
+      getAllOverlayApps()
+        .map((a) => a.name)
+        .sort(),
+    ).toEqual(["a", "b"]);
   });
 
   it("overwrites on re-registration of the same name", () => {
@@ -67,13 +74,19 @@ describe("availability filtering", () => {
   it("hides androidOnly apps on non-AOSP platforms", () => {
     registerOverlayApp(fakeApp("normal"));
     registerOverlayApp(fakeApp("priv", { androidOnly: true }));
-    const apps = getAvailableOverlayApps({ platform: "android", aospAndroid: false });
+    const apps = getAvailableOverlayApps({
+      platform: "android",
+      aospAndroid: false,
+    });
     expect(apps.map((a) => a.name)).toEqual(["normal"]);
   });
 
   it("shows androidOnly apps on AOSP Android", () => {
     registerOverlayApp(fakeApp("priv", { androidOnly: true }));
-    const apps = getAvailableOverlayApps({ platform: "android", aospAndroid: true });
+    const apps = getAvailableOverlayApps({
+      platform: "android",
+      aospAndroid: true,
+    });
     expect(apps.map((a) => a.name)).toEqual(["priv"]);
   });
 
@@ -85,7 +98,10 @@ describe("availability filtering", () => {
 
   it("detects AOSP from user agent", () => {
     expect(
-      isAospAndroid({ platform: "android", userAgent: "Mozilla ElizaOS/1.2.3" }),
+      isAospAndroid({
+        platform: "android",
+        userAgent: "Mozilla ElizaOS/1.2.3",
+      }),
     ).toBe(true);
     expect(
       isAospAndroid({ platform: "android", userAgent: "Mozilla plain" }),

--- a/packages/shared/src/apps/__tests__/overlay-app-registry.test.ts
+++ b/packages/shared/src/apps/__tests__/overlay-app-registry.test.ts
@@ -1,7 +1,7 @@
 /** Exercises overlay app registration and platform availability with mocked host boundaries. */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OverlayApp } from "../overlay-app-registry.ts";
+import type { OverlayApp } from "../overlay-app-api.ts";
 import {
   getAllOverlayApps,
   getAvailableOverlayApps,


### PR DESCRIPTION
## Summary

Consolidates the useful test coverage from #24443, #24444, #24445, #24446, #24447, and #24449 onto current `develop`.

The original branches were over 1,000 commits behind and their new tests could not resolve their production modules. This replacement:

- fixes every production import and nested mock import
- adds the repository-required test file headers
- applies each owning package Biome configuration
- preserves all six test suites and their assertions

## Verification

- combined focused run — 6 files, 59 tests passed
- owning package Biome checks
- `git diff --check`

A later package-scoped test invocation was blocked by a missing optional sparse-worktree dependency; the same test already passed in the combined focused run.

## Attribution

Coverage originated in #24443, #24444, #24445, #24446, #24447, and #24449. This PR repairs and consolidates those contributions rather than discarding them.

<!-- evidence-head:4526e723b2 -->




