### PR TITLE
fix(core): clear every room message

### DIFF
--- a/packages/core/src/services/message.clear-channel.test.ts
+++ b/packages/core/src/services/message.clear-channel.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Drives the real {@link DefaultMessageService.clearChannel} against a real
+ * {@link AgentRuntime} + {@link InMemoryDatabaseAdapter}. Origin getMemoriesByRoomIds
+ * defaulted limit to 20, so a 25-message room left 5 rows after a successful
+ * clear. The bulk deleteAllMemories path must empty the room regardless of that
+ * default.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter.ts";
+import { AgentRuntime } from "../runtime.ts";
+import type { Character, UUID } from "../types";
+import { DefaultMessageService } from "./message.ts";
+
+const ROOM_ID = "20000000-0000-0000-0000-0000000000aa" as UUID;
+const ENTITY_ID = "10000000-0000-0000-0000-0000000000aa" as UUID;
+
+async function seededRuntime(count: number): Promise<{
+	runtime: AgentRuntime;
+	adapter: InMemoryDatabaseAdapter;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	await adapter.initialize();
+	const runtime = new AgentRuntime({
+		character: { name: "ClearChannelAgent", bio: "test" } as Character,
+		adapter,
+		logLevel: "fatal",
+	});
+	const memories = Array.from({ length: count }, (_, index) => ({
+		memory: {
+			id: `30000000-0000-0000-0000-0000000000${String(index).padStart(2, "0")}` as UUID,
+			entityId: ENTITY_ID,
+			agentId: runtime.agentId,
+			roomId: ROOM_ID,
+			content: { text: `msg ${index}` },
+			createdAt: index,
+		},
+		tableName: "messages",
+	}));
+	await adapter.createMemories(memories);
+	return { runtime, adapter };
+}
+
+describe("DefaultMessageService.clearChannel", () => {
+	it("deletes every message in a room larger than the in-memory default page", async () => {
+		const { runtime, adapter } = await seededRuntime(25);
+		const before = await adapter.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+		});
+		expect(before).toHaveLength(25);
+
+		await new DefaultMessageService().clearChannel(
+			runtime,
+			ROOM_ID,
+			"chan-repro",
+		);
+
+		const remaining = await adapter.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+		});
+		expect(remaining).toHaveLength(0);
+	});
+
+	it("is a no-op on an already empty room", async () => {
+		const { runtime, adapter } = await seededRuntime(0);
+		await new DefaultMessageService().clearChannel(
+			runtime,
+			ROOM_ID,
+			"chan-empty",
+		);
+		const remaining = await adapter.getMemories({
+			tableName: "messages",
+			roomId: ROOM_ID,
+		});
+		expect(remaining).toHaveLength(0);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -15712,44 +15712,24 @@ export class DefaultMessageService implements IMessageService {
 			"Clearing message memories from channel",
 		);
 
-		// Get all message memories for this room
-		const memories = await runtime.getMemoriesByRoomIds({
-			tableName: "messages",
+		// Bulk room delete — do not snapshot via getMemoriesByRoomIds. The
+		// in-memory adapter defaults that read to 20 rows, so a successful
+		// per-id loop left the rest of the channel intact. deleteAllMemories
+		// is the adapter contract for "this room, this table, all rows".
+		const totalCount = await runtime.countMemories({
 			roomIds: [roomId],
+			tableName: "messages",
+			unique: false,
 		});
-
-		runtime.logger.debug(
-			{ src: "service:message", channelId, count: memories.length },
-			"Found message memories to delete",
-		);
-
-		const messageIds: UUID[] = [];
-		for (const memory of memories) {
-			if (!memory.id) {
-				throw new ElizaError(
-					"Cannot clear a channel containing a message memory without an ID",
-					{
-						code: "CHANNEL_MESSAGE_ID_MISSING",
-						context: { roomId, channelId },
-					},
-				);
-			}
-			messageIds.push(memory.id);
-		}
-
-		let deletedCount = 0;
-		for (const messageId of messageIds) {
-			await runtime.deleteMemory(messageId);
-			deletedCount++;
-		}
+		await runtime.deleteAllMemories([roomId], "messages");
 
 		runtime.logger.info(
 			{
 				src: "service:message",
 				agentId: runtime.agentId,
 				channelId,
-				deletedCount,
-				totalCount: memories.length,
+				deletedCount: totalCount,
+				totalCount,
 			},
 			"Cleared message memories from channel",
 		);


### PR DESCRIPTION
Relates to #24511. Supersedes #24464 because the external fork cannot be rebased through the current queue with the available OAuth scope.

This carries the reviewed implementation by @ss251 onto current `develop`. Channel clearing now uses the adapter bulk-delete contract instead of reading the default first page and deleting only those IDs, so rooms larger than the in-memory 20-row default are actually emptied.

## Validation

- real AgentRuntime plus InMemoryDatabaseAdapter regression: 2/2 passed, including a 25-message room and an empty room
- core typecheck passed
- core build and package verification passed
- changed-file Biome and `git diff --check` passed
- no workflow delta

Exact reviewed SHA: `24fdb2bfa4a9f40980b09d6be1c0abeb1b1808b0`

Screenshots, video, frontend/backend logs, and LLM trajectories are N/A because this is a deterministic backend memory-deletion contract. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation and regression by @ss251 in #24464; current-base migration and independent execution by Codex.
