### PR TITLE
fix(plugin-x): honor v2 search next_token and page mentions to the watermark

### DIFF
--- a/plugins/plugin-x/src/client/client.ts
+++ b/plugins/plugin-x/src/client/client.ts
@@ -49,6 +49,7 @@ import {
   searchProfiles,
   searchQuotedTweets,
   searchTweets,
+  searchTweetsPage,
 } from "./search";
 
 import {
@@ -330,27 +331,17 @@ export class Client {
     query: string,
     maxTweets: number,
     searchMode: SearchMode,
-    _cursor?: string,
+    cursor?: string,
   ): Promise<QueryTweetsResponse> {
-    return this.withAuthenticatedSession(async () => {
-      const tweets: Tweet[] = [];
-      const generator = searchTweets(
+    return this.withAuthenticatedSession(() =>
+      searchTweetsPage(
         query,
         maxTweets,
         searchMode,
         this.requireAuth(),
-      );
-
-      for await (const tweet of generator) {
-        tweets.push(tweet);
-      }
-
-      return {
-        tweets,
-        // v2 API doesn't provide cursor-based pagination for search
-        next: undefined,
-      };
-    });
+        cursor,
+      ),
+    );
   }
 
   /**

--- a/plugins/plugin-x/src/client/fetch-search-tweets.test.ts
+++ b/plugins/plugin-x/src/client/fetch-search-tweets.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Real-module tests for `Client.fetchSearchTweets` page cursors. The v2
+ * recent-search paginator is the injected transport; conversion and cursor
+ * plumbing run unmocked.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { TwitterAuth } from "./auth";
+import { Client } from "./client";
+import { SearchMode } from "./search";
+
+function fakeAuth(v2: Record<string, unknown>): TwitterAuth {
+  const session = {
+    client: {},
+    profile: { userId: "1", username: "bot", name: "Bot" },
+    revision: 1,
+  };
+  return {
+    getV2Client: async () => ({ v2 }),
+    withAuthenticatedSession: async <T>(
+      operation: (session: typeof session) => Promise<T>,
+    ) => operation(session),
+    getAuthenticatedSession: async () => session,
+    isAuthenticatedSessionCurrent: () => true,
+    deferUntil: () => undefined,
+    logout: async () => undefined,
+  } as unknown as TwitterAuth;
+}
+
+function tweetPage(ids: string[], next?: string) {
+  const tweets = ids.map((id) => ({
+    id,
+    text: `tweet-${id}`,
+    author_id: "u1",
+    created_at: "2026-01-01T00:00:00.000Z",
+    conversation_id: id,
+  }));
+  const paginator = {
+    tweets,
+    includes: { users: [{ id: "u1", name: "User", username: "user" }] },
+    meta: { next_token: next },
+    async *[Symbol.asyncIterator]() {
+      yield* tweets;
+    },
+  };
+  return paginator;
+}
+
+describe("Client.fetchSearchTweets pagination", () => {
+  it("returns the v2 next_token and forwards a resume cursor", async () => {
+    const search = vi.fn(
+      async (_query: string, options: { next_token?: string }) => {
+        if (options.next_token === "page-2") {
+          return tweetPage(["8", "9"]);
+        }
+        return tweetPage(["10", "11"], "page-2");
+      },
+    );
+    const client = new Client();
+    client.updateAuth(fakeAuth({ search }));
+
+    const first = await client.fetchSearchTweets(
+      "from:user",
+      20,
+      SearchMode.Latest,
+    );
+    expect(first.tweets.map((tweet) => tweet.id)).toEqual(["10", "11"]);
+    expect(first.next).toBe("page-2");
+    expect(search.mock.calls[0]?.[1]).not.toHaveProperty("next_token");
+
+    const second = await client.fetchSearchTweets(
+      "from:user",
+      20,
+      SearchMode.Latest,
+      "page-2",
+    );
+    expect(second.tweets.map((tweet) => tweet.id)).toEqual(["8", "9"]);
+    expect(second.next).toBeUndefined();
+    expect(search.mock.calls[1]?.[1]).toMatchObject({ next_token: "page-2" });
+  });
+
+  it("does not send a blank cursor as next_token", async () => {
+    const search = vi.fn(async () => tweetPage(["1"]));
+    const client = new Client();
+    client.updateAuth(fakeAuth({ search }));
+
+    await client.fetchSearchTweets("hello", 20, SearchMode.Latest, "  ");
+    expect(search.mock.calls[0]?.[1]).not.toHaveProperty("next_token");
+  });
+
+  it("keeps first-page tweet ids stable for previously valid uncursored searches", async () => {
+    const ids = ["a", "b", "c", "d", "e"];
+    const search = vi.fn(async () => tweetPage(ids, "more"));
+    const client = new Client();
+    client.updateAuth(fakeAuth({ search }));
+
+    const result = await client.fetchSearchTweets(
+      "javascript",
+      5,
+      SearchMode.Latest,
+    );
+    expect(result.tweets.map((tweet) => tweet.id)).toEqual(ids);
+    expect(result.tweets.map((tweet) => tweet.username)).toEqual(
+      Array(5).fill("user"),
+    );
+  });
+});

--- a/plugins/plugin-x/src/client/search.ts
+++ b/plugins/plugin-x/src/client/search.ts
@@ -1,5 +1,10 @@
+/**
+ * X recent-search helpers: one-page `searchTweetsPage` (honors `next_token`)
+ * and the `searchTweets` generator that walks those pages up to `maxTweets`.
+ */
 import { ElizaError } from "@elizaos/core";
-import type { TweetV2 } from "twitter-api-v2";
+import type { TweetV2, Tweetv2SearchParams, UserV2 } from "twitter-api-v2";
+import type { QueryTweetsResponse } from "./api-types";
 import type { TwitterAuth } from "./auth";
 import type { Profile } from "./profile";
 import type { Tweet } from "./tweets";
@@ -20,6 +25,162 @@ export enum SearchMode {
   Users = 4,
 }
 
+type SearchIncludes = {
+  users?: UserV2[];
+  tweets?: TweetV2[];
+};
+
+type SearchPaginator = {
+  tweets?: TweetV2[];
+  includes?: SearchIncludes;
+  meta?: { next_token?: string };
+};
+
+const SEARCH_TWEET_QUERY: Partial<Tweetv2SearchParams> = {
+  "tweet.fields": [
+    "id",
+    "text",
+    "conversation_id",
+    "created_at",
+    "author_id",
+    "referenced_tweets",
+    "entities",
+    "public_metrics",
+    "attachments",
+  ],
+  "user.fields": ["id", "name", "username", "profile_image_url"],
+  "media.fields": ["url", "preview_image_url", "type"],
+  expansions: [
+    "author_id",
+    "attachments.media_keys",
+    "referenced_tweets.id",
+    "referenced_tweets.id.author_id",
+  ],
+};
+
+function applySearchMode(query: string, searchMode: SearchMode): string {
+  switch (searchMode) {
+    case SearchMode.Photos:
+      return `${query} has:media has:images`;
+    case SearchMode.Videos:
+      return `${query} has:media has:videos`;
+    default:
+      return query;
+  }
+}
+
+function currentPageTweets(paginator: SearchPaginator): TweetV2[] {
+  return Array.isArray(paginator.tweets) ? paginator.tweets : [];
+}
+
+function convertSearchTweet(tweet: TweetV2, includes?: SearchIncludes): Tweet {
+  const author = includes?.users?.find((user) => user.id === tweet.author_id);
+  const inReplyToStatusId = tweet.referenced_tweets?.find(
+    (rt) => rt.type === "replied_to",
+  )?.id;
+  const inReplyToStatus = inReplyToStatusId
+    ? includes?.tweets?.find(
+        (includedTweet) => includedTweet.id === inReplyToStatusId,
+      )
+    : undefined;
+  const inReplyToAuthor = inReplyToStatus?.author_id
+    ? includes?.users?.find((user) => user.id === inReplyToStatus.author_id)
+    : undefined;
+
+  return {
+    id: tweet.id,
+    text: tweet.text || "",
+    timestamp: tweet.created_at
+      ? new Date(tweet.created_at).getTime()
+      : Date.now(),
+    timeParsed: tweet.created_at ? new Date(tweet.created_at) : new Date(),
+    userId: tweet.author_id || "",
+    name: author?.name || "",
+    username: author?.username || "",
+    conversationId: tweet.conversation_id || tweet.id,
+    hashtags: tweet.entities?.hashtags?.map((h) => h.tag) || [],
+    mentions:
+      tweet.entities?.mentions?.map((m) => ({
+        id: m.id || "",
+        username: m.username || "",
+        name: "",
+      })) || [],
+    inReplyToStatusId,
+    inReplyToStatus: inReplyToStatus
+      ? {
+          id: inReplyToStatus.id,
+          text: inReplyToStatus.text || "",
+          userId: inReplyToStatus.author_id || "",
+          name: inReplyToAuthor?.name || "",
+          username: inReplyToAuthor?.username || "",
+          hashtags: [],
+          mentions: [],
+          photos: [],
+          thread: [],
+          urls: [],
+          videos: [],
+        }
+      : undefined,
+    photos: [],
+    thread: [],
+    urls: tweet.entities?.urls?.map((u) => u.expanded_url || u.url) || [],
+    videos: [],
+    isRetweet:
+      tweet.referenced_tweets?.some((rt) => rt.type === "retweeted") || false,
+    isReply:
+      tweet.referenced_tweets?.some((rt) => rt.type === "replied_to") || false,
+    isQuoted:
+      tweet.referenced_tweets?.some((rt) => rt.type === "quoted") || false,
+    isPin: false,
+    sensitiveContent: false,
+    likes: tweet.public_metrics?.like_count || undefined,
+    replies: tweet.public_metrics?.reply_count || undefined,
+    retweets: tweet.public_metrics?.retweet_count || undefined,
+    views: tweet.public_metrics?.impression_count || undefined,
+    quotes: tweet.public_metrics?.quote_count || undefined,
+  };
+}
+
+/**
+ * Fetch one page of v2 recent-search results, honoring `next_token` and
+ * returning the provider's next cursor so callers can resume.
+ */
+export async function searchTweetsPage(
+  query: string,
+  maxTweets: number,
+  searchMode: SearchMode,
+  auth: TwitterAuth,
+  cursor?: string,
+): Promise<QueryTweetsResponse> {
+  const client = await auth.getV2Client();
+  const finalQuery = applySearchMode(query, searchMode);
+  const paginationToken = cursor?.trim() ? cursor.trim() : undefined;
+
+  try {
+    const paginator = (await client.v2.search(finalQuery, {
+      max_results: Math.min(maxTweets, 100),
+      ...SEARCH_TWEET_QUERY,
+      ...(paginationToken ? { next_token: paginationToken } : {}),
+    })) as SearchPaginator;
+
+    const converted = currentPageTweets(paginator)
+      .slice(0, maxTweets)
+      .map((tweet) => convertSearchTweet(tweet, paginator.includes));
+
+    return {
+      tweets: converted,
+      next: paginator.meta?.next_token,
+    };
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — attach the query that faulted.
+    throw new ElizaError("Tweet search failed", {
+      code: "X_SEARCH_FAILED",
+      cause: error,
+      context: { query, searchMode },
+    });
+  }
+}
+
 /**
  * Search for tweets using Twitter API v2
  *
@@ -36,123 +197,18 @@ export async function* searchTweets(
   auth: TwitterAuth,
 ): AsyncGenerator<Tweet, void> {
   const client = await auth.getV2Client();
-
-  // Build query based on search mode
-  let finalQuery = query;
-  switch (searchMode) {
-    case SearchMode.Photos:
-      finalQuery = `${query} has:media has:images`;
-      break;
-    case SearchMode.Videos:
-      finalQuery = `${query} has:media has:videos`;
-      break;
-  }
+  const finalQuery = applySearchMode(query, searchMode);
 
   try {
-    const searchIterator = await client.v2.search(finalQuery, {
+    const searchIterator = (await client.v2.search(finalQuery, {
       max_results: Math.min(maxTweets, 100),
-      "tweet.fields": [
-        "id",
-        "text",
-        "conversation_id",
-        "created_at",
-        "author_id",
-        "referenced_tweets",
-        "entities",
-        "public_metrics",
-        "attachments",
-      ],
-      "user.fields": ["id", "name", "username", "profile_image_url"],
-      "media.fields": ["url", "preview_image_url", "type"],
-      expansions: [
-        "author_id",
-        "attachments.media_keys",
-        "referenced_tweets.id",
-        "referenced_tweets.id.author_id",
-      ],
-    });
+      ...SEARCH_TWEET_QUERY,
+    })) as SearchPaginator & AsyncIterable<TweetV2>;
 
     let count = 0;
     for await (const tweet of searchIterator) {
       if (count >= maxTweets) break;
-
-      const author = searchIterator.includes?.users?.find(
-        (u) => u.id === tweet.author_id,
-      );
-      const inReplyToStatusId = tweet.referenced_tweets?.find(
-        (rt) => rt.type === "replied_to",
-      )?.id;
-      const referencedTweets = (
-        searchIterator.includes as { tweets?: TweetV2[] }
-      )?.tweets;
-      const inReplyToStatus = inReplyToStatusId
-        ? referencedTweets?.find(
-            (includedTweet) => includedTweet.id === inReplyToStatusId,
-          )
-        : undefined;
-      const inReplyToAuthor = inReplyToStatus?.author_id
-        ? searchIterator.includes?.users?.find(
-            (u) => u.id === inReplyToStatus.author_id,
-          )
-        : undefined;
-
-      // Convert to Tweet format
-      const convertedTweet: Tweet = {
-        id: tweet.id,
-        text: tweet.text || "",
-        timestamp: tweet.created_at
-          ? new Date(tweet.created_at).getTime()
-          : Date.now(),
-        timeParsed: tweet.created_at ? new Date(tweet.created_at) : new Date(),
-        userId: tweet.author_id || "",
-        name: author?.name || "",
-        username: author?.username || "",
-        conversationId: tweet.conversation_id || tweet.id,
-        hashtags: tweet.entities?.hashtags?.map((h) => h.tag) || [],
-        mentions:
-          tweet.entities?.mentions?.map((m) => ({
-            id: m.id || "",
-            username: m.username || "",
-            name: "",
-          })) || [],
-        inReplyToStatusId,
-        inReplyToStatus: inReplyToStatus
-          ? {
-              id: inReplyToStatus.id,
-              text: inReplyToStatus.text || "",
-              userId: inReplyToStatus.author_id || "",
-              name: inReplyToAuthor?.name || "",
-              username: inReplyToAuthor?.username || "",
-              hashtags: [],
-              mentions: [],
-              photos: [],
-              thread: [],
-              urls: [],
-              videos: [],
-            }
-          : undefined,
-        photos: [],
-        thread: [],
-        urls: tweet.entities?.urls?.map((u) => u.expanded_url || u.url) || [],
-        videos: [],
-        isRetweet:
-          tweet.referenced_tweets?.some((rt) => rt.type === "retweeted") ||
-          false,
-        isReply:
-          tweet.referenced_tweets?.some((rt) => rt.type === "replied_to") ||
-          false,
-        isQuoted:
-          tweet.referenced_tweets?.some((rt) => rt.type === "quoted") || false,
-        isPin: false,
-        sensitiveContent: false,
-        likes: tweet.public_metrics?.like_count || undefined,
-        replies: tweet.public_metrics?.reply_count || undefined,
-        retweets: tweet.public_metrics?.retweet_count || undefined,
-        views: tweet.public_metrics?.impression_count || undefined,
-        quotes: tweet.public_metrics?.quote_count || undefined,
-      };
-
-      yield convertedTweet;
+      yield convertSearchTweet(tweet, searchIterator.includes);
       count++;
     }
   } catch (error) {

--- a/plugins/plugin-x/src/interactions-mention-pagination.test.ts
+++ b/plugins/plugin-x/src/interactions-mention-pagination.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Real `TwitterInteractionClient.handleTwitterInteractions` coverage for mention
+ * paging: a live next_token is followed until the snowflake watermark, so
+ * mentions past the first page are not dropped.
+ */
+import { type IAgentRuntime, logger, type UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientBase } from "./base";
+import type { Tweet } from "./client";
+import { TwitterInteractionClient } from "./interactions";
+import type { TwitterClientState } from "./types";
+
+vi.mock("@elizaos/core", async () => {
+  const node = await import("@elizaos/core/node");
+  return node;
+});
+
+const PROFILE_ID = "bot-user";
+
+function createRuntime() {
+  const cache = new Map<string, unknown>();
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+    character: { name: "Agent", templates: {} },
+    composeState: vi.fn(async () => ({ values: {}, data: {}, text: "" })),
+    createMemory: vi.fn(async () => undefined),
+    emitEvent: vi.fn(),
+    ensureConnection: vi.fn(async () => undefined),
+    ensureRoomExists: vi.fn(async () => undefined),
+    ensureWorldExists: vi.fn(async () => undefined),
+    updateWorld: vi.fn(async () => undefined),
+    cache,
+    getCache: vi.fn(async (key: string) => cache.get(key)),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    }),
+    deleteCache: vi.fn(async (key: string) => cache.delete(key)),
+    getMemoryById: vi.fn(async () => null),
+    getMemories: vi.fn(async () => []),
+    getSetting: vi.fn((key: string) =>
+      key === "TWITTER_ENABLE_REPLIES" ? "true" : undefined,
+    ),
+    reportError: vi.fn(),
+    useModel: vi.fn(async () => ""),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    messageService: {
+      handleMessage: vi.fn(async () => ({ responseMessages: [] })),
+    },
+  };
+  return runtime as unknown as IAgentRuntime & typeof runtime;
+}
+
+function mention(id: string): Tweet {
+  return {
+    id,
+    userId: "user-1",
+    username: "alice",
+    name: "Alice",
+    conversationId: id,
+    text: `@bot mention ${id}`,
+    timestamp: Date.now(),
+    thread: [],
+    permanentUrl: `https://x.com/alice/status/${id}`,
+  } as Tweet;
+}
+
+describe("mention search pagination", () => {
+  beforeEach(() => {
+    logger.log = vi.fn();
+    logger.info = vi.fn();
+    logger.warn = vi.fn();
+    logger.error = vi.fn();
+  });
+
+  it("follows next_token until the lastChecked watermark instead of stopping at 20", async () => {
+    const runtime = createRuntime();
+    const page1 = Array.from({ length: 20 }, (_, i) =>
+      mention(String(200 - i)),
+    );
+    const page2 = Array.from({ length: 10 }, (_, i) =>
+      mention(String(180 - i)),
+    );
+    const fetchSearchTweets = vi.fn(
+      async (_query: string, _max: number, _mode: unknown, cursor?: string) => {
+        if (cursor === "page-2") {
+          return { tweets: page2 };
+        }
+        return { tweets: page1, next: "page-2" };
+      },
+    );
+
+    let lastChecked: bigint | null = 175n;
+    const profile = {
+      id: PROFILE_ID,
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    };
+    const client = {
+      accountId: "default",
+      runtime,
+      profile,
+      twitterClient: { getTweetsV2: vi.fn(async () => []) },
+      withAuthenticatedSession: vi.fn(
+        async (operation: (session: unknown) => Promise<unknown>) =>
+          operation({ client: {}, profile, revision: 1 }),
+      ),
+      isAuthenticatedSessionCurrent: vi.fn(() => true),
+      getLatestCheckedTweetId: vi.fn((profileId: string) =>
+        profileId === PROFILE_ID ? lastChecked : null,
+      ),
+      recordLatestCheckedTweetId: vi.fn((profileId: string, id: bigint) => {
+        if (profileId !== PROFILE_ID) return;
+        if (lastChecked !== null && id <= lastChecked) return;
+        lastChecked = id;
+      }),
+      cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+      getIdentityCache: vi.fn(async () => undefined),
+      setIdentityCache: vi.fn(async () => undefined),
+      fetchSearchTweets,
+    };
+
+    const interactions = new TwitterInteractionClient(
+      client as unknown as ClientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+    const collected: Tweet[][] = [];
+    Object.assign(interactions, {
+      processMentionTweetsForSession: async (candidates: Tweet[]) => {
+        collected.push(candidates);
+      },
+    });
+
+    await interactions.handleTwitterInteractions();
+
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(2);
+    expect(fetchSearchTweets.mock.calls[0]?.[3]).toBeUndefined();
+    expect(fetchSearchTweets.mock.calls[1]?.[3]).toBe("page-2");
+    expect(collected).toHaveLength(1);
+    expect(collected[0]?.map((tweet) => tweet.id)).toEqual([
+      ...page1.map((tweet) => tweet.id),
+      ...page2.map((tweet) => tweet.id),
+    ]);
+  });
+
+  it("does not request a second page when the first page has no next_token", async () => {
+    const runtime = createRuntime();
+    const fetchSearchTweets = vi.fn(async () => ({
+      tweets: [mention("50")],
+    }));
+    const profile = {
+      id: PROFILE_ID,
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    };
+    const client = {
+      accountId: "default",
+      runtime,
+      profile,
+      twitterClient: { getTweetsV2: vi.fn(async () => []) },
+      withAuthenticatedSession: vi.fn(
+        async (operation: (session: unknown) => Promise<unknown>) =>
+          operation({ client: {}, profile, revision: 1 }),
+      ),
+      isAuthenticatedSessionCurrent: vi.fn(() => true),
+      getLatestCheckedTweetId: vi.fn(() => null),
+      recordLatestCheckedTweetId: vi.fn(),
+      cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+      getIdentityCache: vi.fn(async () => undefined),
+      setIdentityCache: vi.fn(async () => undefined),
+      fetchSearchTweets,
+    };
+    const interactions = new TwitterInteractionClient(
+      client as unknown as ClientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+    Object.assign(interactions, {
+      processMentionTweetsForSession: async () => undefined,
+    });
+
+    await interactions.handleTwitterInteractions();
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -283,36 +283,39 @@ export class TwitterInteractionClient {
   private async handleMentions(session: TwitterAccountSession) {
     const { profile } = session;
     const twitterUsername = profile.username;
-    const cachedCursor =
-      (await this.client.getIdentityCache<string>(profile, "mention_cursor")) ??
-      "";
-
-    const searchResult = await this.client.fetchSearchTweets(
-      `@${twitterUsername}`,
-      20,
-      SearchMode.Latest,
-      String(cachedCursor),
-    );
-
-    const mentionCandidates = searchResult.tweets;
+    const lastCheckedTweetId = this.client.getLatestCheckedTweetId(profile.id);
+    const mentionCandidates: ClientTweet[] = [];
+    let cursor: string | undefined;
+    // Stay inside the recent-search window without silently dropping mentions
+    // that sit past the first page. Stop at the snowflake watermark so already
+    // processed ids are not re-fetched on later pages.
+    const maxMentionPages = 5;
+    for (let page = 0; page < maxMentionPages; page++) {
+      const searchResult = await this.client.fetchSearchTweets(
+        `@${twitterUsername}`,
+        20,
+        SearchMode.Latest,
+        cursor,
+      );
+      let hitWatermark = false;
+      for (const tweet of searchResult.tweets) {
+        mentionCandidates.push(tweet);
+        if (
+          lastCheckedTweetId !== null &&
+          typeof tweet.id === "string" &&
+          tweet.id.length > 0 &&
+          BigInt(tweet.id) <= lastCheckedTweetId
+        ) {
+          hitWatermark = true;
+        }
+      }
+      if (hitWatermark || !searchResult.next) {
+        break;
+      }
+      cursor = searchResult.next;
+    }
 
     await this.processMentionTweetsForSession(mentionCandidates, session);
-    this.assertCurrentSession(session);
-    if (mentionCandidates.length > 0 && searchResult.previous) {
-      await this.client.setIdentityCache(
-        profile,
-        "mention_cursor",
-        searchResult.previous,
-        session,
-      );
-    } else if (!searchResult.previous && !searchResult.next) {
-      await this.client.setIdentityCache(
-        profile,
-        "mention_cursor",
-        "",
-        session,
-      );
-    }
   }
 
   /**


### PR DESCRIPTION
Closes #24509.

This is independently motivated from the request-queue retry and tweet-weighted-length plugin-x defects; those branches do not share files with this one.

# Relates to

Closes #24509.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`5abed3bccf5d`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5abed3bccf5d`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin-x tests are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Uncursored first-page tweet ids stay `["a","b","c","d","e"]` against the same paginator. Callers that ignore `next` still see the same tweets. A blank cursor is still omitted. `searchTweets` generator still auto-paginates via `for await`. Mention poll with no `next_token` still makes one search.

`TWITTER_MAX_ENGAGEMENTS_PER_RUN` still caps how many mentions are *processed* per cycle (default 10). This PR only stops the fetch from dropping candidates past page 1.

# Background

## What does this PR do?

Honors v2 search `meta.next_token` in `Client.fetchSearchTweets` (forwards a resume cursor; returns `next` instead of always `undefined`) and pages mention search to the `lastCheckedTweetId` watermark instead of stopping at the first 20.

## What kind of change is this?

Bug fix (non-breaking). Wrong return value (`next: undefined`, first page only), not a throw.

## Why are we doing this? Any context or related work?

The comment "v2 API doesn't provide cursor-based pagination for search" is false: twitter-api-v2 `GET /2/tweets/search/recent` paginates with `meta.next_token`. `XService.searchConnectorPosts`, `TwitterPostService.getMentions`, and `TwitterInteractionClient.handleMentions` pass a cursor and always get page 1. Mentions past page 1 are never seen; `lastCheckedTweetId` then skips them forever.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/client/fetch-search-tweets.test.ts` — `Client.fetchSearchTweets` returns `next_token` and forwards a resume cursor.

`plugins/plugin-x/src/interactions-mention-pagination.test.ts` — mention poll follows `next_token` to the watermark.

## Detailed testing steps

Automated tests:

```
bun run --cwd plugins/plugin-x test src/client/fetch-search-tweets.test.ts src/interactions-mention-pagination.test.ts src/client/fetch-error-path.real.test.ts src/interactions-mention-cursor.test.ts
# Test Files  4 passed (4)
# Tests  17 passed (17)
```

Load-bearing revert (copy-aside origin `client.ts` / `search.ts` / `interactions.ts` under the new tests): 3 failed | 2 passed (5). Restore the fix: 5 passed (5). The 2 origin passes are first-page ids `["a","b","c","d","e"]` and a blank cursor still omitted.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:eaf4963c8645c35fa91fe54118a1e89c00657a29 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is `next: undefined` and a first-page-only search.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] Origin: `Client.fetchSearchTweets` returned `next === undefined` (`expected undefined to be 'page-2'`). Mention poll did not follow `next_token`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - not driven against live `GET /2/tweets/search/recent`. Paginator shape is installed `twitter-api-v2` 1.23.2 `TweetSearchRecentV2Paginator.meta.next_token`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `eaf4963c8645c35fa91fe54118a1e89c00657a29`: 4 files / 17 tests passed.

Load-bearing revert under the new tests:

```
FAIL  Client.fetchSearchTweets pagination > returns the v2 next_token and forwards a resume cursor
AssertionError: expected undefined to be 'page-2'

FAIL  mention search pagination > follows next_token until the lastChecked watermark instead of stopping at 20
AssertionError: expected "vi.fn()" to be called 2 times, but got 0 times
Test Files  2 failed (2)
Tests  3 failed | 2 passed (5)
```

Restore the fix: `Tests  5 passed (5)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Did **not** hit live `GET /2/tweets/search/recent` (no X credentials in this seat). Paginator shape is from installed `twitter-api-v2` 1.23.2 (`TweetSearchRecentV2Paginator.meta.next_token`).
- `handleMentions` origin load-bearing used a client stub; origin also calls `getIdentityCache` before search. The **Client.fetchSearchTweets** `next === undefined` failure is the one driven through the real module.
- `fetchSearchProfiles` still returns `next: undefined`. No production caller found. Left alone.
- `TWITTER_MAX_ENGAGEMENTS_PER_RUN` still caps how many mentions are *processed* per cycle (default 10). This PR only stops the fetch from dropping candidates past page 1.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- In-worktree `tsc --noEmit` reports missing `@elizaos/core` types (sparse worktree). After typing `SEARCH_TWEET_QUERY` as `Partial<Tweetv2SearchParams>`, no TS2345 remains on the new search options. Remaining `interactions.ts` payload errors are on lines this PR does not change.
- `bunx biome check --write` on the five files: clean (second pass no-op).

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-x-search-pagination]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N7ZS8APB4AXAX38CTNZE04","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T17:23:39.914Z","completed_at":"2026-08-22T17:27:49.651Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T17:23:40.593Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5ac44b06f035509fbdbca634fe02ef5b35dc7ed342808664ca24899ef8ee365a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"de589e8d-1679-4427-acec-99f308a04dee","object_id":"sha256:5ac44b06f035509fbdbca634fe02ef5b35dc7ed342808664ca24899ef8ee365a","sha256":"5ac44b06f035509fbdbca634fe02ef5b35dc7ed342808664ca24899ef8ee365a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"EaV6BwsylZARAzVu3yi1GrExKRgQ694_nSm-DJ446xyJyfR2JQ5ChFJsSnEKGWqSm-OFcm9HfAQMD9BbZfcEBg"}} -->
