### PR TITLE
fix(agent): fail closed on invalid replay limits

### DIFF
--- a/packages/agent/src/api/__tests__/ws-event-replay.test.ts
+++ b/packages/agent/src/api/__tests__/ws-event-replay.test.ts
@@ -149,4 +149,18 @@ describe("selectReplayEvents — fail-closed on non-positive limit", () => {
     expect(selectReplayEvents(buffer, 5, -1)).toEqual([]);
     expect(selectReplayEvents(buffer, 5, NaN)).toEqual([]);
   });
+
+  it("returns [] for sub-unit and non-finite limits", () => {
+    const buffer = makeBuffer(20);
+    for (const limit of [0.5, Number.POSITIVE_INFINITY]) {
+      expect(selectReplayEvents(buffer, null, limit)).toEqual([]);
+      expect(selectReplayEvents(buffer, 5, limit)).toEqual([]);
+    }
+  });
+
+  it("floors a positive fractional limit before slicing", () => {
+    const buffer = makeBuffer(20);
+    expect(selectReplayEvents(buffer, null, 1.9)).toEqual(buffer.slice(-1));
+    expect(selectReplayEvents(buffer, 5, 1.9)).toEqual([buffer.at(-1)]);
+  });
 });

--- a/packages/agent/src/api/__tests__/ws-event-replay.test.ts
+++ b/packages/agent/src/api/__tests__/ws-event-replay.test.ts
@@ -134,3 +134,19 @@ describe("selectReplayEvents — no cursor (backward compatible)", () => {
     expect(result).toEqual(buffer.slice(-120));
   });
 });
+
+describe("selectReplayEvents — fail-closed on non-positive limit", () => {
+  it("returns [] for limit=0, negative, and NaN with no cursor", () => {
+    const buffer = makeBuffer(20);
+    expect(selectReplayEvents(buffer, null, 0)).toEqual([]);
+    expect(selectReplayEvents(buffer, null, -5)).toEqual([]);
+    expect(selectReplayEvents(buffer, null, NaN)).toEqual([]);
+  });
+
+  it("returns [] for limit=0, negative, and NaN with a cursor", () => {
+    const buffer = makeBuffer(20);
+    expect(selectReplayEvents(buffer, 5, 0)).toEqual([]);
+    expect(selectReplayEvents(buffer, 5, -1)).toEqual([]);
+    expect(selectReplayEvents(buffer, 5, NaN)).toEqual([]);
+  });
+});

--- a/packages/agent/src/api/ws-event-replay.ts
+++ b/packages/agent/src/api/ws-event-replay.ts
@@ -91,7 +91,7 @@ export function selectReplayEvents<T extends ReplayableEvent>(
   cursor: number | null,
   limit: number = DEFAULT_REPLAY_LIMIT,
 ): T[] {
-  const cap = limit > 0 ? limit : 0;
+  const cap = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 0;
   if (cap === 0) return [];
   if (cursor === null) {
     return cap >= buffer.length ? buffer.slice() : buffer.slice(-cap);

--- a/packages/agent/src/api/ws-event-replay.ts
+++ b/packages/agent/src/api/ws-event-replay.ts
@@ -92,6 +92,7 @@ export function selectReplayEvents<T extends ReplayableEvent>(
   limit: number = DEFAULT_REPLAY_LIMIT,
 ): T[] {
   const cap = limit > 0 ? limit : 0;
+  if (cap === 0) return [];
   if (cursor === null) {
     return cap >= buffer.length ? buffer.slice() : buffer.slice(-cap);
   }


### PR DESCRIPTION
Relates to #23737. Supersedes #23948 because the external fork cannot be rebased through the current queue with the available OAuth scope.

This carries the original fix by @OutstandingRetard and the reviewed normalization follow-up onto current `develop`. Replay selection now returns no events for zero, negative, sub-unit, NaN, or infinite caps instead of allowing JavaScript `slice(-0)` coercion to replay the full buffer. Positive fractional caps are normalized before slicing.

## Validation

- focused WebSocket replay suite: 19/19 passed
- agent build passed
- changed-file Biome and `git diff --check` passed
- package typecheck reached only unrelated unavailable optional-workspace declarations in this review worktree; neither changed file emitted a diagnostic
- no workflow delta

Exact reviewed SHA: `fb93e9436b5261183ce76e0f2f163c406c2cea93`

Screenshots, video, frontend logs, and LLM trajectories are N/A because this is a deterministic server-side replay selector. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation by @OutstandingRetard in #23948; normalization/tests by @lalalune; current-base migration and independent execution by Codex.
