### PR TITLE
fix(plugin-x): retry repeat-safe queued reads

### DIFF
--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -148,13 +148,29 @@ export function resolveMaxAuthRetries(raw: string | undefined): number {
  * Class representing a request queue for handling asynchronous requests in a controlled manner.
  */
 
-type QueuedRequest = () => Promise<unknown>;
+type QueuedItem = {
+  run: () => Promise<void>;
+  reject: (error: unknown) => void;
+  retrySafe: boolean;
+};
 
-class RequestQueue {
-  private queue: QueuedRequest[] = [];
+export type RequestQueueOptions = {
+  /** Retry only operations that are safe to repeat after an ambiguous failure. */
+  retry?: "safe";
+};
+
+export class RequestQueue {
+  private queue: QueuedItem[] = [];
   private processing = false;
   private maxRetries = 3;
-  private retryAttempts = new Map<QueuedRequest, number>();
+  private retryAttempts = new Map<QueuedItem, number>();
+
+  constructor(
+    private readonly waits: {
+      backoff?: (retryCount: number) => Promise<void>;
+      jitter?: () => Promise<void>;
+    } = {},
+  ) {}
 
   /**
    * Asynchronously adds a request to the queue, then processes the queue.
@@ -163,17 +179,20 @@ class RequestQueue {
    * @param {() => Promise<T>} request - The request to be added to the queue
    * @returns {Promise<T>} - A promise that resolves with the result of the request or rejects with an error
    */
-  async add<T>(request: () => Promise<T>): Promise<T> {
+  async add<T>(
+    request: () => Promise<T>,
+    options: RequestQueueOptions = {},
+  ): Promise<T> {
     return new Promise((resolve, reject) => {
-      this.queue.push(async () => {
-        try {
+      this.queue.push({
+        run: async () => {
           const result = await request();
           resolve(result);
-        } catch (error) {
-          reject(error);
-        }
+        },
+        reject,
+        retrySafe: options.retry === "safe",
       });
-      this.processQueue();
+      void this.processQueue();
     });
   }
 
@@ -189,38 +208,39 @@ class RequestQueue {
     this.processing = true;
 
     while (this.queue.length > 0) {
-      const request = this.queue.shift();
-      if (!request) break;
+      const item = this.queue.shift();
+      if (!item) break;
       try {
-        await request();
-        // Clear retry count on success
-        this.retryAttempts.delete(request);
+        await item.run();
+        this.retryAttempts.delete(item);
       } catch (error) {
+        // error-policy:J1 queue boundary retries only explicitly repeat-safe
+        // work and rejects the original caller when no retry is authorized.
         logger.error("Error processing request:", errorDetail(error));
 
-        const retryCount = (this.retryAttempts.get(request) || 0) + 1;
+        const retryCount = (this.retryAttempts.get(item) || 0) + 1;
 
-        if (retryCount < this.maxRetries) {
-          this.retryAttempts.set(request, retryCount);
-          this.queue.unshift(request);
+        if (item.retrySafe && retryCount < this.maxRetries) {
+          this.retryAttempts.set(item, retryCount);
+          this.queue.unshift(item);
           await this.exponentialBackoff(retryCount);
-          // Break the loop to allow exponential backoff to take effect
-          break;
-        } else {
+          continue;
+        }
+        if (item.retrySafe) {
           logger.error(
             `Max retries (${this.maxRetries}) exceeded for request, skipping`,
           );
-          this.retryAttempts.delete(request);
         }
+        this.retryAttempts.delete(item);
+        item.reject(error);
       }
       await this.randomDelay();
     }
 
     this.processing = false;
 
-    // If there are still items in the queue, restart processing
     if (this.queue.length > 0) {
-      this.processQueue();
+      void this.processQueue();
     }
   }
 
@@ -230,6 +250,10 @@ class RequestQueue {
    * @returns {Promise<void>} - A promise that resolves after a delay based on the retry count.
    */
   private async exponentialBackoff(retryCount: number): Promise<void> {
+    if (this.waits.backoff) {
+      await this.waits.backoff(retryCount);
+      return;
+    }
     const delay = 2 ** retryCount * 1000;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
@@ -240,6 +264,10 @@ class RequestQueue {
    * @returns A Promise that resolves after the random delay has passed.
    */
   private async randomDelay(): Promise<void> {
+    if (this.waits.jitter) {
+      await this.waits.jitter();
+      return;
+    }
     const delay = Math.floor(Math.random() * 2000) + 1500;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
@@ -336,8 +364,9 @@ export class ClientBase {
       return cachedTweet;
     }
 
-    const tweet = await this.requestQueue.add(() =>
-      this.twitterClient.getTweet(tweetId),
+    const tweet = await this.requestQueue.add(
+      () => this.twitterClient.getTweet(tweetId),
+      { retry: "safe" },
     );
 
     if (!tweet) {
@@ -683,16 +712,18 @@ export class ClientBase {
           15_000,
         );
       });
-      const result = await this.requestQueue.add(() =>
-        Promise.race([
-          this.twitterClient.fetchSearchTweets(
-            query,
-            maxTweets,
-            searchMode,
-            cursor,
-          ),
-          timeoutPromise,
-        ]),
+      const result = await this.requestQueue.add(
+        () =>
+          Promise.race([
+            this.twitterClient.fetchSearchTweets(
+              query,
+              maxTweets,
+              searchMode,
+              cursor,
+            ),
+            timeoutPromise,
+          ]),
+        { retry: "safe" },
       );
       if (!result) {
         throw new ElizaError("X search returned no response", {
@@ -1095,43 +1126,46 @@ export class ClientBase {
 
   async fetchProfile(username: string): Promise<TwitterProfile> {
     try {
-      const profile = await this.requestQueue.add(async () => {
-        const profile = await this.twitterClient.getProfile(username);
+      const profile = await this.requestQueue.add(
+        async () => {
+          const profile = await this.twitterClient.getProfile(username);
 
-        // Handle case where runtime.character might be undefined
-        const defaultName = "AI Assistant";
-        const defaultBio = "";
+          // Handle case where runtime.character might be undefined
+          const defaultName = "AI Assistant";
+          const defaultBio = "";
 
-        let characterName = defaultName;
-        let characterBio = defaultBio;
+          let characterName = defaultName;
+          let characterBio = defaultBio;
 
-        if (this.runtime?.character) {
-          characterName = this.runtime.character.name || defaultName;
+          if (this.runtime?.character) {
+            characterName = this.runtime.character.name || defaultName;
 
-          if (typeof this.runtime.character.bio === "string") {
-            characterBio = this.runtime.character.bio;
-          } else if (
-            Array.isArray(this.runtime.character.bio) &&
-            this.runtime.character.bio.length > 0
-          ) {
-            characterBio = this.runtime.character.bio[0] ?? defaultBio;
+            if (typeof this.runtime.character.bio === "string") {
+              characterBio = this.runtime.character.bio;
+            } else if (
+              Array.isArray(this.runtime.character.bio) &&
+              this.runtime.character.bio.length > 0
+            ) {
+              characterBio = this.runtime.character.bio[0] ?? defaultBio;
+            }
           }
-        }
 
-        if (!profile.userId) {
-          throw new Error(
-            `Twitter profile for ${username} is missing a user id`,
-          );
-        }
+          if (!profile.userId) {
+            throw new Error(
+              `Twitter profile for ${username} is missing a user id`,
+            );
+          }
 
-        return {
-          id: profile.userId,
-          username,
-          screenName: profile.name || characterName,
-          bio: profile.biography || characterBio,
-          nicknames: [],
-        } satisfies TwitterProfile;
-      });
+          return {
+            id: profile.userId,
+            username,
+            screenName: profile.name || characterName,
+            bio: profile.biography || characterBio,
+            nicknames: [],
+          } satisfies TwitterProfile;
+        },
+        { retry: "safe" },
+      );
 
       return profile;
     } catch (error) {
@@ -1167,12 +1201,14 @@ export class ClientBase {
     try {
       return await this.withAuthenticatedSession(async ({ profile }) => {
         // Use fetchSearchTweets to get mentions instead of the non-existent get method
-        const mentionsResponse = await this.requestQueue.add(() =>
-          this.twitterClient.fetchSearchTweets(
-            `@${profile.username}`,
-            100,
-            SearchMode.Latest,
-          ),
+        const mentionsResponse = await this.requestQueue.add(
+          () =>
+            this.twitterClient.fetchSearchTweets(
+              `@${profile.username}`,
+              100,
+              SearchMode.Latest,
+            ),
+          { retry: "safe" },
         );
 
         // Process tweets directly into the expected interaction format

--- a/plugins/plugin-x/src/request-queue.test.ts
+++ b/plugins/plugin-x/src/request-queue.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Real `ClientBase.requestQueue` coverage: a swallowed wrapper catch used to
+ * reject `add()` on the first failure and skip retry/backoff. The queue now
+ * retries explicitly repeatable reads, then rejects only after the budget is
+ * exhausted. Ambiguous mutations remain single-attempt.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { ClientBase, RequestQueue } from "./base";
+import type { TwitterClientState } from "./types";
+
+function makeClient(): ClientBase {
+  const client = new ClientBase(
+    {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+    } as unknown as IAgentRuntime,
+    { accountId: "default" } as TwitterClientState,
+  );
+  client.requestQueue = new RequestQueue({
+    backoff: async () => undefined,
+    jitter: async () => undefined,
+  });
+  return client;
+}
+
+describe("RequestQueue retries provider failures", () => {
+  it("retries a failed request and resolves when a later attempt succeeds", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(
+        async () => {
+          calls += 1;
+          if (calls < 2) {
+            throw new Error("HTTP 429 rate limited");
+          }
+          return "ok";
+        },
+        { retry: "safe" },
+      ),
+    ).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  }, 20_000);
+
+  it("rejects after the retry budget instead of hanging or skipping", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(
+        async () => {
+          calls += 1;
+          throw new Error("HTTP 429 rate limited");
+        },
+        { retry: "safe" },
+      ),
+    ).rejects.toThrow("HTTP 429 rate limited");
+    expect(calls).toBe(3);
+  }, 20_000);
+
+  it("still resolves a first-try success without extra attempts", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        return 42;
+      }),
+    ).resolves.toBe(42);
+    expect(calls).toBe(1);
+  });
+
+  it("does not retry an operation without explicit repeat-safe authority", async () => {
+    const client = makeClient();
+    let calls = 0;
+
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        throw new Error("delivery receipt lost after provider acceptance");
+      }),
+    ).rejects.toThrow("delivery receipt lost after provider acceptance");
+
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
Replacement for #24524; preserves and credits its queue-settlement/retry implementation while repairing the ambiguous-write retry defect. Relates to #24522.

What changed:
- queued callers now settle correctly after retry success or budget exhaustion;
- retry authority is explicit (`{ retry: "safe" }`) and applied to repeatable read operations only;
- quote-tweet and other ambiguous mutations remain single-attempt, preventing duplicate provider effects after a lost receipt;
- tests prove read retry/success/exhaustion and mutation no-retry behavior.

Validation (Bun 1.3.14):
- focused queue + auth retry suites: 2 files, 9/9 passed
- `bun run --cwd plugins/plugin-x typecheck` — passed
- `bun run --cwd plugins/plugin-x lint:check` — 95 files clean
- `git diff --check` — passed

Authorship of the original retry repair remains attributed to ss251 via the preserved commit author and cherry-pick provenance. No live X write was issued.