### PR TITLE
fix(elizaos): fail closed when info cannot resolve a named template

### DIFF
--- a/packages/elizaos/src/commands/info.test.ts
+++ b/packages/elizaos/src/commands/info.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Info command tests drive the real template manifest. Named lookups that
+ * cannot be satisfied must exit 1; previously-valid listings stay byte-identical.
+ */
+
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { info } from "./info.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function captureInfo(fn: () => void): {
+  code: number | null;
+  stdout: string[];
+  stderr: string[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...args) => {
+    stdout.push(args.map(String).join(" "));
+  });
+  const error = vi.spyOn(console, "error").mockImplementation((...args) => {
+    stderr.push(args.map(String).join(" "));
+  });
+  const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`exit:${code ?? 0}`);
+  });
+  let code: number | null = null;
+  try {
+    fn();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const matched = /^exit:(\d+)$/.exec(message);
+    if (!matched) {
+      throw err;
+    }
+    code = Number(matched[1]);
+  } finally {
+    log.mockRestore();
+    error.mockRestore();
+    exit.mockRestore();
+  }
+  return { code, stdout, stderr };
+}
+
+describe("info command", () => {
+  it("exits 1 and does not print an empty JSON array for an unknown template", () => {
+    const result = captureInfo(() =>
+      info({ json: true, template: "does-not-exist" }),
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stdout.join("\n")).not.toBe("[]");
+    const parsed = JSON.parse(result.stdout.join("\n")) as { error: string };
+    expect(parsed.error).toContain("Template 'does-not-exist' not found.");
+  });
+
+  it("exits 1 for an unknown template in human output", () => {
+    const result = captureInfo(() => info({ template: "does-not-exist" }));
+
+    expect(result.code).toBe(1);
+    expect(result.stderr.join("\n")).toContain(
+      "Template 'does-not-exist' not found.",
+    );
+    expect(result.stdout.join("\n")).not.toContain("elizaOS Templates");
+  });
+
+  it("exits 1 when a named template does not support the requested language", () => {
+    const result = captureInfo(() =>
+      info({ json: true, language: "python", template: "plugin" }),
+    );
+
+    expect(result.code).toBe(1);
+    const parsed = JSON.parse(result.stdout.join("\n")) as { error: string };
+    expect(parsed.error).toContain("does not support language 'python'");
+  });
+
+  it("keeps a language-only filter that matches nothing as an empty listing", () => {
+    const result = captureInfo(() => info({ json: true, language: "python" }));
+
+    expect(result.code).toBeNull();
+    expect(result.stdout.join("\n")).toBe("[]");
+  });
+
+  it.each([
+    [
+      "all templates",
+      { json: true },
+      "d940239cd78ec0731abf792cc9b38fe755b04fe121475308c96825ddd9f4906c",
+    ],
+    [
+      "plugin id",
+      { json: true, template: "plugin" },
+      "2f502f3339a93fa4b59c52876d8d606e462364c631b8322ba9859209eaf4193f",
+    ],
+    [
+      "project id",
+      { json: true, template: "project" },
+      "b4a1d20a0c782f1801ada305bdd094575106e7f83e8a915e3ac1c0a2e7c9a590",
+    ],
+    [
+      "typescript language filter",
+      { json: true, language: "typescript" },
+      "d940239cd78ec0731abf792cc9b38fe755b04fe121475308c96825ddd9f4906c",
+    ],
+    [
+      "plugin plus typescript",
+      { json: true, language: "typescript", template: "plugin" },
+      "2f502f3339a93fa4b59c52876d8d606e462364c631b8322ba9859209eaf4193f",
+    ],
+  ] as const)(
+    "preserves origin JSON bytes for %s",
+    (_name, options, digest) => {
+      const result = captureInfo(() => info(options));
+
+      expect(result.code).toBeNull();
+      expect(sha256(result.stdout.join("\n"))).toBe(digest);
+    },
+  );
+});

--- a/packages/elizaos/src/commands/info.ts
+++ b/packages/elizaos/src/commands/info.ts
@@ -1,27 +1,31 @@
 /**
  * Template discovery command that prints the shipped template manifest in human
- * readable or JSON form.
+ * readable or JSON form. Named lookups that cannot be satisfied fail closed
+ * with a non-zero exit instead of printing an empty successful listing.
  */
 
 import pc from "picocolors";
 import { getTemplateById, loadManifest, TEMPLATE_ICONS } from "../manifest.js";
-import type { InfoOptions } from "../types.js";
+import type {
+  InfoOptions,
+  TemplateDefinition,
+  TemplatesManifest,
+} from "../types.js";
 
-export function info(options: InfoOptions): void {
-  const manifest = loadManifest();
-  const template = options.template
-    ? getTemplateById(options.template)
-    : undefined;
-  const templates = options.template
-    ? template
-      ? [template]
-      : []
-    : options.language
-      ? manifest.templates.filter((template) =>
-          template.languages.includes(options.language as string),
-        )
-      : manifest.templates;
+function failInfo(options: InfoOptions, message: string): never {
+  if (options.json) {
+    console.log(JSON.stringify({ error: message }, null, 2));
+  } else {
+    console.error(pc.red(message));
+  }
+  process.exit(1);
+}
 
+function printTemplates(
+  options: InfoOptions,
+  manifest: TemplatesManifest,
+  templates: TemplateDefinition[],
+): void {
   if (options.json) {
     console.log(JSON.stringify(templates, null, 2));
     return;
@@ -42,9 +46,30 @@ export function info(options: InfoOptions): void {
     );
     console.log();
   }
+}
 
-  if (options.template && !template) {
-    console.log(pc.yellow(`Template '${options.template}' not found.`));
-    console.log();
+export function info(options: InfoOptions): void {
+  const manifest = loadManifest();
+
+  if (options.template) {
+    const template = getTemplateById(options.template);
+    if (!template) {
+      failInfo(options, `Template '${options.template}' not found.`);
+    }
+    if (options.language && !template.languages.includes(options.language)) {
+      failInfo(
+        options,
+        `Template '${template.name}' does not support language '${options.language}'.`,
+      );
+    }
+    printTemplates(options, manifest, [template]);
+    return;
   }
+
+  const templates = options.language
+    ? manifest.templates.filter((template) =>
+        template.languages.includes(options.language as string),
+      )
+    : manifest.templates;
+  printTemplates(options, manifest, templates);
 }


### PR DESCRIPTION
# Relates to

Closes #24543.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the `origin/develop` SHA this branch was cut from (`5abed3bccf5d20f7d86883fce20622d6b44266d3`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` at `5abed3bccf5d20f7d86883fce20622d6b44266d3`; zero conflicts.
- [ ] `bun run verify` was not run repo-wide. Focused package tests are recorded below. The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.

# Risks

Low. Previously-valid JSON listings stay byte-identical (five SHA-256s recorded). Language-only empty filter (`-l python --json`) still prints `[]` and does not exit 1. Named-resource misses now fail closed.

# Background

## What does this PR do?

Makes `elizaos info` fail closed when a named template cannot be resolved, including when `-t` plus `-l` names a template that does not support that language. Origin printed `[]` (JSON) or a yellow "not found" after the success header (human) and exited 0.

## What kind of change is this?

Bug fix (non-breaking). Unknown named template → exit 1.

## Why are we doing this? Any context or related work?

`create` already fails closed on the same unknown template. Scripts that key off exit code currently treat a missing template as success.

Independently motivated from already-filed #24528 / #24534 (`fix/elizaos-upgrade-conflict-retrack`, `scaffold.ts`) and #24537 / #24541 (`fix/elizaos-template-json-atomic-write`, `project-metadata.ts`). Different files; do not combine.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/commands/info.test.ts` — unknown template JSON/human exit 1, plus language mismatch.

## Detailed testing steps

Automated tests:

```
bun run --cwd packages/elizaos test src/commands/info.test.ts
# Test Files  1 passed (1)
# Tests  9 passed (9)
```

Load-bearing revert (copy-aside origin `info.ts` under the new tests): 3 failed | 6 passed (9). Restore the fix: 9 passed (9).

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:44138a9b3e2f83ba837b64ce908b3569a9da06ae -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI. Failure is exit 0 plus `[]` for a missing named template.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI / no user-visible web flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime server logs. Origin drive of the real `info()` printed `[]` and never called `process.exit` for `-t does-not-exist --json`. Focused suite transcript is in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - did not spawn the built `dist/cli.js` binary; tests import the command module the bin's action uses.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - no UI. Focused vitest at `44138a9b3e2f83ba837b64ce908b3569a9da06ae`: 1 file / 9 tests passed.

Load-bearing revert under the new tests:

```
FAIL  ... exits 1 and does not print an empty JSON array for an unknown template
AssertionError: expected null to be 1
FAIL  ... exits 1 for an unknown template in human output
AssertionError: expected null to be 1
FAIL  ... exits 1 when a named template does not support the requested language
AssertionError: expected null to be 1
Test Files  1 failed (1)
Tests  3 failed | 6 passed (9)
```

Restore the fix: `Test Files  1 passed (1)` / `Tests  9 passed (9)`.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.

## Known gaps / failures

- Did not run `bun run verify` (full workspace). Focused package tests + typecheck + biome.
- Did not spawn the built `dist/cli.js` binary; tests import the command module the bin's action uses. The exit code is `process.exit(1)` from that action, which is what Commander runs.
- `src/migrate/migrate.test.ts` fails to collect in these fresh worktrees (`Failed to resolve entry for package "@elizaos/core"`). Same failure with origin `info.ts` restored. Not introduced.
- **Hosted CI does not run on this PR.** It is filed from a fork (`ss251/eliza`), so no workflow result here should be read as a pass.
- The repo-wide "All Tests Passed" gate is currently red on `develop` for an unrelated `packages/ui lint:check` failure; it is not a signal either way.
- Package typecheck vs origin `info.ts` restored in the same worktree: 0 unique `error TS` lines on both sides, added=0, removed=0.
- `bunx biome check` on the two files: clean.

## Maintainer CI exception record

N/A - no exception requested

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-elizaos-cli-mine]
<!-- slop-contribution-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0N5NBGZND2M8MS1QDK26HMM","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T16:43:01.023Z","completed_at":"2026-08-22T16:56:22.493Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T16:43:01.371Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4342bf6599fcba0d91e16d53c8532bb05bec1a5e9b8458b4ee4386ccd8c64ded","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"81dee58b-5a40-49b6-9a62-c4b06e7bf9fc","object_id":"sha256:4342bf6599fcba0d91e16d53c8532bb05bec1a5e9b8458b4ee4386ccd8c64ded","sha256":"4342bf6599fcba0d91e16d53c8532bb05bec1a5e9b8458b4ee4386ccd8c64ded"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"vYnc_IHbI6HL40OT-B2xu2xHEGQ4CcBiVZLom0JSKPen2KQsvfME68xnWCd7cWb7NIJzeEFHHYpdlPt7jBxBCg"}} -->
