### PR TITLE
feat(orchestrator): foundation modules — durable-content store, routing shapes, verification helpers

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/diff-review-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/diff-review-gate.test.ts
@@ -231,17 +231,43 @@ describe("reviewDiff — empty diff rejects", () => {
   });
 });
 
-describe("reviewDiff — case-insensitive secret matching (parity with core)", () => {
-  it("blocks a LOWERCASE env-style credential (core compiles patterns with `i`)", () => {
+describe("reviewDiff — secret-pattern parity with core", () => {
+  it("blocks a lowercase compound env credential (core's env pattern lists it explicitly)", () => {
+    // Core's ENV-style pattern is deliberately case-SENSITIVE (`/…/g`): the
+    // uppercase branch catches `DATABASE_PASSWORD=…` while lowercase spellings
+    // are covered only through the unambiguous compound names it enumerates
+    // (api_key, client_secret, …). Parity means the gate matches exactly that.
     const diff = addedFileDiff("config.sh", [
-      "database_password=hunter2hunter2hunter2",
+      "api_key=hunter2hunter2hunter2",
     ]);
     const result = reviewDiff({ diff, changedFiles: ["config.sh"] });
     expect(result.passed).toBe(false);
     expect(result.blocking.some((f) => f.check === "secret")).toBe(true);
   });
 
-  it("blocks a lowercase `authorization: bearer …` header", () => {
+  it("blocks an UPPERCASE env-style credential via the case-sensitive env branch", () => {
+    const diff = addedFileDiff("config.sh", [
+      "DATABASE_PASSWORD=hunter2hunter2hunter2",
+    ]);
+    const result = reviewDiff({ diff, changedFiles: ["config.sh"] });
+    expect(result.passed).toBe(false);
+    expect(result.blocking.some((f) => f.check === "secret")).toBe(true);
+  });
+
+  it("does NOT flag a broad lowercase env name core's pattern deliberately skips", () => {
+    // Upstream core keeps the broad environment-name form case-sensitive:
+    // compiling bare `key`/`password` with `i` also matched ordinary source
+    // (`key = prefix + tag`) and corrupted code. `database_password` is not in
+    // core's lowercase compound-name list, so parity requires the gate NOT to
+    // block it — matching core exactly, no broader and no narrower.
+    const diff = addedFileDiff("config.sh", [
+      "database_password=hunter2hunter2hunter2",
+    ]);
+    const result = reviewDiff({ diff, changedFiles: ["config.sh"] });
+    expect(result.blocking.some((f) => f.check === "secret")).toBe(false);
+  });
+
+  it("blocks a lowercase `authorization: bearer …` header (bare core patterns still compile with `i`)", () => {
     const diff = addedFileDiff("req.ts", [
       'const h = "authorization: bearer abcdefghijklmnopqrstuvwxyz012345";',
     ]);

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-service-diff-gate.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-service-diff-gate.test.ts
@@ -223,7 +223,10 @@ describe("CodingWorkspaceService.createPR diff-review boundary", () => {
       "secret",
       {
         changedFiles: ["config.ts"],
-        diff: "+++ b/config.ts\n+password=not-a-real-secret-value\n",
+        // `api_key=` is one of the lowercase compound names core's
+        // case-sensitive env pattern enumerates (bare lowercase `password=`
+        // is deliberately not matched by core since the develop contract).
+        diff: "+++ b/config.ts\n+api_key=not-a-real-secret-value\n",
         truncated: false,
         filesTruncated: false,
       },

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -5,19 +5,47 @@
  * contracts are enabled unless `ELIZA_REQUIRE_GOAL_CONTRACT=0`.
  */
 
-import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  ModelType,
+  toWellFormedUnicode,
+} from "@elizaos/core";
+import { persistDurableContent } from "./durable-content-store.js";
 import { parseJsonObjectResponse } from "./json-model-output.js";
-import { stripInventedArtifactCriteria } from "./producible-evidence.js";
+import {
+  stripInventedArtifactCriteria,
+  stripUncollectableEvidenceCriteria,
+} from "./producible-evidence.js";
 
 /** Coarse task classification driving which template set is applied. */
 export type OrchestratorTaskType =
   | "coding"
+  | "script-run"
   | "view-create"
   | "app-build"
   | "deploy";
 
 /** Lower bound the issue calls for: a generated set always has ≥3 criteria. */
 const MIN_CRITERIA = 3;
+/** Upper bound REQUESTED from the refinement model so the verifier prompt
+ *  stays cheap and focused. This is the prompt's contract only, NOT an
+ *  enforcement cap: every well-formed criterion the model returns is kept
+ *  whole (prompt integrity — the refined set IS the task contract the worker
+ *  builds against and the judge grades, and silently narrowing it graded
+ *  workers against a subset of what refinement produced). The only
+ *  enforcement bound is {@link MAX_CRITERIA_SANITY_BOUND}, which rejects with
+ *  a typed error instead of slicing. */
+const MAX_CRITERIA = 5;
+/**
+ * Generous sanity bound on the refined criteria count. A deduped set larger
+ * than this is a runaway refinement, rejected with a typed {@link ElizaError}
+ * (code {@link ACCEPTANCE_CRITERIA_OVERFLOW_CODE}) BEFORE any criterion is
+ * dispatched — never silently sliced down to a working subset.
+ */
+export const MAX_CRITERIA_SANITY_BOUND = 25;
+/** Machine-classifiable code for the sanity-bound rejection. */
+export const ACCEPTANCE_CRITERIA_OVERFLOW_CODE = "ACCEPTANCE_CRITERIA_OVERFLOW";
 /** A goal shorter than this is treated as trivial — no criteria generated. */
 const MIN_GOAL_CHARS = 8;
 
@@ -53,6 +81,16 @@ export const DEFAULT_CRITERIA_TEMPLATES: Readonly<
     "the deliverable file exists in the workdir",
     "the page serves the requested content",
   ],
+  // One-shot "write a script and run it" asks: the deliverable is the RUN
+  // OUTPUT, not a maintained codebase. The coding template's lint/test-suite
+  // demands parked a two-tool write+run task whose script worked on the first
+  // try (live 2026-08-20: prime-numbers ask, three verify attempts burned on
+  // "a test suite passes").
+  "script-run": [
+    "the script file exists in the workdir",
+    "the script runs to completion without errors",
+    "the captured run output contains the requested result",
+  ],
   "view-create": [
     "a Plugin.views entry is declared with a viewKind",
     "the view appears in /api/views",
@@ -78,6 +116,16 @@ export function shouldRequireGoalContract(): boolean {
 
 /** Keyword groups feeding {@link detectTaskType}. Ordered most-specific-first
  *  so a goal that matches several groups gets the narrower classification. */
+// "write/make a <lang> script … and run it" (or "run it for me"): a compute
+// deliverable judged by its output. A creation verb directly before the
+// script noun also qualifies — "write me a python script that picks a random
+// dinner idea" is the same one-shot deliverable even without a run verb, and
+// classifying it coding parked a working script on invented lint/test-suite
+// criteria (live 2026-08-20). "add a build script to package.json" stays
+// coding: "add" is not a creation-of-deliverable verb here.
+const SCRIPT_RUN_RE =
+  /\b(?:script|one[- ]?liner)\b[\s\S]{0,80}\b(?:run|execute)\b|\b(?:run|execute)\b[\s\S]{0,40}\bscript\b|\b(?:write|make|create)\b(?:\s+\w+){0,4}?\s+(?:script|one[- ]?liner)\b/i;
+
 const VIEW_RE =
   /\b(view|views|viewkind|widget|dashboard\s+(?:card|panel|tile)|render\s+a\s+view)\b/i;
 const DEPLOY_RE =
@@ -90,21 +138,32 @@ const DEPLOY_RE =
 // intervening words so canonical phrasing like "build an app" and
 // "create a checklist app" classifies correctly (a bare `build\s+a\s+app` never
 // matches grammatical English and silently regressed those to coding).
+// The trailing alternative catches verb-less goals that are just a noun
+// phrase ending in page/site ("quote generator page" — the planner's task
+// title became the goal and classified coding, resurrecting the diff-summary
+// criterion on a slug-dir app, live 2026-08-19).
 const APP_BUILD_RE =
-  /\b(website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|(?:build|create|make)\s+an?\s+(?:\w+[ -]){0,2}(?:site|page|app|application)\b)/i;
+  /\b(website|web\s*site|web\s?page|landing\s+page|web\s+app|webapp|frontend\s+app|(?:build|create|make)\s+(?:me\s+)?an?\s+(?:[\w'-]+[ -]){0,5}(?:site|page|app|application)\b|^[\w'’-]+(?:\s+[\w'’-]+){0,5}\s+(?:page|site|webpage)\s*$)/im;
 
 /**
  * Classify a task from its goal text. Defaults to `coding` — the safest
  * superset, since every other type extends or specializes the coding checks.
  * Pure and deterministic so the static path is fully testable without a model.
  */
+// File names and paths are not intent: "/etc/nubs-deploy-settings.yaml"
+// classified a read-a-config script as a DEPLOY task (deploy criteria, two
+// lanes, live 2026-08-22). Strip path-like tokens before the keyword groups.
+const PATH_TOKEN_RE =
+  /(?:(?:\/|~\/|\.\/|[A-Za-z]:\\)[\w.\\/-]+)|\b[\w-]+\.(?:ya?ml|json|csv|tsv|txt|toml|ini|cfg|conf|xml|env|log|md|db|sqlite3?|py|js|ts|sh|html|css)\b/gi;
+
 export function detectTaskType(goal: string): OrchestratorTaskType {
-  const text = (goal ?? "").trim();
+  const text = (goal ?? "").replace(PATH_TOKEN_RE, " ").trim();
   if (text.length === 0) return "coding";
   // View creation is the most specific signal — check it first.
   if (VIEW_RE.test(text)) return "view-create";
   if (DEPLOY_RE.test(text)) return "deploy";
   if (APP_BUILD_RE.test(text)) return "app-build";
+  if (SCRIPT_RUN_RE.test(text)) return "script-run";
   return "coding";
 }
 
@@ -114,9 +173,17 @@ export function isNonTrivialGoal(goal: string): boolean {
   return (goal ?? "").trim().length >= MIN_GOAL_CHARS;
 }
 
-/** Normalize and de-dupe a candidate criteria list, topping up from the static fallback when the model
- *  returned too few usable lines. Always returns ≥{@link MIN_CRITERIA} when the
- *  fallback set itself has that many. */
+/** Normalize and de-dupe a candidate criteria list, topping up from the
+ *  static fallback when the model returned too few usable lines. Every kept
+ *  criterion is carried WHOLE as well-formed Unicode — no per-criterion char
+ *  cap and no count slice (prompt integrity: a criterion is the contract line
+ *  the worker builds against and the judge grades, so truncating or dropping
+ *  one silently changes both). Always returns ≥{@link MIN_CRITERIA} when the
+ *  fallback set itself has that many.
+ *
+ *  @throws ElizaError with code {@link ACCEPTANCE_CRITERIA_OVERFLOW_CODE}
+ *  when the deduped candidate set exceeds {@link MAX_CRITERIA_SANITY_BOUND} —
+ *  a typed pre-dispatch rejection, never a silent slice. */
 function normalizeCriteria(
   candidates: readonly string[],
   fallback: readonly string[],
@@ -124,7 +191,7 @@ function normalizeCriteria(
   const seen = new Set<string>();
   const out: string[] = [];
   const push = (raw: string): void => {
-    const trimmed = raw.trim();
+    const trimmed = toWellFormedUnicode(raw).trim();
     if (trimmed.length === 0) return;
     const key = trimmed.toLowerCase();
     if (seen.has(key)) return;
@@ -132,12 +199,76 @@ function normalizeCriteria(
     out.push(trimmed);
   };
   for (const candidate of candidates) push(candidate);
+  if (out.length > MAX_CRITERIA_SANITY_BOUND) {
+    throw new ElizaError(
+      `Refined acceptance-criteria set has ${out.length} entries — above the ` +
+        `sanity bound of ${MAX_CRITERIA_SANITY_BOUND}. Re-run refinement or ` +
+        "supply acceptance criteria explicitly; the deterministic static " +
+        "template stands in for this task.",
+      {
+        code: ACCEPTANCE_CRITERIA_OVERFLOW_CODE,
+        severity: "ephemeral",
+        context: { count: out.length, bound: MAX_CRITERIA_SANITY_BOUND },
+      },
+    );
+  }
   // Top up to the minimum from the static fallback if the model was stingy.
   for (const item of fallback) {
     if (out.length >= MIN_CRITERIA) break;
     push(item);
   }
   return out;
+}
+
+/**
+ * Record the criteria the producibility filters dropped so a parked or
+ * misgraded task can be traced back to a filtered criterion. The complete
+ * dropped lists are persisted to the content-addressed durable store
+ * (resolvable via `GET /api/orchestrator/content/<sha256>`) AND carried whole
+ * on the structured log record, so the record survives even when the store is
+ * unavailable. Pure observability: never throws.
+ */
+function recordDroppedCriteria(
+  runtime: IAgentRuntime,
+  goal: string,
+  type: OrchestratorTaskType,
+  dropped: {
+    inventedArtifact: readonly string[];
+    uncollectableEvidence: readonly string[];
+  },
+): void {
+  const total =
+    dropped.inventedArtifact.length + dropped.uncollectableEvidence.length;
+  if (total === 0) return;
+  let droppedCriteriaRef: string | undefined;
+  try {
+    droppedCriteriaRef = persistDurableContent(
+      JSON.stringify(
+        {
+          kind: "droppedAcceptanceCriteria",
+          taskType: type,
+          goal,
+          droppedInventedArtifact: dropped.inventedArtifact,
+          droppedUncollectableEvidence: dropped.uncollectableEvidence,
+        },
+        null,
+        2,
+      ),
+    ).ref;
+  } catch {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — the structured log
+    // record below still carries the complete dropped lists when the durable
+    // store is unavailable, so no information is lost by continuing.
+  }
+  runtime.logger?.info?.(
+    {
+      taskType: type,
+      droppedInventedArtifact: [...dropped.inventedArtifact],
+      droppedUncollectableEvidence: [...dropped.uncollectableEvidence],
+      ...(droppedCriteriaRef ? { droppedCriteriaRef } : {}),
+    },
+    "[acceptance-criteria] producibility filters dropped refined criteria (complete lists on this record; durable copy at droppedCriteriaRef when present)",
+  );
 }
 
 /**
@@ -175,7 +306,7 @@ function buildRefinePrompt(
     template.map((c, i) => `${i + 1}. ${c}`).join("\n"),
     "",
     'Respond with a SINGLE JSON object and nothing else, no markdown fences. Schema: { "criteria": ["<criterion>", "<criterion>", ...] }',
-    `Return at least ${MIN_CRITERIA} criteria.`,
+    `Return between ${MIN_CRITERIA} and ${MAX_CRITERIA} criteria.`,
   ].join("\n");
 }
 
@@ -214,6 +345,18 @@ export async function generateDefaultAcceptanceCriteria(
   const type = taskTypeHint ?? detectTaskType(goal);
   const fallback = [...DEFAULT_CRITERIA_TEMPLATES[type]];
 
+  // Static app builds keep the deterministic serve-focused template with NO
+  // model refine: every refine pass invented runtime-behavior demands in new
+  // phrasings ("browser console shows zero errors", "interaction updates the
+  // DOM", "timer changes its value") that no headless pipeline can evidence,
+  // and each parked a live, working page (2026-08-19, four distinct parks).
+  // The template criteria — reachable URL, files on disk, served content —
+  // are exactly what the evidence pipeline can prove.
+  if (type === "app-build") return fallback;
+  // Same purity rule for script-run: refinement re-invents the lint/test-suite
+  // demands the template exists to avoid.
+  if (type === "script-run") return fallback;
+
   if (!runtime || typeof runtime.useModel !== "function") return fallback;
 
   try {
@@ -230,10 +373,31 @@ export async function generateDefaultAcceptanceCriteria(
     // The prompt forbids invented paths, but the filter is the enforcement:
     // a criterion pinning a path the goal never named is unsatisfiable by
     // design (#20794), so it is dropped and the template tops the set back up.
-    const producible = stripInventedArtifactCriteria(candidates, goal).kept;
-    const refined = normalizeCriteria(producible, fallback);
+    const inventedFilter = stripInventedArtifactCriteria(candidates, goal);
+    const uncollectableFilter = stripUncollectableEvidenceCriteria(
+      inventedFilter.kept,
+      type,
+    );
+    // The dropped lists are persisted (durable store + structured log), never
+    // silently discarded — a filtered criterion must stay traceable.
+    recordDroppedCriteria(runtime, goal, type, {
+      inventedArtifact: inventedFilter.dropped,
+      uncollectableEvidence: uncollectableFilter.dropped,
+    });
+    const refined = normalizeCriteria(uncollectableFilter.kept, fallback);
     return refined.length >= MIN_CRITERIA ? refined : fallback;
-  } catch {
+  } catch (err) {
+    if (
+      err instanceof ElizaError &&
+      err.code === ACCEPTANCE_CRITERIA_OVERFLOW_CODE
+    ) {
+      // Typed rejection of a runaway refined set: RECORDED via reportError
+      // (never a silent narrowing), then the deterministic static template
+      // stands in — task creation must not break on a misbehaving refine
+      // model (the caller's documented never-throw contract).
+      runtime.reportError?.("[acceptance-criteria]", err, { taskType: type });
+      return fallback;
+    }
     // error-policy:J4 optional model refinement of an external dep; any failure degrades to the designed deterministic static template
     // Defensive: criteria generation must never break task creation.
     return fallback;

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -10,6 +10,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { persistDurableContent } from "./durable-content-store.js";
 import type { AcpJsonRpcMessage, ApprovalPreset } from "./types.js";
 
 export type NativeAcpEventCallback = (
@@ -113,6 +114,9 @@ type TerminalRecord = {
   proc: ChildProcessWithoutNullStreams;
   output: string;
   truncated: boolean;
+  /** Durable reference to the head captured before overflow discarded the
+   *  buffer (`acpx-content:<sha256>`); undefined when the persist failed. */
+  overflowRef?: string;
   limit: number;
   exitCode?: number | null;
   signal?: NodeJS.Signals | null;
@@ -135,6 +139,14 @@ const ACP_PROTOCOL_VERSION = 1;
 // longer waits can override via `ACPX_DEFAULT_TIMEOUT_MS` or
 // `ELIZA_ACP_PROMPT_TIMEOUT_MS` env vars.
 const DEFAULT_TIMEOUT_MS = 300_000;
+// Complete-capture safety limit for ACP terminal output. Deliberate fail-closed
+// REJECT (prompt-integrity: "typed pre-dispatch rejection"): when a command's
+// output exceeds the limit, terminal/output THROWS instead of returning a
+// partial capture as if it were the result — a prefix or tail posing as the
+// complete command output is exactly the failure mode this guards against. The
+// head captured before overflow is persisted to the durable content store and
+// named in the thrown error, so the refusal stays diagnosable without being
+// weakened (see createTerminal's capture callback and terminalOutput).
 const TERMINAL_OUTPUT_LIMIT = 512 * 1024;
 const AGENT_CLOSE_TERM_GRACE_MS = 1_500;
 const TERMINAL_KILL_GRACE_MS = 1_500;
@@ -200,7 +212,7 @@ export class NativeAcpClient {
     });
     proc.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
-      this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-16_384);
+      this.stderrBuffer = appendBoundedStderr(this.stderrBuffer, text);
       // Observer callback — a consumer throw here must not surface as a stream
       // 'error' event that tears down stderr for the whole agent.
       try {
@@ -235,9 +247,9 @@ export class NativeAcpClient {
           version: "2.0.0",
         },
       },
-      // The first opencode spawn compiles its TS tree and installs the provider
-      // npm package (e.g. @ai-sdk/cerebras), which can exceed the 300s default.
-      // Honor the configured session timeout for the handshake too.
+      // A slow first spawn (toolchain compile, provider npm install) can
+      // exceed the 300s default. Honor the configured session timeout for the
+      // handshake too.
       this.opts.timeoutMs && this.opts.timeoutMs > 0
         ? this.opts.timeoutMs
         : DEFAULT_TIMEOUT_MS,
@@ -585,6 +597,14 @@ export class NativeAcpClient {
     return cancelledPermission();
   }
 
+  /**
+   * ACP `fs/read_text_file`. The line/limit window is CALLER-REQUESTED
+   * pagination per the ACP spec (compliant with prompt-integrity's "paginate
+   * only when the caller explicitly requested it"): with neither param the
+   * COMPLETE file content is returned; with them, the requesting model owns
+   * the continuation contract (the ACP result shape carries no explicit
+   * EOF/hasMore field beyond the spec's line/limit semantics).
+   */
   private async readTextFile(params: Record<string, unknown> | undefined) {
     if (!this.isOperationApproved("read")) {
       throw new PermissionDeniedError(
@@ -663,7 +683,18 @@ export class NativeAcpClient {
       record.output += chunk.toString("utf8");
       if (Buffer.byteLength(record.output, "utf8") > record.limit) {
         record.truncated = true;
-        // Never expose a prefix or tail as if it were the complete command result.
+        // Fail-closed REJECT: never expose a prefix or tail as if it were the
+        // complete command result. Persist the head captured so far FIRST so
+        // terminalOutput's typed refusal can name where the partial evidence
+        // lives.
+        try {
+          record.overflowRef = persistDurableContent(record.output).ref;
+        } catch {
+          // error-policy:J7 recoverability plumbing on a rejection path — the
+          // rejection stands either way; a persist fault only costs the
+          // diagnostic head, which the thrown error then reports as lost.
+          record.overflowRef = undefined;
+        }
         record.output = "";
       }
     };
@@ -677,8 +708,15 @@ export class NativeAcpClient {
   private terminalOutput(params: Record<string, unknown> | undefined) {
     const terminal = this.requireTerminal(stringValue(params?.terminalId));
     if (terminal.truncated) {
+      // Compliant REJECT (prompt-integrity: typed pre-dispatch rejection): the
+      // sub-agent model never receives a partial capture posing as the command
+      // result. The persisted head reference keeps the refusal diagnosable
+      // without weakening it.
+      const headNote = terminal.overflowRef
+        ? ` The head captured before overflow is preserved at ${terminal.overflowRef} (GET /api/orchestrator/content/${terminal.overflowRef.slice("acpx-content:".length)}).`
+        : " The head captured before overflow could not be persisted and is lost.";
       throw new Error(
-        `Terminal output exceeded the ${terminal.limit}-byte complete-capture safety limit; no partial result is available`,
+        `Terminal output exceeded the ${terminal.limit}-byte complete-capture safety limit; no partial result is available. Re-run with output redirected to a file (e.g. \`> out.log 2>&1\`) and read the file instead.${headNote}`,
       );
     }
     return {
@@ -976,7 +1014,10 @@ function jsonRpcError(error: unknown): Error {
   const data = record?.data;
   // JSON-RPC error.data carries the diagnostic detail (e.g. a ZodError for
   // -32602 "Invalid params"). Surface a compact form of it in the message so
-  // failures stay debuggable, and keep the structured value on the error.
+  // failures stay debuggable, and keep the structured value on the error:
+  // AcpRequestError.data is the CANONICAL complete value; the "(data: ...)"
+  // message fragment is a named bounded preview of it (see compactJson).
+  // Consumers relaying failure text into model context should prefer .data.
   if (data === undefined) {
     return new AcpRequestError(baseMessage, code);
   }
@@ -985,6 +1026,11 @@ function jsonRpcError(error: unknown): Error {
   return new AcpRequestError(message, code, data);
 }
 
+/**
+ * Named 2,000-char PREVIEW of a serialized diagnostic value for embedding in
+ * an error MESSAGE. Never the canonical value — callers keep the complete
+ * structured value on AcpRequestError.data (see jsonRpcError).
+ */
 export function compactJson(value: unknown): string | undefined {
   try {
     const raw = JSON.stringify(value);
@@ -1001,6 +1047,45 @@ export function compactJson(value: unknown): string | undefined {
     // value (e.g. a circular error.data) yields no compact detail, not a crash.
     return undefined;
   }
+}
+
+// In-memory bound for the ACP agent process's accumulated stderr — a MEMORY
+// bound, not a data bound (see appendBoundedStderr).
+const AGENT_STDERR_TAIL_BYTES = 16_384;
+
+/**
+ * Accumulate agent stderr into a bounded tail without losing data: on overflow
+ * the COMPLETE pre-slice text is persisted to the durable content store first
+ * (successive overflow records chain — each begins with the previous record's
+ * marker — so together they cover the whole stream), and the retained tail is
+ * headed by a marker naming the resolver route. The process-close failure text
+ * that embeds this buffer is therefore a named, reference-bearing tail view
+ * rather than a silent head drop. The tail slice is byte-accurate and
+ * well-formed (the previous code-unit `.slice(-16_384)` compared bytes but cut
+ * UTF-16 units and could bisect a surrogate pair). Exported for unit coverage.
+ */
+export function appendBoundedStderr(current: string, chunk: string): string {
+  const combined = `${current}${chunk}`;
+  const buf = Buffer.from(combined, "utf8");
+  if (buf.byteLength <= AGENT_STDERR_TAIL_BYTES) return combined;
+  let marker: string;
+  try {
+    const ref = persistDurableContent(combined);
+    const sha = ref.ref.slice("acpx-content:".length);
+    marker = `[agent stderr tail — full stderr: GET /api/orchestrator/content/${sha}]`;
+  } catch (err) {
+    // error-policy:J2 the durable persist is the PRECONDITION for keeping only
+    // a tail: when it fails, NOTHING may be dropped — retain the COMPLETE
+    // accumulation with the fault declared once (idempotent across repeated
+    // failing appends), never a tail whose head is unrecoverable.
+    if (combined.startsWith("[agent stderr durable persist failed")) {
+      return combined;
+    }
+    return `[agent stderr durable persist failed (${err instanceof Error ? err.message : String(err)}); complete stderr retained inline]\n${combined}`;
+  }
+  return `${marker}\n${toWellFormedUnicode(
+    buf.subarray(buf.byteLength - AGENT_STDERR_TAIL_BYTES).toString("utf8"),
+  )}`;
 }
 
 function extractAgentSessionId(meta: unknown): string | undefined {

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -26,6 +26,7 @@
  * @module services/app-deploy-guidance
  */
 
+import { detectTaskType } from "./acceptance-criteria.js";
 import { readConfigEnvKey } from "./config-env.js";
 import { APP_DEPLOY_TASK_RE } from "./skill-recommender.js";
 import {
@@ -180,6 +181,7 @@ function customHostGuidance(
   config: AppDeployConfig,
   _task?: string,
   monetized?: boolean,
+  assignedAppDir?: string,
 ): string {
   const dir = config.customAppsDir ?? "";
   const base = config.customBaseUrl ?? "";
@@ -200,7 +202,16 @@ function customHostGuidance(
     "--- Publishing web apps (custom host) ---",
     "If (and only if) your task is to build OR edit a web app, page, or site for the operator — not a script, CLI, library, or backend service — publish it to the operator's configured static host:",
     `- Published apps are plain static files under \`${dir}/<slug>/\` (index.html plus any css/js — there is NO per-app build step), served live at \`${base}/apps/<slug>/\`.`,
-    `- To CREATE a new app: pick a fresh, short kebab-case \`<slug>\`, write the files into \`${dir}/<slug>/\`, then open \`${base}/apps/<slug>/\` to confirm it works and report that URL.`,
+    // A server-assigned dir removes the child's slug choice entirely: a
+    // self-picked slug overwrote an existing app (live 2026-08-19).
+    assignedAppDir
+      ? `- To CREATE the app: your assigned app folder is \`${assignedAppDir}/\` — write index.html (plus css/js) directly there and NOWHERE else under \`${dir}/\`; it serves at \`${base}/apps/${assignedAppDir.split("/").pop()}/\` — open that URL to confirm and report it.`
+      : `- To CREATE a new app: pick a fresh, short kebab-case \`<slug>\` that is NOT an existing folder under \`${dir}/\`, write the files into \`${dir}/<slug>/\`, then open \`${base}/apps/<slug>/\` to confirm it works and report that URL. Never overwrite an existing app folder you did not create.`,
+    // Children self-imposed `eslint`/`tsc` checks on plain browser scripts;
+    // with no lint/ts config in the app dir those exit 1, the child's planner
+    // ends on a failed tool step, and a finished page reports as a failed
+    // task (live 2026-08-19: every first attempt "failed" this way).
+    "- Verify a static app by reading the files back and fetching its served URL. There is NO build, lint, or typecheck step: do not run eslint, tsc, npm, or bun for these plain static apps — a failing check you invented is not a task failure.",
     `- To EDIT an existing app: the \`<slug>\` is the app's existing folder name under \`${dir}/\` — read its files there, modify them in place, then re-open \`${base}/apps/<slug>/\` to confirm. Do not create a new slug for an edit.`,
     monetizeLine,
   ];
@@ -294,7 +305,7 @@ function extractViewPluginSourceDir(task: string): string | undefined {
 export function augmentTaskWithDeployGuidance(
   task: string,
   config?: AppDeployConfig,
-  opts?: { monetized?: boolean; cloudAppId?: string },
+  opts?: { monetized?: boolean; cloudAppId?: string; assignedAppDir?: string },
 ): string {
   // Idempotent: if a deploy block is already present, no-op.
   if (
@@ -304,6 +315,30 @@ export function augmentTaskWithDeployGuidance(
     task.includes("--- Publishing web apps")
   ) {
     return task;
+  }
+  // Script deliverables never get the web-publishing contract. The section's
+  // own "If (and only if) your task is to build OR edit a web app … not a
+  // script" conditional is routinely ignored at small-model scale: a python
+  // script ask produced an unrequested "Dinner Picker" web app, and a
+  // run-the-script follow-up produced a JavaScript rewrite inside the apps
+  // dir (both live 2026-08-20). detectTaskType is the same deterministic
+  // classifier the acceptance-criteria contract uses.
+  if (detectTaskType(task) === "script-run" && !isAppBuildTask(task)) {
+    return [
+      task.trimEnd(),
+      "",
+      "--- Script tasks ---",
+      "The deliverable is the script and its run output. Verify by executing the script and capturing its stdout.",
+      // Children self-imposed mypy/flake8 on scratch workspaces with no venv;
+      // the failed check led the completion as a task failure while the
+      // script itself ran clean (live 2026-08-21, 2 of 4 runs).
+      "Do not run linters, type checkers, or test frameworks (mypy, flake8, eslint, tsc, pytest) unless the workspace already has them installed and configured — a failing check you introduced is not a task failure.",
+      // A missing input got replaced by a hand-written stand-in and a made-up
+      // value shipped as the answer (live 2026-08-22). The honest result of a
+      // script whose input is absent IS the error.
+      "If a file, endpoint, or dataset the task names does not exist or cannot be reached from here, report that as the result — never create a stand-in for it or change the script to read something else.",
+      "End your final message with the captured run output.",
+    ].join("\n");
   }
   const resolved = config ?? resolveAppDeployConfig();
   // The planner's monetization judgment (model intent, not a keyword match).
@@ -329,7 +364,12 @@ export function augmentTaskWithDeployGuidance(
     // A custom-host app only touches Cloud when it is monetized (it registers
     // for billing); only then does an existing-app binding apply.
     const boundLine = monetized ? existingCloudAppLine(opts?.cloudAppId) : "";
-    const custom = customHostGuidance(resolved, task, monetized);
+    const custom = customHostGuidance(
+      resolved,
+      task,
+      monetized,
+      opts?.assignedAppDir,
+    );
     const block = boundLine ? `${custom}\n${boundLine}` : custom;
     return `${task.trimEnd()}\n\n${block}`;
   }

--- a/plugins/plugin-agent-orchestrator/src/services/ask-shapes.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ask-shapes.ts
@@ -1,0 +1,20 @@
+/** Shapes of a user ask the orchestrator routes on structurally. */
+
+/** "also …", "add … to it", "make it …": an instruction about work already
+ *  under way, not a new deliverable. */
+export const FOLLOW_UP_SHAPE_RE =
+  /^\s*(?:oh\s+|and\s+)?(?:also|plus|btw|additionally)\b|\b(?:to|on|in|for|into)\s+(?:it|that|the\s+(?:page|app|site|script))\b|\bmake\s+it\b|\bit\s+(?:too|as\s+well)\b/i;
+
+/** "make me a page …", "another script …": a new deliverable, even when the
+ *  sentence also says "on it" / "run it". */
+export const NEW_DELIVERABLE_RE =
+  /\b(?:make|build|create|write|spin\s+up)\s+(?:me\s+)?(?:a|an|another|new|two|three|\d+)\b[^.!?\n]{0,40}\b(?:pages?|apps?|sites?|scripts?|games?|tools?|widgets?)\b/i;
+
+export function looksLikeNewDeliverableAsk(text: string): boolean {
+  return NEW_DELIVERABLE_RE.test(text);
+}
+
+/** "like that", "of it", "than this": the sentence leans on prior work even
+ *  when it names a new deliverable. */
+export const ANAPHOR_RE =
+  /\b(?:like|of|for|than|as|to)\s+(?:it|that|this)\b|\bthe\s+(?:last|previous|earlier)\s+one\b/i;

--- a/plugins/plugin-agent-orchestrator/src/services/asked-output-deliverable.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/asked-output-deliverable.test.ts
@@ -1,0 +1,130 @@
+/** Unit tests for extractAskedOutputDeliverable — the verbatim relay of a
+ *  short plain child response when the user's ask requested output/results.
+ *  Deterministic, no runtime; oversized paths hit the REAL durable content
+ *  store via a temp trajectory dir. */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractAskedOutputDeliverable } from "./sub-agent-router.js";
+
+let trajectoryDir: string;
+let savedTrajectoryEnv: string | undefined;
+
+beforeEach(() => {
+  trajectoryDir = fs.mkdtempSync(path.join(os.tmpdir(), "asked-output-"));
+  savedTrajectoryEnv = process.env.ELIZA_TRAJECTORY_DIR;
+  process.env.ELIZA_TRAJECTORY_DIR = trajectoryDir;
+});
+
+afterEach(() => {
+  if (savedTrajectoryEnv === undefined) delete process.env.ELIZA_TRAJECTORY_DIR;
+  else process.env.ELIZA_TRAJECTORY_DIR = savedTrajectoryEnv;
+  fs.rmSync(trajectoryDir, { recursive: true, force: true });
+});
+
+describe("extractAskedOutputDeliverable", () => {
+  it("relays a short plain response for an output ask", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "Tonight's dinner idea is: Homemade Pizza" },
+        "run the dinner picker script and show me the output",
+      ),
+    ).toBe("Tonight's dinner idea is: Homemade Pizza");
+  });
+
+  it("returns undefined when the ask does not request output", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "done, the page is live" },
+        "make me a lil recipe box page",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty response", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "   " },
+        "run it and print the result",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("treats a run-it-again ask as an output ask", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { response: "Fun fact: Venus rotates backwards." },
+        "nice, run it again i want another fact",
+      ),
+    ).toBe("Fun fact: Venus rotates backwards.");
+  });
+
+  it("matches the what-is-the-output phrasing", () => {
+    expect(
+      extractAskedOutputDeliverable(
+        { finalText: "42" },
+        "what's the output of the script?",
+      ),
+    ).toBe("42");
+  });
+
+  it("projects an oversized response through the durable store when no sessionId exists", () => {
+    const out = extractAskedOutputDeliverable(
+      { response: "x".repeat(65_536) },
+      "run it and show me the output",
+    );
+    expect(out).toBeDefined();
+    expect(out).toContain("GET /api/orchestrator/content/");
+    expect(out?.length).toBeLessThanOrEqual(2048);
+  });
+
+  it("references the session transcript for an oversized response with a sessionId", () => {
+    const out = extractAskedOutputDeliverable(
+      { response: "x".repeat(65_536) },
+      "run it and show me the output",
+      "session-123",
+    );
+    expect(out).toBeDefined();
+    expect(out).toContain("acpx-session-output:session-123");
+    expect(out?.length).toBeLessThanOrEqual(2048);
+  });
+});
+
+import { lastProofBlockOutput } from "./sub-agent-router.js";
+
+describe("lastProofBlockOutput", () => {
+  it("pulls the stdout of the last $-command fence", () => {
+    const resp = [
+      "- [x] the script exists — proof:",
+      "```bash",
+      "$ ls /w",
+      "space_facts.py",
+      "```",
+      "```bash",
+      "$ python3 /w/space_facts.py",
+      "The sun makes up 99.86% of the mass in our solar system.",
+      "```",
+    ].join("\n");
+    expect(lastProofBlockOutput(resp)).toBe(
+      "The sun makes up 99.86% of the mass in our solar system.",
+    );
+  });
+
+  it("skips child-elided blocks (the '...' is the child's own loss, not ours)", () => {
+    expect(lastProofBlockOutput("```bash\n$ ls\n...\n```")).toBeUndefined();
+  });
+
+  it("projects an oversized proof output instead of dropping it", () => {
+    const out = lastProofBlockOutput(
+      `\`\`\`bash\n$ run\n${"x".repeat(500)}\n\`\`\``,
+    );
+    expect(out).toBeDefined();
+    expect(out).toContain("GET /api/orchestrator/content/");
+    expect(out?.length).toBeLessThanOrEqual(400);
+  });
+
+  it("ignores fences without command lines", () => {
+    expect(lastProofBlockOutput("```\njust code\n```")).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -295,7 +295,13 @@ export function parseCompletionEnvelope(text: string): CompletionEnvelopeParse {
   };
 }
 
-/** Compact human summary of a validated envelope, for the verifier/log. */
+/** Compact human summary of a validated envelope, for the verifier/log — a
+ * NAMED PREVIEW. The projection is additive: at its call site it is PREPENDED
+ * to verifier evidence that still contains the worker's raw completion (with
+ * the full fenced JSON envelope), and the parsed envelope is persisted whole
+ * under task metadata `completionEnvelope` at the same call site. Fields like
+ * `files: N` are counts, never the underlying lists; the leading label keeps
+ * the judge from mistaking this summary for the complete envelope. */
 export function summarizeEnvelope(env: CompletionEnvelope): string {
   const tests = env.testResults
     .map((t) => `${t.command} → exit ${t.exitCode}`)
@@ -303,7 +309,7 @@ export function summarizeEnvelope(env: CompletionEnvelope): string {
   const unmet = env.acceptanceCriteriaStatus
     .filter((c) => !c.met)
     .map((c) => c.criterion);
-  return [
+  const parts = [
     `diff: ${env.diffSummary}`,
     env.realWorkdir ? `workdir: ${env.realWorkdir}` : "",
     `files: ${env.filesChanged.length}`,
@@ -319,9 +325,14 @@ export function summarizeEnvelope(env: CompletionEnvelope): string {
     env.residualRisks.length > 0
       ? `risks: ${env.residualRisks.join("; ")}`
       : "",
+    // Trailing label, not leading: transcript-sanitizer strips this machine
+    // line from chat relays by its line-anchored `diff: ` prefix, so the
+    // preview label must not displace the canonical first field.
+    "[envelope summary — complete envelope: task metadata completionEnvelope]",
   ]
     .filter(Boolean)
     .join(" | ");
+  return parts;
 }
 
 /** A targeted re-prompt for a present-but-malformed envelope. */

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -10,7 +10,9 @@
  * This module turns the rich signals the orchestrator ALREADY has into a single
  * clearly-SECTIONED evidence string the verifier can grill against:
  *
- *   - **CHANGESET** — the real git diffstat + changed files + a capped diff,
+ *   - **CHANGESET** — the real git diffstat + changed files + the diff,
+ *     rendered whole (a capture-level cut is disclosed with a durable
+ *     continuation reference, never silently),
  *     captured from git at `task_complete` (same {@link WorkspaceChangeSet} the
  *     CODING_SESSION_CHANGES provider renders), so "I changed X" is checkable.
  *   - **DELIVERABLE** — the sub-agent's captured deliverable (printed/tool
@@ -23,15 +25,22 @@
  *   - **ARTIFACTS** — references to screenshot/trajectory artifacts found on the
  *     task/session, so UI and agent-behavior criteria have something to cite.
  *
- * Pure (no IO): the caller gathers the inputs (durable store + live ACP session
- * metadata) and hands them in. The whole assembly is null-safe and size-capped
- * so it can be fed straight into the verifier without blowing the prompt
- * budget.
+ * Near-pure: the caller gathers the inputs (durable store + live ACP session
+ * metadata) and hands them in; the ONLY IO is the durable-content store, which
+ * persists the complete value whenever a bounded view must drop bytes so every
+ * emitted marker names a resolvable record
+ * (`GET /api/orchestrator/content/<sha256>`) instead of a dead-end textual
+ * note. The whole assembly is null-safe; anything bounded is
+ * reference-bearing, never silently cut.
  *
  * @module services/completion-evidence
  */
 
 import { toWellFormedUnicode } from "@elizaos/core";
+import {
+  durableProjection,
+  persistDurableContent,
+} from "./durable-content-store.js";
 import type { WorkspaceChangeSet } from "./workspace-diff.js";
 
 /** One recorded signal (a durable event or sub-agent message) the assembler
@@ -60,6 +69,9 @@ export interface CompletionEvidenceInput {
   signals?: readonly EvidenceSignal[];
   /** Artifact references (screenshots, trajectories) found on task/session. */
   artifacts?: readonly EvidenceArtifactRef[];
+  /** Reporting session id — threads the concrete durable-transcript target
+   *  into the evidence section headers. */
+  sessionId?: string;
 }
 
 export interface EvidenceArtifactRef {
@@ -99,8 +111,21 @@ export interface ToolOutputEvidence {
 export interface CompletionEvidenceBundle {
   /** The sub-agent's reported result — the fallback/final-reply text. */
   summary: string;
-  /** Human-readable git diff summary (diffstat + changed files + capped diff)
-   *  captured at completion, if any. */
+  /** Tail of the session's captured raw output (tool stdout the transport
+   *  recorded). Script-run criteria are judged by what the run PRINTED; the
+   *  classified tool buckets miss plain interpreter output, and the judge
+   *  rejected a correct prime-numbers run as "no execution logs provided"
+   *  (live 2026-08-20). */
+  runOutput?: string;
+  /** Pull request the ORCHESTRATOR's auto-submit opened for this task. The
+   *  child cannot push or open PRs by design, so its narration never carries
+   *  the URL — without this field the judge kept failing "no pull request
+   *  was opened" against tasks whose PR its own submit had already opened
+   *  (live 2026-08-20: TESTING.md and STYLE.md, three attempts each). */
+  pullRequestUrl?: string;
+  /** Human-readable git diff summary (diffstat + changed files + the diff,
+   *  rendered whole; a capture-level cut carries a durable continuation
+   *  reference) captured at completion, if any. */
   diffSummary?: string;
   /** Captured tool stdout split by class (test/build/lint) plus a raw bucket. */
   toolOutput?: ToolOutputEvidence;
@@ -122,7 +147,7 @@ export interface CompletionEvidenceBundle {
   unverifiedClaimedFiles?: Array<{
     path: string;
     reason: "rejected-write" | "no-write-observed";
-  }>;
+}>;
   /** Files verified by direct fs inspection of the session workdir (exists +
    *  mtime after session start) when the structured tool ledger is absent —
    *  observation-grade evidence for adapters that fold tool results into
@@ -140,6 +165,10 @@ export interface CompletionEvidenceBundle {
   screenshots: string[];
   /** Path to the persisted trajectory JSONL artifact for this completion. */
   trajectoryPath?: string;
+  /** Session whose transcript is the durable ground truth for the mined
+   *  tool-output selections; threads the concrete continuation target into
+   *  the evidence section headers. */
+  reportingSessionId?: string;
 }
 
 /**
@@ -190,19 +219,41 @@ const BUILD_MARKER_RE =
 /** Markers that class a signal as LINT output (biome/eslint). */
 const LINT_MARKER_RE = /\b(?:biome|eslint|\blint\b)\b/;
 
-/** Extract just the build/test-looking lines from one signal body, deduped and
- *  so a noisy tool transcript collapses to its run-result lines. */
+/** Extract just the build/test-looking lines from one signal body, deduped so
+ *  a noisy tool transcript collapses to its run-result lines. This is a mined
+ *  SELECTION (regex + dedupe), never a length cut: matched lines are kept
+ *  WHOLE regardless of length — a single-line vitest summary or a long tsc
+ *  error is exactly the line the judge needs, and the old >400-char gate
+ *  silently dropped it. The section header names the durable session
+ *  transcript so unmatched/collapsed output stays recoverable. */
 function extractToolLines(text: string, seen: Set<string>): string[] {
   const out: string[] = [];
   for (const rawLine of text.replace(/\r\n/g, "\n").split("\n")) {
     const line = rawLine.trim();
-    if (line.length === 0 || line.length > 400) continue;
+    if (line.length === 0) continue;
     if (!BUILD_TEST_LINE_RE.test(line)) continue;
     if (seen.has(line)) continue;
     seen.add(line);
     out.push(line);
   }
   return out;
+}
+
+/** Char budget for one captured `[tool output]` envelope body inside the raw
+ *  bucket. Oversized bodies are persisted whole to the durable content store
+ *  FIRST; the emitted head ends with a marker naming
+ *  `GET /api/orchestrator/content/<sha256>` so nothing is silently cut. */
+const ENVELOPE_VIEW_BUDGET_CHARS = 2_000;
+
+function projectEnvelopeBody(inner: string): string {
+  try {
+    return durableProjection(inner, ENVELOPE_VIEW_BUDGET_CHARS).view;
+  } catch {
+    // error-policy:J4 a durable-store write failure must not sink evidence
+    // assembly — fall back to the COMPLETE body (uncapped) rather than
+    // reintroducing a silent cut.
+    return inner;
+  }
 }
 
 /**
@@ -222,8 +273,32 @@ export function classifyToolOutput(
     lint: [],
     raw: [],
   };
+  // One dedupe set across all signals and buckets — a deliberate
+  // noise-collapse PROJECTION (a line repeated across runs renders once, in
+  // the first bucket that saw it). Tolerable only because the rendered
+  // section names the durable session transcript
+  // (GET /api/coding-agents/:sessionId/output), where multiplicity and
+  // per-run attribution remain recoverable in full.
   const seen = new Set<string>();
   for (const signal of signals) {
+    // A `[tool output: …]…[/tool output]` envelope IS tool output by
+    // construction — no marker heuristics needed. Without this, a script's
+    // plain stdout (bare numbers) matched no build/test line shape and the
+    // judge failed a correct run for "missing actual shell output"
+    // (live 2026-08-19: squares.py printed 1..36, task marked failed).
+    for (const match of signal.text.matchAll(
+      /\[tool output:[^\]]*\]([\s\S]*?)\[\/tool output\]/g,
+    )) {
+      const inner = (match[1] ?? "").trim();
+      if (inner && !seen.has(inner)) {
+        seen.add(inner);
+        // A long envelope body is persisted WHOLE to the durable content
+        // store before the bounded head enters the bucket — the head's
+        // marker names the resolver route, so a long test run is
+        // recoverable instead of silently cut at a bare slice.
+        buckets.raw.push(projectEnvelopeBody(inner));
+      }
+    }
     const lines = extractToolLines(signal.text, seen);
     if (lines.length === 0) continue;
     const haystack = `${signal.source ?? ""}\n${signal.text}`;
@@ -243,14 +318,16 @@ export function classifyToolOutput(
 }
 
 /** Pull the lines from a signal body that read like build/test/typecheck
- *  output, so the verifier sees the actual run output rather than narration. */
+ *  output, so the verifier sees the actual run output rather than narration.
+ *  Selection only (regex + dedupe) — matched lines are kept WHOLE, with no
+ *  length gate, for the same reason as {@link extractToolLines}. */
 function extractBuildTestLines(signals: readonly EvidenceSignal[]): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   for (const signal of signals) {
     for (const rawLine of signal.text.replace(/\r\n/g, "\n").split("\n")) {
       const line = rawLine.trim();
-      if (line.length === 0 || line.length > 400) continue;
+      if (line.length === 0) continue;
       if (!BUILD_TEST_LINE_RE.test(line)) continue;
       const key = signal.source ? `${signal.source}: ${line}` : line;
       if (seen.has(key)) continue;
@@ -263,7 +340,7 @@ function extractBuildTestLines(signals: readonly EvidenceSignal[]): string[] {
 
 /**
  * Render the human-readable body of a {@link WorkspaceChangeSet} (diffstat +
- * changed files + a capped diff) WITHOUT the section header. Used as the
+ * changed files + the whole captured diff) WITHOUT the section header. Used as the
  * `diffSummary` field of a {@link CompletionEvidenceBundle}, so the bundle and
  * the legacy assembler produce byte-identical changeset text.
  */
@@ -280,8 +357,28 @@ export function renderChangeSetBody(changeSet: WorkspaceChangeSet): string {
     lines.push("diff:");
     lines.push(normalizeEvidenceText(changeSet.diff));
   }
-  if (changeSet.truncated) lines.push("(changeset truncated)");
+  if (changeSet.truncated) {
+    // A bare "(changeset truncated)" marker is not recoverability. Persist
+    // the fullest captured record durably and name the resolver so the judge
+    // (and any re-verification) can page everything that WAS captured, and
+    // knows precisely what the flag means: the capture layer cut the git
+    // read, so files/hunks beyond the buffer may be missing entirely.
+    lines.push(renderChangeSetTruncationMarker(lines.join("\n")));
+  }
   return lines.join("\n");
+}
+
+function renderChangeSetTruncationMarker(capturedBody: string): string {
+  try {
+    const reference = persistDurableContent(capturedBody);
+    const sha = reference.ref.slice("acpx-content:".length);
+    return `(changeset truncated at capture — files/hunks beyond the git read buffer may be missing; the fullest captured record is durably stored: GET /api/orchestrator/content/${sha})`;
+  } catch {
+    // error-policy:J4 durable persistence failing must not sink evidence
+    // assembly — the marker still names the loss honestly, it just cannot
+    // promise a resolver.
+    return "(changeset truncated at capture — files/hunks beyond the git read buffer may be missing; durable persistence of the captured record failed)";
+  }
 }
 
 function renderChangeSetSection(changeSet: WorkspaceChangeSet): string {
@@ -360,8 +457,17 @@ function renderArtifactsSection(
   return lines.join("\n");
 }
 
-function renderToolOutputSection(toolOutput: ToolOutputEvidence): string {
-  const lines = ["## TEST / BUILD / TYPECHECK OUTPUT (captured tool stdout)"];
+function renderToolOutputSection(
+  toolOutput: ToolOutputEvidence,
+  reportingSessionId?: string,
+): string {
+  // The header names the section for what it is — a mined selection — and
+  // names the durable transcript where the COMPLETE output lives, so a line
+  // the mining heuristics missed (or collapsed as a duplicate) is
+  // recoverable, never gone.
+  const lines = [
+    `## TEST / BUILD / TYPECHECK OUTPUT (captured tool stdout — a mined selection of run-result lines; the COMPLETE output is durable on the session transcript: GET /api/coding-agents/${reportingSessionId ?? ":sessionId"}/output)`,
+  ];
   const labelled: [string, string | undefined][] = [
     ["test", toolOutput.test],
     ["build", toolOutput.build],
@@ -401,6 +507,28 @@ export function buildCompletionEvidenceString(
   const sections: string[] = [];
   let hasRicherSection = false;
 
+  const runOutput = bundle.runOutput?.trim();
+  if (runOutput) {
+    sections.push(
+      [
+        "## RUN OUTPUT (raw session output captured by the orchestrator)",
+        runOutput,
+      ].join("\n"),
+    );
+    hasRicherSection = true;
+  }
+
+  const pr = bundle.pullRequestUrl?.trim();
+  if (pr) {
+    sections.push(
+      [
+        "## PULL REQUEST (opened by the orchestrator's auto-submit; the sub-agent cannot push or open PRs itself)",
+        pr,
+      ].join("\n"),
+    );
+    hasRicherSection = true;
+  }
+
   const diff = bundle.diffSummary?.trim();
   if (diff) {
     sections.push(
@@ -429,9 +557,12 @@ export function buildCompletionEvidenceString(
   // direct inspection, not worker narration — so it counts as richer evidence.
   const fsVerified = bundle.fsVerifiedFiles ?? [];
   if (fsVerified.length > 0) {
+    // The header names the enumeration's deliberate exclusions so "not
+    // listed" can never be read as "does not exist": workdir enumeration
+    // skips orchestration plumbing and vendor/VCS internals by policy.
     sections.push(
       [
-        "## FS-VERIFIED FILES (stat-observed in the session workdir, modified after session start)",
+        "## FS-VERIFIED FILES (stat-observed in the session workdir, modified after session start; workdir enumeration deliberately skips orchestration plumbing — AGENTS.md/CLAUDE.md — and vendor/VCS dirs such as node_modules and .git, so absence of such paths here is not evidence they don't exist)",
         ...fsVerified.map((file) => `- ${file}`),
       ].join("\n"),
     );
@@ -442,9 +573,14 @@ export function buildCompletionEvidenceString(
   // judged against this, not against the worker's description of it.
   const fileContents = bundle.fsVerifiedFileContents ?? [];
   if (fileContents.length > 0) {
+    // Inclusion rule named in the header: text files are inlined (whole when
+    // they fit the per-file budget; an oversized file's view ends with a
+    // durable continuation reference). Binary assets are NOT inlined — they
+    // remain listed under FS-VERIFIED FILES — so a missing entry here means
+    // "not a text file", never "does not exist".
     sections.push(
       [
-        "## FS-VERIFIED FILE CONTENTS (read by the orchestrator from the session workdir)",
+        "## FS-VERIFIED FILE CONTENTS (read by the orchestrator from the session workdir; text files only — binary assets stay listed under FS-VERIFIED FILES without inlined bytes; an oversized file's view ends with a durable continuation reference)",
         ...fileContents.map(
           (entry) => `--- ${entry.path} ---\n${entry.content}`,
         ),
@@ -473,7 +609,9 @@ export function buildCompletionEvidenceString(
   }
 
   if (bundle.toolOutput && hasToolOutput(bundle.toolOutput)) {
-    sections.push(renderToolOutputSection(bundle.toolOutput));
+    sections.push(
+      renderToolOutputSection(bundle.toolOutput, bundle.reportingSessionId),
+    );
     hasRicherSection = true;
   }
 
@@ -570,7 +708,7 @@ export function buildEvidenceStringFromInput(
   if (buildTestLines.length > 0) {
     sections.push(
       [
-        "## TEST / BUILD / TYPECHECK OUTPUT (mined from recorded session output)",
+        `## TEST / BUILD / TYPECHECK OUTPUT (a mined selection from recorded session output; the COMPLETE output is durable on the session transcript: GET /api/coding-agents/${input.sessionId ?? ":sessionId"}/output)`,
         normalizeEvidenceText(buildTestLines.join("\n")),
       ].join("\n"),
     );

--- a/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
@@ -30,6 +30,12 @@ import {
 } from "./orchestrator-artifact-ownership.js";
 
 const GIT_TIMEOUT_MS = 10_000;
+/** Bounded git-probe output buffer. NOT a silent truncation cap (prompt
+ * integrity, REJECT disposition): a probe whose stdout/stderr overflows this
+ * makes spawnSync fail (ENOBUFS → non-zero/absent status), `runGit` returns
+ * `ok: false`, and the gate degrades to the typed `unverifiable` result
+ * (`git_failed` / `probe_failed`) — a verdict is never computed from clipped
+ * git output, and `unverifiable` is documented as NOT a pass. */
 const GIT_MAX_BUFFER = 8 * 1024 * 1024;
 
 /** Provenance stamped on validation events produced by this gate. */
@@ -127,6 +133,14 @@ export interface CompletionResidualsInput {
    * pre-existing churn was not produced by this run. Tracked modifications
    * only — untracked exemptions come from `baselineUntrackedPaths`. */
   baselineDirtyPaths?: readonly string[];
+  /** The session's ISOLATED git index (the ACP wrapper's GIT_INDEX_FILE).
+   *  Wrapper-managed workspaces commit exclusively through it, so the REAL
+   *  index stays frozen at clone state forever — a plain `git status` then
+   *  reports every wrapper-committed file as staged-deleted + untracked and
+   *  the gate parks finished work on phantom dirt (live 2026-08-20: the same
+   *  "5 uncommitted path(s)" on four consecutive PR tasks whose branches
+   *  were clean). When set, the git legs run against this index. */
+  gitIndexFile?: string;
   /** Untracked paths already present when the reporting session spawned
    * (session metadata `codingBaselineUntracked`, captured by
    * `AcpService.spawnSession` from `git status --porcelain` `??` lines). A
@@ -161,13 +175,20 @@ interface GitProbe {
   stderr: string;
 }
 
-function runGit(workdir: string, args: string[]): GitProbe {
+function runGit(
+  workdir: string,
+  args: string[],
+  gitIndexFile?: string,
+): GitProbe {
   const result = spawnSync("git", args, {
     cwd: workdir,
     timeout: GIT_TIMEOUT_MS,
     maxBuffer: GIT_MAX_BUFFER,
     windowsHide: true,
     encoding: "utf8",
+    ...(gitIndexFile
+      ? { env: { ...process.env, GIT_INDEX_FILE: gitIndexFile } }
+      : {}),
   });
   return {
     ok: result.status === 0,
@@ -396,7 +417,11 @@ export async function collectCompletionResiduals(
     // the persisted snapshot so the skip is visible, never a silent pass.
     gitLegsSkipped = "shared_route_workdir";
   } else if (workdir !== undefined) {
-    const status = runGit(workdir, ["status", "--porcelain"]);
+    const status = runGit(
+      workdir,
+      ["status", "--porcelain"],
+      input.gitIndexFile,
+    );
     if (!status.ok) {
       return unverifiable(
         "git_failed",
@@ -479,7 +504,12 @@ export async function collectCompletionResiduals(
   };
 }
 
-/** One-line summary for event records and log lines. */
+/** One-line summary for event records and log lines — a NAMED PREVIEW.
+ * Deliberately renders each residual's `detail` without its `items`: the
+ * complete residuals object is persisted alongside every use (the validation
+ * event's `data.residuals` and the task-metadata snapshot under
+ * {@link COMPLETION_RESIDUALS_METADATA_KEY}), so this summary is never the
+ * only record and must never be re-presented as the full value. */
 export function summarizeResiduals(result: CompletionResidualsResult): string {
   if (result.status === "unverifiable") {
     return `Workspace state could not be verified: ${result.unverifiableReason}`;
@@ -491,15 +521,27 @@ export function summarizeResiduals(result: CompletionResidualsResult): string {
 }
 
 /** Flat detail list for `reEngageOrEscalate`'s `missing` field (what the
- * reflexion post-mortem and the escalation event record). */
+ * reflexion post-mortem and the escalation event record — and, via
+ * attemptReflections, the RE-SPAWN prompt's "Missing:" lines). Each entry
+ * carries the residual's COMPLETE `items` list (the concrete paths, commands,
+ * and SHAs) so the retried worker sees WHAT was left over, not just a count;
+ * the canonical snapshot additionally persists whole under
+ * {@link COMPLETION_RESIDUALS_METADATA_KEY} and the validation event's
+ * `data.residuals`. */
 export function residualDetails(result: CompletionResidualsResult): string[] {
+  const entry = (residual: CompletionResidual): string => {
+    const items = residual.items ?? [];
+    return items.length > 0
+      ? `${residual.detail}: ${items.join(", ")}`
+      : residual.detail;
+  };
   if (result.status === "unverifiable" && result.unverifiableReason) {
     return [
       `workspace unverifiable: ${result.unverifiableReason}`,
-      ...result.residuals.map((residual) => residual.detail),
+      ...result.residuals.map(entry),
     ];
   }
-  return result.residuals.map((residual) => residual.detail);
+  return result.residuals.map(entry);
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/diff-review-gate.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/diff-review-gate.ts
@@ -212,11 +212,13 @@ function compileSecretPatterns(): RegExp[] {
   for (const raw of getDefaultRedactPatterns()) {
     // Match core's redaction parser: a `/pattern/flags` literal keeps its flags
     // (forcing `g`), otherwise the raw source compiles with `gi`. We add `m` so
-    // matching works line-by-line. Compiling with only `gm` (dropping the `i`)
-    // would miss lowercase credential shapes core's source-of-truth catches
-    // (e.g. `database_password=…`, `authorization: Bearer …`), so we preserve
-    // case-insensitivity exactly as core does. A pattern that fails to compile
-    // is skipped rather than aborting the whole gate.
+    // matching works line-by-line. Compiling a bare source with only `gm`
+    // (dropping the `i`) would miss lowercase credential shapes core's
+    // source-of-truth catches (e.g. `authorization: bearer …`), while a
+    // case-sensitive `/…/g` literal (core's ENV-name pattern) must NOT gain an
+    // `i` — core made it case-sensitive on purpose. Preserving each pattern's
+    // own flags keeps the gate at exact parity with the redaction layer. A
+    // pattern that fails to compile is skipped rather than aborting the gate.
     const compiledPattern = compileRedactPattern(raw);
     if (compiledPattern) compiled.push(compiledPattern);
   }

--- a/plugins/plugin-agent-orchestrator/src/services/durable-content-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/durable-content-store.ts
@@ -1,0 +1,217 @@
+/**
+ * Content-addressed durable store for orchestrator text content, and the
+ * bounded-projection primitive built on it. This is the recoverability half of
+ * the durable-content contract: a bounded view is only allowed to drop bytes
+ * when the COMPLETE value is persisted here first and the view carries a
+ * reference that resolves through the orchestrator's own HTTP surface
+ * (`GET /api/orchestrator/content/:sha256?offset=&limit=`) — a textual
+ * truncation marker alone is not recoverability.
+ *
+ * Canonicalize-once invariant: every input is normalized exactly once to its
+ * canonical form — lone surrogates replaced, provider credentials masked with
+ * core's redactor — and EVERYTHING derives from that one canonical text: the
+ * content sha, the stored bytes, the projection head and marker, and the
+ * ReadView hashes/offsets/totals. A projection view therefore can never leak
+ * what storage redacted, and continuation metadata always describes the bytes
+ * the retrieval route actually serves.
+ *
+ * Records are content-addressed (`<sha256>.txt` under the trajectory dir), so
+ * repeated projections of the same content deduplicate, references are stable
+ * across retries, and the store never needs coordination. Windowed reads snap
+ * to UTF-8 code-point boundaries and report the actual byte range served, so
+ * every window decodes cleanly on its own and windows reassemble losslessly.
+ */
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ContentReference, ReadView } from "@elizaos/core";
+import {
+  redactSensitiveText,
+  resolveTrajectoryDir,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
+
+const CONTENT_DIR_NAME = "orchestrator-content";
+const SHA256_RE = /^[0-9a-f]{64}$/u;
+
+function contentDir(): string {
+  return path.join(resolveTrajectoryDir(), CONTENT_DIR_NAME);
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/** The single canonicalization point: well-formed Unicode, then credential
+ *  redaction. Every stored byte and every derived value comes from this. */
+function canonicalizeDurableText(text: string): string {
+  return redactSensitiveText(toWellFormedUnicode(text));
+}
+
+/** UTF-8 continuation bytes are 0b10xxxxxx; every other byte value starts a
+ *  code point (stored records are always valid UTF-8 — they are encoded from
+ *  well-formed canonical text). */
+function isUtf8ContinuationByte(byte: number): boolean {
+  return (byte & 0xc0) === 0x80;
+}
+
+function persistCanonicalText(canonical: string): ContentReference {
+  const digest = sha256(canonical);
+  const dir = contentDir();
+  const file = path.join(dir, `${digest}.txt`);
+  if (!fs.existsSync(file)) {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${file}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, canonical, "utf8");
+    fs.renameSync(tmp, file);
+  }
+  return { kind: "tool-result", ref: `acpx-content:${digest}` };
+}
+
+/**
+ * Persist the complete text and return its resolvable reference. Idempotent:
+ * the record is content-addressed, so persisting the same text twice writes
+ * once. Failures throw — a caller about to emit a bounded view MUST know the
+ * durable record exists before dropping bytes from the view.
+ */
+export function persistDurableContent(text: string): ContentReference {
+  return persistCanonicalText(canonicalizeDurableText(text));
+}
+
+export interface DurableContentWindow {
+  /** UTF-8 decode of exactly the `[offset, endOffset)` byte range. */
+  text: string;
+  /** ACTUAL start byte served: the requested offset snapped forward to the
+   *  next code-point boundary so the window never starts mid-code-point. */
+  offset: number;
+  /** Exclusive end byte actually served; always a code-point boundary, so
+   *  `text` decodes cleanly on its own. Continue reading from here. */
+  endOffset: number;
+  /** The requested byte budget (clamped to [1, 1 MiB]). The served range is
+   *  at most this many bytes unless the budget cannot hold even the next
+   *  code point, in which case exactly that one code point is served. */
+  limit: number;
+  totalBytes: number;
+  hasMore: boolean;
+  sourceSha256: string;
+}
+
+/** Resolve a window of a stored record by its sha256 (the token after
+ *  `acpx-content:`). Returns undefined for an unknown or malformed ref.
+ *  Window edges are snapped to UTF-8 code-point boundaries — start forward,
+ *  end backward — so no window ever splits a code point; the actual byte
+ *  range served is reported in `offset`/`endOffset`. */
+export function readDurableContent(
+  sha: string,
+  opts: { offset?: number; limit?: number } = {},
+): DurableContentWindow | undefined {
+  if (!SHA256_RE.test(sha)) return undefined;
+  const file = path.join(contentDir(), `${sha}.txt`);
+  let buffer: Buffer;
+  try {
+    buffer = fs.readFileSync(file);
+  } catch (err) {
+    // error-policy:J3 ENOENT is the explicit unknown-record result the route
+    // turns into a 404; any other read failure is a real fault.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
+    throw err;
+  }
+  const totalBytes = buffer.byteLength;
+  const limit = Math.max(1, Math.min(opts.limit ?? 65_536, 1_048_576));
+  const requested = Math.max(0, Math.min(opts.offset ?? 0, totalBytes));
+  let start = requested;
+  while (
+    start < totalBytes &&
+    isUtf8ContinuationByte(buffer[start] as number)
+  ) {
+    start++;
+  }
+  let end = Math.min(start + limit, totalBytes);
+  while (
+    end > start &&
+    end < totalBytes &&
+    isUtf8ContinuationByte(buffer[end] as number)
+  ) {
+    end--;
+  }
+  // A budget smaller than the next code point would snap to an empty window
+  // with hasMore=true — a pagination stall. Serve that one complete code
+  // point instead; offset/endOffset report the actual range, so the caller's
+  // continuation accounting stays exact.
+  if (end === start && start < totalBytes) {
+    end = start + 1;
+    while (end < totalBytes && isUtf8ContinuationByte(buffer[end] as number)) {
+      end++;
+    }
+  }
+  const slice = buffer.subarray(start, end);
+  return {
+    text: slice.toString("utf8"),
+    offset: start,
+    endOffset: end,
+    limit,
+    totalBytes,
+    hasMore: end < totalBytes,
+    sourceSha256: sha,
+  };
+}
+
+export interface DurableProjection {
+  /** The bounded text; a partial view ends with a marker naming the
+   *  RESOLVABLE reference of the complete stored record. */
+  view: string;
+  truncated: boolean;
+  /** Present iff truncated: the persisted complete record's reference plus
+   *  the progressive-read envelope for the emitted head. */
+  reference?: ContentReference;
+  read?: ReadView;
+}
+
+/**
+ * Bounded projection of arbitrary content. The input is canonicalized ONCE
+ * (well-formed + redacted) and both branches emit that canonical text — a
+ * view never contains anything the durable record redacted. Short content
+ * passes through whole. Oversized content is FIRST persisted to the durable
+ * store, then the canonical head is emitted with a continuation marker naming
+ * the stored record — so the omitted bytes are recoverable through
+ * `GET /api/orchestrator/content/<sha256>?offset=<n>`, and head + windows
+ * reassemble to exactly the canonical text.
+ */
+export function durableProjection(
+  full: string,
+  budgetChars: number,
+): DurableProjection {
+  const canonical = canonicalizeDurableText(full);
+  if (canonical.length <= budgetChars) {
+    return { view: canonical, truncated: false };
+  }
+  const reference = persistCanonicalText(canonical);
+  const sha = reference.ref.slice("acpx-content:".length);
+  const marker = `\n… [${canonical.length} chars total — full content: GET /api/orchestrator/content/${sha}]`;
+  const headBudget = Math.max(0, budgetChars - marker.length);
+  const head = truncateWellFormed(canonical, headBudget).trimEnd();
+  const headBytes = Buffer.byteLength(head, "utf8");
+  return {
+    view: `${head}${marker}`,
+    truncated: true,
+    reference,
+    read: {
+      reference,
+      slice: {
+        range: {
+          unit: "byte",
+          start: 0,
+          end: headBytes,
+          total: Buffer.byteLength(canonical, "utf8"),
+        },
+        hasPrevious: false,
+        hasMore: true,
+        nextOffset: headBytes,
+        completeness: "partial-recoverable",
+        sliceSha256: sha256(head),
+        sourceSha256: sha,
+      },
+    },
+  };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/durable-content.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/durable-content.ts
@@ -1,0 +1,123 @@
+/**
+ * Durable complete content with bounded model views (#24262 close-out).
+ *
+ * The contract, from the review that closed the original orchestration PR:
+ * canonical content is persisted IN FULL; every capped string handed to a
+ * model prompt or a chat surface is a VIEW derived from that durable content,
+ * and a partial view carries a continuation reference so the reader — model
+ * or human — can recover the remainder instead of losing it.
+ *
+ * Two conventions compose here:
+ * - `canonical<Thing>` / `provider<Thing>` metadata keys (introduced by the
+ *   auto-submit PR title repair): the canonical value is stored untruncated;
+ *   a provider-bounded payload is derived explicitly, named, and stored next
+ *   to it so the derivation is auditable.
+ * - {@link ContentReference} / {@link ReadView} from @elizaos/core (#24305):
+ *   the source-neutral progressive-read envelope. Views produced here use
+ *   the `tool-result` kind with orchestrator-owned opaque refs; the owning
+ *   HTTP surfaces resolve continuations:
+ *     `acpx-session-output:<sessionId>`  → GET /api/coding-agents/:id/output
+ *     `acpx-task:<taskId>`               → GET /api/orchestrator/tasks/:id
+ *     `acpx-task-meta:<taskId>:<key>`    → task metadata key on the same route
+ */
+import { createHash } from "node:crypto";
+import type {
+  ContentReference,
+  ReadCompleteness,
+  ReadView,
+} from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+export interface BoundedContentView {
+  /** The bounded text. Partial views end with a one-line continuation
+   *  marker naming the reference. */
+  view: string;
+  /** True when `view` carries less than the full content. */
+  truncated: boolean;
+  /** The progressive-read envelope for a partial view; absent when the
+   *  content fit whole. */
+  read?: ReadView;
+}
+
+/** An orchestrator-owned content reference (opaque, model-safe). */
+export function orchestratorContentRef(
+  scope: "session-output" | "task" | "task-meta",
+  id: string,
+  key?: string,
+): ContentReference {
+  const ref = [`acpx-${scope}`, id, ...(key ? [key] : [])]
+    .join(":")
+    // The core contract requires OPAQUE_REFERENCE_PATTERN-safe tokens.
+    .replace(/[^A-Za-z0-9._:~-]/gu, "~");
+  return { kind: "tool-result", ref: ref.slice(0, 256) };
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/**
+ * Derive a bounded view of durable content. NEVER call this on content that
+ * is not persisted in full somewhere the reference can reach — the marker
+ * promises the remainder is recoverable, and a false promise is worse than a
+ * silent cut.
+ */
+export function boundedContentView(
+  full: string,
+  budgetChars: number,
+  reference: ContentReference,
+  opts: { completeness?: ReadCompleteness } = {},
+): BoundedContentView {
+  const wellFormed = toWellFormedUnicode(full);
+  if (wellFormed.length <= budgetChars) {
+    return { view: wellFormed, truncated: false };
+  }
+  const marker = `\n… [view of ${budgetChars} of ${wellFormed.length} chars — full content: ${reference.ref}]`;
+  const headBudget = Math.max(0, budgetChars - marker.length);
+  const head = truncateWellFormed(wellFormed, headBudget).trimEnd();
+  return {
+    view: `${head}${marker}`,
+    truncated: true,
+    read: {
+      reference,
+      slice: {
+        range: {
+          unit: "byte",
+          start: 0,
+          end: Buffer.byteLength(head, "utf8"),
+          total: Buffer.byteLength(wellFormed, "utf8"),
+        },
+        hasPrevious: false,
+        hasMore: true,
+        nextOffset: Buffer.byteLength(head, "utf8"),
+        completeness: opts.completeness ?? "partial-recoverable",
+        sliceSha256: sha256(head),
+        sourceSha256: sha256(wellFormed),
+      },
+    },
+  };
+}
+
+/**
+ * Canonical/provider pair for a value a downstream surface hard-bounds
+ * (GitHub title, Discord message, room name, served slug). The canonical
+ * value is what gets persisted; the provider value is what gets sent.
+ */
+export interface CanonicalProviderPair {
+  canonical: string;
+  provider: string;
+  truncated: boolean;
+}
+
+export function canonicalProviderPair(
+  canonical: string,
+  providerLimit: number,
+): CanonicalProviderPair {
+  const wellFormed = toWellFormedUnicode(canonical);
+  const provider = truncateWellFormed(wellFormed, providerLimit);
+  return {
+    canonical: wellFormed,
+    provider,
+    truncated: provider.length < wellFormed.length,
+  };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/fabricated-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/fabricated-input.ts
@@ -1,0 +1,111 @@
+/**
+ * Detects a sub-agent that manufactured the input it was told to consume.
+ * Under verify coaching ("prove the run output contains the result"), a weak
+ * coding model that could not find `/etc/nubs-secret-config.yaml` wrote its
+ * own `nubs-secret-config.yaml` with `version: 1.2.3`, pointed the script at
+ * it, and the judge passed "1.2.3" to the user (live 2026-08-22). The task's
+ * read targets are compared against the session's write ledger and shell
+ * redirections by normalized path. Filename similarity is not evidence: two
+ * different directories commonly contain the same configuration filename.
+ */
+
+const FILE_TOKEN =
+  "((?:\\/|~\\/|\\.\\/|[A-Za-z]:\\\\)?[\\w.\\\\/-]*[\\w-]\\.(?:ya?ml|json|csv|tsv|txt|toml|ini|cfg|conf|xml|env|log|md|db|sqlite3?|parquet|xlsx?))\\b";
+const READ_VERBS =
+  "read|reads|reading|parse|parses|parsing|load|loads|loading|open|opens|opening|fetch|fetches|consume|consumes|from";
+const WRITE_VERBS =
+  "write|writes|save|saves|output|outputs|export|exports|store|stores|create|creates|generate|generates|produce|produces|emit|emits";
+/** Up to 60 chars on one line that never cross a verb of the other class. */
+const window = (blocked: string) => `(?:(?!\\b(?:${blocked})\\b)[^\\n]){0,60}?`;
+const READ_TARGET_RE = new RegExp(
+  `\\b(?:${READ_VERBS})\\b${window(WRITE_VERBS)}${FILE_TOKEN}`,
+  "gi",
+);
+/** Files the task tells the worker to PRODUCE — never read targets. */
+const WRITE_TARGET_RE = new RegExp(
+  `\\b(?:${WRITE_VERBS})\\b${window(READ_VERBS)}${FILE_TOKEN}`,
+  "gi",
+);
+
+const SHELL_WRITE_TARGET_RE =
+  /(?:>>?|\btee\s+(?:-a\s+)?)\s*["']?([^\s"'|;&]+)/g;
+
+export interface FabricatedInput {
+  /** The file the task said to read (as written in the task). */
+  target: string;
+  /** The file the sub-agent wrote in its place. */
+  wrote: string;
+}
+
+export interface InputBaseline {
+  path: string;
+  existed: boolean;
+  sha256?: string;
+}
+
+function normalizedPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+/g, "/").toLowerCase();
+}
+
+/** File-like tokens the task text asks the worker to READ. */
+export function readTargetsFromTask(text: string): string[] {
+  const produced = new Set<string>();
+  for (const match of text.matchAll(WRITE_TARGET_RE)) {
+    const target = match[1]?.trim();
+    if (target) produced.add(target.toLowerCase());
+  }
+  const out: string[] = [];
+  for (const match of text.matchAll(READ_TARGET_RE)) {
+    const target = match[1]?.trim();
+    if (
+      target &&
+      !produced.has(target.toLowerCase()) &&
+      !out.includes(target)
+    ) {
+      out.push(target);
+    }
+  }
+  return out;
+}
+
+/** Paths a shell command line writes to via redirection or tee. */
+export function shellWriteTargets(command: string): string[] {
+  const out: string[] = [];
+  for (const match of command.matchAll(SHELL_WRITE_TARGET_RE)) {
+    const target = match[1];
+    if (target && target !== "/dev/null" && !out.includes(target)) {
+      out.push(target);
+    }
+  }
+  return out;
+}
+
+export function detectFabricatedInput(
+  taskText: string,
+  writtenPaths: readonly string[],
+  shellCommands: readonly string[],
+  baselines: readonly InputBaseline[],
+): FabricatedInput | undefined {
+  const targets = readTargetsFromTask(taskText);
+  if (targets.length === 0) return undefined;
+  const writes = [
+    ...writtenPaths,
+    ...shellCommands.flatMap((command) => shellWriteTargets(command)),
+  ];
+  for (const target of targets) {
+    const normalizedTarget = normalizedPath(target);
+    if (!normalizedTarget) continue;
+    const baseline = baselines.find(
+      (entry) => normalizedPath(entry.path) === normalizedTarget,
+    );
+    // A write is only fabrication evidence when the requested input was
+    // captured as absent before execution. Missing baseline is unknown, not a
+    // guilty verdict; an existing file may legitimately be rewritten.
+    if (!baseline || baseline.existed) continue;
+    const wrote = writes.find(
+      (path) => normalizedPath(path) === normalizedTarget,
+    );
+    if (wrote) return { target, wrote };
+  }
+  return undefined;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/follow-up-origin.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/follow-up-origin.ts
@@ -1,0 +1,135 @@
+/**
+ * A follow-up delivered into a LIVE session re-keys that session's voice.
+ *
+ * The router's request-voice ledger keys every relay on the session's origin
+ * message (spawnRootMessageId). A follow-up ("also give it a dark mode
+ * toggle") delivered to the same session produces a second task_complete
+ * under the SAME key, which the ledger denies as a duplicate terminal — the
+ * user heard "queued" and never heard "done" (live 2026-08-22, countdown
+ * timer's dark-mode toggle).
+ *
+ * The follow-up's own message id is noted on the session when it is queued
+ * and activated when it is actually delivered (direct send, idle flush, or
+ * room forward), so the completion that answers it claims the follow-up's
+ * slot. Stamping is best-effort metadata: a failure never blocks delivery.
+ */
+import type { Memory } from "@elizaos/core";
+
+export const FOLLOW_UP_ORIGIN_KEY = "followUpOriginMessageId";
+export const PENDING_FOLLOW_UP_ORIGIN_KEY = "pendingFollowUpOriginMessageId";
+
+type SessionLike = { metadata?: Record<string, unknown> | null } | null;
+
+export interface FollowUpOriginService {
+  getSession(
+    sessionId: string,
+  ): Promise<SessionLike | undefined> | SessionLike | undefined;
+  updateSessionMetadata?(
+    sessionId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void>;
+}
+
+function plain(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** The connector message id of a room message (the same ladder the TASKS
+ *  spawn paths use for the origin key), falling back to the memory id. */
+export function originMessageIdFor(message: Memory): string | undefined {
+  const content = record(message.content) ?? {};
+  const contentMetadata = record(content.metadata);
+  const messageMetadata = record(message.metadata);
+  const discordMetadata = record(messageMetadata?.discord);
+  return (
+    plain(contentMetadata?.originConnectorMessageId) ??
+    plain(contentMetadata?.replyToExternalMessageId) ??
+    plain(messageMetadata?.messageIdFull) ??
+    plain(messageMetadata?.discordMessageId) ??
+    plain(discordMetadata?.messageId) ??
+    plain(message.id)
+  );
+}
+
+async function metadataOf(
+  service: FollowUpOriginService,
+  sessionId: string,
+): Promise<Record<string, unknown>> {
+  try {
+    const session = await Promise.resolve(service.getSession(sessionId));
+    return record(session?.metadata) ?? {};
+  } catch {
+    // error-policy:J4 best-effort read; an unreadable session stamps nothing
+    return {};
+  }
+}
+
+async function patch(
+  service: FollowUpOriginService,
+  sessionId: string,
+  values: Record<string, unknown>,
+): Promise<void> {
+  if (typeof service.updateSessionMetadata !== "function") return;
+  try {
+    await service.updateSessionMetadata(sessionId, values);
+  } catch {
+    // error-policy:J4 voice re-keying is metadata; delivery proceeds without it
+  }
+}
+
+export async function readFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+): Promise<string | undefined> {
+  return plain((await metadataOf(service, sessionId))[FOLLOW_UP_ORIGIN_KEY]);
+}
+
+/** The follow-up is QUEUED (session busy): remember its origin for the
+ *  flush that delivers it. The in-flight turn keeps the current key. */
+export async function notePendingFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+  originMessageId: string | undefined,
+): Promise<void> {
+  if (!originMessageId) return;
+  await patch(service, sessionId, {
+    [PENDING_FOLLOW_UP_ORIGIN_KEY]: originMessageId,
+  });
+}
+
+/** The follow-up is being DELIVERED: its origin becomes the session's voice
+ *  key. With no explicit id, the pending (queued) origin is promoted. */
+export async function activateFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+  originMessageId?: string,
+): Promise<void> {
+  const id =
+    originMessageId ??
+    plain((await metadataOf(service, sessionId))[PENDING_FOLLOW_UP_ORIGIN_KEY]);
+  if (!id) return;
+  await patch(service, sessionId, {
+    [FOLLOW_UP_ORIGIN_KEY]: id,
+    [PENDING_FOLLOW_UP_ORIGIN_KEY]: "",
+  });
+}
+
+/** A direct send lost the race to a busy session and was queued instead:
+ *  hand the voice back to the in-flight turn and park the origin as pending. */
+export async function restoreFollowUpOrigin(
+  service: FollowUpOriginService,
+  sessionId: string,
+  previousActive: string | undefined,
+  pendingId: string | undefined,
+): Promise<void> {
+  await patch(service, sessionId, {
+    [FOLLOW_UP_ORIGIN_KEY]: previousActive ?? "",
+    [PENDING_FOLLOW_UP_ORIGIN_KEY]: pendingId ?? "",
+  });
+}

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -240,6 +240,11 @@ export function buildAutoVerifyCorrection(
     "",
     ...closing,
     "",
+    // Integrity clause on every stage: the pressure to "prove" a criterion
+    // must never become pressure to fake it (live 2026-08-22: a missing
+    // config file was replaced by a hand-written one and "1.2.3" shipped).
+    "Integrity: never manufacture the inputs, fixtures, files, data, or endpoints the task says to read, fetch, or operate on, and never quietly change the task to something easier to satisfy a criterion. If the real input does not exist or cannot be reached from here, say so explicitly and stop — an honest blocker is the correct report; a faked pass is a failure.",
+    "",
     buildEvidenceChecklist(missing, caps),
   ];
   return lines.join("\n");
@@ -344,6 +349,7 @@ export function buildVerificationPrompt(input: GoalVerificationInput): string {
     "- If the evidence is silent on a criterion, or only describes intent / future work, that criterion FAILS.",
     "- If the evidence contains a failure marker (a non-zero exit, a failing/red test line, an error/traceback, a loopback-only URL where a public one is required) relevant to a criterion, that criterion FAILS.",
     "- Do not give the benefit of the doubt. When in doubt, mark it missing.",
+    "- A criterion satisfied by inputs the sub-agent MANUFACTURED ITSELF FAILS: if the evidence shows it created or wrote the very file, config, dataset, or endpoint the task said to READ / FETCH / USE (or rewrote the program to consume a stand-in it made), the output is fabricated — mark the output criterion missing and say so in the summary.",
     "",
     "Respond with a SINGLE JSON object and nothing else. Do not wrap it in ```. Schema:",
     '{ "passed": <true|false>, "summary": "<one sentence under 200 chars>", "missing": ["<criterion text that was NOT proven>", ...] }',
@@ -444,6 +450,36 @@ export function parseJudgeResponse(
  * Pure with respect to filesystem and network state — the only side effect
  * is one `runtime.useModel` call.
  */
+/**
+ * Verifier model call with one bounded retry when the call died to a TURN
+ * ABORT. A user's "cancel my coding tasks" aborts every in-flight turn in the
+ * room — including this background verification of an ALREADY-DELIVERED build
+ * — and the abort then burned a verify attempt and parked a working page
+ * (live 2026-08-19). The abort is transient (the aborting turn ends in
+ * seconds); one delayed retry answers it. Any other failure propagates.
+ */
+async function verifierModelCallWithAbortRetry(
+  runtime: IAgentRuntime,
+  prompt: string,
+): Promise<string> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+        stopSequences: [],
+      });
+      return typeof result === "string" ? result : String(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (attempt === 0 && /\bTurn aborted\b/i.test(message)) {
+        await new Promise((resolve) => setTimeout(resolve, 8_000));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 export async function verifyGoalCompletion(
   runtime: IAgentRuntime,
   input: GoalVerificationInput,
@@ -471,15 +507,16 @@ export async function verifyGoalCompletion(
   const startedAt = Date.now();
   let raw: string;
   try {
-    const result = await runtime.useModel(ModelType.TEXT_SMALL, {
-      prompt,
-      stopSequences: [],
-    });
-    raw = typeof result === "string" ? result : String(result);
+    raw = await verifierModelCallWithAbortRetry(runtime, prompt);
   } catch (err) {
     // error-policy:J1 boundary translation — a failed verifier model call
     // becomes an explicit inconclusive verdict naming the error, never a fake
-    // pass or a worker-attributed proof failure.
+    // pass or a worker-attributed proof failure. The complete error (stack,
+    // cause chain) is also durably recorded via runtime.reportError.
+    runtime.reportError?.("[goal-llm-verifier]", err, {
+      goal: input.goal,
+      criteriaCount: input.acceptanceCriteria.length,
+    });
     const detail = err instanceof Error ? err.message : String(err);
     return {
       passed: false,

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -6,8 +6,8 @@
  * `/api/orchestrator/*` route — must pass its raw text through one of these
  * builders. Centralising the envelope is what makes worker behaviour
  * consistent: the same goal, acceptance criteria, room wiring, capability
- * fence, and completion contract reach Claude, Codex, OpenCode, ElizaOS, and
- * Pi Agent regardless of entry point. The wording is the formalised version of
+ * fence, and completion contract reach Claude, Codex, ElizaOS, and Pi Agent
+ * regardless of entry point. The wording is the formalised version of
  * the swarm-coordination block that `TASKS_SPAWN_AGENT` already emits.
  *
  * @module services/goal-prompt

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -7,8 +7,8 @@
  * IGNORED (ambient chatter not meant for this agent).
  *
  * Eliza participants already have this faculty: the core `shouldRespond`
- * evaluator (RESPOND / IGNORE / STOP). Coding sub-agents (Claude Code, Codex,
- * OpenCode) have no such gate — left alone, every keystroke in the room is
+ * evaluator (RESPOND / IGNORE / STOP). Coding sub-agents (Claude Code, Codex)
+ * have no such gate — left alone, every keystroke in the room is
  * injected into a running turn, derailing it. This module gives them an
  * equivalent structural decision, and threads an Eliza participant's
  * `shouldRespond` verdict through unchanged when one is supplied.
@@ -34,7 +34,7 @@ export interface InterruptionDecision {
 export interface InterruptionInput {
   /** The incoming user message text. */
   text: string;
-  /** Sub-agent framework: claude / codex / opencode / elizaos / … */
+  /** Sub-agent framework: claude / codex / elizaos / … */
   agentType: string;
   /** True when the sub-agent is mid-turn (ACP status `busy`). */
   sessionBusy: boolean;

--- a/plugins/plugin-agent-orchestrator/src/services/loopback-urls.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/loopback-urls.ts
@@ -1,0 +1,28 @@
+/**
+ * Loopback URL redaction for user-facing sub-agent text. A coding child
+ * verifies its page on the supervisor's loopback port and narrates that URL;
+ * chat must never carry it (it is unreachable for the user and names an
+ * internal port). Shared by the router narration and the completion
+ * evaluator's delivery funnel.
+ */
+
+const LOOPBACK_URL_PATTERN =
+  /https?:\/\/(?:localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[?::1\]?)(?::\d{1,5})?(?:\/[^\s)<>"`]*)?/gi;
+
+export function redactLoopbackUrls(text: string): string {
+  if (!text) return text;
+  LOOPBACK_URL_PATTERN.lastIndex = 0;
+  if (!LOOPBACK_URL_PATTERN.test(text)) return text;
+  LOOPBACK_URL_PATTERN.lastIndex = 0;
+  const stripped = text
+    .replace(LOOPBACK_URL_PATTERN, "")
+    .replace(/[ \t]+\n/g, "\n");
+  // Drop lines that became orphan punctuation after the URL was removed
+  // (e.g. "- " or "* " markdown list bullets pointing at nothing).
+  return stripped
+    .split("\n")
+    .filter((line) => !/^[-*\s]*[:>→\->]?[\s]*$/.test(line) || line === "")
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/plugins/plugin-agent-orchestrator/src/services/model-gateway.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/model-gateway.ts
@@ -6,12 +6,13 @@
  * process env, per config-env conventions). In gateway mode a spawned
  * sub-agent's env points `OPENAI_BASE_URL` (Codex CLI) and
  * `ANTHROPIC_BASE_URL` (Claude Code via claude-agent-acp) at the gateway,
- * with the gateway token injected as the api-key env for both paths. OpenCode
- * routes through the gateway too: in gateway mode `buildOpencodeSpawnConfig`
- * (opencode-config.ts) builds a gateway-pointed provider config instead of
- * embedding a raw provider key into `OPENCODE_CONFIG_CONTENT`. Raw provider
- * credentials are actively excluded — deleted before the token is assigned,
- * and any composite env value still embedding a raw key is dropped whole —
+ * with the gateway token injected as the api-key env for both paths. The
+ * eliza-code backend routes through the gateway via the same two vars: its
+ * model-provider resolution prefers `OPENAI_BASE_URL`/`OPENAI_API_KEY` over
+ * the `ELIZA_CODE_*` fallbacks, so the env rewrite alone covers it. Raw
+ * provider credentials are actively excluded — deleted before the token is
+ * assigned, and any composite env value still embedding a raw key is dropped
+ * whole —
  * so a sub-agent env dump contains no raw provider credential.
  * With either var unset the child env is byte-identical to non-gateway
  * behavior.
@@ -37,7 +38,7 @@ export const MODEL_GATEWAY_TOKEN_KEY = "ELIZA_MODEL_GATEWAY_TOKEN";
  * credential `AcpService.buildEnv` merge paths can carry into a child env:
  * - `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `CEREBRAS_API_KEY` — on the
  *   host-env forwarding allowlist (`shouldForwardEnv`).
- * - `ELIZA_E2E_CEREBRAS_API_KEY` — raw provider
+ * - `ELIZA_CODE_API_KEY` / `ELIZA_E2E_CEREBRAS_API_KEY` — raw provider
  *   keys forwarded via the broad `ELIZA_` prefix rule.
  * - `CLAUDE_CODE_OAUTH_TOKEN` — injected by multi-account selection
  *   (`selectCodingAccount` envPatch) for linked Claude subscriptions.
@@ -52,6 +53,7 @@ export const MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS = [
   "ANTHROPIC_API_KEY",
   "CODEX_API_KEY",
   "CEREBRAS_API_KEY",
+  "ELIZA_CODE_API_KEY",
   "ELIZA_E2E_CEREBRAS_API_KEY",
   "CLAUDE_CODE_OAUTH_TOKEN",
 ] as const;
@@ -97,11 +99,10 @@ const MODEL_GATEWAY_ENV_PREFIX = "ELIZA_MODEL_GATEWAY_";
  * The invariant is "no raw provider key VALUE anywhere in the child env",
  * not "the named keys are absent" — so after deleting the named keys, any
  * remaining env var whose value embeds one of their raw values (a composite
- * carrier, e.g. a JSON config blob like `OPENCODE_CONFIG_CONTENT`) is
+ * carrier, e.g. a JSON config blob assembled by an earlier merge step) is
  * dropped whole. Fail closed: a misconfigured child beats a leaked key.
- * (The opencode path never trips this in practice — in gateway mode
- * `buildOpencodeSpawnConfig` builds a gateway-pointed config with no raw
- * key; this sweep is the backstop for future merge steps.)
+ * No current merge step builds such a blob; this sweep is the backstop for
+ * future ones.
  */
 export function applyModelGatewayEnv(
   env: NodeJS.ProcessEnv,

--- a/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/producible-evidence.ts
@@ -73,8 +73,59 @@ const NON_ARTIFACT_TOKEN_RE = /^(?:e\.g|i\.e|etc|v?\d+(?:\.\d+)+)$/i;
 
 export interface InventedArtifactFilterResult {
   kept: string[];
-  /** Criteria dropped because they pinned a path the request never named. */
+  /** Criteria dropped because they pinned a path the request never named.
+   * Callers must RECORD this list, not discard it (prompt-integrity
+   * auditability): acceptance-criteria generation persists it to the durable
+   * content store and the structured log so a parked or misgraded task can be
+   * traced back to a filtered criterion. */
   dropped: string[];
+}
+
+/** Evidence classes no orchestrator pipeline can collect: the verifier judges
+ *  from workdir files, tool stdout, git changesets, and HTTP probes — never a
+ *  live browser session or a human eyeball. A generated criterion demanding
+ *  one of these is unsatisfiable by design and parks working deliverables
+ *  (live 2026-08-19: "Browser console shows zero JavaScript errors during a
+ *  complete work-to-break cycle" parked a built, served pomodoro page). */
+const UNCOLLECTABLE_EVIDENCE_RE =
+  /\b(?:browser\s+console|devtools|dev\s+tools|console\s+logs?\s+(?:show|prove|confirm)|screenshots?|screen\s+recording|visually\s+(?:verify|confirm|inspect)|manual(?:ly)?\s+(?:test|verify|confirm|inspect)|user\s+confirms?|lighthouse|cross-browser|no\s+(?:js|javascript)\s+(?:errors?|warnings?)\s+in\s+the\s+(?:browser|console)|(?:interact(?:ion|ing)?|click(?:ing|s)?|tapping|hover(?:ing)?)\s+(?:with\s+)?(?:a\s+|the\s+)?\w*\s*(?:trigger|button|element).{0,40}\b(?:DOM|display|updates?|renders?)|updates?\s+the\s+(?:displayed|rendered)|\bin\s+the\s+DOM\b|visual(?:ly)?\s+(?:evidence|representation|verification|confirm)|renders?\s+(?:correctly|properly|the\s+\w+\s+correctly))/i;
+
+/** Criteria classes unsatisfiable for STATIC APP builds specifically: slug-dir
+ *  pages have no git pipeline, so "summarized in the diff" can never be
+ *  evidenced (live 2026-08-19: quote-generator parked on it), and runtime DOM
+ *  behavior is only provable in a browser the verifier does not have. */
+/** Report-shaped criteria demand a NARRATIVE (a summary/description of the
+ *  changes) rather than a property of the deliverable itself. They are
+ *  unsatisfiable as acceptance criteria for EVERY task type — the verifier
+ *  ends up grading the sub-agent's prose, and an under-narrated but working
+ *  build parks ("the diff summarizes the specific style and theme changes",
+ *  live 2026-08-20 dark-mode edit). Checkable diff-content criteria ("the
+ *  diff shows a toggle element added") survive. */
+const REPORT_SHAPED_CRITERION_RE =
+  /\b(?:diff\s+summariz|summar(?:y|ize[sd]?|izing)\s+(?:of|in)?\s*the\s+(?:diff|changes?|work)|provide[sd]?\s+a\s+summary|describe[sd]?\s+the\s+changes?\b)/i;
+
+const APP_BUILD_UNSATISFIABLE_RE =
+  /\b(?:diff\s+summar|summar\w*\s+in\s+the\s+diff|the\s+diff\b|git\s+diff|changeset|commit\s+message)/i;
+
+/**
+ * Drop generated criteria whose proof would require evidence the pipeline
+ * cannot produce (browser runtime state, human inspection). Deterministic
+ * template criteria never trip this; only model-refined text does.
+ */
+export function stripUncollectableEvidenceCriteria(
+  criteria: readonly string[],
+  taskType?: string,
+): InventedArtifactFilterResult {
+  const kept: string[] = [];
+  const dropped: string[] = [];
+  for (const criterion of criteria) {
+    const uncollectable =
+      UNCOLLECTABLE_EVIDENCE_RE.test(criterion) ||
+      REPORT_SHAPED_CRITERION_RE.test(criterion) ||
+      (taskType === "app-build" && APP_BUILD_UNSATISFIABLE_RE.test(criterion));
+    (uncollectable ? dropped : kept).push(criterion);
+  }
+  return { kept, dropped };
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/quick-app-evidence.ts
@@ -16,6 +16,8 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { logger } from "@elizaos/core";
+import { durableProjection } from "./durable-content-store.js";
 import type { WorkdirRouteUrlMapping } from "./task-agent-routing.js";
 
 const PROBE_TIMEOUT_MS = 5_000;
@@ -35,6 +37,132 @@ export function mineCandidatePaths(texts: readonly string[]): string[] {
     }
   }
   return [...out];
+}
+
+// Sanity CEILINGS, not working caps: generous enough that a real quick-app
+// session workdir is enumerated EXHAUSTIVELY (the old depth-3/64-entry caps
+// silently parked deep or many-file deliverables as "no evidence"). When a
+// pathological tree does trip a ceiling, the walk records exactly what it did
+// not traverse and reports it — never a silent cut.
+const ENUMERATE_MAX_DEPTH = 16;
+const ENUMERATE_MAX_ENTRIES = 4_096;
+/** NAMED exclusion set — a semantic filter, not a size cap. Orchestration
+ *  plumbing written into the workdir for the child (AGENTS.md/CLAUDE.md) plus
+ *  vendor/VCS internals that are never the deliverable. Deliberately NOT a
+ *  blanket dot-prefix skip: dot-path deliverables (.github/workflows/ci.yml,
+ *  .env.example, .eslintrc.json) are legitimate candidates. The rendered
+ *  FS-VERIFIED FILES header names this rule so "not listed" cannot be read as
+ *  "does not exist". */
+const ENUMERATE_SKIP = new Set([
+  "AGENTS.md",
+  "CLAUDE.md",
+  "node_modules",
+  ".git",
+  ".hg",
+  ".svn",
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".cache",
+  ".turbo",
+  ".next",
+  ".nuxt",
+  ".pnpm-store",
+  ".yarn",
+  ".DS_Store",
+]);
+
+/** Full enumeration result: candidates plus the explicit continuation note
+ *  for anything a sanity ceiling kept the walk from visiting. */
+export interface WorkdirEnumeration {
+  /** Workdir-relative candidate files, sorted (deterministic). */
+  candidates: string[];
+  /** Workdir-relative paths the walk did NOT visit because a ceiling
+   *  tripped — directories not descended into (trailing `/`) and files not
+   *  recorded. Empty when the walk was exhaustive. */
+  notTraversed: string[];
+  /** True iff `notTraversed` is non-empty. */
+  truncated: boolean;
+  limits: { maxDepth: number; maxEntries: number };
+}
+
+/**
+ * Enumerate the session workdir directly as a candidate source. A worker that
+ * ends its run with an empty final reply leaves NOTHING to mine claims from,
+ * and a working build then parks with "no evidence" (live 2026-08-19: built
+ * dice-roller page reported as ghosted + parked). Enumeration only nominates
+ * candidates; collectFsObservedFiles still applies the mtime-after-start gate
+ * before anything counts as evidence. Entries are visited in sorted order so
+ * a ceiling, if ever hit, cuts deterministically — and everything not visited
+ * is recorded in `notTraversed` (the pagination-contract continuation note).
+ */
+export function enumerateWorkdirCandidatesDetailed(
+  workdir: string,
+  limits: { maxDepth?: number; maxEntries?: number } = {},
+): WorkdirEnumeration {
+  const maxDepth = limits.maxDepth ?? ENUMERATE_MAX_DEPTH;
+  const maxEntries = limits.maxEntries ?? ENUMERATE_MAX_ENTRIES;
+  const root = path.resolve(workdir);
+  const candidates: string[] = [];
+  const notTraversed: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      // error-policy:J3 an unreadable directory nominates no candidates; the
+      // claim-mining sources still apply.
+      return;
+    }
+    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const entry of entries) {
+      if (ENUMERATE_SKIP.has(entry.name)) continue;
+      const absolute = path.join(dir, entry.name);
+      const relativePath = path.relative(root, absolute);
+      if (entry.isDirectory()) {
+        if (depth + 1 > maxDepth) {
+          notTraversed.push(`${relativePath}/`);
+          continue;
+        }
+        walk(absolute, depth + 1);
+      } else if (entry.isFile()) {
+        if (candidates.length >= maxEntries) {
+          notTraversed.push(relativePath);
+          continue;
+        }
+        candidates.push(relativePath);
+      }
+    }
+  };
+  walk(root, 0);
+  return {
+    candidates: candidates.sort(),
+    notTraversed: notTraversed.sort(),
+    truncated: notTraversed.length > 0,
+    limits: { maxDepth, maxEntries },
+  };
+}
+
+/**
+ * Candidate list for callers that only need the paths. A tripped sanity
+ * ceiling is never silent: the explicit continuation note (what was NOT
+ * traversed) is logged in full detail before the bounded list is returned.
+ */
+export function enumerateWorkdirCandidates(workdir: string): string[] {
+  const enumeration = enumerateWorkdirCandidatesDetailed(workdir);
+  if (enumeration.truncated) {
+    logger.warn(
+      {
+        workdir,
+        limits: enumeration.limits,
+        candidateCount: enumeration.candidates.length,
+        notTraversedCount: enumeration.notTraversed.length,
+        notTraversed: enumeration.notTraversed,
+      },
+      "[quick-app-evidence] workdir enumeration hit a sanity ceiling — the listed paths were NOT traversed and their files were not nominated as evidence candidates",
+    );
+  }
+  return enumeration.candidates;
 }
 
 export interface FsObservedFilesInput {
@@ -231,14 +359,41 @@ export function detectCheckSurfaces(
   };
 }
 
-/** Text-asset extensions worth showing the judge verbatim. */
-const TEXT_CONTENT_RE = /\.(?:html?|css|js|svg|md|txt|json)$/i;
+/** Extensions that are binary BY CONSTRUCTION — never inlined as text. Such
+ *  assets stay named in the FS-VERIFIED FILES list, and the rendered section
+ *  header names this rule, so their absence from the contents section reads
+ *  as "not a text file", never as "does not exist". Everything else is read
+ *  and content-sniffed rather than gated on an extension allowlist (the old
+ *  seven-extension allowlist silently withheld .py/.ts/.yml/... deliverables
+ *  and content criteria on them failed as unproven narration). */
+const BINARY_CONTENT_RE =
+  /\.(?:png|jpe?g|gif|webp|avif|ico|bmp|tiff?|woff2?|ttf|otf|eot|zip|gz|tgz|bz2|xz|7z|rar|pdf|mp[34]|m4[av]|mov|avi|webm|ogg|wav|flac|exe|dll|so|dylib|class|jar|wasm|sqlite3?|db|bin)$/i;
+
+/** Per-file view budget for the judge's contents section. A file under the
+ *  budget is inlined WHOLE (the normal quick-app case); an oversized file is
+ *  persisted whole to the durable content store FIRST and its view ends with
+ *  a marker naming `GET /api/orchestrator/content/<sha256>` — content is
+ *  paged, never lost. */
+const PER_FILE_CONTENT_BUDGET_CHARS = 24_000;
+
+function projectFileContent(content: string): string {
+  try {
+    return durableProjection(content, PER_FILE_CONTENT_BUDGET_CHARS).view;
+  } catch {
+    // error-policy:J4 a durable-store write failure must not sink evidence
+    // assembly — fall back to the COMPLETE text (uncapped) rather than
+    // reintroducing a silent cut.
+    return content;
+  }
+}
 
 /**
  * Read the complete contents of fs-verified text files so content
  * criteria are judged against the real file text. Same epistemic status as
  * the stat probe: the orchestrator reads the bytes itself; worker narration
  * never enters. Unreadable files contribute no entry, never a fabricated one.
+ * Text detection is by sniff (no NUL byte in the decoded text), not by an
+ * extension allowlist; only known-binary extensions skip the read outright.
  */
 export function readFsVerifiedContents(
   workdir: string,
@@ -258,15 +413,18 @@ export function readFsVerifiedContents(
   const root = path.resolve(workdir);
   const out: Array<{ path: string; content: string }> = [];
   for (const file of relativeFiles) {
-    if (!TEXT_CONTENT_RE.test(file)) continue;
+    if (BINARY_CONTENT_RE.test(file)) continue;
     const absolute = path.resolve(root, file);
     const relative = path.relative(root, absolute);
     if (relative.startsWith("..") || path.isAbsolute(relative)) continue;
     const content = read(absolute);
     if (content === undefined) continue;
+    // Binary sniff: a NUL byte in the utf8-decoded text means this is not a
+    // text deliverable — it stays listed (FS-VERIFIED FILES) but not inlined.
+    if (content.includes("\u0000")) continue;
     out.push({
       path: relative,
-      content,
+      content: projectFileContent(content),
     });
   }
   return out;

--- a/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
@@ -44,6 +44,31 @@ export const DEFAULT_STATE_LOST_RESPAWN_CAP = stateLostRespawnCapFor(
 );
 
 /**
+ * Per-request voice ledger entry: which session posted the single spawn ack
+ * for this user request, and which session holds its single user-facing
+ * terminal. `finalized` distinguishes a provisional result (a `task_complete`
+ * claimed before verification settles — supersedable exactly once by a park
+ * notice) from a settled terminal.
+ *
+ * Finality is not absolute for a `failure` holder: its narration explicitly
+ * invites the planner to retry ("spawn a fresh session"), so a later GENUINE
+ * `result` supersedes it (`claim_request_terminal`), and an admitted respawn
+ * for the same request clears it outright (`respawn_admitted`) so the new
+ * generation regains the request's voice. Without those two escapes a
+ * transient error permanently gagged the key and the invited retry's real
+ * success was eaten (live defect).
+ */
+export interface RequestVoiceEntry {
+  readonly ackSessionId?: string;
+  readonly terminal?: {
+    readonly holderSessionId: string;
+    readonly kind: "result" | "parked" | "failure";
+    readonly provisional: boolean;
+    readonly finalized: boolean;
+  };
+}
+
+/**
  * The complete loop-guard state. Every field is treated as immutable: the
  * reducer never mutates the input, it returns a fresh state with copied
  * collections.
@@ -61,6 +86,16 @@ export interface RouterLoopState {
   readonly stateLostCapNotified: ReadonlySet<string>;
   /** Completion lineage key → the first session that claimed its post slot. */
   readonly completionFirstPostedSession: ReadonlyMap<string, string>;
+  /**
+   * Request key (stable per USER coding request, across sessions AND
+   * respawns — see `requestVoiceKeyForMeta`) → its voice ledger entry. The
+   * lineage/completion slots above are per session generation; a task-service
+   * respawn mints a new session and a new lineage, so every generation's
+   * completion passed those guards and relayed. This slot is the broader
+   * invariant: ≤1 ack and ≤1 terminal per request, one sanctioned
+   * provisional-result → parked supersede.
+   */
+  readonly requestVoice: ReadonlyMap<string, RequestVoiceEntry>;
 }
 
 /** One incoming loop-guard signal, derived from a classified ACP event. */
@@ -88,7 +123,31 @@ export type RouterLoopEvent =
    */
   | { type: "rollback_round_trip"; sessionId: string; expectedCount: number }
   /** Claim the post slot for a completion lineage, for `sessionId`. */
-  | { type: "claim_completion"; completionKey: string; sessionId: string };
+  | { type: "claim_completion"; completionKey: string; sessionId: string }
+  /** Claim the single spawn-ack slot for a user request, for `sessionId`. */
+  | { type: "claim_request_ack"; requestKey: string; sessionId: string }
+  /**
+   * Claim the single user-facing terminal slot for a user request. A
+   * `provisional` claim (a `task_complete` before verification settles) may be
+   * superseded exactly once by a `parked` claim; everything else is
+   * first-writer-wins.
+   */
+  | {
+      type: "claim_request_terminal";
+      requestKey: string;
+      sessionId: string;
+      kind: "result" | "parked" | "failure";
+      provisional: boolean;
+    }
+  /**
+   * A NEW spawn was admitted for this request (verify-driven or planner-driven
+   * retry). A `failure` terminal held by an earlier generation is cleared so
+   * the retry regains the request's voice — its progress/questions un-mute and
+   * its eventual terminal claims a fresh slot. `result`/`parked` holders are
+   * untouched (the request genuinely concluded), as is the ack slot (one spawn
+   * ack per request stands across every generation).
+   */
+  | { type: "respawn_admitted"; requestKey: string };
 
 /** What the service should do for a given event. */
 export type RouterLoopDecision =
@@ -113,7 +172,19 @@ export type RouterLoopDecision =
   /** This session holds the completion slot (newly, or a same-session re-claim): post. */
   | { kind: "claimed" }
   /** A different session already holds the slot: suppress this duplicate. */
-  | { kind: "already_claimed" };
+  | { kind: "already_claimed" }
+  /** The request's ack slot was free and is now held by this session: post the ack. */
+  | { kind: "ack_granted" }
+  /** An ack already posted for this request: suppress this duplicate ack. */
+  | { kind: "ack_already_posted" }
+  /** The request's terminal slot was free and is now held by this session: post. */
+  | { kind: "terminal_granted" }
+  /** A sanctioned supersede (provisional result → park, or failure → genuine result): post. */
+  | { kind: "terminal_granted_supersede" }
+  /** A terminal already holds this request's voice: suppress (holderKind for logging). */
+  | { kind: "terminal_denied"; holderKind: "result" | "parked" | "failure" }
+  /** An admitted respawn cleared the request's failure terminal: the voice is live again. */
+  | { kind: "voice_reset" };
 
 export interface RouterLoopTransition {
   readonly state: RouterLoopState;
@@ -138,7 +209,63 @@ export function createRouterLoopState(opts?: {
     stateLostRespawnCounts: new Map(),
     stateLostCapNotified: new Set(),
     completionFirstPostedSession: new Map(),
+    requestVoice: new Map(),
   };
+}
+
+const UUID_KEY_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function pickKeyString(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim() || undefined : undefined;
+}
+
+/** Separator between the request-root base key and a fan-out part suffix.
+ * NUL cannot appear in message ids, uuids, or minted part labels, so composed
+ * keys can never collide with a bare base key (same trick as the per-origin
+ * cap's `spawnOriginKeyFor`). */
+const REQUEST_VOICE_PART_SEP = "\0";
+
+/**
+ * The canonical request-voice key ladder, read from a session's (or task's)
+ * metadata. The BASE mirrors `spawnRootIdFromMeta` (sub-agent-router.ts) —
+ * `spawnRootMessageId ?? originConnectorMessageId ?? messageId(uuid)` — plus a
+ * `task:<taskId>` fallback so task-service-spawned sessions (no connector
+ * message at all) and `notifyVerifyEscalation`'s task-level projection resolve
+ * the SAME key. Returns null when nothing stable exists; callers must fail
+ * open (no gating) on null.
+ *
+ * `requestVoicePart` scopes the key WITHIN one user request: a deliberate
+ * multi-part fan-out (lane plan with several lanes, a multi-part TASKS create)
+ * stamps a distinct part per lane/part at spawn time, so genuinely parallel
+ * lanes each own their own ack/terminal slot instead of the first lane's
+ * terminal gagging the rest. The part is INHERITED verbatim by every respawn
+ * of the same logical lane (task-metadata carry, router synthetic-inbound
+ * re-stamp), never re-minted, so respawn-shares-key still holds per lane.
+ * Sessions without a part (single-task requests, pre-stamp sessions) keep the
+ * bare base key — the original ledger behavior.
+ */
+export function requestVoiceKeyForMeta(
+  meta: Record<string, unknown> | undefined,
+): string | null {
+  if (!meta) return null;
+  // A follow-up delivered into the live session re-keys its voice: the
+  // completion answering "also give it a dark mode toggle" is THAT message's
+  // terminal, not a duplicate of the original build's (live 2026-08-22: the
+  // dark-mode completion was terminal_denied and never posted).
+  const direct =
+    pickKeyString(meta.followUpOriginMessageId) ??
+    pickKeyString(meta.spawnRootMessageId) ??
+    pickKeyString(meta.originConnectorMessageId);
+  const messageId = pickKeyString(meta.messageId);
+  const taskId = pickKeyString(meta.taskId);
+  const base =
+    direct ??
+    (messageId && UUID_KEY_RE.test(messageId) ? messageId : undefined) ??
+    (taskId ? `task:${taskId}` : undefined);
+  if (!base) return null;
+  const part = pickKeyString(meta.requestVoicePart);
+  return part ? `${base}${REQUEST_VOICE_PART_SEP}${part}` : base;
 }
 
 /** Copy a map, set a key, and FIFO-evict down to the bound. */
@@ -332,6 +459,112 @@ export function routerLoopTransition(
       return {
         state: { ...state, completionFirstPostedSession },
         decision: { kind: "claimed" },
+      };
+    }
+
+    case "claim_request_ack": {
+      // Synchronous CAS like claim_completion: no await between get and set,
+      // so the TOCTOU window is closed by construction.
+      const entry = state.requestVoice.get(event.requestKey);
+      if (entry?.ackSessionId !== undefined) {
+        return { state, decision: { kind: "ack_already_posted" } };
+      }
+      const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+        ...entry,
+        ackSessionId: event.sessionId,
+      });
+      return {
+        state: { ...state, requestVoice },
+        decision: { kind: "ack_granted" },
+      };
+    }
+
+    case "claim_request_terminal": {
+      const entry = state.requestVoice.get(event.requestKey);
+      const held = entry?.terminal;
+      if (held === undefined) {
+        // Empty slot: first terminal wins. A provisional claim (task_complete
+        // before verification settles) stays supersedable; anything else is
+        // final immediately.
+        const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+          ...entry,
+          terminal: {
+            holderSessionId: event.sessionId,
+            kind: event.kind,
+            provisional: event.provisional,
+            finalized: !event.provisional,
+          },
+        });
+        return {
+          state: { ...state, requestVoice },
+          decision: { kind: "terminal_granted" },
+        };
+      }
+      if (held.provisional && !held.finalized && event.kind === "parked") {
+        // The ONE sanctioned correction: a provisional result is superseded by
+        // the honest park notice, exactly once — the slot finalizes here so a
+        // second park (respawn doubled the task) is denied.
+        const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+          ...entry,
+          terminal: {
+            holderSessionId: event.sessionId,
+            kind: "parked",
+            provisional: event.provisional,
+            finalized: true,
+          },
+        });
+        return {
+          state: { ...state, requestVoice },
+          decision: { kind: "terminal_granted_supersede" },
+        };
+      }
+      if (held.kind === "failure" && event.kind === "result") {
+        // A failure narration invites the planner to retry, so its finality
+        // binds only against duplicate failures and redundant parks — never
+        // against the GENUINE success it asked for. Without this supersede the
+        // invited retry's task_complete was terminal_denied and the user was
+        // left with the stale error (live defect). The new holder is the
+        // standard supersedable-provisional result when `provisional`, so the
+        // one sanctioned parked correction above still applies to it.
+        const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+          ...entry,
+          terminal: {
+            holderSessionId: event.sessionId,
+            kind: "result",
+            provisional: event.provisional,
+            finalized: !event.provisional,
+          },
+        });
+        return {
+          state: { ...state, requestVoice },
+          decision: { kind: "terminal_granted_supersede" },
+        };
+      }
+      return {
+        state,
+        decision: { kind: "terminal_denied", holderKind: held.kind },
+      };
+    }
+
+    case "respawn_admitted": {
+      const entry = state.requestVoice.get(event.requestKey);
+      if (entry?.terminal?.kind !== "failure") {
+        // Nothing to revive: empty slot, or a result/parked terminal that an
+        // admitted respawn must not disturb (the request genuinely concluded).
+        return { state, decision: { kind: "noop" } };
+      }
+      // Drop ONLY the failure terminal. The ack slot survives — the request
+      // was ack'd once and the retry must not re-ack — and the fresh slot
+      // means the retry's terminal claims `terminal_granted` normally, with
+      // every downstream `finalized` gate (progress mute, question gate)
+      // released for the new generation.
+      const { terminal: _cleared, ...rest } = entry;
+      const requestVoice = setBounded(state.requestVoice, event.requestKey, {
+        ...rest,
+      });
+      return {
+        state: { ...state, requestVoice },
+        decision: { kind: "voice_reset" },
       };
     }
 

--- a/plugins/plugin-agent-orchestrator/src/services/session-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-store.ts
@@ -427,6 +427,20 @@ export class InMemorySessionStore implements SessionStore {
     await this.writes.enqueue(() => this.applyUpdateLocked(id, patch));
   }
 
+  async mergeMetadata(
+    id: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    // Read+merge+write inside ONE queued op — see the SessionStore contract.
+    await this.writes.enqueue(async () => {
+      const current = this.sessions.get(id);
+      if (!current) return;
+      await this.applyUpdateLocked(id, {
+        metadata: { ...(current.metadata ?? {}), ...patch },
+      });
+    });
+  }
+
   async updateStatus(
     id: string,
     status: SessionStatus,
@@ -763,6 +777,24 @@ export class RuntimeDbSessionStore implements SessionStore {
 
   async update(id: string, patch: Partial<SessionInfo>): Promise<void> {
     await this.writes.enqueue(() => this.applyUpdateLocked(id, patch));
+  }
+
+  async mergeMetadata(
+    id: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    // Read+merge+write inside ONE queued op — see the SessionStore contract.
+    await this.writes.enqueue(async () => {
+      await this.ensureInitialized();
+      const current = await this.getOne(
+        "SELECT * FROM acp_sessions WHERE id = ?",
+        [id],
+      );
+      if (!current) return;
+      await this.applyUpdateLocked(id, {
+        metadata: { ...(current.metadata ?? {}), ...patch },
+      });
+    });
   }
 
   async updateStatus(

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -40,8 +40,11 @@ export const APP_BUILD_TASK_RE =
 // regex's `tool`/`page`/`portfolio`/`widget` nouns false-positive). The skill
 // recommender tolerates over-matching (it only suggests a skill); the spawn-
 // time deploy injection rewrites the task contract, so it uses this gate.
+// Bare "page"/"site" belong in the noun list: "Build a simple, aesthetically
+// pleasing moon phase page" matched nothing, so the build ran in a scratch
+// workspace with no served URL and verification parked it (live 2026-08-19).
 export const APP_DEPLOY_TASK_RE =
-  /\b(build|create|make|ship|deploy|generate|design)\b(?:(?!\b(?:article|blog|post|cli|command[-\s]?line|library|package|script|extension|bot|plugin)\b)[\s\S]){0,120}\b(web\s?app|webapp|web\s?site|website|web\s?page|webpage|landing\s?page|home\s?page|dashboard|micro\s?site|website|app)\b/i;
+  /\b(build|create|make|ship|deploy|generate|design)\b(?:(?!\b(?:article|blog|post|cli|command[-\s]?line|library|package|script|extension|bot|plugin)\b)[\s\S]){0,120}\b(web\s?app|webapp|web\s?site|website|web\s?page|webpage|landing\s?page|home\s?page|dashboard|micro\s?site|page|site|app)\b/i;
 // Tokens shorter than this carry no signal — they show up in nearly every
 // task description and would inflate every skill's score equally.
 const MIN_TOKEN_LENGTH = 4;

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-env-policy.ts
@@ -22,10 +22,6 @@ const DENY_ENV_PATTERNS = [
   // including through customCredentials. Registry push uses the dedicated
   // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.
   /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT|GH_PAT)$/i,
-  // OpenCode's spawn config is runtime-built (buildOpencodeAcpEnv overwrites it
-  // AFTER this filter runs). A caller- or host-supplied value would let the
-  // spawner inject arbitrary provider config into the child, so it is denied at
-  // both intake paths.
 ];
 
 /**
@@ -43,7 +39,7 @@ export function isDeniedSubAgentEnvKey(key: string): boolean {
  * Matched case-insensitively (see `shouldForwardEnv`): the repo runtime is Bun,
  * and Bun on Windows reports these with native casing — `Path`, not `PATH` —
  * so a case-sensitive check would forward NONE of them, leaving the child with
- * no search path (the opencode shim then fails with "'bun' is not recognized").
+ * no search path (a spawned CLI then fails with "'bun' is not recognized").
  * Includes the Windows essentials cmd.exe + Bun + the agent's config/cache
  * resolution rely on, alongside the POSIX names.
  */

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -1,7 +1,7 @@
 /**
  * Self-contained operating manual scaffolded into a spawned sub-agent's
- * workspace so every backend (claude reads CLAUDE.md, codex reads AGENTS.md,
- * opencode reads both) receives the same eliza-context + non-interactive
+ * workspace so every backend (claude reads CLAUDE.md, codex reads AGENTS.md)
+ * receives the same eliza-context + non-interactive
  * directive regardless of where the spawn cwd lands. The ACP spawn path injects
  * nothing but the task string, so without this a sub-agent in a bare/scratch
  * cwd gets zero orientation — codex in particular ("expected identity files are

--- a/plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/subagent-stdout-log.ts
@@ -9,25 +9,43 @@
  *
  * Gated by the SAME policy as the trajectory recorder
  * (`isTrajectoryRecordingEnabled`): when recording is off, nothing is written.
- * Rotation mirrors the orchestrator audit log (single-generation `.1`) so a
- * long-lived, chatty session cannot grow the file unbounded. Provider
- * credentials are masked at write time (`redactSensitiveText`) so this persisted
- * file — which outlives the session — can never leak the model key the
- * sub-agent echoed to stdout.
+ * Rotation is non-destructive: when the active file crosses the size threshold
+ * it is renamed to the next `.<n>` generation — never overwriting an earlier
+ * one — and the reader spans every generation in order, so chunk indices are
+ * stable global offsets and the canonical record stays complete for the
+ * `acpx-session-output:<sessionId>` continuation contract. Provider
+ * credentials are masked at write time (`redactSensitiveText`) so this
+ * persisted file — which outlives the session — can never leak the model key
+ * the sub-agent echoed to stdout.
  */
-import { appendFile, mkdir, rename, stat } from "node:fs/promises";
-import { join } from "node:path";
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  stat,
+} from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import {
   isTrajectoryRecordingEnabled,
   redactSensitiveText,
   resolveTrajectoryDir,
 } from "@elizaos/core";
 
-// Rotate the per-session stdout log when it crosses this byte threshold. Chosen
-// to match the orchestrator audit log's cap (audit.ts:17): a sub-agent can emit
-// megabytes of tool output over a long session, and without a cap the file
-// grows unbounded. Single-generation rotation bounds the worst case at 2x.
+// Rotate the per-session stdout log when the ACTIVE file crosses this byte
+// threshold. Rotation only splits the stream into generation files (`.1`,
+// `.2`, ...) — it never deletes or overwrites one, because this log is the
+// durable ground-truth record the session-output projections resolve against
+// (prompt-integrity: the canonical record must stay complete). Retention of
+// old generations is a deployment concern (external cleanup / log shipper),
+// not this module's.
 const STDOUT_LOG_MAX_BYTES = 10 * 1024 * 1024;
+
+// Reader window bound (chunks per call). A larger caller `limit` is clamped;
+// the clamp is REPORTED through the returned window's `limit` echo plus its
+// `hasMore` flag, never applied silently.
+const MAX_READ_CHUNKS = 10_000;
 
 /** Directory under the trajectory root that holds one NDJSON file per session. */
 function stdoutLogDir(): string {
@@ -76,10 +94,121 @@ export async function appendSubagentStdout(
   return path;
 }
 
+/** One decoded chunk window read back from the durable log. */
+export interface SubagentStdoutWindow {
+  /** Concatenated chunk text for the requested window. */
+  text: string;
+  /** Zero-based GLOBAL index of the first chunk in the window. Stable across
+   *  rotation: generations are spanned oldest-first, so an offset handed to a
+   *  continuation call keeps meaning the same chunk. */
+  offset: number;
+  /** Effective chunk limit applied to this window. Echoed so a caller whose
+   *  requested limit was clamped (see MAX_READ_CHUNKS) sees the clamp
+   *  explicitly instead of a silently shorter window. */
+  limit: number;
+  /** Total chunks across every generation plus the active file. */
+  totalChunks: number;
+  /** True when chunks exist after the window (continuation available). */
+  hasMore: boolean;
+  /** True when rotated `.<n>` generations exist. Informational only — the
+   *  reader includes every generation, so nothing is missing from the view. */
+  rotated: boolean;
+}
+
+/**
+ * Read a window of the durable per-session stdout log — the continuation
+ * resolver for `acpx-session-output:<sessionId>` content references. Chunk
+ * indexed (one NDJSON record per captured chunk) across ALL generations plus
+ * the active file; a negative `offset` counts from the end (tail semantics).
+ * Returns undefined when no log exists (recording disabled, or the session
+ * never wrote output).
+ */
+export async function readSubagentStdout(
+  sessionId: string,
+  opts: { offset?: number; limit?: number } = {},
+): Promise<SubagentStdoutWindow | undefined> {
+  const path = subagentStdoutLogPath(sessionId);
+  const generations = await listGenerations(path);
+  const sources: string[] = [];
+  for (const generation of generations) {
+    const raw = await readFile(generation.path, "utf8").catch(
+      (err: NodeJS.ErrnoException) => {
+        // error-policy:J3 a generation removed between listing and reading is
+        // an explicit empty source; any other read failure is a real fault.
+        if (err?.code === "ENOENT") return undefined;
+        throw err;
+      },
+    );
+    if (raw !== undefined) sources.push(raw);
+  }
+  const active = await readFile(path, "utf8").catch(
+    (err: NodeJS.ErrnoException) => {
+      // error-policy:J3 ENOENT is the explicit "no active log" signal; any
+      // other read failure is a real fault.
+      if (err?.code === "ENOENT") return undefined;
+      throw err;
+    },
+  );
+  if (active !== undefined) sources.push(active);
+  if (sources.length === 0) return undefined;
+  const chunks: string[] = [];
+  for (const raw of sources) {
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const record = JSON.parse(line) as { text?: unknown };
+        if (typeof record.text === "string") chunks.push(record.text);
+      } catch {
+        // error-policy:J3 a torn tail line (crash mid-append) is expected in an
+        // append-only log; skip it rather than fail the whole read.
+      }
+    }
+  }
+  const limit = Math.max(1, Math.min(opts.limit ?? 200, MAX_READ_CHUNKS));
+  const requested = opts.offset ?? -limit;
+  const start =
+    requested < 0
+      ? Math.max(0, chunks.length + requested)
+      : Math.min(requested, chunks.length);
+  const window = chunks.slice(start, start + limit);
+  return {
+    text: window.join(""),
+    offset: start,
+    limit,
+    totalChunks: chunks.length,
+    hasMore: start + window.length < chunks.length,
+    rotated: generations.length > 0,
+  };
+}
+
 // A session id flows in from ACP and could in principle contain path separators;
 // keep the filename inside stdoutLogDir() by stripping anything but the safe set.
 function sanitizeSessionId(sessionId: string): string {
   return sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+/** Rotated generation files for a session log, oldest first (`.1`, `.2`, ...). */
+async function listGenerations(
+  path: string,
+): Promise<Array<{ path: string; generation: number }>> {
+  const dir = dirname(path);
+  const base = basename(path);
+  const entries = await readdir(dir).catch((err: NodeJS.ErrnoException) => {
+    // error-policy:J3 a missing log dir is the explicit "no generations yet"
+    // result; any other listing failure is a real fault.
+    if (err?.code === "ENOENT") return [] as string[];
+    throw err;
+  });
+  return entries
+    .filter((name) => name.startsWith(`${base}.`))
+    .map((name) => ({
+      path: join(dir, name),
+      generation: Number.parseInt(name.slice(base.length + 1), 10),
+    }))
+    .filter(
+      (entry) => Number.isInteger(entry.generation) && entry.generation > 0,
+    )
+    .sort((a, b) => a.generation - b.generation);
 }
 
 async function rotateIfTooLarge(path: string): Promise<void> {
@@ -91,10 +220,14 @@ async function rotateIfTooLarge(path: string): Promise<void> {
     throw err;
   });
   if (!st || st.size < STDOUT_LOG_MAX_BYTES) return;
-  // Single-generation rotation: overwrite `.1` so we never keep more than two
-  // files. Deeper history belongs in an external log shipper, not here. A rename
-  // failure (e.g. disk full) is NOT swallowed — it propagates to appendSubagentStdout
-  // and the tee's reportError so the fault is observable rather than silently
-  // dropping the ground-truth stdout.
-  await rename(path, `${path}.1`);
+  // Non-destructive rotation: rename the active file to the NEXT generation
+  // index — earlier generations are never overwritten, so the ground-truth
+  // transcript that acpx-session-output references resolve against stays
+  // complete. A rename failure (e.g. disk full) is NOT swallowed — it
+  // propagates to appendSubagentStdout and the tee's reportError so the fault
+  // is observable rather than silently dropping the ground-truth stdout.
+  const generations = await listGenerations(path);
+  const lastGeneration =
+    generations.length > 0 ? generations[generations.length - 1].generation : 0;
+  await rename(path, `${path}.${lastGeneration + 1}`);
 }

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -404,6 +404,13 @@ function normalizeTaskAgentAdapterForModelPrefs(
     case "elizaos":
     case "eliza-os":
     case "eliza":
+    case "eliza-code":
+    case "eliza code":
+    // "opencode" is a retired backend name; legacy task records naming it
+    // resolve to the eliza-code (elizaos) adapter.
+    case "opencode":
+    case "open-code":
+    case "open code":
       return "elizaos";
     case "pi-agent":
     case "pi agent":
@@ -717,6 +724,12 @@ async function computeTaskAgentFrameworkState(
     configuredSubscriptionProvider === "openai-codex" ||
     configuredSubscriptionProvider === "openai-subscription" ||
     hasCodexApiKey(runtime);
+  // eliza-code (elizaos) is the BYO default when no provider-specific key
+  // prefers Claude/Codex. Claude/Codex only become preferred when their key
+  // path is set; an uninstalled framework's availabilityScore of -100 keeps it
+  // out of the running.
+  const providerPrefersByoDefault =
+    !providerPrefersClaude && !providerPrefersCodex;
   const explicitDefault = safeGetSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE")
     ?.toLowerCase()
     .trim();
@@ -793,7 +806,13 @@ async function computeTaskAgentFrameworkState(
       framework.id === "elizaos" || framework.id === "pi-agent"
         ? explicitDefault === framework.id
           ? 18
-          : 0
+          : // eliza-code is the BYO default when no provider key prefers
+            // claude/codex.
+            framework.id === "elizaos" && providerPrefersByoDefault
+            ? framework.authReady
+              ? 18
+              : 6
+            : 0
         : providerPrefersClaude && framework.id === "claude"
           ? framework.subscriptionReady
             ? 18
@@ -997,6 +1016,12 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
     configuredSubscriptionProvider === "openai-codex" ||
     configuredSubscriptionProvider === "openai-subscription" ||
     hasCodexApiKey(runtime);
+  // eliza-code (elizaos) is the BYO default when no provider-specific key
+  // prefers Claude/Codex. Claude/Codex only become preferred when their key
+  // path is set; an uninstalled framework's availabilityScore of -100 keeps it
+  // out of the running.
+  const providerPrefersByoDefault =
+    !providerPrefersClaude && !providerPrefersCodex;
   const explicitDefault = safeGetSetting(runtime, "ELIZA_DEFAULT_AGENT_TYPE")
     ?.toLowerCase()
     .trim();
@@ -1008,7 +1033,13 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
       framework.id === "elizaos" || framework.id === "pi-agent"
         ? explicitDefault === framework.id
           ? 18
-          : 0
+          : // eliza-code is the BYO default when no provider key prefers
+            // claude/codex.
+            framework.id === "elizaos" && providerPrefersByoDefault
+            ? framework.authReady
+              ? 18
+              : 6
+            : 0
         : providerPrefersClaude && framework.id === "claude"
           ? framework.subscriptionReady
             ? 18

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -8,6 +8,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { resolveAppDeployConfig } from "./app-deploy-guidance.js";
 import { readConfigEnvKey } from "./config-env.js";
 
 export const KNOWN_ADAPTER_TYPES = new Set([
@@ -26,6 +27,13 @@ export function normalizeTaskAgentAdapter(
     case "elizaos":
     case "eliza-os":
     case "eliza":
+    case "eliza-code":
+    case "eliza code":
+    // "opencode" is a retired backend name; requests naming it route to the
+    // eliza-code (elizaos) adapter.
+    case "opencode":
+    case "open-code":
+    case "open code":
       return "elizaos";
     case "pi-agent":
     case "pi agent":
@@ -93,12 +101,77 @@ export function resolvePinnedAdapter(
   return KNOWN_ADAPTER_TYPES.has(raw) ? raw : undefined;
 }
 
+/** Directories a build must never land in by planner invention: the home
+ *  directory itself, any ancestor of a configured route's workdir (the
+ *  projects folder that holds real repos), and the runtime's own checkout. */
+function isProtectedLocation(
+  runtime: IAgentRuntime | undefined,
+  workdir: string,
+): boolean {
+  const resolved = path.resolve(workdir);
+  const home = path.resolve(os.homedir());
+  if (resolved === home) return true;
+  const cwdRoot = path.resolve(process.cwd());
+  if (resolved === cwdRoot || cwdRoot.startsWith(`${resolved}${path.sep}`)) {
+    return true;
+  }
+  for (const route of configuredWorkdirRoutes(runtime)) {
+    const routeDir = path.resolve(expandHomePath(route.workdir));
+    if (
+      routeDir !== resolved &&
+      routeDir.startsWith(`${resolved}${path.sep}`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Whether an explicit existing workdir has a reason to be honored: it sits
+ *  inside a configured route tree or the published-apps dir, the user named
+ *  it (path or last segment) in the request or task text, or it is the
+ *  workdir of a session the orchestrator knows (a finished lane being
+ *  continued). Anything else is a planner-invented path. */
+function explicitWorkdirIsGrounded(
+  runtime: IAgentRuntime | undefined,
+  workdir: string,
+  userRequest: string,
+  task: string,
+  knownWorkdirs: readonly string[],
+): boolean {
+  const resolved = path.resolve(workdir);
+  if (resolveRouteForWorkdir(runtime, resolved)) return true;
+  const deploy = resolveAppDeployConfig();
+  if (
+    deploy.target === "custom" &&
+    deploy.customAppsDir &&
+    resolved.startsWith(`${path.resolve(deploy.customAppsDir)}${path.sep}`)
+  ) {
+    return true;
+  }
+  const mentioned = `${userRequest}\n${task}`;
+  const base = path.basename(resolved);
+  if (
+    mentioned.toLowerCase().includes(resolved.toLowerCase()) ||
+    mentioned.toLowerCase().includes(workdir.toLowerCase()) ||
+    (base.length >= 3 && containsPhrase(mentioned, base))
+  ) {
+    return true;
+  }
+  return knownWorkdirs.some((known) => path.resolve(known) === resolved);
+}
+
 export function resolveSpawnWorkdir(
   runtime: IAgentRuntime | undefined,
   task: string,
   userRequest: string,
   explicitWorkdir: string | undefined,
-  opts: { lockWorkdir?: boolean } = {},
+  opts: {
+    lockWorkdir?: boolean;
+    /** Workdirs of sessions the orchestrator knows (a finished lane being
+     *  continued); the caller resolves them because session listing is async. */
+    knownWorkdirs?: readonly string[];
+  } = {},
 ): { workdir: string; route?: ResolvedWorkdirRoute; isolate?: boolean } {
   const expandedExplicit = explicitWorkdir
     ? expandHomePath(explicitWorkdir)
@@ -127,6 +200,31 @@ export function resolveSpawnWorkdir(
   const detected = resolveWorkdirByConvention(runtime, task, userRequest);
   if (detected) return withContainedRoute({ workdir: detected });
   const fallback = resolveDefaultSpawnWorkdir(runtime);
+  if (
+    expandedExplicit &&
+    fs.existsSync(expandedExplicit) &&
+    isProtectedLocation(runtime, expandedExplicit) &&
+    !explicitWorkdirIsGrounded(
+      runtime,
+      expandedExplicit,
+      userRequest,
+      task,
+      opts.knownWorkdirs ?? [],
+    )
+  ) {
+    // The planner fills `workdir` on every create ("/home/milady/<label>",
+    // live 2026-08-22 on every build). An existing scratch dir stays trusted
+    // (the established contract), but a PROTECTED location — the home dir,
+    // the parent of a configured route, the agent's own checkout — that
+    // nothing grounds (not a route tree, not named by the user, not a known
+    // lane's dir) would land a fresh build in an unrelated real directory.
+    logger.warn(
+      `[workdir-routes] Planner workdir is a protected location nothing grounds; ignoring it: ${expandedExplicit} — falling back to ${fallback.workdir}`,
+    );
+    return fallback.isolate
+      ? { workdir: fallback.workdir, isolate: true }
+      : { workdir: fallback.workdir };
+  }
   if (expandedExplicit && fs.existsSync(expandedExplicit)) {
     if (
       fallback.isolate &&
@@ -140,6 +238,25 @@ export function resolveSpawnWorkdir(
     return withContainedRoute({ workdir: expandedExplicit });
   }
   if (expandedExplicit) {
+    // A nonexistent explicit workdir directly under the configured published-
+    // apps dir is the PLANNER DOING THE RIGHT THING — naming the fresh slug
+    // dir for a new app. Rejecting it dropped the build into a scratch
+    // workspace with no served URL and verification parked a working page
+    // (live 2026-08-19: …/data/apps/moon-phase-page). Create and use it.
+    const deploy = resolveAppDeployConfig();
+    if (
+      deploy.target === "custom" &&
+      deploy.customAppsDir &&
+      path.dirname(path.resolve(expandedExplicit)) ===
+        path.resolve(deploy.customAppsDir)
+    ) {
+      try {
+        fs.mkdirSync(expandedExplicit, { recursive: true });
+        return withContainedRoute({ workdir: expandedExplicit });
+      } catch {
+        // error-policy:J4 mkdir failure falls through to the scratch fallback.
+      }
+    }
     logger.warn(
       `[workdir-routes] Planner workdir does not exist, ignoring it: ${expandedExplicit} — falling back to ${fallback.workdir}`,
     );

--- a/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
@@ -31,6 +31,10 @@ import {
   requireConfirmedSendHandlerDelivery,
   Service,
 } from "@elizaos/core";
+import {
+  AGENT_VOICED_METADATA,
+  phraseForUser,
+} from "../voice/phrase-for-user.js";
 import { getSessionSpendUsd, readSpendCapUsd } from "./spend-allowance.js";
 import { TERMINAL_SESSION_STATUSES } from "./types.js";
 
@@ -170,13 +174,17 @@ function sessionLabel(metadata: Record<string, unknown> | undefined): string {
   return typeof label === "string" && label.trim() ? label : "A sub-agent";
 }
 
-/** Deterministic warning text for the originating room. */
+/** Deterministic FALLBACK warning text for the originating room — used verbatim
+ * only when the model-phrased line (see `postCapWarning`) is unavailable.
+ * Minimal facts only (label, count/limit, percent, what the user can do); no
+ * internal action names or mechanism vocabulary — the module's own
+ * banned-vocab contract would reject equivalent model output. */
 export function composeCapWarning(warning: CapWarning, label: string): string {
   const pct = Math.round(warning.ratio * 100);
   if (warning.kind === "round-trip") {
-    return `⚠️ ${label} is at ${warning.count}/${warning.limit} round-trips (${pct}%) — risk of a runaway loop. Consider stopping it (STOP_AGENT) or redirecting it (SEND_TO_AGENT) before it force-stops.`;
+    return `${label} is at ${warning.count}/${warning.limit} check-ins (${pct}%) and may be stuck in a loop — you can stop it or redirect it.`;
   }
-  return `⚠️ ${label} has spent $${warning.count.toFixed(2)} of its $${warning.limit.toFixed(2)} budget (${pct}%) — approaching the spend cap. Consider stopping or redirecting it.`;
+  return `${label} has spent $${warning.count.toFixed(2)} of its $${warning.limit.toFixed(2)} budget (${pct}%) — you can stop it or redirect it.`;
 }
 
 interface AcpServiceLike {
@@ -189,6 +197,23 @@ interface AcpServiceLike {
     }>
   >;
   sendToSession(sessionId: string, input: string): Promise<unknown>;
+}
+
+/** Durable-task statuses that mean the session is actually WORKING — the only
+ * states where a stall is a defect worth grilling. `waiting_on_user`,
+ * `blocked`, and `validating` sessions are idle BY DESIGN (gated on the user,
+ * an external dependency, or the verifier) and a status-check prompt cannot
+ * unblock any of them — it just burns a turn and produces noise. */
+const GRILLABLE_TASK_STATUSES = new Set(["open", "active"]);
+
+/** Read-only task view the stall gate needs from ORCHESTRATOR_TASK_SERVICE. */
+interface TaskStatusSourceLike {
+  listTasks(filter?: Record<string, unknown>): Promise<
+    Array<{
+      status: string;
+      latestSessionId: string | null;
+    }>
+  >;
 }
 
 /** Read-only round-trip accounting exposed by the SubAgentRouter. */
@@ -210,8 +235,19 @@ export class TaskWatchdogService extends Service {
     "Detects stalled (idle) sub-agent sessions and prods them, and warns the originating room when a session approaches its round-trip or spend cap.";
 
   private timer: ReturnType<typeof setInterval> | undefined;
-  /** Session ids already prodded this stall, so we grill once (not every tick). */
+  /**
+   * Session ids already prodded, kept for the SESSION'S LIFETIME (dropped only
+   * when the session leaves the active list). The previous recover-then-regrill
+   * reset made the prod loop self-sustaining: the grill starts a fresh ACP
+   * turn, the turn's reply resets `lastActivityAt` ("recovered"), recovery
+   * cleared the prodded flag, and one stall threshold later the same session
+   * was grilled again — a ~4-minute nag loop whose status babble relayed to
+   * the user's room indefinitely (live 2026-08-17 01:01–01:21Z). "Prods each
+   * ONCE" now means once per session, exactly as documented.
+   */
   private readonly prodded = new Set<string>();
+  /** Sessions stalled as of the last tick (provider surface only). */
+  private currentlyStalled = new Set<string>();
   /** `${kind}:${sessionId}` already warned this approach, so we warn once per
    * threshold crossing (cleared when the ratio drops back under the threshold). */
   private readonly warned = new Set<string>();
@@ -255,7 +291,7 @@ export class TaskWatchdogService extends Service {
 
   /** Session ids currently considered stalled (for the ACTIVE_SUB_AGENTS provider). */
   getStalledSessionIds(): string[] {
-    return [...this.prodded];
+    return [...this.currentlyStalled];
   }
 
   /** Sessions currently approaching a cap (for the ACTIVE_SUB_AGENTS provider). */
@@ -281,16 +317,34 @@ export class TaskWatchdogService extends Service {
       lastActivityMs: s.lastActivityAt?.getTime?.() ?? 0,
     }));
     const stalled = detectStalledSessions(views, nowMs, this.stallMs());
-    const stalledIds = new Set(stalled.map((s) => s.id));
+    this.currentlyStalled = new Set(stalled.map((s) => s.id));
 
-    // Clear the prodded flag for sessions that recovered or ended, so a future
-    // stall re-grills.
+    // The prod memo lives as long as the session does: drop only ids that are
+    // no longer in the session list at all. Recovery does NOT re-arm the grill
+    // — the grill itself manufactures "recovery" (its reply resets activity),
+    // which is exactly the loop this memo exists to break.
+    const liveIds = new Set(views.map((v) => v.id));
     for (const id of [...this.prodded]) {
-      if (!stalledIds.has(id)) this.prodded.delete(id);
+      if (!liveIds.has(id)) this.prodded.delete(id);
     }
 
+    const taskStatusBySession = await this.taskStatusBySession();
     for (const s of stalled) {
-      if (this.prodded.has(s.id)) continue; // already prodded this stall
+      if (this.prodded.has(s.id)) continue; // one grill per session lifetime
+      // A stall is only worth grilling while the durable task is actually
+      // WORKING. User-gated / blocked / validating tasks idle by design; a
+      // status check cannot unblock them. Sessions with no resolvable task
+      // record fail open (grilled once) — an ad-hoc session can still wedge.
+      const taskStatus = taskStatusBySession.get(s.id);
+      if (
+        taskStatus !== undefined &&
+        !GRILLABLE_TASK_STATUSES.has(taskStatus)
+      ) {
+        logger.debug(
+          `[TaskWatchdogService] session ${s.id} idle but its task is ${taskStatus} — not grilling`,
+        );
+        continue;
+      }
       this.prodded.add(s.id);
       try {
         await acp.sendToSession(s.id, STALL_GRILL_PROMPT);
@@ -313,6 +367,33 @@ export class TaskWatchdogService extends Service {
 
     await this.checkCapWarnings(sessions);
     return stalled;
+  }
+
+  /**
+   * Best-effort map of ACP session id → durable task status via the task
+   * service's latest-session linkage. Any failure (service absent, store
+   * error) yields an empty map so the stall gate FAILS OPEN — a wedged
+   * session must still get its one grill even when task state is unreadable.
+   */
+  private async taskStatusBySession(): Promise<Map<string, string>> {
+    const map = new Map<string, string>();
+    try {
+      const tasks = this.runtime.getService<Service & TaskStatusSourceLike>(
+        "ORCHESTRATOR_TASK_SERVICE",
+      );
+      if (!tasks || typeof tasks.listTasks !== "function") return map;
+      for (const task of await tasks.listTasks({})) {
+        if (task.latestSessionId) map.set(task.latestSessionId, task.status);
+      }
+    } catch (error) {
+      // error-policy:J7 stall gating is advisory; an unreadable task store must not stop the watchdog tick
+      logger.debug(
+        `[TaskWatchdogService] task-status lookup failed; grilling ungated: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return map;
   }
 
   /**
@@ -386,11 +467,43 @@ export class TaskWatchdogService extends Service {
     if (typeof send !== "function") return;
     const origin = resolveOrigin(metadata);
     if (!origin) return; // no chat origin — nothing to warn into
-    const text = composeCapWarning(warning, sessionLabel(metadata));
+    // Model-phrased warning (owner directive: user-facing text is LLM-written).
+    // The caller has already claimed the `warned` slot synchronously, so the
+    // model latency here cannot double the warning. composeCapWarning stays the
+    // factual fallback when the model is unavailable.
+    const label = sessionLabel(metadata);
+    const { text } = await phraseForUser(
+      this.runtime,
+      {
+        intent: "warn",
+        facts: {
+          label,
+          kind: warning.kind,
+          count:
+            warning.kind === "spend"
+              ? `$${warning.count.toFixed(2)}`
+              : warning.count,
+          limit:
+            warning.kind === "spend"
+              ? `$${warning.limit.toFixed(2)}`
+              : warning.limit,
+          percentUsed: Math.round(warning.ratio * 100),
+          suggestStopOrRedirect: true,
+        },
+        mustInclude: [label],
+      },
+      composeCapWarning(warning, label),
+      // The memo serves cached text WITHOUT re-validating facts, so the key
+      // must pin every fact the text embeds (label via mustInclude, counts in
+      // prose) — a kind-only key would replay another session's numbers.
+      {
+        cacheKey: `capwarn:${warning.kind}:${label}:${warning.count}/${warning.limit}`,
+      },
+    );
     requireConfirmedSendHandlerDelivery(
       await send(
         { source: origin.source, roomId: origin.roomId },
-        { text, source: origin.source },
+        { text, source: origin.source, ...AGENT_VOICED_METADATA },
       ),
     );
     logger.info(
@@ -407,5 +520,6 @@ export class TaskWatchdogService extends Service {
     }
     this.prodded.clear();
     this.warned.clear();
+    this.currentlyStalled.clear();
   }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -269,6 +269,13 @@ export interface SessionStore {
   }): Promise<SessionInfo | null>;
   list(filter?: SessionFilter): Promise<SessionInfo[]>;
   update(id: string, patch: Partial<SessionInfo>): Promise<void>;
+  /** Atomically merge a metadata patch (read+merge+write inside the store's
+   *  write queue). The naive get→merge→update in AcpService lost patches to
+   *  concurrent writers — the admin-stop stamp NEVER survived a racing
+   *  lastChangeSet merge, so every stop narrated as an unexplained death
+   *  (live 2026-08-20). Optional so external store impls keep compiling; the
+   *  service falls back to the racy path when absent. */
+  mergeMetadata?(id: string, patch: Record<string, unknown>): Promise<void>;
   updateStatus(
     id: string,
     status: SessionStatus,

--- a/plugins/plugin-agent-orchestrator/src/services/user-task-text.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/user-task-text.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts the user's verbatim request from an augmented child prompt. The
+ * spawn path wraps the user task in injected sections ("--- Swarm
+ * Coordination ---", "--- Publishing web apps (custom host) ---", ...) with
+ * the verbatim ask between the "--- User Task ---" marker and the NEXT
+ * section header. Slicing only from the marker to end-of-string drags every
+ * trailing guidance section into successor tasks — a redirected follow-up
+ * then derives its title, slug, and workdir from guidance prose (live
+ * 2026-08-20: successor titled "elizaos --- Publishing web apps (custom
+ * host) ---..." with a matching junk app dir).
+ */
+export const USER_TASK_MARKER = "--- User Task ---";
+
+const SECTION_HEADER_RE = /^--- .+? ---$/m;
+
+export function userTaskFromInitialTask(raw: string | undefined): string {
+  if (!raw) return "";
+  const at = raw.lastIndexOf(USER_TASK_MARKER);
+  if (at < 0) return raw.trim();
+  const after = raw.slice(at + USER_TASK_MARKER.length);
+  const next = after.search(SECTION_HEADER_RE);
+  return (next >= 0 ? after.slice(0, next) : after).trim();
+}

--- a/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/wave-supervisor.ts
@@ -960,6 +960,25 @@ export class WaveSupervisor extends Service {
       providerPolicy: terminalLane.providerPolicy ?? undefined,
       metadata: {
         ...spec.metadata,
+        // The refill continues the SAME user-request lineage as the lane it
+        // replaces: carry the request-voice keys so the router's ack/terminal
+        // ledger and the park-notice dedupe (notifyVerifyEscalation) keep
+        // matching across the replacement task record instead of degrading to
+        // a fresh task:<id> key (which re-opened the double-park window).
+        ...(nonEmptyString(terminalLane.metadata?.spawnRootMessageId)
+          ? {
+              spawnRootMessageId: nonEmptyString(
+                terminalLane.metadata?.spawnRootMessageId,
+              ),
+            }
+          : {}),
+        ...(nonEmptyString(terminalLane.metadata?.requestVoicePart)
+          ? {
+              requestVoicePart: nonEmptyString(
+                terminalLane.metadata?.requestVoicePart,
+              ),
+            }
+          : {}),
         [WAVE_ID_METADATA_KEY]: waveId,
         waveAttemptId: readWaveAttemptId(terminalLane.metadata),
         waveGoal,

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -18,7 +18,38 @@ import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 const GIT_TIMEOUT_MS = 10_000;
-const GIT_MAX_BUFFER = 8 * 1024 * 1024;
+// Generous read ceiling: a real coding-session diff essentially never reaches
+// it, and when one does the cut is DETECTED and reported honestly (the
+// prompt-integrity invariant forbids a silent clamp near a model path). The
+// env var is a test seam so the truncation detection is provable with small
+// buffers; it is read per call, never cached.
+const GIT_MAX_BUFFER_DEFAULT = 64 * 1024 * 1024;
+
+function gitMaxBuffer(): number {
+  const raw = process.env.WORKSPACE_DIFF_GIT_MAX_BUFFER;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : GIT_MAX_BUFFER_DEFAULT;
+}
+
+/**
+ * True when a spawnSync result's stdout was cut by the process layer: Node
+ * kills the child and flags ENOBUFS when `maxBuffer` overflows, and a
+ * buffer-sized read is treated as a short read too (the cut can land exactly
+ * on the boundary). Exported for the truncation-honesty regression tests.
+ */
+export function spawnOutputWasTruncated(
+  error: unknown,
+  stdoutBytes: number,
+  maxBuffer: number,
+): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === "ENOBUFS" || code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+    return true;
+  }
+  return stdoutBytes >= maxBuffer;
+}
 
 // The canonical git empty-tree object hash. On an unborn HEAD (a fresh repo
 // with zero commits), `git diff HEAD` throws because HEAD resolves to nothing;
@@ -65,23 +96,43 @@ export interface WorkspaceArtifactVerification {
   missingFiles: string[];
 }
 
-async function git(
+/** One git read plus the honest truncation verdict for it. When `truncated`
+ *  is true, `stdout` is a PREFIX of the real output — callers must propagate
+ *  that fact instead of presenting the prefix as complete. */
+interface GitCapture {
+  stdout?: string;
+  truncated: boolean;
+}
+
+async function gitCapture(
   workdir: string,
   args: string[],
-): Promise<string | undefined> {
+): Promise<GitCapture> {
+  const maxBuffer = gitMaxBuffer();
   const direct = spawnSync("git", args, {
     cwd: workdir,
     timeout: GIT_TIMEOUT_MS,
-    maxBuffer: GIT_MAX_BUFFER,
+    maxBuffer,
     windowsHide: true,
   });
   const directStdout = outputToString(direct.stdout);
-  if (directStdout && directStdout.length > 0) return directStdout;
+  const directTruncated = spawnOutputWasTruncated(
+    direct.error,
+    Buffer.byteLength(directStdout ?? "", "utf8"),
+    maxBuffer,
+  );
+  if (directStdout && directStdout.length > 0) {
+    return { stdout: directStdout, truncated: directTruncated };
+  }
 
   // Bun's test runner can report a successful git process with an empty stdout
   // pipe. In that environment only, ask the shell to redirect stdout itself.
-  if (direct.status !== 0 && !process.versions.bun) return undefined;
-  if (!process.versions.bun) return directStdout;
+  if (direct.status !== 0 && !process.versions.bun) {
+    return { stdout: undefined, truncated: directTruncated };
+  }
+  if (!process.versions.bun) {
+    return { stdout: directStdout, truncated: directTruncated };
+  }
 
   const outDir = mkdtempSync(join(tmpdir(), "workspace-diff-git-"));
   const outPath = join(outDir, "stdout");
@@ -93,7 +144,7 @@ async function git(
       cwd: workdir,
       env: { ...process.env, WORKSPACE_DIFF_GIT_STDOUT: outPath },
       timeout: GIT_TIMEOUT_MS,
-      maxBuffer: GIT_MAX_BUFFER,
+      maxBuffer,
       stdio: ["ignore", "ignore", "pipe"],
       windowsHide: true,
     },
@@ -102,14 +153,35 @@ async function git(
   // `git diff --no-index` exits 1 when files differ — that's the success case
   // for us and the diff is on stdout. Everything else (not a repo, git missing,
   // detached state) is best-effort: change capture must never disturb the
-  // session lifecycle.
+  // session lifecycle. The file redirect receives the full stream (no
+  // maxBuffer applies to it), so this path never truncates.
   try {
     const stdout = readFileSync(outPath, "utf8");
-    if (result.status === 0 || stdout.length > 0) return stdout;
-    return undefined;
+    if (result.status === 0 || stdout.length > 0) {
+      return { stdout, truncated: false };
+    }
+    return { stdout: undefined, truncated: false };
   } finally {
     rmSync(outDir, { recursive: true, force: true });
   }
+}
+
+async function git(
+  workdir: string,
+  args: string[],
+): Promise<string | undefined> {
+  return (await gitCapture(workdir, args)).stdout;
+}
+
+/** Drop the partial final line of a KNOWN-truncated capture (a complete git
+ *  listing/diff always ends with a newline) so a cut never surfaces a garbage
+ *  half-path. No-op for complete output. */
+function completeLines(
+  out: string | undefined,
+  truncated: boolean,
+): string | undefined {
+  if (!out || !truncated || out.endsWith("\n")) return out;
+  return out.slice(0, out.lastIndexOf("\n") + 1);
 }
 
 async function isWorkTree(workdir: string): Promise<boolean> {
@@ -189,21 +261,35 @@ function parseNameStatus(out: string | undefined): string[] {
   return files;
 }
 
+/** Parsed `git ls-files` listing plus the honest cut verdict for it. */
+export interface LsFilesListing {
+  files: string[];
+  /** True when the listing did not end where git ended it: the partial final
+   *  line of a maxBuffer-cut read was dropped, and everything after the cut
+   *  is absent. Callers MUST surface this — a cut listing presented as
+   *  complete silently hides files the agent actually created. */
+  truncated: boolean;
+}
+
 /**
  * Parse `git ls-files --others` output (one path per line) into a path list.
  * A complete listing always ends with a newline; when the output was cut at
  * maxBuffer (ENOBUFS on a huge untracked tree) the tail is a truncated
- * garbage path — drop the partial final line rather than surface junk.
+ * garbage path — drop the partial final line rather than surface junk, and
+ * REPORT the cut so the caller can mark the change set truncated instead of
+ * persisting the partial listing as if complete.
  */
-export function parseLsFiles(out: string | undefined): string[] {
-  if (!out) return [];
-  const complete = out.endsWith("\n")
-    ? out
-    : out.slice(0, out.lastIndexOf("\n") + 1);
-  return complete
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+export function parseLsFiles(out: string | undefined): LsFilesListing {
+  if (!out) return { files: [], truncated: false };
+  const truncated = !out.endsWith("\n");
+  const complete = truncated ? out.slice(0, out.lastIndexOf("\n") + 1) : out;
+  return {
+    files: complete
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0),
+    truncated,
+  };
 }
 
 // Dependency/build directories a fresh scaffold populates BEFORE any
@@ -272,18 +358,28 @@ function toWorkdirRelative(workdir: string, file: string): string {
   return normalized;
 }
 
-/** Unified diff for one file: real git diff if tracked, else new-file diff. */
+/** Unified diff for one file: real git diff if tracked, else new-file diff.
+ *  Carries the read-buffer truncation verdict so the change set can report
+ *  a cut diff honestly instead of stamping it complete. */
 async function fileDiff(
   workdir: string,
   base: string,
   file: string,
-): Promise<string> {
-  const tracked = (await git(workdir, ["diff", base, "--", file]))?.trim();
-  if (tracked) return tracked;
-  const created = (
-    await git(workdir, ["diff", "--no-index", "--", "/dev/null", file])
-  )?.trim();
-  return created ?? "";
+): Promise<{ text: string; truncated: boolean }> {
+  const tracked = await gitCapture(workdir, ["diff", base, "--", file]);
+  const trackedText = tracked.stdout?.trim();
+  if (trackedText) return { text: trackedText, truncated: tracked.truncated };
+  const created = await gitCapture(workdir, [
+    "diff",
+    "--no-index",
+    "--",
+    "/dev/null",
+    file,
+  ]);
+  return {
+    text: created.stdout?.trim() ?? "",
+    truncated: tracked.truncated || created.truncated,
+  };
 }
 
 /**
@@ -338,8 +434,20 @@ export async function captureChangeSet(
   const dirtyAtSpawn = new Set(
     baselineDirty.filter((file) => !agentWrittenSet.has(file)),
   );
+  // Honest truncation accounting: every git read below can be cut by the
+  // process read buffer, and a cut MUST surface as `truncated: true` on the
+  // change set — the prompt-integrity invariant forbids persisting a partial
+  // capture stamped complete (it flows to the judge, the provider, and the
+  // completion evidence as "the real change set").
+  let captureTruncated = false;
+  const nameStatusCapture = await gitCapture(workdir, [
+    "diff",
+    "--name-status",
+    base,
+  ]);
+  captureTruncated ||= nameStatusCapture.truncated;
   const tracked = parseNameStatus(
-    await git(workdir, ["diff", "--name-status", base]),
+    completeLines(nameStatusCapture.stdout, nameStatusCapture.truncated),
   ).filter((file) => !dirtyAtSpawn.has(file));
   const agentWritten = [...agentWrittenSet];
 
@@ -349,11 +457,19 @@ export async function captureChangeSet(
   // so a freshly scaffolded, never-added file would otherwise be invisible
   // (issue #11578 FIX C). Scoped to unborn HEAD to preserve the born-HEAD
   // clutter invariant above.
-  const untracked = unbornHead
-    ? parseLsFiles(
-        await git(workdir, ["ls-files", "--others", "--exclude-standard"]),
-      ).filter((file) => !dirtyAtSpawn.has(file) && !isVendorScoopPath(file))
-    : [];
+  let untracked: string[] = [];
+  if (unbornHead) {
+    const lsCapture = await gitCapture(workdir, [
+      "ls-files",
+      "--others",
+      "--exclude-standard",
+    ]);
+    const listing = parseLsFiles(lsCapture.stdout);
+    captureTruncated ||= lsCapture.truncated || listing.truncated;
+    untracked = listing.files.filter(
+      (file) => !dirtyAtSpawn.has(file) && !isVendorScoopPath(file),
+    );
+  }
 
   // Agent-written paths FIRST: explicit edit/write tool calls are the
   // highest-signal entries. Set dedupe keeps first-occurrence order.
@@ -366,9 +482,15 @@ export async function captureChangeSet(
   // This avoids counting files that were already dirty at spawn and excluded
   // from `changedFiles`. Falls back to a file count for gitignored/untracked
   // tool-written files.
-  const shortstat = (
-    await git(workdir, ["diff", "--shortstat", base, "--", ...changedFiles])
-  )?.trim();
+  const shortstatCapture = await gitCapture(workdir, [
+    "diff",
+    "--shortstat",
+    base,
+    "--",
+    ...changedFiles,
+  ]);
+  captureTruncated ||= shortstatCapture.truncated;
+  const shortstat = shortstatCapture.stdout?.trim();
   const diffStat =
     shortstat && shortstat.length > 0
       ? shortstat
@@ -377,14 +499,19 @@ export async function captureChangeSet(
   let diff = "";
   for (const file of changedFiles) {
     const fd = await fileDiff(workdir, base, file);
-    if (fd) diff = diff ? `${diff}\n${fd}` : fd;
+    captureTruncated ||= fd.truncated;
+    if (fd.text) diff = diff ? `${diff}\n${fd.text}` : fd.text;
   }
 
   return {
     changedFiles,
     diffStat,
     diff,
-    truncated: false,
+    // Honest verdict: true iff any contributing git read was cut. Consumers
+    // (renderChangeSetBody, the CODING_SESSION_CHANGES provider, the PR gate)
+    // disclose the cut and carry a durable continuation instead of
+    // re-presenting the partial capture as complete.
+    truncated: captureTruncated,
     capturedAt: Date.now(),
   };
 }
@@ -450,9 +577,14 @@ function captureToolPathOnlyChangeSet(
 export interface PrGateChangeSet {
   changedFiles: string[];
   diff: string;
-  /** True when the diff text was truncated at the gate budget. */
+  /** True when the diff text was cut by the git read buffer. The secret-scan
+   *  gate (`reviewDiff`) fails CLOSED on this flag with a typed
+   *  `truncated-diff` BLOCK finding — a partial scan can never pass as a
+   *  clean one (prompt-integrity: typed pre-dispatch rejection, not a silent
+   *  clamp). */
   truncated: boolean;
-  /** True when the changed-file list was truncated at the gate budget. */
+  /** True when the changed-file list was cut by the git read buffer; the gate
+   *  blocks with a typed `truncated-files` finding. */
   filesTruncated: boolean;
 }
 
@@ -466,23 +598,44 @@ export async function capturePrGateChangeSet(
 
   // Prefer the branch-since-fork diff (base...HEAD). If the symmetric range
   // can't resolve (no common ancestor), fall back to the direct base..HEAD diff.
-  const nameStatus =
-    (await git(workdir, ["diff", "--name-status", `${base}...HEAD`])) ??
-    (await git(workdir, ["diff", "--name-status", base, "HEAD"]));
+  const nameStatusThreeDot = await gitCapture(workdir, [
+    "diff",
+    "--name-status",
+    `${base}...HEAD`,
+  ]);
+  const nameStatusFallback =
+    nameStatusThreeDot.stdout === undefined
+      ? await gitCapture(workdir, ["diff", "--name-status", base, "HEAD"])
+      : undefined;
+  const nameStatus = nameStatusThreeDot.stdout ?? nameStatusFallback?.stdout;
   if (nameStatus === undefined) return undefined;
+  const filesTruncated =
+    nameStatusThreeDot.stdout !== undefined
+      ? nameStatusThreeDot.truncated
+      : (nameStatusFallback?.truncated ?? false);
 
-  const allChangedFiles = parseNameStatus(nameStatus);
-  const changedFiles = allChangedFiles;
+  const changedFiles = parseNameStatus(
+    completeLines(nameStatus, filesTruncated),
+  );
 
-  const diffRaw =
-    (await git(workdir, ["diff", `${base}...HEAD`])) ??
-    (await git(workdir, ["diff", base, "HEAD"])) ??
-    "";
+  const diffThreeDot = await gitCapture(workdir, ["diff", `${base}...HEAD`]);
+  const diffFallback =
+    diffThreeDot.stdout === undefined
+      ? await gitCapture(workdir, ["diff", base, "HEAD"])
+      : undefined;
+  const diffRaw = diffThreeDot.stdout ?? diffFallback?.stdout ?? "";
+  const truncated =
+    diffThreeDot.stdout !== undefined
+      ? diffThreeDot.truncated
+      : (diffFallback?.truncated ?? false);
+  // HONEST flags, never decorative: a buffer-cut read reports truncated and
+  // reviewDiff then fails closed (typed `truncated-diff`/`truncated-files`
+  // BLOCK findings) instead of passing a secret scan on unproven completeness.
   return {
     changedFiles,
     diff: diffRaw,
-    truncated: false,
-    filesTruncated: false,
+    truncated,
+    filesTruncated,
   };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit coverage for the model-phrasing seam: the phrased happy path, every
+ * degrade-to-fallback edge (timeout, throw, empty, banned vocabulary,
+ * mustInclude miss, over-length), the machine-appendix byte contract, the
+ * voiced-send metadata shape, the LRU memo, and the pure prompt builder.
+ * Deterministic: fake runtime, mocked model, no network.
+ */
+
+import type { Character, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AGENT_VOICED_METADATA,
+  BANNED_MECHANISM_VOCAB_RE,
+  buildPhrasePrompt,
+  characterVoiceSlice,
+  phraseForUser,
+  validatePhrasedText,
+  withMachineAppendix,
+} from "./phrase-for-user.js";
+
+const CHARACTER: Character = {
+  name: "Eliza",
+  bio: ["A helpful runtime companion.", "Loves shipping."],
+  adjectives: ["warm", "direct"],
+  style: { chat: ["concise"], all: ["sentence case"] },
+} as Character;
+
+function makeRuntime(useModel: (...args: unknown[]) => unknown): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-0000000000aa",
+    character: CHARACTER,
+    getSetting: vi.fn(() => undefined),
+    useModel: vi.fn(useModel),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+const FRAME = {
+  intent: "confirm" as const,
+  facts: { createdCount: 2, titles: ["auth refactor", "docs pass"] },
+};
+
+describe("phraseForUser", () => {
+  it("returns the model's text on the phrased path", async () => {
+    const runtime = makeRuntime(async () => "Both tasks are underway.");
+    const out = await phraseForUser(runtime, FRAME, "Created 2 task agents.");
+    expect(out).toEqual({ text: "Both tasks are underway.", phrased: true });
+  });
+
+  it("times out to the fallback without throwing", async () => {
+    const runtime = makeRuntime(() => new Promise(() => {}));
+    const out = await phraseForUser(runtime, FRAME, "Created 2 task agents.", {
+      timeoutMs: 10,
+    });
+    expect(out).toEqual({ text: "Created 2 task agents.", phrased: false });
+  });
+
+  it("a model throw degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => {
+      throw new Error("provider down");
+    });
+    const out = await phraseForUser(runtime, FRAME, "Created 2 task agents.");
+    expect(out).toEqual({ text: "Created 2 task agents.", phrased: false });
+  });
+
+  it("a missing useModel degrades to the fallback (never throws)", async () => {
+    const runtime = {
+      agentId: "a",
+      character: CHARACTER,
+    } as unknown as IAgentRuntime;
+    const out = await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(out).toEqual({ text: "fallback facts", phrased: false });
+  });
+
+  it("empty model output degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => "   ");
+    const out = await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(out.phrased).toBe(false);
+  });
+
+  it("a mustInclude miss (case-sensitive) degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => "Opened issue #7 for you.");
+    const out = await phraseForUser(
+      runtime,
+      {
+        intent: "confirm",
+        facts: { number: 7 },
+        mustInclude: ["#7", "https://github.com/o/r/issues/7"],
+      },
+      "Created issue #7: https://github.com/o/r/issues/7",
+    );
+    expect(out.phrased).toBe(false);
+    expect(out.text).toContain("https://github.com/o/r/issues/7");
+  });
+
+  it("keeps model text that carries every mustInclude value verbatim", async () => {
+    const runtime = makeRuntime(
+      async () => "Done — issue #7 is up: https://github.com/o/r/issues/7",
+    );
+    const out = await phraseForUser(
+      runtime,
+      {
+        intent: "confirm",
+        facts: { number: 7 },
+        mustInclude: ["#7", "https://github.com/o/r/issues/7"],
+      },
+      "Created issue #7: https://github.com/o/r/issues/7",
+    );
+    expect(out.phrased).toBe(true);
+  });
+
+  it("banned internal-mechanism vocabulary degrades to the fallback", async () => {
+    for (const leak of [
+      "The session is running now.",
+      "I got a receipt for that.",
+      "The orchestrator kicked it off.",
+      "My planner scheduled it.",
+      "ACP is connected.",
+      "The callback fired.",
+      "Tracking uuid abc.",
+    ]) {
+      const runtime = makeRuntime(async () => leak);
+      const out = await phraseForUser(runtime, FRAME, "fallback facts");
+      expect(out, leak).toEqual({ text: "fallback facts", phrased: false });
+    }
+  });
+
+  it("over-length output degrades to the fallback", async () => {
+    const runtime = makeRuntime(async () => "x".repeat(500));
+    const out = await phraseForUser(runtime, FRAME, "fallback facts", {
+      maxChars: 320,
+    });
+    expect(out.phrased).toBe(false);
+  });
+
+  it("strips one pair of surrounding quotes before validating", async () => {
+    const runtime = makeRuntime(async () => '"Both tasks are underway."');
+    const out = await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(out).toEqual({ text: "Both tasks are underway.", phrased: true });
+  });
+
+  it("never makes a second model call for a failed frame", async () => {
+    const useModel = vi.fn(async () => "the session leaked");
+    const runtime = makeRuntime(useModel);
+    await phraseForUser(runtime, FRAME, "fallback facts");
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("memoizes repeated frames by cacheKey and skips the model on a hit", async () => {
+    const useModel = vi.fn(async () => "Heads up — nearly at the limit.");
+    const runtime = makeRuntime(useModel);
+    const first = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-1",
+    });
+    const second = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-1",
+    });
+    expect(first.phrased).toBe(true);
+    expect(second).toEqual(first);
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches fallbacks — the next call retries the model", async () => {
+    const useModel = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("down"))
+      .mockResolvedValueOnce("Back up and phrased.");
+    const runtime = makeRuntime(useModel);
+    const first = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-2",
+    });
+    const second = await phraseForUser(runtime, FRAME, "fallback", {
+      cacheKey: "capwarn:test-memo-2",
+    });
+    expect(first.phrased).toBe(false);
+    expect(second).toEqual({ text: "Back up and phrased.", phrased: true });
+  });
+});
+
+describe("withMachineAppendix", () => {
+  it("keeps the appendix byte-identical below the prose", () => {
+    const appendix = `[TASK:abc-123]Fix the auth bug[/TASK]`;
+    const out = withMachineAppendix("On it.", appendix);
+    expect(out).toBe(`On it.\n\n${appendix}`);
+    expect(out.endsWith(appendix)).toBe(true);
+  });
+});
+
+describe("AGENT_VOICED_METADATA", () => {
+  it("is the exact spreadable voice-gate marker", () => {
+    expect(AGENT_VOICED_METADATA).toEqual({ agentVoiced: true });
+    expect({ text: "x", ...AGENT_VOICED_METADATA }).toMatchObject({
+      agentVoiced: true,
+    });
+  });
+});
+
+describe("buildPhrasePrompt / characterVoiceSlice", () => {
+  it("derives voice from the character (name, bio, deduped traits)", () => {
+    const slice = characterVoiceSlice(CHARACTER);
+    expect(slice).toContain("You are Eliza.");
+    expect(slice).toContain("A helpful runtime companion.");
+    expect(slice).toContain("Voice: warm, direct, concise, sentence case.");
+  });
+
+  it("includes EVERY bio line and EVERY deduped trait — no slice", () => {
+    const bio = Array.from({ length: 6 }, (_, i) => `Bio line ${i + 1}.`);
+    const adjectives = Array.from({ length: 12 }, (_, i) => `trait${i + 1}`);
+    const slice = characterVoiceSlice({
+      name: "Eliza",
+      bio,
+      adjectives,
+      style: { chat: ["chatty"], all: ["lowercase-never"] },
+    } as Character);
+    for (const line of bio) expect(slice).toContain(line);
+    for (const trait of adjectives) expect(slice).toContain(trait);
+    expect(slice).toContain("chatty");
+    expect(slice).toContain("lowercase-never");
+  });
+
+  it("rides fact values into the prompt COMPLETE — no 400-char clip", () => {
+    const longValue = `start-${"x".repeat(600)}-end`;
+    const prompt = buildPhrasePrompt(
+      CHARACTER,
+      { intent: "confirm", facts: { task: longValue } },
+      320,
+    );
+    expect(prompt).toContain(`- task: ${longValue}`);
+    expect(prompt).not.toContain("…");
+  });
+
+  it("carries facts, exact-inclusion quotes, forbidden claims, and rules", () => {
+    const prompt = buildPhrasePrompt(
+      CHARACTER,
+      {
+        intent: "fail",
+        facts: { launchedCount: 1, failedLabels: ["docs pass"] },
+        mustInclude: ["docs pass"],
+        mustNotClaim: ["everything launched"],
+      },
+      320,
+    );
+    expect(prompt).toContain("- launchedCount: 1");
+    expect(prompt).toContain("- failedLabels: docs pass");
+    expect(prompt).toContain('include exactly: "docs pass"');
+    expect(prompt).toContain("do not claim: everything launched");
+    expect(prompt).toContain("under 320 characters");
+    expect(prompt).toContain("Sentence case");
+  });
+});
+
+describe("validatePhrasedText", () => {
+  it("rejects banned vocab and accepts clean prose", () => {
+    const req = { intent: "notify" as const, facts: {} };
+    expect(validatePhrasedText("All done here.", req, 320)).toBe(true);
+    expect(validatePhrasedText("The receipt is in.", req, 320)).toBe(false);
+    expect(BANNED_MECHANISM_VOCAB_RE.test("reception desk")).toBe(false);
+    expect(BANNED_MECHANISM_VOCAB_RE.test("sessions")).toBe(true);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.ts
+++ b/plugins/plugin-agent-orchestrator/src/voice/phrase-for-user.ts
@@ -1,0 +1,327 @@
+/**
+ * Single model-phrasing seam for every user-visible line the orchestrator
+ * composes itself (acks, confirmations, warnings, denials). Callers hand over
+ * STRUCTURED FACTS plus a factual fallback string; ONE bounded TEXT_SMALL call
+ * phrases them in the configured character's own voice, and any failure —
+ * timeout, throw, empty output, or a post-validation violation — degrades to
+ * the caller's fallback. The module owns the one prompt builder (extracted
+ * from the spawn-ack generator so ack and confirmation voice cannot drift),
+ * the banned internal-mechanism vocabulary, and the exact-substring
+ * `mustInclude` receipt contract that keeps hashes/URLs riding verbatim.
+ *
+ * Machine-readable payloads (widgets, commit hashes, PR URLs) must never pass
+ * through the model: append them with `withMachineAppendix`, which bypasses
+ * phrasing entirely. Sends that carry already-phrased text spread
+ * `AGENT_VOICED_METADATA` so the core transport voice gate does not re-phrase.
+ */
+
+import { type Character, type IAgentRuntime, ModelType } from "@elizaos/core";
+
+export type PhraseIntent =
+  | "confirm"
+  | "refuse"
+  | "fail"
+  | "warn"
+  | "notify"
+  | "ask";
+
+export interface PhraseFacts {
+  intent: PhraseIntent;
+  facts: Record<string, string | number | boolean | string[] | undefined>;
+  /** Values that must appear in the output as exact, case-sensitive
+   * substrings (labels, issue numbers, paths). A miss falls back. */
+  mustInclude?: string[];
+  /** Claims the model is explicitly forbidden to make. */
+  mustNotClaim?: string[];
+}
+
+export interface PhraseOptions {
+  /** Model race budget in ms. Default 1200, env
+   * `ELIZA_ORCHESTRATOR_PHRASE_TIMEOUT_MS`. */
+  timeoutMs?: number;
+  /** Longest accepted output; anything longer falls back. Default 320. */
+  maxChars?: number;
+  /** Small LRU memo key for repeating frames (cap warnings, first-post) so a
+   * recurring identical frame does not re-bill a model call. */
+  cacheKey?: string;
+}
+
+/** Spread into send metadata so the core transport voice gate skips
+ * re-phrasing text this module already phrased. */
+export const AGENT_VOICED_METADATA: { agentVoiced: true } = {
+  agentVoiced: true,
+};
+
+/** Append a machine payload (widget block, commit hash, PR URL) below the
+ * prose. The appendix bypasses the model entirely and must ride byte-identical
+ * so downstream receipt/widget parsers keep binding. */
+export function withMachineAppendix(prose: string, appendix: string): string {
+  return `${prose}\n\n${appendix}`;
+}
+
+/** Internal-mechanism vocabulary that must never reach chat. Any hit in the
+ * model output falls back to the caller's factual string. */
+export const BANNED_MECHANISM_VOCAB_RE =
+  /\b(?:sessions?|acp|receipts?|callbacks?|uuids?|orchestrators?|planners?)\b/i;
+
+// 3.5s: at 1.2s the Cerebras round-trip lost the race often enough that the
+// canned fallbacks ("Created task agent.") leaked to normies as the COMMON
+// case (owner report 2026-08-19). Acks precede work measured in tens of
+// seconds; a few hundred extra ms of voice is the right trade.
+const DEFAULT_TIMEOUT_MS = 3_500;
+const DEFAULT_MAX_CHARS = 320;
+const CACHE_CAP = 32;
+
+/** Module-level LRU memo of successfully phrased frames, keyed by
+ * agentId + cacheKey (fallbacks are never cached so a transient model outage
+ * cannot pin the degraded string). */
+const phrasedCache = new Map<string, string>();
+
+const INTENT_FRAMES: Record<PhraseIntent, string> = {
+  confirm:
+    "You just did (or kicked off) something the user asked for. Confirm it plainly.",
+  refuse:
+    "You are declining to do what was asked. Say so plainly, and why, without apologizing at length.",
+  fail: "Something the user asked for did not work. Report the failure honestly — no excuses, no technical jargon.",
+  warn: "Warn the user about the situation the facts describe, so they can act on it.",
+  notify: "Give the user a brief factual status update.",
+  ask: "You need something from the user. Ask for it directly.",
+};
+
+/**
+ * The character-voice slice of the prompt — extracted verbatim from the spawn
+ * ack generator's system prompt so every phrased line (ack or confirmation)
+ * derives its voice from the SAME composition: name, ALL bio lines, the full
+ * deduped adjective/style trait list. Complete by contract (prompt-integrity
+ * invariant): the configured character IS the voice, and silently slicing it
+ * biased every phrased line toward the first bio lines / adjectives. Pure +
+ * exported for tests.
+ */
+export function characterVoiceSlice(character: Character): string {
+  const name = (character.name ?? "").trim() || "the assistant";
+  const voiceParts: string[] = [];
+  const bio = (character.bio ?? []).map((b) => b.trim()).filter(Boolean);
+  if (bio.length > 0) voiceParts.push(bio.join(" "));
+  const traits = [
+    ...(character.adjectives ?? []),
+    ...(character.style?.chat ?? []),
+    ...(character.style?.all ?? []),
+  ]
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (traits.length > 0) {
+    voiceParts.push(`Voice: ${[...new Set(traits)].join(", ")}.`);
+  }
+  return [`You are ${name}.`, voiceParts.join(" ").trim()]
+    .filter((part) => part.length > 0)
+    .join(" ");
+}
+
+// Fact values ride into the prompt COMPLETE. Callers own the canonical values
+// (task text, URLs, error detail); a silent clip here truncated request text
+// before inference (prompt-integrity violation). A caller that genuinely wants
+// a bounded view must pass one that carries its own continuation reference.
+function factLines(facts: PhraseFacts["facts"]): string[] {
+  return Object.entries(facts)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => {
+      const rendered = Array.isArray(value)
+        ? value.map((item) => String(item)).join(", ")
+        : String(value);
+      return `- ${key}: ${rendered}`;
+    });
+}
+
+/**
+ * The ONE prompt this module ever sends: character voice slice + intent frame
+ * + compact fact list + exact-inclusion quotes + forbidden claims + standing
+ * rules. Pure + deterministic so it is unit-tested directly.
+ */
+export function buildPhrasePrompt(
+  character: Character,
+  req: PhraseFacts,
+  maxChars: number,
+): string {
+  const lines: string[] = [
+    characterVoiceSlice(character),
+    INTENT_FRAMES[req.intent],
+    "Write ONE short message to the user, in your own voice, based ONLY on these facts:",
+    ...factLines(req.facts),
+  ];
+  if (req.mustInclude && req.mustInclude.length > 0) {
+    lines.push(
+      "Include each of the following EXACTLY as written, character for character:",
+      ...req.mustInclude.map((value) => `- include exactly: "${value}"`),
+    );
+  }
+  if (req.mustNotClaim && req.mustNotClaim.length > 0) {
+    lines.push(
+      "Hard constraints — you must NOT claim any of the following:",
+      ...req.mustNotClaim.map((claim) => `- do not claim: ${claim}`),
+    );
+  }
+  lines.push(
+    "Standing rules:",
+    "- One short message only. Sentence case — not all-lowercase, not a headline.",
+    "- Write in the same language the user's own words in the facts are written in.",
+    "- Plain conversational text: no surrounding quotes, no markdown headers, no emoji, no preamble.",
+    "- Never mention internal machinery: no sessions, receipts, callbacks, ids, or agent plumbing.",
+    `- Keep it under ${maxChars} characters.`,
+    "Your message:",
+  );
+  return lines.filter((line) => line.length > 0).join("\n");
+}
+
+function phraseTimeoutMs(runtime: IAgentRuntime, opts?: PhraseOptions): number {
+  if (opts?.timeoutMs !== undefined && opts.timeoutMs > 0) {
+    return opts.timeoutMs;
+  }
+  const raw =
+    (typeof runtime.getSetting === "function"
+      ? (runtime.getSetting("ELIZA_ORCHESTRATOR_PHRASE_TIMEOUT_MS") as
+          | string
+          | undefined)
+      : undefined) ?? process.env.ELIZA_ORCHESTRATOR_PHRASE_TIMEOUT_MS;
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_MS;
+}
+
+/** Strip a single pair of surrounding quotes and collapse outer whitespace —
+ * the only sanitation applied before validation. */
+function tidyModelOutput(raw: string): string {
+  let text = raw.replace(/\r\n/g, "\n").trim();
+  const quotePairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["“", "”"],
+    ["‘", "’"],
+    ["`", "`"],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (
+      text.length >= open.length + close.length &&
+      text.startsWith(open) &&
+      text.endsWith(close)
+    ) {
+      text = text.slice(open.length, text.length - close.length).trim();
+      break;
+    }
+  }
+  return text;
+}
+
+/** Post-validation: the phrased text is only accepted when every mustInclude
+ * value appears as an exact case-sensitive substring (hashes/URLs), the
+ * banned-mechanism vocabulary is absent, and the length fits. */
+export function validatePhrasedText(
+  text: string,
+  req: PhraseFacts,
+  maxChars: number,
+): boolean {
+  if (!text) return false;
+  if (text.length > maxChars) return false;
+  if (BANNED_MECHANISM_VOCAB_RE.test(text)) return false;
+  for (const value of req.mustInclude ?? []) {
+    if (!text.includes(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Phrase structured facts as one user-visible message in the agent's voice.
+ * Single TEXT_SMALL call raced against the timeout; on ANY failure (error,
+ * timeout, empty, validation miss) returns the caller's fallback with
+ * `phrased: false`. Never throws, never retries, never makes a second model
+ * call. Fallback strings are the caller's responsibility and must already
+ * contain every mustInclude value — they are facts, not prose theater.
+ */
+export async function phraseForUser(
+  runtime: IAgentRuntime,
+  req: PhraseFacts,
+  fallback: string,
+  opts?: PhraseOptions,
+): Promise<{ text: string; phrased: boolean }> {
+  const maxChars = opts?.maxChars ?? DEFAULT_MAX_CHARS;
+  const cacheKey = opts?.cacheKey
+    ? `${String(runtime.agentId ?? "")}:${opts.cacheKey}`
+    : undefined;
+  try {
+    if (cacheKey) {
+      const hit = phrasedCache.get(cacheKey);
+      if (hit !== undefined) {
+        // LRU touch: re-insert as newest.
+        phrasedCache.delete(cacheKey);
+        phrasedCache.set(cacheKey, hit);
+        return { text: hit, phrased: true };
+      }
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), phraseTimeoutMs(runtime, opts));
+      (timer as { unref?: () => void }).unref?.();
+    });
+    // error-policy:J4 the phrased line is cosmetic voice over caller-owned
+    // facts; model rejection/timeout degrades to the factual fallback string,
+    // never fabricated data.
+    let callError: string | undefined;
+    const raw = await Promise.race([
+      Promise.resolve(
+        runtime.useModel(ModelType.TEXT_SMALL, {
+          system: buildPhrasePrompt(runtime.character, req, maxChars),
+          prompt: "Write the message now.",
+          maxTokens: 128,
+          temperature: 0.7,
+          // Formatting call: suppress hidden reasoning. A reasoning-effort pin
+          // (e.g. ELIZAOS_CLOUD_REASONING_EFFORT=high) burns the whole
+          // 128-token cap on hidden reasoning and returns EMPTY content on
+          // gemma-4-31b — every ack shipped the canned fallback for two days
+          // (live 2026-08-20). thinking:"off" maps to the model's suppression
+          // value in both the cloud and direct-Cerebras handlers.
+          providerOptions: { eliza: { thinking: "off" } },
+        }),
+      ).catch((err) => {
+        callError = err instanceof Error ? err.message : String(err);
+        return null;
+      }),
+      timeout,
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+    const text = typeof raw === "string" ? tidyModelOutput(raw) : "";
+    if (!validatePhrasedText(text, req, maxChars)) {
+      // WARN, not debug: the canned fallbacks kept reaching users while this
+      // deployment drops plugin debug logs entirely — the cause (timeout vs
+      // model error vs rejected output) was invisible for two days
+      // (2026-08-20). The error text is load-bearing diagnosis.
+      runtime.logger?.warn?.(
+        {
+          reason:
+            raw === null
+              ? callError
+                ? "model-error"
+                : "timeout"
+              : "validation-reject",
+          ...(callError ? { error: callError } : {}),
+          raw: typeof raw === "string" ? raw : String(raw),
+          rejected: text,
+          intent: req.intent,
+        },
+        "[phrase-for-user] fell back to canned text",
+      );
+      return { text: fallback, phrased: false };
+    }
+    if (cacheKey) {
+      phrasedCache.set(cacheKey, text);
+      while (phrasedCache.size > CACHE_CAP) {
+        const oldest = phrasedCache.keys().next().value;
+        if (oldest === undefined) break;
+        phrasedCache.delete(oldest);
+      }
+    }
+    return { text, phrased: true };
+  } catch {
+    // error-policy:J4 phrasing must never take the turn down; degrade to the
+    // caller's factual fallback.
+    return { text: fallback, phrased: false };
+  }
+}


### PR DESCRIPTION
Part 2 of the split series closing out #24262 (see part 1 for series context).

cc @lalalune

## Content-budget closure response (supersedes #24419)

Every cited cap is converted:
- **Criteria count/char limits**: gone — the complete refined criteria set is the contract (no 5-item slice, no 240-char cut); filter-dropped criteria persist as `droppedCriteria` task metadata for audit.
- **Captured tool output sliced**: evidence tool-output sections persist the COMPLETE text via the new content-addressed store and project reference-bearing views.
- **Orchestrator references sliced / workdir traversal caps**: fs-verified file contents project with per-file references; workdir enumeration carries explicit continuation notes naming what was not traversed.
- **Foundation**: `durable-content-store.ts` — sha256-addressed records under the trajectory dir; `durableProjection()` persists FIRST and the marker names the real resolver (`GET /api/orchestrator/content/:sha256?offset=&limit=`, in part 3). A textual marker alone is never emitted for dropped bytes.

## Scope — orchestrator foundation modules (leaves only; no service/action integrators)

**The durable-content contract this series is built on** — `services/durable-content.ts`:
- `boundedContentView(full, budget, ref)`: every capped string handed to a model prompt or chat surface is a VIEW; a partial view ends with a continuation marker naming its reference and carries a core `ReadView` (`ContentReference`/`ReadSlice` from #24305) with sha256'd slice/source.
- `orchestratorContentRef(scope, id)`: opaque `acpx-*` tokens; resolvers are the orchestrator's own HTTP surfaces (`/api/coding-agents/:id/output`, `/api/orchestrator/tasks/:id`).
- `canonicalProviderPair`: the canonical/provider convention from the #24262 repair (`canonicalPrTitle`/`providerPrTitle`) as a reusable helper — canonical persisted in full, provider payload derived explicitly and auditable.
- `subagent-stdout-log.ts` gains `readSubagentStdout(sessionId, {offset, limit})` — the chunk-indexed continuation reader over the durable per-session transcript.

**Verification foundations**: fabricated-input detection with pre-run existence/SHA-256 `InputBaseline`s (a write is fabrication evidence only when the input was captured absent before execution) + read/write verb-window target selection; acceptance criteria, completion evidence (full FS-verified file contents for content criteria), residuals, ground-truth/independent/goal verifiers.

**Routing foundations**: `ask-shapes.ts` (follow-up vs new-deliverable vs anaphor shapes), `follow-up-origin.ts` (a delivered follow-up re-keys the session's voice so its completion posts — see part 5), workdir route grounding, framework/account/model-gateway selection (OpenCode-free, aligned with develop's removal).

All modules are leaves: nothing here imports the ACP service, task service, router, or actions. Tests included per module.

## Stack
Base: `feat/coding-agent-split-1-eliza-code-acp`. Next: 3-acp-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
