### PR TITLE
fix(vision): enforce screen-capture timer boundaries

### DIFF
--- a/plugins/plugin-vision/src/capture-interval.test.ts
+++ b/plugins/plugin-vision/src/capture-interval.test.ts
@@ -48,6 +48,12 @@ describe("resolveCaptureIntervalMs", () => {
     expectInvalid("-5");
   });
 
+  it("rejects positive sub-millisecond values that Node clamps to 1ms", () => {
+    expectInvalid("0.5");
+    expectInvalid("0.999");
+    expect(resolveCaptureIntervalMs("1", DEFAULT, NAME)).toBe(1);
+  });
+
   it("rejects a non-numeric configured value rather than substituting the default", () => {
     // The distinction that matters: absent is a default, configured-and-wrong
     // is a mistake the operator needs to see.
@@ -98,6 +104,19 @@ describe("VisionService config wiring", () => {
         }
       ).visionConfig.screenCaptureInterval,
     ).toBe(750);
+  });
+
+  it("attributes an invalid legacy alias to the alias setting", () => {
+    expect(() =>
+      serviceWith({ VISION_SCREEN_CAPTURE_INTERVAL: "abc" }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: "VISION_CAPTURE_INTERVAL_INVALID",
+        context: expect.objectContaining({
+          settingName: "VISION_SCREEN_CAPTURE_INTERVAL",
+        }),
+      }),
+    );
   });
 
   it("refuses to construct — and so arms no timer — on an invalid configured interval", () => {

--- a/plugins/plugin-vision/src/capture-interval.test.ts
+++ b/plugins/plugin-vision/src/capture-interval.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Capture-interval setting resolution.
+ *
+ * `screenCaptureInterval` is passed straight to `setInterval`. Node clamps any
+ * delay that is non-finite, <= 0, or above the 32-bit signed maximum to 1ms, so
+ * a value that slips through becomes a screen-capture busy loop. An absent
+ * setting takes the documented default; an explicitly configured value that
+ * cannot be honoured is an operator mistake and fails loudly.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveCaptureIntervalMs, VisionService } from "./service";
+
+/** Assert the call throws the typed config error, checked by `code`. */
+function expectInvalid(raw: string): void {
+  expect(() => resolveCaptureIntervalMs(raw, DEFAULT, NAME)).toThrowError(
+    expect.objectContaining({ code: "VISION_CAPTURE_INTERVAL_INVALID" }),
+  );
+}
+
+const DEFAULT = 2000;
+const MAX_TIMER = 2_147_483_647;
+const NAME = "SCREEN_CAPTURE_INTERVAL";
+
+describe("resolveCaptureIntervalMs", () => {
+  it("uses the documented default when the setting is absent or blank", () => {
+    expect(resolveCaptureIntervalMs(undefined, DEFAULT, NAME)).toBe(DEFAULT);
+    expect(resolveCaptureIntervalMs("   ", DEFAULT, NAME)).toBe(DEFAULT);
+  });
+
+  it("accepts the exact timer maximum", () => {
+    expect(resolveCaptureIntervalMs(String(MAX_TIMER), DEFAULT, NAME)).toBe(
+      MAX_TIMER,
+    );
+  });
+
+  it("rejects one millisecond above the timer maximum", () => {
+    // Node clamps this to 1ms (TimeoutOverflowWarning), recreating the busy
+    // loop this guard exists to prevent.
+    expectInvalid(String(MAX_TIMER + 1));
+  });
+
+  it("rejects an exponent form that exceeds the timer maximum", () => {
+    expectInvalid("1e10");
+  });
+
+  it("rejects Infinity and negative values, which Node also clamps to 1ms", () => {
+    expectInvalid("Infinity");
+    expectInvalid("-5");
+  });
+
+  it("rejects a non-numeric configured value rather than substituting the default", () => {
+    // The distinction that matters: absent is a default, configured-and-wrong
+    // is a mistake the operator needs to see.
+    expectInvalid("abc");
+  });
+
+  it("accepts a valid interval, including a fractional millisecond", () => {
+    expect(resolveCaptureIntervalMs("500", DEFAULT, NAME)).toBe(500);
+    expect(resolveCaptureIntervalMs("1500.5", DEFAULT, NAME)).toBe(1500.5);
+  });
+});
+
+describe("VisionService config wiring", () => {
+  function serviceWith(settings: Record<string, string>) {
+    const runtime = {
+      getSetting: (key: string) => settings[key],
+      character: { name: "test", settings: {} },
+      getService: () => null,
+    } as unknown as ConstructorParameters<typeof VisionService>[0];
+    return new VisionService(runtime);
+  }
+
+  it("preserves existing alias precedence for a whitespace-only primary", () => {
+    // Documented as a deliberate no-change: `getSettingString` returns the
+    // whitespace string, which is truthy, so `||` does NOT reach the alias —
+    // and `Number("   ")` is 0, which the old code turned into the default.
+    // This PR keeps that exact outcome rather than silently widening alias
+    // precedence while fixing a timer bug.
+    const service = serviceWith({
+      SCREEN_CAPTURE_INTERVAL: "   ",
+      VISION_SCREEN_CAPTURE_INTERVAL: "750",
+    });
+    expect(
+      (
+        service as unknown as {
+          visionConfig: { screenCaptureInterval: number };
+        }
+      ).visionConfig.screenCaptureInterval,
+    ).toBe(2000);
+  });
+
+  it("uses a valid legacy alias when the primary is entirely absent", () => {
+    const service = serviceWith({ VISION_SCREEN_CAPTURE_INTERVAL: "750" });
+    expect(
+      (
+        service as unknown as {
+          visionConfig: { screenCaptureInterval: number };
+        }
+      ).visionConfig.screenCaptureInterval,
+    ).toBe(750);
+  });
+
+  it("refuses to construct — and so arms no timer — on an invalid configured interval", () => {
+    expect(() =>
+      serviceWith({ SCREEN_CAPTURE_INTERVAL: "Infinity" }),
+    ).toThrow();
+  });
+});

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -217,6 +217,7 @@ interface CameraDevice {
 
 /** Node clamps a `setInterval` delay above this to 1ms, so it is the real ceiling. */
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const DEFAULT_SCREEN_CAPTURE_INTERVAL_MS = 2_000;
 
 /**
  * Resolve a capture-interval setting that is passed directly to `setInterval`.
@@ -228,8 +229,9 @@ const MAX_TIMER_DELAY_MS = 2_147_483_647;
  *     default would hide it
  *   - valid            -> the configured number
  *
- * "Invalid" is anything Node cannot use as a timer delay: non-finite, <= 0, or
- * above `MAX_TIMER_DELAY_MS`. Node clamps ALL of those to 1ms
+ * "Invalid" is anything Node cannot use as the requested timer delay:
+ * non-finite, below 1ms, or above `MAX_TIMER_DELAY_MS`. Node clamps ALL of
+ * those out-of-range values to 1ms
  * (`TimeoutOverflowWarning` / `TimeoutNegativeWarning`), turning a mistyped
  * interval into a capture busy-loop rather than a slower cadence.
  */
@@ -240,9 +242,9 @@ export function resolveCaptureIntervalMs(
 ): number {
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TIMER_DELAY_MS) {
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > MAX_TIMER_DELAY_MS) {
     throw new ElizaError(
-      `${settingName} must be a positive number of milliseconds no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+      `${settingName} must be at least 1 millisecond and no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
       {
         code: "VISION_CAPTURE_INTERVAL_INVALID",
         context: { settingName, raw, maxMs: MAX_TIMER_DELAY_MS },
@@ -251,7 +253,6 @@ export function resolveCaptureIntervalMs(
   }
   return parsed;
 }
-
 
 export class VisionService extends Service {
   static override serviceType: ServiceTypeName =
@@ -330,7 +331,7 @@ export class VisionService extends Service {
     tfChangeThreshold: 10, // 10% change triggers TF update
     vlmChangeThreshold: 50, // 50% change triggers VLM update
     visionMode: VisionMode.OFF, // Capture requires explicit activation
-    screenCaptureInterval: 2000, // Screen capture every 2 seconds
+    screenCaptureInterval: DEFAULT_SCREEN_CAPTURE_INTERVAL_MS,
     tileSize: 256,
     tileProcessingOrder: "priority",
     ocrEnabled: true,
@@ -398,6 +399,13 @@ export class VisionService extends Service {
       if (raw === undefined) return defaultValue;
       return raw.trim().toLowerCase() === "true";
     };
+    const primaryCaptureInterval = getSettingString("SCREEN_CAPTURE_INTERVAL");
+    const captureIntervalSetting =
+      primaryCaptureInterval ||
+      getSettingString("VISION_SCREEN_CAPTURE_INTERVAL");
+    const captureIntervalSettingName = primaryCaptureInterval
+      ? "SCREEN_CAPTURE_INTERVAL"
+      : "VISION_SCREEN_CAPTURE_INTERVAL";
 
     return {
       ...this.DEFAULT_CONFIG,
@@ -443,13 +451,13 @@ export class VisionService extends Service {
       visionMode:
         (getSettingString("VISION_MODE") as VisionMode) ||
         this.DEFAULT_CONFIG.visionMode,
-      // `||` (not `??`) preserves the existing alias precedence: a blank
-      // primary falls through to the legacy alias exactly as before.
+      // `||` (not `??`) preserves the existing alias precedence: an empty
+      // primary reaches the legacy alias, while a whitespace-only primary is
+      // truthy and therefore suppresses the alias exactly as before.
       screenCaptureInterval: resolveCaptureIntervalMs(
-        getSettingString("SCREEN_CAPTURE_INTERVAL") ||
-          getSettingString("VISION_SCREEN_CAPTURE_INTERVAL"),
-        this.DEFAULT_CONFIG.screenCaptureInterval,
-        "SCREEN_CAPTURE_INTERVAL",
+        captureIntervalSetting,
+        DEFAULT_SCREEN_CAPTURE_INTERVAL_MS,
+        captureIntervalSettingName,
       ),
       ocrEnabled: getBooleanSetting(
         "OCR_ENABLED",

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import {
+  ElizaError,
   type IAgentRuntime,
   logger,
   ModelType,
@@ -214,6 +215,44 @@ interface CameraDevice {
   capture: () => Promise<Buffer>;
 }
 
+/** Node clamps a `setInterval` delay above this to 1ms, so it is the real ceiling. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Resolve a capture-interval setting that is passed directly to `setInterval`.
+ *
+ * Three outcomes, deliberately distinct:
+ *   - absent or blank  -> `fallback` (the documented default)
+ *   - explicit invalid -> throws `ElizaError`, because a configured value that
+ *     cannot be honoured is an operator mistake, and silently substituting the
+ *     default would hide it
+ *   - valid            -> the configured number
+ *
+ * "Invalid" is anything Node cannot use as a timer delay: non-finite, <= 0, or
+ * above `MAX_TIMER_DELAY_MS`. Node clamps ALL of those to 1ms
+ * (`TimeoutOverflowWarning` / `TimeoutNegativeWarning`), turning a mistyped
+ * interval into a capture busy-loop rather than a slower cadence.
+ */
+export function resolveCaptureIntervalMs(
+  raw: string | undefined,
+  fallback: number,
+  settingName: string,
+): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TIMER_DELAY_MS) {
+    throw new ElizaError(
+      `${settingName} must be a positive number of milliseconds no greater than ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+      {
+        code: "VISION_CAPTURE_INTERVAL_INVALID",
+        context: { settingName, raw, maxMs: MAX_TIMER_DELAY_MS },
+      },
+    );
+  }
+  return parsed;
+}
+
+
 export class VisionService extends Service {
   static override serviceType: ServiceTypeName =
     VisionServiceType.VISION as ServiceTypeName;
@@ -404,11 +443,14 @@ export class VisionService extends Service {
       visionMode:
         (getSettingString("VISION_MODE") as VisionMode) ||
         this.DEFAULT_CONFIG.visionMode,
-      screenCaptureInterval:
-        Number(
-          runtime.getSetting("SCREEN_CAPTURE_INTERVAL") ||
-            runtime.getSetting("VISION_SCREEN_CAPTURE_INTERVAL"),
-        ) || this.DEFAULT_CONFIG.screenCaptureInterval,
+      // `||` (not `??`) preserves the existing alias precedence: a blank
+      // primary falls through to the legacy alias exactly as before.
+      screenCaptureInterval: resolveCaptureIntervalMs(
+        getSettingString("SCREEN_CAPTURE_INTERVAL") ||
+          getSettingString("VISION_SCREEN_CAPTURE_INTERVAL"),
+        this.DEFAULT_CONFIG.screenCaptureInterval,
+        "SCREEN_CAPTURE_INTERVAL",
+      ),
       ocrEnabled: getBooleanSetting(
         "OCR_ENABLED",
         "VISION_OCR_ENABLED",


### PR DESCRIPTION
Relates to #24511. Supersedes #24378 because that maintained fork cannot incorporate current workflow changes with the available OAuth scope.

This carries the reviewed implementation from original author @Svector-anu plus the follow-up repairs onto current `develop`, with no workflow delta. Screen capture accepts only delays Node can honor (1..2,147,483,647ms), distinguishes absent/blank defaults from explicit invalid configuration, reports the actual primary or legacy setting key in typed errors, and fails before arming a busy-loop timer. Historical alias precedence is preserved.

Verification on exact head `127d436e96`:

- focused Vitest: 12/12 passed
- plugin-vision typecheck passed
- plugin-vision build passed
- full plugin Biome: 120 files clean
- `git diff --check` passed
- no `.github/workflows` delta

Evidence: screenshots/video/frontend/backend/LLM/domain artifacts are N/A because this is a startup configuration and timer-boundary change with no UI or external call. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation by @Svector-anu in #24378; follow-up boundary/type/error-attribution repair and current-base migration by Codex.