### PR TITLE
chore(cloud-shared): format the three files failing lint:check on develop

### DIFF
--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
@@ -2,14 +2,7 @@
  * Exercises Personal Shared group claims and bindings against isolated PGlite,
  * including atomic consumption, tenant-takeover resistance, and safe reclaim.
  */
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
@@ -62,36 +55,23 @@ async function consume(codeHash: string, platformUserId: string) {
 }
 
 beforeAll(async () => {
-  ({ closeDatabaseConnectionsForTests, getPgliteClientForTests } = await import(
-    "../client"
-  ));
-  ({ personalSharedGroupsRepository: repository } = await import(
-    "./personal-shared-groups"
-  ));
+  ({ closeDatabaseConnectionsForTests, getPgliteClientForTests } = await import("../client"));
+  ({ personalSharedGroupsRepository: repository } = await import("./personal-shared-groups"));
   const database = getPgliteClientForTests();
   await database.exec(`
     CREATE TABLE organizations (id uuid PRIMARY KEY);
     CREATE TABLE users (id uuid PRIMARY KEY);
   `);
   const migration = await Bun.file(
-    new URL(
-      "../migrations/0297_personal_shared_group_bindings.sql",
-      import.meta.url,
-    ),
+    new URL("../migrations/0297_personal_shared_group_bindings.sql", import.meta.url),
   ).text();
   await database.exec(migration);
   const authorityMigration = await Bun.file(
-    new URL(
-      "../migrations/0300_personal_shared_group_authority_version.sql",
-      import.meta.url,
-    ),
+    new URL("../migrations/0300_personal_shared_group_authority_version.sql", import.meta.url),
   ).text();
   await database.exec(authorityMigration);
   const leaseMigration = await Bun.file(
-    new URL(
-      "../migrations/0301_personal_shared_group_delivery_lease.sql",
-      import.meta.url,
-    ),
+    new URL("../migrations/0301_personal_shared_group_delivery_lease.sql", import.meta.url),
   ).text();
   await database.exec(leaseMigration);
 });
@@ -129,10 +109,7 @@ describe("personalSharedGroupsRepository", () => {
       consume("claim-a", "+15551110001"),
       consume("claim-a", "+15551110001"),
     ]);
-    expect(attempts.map(({ status }) => status).sort()).toEqual([
-      "already_used",
-      "bound",
-    ]);
+    expect(attempts.map(({ status }) => status).sort()).toEqual(["already_used", "bound"]);
     const result = attempts.find(({ status }) => status === "bound");
     if (result?.status !== "bound") {
       throw new Error("expected a bound claim");
@@ -156,9 +133,7 @@ describe("personalSharedGroupsRepository", () => {
       personalAgentId: "personal:owner-a",
       platformUserId: "+15551110001",
     });
-    expect((await consume("claim-owner-a", "+15551110001")).status).toBe(
-      "bound",
-    );
+    expect((await consume("claim-owner-a", "+15551110001")).status).toBe("bound");
 
     await issue({
       codeHash: "claim-owner-b",
@@ -275,9 +250,7 @@ describe("personalSharedGroupsRepository", () => {
       personalAgentId: "personal:owner-a",
       platformUserId: "+15551110001",
     });
-    await expect(
-      consume("claim-reconnect-retry", "+15551110001"),
-    ).rejects.toMatchObject({
+    await expect(consume("claim-reconnect-retry", "+15551110001")).rejects.toMatchObject({
       code: "PERSONAL_SHARED_GROUP_DELIVERY_PENDING",
     });
 
@@ -287,8 +260,7 @@ describe("personalSharedGroupsRepository", () => {
       WHERE id = '${initial.binding.id}';
     `);
     const reconnected = await consume("claim-reconnect-retry", "+15551110001");
-    if (reconnected.status !== "bound")
-      throw new Error("expected reconnect after lease expiry");
+    if (reconnected.status !== "bound") throw new Error("expected reconnect after lease expiry");
     expect(reconnected.binding).toMatchObject({
       owner_user_id: USER_A,
       authority_version: initial.binding.authority_version + 1,
@@ -373,8 +345,7 @@ describe("personalSharedGroupsRepository", () => {
       platformUserId: "+15551110002",
     });
     const takeover = await consume("claim-revoked-takeover", "+15551110002");
-    if (takeover.status !== "bound")
-      throw new Error("expected revoked-owner takeover");
+    if (takeover.status !== "bound") throw new Error("expected revoked-owner takeover");
     expect(takeover.binding).toMatchObject({
       owner_user_id: USER_B,
       personal_agent_id: "personal:owner-b",
@@ -597,9 +568,7 @@ describe("personalSharedGroupsRepository", () => {
       sourceMessageId: "incoming-restored",
       leaseToken: restoredLeaseToken,
     };
-    expect(
-      await repository.authorizeDelivery(leasedRestoredRequest),
-    ).toMatchObject({
+    expect(await repository.authorizeDelivery(leasedRestoredRequest)).toMatchObject({
       authorized: true,
     });
     expect(await repository.commitDelivery(leasedRestoredRequest)).toBe(true);
@@ -615,9 +584,7 @@ describe("personalSharedGroupsRepository", () => {
         providerMessageIds: ["outgoing-restored"],
       }),
     ).toEqual({ recorded: true, inserted: 1 });
-    expect(
-      await repository.authorizeDelivery(leasedRestoredRequest),
-    ).toMatchObject({
+    expect(await repository.authorizeDelivery(leasedRestoredRequest)).toMatchObject({
       authorized: false,
     });
   }, 10_000);

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -1,17 +1,6 @@
 /** Atomic claim and binding authority for Personal Shared provider groups. */
 import { ElizaError } from "@elizaos/core";
-import {
-  and,
-  eq,
-  gt,
-  inArray,
-  isNotNull,
-  isNull,
-  lte,
-  notExists,
-  or,
-  sql,
-} from "drizzle-orm";
+import { and, eq, gt, inArray, isNotNull, isNull, lte, notExists, or, sql } from "drizzle-orm";
 import { v5 as uuidv5 } from "uuid";
 import { dbWrite } from "../client";
 import {
@@ -138,10 +127,7 @@ export const personalSharedGroupsRepository = {
             eq(personalSharedGroupClaims.owner_user_id, input.ownerUserId),
             eq(personalSharedGroupClaims.platform, input.platform),
             eq(personalSharedGroupClaims.project, input.project),
-            eq(
-              personalSharedGroupClaims.connector_account_id,
-              input.connectorAccountId,
-            ),
+            eq(personalSharedGroupClaims.connector_account_id, input.connectorAccountId),
             isNull(personalSharedGroupClaims.consumed_at),
           ),
         );
@@ -179,14 +165,8 @@ export const personalSharedGroupsRepository = {
             eq(personalSharedGroupClaims.code_hash, input.codeHash),
             eq(personalSharedGroupClaims.platform, input.platform),
             eq(personalSharedGroupClaims.project, input.project),
-            eq(
-              personalSharedGroupClaims.connector_account_id,
-              input.connectorAccountId,
-            ),
-            eq(
-              personalSharedGroupClaims.issued_to_platform_user_id,
-              input.actorPlatformUserId,
-            ),
+            eq(personalSharedGroupClaims.connector_account_id, input.connectorAccountId),
+            eq(personalSharedGroupClaims.issued_to_platform_user_id, input.actorPlatformUserId),
             isNull(personalSharedGroupClaims.consumed_at),
             gt(personalSharedGroupClaims.expires_at, now),
           ),
@@ -219,14 +199,8 @@ export const personalSharedGroupsRepository = {
           and(
             eq(personalSharedGroupBindings.platform, input.platform),
             eq(personalSharedGroupBindings.project, input.project),
-            eq(
-              personalSharedGroupBindings.connector_account_id,
-              input.connectorAccountId,
-            ),
-            eq(
-              personalSharedGroupBindings.provider_chat_id,
-              input.providerChatId,
-            ),
+            eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+            eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
           ),
         )
         .limit(1);
@@ -283,10 +257,7 @@ export const personalSharedGroupsRepository = {
           // boundary merely by presenting their own valid claim.
           setWhere: and(
             or(
-              eq(
-                personalSharedGroupBindings.owner_user_id,
-                claim.owner_user_id,
-              ),
+              eq(personalSharedGroupBindings.owner_user_id, claim.owner_user_id),
               eq(personalSharedGroupBindings.state, "revoked"),
             ),
             deliveryLeaseAllowsAuthorityMutation(leaseNow),
@@ -304,20 +275,13 @@ export const personalSharedGroupsRepository = {
             and(
               eq(personalSharedGroupBindings.platform, input.platform),
               eq(personalSharedGroupBindings.project, input.project),
-              eq(
-                personalSharedGroupBindings.connector_account_id,
-                input.connectorAccountId,
-              ),
-              eq(
-                personalSharedGroupBindings.provider_chat_id,
-                input.providerChatId,
-              ),
+              eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+              eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
             ),
           )
           .limit(1);
         const mayRebind =
-          current?.ownerUserId === claim.owner_user_id ||
-          current?.state === "revoked";
+          current?.ownerUserId === claim.owner_user_id || current?.state === "revoked";
         if (mayRebind) {
           // Throwing rolls back claim consumption so the exact owner can retry
           // after an uncommitted lease expires or a committed send is reconciled.
@@ -342,14 +306,8 @@ export const personalSharedGroupsRepository = {
         and(
           eq(personalSharedGroupBindings.platform, input.platform),
           eq(personalSharedGroupBindings.project, input.project),
-          eq(
-            personalSharedGroupBindings.connector_account_id,
-            input.connectorAccountId,
-          ),
-          eq(
-            personalSharedGroupBindings.provider_chat_id,
-            input.providerChatId,
-          ),
+          eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+          eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
         ),
       )
       .limit(1);
@@ -398,10 +356,7 @@ export const personalSharedGroupsRepository = {
     );
   },
 
-  async revokeBinding(input: {
-    bindingId: string;
-    ownerUserId: string;
-  }): Promise<boolean> {
+  async revokeBinding(input: { bindingId: string; ownerUserId: string }): Promise<boolean> {
     return Boolean(
       await waitForAuthorityMutation(
         async (now) => {
@@ -415,10 +370,7 @@ export const personalSharedGroupsRepository = {
             .where(
               and(
                 eq(personalSharedGroupBindings.id, input.bindingId),
-                eq(
-                  personalSharedGroupBindings.owner_user_id,
-                  input.ownerUserId,
-                ),
+                eq(personalSharedGroupBindings.owner_user_id, input.ownerUserId),
                 deliveryLeaseAllowsAuthorityMutation(now),
               ),
             )
@@ -432,10 +384,7 @@ export const personalSharedGroupsRepository = {
             .where(
               and(
                 eq(personalSharedGroupBindings.id, input.bindingId),
-                eq(
-                  personalSharedGroupBindings.owner_user_id,
-                  input.ownerUserId,
-                ),
+                eq(personalSharedGroupBindings.owner_user_id, input.ownerUserId),
                 deliveryLeaseBlocksAuthorityMutation(now),
               ),
             )
@@ -470,14 +419,8 @@ export const personalSharedGroupsRepository = {
             and(
               eq(personalSharedGroupBindings.platform, input.platform),
               eq(personalSharedGroupBindings.project, input.project),
-              eq(
-                personalSharedGroupBindings.connector_account_id,
-                input.connectorAccountId,
-              ),
-              eq(
-                personalSharedGroupBindings.provider_chat_id,
-                input.providerChatId,
-              ),
+              eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+              eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
               eq(
                 personalSharedGroupBindings.state,
                 input.membershipChange === "joined" ? "suspended" : "active",
@@ -496,14 +439,8 @@ export const personalSharedGroupsRepository = {
             and(
               eq(personalSharedGroupBindings.platform, input.platform),
               eq(personalSharedGroupBindings.project, input.project),
-              eq(
-                personalSharedGroupBindings.connector_account_id,
-                input.connectorAccountId,
-              ),
-              eq(
-                personalSharedGroupBindings.provider_chat_id,
-                input.providerChatId,
-              ),
+              eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+              eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
               deliveryLeaseBlocksAuthorityMutation(now),
             ),
           )
@@ -534,28 +471,13 @@ export const personalSharedGroupsRepository = {
       .where(
         and(
           eq(personalSharedGroupBindings.id, input.authority.bindingId),
-          eq(
-            personalSharedGroupBindings.owner_user_id,
-            input.authority.ownerUserId,
-          ),
-          eq(
-            personalSharedGroupBindings.personal_agent_id,
-            input.authority.personalAgentId,
-          ),
-          eq(
-            personalSharedGroupBindings.authority_version,
-            input.authority.version,
-          ),
+          eq(personalSharedGroupBindings.owner_user_id, input.authority.ownerUserId),
+          eq(personalSharedGroupBindings.personal_agent_id, input.authority.personalAgentId),
+          eq(personalSharedGroupBindings.authority_version, input.authority.version),
           eq(personalSharedGroupBindings.platform, input.platform),
           eq(personalSharedGroupBindings.project, input.project),
-          eq(
-            personalSharedGroupBindings.connector_account_id,
-            input.connectorAccountId,
-          ),
-          eq(
-            personalSharedGroupBindings.provider_chat_id,
-            input.providerChatId,
-          ),
+          eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+          eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
           eq(personalSharedGroupBindings.state, "active"),
           notExists(
             dbWrite
@@ -567,10 +489,7 @@ export const personalSharedGroupsRepository = {
                     personalSharedGroupDeliveryReceipts.binding_id,
                     personalSharedGroupBindings.id,
                   ),
-                  eq(
-                    personalSharedGroupDeliveryReceipts.source_message_id,
-                    input.sourceMessageId,
-                  ),
+                  eq(personalSharedGroupDeliveryReceipts.source_message_id, input.sourceMessageId),
                 ),
               ),
           ),
@@ -580,14 +499,8 @@ export const personalSharedGroupsRepository = {
           or(
             deliveryLeaseAvailable(now),
             and(
-              eq(
-                personalSharedGroupBindings.delivery_lease_source_id,
-                input.sourceMessageId,
-              ),
-              eq(
-                personalSharedGroupBindings.delivery_lease_token,
-                input.leaseToken,
-              ),
+              eq(personalSharedGroupBindings.delivery_lease_source_id, input.sourceMessageId),
+              eq(personalSharedGroupBindings.delivery_lease_token, input.leaseToken),
             ),
           ),
         ),
@@ -629,37 +542,16 @@ export const personalSharedGroupsRepository = {
       .where(
         and(
           eq(personalSharedGroupBindings.id, input.authority.bindingId),
-          eq(
-            personalSharedGroupBindings.owner_user_id,
-            input.authority.ownerUserId,
-          ),
-          eq(
-            personalSharedGroupBindings.personal_agent_id,
-            input.authority.personalAgentId,
-          ),
-          eq(
-            personalSharedGroupBindings.authority_version,
-            input.authority.version,
-          ),
+          eq(personalSharedGroupBindings.owner_user_id, input.authority.ownerUserId),
+          eq(personalSharedGroupBindings.personal_agent_id, input.authority.personalAgentId),
+          eq(personalSharedGroupBindings.authority_version, input.authority.version),
           eq(personalSharedGroupBindings.platform, input.platform),
           eq(personalSharedGroupBindings.project, input.project),
-          eq(
-            personalSharedGroupBindings.connector_account_id,
-            input.connectorAccountId,
-          ),
-          eq(
-            personalSharedGroupBindings.provider_chat_id,
-            input.providerChatId,
-          ),
+          eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+          eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
           eq(personalSharedGroupBindings.state, "active"),
-          eq(
-            personalSharedGroupBindings.delivery_lease_source_id,
-            input.sourceMessageId,
-          ),
-          eq(
-            personalSharedGroupBindings.delivery_lease_token,
-            input.leaseToken,
-          ),
+          eq(personalSharedGroupBindings.delivery_lease_source_id, input.sourceMessageId),
+          eq(personalSharedGroupBindings.delivery_lease_token, input.leaseToken),
           or(
             isNotNull(personalSharedGroupBindings.delivery_lease_committed_at),
             gt(personalSharedGroupBindings.delivery_lease_expires_at, now),
@@ -685,18 +577,13 @@ export const personalSharedGroupsRepository = {
       if (expected.size > 0) {
         const prior = await tx
           .select({
-            providerMessageId:
-              personalSharedGroupDeliveryReceipts.provider_message_id,
-            sourceMessageId:
-              personalSharedGroupDeliveryReceipts.source_message_id,
+            providerMessageId: personalSharedGroupDeliveryReceipts.provider_message_id,
+            sourceMessageId: personalSharedGroupDeliveryReceipts.source_message_id,
           })
           .from(personalSharedGroupDeliveryReceipts)
           .where(
             and(
-              eq(
-                personalSharedGroupDeliveryReceipts.binding_id,
-                input.authority.bindingId,
-              ),
+              eq(personalSharedGroupDeliveryReceipts.binding_id, input.authority.bindingId),
               inArray(
                 personalSharedGroupDeliveryReceipts.provider_message_id,
                 input.providerMessageIds,
@@ -705,9 +592,7 @@ export const personalSharedGroupsRepository = {
           );
         const durablePrior = new Set(
           prior
-            .filter(
-              (receipt) => receipt.sourceMessageId === input.sourceMessageId,
-            )
+            .filter((receipt) => receipt.sourceMessageId === input.sourceMessageId)
             .map((receipt) => receipt.providerMessageId),
         );
         if (
@@ -728,22 +613,10 @@ export const personalSharedGroupsRepository = {
             eq(personalSharedGroupBindings.id, input.authority.bindingId),
             eq(personalSharedGroupBindings.platform, input.platform),
             eq(personalSharedGroupBindings.project, input.project),
-            eq(
-              personalSharedGroupBindings.connector_account_id,
-              input.connectorAccountId,
-            ),
-            eq(
-              personalSharedGroupBindings.provider_chat_id,
-              input.providerChatId,
-            ),
-            eq(
-              personalSharedGroupBindings.delivery_lease_source_id,
-              input.sourceMessageId,
-            ),
-            eq(
-              personalSharedGroupBindings.delivery_lease_token,
-              input.leaseToken,
-            ),
+            eq(personalSharedGroupBindings.connector_account_id, input.connectorAccountId),
+            eq(personalSharedGroupBindings.provider_chat_id, input.providerChatId),
+            eq(personalSharedGroupBindings.delivery_lease_source_id, input.sourceMessageId),
+            eq(personalSharedGroupBindings.delivery_lease_token, input.leaseToken),
             isNotNull(personalSharedGroupBindings.delivery_lease_committed_at),
           ),
         )
@@ -768,10 +641,8 @@ export const personalSharedGroupsRepository = {
         .returning({ id: personalSharedGroupDeliveryReceipts.id });
       const recorded = await tx
         .select({
-          providerMessageId:
-            personalSharedGroupDeliveryReceipts.provider_message_id,
-          sourceMessageId:
-            personalSharedGroupDeliveryReceipts.source_message_id,
+          providerMessageId: personalSharedGroupDeliveryReceipts.provider_message_id,
+          sourceMessageId: personalSharedGroupDeliveryReceipts.source_message_id,
         })
         .from(personalSharedGroupDeliveryReceipts)
         .where(
@@ -785,15 +656,11 @@ export const personalSharedGroupsRepository = {
         );
       const durable = new Set(
         recorded
-          .filter(
-            (receipt) => receipt.sourceMessageId === input.sourceMessageId,
-          )
+          .filter((receipt) => receipt.sourceMessageId === input.sourceMessageId)
           .map((receipt) => receipt.providerMessageId),
       );
       const result = {
-        recorded:
-          durable.size === expected.size &&
-          [...expected].every((id) => durable.has(id)),
+        recorded: durable.size === expected.size && [...expected].every((id) => durable.has(id)),
         inserted: inserted.length,
       };
       if (result.recorded) {
@@ -808,14 +675,8 @@ export const personalSharedGroupsRepository = {
           .where(
             and(
               eq(personalSharedGroupBindings.id, binding.id),
-              eq(
-                personalSharedGroupBindings.delivery_lease_source_id,
-                input.sourceMessageId,
-              ),
-              eq(
-                personalSharedGroupBindings.delivery_lease_token,
-                input.leaseToken,
-              ),
+              eq(personalSharedGroupBindings.delivery_lease_source_id, input.sourceMessageId),
+              eq(personalSharedGroupBindings.delivery_lease_token, input.leaseToken),
             ),
           );
       }
@@ -833,10 +694,7 @@ export const personalSharedGroupsRepository = {
       .where(
         and(
           eq(personalSharedGroupDeliveryReceipts.binding_id, input.bindingId),
-          eq(
-            personalSharedGroupDeliveryReceipts.provider_message_id,
-            input.providerMessageId,
-          ),
+          eq(personalSharedGroupDeliveryReceipts.provider_message_id, input.providerMessageId),
         ),
       )
       .limit(1);

--- a/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/schemas/personal-shared-groups.ts
@@ -14,10 +14,7 @@ import { organizations } from "./organizations";
 import { users } from "./users";
 
 export type PersonalSharedGroupPlatform = "telegram" | "blooio";
-export type PersonalSharedGroupBindingState =
-  | "active"
-  | "suspended"
-  | "revoked";
+export type PersonalSharedGroupBindingState = "active" | "suspended" | "revoked";
 export type PersonalSharedGroupResponsePolicy = "mention_only" | "ambient";
 
 export const personalSharedGroupClaims = pgTable(
@@ -38,18 +35,14 @@ export const personalSharedGroupClaims = pgTable(
     issued_to_platform_user_id: text("issued_to_platform_user_id").notNull(),
     expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
     consumed_at: timestamp("consumed_at", { withTimezone: true }),
-    created_at: timestamp("created_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     platform_check: check(
       "personal_shared_group_claims_platform_check",
       sql`${table.platform} IN ('telegram', 'blooio')`,
     ),
-    expires_idx: index("personal_shared_group_claims_expires_idx").on(
-      table.expires_at,
-    ),
+    expires_idx: index("personal_shared_group_claims_expires_idx").on(table.expires_at),
     owner_idx: index("personal_shared_group_claims_owner_idx").on(
       table.owner_user_id,
       table.platform,
@@ -73,17 +66,12 @@ export const personalSharedGroupBindings = pgTable(
     connector_account_id: text("connector_account_id").notNull(),
     provider_chat_id: text("provider_chat_id").notNull(),
     conversation_id: text("conversation_id").notNull(),
-    state: text("state")
-      .$type<PersonalSharedGroupBindingState>()
-      .notNull()
-      .default("active"),
+    state: text("state").$type<PersonalSharedGroupBindingState>().notNull().default("active"),
     response_policy: text("response_policy")
       .$type<PersonalSharedGroupResponsePolicy>()
       .notNull()
       .default("mention_only"),
-    authority_version: bigint("authority_version", { mode: "number" })
-      .notNull()
-      .default(1),
+    authority_version: bigint("authority_version", { mode: "number" }).notNull().default(1),
     delivery_lease_source_id: text("delivery_lease_source_id"),
     delivery_lease_token: uuid("delivery_lease_token"),
     delivery_lease_expires_at: timestamp("delivery_lease_expires_at", {
@@ -94,12 +82,8 @@ export const personalSharedGroupBindings = pgTable(
     }),
     created_by_platform_user_id: text("created_by_platform_user_id").notNull(),
     last_verified_at: timestamp("last_verified_at", { withTimezone: true }),
-    created_at: timestamp("created_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updated_at: timestamp("updated_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     platform_check: check(
@@ -114,9 +98,7 @@ export const personalSharedGroupBindings = pgTable(
       "personal_shared_group_bindings_policy_check",
       sql`${table.response_policy} IN ('mention_only', 'ambient')`,
     ),
-    provider_chat_unique: uniqueIndex(
-      "personal_shared_group_bindings_provider_chat_uidx",
-    ).on(
+    provider_chat_unique: uniqueIndex("personal_shared_group_bindings_provider_chat_uidx").on(
       table.platform,
       table.project,
       table.connector_account_id,
@@ -144,42 +126,31 @@ export const personalSharedGroupDeliveryReceipts = pgTable(
     provider_chat_id: text("provider_chat_id").notNull(),
     source_message_id: text("source_message_id").notNull(),
     provider_message_id: text("provider_message_id").notNull(),
-    created_at: timestamp("created_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     platform_check: check(
       "personal_shared_group_delivery_receipts_platform_check",
       sql`${table.platform} IN ('telegram', 'blooio')`,
     ),
-    provider_unique: uniqueIndex(
-      "personal_shared_group_delivery_receipts_provider_uidx",
-    ).on(
+    provider_unique: uniqueIndex("personal_shared_group_delivery_receipts_provider_uidx").on(
       table.platform,
       table.project,
       table.connector_account_id,
       table.provider_chat_id,
       table.provider_message_id,
     ),
-    binding_created_idx: index(
-      "personal_shared_group_delivery_receipts_binding_created_idx",
-    ).on(table.binding_id, table.created_at),
+    binding_created_idx: index("personal_shared_group_delivery_receipts_binding_created_idx").on(
+      table.binding_id,
+      table.created_at,
+    ),
   }),
 );
 
-export type PersonalSharedGroupClaim = InferSelectModel<
-  typeof personalSharedGroupClaims
->;
-export type NewPersonalSharedGroupClaim = InferInsertModel<
-  typeof personalSharedGroupClaims
->;
-export type PersonalSharedGroupBinding = InferSelectModel<
-  typeof personalSharedGroupBindings
->;
-export type NewPersonalSharedGroupBinding = InferInsertModel<
-  typeof personalSharedGroupBindings
->;
+export type PersonalSharedGroupClaim = InferSelectModel<typeof personalSharedGroupClaims>;
+export type NewPersonalSharedGroupClaim = InferInsertModel<typeof personalSharedGroupClaims>;
+export type PersonalSharedGroupBinding = InferSelectModel<typeof personalSharedGroupBindings>;
+export type NewPersonalSharedGroupBinding = InferInsertModel<typeof personalSharedGroupBindings>;
 export type PersonalSharedGroupDeliveryReceipt = InferSelectModel<
   typeof personalSharedGroupDeliveryReceipts
 >;


### PR DESCRIPTION
Formatting only (`biome format`, no code-token change): `personal-shared-groups.{ts,integration.test.ts}` + its schema were left unformatted on develop and fail `@elizaos/cloud-shared:lint:check` in the **All Tests Passed** gate on every PR (seen on #24425). Same class as the merged #24426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)