### PR TITLE
fix(types): resolve native secure store source

### DIFF
--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -132,6 +132,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/packages/app-core/tsconfig.build.json
+++ b/packages/app-core/tsconfig.build.json
@@ -42,6 +42,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/dist/esm/index.d.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/dist/esm/index.d.ts"
+      ],
       "@elizaos/capacitor-phone": [
         "../../plugins/plugin-native-phone/dist/esm/index.d.ts"
       ],

--- a/packages/app-core/tsconfig.json
+++ b/packages/app-core/tsconfig.json
@@ -127,6 +127,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-phone": [
         "../../plugins/plugin-native-phone/src/index.ts"
       ],

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -93,6 +93,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/packages/app/tsconfig.typecheck.json
+++ b/packages/app/tsconfig.typecheck.json
@@ -120,6 +120,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/packages/scenario-runner/tsconfig.json
+++ b/packages/scenario-runner/tsconfig.json
@@ -121,6 +121,9 @@
       "@elizaos/capacitor-phone": [
         "../../plugins/plugin-native-phone/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-system": [
         "../../plugins/plugin-native-system/src/index.ts"
       ]

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -87,6 +87,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-bun-runtime": [
         "../../plugins/plugin-native-bun-runtime/src/index.ts"
       ],

--- a/plugins/plugin-browser/tsconfig.json
+++ b/plugins/plugin-browser/tsconfig.json
@@ -40,6 +40,9 @@
       "@elizaos/capacitor-appblocker": [
         "../../plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "../../plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-mobile-signals": [
         "../../plugins/plugin-native-mobile-signals/src/index.ts"
       ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -107,6 +107,9 @@
       "@elizaos/capacitor-appblocker": [
         "./plugins/plugin-native-appblocker/src/index.ts"
       ],
+      "@elizaos/capacitor-secure-store": [
+        "./plugins/plugin-native-secure-store/src/index.ts"
+      ],
       "@elizaos/capacitor-bun-runtime": [
         "./plugins/plugin-native-bun-runtime/src/index.ts"
       ],


### PR DESCRIPTION
Fixes #24542.

Clean affected-workspace checks compile shared UI source from several package tsconfigs. Map `@elizaos/capacitor-secure-store` to its workspace source (or built declaration in the app-core build config), matching the existing native-plugin mappings, so those compilers do not require an unbuilt package export.

Validation:
- UI typecheck passes
- app and scenario-runner direct typechecks no longer report the secure-store resolution error; their remaining local diagnostics are unrelated unbuilt optional workspace dependencies that hosted affected checks build first
- all nine changed JSON files pass Biome and `git diff --check`
- hosted affected typecheck is the acceptance gate