### PR TITLE
docs(scenarios): align fixture ratchet counts

### DIFF
--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -196,9 +196,9 @@ task was killed.
 
 The rollout is staged: undeclared scenarios temporarily retain the legacy
 resolver and reports mark them `legacy-fallback`; declared attempts report
-`strict-fixtures` or `model-free`. The migration ratchet currently records 46
-strict or explicitly model-free and 74 legacy `pr-deterministic` scenario sources across
-the repository. The declared rows contain only direct action/API work or
+`strict-fixtures` or `model-free`. The migration ratchet currently records 48
+strict or explicitly model-free and 72 legacy `pr-deterministic` scenario
+sources across the repository. The declared rows contain only direct action/API work or
 wait/seed/final checks and are validated again by the real executor before each
 attempt. The legacy count may only decrease, and the epic is complete only when
 it reaches zero.


### PR DESCRIPTION
Follow-up to #24562 and #24560. The ratchet implementation merged with the correct current inventory (48 strict/model-free, 72 legacy, 120 total), but its owning README still claimed 46/74. This updates the factual documentation to the exact enforced tuple.

Validation:
- `mise x bun@1.3.14 -- bunx vitest run src/model-fixture-migration.test.ts --config vitest.config.ts` — 2/2 passed
- `mise x bun@1.3.14 -- bunx biome check README.md src/model-fixture-migration.test.ts` — passed
- `git diff --check` — passed

No runtime, model, UI, or external integration behavior changes.