### PR TITLE
fix(core): align in-memory vector search threshold and entityId with plugin-sql

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
@@ -162,31 +162,87 @@ describe("InMemoryDatabaseAdapter.searchMemories", () => {
 		expect(results).toEqual([]);
 	});
 
-	it("uses the SQL-compatible default threshold while preserving an explicit zero", async () => {
-		const belowDefault = offAxis(2);
+	it("applies no similarity floor when match_threshold is absent or zero, and filters when set", async () => {
 		const adapter = await seed([
 			{
 				entityId: entityA,
 				roomId: roomA,
 				agentId,
-				content: { text: "below default" },
-				embedding: belowDefault,
+				content: { text: "near" },
+				embedding: offAxis(0.1),
+			},
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "far" },
+				embedding: offAxis(2),
+			},
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "opposite" },
+				embedding: onAxis().map((value) => -value),
 			},
 		]);
 
+		const texts = (memories: Memory[]) =>
+			memories.map((memory) => memory.content.text);
+
 		expect(
-			await adapter.searchMemories({
-				tableName: "memories",
-				embedding: onAxis(),
-			}),
-		).toEqual([]);
+			texts(
+				await adapter.searchMemories({
+					tableName: "memories",
+					embedding: onAxis(),
+				}),
+			),
+		).toEqual(["near", "far", "opposite"]);
 		expect(
-			await adapter.searchMemories({
-				tableName: "memories",
+			texts(
+				await adapter.searchMemories({
+					tableName: "memories",
+					embedding: onAxis(),
+					match_threshold: 0,
+				}),
+			),
+		).toEqual(["near", "far", "opposite"]);
+		expect(
+			texts(
+				await adapter.searchMemories({
+					tableName: "memories",
+					embedding: onAxis(),
+					match_threshold: 0.5,
+				}),
+			),
+		).toEqual(["near"]);
+	});
+
+	it("treats entityId as a row predicate like the SQL vector search", async () => {
+		const adapter = await seed([
+			{
+				entityId: entityA,
+				roomId: roomA,
+				agentId,
+				content: { text: "mine" },
+				embedding: offAxis(0.2),
+			},
+			{
+				entityId: entityB,
+				roomId: roomA,
+				agentId,
+				content: { text: "theirs" },
 				embedding: onAxis(),
-				match_threshold: 0,
-			}),
-		).toMatchObject([{ content: { text: "below default" } }]);
+			},
+		]);
+
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(),
+			entityId: entityA,
+			count: 5,
+		});
+		expect(results.map((memory) => memory.content.text)).toEqual(["mine"]);
 	});
 });
 

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -133,13 +133,14 @@ function memoryMatchesMetadata(
 }
 
 /**
- * Cosine similarity for in-process vector recall. Returns -1 when the vectors
- * cannot be compared (empty, mixed width, or non-finite components) so a search
- * can skip them instead of inventing a score. Matches the document-fragment
- * in-memory twin.
+ * Cosine similarity for in-process vector recall. Returns null when the vectors
+ * cannot be compared (empty, mixed width, non-finite components, or a zero
+ * vector) so a search can skip them instead of inventing a score. A genuine
+ * negative similarity is a valid score, not a sentinel, which is why the
+ * incomparable case is null rather than -1.
  */
-function cosineSimilarity(left: number[], right: number[]): number {
-	if (left.length !== right.length || left.length === 0) return -1;
+function cosineSimilarity(left: number[], right: number[]): number | null {
+	if (left.length !== right.length || left.length === 0) return null;
 	let dot = 0;
 	let leftMagnitude = 0;
 	let rightMagnitude = 0;
@@ -152,13 +153,13 @@ function cosineSimilarity(left: number[], right: number[]): number {
 			!Number.isFinite(leftValue) ||
 			!Number.isFinite(rightValue)
 		) {
-			return -1;
+			return null;
 		}
 		dot += leftValue * rightValue;
 		leftMagnitude += leftValue * leftValue;
 		rightMagnitude += rightValue * rightValue;
 	}
-	if (leftMagnitude === 0 || rightMagnitude === 0) return -1;
+	if (leftMagnitude === 0 || rightMagnitude === 0) return null;
 	return dot / (Math.sqrt(leftMagnitude) * Math.sqrt(rightMagnitude));
 }
 
@@ -1437,27 +1438,33 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		// Scope eligibility first, then the top-K cut — the plugin-sql contract.
 		// A global top-K followed by a post-hoc room/world/entity filter silently
 		// drops eligible matches whenever closer out-of-scope vectors outnumber
-		// the candidate pool.
-		const candidates = await this.getMemories({
-			tableName: params.tableName,
-			roomId: params.roomId,
-			worldId: params.worldId,
-			entityId: params.entityId,
-			unique: params.unique,
-			accessContext: params.accessContext,
-		});
+		// the candidate pool. `entityId` is a row predicate here (as in the SQL
+		// vector search), unlike getMemories where it only names the RLS context.
+		const candidates = (
+			await this.getMemories({
+				tableName: params.tableName,
+				roomId: params.roomId,
+				worldId: params.worldId,
+				unique: params.unique,
+				accessContext: params.accessContext,
+			})
+		).filter(
+			(memory) => !params.entityId || memory.entityId === params.entityId,
+		);
 		const limit = params.count ?? params.limit ?? 10;
-		const threshold = params.match_threshold ?? 0.5;
+		// Same truthiness contract as plugin-sql: an absent or zero threshold
+		// applies no similarity floor.
+		const threshold = params.match_threshold;
 		const scored: Memory[] = [];
 		for (const memory of candidates) {
 			if (!Array.isArray(memory.embedding) || memory.embedding.length === 0) {
 				continue;
 			}
 			const similarity = cosineSimilarity(memory.embedding, params.embedding);
-			if (similarity < 0) {
+			if (similarity === null) {
 				continue;
 			}
-			if (similarity < threshold) {
+			if (threshold && similarity < threshold) {
 				continue;
 			}
 			scored.push({ ...memory, similarity });


### PR DESCRIPTION
Follow-up to #24504 (already merged as 15fb0e6d2d97). Refs #24460.

## What
`InMemoryDatabaseAdapter.searchMemories` diverged from the plugin-sql vector search in three ways:

- **Default threshold**: it applied `match_threshold ?? 0.5`. plugin-sql (`base.ts` searchMemoriesByEmbedding) applies a floor only when the threshold is truthy; an absent or zero threshold returns the top-K unfiltered. Every runtime caller in `packages/core` omits `match_threshold`, so the ALLOW_NO_DATABASE path silently lost recall below 0.5.
- **entityId**: it was forwarded to `getMemories`, which deliberately ignores it (RLS-context semantics). The SQL vector search treats it as a row predicate; now so does the in-memory one.
- **Incomparable sentinel**: `cosineSimilarity` returned -1 for mixed-width/non-finite/zero vectors and the search skipped `similarity < 0`, which also dropped genuinely opposite vectors. Incomparable is now `null`.

## Verification
- `bun run --cwd packages/core test -- src/database/inMemoryAdapter.search-memories.test.ts` → 7 passed.
- Load-bearing: same test file against the develop adapter source → 2 failed (the two new cases) | 5 passed.
- `bun run --cwd packages/core test -- src/database/inMemoryAdapter` → 25 passed, 1 failed (`message-search.test.ts` entityId case, pre-existing on develop and noted in #24504).
- `packages/core` `tsc --noEmit`: 0 errors. `biome check` on both files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)