### PR TITLE
fix(plugin-x): count tweet length with X weighted code points

### DIFF
--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -498,6 +498,83 @@ describe("XService trusted account routing", () => {
     );
   });
 
+  it("rejects CJK text that exceeds the X weighted 280 cap before egress", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const getClient = vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    );
+
+    await expect(
+      service.handleSendPost(runtime, {
+        text: "你".repeat(141),
+      } as Content),
+    ).rejects.toThrow(/weighted characters; received 282/);
+    expect(getClient).not.toHaveBeenCalled();
+  });
+
+  it("admits 140 CJK characters and 280 Latin characters", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const profile = {
+      id: "account-owner",
+      username: "account-owner",
+      screenName: "Account Owner",
+      bio: "",
+      nicknames: [],
+    };
+    const base = {
+      profile,
+      withAuthenticatedSession: async <T>(
+        operation: (session: {
+          client: never;
+          profile: typeof profile;
+          revision: number;
+        }) => Promise<T>,
+      ) => operation({ client: {} as never, profile, revision: 1 }),
+    } as unknown as ClientBase;
+    vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    ).mockResolvedValue({ client: base });
+    const createPost = vi
+      .spyOn(TwitterPostService.prototype, "createPost")
+      .mockResolvedValue({
+        id: "post-cjk",
+        agentId: runtime.agentId,
+        roomId: "room-1" as never,
+        userId: "account-owner",
+        username: "account-owner",
+        text: "ok",
+        timestamp: 1,
+      });
+
+    createPost.mockClear();
+    await service.handleSendPost(runtime, {
+      text: "你".repeat(140),
+    } as Content);
+    await service.handleSendPost(runtime, {
+      text: "a".repeat(280),
+    } as Content);
+
+    expect(createPost).toHaveBeenCalledTimes(2);
+    expect(createPost).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "你".repeat(140) }),
+      profile,
+    );
+    expect(createPost).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "a".repeat(280) }),
+      profile,
+    );
+  });
+
   it("keeps DM recipient lookup and send inside one authenticated session", async () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -44,6 +44,7 @@ import { validateTwitterConfig } from "../environment";
 import { TwitterInteractionClient } from "../interactions";
 import { TwitterPostClient } from "../post";
 import { TwitterTimelineClient } from "../timeline";
+import { countTwitterWeightedLength } from "../tweet-length";
 import type { ITwitterClient, TwitterClientState } from "../types";
 import { normalizeXReceiptId } from "../utils/provider-receipt";
 import { getSetting } from "../utils/settings";
@@ -816,9 +817,10 @@ export class XService extends Service {
     if (!text) {
       throw new Error("X post connector requires non-empty text content.");
     }
-    if (text.length > X_MAX_POST_LENGTH) {
+    const weightedLength = countTwitterWeightedLength(text);
+    if (weightedLength > X_MAX_POST_LENGTH) {
       throw new Error(
-        `X post connector requires text <= ${X_MAX_POST_LENGTH} characters; received ${text.length}.`,
+        `X post connector requires text <= ${X_MAX_POST_LENGTH} weighted characters; received ${weightedLength}.`,
       );
     }
 

--- a/plugins/plugin-x/src/tweet-length.test.ts
+++ b/plugins/plugin-x/src/tweet-length.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Deterministic coverage of twitter-text v3 weighted tweet length: CJK is 2
+ * units, Latin is 1, URLs are 23, and truncation never splits a supplementary
+ * code point.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  countTwitterWeightedLength,
+  truncateToTwitterWeightedLength,
+} from "./tweet-length";
+
+describe("countTwitterWeightedLength", () => {
+  it("counts Latin, CJK, emoji, and URLs the way X does", () => {
+    expect(countTwitterWeightedLength("a".repeat(280))).toBe(280);
+    expect(countTwitterWeightedLength("a".repeat(281))).toBe(281);
+    expect(countTwitterWeightedLength("你".repeat(140))).toBe(280);
+    expect(countTwitterWeightedLength("你".repeat(141))).toBe(282);
+    expect(countTwitterWeightedLength("🦊")).toBe(2);
+    expect("🦊".length).toBe(2);
+    expect("你".length).toBe(1);
+    expect(
+      countTwitterWeightedLength("see https://example.com/this/is/a/long/path"),
+    ).toBe(4 + 23);
+  });
+
+  it("matches origin JavaScript length on a previously-valid Latin corpus", () => {
+    const corpus = [
+      "",
+      "hello",
+      "hello world",
+      "a".repeat(280),
+      "The quick brown fox jumps over the lazy dog.",
+      "gm",
+      "1234567890",
+      "Hello, world!",
+    ];
+    for (const text of corpus) {
+      expect(countTwitterWeightedLength(text)).toBe(text.length);
+    }
+  });
+});
+
+describe("truncateToTwitterWeightedLength", () => {
+  it("keeps 140 CJK characters and drops the 141st", () => {
+    const text = "你".repeat(141);
+    const truncated = truncateToTwitterWeightedLength(text, 280);
+    expect(truncated).toBe("你".repeat(140));
+    expect(countTwitterWeightedLength(truncated)).toBe(280);
+  });
+
+  it("does not split a supplementary-plane emoji at the cap", () => {
+    const text = `${"a".repeat(279)}🦊`;
+    expect(text.length).toBe(281);
+    const truncated = truncateToTwitterWeightedLength(text, 280);
+    expect(truncated).toBe("a".repeat(279));
+    expect(truncated.includes("\uD83E") || truncated.includes("🦊")).toBe(
+      false,
+    );
+  });
+});

--- a/plugins/plugin-x/src/tweet-length.ts
+++ b/plugins/plugin-x/src/tweet-length.ts
@@ -1,0 +1,92 @@
+/**
+ * X/Twitter weighted tweet length (twitter-text v3): Latin-range code points
+ * count as 1, CJK and other default-weight code points as 2, and http(s) URLs
+ * as 23. Used by the connector post gate and the generated-post / thread
+ * splitters so a string that JavaScript `.length` calls "short" is not sent
+ * when X would reject it.
+ */
+
+export const TWEET_WEIGHTED_SCALE = 100;
+export const TWEET_DEFAULT_WEIGHT = 200;
+export const TWEET_TRANSFORMED_URL_LENGTH = 23;
+
+const WEIGHT_RANGES: ReadonlyArray<readonly [number, number, number]> = [
+  [0, 4351, 100],
+  [8192, 8205, 100],
+  [8208, 8223, 100],
+  [8242, 8247, 100],
+];
+
+const URL_RE = /https?:\/\/[^\s]+/i;
+
+function codePointWeight(codePoint: number): number {
+  for (const [start, end, weight] of WEIGHT_RANGES) {
+    if (codePoint >= start && codePoint <= end) {
+      return weight;
+    }
+  }
+  return TWEET_DEFAULT_WEIGHT;
+}
+
+function nextUrlAt(text: string, index: number): string | undefined {
+  if (index >= text.length) return undefined;
+  const match = text.slice(index).match(URL_RE);
+  if (match?.index !== 0) return undefined;
+  return match[0];
+}
+
+function unitWeight(codePoint: number): number {
+  return codePointWeight(codePoint) / TWEET_WEIGHTED_SCALE;
+}
+
+/**
+ * Weighted length used by X for the 280-unit tweet cap (twitter-text v3).
+ */
+export function countTwitterWeightedLength(text: string): number {
+  let used = 0;
+  let index = 0;
+  while (index < text.length) {
+    const url = nextUrlAt(text, index);
+    if (url) {
+      used += TWEET_TRANSFORMED_URL_LENGTH;
+      index += url.length;
+      continue;
+    }
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) break;
+    used += unitWeight(codePoint);
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+  return Math.floor(used);
+}
+
+/**
+ * Longest prefix of `text` whose weighted length is <= `maxLength`.
+ * Walks Unicode code points so a supplementary-plane character is never split.
+ */
+export function truncateToTwitterWeightedLength(
+  text: string,
+  maxLength: number,
+): string {
+  if (maxLength <= 0) return "";
+  if (countTwitterWeightedLength(text) <= maxLength) return text;
+
+  let used = 0;
+  let index = 0;
+  while (index < text.length) {
+    const url = nextUrlAt(text, index);
+    if (url) {
+      if (used + TWEET_TRANSFORMED_URL_LENGTH > maxLength) break;
+      used += TWEET_TRANSFORMED_URL_LENGTH;
+      index += url.length;
+      continue;
+    }
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) break;
+    const weight = unitWeight(codePoint);
+    if (used + weight > maxLength) break;
+    used += weight;
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+  return text.slice(0, index);
+}

--- a/plugins/plugin-x/src/utils.test.ts
+++ b/plugins/plugin-x/src/utils.test.ts
@@ -88,6 +88,66 @@ describe("sendTweet", () => {
     );
   });
 
+  it("truncates 141 CJK characters to the X weighted 280 cap before egress", async () => {
+    const authenticatedProfile = profile("account-a");
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    const send = vi.fn().mockResolvedValue({
+      data: { data: { id: "cjk-1", text: "你".repeat(140) } },
+    });
+    client.twitterClient = {
+      sendTweet: send,
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: {} as never,
+        profile: authenticatedProfile,
+        revision: 1,
+      });
+    client.isAuthenticatedSessionCurrent = () => true;
+
+    await sendTweet(client, "你".repeat(141));
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe("你".repeat(140));
+  });
+
+  it("sends a 280-character Latin tweet unchanged", async () => {
+    const authenticatedProfile = profile("account-a");
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    const latin = "a".repeat(280);
+    const send = vi.fn().mockResolvedValue({
+      data: { data: { id: "latin-1", text: latin } },
+    });
+    client.twitterClient = {
+      sendTweet: send,
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: {} as never,
+        profile: authenticatedProfile,
+        revision: 1,
+      });
+    client.isAuthenticatedSessionCurrent = () => true;
+
+    await sendTweet(client, latin);
+    expect(send.mock.calls[0]?.[0]).toBe(latin);
+  });
+
   it("leaves a null mention cursor untouched after publishing", async () => {
     // With no prior mention checkpoint, a send must not seed the cursor either;
     // the interactions loop, not the poster, owns the very first checkpoint.

--- a/plugins/plugin-x/src/utils.ts
+++ b/plugins/plugin-x/src/utils.ts
@@ -22,6 +22,10 @@ import {
 import type { ClientBase } from "./base";
 import type { Tweet } from "./client";
 import { TWEET_MAX_LENGTH } from "./constants";
+import {
+  countTwitterWeightedLength,
+  truncateToTwitterWeightedLength,
+} from "./tweet-length";
 import type { ActionResponse, MediaData } from "./types";
 import { normalizeXReceiptId } from "./utils/provider-receipt";
 
@@ -228,9 +232,9 @@ export async function sendTweet(
 ): Promise<SentTweet> {
   return client.withAuthenticatedSession(async (session) => {
     const { profile } = session;
-    const isNoteTweet = text.length > TWEET_MAX_LENGTH;
+    const isNoteTweet = countTwitterWeightedLength(text) > TWEET_MAX_LENGTH;
     const postText = isNoteTweet
-      ? truncateToCompleteSentence(text, TWEET_MAX_LENGTH)
+      ? truncateToTwitterWeightedLength(text, TWEET_MAX_LENGTH)
       : text;
 
     if (!client.isAuthenticatedSessionCurrent(session)) {
@@ -387,7 +391,10 @@ function splitTweetContent(content: string, maxLength: number): string[] {
   for (const paragraph of paragraphs) {
     if (!paragraph) continue;
 
-    if (`${currentTweet}\n\n${paragraph}`.trim().length <= maxLength) {
+    if (
+      countTwitterWeightedLength(`${currentTweet}\n\n${paragraph}`.trim()) <=
+      maxLength
+    ) {
       if (currentTweet) {
         currentTweet += `\n\n${paragraph}`;
       } else {
@@ -397,7 +404,7 @@ function splitTweetContent(content: string, maxLength: number): string[] {
       if (currentTweet) {
         tweets.push(currentTweet.trim());
       }
-      if (paragraph.length <= maxLength) {
+      if (countTwitterWeightedLength(paragraph) <= maxLength) {
         currentTweet = paragraph;
       } else {
         // Split long paragraph into smaller chunks
@@ -458,7 +465,10 @@ function splitSentencesAndWords(text: string, maxLength: number): string[] {
   let currentChunk = "";
 
   for (const sentence of sentences) {
-    if (`${currentChunk} ${sentence}`.trim().length <= maxLength) {
+    if (
+      countTwitterWeightedLength(`${currentChunk} ${sentence}`.trim()) <=
+      maxLength
+    ) {
       if (currentChunk) {
         currentChunk += ` ${sentence}`;
       } else {
@@ -471,14 +481,17 @@ function splitSentencesAndWords(text: string, maxLength: number): string[] {
       }
 
       // If current sentence itself is less than or equal to maxLength
-      if (sentence.length <= maxLength) {
+      if (countTwitterWeightedLength(sentence) <= maxLength) {
         currentChunk = sentence;
       } else {
         // Need to split sentence by spaces
         const words = sentence.split(" ");
         currentChunk = "";
         for (const word of words) {
-          if (`${currentChunk} ${word}`.trim().length <= maxLength) {
+          if (
+            countTwitterWeightedLength(`${currentChunk} ${word}`.trim()) <=
+            maxLength
+          ) {
             if (currentChunk) {
               currentChunk += ` ${word}`;
             } else {

--- a/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "../base";
+import { countTwitterWeightedLength } from "../tweet-length";
 import { addToRecentTweets, getRecentTweets, isDuplicateTweet } from "./memory";
 import { createTwitterPostCallback } from "./twitter-post-callback";
 
@@ -283,6 +284,20 @@ describe("createTwitterPostCallback", () => {
     expect(recentTweets).toHaveLength(1);
     expect(typeof recentTweets?.[0]).toBe("string");
     expect(recentTweets?.[0]?.length).toBeLessThanOrEqual(X_MAX_POST_LENGTH);
+  });
+
+  it("truncates generated CJK text to the X weighted cap before posting", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const callback = makeCallback({ client, runtime });
+    await callback({ text: "你".repeat(141) });
+    expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
+    const posted = vi.mocked(client.twitterClient.sendTweet).mock.calls[0]?.[0];
+    expect(typeof posted).toBe("string");
+    expect(countTwitterWeightedLength(posted as string)).toBeLessThanOrEqual(
+      X_MAX_POST_LENGTH,
+    );
+    expect(posted).not.toBe("你".repeat(141));
   });
 
   it("partitions recent-post duplicate state by account and profile identity", async () => {

--- a/plugins/plugin-x/src/utils/twitter-post-callback.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.ts
@@ -18,6 +18,10 @@ import {
 } from "@elizaos/core";
 import type { ClientBase } from "../base";
 import { TWEET_MAX_LENGTH } from "../constants";
+import {
+  countTwitterWeightedLength,
+  truncateToTwitterWeightedLength,
+} from "../tweet-length";
 import type { TwitterClientState } from "../types";
 import { sendTweet } from "../utils";
 import {
@@ -33,14 +37,15 @@ function errorMessage(error: unknown): string {
 }
 
 function normalizePostText(text: string): string {
-  if (text.length <= TWEET_MAX_LENGTH) {
+  if (countTwitterWeightedLength(text) <= TWEET_MAX_LENGTH) {
     return text;
   }
 
   const sentenceMatches = text.match(/[^.!?]+[.!?]+/g) || [];
   let sentenceText = "";
   for (const sentence of sentenceMatches) {
-    if ((sentenceText + sentence).trim().length <= TWEET_MAX_LENGTH) {
+    const candidate = `${sentenceText}${sentence}`.trim();
+    if (countTwitterWeightedLength(candidate) <= TWEET_MAX_LENGTH) {
       sentenceText += sentence;
     } else {
       break;
@@ -50,12 +55,15 @@ function normalizePostText(text: string): string {
     return sentenceText.trim();
   }
 
-  const spaceIndex = text.lastIndexOf(" ", TWEET_MAX_LENGTH - 4);
+  const truncated = truncateToTwitterWeightedLength(text, TWEET_MAX_LENGTH - 3);
+  const spaceIndex = truncated.lastIndexOf(" ");
   if (spaceIndex > 0) {
-    return `${text.slice(0, spaceIndex).trim()}...`;
+    return `${truncated.slice(0, spaceIndex).trim()}...`;
   }
-
-  return `${text.slice(0, TWEET_MAX_LENGTH - 3).trim()}...`;
+  if (truncated.trim()) {
+    return `${truncated.trim()}...`;
+  }
+  return truncateToTwitterWeightedLength(text, TWEET_MAX_LENGTH);
 }
 
 export function createTwitterPostCallback({


### PR DESCRIPTION
Closes #24529.

This is independently motivated from the search-pagination and request-queue-retry plugin-x defects; those branches do not share files with this one.

# Relates to

Closes #24529.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`5abed3bccf5d`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5abed3bccf5d`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused plugin-x tests are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Latin corpus of 8 previously-valid strings (`""`, `"hello"`, `"hello world"`, `"a".repeat(280)`, pangram, `"gm"`, digits, `"Hello, world!"`): `countTwitterWeightedLength(text) === text.length` on every row. `sendTweet("a".repeat(280))` still sends the same 280 Latin characters. `handleSendPost` still admits 140 CJK (weighted 280) and 280 Latin.

ZWJ emoji sequences are **not** collapsed the way twitter-text does with `emojiParsingEnabled`. That overcounts vs X (extra truncation), it does not undercount.

# Background

## What does this PR do?

Counts tweet length with X weighted code points (twitter-text v3) instead of JavaScript UTF-16 `.length`, on `sendTweet`, `createTwitterPostCallback` / `normalizePostText`, `XService.handleSendPost`, and the thread splitter.

## What kind of change is this?

Bug fix (non-breaking). Local gate undercounted CJK so over-weight text was dispatched.

## Why are we doing this? Any context or related work?

`"你".repeat(141)` has JS length 141 (passes `<= 280`) and X weighted length 282 (API rejects). The same 141 Latin characters would have been truncated or rejected locally.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/tweet-length.test.ts` — weighted counting vs twitter-text v3.

`plugins/plugin-x/src/utils.test.ts` — `sendTweet` truncates 141 CJK to 140 before egress.

`plugins/plugin-x/src/utils/twitter-post-callback.test.ts` — callback truncates generated CJK to the weighted cap.

## Detailed testing steps

Automated tests:

```
bun run --cwd plugins/plugin-x test src/tweet-length.test.ts src/utils.test.ts src/utils/twitter-post-callback.test.ts
# Test Files  3 passed (3)
# Tests  23 passed (23)
```

Load-bearing revert (copy-aside origin sources under the new tests): 3 failed | 35 skipped (38). Restore the fix: 3 passed | 35 skipped (38).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:75c328a551c920efd341cc4088e68553432af8b7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is over-weight CJK text dispatched because `.length` undercounts.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] Origin: `sendTweet` sent `"你".repeat(141)`; callback posted weighted 282; `handleSendPost` skipped the length check and proceeded into client resolution.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - did not POST a 141-CJK tweet to live X. Weighted numbers are published twitter-text v3 config.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `75c328a551c920efd341cc4088e68553432af8b7`: 3 files / 23 tests passed.

Load-bearing revert under the new tests:

```
FAIL  sendTweet > truncates 141 CJK characters to the X weighted 280 cap before egress
AssertionError: expected 141-char CJK string to be 140-char CJK string

FAIL  createTwitterPostCallback > truncates generated CJK text to the X weighted cap before posting
AssertionError: expected 282 to be less than or equal to 280

FAIL  XService trusted account routing > rejects CJK text that exceeds the X weighted 280 cap before egress
AssertionError: expected [Function] to throw error matching /weighted characters; received 282/
Tests  3 failed | 35 skipped (38)
```

Restore the fix: `Tests  3 passed | 35 skipped (38)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Did **not** POST a 141-CJK tweet to live X (no credentials). Weighted numbers are the published twitter-text v3 config, not a live 400 body.
- ZWJ emoji sequences (e.g. family emoji) are **not** collapsed the way twitter-text does with `emojiParsingEnabled`. That overcounts vs X (extra truncation), it does not undercount. Declared, not silently omitted.
- `TWITTER_MAX_TWEET_LENGTH` env (schema default 280, package.json copy 4000) is still unused by `sendTweet`; the cap remains the `TWEET_MAX_LENGTH = 280` constant. Out of scope.
- `_handleNoteTweet` still uses `truncateToCompleteSentence` (JS length) and is unused (`_` prefix). Left alone.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- `bun run verify` was not run repo-wide. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Pre-existing `x.service.test.ts` account-status cases (`config_missing`) fail on unmodified origin in this environment as well. Not introduced here.
- Touched-file `tsc` messages are missing `@elizaos/core` and pre-existing `XService.runtime` / connector typing on lines this PR does not change. `tweet-length.ts` itself is clean.
- `bunx biome check --write` on the eight files: clean after applying the `match?.index !== 0` optional-chain form.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-x-tweet-weighted-length]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N8HXDYHDDZKK71Q88SRT8Z","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T17:33:34.014Z","completed_at":"2026-08-22T17:36:14.608Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T17:33:34.682Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e5a2041204f28b07dd11242638b63cd720d0f6180e14dde92e72e7f59347adb9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"bc3eda23-31a5-4545-8a70-df8edf27c33d","object_id":"sha256:e5a2041204f28b07dd11242638b63cd720d0f6180e14dde92e72e7f59347adb9","sha256":"e5a2041204f28b07dd11242638b63cd720d0f6180e14dde92e72e7f59347adb9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"isf8c0tSGNV1_Dfuoz92qDpw2YDWsOZV8WpHQF_UNy6EZWtURKN9f8qPknkqZ6hfvfZ_s-zEoZ_S7SACndLHCA"}} -->
