### PR TITLE
fix(cloud): use UTC wall clock for app key expiry

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
@@ -1,15 +1,18 @@
 /**
- * Proves app and initial API-key creation share one real PostgreSQL transaction.
+ * Proves app admission, initial-key attachment, and expiry checks against real PostgreSQL.
  *
  * Two service calls run on independent pool sessions while an external holder
  * owns the organization row lock. Both calls must be blocked in open
  * transactions before the holder releases them; with one slot remaining,
  * exactly one linked app/key pair commits and the loser never reaches minting.
+ * Repository cases also exercise PostgreSQL transaction-clock and session-zone
+ * semantics that an in-process substitute cannot establish authoritatively.
  */
 
 import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { pushSchema } from "drizzle-kit/api";
+import { eq, sql } from "drizzle-orm";
 import { Client } from "pg";
 import {
   acquireEphemeralPostgres,
@@ -85,6 +88,43 @@ async function waitUntilBlockedWaiters(observer: Client, minimum: number): Promi
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(`Timed out waiting for ${minimum} blocked app-create transactions`);
+}
+
+async function createAttachableCandidate(
+  database: NonNullable<typeof dbWrite>,
+  initializedAppsRepository: NonNullable<typeof appsRepository>,
+  initializedApiKeysRepository: NonNullable<typeof apiKeysRepository>,
+  expiresAt: Date,
+) {
+  const suffix = randomUUID();
+  const [organization] = await database
+    .insert(organizations)
+    .values({ name: "Expiry Org", slug: `expiry-org-${suffix}` })
+    .returning();
+  const [user] = await database
+    .insert(users)
+    .values({
+      steward_user_id: `expiry-user-${suffix}`,
+      organization_id: organization.id,
+    })
+    .returning();
+  const app = await initializedAppsRepository.create({
+    name: "Expiry App",
+    slug: `expiry-app-${suffix}`,
+    organization_id: organization.id,
+    created_by_user_id: user.id,
+    app_url: "https://expiry.example",
+    api_key_id: null,
+  });
+  const candidate = await initializedApiKeysRepository.create({
+    name: "Expiry Candidate",
+    key_hash: `expiry-${suffix}`,
+    key_prefix: suffix.slice(0, 12),
+    organization_id: organization.id,
+    user_id: user.id,
+    expires_at: expiresAt,
+  });
+  return { app, candidate };
 }
 
 async function cleanupHarness(): Promise<void> {
@@ -320,4 +360,70 @@ realPostgres("app and initial API-key atomicity", () => {
       await Promise.all([holder.end(), observer.end()]);
     }
   }, 30_000);
+
+  test("rejects a key that expires after transaction start but before attachment", async () => {
+    if (!dbWrite || !appsRepository || !apiKeysRepository) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+    const initializedDatabase = dbWrite;
+    const initializedAppsRepository = appsRepository;
+    const { app, candidate } = await createAttachableCandidate(
+      initializedDatabase,
+      initializedAppsRepository,
+      apiKeysRepository,
+      new Date(Date.now() + 60_000),
+    );
+
+    const attached = await initializedDatabase.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL TIME ZONE 'UTC'`);
+      await tx.execute(sql`SELECT CURRENT_TIMESTAMP`);
+      await tx
+        .update(apiKeys)
+        .set({
+          expires_at: sql`(clock_timestamp() AT TIME ZONE 'UTC') + INTERVAL '100 milliseconds'`,
+        })
+        .where(eq(apiKeys.id, candidate.id));
+      await tx.execute(sql`SELECT pg_sleep(0.25)`);
+      return initializedAppsRepository.attachInitialApiKey(
+        app.id,
+        app.organization_id,
+        candidate.id,
+        tx,
+      );
+    });
+
+    expect(attached).toBeUndefined();
+    expect(
+      (await initializedDatabase.query.apps.findFirst({ where: eq(apps.id, app.id) }))?.api_key_id,
+    ).toBeNull();
+  });
+
+  test("rejects an expired UTC key in a non-UTC database session", async () => {
+    if (!dbWrite || !appsRepository || !apiKeysRepository) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+    const initializedDatabase = dbWrite;
+    const initializedAppsRepository = appsRepository;
+    const { app, candidate } = await createAttachableCandidate(
+      initializedDatabase,
+      initializedAppsRepository,
+      apiKeysRepository,
+      new Date(Date.now() - 60 * 60 * 1000),
+    );
+
+    const attached = await initializedDatabase.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL TIME ZONE 'Pacific/Honolulu'`);
+      return initializedAppsRepository.attachInitialApiKey(
+        app.id,
+        app.organization_id,
+        candidate.id,
+        tx,
+      );
+    });
+
+    expect(attached).toBeUndefined();
+    expect(
+      (await initializedDatabase.query.apps.findFirst({ where: eq(apps.id, app.id) }))?.api_key_id,
+    ).toBeNull();
+  });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -38,7 +38,7 @@ process.env.CACHE_ENABLED = "true";
 process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import { buildMobileAppAuthCredentialProvenance } from "../../mobile-app-auth-credential-policy";
 import { type ApiKey, apiKeys, type NewApiKey } from "../../schemas/api-keys";
@@ -1418,6 +1418,28 @@ describe("AppsRepository.attachInitialApiKey", () => {
       ).toBeNull();
     });
   }
+
+  test("rejects a key that expires after the transaction starts but before attachment", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+    const app = await createProvisionalApp(organizationId, userId);
+    const candidate = await createAttachmentCandidate(organizationId, userId);
+
+    const attached = await dbWrite.transaction(async (tx) => {
+      await tx.execute(sql`SELECT CURRENT_TIMESTAMP`);
+      await tx
+        .update(apiKeys)
+        .set({ expires_at: new Date(Date.now() + 100) })
+        .where(eq(apiKeys.id, candidate.id));
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return appsRepository.attachInitialApiKey(app.id, organizationId, candidate.id, tx);
+    });
+
+    expect(attached).toBeUndefined();
+    expect(
+      (await dbWrite.query.apps.findFirst({ where: eq(apps.id, app.id) }))?.api_key_id,
+    ).toBeNull();
+  });
 
   test("rejects a second attachment and preserves the first key", async () => {
     expect(pgliteReady).toBe(true);

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -583,6 +583,8 @@ export class AppsRepository {
    *
    * The correlated ownership and lifecycle predicates keep this repository
    * boundary fail-closed even when it is called outside `AppsService.create`.
+   * Expiry uses the wall clock projected to UTC so it matches the
+   * timestamp-without-time-zone column without transaction or session drift.
    */
   async attachInitialApiKey(
     appId: string,
@@ -607,7 +609,10 @@ export class AppsRepository {
               AND ${apiKeys.is_active} = TRUE
               AND ${apiKeys.deleted_at} IS NULL
               AND ${apiKeys.source_app_id} IS NULL
-              AND (${apiKeys.expires_at} IS NULL OR ${apiKeys.expires_at} > CURRENT_TIMESTAMP)
+              AND (
+                ${apiKeys.expires_at} IS NULL
+                OR ${apiKeys.expires_at} > (clock_timestamp() AT TIME ZONE 'UTC')
+              )
           )`,
         ),
       )


### PR DESCRIPTION
# Relates to

Fixes #24508.

This is a second fix-forward after #24566: the ownership/lifecycle CAS remains intact, while its expiry comparison now uses a UTC wall clock with the same PostgreSQL type as `api_keys.expires_at`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop@3daae2d17930eafa378211546c26b59c999ba17f`; zero conflicts.
- [x] `bun run verify` reaches an unrelated baseline failure documented in
      **Known gaps / failures** below; focused exact-head gates pass.

# Risks

Low. The change is one PostgreSQL expiry predicate plus focused repository tests. It preserves the existing app/key ownership, active, deletion, ordinary-key, and single-attachment predicates. The affected behavior is initial API-key attachment for app creation.

# Background

## What does this PR do?

`api_keys.expires_at` is `timestamp without time zone`, but #24566 compared it with `CURRENT_TIMESTAMP` (`timestamptz`). That comparison is transaction-stable and session-zone sensitive: an already-expired key could attach after a long transaction or in a non-UTC session.

This PR compares against `clock_timestamp() AT TIME ZONE 'UTC'`. PostgreSQL now evaluates current wall time at the CAS and returns `timestamp without time zone`, matching Drizzle's UTC-naive `Date` storage contract.

It adds real PGlite and PostgreSQL 17.11 regressions for delayed/open transactions and non-UTC sessions. The real PostgreSQL suite also preserves the N/N+1 proof that one quota winner mints and the loser never does.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; the repository JSDoc records the UTC wall-clock contract.

# Testing

## Where should a reviewer start?

Start with `AppsRepository.attachInitialApiKey` in `packages/cloud/shared/src/db/repositories/apps.ts`, then the two expiry regressions in the repository test files.

## Detailed testing steps

All post-fix results below are from exact HEAD `3e96a1585e36159ff57e3703eee90a1a3eeba3ad` on base `3daae2d17930eafa378211546c26b59c999ba17f`, Bun 1.3.14, Node 24.15.0.

- Pre-fix PGlite reproduction against merged #24566 predicate (`49cb1455fea15f5ec3f98518473666f68803723a`, regression test applied): `47 pass, 1 fail, 256 assertions`; the delayed transaction incorrectly attached the key.
- Pre-fix PostgreSQL 17.11 reproduction against the same merged predicate: `1 pass, 2 fail, 14 assertions`; both delayed transaction and Honolulu-session cases incorrectly attached the key.
- Equivalent direct probes on PGlite and PostgreSQL returned `merged=true, fixed=false` for both scenarios.
- PGlite focused suite, `--rerun-each=5`: `240 pass, 0 fail, 1285 assertions`.
- Real PostgreSQL 17.11 suite, `--rerun-each=10`: `30 pass, 0 fail, 160 assertions`.
- `bun run --cwd packages/cloud/shared typecheck`: pass.
- `bun run --cwd packages/cloud/shared lint:check`: pass (`2304` files).
- Exact-file Biome and `git diff --check origin/develop...HEAD`: pass.
- Independent exact-head review: pass, no actionable findings.

# Evidence Gate

<!-- evidence-head:3e96a1585e36159ff57e3703eee90a1a3eeba3ad -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only repository predicate; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only repository predicate; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only repository predicate; no interactive UI flow
<!-- evidence-row:backend-logs -->
- [x] [24585-app-key-expiry-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24585-app-key-expiry-backend.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request surface changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [24585-app-key-expiry-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24585-app-key-expiry-domain.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

The evidence attachment contains the exact-head focused test commands, pre-fix reproductions, result counts, and validation gates. Frontend logs are N/A because no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only repository predicate and tests; no UI changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

`mise exec node@24.15.0 -- bun run verify` exits 1 at `audit:tsconfig-workspace-resolution` with 16 unresolved `@elizaos/capacitor-secure-store` imports from `packages/ui/src/bridge/storage-bridge.ts` across unrelated plugin tsconfigs. The same command fails with the identical 16 violations on a detached worktree at exact base `3daae2d17930eafa378211546c26b59c999ba17f`; none of those files are in this PR. All affected-package and exact-head focused gates pass.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@3daae2d17930eafa378211546c26b59c999ba17f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-app-key-expiry]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@3daae2d17930eafa378211546c26b59c999ba17f:packages/skills/skills/contribute-to-eliza"} -->

