### PR TITLE
fix(core): validate draft schedule before mutation

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/deferred-send.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/deferred-send.test.ts
@@ -14,7 +14,10 @@ import type {
 	IAgentRuntime,
 	Memory,
 } from "../../../../types/index.ts";
-import { scheduleDraftSendAction } from "../actions/scheduleDraftSend.ts";
+import {
+	formatSendAtIso,
+	scheduleDraftSendAction,
+} from "../actions/scheduleDraftSend.ts";
 import { BaseMessageAdapter } from "../adapters/base.ts";
 import { registerDeferredMessageScheduler } from "../deferred-send-scheduler.ts";
 import {
@@ -123,6 +126,54 @@ afterEach(() => {
 });
 
 describe("durable deferred MESSAGE core contract", () => {
+	it("formats valid schedule timestamps as ISO-8601", () => {
+		expect(formatSendAtIso(1700000000000)).toBe("2023-11-14T22:13:20.000Z");
+	});
+
+	it.each([
+		["NaN", Number.NaN, "not finite"],
+		["positive infinity", Number.POSITIVE_INFINITY, "not finite"],
+		["negative infinity", Number.NEGATIVE_INFINITY, "not finite"],
+		["out-of-range epoch", 8640000000000001, "out of Date range"],
+	])(
+		"rejects %s schedule timestamps with a typed error",
+		(_label, value, message) => {
+			expect(() => formatSendAtIso(value as number)).toThrow(
+				expect.objectContaining({
+					code: "MESSAGE_DRAFT_SCHEDULE_INVALID_TIME",
+					message: expect.stringContaining(message as string),
+				}),
+			);
+		},
+	);
+
+	it("rejects an invalid time before reading or scheduling a draft", async () => {
+		const service = getDefaultTriageService();
+		const getDraft = vi.spyOn(service.getStore(), "getDraft");
+		const scheduleDraftSend = vi.spyOn(service, "scheduleDraftSend");
+		const callback = vi.fn();
+
+		await expect(
+			scheduleDraftSendAction.handler(
+				runtime(),
+				{ content: {} } as Memory,
+				undefined,
+				{
+					parameters: {
+						draftId: "draft-1",
+						sendAtMs: 8640000000000001,
+					},
+				} as HandlerOptions,
+				callback,
+			),
+		).rejects.toMatchObject({
+			code: "MESSAGE_DRAFT_SCHEDULE_INVALID_TIME",
+		});
+		expect(getDraft).not.toHaveBeenCalled();
+		expect(scheduleDraftSend).not.toHaveBeenCalled();
+		expect(callback).not.toHaveBeenCalled();
+	});
+
 	it("fails closed when no durable scheduler is registered", async () => {
 		const rt = runtime();
 		const service = new TriageService(new MessageRefStore());

--- a/packages/core/src/features/messaging/triage/actions/scheduleDraftSend.ts
+++ b/packages/core/src/features/messaging/triage/actions/scheduleDraftSend.ts
@@ -25,6 +25,29 @@ import {
 	validateMessageAction,
 } from "./_shared.ts";
 
+export function formatSendAtIso(sendAtMs: number): string {
+	if (!Number.isFinite(sendAtMs)) {
+		throw new ElizaError(
+			`Invalid sendAtMs: ${String(sendAtMs)} is not finite`,
+			{
+				code: "MESSAGE_DRAFT_SCHEDULE_INVALID_TIME",
+				context: { sendAtMs },
+			},
+		);
+	}
+	const date = new Date(sendAtMs);
+	if (Number.isNaN(date.getTime())) {
+		throw new ElizaError(
+			`Invalid sendAtMs: ${String(sendAtMs)} is out of Date range`,
+			{
+				code: "MESSAGE_DRAFT_SCHEDULE_INVALID_TIME",
+				context: { sendAtMs },
+			},
+		);
+	}
+	return date.toISOString();
+}
+
 export const scheduleDraftSendAction: Action = {
 	name: "MESSAGE",
 	contexts: ["messaging", "email", "calendar", "automation"],
@@ -90,6 +113,7 @@ export const scheduleDraftSendAction: Action = {
 			logger.warn(`[ScheduleDraftSend] ${parsed.error}`);
 			return { success: false, text: parsed.error, error: parsed.error };
 		}
+		const sendAtIso = formatSendAtIso(parsed.sendAtMs);
 
 		const service = getDefaultTriageService();
 		const existing = service.getStore().getDraft(parsed.draftId);
@@ -105,7 +129,7 @@ export const scheduleDraftSendAction: Action = {
 			parsed.sendAtMs,
 		);
 
-		const text = `Scheduled draft ${parsed.draftId} for ${new Date(parsed.sendAtMs).toISOString()}.`;
+		const text = `Scheduled draft ${parsed.draftId} for ${sendAtIso}.`;
 		const commit = updated.scheduleCommit;
 		if (!commit) {
 			throw new ElizaError(


### PR DESCRIPTION
Replaces #23983 on current `develop` because the external fork branch cannot be updated without OAuth workflow scope. Tracks #24511.

Preserves @byt61’s invalid-date fix while migrating its regression coverage into the current deferred-send contract suite. Invalid/non-finite timestamps now fail with `MESSAGE_DRAFT_SCHEDULE_INVALID_TIME` before draft lookup or scheduling mutation.

Local validation:
- `bun test packages/core/src/features/messaging/triage/__tests__/deferred-send.test.ts` (11/11)
- `bun run --cwd packages/core typecheck`
- Biome check on both changed files
- no `.github/workflows` delta