### PR TITLE
feat(orchestrator): sub-agent router — per-lane relays, voice re-keying, reference-bearing views

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/deferred-relay-durability.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/deferred-relay-durability.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Deferred completion relays survive a router restart and never fabricate a
+ * verification pass. A deferral is stamped durably on the task record at
+ * capture time and cleared only after the released relay posts; a new router
+ * instance reconstructs pending stamps at start() (release, drop, or re-arm
+ * from the task's durable state); and the fallback timeout releases with an
+ * explicit `unverified` disclosure in the relay body — never verdict
+ * "passed". Drives the REAL SubAgentRouter with a fake ACP service and a fake
+ * in-memory task record; deterministic (fake timers for the timeout leg).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFERRED_RELAY_FALLBACK_MS,
+  PENDING_COMPLETION_RELAYS_META_KEY,
+  SubAgentRouter,
+  UNVERIFIED_RELAY_DISCLOSURE,
+} from "../services/sub-agent-router.ts";
+
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const MSG = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+const TASK_ID = "task-defer-1";
+const SESSION_ID = "sess-defer-1";
+
+type RouterInternals = {
+  handleEvent(sessionId: string, event: string, data: unknown): Promise<void>;
+  deferredCompletionRelays: Map<string, { sessionId: string }>;
+};
+
+interface FakeTaskRecord {
+  id: string;
+  status: string;
+  acceptanceCriteria: string[];
+  metadata: Record<string, unknown>;
+}
+
+function makeTaskService(record: FakeTaskRecord) {
+  return {
+    getTaskForSession: vi.fn(async () => record),
+    getTask: vi.fn(async (taskId: string) =>
+      taskId === record.id ? record : null,
+    ),
+    listTasks: vi.fn(async () => [{ id: record.id, status: record.status }]),
+    updateTask: vi.fn(
+      async (taskId: string, patch: { metadata?: Record<string, unknown> }) => {
+        if (taskId !== record.id) return null;
+        if (patch.metadata) record.metadata = patch.metadata;
+        return record;
+      },
+    ),
+  };
+}
+
+function makeSession(): Record<string, unknown> {
+  return {
+    id: SESSION_ID,
+    agentType: "codex",
+    name: "Defer",
+    workdir: "/tmp/deferred-relay-durability-test",
+    status: "ready",
+    createdAt: new Date(0),
+    lastActivityAt: new Date(0),
+    metadata: {
+      roomId: ROOM,
+      taskRoomId: ROOM,
+      messageId: MSG,
+      source: "discord",
+      label: "quotes-page",
+      initialTask: "Build the quotes page",
+    },
+  };
+}
+
+function makeAcp(sessions: Map<string, Record<string, unknown>>) {
+  return {
+    onSessionEvent: vi.fn(() => () => {}),
+    getSession: vi.fn(async (sessionId: string) => sessions.get(sessionId)),
+    getSessions: vi.fn(async () => [...sessions.values()]),
+    getChangedPaths: vi.fn(() => [] as string[]),
+    spawnSession: vi.fn(async () => ({ sessionId: "retry-1" })),
+    stopSession: vi.fn(async () => undefined),
+    updateSessionMetadata: vi.fn(async () => undefined),
+  };
+}
+
+function makeRuntime(
+  acp: ReturnType<typeof makeAcp>,
+  tasks: ReturnType<typeof makeTaskService>,
+  created: Array<Record<string, unknown>>,
+): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Tester" },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: () => undefined,
+    getService: (type: string) => {
+      if (type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE")
+        return acp;
+      if (type === "ORCHESTRATOR_TASK_SERVICE") return tasks;
+      return undefined;
+    },
+    createEntity: vi.fn(async () => true),
+    addParticipant: vi.fn(async () => true),
+    getEntitiesForRoom: vi.fn(async () => []),
+    deleteParticipants: vi.fn(async () => true),
+    reportError: vi.fn(),
+    createMemory: vi.fn(async (memory: Record<string, unknown>) => {
+      created.push(memory);
+      return MSG;
+    }),
+    emitEvent: vi.fn(async () => undefined),
+    useModel: vi.fn(async () => "{}"),
+  } as unknown as IAgentRuntime;
+}
+
+function relayTexts(created: Array<Record<string, unknown>>): string[] {
+  return created
+    .map((m) => (m.content as { text?: string } | undefined)?.text ?? "")
+    .filter((text) => text.includes("[sub-agent"));
+}
+
+function stamps(record: FakeTaskRecord): Record<string, unknown> {
+  const raw = record.metadata[PENDING_COMPLETION_RELAYS_META_KEY];
+  return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  expect(predicate()).toBe(true);
+}
+
+interface Harness {
+  router: SubAgentRouter;
+  internals: RouterInternals;
+  created: Array<Record<string, unknown>>;
+  record: FakeTaskRecord;
+  tasks: ReturnType<typeof makeTaskService>;
+}
+
+async function makeHarness(record: FakeTaskRecord): Promise<Harness> {
+  const sessions = new Map([[SESSION_ID, makeSession()]]);
+  const acp = makeAcp(sessions);
+  const tasks = makeTaskService(record);
+  const created: Array<Record<string, unknown>> = [];
+  const runtime = makeRuntime(acp, tasks, created);
+  const router = new SubAgentRouter(runtime);
+  await router.start();
+  return {
+    router,
+    internals: router as unknown as RouterInternals,
+    created,
+    record,
+    tasks,
+  };
+}
+
+function activeRecord(
+  metadata: Record<string, unknown> = {},
+  status = "active",
+): FakeTaskRecord {
+  return {
+    id: TASK_ID,
+    status,
+    acceptanceCriteria: ["the page renders"],
+    metadata,
+  };
+}
+
+function stampFor(deferredAt: string): Record<string, unknown> {
+  return {
+    [PENDING_COMPLETION_RELAYS_META_KEY]: {
+      [SESSION_ID]: {
+        taskId: TASK_ID,
+        sessionId: SESSION_ID,
+        deferredAt,
+        data: {
+          response: "The quotes page is ready.",
+          stopReason: "end_turn",
+        },
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("deferral stamps the pending relay durably", () => {
+  it("defer writes the task stamp; a passed release posts and clears it", async () => {
+    const h = await makeHarness(activeRecord());
+    await h.internals.handleEvent(SESSION_ID, "task_complete", {
+      response: "The quotes page is ready.",
+      stopReason: "end_turn",
+    });
+    // Held, not relayed — and durably stamped for restart recovery.
+    expect(relayTexts(h.created)).toHaveLength(0);
+    const stamp = stamps(h.record)[SESSION_ID] as Record<string, unknown>;
+    expect(stamp).toBeDefined();
+    expect(stamp.taskId).toBe(TASK_ID);
+    expect(stamp.sessionId).toBe(SESSION_ID);
+    expect(typeof stamp.deferredAt).toBe("string");
+    expect(stamp.data).toMatchObject({
+      response: "The quotes page is ready.",
+    });
+
+    h.router.releaseDeferredCompletionRelay(TASK_ID, "passed", SESSION_ID);
+    await waitFor(() => relayTexts(h.created).length > 0);
+    const texts = relayTexts(h.created);
+    expect(texts.join("\n")).toContain("quotes page");
+    // A verdict-released relay carries no unverified disclosure.
+    expect(texts.join("\n")).not.toContain(UNVERIFIED_RELAY_DISCLOSURE);
+    // The durable stamp is cleared only after the relay posted.
+    await waitFor(() => stamps(h.record)[SESSION_ID] === undefined);
+    await h.router.stop();
+  });
+
+  it("a failed verdict drops the relay and clears the stamp", async () => {
+    const h = await makeHarness(activeRecord());
+    await h.internals.handleEvent(SESSION_ID, "task_complete", {
+      response: "The quotes page is ready.",
+      stopReason: "end_turn",
+    });
+    expect(stamps(h.record)[SESSION_ID]).toBeDefined();
+
+    h.router.releaseDeferredCompletionRelay(TASK_ID, "failed", SESSION_ID);
+    await waitFor(() => stamps(h.record)[SESSION_ID] === undefined);
+    expect(relayTexts(h.created)).toHaveLength(0);
+    await h.router.stop();
+  });
+});
+
+describe("the fallback timeout never fabricates a pass", () => {
+  it("releases with verdict unverified and disclosure in the relay body", async () => {
+    vi.useFakeTimers();
+    const h = await makeHarness(activeRecord());
+    await h.internals.handleEvent(SESSION_ID, "task_complete", {
+      response: "The quotes page is ready.",
+      stopReason: "end_turn",
+    });
+    expect(relayTexts(h.created)).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(DEFERRED_RELAY_FALLBACK_MS);
+    // The release chain is promise-based; drain it under fake timers.
+    await vi.advanceTimersByTimeAsync(1000);
+    const texts = relayTexts(h.created);
+    expect(texts.length).toBeGreaterThan(0);
+    expect(texts.join("\n")).toContain(UNVERIFIED_RELAY_DISCLOSURE);
+    expect(texts.join("\n")).toContain(
+      "verification did not complete — result delivered unverified",
+    );
+    await h.router.stop();
+  });
+});
+
+describe("restart reconstructs pending relays from durable stamps", () => {
+  it("a stamp past its fallback window releases unverified on start()", async () => {
+    const past = new Date(
+      Date.now() - DEFERRED_RELAY_FALLBACK_MS - 60_000,
+    ).toISOString();
+    // Fresh router instance: nothing in memory, only the durable stamp.
+    const h = await makeHarness(activeRecord(stampFor(past), "validating"));
+    await waitFor(() => relayTexts(h.created).length > 0);
+    const texts = relayTexts(h.created);
+    expect(texts.join("\n")).toContain("quotes page");
+    expect(texts.join("\n")).toContain(UNVERIFIED_RELAY_DISCLOSURE);
+    await waitFor(() => stamps(h.record)[SESSION_ID] === undefined);
+    await h.router.stop();
+  });
+
+  it("a stamp on a done task releases as passed (durable verdict, no disclosure)", async () => {
+    const past = new Date(
+      Date.now() - DEFERRED_RELAY_FALLBACK_MS - 60_000,
+    ).toISOString();
+    const h = await makeHarness(activeRecord(stampFor(past), "done"));
+    await waitFor(() => relayTexts(h.created).length > 0);
+    expect(relayTexts(h.created).join("\n")).not.toContain(
+      UNVERIFIED_RELAY_DISCLOSURE,
+    );
+    await waitFor(() => stamps(h.record)[SESSION_ID] === undefined);
+    await h.router.stop();
+  });
+
+  it("a stamp on a parked task is dropped, never relayed", async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const h = await makeHarness(activeRecord(stampFor(past), "parked"));
+    await waitFor(() => stamps(h.record)[SESSION_ID] === undefined);
+    expect(relayTexts(h.created)).toHaveLength(0);
+    await h.router.stop();
+  });
+
+  it("a stamp still inside its window re-arms instead of posting", async () => {
+    const fresh = new Date(Date.now() - 1000).toISOString();
+    const h = await makeHarness(activeRecord(stampFor(fresh), "validating"));
+    const deferKey = `${TASK_ID}\u0000${SESSION_ID}`;
+    await waitFor(() => h.internals.deferredCompletionRelays.has(deferKey));
+    // Held (no relay), stamp intact — the verdict can still release it.
+    expect(relayTexts(h.created)).toHaveLength(0);
+    expect(stamps(h.record)[SESSION_ID]).toBeDefined();
+
+    h.router.releaseDeferredCompletionRelay(TASK_ID, "passed", SESSION_ID);
+    await waitFor(() => relayTexts(h.created).length > 0);
+    expect(relayTexts(h.created).join("\n")).not.toContain(
+      UNVERIFIED_RELAY_DISCLOSURE,
+    );
+    await h.router.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/evaluators/durable-cancel-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/durable-cancel-routing.ts
@@ -1,0 +1,45 @@
+/**
+ * Deterministic stage-1 routing for cancel/stop requests aimed at durable
+ * coding work. The planner's model routing is not stable here: across live
+ * runs the same "cancel all ur running coding tasks" variously produced
+ * hallucinated candidate names, an APP action=stop with an invented run id,
+ * or no usable candidate at all — each ending in a wrong or hedged reply
+ * while the real TASKS stop machinery sat unused (live 2026-08-19). The
+ * phrasing is unambiguous, so the candidate surface is narrowed structurally
+ * instead of hoping the model picks the right tool.
+ */
+import type { Memory, ResponseHandlerEvaluator } from "@elizaos/core";
+
+/** Cancel/stop verb followed (within a short window) by a durable-work noun.
+ *  Plain media/app phrasing ("stop the music", "stop the timer app") carries
+ *  none of these nouns and keeps its normal routing. */
+const DURABLE_CANCEL_RE =
+  /\b(?:cancel|stop|kill|abort|end)\b[\s\S]{0,40}\b(?:coding\s+)?(?:tasks?|(?:sub[- ]?)?agents?|jobs?|builds?|sessions?)\b/i;
+
+function messageText(message: Memory): string {
+  const content = message.content;
+  return content && typeof content === "object" && "text" in content
+    ? String((content as { text?: unknown }).text ?? "")
+    : "";
+}
+
+export const durableCancelRoutingEvaluator: ResponseHandlerEvaluator = {
+  name: "agent-orchestrator.durable-cancel-routing",
+  description:
+    "Routes cancel/stop-of-coding-work phrasing to the TASKS surface deterministically.",
+  priority: 20,
+  shouldRun: ({ message }) => DURABLE_CANCEL_RE.test(messageText(message)),
+  evaluate: ({ messageHandler }) => {
+    if (messageHandler.processMessage !== "RESPOND") return undefined;
+    return {
+      clearCandidateActions: true,
+      addCandidateActions: ["TASKS", "TASKS_STOP_AGENT", "TASKS_CANCEL"],
+      // TASKS' contextGate accepts automation; without it the planner can
+      // reject the injected candidates as out-of-context.
+      addContextSlices: ["automation"],
+      debug: [
+        "durable-work cancel phrasing: candidate surface narrowed to TASKS",
+      ],
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/evaluators/finished-work-followup-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/finished-work-followup-routing.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic stage-1 routing for run-it / show-me follow-ups aimed at
+ * recently finished sub-agent work. The planner's model routing is not stable
+ * here: with the finished lane's workdir already garbage-collected, the same
+ * "run the lunch spot picker and show me what it prints" repeatedly chose a
+ * direct SHELL against the dead path — even with an explicit "(cleaned up —
+ * reopen via SEND_TO_AGENT)" provider line in context — and the turn ended in
+ * an apology (live 2026-08-20, three attempts). The TASKS send/create surface
+ * is the only route that reliably reopens finished work (its terminal-session
+ * redirect rebuilds in a fresh workspace), so the candidate surface is
+ * narrowed structurally whenever a fresh terminal lane exists and nothing is
+ * running.
+ */
+import type { Memory, ResponseHandlerEvaluator } from "@elizaos/core";
+import { unwrapUserMessageText } from "@elizaos/core";
+import { getAcpService } from "../actions/common.js";
+import { looksLikeNewDeliverableAsk } from "../services/ask-shapes.js";
+import { TERMINAL_SESSION_STATUSES } from "../services/types.js";
+
+/** Run/show verb aimed at prior work ("it", "again", the/that <thing>) or an
+ *  output ask. Bare coding asks ("write me a script") carry none of these. */
+const RUN_FOLLOWUP_RE =
+  /\b(?:run|execute|rerun|re-run)\b[\s\S]{0,60}\b(?:it|its|again|that|the|once\s+more|one\s+more\s+time)\b|\bshow\s+me\b[\s\S]{0,60}\b(?:output|result|prints?)\b|\bwhat\s+(?:does|did)\s+it\s+print\b/i;
+
+const RECENT_TERMINAL_WINDOW_MS = 30 * 60_000;
+
+/** Connector-rendered mention of the agent that leads an addressed message
+ *  ("Name (@123) ", "<@123> ", "@name "). It is not part of the ask; left in,
+ *  it became the successor task's title and the kickoff ack named it. */
+const LEADING_MENTION_RE =
+  /^\s*(?:<@!?\d+>\s*|@\S+\s+|[^()\n]{0,80}\(@\d+\)\s*)/u;
+
+function messageText(message: Memory): string {
+  // The user's words only: no untrusted-content envelope (API/webhook
+  // messages arrive wrapped; forwarding the wrapped text as a child task
+  // embedded the whole SECURITY NOTICE banner and the outbound envelope guard
+  // then blocked the completion) and no connector context header ("[Discord
+  // #general | server] @e2e (ts):" became a successor's title and was quoted
+  // back in its park notice) — both live 2026-08-21.
+  return unwrapUserMessageText(message).replace(LEADING_MENTION_RE, "").trim();
+}
+
+export const finishedWorkFollowUpRoutingEvaluator: ResponseHandlerEvaluator = {
+  name: "agent-orchestrator.finished-work-followup-routing",
+  description:
+    "Routes run-it/show-me follow-ups on finished sub-agent work to the TASKS surface deterministically.",
+  priority: 20,
+  deterministicActions: ["TASKS"],
+  // "write me a script … and run it" is a NEW build that happens to say
+  // "run it"; sending it into the latest finished lane inherited that lane's
+  // title, criteria and repo workdir (live 2026-08-22, count-ts-files).
+  shouldRun: ({ message }) => {
+    const text = messageText(message);
+    return RUN_FOLLOWUP_RE.test(text) && !looksLikeNewDeliverableAsk(text);
+  },
+  evaluate: async ({ runtime, message, messageHandler }) => {
+    if (messageHandler.processMessage !== "RESPOND") return undefined;
+    const service = getAcpService(runtime);
+    if (!service) return undefined;
+    let sessions: Awaited<ReturnType<typeof service.listSessions>>;
+    try {
+      sessions = await Promise.resolve(service.listSessions());
+    } catch {
+      // error-policy:J4 routing enrichment only — an unavailable session list
+      // leaves the planner's normal candidate surface untouched.
+      return undefined;
+    }
+    const routed = (Array.isArray(sessions) ? sessions : []).filter((s) => {
+      const meta = s.metadata as Record<string, unknown> | undefined;
+      if (typeof meta?.roomId !== "string" || meta.roomId.length === 0) {
+        return false;
+      }
+      // Quarantine lanes born from sprayed planner args (serialized param
+      // junk in the label/task) — redirect chains otherwise propagate the
+      // garbage title into every successor (live 2026-08-21). The sniff scans
+      // the FULL initialTask (no prefix slice): sprayed junk can sit past any
+      // fixed offset, and the string is already in memory.
+      const label = `${String(meta.label ?? "")} ${String(meta.initialTask ?? "")}`;
+      return !/appMonetized\s*[:=]|approvalPreset\s*[:=]/.test(label);
+    });
+    // A live lane owns its own follow-up routing (send/queue paths).
+    if (routed.some((s) => !TERMINAL_SESSION_STATUSES.has(s.status))) {
+      return undefined;
+    }
+    const now = Date.now();
+    const recentTerminal = routed
+      .filter((s) => TERMINAL_SESSION_STATUSES.has(s.status))
+      .filter((s) => {
+        const at = new Date(s.lastActivityAt ?? s.createdAt).getTime();
+        return Number.isFinite(at) && now - at < RECENT_TERMINAL_WINDOW_MS;
+      })
+      .sort(
+        (a, b) =>
+          new Date(b.lastActivityAt ?? b.createdAt).getTime() -
+          new Date(a.lastActivityAt ?? a.createdAt).getTime(),
+      )[0];
+    if (!recentTerminal) return undefined;
+    const userText = messageText(message).trim();
+    if (!userText) return undefined;
+    // Fully deterministic: the model writes NO tool args. Candidate-narrowing
+    // alone still let the planner fill the wide TASKS schema itself, and it
+    // sprayed values into wrong params — a send whose `agents` field carried
+    // serialized junk ("\"\"\",appMonetized:false,approvalPreset:") became a
+    // garbage-labeled second lane (live 2026-08-21). runSend's terminal
+    // redirect turns this into the merged successor create.
+    return {
+      deterministicToolCall: {
+        name: "TASKS",
+        params: {
+          action: "send",
+          sessionId: recentTerminal.id,
+          input: userText,
+        },
+      },
+      debug: [
+        `run-it follow-up on finished sub-agent work: deterministic TASKS send to ${recentTerminal.id}`,
+      ],
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/evaluators/route-scoped-work-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/route-scoped-work-routing.ts
@@ -1,0 +1,54 @@
+/**
+ * Deterministic stage-1 routing for work the user scopes to a configured
+ * workdir route ("in the milady-fork repo, count the .ts files under apps/").
+ * Stage-1 routinely answers such asks with the parent's OWN shell (which runs
+ * in the agent's cwd — `find milady-fork/apps` then fails) or by re-reading a
+ * stale attachment, and the user hears "finished successfully with exit code
+ * 0" / "that folder isn't there" (live 2026-08-22). The routed repo is only
+ * reachable through the TASKS surface (its spawn resolves the route's
+ * workdir), so a route-scoped work ask without a delegation candidate is
+ * narrowed to TASKS.
+ */
+import type { Memory, ResponseHandlerEvaluator } from "@elizaos/core";
+import { unwrapUserMessageText } from "@elizaos/core";
+import { resolveWorkdirRoute } from "../services/task-agent-routing.js";
+
+const DELEGATION_CLASS_RE =
+  /^(?:tasks(?:_[a-z_]+)?|spawn_agent|spawn_coding_agent|start_coding_task|send_to_agent|create_agent_task)$/i;
+/** Something to DO in the repo, as opposed to talk about it. */
+const WORK_VERB_RE =
+  /\b(?:count|list|find|look(?:\s+up)?|check|show|read|grep|search|inspect|fix|add|update|change|edit|write|run|test|build|create|remove|delete|rename|refactor|review|audit|bump|lint|format|commit|diff|compare|measure|how many)\b/i;
+
+function messageText(message: Memory): string {
+  return unwrapUserMessageText(message).trim();
+}
+
+export const routeScopedWorkRoutingEvaluator: ResponseHandlerEvaluator = {
+  name: "agent-orchestrator.route-scoped-work-routing",
+  description:
+    "Work scoped to a configured workdir route runs through TASKS, never the parent's own shell.",
+  priority: 20,
+  shouldRun: ({ message }) => messageText(message).length > 0,
+  evaluate: ({ runtime, message, messageHandler }) => {
+    if (messageHandler.processMessage !== "RESPOND") return undefined;
+    const candidates = Array.isArray(messageHandler.plan.candidateActions)
+      ? messageHandler.plan.candidateActions.map((name) => String(name))
+      : [];
+    if (candidates.some((name) => DELEGATION_CLASS_RE.test(name.trim()))) {
+      return undefined;
+    }
+    const text = messageText(message);
+    if (!WORK_VERB_RE.test(text)) return undefined;
+    const route = resolveWorkdirRoute(runtime, text, text);
+    if (!route) return undefined;
+    return {
+      requiresTool: true,
+      setContexts: ["code"],
+      clearCandidateActions: true,
+      addCandidateActions: ["TASKS"],
+      debug: [
+        `route-scoped work (route ${route.id}): candidates [${candidates.join(", ")}] replaced with TASKS`,
+      ],
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -7,10 +7,9 @@
  * router/tool-transcript noise — captured `[tool output: …]` envelopes, raw
  * path/transcript leaks, loopback-vs-user-facing URLs, empty-completion
  * placeholders, and failure markers reported without positive evidence. A short
- * clean answer is relayed. An incomplete (`length` / `content_filter`) result
- * is rejected explicitly rather than presenting partial text as a completed
- * answer or re-spawning it; that is the guard against the weak-model re-spawn
- * loop (elizaOS/eliza#8875). Its failure-side twin is
+ * clean answer, or a degenerate (`length` / `content_filter`) completion, is
+ * relayed once instead of re-spawned; that is the guard against the weak-model
+ * re-spawn loop (elizaOS/eliza#8875). Its failure-side twin is
  * `sub-agent-failure.ts`.
  *
  * Relayed replies are verification-aware: when the durable task behind the
@@ -27,6 +26,7 @@ import {
   type ResponseHandlerEvaluator,
   SIMPLE_CONTEXT_ID,
 } from "@elizaos/core";
+import { redactLoopbackUrls } from "../services/loopback-urls.js";
 
 const SUB_AGENT_SOURCE = MESSAGE_SOURCE_SUB_AGENT;
 const EMPTY_COMPLETION_PLACEHOLDER =
@@ -407,8 +407,9 @@ function deliverableFromMetadata(message: Memory): string | undefined {
 // `length` (ran out of token / turn budget mid-answer — truncated) or
 // `content_filter` (refused / blocked). The ACP `stopReason` is normalized to
 // one of these by the router (subAgentFinishReason metadata) before it reaches
-// here. Re-spawning the SAME root request repeats the failure, while relaying
-// the prefix falsely presents an incomplete answer as complete. Reject it.
+// here. Re-spawning the SAME root request on a degenerate completion just
+// truncates/blocks again — the ~70x weak-model re-spawn loop (issue
+// elizaOS/eliza#8875). We relay the best partial once instead.
 const DEGENERATE_FINISH_REASONS = new Set(["length", "content_filter"]);
 
 function finishReasonFromMetadata(message: Memory): string | undefined {
@@ -423,7 +424,9 @@ function isDegenerateFinishReason(reason: string | undefined): boolean {
 // Longest completion body we treat as a bare "answer value" worth relaying over
 // a planner re-spawn. Tight on purpose: a price / short sentence qualifies; a
 // multi-line build report or transcript does not and keeps the existing
-// step-aside-for-follow-up routing.
+// step-aside-for-follow-up routing. Pure CLASSIFICATION threshold, not a
+// content cap: neither branch cuts or drops text — the complete body flows
+// through whichever routing wins.
 const SHORT_CLEAN_COMPLETION_BODY_MAX_CHARS = 120;
 
 // Continuing the EXISTING session (TASKS_SEND_TO_AGENT / TASKS_SEND) is the only
@@ -660,6 +663,21 @@ function respondIfNeeded(messageHandler: MessageHandlerResult) {
     : { processMessage: "RESPOND" as const };
 }
 
+/** The relay body when it is orchestrator-composed OBSERVATION (workdir
+ *  file verification and/or the served URL). Undefined for
+ *  worker-authored prose — that still goes through normal routing. */
+function orchestratorObservedBody(completionText: string): string | undefined {
+  const trimmed = completionText.trimStart();
+  if (!trimmed.startsWith("[sub-agent:")) return undefined;
+  const headerEnd = trimmed.indexOf("]");
+  if (headerEnd < 0) return undefined;
+  const body = trimmed.slice(headerEnd + 1).trim();
+  if (!body?.includes("Files written (verified on disk)")) {
+    return undefined;
+  }
+  return body;
+}
+
 export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
   name: "agent-orchestrator.sub-agent-completion",
   description:
@@ -680,6 +698,7 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
       return true;
     }
     if (deliverableFromMetadata(message) !== undefined) return true;
+    if (orchestratorObservedBody(completionText) !== undefined) return true;
     if (hasVerifiedCompletionReply(currentReply, completionText, verifiedUrls))
       return true;
     if (hasCleanFinalProseAfterToolOutput(completionText)) return true;
@@ -703,12 +722,12 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     ) {
       return true;
     }
-    // An output-limited (`length`) or content-filtered (`content_filter`) sub-agent
+    // A truncated (`length`) or content-filtered (`content_filter`) sub-agent
     // completion is TERMINAL for the planner: the model ran out of room or was
     // blocked mid-answer, so a fresh TASKS_SPAWN_AGENT on the SAME root request
     // just truncates/blocks again — the ~70x weak-model re-spawn loop the cap
     // only bounds (issue elizaOS/eliza#8875). The ACP completion's stopReason is
-    // threaded here as subAgentFinishReason. Reject the partial, UNLESS
+    // threaded here as subAgentFinishReason. Relay the best partial once, UNLESS
     // the plan is feeding the still-running session more input
     // (TASKS_SEND_TO_AGENT), which is the one legitimate non-relay follow-up.
     if (
@@ -741,8 +760,15 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     const verificationCaveat = completionHasVerificationFailure(completionText)
       ? "Note: some resources referenced by the build failed verification — parts of the page may be broken."
       : undefined;
-    const withVerificationCaveat = (reply: string): string =>
-      verificationCaveat ? `${reply}\n\n${verificationCaveat}` : reply;
+    // Delivery funnel for every relay branch below: whatever authored the
+    // body, a loopback verification URL never reaches chat (live 2026-08-22:
+    // "serving correctly at `http://127.0.0.1:6900/apps/snake-game-2/`").
+    const withVerificationCaveat = (reply: string): string => {
+      const scrubbed = redactLoopbackUrls(reply);
+      return verificationCaveat
+        ? `${scrubbed}\n\n${verificationCaveat}`
+        : scrubbed;
+    };
     // The deliverable IS the sub-agent's printed/tool output (short, single
     // block; the router stripped it from the narration). Relay it verbatim
     // rather than letting the parent model re-summarize or truncate it.
@@ -763,9 +789,34 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
         ],
       };
     }
+    // Orchestrator-OBSERVED completion body (the router's direct workdir
+    // observation — "Files written (verified on disk): …" plus the served
+    // URL): these lines are verified fact, composed for delivery. Letting the
+    // planner re-phrase them produced a confident fabrication ("your
+    // static-noise app is live and the tv static effect is working" for a
+    // water-tracker build, live 2026-08-19). Relay verbatim.
+    const observedBody = orchestratorObservedBody(completionText);
+    if (observedBody !== undefined) {
+      return {
+        ...respondIfNeeded(messageHandler),
+        requiresTool: false,
+        setContexts: [SIMPLE_CONTEXT_ID],
+        clearCandidateActions: true,
+        clearParentActionHints: true,
+        reply: frameReplyWithVerification(
+          withVerificationCaveat(observedBody),
+          verification,
+        ),
+        debug: [
+          "completion body carries orchestrator-observed facts; relaying verbatim instead of re-phrasing",
+        ],
+      };
+    }
     // Incomplete completion (output-limited / content-filtered): reject it and
     // clear planner actions so neither a partial answer nor a re-spawn loop can
-    // masquerade as success (issue elizaOS/eliza#8875).
+    // masquerade as success (issue elizaOS/eliza#8875). Prompt-integrity: a
+    // paraphrased partial presented as the result is worse than an explicit
+    // failure the user can act on.
     const finishReason = finishReasonFromMetadata(message);
     if (
       isDegenerateFinishReason(finishReason) &&

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -115,6 +115,20 @@ export function extractFailureReason(errorOutput: string): string {
         .replace(/^\[[^\]]*\]\s*/, "")
         .trim(),
     )
+    // Never present the child's SUCCESS evidence as the failure reason: a
+    // verify-failed completion whose body leads with "Changed 1 file:
+    // README.md (verified on disk)" produced "Couldn't finish — Changed 1
+    // file… (verified on disk)" (live 2026-08-18) — an honesty inversion.
+    // Better no reason than a reason that contradicts the sentence.
+    .filter(
+      (line) =>
+        !/\(verified on disk\)|\bverified\b.*\b(?:file|url|disk)\b/i.test(
+          line,
+        ) &&
+        !/^(?:changed|created|updated|added|fixed|wrote)\b[^.!?]*\b(?:file|files|readme|\.md)\b/i.test(
+          line,
+        ),
+    )
     .find((line) => line.length > 0 && /\s/.test(line));
   if (!firstLine) return "";
   return toWellFormedUnicode(firstLine);
@@ -123,7 +137,10 @@ const shortReason = extractFailureReason;
 
 function buildFailureReply(label: string, reason: string): string {
   const what = label ? `the "${label}" task` : "that task";
-  const because = reason ? ` — ${reason}` : "";
+  // A reason often ends with its own period; strip it so the sentence
+  // punctuation composes ("timed out." → "timed out. Want me to retry?").
+  const trimmedReason = reason.replace(/[.\s]+$/u, "");
+  const because = trimmedReason ? ` — ${trimmedReason}` : "";
   return `Couldn't finish ${what}${because}. Want me to retry?`;
 }
 

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -5,6 +5,7 @@
  * spend-capped, or round-trip-capped session to resolve.
  */
 
+import { existsSync, readdirSync } from "node:fs";
 import {
   type IAgentRuntime,
   type Memory,
@@ -179,8 +180,19 @@ export const activeSubAgentsProvider: Provider = {
     const routed = (Array.isArray(all) ? all : [])
       .filter(hasOrigin)
       .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status));
+    // Finished-work ground truth for follow-ups. With zero active sessions a
+    // "run it / show me" follow-up left the planner blind to where the
+    // deliverable lives — it guessed a wrong path, fell back to
+    // `find $HOME`, and timed out twice in a row (live 2026-08-20). Every
+    // lane finished within the 30-minute window is listed, newest first —
+    // the window (named in the section header) keeps older history out of
+    // context; nothing inside it is elided.
+    const recentDone = recentCompletedLines(Array.isArray(all) ? all : []);
     if (routed.length === 0)
-      return emptyResult(capacity, admission, waves, inFlightTaskLines);
+      return emptyResult(capacity, admission, waves, [
+        ...inFlightTaskLines,
+        ...recentDone,
+      ]);
 
     routed.sort((a, b) => a.id.localeCompare(b.id));
 
@@ -195,6 +207,9 @@ export const activeSubAgentsProvider: Provider = {
     // just `status=busy`. The buffer mixes message chunks and captured
     // tool output — we take the last ~200 chars, strip noise, and surface
     // it as a one-line `live: …` suffix.
+    // NAMED PREVIEW: `live="…"` is a TAIL of the session output, never the
+    // output itself — a live-status indicator by design. The complete output
+    // is durable and resolvable via GET /api/coding-agents/:id/output?offset=.
     const liveByName = new Map<string, string>();
     if (typeof service.getSessionOutput === "function") {
       await Promise.all(
@@ -231,6 +246,7 @@ export const activeSubAgentsProvider: Provider = {
       );
     }
     lines.push(...inFlightTaskLines);
+    lines.push(...recentDone);
     const text = lines.join("\n");
 
     return {
@@ -244,6 +260,9 @@ export const activeSubAgentsProvider: Provider = {
           status: s.status,
           stalled: stalled.has(s.id),
           approachingCap: approaching.get(s.id) ?? null,
+          // Full absolute workdir is the canonical value; workdirTail is the
+          // NAMED PREVIEW used by the cache-stable text line (see formatLine).
+          workdir: s.workdir,
           workdirTail: workdirTail(s.workdir),
           originRoomId: (s.metadata as Record<string, unknown> | undefined)
             ?.roomId,
@@ -413,6 +432,74 @@ function formatWaveLines(waves: readonly WaveStatusSnapshot[]): string[] {
   );
 }
 
+const RECENT_COMPLETED_WINDOW_MS = 30 * 60_000;
+
+/** Compact "recently finished" lines: label, terminal status, sessionId, and
+ *  full workdir — the path ground truth a follow-up needs. Steers the planner
+ *  to SEND_TO_AGENT (whose dead-session redirect reopens the work in the same
+ *  workdir) instead of guessing paths or scanning the filesystem.
+ *
+ *  COMPLETE within its named scope (prompt integrity): every finished lane in
+ *  the 30-minute window is listed, newest-first — the window is the section's
+ *  definition of "recent", not a render bound, and the header names it.
+ *  Older history stays out by design; TASKS_HISTORY is its durable handle. */
+function recentCompletedLines(all: SessionInfo[]): string[] {
+  const now = Date.now();
+  const done = all
+    .filter(hasOrigin)
+    .filter((s) => TERMINAL_SESSION_STATUSES.has(s.status))
+    .filter((s) => {
+      const at = new Date(s.lastActivityAt ?? s.createdAt).getTime();
+      return Number.isFinite(at) && now - at < RECENT_COMPLETED_WINDOW_MS;
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.lastActivityAt ?? b.createdAt).getTime() -
+        new Date(a.lastActivityAt ?? a.createdAt).getTime(),
+    );
+  if (done.length === 0) return [];
+  return [
+    "## Recently finished sub-agent work (last 30 min — complete list, newest first)",
+    "Ground truth for follow-ups on a finished deliverable. When files are listed, they are verified on disk in the workdir. When the workdir was cleaned up, the ONLY working route is SEND_TO_AGENT { sessionId, text } — the orchestrator rebuilds and reopens the work; a SHELL path there fails. Never guess paths or search the filesystem for these files. For work older than this window, call TASKS_HISTORY.",
+    ...done.map(
+      (s) =>
+        `- [${labelOf(s)}] sessionId=${s.id} status=${s.status} ${describeFinishedWorkdir(s.workdir)}`,
+    ),
+  ];
+}
+
+/** Scratch workdirs are garbage-collected shortly after completion, so a
+ *  listed path may already be gone — the planner then runs a doomed SHELL
+ *  against it (live 2026-08-20: python3 <gc'd workspace>/main.py errored and
+ *  the turn ended in an apology). Verify on disk and, when present, name every
+ *  visible top-level file so a run-it follow-up needs zero guessing. */
+function describeFinishedWorkdir(workdir: string): string {
+  try {
+    if (!workdir || !existsSync(workdir)) {
+      return "workdir=(cleaned up — reopen via SEND_TO_AGENT)";
+    }
+    const files = readdirSync(workdir)
+      .filter(
+        (name) =>
+          !name.startsWith(".") && name !== "node_modules" && name !== "venv",
+      )
+      // Deterministic: readdir order is fs-dependent; sort so the same names
+      // show in the same order every turn (cache-stable provider text).
+      .sort();
+    // COMPLETE listing (prompt integrity): every visible top-level entry is
+    // named with its exact count, so a run-it follow-up never needs to probe
+    // for a file the bound used to hide. The workdir path on the same line
+    // remains the durable on-disk location.
+    return files.length > 0
+      ? `workdir=${workdir} files(${files.length})=${files.join(",")}`
+      : `workdir=${workdir} (empty)`;
+  } catch {
+    // error-policy:J4 disk probe is per-line enrichment; an unreadable dir
+    // degrades to the bare path rather than dropping the session line.
+    return `workdir=${workdir}`;
+  }
+}
+
 function emptyResult(
   capacity: AcpCapacity | null = null,
   admission: AdmissionSnapshot | null = null,
@@ -460,6 +547,12 @@ function hasOrigin(session: SessionInfo): boolean {
   return typeof roomId === "string" && roomId.length > 0;
 }
 
+// NAMED PREVIEW: `workdir=…{tail}` shows only the last two path segments (the
+// `…` marker names the elision). The FULL absolute workdir rides in the data
+// payload (`sessions[].workdir`), and the sanctioned handle for acting on an
+// ACTIVE lane is SEND_TO_AGENT { sessionId } — never a path reconstructed from
+// this preview (truncated paths caused live path-guessing failures; the
+// finished-work section switched to full paths for exactly that reason).
 function formatLine(
   session: SessionInfo,
   live?: string,

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -14,8 +14,21 @@ import {
   type Memory,
 } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
-import { markSessionAdministrativelyStopped } from "./admin-stop-marker.js";
+import {
+  activateFollowUpOrigin,
+  notePendingFollowUpOrigin,
+  originMessageIdFor,
+} from "./follow-up-origin.js";
+import {
+  ADMIN_STOP_META_KEY,
+  markSessionAdministrativelyStopped,
+} from "./admin-stop-marker.js";
 import { decideInterruptionWithModel } from "./interruption-decider.js";
+import { OrchestratorTaskService } from "./orchestrator-task-service.js";
+import type {
+  OrchestratorTaskRecord,
+  OrchestratorTaskStatus,
+} from "./orchestrator-task-types.js";
 import { sessionBoundRoomIds } from "./session-room-binding.js";
 import type { SubAgentInbox } from "./sub-agent-inbox.js";
 import { requireTaskAgentAccess } from "./task-policy.js";
@@ -43,6 +56,73 @@ export function isSessionBusy(status: string): boolean {
 }
 
 const SRC = "@elizaos/plugin-agent-orchestrator";
+
+/** Structural view of ORCHESTRATOR_TASK_SERVICE for the forward gate. Looked
+ * up per event and typeof-guarded so the forwarder behaves identically (fails
+ * OPEN: forward) when the service is absent or its surface drifts. */
+type DurableTaskLookup = {
+  getTaskForSession?: (
+    sessionId: string,
+  ) => Promise<OrchestratorTaskRecord | null>;
+};
+
+const ORCHESTRATOR_TASK_SERVICE_TYPE = "ORCHESTRATOR_TASK_SERVICE";
+
+/** Task statuses whose sessions must never receive live room forwards. */
+const FORWARD_DROP_STATUSES: ReadonlySet<OrchestratorTaskStatus> =
+  new Set<OrchestratorTaskStatus>(["archived", "failed"]);
+
+/**
+ * Should a live-room user message still be forwarded to this session, given
+ * its durable task record? The contamination defect: sessions SURVIVE their
+ * task being parked/archived (keepAliveAfterComplete workers sit `ready`), and
+ * without this gate an old session absorbed a NEW request and built the wrong
+ * artifact under the dead task's label.
+ *
+ * Rules (fail-open — only a POSITIVE terminal signal drops):
+ *  - no record → forward (sessions without durable tasks are legitimate);
+ *  - archived flag or archived/failed status → drop;
+ *  - done → drop unless the session opted into completed-session follow-ups
+ *    (its own `keepAliveAfterComplete` metadata — the deliberate feature);
+ *  - waiting_on_user → drop for verify parks: the new stamps (verifyParkedAt /
+ *    verifyEscalationNotifiedAt) or, for tasks parked BEFORE the stamps
+ *    existed, a persisted `autoVerifyAttempts` counter — both park branches
+ *    write that counter before parking, so every pre-stamp verify park
+ *    carries it. Question/login parks keep forwarding so the user's answer
+ *    still reaches the blocked session;
+ *  - open/active/blocked/validating/interrupted → forward.
+ */
+export function shouldForwardForTask(
+  task: OrchestratorTaskRecord | null,
+  sessionMeta: Record<string, unknown> | undefined,
+): boolean {
+  if (!task) return true;
+  if (task.archived === true) return false;
+  const status = task.status;
+  if (FORWARD_DROP_STATUSES.has(status)) return false;
+  if (status === "done") {
+    return sessionMeta?.keepAliveAfterComplete === true;
+  }
+  if (status === "waiting_on_user") {
+    const meta = task.metadata ?? {};
+    // Tradeoff, deliberate: `autoVerifyAttempts >= 1` also matches the narrow
+    // case of a login/question park that happens AFTER a failed verify
+    // attempt on a row without the new stamps — that user answer is muted
+    // too. Accepted: the alternative left every pre-stamp verify-parked
+    // session absorbing NEW room messages forever (the live contamination
+    // defect), and post-stamp verify parks always carry verifyParkedAt so
+    // the ambiguity only spans rows parked before the stamps deployed.
+    // Unstamped waiting_on_user WITHOUT any verify signal keeps forwarding —
+    // muting it would break every live login/question park.
+    const verifyParked = Boolean(
+      meta.verifyParkedAt ||
+        meta.verifyEscalationNotifiedAt ||
+        Number(meta.autoVerifyAttempts) >= 1,
+    );
+    return !verifyParked;
+  }
+  return true;
+}
 
 /**
  * Build the MESSAGE_RECEIVED handler that forwards mid-task user messages to
@@ -98,29 +178,118 @@ export function createActiveSessionForwardHandler(
       };
       const bound = sessions.filter(boundToRoom);
       if (bound.length === 0) return;
+      // Belt (sync): a session stamped administratively stopped is dead to
+      // the room even when the actual ACP stop failed/raced — never forward
+      // into it.
+      const unstopped = bound.filter((s) => {
+        const meta = s.metadata as Record<string, unknown> | undefined;
+        const adminStopped =
+          typeof meta?.[ADMIN_STOP_META_KEY] === "string" &&
+          (meta[ADMIN_STOP_META_KEY] as string).length > 0;
+        if (adminStopped) {
+          runtime.logger?.debug?.(
+            { src: SRC, sessionId: s.id, reason: meta?.[ADMIN_STOP_META_KEY] },
+            "active-session forward suppressed: administratively stopped",
+          );
+        }
+        return !adminStopped;
+      });
+      if (unstopped.length === 0) return;
+      // Durable-task gate (async): a session whose task is archived, failed,
+      // done (without the deliberate keep-alive follow-up opt-in), or
+      // verify-parked must not absorb live room traffic — that contamination
+      // built the wrong artifact under a dead task's label. Fail-open at
+      // every step: no service, no record, or a lookup error keeps
+      // forwarding.
+      const taskSvc = runtime.getService(
+        ORCHESTRATOR_TASK_SERVICE_TYPE,
+      ) as DurableTaskLookup | null;
+      const hasTaskLookup = typeof taskSvc?.getTaskForSession === "function";
+      const gated: SessionInfo[] = [];
+      for (const s of unstopped) {
+        if (!hasTaskLookup) {
+          gated.push(s);
+          continue;
+        }
+        let task: OrchestratorTaskRecord | null = null;
+        let lookupFailed = false;
+        try {
+          task = (await taskSvc?.getTaskForSession?.(s.id)) ?? null;
+        } catch (err) {
+          // error-policy:J4 task lookup unavailable degrades to forwarding
+          // (today's behavior); the failure is warned so a broken gate is
+          // observable instead of silently dropping user messages.
+          lookupFailed = true;
+          runtime.logger?.warn?.(
+            {
+              src: SRC,
+              sessionId: s.id,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "active-session forward task lookup failed; forwarding",
+          );
+        }
+        if (
+          lookupFailed ||
+          shouldForwardForTask(
+            task,
+            s.metadata as Record<string, unknown> | undefined,
+          )
+        ) {
+          gated.push(s);
+        } else {
+          runtime.logger?.debug?.(
+            {
+              src: SRC,
+              sessionId: s.id,
+              taskId: task?.id,
+              taskStatus: task?.status,
+            },
+            "active-session forward suppressed: task no longer accepts room forwards",
+          );
+        }
+      }
+      if (gated.length === 0) return;
       const text =
         typeof (message.content as { text?: unknown })?.text === "string"
           ? ((message.content as { text: string }).text ?? "").trim()
           : "";
       if (!text) return;
       if (typeof acp.sendPrompt !== "function") return;
+      const followUpOriginId = originMessageIdFor(message);
       // ACL: forwarding user text mid-flight is functionally identical to the
       // TASKS_SEND_TO_AGENT action — without this any user with channel write
       // access could inject prompts into another user's sub-agent.
       const access = await requireTaskAgentAccess(runtime, message, "interact");
       if (!access.allowed) return;
 
-      // "Crowded room": more than one live sub-agent bound to this room.
-      const multiParty = bound.length > 1;
+      // "Crowded room": more than one live sub-agent bound to this room —
+      // computed from the POST-gate list so suppressed sessions don't inflate
+      // the classifier's crowd signal.
+      const multiParty = gated.length > 1;
       // Every bound live session gets its own interruption decision and its
       // own delivery/queue — a room with several live sub-agents must not
       // quietly forward the user's text to only the first in list order.
-      for (const active of bound) {
+      for (const active of gated) {
         const label =
           typeof active.metadata?.label === "string"
             ? active.metadata.label
             : active.name;
-        const busy = isSessionBusy(active.status);
+        // A smithers-driven session's conversation belongs to the workflow
+        // executor for the run's whole lifetime: a direct deliverNow prompt
+        // races the executor's own turn and killed the workflow mid-build
+        // ("status failed" ~10s after a follow-up arrived, live 2026-08-20
+        // — bmi / password-generator / yahtzee). Treat it as busy so every
+        // relevant follow-up queues; the idle-flush (or the orphan redirect
+        // when the session stops at completion) owns delivery.
+        const activeMeta = (active.metadata ?? {}) as Record<string, unknown>;
+        const smithersRunState = (
+          activeMeta.smithersDurableRun as { state?: string } | undefined
+        )?.state;
+        const busy =
+          isSessionBusy(active.status) ||
+          smithersRunState === "running" ||
+          smithersRunState === "pending";
         // What the sub-agent is working on, for the model classifier's
         // relevance judgement — best-effort from session metadata (all
         // optional).
@@ -177,9 +346,13 @@ export function createActiveSessionForwardHandler(
         // text is never silently dropped — the flush listener retries it.
         const deliverNow = async (payload: string) => {
           try {
+            // The delivered follow-up's completion claims ITS OWN voice slot
+            // (see follow-up-origin.ts).
+            await activateFollowUpOrigin(acp, active.id, followUpOriginId);
             await acp.sendPrompt(active.id, payload);
           } catch (err) {
             // error-policy:J4 sendPrompt failed → requeue for flush-listener retry; user text never dropped
+            await notePendingFollowUpOrigin(acp, active.id, followUpOriginId);
             subAgentInbox.enqueue(active.id, payload);
             runtime.logger?.warn?.(
               {
@@ -196,7 +369,38 @@ export function createActiveSessionForwardHandler(
           case "ignore":
             continue;
           case "interrupt": {
+            const taskService = runtime.getService?.(
+              OrchestratorTaskService.serviceType,
+            ) as OrchestratorTaskService | null | undefined;
             if (!busy) {
+              // The session is idle, but its TASK may still be in flight
+              // (validating / awaiting a verify lap): the stop applies to the
+              // task. Prompting the idle child with "actually stop, cancel
+              // that build" made it invent deploy scripts for three coaching
+              // laps (live 2026-08-22, tetris).
+              let taskInterrupted = false;
+              if (taskService) {
+                try {
+                  const owner = await taskService.getTaskForSession(active.id);
+                  if (owner) {
+                    taskInterrupted = await taskService.interruptTask(
+                      owner.id,
+                      "user_interrupt",
+                    );
+                  }
+                } catch {
+                  // error-policy:J6 best-effort; fall through to delivery.
+                }
+              }
+              if (taskInterrupted) {
+                subAgentInbox.clear(active.id);
+                await markSessionAdministrativelyStopped(
+                  acp,
+                  active.id,
+                  "user_interrupt",
+                ).catch(() => undefined);
+                continue;
+              }
               // Nothing in flight to cancel — deliver the instruction to the
               // idle agent instead of dropping it.
               const queued = subAgentInbox.drain(active.id);
@@ -207,31 +411,76 @@ export function createActiveSessionForwardHandler(
             // planner pipeline runs on this same MESSAGE_RECEIVED and routes
             // the user's redirect; we do not re-deliver to the dead session.
             subAgentInbox.clear(active.id);
-            // Stamp FIRST: the coordinator's stopped/cancelled synthesis reads
-            // this so a user-initiated interrupt never narrates as a task
-            // failure ("stopped before completion") or gets auto-retried.
+            // Stamp FIRST: the coordinator's stopped/cancelled synthesis and
+            // the verify-retry gate read this so a user-initiated interrupt
+            // never narrates as a task failure ("stopped before completion")
+            // or gets auto-retried.
             await markSessionAdministrativelyStopped(
               acp,
               active.id,
               "user_interrupt",
-            );
-            // error-policy:J6 best-effort session cancel on interrupt; warn only
-            await acp.cancelSession?.(active.id)?.catch?.((err: unknown) =>
+            ).catch(() => undefined);
+            // Cooperative cancel first; the eliza-code ACP server often never
+            // confirms `session/cancel`, and giving up there let a cancelled
+            // build run to completion and post its result after the user's
+            // cancel (live 2026-08-19). An unconfirmed interrupt escalates to
+            // a hard stop — that is what the user asked for.
+            // The task OWNS the lane plan, respawns, and verify laps: stop
+            // it first, or the remaining lanes of a phased build launch right
+            // after this session dies (live 2026-08-22, tetris: 3 more lanes
+            // ran to verification after "stopping the build now").
+            if (taskService) {
+              try {
+                const owner = await taskService.getTaskForSession(active.id);
+                if (owner) {
+                  await taskService.interruptTask(owner.id, "user_interrupt");
+                }
+              } catch (err) {
+                // error-policy:J6 best-effort; the session stop below still
+                // ends the in-flight work.
+                runtime.logger?.warn?.(
+                  {
+                    src: SRC,
+                    sessionId: active.id,
+                    err: err instanceof Error ? err.message : String(err),
+                  },
+                  "interrupt could not mark the owning task interrupted",
+                );
+              }
+            }
+            try {
+              await acp.cancelSession?.(active.id);
+            } catch (err) {
               runtime.logger?.warn?.(
                 {
                   src: SRC,
                   sessionId: active.id,
                   err: err instanceof Error ? err.message : String(err),
                 },
-                "interrupt cancel failed",
-              ),
-            );
+                "interrupt cancel unconfirmed; escalating to hard stop",
+              );
+              // error-policy:J6 best-effort teardown; the stop failure is logged
+              await acp.stopSession?.(active.id)?.catch?.((stopErr: unknown) =>
+                runtime.logger?.warn?.(
+                  {
+                    src: SRC,
+                    sessionId: active.id,
+                    err:
+                      stopErr instanceof Error
+                        ? stopErr.message
+                        : String(stopErr),
+                  },
+                  "interrupt hard stop failed",
+                ),
+              );
+            }
             continue;
           }
           default: {
             // deliver / queue. Mid-turn → queue for the flush listener;
             // otherwise flush + deliver immediately.
             if (busy) {
+              await notePendingFollowUpOrigin(acp, active.id, followUpOriginId);
               subAgentInbox.enqueue(active.id, text);
               continue;
             }

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -12,6 +12,15 @@
  * narration, so one task yields one user-facing completion rather than one per
  * lineage generation.
  */
+import {
+  boundedContentView,
+  orchestratorContentRef,
+} from "./durable-content.js";
+import { durableProjection } from "./durable-content-store.js";
+import { redactLoopbackUrls } from "./loopback-urls.js";
+
+export { redactLoopbackUrls } from "./loopback-urls.js";
+
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -34,6 +43,7 @@ import {
   toWellFormedUnicode,
   truncateWellFormed,
 } from "@elizaos/core";
+import { AGENT_VOICED_METADATA } from "../voice/phrase-for-user.js";
 import type { AcpService } from "./acp-service.js";
 import { resolveAppDeployConfig } from "./app-deploy-guidance.js";
 import { registerBuiltAppsForCompletion } from "./built-apps-registry.js";
@@ -44,6 +54,7 @@ import {
   hasHealthyPooledAccount,
   reportCodingAccountFailure,
 } from "./coding-account-selection.js";
+import { shouldAutoVerifyGoal } from "./goal-llm-verifier.js";
 import {
   beginPendingHandoff,
   settlePendingHandoff,
@@ -59,6 +70,12 @@ import {
   parentAgentMarkerIndex,
 } from "./parent-agent-dispatch.js";
 import {
+  collectFsObservedFiles,
+  deriveRouteMappedUrls,
+  enumerateWorkdirCandidates,
+  probeMappedUrls,
+} from "./quick-app-evidence.js";
+import {
   applyResumePreamble,
   buildResumeContext,
   RESUME_CONTEXT_METADATA_KEY,
@@ -68,6 +85,7 @@ import {
 import {
   createRouterLoopState,
   type RouterLoopState,
+  requestVoiceKeyForMeta,
   routerLoopTransition,
 } from "./router-loop-guard.js";
 import {
@@ -101,6 +119,23 @@ type RuntimeWithSendTarget = IAgentRuntime & {
 };
 
 const ACPX_ROUTER_SOURCE = MESSAGE_SOURCE_SUB_AGENT;
+
+/**
+ * Sources that are internal routing markers, never registered connector send
+ * handlers. A session spawned from a SYNTHETIC sub-agent turn can inherit one
+ * of these as its origin source when the tasks.ts one-level unwrap misses (the
+ * triggering synthetic memory carried no `originSource` — observed live: the
+ * app-control flow's "fix … deployment" follow-up spawn delivered its
+ * completion with source=sub_agent, the dashboard fallback handler rightly
+ * refused ambient delivery, and the user never saw the result). Delivery-time
+ * resolution through the room row (which knows its creating connector) is the
+ * catch-all for every spawn path.
+ */
+const INTERNAL_MARKER_SOURCES = new Set<string>([
+  MESSAGE_SOURCE_SUB_AGENT,
+  "sub_agent_complete",
+  "orchestrator",
+]);
 const SUB_AGENT_ENTITY_NAMESPACE = "acpx:sub-agent";
 // Display name of the ONE shared entity every router post is attributed to.
 // The name is frozen at first creation per DB (adapter-side
@@ -143,6 +178,78 @@ const HANDOFF_PENDING_META_KEY = "routerHandoffPendingAt";
 // a first-class one without re-deriving it. Exported as a matching literal in
 // the tests (no cross-import). See sanitizeSuccessorMetadata below.
 export const SUCCESSOR_ROOM_INHERITED_META_KEY = "successorRoomInherited";
+
+// Durable stamp of every deferred (held) completion relay, keyed by sessionId
+// on the owning task's metadata. Written at defer time, cleared only after the
+// released relay actually posts, so a restart between defer and release
+// reconstructs the held completion from the store instead of swallowing it
+// (the in-memory map + timer die with the process).
+export const PENDING_COMPLETION_RELAYS_META_KEY = "pendingCompletionRelays";
+
+/** How long a deferred completion relay waits for a verification verdict
+ *  before the fallback releases it as `unverified`. */
+export const DEFERRED_RELAY_FALLBACK_MS = 5 * 60 * 1000;
+
+/** The three ways a held completion relay resolves. `passed` re-enters the
+ *  deferred task_complete; `failed` drops it (verify-retry/park messaging owns
+ *  the narrative); `unverified` re-enters it WITH an explicit disclosure — the
+ *  verdict never arrived, and the relay must never fabricate a pass. */
+export type DeferredRelayVerdict = "passed" | "failed" | "unverified";
+
+/** Body line appended to a relay released without a verification verdict. */
+export const UNVERIFIED_RELAY_DISCLOSURE =
+  "Note: verification did not complete — result delivered unverified.";
+
+/** Duck-typed task-service surface the durable relay stamps read and write. */
+interface RelayStampTaskService {
+  getTask: (taskId: string) => Promise<{
+    id?: string;
+    status?: string;
+    metadata?: Record<string, unknown> | null;
+  } | null>;
+  updateTask: (
+    taskId: string,
+    patch: { metadata?: Record<string, unknown> },
+  ) => Promise<unknown>;
+  listTasks?: (
+    filter: Record<string, unknown>,
+  ) => Promise<Array<{ id: string; status?: string }>>;
+}
+
+/** One durable pending-relay stamp (see PENDING_COMPLETION_RELAYS_META_KEY). */
+interface PendingRelayStamp {
+  taskId: string;
+  sessionId: string;
+  deferredAt: string;
+  data: unknown;
+  turnId?: string;
+}
+
+/** Parse the durable pending-relay stamps off a task metadata record.
+ *  Malformed entries are dropped (never thrown): the stamps are restart
+ *  recovery data, and a corrupt one must not block startup. */
+function readPendingRelayStamps(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, PendingRelayStamp> {
+  const raw = metadata?.[PENDING_COMPLETION_RELAYS_META_KEY];
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, PendingRelayStamp> = {};
+  for (const [sessionId, value] of Object.entries(
+    raw as Record<string, unknown>,
+  )) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const v = value as Record<string, unknown>;
+    out[sessionId] = {
+      taskId: typeof v.taskId === "string" ? v.taskId : "",
+      sessionId,
+      deferredAt: typeof v.deferredAt === "string" ? v.deferredAt : "",
+      data: v.data,
+      ...(typeof v.turnId === "string" ? { turnId: v.turnId } : {}),
+    };
+  }
+  return out;
+}
+
 const QUESTION_FOR_TASK_CREATOR = "QUESTION_FOR_TASK_CREATOR";
 const AGENT_COORDINATION = "AGENT_COORDINATION";
 const SWARM_ROLE_ORDER = ["task", "worktree", "origin"] as const;
@@ -240,9 +347,13 @@ function collectVerifiableUrlCandidates(
   return candidates;
 }
 
+// COMPLETE extraction: every completion-claimed URL that survives the alias/
+// route filters is returned and probed (in bounded-concurrency batches — see
+// VERIFY_PROBE_BATCH in annotateUnverifiedUrls). The former `.slice(0, 5)`
+// silently exempted the 6th+ URL from liveness verification, so a dead one
+// escaped the verify-retry gate while the relay implied full coverage.
 function extractVerifiableUrls(
   text: string,
-  limit = 5,
   referenceText?: string,
   ignoredUrls?: ReadonlySet<string>,
 ): string[] {
@@ -267,7 +378,7 @@ function extractVerifiableUrls(
   const aliasFiltered = referenceUrls?.size
     ? filterModelIntroducedUrlAliases(routeFocused, referenceUrls)
     : routeFocused;
-  return aliasFiltered.slice(0, limit);
+  return aliasFiltered;
 }
 
 // The augmented initial task (taskWithResolvedRoute) appends the user's verbatim
@@ -275,14 +386,11 @@ function extractVerifiableUrls(
 // We slice the user portion out so intent/URL detection never keys on the
 // injected route hint text (which literally contains the word "URL" and a
 // route-prefix URL).
-const USER_TASK_MARKER = "--- User Task ---";
+import { ADMIN_STOP_META_KEY } from "./admin-stop-marker.js";
+import { userTaskFromInitialTask } from "./user-task-text.js";
 
 function userTaskSlice(referenceText: string | undefined): string {
-  if (!referenceText) return "";
-  const idx = referenceText.lastIndexOf(USER_TASK_MARKER);
-  return idx >= 0
-    ? referenceText.slice(idx + USER_TASK_MARKER.length)
-    : referenceText;
+  return userTaskFromInitialTask(referenceText);
 }
 
 function shouldVerifyCompletionUrls(
@@ -548,25 +656,8 @@ function supervisorAllowedLoopbackPorts(
 // (localhost / 127.x.x.x / ::1) and strip trailing whitespace cleanly so
 // the surrounding sentence stays readable; if a line becomes only a
 // dangling colon / dash after stripping, drop the line.
-const LOOPBACK_URL_PATTERN =
-  /https?:\/\/(?:localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[?::1\]?)(?::\d{1,5})?(?:\/[^\s)<>"`]*)?/gi;
-export function redactLoopbackUrls(text: string): string {
-  if (!text) return text;
-  LOOPBACK_URL_PATTERN.lastIndex = 0;
-  if (!LOOPBACK_URL_PATTERN.test(text)) return text;
-  LOOPBACK_URL_PATTERN.lastIndex = 0;
-  const stripped = text
-    .replace(LOOPBACK_URL_PATTERN, "")
-    .replace(/[ \t]+\n/g, "\n");
-  // Drop lines that became orphan punctuation after the URL was removed
-  // (e.g. "- " or "* " markdown list bullets pointing at nothing).
-  return stripped
-    .split("\n")
-    .filter((line) => !/^[-*\s]*[:>→\->]?[\s]*$/.test(line) || line === "")
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
+// redactLoopbackUrls lives in ./loopback-urls.ts (shared with the completion
+// evaluator); re-exported here for existing callers.
 
 function isTelemetryReportUrl(url: string): boolean {
   try {
@@ -669,6 +760,38 @@ export class SubAgentRouter extends Service {
   // double-post, no early force-stop, no leaked session (#9960, #7967).
   private loopState: RouterLoopState = createRouterLoopState();
 
+  // Completion relays deferred until the auto-verifier's verdict (default ON;
+  // ELIZA_RELAY_AFTER_VERIFY=0 restores immediate relays). Posting the child's
+  // "all set" the moment it reported, then parking two minutes later when
+  // verification failed, whipsawed the user with contradictory messages (live
+  // 2026-08-20, dark-mode edit). Keyed by taskId; a fallback timer releases
+  // the relay if no verdict ever lands (the verify body has silent
+  // stay-validating exits), so this can delay but never swallow a completion.
+  // The in-memory map is a fast path only: every deferral is ALSO stamped
+  // durably on the task record (metadata.pendingCompletionRelays, cleared
+  // after the released relay posts) so a restart reconstructs held
+  // completions instead of swallowing them — see
+  // reconstructPendingRelayStamps.
+  private readonly deferredCompletionRelays = new Map<
+    string,
+    {
+      sessionId: string;
+      data: unknown;
+      turnId?: string;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  /** Sessions currently re-entering handleEvent from a deferral release —
+   *  the defer check must not re-capture them. */
+  private readonly releasingDeferredRelaySessions = new Set<string>();
+
+  /** Sessions whose deferred relay is being released WITHOUT a verification
+   *  verdict (fallback timeout, or restart reconstruction past the window).
+   *  handleEvent appends {@link UNVERIFIED_RELAY_DISCLOSURE} to their relay
+   *  body so the completion never reads as a verified pass. */
+  private readonly unverifiedReleaseSessions = new Set<string>();
+
   // Per-root-origin spawn cap. The completion-dedupe slot above only
   // suppresses duplicate POSTS; it does not stop the PLANNER from re-spawning a
   // fresh sub-agent each time a (weak-model) completion comes back truncated or
@@ -683,6 +806,10 @@ export class SubAgentRouter extends Service {
   // NOT the per-spawn instruction text — so re-spawns collapse to one key while
   // distinct parallel TASKS:create subtasks are unaffected). FIFO bounded 1024.
   private readonly spawnCountsForOrigin = new Map<string, number>();
+  /** Volatile fast path only: the durable record is the task's
+   *  `metadata.canonicalBestResult`, persisted at capture time by
+   *  {@link persistCanonicalBestResult} — FIFO eviction here never loses the
+   *  captured answer. */
   private readonly bestResultForOrigin = new Map<
     string,
     { text: string; deliverable?: string }
@@ -717,22 +844,26 @@ export class SubAgentRouter extends Service {
    *  truncated 479). Longest-wins presumes every recorded result is relayable —
    *  handleEvent gates verify-FAILED completions out upstream
    *  (captureOriginResultForCompletion) so a failed build's verbose narration
-   *  can never shadow a successful retry's shorter answer. */
+   *  can never shadow a successful retry's shorter answer.
+   *  Returns true when the result became the new best (the caller then
+   *  persists it as the task's `canonicalBestResult` — this map is a volatile
+   *  FIFO-bounded fast path, not the durable record). */
   recordOriginResult(
     originKey: string,
     result: { text: string; deliverable?: string },
-  ): void {
+  ): boolean {
     const candidate = (result.deliverable ?? result.text ?? "").trim();
-    if (!candidate) return;
+    if (!candidate) return false;
     const prev = this.bestResultForOrigin.get(originKey);
     const prevLen = (prev?.deliverable ?? prev?.text ?? "").trim().length;
-    if (prev && candidate.length <= prevLen) return;
+    if (prev && candidate.length <= prevLen) return false;
     this.bestResultForOrigin.set(originKey, result);
     while (this.bestResultForOrigin.size > 1024) {
       const oldest = this.bestResultForOrigin.keys().next().value;
       if (!oldest) break;
       this.bestResultForOrigin.delete(oldest);
     }
+    return true;
   }
 
   /**
@@ -766,10 +897,77 @@ export class SubAgentRouter extends Service {
     const originResultKey =
       origin.parentConnectorMessageId ?? origin.spawnRootMessageId;
     if (!originResultKey) return;
-    this.recordOriginResult(`${originResultKey}\0${session.agentType}`, {
+    const originKey = `${originResultKey}\0${session.agentType}`;
+    const becameBest = this.recordOriginResult(originKey, {
       text,
       deliverable,
     });
+    // Durable twin of the volatile map: persist the captured best result onto
+    // the task record at capture time, so a spawn-cap relay (or any reader)
+    // can recover the finished answer after FIFO eviction or a restart.
+    if (becameBest) {
+      void this.persistCanonicalBestResult(session.id, originKey, {
+        text,
+        deliverable,
+      });
+    }
+  }
+
+  /**
+   * Persist the origin's best captured result as `metadata.canonicalBestResult`
+   * on the session's durable task record. Best-effort by design: the volatile
+   * map stays authoritative for the in-process fast path, and a persistence
+   * failure must never break completion routing — but it is reported, not
+   * swallowed silently.
+   */
+  private async persistCanonicalBestResult(
+    sessionId: string,
+    originKey: string,
+    result: { text: string; deliverable?: string },
+  ): Promise<void> {
+    try {
+      const tasks = this.runtime.getService("ORCHESTRATOR_TASK_SERVICE") as {
+        getTaskForSession?: (sessionId: string) => Promise<{
+          id?: string;
+          metadata?: Record<string, unknown> | null;
+        } | null>;
+        updateTask?: (
+          taskId: string,
+          patch: { metadata?: Record<string, unknown> },
+        ) => Promise<unknown>;
+      } | null;
+      if (
+        !tasks ||
+        typeof tasks.getTaskForSession !== "function" ||
+        typeof tasks.updateTask !== "function"
+      ) {
+        return;
+      }
+      const record = await tasks.getTaskForSession(sessionId);
+      if (!record?.id) return;
+      await tasks.updateTask(record.id, {
+        metadata: {
+          ...(record.metadata ?? {}),
+          canonicalBestResult: {
+            originKey,
+            text: result.text,
+            ...(result.deliverable !== undefined
+              ? { deliverable: result.deliverable }
+              : {}),
+            sessionId,
+            capturedAt: new Date().toISOString(),
+          },
+        },
+      });
+    } catch (err) {
+      // error-policy:J7 durable-record write is recovery bookkeeping alongside
+      // the live relay; a failed write is reported and must not kill routing.
+      this.log("warn", "canonicalBestResult persistence failed", {
+        sessionId,
+        originKey,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**
@@ -785,6 +983,94 @@ export class SubAgentRouter extends Service {
   /** The configured per-session round-trip cap (the runaway-loop force-stop limit). */
   getRoundTripCap(): number {
     return this.loopState.roundTripCap;
+  }
+
+  // ---- request-voice ledger ------------------------------------------------
+  // ONE user coding request (stable requestKey, across sessions AND respawns)
+  // gets at most one spawn ack and one user-facing terminal, with a single
+  // sanctioned provisional-result → parked supersede. The task service and
+  // coordinator consume these STRUCTURALLY via
+  // runtime.getService("ACPX_SUB_AGENT_ROUTER") + per-method typeof checks and
+  // fail open when the router is absent — the ledger can only ever REMOVE
+  // messages, never introduce a silent-drop mode of its own.
+
+  /**
+   * Claim the single spawn-ack slot for `requestKey`. True ⇒ this caller may
+   * post the ack; false ⇒ an ack already went out for this request.
+   */
+  claimRequestAck(requestKey: string, sessionId: string): boolean {
+    const t = routerLoopTransition(this.loopState, {
+      type: "claim_request_ack",
+      requestKey,
+      sessionId,
+    });
+    this.loopState = t.state;
+    return t.decision.kind === "ack_granted";
+  }
+
+  /**
+   * Claim the single user-facing terminal slot for `requestKey`. `granted`
+   * false ⇒ suppress the post (`holderKind` says what already holds the
+   * voice); `superseded` true ⇒ a sanctioned correction replaced the holder
+   * (park notice over a provisional result, or a genuine result over the
+   * failure narration that invited the retry).
+   */
+  claimRequestTerminal(
+    requestKey: string,
+    sessionId: string,
+    kind: "result" | "parked" | "failure",
+    provisional: boolean,
+  ): { granted: boolean; superseded?: boolean; holderKind?: string } {
+    const t = routerLoopTransition(this.loopState, {
+      type: "claim_request_terminal",
+      requestKey,
+      sessionId,
+      kind,
+      provisional,
+    });
+    this.loopState = t.state;
+    switch (t.decision.kind) {
+      case "terminal_granted":
+        return { granted: true };
+      case "terminal_granted_supersede":
+        return { granted: true, superseded: true };
+      case "terminal_denied":
+        return { granted: false, holderKind: t.decision.holderKind };
+      default:
+        // Unreachable: the two claim events only produce the three decisions
+        // above. Fail open (post) rather than invent a new silent-drop mode.
+        return { granted: true };
+    }
+  }
+
+  /** Whether `requestKey`'s terminal slot is settled (nothing may post after it). */
+  isRequestTerminalFinalized(requestKey: string): boolean {
+    return (
+      this.loopState.requestVoice.get(requestKey)?.terminal?.finalized === true
+    );
+  }
+
+  /**
+   * A NEW spawn was admitted for `requestKey` (verify-driven or planner-driven
+   * retry, via the TASKS spawn paths). Clears a `failure` terminal held by an
+   * earlier generation so the retry regains the request's voice — without this
+   * the error narration that INVITED the retry kept the key finalized: the
+   * retry's progress and questions were muted and its genuine completion was
+   * terminal_denied (live defect). Result/parked holders and the ack slot are
+   * untouched. True ⇒ a failure terminal was cleared.
+   */
+  noteRespawnAdmitted(requestKey: string): boolean {
+    const t = routerLoopTransition(this.loopState, {
+      type: "respawn_admitted",
+      requestKey,
+    });
+    this.loopState = t.state;
+    return t.decision.kind === "voice_reset";
+  }
+
+  /** Thin re-export of the canonical request-key ladder (router-loop-guard.ts). */
+  requestKeyForMeta(meta: Record<string, unknown> | undefined): string | null {
+    return requestVoiceKeyForMeta(meta);
   }
 
   /**
@@ -875,6 +1161,10 @@ export class SubAgentRouter extends Service {
     const acpBound = !!this.unsubscribe;
     if (acpBound) {
       this.log("info", "router bound to AcpService");
+      // Restart recovery: a deferral held only in the predecessor process's
+      // Map/timer would otherwise be swallowed. Rebuild pending relays from
+      // their durable task stamps now that the session source is available.
+      void this.reconstructPendingRelayStamps();
       return;
     }
     // Service startup is lazy and can happen outside this plugin's ordered
@@ -897,6 +1187,11 @@ export class SubAgentRouter extends Service {
   }
 
   async stop(): Promise<void> {
+    for (const pending of this.deferredCompletionRelays.values()) {
+      clearTimeout(pending.timer);
+    }
+    this.deferredCompletionRelays.clear();
+    this.unverifiedReleaseSessions.clear();
     this.stopped = true;
     if (this.bindRetryTimer) {
       clearTimeout(this.bindRetryTimer);
@@ -1049,7 +1344,7 @@ export class SubAgentRouter extends Service {
     if (!session) return;
     if (this.verifyRetryHandedOffSessions.has(sessionId)) {
       this.log(
-        "debug",
+        "warn",
         "suppressing original session event after verify retry handoff",
         {
           sessionId,
@@ -1057,6 +1352,87 @@ export class SubAgentRouter extends Service {
         },
       );
       return;
+    }
+    if (
+      event === "task_complete" &&
+      !this.releasingDeferredRelaySessions.has(sessionId)
+    ) {
+      const deferTaskId = await this.completionRelayDeferralTaskId(sessionId);
+      if (deferTaskId === "drop") return;
+      if (deferTaskId) {
+        // Keyed per lane: two lanes of one task defer independently, and a
+        // lane's verdict releases only its own relay (live 2026-08-22: the
+        // second lane's deferral overwrote the first's).
+        const deferKey = `${deferTaskId}\u0000${sessionId}`;
+        const existing = this.deferredCompletionRelays.get(deferKey);
+        if (existing) clearTimeout(existing.timer);
+        const timer = setTimeout(() => {
+          // Never-silent fallback: a verdict that never lands (silent
+          // stay-validating exits in the verify body) must not swallow the
+          // completion forever. Released as `unverified`, never `passed` —
+          // the relay body discloses that verification did not complete
+          // instead of fabricating a pass.
+          this.log(
+            "warn",
+            "deferred completion relay released by timeout — no verification verdict arrived; relaying unverified",
+            { taskId: deferTaskId, sessionId },
+          );
+          this.releaseDeferredCompletionRelay(
+            deferTaskId,
+            "unverified",
+            sessionId,
+          );
+        }, DEFERRED_RELAY_FALLBACK_MS);
+        timer.unref?.();
+        this.deferredCompletionRelays.set(deferKey, {
+          sessionId,
+          data,
+          turnId,
+          timer,
+        });
+        // Durable twin of the map entry: awaited so the completion is
+        // restart-recoverable BEFORE handleEvent yields the defer.
+        await this.persistPendingRelayStamp(
+          deferTaskId,
+          sessionId,
+          data,
+          turnId,
+        );
+        this.log(
+          "info",
+          "deferring completion relay until the verification verdict",
+          { taskId: deferTaskId, sessionId },
+        );
+        return;
+      }
+    }
+    if (event === "error" || event === "stopped") {
+      // A user-initiated stop must not narrate as a task failure: the stop
+      // confirmation is the single notice, but the killed child's terminal
+      // raced the admin-stop stamp and relayed "couldn't finish X. try again."
+      // right before "Stopped N task agents." (live 2026-08-19). Fresh-read
+      // the stamp — the event-time snapshot predates it.
+      try {
+        const freshStamp = await this.acp?.getSession(sessionId);
+        const stampMeta = freshStamp?.metadata as
+          | Record<string, unknown>
+          | undefined;
+        if (typeof stampMeta?.[ADMIN_STOP_META_KEY] === "string") {
+          this.log(
+            "info",
+            "suppressing terminal relay for user-stopped session",
+            {
+              sessionId,
+              event,
+              reason: stampMeta[ADMIN_STOP_META_KEY],
+            },
+          );
+          return;
+        }
+      } catch {
+        // error-policy:J4 stamp lookup failure falls through to the normal
+        // relay; a missed suppression is noise, not data loss.
+      }
     }
     if (event === "error" && isUnsupportedAcpMethodError(data)) {
       this.log(
@@ -1105,6 +1481,33 @@ export class SubAgentRouter extends Service {
         type: "task_complete_progress",
         lineageKey: respawnLineageKey(session, origin),
       }).state;
+      // A completion that is a VERIFY RE-ENGAGE response must not reach the
+      // user: each auto-verify correction prompt makes the session run another
+      // turn ending in task_complete, and relaying every one produced 4
+      // contradictory "done"/"failed"/"stuck" messages for a single request
+      // (live: tide-lines, 6 bot messages for one prompt). The task-service
+      // event bridge subscribes to AcpService independently, so verification
+      // still consumes this event; only the user-facing post is suppressed.
+      // Keyed on autoVerifyAttempts (persisted BEFORE each correction prompt),
+      // so the FIRST completion always relays regardless of subscriber order,
+      // and lookup failure fails open (relay as before).
+      // A verdict-released relay is the deferral design's ONE authorized
+      // user-facing completion — but it races the task's status write:
+      // releaseDeferredCompletionRelay fires before the store commits
+      // "done", so the churn gate still saw status=validating with
+      // attempts>=1 and suppressed the real completion. The user then got
+      // only a generic model summary with the child's answer dropped (every
+      // "ran it and here is the output" with no output, live 2026-08-21).
+      const suppressReason = this.releasingDeferredRelaySessions.has(sessionId)
+        ? null
+        : await this.verifyChurnSuppression(sessionId);
+      if (suppressReason) {
+        this.log("warn", "suppressing verify-churn completion relay", {
+          sessionId,
+          reason: suppressReason,
+        });
+        return;
+      }
     }
 
     // The ACP session/prompt stopReason for a task_complete tells us whether the
@@ -1517,6 +1920,25 @@ export class SubAgentRouter extends Service {
       text = redactLoopbackUrls(verified.text);
       deadUrls = verified.dead;
       verifiedUrls = verified.verifiedUrls;
+      // A child that never NAMES its page leaves nothing to verify, and the
+      // relay then shipped "it's all in index.html" with no link (live
+      // 2026-08-22, two-lane build). The served dir is known: probe it.
+      if (verifiedUrls.length === 0) {
+        const servedUrl = publicUrlForServedWorkdir(session.workdir);
+        if (servedUrl) {
+          const probed = await probeMappedUrls([servedUrl]);
+          if (probed.length > 0) verifiedUrls = probed;
+        }
+      }
+      // The task service's evidence bundle reads `subAgentVerifiedUrls` off
+      // the session — until now only the relay Memory carried it, so the
+      // verifier never saw the URL this probe had just confirmed and demanded
+      // a non-loopback URL for a live page (2026-08-22, quotes-page parked).
+      if (verifiedUrls.length > 0) {
+        await this.patchHandoffMetadata(sessionId, {
+          subAgentVerifiedUrls: verifiedUrls,
+        });
+      }
     }
     // When the deliverable IS the printed/tool output and there is no change
     // set and no verified URL, composeNarration→stripToolTranscript has just
@@ -1530,6 +1952,69 @@ export class SubAgentRouter extends Service {
     // only the diff summary. The verifiedUrls path keeps its dedicated handling.
     if (event === "task_complete" && verifiedUrls.length === 0) {
       deliverable = extractShortToolDeliverable(data);
+      // (trimmed of trailing proof checklists below, whatever branch set it)
+      if (deliverable === undefined) {
+        const ask = userTaskFromInitialTask(
+          pickPlainString(
+            (session.metadata as Record<string, unknown> | undefined)
+              ?.initialTask,
+          ),
+        );
+        deliverable = extractAskedOutputDeliverable(data, ask, sessionId);
+      }
+      if (deliverable === undefined) {
+        // Verify-lap completions bury the answer under criteria-proof fences;
+        // the answer head (before the first "- [x]" checklist) or the last
+        // `$ <cmd>` block's stdout is the user's answer. No naive short-
+        // response floor here: "short" is not "answer" — it verbatim-relayed
+        // raw agent reasoning and routing banners (unit-caught 2026-08-21).
+        const response =
+          pickPayloadString(data, "response") ??
+          pickPayloadString(data, "finalText");
+        const trimmed = response?.trim();
+        if (trimmed?.includes("- [x] ")) {
+          const proofAt = trimmed.search(/\n(?:Evidence:\s*\n)?- \[x\] /);
+          const head = proofAt > 0 ? trimmed.slice(0, proofAt).trim() : "";
+          if (
+            head &&
+            !head.includes("[tool output") &&
+            !/https?:\/\//.test(head)
+          ) {
+            // The answer head IS the user's answer. When it exceeds the
+            // chat-verbatim budget it is no longer silently abandoned for the
+            // (paraphrase-prone) summarized path: durableProjection persists
+            // the COMPLETE head first and relays a view whose marker names
+            // GET /api/orchestrator/content/<sha256>.
+            deliverable =
+              Buffer.byteLength(head, "utf8") <= 400
+                ? head
+                : projectedDeliverableView(head, 400);
+          } else {
+            deliverable = lastProofBlockOutput(trimmed);
+          }
+        }
+      }
+      if (deliverable !== undefined && !isDurableProjectionView(deliverable)) {
+        // Whatever branch produced it: a verify-lap deliverable may carry the
+        // criteria-proof checklist after the answer — chat gets the answer,
+        // not the ls/diff evidence (live 2026-08-21). Skipped for projected
+        // views: trimming would sever the trailing continuation marker from
+        // the durably stored record it names.
+        const proofAt = deliverable.search(/\n(?:Evidence:\s*\n)?- \[x\] /);
+        if (proofAt > 0) {
+          const head = deliverable.slice(0, proofAt).trim();
+          if (head) deliverable = head;
+        }
+      }
+      // Kept at warn deliberately: plugin info/debug never reaches bot.log
+      // on this deployment, and the invisible relay path cost two days of
+      // blind debugging (2026-08-21). One line per completion.
+      // `deliverablePreview` is a bounded LOG PREVIEW only — the complete
+      // deliverable continues through the relay flow untouched.
+      this.log("warn", "completion deliverable capture", {
+        sessionId,
+        deliverablePreview: deliverable?.slice(0, 100),
+      });
     }
     // Verify-retry: the sub-agent reported done but referenced URLs that
     // are unreachable — the build is incomplete (missing or empty files).
@@ -1595,7 +2080,7 @@ export class SubAgentRouter extends Service {
       this.loopState = claim.state;
       if (claim.decision.kind === "already_claimed") {
         this.log(
-          "debug",
+          "warn",
           "suppressing duplicate sub-agent task_complete for lineage; another session already claimed this task",
           {
             sessionId,
@@ -1612,6 +2097,80 @@ export class SubAgentRouter extends Service {
         );
         rollbackRoundTrip();
         return;
+      }
+    }
+    // Request-voice terminal claim: ONE user-facing terminal per user coding
+    // request, across sessions AND respawns. Broader than the per-lineage
+    // claim above — a task-service respawn mints a new session and a new
+    // lineage, so each generation's re-engage completion passed the lineage
+    // claim and relayed (~12 messages for one request, live defect). Placed
+    // BEFORE the verified-URL handling so a denial also suppresses the OS
+    // notification and screenshot delivery downstream. requestKey null ⇒ no
+    // stable per-request id ⇒ fail open (no gating).
+    const routingKind = routingKindForEvent(event, data, capExceeded);
+    const requestKey = requestVoiceKeyForMeta(
+      session.metadata as Record<string, unknown> | undefined,
+    );
+    if (routingKind === QUESTION_FOR_TASK_CREATOR) {
+      // Questions never claim the terminal slot — but a session still asking
+      // after its request reached a FINAL terminal (parked/failed) is noise:
+      // the user was already told the request is over. A merely-provisional
+      // result does not gag questions.
+      if (requestKey && this.isRequestTerminalFinalized(requestKey)) {
+        this.log(
+          "info",
+          "suppressing sub-agent question after finalized request terminal",
+          { sessionId, event, requestKey },
+        );
+        rollbackRoundTrip();
+        return;
+      }
+    } else {
+      // Failure conditions FIRST: when capExceeded/stateLostExhausted forced a
+      // terminal narration, that narration is what posts (baseText above) even
+      // if the underlying event was a task_complete — claim it as the failure
+      // it reads as, not a supersedable provisional result.
+      const terminalKind: "result" | "failure" | null =
+        capExceeded || stateLostExhausted || event === "error"
+          ? "failure"
+          : event === "task_complete"
+            ? "result"
+            : null;
+      if (terminalKind && requestKey) {
+        // task_complete claims provisional ALWAYS: whether verification will
+        // re-engage is unknowable here (router vs task-service event-bridge
+        // subscriber order is unspecified), and provisionality is consumed
+        // only by the one sanctioned parked supersede.
+        const claim = this.claimRequestTerminal(
+          requestKey,
+          sessionId,
+          terminalKind,
+          terminalKind === "result",
+        );
+        if (!claim.granted) {
+          this.log(
+            "warn",
+            "suppressing duplicate request terminal; request voice already held",
+            {
+              sessionId,
+              event,
+              requestKey,
+              terminalKind,
+              holderKind: claim.holderKind,
+            },
+          );
+          if (event === "task_complete") {
+            this.captureOriginResultForCompletion(
+              origin,
+              session,
+              text,
+              deliverable,
+              deadUrls,
+            );
+          }
+          rollbackRoundTrip();
+          return;
+        }
       }
     }
     if (event === "task_complete" && verifiedUrls.length > 0) {
@@ -1639,9 +2198,25 @@ export class SubAgentRouter extends Service {
       // Stage-1 regenerates any bare-numeric reply from it. So surface the
       // verbatim deliverable as the narration body (the header's relay /
       // do-not-respawn directive is preserved on the first line).
+      // CANONICAL-WINS SUBSTITUTION: the model's completion prose after the
+      // header is deliberately replaced here — the paraphrase is the known
+      // lossy artifact, the deliverable the ground truth. The replaced prose
+      // is not lost: the child's complete final response stays durable on the
+      // session transcript, resolvable via GET /api/coding-agents/:id/output.
       const firstNewline = text.indexOf("\n");
       const header = firstNewline === -1 ? text : text.slice(0, firstNewline);
       text = `${header}\n${deliverable}`;
+    }
+    if (
+      event === "task_complete" &&
+      this.unverifiedReleaseSessions.has(sessionId)
+    ) {
+      // The deferral released without a verdict (fallback timeout, or restart
+      // reconstruction past the window). Disclose it in the relay body so the
+      // completion never reads as a verified pass. Appended AFTER the
+      // verified-URL / deliverable substitutions above so the line survives
+      // every body rewrite.
+      text = `${text}\n${UNVERIFIED_RELAY_DISCLOSURE}`;
     }
     if (event === "task_complete") {
       // Remember the best (longest) CLEAN result for this root origin so the
@@ -1664,10 +2239,16 @@ export class SubAgentRouter extends Service {
       const previewSource = (
         deliverable ?? stripSubAgentHeaderLine(text)
       ).trim();
-      const preview = truncateWellFormed(
-        toWellFormedUnicode(previewSource),
-        200,
-      );
+      // NAMED PREVIEW: OS/push notification banner only — a bounded surface
+      // that never re-enters model context. The complete result is separately
+      // relayed to chat and durable on the session transcript, and the
+      // notification's deepLink opens the full view. The "…" marks the cut so
+      // the banner reads as a preview, not as the value.
+      const wellFormedPreview = toWellFormedUnicode(previewSource);
+      const preview =
+        wellFormedPreview.length > 200
+          ? `${truncateWellFormed(wellFormedPreview, 199)}…`
+          : wellFormedPreview;
       void getNotifier(this.runtime)
         ?.notify({
           title: `${origin.label || "Agent task"} finished`,
@@ -1711,7 +2292,6 @@ export class SubAgentRouter extends Service {
         );
       }
     }
-    const routingKind = routingKindForEvent(event, data, capExceeded);
     const targets = swarmTargetsForRouting(origin, routingKind);
     // User-facing leg of a blocked sub-agent's question: with per-task GROUP
     // rooms on by default the task room maps to no live connector channel, so
@@ -1761,6 +2341,13 @@ export class SubAgentRouter extends Service {
     // source and selected swarm room. If the connector isn't registered, fall through to
     // handleMessage without a callback — the planner will still update
     // state but no message reaches the user.
+    if (event === "task_complete") {
+      this.log("warn", "completion relay injecting", {
+        sessionId,
+        targets: targets.length,
+        requestKey: requestKey ?? null,
+      });
+    }
     for (const target of targets) {
       const sessionMeta = session.metadata as
         | Record<string, unknown>
@@ -1849,6 +2436,12 @@ export class SubAgentRouter extends Service {
             ...(origin.spawnRootMessageId
               ? { spawnRootMessageId: origin.spawnRootMessageId }
               : {}),
+            // Re-stamp the fan-out part so a respawn of this lane inherits its
+            // predecessor's request-voice key instead of minting a new one
+            // (respawn-shares-key per lane; see requestVoiceKeyForMeta).
+            ...(origin.requestVoicePart
+              ? { requestVoicePart: origin.requestVoicePart }
+              : {}),
             ...(origin.source ? { originSource: origin.source } : {}),
             ...(sessionRouteId ? { workdirRouteId: sessionRouteId } : {}),
             ...(sessionRoute ? { workdirRoute: sessionRoute } : {}),
@@ -1925,6 +2518,391 @@ export class SubAgentRouter extends Service {
    * the session. The planner-directed `[sub-agent: …]` header is stripped —
    * it is relay guidance for the task-room turn, not user prose.
    */
+  /** The taskId to defer this session's completion relay on, or null when the
+   *  relay should post immediately (deferral disabled, no durable task, no
+   *  acceptance criteria to verify, or the task already reached a terminal
+   *  state). Mirrors only the STABLE auto-verify gates; anything the verify
+   *  body decides internally is covered by the release fallback timer. */
+  private async completionRelayDeferralTaskId(
+    sessionId: string,
+  ): Promise<string | null | "drop"> {
+    const deferralEnabled =
+      process.env.ELIZA_RELAY_AFTER_VERIFY !== "0" && shouldAutoVerifyGoal();
+    const tasks = this.runtime.getService("ORCHESTRATOR_TASK_SERVICE") as {
+      getTaskForSession?: (sessionId: string) => Promise<{
+        id?: string;
+        status?: string;
+        acceptanceCriteria?: string[];
+        metadata?: Record<string, unknown> | null;
+      } | null>;
+    } | null;
+    if (!tasks?.getTaskForSession) return null;
+    try {
+      const record = await tasks.getTaskForSession(sessionId);
+      // Kept at warn: an undeferred relay ships before the verdict, and the
+      // only trace of why is here (plugin info never reaches bot.log).
+      if (!record?.id) {
+        if (!deferralEnabled) return null;
+        this.log("warn", "completion relay not deferred: no task record", {
+          sessionId,
+        });
+        return null;
+      }
+      const interruptReason = record.metadata?.interruptReason;
+      if (
+        record.status === "interrupted" &&
+        typeof interruptReason === "string" &&
+        interruptReason.startsWith("user")
+      ) {
+        // The user stopped the task; the child's last turn still reported a
+        // completion. "it's ready" for a cancelled build is never right —
+        // whether or not verification/deferral is enabled.
+        this.log("info", "completion relay dropped: task stopped by user", {
+          sessionId,
+          taskId: record.id,
+        });
+        return "drop";
+      }
+      if (!deferralEnabled) return null;
+      if (
+        ["done", "parked", "failed", "cancelled", "archived"].includes(
+          String(record.status),
+        )
+      ) {
+        this.log("warn", "completion relay not deferred: task is terminal", {
+          sessionId,
+          taskId: record.id,
+          status: record.status,
+        });
+        return null;
+      }
+      const criteria = Array.isArray(record.acceptanceCriteria)
+        ? record.acceptanceCriteria
+        : [];
+      if (criteria.length === 0) {
+        this.log(
+          "warn",
+          "completion relay not deferred: task has no criteria",
+          {
+            sessionId,
+            taskId: record.id,
+          },
+        );
+        return null;
+      }
+      return record.id;
+    } catch {
+      // error-policy:J4 a lookup failure must degrade to the immediate relay,
+      // never to a swallowed completion.
+      return null;
+    }
+  }
+
+  /** Called by OrchestratorTaskService when the auto-verifier's verdict lands
+   *  (and by the fallback timeout / restart reconstruction). `passed`
+   *  re-enters the deferred task_complete with fresh state; `failed` drops it
+   *  — the verify-retry loop or the park notice owns messaging from here;
+   *  `unverified` re-enters it WITH an explicit no-verdict disclosure in the
+   *  relay body (never a fabricated pass). No-op when nothing is deferred for
+   *  the task. */
+  releaseDeferredCompletionRelay(
+    taskId: string,
+    verdict: DeferredRelayVerdict,
+    sessionId?: string,
+  ): void {
+    const keys = [...this.deferredCompletionRelays.keys()].filter((key) => {
+      const [keyTask, keySession] = key.split("\u0000");
+      return keyTask === taskId && (!sessionId || keySession === sessionId);
+    });
+    for (const key of keys) this.releaseDeferredRelayByKey(key, verdict);
+  }
+
+  private releaseDeferredRelayByKey(
+    key: string,
+    verdict: DeferredRelayVerdict,
+  ): void {
+    const pending = this.deferredCompletionRelays.get(key);
+    if (!pending) return;
+    const taskId = key.split("\u0000")[0];
+    this.deferredCompletionRelays.delete(key);
+    clearTimeout(pending.timer);
+    if (verdict === "failed") {
+      this.log(
+        "info",
+        "dropping deferred completion relay after failed verification",
+        { taskId, sessionId: pending.sessionId },
+      );
+      // A dropped relay is resolved: clear the durable stamp so a restart
+      // does not resurrect a completion the verify-retry/park path owns.
+      void this.clearPendingRelayStamp(taskId, pending.sessionId);
+      return;
+    }
+    this.releasingDeferredRelaySessions.add(pending.sessionId);
+    if (verdict === "unverified") {
+      this.unverifiedReleaseSessions.add(pending.sessionId);
+    }
+    void this.waitForOriginTurnToSettle(pending.sessionId)
+      .then(() =>
+        this.handleEvent(
+          pending.sessionId,
+          "task_complete",
+          pending.data,
+          undefined,
+          pending.turnId,
+        ),
+      )
+      .then(() =>
+        // Cleared only AFTER the relay posted: a crash mid-release leaves the
+        // stamp in place, and the next start() reconstructs the held
+        // completion instead of swallowing it.
+        this.clearPendingRelayStamp(taskId, pending.sessionId),
+      )
+      .catch((err) => {
+        // error-policy:J7 the released relay is observability-critical; a
+        // failure is reported, not rethrown into the verdict writer.
+        this.log("error", "deferred completion relay release failed", {
+          taskId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        this.releasingDeferredRelaySessions.delete(pending.sessionId);
+        this.unverifiedReleaseSessions.delete(pending.sessionId);
+      });
+  }
+
+  /** Durably stamp a deferred completion relay on its task record so a
+   *  restart can reconstruct it (see reconstructPendingRelayStamps). */
+  private async persistPendingRelayStamp(
+    taskId: string,
+    sessionId: string,
+    data: unknown,
+    turnId?: string,
+  ): Promise<void> {
+    try {
+      const tasks = this.relayStampTaskService();
+      if (!tasks) return;
+      const record = await tasks.getTask(taskId);
+      if (!record?.id) return;
+      const existing = readPendingRelayStamps(record.metadata);
+      await tasks.updateTask(taskId, {
+        metadata: {
+          ...(record.metadata ?? {}),
+          [PENDING_COMPLETION_RELAYS_META_KEY]: {
+            ...existing,
+            [sessionId]: {
+              taskId,
+              sessionId,
+              deferredAt: new Date().toISOString(),
+              data,
+              ...(turnId !== undefined ? { turnId } : {}),
+            },
+          },
+        },
+      });
+    } catch (err) {
+      // error-policy:J7 the durable stamp is restart insurance alongside the
+      // live in-memory deferral; a failed write is reported (the fallback
+      // timer still guarantees in-process delivery) and must not kill routing.
+      this.log("warn", "pending completion relay stamp persistence failed", {
+        taskId,
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Remove a session's durable pending-relay stamp from its task record. */
+  private async clearPendingRelayStamp(
+    taskId: string,
+    sessionId: string,
+  ): Promise<void> {
+    try {
+      const tasks = this.relayStampTaskService();
+      if (!tasks) return;
+      const record = await tasks.getTask(taskId);
+      if (!record?.id) return;
+      const existing = readPendingRelayStamps(record.metadata);
+      if (!(sessionId in existing)) return;
+      const { [sessionId]: _cleared, ...rest } = existing;
+      await tasks.updateTask(taskId, {
+        metadata: {
+          ...(record.metadata ?? {}),
+          [PENDING_COMPLETION_RELAYS_META_KEY]: rest,
+        },
+      });
+    } catch (err) {
+      // error-policy:J7 a failed clear risks (at worst) a duplicate relay on
+      // the next restart — strictly better than a swallowed completion — so
+      // it is reported, never rethrown into the release path.
+      this.log("warn", "pending completion relay stamp clear failed", {
+        taskId,
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** The task service behind the durable relay stamps, or null when it (or a
+   *  required method) is unavailable. */
+  private relayStampTaskService(): RelayStampTaskService | null {
+    const tasks = this.runtime.getService(
+      "ORCHESTRATOR_TASK_SERVICE",
+    ) as Partial<RelayStampTaskService> | null;
+    if (
+      !tasks ||
+      typeof tasks.getTask !== "function" ||
+      typeof tasks.updateTask !== "function"
+    ) {
+      return null;
+    }
+    return tasks as RelayStampTaskService;
+  }
+
+  /** Restart recovery for held completions: rebuild every durable
+   *  pending-relay stamp into a live deferral, then resolve it from the
+   *  task's DURABLE state — `done` releases as passed (the store attests the
+   *  verdict; only the relay was lost), a failed terminal drops it, and a
+   *  still-pending task re-arms the fallback window (releasing as
+   *  `unverified` when the window already elapsed — no verdict is coming).
+   *  Runs once per bind, after the ACP source is available (the release path
+   *  re-enters handleEvent, which reads the session store). */
+  private async reconstructPendingRelayStamps(): Promise<void> {
+    try {
+      const tasks = this.relayStampTaskService();
+      if (!tasks || typeof tasks.listTasks !== "function") return;
+      const rows = await tasks.listTasks({});
+      for (const row of Array.isArray(rows) ? rows : []) {
+        if (!row?.id) continue;
+        const detail = await tasks.getTask(row.id).catch(() => null);
+        if (!detail?.id) continue;
+        const stamps = readPendingRelayStamps(detail.metadata);
+        const status = String(detail.status ?? "");
+        for (const stamp of Object.values(stamps)) {
+          this.rearmReconstructedRelay(detail.id, stamp);
+          if (status === "done") {
+            this.log(
+              "info",
+              "reconstructed deferred relay released: task already done",
+              { taskId: detail.id, sessionId: stamp.sessionId },
+            );
+            this.releaseDeferredCompletionRelay(
+              detail.id,
+              "passed",
+              stamp.sessionId,
+            );
+          } else if (
+            ["parked", "failed", "cancelled", "archived"].includes(status)
+          ) {
+            this.log(
+              "info",
+              "reconstructed deferred relay dropped: task reached a failed terminal",
+              { taskId: detail.id, sessionId: stamp.sessionId, status },
+            );
+            this.releaseDeferredCompletionRelay(
+              detail.id,
+              "failed",
+              stamp.sessionId,
+            );
+          } else {
+            const deferredAtMs = Date.parse(stamp.deferredAt);
+            const elapsed = Number.isFinite(deferredAtMs)
+              ? Date.now() - deferredAtMs
+              : Number.POSITIVE_INFINITY;
+            if (elapsed >= DEFERRED_RELAY_FALLBACK_MS) {
+              this.log(
+                "warn",
+                "reconstructed deferred relay past its fallback window; relaying unverified",
+                { taskId: detail.id, sessionId: stamp.sessionId },
+              );
+              this.releaseDeferredCompletionRelay(
+                detail.id,
+                "unverified",
+                stamp.sessionId,
+              );
+            } else {
+              this.log(
+                "info",
+                "re-armed deferred completion relay from durable stamp",
+                { taskId: detail.id, sessionId: stamp.sessionId },
+              );
+            }
+          }
+        }
+      }
+    } catch (err) {
+      // error-policy:J7 reconstruction is best-effort restart recovery; a
+      // failure is reported and must not block router startup.
+      this.log("warn", "pending completion relay reconstruction failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Put a durable stamp back into the in-memory deferral map with a fallback
+   *  timer for the REMAINDER of its window (0 when already elapsed — the
+   *  caller then releases it immediately after re-arming). */
+  private rearmReconstructedRelay(
+    taskId: string,
+    stamp: PendingRelayStamp,
+  ): void {
+    const deferKey = `${taskId}\u0000${stamp.sessionId}`;
+    const existing = this.deferredCompletionRelays.get(deferKey);
+    if (existing) clearTimeout(existing.timer);
+    const deferredAtMs = Date.parse(stamp.deferredAt);
+    const elapsed = Number.isFinite(deferredAtMs)
+      ? Date.now() - deferredAtMs
+      : DEFERRED_RELAY_FALLBACK_MS;
+    const remaining = Math.max(DEFERRED_RELAY_FALLBACK_MS - elapsed, 0);
+    const timer = setTimeout(() => {
+      this.log(
+        "warn",
+        "deferred completion relay released by timeout — no verification verdict arrived; relaying unverified",
+        { taskId, sessionId: stamp.sessionId },
+      );
+      this.releaseDeferredCompletionRelay(
+        taskId,
+        "unverified",
+        stamp.sessionId,
+      );
+    }, remaining);
+    timer.unref?.();
+    this.deferredCompletionRelays.set(deferKey, {
+      sessionId: stamp.sessionId,
+      data: stamp.data,
+      ...(stamp.turnId !== undefined ? { turnId: stamp.turnId } : {}),
+      timer,
+    });
+  }
+
+  /** Let the origin room's in-flight planner turn finish before the released
+   *  relay posts. A follow-up absorbed into the running build produces a slow
+   *  planner turn whose reply PROMISES the work ("got it — adding the split
+   *  option now"), and the verified completion beat it by ~1s — the user read
+   *  fulfillment, then the promise, then silence (live 2026-08-20). Bounded:
+   *  a turn that never settles only delays the relay, never drops it. */
+  private async waitForOriginTurnToSettle(sessionId: string): Promise<void> {
+    const deadline = Date.now() + 60_000;
+    try {
+      const session = await this.acp?.getSession(sessionId);
+      const roomId = (session?.metadata as { roomId?: unknown } | undefined)
+        ?.roomId;
+      if (typeof roomId !== "string" || !roomId) return;
+      const registry = (
+        this.runtime as {
+          turnControllers?: { hasActiveTurn?: (roomId: string) => boolean };
+        }
+      ).turnControllers;
+      if (typeof registry?.hasActiveTurn !== "function") return;
+      while (registry.hasActiveTurn(roomId) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    } catch {
+      // error-policy:J4 settle-wait is best-effort ordering; a probe failure
+      // releases the relay immediately rather than risking a swallowed one.
+    }
+  }
+
   private async postQuestionToOriginRoom(
     origin: OriginInfo,
     sessionId: string,
@@ -1944,16 +2922,23 @@ export class SubAgentRouter extends Service {
     const body = stripSubAgentHeaderLine(text).trim() || text.trim();
     const originReplyTarget =
       origin.parentConnectorMessageId ?? origin.parentMessageId;
+    const questionSource =
+      (await this.resolveDeliverySource(origin)) ?? origin.source;
     try {
       requireConfirmedSendHandlerDelivery(
         await sendToTarget(
-          { source: origin.source, roomId: origin.roomId },
+          { source: questionSource, roomId: origin.roomId },
           {
             text: `❓ [${origin.label}] ${body}`,
             // Same source the router stamps on its posts: the mid-task forward
             // handler skips it (echo-loop guard), so the question is never fed
             // back into the asking session as a prompt.
             source: ACPX_ROUTER_SOURCE,
+            // The body is the sub-agent's OWN model prose — rewriting it risks
+            // corrupting the question, and the core transport voice gate would
+            // also strip the `❓ [label]` marker. Stamp it as already voiced so
+            // the gate passes it through verbatim.
+            ...AGENT_VOICED_METADATA,
             ...(originReplyTarget ? { inReplyTo: originReplyTarget } : {}),
           },
         ),
@@ -1968,6 +2953,99 @@ export class SubAgentRouter extends Service {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  /** Per-room memo of resolved connector sources (FIFO-bounded). */
+  private readonly roomSourceMemo = new Map<string, string>();
+
+  /**
+   * Whether this session's task_complete is verify-churn that must not relay
+   * to the user: the durable task is mid-validation with at least one
+   * re-engage already issued (`autoVerifyAttempts >= 1`), or already parked
+   * with the escalation notice sent. Returns the suppress reason, or null to
+   * relay. Every failure path returns null — an unreadable task store must
+   * never silence a genuine completion.
+   */
+  private async verifyChurnSuppression(
+    sessionId: string,
+  ): Promise<string | null> {
+    try {
+      // Resolve via the task service's per-SESSION mapping (store.findSession),
+      // not listTasks().latestSessionId: a verify-driven respawn creates a
+      // second session and moves latestSessionId to it, so the ORIGINAL
+      // session's re-engage completions resolved no task and relayed anyway
+      // (the stated live insufficiency of this gate).
+      const tasks = this.runtime.getService("ORCHESTRATOR_TASK_SERVICE") as
+        | {
+            getTaskForSession?: (sessionId: string) => Promise<{
+              status: string;
+              metadata?: Record<string, unknown>;
+            } | null>;
+          }
+        | undefined;
+      if (typeof tasks?.getTaskForSession !== "function") return null;
+      const task = await tasks.getTaskForSession(sessionId);
+      if (!task) return null;
+      const attempts = Number(task.metadata?.autoVerifyAttempts) || 0;
+      if (task.status === "validating" && attempts >= 1) {
+        return `re-engage response (attempt ${attempts}, task validating)`;
+      }
+      if (
+        task.status === "waiting_on_user" &&
+        task.metadata?.verifyEscalationNotifiedAt
+      ) {
+        return "task already parked and escalation notice delivered";
+      }
+      return null;
+    } catch (err) {
+      // error-policy:J7 churn gating is advisory; an unreadable task store must not suppress a real completion
+      this.log("debug", "verify-churn lookup failed; relaying", {
+        sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the source a delivery should actually use. A real connector source
+   * passes through untouched; an internal marker (or a missing source) is
+   * re-resolved through the room row, which records the connector that created
+   * it — the same fallback `getTaskOriginTarget` uses. Falls back to the
+   * original value so a failed lookup degrades to the prior loud delivery
+   * failure, never a silent drop.
+   */
+  private async resolveDeliverySource(
+    origin: Pick<OriginInfo, "roomId" | "source">,
+  ): Promise<string | undefined> {
+    const source = origin.source;
+    if (source && !INTERNAL_MARKER_SOURCES.has(source)) return source;
+    const memo = this.roomSourceMemo.get(origin.roomId);
+    if (memo) return memo;
+    try {
+      const room = await this.runtime.getRoom?.(origin.roomId);
+      const roomSource =
+        typeof room?.source === "string" && room.source.trim()
+          ? room.source.trim()
+          : undefined;
+      if (roomSource && !INTERNAL_MARKER_SOURCES.has(roomSource)) {
+        this.roomSourceMemo.set(origin.roomId, roomSource);
+        while (this.roomSourceMemo.size > 1024) {
+          const oldest = this.roomSourceMemo.keys().next().value;
+          if (!oldest) break;
+          this.roomSourceMemo.delete(oldest);
+        }
+        return roomSource;
+      }
+    } catch (err) {
+      // error-policy:J7 source resolution is best-effort routing repair; a room
+      // lookup failure falls back to the original (possibly failing) source.
+      this.log("debug", "room-source resolution failed", {
+        roomId: origin.roomId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return source;
   }
 
   private buildReplyCallback(
@@ -2034,9 +3112,11 @@ export class SubAgentRouter extends Service {
             inReplyTo: originReplyTarget,
           }
         : { ...response, source: "sub_agent_complete" };
+      const deliverySource =
+        (await this.resolveDeliverySource(origin)) ?? source;
       const delivered = await sendToTarget(
         {
-          source,
+          source: deliverySource,
           roomId: origin.roomId,
         },
         threadedResponse,
@@ -2045,7 +3125,7 @@ export class SubAgentRouter extends Service {
         // delivered list on failure (honest "0 delivered").
         this.log("warn", "sub-agent reply delivery failed", {
           sessionId,
-          source,
+          source: deliverySource,
           roomId: origin.roomId,
           targetRoomId: target.roomId,
           error: err instanceof Error ? err.message : String(err),
@@ -2448,6 +3528,33 @@ export class SubAgentRouter extends Service {
     if (!Number.isFinite(maxRetries) || maxRetries <= 0) return false;
 
     const meta = (session.metadata ?? {}) as Record<string, unknown>;
+    // A session the USER stopped is not an incomplete build to repair —
+    // retrying it resurrects cancelled work (live 2026-08-19: "cancel all ur
+    // running coding tasks" hard-stopped the child and the retry rebuilt and
+    // delivered the page anyway). The stamp races the terminal event, so the
+    // event-time snapshot is not trustworthy — read the LIVE session row
+    // (same fresh-read the swarm coordinator uses for this exact stamp).
+    let freshMeta: Record<string, unknown> = meta;
+    try {
+      const fresh = await this.acp?.getSession(session.id);
+      if (fresh?.metadata) {
+        freshMeta = fresh.metadata as Record<string, unknown>;
+      }
+    } catch {
+      // error-policy:J4 stale-snapshot fallback; the event-time metadata still
+      // gates when the live read fails.
+    }
+    if (typeof freshMeta[ADMIN_STOP_META_KEY] === "string") {
+      this.log(
+        "info",
+        "verify-retry skipped: session was stopped by the user",
+        {
+          sessionId: session.id,
+          reason: freshMeta[ADMIN_STOP_META_KEY],
+        },
+      );
+      return false;
+    }
     // One typed read of the canonical retry counter (the router's respawn
     // lineage and the durable OrchestratorTaskSession.retryCount share this
     // field), rather than a bare untyped `meta.buildVerifyRetryCount`.
@@ -2637,6 +3744,7 @@ Do not report done until every referenced URL in the final page resolves without
         : "";
     if (!chunk) return;
 
+    const MAX_BUFFER = 16_384;
     const TAIL = 64; // ≥ marker length, to catch a marker split across chunks
     let buf = (this.parentAgentBuffers.get(sessionId) ?? "") + chunk;
 
@@ -2649,9 +3757,30 @@ Do not report done until every referenced URL in the final page resolves without
 
     const directive = extractParentAgentDirective(buf);
     if (!directive) {
-      // Once the marker is present, retain the complete streamed directive.
-      // Cutting its JSON tail can silently turn a valid large parent-agent
-      // request into a different or permanently unparsable request.
+      // Marker present but the JSON is still streaming (or malformed; the
+      // extractor returns null for both).
+      if (buf.length > MAX_BUFFER) {
+        // Typed pre-dispatch REJECTION (mirrors the round-trip-cap path
+        // below): the envelope crossed the 16KB bound before its JSON
+        // completed. The old head-slice silently cut the USE_SKILL marker
+        // off, so the directive never dispatched and the child got no
+        // signal. Drop the buffer to a tail and tell the child explicitly.
+        this.parentAgentBuffers.set(sessionId, buf.slice(-TAIL));
+        this.log(
+          "warn",
+          "parent-agent directive exceeded buffer bound before completing; rejecting",
+          { sessionId, bufferedChars: buf.length, cap: MAX_BUFFER },
+        );
+        await acp
+          .sendToSession(
+            sessionId,
+            `parent-agent bridge: your USE_SKILL parent-agent directive exceeded ${MAX_BUFFER} characters before its JSON completed and was NOT dispatched. Resend a smaller directive, or reference a file path instead of inlining large content.`,
+          )
+          // error-policy:J6 best-effort rejection notice; the reject already
+          // happened (buffer dropped), a failed notice changes nothing.
+          .catch(() => undefined);
+        return;
+      }
       this.parentAgentBuffers.set(sessionId, buf);
       return;
     }
@@ -2661,6 +3790,8 @@ Do not report done until every referenced URL in the final page resolves without
 
     const nextCount = (this.parentAgentDispatchCounts.get(sessionId) ?? 0) + 1;
     this.parentAgentDispatchCounts.set(sessionId, nextCount);
+    // Typed pre-dispatch rejection (compliant loop backstop): the directive is
+    // dropped WHOLE and the child is told in-band — never a silent clamp.
     if (nextCount > this.loopState.roundTripCap) {
       this.log(
         "warn",
@@ -2869,6 +4000,11 @@ interface OriginInfo {
   /** Stable per-request root id for the per-origin spawn cap; present on every
    * transport (connector message id, else the origin user message id). (#8875) */
   spawnRootMessageId?: string;
+  /** Fan-out part suffix for the request-voice key (`requestVoiceKeyForMeta`):
+   * minted once per lane/part on a deliberate multi-part create and inherited
+   * verbatim by every respawn of that lane, so parallel lanes own distinct
+   * voice slots while a respawn still shares its predecessor's key. */
+  requestVoicePart?: string;
   label: string;
   source?: string;
 }
@@ -2934,6 +4070,7 @@ export function readOrigin(session: SessionInfo): OriginInfo | null {
     parentMessageId: pickUuid(meta.messageId),
     parentConnectorMessageId: pickPlainString(meta.originConnectorMessageId),
     spawnRootMessageId: spawnRootIdFromMeta(meta),
+    requestVoicePart: pickPlainString(meta.requestVoicePart),
     label: pickLabel(meta) ?? session.name ?? session.id,
     source: typeof meta.source === "string" ? meta.source : undefined,
   };
@@ -3244,6 +4381,24 @@ function pickRouteUrlMappings(value: unknown): RouteUrlMapping[] {
     .filter((entry): entry is RouteUrlMapping => entry !== undefined);
 }
 
+/** The public URL of a session workdir directly under the configured
+ *  published-apps dir, when it holds an index page. */
+function publicUrlForServedWorkdir(workdir: string): string | undefined {
+  if (!workdir || !fs.existsSync(path.join(workdir, "index.html"))) {
+    return undefined;
+  }
+  const deploy = resolveAppDeployConfig();
+  if (
+    deploy.target !== "custom" ||
+    !deploy.customAppsDir ||
+    !deploy.customBaseUrl ||
+    path.dirname(path.resolve(workdir)) !== path.resolve(deploy.customAppsDir)
+  ) {
+    return undefined;
+  }
+  return `${deploy.customBaseUrl.replace(/\/+$/, "")}/apps/${path.basename(workdir)}/`;
+}
+
 function routeVerificationForSession(
   session: SessionInfo,
 ): RouteUrlVerification | undefined {
@@ -3428,16 +4583,41 @@ function normalizeFinishReason(
 // leaked on the synthesis path.
 
 // Maximum size of a captured tool-output block we will relay verbatim. Above
-// this, the deliverable is a multi-KB transcript and stays on the
-// model-rendered (summarized) path rather than being dumped to the user.
+// this, the deliverable becomes a durable-store projection: the COMPLETE
+// output is persisted first and a bounded view with a resolvable continuation
+// marker is relayed instead of being dumped raw to the user.
 const MAX_VERBATIM_DELIVERABLE_BYTES = 2048;
+
+// Marker fragment every durableProjection view carries; used to recognize a
+// projected deliverable so post-processing never severs the continuation
+// marker from the record it names.
+const DURABLE_CONTENT_MARKER = "GET /api/orchestrator/content/";
+
+export function isDurableProjectionView(text: string): boolean {
+  return text.includes(DURABLE_CONTENT_MARKER);
+}
+
+/** Bounded deliverable view whose omitted bytes are recoverable through the
+ *  durable content store (persist-first, marker names the resolver route).
+ *  On a store WRITE failure the complete content is returned WHOLE — the
+ *  prompt-integrity invariant forbids dropping bytes with no durable record. */
+function projectedDeliverableView(full: string, budgetChars: number): string {
+  try {
+    return durableProjection(full, budgetChars).view;
+  } catch {
+    // error-policy:J4 store failure degrades to the COMPLETE value, never a cut.
+    return toWellFormedUnicode(full);
+  }
+}
 
 // Recover the deliverable when it is the sub-agent's printed/tool output and
 // composeNarration→stripToolTranscript has deleted it. Extracts the inner body
-// of the FIRST `[tool output: …] … [/tool output]` block from the RAW response
-// (the same envelope captureTerminalToolOutput emits). Returns it only when it
-// is a single short block (≤2KB); multi-block or multi-KB transcripts return
-// undefined so they stay on the summarized path.
+// of the LAST non-empty `[tool output: …] … [/tool output]` block from the RAW
+// response (the same envelope captureTerminalToolOutput emits). A short block
+// (≤2KB) is returned verbatim; an oversized block is returned as a durable
+// projection — persisted whole, bounded view with a resolvable continuation
+// marker — instead of being silently abandoned to the summarized path, which
+// stripToolTranscript then deleted entirely (the >2KB output reached nobody).
 export function extractShortToolDeliverable(data: unknown): string | undefined {
   const response =
     pickPayloadString(data, "response") ?? pickPayloadString(data, "finalText");
@@ -3458,12 +4638,150 @@ export function extractShortToolDeliverable(data: unknown): string | undefined {
       .replace(/^\[tool output:[^\]]*\]/, "")
       .replace(/\[\/tool output\]$/, "")
       .trim();
-    if (!inner) continue;
-    return Buffer.byteLength(inner, "utf8") > MAX_VERBATIM_DELIVERABLE_BYTES
-      ? undefined
-      : inner;
+    // A write confirmation names an internal workspace path and is not what
+    // the user asked for; the deliverable is an earlier run's output.
+    if (!inner || WRITE_CONFIRMATION_RE.test(inner)) continue;
+    const deliverable = shellTranscriptStdout(inner) ?? inner;
+    return Buffer.byteLength(deliverable, "utf8") >
+      MAX_VERBATIM_DELIVERABLE_BYTES
+      ? projectedDeliverableView(deliverable, MAX_VERBATIM_DELIVERABLE_BYTES)
+      : deliverable;
   }
   return undefined;
+}
+
+const WRITE_CONFIRMATION_RE = /^Wrote \d+ bytes? to \S+$/;
+
+/** The coding tools' SHELL transcript ("$ cmd", "[exit N] (cwd=…, took=…)",
+ *  "--- stdout ---", "--- stderr ---"): for a clean run the deliverable is
+ *  the stdout section, never the command line with its internal workspace
+ *  path (live 2026-08-21: the whole transcript reached chat). A failed run
+ *  keeps the transcript so the error stays visible. */
+export function shellTranscriptStdout(block: string): string | undefined {
+  if (!/^\$ .+\n\[exit 0\] \(/.test(block)) return undefined;
+  const match = block.match(
+    /\n--- stdout ---\n([\s\S]*?)(?:\n--- stderr ---\n[\s\S]*)?$/,
+  );
+  const stdout = match?.[1]?.trim();
+  return stdout && stdout !== "(empty)" ? stdout : undefined;
+}
+
+/** "run it and show me the output" asks: the answer is whatever the child
+ *  printed, and the parent model routinely paraphrases it into a generic
+ *  status line ("dinner-picker is all set. everything passes." for a captured
+ *  "Tonight's dinner idea is: Homemade Pizza", live 2026-08-20). When the ask
+ *  requests output/results and the final response is a short plain block with
+ *  no [tool output] markers, that response IS the deliverable — relay it
+ *  verbatim. */
+const OUTPUT_ASK_RE =
+  /\b(?:show|print|display|give|tell|share)\b[\s\S]{0,40}\b(?:output|result|results)\b|\bwhat(?:'s| is) the (?:output|result)\b|\b(?:run|execute|rerun|re-run)\b[\s\S]{0,40}\b(?:it|again|once\s+more|one\s+more\s+time)\b/i;
+
+/** The verify lap tells the child to paste exact proofs, so its final
+ *  response is a long criteria dump whose LAST fenced block is typically
+ *  `$ <run command>` followed by the captured stdout — the very output the
+ *  user asked for. Pull the output lines (not the command) of the last such
+ *  block when they are chat-short; the narration otherwise re-summarized the
+ *  run into "here is the output" with no output (live 2026-08-21). */
+export function lastProofBlockOutput(response: string): string | undefined {
+  const blocks = response.match(/```(?:bash|sh|shell)?\n([\s\S]*?)```/g);
+  if (!blocks?.length) return undefined;
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const inner = blocks[i]
+      .replace(/^```(?:bash|sh|shell)?\n/, "")
+      .replace(/```$/, "");
+    const lines = inner.split("\n");
+    if (!lines.some((line) => line.startsWith("$ "))) continue;
+    const output = lines
+      .filter((line) => !line.startsWith("$ "))
+      .join("\n")
+      .trim();
+    // Validity gate, not a size cap: an ellipsis means the CHILD already
+    // elided this output — relaying or projecting it would present a lossy
+    // source as the run's stdout, so an older complete block is preferred.
+    if (!output || output.includes("...")) continue;
+    // Oversized verify-lap stdout is the user's answer too: persist it whole
+    // and relay a durable-projection view instead of skipping to a stale
+    // block / leaving the paraphrase ("479" for "479001600") to ship.
+    if (Buffer.byteLength(output, "utf8") > 400) {
+      return projectedDeliverableView(output, 400);
+    }
+    return output;
+  }
+  return undefined;
+}
+
+export function extractAskedOutputDeliverable(
+  data: unknown,
+  userAsk: string,
+  sessionId?: string,
+): string | undefined {
+  if (!OUTPUT_ASK_RE.test(userAsk)) return undefined;
+  const response =
+    pickPayloadString(data, "response") ?? pickPayloadString(data, "finalText");
+  const trimmed = response?.trim();
+  if (!trimmed) return undefined;
+  if (Buffer.byteLength(trimmed, "utf8") <= MAX_VERBATIM_DELIVERABLE_BYTES) {
+    return trimmed;
+  }
+  // The user asked for THE OUTPUT and it is oversized: a bounded view with
+  // its continuation reference beats a summary that may paraphrase the
+  // payload away ("479" for a captured "479001600"). With a sessionId the
+  // full response is durable on the session transcript (#24262 close-out) and
+  // the view references GET /api/coding-agents/:id/output; without one the
+  // content is persisted to the durable content store instead — the former
+  // silent `undefined` degraded the asked-for output to the summary path with
+  // no reference at all.
+  if (!sessionId) {
+    return projectedDeliverableView(trimmed, MAX_VERBATIM_DELIVERABLE_BYTES);
+  }
+  return boundedContentView(
+    trimmed,
+    MAX_VERBATIM_DELIVERABLE_BYTES,
+    orchestratorContentRef("session-output", sessionId),
+  ).view;
+}
+
+/**
+ * Direct observation fallback for workers that end with an empty final reply:
+ * name what is actually in the session workdir (post-start mtimes only) and
+ * its route-mapped public URL. Beats relaying "no captured output" for a
+ * build that exists on disk (live 2026-08-19: built dice-roller page relayed
+ * as ghosted and then parked for lack of evidence).
+ */
+export function observeWorkdirDeliverable(session: SessionInfo): string[] {
+  const observed = collectFsObservedFiles({
+    workdir: session.workdir,
+    candidatePaths: enumerateWorkdirCandidates(session.workdir),
+    sessionStartedAt: new Date(session.createdAt).getTime(),
+  });
+  if (observed.length === 0) return [];
+  const meta = session.metadata as Record<string, unknown> | undefined;
+  const routeMeta =
+    meta && typeof meta.workdirRoute === "object" && meta.workdirRoute !== null
+      ? (meta.workdirRoute as Record<string, unknown>)
+      : undefined;
+  const urlMappings = Array.isArray(routeMeta?.urlMappings)
+    ? (routeMeta.urlMappings as { urlPrefix: string; localPath: string }[])
+    : undefined;
+  const directoryUrls = deriveRouteMappedUrls(observed, urlMappings).filter(
+    (url) => url.endsWith("/"),
+  );
+  const names = observed
+    .map((file) => file.split("/").pop())
+    .filter((name): name is string => typeof name === "string");
+  // COMPLETE observation: every verified file name and every route-mapped
+  // directory URL is narrated. The completion evaluator relays this line as
+  // ground truth, so a silent `slice(0, 8)` / first-URL-only cap made the
+  // planner treat the visible subset as the whole deliverable. (The observed
+  // set itself is bounded upstream by enumerateWorkdirCandidates' walk
+  // budget; the workdir named on the session record holds the full tree.)
+  // NOTE: the "Files written (verified on disk)" prefix is a structural marker
+  // the completion evaluator keys on (orchestratorObservedBody) — keep it
+  // byte-identical.
+  return [
+    `Files written (verified on disk): ${names.join(", ")} — ${names.length} file(s) under ${session.workdir}`,
+    ...directoryUrls,
+  ];
 }
 
 function composeNarration(
@@ -3573,10 +4891,14 @@ function composeNarration(
     ].filter((line) => typeof line === "string" && line.trim().length > 0);
     return `${header}\n${lines.join("\n")}`;
   }
-  // Genuinely no captured output — keep the explicit note. The workdir stays
-  // out of the narration entirely (internal path; session metadata carries it).
+  // Genuinely no captured output: observe the workdir directly before
+  // conceding. The workdir PATH stays out of the narration (internal); only
+  // bare file names and the operator-configured public URL may surface.
   if (response === undefined) {
-    return `${header}\nsub-agent reports task complete (no captured output).`;
+    const observedLines = observeWorkdirDeliverable(session);
+    return observedLines.length > 0
+      ? `${header}\n${observedLines.join("\n")}`
+      : `${header}\nsub-agent reports task complete (no captured output).`;
   }
   // A verification-retry attempt (re-dispatched by retryIncompleteBuild) that
   // produced no change set: never narrate its raw step prose. On weak coding
@@ -3586,15 +4908,56 @@ function composeNarration(
   // (loopback dropped, verified downstream); a genuine failure is covered by
   // the separate build-incomplete report.
   if (readSessionRetryCount(session.metadata) > 0) {
+    // Only the operator's own deploy host is a deliverable address here — the
+    // child's prose also mentions asset CDNs (live 2026-08-19: the retry
+    // relay posted raw fonts.googleapis.com links as "the result").
+    const deployBase = resolveAppDeployConfig().customBaseUrl;
     const urls = collectVerifiableUrlCandidates(response).filter(
-      (url) => !isLoopbackUrl(url),
+      (url) =>
+        !isLoopbackUrl(url) &&
+        (deployBase
+          ? url.startsWith(deployBase.replace(/\/+$/, ""))
+          : // No configured deploy host: an artifact-shaped /apps/<slug>/ URL
+            // is still a deliverable address; only plain third-party links
+            // (asset CDNs) stay dropped. `false` here silently swallowed the
+            // retry's fresh deliverable URL on hosts without the custom
+            // deploy config.
+            Boolean(appRoutePathPrefix(url))),
     );
-    return urls.length > 0 ? `${header}\n${urls.join("\n")}` : header;
+    if (urls.length > 0) return `${header}\n${urls.join("\n")}`;
+    // A recovered retry with no claimed URL still delivered something the
+    // user was told had FAILED — observe the workdir so the recovery is
+    // announced instead of silent (live 2026-08-19: "kanban board failed"
+    // followed by a working app and no follow-up message).
+    const observedLines = observeWorkdirDeliverable(session);
+    return observedLines.length > 0
+      ? `${header}\n${observedLines.join("\n")}`
+      : header;
   }
   // Non-retry completion: keep the (transcript-stripped, banner-stripped) prose
   // so legitimate results ("PR opened: …", a question) still reach the user.
   const cleaned = stripToolTranscript(response);
-  if (!cleaned) return header;
+  if (!cleaned) {
+    const observedLines = observeWorkdirDeliverable(session);
+    return observedLines.length > 0
+      ? `${header}\n${observedLines.join("\n")}`
+      : header;
+  }
+  // A child that ends on an incidental failed check narrates the whole task
+  // as failed while the deliverable sits finished on disk (live 2026-08-19:
+  // self-imposed eslint/tsc on a static page). Direct observation outranks
+  // the child's verdict — append what actually exists so the relay reads as
+  // "reported a failure, but these files are on disk", not a bare failure.
+  if (
+    /\b(?:fail(?:ed|ure)?|crash(?:ed)?|could\s*n[o']t|unable\s+to)\b/i.test(
+      cleaned,
+    )
+  ) {
+    const observedLines = observeWorkdirDeliverable(session);
+    if (observedLines.length > 0) {
+      return `${header}\n${stripRoutingKindBanner(cleaned)}\n${observedLines.join("\n")}`;
+    }
+  }
   return `${header}\n${stripRoutingKindBanner(cleaned)}`;
 }
 
@@ -3692,6 +5055,56 @@ function routingKindFromPayloadBanner(data: unknown): string | undefined {
  * {@link normalizeUrlsInText} so Unicode-dash-corrupted URLs are probed in
  * their intended form.
  */
+/** Authenticated liveness recheck for github.com URLs that probed non-2xx:
+ *  a PRIVATE repo's web URL 404s for anonymous GETs, and the completion
+ *  verifier then branded a real, just-opened PR "dead" and relabeled the
+ *  success a failure (live 2026-08-18: "Couldn't finish … → HTTP 404" one
+ *  minute after the PR link was delivered). The recheck translates the web
+ *  URL to its api.github.com resource and probes THAT with the configured
+ *  token — the token never leaves api.github.com and nothing is sent for
+ *  non-github hosts. Returns true only on a 2xx API answer. */
+async function githubAuthenticatedRecheck(
+  url: string,
+  runtime: IAgentRuntime | undefined,
+): Promise<boolean> {
+  if (!runtime) return false;
+  const m = url.match(
+    /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:\/(pull|issues|commit|tree|blob)\/([^/?#]+))?(?:[/?#]|$)/,
+  );
+  if (!m) return false;
+  const token = runtime.getSetting?.("GITHUB_TOKEN");
+  if (typeof token !== "string" || !token.trim()) return false;
+  const [, owner, repo, kind, ref] = m;
+  const resource =
+    kind === "pull"
+      ? `repos/${owner}/${repo}/pulls/${ref}`
+      : kind === "issues"
+        ? `repos/${owner}/${repo}/issues/${ref}`
+        : kind === "commit"
+          ? `repos/${owner}/${repo}/commits/${ref}`
+          : `repos/${owner}/${repo}`;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 4000);
+    try {
+      const res = await fetch(`https://api.github.com/${resource}`, {
+        headers: {
+          Authorization: `token ${token.trim()}`,
+          "User-Agent": "eliza-orchestrator",
+        },
+        signal: controller.signal,
+      });
+      return res.status >= 200 && res.status < 300;
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // error-policy:J3 recheck is a liveness upgrade only; failure keeps the
+    // anonymous probe's explicit dead status.
+    return false;
+  }
+}
+
 export async function annotateUnverifiedUrls(
   text: string,
   log?: (message: string) => void,
@@ -3707,7 +5120,7 @@ export async function annotateUnverifiedUrls(
   const loopbackPorts =
     allowedLoopbackPorts ?? supervisorAllowedLoopbackPorts(routeVerification);
   const urls = expandRouteUrlAliases(
-    extractVerifiableUrls(text, 5, referenceText, ignoredUrls),
+    extractVerifiableUrls(text, referenceText, ignoredUrls),
     routeVerification,
   )
     .filter(
@@ -3780,6 +5193,12 @@ export async function annotateUnverifiedUrls(
             servedLive: false,
           };
         }
+        if (await githubAuthenticatedRecheck(url, runtime)) {
+          log?.(
+            `[verify] probe ${url} → HTTP ${res.status} anonymously, but the authenticated GitHub API recheck is live (private repo) @ ${new Date().toISOString()}`,
+          );
+          return { status: null, servedLive: true };
+        }
         log?.(
           `[verify] probe ${url} → HTTP ${res.status} @ ${new Date().toISOString()}`,
         );
@@ -3838,55 +5257,64 @@ export async function annotateUnverifiedUrls(
   // roots routinely 404 by design, so their unreachability must never read
   // as "the build did not complete". Deploy-scoped dead URLs stay in `dead`.
   const deadThirdParty: DeadUrl[] = [];
-  await Promise.all(
-    urls.map(async (url) => {
-      const result = await probe(url);
-      if (result.status !== null) {
-        dead.push({ url, status: result.status });
-        return;
-      }
-      const localStatus = verifyMappedLocalUrl(
-        url,
-        routeVerification,
-        result.servedLive,
+  // Complete-coverage probing in bounded-concurrency batches: EVERY mentioned
+  // URL is probed (the retired `slice(0, 5)` cap silently exempted the 6th+
+  // URL, so a dead one escaped the verify-retry gate while the relayed verdict
+  // implied full coverage). The batch size bounds parallel sockets, never the
+  // set of URLs verified.
+  const VERIFY_PROBE_BATCH = 5;
+  const probeMentionedUrl = async (url: string): Promise<void> => {
+    const result = await probe(url);
+    if (result.status !== null) {
+      dead.push({ url, status: result.status });
+      return;
+    }
+    const localStatus = verifyMappedLocalUrl(
+      url,
+      routeVerification,
+      result.servedLive,
+    );
+    if (localStatus) {
+      dead.push({ url, status: localStatus });
+      return;
+    }
+    // Follow the page's own declared dependencies — a 200 index.html
+    // that <link>s a missing style.css is still a broken app.
+    if (result.html) {
+      const subResources = extractSubResources(result.html, url);
+      await Promise.all(
+        subResources.map(async (subUrl) => {
+          const subResult = await probe(subUrl);
+          if (subResult.status !== null) {
+            // Same-origin and route-mapped (deploy-host) sub-resources are
+            // part of the artifact under verification — a missing style.css
+            // IS a broken build. A cross-origin third party is not; keyed on
+            // structured URL origins, never on narration text.
+            const entry = { url: subUrl, status: subResult.status, via: url };
+            if (isThirdPartySubResource(subUrl, url, routeVerification)) {
+              deadThirdParty.push(entry);
+            } else {
+              dead.push(entry);
+            }
+            return;
+          }
+          const subLocalStatus = verifyMappedLocalUrl(
+            subUrl,
+            routeVerification,
+            subResult.servedLive,
+          );
+          if (subLocalStatus) {
+            dead.push({ url: subUrl, status: subLocalStatus, via: url });
+          }
+        }),
       );
-      if (localStatus) {
-        dead.push({ url, status: localStatus });
-        return;
-      }
-      // Follow the page's own declared dependencies — a 200 index.html
-      // that <link>s a missing style.css is still a broken app.
-      if (result.html) {
-        const subResources = extractSubResources(result.html, url);
-        await Promise.all(
-          subResources.map(async (subUrl) => {
-            const subResult = await probe(subUrl);
-            if (subResult.status !== null) {
-              // Same-origin and route-mapped (deploy-host) sub-resources are
-              // part of the artifact under verification — a missing style.css
-              // IS a broken build. A cross-origin third party is not; keyed on
-              // structured URL origins, never on narration text.
-              const entry = { url: subUrl, status: subResult.status, via: url };
-              if (isThirdPartySubResource(subUrl, url, routeVerification)) {
-                deadThirdParty.push(entry);
-              } else {
-                dead.push(entry);
-              }
-              return;
-            }
-            const subLocalStatus = verifyMappedLocalUrl(
-              subUrl,
-              routeVerification,
-              subResult.servedLive,
-            );
-            if (subLocalStatus) {
-              dead.push({ url: subUrl, status: subLocalStatus, via: url });
-            }
-          }),
-        );
-      }
-    }),
-  );
+    }
+  };
+  for (let i = 0; i < urls.length; i += VERIFY_PROBE_BATCH) {
+    await Promise.all(
+      urls.slice(i, i + VERIFY_PROBE_BATCH).map(probeMentionedUrl),
+    );
+  }
   // Tally page-level dead against the mentioned set and sub-resource dead
   // separately: sub-resources are DISCOVERED from page HTML, not mentioned,
   // so folding them into one "N dead of M mentioned" count let N exceed M.
@@ -4105,7 +5533,24 @@ function mappedLocalTarget(
     parsed.pathname.slice(prefixPath.length),
   );
   if (!relativePath) return undefined;
-  const localRoot = path.resolve(workdir, mapping.localPath);
+  let localRoot = path.resolve(workdir, mapping.localPath);
+  if (!fs.existsSync(localRoot)) {
+    // Slug-dir sessions live INSIDE the mapped tree (the route stamp carries
+    // the session's own directory), so resolving localPath against the
+    // session workdir doubles the path — …/name-picker-wheel-2/data/apps/… —
+    // and URL verification reported a live page as missing (2026-08-19).
+    // Anchor at the enclosing mapped tree instead.
+    const normalizedLocal = mapping.localPath
+      .replace(/^\.?\//, "")
+      .replace(/\/+$/, "");
+    const marker = `${path.sep}${normalizedLocal.split("/").join(path.sep)}${path.sep}`;
+    const index = `${workdir}${path.sep}`.indexOf(marker);
+    if (index >= 0) {
+      localRoot = path.resolve(
+        `${workdir.slice(0, index)}${marker}`.replace(/[\\/]+$/, ""),
+      );
+    }
+  }
   const target = path.resolve(localRoot, relativePath);
   if (target !== localRoot && !target.startsWith(`${localRoot}${path.sep}`)) {
     return undefined;


### PR DESCRIPTION
Part 5 of the split series closing out #24262 — the sub-agent router and completion relays.

cc @lalalune

## Content-budget closure response (supersedes #24422)

Rebased on the repaired parents: oversized deliverables project with resolvable references instead of vanishing (undefined-fallback removed where the user asked for the output); origin best-results persist as `canonicalBestResult` task metadata (the volatile LRU is no longer the only record); character bio/traits and fact values feed phrasing models COMPLETE (the cited "character text is sliced"); narration/notification bounds are named previews or reference-bearing views.

## Scope — relays that are honest, lane-scoped, and reference-bearing

- **Per-lane deferred relays**: completion relays defer until the verification verdict per `${taskId}\0${sessionId}`; a verdict releases only its own lane's relay; the re-engage path drops the lane's relay on every exit (the 5-minute fallback was releasing judged-failed completions as "passed"); a user-stopped task's relay is dropped regardless of deferral config.
- **Follow-up voice re-keying**: a follow-up delivered into a live session re-keys that session's request voice (`followUpOriginMessageId`, noted at queue time, activated at delivery) so its completion posts instead of dying as a duplicate terminal — "also give it a dark mode toggle" completed silently before (live).
- **Reference-bearing views**: the mid-run narration flush (800-char chat view) and an oversized asked-output deliverable name their continuation reference (`acpx-session-output:*`) instead of a bare truncation marker; the full content is durable on the session transcript. `recordOriginResult` keeps full text.
- **Diagnosable drops**: every completion-relay suppression decision (duplicate lineage, duplicate request terminal, verify churn, retry handoff) and each actual injection logs at warn — a dropped relay was previously undiagnosable from logs.
- Evaluators: completion/failure relays, durable-cancel routing, finished-work follow-up routing (a "run it again" follow-up routes to the finished lane; a new-deliverable ask that merely says "and run it" does not), route-scoped work routing.

## Stack
Base: `feat/coding-agent-split-4-task-service`. Next: 6-actions-surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
