### PR TITLE
fix(personal-assistant): gate scheduler on workflow claim schema

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -2876,6 +2876,37 @@ export class LifeOpsRepository {
          )
         WHERE idempotency_key IS NOT NULL`,
       );
+      // `IF NOT EXISTS` silently accepts any pre-existing index with this
+      // name. A foreign non-unique (or wrong-column/predicate) index would
+      // pass creation and then be stamped as the durable completion marker
+      // while electing nothing. Verify the live definition before stamping;
+      // the transaction rolls back on mismatch so a later boot retries after
+      // the operator drops or renames the conflicting index.
+      const indexDefinitionRows = await executeRawSqlTx(
+        tx,
+        `SELECT indexdef
+           FROM pg_catalog.pg_indexes
+          WHERE schemaname = 'app_lifeops'
+            AND tablename = 'life_workflow_runs'
+            AND indexname = 'idx_life_workflow_runs_idempotency'`,
+      );
+      const indexDefinition =
+        typeof indexDefinitionRows[0]?.indexdef === "string"
+          ? indexDefinitionRows[0].indexdef
+          : "";
+      const indexDefinitionIsExpected =
+        /\bUNIQUE INDEX\b/i.test(indexDefinition) &&
+        /\(agent_id, workflow_id, idempotency_key\)/i.test(indexDefinition) &&
+        /WHERE \(idempotency_key IS NOT NULL\)/i.test(indexDefinition);
+      if (!indexDefinitionIsExpected) {
+        throw new ElizaError(
+          "[LifeOpsRepository] idx_life_workflow_runs_idempotency exists but is not the expected partial unique index — drop or rename the conflicting index so the workflow-run claim election can be installed",
+          {
+            code: "LIFEOPS_WORKFLOW_RUN_IDEMPOTENCY_INDEX_MISMATCH",
+            context: { indexDefinition },
+          },
+        );
+      }
       await executeRawSqlTx(
         tx,
         `COMMENT ON INDEX app_lifeops.idx_life_workflow_runs_idempotency
@@ -6807,7 +6838,10 @@ export class LifeOpsRepository {
    * Atomically reserve a workflow run before any workflow step can perform a
    * side effect. The unique `(agent, workflow, idempotency key)` index elects
    * one cross-process winner; PostgreSQL NULL semantics keep unkeyed runs
-   * independent.
+   * independent. The conflict target names that partial index explicitly so a
+   * table missing the index raises ("no unique or exclusion constraint
+   * matching the ON CONFLICT specification") instead of letting every
+   * claimant insert-win and duplicate external workflow execution.
    */
   async claimWorkflowRun(run: LifeOpsWorkflowRun): Promise<boolean> {
     assertValidWorkflowRunIdempotencyKey(run.idempotencyKey);
@@ -6840,7 +6874,9 @@ export class LifeOpsRepository {
         ${sqlJson(run.result)},
         ${sqlText(run.auditRef)}
       )
-      ON CONFLICT DO NOTHING
+      ON CONFLICT (agent_id, workflow_id, idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+      DO NOTHING
       RETURNING id`,
     );
     return rows.length === 1;

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -1401,11 +1401,24 @@ const WORKFLOW_RUN_IDEMPOTENCY_BACKFILL_MARKER =
   "elizaos:life_workflow_runs:idempotency-backfill:v1";
 const WORKFLOW_RUN_IDEMPOTENCY_BACKFILL_BATCH_SIZE = 500;
 
-const WORKFLOW_RUN_IDEMPOTENCY_INDEX_DEFINITION_QUERY = `SELECT indexdef
-  FROM pg_catalog.pg_indexes
- WHERE schemaname = 'app_lifeops'
-   AND tablename = 'life_workflow_runs'
-   AND indexname = 'idx_life_workflow_runs_idempotency'`;
+const WORKFLOW_RUN_IDEMPOTENCY_INDEX_DEFINITION_QUERY = `SELECT
+       pg_catalog.pg_get_indexdef(index_catalog.indexrelid) AS indexdef,
+       index_catalog.indisunique AS is_unique,
+       index_catalog.indisvalid AS is_valid,
+       index_catalog.indisready AS is_ready
+  FROM pg_catalog.pg_index AS index_catalog
+  JOIN pg_catalog.pg_class AS index_class
+    ON index_class.oid = index_catalog.indexrelid
+  JOIN pg_catalog.pg_namespace AS index_namespace
+    ON index_namespace.oid = index_class.relnamespace
+  JOIN pg_catalog.pg_class AS table_class
+    ON table_class.oid = index_catalog.indrelid
+  JOIN pg_catalog.pg_namespace AS table_namespace
+    ON table_namespace.oid = table_class.relnamespace
+ WHERE index_namespace.nspname = 'app_lifeops'
+   AND index_class.relname = 'idx_life_workflow_runs_idempotency'
+   AND table_namespace.nspname = 'app_lifeops'
+   AND table_class.relname = 'life_workflow_runs'`;
 
 function assertWorkflowRunIdempotencyIndexDefinition(
   rows: Array<Record<string, unknown>>,
@@ -1413,15 +1426,23 @@ function assertWorkflowRunIdempotencyIndexDefinition(
   const indexDefinition =
     typeof rows[0]?.indexdef === "string" ? rows[0].indexdef : "";
   const indexDefinitionIsExpected =
+    rows[0]?.is_unique === true &&
+    rows[0]?.is_valid === true &&
+    rows[0]?.is_ready === true &&
     /\bUNIQUE INDEX\b/i.test(indexDefinition) &&
     /\(agent_id, workflow_id, idempotency_key\)/i.test(indexDefinition) &&
     /WHERE \(idempotency_key IS NOT NULL\)/i.test(indexDefinition);
   if (!indexDefinitionIsExpected) {
     throw new ElizaError(
-      "[LifeOpsRepository] idx_life_workflow_runs_idempotency exists but is not the expected partial unique index — drop or rename the conflicting index so the workflow-run claim election can be installed",
+      "[LifeOpsRepository] idx_life_workflow_runs_idempotency exists but is not the expected partial unique index or is not usable — drop or rename the conflicting index so the workflow-run claim election can be installed",
       {
         code: "LIFEOPS_WORKFLOW_RUN_IDEMPOTENCY_INDEX_MISMATCH",
-        context: { indexDefinition },
+        context: {
+          indexDefinition,
+          isUnique: rows[0]?.is_unique,
+          isValid: rows[0]?.is_valid,
+          isReady: rows[0]?.is_ready,
+        },
       },
     );
   }

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -1401,6 +1401,32 @@ const WORKFLOW_RUN_IDEMPOTENCY_BACKFILL_MARKER =
   "elizaos:life_workflow_runs:idempotency-backfill:v1";
 const WORKFLOW_RUN_IDEMPOTENCY_BACKFILL_BATCH_SIZE = 500;
 
+const WORKFLOW_RUN_IDEMPOTENCY_INDEX_DEFINITION_QUERY = `SELECT indexdef
+  FROM pg_catalog.pg_indexes
+ WHERE schemaname = 'app_lifeops'
+   AND tablename = 'life_workflow_runs'
+   AND indexname = 'idx_life_workflow_runs_idempotency'`;
+
+function assertWorkflowRunIdempotencyIndexDefinition(
+  rows: Array<Record<string, unknown>>,
+): void {
+  const indexDefinition =
+    typeof rows[0]?.indexdef === "string" ? rows[0].indexdef : "";
+  const indexDefinitionIsExpected =
+    /\bUNIQUE INDEX\b/i.test(indexDefinition) &&
+    /\(agent_id, workflow_id, idempotency_key\)/i.test(indexDefinition) &&
+    /WHERE \(idempotency_key IS NOT NULL\)/i.test(indexDefinition);
+  if (!indexDefinitionIsExpected) {
+    throw new ElizaError(
+      "[LifeOpsRepository] idx_life_workflow_runs_idempotency exists but is not the expected partial unique index — drop or rename the conflicting index so the workflow-run claim election can be installed",
+      {
+        code: "LIFEOPS_WORKFLOW_RUN_IDEMPOTENCY_INDEX_MISMATCH",
+        context: { indexDefinition },
+      },
+    );
+  }
+}
+
 function assertValidWorkflowRunIdempotencyKey(
   idempotencyKey: string | null | undefined,
 ): void {
@@ -2715,6 +2741,12 @@ export class LifeOpsRepository {
         LIMIT 1`;
     const markerRows = await executeRawSql(runtime, markerQuery);
     if (markerRows.length > 0) {
+      assertWorkflowRunIdempotencyIndexDefinition(
+        await executeRawSql(
+          runtime,
+          WORKFLOW_RUN_IDEMPOTENCY_INDEX_DEFINITION_QUERY,
+        ),
+      );
       return;
     }
     await executeRawSql(
@@ -2729,6 +2761,12 @@ export class LifeOpsRepository {
         "LOCK TABLE app_lifeops.life_workflow_runs IN SHARE ROW EXCLUSIVE MODE",
       );
       if ((await executeRawSqlTx(tx, markerQuery)).length > 0) {
+        assertWorkflowRunIdempotencyIndexDefinition(
+          await executeRawSqlTx(
+            tx,
+            WORKFLOW_RUN_IDEMPOTENCY_INDEX_DEFINITION_QUERY,
+          ),
+        );
         return;
       }
       await executeRawSqlTx(
@@ -2882,31 +2920,12 @@ export class LifeOpsRepository {
       // while electing nothing. Verify the live definition before stamping;
       // the transaction rolls back on mismatch so a later boot retries after
       // the operator drops or renames the conflicting index.
-      const indexDefinitionRows = await executeRawSqlTx(
-        tx,
-        `SELECT indexdef
-           FROM pg_catalog.pg_indexes
-          WHERE schemaname = 'app_lifeops'
-            AND tablename = 'life_workflow_runs'
-            AND indexname = 'idx_life_workflow_runs_idempotency'`,
+      assertWorkflowRunIdempotencyIndexDefinition(
+        await executeRawSqlTx(
+          tx,
+          WORKFLOW_RUN_IDEMPOTENCY_INDEX_DEFINITION_QUERY,
+        ),
       );
-      const indexDefinition =
-        typeof indexDefinitionRows[0]?.indexdef === "string"
-          ? indexDefinitionRows[0].indexdef
-          : "";
-      const indexDefinitionIsExpected =
-        /\bUNIQUE INDEX\b/i.test(indexDefinition) &&
-        /\(agent_id, workflow_id, idempotency_key\)/i.test(indexDefinition) &&
-        /WHERE \(idempotency_key IS NOT NULL\)/i.test(indexDefinition);
-      if (!indexDefinitionIsExpected) {
-        throw new ElizaError(
-          "[LifeOpsRepository] idx_life_workflow_runs_idempotency exists but is not the expected partial unique index — drop or rename the conflicting index so the workflow-run claim election can be installed",
-          {
-            code: "LIFEOPS_WORKFLOW_RUN_IDEMPOTENCY_INDEX_MISMATCH",
-            context: { indexDefinition },
-          },
-        );
-      }
       await executeRawSqlTx(
         tx,
         `COMMENT ON INDEX app_lifeops.idx_life_workflow_runs_idempotency

--- a/plugins/plugin-personal-assistant/src/lifeops/runtime.scheduler-tick.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/runtime.scheduler-tick.test.ts
@@ -1,5 +1,6 @@
 /** Verifies the LifeOps scheduler tick processes scheduled work and surfaces subsystem failures rather than swallowing them. Deterministic vitest with the scheduled-work path mocked. */
-import type { IAgentRuntime, TaskWorker, UUID } from "@elizaos/core";
+import type { IAgentRuntime, Task, TaskWorker, UUID } from "@elizaos/core";
+import { TaskService } from "@elizaos/core/node";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { escalateUnacknowledgedIntents } from "./intent-sync.js";
 import {
@@ -43,6 +44,10 @@ vi.mock("./scheduler-task.js", () => ({
   resolveLifeOpsTaskIntervalMs: vi.fn(() => 60_000),
 }));
 
+vi.mock("./app-state.js", () => ({
+  loadLifeOpsAppState: vi.fn(async () => ({ enabled: true })),
+}));
+
 vi.mock("./service.js", () => ({
   LifeOpsService: class {
     async processScheduledWork() {
@@ -67,7 +72,7 @@ describe("registerLifeOpsTaskWorker", () => {
   it("keeps the task identity valid without executing when scheduler is disabled", async () => {
     let registered: TaskWorker | undefined;
     const disabledRuntime = {
-      getTaskWorker: () => undefined,
+      getTaskWorker: () => registered,
       registerTaskWorker: (worker: TaskWorker) => {
         registered = worker;
       },
@@ -81,6 +86,52 @@ describe("registerLifeOpsTaskWorker", () => {
         name: "LIFEOPS_SCHEDULER",
       }),
     ).resolves.toBe(false);
+  });
+
+  it("keeps a persisted due row out of TaskService until the claim schema is ready", async () => {
+    let registered: TaskWorker | undefined;
+    let ready = false;
+    const task: Task = {
+      id: "00000000-0000-0000-0000-0000000000ef" as UUID,
+      name: "LIFEOPS_SCHEDULER",
+      tags: ["queue", "repeat"],
+      metadata: { updateInterval: 1, updatedAt: 0 },
+    };
+    const gatedRuntime = {
+      agentId: AGENT_ID,
+      getTaskWorker: () => registered,
+      registerTaskWorker: (worker: TaskWorker) => {
+        registered = worker;
+      },
+      getTask: vi.fn(async () => task),
+      updateTask: vi.fn(async () => undefined),
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    } as unknown as IAgentRuntime;
+
+    registerLifeOpsTaskWorker(gatedRuntime, {
+      isWorkflowClaimSchemaReady: () => ready,
+    });
+
+    const execute = vi.fn(registered?.execute);
+    if (!registered) throw new Error("expected LifeOps worker registration");
+    registered.execute = execute;
+    const taskService = new TaskService(gatedRuntime);
+
+    await taskService.runTick([task]);
+    expect(execute).not.toHaveBeenCalled();
+    await expect(
+      registered?.execute(gatedRuntime, {}, { name: "LIFEOPS_SCHEDULER" }),
+    ).rejects.toThrow(/claim schema is not ready/i);
+    execute.mockClear();
+
+    ready = true;
+    await taskService.runTick([task]);
+    expect(execute).toHaveBeenCalledOnce();
   });
 });
 

--- a/plugins/plugin-personal-assistant/src/lifeops/runtime.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/runtime.ts
@@ -4,7 +4,7 @@
  * scheduler-task helpers callers use to bootstrap the plugin at init.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { loadLifeOpsAppState } from "./app-state.js";
 import type { HouseholdGrantExpiryWarningReceipt } from "./household/grant-expiry-warning.js";
 import {
@@ -153,7 +153,10 @@ export async function executeLifeOpsSchedulerTask(
 
 export function registerLifeOpsTaskWorker(
   runtime: IAgentRuntime,
-  options: { disabled?: boolean } = {},
+  options: {
+    disabled?: boolean;
+    isWorkflowClaimSchemaReady?: () => boolean;
+  } = {},
 ): void {
   if (runtime.getTaskWorker(LIFEOPS_TASK_NAME)) {
     return;
@@ -169,6 +172,7 @@ export function registerLifeOpsTaskWorker(
     // switch exactly: the timer still validates the row, but never executes it.
     shouldRun: async (rt) => {
       if (disabled) return false;
+      if (options.isWorkflowClaimSchemaReady?.() === false) return false;
       try {
         const state = await loadLifeOpsAppState(rt as IAgentRuntime);
         return state.enabled;
@@ -181,7 +185,21 @@ export function registerLifeOpsTaskWorker(
         return false;
       }
     },
-    execute: async (rt, taskOptions) =>
-      executeLifeOpsSchedulerTask(rt, isRecord(taskOptions) ? taskOptions : {}),
+    execute: async (rt, taskOptions) => {
+      if (options.isWorkflowClaimSchemaReady?.() === false) {
+        throw new ElizaError(
+          "[LifeOpsScheduler] workflow-run claim schema is not ready",
+          {
+            code: "LIFEOPS_WORKFLOW_RUN_CLAIM_SCHEMA_NOT_READY",
+            context: { agentId: rt.agentId },
+            severity: "ephemeral",
+          },
+        );
+      }
+      return executeLifeOpsSchedulerTask(
+        rt,
+        isRecord(taskOptions) ? taskOptions : {},
+      );
+    },
   });
 }

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -4,8 +4,10 @@
  * ELIZA_DISABLE_LIFEOPS_SCHEDULER (issue: preserve disabled scheduler worker
  * identity). A recording stub runtime captures every registerTaskWorker call so
  * the disabled-path behavior is asserted against the real init wiring rather
- * than a hand-rolled fragment. The dynamic Google connector import is stubbed so
- * init runs without the optional third-party plugin present.
+ * than a hand-rolled fragment. Also proves the deferred scheduler-task ensure
+ * awaits the workflow-run claim schema install before ensuring the scheduler
+ * task (#23835). The dynamic Google connector import is stubbed so init runs
+ * without the optional third-party plugin present.
  */
 import {
   getDirectActionRoutingRules,
@@ -45,8 +47,16 @@ vi.mock("@elizaos/plugin-scheduling", async (importOriginal) => ({
   waitForScheduledTaskRunnerService:
     schedulingMocks.waitForScheduledTaskRunnerService,
 }));
+// Replace only the deferred scheduler-task ensure so the boot-ordering test
+// below can observe when init reaches it; worker registration stays real.
+vi.mock("./lifeops/runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureLifeOpsSchedulerTask: vi.fn(async () => undefined),
+}));
 
 import { areLifeOpsActivitySignalsActive } from "./lifeops/activity-signal-lifecycle.js";
+import { LifeOpsRepository } from "./lifeops/repository.js";
+import { ensureLifeOpsSchedulerTask } from "./lifeops/runtime.js";
 import { personalAssistantPlugin } from "./plugin.js";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000ab" as UUID;
@@ -191,6 +201,38 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
       .calls) {
       expect(call).toHaveLength(1);
       expect(call[0]).toBe(runtime);
+    }
+  });
+
+  it("installs the workflow-run claim schema before ensuring the scheduler task", async () => {
+    delete process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER;
+    const { runtime } = createRecordingRuntime();
+
+    // The bootstrap spy resolves on a later tick so a scheduler ensure that
+    // does not await the index install would record its event first (#23835).
+    const events: string[] = [];
+    const bootstrapSpy = vi
+      .spyOn(LifeOpsRepository, "bootstrapSchema")
+      .mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        events.push("bootstrap-schema");
+      });
+    vi.mocked(ensureLifeOpsSchedulerTask).mockImplementation(async () => {
+      events.push("scheduler-task");
+      return undefined;
+    });
+
+    try {
+      await personalAssistantPlugin.init?.({}, runtime);
+      await vi.waitFor(() => {
+        expect(events).toContain("scheduler-task");
+      });
+      expect(events.indexOf("bootstrap-schema")).toBeGreaterThanOrEqual(0);
+      expect(events.indexOf("bootstrap-schema")).toBeLessThan(
+        events.indexOf("scheduler-task"),
+      );
+    } finally {
+      bootstrapSpy.mockRestore();
     }
   });
 });

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -47,6 +47,10 @@ vi.mock("@elizaos/plugin-scheduling", async (importOriginal) => ({
   waitForScheduledTaskRunnerService:
     schedulingMocks.waitForScheduledTaskRunnerService,
 }));
+vi.mock("./lifeops/app-state.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  loadLifeOpsAppState: vi.fn(async () => ({ enabled: true })),
+}));
 // Replace only the deferred scheduler-task ensure so the boot-ordering test
 // below can observe when init reaches it; worker registration stays real.
 vi.mock("./lifeops/runtime.js", async (importOriginal) => ({
@@ -204,9 +208,9 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
     }
   });
 
-  it("installs the workflow-run claim schema before ensuring the scheduler task", async () => {
+  it("gates a persisted scheduler worker until claim schema installation completes", async () => {
     delete process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER;
-    const { runtime } = createRecordingRuntime();
+    const { runtime, taskWorkers } = createRecordingRuntime();
 
     // The bootstrap spy resolves on a later tick so a scheduler ensure that
     // does not await the index install would record its event first (#23835).
@@ -224,6 +228,11 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
 
     try {
       await personalAssistantPlugin.init?.({}, runtime);
+      const worker = taskWorkers.get(LIFEOPS_TASK_NAME);
+      expect(worker).toBeDefined();
+      await expect(
+        worker?.shouldRun?.(runtime, { name: LIFEOPS_TASK_NAME }),
+      ).resolves.toBe(false);
       await vi.waitFor(() => {
         expect(events).toContain("scheduler-task");
       });
@@ -231,6 +240,9 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
       expect(events.indexOf("bootstrap-schema")).toBeLessThan(
         events.indexOf("scheduler-task"),
       );
+      await expect(
+        worker?.shouldRun?.(runtime, { name: LIFEOPS_TASK_NAME }),
+      ).resolves.toBe(true);
     } finally {
       bootstrapSpy.mockRestore();
     }

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -1153,6 +1153,16 @@ const rawPersonalAssistantPlugin: Plugin = {
         prefix: "[lifeops]",
         label: "scheduler task",
         ensure: async () => {
+          // The workflow-run claim is only an election once the partial
+          // unique index exists (installed by the bootstrapSchema compat
+          // repair, not by the ordinary drizzle migration). Install/verify it
+          // before the scheduler task is ensured so a cold worker cannot
+          // execute workflows against an unconstrained table. On failure the
+          // scheduler task stays un-ensured and the failure is logged +
+          // recorded by scheduleTaskEnsureAfterRuntimeInit ("subsystem is
+          // degraded"); claimWorkflowRun's explicit conflict target fails
+          // closed as the backstop for any path that races this install.
+          await LifeOpsRepository.bootstrapSchema(runtime);
           await ensureLifeOpsSchedulerTask(runtime);
         },
       });

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -1132,11 +1132,15 @@ const rawPersonalAssistantPlugin: Plugin = {
     const lifeOpsSchedulerDisabled = isDisabledByEnv(
       "ELIZA_DISABLE_LIFEOPS_SCHEDULER",
     );
+    let workflowClaimSchemaReady = false;
     // Register the identity even when execution is disabled. Owner-profile
     // updates persist on the LIFEOPS_SCHEDULER row and can create it lazily;
     // the disabled worker keeps that row valid while shouldRun=false preserves
     // the process-level kill switch.
-    registerLifeOpsTaskWorker(runtime, { disabled: lifeOpsSchedulerDisabled });
+    registerLifeOpsTaskWorker(runtime, {
+      disabled: lifeOpsSchedulerDisabled,
+      isWorkflowClaimSchemaReady: () => workflowClaimSchemaReady,
+    });
     if (!lifeOpsSchedulerDisabled) {
       registerMessageDraftScheduledTaskBridge(runtime);
       scheduleTaskEnsureAfterRuntimeInit({
@@ -1163,6 +1167,7 @@ const rawPersonalAssistantPlugin: Plugin = {
           // degraded"); claimWorkflowRun's explicit conflict target fails
           // closed as the backstop for any path that races this install.
           await LifeOpsRepository.bootstrapSchema(runtime);
+          workflowClaimSchemaReady = true;
           await ensureLifeOpsSchedulerTask(runtime);
         },
       });

--- a/plugins/plugin-personal-assistant/test/workflow-run-idempotency.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/workflow-run-idempotency.pglite.test.ts
@@ -324,6 +324,42 @@ describe("LifeOps workflow-run idempotency storage (real PGlite)", () => {
     });
   });
 
+  it("rejects an already-marked matching index that is not valid or ready", async () => {
+    await pg.exec(`
+      ALTER TABLE app_lifeops.life_workflow_runs
+        ADD COLUMN idempotency_key TEXT;
+      CREATE UNIQUE INDEX idx_life_workflow_runs_idempotency
+        ON app_lifeops.life_workflow_runs (
+          agent_id, workflow_id, idempotency_key
+        )
+        WHERE idempotency_key IS NOT NULL;
+      COMMENT ON INDEX app_lifeops.idx_life_workflow_runs_idempotency
+        IS 'elizaos:life_workflow_runs:idempotency-backfill:v1';
+      UPDATE pg_catalog.pg_index
+         SET indisvalid = FALSE,
+             indisready = FALSE
+       WHERE indexrelid =
+         'app_lifeops.idx_life_workflow_runs_idempotency'::regclass;
+    `);
+
+    await expect(
+      LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime),
+    ).rejects.toMatchObject({
+      code: "LIFEOPS_WORKFLOW_RUN_IDEMPOTENCY_INDEX_MISMATCH",
+      context: expect.objectContaining({
+        isUnique: true,
+        isValid: false,
+        isReady: false,
+      }),
+    });
+
+    await expect(
+      repository.claimWorkflowRun(
+        runningRun({ id: "invalid-claim", idempotencyKey: "invalid-key" }),
+      ),
+    ).rejects.toThrow(/ON CONFLICT|unique or exclusion constraint/i);
+  });
+
   it("elects one concurrent keyed claimant, scopes keys, and CAS-finalizes only the winner", async () => {
     await LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime);
     const contenders = Array.from({ length: 8 }, (_, index) =>

--- a/plugins/plugin-personal-assistant/test/workflow-run-idempotency.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/workflow-run-idempotency.pglite.test.ts
@@ -309,6 +309,21 @@ describe("LifeOps workflow-run idempotency storage (real PGlite)", () => {
     ).rejects.toThrow(/ON CONFLICT|unique or exclusion constraint/i);
   });
 
+  it("rejects an already-marked impostor index instead of trusting its marker", async () => {
+    await pg.exec(`
+      CREATE INDEX idx_life_workflow_runs_idempotency
+        ON app_lifeops.life_workflow_runs (agent_id);
+      COMMENT ON INDEX app_lifeops.idx_life_workflow_runs_idempotency
+        IS 'elizaos:life_workflow_runs:idempotency-backfill:v1';
+    `);
+
+    await expect(
+      LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime),
+    ).rejects.toMatchObject({
+      code: "LIFEOPS_WORKFLOW_RUN_IDEMPOTENCY_INDEX_MISMATCH",
+    });
+  });
+
   it("elects one concurrent keyed claimant, scopes keys, and CAS-finalizes only the winner", async () => {
     await LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime);
     const contenders = Array.from({ length: 8 }, (_, index) =>

--- a/plugins/plugin-personal-assistant/test/workflow-run-idempotency.pglite.test.ts
+++ b/plugins/plugin-personal-assistant/test/workflow-run-idempotency.pglite.test.ts
@@ -249,6 +249,66 @@ describe("LifeOps workflow-run idempotency storage (real PGlite)", () => {
     expect(temporaryIndexes.rows).toEqual([]);
   });
 
+  it("fails a keyed claim closed when the partial unique index is absent", async () => {
+    // Cold-worker shape: the ordinary drizzle migration creates the
+    // idempotency_key column but NOT the partial unique index, which only the
+    // bootstrapSchema compat repair installs. A claim here must raise, not
+    // silently let every claimant insert-win (#23835).
+    await pg.exec(`
+      ALTER TABLE app_lifeops.life_workflow_runs
+        ADD COLUMN idempotency_key TEXT;
+    `);
+
+    const contenders = Array.from({ length: 4 }, (_, index) =>
+      runningRun({ id: `cold-${index}`, idempotencyKey: "cold-key" }),
+    );
+    for (const run of contenders) {
+      await expect(repository.claimWorkflowRun(run)).rejects.toThrow(
+        /ON CONFLICT|unique or exclusion constraint/i,
+      );
+    }
+
+    const persisted = await pg.query<{ id: string }>(`
+      SELECT id FROM app_lifeops.life_workflow_runs
+    `);
+    expect(persisted.rows).toEqual([]);
+
+    // After the production repair runs, the same claims elect one winner.
+    await LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime);
+    const outcomes = await Promise.all(
+      contenders.map((run) => repository.claimWorkflowRun(run)),
+    );
+    expect(outcomes.filter(Boolean)).toHaveLength(1);
+  });
+
+  it("refuses to stamp the completion marker over a foreign index with the reserved name", async () => {
+    await pg.exec(`
+      CREATE INDEX idx_life_workflow_runs_idempotency
+        ON app_lifeops.life_workflow_runs (agent_id);
+    `);
+
+    await expect(
+      LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime),
+    ).rejects.toThrow(/not the expected partial unique index/i);
+
+    const marker = await pg.query<{ description: string }>(`
+      SELECT description.description
+        FROM pg_catalog.pg_description AS description
+        JOIN pg_catalog.pg_class AS index_class
+          ON index_class.oid = description.objoid
+       WHERE index_class.relname = 'idx_life_workflow_runs_idempotency'
+    `);
+    expect(marker.rows).toEqual([]);
+
+    // The foreign index is not a valid arbiter, so claims stay fail-closed
+    // instead of treating the impostor as an election.
+    await expect(
+      repository.claimWorkflowRun(
+        runningRun({ id: "impostor-claim", idempotencyKey: "impostor-key" }),
+      ),
+    ).rejects.toThrow(/ON CONFLICT|unique or exclusion constraint/i);
+  });
+
   it("elects one concurrent keyed claimant, scopes keys, and CAS-finalizes only the winner", async () => {
     await LifeOpsRepository.ensureWorkflowRunIdempotencyKey(runtime);
     const contenders = Array.from({ length: 8 }, (_, index) =>


### PR DESCRIPTION
Relates to #23835. Supersedes #23938 because the external fork cannot be rebased through current scheduling changes with the available OAuth scope.

This carries the original workflow-run claim hardening by @Uuriko and the reviewed follow-ups onto current `develop`. The current scheduling-owned runner-readiness contract is preserved alongside the new claim-schema gate.

## Scope

- install and validate the workflow-run partial unique index before scheduler-task ensure
- gate both TaskService admission and defensive direct execution until the schema is ready
- use the explicit partial-index conflict target so a missing arbiter fails closed
- validate table/schema ownership, uniqueness, exact keys/predicate, valid/ready state, and durable marker
- reject wrong-shape, pre-marked impostor, invalid, and not-ready indexes with a typed mismatch error

The closed #24231 variant was audited too. This replacement deliberately keeps the safer fail-closed mismatch contract rather than automatically dropping an unexpected same-name production index.

## Validation

- real PGlite claim election, scheduler ordering/readiness, real TaskService gate, and workflow execution contract: 4 files, 37/37 passed
- package build passed
- changed-file Biome on all 6 files and `git diff --check` passed
- package typecheck in this review worktree is blocked by unrelated unavailable optional-workspace declarations and generated sibling exports; no changed-file diagnostic was emitted

Exact reviewed SHA: `e4c88f5ef8044742636b2d9c43ff038d85230a96`

UI screenshots/video and LLM trajectories are N/A because this is a database and scheduler admission invariant. Hosted exact-head static smoke remains the merge gate.

Attribution: original implementation by @Uuriko in #23938; claim-schema and unusable-index follow-ups by @lalalune; current-base conflict resolution, #24231 audit, and independent execution by Codex.
