### PR TITLE
fix(elizaos): keep conflicted upgrade files out of the managed ledger

### DIFF
--- a/packages/elizaos/src/scaffold.test.ts
+++ b/packages/elizaos/src/scaffold.test.ts
@@ -316,6 +316,48 @@ describe("updateManagedFiles", () => {
       expect(() => readFileSync(join(projectRoot, "delete.txt"))).toThrow();
     }));
 
+  it("does not re-track a previously untracked conflict with the unwritten template hash", () =>
+    withTempDir((dir) => {
+      const projectRoot = join(dir, "project");
+      const renderedDir = join(dir, "rendered");
+      mkdirSync(projectRoot, { recursive: true });
+      mkdirSync(renderedDir, { recursive: true });
+      writeFileSync(join(projectRoot, "conflict.txt"), "local edit");
+      writeFileSync(join(renderedDir, "conflict.txt"), "new conflict");
+
+      const first = updateManagedFiles({
+        projectRoot,
+        renderedDir,
+        currentMetadata: metadata({
+          "conflict.txt": hashFor("old conflict"),
+        }),
+        renderedManagedFiles: {
+          "conflict.txt": hashFor("new conflict"),
+        },
+      });
+
+      expect(first.conflicts).toEqual(["conflict.txt"]);
+      expect(first.nextManagedFiles).not.toHaveProperty("conflict.txt");
+      expect(readFileSync(join(projectRoot, "conflict.txt"), "utf8")).toBe(
+        "local edit",
+      );
+
+      const second = updateManagedFiles({
+        projectRoot,
+        renderedDir,
+        currentMetadata: metadata(first.nextManagedFiles),
+        renderedManagedFiles: {
+          "conflict.txt": hashFor("new conflict"),
+        },
+      });
+
+      expect(second.conflicts).toEqual(["conflict.txt"]);
+      expect(second.nextManagedFiles).not.toHaveProperty("conflict.txt");
+      expect(readFileSync(join(projectRoot, "conflict.txt"), "utf8")).toBe(
+        "local edit",
+      );
+    }));
+
   it("does not write during dry runs", () =>
     withTempDir((dir) => {
       const projectRoot = join(dir, "project");

--- a/packages/elizaos/src/scaffold.ts
+++ b/packages/elizaos/src/scaffold.ts
@@ -1,7 +1,8 @@
 /**
  * Template rendering engine for the CLI: builds token values, copies template
  * trees, hydrates upstream submodules, and computes managed-file diffs for
- * create and upgrade.
+ * create and upgrade. Conflicted paths stay untracked so the ledger hash always
+ * matches bytes last written by this engine.
  */
 
 import { execFileSync } from "node:child_process";
@@ -538,6 +539,10 @@ export function updateManagedFiles(options: {
     if (!previousHash && nextHash) {
       if (currentHash && currentHash !== nextHash) {
         conflicts.push(relativePath);
+        // Same untrack policy as a locally-edited managed file: recording the
+        // rendered hash here would claim the template contents were written
+        // when the on-disk file is still the local copy.
+        delete nextManagedFiles[relativePath];
         continue;
       }
       created.push(relativePath);


### PR DESCRIPTION
# Relates to

Closes #24528.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`5abed3bccf5d20f7d86883fce20622d6b44266d3`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` at `5abed3bccf5d20f7d86883fce20622d6b44266d3`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused package tests are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. First-pass conflict still untracks. Disk bytes for conflicted files are still not overwritten. Dry-run still does not write. The 12 origin classification behaviors are preserved; one new assertion covers the second-pass re-track.

# Background

## What does this PR do?

Keeps a previously untracked conflict out of `nextManagedFiles` on later `elizaos upgrade` runs, so `.elizaos/template.json` is not written with the template hash while disk still holds the local edit.

## What kind of change is this?

Bug fix (non-breaking). Lying managed-file hash → stay untracked.

## Why are we doing this? Any context or related work?

Second-pass classification sees `!previousHash && nextHash` and treated it as a new template file even though the first pass already untracked it as a conflict. `upgrade.ts` persists that map. Recording the local hash instead would make the next upgrade overwrite the local file.

Independently motivated from `fix/elizaos-info-unknown-template-exit` (`commands/info.ts`) and `fix/elizaos-template-json-atomic-write` (`project-metadata.ts`). Different files; do not combine.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/scaffold.test.ts` — second-pass re-track of a previously untracked conflict.

## Detailed testing steps

Automated tests:

```
bun run --cwd packages/elizaos test src/scaffold.test.ts
# Test Files  1 passed (1)
# Tests  13 passed (13)
```

Load-bearing revert (copy-aside origin `scaffold.ts` under the new tests): 1 failed | 12 passed (13). Restore the fix: 13 passed (13).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a21a1ffc31c782a96c02524012dec37bb531a37f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is a template hash stored while disk still has the local edit.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime server logs. Origin vitest on the real `updateManagedFiles` showed pass2 ledger hash equal to the unwritten template hash while disk still had the local edit. Focused suite transcript is in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - did not run a full `elizaos upgrade` against a packaged template tree with a live git submodule.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `a21a1ffc31c782a96c02524012dec37bb531a37f`: 1 file / 13 tests passed.

Load-bearing revert under the new tests:

```
FAIL  updateManagedFiles > does not re-track a previously untracked conflict with the unwritten template hash
AssertionError: expected { Object (conflict.txt) } to not have property "conflict.txt"
 + Received: "6c51459f2f50e39383c3778ad8a9d144599eabf6b3a66e254ddd17e197b3fed6"
Test Files  1 failed (1)
Tests  1 failed | 12 passed (13)
```

Restore the fix: `Test Files  1 passed (1)` / `Tests  13 passed (13)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Did not run a full `elizaos upgrade` against a packaged template tree with a live git submodule. The lying hash is produced by `updateManagedFiles` before submodule/hydrate; `upgrade.ts` persists that map unchanged.
- Did not run `bun run verify`.
- `src/migrate/migrate.test.ts` collect failure is environmental (`@elizaos/core` dist). Untouched.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Package typecheck vs origin `scaffold.ts` restored in the same worktree: 0 unique `error TS` lines on both sides, added=0.
- `bunx biome check` on the two files: clean.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-elizaos-upgrade-retrack]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N8JHMGS2GSHN61TVYS1TBP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T17:33:54.704Z","completed_at":"2026-08-22T17:36:36.545Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T17:33:55.069Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"554bd5925e5e418268e4b29ef5eb2423590d7784d415cd1bb622b43e5e40179c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"963e3302-5b45-4b0e-bfd6-ce8319951bb4","object_id":"sha256:554bd5925e5e418268e4b29ef5eb2423590d7784d415cd1bb622b43e5e40179c","sha256":"554bd5925e5e418268e4b29ef5eb2423590d7784d415cd1bb622b43e5e40179c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"4ii-_Ks5FuKOCtuvverHUrUBxexZtCEjcqktJyZ5MOgnzixsNmqbCJdbRbCWwQH6VUpz18WubZU6zzq-OypEDw"}} -->
