### PR TITLE
fix(cloud): harden initial app key attachment

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -41,7 +41,7 @@ import { pushSchema } from "drizzle-kit/api";
 import { eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import { buildMobileAppAuthCredentialProvenance } from "../../mobile-app-auth-credential-policy";
-import { apiKeys } from "../../schemas/api-keys";
+import { type ApiKey, apiKeys, type NewApiKey } from "../../schemas/api-keys";
 import { appConfig } from "../../schemas/app-config";
 import { appDomains } from "../../schemas/app-domains";
 import type { AppFrontendDeployment } from "../../schemas/app-frontend-deployments";
@@ -198,6 +198,43 @@ async function createApp(
     api_key_id: overrides.api_key_id ?? crypto.randomUUID(),
     ...overrides,
   });
+}
+
+/** Persists the nullable app state that the initial-key CAS is allowed to mutate. */
+async function createProvisionalApp(organizationId: string, userId: string): Promise<App> {
+  const name = uniq("provisional-app");
+  return appsRepository.create({
+    name,
+    slug: uniq("provisional-app-slug"),
+    app_url: `https://${name}.example`,
+    organization_id: organizationId,
+    created_by_user_id: userId,
+    api_key_id: null,
+  });
+}
+
+/** Inserts one real candidate row so attachment tests exercise the SQL boundary. */
+async function createAttachmentCandidate(
+  organizationId: string,
+  userId: string,
+  overrides: Partial<NewApiKey> = {},
+): Promise<ApiKey> {
+  const secret = uniq("attachment-key");
+  return apiKeysRepository.create({
+    name: uniq("Attachment Candidate"),
+    key_hash: createHash("sha256").update(secret).digest("hex"),
+    key_prefix: secret.slice(0, 12),
+    organization_id: organizationId,
+    user_id: userId,
+    ...overrides,
+  });
+}
+
+/** Runs the production repository CAS in a real write transaction. */
+async function attachCandidate(app: App, candidate: ApiKey): Promise<App | undefined> {
+  return dbWrite.transaction(async (tx) =>
+    appsRepository.attachInitialApiKey(app.id, app.organization_id, candidate.id, tx),
+  );
 }
 
 describe("AppsRepository.create + reads", () => {
@@ -1312,6 +1349,91 @@ describe("AppsService.isNameAvailable", () => {
   });
 });
 
+describe("AppsRepository.attachInitialApiKey", () => {
+  test("attaches one active ordinary key owned by the app creator", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+    const app = await createProvisionalApp(organizationId, userId);
+    const candidate = await createAttachmentCandidate(organizationId, userId, {
+      expires_at: new Date(Date.now() + 60_000),
+    });
+
+    const attached = await attachCandidate(app, candidate);
+    const persisted = await dbWrite.query.apps.findFirst({ where: eq(apps.id, app.id) });
+
+    expect(attached?.api_key_id).toBe(candidate.id);
+    expect(persisted?.api_key_id).toBe(candidate.id);
+  });
+
+  const rejectedCandidates: Array<{
+    name: string;
+    build: (context: { app: App; organizationId: string; userId: string }) => Promise<ApiKey>;
+  }> = [
+    {
+      name: "a same-organization key owned by another user",
+      build: async ({ organizationId }) =>
+        createAttachmentCandidate(organizationId, await seedUser(organizationId)),
+    },
+    {
+      name: "a cross-organization key",
+      build: async ({ userId }) => createAttachmentCandidate(await seedOrg(), userId),
+    },
+    {
+      name: "an inactive key",
+      build: async ({ organizationId, userId }) =>
+        createAttachmentCandidate(organizationId, userId, { is_active: false }),
+    },
+    {
+      name: "an expired key",
+      build: async ({ organizationId, userId }) =>
+        createAttachmentCandidate(organizationId, userId, {
+          expires_at: new Date(Date.now() - 60_000),
+        }),
+    },
+    {
+      name: "a soft-deleted key",
+      build: async ({ organizationId, userId }) =>
+        createAttachmentCandidate(organizationId, userId, {
+          deleted_at: new Date(),
+          is_active: true,
+        }),
+    },
+    {
+      name: "a mobile lifecycle credential",
+      build: async ({ app, organizationId, userId }) =>
+        createAttachmentCandidate(organizationId, userId, { source_app_id: app.id }),
+    },
+  ];
+
+  for (const rejected of rejectedCandidates) {
+    test(`rejects ${rejected.name}`, async () => {
+      expect(pgliteReady).toBe(true);
+      const { organizationId, userId } = await seedOrgAndUser();
+      const app = await createProvisionalApp(organizationId, userId);
+      const candidate = await rejected.build({ app, organizationId, userId });
+
+      expect(await attachCandidate(app, candidate)).toBeUndefined();
+      expect(
+        (await dbWrite.query.apps.findFirst({ where: eq(apps.id, app.id) }))?.api_key_id,
+      ).toBeNull();
+    });
+  }
+
+  test("rejects a second attachment and preserves the first key", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+    const app = await createProvisionalApp(organizationId, userId);
+    const first = await createAttachmentCandidate(organizationId, userId);
+    const second = await createAttachmentCandidate(organizationId, userId);
+
+    expect((await attachCandidate(app, first))?.api_key_id).toBe(first.id);
+    expect(await attachCandidate(app, second)).toBeUndefined();
+    expect((await dbWrite.query.apps.findFirst({ where: eq(apps.id, app.id) }))?.api_key_id).toBe(
+      first.id,
+    );
+  });
+});
+
 describe("AppsService.create organization cap", () => {
   test("uses the default cap only when the environment variable is unset", () => {
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
@@ -1584,16 +1706,34 @@ describe("AppsService.create organization cap", () => {
     }
   });
 
-  test("rolls back the provisional app and minted key when initial attachment loses its CAS", async () => {
+  test("rolls back the provisional app and key when the real attachment CAS rejects ownership", async () => {
     expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
     try {
       const { organizationId, userId } = await seedOrgAndUser();
-      const createKey = spyOn(apiKeysService, "create");
-      const attachInitialApiKey = spyOn(appsRepository, "attachInitialApiKey").mockResolvedValue(
-        undefined,
-      );
+      const wrongUserId = await seedUser(organizationId);
+      const candidateId = crypto.randomUUID();
+      const createKey = spyOn(apiKeysService, "create").mockImplementation(async (data, tx) => {
+        if (!tx) throw new Error("app creation must pass its write transaction to key creation");
+        const secret = uniq("wrong-owner-key");
+        const apiKey = await apiKeysRepository.create(
+          {
+            id: candidateId,
+            name: data.name,
+            description: data.description,
+            key_hash: createHash("sha256").update(secret).digest("hex"),
+            key_prefix: secret.slice(0, 12),
+            organization_id: data.organization_id,
+            user_id: wrongUserId,
+            rate_limit: data.rate_limit,
+            is_active: true,
+            expires_at: null,
+          },
+          tx,
+        );
+        return { apiKey, plainKey: `eliza_${secret}` };
+      });
 
       try {
         await expect(
@@ -1609,13 +1749,15 @@ describe("AppsService.create organization cap", () => {
         });
 
         expect(createKey).toHaveBeenCalledTimes(1);
-        expect(attachInitialApiKey).toHaveBeenCalledTimes(1);
         expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+        expect(await apiKeysRepository.findById(candidateId)).toBeUndefined();
         expect(
-          await apiKeysRepository.findByUserAndName(userId, "Attach Failure App - App API Key"),
+          await apiKeysRepository.findByUserAndName(
+            wrongUserId,
+            "Attach Failure App - App API Key",
+          ),
         ).toEqual([]);
       } finally {
-        attachInitialApiKey.mockRestore();
         createKey.mockRestore();
       }
     } finally {

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -578,7 +578,12 @@ export class AppsRepository {
     return app;
   }
 
-  /** Attaches the first API key once to an admitted app inside its creation transaction. */
+  /**
+   * Attaches one usable ordinary key owned by the admitted app's creator.
+   *
+   * The correlated ownership and lifecycle predicates keep this repository
+   * boundary fail-closed even when it is called outside `AppsService.create`.
+   */
   async attachInitialApiKey(
     appId: string,
     organizationId: string,
@@ -597,7 +602,12 @@ export class AppsRepository {
             SELECT 1
             FROM ${apiKeys}
             WHERE ${apiKeys.id} = ${apiKeyId}
-              AND ${apiKeys.organization_id} = ${organizationId}
+              AND ${apiKeys.organization_id} = ${apps.organization_id}
+              AND ${apiKeys.user_id} = ${apps.created_by_user_id}
+              AND ${apiKeys.is_active} = TRUE
+              AND ${apiKeys.deleted_at} IS NULL
+              AND ${apiKeys.source_app_id} IS NULL
+              AND (${apiKeys.expires_at} IS NULL OR ${apiKeys.expires_at} > CURRENT_TIMESTAMP)
           )`,
         ),
       )


### PR DESCRIPTION
# Relates to

Fixes #24508. This is a focused fix-forward after #24554.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync; the exact unrelated package-wide lint blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `6fb1a69ad69b9011490bf8fcd4c2e169e6707d25`; zero conflicts.
- [x] Focused exact-head verification passes; the inherited package-wide lint blocker is documented in **Known gaps / failures**.

# Risks

Low. The change only tightens the transaction-local initial-key compare-and-set. A candidate must now be an active, non-deleted, unexpired ordinary key owned by both the app creator and the app organization; invalid candidates fail closed and roll the app transaction back.

# Background

## What does this PR do?

- Correlates the candidate key to the provisional app's organization and creator at the repository boundary.
- Rejects inactive, expired, soft-deleted, and mobile lifecycle credentials.
- Preserves the null-only compare-and-set so a second attachment cannot replace the initial key.
- Replaces the mocked attachment-failure proof with a real SQL CAS and transactional rollback assertion.
- Adds real PGlite negative coverage for wrong-user, cross-org, inactive, expired, soft-deleted, mobile, and second-attach candidates.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; this hardens an internal database boundary without changing the public API.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/repositories/apps.ts`, then `packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts`.

## Detailed testing steps

Bun: `1.3.14`

- `bun install --frozen-lockfile` — pass; no changes.
- `bun --config=/dev/null test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts --reporter=dots` — 47 pass, 0 fail, 254 assertions.
- `APPS_TENANT_DB_TEST_DSN=<isolated-local-postgres-17-dsn> bun --config=/dev/null test packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts --rerun-each=10 --reporter=dots` — 10 pass, 0 fail, 120 assertions.
- `mise exec node@24.15.0 -- bun run --cwd packages/cloud/shared typecheck` — pass.
- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/apps.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts` — pass, 2 files checked.
- `git diff --check origin/develop...HEAD` — pass.
- Independent read-only review — no actionable defects found.

# Evidence Gate

<!-- evidence-head:3796db53ed6becec7fe1996ef31254e787774132 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only repository predicate change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only repository predicate change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only transaction boundary; no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] [24566-.tmp-pr-24566-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24566-.tmp-pr-24566-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console behavior, or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24566-.tmp-pr-24566-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24566-.tmp-pr-24566-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model path changed.

## Backend + frontend logs

Backend: exact-head PGlite and real PostgreSQL result artifacts are attached in the Evidence Gate. The real PostgreSQL test uses independent app-create transactions competing for one quota slot and proves one mint call, one admitted app, one linked key, and no loser mint.

Frontend: N/A - no frontend code or request/response surface changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only repository predicate change; no rendered UI.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.

## Known gaps / failures

`mise exec node@24.15.0 -- bun run --cwd packages/cloud/shared lint:check` checks 2,304 files and exits 1 because Biome would reformat these three unchanged files already present on `origin/develop`:

- `src/db/repositories/personal-shared-groups.integration.test.ts`
- `src/db/repositories/personal-shared-groups.ts`
- `src/db/schemas/personal-shared-groups.ts`

None is in this two-file PR diff. The exact two affected files pass Biome. Root `bun run verify` includes the same package-wide lint gate, so it was not rerun after this blocker was reproduced exactly.

Docker's cached `postgres:16-alpine` blob is locally unreadable; the required real-PostgreSQL proof ran successfully against an isolated temporary PostgreSQL 17.11 cluster, which was stopped and moved to Trash after the test.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

No migration, deployment, provider call, or production mutation is part of this PR.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@6fb1a69ad69b9011490bf8fcd4c2e169e6707d25:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-app-key-cas]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@6fb1a69ad69b9011490bf8fcd4c2e169e6707d25:packages/skills/skills/contribute-to-eliza"} -->

