### PR TITLE
fix(scenario-runner): validate turn timeout before startup

### DIFF
--- a/packages/scenario-runner/src/cli.test.ts
+++ b/packages/scenario-runner/src/cli.test.ts
@@ -737,6 +737,7 @@ describe("scenario-runner CLI", () => {
     await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
       "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
     );
+    expect(dependencies.createScenarioRuntime).not.toHaveBeenCalled();
     expect(dependencies.runScenario).not.toHaveBeenCalled();
   });
 
@@ -746,7 +747,11 @@ describe("scenario-runner CLI", () => {
     const dependencies = createDependencies(() => "passed");
 
     await runCli(["run", tempDir], dependencies);
-    expect(dependencies.runScenario).toHaveBeenCalled();
+    expect(dependencies.runScenario).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ turnTimeoutMs: 500 }),
+    );
   });
 
   it("still accepts an explicitly signed positive timeout", async () => {
@@ -767,6 +772,18 @@ describe("scenario-runner CLI", () => {
     await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
       "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
     );
+    expect(dependencies.createScenarioRuntime).not.toHaveBeenCalled();
+  });
+
+  it("rejects a timeout beyond Node's supported timer range", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "2147483648";
+    writeScenario(tempDir, "cli-timeout-timer-overflow");
+    const dependencies = createDependencies(() => "passed");
+
+    await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
+      "no greater than 2147483647",
+    );
+    expect(dependencies.createScenarioRuntime).not.toHaveBeenCalled();
   });
 
   it("allows skipped scenarios when SKIP_REASON documents the skip", async () => {

--- a/packages/scenario-runner/src/cli.test.ts
+++ b/packages/scenario-runner/src/cli.test.ts
@@ -39,6 +39,7 @@ const ENV_KEYS = [
   "ELIZA_LIFEOPS_RUN_ID",
   "ELIZA_LIFEOPS_SCENARIO_ID",
   "LIFEOPS_LIVE_JUDGE_MIN_SCORE",
+  "SCENARIO_TURN_TIMEOUT_MS",
   "OPENAI_API_KEY",
   "CEREBRAS_API_KEY",
   "SCENARIO_JUDGE_REQUIRE_INDEPENDENT",
@@ -726,6 +727,46 @@ describe("scenario-runner CLI", () => {
 
     expect(code).toBe(2);
     expect(stderr).toContain("skipped without SKIP_REASON");
+  });
+
+  it("rejects trailing garbage in the per-turn timeout environment", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "500junk";
+    writeScenario(tempDir, "cli-timeout-config");
+    const dependencies = createDependencies(() => "passed");
+
+    await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
+      "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
+    );
+    expect(dependencies.runScenario).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a clean per-turn timeout value", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "500";
+    writeScenario(tempDir, "cli-timeout-ok");
+    const dependencies = createDependencies(() => "passed");
+
+    await runCli(["run", tempDir], dependencies);
+    expect(dependencies.runScenario).toHaveBeenCalled();
+  });
+
+  it("still accepts an explicitly signed positive timeout", async () => {
+    // `Number.parseInt` accepted "+500"; rejecting it would be a regression.
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "+500";
+    writeScenario(tempDir, "cli-timeout-signed");
+    const dependencies = createDependencies(() => "passed");
+
+    await runCli(["run", tempDir], dependencies);
+    expect(dependencies.runScenario).toHaveBeenCalled();
+  });
+
+  it("rejects a timeout beyond the safe integer range", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "9007199254740993";
+    writeScenario(tempDir, "cli-timeout-unsafe");
+    const dependencies = createDependencies(() => "passed");
+
+    await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
+      "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
+    );
   });
 
   it("allows skipped scenarios when SKIP_REASON documents the skip", async () => {

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -737,8 +737,12 @@ export async function runCli(
   const turnTimeoutMs = (() => {
     const raw = process.env.SCENARIO_TURN_TIMEOUT_MS?.trim();
     if (!raw) return 120_000;
-    const parsed = Number.parseInt(raw, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    // `Number.parseInt` stops at the first non-digit, so "500junk" parsed to a
+    // finite, positive 500 and slipped past the guard below — silently running
+    // every turn on a 500ms budget instead of failing the way this check
+    // already intends to.
+    const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
       throw new Error(
         `SCENARIO_TURN_TIMEOUT_MS must be a positive integer (got '${raw}')`,
       );

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -53,6 +53,8 @@ const LIVE_PROVIDER_NAMES = [
   "cli",
 ] as const satisfies readonly LiveProviderName[];
 
+const MAX_TURN_TIMEOUT_MS = 2_147_483_647;
+
 function isScenarioLane(value: string): value is ScenarioLane {
   return (SCENARIO_LANES as readonly string[]).includes(value);
 }
@@ -632,6 +634,26 @@ export async function runCli(
     return 2;
   }
 
+  // A real local model on a CPU backend may need a larger per-turn budget than
+  // the 120s default, but the configured value must remain an exact timer
+  // delay. Number.parseInt would accept prefixes such as "500junk", while
+  // delays above Node's timer ceiling are clamped and fire almost immediately.
+  const turnTimeoutMs = (() => {
+    const raw = process.env.SCENARIO_TURN_TIMEOUT_MS?.trim();
+    if (!raw) return 120_000;
+    const parsedTimeoutMs = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+    if (
+      !Number.isSafeInteger(parsedTimeoutMs) ||
+      parsedTimeoutMs <= 0 ||
+      parsedTimeoutMs > MAX_TURN_TIMEOUT_MS
+    ) {
+      throw new Error(
+        `SCENARIO_TURN_TIMEOUT_MS must be a positive integer no greater than ${MAX_TURN_TIMEOUT_MS} (got '${raw}')`,
+      );
+    }
+    return parsedTimeoutMs;
+  })();
+
   const loaded = await loadAllScenarios(
     parsed.dir,
     parsed.filter,
@@ -730,25 +752,6 @@ export async function runCli(
   logger.info(
     `[eliza-scenarios] provider: ${providerName}; execution profile: ${executionProfile}`,
   );
-
-  // Per-turn timeout. Defaults to 120s (fast hosted providers), but a real
-  // local model on a CPU backend needs a larger budget; expose it via env so
-  // the local-model bench lane can run without editing this file.
-  const turnTimeoutMs = (() => {
-    const raw = process.env.SCENARIO_TURN_TIMEOUT_MS?.trim();
-    if (!raw) return 120_000;
-    // `Number.parseInt` stops at the first non-digit, so "500junk" parsed to a
-    // finite, positive 500 and slipped past the guard below — silently running
-    // every turn on a 500ms budget instead of failing the way this check
-    // already intends to.
-    const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
-    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-      throw new Error(
-        `SCENARIO_TURN_TIMEOUT_MS must be a positive integer (got '${raw}')`,
-      );
-    }
-    return parsed;
-  })();
 
   const reports: ScenarioReport[] = [];
   let interruptedSignal: NodeJS.Signals | undefined;


### PR DESCRIPTION
Relates to #24511. Supersedes #23995 because that maintained fork cannot incorporate current workflow changes with the available OAuth scope.

This carries the reviewed implementation from original author @Svector-anu and its timer-ceiling follow-up onto current `develop`, with no workflow delta. `SCENARIO_TURN_TIMEOUT_MS` is parsed before runtime construction as a complete signed decimal safe integer; malformed, non-positive, unsafe, and Node timer-overflow values fail fast, while the documented default and previously accepted explicit plus sign remain supported.

Verification on exact head `afb6fb571c`:

- focused scenario-runner CLI Vitest: 26/26 passed through the real Vitest runner
- scenario-runner build passed
- changed-file Biome passed
- `git diff --check` passed
- no `.github/workflows` delta

The focused run built the declared app-control, local-inference, SQL, agent-skills, scheduling, workflow, and personal-assistant workspace dependencies first. Evidence screenshots/video/frontend/backend/LLM/domain artifacts are N/A because this is a pre-startup CLI configuration boundary. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation by @Svector-anu in #23995; timer-ceiling follow-up by @lalalune; current-base migration and exact-head execution by Codex.