### PR TITLE
fix(core): prevent canonical recall dedupe-key collisions

### DIFF
--- a/packages/core/src/access-control/canonical-dedupe-key.test.ts
+++ b/packages/core/src/access-control/canonical-dedupe-key.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Canonical connector-memory dedupe-key tests exercise the real recall
+ * evaluator with deterministic in-memory records. They prove delimiter-bearing
+ * connector identifiers cannot collapse distinct records while exact
+ * redeliveries and the legacy separator-free key corpus retain their contract.
+ */
+import { describe, expect, it } from "vitest";
+import type { AccessContext, Memory, UUID } from "../types";
+import {
+	buildCanonicalRecall,
+	type CanonicalProvenance,
+	canonicalDedupeKey,
+} from "./provenance-envelope";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const SENDER_ID = "00000000-0000-0000-0000-000000000002" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-000000000003" as UUID;
+const REQUESTER: AccessContext = {
+	requesterEntityId: SENDER_ID,
+	role: "USER",
+};
+
+function provenance(
+	accountId: string,
+	platformMessageId: string,
+): CanonicalProvenance {
+	return {
+		source: "discord",
+		accountId,
+		roomId: ROOM_ID,
+		senderId: SENDER_ID,
+		timestampMs: 1,
+		trust: "sender-stamped",
+		platformMessageId,
+		scope: "shared",
+	};
+}
+
+function memory(
+	id: UUID,
+	accountId: string,
+	platformMessageId: string,
+	createdAt: number,
+): Memory {
+	return {
+		id,
+		agentId: AGENT_ID,
+		entityId: SENDER_ID,
+		roomId: ROOM_ID,
+		createdAt,
+		content: { source: "discord", text: platformMessageId },
+		metadata: {
+			provider: "discord",
+			accountId,
+			platformMessageId,
+			scope: "shared",
+			discord: { userId: "user-123" },
+		},
+	} as Memory;
+}
+
+describe("canonicalDedupeKey", () => {
+	it("keeps a separator-free legacy corpus byte-identical", () => {
+		const corpus = Array.from({ length: 100 }, (_, index) =>
+			provenance(
+				`account-${index}@example.com`,
+				`message_${index}/with?query=${index}`,
+			),
+		);
+		for (const item of corpus) {
+			expect(canonicalDedupeKey(item)).toBe(
+				`${item.source}:${item.accountId}:${item.roomId}:${item.platformMessageId}`,
+			);
+		}
+	});
+
+	it("keeps distinct delimiter-bearing tuples distinct through recall", () => {
+		const firstAccount = "acct";
+		const firstMessage = `part:${ROOM_ID}:tail`;
+		const secondAccount = `acct:${ROOM_ID}:part`;
+		const secondMessage = "tail";
+		expect(canonicalDedupeKey(provenance(firstAccount, firstMessage))).not.toBe(
+			canonicalDedupeKey(provenance(secondAccount, secondMessage)),
+		);
+
+		const result = buildCanonicalRecall({
+			candidates: [
+				memory(
+					"00000000-0000-0000-0000-000000000010" as UUID,
+					firstAccount,
+					firstMessage,
+					1,
+				),
+				memory(
+					"00000000-0000-0000-0000-000000000011" as UUID,
+					secondAccount,
+					secondMessage,
+					2,
+				),
+			],
+			agentId: AGENT_ID,
+			requester: REQUESTER,
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items).toHaveLength(2);
+		expect(result.items.map((item) => item.memory.content.text)).toEqual([
+			firstMessage,
+			secondMessage,
+		]);
+	});
+
+	it("still collapses an exact redelivery", () => {
+		const original = memory(
+			"00000000-0000-0000-0000-000000000020" as UUID,
+			"account:with:delimiter",
+			"message:with:delimiter",
+			1,
+		);
+		const redelivery = {
+			...original,
+			id: "00000000-0000-0000-0000-000000000021" as UUID,
+			createdAt: 2,
+		};
+		const result = buildCanonicalRecall({
+			candidates: [redelivery, original],
+			agentId: AGENT_ID,
+			requester: REQUESTER,
+			destinationRoomId: ROOM_ID,
+		});
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.memory.id).toBe(original.id);
+	});
+});

--- a/packages/core/src/access-control/provenance-envelope.ts
+++ b/packages/core/src/access-control/provenance-envelope.ts
@@ -385,8 +385,10 @@ export function deriveCanonicalProvenance(
 }
 
 /**
- * Stable idempotency key for a canonical item:
- * `source:account:room:platformRecordId`.
+ * Stable idempotency key for a canonical item. Separator-free identifiers keep
+ * the legacy `source:account:room:platformRecordId` form; delimiter-bearing
+ * account or record identifiers use a versioned JSON tuple so distinct tuples
+ * cannot serialize to the same key.
  *
  * Redelivery of one webhook collapses to one key. The same text arriving under
  * two connector accounts yields two keys, so account identity survives
@@ -395,6 +397,21 @@ export function deriveCanonicalProvenance(
  * scoped to a chat, so the same id in two chats is two records, not one.
  */
 export function canonicalDedupeKey(provenance: CanonicalProvenance): string {
+	if (
+		provenance.accountId.includes(":") ||
+		provenance.platformMessageId.includes(":")
+	) {
+		// The legacy key is retained byte-for-byte for its unambiguous input
+		// domain. Delimiter-bearing identifiers use a versioned JSON tuple: JSON
+		// string encoding is injective for strings, and `|` cannot occur in a
+		// validated canonical source, so a v2 key cannot collide with a legacy key.
+		return `v2|${JSON.stringify([
+			provenance.source,
+			provenance.accountId,
+			provenance.roomId,
+			provenance.platformMessageId,
+		])}`;
+	}
 	return `${provenance.source}:${provenance.accountId}:${provenance.roomId}:${provenance.platformMessageId}`;
 }
 


### PR DESCRIPTION
Closes #24567.

## Summary

Canonical recall used a colon-joined dedupe key. Because connector account IDs and platform record IDs accept non-empty strings, two distinct `(source, accountId, roomId, platformMessageId)` tuples could serialize to the same key. The real recall evaluator then returned the earlier item and silently lost the other.

This keeps the legacy key byte-identical when both variable fields are delimiter-free. If either contains `:`, it uses a versioned JSON tuple, which is unambiguous and cannot collide with a validated legacy-source prefix.

## Containment trace

`MESSAGE op=search` awaits canonical recall inside a J1 boundary, but this path throws nothing: the dedupe map returns a successful wrong value with one item already removed. The outer catch therefore passes the loss through unchanged and cannot restore the missing record.

## Completeness / adjacent invariants

- Distinct delimiter-bearing tuples remain distinct.
- Exact webhook redeliveries still collapse to the earliest record.
- A 100-case separator-free corpus retains byte-identical legacy keys.
- No truncation, clamping, windowing, or content rewriting is introduced.
- The key is computed at recall time and is not persisted, so there is no legacy-row migration or cleanup requirement.

## Origin reproduction

The production file was byte-identical to `origin/develop` before modification. Driving the real `buildCanonicalRecall` module with two valid same-room memories produced:

```json
{"collide":true,"input":2,"recalled":1}
```

## Verification

- Post-rebase focused tests: `13 pass, 0 fail, 127 expect() calls`.
- Load-bearing revert: original source under the new tests produced `2 pass, 1 fail, 103 expect() calls`; restoring the fix produced `3 pass, 0 fail, 105 expect() calls`.
- No-over-rejection corpus: 100 previously valid delimiter-free keys were byte-identical.
- Untouched-control core typecheck: zero errors. Fixed-head core typecheck: zero errors, therefore zero added errors.
- `bunx biome check` on both changed files: `Checked 2 files ... No fixes applied`.
- Core build printed successful Node, browser, edge, testing-module, and declaration completion.
- Exact reviewed head: `8c7ab7d78945d2502f1de18cef7ab6c7c87f33f5`; base: `3daae2d17930eafa378211546c26b59c999ba17f`.

## Evidence Gate

<!-- evidence-head:8c7ab7d78945d2502f1de18cef7ab6c7c87f33f5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure core runtime logic; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure core runtime logic; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the changed evaluator is pure and emits no structured backend logs; executed origin/fixed outputs are quoted above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, network, or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action-planning, or model-context construction changed.
<!-- evidence-row:domain-artifacts -->
- [x] Inline domain artifact - origin recall returned 1 of 2 distinct records; fixed tests prove 2 of 2 survive and exact redelivery remains 1 of 2.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

## Known gaps / failures

- `bun run verify` stopped in the repository-wide workspace-resolution audit on 16 unrelated unresolved `@elizaos/capacitor-secure-store` imports from `packages/ui/src/bridge/storage-bridge.ts`; the changed core package typechecks with zero errors.
- The full core build printed `All builds complete` after Node/browser/edge/testing/declaration success but retained a process handle; it was interrupted after completion output, so its shell exit was 130.
- This is a fork-authored PR, so hosted CI does not run on it. No hosted check is claimed as passing.
- No live connector was needed: the defect and fix are deterministic in the real canonical recall module, and the test uses valid production-shaped memories through that module.

## Risks

Low. Separator-free keys remain identical. Only keys whose account or record component contains the ambiguous delimiter move to the unambiguous versioned form; exact duplicates continue to dedupe.

## Documentation

No project documentation change is needed; the exported function's JSDoc now describes both stable formats.

## Maintainer CI exception record

N/A - no exception requested.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [c2-escal-dedupe]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NDJSGJJV676ANESH0CQKY0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T19:01:25.652Z","completed_at":"2026-08-22T19:06:58.111Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T19:01:40.809Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6a3618cf35b1caa297009cd3dd97582ae53c679820c452d8e99faefd7bde4321","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"54e9b0f4-7a11-4fee-831e-30af799a99ea","object_id":"sha256:6a3618cf35b1caa297009cd3dd97582ae53c679820c452d8e99faefd7bde4321","sha256":"6a3618cf35b1caa297009cd3dd97582ae53c679820c452d8e99faefd7bde4321"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"spLlIfdL9efw0jWwA2F583hCz_erD8TCHJU4osDmrL29Zy0Tfr8qfH7UCgQ1TEGoxdVUWGOqgyJ1jiiSIKzLDg"}} -->
