### PR TITLE
fix(documents): narrow direct grant metadata safely

### DIFF
--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -1076,12 +1076,13 @@ export async function handleDocumentsRoutes(
       // `metadata` is the MemoryMetadata union; only DocumentMetadata carries
       // the grants, so narrow with `in` before reading.
       const metadata = document.metadata;
-      const directGrantEntityIds =
+      const directGrantCandidate =
         metadata &&
         "directGrantEntityIds" in metadata &&
-        Array.isArray(metadata.directGrantEntityIds)
-          ? metadata.directGrantEntityIds
-          : [];
+        (metadata as { directGrantEntityIds?: unknown }).directGrantEntityIds;
+      const directGrantEntityIds = Array.isArray(directGrantCandidate)
+        ? directGrantCandidate
+        : [];
       json(res, { ok: true, documentId: document.id, directGrantEntityIds });
     } catch (cause) {
       // error-policy:J1 The HTTP boundary translates typed ACL failures without exposing storage details.


### PR DESCRIPTION
Relates to #23103.

## Summary

Fix the current `develop` typecheck failure in the document direct-grant response. `MemoryMetadata` is a union; after the runtime `in` guard, TypeScript still requires the unknown field to be narrowed through a structural view before `Array.isArray` establishes the response type.

This is a type-only narrowing of the already-validated runtime value. It does not change authorization, storage, response shape, or fallback behavior.

## Validation

- `bun run --cwd plugins/plugin-documents typecheck` — passed
- `bun run --cwd plugins/plugin-documents test -- test/routes.test.ts` — 57 passed
- `bun run --cwd plugins/plugin-documents build` — passed
- `bun run --cwd plugins/plugin-documents lint:check` — passed

## Evidence Gate

<!-- evidence-head:50acdda78e25e3e1b443aaa7bb2914a83bab3697 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — server-side type narrowing only.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no UI flow.
<!-- evidence-row:backend-logs -->
- [x] The exact package typecheck now exits zero; the direct-grant route suite passes 57/57.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model path.
<!-- evidence-row:domain-artifacts -->
- [x] Route tests cover the API response and authorization behavior; runtime bytes are unchanged.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual artifact.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: GPT-5.6
<!-- attribution-row:client -->
- Agent tooling: Codex
<!-- attribution-row:skill-revision -->
- Skill path: N/A
<!-- attribution-row:status -->
- Provenance status: self-reported

