### PR TITLE
fix(telegram): repair reaction-reply failure test after #24501 helper change

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -1205,8 +1205,8 @@ describe("MessageManager.sendMessage transport failure", () => {
 
 describe("MessageManager reaction reply transport failure", () => {
   it("does not report an empty successful turn when ctx.reply fails", async () => {
-    const { callback, reply } = await captureReactionCallback();
-    reply.mockRejectedValueOnce(new Error("Forbidden: bot was blocked"));
+    const { callback, sendMessage } = await captureReactionCallback();
+    sendMessage.mockRejectedValueOnce(new Error("Forbidden: bot was blocked"));
 
     await expect(
       callback({ text: "thanks for the reaction" }),


### PR DESCRIPTION
Follow-up to #24507 (merged) and #24501 (merged).

#24501 moved the reaction reply onto `sendMessageInChunks` and removed the `reply` mock from `captureReactionCallback`. #24507 merged afterward with a test still reading `reply.mockRejectedValueOnce`, so `plugins/plugin-telegram/src/messageManager.test.ts` fails on develop with `TypeError: Cannot read properties of undefined (reading 'mockRejectedValueOnce')`.

This rejects `sendMessage` instead (the wire call the reaction callback now makes) and keeps the assertion that the callback rejects with `TELEGRAM_REACTION_REPLY_FAILED`.

Verified in a worktree on origin/develop:
- `bun run --cwd plugins/plugin-telegram test src/messageManager.test.ts` → 38 passed (38) (was 1 failed | 37 passed)
- `bun run --cwd plugins/plugin-telegram typecheck` → clean
- `bun run --cwd plugins/plugin-telegram lint:check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)