### PR TITLE
fix(orchestrator): enforce supervisor timer boundaries

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-supervisor.test.ts
@@ -16,6 +16,7 @@ function makeRuntime(
     target: { source: string; roomId?: UUID },
     content: Content,
   ) => SendHandlerResult,
+  settings: Record<string, string> = {},
 ): IAgentRuntime {
   const taskService = {
     listTasks: vi.fn(async () => [
@@ -33,7 +34,7 @@ function makeRuntime(
     })),
   };
   return {
-    getSetting: () => undefined,
+    getSetting: (key: string) => settings[key],
     getService: (serviceType: string) =>
       serviceType === "ORCHESTRATOR_TASK_SERVICE" ? taskService : undefined,
     sendMessageToTarget,
@@ -116,5 +117,96 @@ describe("TaskSupervisorService digest sinks (#8902 AC2)", () => {
       posted: [],
       skipped: [],
     });
+  });
+});
+
+describe("TaskSupervisorService sweep interval parsing", () => {
+  /** Capture the delay the supervisor arms its sweep timer with. */
+  async function armedIntervalMs(raw: string): Promise<number> {
+    const spy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockReturnValue(0 as unknown as ReturnType<typeof setInterval>);
+    try {
+      const service = await TaskSupervisorService.start(
+        makeRuntime(undefined, {
+          ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS: raw,
+        }),
+      );
+      await service.stop();
+      return spy.mock.calls[0]?.[1] as number;
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  /** Start with an invalid value and return the rejection. */
+  async function startWith(raw: string): Promise<unknown> {
+    const spy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockReturnValue(0 as unknown as ReturnType<typeof setInterval>);
+    try {
+      await TaskSupervisorService.start(
+        makeRuntime(undefined, {
+          ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS: raw,
+        }),
+      );
+      return { armed: spy.mock.calls.length };
+    } catch (err) {
+      return { error: err, armed: spy.mock.calls.length };
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it("uses the documented default when the setting is absent or blank", async () => {
+    expect(await armedIntervalMs("")).toBe(45_000);
+    expect(await armedIntervalMs("   ")).toBe(45_000);
+  });
+
+  it("rejects a trailing-garbage interval and arms no timer", async () => {
+    // parseInt("12000junk") is 12000, which clears MIN_INTERVAL_MS, so a
+    // typo silently swept every 12s instead of 45s — 3.75x the load.
+    const outcome = (await startWith("12000junk")) as {
+      error?: { code?: string };
+      armed: number;
+    };
+    expect(outcome.error?.code).toBe(
+      "ORCHESTRATOR_SUPERVISOR_INTERVAL_INVALID",
+    );
+    expect(outcome.armed).toBe(0);
+  });
+
+  it("rejects a value below the documented minimum", async () => {
+    const outcome = (await startWith("1000")) as { error?: { code?: string } };
+    expect(outcome.error?.code).toBe(
+      "ORCHESTRATOR_SUPERVISOR_INTERVAL_INVALID",
+    );
+  });
+
+  it("accepts the exact timer maximum and rejects one above it", async () => {
+    // Node clamps a delay above the 32-bit signed max to 1ms, which would
+    // sweep continuously instead of on a schedule.
+    expect(await armedIntervalMs("2147483647")).toBe(2_147_483_647);
+    const outcome = (await startWith("2147483648")) as {
+      error?: { code?: string };
+    };
+    expect(outcome.error?.code).toBe(
+      "ORCHESTRATOR_SUPERVISOR_INTERVAL_INVALID",
+    );
+  });
+
+  it("rejects a fractional and an unsafe-range interval", async () => {
+    for (const raw of ["12000.5", "9007199254740993"]) {
+      const outcome = (await startWith(raw)) as { error?: { code?: string } };
+      expect(outcome.error?.code).toBe(
+        "ORCHESTRATOR_SUPERVISOR_INTERVAL_INVALID",
+      );
+    }
+  });
+
+  it("still honours a clean interval, including a signed one", async () => {
+    expect(await armedIntervalMs("12000")).toBe(12_000);
+    // `parseInt` accepted "+12000"; rejecting it would be a regression.
+    expect(await armedIntervalMs("+12000")).toBe(12_000);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -35,6 +35,7 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
+  ElizaError,
   logger,
   requireConfirmedSendHandlerDelivery,
   Service,
@@ -286,6 +287,8 @@ export async function runSupervisorTick(
 
 const DEFAULT_INTERVAL_MS = 45_000;
 const MIN_INTERVAL_MS = 5_000;
+/** Node clamps a `setInterval` delay above this to 1ms, so it is the real ceiling. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 type RuntimeWithSendTarget = IAgentRuntime & {
   sendMessageToTarget?: (
@@ -375,10 +378,44 @@ export class TaskSupervisorService extends Service {
     return this.readSetting("ELIZA_ORCHESTRATOR_SUPERVISOR") !== "0";
   }
 
+  /**
+   * Resolve the sweep interval.
+   *
+   * Three distinct outcomes: absent or blank takes the documented default; a
+   * configured value that cannot be honoured throws, because substituting the
+   * default would hide an operator mistake; anything else is the configured
+   * number.
+   *
+   * "Cannot be honoured" is a value `setInterval` would not use as written —
+   * not a whole decimal integer, below `MIN_INTERVAL_MS`, or above
+   * `MAX_TIMER_DELAY_MS` (Node clamps a larger delay to 1ms, which would sweep
+   * continuously instead of on a schedule). `Number.parseInt` alone accepted
+   * all three: "12000junk" parsed to 12000 and cleared the floor.
+   */
   private intervalMs(): number {
     const raw = this.readSetting("ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS");
-    const n = typeof raw === "string" ? Number.parseInt(raw, 10) : NaN;
-    return Number.isFinite(n) && n >= MIN_INTERVAL_MS ? n : DEFAULT_INTERVAL_MS;
+    if (typeof raw !== "string" || raw.trim() === "")
+      return DEFAULT_INTERVAL_MS;
+    const text = raw.trim();
+    const n = /^[+-]?\d+$/.test(text) ? Number(text) : Number.NaN;
+    if (
+      !Number.isSafeInteger(n) ||
+      n < MIN_INTERVAL_MS ||
+      n > MAX_TIMER_DELAY_MS
+    ) {
+      throw new ElizaError(
+        `ELIZA_ORCHESTRATOR_SUPERVISOR_INTERVAL_MS must be a whole number of milliseconds between ${MIN_INTERVAL_MS} and ${MAX_TIMER_DELAY_MS}; received ${JSON.stringify(raw)}`,
+        {
+          code: "ORCHESTRATOR_SUPERVISOR_INTERVAL_INVALID",
+          context: {
+            raw,
+            minMs: MIN_INTERVAL_MS,
+            maxMs: MAX_TIMER_DELAY_MS,
+          },
+        },
+      );
+    }
+    return n;
   }
 
   private startTimer(): void {


### PR DESCRIPTION
Relates to #24511. Supersedes #24306 because that maintained fork cannot incorporate current workflow changes with the available OAuth scope.

This carries the source-reviewed implementation from original author @Svector-anu onto current `develop`, with no workflow delta. Absent/blank configuration keeps the 45-second default; explicit malformed, fractional, unsafe, below-minimum, or timer-overflow values fail startup with typed `ORCHESTRATOR_SUPERVISOR_INTERVAL_INVALID` before any interval is armed. Valid signed whole values in the exact 5,000..2,147,483,647ms range are accepted.

Verification on exact head `5413f9581b`:

- focused task-supervisor Vitest: 10/10 passed
- package typecheck passed after wiring declared shared dependencies
- package build passed
- full package Biome passed with one unrelated existing warning
- `git diff --check` passed
- no `.github/workflows` delta

Evidence: screenshots/video/frontend/backend/LLM/domain artifacts are N/A because this is a startup timer-configuration boundary with no UI or external integration. Hosted exact-head static smoke remains the merge gate.

Attribution: implementation by @Svector-anu in #24306; current-base migration and exact-head execution by Codex.