### PR TITLE
fix(cli-inference): reject prefix-parsed timeout values

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -6,7 +6,6 @@
  * so no real model runs; the few real-binary cases are skipped unless
  * `claude`/`codex` resolve through the SOC2 allowlist on this box.
  */
-import { readFileSync } from "node:fs";
 import type { ChatMessage, IAgentRuntime, PluginAutoEnableContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
@@ -70,21 +69,13 @@ const FAKE_CODEX = "/usr/local/bin/codex";
 interface Captured {
   argv: string[];
   opts: SpawnOptions;
-  stdinText: string;
-  systemText?: string;
 }
 
 /** A mock spawner that records the call and returns a canned result. */
 function recordingSpawn(result: Partial<SpawnResult>) {
   const calls: Captured[] = [];
   const fn = async (argv: string[], opts: SpawnOptions): Promise<SpawnResult> => {
-    const systemIndex = argv.indexOf("--system-prompt-file");
-    calls.push({
-      argv,
-      opts,
-      stdinText: readFileSync(opts.stdinPath, "utf8"),
-      systemText: systemIndex >= 0 ? readFileSync(argv[systemIndex + 1], "utf8") : undefined,
-    });
+    calls.push({ argv, opts });
     return {
       code: result.code ?? 0,
       signal: result.signal ?? null,
@@ -134,7 +125,7 @@ describe("flattenPrompt", () => {
 });
 
 describe("claude CLI variant", () => {
-  it("streams the complete body and system from private files instead of process arguments", async () => {
+  it("assembles argv: -p<body>, --system-prompt<verbatim>, --output-format text, --model; stdin /dev/null; isolated cwd", async () => {
     const { calls, fn } = recordingSpawn({ stdout: "hello world\n" });
     const restore = __setClaudeSpawn(fn);
     try {
@@ -149,17 +140,17 @@ describe("claude CLI variant", () => {
       });
       expect(out).toBe("hello world");
       expect(calls).toHaveLength(1);
-      const { argv, opts, stdinText, systemText } = calls[0];
+      const { argv, opts } = calls[0];
 
-      // `-p` selects print mode; the complete body arrives on stdin.
+      // -p carries the flattened body (the messages)
       const pIdx = argv.indexOf("-p");
       expect(pIdx).toBeGreaterThanOrEqual(0);
-      expect(stdinText).toContain("hi there");
+      expect(argv[pIdx + 1]).toContain("hi there");
 
-      // The system prompt is a full replacement loaded from a file.
-      const sysIdx = argv.indexOf("--system-prompt-file");
+      // --system-prompt carries the system VERBATIM (full replace)
+      const sysIdx = argv.indexOf("--system-prompt");
       expect(sysIdx).toBeGreaterThanOrEqual(0);
-      expect(systemText).toBe("SYSTEM PROMPT VERBATIM");
+      expect(argv[sysIdx + 1]).toBe("SYSTEM PROMPT VERBATIM");
 
       // output format + model + dynamic-section suppression
       const ofIdx = argv.indexOf("--output-format");
@@ -173,9 +164,8 @@ describe("claude CLI variant", () => {
       expect(toolsIdx).toBeGreaterThanOrEqual(0);
       expect(argv[toolsIdx + 1]).toBe("");
 
-      // Both files live inside the isolated per-call directory.
-      expect(opts.stdinPath).toBe(`${opts.cwd}/prompt.txt`);
-      expect(argv[sysIdx + 1]).toBe(`${opts.cwd}/system-prompt.txt`);
+      // stdin from /dev/null, isolated tmpdir cwd
+      expect(opts.stdinPath).toBe("/dev/null");
       expect(opts.cwd).toContain("eliza-cli-inference-");
     } finally {
       restore();
@@ -207,7 +197,7 @@ describe("claude CLI variant", () => {
     }
   });
 
-  it("threads system+user+assistant messages through files with none dropped", async () => {
+  it("threads system+user+assistant messages: system -> --system-prompt, rest -> body, none dropped", async () => {
     const { calls, fn } = recordingSpawn({ stdout: "answer" });
     const restore = __setClaudeSpawn(fn);
     try {
@@ -220,28 +210,13 @@ describe("claude CLI variant", () => {
           { role: "user", content: "USER-B" },
         ],
       });
-      const { stdinText: body, systemText: system } = calls[0];
+      const { argv } = calls[0];
+      const system = argv[argv.indexOf("--system-prompt") + 1];
+      const body = argv[argv.indexOf("-p") + 1];
       expect(system).toContain("SYS-A");
       expect(body).toContain("USER-A");
       expect(body).toContain("ASSIST-A");
       expect(body).toContain("USER-B");
-    } finally {
-      restore();
-    }
-  });
-
-  it("keeps million-character prompts intact and out of argv", async () => {
-    const { calls, fn } = recordingSpawn({ stdout: "answer" });
-    const restore = __setClaudeSpawn(fn);
-    try {
-      const cli = new ClaudeCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CLAUDE });
-      const system = `SYSTEM-${"s".repeat(1_100_000)}`;
-      const body = `BODY-${"b".repeat(1_100_000)}`;
-      await cli.generate({ system, prompt: body });
-      expect(calls[0].systemText).toBe(system);
-      expect(calls[0].stdinText).toBe(body);
-      expect(calls[0].argv.join(" ")).not.toContain(system);
-      expect(calls[0].argv.join(" ")).not.toContain(body);
     } finally {
       restore();
     }
@@ -341,7 +316,7 @@ describe("codex CLI variant", () => {
       });
       const out = await cli.generate({ system: "SYS", prompt: "do a thing" });
       expect(out).toBe("codex says hi");
-      const { argv, opts, stdinText } = calls[0];
+      const { argv, opts } = calls[0];
       expect(argv).toContain("exec");
       expect(argv[argv.indexOf("-m") + 1]).toBe("gpt-5.5");
       expect(argv[argv.indexOf("-s") + 1]).toBe("read-only");
@@ -349,28 +324,11 @@ describe("codex CLI variant", () => {
       expect(argv).toContain("-C");
       expect(argv[argv.indexOf("--color") + 1]).toBe("never");
       expect(argv).toContain("--json");
-      // system is folded into one complete stdin prompt; `-` requests stdin.
-      expect(argv[argv.length - 1]).toBe("-");
-      expect(stdinText).toContain("SYS");
-      expect(stdinText).toContain("do a thing");
-      expect(opts.stdinPath).toBe(`${opts.cwd}/prompt.txt`);
-    } finally {
-      restore();
-    }
-  });
-
-  it("keeps a million-character prompt intact and out of argv", async () => {
-    const jsonl = `{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n`;
-    const { calls, fn } = recordingSpawn({ stdout: jsonl });
-    const restore = __setCodexSpawn(fn);
-    try {
-      const cli = new CodexCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CODEX });
-      const system = `SYSTEM-${"s".repeat(1_100_000)}`;
-      const body = `BODY-${"b".repeat(1_100_000)}`;
-      await cli.generate({ system, prompt: body });
-      expect(calls[0].stdinText).toBe(`${system}\n\n${body}`);
-      expect(calls[0].argv.join(" ")).not.toContain(system);
-      expect(calls[0].argv.join(" ")).not.toContain(body);
+      // system is folded into the single positional prompt
+      const prompt = argv[argv.length - 1];
+      expect(prompt).toContain("SYS");
+      expect(prompt).toContain("do a thing");
+      expect(opts.stdinPath).toBe("/dev/null");
     } finally {
       restore();
     }
@@ -1280,5 +1238,25 @@ describe("parseTurnTimeout (#16553)", () => {
     expect(parseTurnTimeout(undefined)).toBeUndefined();
     expect(parseTurnTimeout("abc")).toBeUndefined();
     expect(parseTurnTimeout("-5")).toBeUndefined();
+  });
+
+  it("does not let a prefix-parsed value become the unbounded opt-out", () => {
+    // `parseInt("0junk")` is 0 — which this function documents as "unbounded
+    // turn". A typo therefore REMOVED the turn timeout instead of falling back
+    // to the bounded default.
+    expect(parseTurnTimeout("0junk")).toBeUndefined();
+    expect(parseTurnTimeout("0.5")).toBeUndefined();
+  });
+
+  it("rejects a prefix-parsed positive budget", () => {
+    expect(parseTurnTimeout("120000junk")).toBeUndefined();
+  });
+
+  it("rejects a budget beyond the safe integer range", () => {
+    expect(parseTurnTimeout("9007199254740993")).toBeUndefined();
+  });
+
+  it("keeps accepting a signed budget, which parseInt accepted", () => {
+    expect(parseTurnTimeout("+120000")).toBe(120_000);
   });
 });

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -6,6 +6,7 @@
  * so no real model runs; the few real-binary cases are skipped unless
  * `claude`/`codex` resolve through the SOC2 allowlist on this box.
  */
+import { readFileSync } from "node:fs";
 import type { ChatMessage, IAgentRuntime, PluginAutoEnableContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
@@ -22,6 +23,7 @@ import {
   cliInferencePlugin,
   findHandleResponseTool,
   LARGE_TIER_MODEL_TYPES,
+  parseTimeout,
   parseTurnTimeout,
   resolveCliBackend,
   resolveSdkEffort,
@@ -69,13 +71,21 @@ const FAKE_CODEX = "/usr/local/bin/codex";
 interface Captured {
   argv: string[];
   opts: SpawnOptions;
+  stdinText: string;
+  systemText?: string;
 }
 
 /** A mock spawner that records the call and returns a canned result. */
 function recordingSpawn(result: Partial<SpawnResult>) {
   const calls: Captured[] = [];
   const fn = async (argv: string[], opts: SpawnOptions): Promise<SpawnResult> => {
-    calls.push({ argv, opts });
+    const systemIndex = argv.indexOf("--system-prompt-file");
+    calls.push({
+      argv,
+      opts,
+      stdinText: readFileSync(opts.stdinPath, "utf8"),
+      systemText: systemIndex >= 0 ? readFileSync(argv[systemIndex + 1], "utf8") : undefined,
+    });
     return {
       code: result.code ?? 0,
       signal: result.signal ?? null,
@@ -125,7 +135,7 @@ describe("flattenPrompt", () => {
 });
 
 describe("claude CLI variant", () => {
-  it("assembles argv: -p<body>, --system-prompt<verbatim>, --output-format text, --model; stdin /dev/null; isolated cwd", async () => {
+  it("streams the complete body and system from private files instead of process arguments", async () => {
     const { calls, fn } = recordingSpawn({ stdout: "hello world\n" });
     const restore = __setClaudeSpawn(fn);
     try {
@@ -140,17 +150,17 @@ describe("claude CLI variant", () => {
       });
       expect(out).toBe("hello world");
       expect(calls).toHaveLength(1);
-      const { argv, opts } = calls[0];
+      const { argv, opts, stdinText, systemText } = calls[0];
 
-      // -p carries the flattened body (the messages)
+      // `-p` selects print mode; the complete body arrives on stdin.
       const pIdx = argv.indexOf("-p");
       expect(pIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[pIdx + 1]).toContain("hi there");
+      expect(stdinText).toContain("hi there");
 
-      // --system-prompt carries the system VERBATIM (full replace)
-      const sysIdx = argv.indexOf("--system-prompt");
+      // The system prompt is a full replacement loaded from a file.
+      const sysIdx = argv.indexOf("--system-prompt-file");
       expect(sysIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[sysIdx + 1]).toBe("SYSTEM PROMPT VERBATIM");
+      expect(systemText).toBe("SYSTEM PROMPT VERBATIM");
 
       // output format + model + dynamic-section suppression
       const ofIdx = argv.indexOf("--output-format");
@@ -164,8 +174,9 @@ describe("claude CLI variant", () => {
       expect(toolsIdx).toBeGreaterThanOrEqual(0);
       expect(argv[toolsIdx + 1]).toBe("");
 
-      // stdin from /dev/null, isolated tmpdir cwd
-      expect(opts.stdinPath).toBe("/dev/null");
+      // Both files live inside the isolated per-call directory.
+      expect(opts.stdinPath).toBe(`${opts.cwd}/prompt.txt`);
+      expect(argv[sysIdx + 1]).toBe(`${opts.cwd}/system-prompt.txt`);
       expect(opts.cwd).toContain("eliza-cli-inference-");
     } finally {
       restore();
@@ -197,7 +208,7 @@ describe("claude CLI variant", () => {
     }
   });
 
-  it("threads system+user+assistant messages: system -> --system-prompt, rest -> body, none dropped", async () => {
+  it("threads system+user+assistant messages through files with none dropped", async () => {
     const { calls, fn } = recordingSpawn({ stdout: "answer" });
     const restore = __setClaudeSpawn(fn);
     try {
@@ -210,13 +221,28 @@ describe("claude CLI variant", () => {
           { role: "user", content: "USER-B" },
         ],
       });
-      const { argv } = calls[0];
-      const system = argv[argv.indexOf("--system-prompt") + 1];
-      const body = argv[argv.indexOf("-p") + 1];
+      const { stdinText: body, systemText: system } = calls[0];
       expect(system).toContain("SYS-A");
       expect(body).toContain("USER-A");
       expect(body).toContain("ASSIST-A");
       expect(body).toContain("USER-B");
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps million-character prompts intact and out of argv", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "answer" });
+    const restore = __setClaudeSpawn(fn);
+    try {
+      const cli = new ClaudeCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CLAUDE });
+      const system = `SYSTEM-${"s".repeat(1_100_000)}`;
+      const body = `BODY-${"b".repeat(1_100_000)}`;
+      await cli.generate({ system, prompt: body });
+      expect(calls[0].systemText).toBe(system);
+      expect(calls[0].stdinText).toBe(body);
+      expect(calls[0].argv.join(" ")).not.toContain(system);
+      expect(calls[0].argv.join(" ")).not.toContain(body);
     } finally {
       restore();
     }
@@ -316,7 +342,7 @@ describe("codex CLI variant", () => {
       });
       const out = await cli.generate({ system: "SYS", prompt: "do a thing" });
       expect(out).toBe("codex says hi");
-      const { argv, opts } = calls[0];
+      const { argv, opts, stdinText } = calls[0];
       expect(argv).toContain("exec");
       expect(argv[argv.indexOf("-m") + 1]).toBe("gpt-5.5");
       expect(argv[argv.indexOf("-s") + 1]).toBe("read-only");
@@ -324,11 +350,28 @@ describe("codex CLI variant", () => {
       expect(argv).toContain("-C");
       expect(argv[argv.indexOf("--color") + 1]).toBe("never");
       expect(argv).toContain("--json");
-      // system is folded into the single positional prompt
-      const prompt = argv[argv.length - 1];
-      expect(prompt).toContain("SYS");
-      expect(prompt).toContain("do a thing");
-      expect(opts.stdinPath).toBe("/dev/null");
+      // system is folded into one complete stdin prompt; `-` requests stdin.
+      expect(argv[argv.length - 1]).toBe("-");
+      expect(stdinText).toContain("SYS");
+      expect(stdinText).toContain("do a thing");
+      expect(opts.stdinPath).toBe(`${opts.cwd}/prompt.txt`);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps a million-character prompt intact and out of argv", async () => {
+    const jsonl = `{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n`;
+    const { calls, fn } = recordingSpawn({ stdout: jsonl });
+    const restore = __setCodexSpawn(fn);
+    try {
+      const cli = new CodexCli({ env: { PATH: process.env.PATH }, binaryPath: FAKE_CODEX });
+      const system = `SYSTEM-${"s".repeat(1_100_000)}`;
+      const body = `BODY-${"b".repeat(1_100_000)}`;
+      await cli.generate({ system, prompt: body });
+      expect(calls[0].stdinText).toBe(`${system}\n\n${body}`);
+      expect(calls[0].argv.join(" ")).not.toContain(system);
+      expect(calls[0].argv.join(" ")).not.toContain(body);
     } finally {
       restore();
     }
@@ -1240,23 +1283,28 @@ describe("parseTurnTimeout (#16553)", () => {
     expect(parseTurnTimeout("-5")).toBeUndefined();
   });
 
-  it("does not let a prefix-parsed value become the unbounded opt-out", () => {
-    // `parseInt("0junk")` is 0 — which this function documents as "unbounded
-    // turn". A typo therefore REMOVED the turn timeout instead of falling back
-    // to the bounded default.
+  it("rejects prefix-parsed, fractional, and unsafe values", () => {
     expect(parseTurnTimeout("0junk")).toBeUndefined();
     expect(parseTurnTimeout("0.5")).toBeUndefined();
-  });
-
-  it("rejects a prefix-parsed positive budget", () => {
     expect(parseTurnTimeout("120000junk")).toBeUndefined();
-  });
-
-  it("rejects a budget beyond the safe integer range", () => {
     expect(parseTurnTimeout("9007199254740993")).toBeUndefined();
   });
 
-  it("keeps accepting a signed budget, which parseInt accepted", () => {
+  it("preserves the previously accepted explicit plus sign", () => {
     expect(parseTurnTimeout("+120000")).toBe(120_000);
+  });
+});
+
+describe("parseTimeout", () => {
+  it("accepts only whole, safe, strictly positive values", () => {
+    expect(parseTimeout("120000")).toBe(120_000);
+    expect(parseTimeout("+120000")).toBe(120_000);
+    expect(parseTimeout(" 120000 ")).toBe(120_000);
+    expect(parseTimeout(undefined)).toBeUndefined();
+    expect(parseTimeout("0")).toBeUndefined();
+    expect(parseTimeout("-5")).toBeUndefined();
+    expect(parseTimeout("120000junk")).toBeUndefined();
+    expect(parseTimeout("120000.5")).toBeUndefined();
+    expect(parseTimeout("9007199254740993")).toBeUndefined();
   });
 });

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -377,8 +377,13 @@ function getCodexSdkSession(
 
 function parseTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
-  const n = Number.parseInt(value, 10);
-  return Number.isFinite(n) && n > 0 ? n : undefined;
+  // `Number.parseInt` stops at the first non-digit, so "300junk" parsed to 300
+  // and was taken as a deliberate setting. Require the whole trimmed value to
+  // be decimal; the sign is kept because `parseInt` accepted it, and the `> 0`
+  // check below stays the range authority.
+  const trimmed = value.trim();
+  const n = /^[+-]?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  return Number.isSafeInteger(n) && n > 0 ? n : undefined;
 }
 
 /** Turn-timeout parse (#16553): like {@link parseTimeout}, but an explicit
@@ -387,8 +392,13 @@ function parseTimeout(value: string | undefined): number | undefined {
  *  bounded default applies. Exported for tests. */
 export function parseTurnTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
-  const n = Number.parseInt(value, 10);
-  if (!Number.isFinite(n) || n < 0) return undefined;
+  // Same prefix-parse hole, and it matters more here: `0` is the documented
+  // opt-out to an unbounded turn, so "0junk" and "0.5" both truncated to 0 and
+  // silently REMOVED the turn timeout rather than falling back to the bounded
+  // default. An explicit "0" is still honoured.
+  const trimmed = value.trim();
+  const n = /^[+-]?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (!Number.isSafeInteger(n) || n < 0) return undefined;
   return n;
 }
 

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -375,7 +375,8 @@ function getCodexSdkSession(
   return session;
 }
 
-function parseTimeout(value: string | undefined): number | undefined {
+/** Parse a strictly positive timeout or restart cadence. Exported for tests. */
+export function parseTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
   // `Number.parseInt` stops at the first non-digit, so "300junk" parsed to 300
   // and was taken as a deliberate setting. Require the whole trimmed value to


### PR DESCRIPTION
Relates to #24511. Supersedes #24434 because that maintained fork cannot incorporate current workflow changes with the available OAuth scope.

This carries the reviewed parser change from original author @Svector-anu and the corrective test restoration onto current `develop`, with no workflow delta. Both the positive timeout/restart cadence and explicit-zero turn-timeout parser now require a complete signed decimal safe integer. The final diff preserves private prompt-file transport and million-character integrity coverage; it does not place prompts in argv.

Verification on exact head `901495bce3`:

- final diff is 42 insertions/5 deletions in parser + focused tests only
- package Vitest: 165/165 passed
- package typecheck passed
- package build passed
- full package Biome: 21 files clean
- `git diff --check` passed
- no `.github/workflows` delta

Evidence: screenshots/video/frontend/backend/LLM/domain artifacts are N/A because this is a local configuration parser and test-contract change; no prompt contents were sent to a real model. Hosted exact-head static smoke remains the merge gate.

Attribution: original parser implementation by @Svector-anu in #24434; prompt-transport regression restoration, sibling parser coverage, and current-base migration by Codex.