### PR TITLE
fix(agent): strictly parse documents-service timeout

### DIFF
--- a/packages/agent/src/api/documents-service-loader.test.ts
+++ b/packages/agent/src/api/documents-service-loader.test.ts
@@ -174,8 +174,8 @@ describe("getDocumentsServiceTimeoutMs", () => {
     expect(getDocumentsServiceTimeoutMs()).toBe(2_500);
   });
 
-  it("falls back for a timeout beyond the safe integer range", () => {
+  it("ceiling-clamps a clean timeout beyond the safe integer range", () => {
     vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "9007199254740993");
-    expect(getDocumentsServiceTimeoutMs()).toBe(10_000);
+    expect(getDocumentsServiceTimeoutMs()).toBe(60_000);
   });
 });

--- a/packages/agent/src/api/documents-service-loader.test.ts
+++ b/packages/agent/src/api/documents-service-loader.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type DocumentsServiceLike,
   getDocumentsService,
+  getDocumentsServiceTimeoutMs,
 } from "./documents-service-loader.ts";
 
 const service = {} as DocumentsServiceLike;
@@ -149,5 +150,32 @@ describe("documents-service loader process lifecycle", () => {
       reason: "timeout",
     });
     expect(durationMs).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe("getDocumentsServiceTimeoutMs", () => {
+  it("ignores a trailing-garbage timeout instead of parsing its prefix", () => {
+    // parseInt("1junk") is 1 — a 1ms budget that makes every load report
+    // `timeout`, from a value nobody meant as a timeout.
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "1junk");
+    expect(getDocumentsServiceTimeoutMs()).toBe(10_000);
+  });
+
+  it("still honours a clean timeout and its ceiling", () => {
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "2500");
+    expect(getDocumentsServiceTimeoutMs()).toBe(2_500);
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "999999");
+    expect(getDocumentsServiceTimeoutMs()).toBe(60_000);
+  });
+
+  it("still honours an explicitly signed positive timeout", () => {
+    // `Number.parseInt` accepted "+2500"; rejecting it would be a regression.
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "+2500");
+    expect(getDocumentsServiceTimeoutMs()).toBe(2_500);
+  });
+
+  it("falls back for a timeout beyond the safe integer range", () => {
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "9007199254740993");
+    expect(getDocumentsServiceTimeoutMs()).toBe(10_000);
   });
 });

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -162,7 +162,7 @@ export function getDocumentsServiceTimeoutMs(): number {
   // timeout. Require the whole trimmed value to be decimal.
   const trimmed = envVal.trim();
   const parsed = /^\+?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
   return Math.min(parsed, MAX_TIMEOUT_MS);
 }
 

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -156,8 +156,13 @@ const MAX_TIMEOUT_MS = 60_000;
 export function getDocumentsServiceTimeoutMs(): number {
   const envVal = process.env.DOCUMENTS_SERVICE_TIMEOUT_MS;
   if (!envVal) return DEFAULT_TIMEOUT_MS;
-  const parsed = Number.parseInt(envVal, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  // `Number.parseInt` stops at the first non-digit, so "1junk" parsed to a
+  // positive 1 and passed the guard below — a 1ms budget that makes every
+  // documents-service load report `timeout`, from a value nobody set as a
+  // timeout. Require the whole trimmed value to be decimal.
+  const trimmed = envVal.trim();
+  const parsed = /^\+?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
   return Math.min(parsed, MAX_TIMEOUT_MS);
 }
 


### PR DESCRIPTION
Relates to #24511. Supersedes #24001 because that maintained fork cannot incorporate current workflow changes with the available OAuth scope.

This carries the reviewed implementation from original author @Svector-anu and compatibility follow-up onto current `develop`, with no workflow delta. `DOCUMENTS_SERVICE_TIMEOUT_MS` now requires a complete signed decimal value, so trailing garbage cannot create a 1ms failure loop. Clean positive values and the established 60-second ceiling—including beyond-safe-integer clean decimals—retain their prior behavior.

Verification on exact head `7b054ef8d0`:

- focused documents-service loader Vitest: 10/10 passed
- agent package build passed
- changed-file Biome passed
- `git diff --check` passed
- no `.github/workflows` delta

Evidence screenshots/video/frontend/backend/LLM/domain artifacts are N/A because this is a local loader timeout parser with no UI or external integration. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation by @Svector-anu in #24001; compatibility follow-up by @lalalune; current-base migration and exact-head execution by Codex.