### PR TITLE
fix(scenarios): refresh fixture migration ratchet

### DIFF
--- a/packages/scenario-runner/src/model-fixture-migration.test.ts
+++ b/packages/scenario-runner/src/model-fixture-migration.test.ts
@@ -184,7 +184,7 @@ describe("scenario model fixture migration", () => {
       strictOrModelFree: deterministic.length - legacy.length,
       legacy: legacy.length,
       total: deterministic.length,
-    }).toEqual({ strictOrModelFree: 47, legacy: 73, total: 120 });
+    }).toEqual({ strictOrModelFree: 48, legacy: 72, total: 120 });
   }, 120_000);
 
   it("recognizes authored properties while ignoring comments and setup strings", () => {


### PR DESCRIPTION
## Summary

- update the exact scenario fixture migration inventory after one fixture moved from legacy to strict/model-free
- preserve the 120-fixture total and the ratchet's fail-on-unreviewed-change behavior

Closes #24560

## Validation

- `bunx vitest run src/model-fixture-migration.test.ts --config vitest.config.ts` — 2/2 passed
- `bun run build` — passed
- `bunx biome check src/model-fixture-migration.test.ts` — passed
- `bun run typecheck` — blocked by pre-existing workspace resolution/type failures on current `develop` (including missing optional plugin modules and unrelated personal-assistant types); the changed test is type-checked by the focused Vitest transform and contains only literal expectation values

Exact reviewed SHA: `340b3b43d92ce881ac2818a78f7c6cce0de607c1`
