### PR TITLE
fix(cloud): mint app key after quota admission

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
@@ -4,7 +4,7 @@
  * Two service calls run on independent pool sessions while an external holder
  * owns the organization row lock. Both calls must be blocked in open
  * transactions before the holder releases them; with one slot remaining,
- * exactly one linked app/key pair commits and the losing key rolls back.
+ * exactly one linked app/key pair commits and the loser never reaches minting.
  */
 
 import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
@@ -218,6 +218,7 @@ realPostgres("app and initial API-key atomicity", () => {
     }
     const initializedAppsService = appsService;
     const initializedApiKeysRepository = apiKeysRepository;
+    const initializedApiKeysService = apiKeysService;
 
     const suffix = randomUUID();
     const [organization] = await dbWrite
@@ -249,7 +250,8 @@ realPostgres("app and initial API-key atomicity", () => {
       organization.id,
     ]);
 
-    const deleteKey = spyOn(apiKeysService, "delete");
+    const createKey = spyOn(initializedApiKeysService, "create");
+    const deleteKey = spyOn(initializedApiKeysService, "delete");
     const creates = names.map((name, index) =>
       initializedAppsService.create({
         name,
@@ -305,11 +307,15 @@ realPostgres("app and initial API-key atomicity", () => {
       expect(durableApp.api_key_id).toBe(durableKey.id);
       expect(winner.value.app.id).toBe(durableApp.id);
       expect(winner.value.app.api_key_id).toBe(durableKey.id);
-      expect((await apiKeysService.validateApiKey(winner.value.apiKey))?.id).toBe(durableKey.id);
+      expect((await initializedApiKeysService.validateApiKey(winner.value.apiKey))?.id).toBe(
+        durableKey.id,
+      );
+      expect(createKey).toHaveBeenCalledTimes(1);
       expect(deleteKey).not.toHaveBeenCalled();
     } finally {
       if (!holderReleased) await holder.query("ROLLBACK");
       await Promise.allSettled(creates);
+      createKey.mockRestore();
       deleteKey.mockRestore();
       await Promise.all([holder.end(), observer.end()]);
     }

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -1377,7 +1377,7 @@ describe("AppsService.create organization cap", () => {
     }
   });
 
-  test("rolls back the API key when the org is already at the configured app cap", async () => {
+  test("rejects at the configured app cap before API-key minting", async () => {
     expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "1";
@@ -1388,7 +1388,9 @@ describe("AppsService.create organization cap", () => {
         organization_id: organizationId,
         created_by_user_id: userId,
       });
-      const deleteKey = spyOn(apiKeysService, "delete");
+      const createKey = spyOn(apiKeysService, "create").mockRejectedValue(
+        new Error("API-key mint must not run after quota rejection"),
+      );
 
       try {
         await expect(
@@ -1408,9 +1410,9 @@ describe("AppsService.create organization cap", () => {
         expect(
           await apiKeysRepository.findByUserAndName(userId, "Blocked App - App API Key"),
         ).toEqual([]);
-        expect(deleteKey).not.toHaveBeenCalled();
+        expect(createKey).not.toHaveBeenCalled();
       } finally {
-        deleteKey.mockRestore();
+        createKey.mockRestore();
       }
     } finally {
       if (previousLimit === undefined) {
@@ -1455,7 +1457,7 @@ describe("AppsService.create organization cap", () => {
     }
   });
 
-  test("rolls back the generated API key without compensation when the cap check rejects", async () => {
+  test("does not mint an API key when the quota-authoritative insert rejects", async () => {
     expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
@@ -1465,7 +1467,9 @@ describe("AppsService.create organization cap", () => {
         appsRepository,
         "createIfOrganizationBelowLimit",
       ).mockImplementation(async () => undefined);
-      const deleteKey = spyOn(apiKeysService, "delete");
+      const createKey = spyOn(apiKeysService, "create").mockRejectedValue(
+        new Error("API-key mint must not run after quota rejection"),
+      );
 
       try {
         await expect(
@@ -1485,9 +1489,9 @@ describe("AppsService.create organization cap", () => {
           await apiKeysRepository.findByUserAndName(userId, "Race Rejected App - App API Key"),
         ).toEqual([]);
         expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
-        expect(deleteKey).not.toHaveBeenCalled();
+        expect(createKey).not.toHaveBeenCalled();
       } finally {
-        deleteKey.mockRestore();
+        createKey.mockRestore();
         createIfBelowLimit.mockRestore();
       }
     } finally {
@@ -1499,7 +1503,7 @@ describe("AppsService.create organization cap", () => {
     }
   });
 
-  test("preserves an app insert failure while rolling back the generated API key", async () => {
+  test("preserves a provisional app insert failure without minting an API key", async () => {
     expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
@@ -1512,7 +1516,9 @@ describe("AppsService.create organization cap", () => {
       ).mockImplementation(async () => {
         throw insertFailure;
       });
-      const deleteKey = spyOn(apiKeysService, "delete");
+      const createKey = spyOn(apiKeysService, "create").mockRejectedValue(
+        new Error("API-key mint must not run after app insert failure"),
+      );
 
       try {
         await expect(
@@ -1528,10 +1534,89 @@ describe("AppsService.create organization cap", () => {
           await apiKeysRepository.findByUserAndName(userId, "Insert Failure App - App API Key"),
         ).toEqual([]);
         expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
-        expect(deleteKey).not.toHaveBeenCalled();
+        expect(createKey).not.toHaveBeenCalled();
       } finally {
-        deleteKey.mockRestore();
+        createKey.mockRestore();
         createIfBelowLimit.mockRestore();
+      }
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
+  });
+
+  test("rolls back the provisional app when API-key minting fails", async () => {
+    expect(pgliteReady).toBe(true);
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+      const mintFailure = new Error("synthetic API-key mint failure");
+      const createKey = spyOn(apiKeysService, "create").mockRejectedValue(mintFailure);
+
+      try {
+        await expect(
+          appsService.create({
+            name: "Mint Failure App",
+            organization_id: organizationId,
+            created_by_user_id: userId,
+            app_url: "https://mint-failure.example",
+          }),
+        ).rejects.toBe(mintFailure);
+
+        expect(createKey).toHaveBeenCalledTimes(1);
+        expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+        expect(
+          await apiKeysRepository.findByUserAndName(userId, "Mint Failure App - App API Key"),
+        ).toEqual([]);
+      } finally {
+        createKey.mockRestore();
+      }
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
+  });
+
+  test("rolls back the provisional app and minted key when initial attachment loses its CAS", async () => {
+    expect(pgliteReady).toBe(true);
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+      const createKey = spyOn(apiKeysService, "create");
+      const attachInitialApiKey = spyOn(appsRepository, "attachInitialApiKey").mockResolvedValue(
+        undefined,
+      );
+
+      try {
+        await expect(
+          appsService.create({
+            name: "Attach Failure App",
+            organization_id: organizationId,
+            created_by_user_id: userId,
+            app_url: "https://attach-failure.example",
+          }),
+        ).rejects.toMatchObject({
+          name: "ElizaError",
+          code: "APP_INITIAL_API_KEY_ATTACH_FAILED",
+        });
+
+        expect(createKey).toHaveBeenCalledTimes(1);
+        expect(attachInitialApiKey).toHaveBeenCalledTimes(1);
+        expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+        expect(
+          await apiKeysRepository.findByUserAndName(userId, "Attach Failure App - App API Key"),
+        ).toEqual([]);
+      } finally {
+        attachInitialApiKey.mockRestore();
+        createKey.mockRestore();
       }
     } finally {
       if (previousLimit === undefined) {

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -546,15 +546,15 @@ export class AppsRepository {
   }
 
   /**
-   * Creates a new app only if the owning organization is still under its app cap.
+   * Creates a provisional app only if the owning organization is still under its app cap.
    *
    * The organization row lock serializes concurrent app creates for one org in
    * Postgres, so parallel requests cannot all observe the same pre-insert count.
-   * `NO KEY UPDATE` remains exclusive between contenders while staying compatible
-   * with the foreign-key `KEY SHARE` lock held by their transactional API-key insert.
+   * The initial API key stays null until the admitted transaction mints and
+   * attaches it, so a quota loser cannot generate a credential first.
    */
   async createIfOrganizationBelowLimit(
-    data: NewApp,
+    data: Omit<NewApp, "api_key_id">,
     maxApps: number,
     tx: DbTransaction,
   ): Promise<App | undefined> {
@@ -571,7 +571,37 @@ export class AppsRepository {
       return undefined;
     }
 
-    const [app] = await tx.insert(apps).values(data).returning();
+    const [app] = await tx
+      .insert(apps)
+      .values({ ...data, api_key_id: null })
+      .returning();
+    return app;
+  }
+
+  /** Attaches the first API key once to an admitted app inside its creation transaction. */
+  async attachInitialApiKey(
+    appId: string,
+    organizationId: string,
+    apiKeyId: string,
+    tx: DbTransaction,
+  ): Promise<App | undefined> {
+    const [app] = await tx
+      .update(apps)
+      .set({ api_key_id: apiKeyId })
+      .where(
+        and(
+          eq(apps.id, appId),
+          eq(apps.organization_id, organizationId),
+          isNull(apps.api_key_id),
+          sql`EXISTS (
+            SELECT 1
+            FROM ${apiKeys}
+            WHERE ${apiKeys.id} = ${apiKeyId}
+              AND ${apiKeys.organization_id} = ${organizationId}
+          )`,
+        ),
+      )
+      .returning();
     return app;
   }
 

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -458,6 +458,27 @@ export class AppsService {
 
     const limit = getMaxAppsPerOrg();
     const created = await writeTransaction(async (tx) => {
+      const provisionalApp = await appsRepository.createIfOrganizationBelowLimit(
+        {
+          name: data.name,
+          description: data.description,
+          slug,
+          organization_id: data.organization_id,
+          created_by_user_id: data.created_by_user_id,
+          app_url: data.app_url,
+          allowed_origins: data.allowed_origins || [data.app_url],
+          logo_url: data.logo_url,
+          website_url: data.website_url,
+          contact_email: data.contact_email,
+        },
+        limit,
+        tx,
+      );
+
+      if (!provisionalApp) {
+        throw new AppCreationLimitError(data.organization_id, limit);
+      }
+
       const { apiKey, plainKey } = await apiKeysService.create(
         {
           name: `${data.name} - App API Key`,
@@ -469,26 +490,23 @@ export class AppsService {
         tx,
       );
 
-      const app = await appsRepository.createIfOrganizationBelowLimit(
-        {
-          name: data.name,
-          description: data.description,
-          slug,
-          organization_id: data.organization_id,
-          created_by_user_id: data.created_by_user_id,
-          app_url: data.app_url,
-          allowed_origins: data.allowed_origins || [data.app_url],
-          api_key_id: apiKey.id,
-          logo_url: data.logo_url,
-          website_url: data.website_url,
-          contact_email: data.contact_email,
-        },
-        limit,
+      const app = await appsRepository.attachInitialApiKey(
+        provisionalApp.id,
+        data.organization_id,
+        apiKey.id,
         tx,
       );
 
       if (!app) {
-        throw new AppCreationLimitError(data.organization_id, limit);
+        throw new ElizaError("App lost its initial API-key attachment compare-and-set", {
+          code: "APP_INITIAL_API_KEY_ATTACH_FAILED",
+          context: {
+            appId: provisionalApp.id,
+            apiKeyId: apiKey.id,
+            organizationId: data.organization_id,
+          },
+          severity: "fatal",
+        });
       }
 
       return { app, apiKey: plainKey };


### PR DESCRIPTION
# Relates to

Fixes #24508

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync; the exact unrelated package-wide lint blocker is recorded below.
- [x] A reviewer can confirm the change from the focused PGlite and repeated real-PostgreSQL evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `1d4a68c7745d3e93b44e2d8c5e2937efa821e89c`; zero conflicts.
- [x] Focused exact-head verification passes; the inherited package-wide lint blocker is documented in **Known gaps / failures**.

# Risks

Low. The change is limited to app creation transaction ordering and focused tests. A quota-admitted app is briefly provisional only inside the uncommitted transaction; any mint or compare-and-set attachment failure aborts that transaction.

# Background

## What does this PR do?

- Performs the quota-authoritative app insert first with `api_key_id = NULL`.
- Mints the initial key only after app admission succeeds, in the same write transaction.
- Attaches the key with an organization-scoped, null-only compare-and-set that also verifies the key belongs to the organization.
- Rolls back the provisional app and any minted key when minting or attachment fails.
- Extends PGlite coverage and the real two-session PostgreSQL N/N+1 test to prove the losing contender never calls key creation.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; this is backend transactional ordering with no public API change.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/apps.ts`, then `packages/cloud/shared/src/db/repositories/apps.ts`. The real concurrency proof is `packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts`.

## Detailed testing steps

Bun: `1.3.14`

- `bun --config=/dev/null test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts --reporter=dots` — 39 pass, 0 fail, 229 assertions.
- `APPS_TENANT_DB_TEST_DSN=<isolated-local-postgres-17-dsn> bun --config=/dev/null test packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts --rerun-each=10 --reporter=dots` — 10 pass, 0 fail, 120 assertions.
- `mise exec node@24.15.0 -- bun run --cwd packages/cloud/shared typecheck` — pass.
- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/apps.ts packages/cloud/shared/src/lib/services/apps.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts` — pass, 4 files checked.
- `git diff --check origin/develop...HEAD` — pass.
- Independent read-only review — no actionable defects found.

The PostgreSQL test holds the organization row lock from an external session, waits until both independent app-create transactions are blocked, releases them into one remaining slot, and asserts one canonical quota error, one key-service create call, one durable app, one durable key, and a valid app-to-key link.

# Evidence Gate

<!-- evidence-head:613865909342817574fff493ccc9b984775a038c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only transaction ordering; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only transaction ordering; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only transaction ordering; no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] [24554-pr-24554-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24554-pr-24554-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24554-pr-24554-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24554-pr-24554-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model path changed.

## Backend + frontend logs

Exact-head PGlite result:

```text
39 pass
0 fail
229 expect() calls
Ran 39 tests across 1 file.
```

Exact-head PostgreSQL 17.11 N/N+1 result (`--rerun-each=10`):

```text
10 pass
0 fail
120 expect() calls
Ran 10 tests across 1 file.
```

Frontend: N/A - no frontend code or request/response surface changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only transaction ordering; no rendered UI.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

`bun run --cwd packages/cloud/shared lint:check` checks 2,304 files and currently exits 1 because Biome would reformat these three files already present unchanged on `origin/develop`:

- `src/db/repositories/personal-shared-groups.integration.test.ts`
- `src/db/repositories/personal-shared-groups.ts`
- `src/db/schemas/personal-shared-groups.ts`

None is in this four-file PR diff. The exact four affected files pass Biome. Root `bun run verify` includes the same package-wide lint gate, so it was not rerun after this blocker was reproduced exactly.

Docker's cached `postgres:16-alpine` blob is locally unreadable; the required real-PostgreSQL proof instead ran successfully against an isolated temporary PostgreSQL 17.11 cluster, which was stopped after the test.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

No migration, deploy, provider call, or production mutation is part of this PR.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@1d4a68c7745d3e93b44e2d8c5e2937efa821e89c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-api-key-order]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@1d4a68c7745d3e93b44e2d8c5e2937efa821e89c:packages/skills/skills/contribute-to-eliza"} -->


