### PR TITLE
fix(doordash): prefer native handoff when provider blocks

### DIFF
--- a/packages/ui/src/doordash-human-handoff.test.ts
+++ b/packages/ui/src/doordash-human-handoff.test.ts
@@ -1,4 +1,4 @@
-/** Tests that only authentic Cloudflare Live View action results can navigate the app Browser. */
+/** Tests that DoorDash handoffs route only validated Live View or native provider targets. */
 
 import { describe, expect, it } from "vitest";
 import { findDoorDashHumanHandoff } from "./doordash-human-handoff";
@@ -16,6 +16,54 @@ describe("DoorDash human handoff", () => {
             humanInterventionRequired: true,
             humanInterventionKind: "cloudflare-browser-run",
             liveViewUrl,
+          },
+        },
+      ]),
+    ).toEqual({
+      liveViewUrl,
+      viewPath: `/browser?browse=${encodeURIComponent(liveViewUrl)}`,
+    });
+  });
+
+  it("prefers native DoorDash when Cloudflare Browser Run is provider-blocked", () => {
+    const liveViewUrl = "https://live.browser.run/session?token=secret";
+    const nativeUrl = "https://www.doordash.com/consumer/login";
+    expect(
+      findDoorDashHumanHandoff([
+        {
+          actionName: "DOORDASH",
+          success: true,
+          values: {
+            provider: "doordash",
+            humanInterventionRequired: true,
+            humanInterventionKind: "cloudflare-browser-run",
+            providerBlocked: true,
+            liveViewUrl,
+            nativeAppDeepLink: `elizaos://browser?browse=${encodeURIComponent(nativeUrl)}`,
+          },
+        },
+      ]),
+    ).toEqual({
+      liveViewUrl,
+      viewPath: `/browser?browse=${encodeURIComponent(nativeUrl)}`,
+    });
+  });
+
+  it("falls back to validated Live View when a native fallback is unsafe", () => {
+    const liveViewUrl = "https://live.browser.run/session?token=secret";
+    expect(
+      findDoorDashHumanHandoff([
+        {
+          actionName: "DOORDASH",
+          success: true,
+          values: {
+            provider: "doordash",
+            humanInterventionRequired: true,
+            humanInterventionKind: "cloudflare-browser-run",
+            providerBlocked: true,
+            liveViewUrl,
+            nativeAppDeepLink:
+              "elizaos://browser?browse=https%3A%2F%2Fattacker.example%2Flogin",
           },
         },
       ]),

--- a/packages/ui/src/doordash-human-handoff.ts
+++ b/packages/ui/src/doordash-human-handoff.ts
@@ -1,4 +1,4 @@
-/** Validates and dispatches DoorDash Cloudflare Live View handoffs into the app Browser. */
+/** Routes validated DoorDash Live View or provider-blocked native handoffs into the app Browser. */
 
 import type { ChatActionResultSummary } from "./api";
 import { dispatchNavigateViewRequest } from "./events";
@@ -23,6 +23,26 @@ function safeLiveViewUrl(value: unknown): string | null {
   }
 }
 
+function safeNativeDoorDashDeepLink(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const deepLink = new URL(value);
+    if (deepLink.protocol !== "elizaos:" || deepLink.hostname !== "browser") {
+      return null;
+    }
+    const browse = deepLink.searchParams.get("browse");
+    if (!browse) return null;
+    const target = new URL(browse);
+    return target.protocol === "https:" &&
+      target.hostname === "www.doordash.com"
+      ? target.href
+      : null;
+  } catch {
+    // error-policy:J3 untrusted action output is non-routable when malformed.
+    return null;
+  }
+}
+
 export function findDoorDashHumanHandoff(
   results: readonly ChatActionResultSummary[] | undefined,
 ): DoorDashHumanHandoff | null {
@@ -39,9 +59,13 @@ export function findDoorDashHumanHandoff(
     }
     const liveViewUrl = safeLiveViewUrl(values.liveViewUrl);
     if (!liveViewUrl) continue;
+    const browserUrl =
+      values.providerBlocked === true
+        ? (safeNativeDoorDashDeepLink(values.nativeAppDeepLink) ?? liveViewUrl)
+        : liveViewUrl;
     return {
       liveViewUrl,
-      viewPath: `/browser?browse=${encodeURIComponent(liveViewUrl)}`,
+      viewPath: `/browser?browse=${encodeURIComponent(browserUrl)}`,
     };
   }
   return null;

--- a/plugins/plugin-doordash/src/action.test.ts
+++ b/plugins/plugin-doordash/src/action.test.ts
@@ -191,6 +191,11 @@ describe("DoorDash checkout safety", () => {
 
     expect(result.values).toMatchObject({
       providerBlocked: true,
+      liveViewUrl,
+      appBrowserPath:
+        "/browser?browse=https%3A%2F%2Fwww.doordash.com%2Fconsumer%2Flogin",
+      appDeepLink:
+        "elizaos://browser?browse=https%3A%2F%2Fwww.doordash.com%2Fconsumer%2Flogin",
       nativeAppDeepLink:
         "elizaos://browser?browse=https%3A%2F%2Fwww.doordash.com%2Fconsumer%2Flogin",
     });

--- a/plugins/plugin-doordash/src/action.ts
+++ b/plugins/plugin-doordash/src/action.ts
@@ -109,6 +109,7 @@ function humanIntervention(value: unknown): DoorDashHumanIntervention | null {
     // error-policy:J3 untrusted MCP handoff output is never rendered as a link.
     return null;
   }
+  let appBrowserUrl = liveViewUrl;
   let nativeAppDeepLink: string | undefined;
   if (
     value.providerBlocked === true &&
@@ -120,6 +121,7 @@ function humanIntervention(value: unknown): DoorDashHumanIntervention | null {
         native.protocol === "https:" &&
         native.hostname === "www.doordash.com"
       ) {
+        appBrowserUrl = native.href;
         nativeAppDeepLink = `elizaos://browser?browse=${encodeURIComponent(native.href)}`;
       }
     } catch {
@@ -128,8 +130,8 @@ function humanIntervention(value: unknown): DoorDashHumanIntervention | null {
   }
   return {
     liveViewUrl,
-    appBrowserPath: `/browser?browse=${encodeURIComponent(liveViewUrl)}`,
-    appDeepLink: `elizaos://browser?browse=${encodeURIComponent(liveViewUrl)}`,
+    appBrowserPath: `/browser?browse=${encodeURIComponent(appBrowserUrl)}`,
+    appDeepLink: `elizaos://browser?browse=${encodeURIComponent(appBrowserUrl)}`,
     providerBlocked: value.providerBlocked === true,
     ...(nativeAppDeepLink ? { nativeAppDeepLink } : {}),
     ...(typeof value.handoffId === "string"


### PR DESCRIPTION
# Relates to

Fixes #24490

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated final-audit blocker is recorded below and reproduced on untouched `origin/develop`.
- [x] A reviewer can confirm the behavior from focused tests and the app audit summarized below.

# Sync with develop

- [x] Rebases onto `origin/develop` were conflict-free; final pushed commit was `602ffc377de33b0581f8911052609d5629394737`.
- [x] `bun run verify` passed 372/372 typecheck/lint tasks and all repository audits except the unrelated mock-export baseline described below.

# Risks

Low. The change only selects which already-validated handoff URL opens when the managed service reports `providerBlocked`. Live View remains present as a fallback, native targets are restricted to HTTPS `www.doordash.com`, and checkout authorization is unchanged.

# Background

## What does this PR do?

- Preserves the Cloudflare Browser Run Live View URL for operator access.
- When DoorDash blocks Cloudflare, directs desktop/iOS/Android in-app browser handoff to native DoorDash login instead of reopening the blocked Cloudflare page.
- Validates native deep links and falls back to the validated Live View when the native target is missing or unsafe.
- Adds regression coverage for provider-blocked native selection and unsafe-link fallback.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the documented handoff contract without changing configuration or public setup.

# Testing

## Where should a reviewer start?

- `packages/ui/src/doordash-human-handoff.ts`
- `plugins/plugin-doordash/src/action.ts`

## Detailed testing steps

1. Run `bun run --cwd plugins/plugin-doordash test` — 18/18 pass.
2. Run `bunx vitest run src/doordash-human-handoff.test.ts` from `packages/ui` — 7/7 pass.
3. Run both package typechecks and lints — pass (UI reports five pre-existing cookie warnings).
4. Run `bun run --cwd packages/app audit:app` — 227/227 Playwright tests pass; 224 captures, broken=0, needs-work=0.

# Evidence Gate

<!-- evidence-head:602ffc377de33b0581f8911052609d5629394737 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - navigation-only TypeScript helper change; no rendered pixels or layout changed. Live pre-fix response evidence is recorded in #24490.
<!-- evidence-row:after-screenshots -->
- [x] N/A - navigation-only TypeScript helper change; the full app capture matrix was run and produced 0 broken/0 needs-work findings.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - provider blocks Cloudflare Browser Run before the repaired code is deployed; exact post-merge live walkthrough is a deployment acceptance item.
<!-- evidence-row:backend-logs -->
- [x] Live managed MCP pre-fix probe created a Browser Run session, classified `providerBlocked: true`, required human intervention, and returned both Live View and native-login capabilities; sensitive capability URLs are intentionally omitted.
<!-- evidence-row:frontend-logs -->
- [x] N/A - the regression is covered at the navigation contract boundary; no rendered component or network request changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic handoff routing only; no prompt, provider, model, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, order, cart, wallet, or scheduled artifact is created. No DoorDash order was placed.
<!-- evidence-row:ocr-review -->
- [x] `audit:app` OCR triage: 224 views; verified=211, broken=0, needs-eyeball=13, needs-work=0.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Live production managed MCP acceptance before this patch verified all 11 DoorDash tools, conversation-scoped Browser Run isolation, provider-blocked classification, and checkout rejection without `expectedCheckoutDigest`. Capability-bearing Live View URLs are not included in public evidence.

## Screenshots (before / after) + video walkthrough

N/A - no rendered view changed. The required app audit passed every mobile, desktop, and iPad capture. Post-merge live native handoff remains deployment acceptance because production currently runs the pre-fix route.

## Known gaps / failures

- `bun run verify`: all 372 typecheck/lint tasks and preceding/following audits passed until `audit:mock-module-exports`, which failed with 21 unrelated Cloud test baseline violations. The identical audit was run in a clean detached worktree at `origin/develop` (`2c4d61d54a90943f06c0520d2caa77c5443fec4f`) and reproduced the same 21 baseline violations. None of the implicated files are in this four-file diff.
- Real provider login/search/menu/cart preview requires human DoorDash authentication and possible CAPTCHA after deployment. This PR does not place or authorize an order.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
