### PR TITLE
fix(plugin-discord): wire speaking listeners once per voice connection

### DIFF
--- a/plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts
+++ b/plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts
@@ -127,6 +127,8 @@ describe("VoiceManager voice-connection lifecycle", () => {
 		// `error` is not asserted: each still-pending `entersState` loser from
 		// `Promise.race` holds one of its own until its 20s deadline.
 		expect(connection.listenerCount("stateChange")).toBe(1);
+		expect(connection.receiver.speaking.listenerCount("start")).toBe(1);
+		expect(connection.receiver.speaking.listenerCount("end")).toBe(1);
 
 		closeWithoutReconnect(connection);
 		await afterReconnectProbe();

--- a/plugins/plugin-discord/__tests__/voice.test.ts
+++ b/plugins/plugin-discord/__tests__/voice.test.ts
@@ -209,4 +209,58 @@ describe("VoiceManager", () => {
 			);
 		});
 	});
+
+	it("wires speaking start/end once when two joins share a connection", async () => {
+		const connection = makeConnection();
+		voiceModule.joinVoiceChannel.mockReturnValue(connection);
+		voiceModule.entersState.mockResolvedValue(connection);
+		const manager = new VoiceManager(
+			{ accountId: "test", client: new EventEmitter() as never },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+		const channel = makeChannel();
+
+		await Promise.all([
+			manager.joinChannel(channel as never),
+			manager.joinChannel(channel as never),
+		]);
+
+		expect(connection.receiver.speaking.listenerCount("start")).toBe(1);
+		expect(connection.receiver.speaking.listenerCount("end")).toBe(1);
+	});
+
+	it("does not resubscribe a member on a second speaking start", async () => {
+		const receiveStream = new PassThrough();
+		const connection = makeConnection(receiveStream);
+		voiceModule.joinVoiceChannel.mockReturnValue(connection);
+		voiceModule.entersState.mockResolvedValue(connection);
+
+		const client = new EventEmitter() as EventEmitter & {
+			user?: { id: string };
+		};
+		client.user = { id: "bot-1" };
+		const member = {
+			displayName: "Owner",
+			guild: { id: "guild-1" },
+			id: "user-1",
+			user: { bot: false, displayName: "Owner", username: "owner" },
+		};
+		const channel = makeChannel(member);
+		const manager = new VoiceManager(
+			{ accountId: "test", client: client as never },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+
+		await manager.joinChannel(channel as never);
+		connection.receiver.speaking.emit("start", "user-1");
+		await vi.waitFor(() => {
+			expect(connection.receiver.subscribe).toHaveBeenCalledTimes(1);
+		});
+
+		connection.receiver.speaking.emit("start", "user-1");
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(connection.receiver.subscribe).toHaveBeenCalledTimes(1);
+	});
 });

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -369,8 +369,9 @@ export class VoiceManager extends EventEmitter {
 	 * Connections this manager has already wired lifecycle listeners onto.
 	 * `joinVoiceChannel()` returns the connection it is *already* tracking for the
 	 * same (group, guildId) instead of creating a new one, so two overlapping
-	 * joins would otherwise stack a second copy of the `stateChange`/`error`
-	 * listeners onto a single connection and run its teardown twice.
+	 * joins would otherwise stack a second copy of the `stateChange`/`error`/
+	 * `speaking` listeners onto a single connection and run teardown twice /
+	 * subscribe the same member twice.
 	 */
 	private wiredConnections = new WeakSet<VoiceConnection>();
 	private audioLanes = new Map<string, DiscordAudioLaneConfig>();
@@ -774,6 +775,47 @@ export class VoiceManager extends EventEmitter {
 						"Will attempt to recover",
 					);
 				});
+
+				connection.receiver.speaking.on("start", async (entityId: string) => {
+					let user = channel.members.get(entityId);
+					if (!user) {
+						try {
+							user = await channel.guild.members.fetch(entityId);
+						} catch (error) {
+							this.runtime.logger.error(
+								{
+									src: "plugin:discord:service:voice",
+									agentId: this.runtime.agentId,
+									entityId,
+									error: error instanceof Error ? error.message : String(error),
+								},
+								"Failed to fetch user",
+							);
+						}
+					}
+
+					const userUser = user?.user;
+					if (user && userUser && !userUser.bot) {
+						await this.monitorMember(user as GuildMember, channel);
+						const entityStream = this.streams.get(entityId);
+						if (entityStream) {
+							entityStream.emit("speakingStarted");
+						}
+					}
+				});
+
+				connection.receiver.speaking.on("end", async (entityId: string) => {
+					const user = channel.members.get(entityId);
+					const userUser = user?.user;
+					if (user && userUser && !userUser.bot) {
+						const entityStream = this.streams.get(entityId);
+						if (entityStream) {
+							entityStream.emit("speakingStopped");
+						}
+						// Speaking end = utterance boundary for the meeting pipeline.
+						this.meetingSessions.get(channel.id)?.flushSpeaker(entityId);
+					}
+				});
 			}
 
 			// Store the connection
@@ -834,47 +876,6 @@ export class VoiceManager extends EventEmitter {
 					// Continue even if this fails
 				}
 			}
-
-			connection.receiver.speaking.on("start", async (entityId: string) => {
-				let user = channel.members.get(entityId);
-				if (!user) {
-					try {
-						user = await channel.guild.members.fetch(entityId);
-					} catch (error) {
-						this.runtime.logger.error(
-							{
-								src: "plugin:discord:service:voice",
-								agentId: this.runtime.agentId,
-								entityId,
-								error: error instanceof Error ? error.message : String(error),
-							},
-							"Failed to fetch user",
-						);
-					}
-				}
-
-				const userUser = user?.user;
-				if (user && userUser && !userUser.bot) {
-					this.monitorMember(user as GuildMember, channel);
-					const entityStream = this.streams.get(entityId);
-					if (entityStream) {
-						entityStream.emit("speakingStarted");
-					}
-				}
-			});
-
-			connection.receiver.speaking.on("end", async (entityId: string) => {
-				const user = channel.members.get(entityId);
-				const userUser = user?.user;
-				if (user && userUser && !userUser.bot) {
-					const entityStream = this.streams.get(entityId);
-					if (entityStream) {
-						entityStream.emit("speakingStopped");
-					}
-					// Speaking end = utterance boundary for the meeting pipeline.
-					this.meetingSessions.get(channel.id)?.flushSpeaker(entityId);
-				}
-			});
 		} catch (error) {
 			this.runtime.logger.error(
 				{
@@ -1012,6 +1013,9 @@ export class VoiceManager extends EventEmitter {
 		const name = memberUser?.displayName;
 		const memberGuild = member?.guild;
 		const memberGuildId = memberGuild?.id;
+		if (entityId && this.streams.has(entityId)) {
+			return;
+		}
 		const connection = this.getVoiceConnection(memberGuildId);
 
 		const connectionReceiver = connection?.receiver;


### PR DESCRIPTION
# Relates to

Closes #24519.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`5abed3bccf5d20f7d86883fce20622d6b44266d3`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` at `5abed3bccf5d20f7d86883fce20622d6b44266d3`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin tests are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Speaking listeners are wired once per reused connection. Previously-valid joins still succeed (single join, failed join still destroys the connection, newly-speaking member still subscribes once). Lifecycle leave-during-probe / ordinary disconnect still tear down. Voice-meetings suite 22/22.

# Background

## What does this PR do?

Moves `connection.receiver.speaking.on("start"|"end")` inside the existing `wiredConnections` guard, and skips `monitorMember` when `streams` already has that entity. Overlapping `joinChannel` calls on the connection `joinVoiceChannel()` reuses no longer stack a second speaking pair or a second `AudioMonitor`.

## What kind of change is this?

Bug fix (non-breaking). Duplicate listener registration → once per connection.

## Why are we doing this? Any context or related work?

`wiredConnections` already prevented stacking `stateChange`/`error`. Speaking sat outside that guard. A second `start` re-subscribed and `handleUserStream` installed another monitor.

Independently motivated from already-filed #24510 / #24512 (`fix/discord-smartsplit-partial-chunks`, `utils.ts`). Different file; do not combine.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-discord/__tests__/voice.test.ts` — overlap listenerCount and second-start subscribe.

## Detailed testing steps

Automated tests:

```
bun run --cwd plugins/plugin-discord test __tests__/voice.test.ts __tests__/voice-connection-lifecycle.test.ts
# Test Files  2 passed (2)
# Tests  9 passed (9)
```

Load-bearing revert (copy-aside origin `voice.ts` under the new tests): 2 failed | 4 passed (6). Restore the fix: 6 passed (6). Real `@discordjs/voice` overlap path: 3 passed (3). Voice-meetings: 22 passed (22).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:f1b54392b9c88c49c5f839503e69b3d799d23cca -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is `listenerCount("start")` 2 instead of 1 on overlapping joins.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime server logs. Origin vitest on the real `VoiceManager.joinChannel` showed `listenerCount("start")` 2 instead of 1, and a second subscribe on a second speaking start. Focused suite transcript is in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - not driven against a live Discord voice gateway reconnect (no bot token / no guild in this seat).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `f1b54392b9c88c49c5f839503e69b3d799d23cca`: 2 files / 9 tests passed.

Load-bearing revert under the new tests:

```
FAIL  VoiceManager > wires speaking start/end once when two joins share a connection
AssertionError: expected 2 to be 1

FAIL  VoiceManager > does not resubscribe a member on a second speaking start
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
Test Files  1 failed (1)
Tests  2 failed | 4 passed (6)
```

Restore the fix: `Test Files  1 passed (1)` / `Tests  6 passed (6)`. Real `@discordjs/voice` overlap path: 3 passed (3).

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - this change is listener registration on `receiver.speaking`, not a captured voice round-trip. Not driven against a live Discord voice gateway.

## Known gaps / failures

- Not driven against a live Discord voice gateway reconnect (no bot token / no guild in this seat). Overlap is the production `joinVoiceChannel()` reuse the existing lifecycle suite already documents.
- Sequential re-join after a **real** `VoiceConnection.destroy()` that reused the same object was not observed; `@discordjs/voice` typically returns a new object, which `wiredConnections` treats as unwired. If destroy+reuse of the same object ever happens, `stateChange` had the same gap before this PR.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Package `tsc --noEmit` vs the smartsplit worktree: 104 shared errors, 0 unique. Hits on `voice.ts`: none. Unique messages added: 0.
- `bunx biome check --write` on the three files: clean on second pass.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-discord-mine-20260822]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N5WVEFM6DYRYVAN2GMF20K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T16:47:06.703Z","completed_at":"2026-08-22T16:58:44.132Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T16:47:07.072Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0ac7740849c46639fce90f0debec1cd015f078d7c7f6bd2d6eba3b9a22b3f06a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6147aaa6-597d-4e38-8a7d-a84880e7aeb1","object_id":"sha256:0ac7740849c46639fce90f0debec1cd015f078d7c7f6bd2d6eba3b9a22b3f06a","sha256":"0ac7740849c46639fce90f0debec1cd015f078d7c7f6bd2d6eba3b9a22b3f06a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"ESrsnF1GkLKf1Yisrs_6Z1LDPLlZ0DfIDpluQq7SnjXVVFVOg3krGSAToB08AZ1MNB7eyq0FHQ9Brf0BdKsEAw"}} -->
