### PR TITLE
test(app-core): cover power-state parsers

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/__tests__/power-state.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/__tests__/power-state.test.ts
@@ -1,0 +1,136 @@
+/** Verifies desktop power and idle-state parsers with deterministic platform command output. */
+
+import { describe, expect, it } from "vitest";
+import {
+  parseLinuxLockedHintOutput,
+  parseMacOsHidIdleTimeOutput,
+  parseMacOsPowerSourceOutput,
+  parseMacOsSessionLockedOutput,
+  parseWindowsIdleTimeOutput,
+  parseWindowsLockStateOutput,
+  parseWindowsPowerLineOutput,
+  parseXprintidleOutput,
+} from "../power-state.ts";
+
+describe("parseWindowsPowerLineOutput", () => {
+  it("parses Offline as on battery", () => {
+    expect(parseWindowsPowerLineOutput("Offline")).toEqual({
+      onBattery: true,
+      known: true,
+    });
+  });
+
+  it("parses Online and Unknown as AC", () => {
+    expect(parseWindowsPowerLineOutput("Online")).toEqual({
+      onBattery: false,
+      known: true,
+    });
+    expect(parseWindowsPowerLineOutput("Unknown")).toEqual({
+      onBattery: false,
+      known: true,
+    });
+  });
+
+  it("takes the last non-empty line and rejects garbage", () => {
+    expect(parseWindowsPowerLineOutput("warning line\nOffline")).toEqual({
+      onBattery: true,
+      known: true,
+    });
+    expect(parseWindowsPowerLineOutput("garbage")).toEqual({
+      onBattery: false,
+      known: false,
+    });
+    expect(parseWindowsPowerLineOutput("")).toEqual({
+      onBattery: false,
+      known: false,
+    });
+  });
+});
+
+describe("parseMacOsPowerSourceOutput", () => {
+  it("detects battery and AC power", () => {
+    expect(
+      parseMacOsPowerSourceOutput("Current Power Source: Battery Power"),
+    ).toEqual({
+      onBattery: true,
+      known: true,
+    });
+    expect(
+      parseMacOsPowerSourceOutput("Current Power Source: AC Power"),
+    ).toEqual({
+      onBattery: false,
+      known: true,
+    });
+    expect(parseMacOsPowerSourceOutput("weird")).toEqual({
+      onBattery: false,
+      known: false,
+    });
+  });
+});
+
+describe("parseMacOsHidIdleTimeOutput", () => {
+  it("parses HIDIdleTime ns to seconds", () => {
+    expect(parseMacOsHidIdleTimeOutput('"HIDIdleTime" = 5000000000')).toBe(5);
+  });
+
+  it("returns null for missing or malformed output", () => {
+    expect(parseMacOsHidIdleTimeOutput("nothing")).toBeNull();
+    expect(parseMacOsHidIdleTimeOutput('"HIDIdleTime" = abc')).toBeNull();
+  });
+});
+
+describe("parseMacOsSessionLockedOutput", () => {
+  it("parses locked/unlocked", () => {
+    expect(parseMacOsSessionLockedOutput("CGSSessionScreenIsLocked = 1")).toBe(
+      true,
+    );
+    expect(parseMacOsSessionLockedOutput("screenIsLocked = 0")).toBe(false);
+    expect(parseMacOsSessionLockedOutput("nothing")).toBeNull();
+  });
+});
+
+describe("parseXprintidleOutput", () => {
+  it("parses ms to seconds", () => {
+    expect(parseXprintidleOutput("5000")).toBe(5);
+    expect(parseXprintidleOutput("idle\n12345")).toBe(12);
+  });
+
+  it("returns null for garbage", () => {
+    expect(parseXprintidleOutput("abc")).toBeNull();
+    expect(parseXprintidleOutput("")).toBeNull();
+    expect(parseXprintidleOutput("-1")).toBeNull();
+    expect(parseXprintidleOutput("1.5")).toBeNull();
+    expect(parseXprintidleOutput("9".repeat(400))).toBeNull();
+  });
+});
+
+describe("parseLinuxLockedHintOutput", () => {
+  it("parses yes/no and true/false", () => {
+    expect(parseLinuxLockedHintOutput("LockedHint=yes")).toBe(true);
+    expect(parseLinuxLockedHintOutput("LockedHint=no")).toBe(false);
+    expect(parseLinuxLockedHintOutput("LockedHint=true")).toBe(true);
+    expect(parseLinuxLockedHintOutput("LockedHint=false")).toBe(false);
+    expect(parseLinuxLockedHintOutput("LockedHint=maybe")).toBeNull();
+  });
+});
+
+describe("parseWindowsIdleTimeOutput", () => {
+  it("parses ms to seconds", () => {
+    expect(parseWindowsIdleTimeOutput("90000")).toBe(90);
+  });
+
+  it("returns null for garbage", () => {
+    expect(parseWindowsIdleTimeOutput("nope")).toBeNull();
+    expect(parseWindowsIdleTimeOutput("-1")).toBeNull();
+    expect(parseWindowsIdleTimeOutput("1.5")).toBeNull();
+    expect(parseWindowsIdleTimeOutput("9".repeat(400))).toBeNull();
+  });
+});
+
+describe("parseWindowsLockStateOutput", () => {
+  it("parses count as locked signal", () => {
+    expect(parseWindowsLockStateOutput("1")).toBe(true);
+    expect(parseWindowsLockStateOutput("0")).toBe(false);
+    expect(parseWindowsLockStateOutput("abc")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Repairs and extends the useful Electrobun power-state parser coverage originally proposed by wwl-hub in #24546.

- imports the production module from the correct parent path
- adds the required maintained-test responsibility header
- removes unused Vitest imports and applies the owning workspace formatter
- adds negative, fractional, and numeric-overflow parser cases

## Verification

- focused Vitest: 13/13 passed
- Electrobun lint: 216 files, no errors
- `git diff --check`

The sparse worktree cannot complete the broad Electrobun typecheck because many optional workspace dependencies are absent; hosted CI is authoritative.

## Attribution

Coverage originated in #24546 by wwl-hub; this current-base replacement repairs the branch rather than discarding the contribution.

<!-- evidence-head:9e10f2b3c480dec53bf8ee5cc4539b2d92e40c5e -->