### PR TITLE
fix: harden coding-agent execution and artifact retrieval

### DIFF
--- a/packages/agent/src/cli/benchmark.test.ts
+++ b/packages/agent/src/cli/benchmark.test.ts
@@ -48,11 +48,13 @@ describe("runBenchmarkTask", () => {
     const runtime = createRuntime();
     const controller = new AbortController();
     let receivedSignal: AbortSignal | undefined;
+    let receivedCodingMode: boolean | undefined;
     let receivedText: string | undefined;
     let receivedBenchmarkContext: string | undefined;
     vi.spyOn(getMessageService(runtime), "handleMessage").mockImplementation(
       async (_runtime, message, callback, options) => {
         receivedSignal = options?.abortSignal;
+        receivedCodingMode = options?.codingMode;
         receivedText = message.content.text;
         receivedBenchmarkContext =
           message.metadata?.type === "message"
@@ -82,6 +84,7 @@ describe("runBenchmarkTask", () => {
     );
 
     expect(receivedSignal).toBe(controller.signal);
+    expect(receivedCodingMode).toBeUndefined();
     expect(receivedText).toBe("Explain the result");
     expect(receivedBenchmarkContext).toBe('{"fixture":"ground truth"}');
     expect(result).toMatchObject({
@@ -90,6 +93,30 @@ describe("runBenchmarkTask", () => {
       actions_taken: ["SEARCH"],
       success: true,
     });
+  });
+
+  it("routes explicit coding tasks through the coding message loop", async () => {
+    const runtime = createRuntime();
+    let receivedCodingMode: boolean | undefined;
+    vi.spyOn(getMessageService(runtime), "handleMessage").mockImplementation(
+      async (_runtime, _message, _callback, options) => {
+        receivedCodingMode = options?.codingMode;
+        return {
+          didRespond: true,
+          responseContent: { text: "implemented and verified" },
+          responseMessages: [],
+        };
+      },
+    );
+
+    const result = await runBenchmarkTask(
+      runtime,
+      { id: "coding", type: "coding", prompt: "Fix the parser" },
+      new AbortController().signal,
+    );
+
+    expect(receivedCodingMode).toBe(true);
+    expect(result).toMatchObject({ task_type: "coding", success: true });
   });
 
   it("returns partial streamed output when the owner cancels without late completion", async () => {

--- a/packages/agent/src/cli/benchmark.test.ts
+++ b/packages/agent/src/cli/benchmark.test.ts
@@ -43,6 +43,12 @@ function getMessageService(runtime: AgentRuntime): DefaultMessageService {
   return service;
 }
 
+function installCodingActions(runtime: AgentRuntime): void {
+  for (const name of ["READ", "WRITE", "EDIT", "SHELL"]) {
+    runtime.actions.push({ name } as never);
+  }
+}
+
 describe("runBenchmarkTask", () => {
   it("passes owner cancellation into the message loop and captures every output channel", async () => {
     const runtime = createRuntime();
@@ -97,6 +103,7 @@ describe("runBenchmarkTask", () => {
 
   it("routes explicit coding tasks through the coding message loop", async () => {
     const runtime = createRuntime();
+    installCodingActions(runtime);
     let receivedCodingMode: boolean | undefined;
     vi.spyOn(getMessageService(runtime), "handleMessage").mockImplementation(
       async (_runtime, _message, _callback, options) => {
@@ -117,6 +124,26 @@ describe("runBenchmarkTask", () => {
 
     expect(receivedCodingMode).toBe(true);
     expect(result).toMatchObject({ task_type: "coding", success: true });
+  });
+
+  it("fails closed before model inference when coding tools are unavailable", async () => {
+    const runtime = createRuntime();
+    const handleMessage = vi.spyOn(getMessageService(runtime), "handleMessage");
+
+    const result = await runBenchmarkTask(
+      runtime,
+      { id: "missing-tools", type: "coding", prompt: "Fix the parser" },
+      new AbortController().signal,
+    );
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      task_type: "coding",
+      success: false,
+      response: "",
+      error:
+        "Coding benchmark runtime is missing required actions: READ, WRITE, EDIT, SHELL",
+    });
   });
 
   it("returns partial streamed output when the owner cancels without late completion", async () => {
@@ -359,6 +386,31 @@ describe("runBenchmark lifecycle", () => {
     vi.restoreAllMocks();
     process.exitCode = undefined;
     await rm(fixtureDir, { recursive: true, force: true });
+  });
+
+  it("blocks for deferred capabilities during boot and restores the caller environment", async () => {
+    const previous = process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS;
+    delete process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS;
+    lifecycle.boot.mockImplementation(async () => {
+      expect(process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS).toBe("1");
+      return runtime;
+    });
+    vi.spyOn(getMessageService(runtime), "handleMessage").mockResolvedValue({
+      didRespond: true,
+      responseContent: { text: "done" },
+      responseMessages: [],
+    });
+    const taskPath = join(fixtureDir, "task.json");
+    await writeFile(taskPath, JSON.stringify({ id: "boot", prompt: "Run it" }));
+
+    try {
+      await runBenchmark({ task: taskPath });
+      expect(process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS).toBeUndefined();
+    } finally {
+      if (previous === undefined)
+        delete process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS;
+      else process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS = previous;
+    }
   });
 
   it("shuts down the runtime after a successful task", async () => {

--- a/packages/agent/src/cli/benchmark.ts
+++ b/packages/agent/src/cli/benchmark.ts
@@ -121,6 +121,7 @@ export async function runBenchmarkTask(
       },
       {
         abortSignal,
+        ...(taskType === "coding" ? { codingMode: true } : {}),
         onStreamChunk: async (chunk: string) => {
           if (chunk) streamText += chunk;
         },

--- a/packages/agent/src/cli/benchmark.ts
+++ b/packages/agent/src/cli/benchmark.ts
@@ -37,6 +37,15 @@ export interface BenchmarkResult {
   error?: string;
 }
 
+const REQUIRED_CODING_ACTIONS = ["READ", "WRITE", "EDIT", "SHELL"] as const;
+
+function missingCodingActions(runtime: AgentRuntime): string[] {
+  const names = new Set(
+    runtime.actions.map((action) => action.name.trim().toUpperCase()),
+  );
+  return REQUIRED_CODING_ACTIONS.filter((name) => !names.has(name));
+}
+
 function detectTaskType(task: BenchmarkTask): string {
   if (task.type) return task.type;
   if (
@@ -67,6 +76,20 @@ export async function runBenchmarkTask(
 
   try {
     abortSignal.throwIfAborted();
+    if (taskType === "coding") {
+      const missing = missingCodingActions(runtime);
+      if (missing.length > 0) {
+        return {
+          id: task.id,
+          response: "",
+          task_type: taskType,
+          actions_taken: [],
+          duration_ms: Math.round(performance.now() - start),
+          success: false,
+          error: `Coding benchmark runtime is missing required actions: ${missing.join(", ")}`,
+        };
+      }
+    }
     await runtime.ensureConnection({
       entityId: userId,
       roomId,
@@ -424,6 +447,11 @@ export async function runBenchmark(
     process.env.LOG_LEVEL = "error";
   }
   process.env.ELIZA_HEADLESS = "1";
+  const previousBlockDeferred = process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS;
+  // Coding tools are part of the normal deferred desktop wave. A benchmark is
+  // not latency-sensitive boot UI: it must await the complete capability set
+  // before sending the first task or the planner can receive zero native tools.
+  process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS = "1";
 
   const ownerController = new AbortController();
   const removeSignalHandlers = installOwnerSignalHandlers(ownerController);
@@ -495,6 +523,11 @@ export async function runBenchmark(
       }
     } finally {
       removeSignalHandlers();
+      if (previousBlockDeferred === undefined) {
+        delete process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS;
+      } else {
+        process.env.ELIZA_BLOCK_DEFERRED_PLUGIN_IMPORTS = previousBlockDeferred;
+      }
     }
   }
 }

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -107,6 +107,7 @@ function createResponseHandlerFieldRegistry(): ResponseHandlerFieldRegistry {
 function makeRuntime(opts: {
 	actions: Action[];
 	responses: CannedResponse[];
+	owner?: boolean;
 	contextRegistry?: ContextRegistry;
 	responseHandlerEvaluators?: import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator[];
 }): IAgentRuntime {
@@ -138,7 +139,9 @@ function makeRuntime(opts: {
 			: {}),
 		emitEvent: vi.fn(async () => undefined),
 		runActionsByMode: vi.fn(async () => undefined),
-		getSetting: vi.fn(() => undefined),
+		getSetting: vi.fn((key: string) =>
+			opts.owner && key === "ELIZA_ADMIN_ENTITY_ID" ? SENDER_ID : undefined,
+		),
 		useModel: vi.fn(
 			async (modelType: unknown, params: unknown, provider: unknown) => {
 				calls.push({ modelType, params, provider });
@@ -266,6 +269,190 @@ function readRecordedTrajectories(agentId: string): unknown[] {
 }
 
 describe("v5 happy path — message handler → planner → executor → evaluator", () => {
+	it("enters the coding planner directly without a HANDLE_RESPONSE model call", async () => {
+		const fileHandler = vi.fn(async () => ({
+			success: true,
+			text: "wrote index.ts",
+			data: { actionName: "FILE" },
+		}));
+		const fileAction = makeMockAction({
+			name: "READ",
+			contexts: ["code", "files"],
+			parameters: [
+				{
+					name: "path",
+					description: "File path",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			handler: fileHandler,
+		});
+		const mediaAction = makeMockAction({
+			name: "GENERATE_MEDIA",
+			contexts: ["files"],
+			handler: async () => ({ success: true }),
+		});
+		const runtime = makeRuntime({
+			actions: [fileAction, mediaAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						completed: true,
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "READ",
+								args: { path: "index.ts" },
+							},
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								args: { text: "Created index.ts." },
+							},
+						],
+					},
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("create index.ts"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") throw new Error("expected reply");
+		expect(result.result.responseContent?.text).toBe("Created index.ts.");
+		expect(fileHandler).toHaveBeenCalledTimes(1);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.ACTION_PLANNER,
+			ModelType.ACTION_PLANNER,
+		]);
+		const actionModes = (
+			runtime.runActionsByMode as ReturnType<typeof vi.fn>
+		).mock.calls.map(([mode]) => mode);
+		expect(actionModes).not.toContain("RESPONSE_HANDLER_BEFORE");
+		expect(actionModes).not.toContain("RESPONSE_HANDLER_DURING");
+		expect(actionModes).not.toContain("RESPONSE_HANDLER_AFTER");
+		const plannerTools = getCalls(runtime).flatMap((call) =>
+			((call.params as { tools?: Array<{ name?: string }> }).tools ?? []).map(
+				(tool) => tool.name,
+			),
+		);
+		expect(plannerTools).toContain("READ");
+		expect(plannerTools).not.toContain("GENERATE_MEDIA");
+		const firstPlannerMessages = (
+			getCalls(runtime)[0]?.params as
+				| {
+						messages?: Array<{ content?: string }>;
+				  }
+				| undefined
+		)?.messages;
+		expect(firstPlannerMessages?.[0]?.content).toContain(
+			"Complete the current coding request",
+		);
+		expect(firstPlannerMessages?.[0]?.content).not.toContain(
+			"Owner life-management side effects",
+		);
+	});
+
+	it("does not leak coding mode into the next ordinary turn", async () => {
+		const replyAction = makeMockAction({
+			name: "REPLY",
+			handler: async () => ({ success: true }),
+		});
+		const runtime = makeRuntime({
+			actions: [replyAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{ id: "reply-1", name: "REPLY", args: { text: "coded" } },
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({ contexts: ["simple"], replyText: "hello" }),
+				},
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("answer from the coding loop"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+		});
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("say hello"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.ACTION_PLANNER,
+			ModelType.RESPONSE_HANDLER,
+		]);
+	});
+
+	it("propagates a coding-loop failure instead of rescuing partial tool work", async () => {
+		const readAction = makeMockAction({
+			name: "READ",
+			contexts: ["code", "files"],
+			handler: async () => ({
+				success: true,
+				text: "partial source",
+				userFacingText: "partial source",
+			}),
+		});
+		const runtime = makeRuntime({
+			actions: [readAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{ id: "read-1", name: "READ", args: { path: "index.ts" } },
+						],
+					},
+				},
+			],
+		});
+
+		await expect(
+			runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage("fix index.ts"),
+				state: makeState(),
+				responseId: RESPONSE_ID,
+				codingMode: true,
+			}),
+		).rejects.toThrow("queue empty");
+	});
+
 	it("runs the full pipeline and records every stage to disk", async () => {
 		let webSearchCalls = 0;
 		const webSearch = makeMockAction({

--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -72,17 +72,7 @@ function executeFailureAThenSuccessB() {
 }
 
 async function withCodingFullSurface<T>(run: () => Promise<T>): Promise<T> {
-	const previous = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-	process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
-	try {
-		return await run();
-	} finally {
-		if (previous === undefined) {
-			delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-		} else {
-			process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = previous;
-		}
-	}
+	return run();
 }
 
 describe("planner-loop failed-operation correlation", () => {
@@ -906,6 +896,7 @@ describe("planner-loop failed-operation correlation", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: { id: "ctx" },
+				codingMode: true,
 				executeToolCall: vi
 					.fn()
 					.mockResolvedValueOnce({
@@ -971,6 +962,7 @@ describe("planner-loop failed-operation correlation", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: { id: "ctx" },
+				codingMode: true,
 				executeToolCall: vi
 					.fn()
 					.mockResolvedValueOnce({

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -518,7 +518,7 @@ describe("v5 planner loop skeleton", () => {
 	});
 
 	// #10132: in chat mode the planner's 1024-token output cap is fine, but a
-	// coding sub-agent (ELIZA_PLANNER_FULL_ACTION_SURFACE=1) must emit a whole
+	// coding sub-agent (selected through per-turn codingMode) must emit a whole
 	// file as a single FILE/WRITE tool-call argument — a real single-file app is
 	// ~4.6k+ tokens once JSON-escaped, so 1024 truncates it mid-stream and the
 	// build silently fails. Coding mode lifts the cap.
@@ -567,16 +567,11 @@ describe("v5 planner loop skeleton", () => {
 	const withCodingRequiredToolDefaults = async <T>(
 		run: () => Promise<T>,
 	): Promise<T> => {
-		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
 		const prevMisses = process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES;
-		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
 		delete process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES;
 		try {
 			return await run();
 		} finally {
-			if (prevSurface === undefined)
-				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
 			if (prevMisses === undefined)
 				delete process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES;
 			else process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES = prevMisses;
@@ -584,15 +579,14 @@ describe("v5 planner loop skeleton", () => {
 	};
 
 	it("raises the planner output-token cap in coding/full-surface mode (#10132)", async () => {
-		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
 		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
-		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
 		delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 		try {
 			const runtime = buildCodingPlannerRuntime();
 			await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
 				evaluate: vi.fn(async () => ({
 					success: true,
@@ -604,9 +598,6 @@ describe("v5 planner loop skeleton", () => {
 			const plannerParams = runtime.useModel.mock.calls[0][1];
 			expect(plannerParams.maxTokens).toBe(16384);
 		} finally {
-			if (prevSurface === undefined)
-				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
 			if (prevMax === undefined)
 				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 			else process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = prevMax;
@@ -614,15 +605,14 @@ describe("v5 planner loop skeleton", () => {
 	});
 
 	it("honors ELIZA_CODING_PLANNER_MAX_TOKENS in coding mode (#10132)", async () => {
-		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
 		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
-		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
 		process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = "32768";
 		try {
 			const runtime = buildCodingPlannerRuntime();
 			await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
 				evaluate: vi.fn(async () => ({
 					success: true,
@@ -634,9 +624,6 @@ describe("v5 planner loop skeleton", () => {
 			const plannerParams = runtime.useModel.mock.calls[0][1];
 			expect(plannerParams.maxTokens).toBe(32768);
 		} finally {
-			if (prevSurface === undefined)
-				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
-			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
 			if (prevMax === undefined)
 				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 			else process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = prevMax;
@@ -669,6 +656,7 @@ describe("v5 planner loop skeleton", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				tools: codingPlannerTools,
 				executeToolCall,
 				evaluate,
@@ -713,6 +701,7 @@ describe("v5 planner loop skeleton", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				tools: codingPlannerTools,
 				config: { maxRequiredToolMisses: 1 },
 				executeToolCall,
@@ -722,6 +711,154 @@ describe("v5 planner loop skeleton", () => {
 			expect(runtime.useModel).toHaveBeenCalledTimes(4);
 			expect(executeToolCall).toHaveBeenCalledTimes(1);
 			expect(result.finalMessage).toBe("Built dice.html.");
+		});
+	});
+
+	it("requires successful shell verification after a coding mutation", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "ok" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-unverified", "Built dice.html."),
+					)
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-1",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-verified", "Built and verified dice.html."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async (toolCall) => ({
+				success: true,
+				text: `${toolCall.name} succeeded`,
+			}));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(runtime.useModel).toHaveBeenCalledTimes(4);
+			expect(executeToolCall).toHaveBeenCalledTimes(2);
+			expect(result.finalMessage).toBe("Built and verified dice.html.");
+			expect(result.trajectory.evaluatorOutputs).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						decision: "CONTINUE",
+						success: false,
+					}),
+				]),
+			);
+		});
+	});
+
+	it("lets final verification supersede failed intermediate coding commands", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const toolResult = (success: boolean, text: string) => ({
+				success,
+				text,
+			});
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "draft" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-failed",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "edit-1",
+								name: "EDIT",
+								arguments: {
+									path: "dice.html",
+									old_string: "draft",
+									new_string: "fixed",
+								},
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-passed",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-verified", "Built and verified dice.html."),
+					),
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce(toolResult(true, "wrote draft"))
+				.mockResolvedValueOnce(toolResult(false, "test failed"))
+				.mockResolvedValueOnce(toolResult(true, "fixed file"))
+				.mockResolvedValueOnce(toolResult(true, "test passed"));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "EDIT", description: "Edit a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toBe("Built and verified dice.html.");
+			expect(executeToolCall).toHaveBeenCalledTimes(4);
 		});
 	});
 
@@ -760,6 +897,7 @@ describe("v5 planner loop skeleton", () => {
 			const result = await runPlannerLoop({
 				runtime,
 				context: codingPlannerContext,
+				codingMode: true,
 				tools: [
 					{ name: "CUSTOM_BUILD_TOOL", description: "Builds something." },
 					{ name: "REPLY", description: "Reply to the user." },

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -779,6 +779,63 @@ describe("v5 planner loop skeleton", () => {
 		});
 	});
 
+	it("fails honestly instead of synthesizing success after repeated calls leave a mutation unverified", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const readCall = {
+				id: "read-1",
+				name: "READ",
+				arguments: { file_path: "/workspace/dice.html" },
+			};
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({ text: "", toolCalls: [readCall] })
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "edit-1",
+								name: "EDIT",
+								arguments: {
+									file_path: "/workspace/dice.html",
+									old_string: "draft",
+									new_string: "fixed",
+								},
+							},
+						],
+					})
+					.mockResolvedValue({ text: "", toolCalls: [readCall] }),
+				logger: { debug: vi.fn(), warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async () => ({
+				success: true,
+				text: "ok",
+			}));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				config: { maxRepeatedToolCalls: 1 },
+				tools: [
+					{ name: "READ", description: "Read a file." },
+					{ name: "EDIT", description: "Edit a file." },
+					{ name: "SHELL", description: "Run a command." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(executeToolCall).toHaveBeenCalledTimes(3);
+			expect(runtime.useModel).toHaveBeenCalledTimes(5);
+			expect(result.evaluator).toMatchObject({
+				success: false,
+				decision: "FINISH",
+			});
+			expect(result.finalMessage).toContain("coding task is incomplete");
+		});
+	});
+
 	it("lets final verification supersede failed intermediate coding commands", async () => {
 		await withCodingRequiredToolDefaults(async () => {
 			const toolResult = (success: boolean, text: string) => ({
@@ -2002,6 +2059,47 @@ describe("v5 planner loop skeleton", () => {
 		expect(partitioned.redundant).toEqual([archivedSuccess]);
 		expect(partitioned.nonRetryable).toEqual([archivedDeadEnd]);
 		expect(partitioned.fresh).toEqual([freshCall]);
+	});
+
+	it("allows a coding inspection to repeat after a successful mutation", () => {
+		const readCall = {
+			name: "READ",
+			params: { file_path: "/workspace/config.go" },
+		};
+		const editCall = {
+			name: "EDIT",
+			params: {
+				file_path: "/workspace/config.go",
+				old_string: "old",
+				new_string: "new",
+			},
+		};
+		const trajectory = {
+			context: { id: "ctx" },
+			codingMode: true,
+			steps: [
+				{
+					iteration: 1,
+					toolCall: readCall,
+					result: { success: true, text: "old" },
+				},
+				{
+					iteration: 2,
+					toolCall: editCall,
+					result: { success: true, text: "edited" },
+				},
+			],
+			archivedSteps: [],
+			plannedQueue: [],
+			evaluatorOutputs: [],
+		};
+
+		const partitioned = partitionRedundantSucceededCalls(
+			[readCall, editCall],
+			trajectory,
+		);
+		expect(partitioned.fresh).toEqual([readCall]);
+		expect(partitioned.redundant).toEqual([editCall]);
 	});
 
 	it("does not capture native text fallback as a required-tool refusal", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -919,6 +919,85 @@ describe("v5 planner loop skeleton", () => {
 		});
 	});
 
+	it("keeps an unrelated failed coding command authoritative after verification", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "draft" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "deploy-failed",
+								name: "SHELL",
+								arguments: { command: "deploy dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "edit-1",
+								name: "EDIT",
+								arguments: {
+									path: "dice.html",
+									old_string: "draft",
+									new_string: "fixed",
+								},
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "verify-passed",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-verified", "Built and deployed dice.html."),
+					),
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({ success: true, text: "wrote draft" })
+				.mockResolvedValueOnce({ success: false, text: "deploy failed" })
+				.mockResolvedValueOnce({ success: true, text: "fixed file" })
+				.mockResolvedValueOnce({ success: true, text: "file check passed" });
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "EDIT", description: "Edit a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(result.finalMessage).toContain("failed");
+			expect(result.finalMessage).not.toContain("Built and deployed");
+		});
+	});
+
 	it("uses owner-declared action summaries for coding fallback replies", async () => {
 		await withCodingRequiredToolDefaults(async () => {
 			const runtime = {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3984,12 +3984,6 @@ function terminalMessageWithFailureAuthority(
 	const unresolvedFailure =
 		latestUnresolvedFailedNonTerminalToolStep(trajectory);
 	if (!unresolvedFailure) return candidate;
-	if (
-		trajectory.codingMode === true &&
-		codingVerificationSupersedesFailure(trajectory, unresolvedFailure)
-	) {
-		return candidate;
-	}
 
 	const pendingInteraction = latestActionablePendingInteractionAfter(
 		trajectory,
@@ -4031,43 +4025,6 @@ function terminalMessageWithFailureAuthority(
 	);
 	if (successEvidence.length === 0) return failureNote;
 	return `${failureNote}\n\nWork that did complete: ${successEvidence.join(" ")}`;
-}
-
-/**
- * A repository verification command validates the resulting tree, not the
- * exact argument identity of every failed intermediate command. In coding
- * mode, a successful SHELL run after the latest successful mutation therefore
- * resolves earlier transient edit/test failures for terminal reporting. A
- * failure after that verification remains authoritative.
- */
-function codingVerificationSupersedesFailure(
-	trajectory: PlannerTrajectory,
-	failure: PlannerStep,
-): boolean {
-	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
-	const failureIndex = steps.lastIndexOf(failure);
-	if (failureIndex < 0) return false;
-
-	let latestMutationIndex = -1;
-	for (let index = 0; index < steps.length; index++) {
-		const step = steps[index];
-		const name = step?.toolCall?.name.toUpperCase();
-		if (
-			(name === "WRITE" || name === "EDIT") &&
-			step.result?.success === true
-		) {
-			latestMutationIndex = index;
-		}
-	}
-	if (latestMutationIndex < 0) return false;
-
-	return steps.some(
-		(step, index) =>
-			index > latestMutationIndex &&
-			index > failureIndex &&
-			step.toolCall?.name.toUpperCase() === "SHELL" &&
-			step.result?.success === true,
-	);
 }
 
 /**

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -163,6 +163,28 @@ export type {
 	PlannerTrajectory,
 } from "./planner-types";
 
+/** Minimal stable loop contract for a dedicated coding turn. */
+const CODING_PLANNER_TEMPLATE = `task: Complete the current coding request with native tools.
+
+rules:
+- act with the smallest grounded tool call; do not narrate work that was not performed
+- inspect before editing and preserve unrelated work
+- when the task names a file, READ it directly; use bounded windows for large files
+- prefer EDIT for existing files; never change tests or fixtures only to hide a failure
+- pass only schema-declared arguments; never invent placeholders
+- after a tool result, continue with the next concrete step until the task is complete
+- after WRITE or EDIT, run a successful narrow SHELL verification before finishing
+- do not claim success when a tool failed or verification is still pending
+- use messageToUser only for the final grounded result or a genuinely blocking question
+- every native tool call requires eliza_turn_scope: use more_work_pending until the final tool batch
+- when complete, call no tool and report changed files, verification, and limitations concisely
+
+context_object:
+{{contextObject}}
+
+trajectory:
+{{trajectory}}`;
+
 /**
  * Chat-lane planner output budget. Reasoning models spend completion tokens on
  * deliberation BEFORE the tool call, and with `toolChoice: required` a budget
@@ -177,17 +199,6 @@ export type {
  * (#10132).
  */
 const DEFAULT_PLANNER_MAX_TOKENS = 4096;
-
-/**
- * Coding/full-surface mode is on when the eliza-code sub-agent sets
- * `ELIZA_PLANNER_FULL_ACTION_SURFACE` (the ACP server does). Centralized so the
- * tool-call ceiling, the queue-drain cadence, and the output-token cap all read
- * the same signal.
- */
-function isCodingFullSurfaceMode(): boolean {
-	const v = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
-	return v === "1" || v === "true" || v === "yes" || v === "on";
-}
 
 /**
  * Default per-call output-token ceiling for a coding planner turn. A single
@@ -250,8 +261,8 @@ export function resolvePositivePlannerInt(
  * `ELIZA_CODING_PLANNER_MAX_TOKENS`). A set-but-malformed override throws via
  * {@link resolvePositivePlannerInt} rather than silently defaulting.
  */
-function resolvePlannerMaxTokens(): number {
-	if (!isCodingFullSurfaceMode()) {
+function resolvePlannerMaxTokens(codingMode: boolean): number {
+	if (!codingMode) {
 		return resolvePositivePlannerInt(
 			"ELIZA_PLANNER_MAX_TOKENS",
 			process.env.ELIZA_PLANNER_MAX_TOKENS,
@@ -274,7 +285,7 @@ export function resolveCodingMaxToolCalls(): number {
 	return resolvePositivePlannerInt(
 		"ELIZA_CODING_MAX_TOOL_CALLS",
 		process.env.ELIZA_CODING_MAX_TOOL_CALLS,
-		80,
+		32,
 	);
 }
 
@@ -357,14 +368,13 @@ async function runPlannerLoopIterations(
 	// arguments: runtime-known secrets composed with the shared tool-shape
 	// patterns. The raw calls stay on `trajectory.plannedQueue` for execution.
 	const redactDiagnosticText = composeToolDiagnosticRedactor(params.runtime);
-	// Coding/full-surface mode (the eliza-code sub-agent sets
-	// ELIZA_PLANNER_FULL_ACTION_SURFACE): a real build legitimately makes many
+	// Coding/full-surface mode: a real build legitimately makes many
 	// tool calls (read several files, write several, run tests). The chat default
 	// (maxToolCalls=16) caps that mid-build, ending the turn on a
 	// TrajectoryLimitExceeded with no terminal REPLY → an EMPTY relay to the user.
 	// Raise the ceiling for coding builds (still bounded). Overridable via
 	// ELIZA_CODING_MAX_TOOL_CALLS.
-	const codingMode = isCodingFullSurfaceMode();
+	const codingMode = params.codingMode === true;
 	const codingMaxToolCalls = resolveCodingMaxToolCalls();
 	// Weak coding models (e.g. Cerebras glm-4.7) sometimes answer a trivial build
 	// with a terminal REPLY ("Creating the app now…") instead of calling FILE.
@@ -408,6 +418,7 @@ async function runPlannerLoopIterations(
 		: plannerContext;
 	const trajectory: PlannerTrajectory = {
 		context: trajectoryContext,
+		codingMode,
 		steps: postToolReplySeed
 			? [
 					{
@@ -581,7 +592,7 @@ async function runPlannerLoopIterations(
 		return accepted;
 	};
 
-	// Coding/full-surface mode (set above from ELIZA_PLANNER_FULL_ACTION_SURFACE):
+	// Coding/full-surface mode (selected explicitly for this turn):
 	// when the model emits a batch of tool calls in a single response, execute
 	// EVERY queued call before re-evaluating. A real build needs all of its
 	// FILE/SHELL calls to run; a dedicated coding agent drains the whole batch and
@@ -989,6 +1000,16 @@ async function runPlannerLoopIterations(
 					iteration,
 					message: plannerOutput.messageToUser,
 				});
+				if (
+					codingDrainQueue &&
+					deferCodingCompletionUntilMutationVerified({
+						trajectory,
+						iteration,
+						redactDiagnosticText,
+					})
+				) {
+					continue;
+				}
 				if (trajectory.steps.some((step) => step.toolCall)) {
 					// Coding mode: the model emitted a final text summary AFTER
 					// executing build tools — it's signalling completion. Finish with
@@ -1236,6 +1257,16 @@ async function runPlannerLoopIterations(
 						reason: "terminal_only_tool_calls",
 						logger: params.runtime.logger,
 					});
+					continue;
+				}
+				if (
+					codingDrainQueue &&
+					deferCodingCompletionUntilMutationVerified({
+						trajectory,
+						iteration,
+						redactDiagnosticText,
+					})
+				) {
 					continue;
 				}
 				// The messageToUser fallback applies only when a REPLY call is
@@ -1854,6 +1885,7 @@ function renderPlannerModelInput(params: {
 	context: ContextObject;
 	trajectory: PlannerTrajectory;
 	template?: string;
+	codingMode?: boolean;
 	runtime?: PlannerRuntime;
 	projectionBudget?: ContentProjectionBudget;
 	omitRecoverableText?: boolean;
@@ -1865,8 +1897,12 @@ function renderPlannerModelInput(params: {
 } {
 	const renderedContext = renderContextObject(params.context);
 	const template = params.template ?? plannerTemplate;
-	const instructions = appendMandatoryPlannerPolicy(
-		template.split("context_object:")[0] ?? template,
+	const instructions = (
+		params.codingMode
+			? template.split("context_object:")[0]
+			: appendMandatoryPlannerPolicy(
+					template.split("context_object:")[0] ?? template,
+				)
 	).trim();
 	let projectionStats: ToolResultProjectionStats = {
 		resultCount: 0,
@@ -2439,7 +2475,11 @@ async function callPlanner(params: {
 	const renderArgs = {
 		context: params.context,
 		trajectory: params.trajectory,
-		template: resolveOptimizedPlannerTemplate(params.runtime),
+		template:
+			params.trajectory.codingMode === true
+				? CODING_PLANNER_TEMPLATE
+				: resolveOptimizedPlannerTemplate(params.runtime),
+		codingMode: params.trajectory.codingMode === true,
 		runtime: params.runtime,
 	};
 	const baselineInput = renderPlannerModelInput({
@@ -2523,7 +2563,7 @@ async function callPlanner(params: {
 		// Chat planner turns stay at the small DEFAULT_PLANNER_MAX_TOKENS; a coding
 		// turn must be able to emit a whole file in one tool call, so coding mode
 		// raises the cap (see resolvePlannerMaxTokens / issue #10132).
-		maxTokens: resolvePlannerMaxTokens(),
+		maxTokens: resolvePlannerMaxTokens(params.trajectory.codingMode === true),
 	};
 	modelParams.providerOptions = {
 		...modelParams.providerOptions,
@@ -3687,6 +3727,64 @@ function isTerminalToolCall(toolCall: PlannerToolCall): boolean {
 	return isTerminalPlannerToolName(toolCall.name);
 }
 
+/**
+ * Prevents a coding turn from treating an unverified file mutation as done.
+ * A successful SHELL call after the most recent successful WRITE/EDIT is the
+ * deliberately small, provider-independent proof boundary: the model chooses
+ * the repository-appropriate command, while the runtime verifies that the
+ * command actually ran and exited successfully.
+ */
+function deferCodingCompletionUntilMutationVerified(args: {
+	trajectory: PlannerTrajectory;
+	iteration: number;
+	redactDiagnosticText?: ToolDiagnosticTextRedactor;
+}): boolean {
+	let latestMutationIndex = -1;
+	for (let index = 0; index < args.trajectory.steps.length; index++) {
+		const step = args.trajectory.steps[index];
+		const name = step?.toolCall?.name.toUpperCase();
+		if (
+			(name === "WRITE" || name === "EDIT") &&
+			step.result?.success === true
+		) {
+			latestMutationIndex = index;
+		}
+	}
+	if (latestMutationIndex < 0) return false;
+
+	const verified = args.trajectory.steps
+		.slice(latestMutationIndex + 1)
+		.some(
+			(step) =>
+				step.toolCall?.name.toUpperCase() === "SHELL" &&
+				step.result?.success === true,
+		);
+	if (verified) return false;
+
+	const evaluator: EvaluatorOutput = {
+		success: false,
+		decision: "CONTINUE",
+		thought:
+			"A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
+		messageToUser:
+			"Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
+	};
+	args.trajectory.evaluatorOutputs.push(
+		projectToolDiagnosticValue(
+			evaluator,
+			args.redactDiagnosticText ?? composeToolDiagnosticRedactor(),
+		) as EvaluatorOutput,
+	);
+	appendEvaluatorContextEvent(
+		args.trajectory,
+		evaluator,
+		args.iteration,
+		args.redactDiagnosticText,
+	);
+	args.trajectory.plannedQueue.length = 0;
+	return true;
+}
+
 function getToolDefinitionName(tool: ToolDefinition): string | undefined {
 	const maybeTool = tool as ToolDefinition & {
 		function?: { name?: unknown };
@@ -3879,6 +3977,12 @@ function terminalMessageWithFailureAuthority(
 	const unresolvedFailure =
 		latestUnresolvedFailedNonTerminalToolStep(trajectory);
 	if (!unresolvedFailure) return candidate;
+	if (
+		trajectory.codingMode === true &&
+		codingVerificationSupersedesFailure(trajectory, unresolvedFailure)
+	) {
+		return candidate;
+	}
 
 	const pendingInteraction = latestActionablePendingInteractionAfter(
 		trajectory,
@@ -3913,13 +4017,50 @@ function terminalMessageWithFailureAuthority(
 		unresolvedFailure,
 		failureReport,
 	);
-	if (!isCodingFullSurfaceMode()) return failureNote;
+	if (trajectory.codingMode !== true) return failureNote;
 	const successEvidence = toolOwnedSuccessEvidenceAfter(
 		trajectory,
 		unresolvedFailure,
 	);
 	if (successEvidence.length === 0) return failureNote;
 	return `${failureNote}\n\nWork that did complete: ${successEvidence.join(" ")}`;
+}
+
+/**
+ * A repository verification command validates the resulting tree, not the
+ * exact argument identity of every failed intermediate command. In coding
+ * mode, a successful SHELL run after the latest successful mutation therefore
+ * resolves earlier transient edit/test failures for terminal reporting. A
+ * failure after that verification remains authoritative.
+ */
+function codingVerificationSupersedesFailure(
+	trajectory: PlannerTrajectory,
+	failure: PlannerStep,
+): boolean {
+	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
+	const failureIndex = steps.lastIndexOf(failure);
+	if (failureIndex < 0) return false;
+
+	let latestMutationIndex = -1;
+	for (let index = 0; index < steps.length; index++) {
+		const step = steps[index];
+		const name = step?.toolCall?.name.toUpperCase();
+		if (
+			(name === "WRITE" || name === "EDIT") &&
+			step.result?.success === true
+		) {
+			latestMutationIndex = index;
+		}
+	}
+	if (latestMutationIndex < 0) return false;
+
+	return steps.some(
+		(step, index) =>
+			index > latestMutationIndex &&
+			index > failureIndex &&
+			step.toolCall?.name.toUpperCase() === "SHELL" &&
+			step.result?.success === true,
+	);
 }
 
 /**
@@ -4543,7 +4684,7 @@ async function ensureToolTurnFinalMessage(
 ): Promise<PlannerLoopResult> {
 	if (result.status !== "finished") return result;
 	if (result.endedWithDeliberateSilence) return result;
-	if (isCodingFullSurfaceMode()) return result;
+	if (params.codingMode === true) return result;
 	const message = result.finalMessage;
 	const unusable =
 		message === undefined ||
@@ -4624,7 +4765,7 @@ async function ensureFailedTurnFinalMessage(
 	// guarantee: its result feeds the orchestrator (which owns its own summary
 	// fallback), not a chat user, and an extra model call per failed build
 	// step would be pure overhead there.
-	if (isCodingFullSurfaceMode()) return result;
+	if (params.codingMode === true) return result;
 	if (result.finalMessage !== FAILED_TOOL_FALLBACK_MESSAGE) return result;
 	const failedStep =
 		latestUnresolvedFailedNonTerminalToolStep(result.trajectory) ??

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3739,27 +3739,7 @@ function deferCodingCompletionUntilMutationVerified(args: {
 	iteration: number;
 	redactDiagnosticText?: ToolDiagnosticTextRedactor;
 }): boolean {
-	let latestMutationIndex = -1;
-	for (let index = 0; index < args.trajectory.steps.length; index++) {
-		const step = args.trajectory.steps[index];
-		const name = step?.toolCall?.name.toUpperCase();
-		if (
-			(name === "WRITE" || name === "EDIT") &&
-			step.result?.success === true
-		) {
-			latestMutationIndex = index;
-		}
-	}
-	if (latestMutationIndex < 0) return false;
-
-	const verified = args.trajectory.steps
-		.slice(latestMutationIndex + 1)
-		.some(
-			(step) =>
-				step.toolCall?.name.toUpperCase() === "SHELL" &&
-				step.result?.success === true,
-		);
-	if (verified) return false;
+	if (!codingMutationRequiresVerification(args.trajectory)) return false;
 
 	const evaluator: EvaluatorOutput = {
 		success: false,
@@ -3783,6 +3763,33 @@ function deferCodingCompletionUntilMutationVerified(args: {
 	);
 	args.trajectory.plannedQueue.length = 0;
 	return true;
+}
+
+function codingMutationRequiresVerification(
+	trajectory: PlannerTrajectory,
+): boolean {
+	let latestMutationIndex = -1;
+	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
+	for (let index = 0; index < steps.length; index++) {
+		const step = steps[index];
+		const name = step?.toolCall?.name.toUpperCase();
+		if (
+			(name === "WRITE" || name === "EDIT") &&
+			step.result?.success === true
+		) {
+			latestMutationIndex = index;
+		}
+	}
+	if (latestMutationIndex < 0) return false;
+
+	const verified = steps
+		.slice(latestMutationIndex + 1)
+		.some(
+			(step) =>
+				step.toolCall?.name.toUpperCase() === "SHELL" &&
+				step.result?.success === true,
+		);
+	return !verified;
 }
 
 function getToolDefinitionName(tool: ToolDefinition): string | undefined {
@@ -4211,7 +4218,9 @@ function toolCallIdentity(toolCall: PlannerToolCall): string {
  * deterministic unavailability (e.g. PAGE_DELEGATE's PAGE_CHILD_UNAVAILABLE)
  * that cannot change within the turn. Neither kind is re-executed. Legacy
  * archived steps still count, so a settled call stays settled after loading
- * an older persisted trajectory.
+ * an older persisted trajectory. In coding mode, a successful WRITE/EDIT
+ * invalidates earlier successes because an identical inspection can now
+ * return changed source.
  */
 export function partitionRedundantSucceededCalls(
 	calls: PlannerToolCall[],
@@ -4227,6 +4236,16 @@ export function partitionRedundantSucceededCalls(
 		if (!step.toolCall || !step.result) continue;
 		const identity = toolCallIdentity(step.toolCall);
 		if (step.result.success === true) {
+			// A successful coding mutation can change the answer to any earlier
+			// inspection. Clear those settled identities before recording the
+			// mutation itself so READ-after-EDIT remains executable while an exact
+			// duplicate EDIT is still suppressed.
+			if (
+				trajectory.codingMode === true &&
+				["WRITE", "EDIT"].includes(step.toolCall.name.toUpperCase())
+			) {
+				succeeded.clear();
+			}
 			succeeded.add(identity);
 		} else if (step.result.data?.retryable === false) {
 			failedNonRetryable.add(identity);
@@ -4432,6 +4451,46 @@ async function finishWithForcedSynthesis(params: {
 	failureAware?: boolean;
 }): Promise<PlannerLoopResult> {
 	const { loop, config, trajectory, iteration } = params;
+	if (
+		trajectory.codingMode === true &&
+		codingMutationRequiresVerification(trajectory)
+	) {
+		const message =
+			"I changed files but could not complete the required command verification. The coding task is incomplete.";
+		const evaluator: EvaluatorOutput = {
+			success: false,
+			decision: "FINISH",
+			thought:
+				"Forced synthesis stopped after repeated calls with an unverified coding mutation.",
+			messageToUser: message,
+		};
+		trajectory.steps.push({
+			iteration,
+			terminalMessage: message,
+			terminalOnly: true,
+		});
+		trajectory.evaluatorOutputs.push(evaluator);
+		appendEvaluatorContextEvent(trajectory, evaluator, iteration);
+		const recordedAt = Date.now();
+		await recordGatedEvaluationStage({
+			runtime: loop.runtime,
+			recorder: loop.recorder,
+			trajectoryId: loop.trajectoryId,
+			parentStageId: loop.parentStageId,
+			iteration,
+			startedAt: recordedAt,
+			endedAt: recordedAt,
+			output: evaluator,
+			reason: "coding_mutation_unverified",
+			logger: loop.runtime.logger,
+		});
+		return {
+			status: "finished",
+			trajectory,
+			evaluator,
+			finalMessage: message,
+		};
+	}
 	trajectory.context = appendContextEvent(trajectory.context, {
 		id: `force-synthesis:${iteration}`,
 		type: "instruction",

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -226,6 +226,8 @@ export interface PlannerStep {
 
 export interface PlannerTrajectory {
 	context: ContextObject;
+	/** Internal execution-mode provenance for mode-specific terminal handling. */
+	codingMode?: boolean;
 	steps: PlannerStep[];
 	archivedSteps: PlannerStep[];
 	plannedQueue: PlannerToolCall[];
@@ -273,6 +275,8 @@ export interface PlannerLoopParams {
 		toolCall: PlannerToolCall;
 		result: PlannerToolResult;
 	};
+	/** Trusted per-turn coding-loop mode; never used as an authorization signal. */
+	codingMode?: boolean;
 	config?: Partial<ChainingLoopConfig>;
 	executeToolCall: (
 		toolCall: PlannerToolCall,

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -85,6 +85,28 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(redactSensitiveText(benign)).toBe(benign);
 	});
 
+	it("does not corrupt ordinary source assignments to key-like variables", () => {
+		const source = [
+			"var (",
+			"\tkey = prefix + tag",
+			"\ttoken = currentToken",
+			")",
+		].join("\n");
+		expect(redactSensitiveText(source)).toBe(source);
+	});
+
+	it("still masks uppercase and compound lowercase environment assignments", () => {
+		for (const assignment of [
+			"API_KEY=credential-value-123456",
+			"api_key=credential-value-123456",
+			"refresh_token=credential-value-123456",
+		]) {
+			expect(redactSensitiveText(assignment)).not.toContain(
+				"credential-value-123456",
+			);
+		}
+	});
+
 	it("masks a quoted credential key the ENV-style row cannot reach", () => {
 		// The ENV-style assignment pattern requires the key's word boundary to be
 		// followed immediately by `=`/`:`; a quoted key's closing quote always

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -36,7 +36,11 @@ const HTTP_TOKEN68_PATTERN = String.raw`[A-Za-z0-9._~+/\-]+={0,}`;
  */
 const DEFAULT_REDACT_PATTERNS: string[] = [
 	// ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
-	String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
+	// Keep the broad environment-name form case-sensitive: compiling bare
+	// `key` case-insensitively also matches ordinary source such as
+	// `key = prefix + tag` and corrupts code returned by READ. Lowercase env
+	// spellings remain covered when they use an unambiguous compound name.
+	String.raw`/\b(?:[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)|(?:api_key|access_token|refresh_token|auth_token|bot_token|session_key|private_key|client_secret|seed_phrase|connection_string|webhook_url))\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
 	// JSON fields.
 	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|client_secret|sessionKey|session_key|authToken|auth_token|botToken|bot_token|connectionString|connection_string|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
 	// Quoted credential keys with arbitrary naming. The ENV-style row above

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1323,6 +1323,7 @@ function _resolvePromptAttachments(
  */
 type ResolvedMessageOptions = {
 	maxRetries: number;
+	codingMode: boolean;
 	continueAfterActions: boolean;
 	keepExistingResponses: boolean;
 	onStreamChunk?: StreamChunkCallback;
@@ -3095,8 +3096,8 @@ function mergeAgentContexts(
 }
 
 /**
- * The agent contexts a focused coding sub-agent (the eliza-code ACP server,
- * which sets ELIZA_PLANNER_FULL_ACTION_SURFACE) is considered to be operating in.
+ * The agent contexts a focused per-turn coding loop is considered to be
+ * operating in.
  * Used to admit the coding tools (FILE/SHELL/WORKTREE gate on these) while the
  * messaging/social chat actions stay gated off.
  */
@@ -3108,19 +3109,29 @@ const CODING_SUB_AGENT_CONTEXTS: readonly AgentContext[] = [
 ];
 
 /**
- * Parent actions a coding sub-agent never needs, excluded from its planner
- * surface even though they'd otherwise pass the coding-context gate. Each extra
- * tool schema enlarges the request, and a large tool set + a large file
+ * Exact action surface for a direct coding turn. Context overlap is too broad:
+ * attachment and media actions also carry file/automation contexts, and each
+ * extra tool schema enlarges the request. A large tool set + a large file
  * generation is exactly what makes weaker hosted models (Cerebras glm-4.7)
  * intermittently reject the request (server_error / 400) or narrate instead of
- * emitting FILE. A coding sub-agent does not open/close UI views or spawn its
- * own sub-agents, so dropping these trims the surface toward the tools that
- * actually do the work (FILE/SHELL/WORKTREE/WEB/REPLY/STOP).
+ * emitting FILE. Keep the surface aligned with the tools that actually do the
+ * work (FILE/SHELL/WORKTREE/WEB plus terminal controls).
  */
-const CODING_SUB_AGENT_EXCLUDED_ACTIONS: ReadonlySet<string> = new Set(
+const CODING_DIRECT_ACTIONS: ReadonlySet<string> = new Set(
 	// Stored in normalizeActionIdentifier() form (uppercase, underscores
 	// stripped), since that is what the filter compares against.
-	["VIEWS", "CLOSEVIEW", "CLOSEALLVIEWS", "TASKS"],
+	[
+		"READ",
+		"WRITE",
+		"EDIT",
+		"SHELL",
+		"WORKTREE",
+		"WEBFETCH",
+		"WEBSEARCH",
+		"REPLY",
+		"STOP",
+		"IGNORE",
+	],
 );
 
 function actionNameTokenKey(name: string): string {
@@ -3262,6 +3273,7 @@ export function getCachedActionCatalog(
 
 function buildV5PlannerActionSurface(params: {
 	actions: readonly Action[];
+	forceFullSurface?: boolean;
 	message: Memory;
 	state?: State;
 	messageHandler: MessageHandlerResult;
@@ -3297,12 +3309,8 @@ function buildV5PlannerActionSurface(params: {
 	// small, all-relevant tool set (FILE/SHELL/READ/EDIT/…) and MUST get them all
 	// exposed natively — otherwise the model sees a tool in the prompt but cannot
 	// call it (it lands in tier-B, described-only), narrates instead of acting, and
-	// trips the terminal-only-continuations guard. `ELIZA_PLANNER_FULL_ACTION_SURFACE=1`
-	// opts a runtime into full mode (the eliza-code ACP coding agent sets it).
-	const fullSurfaceFlag =
-		typeof process !== "undefined"
-			? process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase()
-			: undefined;
+	// trips the terminal-only-continuations guard. The trusted per-turn coding
+	// mode opts this invocation into the full surface without global state.
 	// A task_complete relay's only job is delivering the finished result. Any
 	// catalog tool on this synthetic turn invites task-management
 	// improvisation over the completed work (live 2026-08-19: the planner
@@ -3335,11 +3343,7 @@ function buildV5PlannerActionSurface(params: {
 		};
 	}
 	const forceFullSurface =
-		fullSurfaceFlag === "1" ||
-		fullSurfaceFlag === "true" ||
-		fullSurfaceFlag === "yes" ||
-		fullSurfaceFlag === "on" ||
-		params.actions.length === 0;
+		params.forceFullSurface === true || params.actions.length === 0;
 	if (forceFullSurface) {
 		return buildFullV5PlannerActionSurface({
 			actions: params.actions,
@@ -7881,11 +7885,45 @@ function withoutIntermediateVisibleText(content: Content): Content | null {
 	return hasIntermediateCallbackPayload(filtered) ? filtered : null;
 }
 
+/**
+ * Trusted host routing for a dedicated coding turn. This deliberately looks
+ * like the canonical Stage 1 tool result so the existing parsing and safety
+ * pipeline stays shared, but it is never recorded or accounted as a model
+ * response. Authorization remains owned by the normal context/action gates.
+ */
+function directCodingResponseHandlerResult(): GenerateTextResult {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "direct-coding-route",
+				name: HANDLE_RESPONSE_TOOL_NAME,
+				arguments: {
+					shouldRespond: "RESPOND",
+					contexts: [...CODING_SUB_AGENT_CONTEXTS],
+					intents: [],
+					replyText: "",
+					replyEffectStatus: "none",
+					candidateActionNames: [],
+					facts: [],
+					relationships: [],
+					topics: [],
+					addressedTo: [],
+					emotion: "none",
+				},
+			},
+		],
+		finishReason: "tool_calls",
+	};
+}
+
 export async function runV5MessageRuntimeStage1(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	state: State;
 	responseId: UUID;
+	/** Trusted per-turn direct coding-loop selection. */
+	codingMode?: boolean;
 	callback?: HandlerCallback;
 	deliveredVisibleTexts?: Set<string>;
 	plannerLoopConfig?: PlannerLoopParams["config"];
@@ -8079,38 +8117,36 @@ export async function runV5MessageRuntimeStage1(args: {
 			}),
 		);
 
-		// RESPONSE_HANDLER_BEFORE (blocking): hooks fire right before the Stage 1 model
-		// call. Used to inject providers / facts / relationships into the
-		// stable prefix.
-		await timeInferenceSpan(
-			"actions:response-handler-before",
-			() =>
-				args.runtime.runActionsByMode(
-					"RESPONSE_HANDLER_BEFORE",
-					args.message,
-					args.state,
-				),
-			{ mode: "RESPONSE_HANDLER_BEFORE" },
-		);
+		if (!args.codingMode) {
+			// RESPONSE_HANDLER_BEFORE (blocking): hooks fire right before the Stage 1
+			// model call. A direct coding turn has no such model boundary.
+			await timeInferenceSpan(
+				"actions:response-handler-before",
+				() =>
+					args.runtime.runActionsByMode(
+						"RESPONSE_HANDLER_BEFORE",
+						args.message,
+						args.state,
+					),
+				{ mode: "RESPONSE_HANDLER_BEFORE" },
+			);
 
-		// RESPONSE_HANDLER_DURING (non-blocking): fire-and-forget alongside the model
-		// call. We don't await — the user contract is "during".
-		// error-policy:J7 diagnostics-must-not-kill-the-loop — a rejection escaping
-		// runActionsByMode must not abort the turn, but it must surface.
-		const responseHandlerDuring = args.runtime
-			.runActionsByMode("RESPONSE_HANDLER_DURING", args.message, args.state)
-			.catch((err) =>
-				args.runtime.reportError("MessageService.runActionsByMode", err, {
-					mode: "RESPONSE_HANDLER_DURING",
-				}),
-			);
-		if (args.runTerminalOwner) {
-			args.runTerminalOwner.adopt(
-				"RESPONSE_HANDLER_DURING",
-				responseHandlerDuring,
-			);
-		} else {
-			void responseHandlerDuring;
+			// RESPONSE_HANDLER_DURING runs only alongside a real handler model call.
+			const responseHandlerDuring = args.runtime
+				.runActionsByMode("RESPONSE_HANDLER_DURING", args.message, args.state)
+				.catch((err) =>
+					args.runtime.reportError("MessageService.runActionsByMode", err, {
+						mode: "RESPONSE_HANDLER_DURING",
+					}),
+				);
+			if (args.runTerminalOwner) {
+				args.runTerminalOwner.adopt(
+					"RESPONSE_HANDLER_DURING",
+					responseHandlerDuring,
+				);
+			} else {
+				void responseHandlerDuring;
+			}
 		}
 
 		// Per-turn structure forcing. `buildResponseGrammar` composes the
@@ -8203,16 +8239,26 @@ export async function runV5MessageRuntimeStage1(args: {
 		// number of times before falling back to the planner.
 		const stage1RetryLimit = readStage1EmptyRetryLimit(args.runtime);
 		let stage1RetryCount = 0;
-		recordInferenceSpan(
-			"message:stage1:preprocess",
-			performance.now() - stage1PreprocessStartedAt,
-		);
-		let rawMessageHandler = (await args.runtime.useModel(
-			ModelType.RESPONSE_HANDLER,
-			stage1ModelParams,
-		)) as string | GenerateTextResult;
+		if (!args.codingMode) {
+			recordInferenceSpan(
+				"message:stage1:preprocess",
+				performance.now() - stage1PreprocessStartedAt,
+			);
+		} else {
+			args.runtime.logger.debug?.(
+				{ src: "service:message", codingMode: true },
+				"Skipping Stage 1 model call for direct coding loop",
+			);
+		}
+		let rawMessageHandler: string | GenerateTextResult = args.codingMode
+			? directCodingResponseHandlerResult()
+			: ((await args.runtime.useModel(
+					ModelType.RESPONSE_HANDLER,
+					stage1ModelParams,
+				)) as string | GenerateTextResult);
 		let stage1RetryReason = getStage1RetryReason(rawMessageHandler);
 		while (
+			!args.codingMode &&
 			stage1RetryCount < stage1RetryLimit &&
 			shouldRetryStage1Generation(
 				stage1RetryReason,
@@ -8241,9 +8287,9 @@ export async function runV5MessageRuntimeStage1(args: {
 		// right after it completes, before any later model call could overwrite the
 		// runtime-wide last-resolved-provider, so the recorded stage names the real
 		// provider instead of the fabricated "default" literal (#13623).
-		const messageHandlerProvider = args.runtime.getLastResolvedModelProvider?.(
-			ModelType.RESPONSE_HANDLER,
-		);
+		const messageHandlerProvider = args.codingMode
+			? undefined
+			: args.runtime.getLastResolvedModelProvider?.(ModelType.RESPONSE_HANDLER);
 		const rawFieldParsed = extractMessageHandlerRawParsed(rawMessageHandler);
 		// An explicit continuation turn ("finish my request", "that is good")
 		// carries no inferable intent of its own, so candidate inference runs on
@@ -8346,16 +8392,18 @@ export async function runV5MessageRuntimeStage1(args: {
 		// RESPONSE_HANDLER_AFTER (blocking): hooks fire after Stage 1 returns and the
 		// routing decision is parsed, but before the runtime acts on it.
 		// Lets a hook inspect / mutate the parsed plan.
-		await timeInferenceSpan(
-			"actions:response-handler-after",
-			() =>
-				args.runtime.runActionsByMode(
-					"RESPONSE_HANDLER_AFTER",
-					args.message,
-					args.state,
-				),
-			{ mode: "RESPONSE_HANDLER_AFTER" },
-		);
+		if (!args.codingMode) {
+			await timeInferenceSpan(
+				"actions:response-handler-after",
+				() =>
+					args.runtime.runActionsByMode(
+						"RESPONSE_HANDLER_AFTER",
+						args.message,
+						args.state,
+					),
+				{ mode: "RESPONSE_HANDLER_AFTER" },
+			);
+		}
 
 		if (!messageHandler) {
 			if (isEmptyStage1Result(rawMessageHandler)) {
@@ -8391,7 +8439,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		}
 		const parsedResponseHandlerReply = getMessageHandlerReply(messageHandler);
 
-		if (recorder && trajectoryId) {
+		if (!args.codingMode && recorder && trajectoryId) {
 			messageHandlerStageTask = recordMessageHandlerStage({
 				recorder,
 				trajectoryId,
@@ -8603,7 +8651,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler.plan.replyEffectStatus;
 		const prePatchStageOneReplyIsUngroundedAppliedClaim =
 			prePatchStageOneReplyEffectStatus === "applied";
-		const responseHandlerEvaluation = fieldRunResult?.preempt
+		const responseHandlerEvaluation = args.codingMode
 			? {
 					activeEvaluators: [],
 					appliedPatches: [],
@@ -8611,17 +8659,25 @@ export async function runV5MessageRuntimeStage1(args: {
 					candidateActionsClearedByEvaluators: false,
 					errors: [],
 				}
-			: await timeInferenceSpan("evaluators:response-handler", () =>
-					runResponseHandlerEvaluators({
-						runtime: args.runtime,
-						message: args.message,
-						state: args.state,
-						messageHandler,
-						availableContexts,
-						userRoles: [senderRole],
-						evaluators: BUILTIN_RESPONSE_HANDLER_EVALUATORS,
-					}),
-				);
+			: fieldRunResult?.preempt
+				? {
+						activeEvaluators: [],
+						appliedPatches: [],
+						candidateActionsAddedByEvaluators: [],
+						candidateActionsClearedByEvaluators: false,
+						errors: [],
+					}
+				: await timeInferenceSpan("evaluators:response-handler", () =>
+						runResponseHandlerEvaluators({
+							runtime: args.runtime,
+							message: args.message,
+							state: args.state,
+							messageHandler,
+							availableContexts,
+							userRoles: [senderRole],
+							evaluators: BUILTIN_RESPONSE_HANDLER_EVALUATORS,
+						}),
+					);
 		messageHandler.plan.contexts = filterSelectedContextsForRole(
 			messageHandler.plan.contexts,
 			availableContexts,
@@ -8890,25 +8946,25 @@ export async function runV5MessageRuntimeStage1(args: {
 			attachAvailableContexts(recomposedPlannerState, args.runtime),
 			selectedContextRoutingState,
 		);
+		if (args.codingMode === true) {
+			plannerState.data = {
+				...(plannerState.data ?? {}),
+				// Execution-mode provenance only; actions must never use this as an
+				// authorization signal. Coding tools use it to skip chat-only command
+				// rewrites that would alter an explicit repository command.
+				elizaTrustedCodingMode: true,
+			};
+		}
 		// Full-surface mode (a focused coding sub-agent): skip the relevance/role
 		// narrowing entirely and hand the planner EVERY action whose execution gates
 		// pass. The narrowing is built for big chat catalogs (retrieve the relevant
 		// few); a coding agent's whole small tool set is relevant, and narrowing was
 		// returning zero candidates → planner got no native tools → model narrated.
-		const fullSurfaceEnv =
-			typeof process !== "undefined"
-				? process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase()
-				: undefined;
-		const useFullSurface =
-			fullSurfaceEnv === "1" ||
-			fullSurfaceEnv === "true" ||
-			fullSurfaceEnv === "yes" ||
-			fullSurfaceEnv === "on";
+		const useFullSurface = args.codingMode === true;
 		const plannerCandidateActions = useFullSurface
 			? (args.runtime.actions ?? []).filter(
 					(action) =>
-						// Full-surface = the eliza-code coding sub-agent (its ACP server
-						// sets ELIZA_PLANNER_FULL_ACTION_SURFACE). It must NOT receive the
+						// Full-surface = a trusted coding turn. It must NOT receive the
 						// whole chat action catalog (MESSAGE_*/POST_*/…) — 40 tools drowns
 						// the model and it never calls FILE. Instead treat the coding
 						// contexts (code/files/terminal/automation) as active and run the
@@ -8918,11 +8974,9 @@ export async function runV5MessageRuntimeStage1(args: {
 						// messaging/social chat actions. Role still applies (FILE=ADMIN,
 						// SHELL=OWNER; the coding sub-agent runs as OWNER). UI/orchestration
 						// parents that pass the gate but a coder never needs are dropped
-						// too (see CODING_SUB_AGENT_EXCLUDED_ACTIONS) to keep the request
+						// too (see CODING_DIRECT_ACTIONS) to keep the request
 						// small enough for weaker hosted models to handle large builds.
-						!CODING_SUB_AGENT_EXCLUDED_ACTIONS.has(
-							normalizeActionIdentifier(action.name),
-						) &&
+						CODING_DIRECT_ACTIONS.has(normalizeActionIdentifier(action.name)) &&
 						// Static candidate-action set for a coding sub-agent — no concrete
 						// turn message here, so skip the private-action gate; the eventual
 						// execution still enforces it through the executor.
@@ -9084,6 +9138,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			: null;
 		const actionSurface = buildV5PlannerActionSurface({
 			actions: plannerCandidateActions,
+			forceFullSurface: args.codingMode === true,
 			message: args.message,
 			state: plannerState,
 			messageHandler,
@@ -9521,6 +9576,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				runPlannerLoop({
 					runtime: plannerRuntime,
 					context: loopContext,
+					codingMode: args.codingMode === true,
 					config: args.plannerLoopConfig,
 					tools: plannerTools.length > 0 ? plannerTools : undefined,
 					requireNonTerminalToolCall,
@@ -9657,6 +9713,11 @@ export async function runV5MessageRuntimeStage1(args: {
 					)
 				: await invokePlannerLoop(plannerContextAfterEarlyReply);
 		} catch (error) {
+			// A coding turn is an all-the-way-to-verification transaction. A
+			// successful intermediate file operation cannot rescue a loop that hit
+			// its call/token/provider limit before a grounded terminal result; doing
+			// so makes CLI/ACP report partial work as success.
+			if (args.codingMode === true) throw error;
 			const preservedAnswer = prePatchStageOneReplyIsUngroundedAppliedClaim
 				? undefined
 				: prePatchStageOneReply?.trim();
@@ -9759,11 +9820,14 @@ export async function runV5MessageRuntimeStage1(args: {
 			plannerResult.trajectory,
 			exposedPlannerActions,
 		);
-		const plannedReplyEgressDecision = evaluatePlannedReplyEgress({
-			reply: String(plannerResult.finalMessage ?? ""),
-			actionResults: egressActionResults,
-			actions: args.runtime.actions,
-		});
+		const plannedReplyEgressDecision =
+			args.codingMode === true
+				? ({ verdict: "allow" } as const)
+				: evaluatePlannedReplyEgress({
+						reply: String(plannerResult.finalMessage ?? ""),
+						actionResults: egressActionResults,
+						actions: args.runtime.actions,
+					});
 		// A reply an action callback already delivered this turn (verbatim or as
 		// a strict superset) is a planner echo: the suppression below drops it, so
 		// it never egresses. Bouncing it here instead would follow the visible,
@@ -9946,11 +10010,19 @@ export async function runV5MessageRuntimeStage1(args: {
 				effectiveReplyText = relayBody;
 			}
 		}
-		const finalReplyEgressDecision = evaluatePlannedReplyEgress({
-			reply: effectiveReplyText,
-			actionResults,
-			actions: args.runtime.actions,
-		});
+		// Coding-mode terminal claims were already checked against the concrete
+		// planner trajectory (including mandatory post-mutation SHELL proof).
+		// Generic chat egress requires EffectReceipts, which local file tools do
+		// not mint, and would replace a verified coding result with a false
+		// "couldn't verify" fallback.
+		const finalReplyEgressDecision =
+			args.codingMode === true
+				? ({ verdict: "allow" } as const)
+				: evaluatePlannedReplyEgress({
+						reply: effectiveReplyText,
+						actionResults,
+						actions: args.runtime.actions,
+					});
 		if (finalReplyEgressDecision.verdict === "reject") {
 			effectiveReplyText = finalReplyEgressDecision.fallbackReply;
 		}
@@ -12789,6 +12861,7 @@ export class DefaultMessageService implements IMessageService {
 
 				const opts: ResolvedMessageOptions = {
 					maxRetries: options?.maxRetries ?? 3,
+					codingMode: options?.codingMode === true,
 					continueAfterActions:
 						options?.continueAfterActions ??
 						parseBooleanFromText(
@@ -13749,6 +13822,7 @@ export class DefaultMessageService implements IMessageService {
 							message,
 							state,
 							responseId,
+							codingMode: opts.codingMode,
 							...(callback ? { callback } : {}),
 							deliveredVisibleTexts,
 							...(opts.roomHandlerLease

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -26,6 +26,13 @@ export interface MessageProcessingOptions {
 	maxRetries?: number;
 	useMultiStep?: boolean;
 	maxMultiStepIterations?: number;
+	/**
+	 * Run this trusted host turn as a focused coding-agent loop. Coding turns
+	 * enter the planner directly instead of spending a separate model call on
+	 * conversational Stage 1 routing. This is a per-turn execution choice, not
+	 * an authorization signal; normal role and action gates still apply.
+	 */
+	codingMode?: boolean;
 	shouldRespondModel?: ShouldRespondModelType;
 	onStreamChunk?: StreamChunkCallback;
 	/**

--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -1224,6 +1224,7 @@ During a turn: Enter queues the message, Esc/Ctrl+C aborts (queued messages are 
         room,
         text,
         identity: state.identity,
+        codingMode: true,
         abortSignal: turnAbortController.signal,
         onDelta: (delta) => {
           if (turnAbortController.signal.aborted) return;

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -114,11 +114,6 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
       // the role resolver sees the owner at boot.
       identity = ensureSessionIdentity();
       process.env.ELIZA_ADMIN_ENTITY_ID ??= identity.userId;
-      // A coding sub-agent has a small, all-relevant tool set (FILE/SHELL/READ/
-      // EDIT/…); expose them ALL as native tools (full surface, no chat-style
-      // tiering) so the model can actually CALL them instead of only seeing them
-      // described in the prompt and narrating.
-      process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
       // Headless coding sub-agent: only sql + provider + shell + coding-tools.
       // codingOnly drops mcp/goals AND the orchestrator (recursion guard).
       const runtime = await initializeAgent({
@@ -340,6 +335,7 @@ const _connection = new AgentSideConnection(
         text,
         identity,
         source: "acp",
+        codingMode: true,
       });
       await publishParsedReply(params.sessionId, response, (update) =>
         conn.sessionUpdate(update),

--- a/packages/examples/code/src/cli.ts
+++ b/packages/examples/code/src/cli.ts
@@ -15,7 +15,7 @@
 import { readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as readline from "node:readline";
-import type { AgentRuntime } from "@elizaos/core";
+import { type AgentRuntime, ElizaError } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { getAgentClient } from "./lib/agent-client.js";
 import { getCwd, setCwd } from "./lib/cwd.js";
@@ -42,6 +42,7 @@ interface CLIOptions {
   cwd: string | null;
   message: string | null;
   interactive: boolean;
+  codingOnly: boolean;
 }
 
 interface CLIResult {
@@ -95,6 +96,8 @@ Options:
   -f, --file <path>       Read message from file
   -c, --cwd <path>        Set working directory
   -i, --interactive       Force interactive mode (TUI)
+      --coding-only       Load only the direct coding runtime (no orchestrator)
+      --no-orchestrator   Alias for --coding-only
 
 Examples:
   eliza-code "What files are in the current directory?"
@@ -124,6 +127,7 @@ function parseArgs(args: string[]): CLIOptions {
     cwd: null,
     message: null,
     interactive: false,
+    codingOnly: false,
   };
 
   let i = 0;
@@ -156,6 +160,11 @@ function parseArgs(args: string[]): CLIOptions {
       case "-i":
       case "--interactive":
         options.interactive = true;
+        break;
+
+      case "--coding-only":
+      case "--no-orchestrator":
+        options.codingOnly = true;
         break;
 
       case "-f":
@@ -330,8 +339,7 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
     // step." loops). The env seeds boot-time reads; the runtime setting is
     // what getConfiguredOwnerEntityIds actually resolves per turn.
     process.env.ELIZA_ADMIN_ENTITY_ID ??= session.identity.userId;
-    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
-    runtime = await initializeAgent();
+    runtime = await initializeAgent({ codingOnly: options.codingOnly });
     (
       runtime as unknown as { setSetting?: (k: string, v: unknown) => void }
     ).setSetting?.("ELIZA_ADMIN_ENTITY_ID", session.identity.userId);
@@ -349,6 +357,7 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
       room,
       text: message,
       identity: session.identity,
+      codingMode: true,
       onDelta: shouldStream
         ? (delta) => {
             // Write deltas directly for real-time streaming.
@@ -357,6 +366,16 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
           }
         : undefined,
     });
+
+    if (!response.trim()) {
+      throw new ElizaError(
+        "The coding-agent turn ended without a final response.",
+        {
+          code: "ELIZA_CODE_EMPTY_RESPONSE",
+          severity: "fatal",
+        },
+      );
+    }
 
     if (didPrintStreaming) {
       process.stdout.write("\n");
@@ -373,6 +392,19 @@ async function runCLI(options: CLIOptions): Promise<CLIResult> {
     return {
       success: true,
       response,
+      timing: {
+        startedAt,
+        completedAt,
+        durationMs: completedAt - startedAt,
+      },
+    };
+  } catch (error) {
+    // error-policy:J1 The one-shot CLI translates typed/runtime turn failures
+    // into a non-success result so JSON callers and shell exit status agree.
+    const completedAt = Date.now();
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
       timing: {
         startedAt,
         completedAt,

--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -169,7 +169,6 @@ async function runInteractive(): Promise<void> {
   // a fresh TUI two user IDs and grant OWNER to the one that sends no turns.
   const ownerUserId = await resolveTuiOwnerUserId();
   process.env.ELIZA_ADMIN_ENTITY_ID ??= ownerUserId;
-  process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE ??= "1";
 
   // Initialize the agent
   runtime = await initializeAgent({ codingOnly: shouldRunCodingOnly() });

--- a/packages/examples/code/src/lib/agent-client.streaming.test.ts
+++ b/packages/examples/code/src/lib/agent-client.streaming.test.ts
@@ -1,6 +1,8 @@
 // Exercises the Code example behavior that this module protects.
 import { beforeEach, describe, expect, it } from "bun:test";
 import {
+  type Content,
+  FAILED_TOOL_FALLBACK_MESSAGE,
   type HandlerCallback,
   type IAgentRuntime,
   type Memory,
@@ -12,6 +14,7 @@ import { getAgentClient, resetAgentClient } from "./agent-client.js";
 import type { SessionIdentity } from "./identity.js";
 
 interface HandleMessageOptions {
+  codingMode?: boolean;
   abortSignal?: AbortSignal;
   onStreamChunk?: StreamChunkCallback;
 }
@@ -43,7 +46,11 @@ function makeRuntime(
     message: Memory,
     callback?: HandlerCallback,
     options?: HandleMessageOptions,
-  ) => Promise<{ didRespond: boolean; responseMessages: Memory[] }>,
+  ) => Promise<{
+    didRespond: boolean;
+    responseContent?: Content | null;
+    responseMessages: Memory[];
+  }>,
 ): IAgentRuntime {
   return {
     ensureConnection: async () => {},
@@ -78,12 +85,14 @@ describe("AgentClient streaming", () => {
       room: makeRoom(),
       text: "say hello",
       identity: makeIdentity(),
+      codingMode: true,
       abortSignal: abortController.signal,
       onDelta: (delta) => deltas.push(delta),
     });
 
     expect(response).toBe("hello");
     expect(deltas).toEqual(["hel", "lo"]);
+    expect(seenOptions?.codingMode).toBe(true);
     expect(seenOptions?.abortSignal).toBe(abortController.signal);
     expect(typeof seenOptions?.onStreamChunk).toBe("function");
   });
@@ -139,5 +148,77 @@ describe("AgentClient streaming", () => {
 
     expect(response).toBe("The answer is 42.");
     expect(deltas).toEqual(["The answer", " is 42."]);
+  });
+
+  it("uses the returned response content when a host callback is not invoked", async () => {
+    const runtime = makeRuntime(async () => ({
+      didRespond: true,
+      responseContent: { text: "returned directly" },
+      responseMessages: [],
+    }));
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "answer",
+        identity: makeIdentity(),
+      }),
+    ).resolves.toBe("returned directly");
+  });
+
+  it("rejects synthetic runtime replies instead of returning them as success", async () => {
+    const runtime = makeRuntime(async (_runtime, _message, callback) => {
+      await callback?.({
+        text: "Something went wrong on my end. Please try again.",
+        failureKind: "transient_failure",
+        elizaSyntheticFailure: true,
+        transient: true,
+      });
+      return {
+        didRespond: true,
+        responseContent: {
+          text: "Something went wrong on my end. Please try again.",
+          failureKind: "transient_failure",
+          elizaSyntheticFailure: true,
+          transient: true,
+        },
+        responseMessages: [],
+      };
+    });
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "run a tool",
+        identity: makeIdentity(),
+      }),
+    ).rejects.toMatchObject({
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: { failureKind: "transient_failure", transient: true },
+    });
+  });
+
+  it("rejects the planner's failed-tool fallback as a failed coding turn", async () => {
+    const runtime = makeRuntime(async () => ({
+      didRespond: true,
+      responseContent: {
+        text: `${FAILED_TOOL_FALLBACK_MESSAGE}\n\nWork that did complete: read config.go`,
+      },
+      responseMessages: [],
+    }));
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "run a tool",
+        identity: makeIdentity(),
+      }),
+    ).rejects.toMatchObject({
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: { failureKind: "unknown", transient: false },
+    });
   });
 });

--- a/packages/examples/code/src/lib/agent-client.ts
+++ b/packages/examples/code/src/lib/agent-client.ts
@@ -3,6 +3,8 @@ import {
   ChannelType,
   type Content,
   createMessageMemory,
+  ElizaError,
+  FAILED_TOOL_FALLBACK_MESSAGE,
   type IAgentRuntime,
   type Memory,
   type StreamChunkCallback,
@@ -23,6 +25,8 @@ interface SendMessageParams {
   room: ChatRoom;
   text: string;
   identity: SessionIdentity;
+  /** Enter the runtime's trusted direct coding loop for this turn. */
+  codingMode?: boolean;
   userName?: string;
   source?: string;
   channelType?: ChannelType;
@@ -166,19 +170,54 @@ class AgentClient {
     }
 
     const options =
-      params.abortSignal || onDelta
+      params.codingMode || params.abortSignal || onDelta
         ? {
+            ...(params.codingMode ? { codingMode: true } : {}),
             ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
             ...(onDelta ? { onStreamChunk: handleStreamChunk } : {}),
           }
         : undefined;
 
-    await runtime.messageService.handleMessage(
+    const result = await runtime.messageService.handleMessage(
       runtime,
       messageMemory,
       callback,
       options,
     );
+
+    const resultContent = result.responseContent;
+    const resultRecord =
+      resultContent && typeof resultContent === "object"
+        ? resultContent
+        : undefined;
+    const resultText =
+      resultRecord && typeof resultRecord.text === "string"
+        ? resultRecord.text
+        : undefined;
+    if (
+      resultRecord?.elizaSyntheticFailure === true ||
+      resultText?.startsWith(FAILED_TOOL_FALLBACK_MESSAGE) === true
+    ) {
+      const failureKind =
+        typeof resultRecord?.failureKind === "string"
+          ? resultRecord.failureKind
+          : "unknown";
+      const transient = resultRecord?.transient === true;
+      throw new ElizaError(
+        resultText?.trim()
+          ? resultText
+          : "The coding-agent turn failed before producing a result.",
+        {
+          code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+          context: { failureKind, transient },
+          severity: transient ? "ephemeral" : "fatal",
+        },
+      );
+    }
+
+    if (!response && resultRecord && resultText !== undefined) {
+      response = resultText;
+    }
 
     return response;
   }

--- a/packages/examples/code/src/lib/prompts.ts
+++ b/packages/examples/code/src/lib/prompts.ts
@@ -1,10 +1,12 @@
 // Provides shared support logic for the Code example.
 export const CODE_ASSISTANT_SYSTEM_PROMPT = `
-You are Eliza Code, an autonomous coding agent. You complete tasks by USING TOOLS to make real changes on disk — writing and editing files with the FILE action and running commands with the SHELL action — not by describing what should be done.
+You are Eliza Code, an autonomous coding agent. You complete tasks by USING TOOLS to make real changes on disk — inspecting with READ, changing files with EDIT or WRITE, and verifying with SHELL — not by describing what should be done.
 
 How you work:
-- ACT, don't narrate. When asked to build, create, write, or fix something, immediately call the FILE action with the actual file contents (and SHELL to run/verify). NEVER reply with only a description or plan such as "I'll create..." , "Creating the app now", or "Here's the code:" followed by a code block — a turn that does not call a tool leaves nothing on disk and is a FAILED turn.
-- Put the COMPLETE file content inside the FILE tool call's content argument, not in your text reply. For a single-file web app, write the whole self-contained HTML (inline CSS + JS) in one FILE call.
+- ACT, don't narrate. When asked to build, create, write, or fix something, immediately use READ/EDIT/WRITE and SHELL. NEVER reply with only a description or plan such as "I'll create..." , "Creating the app now", or "Here's the code:" followed by a code block — a turn that does not call a tool leaves nothing on disk and is a FAILED turn.
+- If the request names a file, READ that path directly instead of searching for it. Use offset/limit for targeted windows and avoid reading large files wholesale.
+- Prefer exact EDIT for an existing file; use WRITE for a new file or a deliberate complete replacement. Do not rewrite unrelated code, tests, or fixtures merely to make verification pass.
+- Put complete new-file content inside the WRITE tool call's content argument, not in your text reply. For a single-file web app, write the whole self-contained HTML (inline CSS + JS) in one WRITE call.
 - For multi-file or multi-step tasks, perform each step with its own tool call before moving on; write every file before reporting done.
 - Verify: after writing, read the file back or run it, then report the real result (e.g. the actual program output).
 - Only send a text reply (REPLY) once the work is actually done — to briefly summarize what you changed — or to ask a genuinely blocking question. Never claim a file exists unless you wrote it this session.

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -464,7 +464,7 @@ const HTTP_TOKEN68_PATTERN = String.raw`[A-Za-z0-9._~+/\-]+={0,}`;
  */
 const SENSITIVE_TEXT_PATTERNS: readonly string[] = [
   // ENV-style assignments (incl. seed/mnemonic/passphrase/credential names).
-  String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
+  String.raw`/\b(?:[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)|(?:api_key|access_token|refresh_token|auth_token|bot_token|session_key|private_key|client_secret|seed_phrase|connection_string|webhook_url))\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
   // JSON fields.
   String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|client_secret|sessionKey|session_key|authToken|auth_token|botToken|bot_token|connectionString|connection_string|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
   // Quoted credential keys with arbitrary naming — a closing quote sits where

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
@@ -412,6 +412,42 @@ describe("bridge-routes — credential bridge", () => {
     expect((body() as { value: string }).value).toBe("sk-test");
   });
 
+  it("GET rechecks session authorization immediately before disclosing a ready credential", async () => {
+    const adapter = makeAdapter({
+      tryRetrieveCredential: vi
+        .fn()
+        .mockResolvedValue({ status: "ready", value: "sk-must-not-leak" }),
+    });
+    const getSession = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "pty-1-abc", status: "running" })
+      .mockResolvedValueOnce({ id: "pty-1-abc", status: "running" })
+      .mockResolvedValueOnce({ id: "pty-1-abc", status: "stopped" });
+    const ctx = makeCtx(adapter);
+    ctx.acpService = { getSession } as unknown as RouteContext["acpService"];
+    const req = fakeRequest({
+      method: "GET",
+      url: "/api/coding-agents/pty-1-abc/credentials/OPENAI_API_KEY?token=deadbeef",
+    });
+    const { res, status, body } = fakeResponse();
+
+    await handleBridgeRoutes(
+      req,
+      res,
+      "/api/coding-agents/pty-1-abc/credentials/OPENAI_API_KEY",
+      ctx,
+    );
+
+    expect(getSession).toHaveBeenCalledTimes(3);
+    expect(adapter.tryRetrieveCredential).toHaveBeenCalledTimes(1);
+    expect(status()).toBe(410);
+    expect(body()).toEqual({
+      error: "sub-agent session became inactive before credential delivery",
+      code: "session_not_active",
+    });
+    expect(JSON.stringify(body())).not.toContain("sk-must-not-leak");
+  });
+
   it("GET propagates a 410 when scope expired", async () => {
     const adapter = makeAdapter({
       tryRetrieveCredential: vi.fn().mockResolvedValue({ status: "expired" }),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/child-terminal-result.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/child-terminal-result.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Verifies the typed child terminal-result envelope and task-detail projection.
+ * Deterministic domain tests use durable documents only; no model or subprocess.
+ */
+
+import { describe, expect, it } from "vitest";
+import { deriveChildTerminalResult } from "../../src/services/child-terminal-result.js";
+import { toTaskThreadDetail } from "../../src/services/orchestrator-task-mapper.js";
+import type {
+  OrchestratorTaskDocument,
+  OrchestratorTaskEvent,
+  OrchestratorTaskStatus,
+} from "../../src/services/orchestrator-task-types.js";
+
+const ISO = "2026-08-22T00:00:00.000Z";
+
+function documentFor(input: {
+  status: OrchestratorTaskStatus;
+  event: OrchestratorTaskEvent;
+  artifacts?: OrchestratorTaskDocument["artifacts"];
+}): OrchestratorTaskDocument {
+  return {
+    task: {
+      id: "task-child",
+      title: "Child work",
+      goal: "Finish safely",
+      kind: "task",
+      status: input.status,
+      priority: "normal",
+      originalRequest: "delegate this",
+      acceptanceCriteria: ["evidence is present"],
+      parentTaskId: "task-parent",
+      paused: false,
+      archived: false,
+      createdAt: ISO,
+      updatedAt: ISO,
+      lastActivityAt: 1,
+      metadata: {},
+    },
+    sessions: [
+      {
+        id: "session-row",
+        taskId: "task-child",
+        sessionId: "session-child",
+        framework: "pi-agent",
+        label: "Ada",
+        originalTask: "Finish safely",
+        workdir: "/repo",
+        status: "completed",
+        decisionCount: 0,
+        autoResolvedCount: 0,
+        registeredAt: 1,
+        lastActivityAt: 2,
+        idleCheckCount: 0,
+        taskDelivered: true,
+        lastSeenDecisionIndex: 0,
+        spawnedAt: 1,
+        retryCount: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cacheTokens: 0,
+        costUsd: 0,
+        usageState: "unavailable",
+        traceId: "trace-parent-child",
+        parentTrajectoryStepId: "trajectory-step-parent",
+        childTrajectoryIds: ["trajectory-child"],
+        metadata: { parentSessionId: "session-parent" },
+        createdAt: ISO,
+        updatedAt: ISO,
+      },
+    ],
+    events: [input.event],
+    messages: [],
+    usage: [],
+    artifacts: input.artifacts ?? [],
+    decisions: [],
+    planRevisions: [],
+  };
+}
+
+function event(
+  eventType: string,
+  data: Record<string, unknown>,
+): OrchestratorTaskEvent {
+  return {
+    id: `event-${eventType}`,
+    taskId: "task-child",
+    sessionId: "session-child",
+    eventType,
+    summary: eventType,
+    data,
+    timestamp: 10,
+    createdAt: ISO,
+  };
+}
+
+describe("child terminal-result envelope", () => {
+  it("surfaces a task-creator question as awaiting_user and redacts secrets", () => {
+    const result = deriveChildTerminalResult(
+      documentFor({
+        status: "waiting_on_user",
+        event: event("QUESTION_FOR_TASK_CREATOR", {
+          question:
+            "Which account should I use? OPENAI_API_KEY=sk-live-secret-value",
+          deliveryStatus: "delivered",
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: "awaiting_user",
+      requiresUserInput: true,
+      deliveryStatus: "delivered",
+    });
+    expect(result?.question).toContain("Which account should I use?");
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-value");
+  });
+
+  it("keeps an orchestrator-answerable coordination blocker off the user-question path", () => {
+    const result = deriveChildTerminalResult(
+      documentFor({
+        status: "blocked",
+        event: event("blocked", {
+          routingKind: "AGENT_COORDINATION",
+          message: "Need the orchestrator to inspect the sibling task output.",
+          question: "Can the sibling result satisfy this dependency?",
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      blocker: "Need the orchestrator to inspect the sibling task output.",
+      requiresUserInput: false,
+    });
+    expect(result?.question).toBeUndefined();
+  });
+
+  it("requires evidence before a child completion is sufficient and projects it through the detail API", () => {
+    const pendingDoc = documentFor({
+      status: "validating",
+      event: event("task_complete", { response: "Implemented the change." }),
+    });
+    const pending = toTaskThreadDetail(pendingDoc).childTerminalResult;
+    expect(pending).toMatchObject({
+      status: "completed",
+      verificationStatus: "pending",
+      deliveryStatus: "delivered",
+      evidence: {
+        required: true,
+        present: false,
+        sufficient: false,
+        artifactRefs: [],
+      },
+      lineage: {
+        taskId: "task-child",
+        sessionId: "session-child",
+        parentTaskId: "task-parent",
+        parentSessionId: "session-parent",
+        traceId: "trace-parent-child",
+        parentTrajectoryStepId: "trajectory-step-parent",
+        childTrajectoryIds: ["trajectory-child"],
+      },
+    });
+
+    const passedDoc = documentFor({
+      status: "done",
+      event: event("task_complete", {
+        response: "Implemented and verified the change.",
+        evidence: "bun test: 12 passed",
+      }),
+      artifacts: [
+        {
+          id: "artifact-pr",
+          taskId: "task-child",
+          sessionId: "session-child",
+          artifactType: "pull_request",
+          title: "PR",
+          uri: "https://example.test/pull/1",
+          verificationStatus: "passed",
+          metadata: {},
+          createdAt: ISO,
+        },
+      ],
+    });
+    const passed = toTaskThreadDetail(passedDoc).childTerminalResult;
+    expect(passed).toMatchObject({
+      status: "completed",
+      verificationStatus: "passed",
+      evidence: {
+        required: true,
+        present: true,
+        sufficient: true,
+        artifactRefs: [
+          {
+            id: "artifact-pr",
+            type: "pull_request",
+            ref: "https://example.test/pull/1",
+            verificationStatus: "passed",
+          },
+        ],
+      },
+    });
+  });
+
+  it("represents failed and cancelled children explicitly", () => {
+    const failedDoc = documentFor({
+      status: "failed",
+      event: event("error", { message: "Worker process exited." }),
+    });
+    failedDoc.events.push({
+      ...event("validation_failed", { reason: "Evidence did not verify." }),
+      timestamp: 20,
+    });
+    const failed = deriveChildTerminalResult(failedDoc);
+    expect(failed).toMatchObject({
+      status: "failed",
+      summary: "Worker process exited.",
+      verificationStatus: "failed",
+      requiresUserInput: false,
+    });
+
+    const cancelled = deriveChildTerminalResult(
+      documentFor({
+        status: "interrupted",
+        event: event("stopped", { message: "Cancelled by parent." }),
+      }),
+    );
+    expect(cancelled).toMatchObject({
+      status: "cancelled",
+      summary: "Cancelled by parent.",
+      verificationStatus: "not_applicable",
+      requiresUserInput: false,
+    });
+  });
+
+  it("preserves an inconclusive verifier outcome as retryable evidence state", () => {
+    const doc = documentFor({
+      status: "waiting_on_user",
+      event: event("task_complete", { response: "Work is ready for review." }),
+    });
+    doc.events.push({
+      ...event("goal_verify_inconclusive", {
+        reason: "Verifier model unavailable.",
+      }),
+      timestamp: 20,
+    });
+
+    expect(deriveChildTerminalResult(doc)).toMatchObject({
+      status: "awaiting_user",
+      verificationStatus: "inconclusive",
+      evidence: { required: true, sufficient: false },
+    });
+  });
+
+  it("derives redacted evidence and honest artifact states from a valid CompletionEnvelope", () => {
+    const completion = {
+      diffSummary:
+        "Implemented child results in /private/tmp/internal/src/result.ts",
+      filesChanged: [
+        "/private/tmp/internal/src/result.ts",
+        "src/unverified.ts",
+      ],
+      verifiedChangedFiles: [
+        {
+          path: "/private/tmp/internal/src/result.ts",
+          exists: true,
+          absolutePath: "/private/tmp/internal/src/result.ts",
+        },
+      ],
+      missingArtifacts: ["/private/tmp/internal/screenshots/missing.png"],
+      testResults: [
+        {
+          command: "bun test /private/tmp/internal/result.test.ts",
+          exitCode: 0,
+          summary: "Passed /private/tmp/internal/result.test.ts",
+        },
+      ],
+      screenshotPaths: ["/private/tmp/internal/screenshots/missing.png"],
+      trajectoryPath: "/private/tmp/internal/traces/trajectory.jsonl",
+      acceptanceCriteriaStatus: [
+        {
+          criterion: "Result is projected",
+          met: true,
+          evidence: "Verified in /private/tmp/internal/src/result.ts",
+        },
+      ],
+      residualRisks: [],
+    };
+    const result = deriveChildTerminalResult(
+      documentFor({
+        status: "done",
+        event: event("task_complete", {
+          response: `Finished.\n\`\`\`json\n${JSON.stringify(completion)}\n\`\`\``,
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: "completed",
+      summary: "Implemented child results in result.ts",
+      verificationStatus: "passed",
+      evidence: {
+        required: true,
+        present: true,
+        sufficient: true,
+        artifactRefs: [
+          {
+            type: "verified_file",
+            ref: "result.ts",
+            verificationStatus: "passed",
+          },
+          {
+            type: "claimed_file",
+            ref: "src/unverified.ts",
+            verificationStatus: "unknown",
+          },
+          {
+            type: "screenshot",
+            ref: "missing.png",
+            verificationStatus: "failed",
+          },
+          {
+            type: "trajectory",
+            ref: "trajectory.jsonl",
+            verificationStatus: "unknown",
+          },
+        ],
+      },
+    });
+    expect(result?.evidence.summary).toContain("Tests 1/1 passed");
+    expect(result?.evidence.summary).toContain("Criteria 1/1 met");
+    expect(JSON.stringify(result)).not.toContain("/private/tmp/internal");
+  });
+
+  it("does not let late stopped or error events override verified completion", () => {
+    const doc = documentFor({
+      status: "done",
+      event: event("task_complete", {
+        response: JSON.stringify({
+          diffSummary: "Completed and verified.",
+          filesChanged: [],
+          testResults: [],
+          screenshotPaths: [],
+          acceptanceCriteriaStatus: [],
+          residualRisks: [],
+        }),
+      }),
+    });
+    doc.events.push(
+      { ...event("error", { message: "late adapter error" }), timestamp: 20 },
+      { ...event("stopped", { message: "late stop" }), timestamp: 30 },
+      { ...event("validation_passed", {}), timestamp: 40 },
+    );
+
+    expect(deriveChildTerminalResult(doc)).toMatchObject({
+      status: "completed",
+      summary: "Completed and verified.",
+      verificationStatus: "passed",
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/child-terminal-result.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/child-terminal-result.test.ts
@@ -276,6 +276,13 @@ describe("child terminal-result envelope", () => {
           exitCode: 0,
           summary: "Passed /private/tmp/internal/result.test.ts",
         },
+        { command: "bun run typecheck", exitCode: 0, summary: "Types pass" },
+        { command: "bun run lint", exitCode: 0, summary: "Lint passes" },
+        {
+          command: "bun run test:e2e",
+          exitCode: 1,
+          summary: "Fourth check failed",
+        },
       ],
       screenshotPaths: ["/private/tmp/internal/screenshots/missing.png"],
       trajectoryPath: "/private/tmp/internal/traces/trajectory.jsonl",
@@ -284,6 +291,13 @@ describe("child terminal-result envelope", () => {
           criterion: "Result is projected",
           met: true,
           evidence: "Verified in /private/tmp/internal/src/result.ts",
+        },
+        { criterion: "Types pass", met: true, evidence: "Typecheck output" },
+        { criterion: "Lint passes", met: true, evidence: "Lint output" },
+        {
+          criterion: "End-to-end path passes",
+          met: false,
+          evidence: "Fourth criterion failed",
         },
       ],
       residualRisks: [],
@@ -329,8 +343,12 @@ describe("child terminal-result envelope", () => {
         ],
       },
     });
-    expect(result?.evidence.summary).toContain("Tests 1/1 passed");
-    expect(result?.evidence.summary).toContain("Criteria 1/1 met");
+    expect(result?.evidence.summary).toContain("Tests 3/4 passed");
+    expect(result?.evidence.summary).toContain("failed: Fourth check failed");
+    expect(result?.evidence.summary).toContain("Criteria 3/4 met");
+    expect(result?.evidence.summary).toContain(
+      "unmet: End-to-end path passes (Fourth criterion failed)",
+    );
     expect(JSON.stringify(result)).not.toContain("/private/tmp/internal");
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
@@ -342,6 +342,15 @@ describe("parseJudgeResponse", () => {
     expect(parsed.missing).toEqual(["c1"]);
   });
 
+  it("marks a JSON object without the verdict schema inconclusive", () => {
+    const parsed = parseJudgeResponse("{}", ["c1"]);
+    expect(parsed).toMatchObject({
+      passed: false,
+      missing: ["c1"],
+      inconclusive: true,
+    });
+  });
+
   it("trims whitespace from missing entries and drops empties", () => {
     const parsed = parseJudgeResponse(
       '{"passed": false, "summary": "s", "missing": ["  c1  ", "", "c2"]}',
@@ -376,6 +385,7 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     expect(result.summary).toMatch(/no acceptance criteria/i);
     expect(result.missing).toEqual([]);
     expect(result.rawResponse).toBe("");
+    expect(result.inconclusive).toBe(false);
   });
 
   it("short-circuits to fail when completionEvidence is empty", async () => {
@@ -425,7 +435,7 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     );
   });
 
-  it("returns a structured fail when the model throws", async () => {
+  it("returns an inconclusive verdict when the verifier model is unavailable", async () => {
     const runtime = makeMockRuntime({
       shouldThrow: new Error("provider down"),
     });
@@ -438,6 +448,7 @@ describe("verifyGoalCompletion (orchestration paths)", () => {
     expect(result.summary).toMatch(/provider down/);
     expect(result.missing).toEqual(["c1"]);
     expect(result.rawResponse).toBe("");
+    expect(result.inconclusive).toBe(true);
   });
 
   it("returns a passed verdict on a clean model response", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -48,10 +48,9 @@ import { CodingWorkspaceService } from "../../src/services/workspace-service.js"
 
 // This suite pins the status state machine and the ACP→task event bridge — NOT
 // the #8896 default-criteria feature. createTask now auto-populates acceptance
-// criteria for criteria-free, non-trivial goals (which would make these tasks
-// auto-verify on `task_complete` instead of parking in `validating`). Disable
-// the goal contract here so these tests exercise the original criteria-free
-// behavior; the default-criteria feature has its own dedicated suites
+// criteria for criteria-free, non-trivial goals. Disable the goal contract here
+// so these tests exercise the explicit criteria-free completion gate; the
+// default-criteria feature has its own dedicated suites
 // (acceptance-criteria.test.ts, create-task-default-criteria.test.ts).
 const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
 beforeAll(() => {
@@ -1732,7 +1731,7 @@ describe("OrchestratorTaskService — event bridge session status", () => {
       await drive(acp, sessionId, "task_complete", {
         response: "Updated foo.",
       });
-      await settleStatus(service, task.id, "validating");
+      await settleStatus(service, task.id, "done");
 
       const detail = must(await service.getTask(task.id), "detail");
       const metadata = must(detail.sessions[0], "session").metadata;
@@ -1907,10 +1906,10 @@ describe("OrchestratorTaskService — event bridge session status", () => {
 });
 
 describe("OrchestratorTaskService — task status guards", () => {
-  it("moves the task to validating on completion, never straight to done", async () => {
+  it("completes criteria-free work once deterministic gates pass", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "done" });
-    await settleStatus(service, taskId, "validating");
+    await settleStatus(service, taskId, "done");
   });
 
   it("routes blocked and login_required to the right task status", async () => {
@@ -1934,21 +1933,18 @@ describe("OrchestratorTaskService — task status guards", () => {
     );
   });
 
-  it("does not let a later active signal stomp validating", async () => {
+  it("does not let a later active signal stomp criteria-free completion", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "done" });
-    await settleStatus(service, taskId, "validating");
+    await settleStatus(service, taskId, "done");
     await drive(acp, sessionId, "tool_running", { toolCall: { title: "ls" } });
-    expect(must(await service.getTask(taskId), "detail").status).toBe(
-      "validating",
-    );
+    expect(must(await service.getTask(taskId), "detail").status).toBe("done");
   });
 
   it("never mutates a terminal task from a session event", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "done" });
-    await settleStatus(service, taskId, "validating");
-    await service.validateTask(taskId, { passed: true, summary: "verified" });
+    await settleStatus(service, taskId, "done");
     await drive(acp, sessionId, "tool_running", { toolCall: { title: "ls" } });
     expect(must(await service.getTask(taskId), "detail").status).toBe("done");
   });
@@ -2727,14 +2723,13 @@ describe("OrchestratorTaskService — restart reconstruction (#13771)", () => {
 // teardown race — the process dropped its state AFTER the deliverable shipped.
 // The router suppresses its respawn for exactly this case (the completion
 // claim in router-loop-guard); the task bridge must be symmetric: keep the
-// `completed` session record, keep the task in `validating` so the in-flight
-// verification can finish (validateTask requires `validating`), and spend
-// nothing from the crash-retry budget.
+// `completed` session record, keep the criteria-free task terminal after its
+// deterministic completion gate, and spend nothing from the crash-retry budget.
 describe("OrchestratorTaskService — post-completion teardown race (#13830 audit)", () => {
-  it("drops a late session error after task_complete: task stays validating, session stays completed", async () => {
+  it("drops a late session error after task_complete: task stays done, session stays completed", async () => {
     const { service, acp, taskId, sessionId } = await withSpawnedSession();
     await drive(acp, sessionId, "task_complete", { response: "shipped" });
-    await settleStatus(service, taskId, "validating");
+    await settleStatus(service, taskId, "done");
     expect(
       must(must(await service.getTask(taskId), "mid").sessions[0], "session")
         .status,
@@ -2749,7 +2744,7 @@ describe("OrchestratorTaskService — post-completion teardown race (#13830 audi
     await flush();
 
     const after = must(await service.getTask(taskId), "after");
-    expect(after.status).toBe("validating");
+    expect(after.status).toBe("done");
     expect(must(after.sessions[0], "session").status).toBe("completed");
     expect(
       after.events?.some((e) => e.eventType === "session_error_retrying"),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1603,6 +1603,21 @@ describe("OrchestratorTaskService — event bridge session status", () => {
     expect(session.taskDelivered).toBe(true);
     expect(session.completionSummary).toBe("shipped it");
     expect(session.stoppedAt).toBeTruthy();
+    const completionEvent = must(
+      (await service.getTask(taskId))?.events.find(
+        (event) => event.eventType === "task_complete",
+      ),
+      "completion event",
+    );
+    expect(completionEvent.data.childTerminalResult).toMatchObject({
+      schemaVersion: 1,
+      status: "completed",
+      summary: "shipped it",
+      evidence: { required: true, present: false, sufficient: false },
+      lineage: { taskId, sessionId },
+      verificationStatus: "pending",
+      deliveryStatus: "unknown",
+    });
   });
 
   it("keeps verifier feedback out of the corrected retry's evidence", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -27,10 +27,7 @@ import {
 } from "../services/goal-llm-verifier.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import { OrchestratorTaskStore } from "../services/orchestrator-task-store.js";
-import {
-  type AttemptReflection,
-  MAX_ATTEMPT_REFLECTIONS,
-} from "../services/orchestrator-task-types.js";
+import type { AttemptReflection } from "../services/orchestrator-task-types.js";
 
 describe("shouldAutoVerifyGoal", () => {
   const prev = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
@@ -1009,8 +1006,8 @@ describe("independent read-only verifier (#8898)", () => {
  * Reflexion persistence (#8899): drive the REAL `autoVerifyCompletion` append
  * path (orchestrator-task-service.ts) so each failed verdict writes a
  * `{attempt, missing, summary}` post-mortem into `metadata.attemptReflections`,
- * the buffer caps at {@link MAX_ATTEMPT_REFLECTIONS} (dropping the oldest), and
- * malformed persisted entries are sanitized by `readAttemptReflections`. The
+ * prior post-mortems remain complete, and malformed persisted entries are
+ * sanitized by `readAttemptReflections`. The
  * shipped render leaf is already covered by goal-prompt.test.ts; this exercises
  * the stateful loop end to end with no hand-injected reflection array.
  */
@@ -1103,10 +1100,10 @@ describe("attempt reflection persistence (#8899)", () => {
     });
   });
 
-  it("caps the buffer at MAX_ATTEMPT_REFLECTIONS, dropping the oldest", async () => {
+  it("retains every prior reflection when appending a new one", async () => {
     const seeded: AttemptReflection[] = Array.from(
-      { length: MAX_ATTEMPT_REFLECTIONS },
-      (_unused, index) => ({
+      { length: 5 },
+      (_, index) => ({
         attempt: index + 1,
         summary: `reflection-${index + 1}`,
         missing: ["tests pass"],
@@ -1115,7 +1112,7 @@ describe("attempt reflection persistence (#8899)", () => {
     const { store, taskId } = await driveOneVerify({
       acceptanceCriteria: ["tests pass"],
       // Under the auto-verify attempt cap so the append branch (not the
-      // waiting_on_user escalation) runs and exercises `.slice(-MAX)`.
+      // waiting_on_user escalation) runs.
       seedMetadata: { autoVerifyAttempts: 1, attemptReflections: seeded },
       verdict: {
         passed: false,
@@ -1125,9 +1122,9 @@ describe("attempt reflection persistence (#8899)", () => {
     });
     await vi.waitFor(async () => {
       const reflections = await reflectionsOf(store, taskId);
-      expect(reflections).toHaveLength(MAX_ATTEMPT_REFLECTIONS);
-      // Oldest dropped, newest appended.
+      expect(reflections).toHaveLength(6);
       expect(reflections.map((r) => r.summary)).toEqual([
+        "reflection-1",
         "reflection-2",
         "reflection-3",
         "reflection-4",

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -351,7 +351,7 @@ describe("auto goal verification on task_complete", () => {
     expect(fake.service.sendToSession).not.toHaveBeenCalled();
   });
 
-  it("does nothing extra for a task with no acceptance criteria", async () => {
+  it("completes a criteria-free task after deterministic gates pass", async () => {
     const fake = makeFakeAcp();
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const { taskId, sessionId } = await seedTaskWithSession(store, []);
@@ -371,10 +371,17 @@ describe("auto goal verification on task_complete", () => {
     fake.emit(sessionId, "task_complete", { response: "done" });
     await until(async () => {
       const task = await store.getTask(taskId);
-      return task?.task.status === "validating";
+      return task?.task.status === "done";
     });
     const doc = await store.getTask(taskId);
-    expect(doc?.task.status).toBe("validating");
+    expect(doc?.task.status).toBe("done");
+    expect(
+      doc?.events.some(
+        (event) =>
+          event.eventType === "validation_passed" &&
+          event.data?.verifier === "criteria-free-completion-gate",
+      ),
+    ).toBe(true);
     expect(useModel).not.toHaveBeenCalled();
     expect(fake.service.sendToSession).not.toHaveBeenCalled();
   });
@@ -914,7 +921,7 @@ describe("independent read-only verifier (#8898)", () => {
     expect(useModel).not.toHaveBeenCalled();
   });
 
-  it("an inconclusive verifier verdict keeps the task validating (no false promotion)", async () => {
+  it("an inconclusive verifier verdict is retryable without consuming a worker attempt", async () => {
     const fake = makeVerifierAcp(() => INCONCLUSIVE_VERIFIER_ENVELOPE);
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const { taskId, sessionId } = await seedCodeChangeTask(store, [
@@ -952,6 +959,8 @@ describe("independent read-only verifier (#8898)", () => {
     // promotion) — so the task returns to `active`, not `done`.
     expect(doc?.task.status).toBe("active");
     expect(doc?.task.status).not.toBe("done");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBeUndefined();
+    expect(doc?.task.metadata.attemptReflections).toBeUndefined();
     expect(useModel).not.toHaveBeenCalled();
     // #20794: the worker is an `opencode` session, which never emits a
     // CompletionEnvelope — the correction must demand producible evidence,
@@ -1295,7 +1304,7 @@ describe("deterministic completion-residuals gate", () => {
     );
   });
 
-  it("a criteria-free CLEAN workspace keeps the prior behavior: parks validating, no model spend", async () => {
+  it("a criteria-free CLEAN workspace completes without model spend", async () => {
     const fake = makeFakeAcp();
     const store = new OrchestratorTaskStore({ backend: "memory" });
     const { taskId, sessionId } = await seedTaskWithSession(store, []);
@@ -1305,19 +1314,108 @@ describe("deterministic completion-residuals gate", () => {
 
     fake.emit(sessionId, "task_complete", { response: "done" });
     await until(
-      async () =>
-        (await store.getTask(taskId))?.task.metadata.completionResiduals !==
-        undefined,
+      async () => (await store.getTask(taskId))?.task.status === "done",
     );
 
     const doc = await store.getTask(taskId);
-    expect(doc?.task.status).toBe("validating");
+    expect(doc?.task.status).toBe("done");
     expect(useModel).not.toHaveBeenCalled();
     expect(fake.service.sendToSession).not.toHaveBeenCalled();
     const snapshot = doc?.task.metadata.completionResiduals as
       | { status: string }
       | undefined;
     expect(snapshot?.status).toBe("clean");
+  });
+
+  it("a verifier-model outage reopens retryably without consuming a worker attempt", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    const useModel = vi.fn(async () => {
+      throw new Error("provider temporarily unavailable");
+    });
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      useModel,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done with evidence" });
+    await until(
+      async () =>
+        (await store.getTask(taskId))?.events.some(
+          (event) => event.eventType === "goal_verify_inconclusive",
+        ) === true,
+    );
+
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("active");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBeUndefined();
+    expect(doc?.task.metadata.attemptReflections).toBeUndefined();
+    expect(
+      doc?.events.find(
+        (event) => event.eventType === "goal_verify_inconclusive",
+      )?.data,
+    ).toMatchObject({ retryable: true, verifier: "llm-goal-verifier" });
+    expect(fake.sent.at(-1)?.text).toContain("not counted as a failed attempt");
+  });
+
+  it("an unexpected auto-verifier exception cannot leave the task validating", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    let failSettingRead = true;
+    const reportError = vi.fn();
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: (key: string) => {
+        if (
+          failSettingRead &&
+          key === "ELIZA_ORCHESTRATOR_GROUND_TRUTH_EVIDENCE"
+        ) {
+          failSettingRead = false;
+          throw new Error("settings backend offline");
+        }
+        return undefined;
+      },
+      useModel: vi.fn(async () =>
+        JSON.stringify({ passed: true, summary: "not reached", missing: [] }),
+      ),
+      reportError,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done with evidence" });
+    await until(
+      async () =>
+        (await store.getTask(taskId))?.events.some(
+          (event) => event.eventType === "auto_verify_inconclusive",
+        ) === true,
+    );
+
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("active");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBeUndefined();
+    expect(reportError).toHaveBeenCalledWith(
+      "OrchestratorTaskService.autoVerifyCompletion",
+      expect.any(Error),
+      { taskId, sessionId },
+    );
   });
 
   it("a MISSING workspace on a repo-bound task is unverifiable: stays validating WITHOUT burning an attempt (fail closed, F5a)", async () => {

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -334,13 +334,46 @@ async function handleGet(
       scopedToken,
     });
     if (outcome.status === "ready") {
+      // The long-poll may have waited minutes after the initial ownership
+      // check. Re-authorize at the disclosure boundary: a child that stopped,
+      // was removed, or otherwise became terminal while the adapter was
+      // waiting must never receive the plaintext even if its one-shot scope
+      // became ready in the same race.
+      const authorizedSession = await resolveActiveSession(ctx, sessionId);
+      if (!authorizedSession) {
+        sendJson(
+          res,
+          {
+            error:
+              "sub-agent session became inactive before credential delivery",
+            code: "session_not_active",
+          },
+          410,
+        );
+        return;
+      }
       // #8907: tell the origin thread the task is unblocked (best-effort).
       await emitCredentialResolved({
         runtime: ctx.runtime,
-        metadata: session.metadata,
+        metadata: authorizedSession.metadata,
         key,
-        label: session.name,
+        label: authorizedSession.name,
       });
+      // `emitCredentialResolved` may cross a connector boundary. Close that
+      // final await-shaped race as well: this check is the last operation
+      // before the synchronous plaintext response write.
+      if (!(await resolveActiveSession(ctx, sessionId))) {
+        sendJson(
+          res,
+          {
+            error:
+              "sub-agent session became inactive before credential delivery",
+            code: "session_not_active",
+          },
+          410,
+        );
+        return;
+      }
       sendJson(res, {
         key,
         value: outcome.value,

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -2435,6 +2435,14 @@ export { AcpService } from "./services/acp-service.js";
 // Terminal-output normalizer for chat surfaces; consumed by live smoke harnesses.
 export { cleanForChat } from "./services/ansi-utils.js";
 export {
+  type ChildDeliveryStatus,
+  type ChildTerminalArtifactRef,
+  type ChildTerminalResultEnvelope,
+  type ChildTerminalStatus,
+  type ChildVerificationStatus,
+  deriveChildTerminalResult,
+} from "./services/child-terminal-result.js";
+export {
   COMPLETION_ENVELOPE_INSTRUCTION,
   type CompletionEnvelope,
   envelopeCorrection,

--- a/plugins/plugin-agent-orchestrator/src/services/child-terminal-result.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/child-terminal-result.ts
@@ -1,0 +1,451 @@
+/**
+ * Builds the redacted, typed result envelope shared by durable child events and
+ * the orchestrator task-detail API. The envelope is additive: task/session
+ * records keep their existing schema while event `data.childTerminalResult`
+ * captures the point-in-time result and the detail DTO exposes the latest view.
+ */
+
+import { redactSensitiveText } from "@elizaos/core";
+import {
+  type CompletionEnvelope,
+  parseCompletionEnvelope,
+} from "./completion-envelope.js";
+import type {
+  ArtifactVerificationStatus,
+  OrchestratorTaskDocument,
+  OrchestratorTaskEvent,
+  OrchestratorTaskStatus,
+} from "./orchestrator-task-types.js";
+
+export type ChildTerminalStatus =
+  | "completed"
+  | "failed"
+  | "blocked"
+  | "awaiting_user"
+  | "cancelled";
+
+export type ChildVerificationStatus =
+  | "pending"
+  | "passed"
+  | "failed"
+  | "inconclusive"
+  | "not_applicable";
+
+export type ChildDeliveryStatus =
+  | "pending"
+  | "delivered"
+  | "failed"
+  | "not_requested"
+  | "unknown";
+
+export interface ChildTerminalArtifactRef {
+  id: string;
+  type: string;
+  ref: string;
+  verificationStatus: ArtifactVerificationStatus;
+}
+
+export interface ChildTerminalResultEnvelope {
+  schemaVersion: 1;
+  status: ChildTerminalStatus;
+  summary: string;
+  evidence: {
+    required: boolean;
+    present: boolean;
+    sufficient: boolean;
+    summary?: string;
+    artifactRefs: ChildTerminalArtifactRef[];
+  };
+  blocker?: string;
+  question?: string;
+  requiresUserInput: boolean;
+  lineage: {
+    taskId: string;
+    sessionId?: string;
+    parentTaskId?: string;
+    parentSessionId?: string;
+    traceId?: string;
+    parentTrajectoryStepId?: string;
+    childTrajectoryIds: string[];
+  };
+  verificationStatus: ChildVerificationStatus;
+  deliveryStatus: ChildDeliveryStatus;
+}
+
+const TERMINAL_EVENTS = new Set([
+  "task_complete",
+  "error",
+  "blocked",
+  "login_required",
+  "QUESTION_FOR_TASK_CREATOR",
+  "stopped",
+  "cancelled",
+]);
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function text(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = redactSensitiveText(value).trim();
+  return trimmed || undefined;
+}
+
+function withoutAbsolutePaths(value: string): string {
+  return value.replace(
+    /(^|[\s("'`])((?:\/|[A-Za-z]:\\)[^\s)"',;]+)/g,
+    (_match, prefix: string, path: string) =>
+      `${prefix}${path.split(/[\\/]/).filter(Boolean).at(-1) ?? "artifact"}`,
+  );
+}
+
+function summaryText(value: unknown): string | undefined {
+  const safe = text(value);
+  return safe ? withoutAbsolutePaths(safe) : undefined;
+}
+
+function safeArtifactRef(value: unknown): string | undefined {
+  const safe = text(value);
+  if (!safe) return undefined;
+  try {
+    const url = new URL(safe);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      url.username = "";
+      url.password = "";
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    }
+  } catch {
+    // error-policy:J3 artifact references may be paths or opaque ids, not URLs.
+  }
+  if (/^(?:\/|[A-Za-z]:\\)/.test(safe)) {
+    return safe.split(/[\\/]/).filter(Boolean).at(-1);
+  }
+  return withoutAbsolutePaths(safe);
+}
+
+function sameClaim(left: string, right: string): boolean {
+  const normalize = (value: string) => value.replace(/\\/g, "/");
+  const a = normalize(left);
+  const b = normalize(right);
+  return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+}
+
+function completionEvidenceSummary(envelope: CompletionEnvelope): string {
+  const passedTests = envelope.testResults.filter(
+    (result) => result.exitCode === 0,
+  ).length;
+  const metCriteria = envelope.acceptanceCriteriaStatus.filter(
+    (criterion) => criterion.met,
+  ).length;
+  const testDetails = envelope.testResults
+    .slice(0, 3)
+    .map(
+      (result) =>
+        `${result.exitCode === 0 ? "passed" : "failed"}: ${summaryText(result.summary) ?? "no summary"}`,
+    )
+    .join("; ");
+  const criterionDetails = envelope.acceptanceCriteriaStatus
+    .slice(0, 3)
+    .map(
+      (criterion) =>
+        `${criterion.met ? "met" : "unmet"}: ${summaryText(criterion.criterion) ?? "criterion"} (${summaryText(criterion.evidence) ?? "no evidence"})`,
+    )
+    .join("; ");
+  return [
+    `Tests ${passedTests}/${envelope.testResults.length} passed${testDetails ? ` (${testDetails})` : ""}.`,
+    `Criteria ${metCriteria}/${envelope.acceptanceCriteriaStatus.length} met${criterionDetails ? ` (${criterionDetails})` : ""}.`,
+  ].join(" ");
+}
+
+function completionArtifactRefs(
+  envelope: CompletionEnvelope,
+): ChildTerminalArtifactRef[] {
+  const missing = envelope.missingArtifacts ?? [];
+  const verified = envelope.verifiedChangedFiles ?? [];
+  const statusForClaim = (
+    claim: string,
+    verifiedStatus?: ArtifactVerificationStatus,
+  ): ArtifactVerificationStatus => {
+    if (verifiedStatus) return verifiedStatus;
+    if (missing.some((candidate) => sameClaim(candidate, claim)))
+      return "failed";
+    return envelope.artifactsVerified === true ? "passed" : "unknown";
+  };
+  const refs: ChildTerminalArtifactRef[] = [];
+  const append = (
+    type: string,
+    claim: string,
+    index: number,
+    verificationStatus?: ArtifactVerificationStatus,
+  ): void => {
+    const ref = safeArtifactRef(claim);
+    if (!ref) return;
+    refs.push({
+      id: `completion:${type}:${index}`,
+      type,
+      ref,
+      verificationStatus: statusForClaim(claim, verificationStatus),
+    });
+  };
+  verified.forEach((file, index) => {
+    append(
+      "verified_file",
+      file.path,
+      index,
+      file.exists ? "passed" : "failed",
+    );
+  });
+  envelope.filesChanged
+    .filter((claim) => !verified.some((file) => sameClaim(file.path, claim)))
+    .forEach((claim, index) => {
+      append("claimed_file", claim, index);
+    });
+  envelope.screenshotPaths.forEach((claim, index) => {
+    append("screenshot", claim, index);
+  });
+  if (envelope.trajectoryPath) {
+    append("trajectory", envelope.trajectoryPath, 0);
+  }
+  return refs;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.flatMap((entry) => {
+        const safe = text(entry);
+        return safe ? [safe] : [];
+      })
+    : [];
+}
+
+function deliveryStatus(value: unknown): ChildDeliveryStatus {
+  return value === "pending" ||
+    value === "delivered" ||
+    value === "failed" ||
+    value === "not_requested" ||
+    value === "unknown"
+    ? value
+    : "unknown";
+}
+
+function routingKind(data: Record<string, unknown>): string | undefined {
+  return text(data.routingKind ?? data.type ?? data.kind ?? data.purpose)
+    ?.toUpperCase()
+    .trim();
+}
+
+function statusForEvent(
+  eventType: string,
+  data: Record<string, unknown>,
+): ChildTerminalStatus {
+  if (eventType === "task_complete") return "completed";
+  if (eventType === "error") return "failed";
+  if (eventType === "stopped" || eventType === "cancelled") return "cancelled";
+  const route = routingKind(data);
+  // An explicit coordination route means the parent/orchestrator should answer
+  // even when the child phrased its blocker as a question.
+  if (route === "AGENT_COORDINATION") return "blocked";
+  if (
+    eventType === "login_required" ||
+    eventType === "QUESTION_FOR_TASK_CREATOR" ||
+    route === "QUESTION_FOR_TASK_CREATOR" ||
+    text(data.question)
+  ) {
+    return "awaiting_user";
+  }
+  return "blocked";
+}
+
+function statusForTask(
+  taskStatus: OrchestratorTaskStatus,
+  eventStatus: ChildTerminalStatus,
+): ChildTerminalStatus {
+  if (taskStatus === "done") return "completed";
+  if (taskStatus === "failed") return "failed";
+  if (taskStatus === "waiting_on_user") return "awaiting_user";
+  if (taskStatus === "interrupted") return "cancelled";
+  if (taskStatus === "blocked") return "blocked";
+  return eventStatus;
+}
+
+function verificationFor(
+  taskStatus: OrchestratorTaskStatus,
+  events: readonly OrchestratorTaskEvent[],
+  terminalStatus: ChildTerminalStatus,
+): ChildVerificationStatus {
+  if (taskStatus === "done") return "passed";
+  if (taskStatus === "validating") return "pending";
+  const latestVerification = [...events]
+    .reverse()
+    .find((event) =>
+      [
+        "validation_passed",
+        "validation_failed",
+        "goal_verify_inconclusive",
+        "independent_verify_inconclusive",
+        "auto_verify_inconclusive",
+      ].includes(event.eventType),
+    );
+  if (latestVerification?.eventType === "validation_passed") return "passed";
+  if (latestVerification?.eventType === "validation_failed") return "failed";
+  if (latestVerification?.eventType.includes("inconclusive")) {
+    return "inconclusive";
+  }
+  return terminalStatus === "completed" ? "pending" : "not_applicable";
+}
+
+function latestTerminalEvent(
+  events: readonly OrchestratorTaskEvent[],
+  taskStatus: OrchestratorTaskStatus,
+): OrchestratorTaskEvent | undefined {
+  const terminal = [...events]
+    .filter((event) => TERMINAL_EVENTS.has(event.eventType))
+    .sort((a, b) => b.timestamp - a.timestamp);
+  const preferred =
+    taskStatus === "done" || taskStatus === "validating"
+      ? ["task_complete"]
+      : taskStatus === "failed"
+        ? ["error"]
+        : taskStatus === "interrupted"
+          ? ["cancelled", "stopped"]
+          : taskStatus === "waiting_on_user"
+            ? ["QUESTION_FOR_TASK_CREATOR", "login_required", "blocked"]
+            : taskStatus === "blocked"
+              ? ["blocked", "QUESTION_FOR_TASK_CREATOR"]
+              : [];
+  return (
+    terminal.find((event) => preferred.includes(event.eventType)) ?? terminal[0]
+  );
+}
+
+/** Build the latest terminal child result, or undefined before any terminal event. */
+export function deriveChildTerminalResult(
+  doc: OrchestratorTaskDocument,
+  eventOverride?: Pick<
+    OrchestratorTaskEvent,
+    "eventType" | "sessionId" | "summary" | "data" | "timestamp"
+  >,
+): ChildTerminalResultEnvelope | undefined {
+  const event =
+    eventOverride ?? latestTerminalEvent(doc.events, doc.task.status);
+  if (!event || !TERMINAL_EVENTS.has(event.eventType)) return undefined;
+  const data = record(event.data);
+  const sessionId = event.sessionId;
+  const session = sessionId
+    ? doc.sessions.find((candidate) => candidate.sessionId === sessionId)
+    : undefined;
+  const eventStatus = statusForEvent(event.eventType, data);
+  const status = statusForTask(doc.task.status, eventStatus);
+  const isQuestion = eventStatus === "awaiting_user";
+  const question = isQuestion
+    ? text(data.question ?? data.message ?? data.prompt ?? event.summary)
+    : undefined;
+  const blocker =
+    status === "blocked" || status === "awaiting_user"
+      ? text(data.blocker ?? data.message ?? event.summary)
+      : undefined;
+  const rawCompletion =
+    typeof data.response === "string"
+      ? data.response
+      : typeof data.finalText === "string"
+        ? data.finalText
+        : undefined;
+  const completion =
+    event.eventType === "task_complete" && rawCompletion
+      ? parseCompletionEnvelope(rawCompletion)
+      : { present: false as const };
+  const completionEnvelope =
+    completion.present && completion.ok ? completion.envelope : undefined;
+  const summary =
+    summaryText(
+      completionEnvelope?.diffSummary ??
+        data.response ??
+        data.finalText ??
+        data.message ??
+        event.summary,
+    ) ?? "Child agent returned without a summary.";
+  const durableArtifactRefs = doc.artifacts
+    .filter(
+      (artifact) =>
+        !sessionId || !artifact.sessionId || artifact.sessionId === sessionId,
+    )
+    .flatMap((artifact) => {
+      const ref = safeArtifactRef(artifact.uri ?? artifact.path);
+      return ref
+        ? [
+            {
+              id: artifact.id,
+              type: artifact.artifactType,
+              ref,
+              verificationStatus: artifact.verificationStatus,
+            },
+          ]
+        : [];
+    });
+  const artifactRefs = [
+    ...durableArtifactRefs,
+    ...(completionEnvelope ? completionArtifactRefs(completionEnvelope) : []),
+  ];
+  const evidenceSummary = completionEnvelope
+    ? completionEvidenceSummary(completionEnvelope)
+    : summaryText(data.evidence ?? data.diffSummary ?? data.testSummary);
+  // A completion claim keeps its proof requirement even if an inconclusive
+  // verifier subsequently moves the durable task to a user-waiting state.
+  const evidenceRequired = eventStatus === "completed";
+  const evidencePresent = Boolean(evidenceSummary || artifactRefs.length > 0);
+  const verificationStatus = verificationFor(
+    doc.task.status,
+    doc.events,
+    status,
+  );
+  const childTrajectoryIds = [
+    ...new Set([
+      ...(session?.childTrajectoryIds ?? []),
+      ...stringArray(data.childTrajectoryIds),
+      ...stringArray(data.trajectoryIds),
+      ...(text(data.trajectoryId) ? [text(data.trajectoryId) as string] : []),
+    ]),
+  ];
+  const sessionMeta = record(session?.metadata);
+  const explicitDeliveryStatus = deliveryStatus(data.deliveryStatus);
+  return {
+    schemaVersion: 1,
+    status,
+    summary,
+    evidence: {
+      required: evidenceRequired,
+      present: evidencePresent,
+      sufficient:
+        !evidenceRequired ||
+        (evidencePresent && verificationStatus === "passed"),
+      ...(evidenceSummary ? { summary: evidenceSummary } : {}),
+      artifactRefs,
+    },
+    ...(blocker ? { blocker } : {}),
+    ...(question ? { question } : {}),
+    requiresUserInput: status === "awaiting_user",
+    lineage: {
+      taskId: doc.task.id,
+      ...(sessionId ? { sessionId } : {}),
+      ...(doc.task.parentTaskId ? { parentTaskId: doc.task.parentTaskId } : {}),
+      ...(text(sessionMeta.parentSessionId)
+        ? { parentSessionId: text(sessionMeta.parentSessionId) }
+        : {}),
+      ...(session?.traceId ? { traceId: session.traceId } : {}),
+      ...(session?.parentTrajectoryStepId
+        ? { parentTrajectoryStepId: session.parentTrajectoryStepId }
+        : {}),
+      childTrajectoryIds,
+    },
+    verificationStatus,
+    deliveryStatus:
+      explicitDeliveryStatus === "unknown" && session?.taskDelivered === true
+        ? "delivered"
+        : explicitDeliveryStatus,
+  };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/child-terminal-result.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/child-terminal-result.ts
@@ -143,14 +143,12 @@ function completionEvidenceSummary(envelope: CompletionEnvelope): string {
     (criterion) => criterion.met,
   ).length;
   const testDetails = envelope.testResults
-    .slice(0, 3)
     .map(
       (result) =>
         `${result.exitCode === 0 ? "passed" : "failed"}: ${summaryText(result.summary) ?? "no summary"}`,
     )
     .join("; ");
   const criterionDetails = envelope.acceptanceCriteriaStatus
-    .slice(0, 3)
     .map(
       (criterion) =>
         `${criterion.met ? "met" : "unmet"}: ${summaryText(criterion.criterion) ?? "criterion"} (${summaryText(criterion.evidence) ?? "no evidence"})`,

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -291,6 +291,10 @@ export interface GoalVerificationResult {
   missing: string[];
   /** Raw model response text, kept for the audit log and for tests. */
   rawResponse: string;
+  /** True when verification itself could not produce a verdict. Callers must
+   *  retry/escalate infrastructure without charging the worker's correction
+   *  budget. */
+  inconclusive: boolean;
 }
 
 const EMPTY_CRITERIA_SUMMARY =
@@ -353,6 +357,7 @@ interface ParsedJudgeResponse {
   passed: boolean;
   summary: string;
   missing: string[];
+  inconclusive: boolean;
 }
 
 function findFirstJsonObject(raw: string): string | null {
@@ -381,6 +386,7 @@ export function parseJudgeResponse(
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
       missing: [...acceptanceCriteria],
+      inconclusive: true,
     };
   }
   let parsed: unknown;
@@ -393,6 +399,7 @@ export function parseJudgeResponse(
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
       missing: [...acceptanceCriteria],
+      inconclusive: true,
     };
   }
   if (parsed === null || typeof parsed !== "object") {
@@ -400,17 +407,24 @@ export function parseJudgeResponse(
       passed: false,
       summary: MALFORMED_RESPONSE_SUMMARY,
       missing: [...acceptanceCriteria],
+      inconclusive: true,
     };
   }
   const record = parsed as Record<string, unknown>;
   const passedRaw = record.passed;
   const summaryRaw = record.summary;
   const missingRaw = record.missing;
-  const missing = Array.isArray(missingRaw)
-    ? missingRaw
-        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-        .filter((entry) => entry.length > 0)
-    : [];
+  if (typeof passedRaw !== "boolean" || !Array.isArray(missingRaw)) {
+    return {
+      passed: false,
+      summary: MALFORMED_RESPONSE_SUMMARY,
+      missing: [...acceptanceCriteria],
+      inconclusive: true,
+    };
+  }
+  const missing = missingRaw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
   // Enforce the schema invariant: missing non-empty ⇒ passed false.
   const passed = passedRaw === true && missing.length === 0;
   const summary =
@@ -419,7 +433,7 @@ export function parseJudgeResponse(
       : passed
         ? "All acceptance criteria confirmed by verifier."
         : "Verifier did not confirm every acceptance criterion.";
-  return { passed, summary, missing };
+  return { passed, summary, missing, inconclusive: false };
 }
 
 /**
@@ -441,6 +455,7 @@ export async function verifyGoalCompletion(
       summary: EMPTY_CRITERIA_SUMMARY,
       missing: [],
       rawResponse: "",
+      inconclusive: false,
     };
   }
   if (input.completionEvidence.trim().length === 0) {
@@ -449,6 +464,7 @@ export async function verifyGoalCompletion(
       summary: EMPTY_EVIDENCE_SUMMARY,
       missing: [...input.acceptanceCriteria],
       rawResponse: "",
+      inconclusive: false,
     };
   }
   const prompt = buildVerificationPrompt(input);
@@ -462,13 +478,15 @@ export async function verifyGoalCompletion(
     raw = typeof result === "string" ? result : String(result);
   } catch (err) {
     // error-policy:J1 boundary translation — a failed verifier model call
-    // becomes a structured fail verdict naming the error, never a fake pass.
+    // becomes an explicit inconclusive verdict naming the error, never a fake
+    // pass or a worker-attributed proof failure.
     const detail = err instanceof Error ? err.message : String(err);
     return {
       passed: false,
       summary: `Verifier model call failed: ${toWellFormedUnicode(detail)}`,
       missing: [...input.acceptanceCriteria],
       rawResponse: "",
+      inconclusive: true,
     };
   }
   // Record the grill model boundary (prompt + verdict) so the scenario

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-mapper.ts
@@ -12,6 +12,10 @@
  * @module services/orchestrator-task-mapper
  */
 
+import {
+  type ChildTerminalResultEnvelope,
+  deriveChildTerminalResult,
+} from "./child-terminal-result.js";
 import type {
   ArtifactVerificationStatus,
   OrchestratorTaskDocument,
@@ -230,6 +234,9 @@ export interface TaskThreadDetailDto extends TaskThreadDto {
   messages: TaskMessageDto[];
   transcripts: TaskTranscriptDto[];
   planRevisions: TaskPlanRevisionDto[];
+  /** Additive typed terminal result; absent until a child reaches a terminal or
+   *  user-blocked state, preserving the historical wire shape for active tasks. */
+  childTerminalResult?: ChildTerminalResultEnvelope;
 }
 
 function latestSession(doc: OrchestratorTaskDocument) {
@@ -467,6 +474,7 @@ function deriveAdmission(
 export function toTaskThreadDetail(
   doc: OrchestratorTaskDocument,
 ): TaskThreadDetailDto {
+  const childTerminalResult = deriveChildTerminalResult(doc);
   return {
     ...toTaskThread(doc),
     goal: doc.task.goal,
@@ -560,5 +568,6 @@ export function toTaskThreadDetail(
         createdAt: message.createdAt,
       })),
     planRevisions: doc.planRevisions.map(toTaskPlanRevisionDto),
+    ...(childTerminalResult ? { childTerminalResult } : {}),
   };
 }

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -59,6 +59,7 @@ import {
   type SerializableSpawnOpts,
 } from "./admission-queue.js";
 import { assignAgentName } from "./agent-name-assignment.js";
+import { deriveChildTerminalResult } from "./child-terminal-result.js";
 import {
   extractWriteLedger,
   verifyClaimedFiles,
@@ -1603,6 +1604,17 @@ export class OrchestratorTaskService extends Service {
           ? snapshotTaskId
           : await this.resolveTaskId(sessionId);
       if (!taskId) return;
+      const rawData = isRecord(data) ? data : { value: data };
+      const taskDoc = await this.store.getTask(taskId);
+      const childTerminalResult = taskDoc
+        ? deriveChildTerminalResult(taskDoc, {
+            eventType: event,
+            sessionId,
+            summary: describeEvent(event, data),
+            data: rawData,
+            timestamp: Date.now(),
+          })
+        : undefined;
       await this.store.addEvent({
         id: randomUUID(),
         taskId,
@@ -1610,7 +1622,10 @@ export class OrchestratorTaskService extends Service {
         ...(turnId ? { turnId } : {}),
         eventType: event,
         summary: describeEvent(event, data),
-        data: isRecord(data) ? data : { value: data },
+        data: {
+          ...rawData,
+          ...(childTerminalResult ? { childTerminalResult } : {}),
+        },
         timestamp: Date.now(),
         createdAt: nowIso(),
       });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -3801,9 +3801,10 @@ export class OrchestratorTaskService extends Service {
    * 3. **Independent execution verifier (#8898).** For code-change tasks
    *    ({@link shouldRunIndependentVerify}) a SEPARATE read-only ACP session re-runs
    *    the tests/diff and returns an execution-grounded verdict. A failing verdict
-   *    BLOCKS (provenance `independent-acp-verifier`); an inconclusive verdict keeps
-   *    the task `validating` (never a false promotion on a verifier crash); a
-   *    passing/skipped verdict falls through.
+   *    BLOCKS (provenance `independent-acp-verifier`); an inconclusive verdict
+   *    reopens a retryable worker turn without consuming its corrective-attempt
+   *    budget (never a false promotion on a verifier crash); a passing/skipped
+   *    verdict falls through.
    * 4. **Text judge (fallback).** {@link verifyGoalCompletion} (`ModelType.TEXT_SMALL`)
    *    judges the evidence and promotes (→ `done`) or re-prompts.
    *
@@ -3840,12 +3841,50 @@ export class OrchestratorTaskService extends Service {
       );
     } catch (err) {
       // error-policy:J7 auto-verify is fire-and-forget from the event bridge; a
-      // failure warns and must not break the session-event write path.
+      // failure warns and must not break the session-event write path. Recover
+      // the durable state too: logging alone used to strand the task forever in
+      // `validating`, with no retry surface and no terminal signal.
       this.log("warn", "auto goal verification failed", {
         taskId,
         sessionId,
         error: err instanceof Error ? err.message : String(err),
       });
+      this.runtime.reportError?.(
+        "OrchestratorTaskService.autoVerifyCompletion",
+        err,
+        { taskId, sessionId },
+      );
+      try {
+        await this.withTaskWriteLock(taskId, () =>
+          this.retryInconclusiveVerification({
+            taskId,
+            sessionId,
+            eventType: "auto_verify_inconclusive",
+            verifier: "auto-verifier-infrastructure",
+            summary: `Automatic verification could not run: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            correction:
+              "Automatic verification was temporarily unavailable. Your work was not counted as a failed attempt. Please re-report completion with the same concrete evidence so verification can retry.",
+          }),
+        );
+      } catch (recoveryErr) {
+        // error-policy:J7 diagnostics/recovery must not reject the detached
+        // event handler. A second failure is reported distinctly.
+        this.log("error", "failed to recover inconclusive auto verification", {
+          taskId,
+          sessionId,
+          error:
+            recoveryErr instanceof Error
+              ? recoveryErr.message
+              : String(recoveryErr),
+        });
+        this.runtime.reportError?.(
+          "OrchestratorTaskService.autoVerifyRecovery",
+          recoveryErr,
+          { taskId, sessionId },
+        );
+      }
     } finally {
       this.autoVerifyInFlight.delete(taskId);
     }
@@ -4030,9 +4069,23 @@ export class OrchestratorTaskService extends Service {
       }
 
       const acceptanceCriteria = doc.task.acceptanceCriteria;
-      // Criteria-free tasks keep the prior behavior after deterministic gates:
-      // stay `validating` for a human/manual caller, with no model spend.
-      if (acceptanceCriteria.length === 0) return;
+      // With no criteria there is nothing for the model judge to decide. Once
+      // the deterministic residuals/ground-truth gates above are clear, finish
+      // explicitly instead of leaving the task permanently `validating`.
+      if (acceptanceCriteria.length === 0) {
+        await this.validateTaskLocked(taskId, {
+          passed: true,
+          summary:
+            "No acceptance criteria were specified; deterministic completion gates passed.",
+          evidence:
+            completionEvidence.trim() ||
+            rawCompletion.trim() ||
+            "Criteria-free completion passed deterministic gates.",
+          verifier: "criteria-free-completion-gate",
+        });
+        this.emitChange(taskId);
+        return;
+      }
 
       // 2. Structural envelope gate (#8895) — BEFORE any model spend.
       if (parse.present && !parse.ok) {
@@ -4218,17 +4271,10 @@ export class OrchestratorTaskService extends Service {
       );
       if (independent) {
         if (independent.inconclusive) {
-          // A verifier crash/empty verdict is never a pass — but a silent
-          // return here parked the task in `validating` forever with no
-          // re-prompt, no escalation, and no signal to the task creator
-          // (observed live: a website-build task whose final task_complete hit
-          // "no usable CompletionEnvelope" and then sat `validating` for
-          // hours while the user asked "is it done?"). Route it through the
-          // shared re-engage/escalate path like every other non-pass verdict:
-          // under the attempts cap the worker is re-prompted to re-report
-          // with the structured envelope (making the next verify decidable);
-          // at the cap the task parks on waiting_on_user instead of ghosting.
-          await this.reEngageOrEscalate({
+          // A verifier crash/empty verdict is an infrastructure outcome, not
+          // evidence that the worker failed a criterion. Re-open a retryable
+          // turn, but preserve the worker's bounded corrective-attempt budget.
+          await this.retryInconclusiveVerification({
             taskId,
             sessionId,
             correction: [
@@ -4241,11 +4287,6 @@ export class OrchestratorTaskService extends Service {
             eventType: "independent_verify_inconclusive",
             verifier: INDEPENDENT_ACP_VERIFIER_NAME,
             summary: independent.summary,
-            missing: [
-              ...independent.unmet,
-              ...independent.failedCommands.map((c) => `command failed: ${c}`),
-            ],
-            attempt: attempts,
           });
           return;
         }
@@ -4308,6 +4349,19 @@ export class OrchestratorTaskService extends Service {
         },
       );
 
+      if (verdict.inconclusive) {
+        await this.retryInconclusiveVerification({
+          taskId,
+          sessionId,
+          eventType: "goal_verify_inconclusive",
+          verifier: LLM_GOAL_VERIFIER_NAME,
+          summary: verdict.summary,
+          correction:
+            "The goal-verification model was temporarily unavailable or returned no usable verdict. Your work was not counted as a failed attempt. Please re-report completion with the same concrete evidence so verification can retry.",
+        });
+        return;
+      }
+
       if (verdict.passed) {
         await this.validateTaskLocked(taskId, {
           passed: true,
@@ -4339,6 +4393,70 @@ export class OrchestratorTaskService extends Service {
         attempt: attempts,
       });
     }
+  }
+
+  /**
+   * Re-open a task when the verifier itself could not decide. This deliberately
+   * does not write `autoVerifyAttempts` or `attemptReflections`: those counters
+   * measure worker proof failures, not provider outages, malformed judge
+   * responses, or verifier subprocess failures.
+   */
+  private async retryInconclusiveVerification(args: {
+    taskId: string;
+    sessionId: string;
+    correction: string;
+    eventType: string;
+    verifier: string;
+    summary: string;
+  }): Promise<void> {
+    const { taskId, sessionId, correction, eventType, verifier, summary } =
+      args;
+    const doc = await this.store.getTask(taskId);
+    if (doc?.task.status !== "validating") return;
+    await this.store.addEvent({
+      id: randomUUID(),
+      taskId,
+      sessionId,
+      eventType,
+      summary,
+      data: { verifier, retryable: true },
+      timestamp: Date.now(),
+      createdAt: nowIso(),
+    });
+    try {
+      await this.store.updateSession(sessionId, {
+        status: "ready",
+        taskDelivered: false,
+        stoppedAt: undefined,
+      });
+      await this.sendToTaskAgent(
+        taskId,
+        sessionId,
+        correction,
+        "validation_failed",
+      );
+      await this.advanceTaskStatus(taskId, "validation_failed");
+    } catch (sendErr) {
+      // error-policy:J1 boundary — an inconclusive verifier plus an unavailable
+      // worker is surfaced to a human instead of remaining stuck validating.
+      await this.store.addEvent({
+        id: randomUUID(),
+        taskId,
+        sessionId,
+        eventType: "auto_verify_retry_failed",
+        summary:
+          "Verification was inconclusive and its retry could not be delivered; escalating to a human.",
+        data: {
+          verifier,
+          retryable: true,
+          error: sendErr instanceof Error ? sendErr.message : String(sendErr),
+        },
+        timestamp: Date.now(),
+        createdAt: nowIso(),
+      });
+      await this.advanceTaskStatus(taskId, "awaiting_user");
+    }
+    this.emitChange(taskId);
   }
 
   /**

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -1,6 +1,6 @@
 # @elizaos/plugin-coding-tools
 
-Native Claude-Code-style coding tools (FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
+Native coding tools (READ, WRITE, EDIT, FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
 
 ## Purpose / role
 
@@ -11,13 +11,14 @@ Adds filesystem operations, shell command execution, and git worktree management
 ### Actions
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
+- **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
 - **SHELL** — `action=run` executes a command via `/bin/bash -c`; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
 
-- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects the complete retained command history (stdout/stderr/exit code), cwd, allowed directory, and file operations into context; fires only in `terminal`/`code` contexts.
-- **AVAILABLE_CODING_TOOLS** — injects the list of available tool names (`FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
+- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects a bounded projection of the last 10 commands (size-capped stdout/stderr/exit code), cwd, allowed directory, and recent file operations into context while `ShellService` retains complete history; fires only in `terminal`/`code` contexts.
+- **AVAILABLE_CODING_TOOLS** — injects the available focused and umbrella tool names (`READ`, `WRITE`, `EDIT`, `FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
 
 ### Services
 
@@ -44,6 +45,7 @@ plugins/plugin-coding-tools/
     types.ts                      Service-type constants, ToolFailure/ToolResult types, CODING_TOOLS_CONTEXTS
     actions/
       file.ts                     FILE umbrella action — routes to per-op handlers
+      direct-file-actions.ts      strict READ / WRITE / EDIT action wrappers
       bash.ts                     SHELL action implementation
       worktree.ts                 WORKTREE umbrella action
       read.ts / write.ts / edit.ts  FILE sub-handlers for read/write/edit
@@ -103,7 +105,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |
-| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Pre-stat byte cap on FILE action=read. Larger files are rejected. |
+| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Byte cap for selected FILE read content. Larger files are paged with bounded line or byte reads. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Default `head_limit` for GREP output. Set to 0 to disable. |
 
 The folded `ShellService` also retains compatibility settings for external

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -123,6 +123,15 @@ canonical SHELL action above continues to use the `CODING_TOOLS_*` settings.
 | `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
 | `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
 
+Foreground SHELL transcripts shown to the planner are capped at 50,000
+characters. When that cap is reached, the action writes the complete redacted
+stdout and stderr plus a manifest under
+`ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
+paths with byte/line counts, and leaves the bounded preview in the tool result.
+Artifact directories are owner-only (`0700`) and files are `0600`. They use
+`SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
+opportunistically when the next truncated foreground result is persisted.
+
 Auto-enable keys (in agent `config.features`):
 - `config.features.codingTools` (canonical) — `true` or `{ enabled: true }`.
 - `config.features["coding-agent"]` (legacy alias).

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -12,7 +12,7 @@ Adds filesystem operations, shell command execution, and git worktree management
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
 - **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
-- **SHELL** — `action=run` executes a command via `/bin/bash -c`; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
+- **SHELL** — `action=run` executes a command via `/bin/bash -c`; oversized foreground results return an opaque handle whose complete redacted stdout/stderr can be paged with `read_output_artifact` only by the same agent and conversation; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
@@ -127,8 +127,11 @@ Foreground SHELL transcripts shown to the planner are capped at 50,000
 characters. When that cap is reached, the action writes the complete redacted
 stdout and stderr plus a manifest under
 `ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
-paths with byte/line counts, and leaves the bounded preview in the tool result.
-Artifact directories are owner-only (`0700`) and files are `0600`. They use
+byte/line counts, and leaves the bounded preview in the tool result. The action
+does not disclose state-root paths. `action=read_output_artifact` retrieves a
+bounded stdout or stderr page only when the opaque handle's persisted agent and
+conversation scope match the requesting turn. Artifact directories are
+owner-only (`0700`) and files are `0600`. They use
 `SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
 opportunistically when the next truncated foreground result is persisted.
 

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -1,6 +1,6 @@
 # @elizaos/plugin-coding-tools
 
-Native Claude-Code-style coding tools (FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
+Native coding tools (READ, WRITE, EDIT, FILE, SHELL, WORKTREE) for Eliza agents running in code/terminal/automation contexts.
 
 ## Purpose / role
 
@@ -11,13 +11,14 @@ Adds filesystem operations, shell command execution, and git worktree management
 ### Actions
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
+- **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
 - **SHELL** — `action=run` executes a command via `/bin/bash -c`; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
 
-- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects the complete retained command history (stdout/stderr/exit code), cwd, allowed directory, and file operations into context; fires only in `terminal`/`code` contexts.
-- **AVAILABLE_CODING_TOOLS** — injects the list of available tool names (`FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
+- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects a bounded projection of the last 10 commands (size-capped stdout/stderr/exit code), cwd, allowed directory, and recent file operations into context while `ShellService` retains complete history; fires only in `terminal`/`code` contexts.
+- **AVAILABLE_CODING_TOOLS** — injects the available focused and umbrella tool names (`READ`, `WRITE`, `EDIT`, `FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
 
 ### Services
 
@@ -44,6 +45,7 @@ plugins/plugin-coding-tools/
     types.ts                      Service-type constants, ToolFailure/ToolResult types, CODING_TOOLS_CONTEXTS
     actions/
       file.ts                     FILE umbrella action — routes to per-op handlers
+      direct-file-actions.ts      strict READ / WRITE / EDIT action wrappers
       bash.ts                     SHELL action implementation
       worktree.ts                 WORKTREE umbrella action
       read.ts / write.ts / edit.ts  FILE sub-handlers for read/write/edit
@@ -103,7 +105,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read before truncation. |
-| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Pre-stat byte cap on FILE action=read. Larger files are rejected. |
+| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Byte cap for selected FILE read content. Larger files are paged with bounded line or byte reads. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Default `head_limit` for GREP output. Set to 0 to disable. |
 
 The folded `ShellService` also retains compatibility settings for external

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -123,6 +123,15 @@ canonical SHELL action above continues to use the `CODING_TOOLS_*` settings.
 | `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
 | `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
 
+Foreground SHELL transcripts shown to the planner are capped at 50,000
+characters. When that cap is reached, the action writes the complete redacted
+stdout and stderr plus a manifest under
+`ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
+paths with byte/line counts, and leaves the bounded preview in the tool result.
+Artifact directories are owner-only (`0700`) and files are `0600`. They use
+`SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
+opportunistically when the next truncated foreground result is persisted.
+
 Auto-enable keys (in agent `config.features`):
 - `config.features.codingTools` (canonical) — `true` or `{ enabled: true }`.
 - `config.features["coding-agent"]` (legacy alias).

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -12,7 +12,7 @@ Adds filesystem operations, shell command execution, and git worktree management
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
 - **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
-- **SHELL** — `action=run` executes a command via `/bin/bash -c`; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
+- **SHELL** — `action=run` executes a command via `/bin/bash -c`; oversized foreground results return an opaque handle whose complete redacted stdout/stderr can be paged with `read_output_artifact` only by the same agent and conversation; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
@@ -127,8 +127,11 @@ Foreground SHELL transcripts shown to the planner are capped at 50,000
 characters. When that cap is reached, the action writes the complete redacted
 stdout and stderr plus a manifest under
 `ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
-paths with byte/line counts, and leaves the bounded preview in the tool result.
-Artifact directories are owner-only (`0700`) and files are `0600`. They use
+byte/line counts, and leaves the bounded preview in the tool result. The action
+does not disclose state-root paths. `action=read_output_artifact` retrieves a
+bounded stdout or stderr page only when the opaque handle's persisted agent and
+conversation scope match the requesting turn. Artifact directories are
+owner-only (`0700`) and files are `0600`. They use
 `SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
 opportunistically when the next truncated foreground result is persisted.
 

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -1,13 +1,14 @@
 # @elizaos/plugin-coding-tools
 
-Native Claude-Code-style coding tools for elizaOS agents. Adds filesystem operations (read, write, edit, search, glob, ls), shell command execution, and git worktree management to any Eliza agent running in a code or terminal context.
+Native coding tools for elizaOS agents. Adds focused read/write/edit actions, filesystem search and listing, shell command execution, and git worktree management to any Eliza agent running in a code or terminal context.
 
 ## What it does
 
-The plugin registers three umbrella actions and a set of supporting services:
+The plugin registers three focused file actions, three umbrella actions, and a set of supporting services:
 
 | Action | Operations | Description |
 |---|---|---|
+| **READ / WRITE / EDIT** | one operation each | Pi-shaped strict schemas for direct coding loops. They reuse FILE's sandbox, stale-file, secret, and size guards. |
 | **FILE** | `read`, `write`, `edit`, `grep`, `glob`, `ls` | All file and search operations. Relative read/write/edit paths resolve against the conversation's session cwd before sandbox validation. Optional `target=device` routes through a device filesystem bridge for mobile. |
 | **SHELL** | `run`, `start_background`, `poll_background`, `write_background`, `kill_background`, `list_background`, `clear_history`, `view_history` | `run` executes a command via `/bin/bash -c` with a per-call timeout (clamped to `[100, 600000]` ms, default 120000). Background actions return stable per-conversation handles, poll incremental stdout/stderr offsets with truncation markers, write stdin, terminate process groups, and list sessions. `view_history`/`clear_history` read or clear per-conversation command history. |
 | **WORKTREE** | `enter`, `exit` | Creates and tears down git worktrees, updating the agent's session cwd and sandbox roots automatically. |
@@ -54,7 +55,7 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_BACKGROUND_SHELL_BUFFER_CHARS` | `64000` | Per-stream retained stdout/stderr ring size for background shell polling. |
 | `CODING_TOOLS_BACKGROUND_SHELL_KILL_GRACE_MS` | `1500` | Grace period between SIGTERM and SIGKILL for background shell termination. |
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read. |
-| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | File size cap for reads (bytes). Larger files are rejected. |
+| `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | Selected-content byte cap. Larger files require an explicit line `limit` (and optional `offset`) and are scanned with bounded memory. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Max output lines for GREP. Set to 0 to disable. |
 
 ### SHELL trust boundary

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -10,7 +10,7 @@ The plugin registers three focused file actions, three umbrella actions, and a s
 |---|---|---|
 | **READ / WRITE / EDIT** | one operation each | Pi-shaped strict schemas for direct coding loops. They reuse FILE's sandbox, stale-file, secret, and size guards. |
 | **FILE** | `read`, `write`, `edit`, `grep`, `glob`, `ls` | All file and search operations. Relative read/write/edit paths resolve against the conversation's session cwd before sandbox validation. Optional `target=device` routes through a device filesystem bridge for mobile. |
-| **SHELL** | `run`, `start_background`, `poll_background`, `write_background`, `kill_background`, `list_background`, `clear_history`, `view_history` | `run` executes a command via `/bin/bash -c` with a per-call timeout (clamped to `[100, 600000]` ms, default 120000). Background actions return stable per-conversation handles, poll incremental stdout/stderr offsets with truncation markers, write stdin, terminate process groups, and list sessions. `view_history`/`clear_history` read or clear per-conversation command history. |
+| **SHELL** | `run`, `read_output_artifact`, `start_background`, `poll_background`, `write_background`, `kill_background`, `list_background`, `clear_history`, `view_history` | `run` executes a command via `/bin/bash -c` with a per-call timeout (clamped to `[100, 600000]` ms, default 120000). Oversized foreground results return an opaque handle whose complete redacted streams can be paged with `read_output_artifact`. Background actions return stable per-conversation handles, poll incremental stdout/stderr offsets with truncation markers, write stdin, terminate process groups, and list sessions. `view_history`/`clear_history` read or clear per-conversation command history. |
 | **WORKTREE** | `enter`, `exit` | Creates and tears down git worktrees, updating the agent's session cwd and sandbox roots automatically. |
 
 Supporting services (automatically started):
@@ -71,8 +71,11 @@ Foreground SHELL transcripts shown to the planner are capped at 50,000
 characters. When that cap is reached, the action writes the complete redacted
 stdout and stderr plus a manifest under
 `ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
-paths with byte/line counts, and leaves the bounded preview in the tool result.
-Artifact directories are owner-only (`0700`) and files are `0600`. They use
+byte/line counts, and leaves the bounded preview in the tool result. The action
+does not disclose state-root paths. `action=read_output_artifact` retrieves a
+bounded stdout or stderr page only when the opaque handle's persisted agent and
+conversation scope match the requesting turn. Artifact directories are
+owner-only (`0700`) and files are `0600`. They use
 `SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
 opportunistically when the next truncated foreground result is persisted.
 

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -67,6 +67,15 @@ plugin only where the OWNER role and host/container boundary are trusted for
 that access. Static command analysis and the command denylist are safety checks,
 not filesystem confinement.
 
+Foreground SHELL transcripts shown to the planner are capped at 50,000
+characters. When that cap is reached, the action writes the complete redacted
+stdout and stderr plus a manifest under
+`ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
+paths with byte/line counts, and leaves the bounded preview in the tool result.
+Artifact directories are owner-only (`0700`) and files are `0600`. They use
+`SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
+opportunistically when the next truncated foreground result is persisted.
+
 The folded `ShellService` retains these compatibility settings for external
 callers of `runtime.getService("shell").exec()` / `executeCommand()`; the
 canonical SHELL action continues to use the `CODING_TOOLS_*` settings above.

--- a/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
+++ b/plugins/plugin-coding-tools/__tests__/plugin-integration.test.ts
@@ -32,11 +32,14 @@ import codingToolsPlugin, {
 } from "../src/index.ts";
 
 const EXPECTED_ACTIONS = [
+  "EDIT",
   "FILE",
+  "READ",
   "SHELL",
   "WEB_FETCH",
   "WEB_SEARCH",
   "WORKTREE",
+  "WRITE",
 ];
 
 describe("@elizaos/plugin-coding-tools — plugin export shape", () => {
@@ -49,9 +52,6 @@ describe("@elizaos/plugin-coding-tools — plugin export shape", () => {
   it("does not register legacy leaf actions as planner-facing actions", () => {
     const names = new Set((codingToolsPlugin.actions ?? []).map((a) => a.name));
     for (const legacyName of [
-      "READ",
-      "WRITE",
-      "EDIT",
       "BASH",
       "GREP",
       "GLOB",

--- a/plugins/plugin-coding-tools/package.json
+++ b/plugins/plugin-coding-tools/package.json
@@ -134,7 +134,7 @@
       },
       "CODING_TOOLS_MAX_FILE_SIZE_BYTES": {
         "type": "number",
-        "description": "Pre-stat byte cap on FILE action=read. Files larger than this are rejected with a message instructing the agent to read in chunks.",
+        "description": "Byte cap for selected FILE action=read content. Larger files require an explicit line limit (and optional offset) and are scanned with bounded memory.",
         "required": false,
         "default": 262144,
         "sensitive": false

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -50,6 +50,7 @@ import {
 } from "../types.js";
 
 import {
+  boundedShellText,
   type CommandPlatform,
   localResourceUserFacingText,
   resolveCommandPlatform,
@@ -620,6 +621,105 @@ describeIfPosix("shellAction", () => {
     expect(posts[0].text).toContain(lines[299]);
     expect(posts[0].text).toMatch(/\[\d+ lines omitted — ask to see more\]/);
     expect(posts[0].text.length).toBeLessThan(1700);
+  });
+
+  it("hard-bounds the artifact notice for unusually long state paths", () => {
+    const longPath = `/state/${"nested-segment/".repeat(3_000)}`;
+    const bounded = boundedShellText("output-line\n".repeat(10_000), {
+      handle: "shell_worst_case_notice",
+      manifestPath: `${longPath}manifest.json`,
+      stdoutPath: `${longPath}stdout.txt`,
+      stderrPath: `${longPath}stderr.txt`,
+      createdAt: "2026-08-21T00:00:00.000Z",
+      expiresAt: "2026-08-21T00:30:00.000Z",
+      retentionMs: 1_800_000,
+      stdout: { characters: 120_000, bytes: 120_000, lines: 10_000 },
+      stderr: { characters: 0, bytes: 0, lines: 0 },
+    });
+
+    expect(bounded.truncated).toBe(true);
+    expect(bounded.text.length).toBeLessThanOrEqual(50_000);
+    expect(bounded.text).toContain("shell_worst_case_notice");
+    expect(bounded.text).toContain("manifest: /state/nested-segment/");
+  });
+
+  it("persists complete redacted output for a truncated real foreground shell", async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "coding-tools-shell-artifact-"),
+    );
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousJobTtl = process.env.SHELL_JOB_TTL_MS;
+    process.env.ELIZA_STATE_DIR = stateDir;
+    process.env.SHELL_JOB_TTL_MS = "60000";
+    const artifactRoot = path.join(stateDir, "coding-tools", "shell-output");
+    const staleArtifact = path.join(artifactRoot, "shell_stale");
+    const secret = "marigold9-artifact-secret";
+    try {
+      await fs.mkdir(staleArtifact, { recursive: true });
+      await fs.writeFile(path.join(staleArtifact, "stdout.txt"), "stale");
+      const staleDate = new Date(Date.now() - 120_000);
+      await fs.utimes(staleArtifact, staleDate, staleDate);
+      const { runtime } = await makeRuntime({ configuredSecret: secret });
+      const script = [
+        `process.stdout.write(${JSON.stringify("row\n")}.repeat(14000));`,
+        `process.stdout.write(${JSON.stringify(secret)});`,
+        `process.stderr.write(${JSON.stringify("stderr-tail\n")});`,
+      ].join("");
+
+      const result = requireActionResult(
+        await shellAction.handler?.(runtime, makeMessage(), undefined, {
+          command: `node -e ${JSON.stringify(script)}`,
+        }),
+      );
+      const data = result.data as Record<string, unknown>;
+      const manifestPath = data.output_artifact_path as string;
+      const stdoutPath = data.output_artifact_stdout_path as string;
+      const stderrPath = data.output_artifact_stderr_path as string;
+      const stdout = await fs.readFile(stdoutPath, "utf8");
+      const stderr = await fs.readFile(stderrPath, "utf8");
+      const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
+        stdout: { bytes: number; lines: number };
+        stderr: { bytes: number; lines: number };
+        truncation: { modelCharacterLimit: number; completeBytes: number };
+      };
+
+      expect(result.success).toBe(true);
+      expect(result.text.length).toBeLessThanOrEqual(50_000);
+      expect(result.text).toContain("complete redacted artifact shell_");
+      expect(data.output_truncated).toBe(true);
+      expect(data.output_artifact_handle).toMatch(/^shell_/);
+      expect(stdout).toBe(`${"row\n".repeat(14000)}[REDACTED:TEST_SECRET]`);
+      expect(stderr).toBe("stderr-tail\n");
+      expect(JSON.stringify(result)).not.toContain(secret);
+      expect(await fs.readFile(manifestPath, "utf8")).not.toContain(secret);
+      expect(manifest.stdout).toEqual({
+        path: stdoutPath,
+        characters: stdout.length,
+        bytes: Buffer.byteLength(stdout),
+        lines: 14001,
+      });
+      expect(manifest.stderr).toEqual({
+        path: stderrPath,
+        characters: stderr.length,
+        bytes: Buffer.byteLength(stderr),
+        lines: 1,
+      });
+      expect(manifest.truncation.modelCharacterLimit).toBe(50_000);
+      expect(manifest.truncation.completeBytes).toBe(
+        Buffer.byteLength(stdout) + Buffer.byteLength(stderr),
+      );
+      expect((await fs.stat(manifestPath)).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(path.dirname(manifestPath))).mode & 0o777).toBe(
+        0o700,
+      );
+      expect(await pathExists(staleArtifact)).toBe(false);
+    } finally {
+      if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = previousStateDir;
+      if (previousJobTtl === undefined) delete process.env.SHELL_JOB_TTL_MS;
+      else process.env.SHELL_JOB_TTL_MS = previousJobTtl;
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("marks empty stdout and stderr explicitly for successful commands", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -249,6 +249,21 @@ async function pollUntil(
   throw new Error(`condition not met; last=${last?.text ?? "(none)"}`);
 }
 
+async function waitForBackgroundToSettle(
+  service: BackgroundShellService,
+  conversationId: string,
+  handle: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const session = service
+      .list(conversationId)
+      .find((candidate) => candidate.handle === handle);
+    if (session && session.status !== "running") return;
+    await delay(50);
+  }
+  throw new Error(`background shell ${handle} did not settle`);
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -2394,9 +2409,9 @@ describeIfPosix("shellAction", () => {
     expect(JSON.stringify(afterTaint)).not.toContain(secret);
   });
 
-  it("keeps a split configured secret tainted through tiny visible caps", async () => {
+  it("rejects split-secret output that exceeds the complete-capture limit", async () => {
     const secret = "marigold9";
-    const { runtime } = await makeRuntime({
+    const { runtime, backgroundShell } = await makeRuntime({
       configuredSecret: secret,
       backgroundBufferChars: 5,
     });
@@ -2409,26 +2424,23 @@ describeIfPosix("shellAction", () => {
       }),
     );
     const handle = (start.data as Record<string, unknown>).handle as string;
-    const poll = await pollUntil(
-      runtime,
-      actor,
+    await waitForBackgroundToSettle(
+      backgroundShell,
+      String(actor.roomId),
       handle,
-      (data) => data.status === "exited",
     );
-    const data = poll.data as Record<string, unknown>;
+    const poll = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+      }),
+    );
 
-    expect(
-      JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
-    ).not.toContain("mari");
-    expect(
-      JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
-    ).not.toContain("gold9");
-    expect(data.stdout).toMatchObject({
-      text: "-safe",
-      startOffset: "mariXlater-safe".length - 5,
-      endOffset: "mariXlater-safe".length,
-    });
-    expect((data.stderr as Record<string, unknown>).text).toBe("");
+    expect(poll.success).toBe(false);
+    expect(poll.text).toContain("no partial output is available");
+    expect(JSON.stringify(poll)).not.toContain("mari");
+    expect(JSON.stringify(poll)).not.toContain("gold9");
+    expect(poll.data).toBeUndefined();
   });
 
   it("preserves same-stream event boundaries around harmless bytes", async () => {
@@ -2655,10 +2667,10 @@ describeIfPosix("shellAction", () => {
     );
   });
 
-  it("keeps an eviction-split configured secret inside the private overlap", async () => {
+  it("rejects eviction-split secret output beyond the capture limit", async () => {
     const secret = "violet73";
     const payload = `${"a".repeat(26)}${secret}${"z".repeat(16)}`;
-    const { runtime } = await makeRuntime({
+    const { runtime, backgroundShell } = await makeRuntime({
       backgroundBufferChars: 20,
       configuredSecret: secret,
     });
@@ -2670,25 +2682,30 @@ describeIfPosix("shellAction", () => {
       }),
     );
     const handle = (start.data as Record<string, unknown>).handle as string;
-    const poll = await pollUntil(runtime, actor, handle, (data) => {
-      const stdout = data.stdout as Record<string, unknown> | undefined;
-      return data.status === "exited" && stdout?.truncatedBefore === 30;
-    });
-    const stdout = (poll.data as Record<string, unknown>).stdout as Record<
-      string,
-      unknown
-    >;
+    await waitForBackgroundToSettle(
+      backgroundShell,
+      String(actor.roomId),
+      handle,
+    );
+    const poll = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+      }),
+    );
 
-    expect(stdout.text).toBe("z".repeat(16));
-    expect(stdout.startOffset).toBe(30);
+    expect(poll.success).toBe(false);
+    expect(poll.text).toContain("no partial output is available");
     expect(JSON.stringify(poll)).not.toContain(secret);
     expect(JSON.stringify(poll)).not.toContain(secret.slice(4));
   });
 
-  it("expands the private overlap when a configured secret rotates", async () => {
+  it("rejects rotated-secret output beyond the capture limit", async () => {
     const rotatedSecret = "rotated-secret-value-LEAK_SENTINEL_9Q";
     const payload = `${"a".repeat(10)}${rotatedSecret}${"z".repeat(8)}`;
-    const { runtime } = await makeRuntime({ backgroundBufferChars: 20 });
+    const { runtime, backgroundShell } = await makeRuntime({
+      backgroundBufferChars: 20,
+    });
     runtime.character.settings = {
       secrets: { ROTATED_SECRET: rotatedSecret },
     };
@@ -2703,18 +2720,20 @@ describeIfPosix("shellAction", () => {
       }),
     );
     const handle = (start.data as Record<string, unknown>).handle as string;
-    const poll = await pollUntil(runtime, actor, handle, (data) => {
-      const stdout = data.stdout as Record<string, unknown> | undefined;
-      return (
-        data.status === "exited" &&
-        stdout?.truncatedBefore === payload.length - 20
-      );
-    });
+    await waitForBackgroundToSettle(
+      backgroundShell,
+      String(actor.roomId),
+      handle,
+    );
+    const poll = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+      }),
+    );
 
-    expect(
-      ((poll.data as Record<string, unknown>).stdout as Record<string, unknown>)
-        .text,
-    ).toBe("z".repeat(8));
+    expect(poll.success).toBe(false);
+    expect(poll.text).toContain("no partial output is available");
     expect(JSON.stringify(poll)).not.toContain(rotatedSecret.slice(-12));
   });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -503,6 +503,9 @@ describeIfPosix("shellAction", () => {
     expect(providerResult.text).toContain("start_background");
     expect(providerResult.data?.codingTools).toEqual([
       "FILE",
+      "READ",
+      "WRITE",
+      "EDIT",
       "SHELL",
       "WEB_FETCH",
       "WEB_SEARCH",

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -121,6 +121,7 @@ async function withShellTimeoutEnv<T>(
 
 interface RuntimeOptions {
   blockedPaths?: string;
+  workspaceRoots?: string;
   shellTimeoutMs?: unknown;
   shellHistoryCommands?: string[];
   withShellHistoryService?: boolean;
@@ -151,6 +152,8 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
   const settings: Record<string, unknown> = {};
   if (opts.blockedPaths)
     settings.CODING_TOOLS_BLOCKED_PATHS = opts.blockedPaths;
+  if (opts.workspaceRoots)
+    settings.CODING_TOOLS_WORKSPACE_ROOTS = opts.workspaceRoots;
   if (opts.shellTimeoutMs !== undefined)
     settings.CODING_TOOLS_SHELL_TIMEOUT_MS = opts.shellTimeoutMs;
   if (opts.backgroundBufferChars !== undefined) {
@@ -643,10 +646,11 @@ describeIfPosix("shellAction", () => {
     expect(bounded.truncated).toBe(true);
     expect(bounded.text.length).toBeLessThanOrEqual(50_000);
     expect(bounded.text).toContain("shell_worst_case_notice");
-    expect(bounded.text).toContain("manifest: /state/nested-segment/");
+    expect(bounded.text).toContain("action=read_output_artifact");
+    expect(bounded.text).not.toContain("/state/nested-segment/");
   });
 
-  it("persists complete redacted output for a truncated real foreground shell", async () => {
+  it("retrieves complete redacted output through an authorized opaque handle", async () => {
     const stateDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "coding-tools-shell-artifact-"),
     );
@@ -655,29 +659,38 @@ describeIfPosix("shellAction", () => {
     process.env.ELIZA_STATE_DIR = stateDir;
     process.env.SHELL_JOB_TTL_MS = "60000";
     const artifactRoot = path.join(stateDir, "coding-tools", "shell-output");
+    const workspace = path.join(stateDir, "workspace");
     const staleArtifact = path.join(artifactRoot, "shell_stale");
     const secret = "marigold9-artifact-secret";
     try {
+      await fs.mkdir(workspace, { recursive: true });
       await fs.mkdir(staleArtifact, { recursive: true });
       await fs.writeFile(path.join(staleArtifact, "stdout.txt"), "stale");
       const staleDate = new Date(Date.now() - 120_000);
       await fs.utimes(staleArtifact, staleDate, staleDate);
-      const { runtime } = await makeRuntime({ configuredSecret: secret });
+      const { runtime, sandbox } = await makeRuntime({
+        configuredSecret: secret,
+        workspaceRoots: workspace,
+      });
       const script = [
         `process.stdout.write(${JSON.stringify("row\n")}.repeat(14000));`,
         `process.stdout.write(${JSON.stringify(secret)});`,
         `process.stderr.write(${JSON.stringify("stderr-tail\n")});`,
       ].join("");
 
+      const message = makeMessage();
       const result = requireActionResult(
-        await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        await shellAction.handler?.(runtime, message, undefined, {
           command: `node -e ${JSON.stringify(script)}`,
+          cwd: workspace,
         }),
       );
       const data = result.data as Record<string, unknown>;
-      const manifestPath = data.output_artifact_path as string;
-      const stdoutPath = data.output_artifact_stdout_path as string;
-      const stderrPath = data.output_artifact_stderr_path as string;
+      const handle = data.output_artifact_handle as string;
+      const artifactDirectory = path.join(artifactRoot, handle);
+      const manifestPath = path.join(artifactDirectory, "manifest.json");
+      const stdoutPath = path.join(artifactDirectory, "stdout.txt");
+      const stderrPath = path.join(artifactDirectory, "stderr.txt");
       const stdout = await fs.readFile(stdoutPath, "utf8");
       const stderr = await fs.readFile(stderrPath, "utf8");
       const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
@@ -691,6 +704,9 @@ describeIfPosix("shellAction", () => {
       expect(result.text).toContain("complete redacted artifact shell_");
       expect(data.output_truncated).toBe(true);
       expect(data.output_artifact_handle).toMatch(/^shell_/);
+      expect(data).not.toHaveProperty("output_artifact_path");
+      expect(data).not.toHaveProperty("output_artifact_stdout_path");
+      expect(data).not.toHaveProperty("output_artifact_stderr_path");
       expect(stdout).toBe(`${"row\n".repeat(14000)}[REDACTED:TEST_SECRET]`);
       expect(stderr).toBe("stderr-tail\n");
       expect(JSON.stringify(result)).not.toContain(secret);
@@ -711,6 +727,62 @@ describeIfPosix("shellAction", () => {
       expect(manifest.truncation.completeBytes).toBe(
         Buffer.byteLength(stdout) + Buffer.byteLength(stderr),
       );
+      await expect(
+        sandbox.validatePath(String(message.roomId), manifestPath),
+      ).resolves.toMatchObject({ ok: false });
+
+      const retrieveStream = async (stream: "stdout" | "stderr") => {
+        let offset = 0;
+        let complete = false;
+        let retrieved = "";
+        while (!complete) {
+          const page = requireActionResult(
+            await shellAction.handler?.(runtime, message, undefined, {
+              action: "read_output_artifact",
+              handle,
+              artifact_stream: stream,
+              artifact_offset: offset,
+              artifact_limit: 20_000,
+            }),
+          );
+          expect(page.success).toBe(true);
+          const pageData = page.data as Record<string, unknown>;
+          expect(pageData.handle).toBe(handle);
+          expect(pageData.stream).toBe(stream);
+          expect(pageData.startOffset).toBe(offset);
+          retrieved += pageData.text as string;
+          offset = pageData.nextOffset as number;
+          complete = pageData.complete as boolean;
+        }
+        return retrieved;
+      };
+
+      expect(await retrieveStream("stdout")).toBe(stdout);
+      expect(await retrieveStream("stderr")).toBe(stderr);
+
+      const crossRoom = requireActionResult(
+        await shellAction.handler?.(
+          runtime,
+          makeMessage("99999999-aaaa-bbbb-cccc-222222222222"),
+          undefined,
+          {
+            action: "read_output_artifact",
+            handle,
+            artifact_stream: "stdout",
+          },
+        ),
+      );
+      expect(crossRoom.success).toBe(false);
+      expect(JSON.stringify(crossRoom)).not.toContain("row\n");
+
+      const malformed = requireActionResult(
+        await shellAction.handler?.(runtime, message, undefined, {
+          action: "read_output_artifact",
+          handle: "../manifest.json",
+          artifact_stream: "stdout",
+        }),
+      );
+      expect(malformed.success).toBe(false);
       expect((await fs.stat(manifestPath)).mode & 0o777).toBe(0o600);
       expect((await fs.stat(path.dirname(manifestPath))).mode & 0o777).toBe(
         0o700,

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -34,6 +34,7 @@ import {
   readNumberParam,
   readStringParam,
   successActionResult,
+  truncate,
 } from "../lib/format.js";
 import { runShell, type ShellResult } from "../lib/run-shell.js";
 import { resolveHostShell } from "../lib/terminal-capabilities.js";
@@ -54,6 +55,9 @@ const TIMEOUT_MIN_MS = 100;
 const TIMEOUT_MAX_MS = 600_000;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const USER_FACING_STDOUT_CAP_CHARS = 8_000;
+// Match Pi's model-facing shell budget: preserve the command plus useful head
+// output while preventing one noisy test/build from consuming the next turn.
+const MODEL_FACING_SHELL_OUTPUT_CHARS = 50_000;
 const SHELL_HISTORY_DEFAULT_LIMIT = 20;
 const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
@@ -1263,7 +1267,7 @@ export const shellAction: Action = {
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
-    _state?: State,
+    state?: State,
     options?: unknown,
     callback?: HandlerCallback,
   ): Promise<ActionResult> => {
@@ -1634,11 +1638,13 @@ export const shellAction: Action = {
     // of real output and inflating a 30s build past 90s. Skip all
     // message-text-keyed rewrites for the coding sub-agent; its commands run
     // verbatim.
-    const codingSubAgentShell = ((): boolean => {
-      const v =
-        process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
-      return v === "1" || v === "true" || v === "yes" || v === "on";
-    })();
+    const codingSubAgentShell =
+      state?.data?.elizaTrustedCodingMode === true ||
+      ((): boolean => {
+        const v =
+          process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
+        return v === "1" || v === "true" || v === "yes" || v === "on";
+      })();
     const destructiveGateEnabled = ((): boolean => {
       const v =
         process.env.ELIZA_SHELL_DESTRUCTIVE_CONFIRM?.trim().toLowerCase();
@@ -1872,7 +1878,9 @@ export const shellAction: Action = {
     const streams = formatStreams(redactedStdout, redactedStderr, {
       showEmptyStreams: !result.stdout && !result.stderr,
     });
-    const text = streams.length > 0 ? `${head}\n${streams}` : head;
+    const fullText = streams.length > 0 ? `${head}\n${streams}` : head;
+    const bounded = truncate(fullText, MODEL_FACING_SHELL_OUTPUT_CHARS);
+    const text = bounded.text;
 
     const echoTranscript =
       process.env.ELIZA_SHELL_ECHO_TRANSCRIPT?.trim().toLowerCase();
@@ -1885,7 +1893,12 @@ export const shellAction: Action = {
     if (timedOut) {
       return failureToActionResult(
         { reason: "timeout", message: `command timed out after ${timeout}ms` },
-        { command: redactedCommand, cwd: redactedCwd, output: text },
+        {
+          command: redactedCommand,
+          cwd: redactedCwd,
+          output: text,
+          output_truncated: bounded.truncated,
+        },
       );
     }
     if (result.exitCode !== 0) {
@@ -1899,6 +1912,7 @@ export const shellAction: Action = {
           exit_code: result.exitCode,
           cwd: redactedCwd,
           output: text,
+          output_truncated: bounded.truncated,
         },
       );
     }
@@ -1909,6 +1923,7 @@ export const shellAction: Action = {
       execution_route: result.sandbox === "host" ? "host" : "sandbox",
       sandbox_backend: result.sandbox,
       signal,
+      output_truncated: bounded.truncated,
     });
     // The crypto / disk / memory / status projections are CHAT conveniences
     // keyed on the *message text*, and the coding sub-agent's message text is

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -39,7 +39,9 @@ import {
 import { runShell, type ShellResult } from "../lib/run-shell.js";
 import {
   persistShellOutputArtifact,
+  readShellOutputArtifactPage,
   type ShellOutputArtifact,
+  type ShellOutputArtifactStream,
 } from "../lib/shell-output-artifact.js";
 import { resolveHostShell } from "../lib/terminal-capabilities.js";
 import type { BackgroundShellService } from "../services/background-shell-service.js";
@@ -76,7 +78,8 @@ type ShellActionSubaction =
   | "poll_background"
   | "write_background"
   | "kill_background"
-  | "list_background";
+  | "list_background"
+  | "read_output_artifact";
 
 interface CryptoSpotAsset {
   symbol: string;
@@ -312,6 +315,10 @@ function normalizeShellSubaction(
     case "background_list":
     case "sessions":
       return "list_background";
+    case "artifact":
+    case "read_artifact":
+    case "read_output_artifact":
+      return "read_output_artifact";
     default:
       return "run";
   }
@@ -1158,12 +1165,15 @@ function shellArtifactResultData(
   if (!artifact) return {};
   return {
     output_artifact_handle: artifact.handle,
-    output_artifact_path: artifact.manifestPath,
-    output_artifact_stdout_path: artifact.stdoutPath,
-    output_artifact_stderr_path: artifact.stderrPath,
     output_artifact_created_at: artifact.createdAt,
     output_artifact_expires_at: artifact.expiresAt,
     output_artifact_retention_ms: artifact.retentionMs,
+    output_artifact_retrieval: {
+      action: "read_output_artifact",
+      handle: artifact.handle,
+      streams: ["stdout", "stderr"],
+      max_characters_per_page: 20_000,
+    },
     output_truncation: {
       model_character_limit: MODEL_FACING_SHELL_OUTPUT_CHARS,
       stdout: artifact.stdout,
@@ -1202,13 +1212,13 @@ export function boundedShellText(
   }
   const notice = [
     `[output truncated; complete redacted artifact ${artifact.handle}]`,
-    `manifest: ${artifact.manifestPath}`,
-    `stdout: ${artifact.stdoutPath} (${artifact.stdout.bytes} bytes, ${artifact.stdout.lines} lines)`,
-    `stderr: ${artifact.stderrPath} (${artifact.stderr.bytes} bytes, ${artifact.stderr.lines} lines)`,
+    `retrieve: SHELL action=read_output_artifact handle=${artifact.handle} artifact_stream=stdout artifact_offset=0`,
+    `stdout: ${artifact.stdout.bytes} bytes, ${artifact.stdout.lines} lines`,
+    `stderr: ${artifact.stderr.bytes} bytes, ${artifact.stderr.lines} lines`,
     `expires: ${artifact.expiresAt}`,
   ].join("\n");
-  // State roots are operator-configurable. Bound an unusually long notice
-  // independently while the structured result retains every complete path.
+  // Bound the notice independently so even future opaque-handle formats cannot
+  // consume the planner's entire model-facing shell-output budget.
   const boundedNotice = truncateToHardLimit(
     notice,
     Math.floor(MODEL_FACING_SHELL_OUTPUT_CHARS / 2),
@@ -1232,19 +1242,20 @@ export const shellAction: Action = {
   contextGate: { anyOf: ["code", "terminal", "automation"] },
   similes: ["BASH", "EXEC", "RUN_COMMAND"],
   description:
-    "Run shell commands, manage per-conversation background shell sessions, or view/clear shell history. Each run starts a fresh shell, so prefix any required environment variables on every command. Use bounded commands; default to the session cwd unless the user supplied an exact cwd or the session moved.",
+    "Run shell commands, retrieve complete redacted foreground output by artifact handle, manage per-conversation background shell sessions, or view/clear shell history. Each run starts a fresh shell, so prefix any required environment variables on every command. Use bounded commands; default to the session cwd unless the user supplied an exact cwd or the session moved.",
   descriptionCompressed:
-    "Run shell commands; start/poll/write/kill/list background sessions; clear/view history.",
+    "Run shell commands; page output artifacts; start/poll/write/kill/list background sessions; clear/view history.",
   parameters: [
     {
       name: "action",
       description:
-        "Shell operation: run | start_background | poll_background | write_background | kill_background | list_background | clear_history | view_history.",
+        "Shell operation: run | read_output_artifact | start_background | poll_background | write_background | kill_background | list_background | clear_history | view_history.",
       required: false,
       schema: {
         type: "string",
         enum: [
           "run",
+          "read_output_artifact",
           "start_background",
           "poll_background",
           "write_background",
@@ -1305,9 +1316,30 @@ export const shellAction: Action = {
     {
       name: "handle",
       description:
-        "Stable background shell handle returned by action=start_background.",
+        "Opaque handle returned by action=start_background or by a truncated foreground output artifact.",
       required: false,
       schema: { type: "string" },
+    },
+    {
+      name: "artifact_stream",
+      description:
+        "For action=read_output_artifact: redacted stream to retrieve.",
+      required: false,
+      schema: { type: "string", enum: ["stdout", "stderr"] },
+    },
+    {
+      name: "artifact_offset",
+      description:
+        "For action=read_output_artifact: next character offset returned by the prior page; defaults to 0.",
+      required: false,
+      schema: { type: "number", minimum: 0 },
+    },
+    {
+      name: "artifact_limit",
+      description:
+        "For action=read_output_artifact: page size in characters, capped at 20000.",
+      required: false,
+      schema: { type: "number", minimum: 2, maximum: 20000 },
     },
     {
       name: "stdin",
@@ -1355,6 +1387,63 @@ export const shellAction: Action = {
     const subaction = explicitSubaction
       ? normalizeShellSubaction(explicitSubaction)
       : "run";
+
+    if (subaction === "read_output_artifact") {
+      if (!message.roomId) {
+        return failureToActionResult({
+          reason: "missing_param",
+          message: "no roomId",
+        });
+      }
+      const handle = readStringParam(options, "handle");
+      if (!handle) {
+        return failureToActionResult({
+          reason: "missing_param",
+          message: "read_output_artifact requires 'handle'",
+        });
+      }
+      const requestedStream = readStringParam(options, "artifact_stream");
+      if (requestedStream !== "stdout" && requestedStream !== "stderr") {
+        return failureToActionResult({
+          reason: "invalid_param",
+          message:
+            "read_output_artifact requires artifact_stream=stdout or stderr",
+        });
+      }
+      const page = await readShellOutputArtifactPage({
+        handle,
+        stream: requestedStream as ShellOutputArtifactStream,
+        offset: readNonNegativeOffset(options, "artifact_offset"),
+        limit: readNumberParam(options, "artifact_limit"),
+        requesterAgentId: String(runtime.agentId),
+        requesterConversationId: String(message.roomId),
+      });
+      if (!page.ok) {
+        return failureToActionResult({
+          reason:
+            page.reason === "invalid_handle" ? "invalid_param" : "path_blocked",
+          message: page.message,
+        });
+      }
+      const value = page.value;
+      const text = [
+        `Shell artifact ${value.handle} ${value.stream} characters ${value.startOffset}..${value.endOffset} of ${value.totalCharacters} complete=${value.complete}`,
+        value.text
+          ? `--- ${value.stream} ---\n${value.text}`
+          : `--- ${value.stream} ---\n(empty)`,
+      ].join("\n");
+      if (callback) {
+        await callback({
+          text: fencePreformatted(capTranscriptForChat(text)),
+          source: "coding-tools",
+        });
+      }
+      return successActionResult(text, {
+        actionName: "SHELL",
+        [CANONICAL_SUBACTION_KEY]: "read_output_artifact",
+        ...value,
+      });
+    }
 
     if (subaction === "clear_history" || subaction === "view_history") {
       const shellHistoryService = getShellHistoryService(runtime);
@@ -1969,6 +2058,8 @@ export const shellAction: Action = {
           signal,
           modelCharacterLimit: MODEL_FACING_SHELL_OUTPUT_CHARS,
           modelCharacters: MODEL_FACING_SHELL_OUTPUT_CHARS,
+          ownerAgentId: String(runtime.agentId),
+          ownerConversationId: conversationId,
         });
       } catch (err) {
         // error-policy:J1 artifact persistence is part of the SHELL result

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -1232,7 +1232,7 @@ export const shellAction: Action = {
   contextGate: { anyOf: ["code", "terminal", "automation"] },
   similes: ["BASH", "EXEC", "RUN_COMMAND"],
   description:
-    "Run shell commands, manage per-conversation background shell sessions, or view/clear shell history. Use bounded commands; default to the session cwd unless the user supplied an exact cwd or the session moved.",
+    "Run shell commands, manage per-conversation background shell sessions, or view/clear shell history. Each run starts a fresh shell, so prefix any required environment variables on every command. Use bounded commands; default to the session cwd unless the user supplied an exact cwd or the session moved.",
   descriptionCompressed:
     "Run shell commands; start/poll/write/kill/list background sessions; clear/view history.",
   parameters: [
@@ -1258,7 +1258,7 @@ export const shellAction: Action = {
     {
       name: "command",
       description:
-        "For action=run: /bin/bash -c command. Keep bounded; prefer jq/node for JSON and python3 if Python is needed. Include all requested paths in df/du checks.",
+        "For action=run: /bin/bash -c command in a fresh process; exported variables do not persist to later calls. Keep bounded; prefer jq/node for JSON and python3 if Python is needed. Include all requested paths in df/du checks.",
       required: false,
       schema: { type: "string" },
     },

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -37,6 +37,10 @@ import {
   truncate,
 } from "../lib/format.js";
 import { runShell, type ShellResult } from "../lib/run-shell.js";
+import {
+  persistShellOutputArtifact,
+  type ShellOutputArtifact,
+} from "../lib/shell-output-artifact.js";
 import { resolveHostShell } from "../lib/terminal-capabilities.js";
 import type { BackgroundShellService } from "../services/background-shell-service.js";
 import type { SandboxService } from "../services/sandbox-service.js";
@@ -1148,6 +1152,79 @@ function formatStreams(
   return lines.join("\n");
 }
 
+function shellArtifactResultData(
+  artifact: ShellOutputArtifact | undefined,
+): Record<string, unknown> {
+  if (!artifact) return {};
+  return {
+    output_artifact_handle: artifact.handle,
+    output_artifact_path: artifact.manifestPath,
+    output_artifact_stdout_path: artifact.stdoutPath,
+    output_artifact_stderr_path: artifact.stderrPath,
+    output_artifact_created_at: artifact.createdAt,
+    output_artifact_expires_at: artifact.expiresAt,
+    output_artifact_retention_ms: artifact.retentionMs,
+    output_truncation: {
+      model_character_limit: MODEL_FACING_SHELL_OUTPUT_CHARS,
+      stdout: artifact.stdout,
+      stderr: artifact.stderr,
+    },
+  };
+}
+
+function truncateToHardLimit(
+  text: string,
+  maxCharacters: number,
+): { text: string; truncated: boolean } {
+  if (maxCharacters <= 0) {
+    return { text: "", truncated: text.length > 0 };
+  }
+  let prefixBudget = maxCharacters;
+  let result = truncate(text, prefixBudget);
+  while (result.text.length > maxCharacters && prefixBudget > 0) {
+    prefixBudget = Math.max(
+      0,
+      prefixBudget - (result.text.length - maxCharacters),
+    );
+    result = truncate(text, prefixBudget);
+  }
+  return result.text.length <= maxCharacters
+    ? result
+    : { text: "", truncated: text.length > 0 };
+}
+
+export function boundedShellText(
+  fullText: string,
+  artifact: ShellOutputArtifact | undefined,
+): { text: string; truncated: boolean } {
+  if (!artifact) {
+    return truncateToHardLimit(fullText, MODEL_FACING_SHELL_OUTPUT_CHARS);
+  }
+  const notice = [
+    `[output truncated; complete redacted artifact ${artifact.handle}]`,
+    `manifest: ${artifact.manifestPath}`,
+    `stdout: ${artifact.stdoutPath} (${artifact.stdout.bytes} bytes, ${artifact.stdout.lines} lines)`,
+    `stderr: ${artifact.stderrPath} (${artifact.stderr.bytes} bytes, ${artifact.stderr.lines} lines)`,
+    `expires: ${artifact.expiresAt}`,
+  ].join("\n");
+  // State roots are operator-configurable. Bound an unusually long notice
+  // independently while the structured result retains every complete path.
+  const boundedNotice = truncateToHardLimit(
+    notice,
+    Math.floor(MODEL_FACING_SHELL_OUTPUT_CHARS / 2),
+  );
+  const preview = truncateToHardLimit(
+    fullText,
+    MODEL_FACING_SHELL_OUTPUT_CHARS - boundedNotice.text.length - 1,
+  );
+  return {
+    text: preview.text
+      ? `${preview.text}\n${boundedNotice.text}`
+      : boundedNotice.text,
+    truncated: true,
+  };
+}
+
 export const shellAction: Action = {
   name: "SHELL",
   contexts: [...CODING_TOOLS_CONTEXTS],
@@ -1879,8 +1956,35 @@ export const shellAction: Action = {
       showEmptyStreams: !result.stdout && !result.stderr,
     });
     const fullText = streams.length > 0 ? `${head}\n${streams}` : head;
-    const bounded = truncate(fullText, MODEL_FACING_SHELL_OUTPUT_CHARS);
+    let artifact: ShellOutputArtifact | undefined;
+    if (fullText.length > MODEL_FACING_SHELL_OUTPUT_CHARS) {
+      try {
+        artifact = await persistShellOutputArtifact({
+          command: redactedCommand,
+          cwd: redactedCwd,
+          stdout: redactedStdout,
+          stderr: redactedStderr,
+          exitCode: result.exitCode,
+          timedOut,
+          signal,
+          modelCharacterLimit: MODEL_FACING_SHELL_OUTPUT_CHARS,
+          modelCharacters: MODEL_FACING_SHELL_OUTPUT_CHARS,
+        });
+      } catch (err) {
+        // error-policy:J1 artifact persistence is part of the SHELL result
+        // boundary: do not claim recoverable truncation when storage failed.
+        return failureToActionResult(
+          {
+            reason: "io_error",
+            message: `complete shell output could not be persisted: ${redactShellText(runtime, (err as Error).message)}`,
+          },
+          { command: redactedCommand, cwd: redactedCwd },
+        );
+      }
+    }
+    const bounded = boundedShellText(fullText, artifact);
     const text = bounded.text;
+    const artifactData = shellArtifactResultData(artifact);
 
     const echoTranscript =
       process.env.ELIZA_SHELL_ECHO_TRANSCRIPT?.trim().toLowerCase();
@@ -1898,6 +2002,7 @@ export const shellAction: Action = {
           cwd: redactedCwd,
           output: text,
           output_truncated: bounded.truncated,
+          ...artifactData,
         },
       );
     }
@@ -1913,6 +2018,7 @@ export const shellAction: Action = {
           cwd: redactedCwd,
           output: text,
           output_truncated: bounded.truncated,
+          ...artifactData,
         },
       );
     }
@@ -1924,6 +2030,7 @@ export const shellAction: Action = {
       sandbox_backend: result.sandbox,
       signal,
       output_truncated: bounded.truncated,
+      ...artifactData,
     });
     // The crypto / disk / memory / status projections are CHAT conveniences
     // keyed on the *message text*, and the coding sub-agent's message text is

--- a/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
+++ b/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
@@ -40,13 +40,6 @@ export const readAction: Action = {
       required: false,
       schema: { type: "number" },
     },
-    {
-      name: "expectedRevision",
-      description:
-        "Revision returned by the prior READ; required when continuing with a nonzero offset.",
-      required: false,
-      schema: { type: "string" },
-    },
   ],
   validate: async () => true,
   handler: readFileHandler,

--- a/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
+++ b/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
@@ -40,6 +40,13 @@ export const readAction: Action = {
       required: false,
       schema: { type: "number" },
     },
+    {
+      name: "expectedRevision",
+      description:
+        "Revision returned by the prior READ; required when continuing with a nonzero offset.",
+      required: false,
+      schema: { type: "string" },
+    },
   ],
   validate: async () => true,
   handler: readFileHandler,
@@ -49,7 +56,7 @@ export const writeAction: Action = {
   name: "WRITE",
   ...DIRECT_FILE_GATE,
   description:
-    "Write complete text to a file, creating parent directories when allowed.",
+    "Create a file with complete text. Prefer EDIT for existing files; replacing one requires overwrite=true and complete replacement content.",
   parameters: [
     {
       name: "file_path",
@@ -62,6 +69,13 @@ export const writeAction: Action = {
       description: "Complete replacement file content.",
       required: true,
       schema: { type: "string" },
+    },
+    {
+      name: "overwrite",
+      description:
+        "Set true only to intentionally replace an existing file after reading it completely; defaults to false.",
+      required: false,
+      schema: { type: "boolean" },
     },
   ],
   validate: async () => true,
@@ -95,6 +109,13 @@ export const editAction: Action = {
     {
       name: "replace_all",
       description: "Replace every exact match; defaults to false.",
+      required: false,
+      schema: { type: "boolean" },
+    },
+    {
+      name: "allow_literal_escapes",
+      description:
+        "Set true only when literal backslash-n or backslash-r text is intentionally part of the source; defaults to false.",
       required: false,
       schema: { type: "boolean" },
     },

--- a/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
+++ b/plugins/plugin-coding-tools/src/actions/direct-file-actions.ts
@@ -1,0 +1,104 @@
+/**
+ * Pi-shaped READ, WRITE, and EDIT actions for focused coding loops. They share
+ * the FILE umbrella's handlers and safety services while presenting small,
+ * operation-specific schemas that models can call without fabricating every
+ * unrelated optional FILE field.
+ */
+import type { Action } from "@elizaos/core";
+import { CODING_TOOLS_CONTEXTS } from "../types.js";
+import { editFileHandler } from "./edit.js";
+import { readFileHandler } from "./read.js";
+import { writeFileHandler } from "./write.js";
+
+const DIRECT_FILE_GATE = {
+  contexts: [...CODING_TOOLS_CONTEXTS],
+  contextGate: { anyOf: [...CODING_TOOLS_CONTEXTS] },
+  roleGate: { minRole: "ADMIN" as const },
+};
+
+export const readAction: Action = {
+  name: "READ",
+  ...DIRECT_FILE_GATE,
+  description:
+    "Read a UTF-8 text file with numbered lines. Use offset and limit for a bounded window.",
+  parameters: [
+    {
+      name: "file_path",
+      description: "Absolute file path.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "offset",
+      description: "Zero-based starting line; omit for the beginning.",
+      required: false,
+      schema: { type: "number" },
+    },
+    {
+      name: "limit",
+      description: "Maximum lines to return; omit for the configured cap.",
+      required: false,
+      schema: { type: "number" },
+    },
+  ],
+  validate: async () => true,
+  handler: readFileHandler,
+};
+
+export const writeAction: Action = {
+  name: "WRITE",
+  ...DIRECT_FILE_GATE,
+  description:
+    "Write complete text to a file, creating parent directories when allowed.",
+  parameters: [
+    {
+      name: "file_path",
+      description: "Absolute file path.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "content",
+      description: "Complete replacement file content.",
+      required: true,
+      schema: { type: "string" },
+    },
+  ],
+  validate: async () => true,
+  handler: writeFileHandler,
+};
+
+export const editAction: Action = {
+  name: "EDIT",
+  ...DIRECT_FILE_GATE,
+  description:
+    "Replace an exact string in a previously read file; fails on stale or ambiguous edits.",
+  parameters: [
+    {
+      name: "file_path",
+      description: "Absolute file path.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "old_string",
+      description: "Exact text currently present in the file.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "new_string",
+      description: "Exact replacement text.",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "replace_all",
+      description: "Replace every exact match; defaults to false.",
+      required: false,
+      schema: { type: "boolean" },
+    },
+  ],
+  validate: async () => true,
+  handler: editFileHandler,
+};

--- a/plugins/plugin-coding-tools/src/actions/edit.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.test.ts
@@ -163,6 +163,37 @@ describe("EDIT", () => {
     expect(result.text).toContain("identical");
   });
 
+  it("rejects accidental literal newline escapes unless explicitly allowed", async () => {
+    const file = await seedFile("literal-escape.txt", "const value = 1;");
+
+    const rejected = await editFileHandler(
+      env.runtime,
+      env.message,
+      undefined,
+      {
+        parameters: {
+          file_path: file,
+          old_string: "const value = 1;",
+          new_string: "const value = 1;\\nconst next = 2;",
+        },
+      },
+    );
+    expect(rejected.success).toBe(false);
+    expect(rejected.text).toContain("literal \\n or \\r sequence");
+    expect(await fs.readFile(file, "utf8")).toBe("const value = 1;");
+
+    const allowed = await editFileHandler(env.runtime, env.message, undefined, {
+      parameters: {
+        file_path: file,
+        old_string: "const value = 1;",
+        new_string: 'const value = "\\n";',
+        allow_literal_escapes: true,
+      },
+    });
+    expect(allowed.success).toBe(true);
+    expect(await fs.readFile(file, "utf8")).toBe('const value = "\\n";');
+  });
+
   it("refuses edits that introduce a detected secret", async () => {
     const file = await seedFile("f.txt", "API_KEY = REPLACE_ME");
 

--- a/plugins/plugin-coding-tools/src/actions/edit.ts
+++ b/plugins/plugin-coding-tools/src/actions/edit.ts
@@ -78,6 +78,8 @@ export async function editFileHandler(
   const oldStr = readStringParam(options, "old_string");
   const newStr = readStringParam(options, "new_string");
   const replaceAll = readBoolParam(options, "replace_all") ?? false;
+  const allowLiteralEscapes =
+    readBoolParam(options, "allow_literal_escapes") ?? false;
   if (!filePath || oldStr === undefined || newStr === undefined) {
     return failureToActionResult({
       reason: "missing_param",
@@ -90,6 +92,16 @@ export async function editFileHandler(
     return failureToActionResult({
       reason: "invalid_param",
       message: "old_string and new_string are identical; nothing to do",
+    });
+  }
+  if (
+    !allowLiteralEscapes &&
+    (newStr.includes("\\n") || newStr.includes("\\r"))
+  ) {
+    return failureToActionResult({
+      reason: "invalid_param",
+      message:
+        "new_string contains a literal \\n or \\r sequence. Send an actual newline for a multiline edit, or set allow_literal_escapes=true when the backslash escape is intentionally part of the source.",
     });
   }
 

--- a/plugins/plugin-coding-tools/src/actions/index.ts
+++ b/plugins/plugin-coding-tools/src/actions/index.ts
@@ -1,5 +1,6 @@
 /** Re-exports the FILE/SHELL/WORKTREE actions and their per-operation handlers. */
 export { shellAction } from "./bash.js";
+export { editAction, readAction, writeAction } from "./direct-file-actions.js";
 export { editFileHandler } from "./edit.js";
 export { enterWorktreeHandler } from "./enter-worktree.js";
 export { exitWorktreeHandler } from "./exit-worktree.js";

--- a/plugins/plugin-coding-tools/src/actions/read.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.test.ts
@@ -453,6 +453,78 @@ describe("READ", () => {
     }
   });
 
+  it("streams a bounded line page from a file larger than the page budget", async () => {
+    const env2 = await setupEnv("read-big-line-window", {
+      extraSettings: { CODING_TOOLS_MAX_FILE_SIZE_BYTES: 64 },
+    });
+    try {
+      const file = path.join(env2.tmpDir, "big-lines.txt");
+      const lines = Array.from({ length: 100 }, (_, index) => `line-${index}`);
+      await fs.writeFile(file, lines.join("\n"), "utf8");
+      const first = await readFileHandler(
+        env2.runtime,
+        env2.message,
+        undefined,
+        { parameters: { file_path: file, unit: "line", limit: 1 } },
+      );
+      const revision = (
+        (first.data as Record<string, unknown>).readView as {
+          reference: { revision: string };
+        }
+      ).reference.revision;
+
+      const result = await readFileHandler(
+        env2.runtime,
+        env2.message,
+        undefined,
+        {
+          parameters: {
+            file_path: file,
+            unit: "line",
+            offset: 40,
+            limit: 3,
+            expectedRevision: revision,
+          },
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toBe("line-40\nline-41\nline-42\n");
+      const data = result.data as Record<string, unknown>;
+      expect(
+        (data.readView as { slice: { range: unknown } }).slice.range,
+      ).toMatchObject({ unit: "line", start: 40, end: 43 });
+      expect(
+        (data.diagnostics as { bytesReturned: number }).bytesReturned,
+      ).toBe(Buffer.byteLength(result.text ?? ""));
+      expect(env2.fileState.get("test-room", file)).toBeDefined();
+    } finally {
+      await env2.cleanup();
+    }
+  });
+
+  it("rejects a requested line page whose selected content exceeds the byte cap", async () => {
+    const env2 = await setupEnv("read-big-line-window-cap", {
+      extraSettings: { CODING_TOOLS_MAX_FILE_SIZE_BYTES: 32 },
+    });
+    try {
+      const file = path.join(env2.tmpDir, "huge-line-page.txt");
+      await fs.writeFile(file, `${"x".repeat(128)}\ntail`, "utf8");
+      const result = await readFileHandler(
+        env2.runtime,
+        env2.message,
+        undefined,
+        { parameters: { file_path: file, unit: "line", limit: 1 } },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain("line window exceeds 32 bytes");
+      expect(result.text).toContain("retry with unit=byte");
+    } finally {
+      await env2.cleanup();
+    }
+  });
+
   it("round-trips Unicode byte pages and rejects stale continuations", async () => {
     const file = path.join(env.tmpDir, "unicode.txt");
     await fs.writeFile(file, "ab😀cdéfg", "utf8");

--- a/plugins/plugin-coding-tools/src/actions/read.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.test.ts
@@ -135,7 +135,6 @@ describe("READ", () => {
         file_path: file,
         offset: firstView.slice.nextOffset,
         limit: 2,
-        expectedRevision: firstView.reference.revision,
       },
     });
     expect(`${first.text}${second.text}`).toBe("alpha\r\nbeta\ngamma\r\n");
@@ -701,14 +700,31 @@ describe("READ", () => {
     expect(result.text).toContain("UTF-8 character boundary");
   });
 
-  it("requires revision identity for every nonzero continuation", async () => {
+  it("requires an initial read before a nonzero continuation", async () => {
     const file = path.join(env.tmpDir, "revision-required.txt");
     await fs.writeFile(file, "alpha\nbeta\n", "utf8");
     const result = await readFileHandler(env.runtime, env.message, undefined, {
       parameters: { file_path: file, offset: 1, limit: 1 },
     });
     expect(result.success).toBe(false);
-    expect(result.text).toContain("expectedRevision is required");
+    expect(result.text).toContain("read from offset 0");
+  });
+
+  it("rejects an automatic continuation when the file changed after the initial read", async () => {
+    const file = path.join(env.tmpDir, "automatic-revision-stale.txt");
+    await fs.writeFile(file, "alpha\nbeta\ngamma\n", "utf8");
+    const first = await readFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, limit: 1 },
+    });
+    expect(first.success).toBe(true);
+
+    await fs.appendFile(file, "delta\n", "utf8");
+    const result = await readFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, offset: 1, limit: 1 },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("expected revision");
   });
 
   it("rejects binary files containing NUL bytes", async () => {

--- a/plugins/plugin-coding-tools/src/actions/read.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.test.ts
@@ -725,6 +725,21 @@ describe("READ", () => {
 
     expect(result.success).toBe(false);
     expect(result.text).toContain("expected revision");
+
+    const refreshed = await readFileHandler(
+      env.runtime,
+      env.message,
+      undefined,
+      { parameters: { file_path: file, offset: 0, limit: 1 } },
+    );
+    expect(refreshed.success).toBe(true);
+    expect(refreshed.text).toBe("alpha\n");
+
+    const resumed = await readFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, offset: 1, limit: 1 },
+    });
+    expect(resumed.success).toBe(true);
+    expect(resumed.text).toBe("beta\n");
   });
 
   it("rejects binary files containing NUL bytes", async () => {

--- a/plugins/plugin-coding-tools/src/actions/read.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.ts
@@ -24,7 +24,10 @@ import {
   successActionResult,
 } from "../lib/format.js";
 import { resolveInputPath } from "../lib/path-utils.js";
-import type { FileStateService } from "../services/file-state-service.js";
+import {
+  type FileStateService,
+  fileRevision,
+} from "../services/file-state-service.js";
 import type { SandboxService } from "../services/sandbox-service.js";
 import {
   CODING_TOOLS_LOG_PREFIX,
@@ -46,14 +49,6 @@ type Window = {
 };
 
 const lineCheckpoints = new Map<string, Map<number, number>>();
-
-function revision(stat: Awaited<ReturnType<fs.FileHandle["stat"]>>): string {
-  return createHash("sha256")
-    .update(
-      `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`,
-    )
-    .digest("hex");
-}
 
 function integer(
   options: unknown,
@@ -304,13 +299,15 @@ export async function readFileHandler(
         message:
           "path is not a regular file. READ accepts files only; use SHELL with `ls` or `rg --files` to inspect a directory.",
       });
-    const currentRevision = revision(before);
-    const expected = readStringParam(options, "expectedRevision");
+    const currentRevision = fileRevision(before);
+    const explicitExpected = readStringParam(options, "expectedRevision");
+    const expected =
+      explicitExpected ??
+      fileState.get(conversationId, checked.resolved)?.revision;
     if (offset > 0 && !expected)
       return failureToActionResult({
         reason: "invalid_param",
-        message:
-          "expectedRevision is required when continuing from a nonzero offset",
+        message: "read from offset 0 before continuing from a nonzero offset",
       });
     if (expected && expected !== currentRevision)
       return failureToActionResult(
@@ -370,7 +367,7 @@ export async function readFileHandler(
         message: `line offset ${offset} exceeds total ${window.total}`,
       });
     }
-    const afterRevision = revision(await handle.stat());
+    const afterRevision = fileRevision(await handle.stat());
     if (afterRevision !== currentRevision)
       return failureToActionResult(
         {
@@ -403,7 +400,11 @@ export async function readFileHandler(
           : {}),
       },
     });
-    await fileState.recordRead(conversationId, checked.resolved);
+    await fileState.recordRead(conversationId, checked.resolved, {
+      mtimeMs: before.mtimeMs,
+      size: before.size,
+      revision: currentRevision,
+    });
     logger.debug(
       `${CODING_TOOLS_LOG_PREFIX} READ ${checked.resolved} unit=${unit} offset=${offset} end=${window.end} sourceBytesRead=${window.sourceBytesRead}`,
     );

--- a/plugins/plugin-coding-tools/src/actions/read.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.ts
@@ -303,7 +303,9 @@ export async function readFileHandler(
     const explicitExpected = readStringParam(options, "expectedRevision");
     const expected =
       explicitExpected ??
-      fileState.get(conversationId, checked.resolved)?.revision;
+      (offset > 0
+        ? fileState.get(conversationId, checked.resolved)?.revision
+        : undefined);
     if (offset > 0 && !expected)
       return failureToActionResult({
         reason: "invalid_param",

--- a/plugins/plugin-coding-tools/src/actions/read.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.ts
@@ -301,7 +301,8 @@ export async function readFileHandler(
     if (!before.isFile())
       return failureToActionResult({
         reason: "invalid_param",
-        message: "path is not a regular file",
+        message:
+          "path is not a regular file. READ accepts files only; use SHELL with `ls` or `rg --files` to inspect a directory.",
       });
     const currentRevision = revision(before);
     const expected = readStringParam(options, "expectedRevision");

--- a/plugins/plugin-coding-tools/src/actions/web-search.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-search.test.ts
@@ -141,16 +141,16 @@ describe("coding-tools WEB_SEARCH", () => {
     expect(result.data).toMatchObject({ provider: "exa" });
   });
 
-  it("caps result output before returning it to the model", async () => {
+  it("returns complete provider output to the model", async () => {
     mockSearchProviders({ parallel: mcpJson("y".repeat(20_000)) });
 
     const result = await runSearch({ query: "large result" });
 
     expect(result.success).toBe(true);
-    expect((result.text ?? "").length).toBeLessThanOrEqual(4_012);
+    expect(result.text).toBe("y".repeat(20_000));
     expect(result.data).toMatchObject({
       provider: "parallel",
-      truncated: true,
+      truncated: false,
     });
   });
 

--- a/plugins/plugin-coding-tools/src/actions/web-search.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-search.ts
@@ -1,7 +1,7 @@
 /**
  * WEB_SEARCH exposes the same keyless MCP search path to coding-only agents that
- * the full agent runtime uses: Parallel is primary, Exa is fallback. Results are
- * bounded before they enter the planner loop and no query text is logged.
+ * the full agent runtime uses: Parallel is primary, Exa is fallback. Complete
+ * provider results enter the planner loop and no query text is logged.
  */
 import type {
   Action,
@@ -64,7 +64,7 @@ export const webSearchAction: Action = {
   routingHint:
     "open-ended external info (news, public facts, 'latest on...', recommendations, pages to discover) -> WEB_SEARCH; a live NOW-value with a constructable endpoint (spot crypto/stock price, exchange rate, current weather) -> WEB_FETCH to that live API (api.coingecko.com/api/v3/simple/price, wttr.in/<city>?format=j1) — search-index snippets lag live values by minutes-to-hours, the endpoint is exact and fresh",
   description:
-    "Search the open web for current or external information using keyless MCP search. Uses Parallel first and Exa fallback, returning bounded ranked result text. For a live NOW-value (spot price, exchange rate, current weather) prefer WEB_FETCH to a live JSON endpoint — search snippets lag live values.",
+    "Search the open web for current or external information using keyless MCP search. Uses Parallel first and Exa fallback, returning complete ranked result text. For a live NOW-value (spot price, exchange rate, current weather) prefer WEB_FETCH to a live JSON endpoint — search snippets lag live values.",
   parameters: [
     {
       name: "query",

--- a/plugins/plugin-coding-tools/src/actions/write.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.test.ts
@@ -150,13 +150,29 @@ describe("WRITE", () => {
     expect(onDisk).toBe("original");
   });
 
-  it("allows overwriting after a previous recordRead with matching mtime", async () => {
+  it("requires explicit overwrite after a previous recordRead", async () => {
     const file = path.join(env.tmpDir, "tracked.txt");
     await fs.writeFile(file, "original", "utf8");
     await env.fileState.recordRead("test-room", file);
 
     const result = await writeFileHandler(env.runtime, env.message, undefined, {
       parameters: { file_path: file, content: "fresh" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain(
+      "WRITE would replace the entire existing file",
+    );
+    expect(await fs.readFile(file, "utf8")).toBe("original");
+  });
+
+  it("allows an explicit overwrite after a previous recordRead with matching mtime", async () => {
+    const file = path.join(env.tmpDir, "tracked-overwrite.txt");
+    await fs.writeFile(file, "original", "utf8");
+    await env.fileState.recordRead("test-room", file);
+
+    const result = await writeFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, content: "fresh", overwrite: true },
     });
 
     expect(result.success).toBe(true);

--- a/plugins/plugin-coding-tools/src/actions/write.ts
+++ b/plugins/plugin-coding-tools/src/actions/write.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   failureToActionResult,
+  readBoolParam,
   readStringParam,
   userFacingSuccessResult,
 } from "../lib/format.js";
@@ -128,6 +129,13 @@ export async function writeFileHandler(
     const reason =
       gate.reason === "stale_read" ? "stale_read" : "invalid_param";
     return failureToActionResult({ reason, message: gate.message });
+  }
+  if (gate.exists && readBoolParam(options, "overwrite") !== true) {
+    return failureToActionResult({
+      reason: "invalid_param",
+      message:
+        "WRITE would replace the entire existing file. Use EDIT for a localized change, or set overwrite=true only after reading the complete file and intentionally supplying its complete replacement.",
+    });
   }
 
   const secrets = detectSecrets(content);

--- a/plugins/plugin-coding-tools/src/index.ts
+++ b/plugins/plugin-coding-tools/src/index.ts
@@ -13,11 +13,14 @@
  */
 import type { Plugin } from "@elizaos/core";
 import {
+  editAction,
   fileAction,
+  readAction,
   shellAction,
   webFetchAction,
   webSearchAction,
   worktreeAction,
+  writeAction,
 } from "./actions/index.js";
 import { availableToolsProvider } from "./providers/available-tools.js";
 import {
@@ -71,6 +74,9 @@ export const codingToolsPlugin: Plugin = {
   providers: [availableToolsProvider, shellHistoryProvider],
   actions: [
     fileAction,
+    readAction,
+    writeAction,
+    editAction,
     shellAction,
     worktreeAction,
     webFetchAction,

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -5,7 +5,12 @@
  * coerce loosely-typed handler options into validated values. Keeps every action's
  * success/failure shape identical.
  */
-import type { ActionResult, IAgentRuntime } from "@elizaos/core";
+import {
+  type ActionResult,
+  type IAgentRuntime,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   type ActionResultData,
   FAILURE_TEXT_PREFIX,
@@ -52,6 +57,26 @@ export function capTranscriptForChat(text: string, maxChars = 1500): string {
     .replace(/\n$/, "");
   const omitted = middle.split("\n").length;
   return `${headPart}\n… [${omitted} lines omitted — ask to see more] …\n${tailPart}`;
+}
+
+/**
+ * Keep a model-facing tool result within a character budget without splitting
+ * UTF-16 surrogate pairs. The omitted count describes the sanitized string so
+ * malformed provider or process output cannot leak invalid Unicode downstream.
+ */
+export function truncate(
+  text: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  const sanitized = toWellFormedUnicode(text);
+  if (sanitized.length <= maxChars) {
+    return { text: sanitized, truncated: false };
+  }
+  const prefix = truncateWellFormed(sanitized, Math.max(0, maxChars));
+  return {
+    text: `${prefix}\n… [${sanitized.length - prefix.length} more chars omitted]`,
+    truncated: true,
+  };
 }
 
 export function failureToActionResult(

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -24,7 +24,8 @@ import {
  * get mangled — Discord eats `*` pairs as italics, turning `-name "*.md"`
  * into `-name ".md"` in the rendered message. The fence length adapts to the
  * longest backtick run in the payload so embedded fences cannot break out.
- * Planner-facing ActionResult text stays raw — fence only what users see.
+ * Planner-facing ActionResult text stays unfenced and is bounded separately by
+ * the action that owns the model-context budget.
  */
 export function fencePreformatted(text: string): string {
   const longestRun =
@@ -39,7 +40,9 @@ export function fencePreformatted(text: string): string {
  * anything over their message limit into a flood of follow-up messages (a bare
  * `ls -la` becomes 8+ Discord posts), so the visible copy keeps the head and
  * tail on line boundaries with an elision marker. The planner-facing
- * ActionResult text is never capped — the model always sees the full output.
+ * ActionResult text is bounded separately for model context; when SHELL output
+ * crosses that limit, the complete redacted streams are available by artifact
+ * handle rather than injected into the prompt.
  */
 export function capTranscriptForChat(text: string, maxChars = 1500): string {
   if (text.length <= maxChars) return text;

--- a/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
@@ -120,6 +120,31 @@ describe("plugin-coding-tools runShell mobile routing", () => {
     });
   });
 
+  it("rejects over-limit capability-router output without returning a prefix", async () => {
+    process.env.ELIZA_PLATFORM = "ios";
+    process.env.ELIZA_BUILD_VARIANT = "store";
+    process.env.ELIZA_RUNTIME_MODE = "local-yolo";
+    const { router, runCommand } = remoteRouter();
+    runCommand.mockResolvedValueOnce({
+      output: "x".repeat(1_000_001),
+      exitCode: 0,
+      timedOut: false,
+    });
+
+    const result = await runShell(runtimeWithRouter(router), {
+      command: "noisy-command",
+      cwd: "/workspace",
+      timeoutMs: 10_000,
+    });
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      outputLimitExceeded: true,
+      sandbox: "capability-router",
+    });
+  });
+
   it("rejects iOS coding commands when no Remote capability router is available", async () => {
     process.env.ELIZA_PLATFORM = "ios";
     process.env.ELIZA_RUNTIME_MODE = "local-yolo";
@@ -178,6 +203,36 @@ describe("plugin-coding-tools runShell local-safe sandbox routing", () => {
       durationMs: 7,
       sandbox: "docker",
       timedOut: false,
+    });
+  });
+
+  it("rejects over-limit sandbox output without returning a prefix", async () => {
+    process.env.ELIZA_RUNTIME_MODE = "local-safe";
+    const runtime = {
+      getService: () => null,
+      getSandboxManager: () => ({
+        engine: { engineType: "docker" },
+        exec: vi.fn(async () => ({
+          exitCode: 0,
+          stdout: "x".repeat(1_000_001),
+          stderr: "",
+          durationMs: 7,
+          executedInSandbox: true,
+        })),
+      }),
+    } as unknown as IAgentRuntime;
+
+    const result = await runShell(runtime, {
+      command: "noisy-command",
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+    });
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      outputLimitExceeded: true,
+      sandbox: "docker",
     });
   });
 });

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -61,6 +61,22 @@ export interface ShellResult {
 
 const COMPLETE_SHELL_CAPTURE_LIMIT_CHARS = 1_000_000;
 
+function enforceCompleteCaptureLimit(result: ShellResult): ShellResult {
+  if (
+    result.outputLimitExceeded === true ||
+    result.stdout.length + result.stderr.length <=
+      COMPLETE_SHELL_CAPTURE_LIMIT_CHARS
+  ) {
+    return result;
+  }
+  return {
+    ...result,
+    stdout: "",
+    stderr: "",
+    outputLimitExceeded: true,
+  };
+}
+
 export interface BackgroundShellStartResult {
   process: HostShellProcess;
   pid: number | undefined;
@@ -685,7 +701,7 @@ export async function runShell(
   const mode = resolveRuntimeExecutionMode(runtime);
 
   const routed = await runThroughCapabilityRouter(runtime, opts);
-  if (routed) return routed;
+  if (routed) return enforceCompleteCaptureLimit(routed);
 
   if (mode === "cloud") {
     throw new Error("Local shell execution disabled in cloud mode.");
@@ -721,7 +737,7 @@ export async function runShell(
       workdir: sandboxWorkdir,
       timeoutMs: opts.timeoutMs,
     });
-    return {
+    return enforceCompleteCaptureLimit({
       exitCode: result.exitCode,
       signal: null,
       stdout: result.stdout,
@@ -729,13 +745,15 @@ export async function runShell(
       durationMs: result.durationMs,
       timedOut: false,
       sandbox: backendForManager(manager),
-    };
+    });
   }
 
-  return runOnHost({
-    command: opts.command,
-    cwd: opts.cwd,
-    timeoutMs: opts.timeoutMs,
-    env: hostSpawnEnv(process.env),
-  });
+  return enforceCompleteCaptureLimit(
+    await runOnHost({
+      command: opts.command,
+      cwd: opts.cwd,
+      timeoutMs: opts.timeoutMs,
+      env: hostSpawnEnv(process.env),
+    }),
+  );
 }

--- a/plugins/plugin-coding-tools/src/lib/shell-output-artifact.ts
+++ b/plugins/plugin-coding-tools/src/lib/shell-output-artifact.ts
@@ -1,0 +1,166 @@
+/**
+ * Persists complete redacted foreground-shell streams when the planner-facing
+ * transcript is truncated. Artifacts live in the shared elizaOS state root,
+ * inherit the shell job retention window, and are swept opportunistically.
+ */
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { logger, resolveStateDir } from "@elizaos/core";
+import { resolveShellJobTtlMs } from "../shell/utils/config.js";
+
+const ARTIFACT_ROOT_SEGMENTS = ["coding-tools", "shell-output"] as const;
+const ARTIFACT_PREFIX = "shell_";
+
+export interface ShellStreamMetrics {
+  characters: number;
+  bytes: number;
+  lines: number;
+}
+
+export interface ShellOutputArtifact {
+  handle: string;
+  manifestPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+  createdAt: string;
+  expiresAt: string;
+  retentionMs: number;
+  stdout: ShellStreamMetrics;
+  stderr: ShellStreamMetrics;
+}
+
+interface PersistShellOutputArtifactOptions {
+  command: string;
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+  signal: NodeJS.Signals | null;
+  modelCharacterLimit: number;
+  modelCharacters: number;
+}
+
+function streamMetrics(text: string): ShellStreamMetrics {
+  const newlineCount = text.match(/\n/g)?.length ?? 0;
+  return {
+    characters: text.length,
+    bytes: Buffer.byteLength(text, "utf8"),
+    lines: text.length === 0 ? 0 : newlineCount + (text.endsWith("\n") ? 0 : 1),
+  };
+}
+
+async function sweepExpiredArtifacts(
+  root: string,
+  cutoffMs: number,
+): Promise<void> {
+  try {
+    const entries = await fs.readdir(root, {
+      encoding: "utf8",
+      withFileTypes: true,
+    });
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isDirectory() || !entry.name.startsWith(ARTIFACT_PREFIX)) {
+          return;
+        }
+        const artifactPath = path.join(root, entry.name);
+        try {
+          const stat = await fs.stat(artifactPath);
+          if (stat.mtimeMs < cutoffMs) {
+            await fs.rm(artifactPath, { recursive: true, force: true });
+          }
+        } catch (error) {
+          // error-policy:J6 concurrent expiry/removal is harmless teardown.
+          logger.warn(
+            { artifactPath, error },
+            "[CodingTools] Failed to expire shell-output artifact",
+          );
+        }
+      }),
+    );
+  } catch (error) {
+    // error-policy:J6 artifact expiry is best-effort teardown; persistence of
+    // the new artifact remains authoritative and the failed sweep is visible.
+    logger.warn(
+      { error },
+      "[CodingTools] Failed to inspect expired shell-output artifacts",
+    );
+  }
+}
+
+/** Persist one complete, already-redacted foreground shell result. */
+export async function persistShellOutputArtifact(
+  options: PersistShellOutputArtifactOptions,
+): Promise<ShellOutputArtifact> {
+  const retentionMs = resolveShellJobTtlMs();
+  const createdAtMs = Date.now();
+  const root = path.join(resolveStateDir(), ...ARTIFACT_ROOT_SEGMENTS);
+  await fs.mkdir(root, { recursive: true, mode: 0o700 });
+  await fs.chmod(root, 0o700);
+  await sweepExpiredArtifacts(root, createdAtMs - retentionMs);
+
+  const handle = `${ARTIFACT_PREFIX}${randomUUID()}`;
+  const artifactDirectory = path.join(root, handle);
+  await fs.mkdir(artifactDirectory, { mode: 0o700 });
+  const stdoutPath = path.join(artifactDirectory, "stdout.txt");
+  const stderrPath = path.join(artifactDirectory, "stderr.txt");
+  const manifestPath = path.join(artifactDirectory, "manifest.json");
+  const stdout = streamMetrics(options.stdout);
+  const stderr = streamMetrics(options.stderr);
+  const createdAt = new Date(createdAtMs).toISOString();
+  const expiresAt = new Date(createdAtMs + retentionMs).toISOString();
+
+  await Promise.all([
+    fs.writeFile(stdoutPath, options.stdout, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    }),
+    fs.writeFile(stderrPath, options.stderr, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    }),
+  ]);
+  const artifact: ShellOutputArtifact = {
+    handle,
+    manifestPath,
+    stdoutPath,
+    stderrPath,
+    createdAt,
+    expiresAt,
+    retentionMs,
+    stdout,
+    stderr,
+  };
+  await fs.writeFile(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        version: 1,
+        handle,
+        createdAt,
+        expiresAt,
+        command: options.command,
+        cwd: options.cwd,
+        exitCode: options.exitCode,
+        timedOut: options.timedOut,
+        signal: options.signal,
+        stdout: { path: stdoutPath, ...stdout },
+        stderr: { path: stderrPath, ...stderr },
+        truncation: {
+          modelCharacterLimit: options.modelCharacterLimit,
+          modelCharacters: options.modelCharacters,
+          completeCharacters: options.stdout.length + options.stderr.length,
+          completeBytes: stdout.bytes + stderr.bytes,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    { encoding: "utf8", flag: "wx", mode: 0o600 },
+  );
+  return artifact;
+}

--- a/plugins/plugin-coding-tools/src/lib/shell-output-artifact.ts
+++ b/plugins/plugin-coding-tools/src/lib/shell-output-artifact.ts
@@ -4,9 +4,10 @@
  * inherit the shell job retention window, and are swept opportunistically.
  */
 import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { logger, resolveStateDir } from "@elizaos/core";
+import { logger, resolveStateDir, toWellFormedUnicode } from "@elizaos/core";
 import { resolveShellJobTtlMs } from "../shell/utils/config.js";
 
 const ARTIFACT_ROOT_SEGMENTS = ["coding-tools", "shell-output"] as const;
@@ -40,6 +41,91 @@ interface PersistShellOutputArtifactOptions {
   signal: NodeJS.Signals | null;
   modelCharacterLimit: number;
   modelCharacters: number;
+  ownerAgentId: string;
+  ownerConversationId: string;
+}
+
+export type ShellOutputArtifactStream = "stdout" | "stderr";
+
+export interface ShellOutputArtifactPage {
+  handle: string;
+  stream: ShellOutputArtifactStream;
+  text: string;
+  startOffset: number;
+  endOffset: number;
+  nextOffset: number;
+  totalCharacters: number;
+  complete: boolean;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export type ShellOutputArtifactReadResult =
+  | { ok: true; value: ShellOutputArtifactPage }
+  | {
+      ok: false;
+      reason: "invalid_handle" | "unavailable" | "expired" | "corrupt";
+      message: string;
+    };
+
+const ARTIFACT_HANDLE_PATTERN =
+  /^shell_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ARTIFACT_PAGE_DEFAULT_CHARS = 12_000;
+const ARTIFACT_PAGE_MAX_CHARS = 20_000;
+
+interface PersistedShellOutputManifest {
+  version: 1;
+  handle: string;
+  createdAt: string;
+  expiresAt: string;
+  owner: { agentId: string; conversationId: string };
+}
+
+async function readRegularUtf8(filePath: string): Promise<string> {
+  const file = await fs.open(
+    filePath,
+    fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const stat = await file.stat();
+    if (!stat.isFile()) throw new Error("artifact entry is not a regular file");
+    return await file.readFile({ encoding: "utf8" });
+  } finally {
+    await file.close();
+  }
+}
+
+function normalizePageStart(text: string, requested: number): number {
+  let start = Math.max(0, Math.min(text.length, Math.floor(requested)));
+  if (
+    start > 0 &&
+    start < text.length &&
+    text.charCodeAt(start) >= 0xdc00 &&
+    text.charCodeAt(start) <= 0xdfff &&
+    text.charCodeAt(start - 1) >= 0xd800 &&
+    text.charCodeAt(start - 1) <= 0xdbff
+  ) {
+    start -= 1;
+  }
+  return start;
+}
+
+function normalizePageEnd(text: string, start: number, limit: number): number {
+  let end = Math.min(text.length, start + limit);
+  if (
+    end > start &&
+    end < text.length &&
+    text.charCodeAt(end - 1) >= 0xd800 &&
+    text.charCodeAt(end - 1) <= 0xdbff &&
+    text.charCodeAt(end) >= 0xdc00 &&
+    text.charCodeAt(end) <= 0xdfff
+  ) {
+    end -= 1;
+  }
+  if (end === start && start < text.length) {
+    end = Math.min(text.length, start + 2);
+  }
+  return end;
 }
 
 function streamMetrics(text: string): ShellStreamMetrics {
@@ -143,6 +229,10 @@ export async function persistShellOutputArtifact(
         handle,
         createdAt,
         expiresAt,
+        owner: {
+          agentId: options.ownerAgentId,
+          conversationId: options.ownerConversationId,
+        },
         command: options.command,
         cwd: options.cwd,
         exitCode: options.exitCode,
@@ -163,4 +253,128 @@ export async function persistShellOutputArtifact(
     { encoding: "utf8", flag: "wx", mode: 0o600 },
   );
   return artifact;
+}
+
+/**
+ * Resolve one bounded artifact page by opaque handle. The state-root path is
+ * never accepted from the caller, and the persisted agent/conversation scope
+ * must match the requesting action turn before any stream bytes are returned.
+ */
+export async function readShellOutputArtifactPage(options: {
+  handle: string;
+  stream: ShellOutputArtifactStream;
+  offset?: number;
+  limit?: number;
+  requesterAgentId: string;
+  requesterConversationId: string;
+}): Promise<ShellOutputArtifactReadResult> {
+  if (!ARTIFACT_HANDLE_PATTERN.test(options.handle)) {
+    return {
+      ok: false,
+      reason: "invalid_handle",
+      message: "invalid shell-output artifact handle",
+    };
+  }
+
+  const root = path.join(resolveStateDir(), ...ARTIFACT_ROOT_SEGMENTS);
+  const artifactDirectory = path.join(root, options.handle);
+  try {
+    const [realRoot, realArtifactDirectory] = await Promise.all([
+      fs.realpath(root),
+      fs.realpath(artifactDirectory),
+    ]);
+    if (path.dirname(realArtifactDirectory) !== realRoot) {
+      return {
+        ok: false,
+        reason: "unavailable",
+        message: "shell-output artifact is unavailable for this conversation",
+      };
+    }
+
+    const manifestRaw = await readRegularUtf8(
+      path.join(realArtifactDirectory, "manifest.json"),
+    );
+    const parsed: unknown = JSON.parse(manifestRaw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("artifact manifest is not an object");
+    }
+    const manifest = parsed as Partial<PersistedShellOutputManifest>;
+    if (
+      manifest.version !== 1 ||
+      manifest.handle !== options.handle ||
+      typeof manifest.createdAt !== "string" ||
+      typeof manifest.expiresAt !== "string" ||
+      !manifest.owner ||
+      manifest.owner.agentId !== options.requesterAgentId ||
+      manifest.owner.conversationId !== options.requesterConversationId
+    ) {
+      return {
+        ok: false,
+        reason: "unavailable",
+        message: "shell-output artifact is unavailable for this conversation",
+      };
+    }
+    const expiresAtMs = Date.parse(manifest.expiresAt);
+    if (!Number.isFinite(expiresAtMs)) {
+      throw new Error("artifact expiry is invalid");
+    }
+    if (expiresAtMs <= Date.now()) {
+      return {
+        ok: false,
+        reason: "expired",
+        message: "shell-output artifact has expired",
+      };
+    }
+
+    const raw = await readRegularUtf8(
+      path.join(realArtifactDirectory, `${options.stream}.txt`),
+    );
+    const text = toWellFormedUnicode(raw);
+    const requestedOffset =
+      options.offset !== undefined && Number.isFinite(options.offset)
+        ? options.offset
+        : 0;
+    const requestedLimit =
+      options.limit !== undefined && Number.isFinite(options.limit)
+        ? options.limit
+        : ARTIFACT_PAGE_DEFAULT_CHARS;
+    const limit = Math.max(
+      2,
+      Math.min(ARTIFACT_PAGE_MAX_CHARS, Math.floor(requestedLimit)),
+    );
+    const startOffset = normalizePageStart(text, requestedOffset);
+    const endOffset = normalizePageEnd(text, startOffset, limit);
+    return {
+      ok: true,
+      value: {
+        handle: options.handle,
+        stream: options.stream,
+        text: text.slice(startOffset, endOffset),
+        startOffset,
+        endOffset,
+        nextOffset: endOffset,
+        totalCharacters: text.length,
+        complete: endOffset >= text.length,
+        createdAt: manifest.createdAt,
+        expiresAt: manifest.expiresAt,
+      },
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return {
+        ok: false,
+        reason: "unavailable",
+        message: "shell-output artifact is unavailable for this conversation",
+      };
+    }
+    logger.warn(
+      { handle: options.handle, error },
+      "[CodingTools] Failed to read shell-output artifact",
+    );
+    return {
+      ok: false,
+      reason: "corrupt",
+      message: "shell-output artifact could not be read safely",
+    };
+  }
 }

--- a/plugins/plugin-coding-tools/src/providers/available-tools.ts
+++ b/plugins/plugin-coding-tools/src/providers/available-tools.ts
@@ -14,6 +14,9 @@ import { CODING_TOOLS_CONTEXTS } from "../types.js";
 
 const TOOL_NAMES = [
   "FILE",
+  "READ",
+  "WRITE",
+  "EDIT",
   "SHELL",
   "WEB_FETCH",
   "WEB_SEARCH",
@@ -41,7 +44,7 @@ export const availableToolsProvider: Provider = {
     const lines = [
       "# Native coding tools",
       "",
-      "FILE reads/writes/searches, SHELL runs commands plus background sessions, WEB_FETCH reads public HTTPS pages, WEB_SEARCH researches the web, and WORKTREE manages git worktrees.",
+      "READ, WRITE, and EDIT provide focused file operations; FILE retains grep/glob/list and compatibility operations. SHELL runs commands plus background sessions, WEB_FETCH reads public HTTPS pages, WEB_SEARCH researches the web, and WORKTREE manages git worktrees.",
       "Use absolute workspace paths unless a tool says it defaults to session cwd. Configured private/system paths are blocked.",
       "SHELL background subactions: start_background returns a stable handle; poll_background reads complete incremental stdout/stderr with offsets and rejects if the complete-capture ceiling is exceeded; write_background sends stdin; kill_background terminates; list_background shows sessions.",
       "",

--- a/plugins/plugin-coding-tools/src/services/file-state-service.ts
+++ b/plugins/plugin-coding-tools/src/services/file-state-service.ts
@@ -72,7 +72,7 @@ export class FileStateService extends Service {
     conversationId: string,
     absPath: string,
   ): Promise<
-    | { ok: true }
+    | { ok: true; exists: boolean }
     | { ok: false; reason: "must_read_first" | "stale_read"; message: string }
   > {
     let stat: Awaited<ReturnType<typeof fs.stat>>;
@@ -83,7 +83,7 @@ export class FileStateService extends Service {
       // create-new-file path (Write is allowed; Edit re-verifies existence
       // separately). A genuine permission error is not masked: the subsequent
       // fs.writeFile surfaces it to the caller as an `io_error` failure.
-      return { ok: true };
+      return { ok: true, exists: false };
     }
     const meta = this.get(conversationId, absPath);
     if (!meta) {
@@ -100,7 +100,7 @@ export class FileStateService extends Service {
         message: `File ${absPath} was modified externally since last read (mtime ${meta.mtimeMs} → ${stat.mtimeMs}). Re-read before writing.`,
       };
     }
-    return { ok: true };
+    return { ok: true, exists: true };
   }
 
   invalidate(conversationId: string, absPath: string): void {

--- a/plugins/plugin-coding-tools/src/services/file-state-service.ts
+++ b/plugins/plugin-coding-tools/src/services/file-state-service.ts
@@ -1,10 +1,10 @@
 /**
- * `FileStateService` (serviceType `CODING_TOOLS_FILE_STATE`): tracks the mtime and
- * size of each file per conversation at read time so write/edit handlers can reject
- * a write when the file was modified externally since the last read — the
- * read-before-write invariant that keeps agent edits from clobbering outside
- * changes.
+ * `FileStateService` (serviceType `CODING_TOOLS_FILE_STATE`): tracks each file's
+ * opaque revision per conversation at read time so continuation and mutation
+ * handlers reject externally changed content instead of clobbering it.
  */
+import { createHash } from "node:crypto";
+import type { Stats } from "node:fs";
 import * as fs from "node:fs/promises";
 import {
   logger as coreLogger,
@@ -13,6 +13,17 @@ import {
 } from "@elizaos/core";
 import type { FileMeta } from "../types.js";
 import { CODING_TOOLS_LOG_PREFIX, FILE_STATE_SERVICE } from "../types.js";
+
+/** Produces the stable identity shared by paginated reads and mutation guards. */
+export function fileRevision(
+  stat: Pick<Stats, "dev" | "ino" | "size" | "mtimeMs" | "ctimeMs">,
+): string {
+  return createHash("sha256")
+    .update(
+      `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`,
+    )
+    .digest("hex");
+}
 
 /**
  * Tracks per-(conversation, file) read state. Mirrors Claude's `readFileState` —
@@ -44,13 +55,18 @@ export class FileStateService extends Service {
     return `${conversationId}::${absPath}`;
   }
 
-  async recordRead(conversationId: string, absPath: string): Promise<void> {
-    const stat = await fs.stat(absPath);
+  async recordRead(
+    conversationId: string,
+    absPath: string,
+    observed?: { mtimeMs: number; size: number; revision: string },
+  ): Promise<void> {
+    const stat = observed ?? (await fs.stat(absPath));
     this.state.set(this.key(conversationId, absPath), {
       path: absPath,
       mtimeMs: stat.mtimeMs,
       size: stat.size,
       readAt: Date.now(),
+      ...(observed ? { revision: observed.revision } : {}),
     });
   }
 
@@ -61,6 +77,7 @@ export class FileStateService extends Service {
       mtimeMs: stat.mtimeMs,
       size: stat.size,
       readAt: Date.now(),
+      revision: fileRevision(stat),
     });
   }
 
@@ -93,11 +110,14 @@ export class FileStateService extends Service {
         message: `File ${absPath} exists but was not read in this session. Read it first.`,
       };
     }
-    if (stat.mtimeMs !== meta.mtimeMs) {
+    const changed = meta.revision
+      ? fileRevision(stat) !== meta.revision
+      : stat.mtimeMs !== meta.mtimeMs || stat.size !== meta.size;
+    if (changed) {
       return {
         ok: false,
         reason: "stale_read",
-        message: `File ${absPath} was modified externally since last read (mtime ${meta.mtimeMs} → ${stat.mtimeMs}). Re-read before writing.`,
+        message: `File ${absPath} was modified externally since last read. Re-read before writing.`,
       };
     }
     return { ok: true, exists: true };

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -105,11 +105,11 @@ describePosixShell("shell plugin real local integration", () => {
       "}, 50);",
     ].join("");
     const result = await service.executeCommand(
-      `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`,
+      `node -e ${JSON.stringify(script)}`,
       "room-utf8",
     );
 
-    expect(result.success).toBe(true);
+    expect(result.success, JSON.stringify(result)).toBe(true);
     expect(result.stdout).toBe("\u4f60");
     expect(result.stderr).toBe("\u4f60");
   });
@@ -135,6 +135,37 @@ describePosixShell("shell plugin real local integration", () => {
 
     expect(JSON.stringify(history)).not.toContain(secret);
     expect(JSON.stringify(provider)).not.toContain(secret);
+  });
+
+  it("bounds provider history while retaining complete service history and output", async () => {
+    const largeOutput = "z".repeat(5_000);
+    await service.executeCommand(
+      `printf '%s' '${largeOutput}'`,
+      "room-bounded-history",
+    );
+    for (let index = 1; index <= 10; index += 1) {
+      await service.executeCommand(
+        `printf 'command-${index}'`,
+        "room-bounded-history",
+      );
+    }
+
+    const stored = service.getCommandHistory("room-bounded-history");
+    expect(stored).toHaveLength(11);
+    expect(stored[0]?.stdout).toContain(largeOutput);
+    expect(stored[0]?.stdout.length).toBeGreaterThanOrEqual(largeOutput.length);
+
+    const provider = await shellHistoryProvider.get(
+      runtime,
+      { roomId: "room-bounded-history", agentId: "agent-1" } as never,
+      {} as never,
+    );
+
+    expect(provider.text).not.toContain(largeOutput);
+    expect(provider.text).toContain("command-1");
+    expect(provider.text).toContain("command-10");
+    expect(provider.data?.historyCount).toBe(10);
+    expect(provider.text?.length).toBeLessThanOrEqual(24_000);
   });
 
   it("fails closed when a command tries to escape the allowed directory", async () => {

--- a/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/shell.real.test.ts
@@ -137,7 +137,7 @@ describePosixShell("shell plugin real local integration", () => {
     expect(JSON.stringify(provider)).not.toContain(secret);
   });
 
-  it("bounds provider history while retaining complete service history and output", async () => {
+  it("renders complete service history and output in provider context", async () => {
     const largeOutput = "z".repeat(5_000);
     await service.executeCommand(
       `printf '%s' '${largeOutput}'`,
@@ -161,11 +161,10 @@ describePosixShell("shell plugin real local integration", () => {
       {} as never,
     );
 
-    expect(provider.text).not.toContain(largeOutput);
+    expect(provider.text).toContain(largeOutput);
     expect(provider.text).toContain("command-1");
     expect(provider.text).toContain("command-10");
-    expect(provider.data?.historyCount).toBe(10);
-    expect(provider.text?.length).toBeLessThanOrEqual(24_000);
+    expect(provider.data?.historyCount).toBe(11);
   });
 
   it("fails closed when a command tries to escape the allowed directory", async () => {

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.test.ts
@@ -1,6 +1,6 @@
 /**
- * Verifies that SHELL_HISTORY projects a bounded recent window without mutating
- * the ShellService-owned full command history.
+ * Verifies that SHELL_HISTORY renders complete service-owned command context
+ * without mutating the underlying history.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -9,7 +9,7 @@ import type { CommandHistoryEntry } from "../types";
 import { shellHistoryProvider } from "./shellHistoryProvider";
 
 describe("SHELL_HISTORY provider", () => {
-  it("caps recent output while leaving complete service history intact", async () => {
+  it("renders complete output and history without mutating the service", async () => {
     const largeOutput = "z".repeat(5_000);
     const fullHistory: CommandHistoryEntry[] = Array.from(
       { length: 12 },
@@ -43,16 +43,15 @@ describe("SHELL_HISTORY provider", () => {
       {} as never,
     );
 
-    expect(getCommandHistory).toHaveBeenCalledWith("room-bounded-history", 10);
+    expect(getCommandHistory).toHaveBeenCalledWith("room-bounded-history");
     expect(fullHistory).toHaveLength(12);
     expect(fullHistory[11]?.stdout).toBe(largeOutput);
-    expect(result.text).not.toContain("command-0");
-    expect(result.text).not.toMatch(/command-1(?:\D|$)/);
+    expect(result.text).toContain("command-0");
+    expect(result.text).toMatch(/command-1(?:\D|$)/);
     expect(result.text).toContain("command-2");
     expect(result.text).toContain("command-11");
-    expect(result.text).not.toContain(largeOutput);
-    expect(result.text).toContain("characters omitted");
-    expect(result.text?.length).toBeLessThanOrEqual(24_000);
-    expect(result.data?.historyCount).toBe(10);
+    expect(result.text).toContain(largeOutput);
+    expect(result.text).not.toContain("characters omitted");
+    expect(result.data?.historyCount).toBe(12);
   });
 });

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Verifies that SHELL_HISTORY projects a bounded recent window without mutating
+ * the ShellService-owned full command history.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ShellService } from "../services/shellService";
+import type { CommandHistoryEntry } from "../types";
+import { shellHistoryProvider } from "./shellHistoryProvider";
+
+describe("SHELL_HISTORY provider", () => {
+  it("caps recent output while leaving complete service history intact", async () => {
+    const largeOutput = "z".repeat(5_000);
+    const fullHistory: CommandHistoryEntry[] = Array.from(
+      { length: 12 },
+      (_, index) => ({
+        command: `command-${index}`,
+        stdout: index === 11 ? largeOutput : `output-${index}`,
+        stderr: "",
+        exitCode: 0,
+        timestamp: Date.UTC(2026, 0, 1, 0, index),
+        workingDirectory: "/workspace",
+      }),
+    );
+    const getCommandHistory = vi.fn(
+      (_conversationId: string, limit?: number) =>
+        limit ? fullHistory.slice(-limit) : fullHistory,
+    );
+    const service = {
+      getCommandHistory,
+      getCurrentDirectory: () => "/workspace",
+      getAllowedDirectory: () => "/workspace",
+    } as unknown as ShellService;
+    const runtime = {
+      character: {},
+      getService: (name: string) => (name === "shell" ? service : null),
+      redactSecrets: (text: string) => text,
+    } as unknown as IAgentRuntime;
+
+    const result = await shellHistoryProvider.get(
+      runtime,
+      { roomId: "room-bounded-history", agentId: "agent-1" } as never,
+      {} as never,
+    );
+
+    expect(getCommandHistory).toHaveBeenCalledWith("room-bounded-history", 10);
+    expect(fullHistory).toHaveLength(12);
+    expect(fullHistory[11]?.stdout).toBe(largeOutput);
+    expect(result.text).not.toContain("command-0");
+    expect(result.text).not.toMatch(/command-1(?:\D|$)/);
+    expect(result.text).toContain("command-2");
+    expect(result.text).toContain("command-11");
+    expect(result.text).not.toContain(largeOutput);
+    expect(result.text).toContain("characters omitted");
+    expect(result.text?.length).toBeLessThanOrEqual(24_000);
+    expect(result.data?.historyCount).toBe(10);
+  });
+});

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
@@ -20,6 +20,35 @@ import type { CommandHistoryEntry, FileOperation } from "../types";
 
 const spec = requireProviderSpec("SHELL_HISTORY");
 
+const SHELL_HISTORY_ENTRY_LIMIT = 10;
+const SHELL_HISTORY_STREAM_CHAR_LIMIT = 2_000;
+const SHELL_HISTORY_ENTRY_CHAR_LIMIT = 5_000;
+const SHELL_HISTORY_TEXT_CHAR_LIMIT = 24_000;
+const SHELL_HISTORY_FILE_OPERATION_LIMIT = 20;
+
+function capHistoryText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const marker = `\n… [${text.length - maxChars} characters omitted] …\n`;
+  const remaining = Math.max(0, maxChars - marker.length);
+  const head = Math.floor(remaining * 0.6);
+  return `${text.slice(0, head)}${marker}${text.slice(-(remaining - head))}`;
+}
+
+function renderFileOperation(
+  runtime: IAgentRuntime,
+  op: FileOperation,
+): string {
+  const target = capHistoryText(redactShellText(runtime, op.target), 500);
+  if (op.secondaryTarget) {
+    const secondary = capHistoryText(
+      redactShellText(runtime, op.secondaryTarget),
+      500,
+    );
+    return `- ${op.type}: ${target} → ${secondary}`;
+  }
+  return `- ${op.type}: ${target}`;
+}
+
 export const shellHistoryProvider: Provider = {
   name: spec.name,
   description:
@@ -60,7 +89,12 @@ export const shellHistoryProvider: Provider = {
           data: { historyCount: 0, cwd: "N/A", allowedDir: "N/A" },
         };
       }
-      const history = shellService.getCommandHistory(conversationId);
+      // Bound only the provider projection. ShellService retains the complete
+      // history and full command output for explicit history inspection.
+      const history = shellService.getCommandHistory(
+        conversationId,
+        SHELL_HISTORY_ENTRY_LIMIT,
+      );
       const cwd = redactShellText(
         runtime,
         shellService.getCurrentDirectory(conversationId),
@@ -74,8 +108,14 @@ export const shellHistoryProvider: Provider = {
       if (history.length > 0) {
         historyText = history
           .map((entry: CommandHistoryEntry) => {
-            const stdout = redactShellText(runtime, entry.stdout ?? "");
-            const stderr = redactShellText(runtime, entry.stderr ?? "");
+            const stdout = capHistoryText(
+              redactShellText(runtime, entry.stdout ?? ""),
+              SHELL_HISTORY_STREAM_CHAR_LIMIT,
+            );
+            const stderr = capHistoryText(
+              redactShellText(runtime, entry.stderr ?? ""),
+              SHELL_HISTORY_STREAM_CHAR_LIMIT,
+            );
             let entryStr = redactShellText(
               runtime,
               `[${new Date(entry.timestamp).toISOString()}] ${entry.workingDirectory}> ${entry.command}`,
@@ -102,9 +142,13 @@ export const shellHistoryProvider: Provider = {
               });
             }
 
-            return entryStr;
+            return capHistoryText(entryStr, SHELL_HISTORY_ENTRY_CHAR_LIMIT);
           })
           .join("\n\n");
+        historyText = capHistoryText(
+          historyText,
+          SHELL_HISTORY_TEXT_CHAR_LIMIT,
+        );
       }
 
       const recentFileOps = history
@@ -112,7 +156,8 @@ export const shellHistoryProvider: Provider = {
           (entry: CommandHistoryEntry) =>
             entry.fileOperations && entry.fileOperations.length > 0,
         )
-        .flatMap((entry: CommandHistoryEntry) => entry.fileOperations ?? []);
+        .flatMap((entry: CommandHistoryEntry) => entry.fileOperations ?? [])
+        .slice(-SHELL_HISTORY_FILE_OPERATION_LIMIT);
 
       let fileOpsText = "";
       if (recentFileOps.length > 0) {
@@ -121,20 +166,18 @@ export const shellHistoryProvider: Provider = {
           addHeader(
             "# Recent File Operations",
             recentFileOps
-              .map((op: FileOperation) => {
-                if (op.secondaryTarget) {
-                  return `- ${op.type}: ${redactShellText(runtime, op.target)} → ${redactShellText(runtime, op.secondaryTarget)}`;
-                }
-                return `- ${op.type}: ${redactShellText(runtime, op.target)}`;
-              })
+              .map((op: FileOperation) => renderFileOperation(runtime, op))
               .join("\n"),
           );
       }
 
-      const text = `Current Directory: ${cwd}
+      const text = capHistoryText(
+        `Current Directory: ${cwd}
 Allowed Directory: ${allowedDir}
 
-${addHeader("# Shell History", historyText)}${fileOpsText}`;
+${addHeader("# Shell History", historyText)}${fileOpsText}`,
+        SHELL_HISTORY_TEXT_CHAR_LIMIT,
+      );
 
       return {
         values: {

--- a/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-coding-tools/src/shell/providers/shellHistoryProvider.ts
@@ -1,8 +1,9 @@
 /**
- * SHELL_HISTORY provider — injects recent shell activity into agent context: the
- * last commands with stdout/stderr/exit codes, the current and allowed working
- * directories, and recent file operations. Fires only in terminal/code contexts
- * and reads its state from ShellService.
+ * SHELL_HISTORY provider injects the complete conversation-scoped shell
+ * activity into terminal/code context without changing the service-owned
+ * history. It includes command streams, exit codes, working directories, and
+ * file operations so planner context never presents a bounded projection as
+ * the underlying execution record.
  */
 import {
   addHeader,
@@ -20,30 +21,13 @@ import type { CommandHistoryEntry, FileOperation } from "../types";
 
 const spec = requireProviderSpec("SHELL_HISTORY");
 
-const SHELL_HISTORY_ENTRY_LIMIT = 10;
-const SHELL_HISTORY_STREAM_CHAR_LIMIT = 2_000;
-const SHELL_HISTORY_ENTRY_CHAR_LIMIT = 5_000;
-const SHELL_HISTORY_TEXT_CHAR_LIMIT = 24_000;
-const SHELL_HISTORY_FILE_OPERATION_LIMIT = 20;
-
-function capHistoryText(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  const marker = `\n… [${text.length - maxChars} characters omitted] …\n`;
-  const remaining = Math.max(0, maxChars - marker.length);
-  const head = Math.floor(remaining * 0.6);
-  return `${text.slice(0, head)}${marker}${text.slice(-(remaining - head))}`;
-}
-
 function renderFileOperation(
   runtime: IAgentRuntime,
   op: FileOperation,
 ): string {
-  const target = capHistoryText(redactShellText(runtime, op.target), 500);
+  const target = redactShellText(runtime, op.target);
   if (op.secondaryTarget) {
-    const secondary = capHistoryText(
-      redactShellText(runtime, op.secondaryTarget),
-      500,
-    );
+    const secondary = redactShellText(runtime, op.secondaryTarget);
     return `- ${op.type}: ${target} → ${secondary}`;
   }
   return `- ${op.type}: ${target}`;
@@ -52,9 +36,9 @@ function renderFileOperation(
 export const shellHistoryProvider: Provider = {
   name: spec.name,
   description:
-    "Provides recent shell command history, current working directory, and file operations within the restricted environment",
+    "Provides complete shell command history, current working directory, and file operations within the restricted environment",
   descriptionCompressed:
-    "Recent shell history, cwd, and file ops in restricted env.",
+    "Complete shell history, cwd, and file ops in restricted env.",
   position: 99,
   contexts: ["terminal", "code"],
   contextGate: { anyOf: ["terminal", "code"] },
@@ -89,12 +73,7 @@ export const shellHistoryProvider: Provider = {
           data: { historyCount: 0, cwd: "N/A", allowedDir: "N/A" },
         };
       }
-      // Bound only the provider projection. ShellService retains the complete
-      // history and full command output for explicit history inspection.
-      const history = shellService.getCommandHistory(
-        conversationId,
-        SHELL_HISTORY_ENTRY_LIMIT,
-      );
+      const history = shellService.getCommandHistory(conversationId);
       const cwd = redactShellText(
         runtime,
         shellService.getCurrentDirectory(conversationId),
@@ -108,14 +87,8 @@ export const shellHistoryProvider: Provider = {
       if (history.length > 0) {
         historyText = history
           .map((entry: CommandHistoryEntry) => {
-            const stdout = capHistoryText(
-              redactShellText(runtime, entry.stdout ?? ""),
-              SHELL_HISTORY_STREAM_CHAR_LIMIT,
-            );
-            const stderr = capHistoryText(
-              redactShellText(runtime, entry.stderr ?? ""),
-              SHELL_HISTORY_STREAM_CHAR_LIMIT,
-            );
+            const stdout = redactShellText(runtime, entry.stdout ?? "");
+            const stderr = redactShellText(runtime, entry.stderr ?? "");
             let entryStr = redactShellText(
               runtime,
               `[${new Date(entry.timestamp).toISOString()}] ${entry.workingDirectory}> ${entry.command}`,
@@ -132,52 +105,23 @@ export const shellHistoryProvider: Provider = {
             entryStr += `\n  Exit Code: ${entry.exitCode}`;
 
             if (entry.fileOperations && entry.fileOperations.length > 0) {
-              entryStr += "\n  File Operations:";
-              entry.fileOperations.forEach((op: FileOperation) => {
-                if (op.secondaryTarget) {
-                  entryStr += `\n    - ${op.type}: ${redactShellText(runtime, op.target)} → ${redactShellText(runtime, op.secondaryTarget)}`;
-                } else {
-                  entryStr += `\n    - ${op.type}: ${redactShellText(runtime, op.target)}`;
-                }
-              });
+              entryStr += `\n  File Operations:\n${entry.fileOperations
+                .map(
+                  (op: FileOperation) =>
+                    `    ${renderFileOperation(runtime, op)}`,
+                )
+                .join("\n")}`;
             }
 
-            return capHistoryText(entryStr, SHELL_HISTORY_ENTRY_CHAR_LIMIT);
+            return entryStr;
           })
           .join("\n\n");
-        historyText = capHistoryText(
-          historyText,
-          SHELL_HISTORY_TEXT_CHAR_LIMIT,
-        );
       }
 
-      const recentFileOps = history
-        .filter(
-          (entry: CommandHistoryEntry) =>
-            entry.fileOperations && entry.fileOperations.length > 0,
-        )
-        .flatMap((entry: CommandHistoryEntry) => entry.fileOperations ?? [])
-        .slice(-SHELL_HISTORY_FILE_OPERATION_LIMIT);
-
-      let fileOpsText = "";
-      if (recentFileOps.length > 0) {
-        fileOpsText =
-          "\n\n" +
-          addHeader(
-            "# Recent File Operations",
-            recentFileOps
-              .map((op: FileOperation) => renderFileOperation(runtime, op))
-              .join("\n"),
-          );
-      }
-
-      const text = capHistoryText(
-        `Current Directory: ${cwd}
+      const text = `Current Directory: ${cwd}
 Allowed Directory: ${allowedDir}
 
-${addHeader("# Shell History", historyText)}${fileOpsText}`,
-        SHELL_HISTORY_TEXT_CHAR_LIMIT,
-      );
+${addHeader("# Shell History", historyText)}`;
 
       return {
         values: {

--- a/plugins/plugin-coding-tools/src/shell/utils/config.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/config.ts
@@ -73,6 +73,16 @@ function parsePositiveIntegerEnv(
   );
 }
 
+/** Resolve the retention shared by finished shell jobs and output artifacts. */
+export function resolveShellJobTtlMs(): number {
+  return parsePositiveIntegerEnv(
+    "SHELL_JOB_TTL_MS",
+    DEFAULT_JOB_TTL_MS,
+    MAX_JOB_TTL_MS,
+    MIN_JOB_TTL_MS,
+  );
+}
+
 export const DEFAULT_FORBIDDEN_COMMANDS: readonly string[] = [
   "rm -rf /",
   "rmdir",
@@ -124,12 +134,7 @@ export function loadShellConfig(): ShellConfig {
     MAX_BACKGROUND_MS,
     MIN_BACKGROUND_MS,
   );
-  const jobTtlMs = parsePositiveIntegerEnv(
-    "SHELL_JOB_TTL_MS",
-    DEFAULT_JOB_TTL_MS,
-    MAX_JOB_TTL_MS,
-    MIN_JOB_TTL_MS,
-  );
+  const jobTtlMs = resolveShellJobTtlMs();
   const allowBackground = process.env.SHELL_ALLOW_BACKGROUND !== "false";
 
   const customForbidden = process.env.SHELL_FORBIDDEN_COMMANDS

--- a/plugins/plugin-coding-tools/src/types.ts
+++ b/plugins/plugin-coding-tools/src/types.ts
@@ -27,6 +27,7 @@ export interface FileMeta {
   mtimeMs: number;
   size: number;
   readAt: number;
+  revision?: string;
 }
 
 export type ToolFailureReason =

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -57,7 +57,14 @@ beforeEach(() => {
 vi.mock("ai", () => ({
   generateText: aiMocks.generateText,
   streamText: aiMocks.streamText,
-  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  // Mirror AI SDK v6's accessor-backed schema wrapper. The provider transport
+  // owns this object; Eliza must sanitize the plain schema before wrapping and
+  // must not deep-walk the wrapper afterward.
+  jsonSchema: (schema: unknown) =>
+    Object.defineProperty({}, "jsonSchema", {
+      enumerable: true,
+      get: () => schema,
+    }),
   Output: {
     object: ({
       schema,
@@ -686,6 +693,41 @@ describe("OpenAI native text plumbing", () => {
       },
     });
   }, 180_000);
+
+  it("reaches the response-handler transport with accessor-backed native tool schemas", async () => {
+    aiMocks.generateText.mockResolvedValue({
+      text: "ok",
+      finishReason: "stop",
+      usage: { inputTokens: 2, outputTokens: 1 },
+    });
+
+    const { handleResponseHandler } = await import("../models/text");
+    await handleResponseHandler(createRuntime(), {
+      messages: [{ role: "user", content: "decide whether to respond" }],
+      tools: [
+        {
+          name: "HANDLE_RESPONSE",
+          description: "Return the turn decision.",
+          parameters: {
+            type: "object",
+            properties: { action: { type: "string" } },
+            required: ["action"],
+          },
+        },
+      ],
+    } as never);
+
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(1);
+    const call = aiMocks.generateText.mock.calls[0][0] as {
+      tools: Record<string, { inputSchema: { jsonSchema: unknown } }>;
+    };
+    expect(call.tools.HANDLE_RESPONSE.inputSchema.jsonSchema).toMatchObject({
+      type: "object",
+      properties: { action: { type: "string" } },
+      required: ["action"],
+      additionalProperties: false,
+    });
+  });
 
   it("honors a per-call model override before slot defaults", async () => {
     aiMocks.generateText.mockResolvedValue({


### PR DESCRIPTION
## Summary

Progresses #24299 and replaces the audit-closed #24336 and #24480. This replacement adds the permission-checked opaque artifact resolver requested in the #24480 audit: a secure-root regression proves omitted bytes are retrievable through the actual SHELL action without exposing or authorizing the state-root path.

- add an explicit per-turn `codingMode` that enters the planner directly, uses a compact stable prompt and focused native tools, and avoids the ordinary chat response-handler/evaluator round trip
- propagate coding mode and truthful terminal failure through the code CLI, client, ACP adapter, and standalone benchmark path
- make standalone benchmarks await deferred coding-capability registration and fail before inference if READ/WRITE/EDIT/SHELL are absent
- bound file/shell-history context while preserving complete oversized shell stdout/stderr as retention-limited artifacts; the returned opaque handle is bound to the producing agent and conversation and pages redacted streams through the SHELL action
- harden READ/WRITE/EDIT against stale pagination, accidental overwrite, literal-escape corruption, secret-redaction false positives, and post-mutation inspection deduplication
- require successful post-mutation SHELL evidence; repeated-call forced synthesis now returns a typed failure instead of fabricated success
- add one canonical typed child terminal result across native orchestration and bridge surfaces, with state, evidence, blockers/questions, lineage, delivery, and verification
- harden credential redemption and verifier scheduling against authorization changes, infrastructure-inconclusive verdicts, and criteria-free validation deadlocks

This PR deliberately does **not** claim complete Pi parity. It fixes trace-proven runtime defects and materially closes the efficiency gap, while the controlled sample remains too small and Claude is still unauthenticated.

## Architecture findings

Pi's coding loop is intentionally small: a stable system prefix, a compact append-only conversation, four primary file/shell tools, bounded observations, and model-owned termination. Pi does not implement ACP in core; `pi-acp` adapts it. OpenClaw's current native runtime reaches Pi externally through `acpx -> pi-acp`.

Eliza can express the same loop as a plugin configuration, and this PR adds that direct lane. Eliza retains real advantages for long-running work: plugin composition, durable projects/tasks, services, independent evaluators, secure credential brokering, typed parent/child state, delivery tracking, and restart recovery. The prior inefficiency came from applying the generic chat pipeline to coding turns: extra selection/evaluation calls, broader prompt/action surfaces, unbounded observations, and ambiguous terminal egress.

## Controlled trace benchmark

The lightweight sample used two Flipt tasks from the checked-in SWE-bench Pro corpus (2/731, 0.27%). Full logical trajectories, patches, command logs, normalized usage, timings, graders, and SHA-256 manifests are retained locally under `/private/tmp/coding-parity-runs/final/`. The corrected hidden graders are pinned to each exact base; earlier fixture-inconsistent graders were excluded.

| Agent / lane | Task outcome | Calls | Tools / failures | Prompt or input | Cache ratio | Max context | Wall |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Pi 0.84.2 / Cerebras gpt-oss-120b | whitespace FAIL; comma regression, false success | 20 | 19 / 7 | normalized aggregate | 83.26% | 24,054 | 95.25s |
| Pi 0.84.2 / Cerebras gpt-oss-120b | env FAIL; syntax-invalid, unfinished | 6 | 6 / 1 unfinished | normalized aggregate | 63.92% | recorded | 46.03s |
| Eliza pre-fix / Cerebras gpt-oss-120b | whitespace FAIL; source corruption | 12 | 10 / 6 | 170,230 | 64.82% | 25,944 | 111.64s |
| Eliza after automatic revisions | whitespace FAIL; fabricated pseudo-tool success | 6 | 2 / 0 | 34,250 | 52.69% | 7,382 estimated | 13.96s |
| Eliza final controlled code | whitespace **hidden PASS**, typed terminal failure because no test command passed | 14 | 12 / 6 | 200,560 | 69.37% | 24,822 estimated | 123.94s |
| Eliza controlled env, before final loop fixes | env FAIL | 14 | 13 / 10 | 186,230 | 92.86% | 15,589 | 15.68s |
| Codex CLI 0.144.1 / gpt-5.6-sol | whitespace PASS | 1 turn | 17 | 841,645 | 91.46% | native aggregate | 327.24s |
| Codex CLI 0.144.1 / gpt-5.6-sol | env interrupted before terminal; compile FAIL | incomplete | 19 | unavailable | unavailable | unavailable | interrupted |
| Claude Code | not run: local CLI unauthenticated | — | — | — | — | — | — |

The final Eliza whitespace candidate is functionally correct under the hidden grader and terminally conservative under its own evidence: broad/local test attempts failed because the harness had no persistent Go module-cache environment and unrelated broad tests required unavailable services. The trace directly motivated documenting that every SHELL invocation is a fresh process. No successful agent-visible test means the runtime correctly refuses to claim verified success.

The strongest measured efficiency improvement is causal: automatic session revision tracking reduced the same controlled Eliza task from 85 to 6 calls, 14 to 0 tool failures, and 1.49M to 34k prompt tokens before the next terminal bug became visible. The subsequent runtime fix prevents READ-after-EDIT suppression and converts unverified forced synthesis into typed failure.

## Verification at the rebased head

Exact branch head: `4ee5acf564685f35c22bdb41f4c951557dcdf89c`, rebased on `origin/develop` `c0cd5717b44613d50ad28cb5f6ece9c841ffad8c`.

- focused core planner/redaction suite: 248 passed; core typecheck passed
- coding-tools READ/WRITE/EDIT/history: 51 passed; opaque artifact tool-boundary regression: 2 passed; package typecheck passed
- orchestrator child-result/task-service/bridge suite: 173 passed; package typecheck passed
- standalone benchmark contract: 26 passed, including deferred-capability boot and missing-tool fail-closed behavior
- redaction/logger focused suites: 63 + 56 passed
- guide parity: 160 tracked `CLAUDE.md` / `AGENTS.md` pairs byte-identical
- changed-file Biome and `git diff --check`: clean; the artifact regression also proves normal sandbox path access fails under `CODING_TOOLS_WORKSPACE_ROOTS`, reconstructs every omitted stdout/stderr byte through bounded handle pages, and rejects wrong-room/malformed access
- root `bun run verify` on preceding published head `1768d8cbe1dc0730252ed9cea6cf5299f7df48d7` passed the repository preflight gates and reached 211/213 Turbo tasks; it failed in that base's untouched `packages/cloud/shared` typecheck because `@elizaos/plugin-doordash` and `@cloudflare/playwright` declarations were unavailable, followed by implicit-any diagnostics in `doordash-browser-run.ts`. The first hosted run on `4abaa10ba14c3859869d3b0c7248b8832b35b81f` passed secret scan, core build, and affected lint before hitting an untouched `plugin-documents` union-narrowing failure; newer `develop` fixed that line. The branch is now rebased on that fix, and all branch-owned focused gates above were rerun at `4ee5acf564685f35c22bdb41f4c951557dcdf89c`.

Additional broad focused runs exposed two current-`develop` test defects outside this branch: three background-shell redaction tests configure 5/20-character buffers but now hit the upstream complete-capture fail-closed limit, and the attempt-reflection cap test imports `MAX_ATTEMPT_REFLECTIONS` although current source no longer exports it. They are not counted as branch passes.

## Remaining acceptance work

- authenticate Claude Code locally and run the same pinned tasks; do not paste credentials into GitHub or agent transcripts
- rerun the env task on the final head and expand beyond 2/731 tasks before any statistical parity claim
- eliminate the remaining filesystem compare/write race; current revision checks prevent ordinary stale writes but cannot provide an atomic cross-process compare-and-swap
- distinguish infrastructure-constrained verification from code failure more precisely without allowing a model to self-certify success
- run exact-head hosted CI and review every result before merge
