### PR TITLE
test(agent-skills): align evidence coverage with complete context

### DIFF
--- a/plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts
+++ b/plugins/plugin-agent-skills/src/security/truncateEvidence.suffix.test.ts
@@ -1,73 +1,38 @@
 /**
- * Skill truncateEvidence suffix-reserve — inclusive cap via scanner path.
+ * Scanner evidence preservation coverage for complete, well-formed model context.
  */
 import { describe, expect, it } from "vitest";
 import { truncateEvidence } from "./types.ts";
 
-describe("truncateEvidence suffix-reserve", () => {
-  it("never exceeds max and handles max<=0", () => {
-    const long = "a".repeat(200);
-    expect(truncateEvidence(long, 120).length).toBeLessThanOrEqual(120);
-    expect(truncateEvidence(long, 120).endsWith("…")).toBe(true);
-    expect(truncateEvidence(long, 1)).toBe("…");
-    expect(truncateEvidence(long, 0)).toBe("");
-    expect(truncateEvidence(long, -5)).toBe("");
-    expect(truncateEvidence("short", 120)).toBe("short");
-    expect(truncateEvidence("a".repeat(120), 120).length).toBe(120);
-    expect(truncateEvidence("a".repeat(121), 120).length).toBe(120);
+describe("truncateEvidence", () => {
+  it("preserves complete evidence beyond the retired scanner cap", () => {
+    const evidence = `field: ${JSON.stringify("x".repeat(500))}`;
+    expect(truncateEvidence(evidence, 120)).toBe(evidence);
   });
 
-  it("scanner consumer respects cap", async () => {
-    const longLine = "x".repeat(500);
-    const evidence = truncateEvidence(`field: ${JSON.stringify(longLine)}`, 120);
-    expect(evidence.length).toBeLessThanOrEqual(120);
-    expect(evidence.endsWith("…")).toBe(true);
+  it("does not reinterpret the legacy maxLen argument as a model-context cap", () => {
+    const evidence = "complete scanner evidence";
+    expect(truncateEvidence(evidence, 1)).toBe(evidence);
+    expect(truncateEvidence(evidence, 0)).toBe(evidence);
+    expect(truncateEvidence(evidence, -5)).toBe(evidence);
   });
 
-  it("max=1 edge returns single ellipsis", () => {
-    expect(truncateEvidence("hello world", 1)).toBe("…");
-    expect(truncateEvidence("hello world", 1).length).toBe(1);
-  });
-
-  it("previous bug would overflow by one", () => {
-    const long = "b".repeat(200);
-    const beforeFix = `${long.slice(0, 120)}…`;
-    expect(beforeFix.length).toBe(121);
-    const afterFix = truncateEvidence(long, 120);
-    expect(afterFix.length).toBe(120);
-    expect(afterFix).not.toBe(beforeFix);
-  });
-
-  it("empty and short inputs are unchanged", () => {
+  it("preserves empty and short evidence", () => {
     expect(truncateEvidence("", 120)).toBe("");
     expect(truncateEvidence("hi", 10)).toBe("hi");
-    expect(truncateEvidence("a".repeat(5), 5)).toBe("a".repeat(5));
   });
 
-  it("max=2 reserves suffix correctly", () => {
-    expect(truncateEvidence("hello world", 2)).toBe("h…");
-    expect(truncateEvidence("hello world", 2).length).toBe(2);
-  });
-
-  it("never splits surrogate pairs at the truncation boundary", () => {
+  it("preserves complete surrogate pairs across the former boundary", () => {
     const text = `${"a".repeat(118)}🦊${"b".repeat(50)}`;
-    const truncated = truncateEvidence(text, 120);
-    expect(truncated.isWellFormed()).toBe(true);
-    expect(truncated).toBe(`${"a".repeat(118)}…`);
-    expect(truncated.length).toBe(119);
+    const evidence = truncateEvidence(text, 120);
+    expect(evidence).toBe(text);
+    expect(evidence.isWellFormed()).toBe(true);
   });
 
-  it("sanitizes lone surrogates before truncation", () => {
+  it("sanitizes lone surrogates without dropping surrounding evidence", () => {
     const text = `bad ${String.fromCharCode(0xd800)} evidence`;
-    const truncated = truncateEvidence(text, 120);
-    expect(truncated.isWellFormed()).toBe(true);
-    expect(truncated).toBe("bad \uFFFD evidence");
-  });
-
-  it("preserves fitting emoji without truncation", () => {
-    const text = "safe 🦊";
-    const truncated = truncateEvidence(text, 120);
-    expect(truncated).toBe("safe 🦊");
-    expect(truncated.isWellFormed()).toBe(true);
+    const evidence = truncateEvidence(text, 120);
+    expect(evidence).toBe("bad \uFFFD evidence");
+    expect(evidence.isWellFormed()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- replace stale suffix-cap assertions after the complete-context contract retired scanner evidence truncation
- prove long evidence and surrogate pairs remain complete and well formed
- prove the legacy `maxLen` argument no longer silently drops model-facing evidence

Closes #24570

## Validation

- focused evidence suite: 5/5 passed
- full plugin-agent-skills lane: 30 files, 373/373 passed
- package typecheck passed
- package build passed
- changed-file Biome and `git diff --check` passed

Exact reviewed SHA: `bbca26693e558638d54d0df3b6b91997b18b360d`

Screenshots, video, frontend/backend logs, LLM trajectories, and domain artifacts are N/A because this changes only deterministic test expectations for an already-merged complete-context contract.
