### PR TITLE
fix(scenario-runner): abort api-turn fetches on timeout and caller cancel

### DIFF
--- a/packages/scenario-runner/src/__tests__/executor-api-abort.test.ts
+++ b/packages/scenario-runner/src/__tests__/executor-api-abort.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression tests for #24531: scenario `api` turns must abort their fetch when
+ * the turn deadline expires (or the caller cancels) so a hung route cannot
+ * retain sockets/work after the scenario turn has already failed, and response
+ * body consumption stays inside the same cancellation boundary. Uses the real
+ * `runScenario` executor with its real loopback API server and real fetch; only
+ * the runtime is the package's standard stub.
+ */
+import type {
+  AgentRuntime,
+  Route,
+  RouteRequest,
+  RouteResponse,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { runScenario } from "../executor.js";
+
+function createRuntime(routes: Route[]): AgentRuntime {
+  return {
+    actions: [],
+    agentId: "00000000-0000-4000-8000-000000000001",
+    plugins: [],
+    routes,
+    ensureConnection: async () => undefined,
+    getService: () => null,
+    reportError: () => {},
+    setSetting: () => {},
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  } as unknown as AgentRuntime;
+}
+
+/** Route handler that never completes the response; records socket teardown. */
+function hangHandler(onClose: () => void) {
+  return async (_req: RouteRequest, res: RouteResponse) => {
+    (res as unknown as NodeJS.EventEmitter).on("close", onClose);
+    // Intentionally never responds.
+  };
+}
+
+describe("scenario executor api turn cancellation", () => {
+  it("aborts a hung api fetch when the turn timeout expires", {
+    timeout: 30_000,
+  }, async () => {
+    let serverSawClose = false;
+    const runtime = createRuntime([
+      {
+        type: "GET",
+        path: "/hang",
+        handler: hangHandler(() => {
+          serverSawClose = true;
+        }),
+      },
+    ]);
+
+    const report = await runScenario(
+      {
+        id: "api-abort-timeout",
+        title: "API turn aborts hung fetch on timeout",
+        domain: "executor",
+        turns: [
+          {
+            kind: "api",
+            name: "hung",
+            method: "GET",
+            path: "/hang",
+            timeoutMs: 250,
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 20_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.error).toContain("api(hung) timed out after 250ms");
+    // The abort must reach the server side: the destroyed client socket
+    // fires `close` on the server response object. `runScenario` only
+    // resolves after its loopback server closed, which itself requires the
+    // hung connection to be released (on unfixed code this never happens).
+    await vi.waitFor(() => {
+      expect(serverSawClose).toBe(true);
+    });
+  });
+
+  it("aborts a stalled response body within the same turn deadline", {
+    timeout: 30_000,
+  }, async () => {
+    const runtime = createRuntime([
+      {
+        type: "GET",
+        path: "/drip",
+        handler: async (_req: RouteRequest, res: RouteResponse) => {
+          // Headers + partial body, then the stream never ends: the fetch
+          // resolves while body consumption would hang forever without the
+          // abort signal spanning `response.text()`.
+          const raw = res as unknown as {
+            writeHead: (
+              status: number,
+              headers: Record<string, string>,
+            ) => void;
+            write: (chunk: string) => void;
+          };
+          raw.writeHead(200, { "content-type": "application/json" });
+          raw.write('{"partial":');
+        },
+      },
+    ]);
+
+    const report = await runScenario(
+      {
+        id: "api-abort-drip",
+        title: "API turn aborts stalled response body",
+        domain: "executor",
+        turns: [
+          {
+            kind: "api",
+            name: "drip",
+            method: "GET",
+            path: "/drip",
+            timeoutMs: 250,
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 20_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.error).toContain("api(drip) timed out after 250ms");
+  });
+
+  it("aborts the request when the caller aborts the scenario mid-turn", {
+    timeout: 30_000,
+  }, async () => {
+    let serverSawClose = false;
+    const runtime = createRuntime([
+      {
+        type: "GET",
+        path: "/hang",
+        handler: hangHandler(() => {
+          serverSawClose = true;
+        }),
+      },
+    ]);
+    const callerController = new AbortController();
+    setTimeout(
+      () =>
+        callerController.abort(
+          new Error("scenario cancelled by caller mid-turn"),
+        ),
+      150,
+    );
+
+    const report = await runScenario(
+      {
+        id: "api-abort-caller",
+        title: "API turn aborts when the caller aborts",
+        domain: "executor",
+        turns: [
+          {
+            kind: "api",
+            name: "hung",
+            method: "GET",
+            path: "/hang",
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 20_000,
+        abortSignal: callerController.signal,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    // The caller's abort reason must surface verbatim, not a generic label.
+    expect(report.error).toContain("scenario cancelled by caller mid-turn");
+    await vi.waitFor(() => {
+      expect(serverSawClose).toBe(true);
+    });
+  });
+});

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -1855,6 +1855,7 @@ async function executeApiTurn(args: {
   apiServer: ScenarioApiServer;
   variables: ScenarioVariableState;
   turnTimeoutMs: number;
+  abortSignal?: AbortSignal;
 }): Promise<{
   apiStatus: number;
   apiBody: unknown;
@@ -1894,53 +1895,77 @@ async function executeApiTurn(args: {
     typeof args.turn.timeoutMs === "number"
       ? args.turn.timeoutMs
       : args.turnTimeoutMs;
-  const response = await withTimeout(
-    fetch(`${args.apiServer.baseUrl}${path}`, {
+  // #24531: the deadline must abort the underlying request, not merely race a
+  // rejection against a fetch that keeps its socket alive. Compose the turn
+  // deadline with the caller's cancellation signal into one controller whose
+  // abort reason names the violated boundary, then keep body consumption on
+  // the same signal so a stalled body cannot outlive the failed turn.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(
+      new Error(`api(${args.turn.name}) timed out after ${timeoutMs}ms`),
+    );
+  }, timeoutMs);
+  const abortFromCaller = () => {
+    controller.abort(
+      args.abortSignal?.reason ?? new Error("scenario execution was aborted"),
+    );
+  };
+  args.abortSignal?.addEventListener("abort", abortFromCaller, { once: true });
+  if (args.abortSignal?.aborted) abortFromCaller();
+  let response: Response;
+  try {
+    response = await fetch(`${args.apiServer.baseUrl}${path}`, {
       method,
       headers:
         body === undefined ? undefined : { "content-type": "application/json" },
       body: body === undefined ? undefined : JSON.stringify(body),
-    }),
-    timeoutMs,
-    `api(${args.turn.name})`,
-  );
-  const responseText = await response.text();
-  let responseBody: unknown = responseText;
-  const contentType = response.headers.get("content-type") ?? "";
-  if (responseText.length > 0 && contentType.includes("application/json")) {
-    try {
-      responseBody = JSON.parse(responseText);
-    } catch {
-      responseBody = responseText;
+      signal: controller.signal,
+    });
+    const responseText = await response.text();
+    let responseBody: unknown = responseText;
+    const contentType = response.headers.get("content-type") ?? "";
+    if (responseText.length > 0 && contentType.includes("application/json")) {
+      try {
+        responseBody = JSON.parse(responseText);
+      } catch {
+        // error-policy:J3 A body that claims JSON but does not parse is kept
+        // as its raw text form; downstream template resolution treats the
+        // value as opaque text rather than a fabricated parsed object.
+        responseBody = responseText;
+      }
     }
-  }
-  indexResponseIdentifiers(responseBody, args.variables);
-  captureResponseFields(args.turn, responseBody, args.variables);
-  const explicitRedactions = Array.isArray(args.turn.redactResponseFields)
-    ? args.turn.redactResponseFields.filter(
-        (field): field is string => typeof field === "string",
-      )
-    : [];
-  const reportResponseBody = redactForScenarioReport(
-    responseBody,
-    explicitRedactions,
-  );
+    indexResponseIdentifiers(responseBody, args.variables);
+    captureResponseFields(args.turn, responseBody, args.variables);
+    const explicitRedactions = Array.isArray(args.turn.redactResponseFields)
+      ? args.turn.redactResponseFields.filter(
+          (field): field is string => typeof field === "string",
+        )
+      : [];
+    const reportResponseBody = redactForScenarioReport(
+      responseBody,
+      explicitRedactions,
+    );
 
-  return {
-    apiStatus: response.status,
-    apiBody: responseBody,
-    statusCode: response.status,
-    responseBody,
-    responseText:
-      typeof responseBody === "string"
-        ? responseBody
-        : JSON.stringify(responseBody ?? ""),
-    reportResponseText:
-      typeof reportResponseBody === "string"
-        ? reportResponseBody
-        : JSON.stringify(reportResponseBody ?? ""),
-    durationMs: Date.now() - startedAt,
-  };
+    return {
+      apiStatus: response.status,
+      apiBody: responseBody,
+      statusCode: response.status,
+      responseBody,
+      responseText:
+        typeof responseBody === "string"
+          ? responseBody
+          : JSON.stringify(responseBody ?? ""),
+      reportResponseText:
+        typeof reportResponseBody === "string"
+          ? reportResponseBody
+          : JSON.stringify(reportResponseBody ?? ""),
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+    args.abortSignal?.removeEventListener("abort", abortFromCaller);
+  }
 }
 
 async function executeTickTurn(args: {
@@ -2668,6 +2693,7 @@ export async function runScenario(
                   apiServer: activeApiServer,
                   variables,
                   turnTimeoutMs: opts.turnTimeoutMs || DEFAULT_TURN_TIMEOUT_MS,
+                  abortSignal: opts.abortSignal,
                 })),
               }
             : kind === "tick"


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Closes #24531

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is scoped to `executeApiTurn` in the scenario runner (a test
harness package, not shipped product code). One deliberate semantic tightening:
a response whose body streams slower than the turn deadline now fails at the
deadline, where it previously succeeded (unbounded). That tightening is exactly
the issue's third acceptance criterion ("response-body consumption stays within
the same cancellation boundary"). The timeout rejection message keeps the exact
`withTimeout` label contract (`api(<name>) timed out after <ms>ms`), so anything
grepping `report.error` for the old string is unaffected.

# Background

## What does this PR do?

Scenario `api` turns wrapped `fetch` in `withTimeout`, which rejects at the
deadline **without aborting the underlying request**:

- a hung route kept its socket — the scenario loopback server could then never
  close (execution-proven: `server.close()` never resolves while a hung fetch
  connection is retained; probe timed out at 60s on unfixed code);
- `response.text()` ran **outside** any deadline, so a stalled body (headers +
  partial body, stream never ends) hung the scenario turn unbounded.

The fix composes the turn deadline and the caller's cancellation signal
(`opts.abortSignal`) into one `AbortController` handed to the fetch, and keeps
body consumption inside the same cancellation boundary. Timer and listener are
released in a `finally` on every exit path; double-abort is safe (first reason
wins). On timeout the rejection keeps the established report.error contract; on
caller abort the caller's reason propagates verbatim.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation. (The package
guide documents turn kinds and env vars; fetch-abort behavior is internal to the
executor and matches the documented turn-timeout semantics.)

# Testing

## Where should a reviewer start?

`packages/scenario-runner/src/__tests__/executor-api-abort.test.ts` — three
regression tests on the real production path (`runScenario` → loopback server →
real `fetch`). All three fail on pristine `origin/develop` (RED control
captured): two hang to the vitest 30s timeout (unbounded `response.text()` /
retained socket), the third fails because no caller-abort path existed for api
turns. With the fix: 3/3 pass in ~0.8s.

## Detailed testing steps

1. `bun run --cwd packages/scenario-runner test:unit` (or
   `npx vitest run --config vitest.config.ts` in the package) — full suite
   486 tests: 485 pass + 1 pre-existing failure (`model-fixture-migration`
   corpus-count 48-vs-47) reproduced identically on stashed pristine develop
   (stash control), i.e. not attributable to this PR.
2. `npx tsc --noEmit` — error sets byte-identical head vs. pristine-develop
   control (135 pre-existing `TS2307 Cannot find module` errors from unbuilt
   sibling plugin dists; the only textual delta post-rebase is one such error's
   line-number shift caused by develop's own `seeds.ts` changes above the
   edited region).
3. `npx biome check` on both changed files — clean.
4. RED/GREEN protocol: new tests on pristine develop → 3 failed (2 × 30s hangs,
   1 assertion); apply fix → 3 passed (705ms). After rebase onto the latest
   develop (`085f225ea99`) → 3 passed again, plus the 62 pre-existing
   executor/cli tests green.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:dd95ed22e2eb93a87dbf73aa184da95e86afdbe0 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed; the change is internal to the scenario-runner executor (test harness package)
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed; the change is internal to the scenario-runner executor (test harness package)
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; hung-request cancellation inside the test runner is proven deterministically by the RED/GREEN transcript in backend-logs
<!-- evidence-row:backend-logs -->
- [x] Backend logs — real RED/GREEN execution transcript (same tests, pristine develop vs fix):
<details>
<summary>vitest output: RED control on pristine origin/develop, then GREEN at PR head</summary>

```
$ npx vitest run src/__tests__/executor-api-abort.test.ts   # pristine origin/develop @ 9100fe7c2a6 (fix absent)

 FAIL  src/__tests__/executor-api-abort.test.ts > scenario executor api turn cancellation > aborts a hung api fetch when the turn timeout expires
Error: Test timed out in 30000ms.
 FAIL  src/__tests__/executor-api-abort.test.ts > scenario executor api turn cancellation > aborts a stalled response body within the same turn deadline
Error: Test timed out in 30000ms.
 FAIL  src/__tests__/executor-api-abort.test.ts > scenario executor api turn cancellation > aborts the request when the caller aborts the scenario mid-turn
Error: Test timed out in 30000ms.

 Test Files  1 failed (1)
      Tests  3 failed (3)
   Duration  94.72s        <- two unbounded response.text()/server.close hangs + missing caller-abort path

$ npx vitest run src/__tests__/executor-api-abort.test.ts   # PR head dd95ed22e2e (fix applied)

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  5.30s (tests 705ms)

$ npx vitest run src/__tests__/executor-api-abort.test.ts src/executor.test.ts src/cli.test.ts  # post-rebase head on 085f225ea99

 Test Files  3 passed (3)
      Tests  70 passed (70)
```
</details>

RED semantics (why each hang is the bug, not a flaky test): the `/hang` route never responds and
the `/drip` route writes headers + a partial body then never ends. On unfixed code the turn's
`withTimeout` wrapper rejects but the fetch keeps its socket, so the scenario loopback server's
`close()` never resolves and `response.text()` runs outside any deadline. At the PR head the
composed AbortController aborts the fetch and body read at the 250ms turn deadline — the report
then carries `api(hung) timed out after 250ms` / `api(drip) timed out after 250ms` / the caller's
verbatim abort reason — and the server-side `res.on("close")` assertion (vi.waitFor) proves the
abort reached the socket. Full package suite: 485/486 pass; the single
`model-fixture-migration` corpus-count failure reproduces identically with the fix stashed
(pre-existing, stash control captured).

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or network-facing product surface touched; the only HTTP involved is the scenario runner's internal loopback test server
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change; this is fetch-cancellation plumbing in the scenario test harness
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, wallet or generated artifacts involved; the change ships in the test-runner package and its proof is the RED/GREEN transcript in backend-logs

# Known gaps / failures

- `model-fixture-migration.test.ts` "never increases the undeclared deterministic
  corpus" fails with counts `{strictOrModelFree: 48, legacy: 72}` vs expected
  `{47, 73}`. Proven pre-existing by stash control on pristine develop in the
  same worktree (identical failure before this PR's changes) — corpus-count
  drift unrelated to the executor change.
- Package `tsc --noEmit` reports 135 `TS2307` module-resolution errors from
  sibling plugin dists not being built in this sandbox; identical set with the
  changes stashed (byte-diff empty). Full `bun run verify` was not run to
  completion in this sandbox for the same reason (requires a full workspace
  build); the owning package's build/typecheck/test/lint gates above are the
  verification for this change.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->


