### PR TITLE
fix(agent): re-arm memory watchdog after restart failures

### DIFF
--- a/packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
+++ b/packages/agent/src/runtime/__tests__/memory-watchdog.test.ts
@@ -2,8 +2,9 @@
  * Unit coverage for the memory watchdog: env enable-flag parsing, config
  * defaults/floors, and the tick/start/stop state machine that requests a clean
  * restart after sustained over-threshold RSS (debounced on transient dips,
- * one-shot, never process.exit). Deterministic — RSS is read from a mutable
- * holder, timers are faked, and restart/log are spies.
+ * single-flight with failure recovery, one-shot after success, never
+ * process.exit). Deterministic — RSS is read from a mutable holder, timers are
+ * faked, and restart/log are spies.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -15,6 +16,25 @@ import {
 } from "../memory-watchdog.ts";
 
 const MB = 1024 * 1024;
+
+function deferredRestart(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 /** Build watchdog deps whose RSS is read from a mutable holder, with spy log/restart. */
 function makeDeps(rssMbHolder: { value: number }): {
@@ -160,6 +180,128 @@ describe("createMemoryWatchdog.tick", () => {
     expect(wd.tick()).toBe(true);
     for (let i = 0; i < 5; i += 1) expect(wd.tick()).toBe(false);
     expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms immediately when the restart handler throws synchronously", () => {
+    const rss = { value: 2000 };
+    const { deps, restart, warn } = makeDeps(rss);
+    const failure = new Error("restart bootstrap failed");
+    restart
+      .mockImplementationOnce(() => {
+        throw failure;
+      })
+      .mockImplementationOnce(() => undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    expect(wd.tick()).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: failure }),
+      expect.stringMatching(/\[MemoryWatchdog].*failed.*re-armed/i),
+    );
+  });
+
+  it("stays latched until an asynchronous restart rejection is observed", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart, warn } = makeDeps(rss);
+    const pending = deferredRestart();
+    const failure = new Error("restart rejected");
+    restart
+      .mockReturnValueOnce(pending.promise)
+      .mockImplementationOnce(() => undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    expect(wd.tick()).toBe(false);
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    pending.reject(failure);
+    await flushMicrotasks();
+
+    expect(wd.tick()).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: failure }),
+      expect.stringMatching(/\[MemoryWatchdog].*failed.*re-armed/i),
+    );
+  });
+
+  it("retries after rejection without rebuilding the sustained window", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    const pending = deferredRestart();
+    restart
+      .mockReturnValueOnce(pending.promise)
+      .mockImplementationOnce(() => undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 3 }), deps);
+
+    expect(wd.tick()).toBe(false);
+    expect(wd.tick()).toBe(false);
+    expect(wd.tick()).toBe(true);
+
+    pending.reject(new Error("restart rejected"));
+    await flushMicrotasks();
+
+    expect(wd.tick()).toBe(true);
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps at most one restart request in flight", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    const pending = deferredRestart();
+    restart.mockReturnValue(pending.promise);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    for (let index = 0; index < 5; index += 1) {
+      expect(wd.tick()).toBe(false);
+    }
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    pending.resolve();
+    await flushMicrotasks();
+    expect(wd.tick()).toBe(false);
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("remains one-shot after an asynchronous restart request fulfills", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    restart.mockResolvedValue(undefined);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+
+    expect(wd.tick()).toBe(true);
+    await flushMicrotasks();
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(wd.tick()).toBe(false);
+    }
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("consumes rejected restart promises without leaking unhandledRejection", async () => {
+    const rss = { value: 2000 };
+    const { deps, restart } = makeDeps(rss);
+    const pending = deferredRestart();
+    restart.mockReturnValue(pending.promise);
+    const wd = createMemoryWatchdog(config({ rss: 1000, sustained: 1 }), deps);
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      expect(wd.tick()).toBe(true);
+      pending.reject(new Error("restart rejected"));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 });
 

--- a/packages/agent/src/runtime/memory-watchdog.ts
+++ b/packages/agent/src/runtime/memory-watchdog.ts
@@ -128,9 +128,17 @@ export function createMemoryWatchdog(
   let triggered = false;
   let timer: ReturnType<typeof setInterval> | null = null;
 
+  const rearmAfterRestartFailure = (error: unknown, reason: string): void => {
+    triggered = false;
+    deps.log.warn(
+      { error, reason },
+      "[MemoryWatchdog] clean restart request failed; watchdog re-armed",
+    );
+  };
+
   const tick = (): boolean => {
-    // One-shot: once a restart is requested, stop sampling/acting. The supervisor
-    // owns what happens next; re-requesting would spam the handler.
+    // A pending or successful restart request is one-shot. Failure re-arms this
+    // latch so an unsafe process can try the supervisor again on a later tick.
     if (triggered) return false;
 
     const rss = deps.readRssBytes();
@@ -150,7 +158,19 @@ export function createMemoryWatchdog(
     deps.log.warn(
       `[MemoryWatchdog] ${reason} — requesting clean restart via supervisor`,
     );
-    void deps.requestRestart(reason);
+    try {
+      void Promise.resolve(deps.requestRestart(reason)).catch(
+        (error: unknown) => {
+          // error-policy:J7 the rejected restart request is observed here so the
+          // watchdog can keep protecting a process that remains over threshold.
+          rearmAfterRestartFailure(error, reason);
+        },
+      );
+    } catch (error) {
+      // error-policy:J7 a synchronous handler failure must not kill the watchdog
+      // timer or permanently suppress later clean-restart attempts.
+      rearmAfterRestartFailure(error, reason);
+    }
     return true;
   };
 


### PR DESCRIPTION
Replaces #24451 on current `develop` because its external fork cannot be refreshed without OAuth workflow scope. Tracks #24511 and preserves @startrack3r’s authorship.

The watchdog remains single-flight while restart is pending, remains one-shot after success, and re-arms after synchronous throws or asynchronous rejection so transient supervisor failures do not permanently disable recovery.

Local validation on current `develop`:
- focused watchdog suite: 18/18
- changed-file Biome: clean
- no `.github/workflows` delta
- package typecheck attempted; it is blocked by current workspace dependency-resolution failures outside these two files (the focused suite and changed-file checks are clean)