### PR TITLE
fix(coding-tools): preserve complete shell results

### DIFF
--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -12,12 +12,12 @@ Adds filesystem operations, shell command execution, and git worktree management
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
 - **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
-- **SHELL** — `action=run` executes a command via `/bin/bash -c`; oversized foreground results return an opaque handle whose complete redacted stdout/stderr can be paged with `read_output_artifact` only by the same agent and conversation; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
+- **SHELL** — `action=run` executes a command via `/bin/bash -c` and returns the complete accepted redacted stdout/stderr to the planner; output above the explicit 1,000,000-character capture ceiling is rejected with no partial result. `read_output_artifact` remains available for scoped artifacts retained by earlier runtimes. `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
 
-- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects a bounded projection of the last 10 commands (size-capped stdout/stderr/exit code), cwd, allowed directory, and recent file operations into context while `ShellService` retains complete history; fires only in `terminal`/`code` contexts.
+- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects complete conversation-scoped command history (redacted stdout/stderr/exit code), cwd, allowed directory, and file operations into context; fires only in `terminal`/`code` contexts.
 - **AVAILABLE_CODING_TOOLS** — injects the available focused and umbrella tool names (`READ`, `WRITE`, `EDIT`, `FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
 
 ### Services
@@ -123,17 +123,14 @@ canonical SHELL action above continues to use the `CODING_TOOLS_*` settings.
 | `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
 | `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
 
-Foreground SHELL transcripts shown to the planner are capped at 50,000
-characters. When that cap is reached, the action writes the complete redacted
-stdout and stderr plus a manifest under
-`ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
-byte/line counts, and leaves the bounded preview in the tool result. The action
-does not disclose state-root paths. `action=read_output_artifact` retrieves a
-bounded stdout or stderr page only when the opaque handle's persisted agent and
-conversation scope match the requesting turn. Artifact directories are
-owner-only (`0700`) and files are `0600`. They use
-`SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
-opportunistically when the next truncated foreground result is persisted.
+Foreground SHELL results accepted by the one-million-character complete-capture
+boundary are returned in full after redaction. A larger result fails explicitly
+and exposes no partial prefix. The action never substitutes a preview, summary,
+or optional artifact handle for model-facing stdout/stderr. For compatibility,
+`action=read_output_artifact` can still retrieve bounded pages from an unexpired
+opaque artifact issued by an earlier runtime, but only when its persisted agent
+and conversation scope match the requesting turn; state-root paths remain
+private.
 
 Auto-enable keys (in agent `config.features`):
 - `config.features.codingTools` (canonical) — `true` or `{ enabled: true }`.

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -12,12 +12,12 @@ Adds filesystem operations, shell command execution, and git worktree management
 
 - **FILE** — umbrella for `read/write/edit/grep/glob/ls`. Dispatches to per-operation handlers. Relative `file_path` values for read/write/edit resolve against the conversation's `SessionCwdService` cwd before sandbox validation. Supports `target=device` for `read/write/ls` through a `device_filesystem` bridge service (mobile). Similes: `FILE_OPERATION`, `FILE_IO`.
 - **READ / WRITE / EDIT** — strict, operation-specific schemas for direct coding loops. They delegate to the same FILE handlers and preserve its sandbox, stale-file, secret, and size checks.
-- **SHELL** — `action=run` executes a command via `/bin/bash -c`; oversized foreground results return an opaque handle whose complete redacted stdout/stderr can be paged with `read_output_artifact` only by the same agent and conversation; `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
+- **SHELL** — `action=run` executes a command via `/bin/bash -c` and returns the complete accepted redacted stdout/stderr to the planner; output above the explicit 1,000,000-character capture ceiling is rejected with no partial result. `read_output_artifact` remains available for scoped artifacts retained by earlier runtimes. `action=start_background` starts a per-conversation background process and returns a stable handle; `poll_background` reads incremental stdout/stderr by absolute stream offsets and reports `truncatedBefore`; `write_background` writes stdin; `kill_background` terminates the process group with SIGTERM then SIGKILL escalation; `list_background` lists sessions; `action=view_history`/`clear_history` read or clear per-conversation command history (backed by the in-plugin `ShellService` (`serviceType = "shell"`)). Per-call `timeout` (ms) is clamped to `[100, 600000]`, default `CODING_TOOLS_SHELL_TIMEOUT_MS` (120000). Similes: `BASH`, `EXEC`, `RUN_COMMAND`.
 - **WORKTREE** — umbrella for `enter/exit` git worktrees. On enter, registers new root in `SandboxService` and pushes to `SessionCwdService` stack. On exit, pops. Similes: `GIT_WORKTREE`.
 
 ### Providers
 
-- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects a bounded projection of the last 10 commands (size-capped stdout/stderr/exit code), cwd, allowed directory, and recent file operations into context while `ShellService` retains complete history; fires only in `terminal`/`code` contexts.
+- **SHELL_HISTORY** (`src/shell/providers/shellHistoryProvider.ts`, position `99`) — injects complete conversation-scoped command history (redacted stdout/stderr/exit code), cwd, allowed directory, and file operations into context; fires only in `terminal`/`code` contexts.
 - **AVAILABLE_CODING_TOOLS** — injects the available focused and umbrella tool names (`READ`, `WRITE`, `EDIT`, `FILE`, `SHELL`, `WORKTREE`) into agent state at position `-10`. Stable/agent-scoped cache.
 
 ### Services
@@ -123,17 +123,14 @@ canonical SHELL action above continues to use the `CODING_TOOLS_*` settings.
 | `SHELL_ALLOW_BACKGROUND` | `true` | Set to exact `false` to disable compatibility-service background/yield behavior. |
 | `SHELL_FORBIDDEN_COMMANDS` | — | Comma-separated additions to the built-in forbidden-command set. |
 
-Foreground SHELL transcripts shown to the planner are capped at 50,000
-characters. When that cap is reached, the action writes the complete redacted
-stdout and stderr plus a manifest under
-`ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
-byte/line counts, and leaves the bounded preview in the tool result. The action
-does not disclose state-root paths. `action=read_output_artifact` retrieves a
-bounded stdout or stderr page only when the opaque handle's persisted agent and
-conversation scope match the requesting turn. Artifact directories are
-owner-only (`0700`) and files are `0600`. They use
-`SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
-opportunistically when the next truncated foreground result is persisted.
+Foreground SHELL results accepted by the one-million-character complete-capture
+boundary are returned in full after redaction. A larger result fails explicitly
+and exposes no partial prefix. The action never substitutes a preview, summary,
+or optional artifact handle for model-facing stdout/stderr. For compatibility,
+`action=read_output_artifact` can still retrieve bounded pages from an unexpired
+opaque artifact issued by an earlier runtime, but only when its persisted agent
+and conversation scope match the requesting turn; state-root paths remain
+private.
 
 Auto-enable keys (in agent `config.features`):
 - `config.features.codingTools` (canonical) — `true` or `{ enabled: true }`.

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -10,7 +10,7 @@ The plugin registers three focused file actions, three umbrella actions, and a s
 |---|---|---|
 | **READ / WRITE / EDIT** | one operation each | Pi-shaped strict schemas for direct coding loops. They reuse FILE's sandbox, stale-file, secret, and size guards. |
 | **FILE** | `read`, `write`, `edit`, `grep`, `glob`, `ls` | All file and search operations. Relative read/write/edit paths resolve against the conversation's session cwd before sandbox validation. Optional `target=device` routes through a device filesystem bridge for mobile. |
-| **SHELL** | `run`, `read_output_artifact`, `start_background`, `poll_background`, `write_background`, `kill_background`, `list_background`, `clear_history`, `view_history` | `run` executes a command via `/bin/bash -c` with a per-call timeout (clamped to `[100, 600000]` ms, default 120000). Oversized foreground results return an opaque handle whose complete redacted streams can be paged with `read_output_artifact`. Background actions return stable per-conversation handles, poll incremental stdout/stderr offsets with truncation markers, write stdin, terminate process groups, and list sessions. `view_history`/`clear_history` read or clear per-conversation command history. |
+| **SHELL** | `run`, `read_output_artifact`, `start_background`, `poll_background`, `write_background`, `kill_background`, `list_background`, `clear_history`, `view_history` | `run` executes a command via `/bin/bash -c` with a per-call timeout (clamped to `[100, 600000]` ms, default 120000). Accepted foreground results return complete redacted stdout/stderr; results above the explicit one-million-character capture ceiling fail without partial output. `read_output_artifact` remains for scoped artifacts retained by earlier runtimes. Background actions return stable per-conversation handles, poll incremental stdout/stderr offsets with truncation markers, write stdin, terminate process groups, and list sessions. `view_history`/`clear_history` read or clear per-conversation command history. |
 | **WORKTREE** | `enter`, `exit` | Creates and tears down git worktrees, updating the agent's session cwd and sandbox roots automatically. |
 
 Supporting services (automatically started):
@@ -67,17 +67,13 @@ plugin only where the OWNER role and host/container boundary are trusted for
 that access. Static command analysis and the command denylist are safety checks,
 not filesystem confinement.
 
-Foreground SHELL transcripts shown to the planner are capped at 50,000
-characters. When that cap is reached, the action writes the complete redacted
-stdout and stderr plus a manifest under
-`ELIZA_STATE_DIR/coding-tools/shell-output/<handle>/`, returns the handle and
-byte/line counts, and leaves the bounded preview in the tool result. The action
-does not disclose state-root paths. `action=read_output_artifact` retrieves a
-bounded stdout or stderr page only when the opaque handle's persisted agent and
-conversation scope match the requesting turn. Artifact directories are
-owner-only (`0700`) and files are `0600`. They use
-`SHELL_JOB_TTL_MS` (30 minutes by default) and expired handles are removed
-opportunistically when the next truncated foreground result is persisted.
+Foreground SHELL results accepted by the one-million-character complete-capture
+boundary are returned in full after redaction. Larger results fail explicitly
+without exposing a partial prefix, and model-facing tool results are never
+replaced by a preview or optional artifact handle. For compatibility,
+`action=read_output_artifact` can still page an unexpired opaque artifact issued
+by an earlier runtime when its agent and conversation scope match the requesting
+turn; state-root paths remain private.
 
 The folded `ShellService` retains these compatibility settings for external
 callers of `runtime.getService("shell").exec()` / `executeCommand()`; the

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -37,6 +37,7 @@ const describeIfPosix = process.platform === "win32" ? describe.skip : describe;
 
 import codingToolsPlugin from "../index.js";
 import { runShell } from "../lib/run-shell.js";
+import { persistShellOutputArtifact } from "../lib/shell-output-artifact.js";
 import { availableToolsProvider } from "../providers/available-tools.js";
 import {
   BackgroundShellService,
@@ -50,7 +51,6 @@ import {
 } from "../types.js";
 
 import {
-  boundedShellText,
   type CommandPlatform,
   localResourceUserFacingText,
   resolveCommandPlatform,
@@ -644,28 +644,39 @@ describeIfPosix("shellAction", () => {
     expect(posts[0].text.length).toBeLessThan(1700);
   });
 
-  it("hard-bounds the artifact notice for unusually long state paths", () => {
-    const longPath = `/state/${"nested-segment/".repeat(3_000)}`;
-    const bounded = boundedShellText("output-line\n".repeat(10_000), {
-      handle: "shell_worst_case_notice",
-      manifestPath: `${longPath}manifest.json`,
-      stdoutPath: `${longPath}stdout.txt`,
-      stderrPath: `${longPath}stderr.txt`,
-      createdAt: "2026-08-21T00:00:00.000Z",
-      expiresAt: "2026-08-21T00:30:00.000Z",
-      retentionMs: 1_800_000,
-      stdout: { characters: 120_000, bytes: 120_000, lines: 10_000 },
-      stderr: { characters: 0, bytes: 0, lines: 0 },
-    });
+  it("returns complete redacted Unicode stdout and stderr above the former model cap", async () => {
+    const secret = "marigold9-complete-shell-secret";
+    const stdout = `${"🙂α\n".repeat(7_000)}${secret}\nstdout-tail`;
+    const stderr = `${"界β\n".repeat(8_000)}${secret}\nstderr-tail`;
+    expect(stdout.length + stderr.length).toBeGreaterThan(50_000);
+    const { runtime } = await makeRuntime({ configuredSecret: secret });
+    const script = [
+      `process.stdout.write(${JSON.stringify("🙂α\n")}.repeat(7000)+${JSON.stringify(`${secret}\nstdout-tail`)});`,
+      `process.stderr.write(${JSON.stringify("界β\n")}.repeat(8000)+${JSON.stringify(`${secret}\nstderr-tail`)});`,
+    ].join("");
 
-    expect(bounded.truncated).toBe(true);
-    expect(bounded.text.length).toBeLessThanOrEqual(50_000);
-    expect(bounded.text).toContain("shell_worst_case_notice");
-    expect(bounded.text).toContain("action=read_output_artifact");
-    expect(bounded.text).not.toContain("/state/nested-segment/");
+    const result = requireActionResult(
+      await shellAction.handler?.(runtime, makeMessage(), undefined, {
+        command: `node -e ${JSON.stringify(script)}`,
+      }),
+    );
+    const redactedStdout = stdout.replace(secret, "[REDACTED:TEST_SECRET]");
+    const redactedStderr = stderr.replace(secret, "[REDACTED:TEST_SECRET]");
+    const resultText = result.text ?? "";
+    const streamText = resultText.slice(resultText.indexOf("--- stdout ---"));
+
+    expect(result.success).toBe(true);
+    expect(streamText).toBe(
+      `--- stdout ---\n${redactedStdout}\n--- stderr ---\n${redactedStderr}`,
+    );
+    expect((result.data as Record<string, unknown>).output_truncated).toBe(
+      false,
+    );
+    expect(result).not.toHaveProperty("data.output_artifact_handle");
+    expect(JSON.stringify(result)).not.toContain(secret);
   });
 
-  it("retrieves complete redacted output through an authorized opaque handle", async () => {
+  it("retrieves a retained legacy artifact through an authorized opaque handle", async () => {
     const stateDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "coding-tools-shell-artifact-"),
     );
@@ -687,44 +698,35 @@ describeIfPosix("shellAction", () => {
         configuredSecret: secret,
         workspaceRoots: workspace,
       });
-      const script = [
-        `process.stdout.write(${JSON.stringify("row\n")}.repeat(14000));`,
-        `process.stdout.write(${JSON.stringify(secret)});`,
-        `process.stderr.write(${JSON.stringify("stderr-tail\n")});`,
-      ].join("");
-
       const message = makeMessage();
-      const result = requireActionResult(
-        await shellAction.handler?.(runtime, message, undefined, {
-          command: `node -e ${JSON.stringify(script)}`,
-          cwd: workspace,
-        }),
-      );
-      const data = result.data as Record<string, unknown>;
-      const handle = data.output_artifact_handle as string;
+      const stdout = `${"row\n".repeat(14_000)}[REDACTED:TEST_SECRET]`;
+      const stderr = "stderr-tail\n";
+      const artifact = await persistShellOutputArtifact({
+        command: "legacy large command",
+        cwd: workspace,
+        stdout,
+        stderr,
+        exitCode: 0,
+        timedOut: false,
+        signal: null,
+        modelCharacterLimit: 50_000,
+        modelCharacters: 50_000,
+        ownerAgentId: String(runtime.agentId),
+        ownerConversationId: String(message.roomId),
+      });
+      const handle = artifact.handle;
       const artifactDirectory = path.join(artifactRoot, handle);
       const manifestPath = path.join(artifactDirectory, "manifest.json");
       const stdoutPath = path.join(artifactDirectory, "stdout.txt");
       const stderrPath = path.join(artifactDirectory, "stderr.txt");
-      const stdout = await fs.readFile(stdoutPath, "utf8");
-      const stderr = await fs.readFile(stderrPath, "utf8");
+      expect(await fs.readFile(stdoutPath, "utf8")).toBe(stdout);
+      expect(await fs.readFile(stderrPath, "utf8")).toBe(stderr);
       const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
         stdout: { bytes: number; lines: number };
         stderr: { bytes: number; lines: number };
         truncation: { modelCharacterLimit: number; completeBytes: number };
       };
 
-      expect(result.success).toBe(true);
-      expect(result.text.length).toBeLessThanOrEqual(50_000);
-      expect(result.text).toContain("complete redacted artifact shell_");
-      expect(data.output_truncated).toBe(true);
-      expect(data.output_artifact_handle).toMatch(/^shell_/);
-      expect(data).not.toHaveProperty("output_artifact_path");
-      expect(data).not.toHaveProperty("output_artifact_stdout_path");
-      expect(data).not.toHaveProperty("output_artifact_stderr_path");
-      expect(stdout).toBe(`${"row\n".repeat(14000)}[REDACTED:TEST_SECRET]`);
-      expect(stderr).toBe("stderr-tail\n");
-      expect(JSON.stringify(result)).not.toContain(secret);
       expect(await fs.readFile(manifestPath, "utf8")).not.toContain(secret);
       expect(manifest.stdout).toEqual({
         path: stdoutPath,

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -34,13 +34,10 @@ import {
   readNumberParam,
   readStringParam,
   successActionResult,
-  truncate,
 } from "../lib/format.js";
 import { runShell, type ShellResult } from "../lib/run-shell.js";
 import {
-  persistShellOutputArtifact,
   readShellOutputArtifactPage,
-  type ShellOutputArtifact,
   type ShellOutputArtifactStream,
 } from "../lib/shell-output-artifact.js";
 import { resolveHostShell } from "../lib/terminal-capabilities.js";
@@ -61,9 +58,6 @@ const TIMEOUT_MIN_MS = 100;
 const TIMEOUT_MAX_MS = 600_000;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const USER_FACING_STDOUT_CAP_CHARS = 8_000;
-// Match Pi's model-facing shell budget: preserve the command plus useful head
-// output while preventing one noisy test/build from consuming the next turn.
-const MODEL_FACING_SHELL_OUTPUT_CHARS = 50_000;
 const SHELL_HISTORY_DEFAULT_LIMIT = 20;
 const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
@@ -1159,82 +1153,6 @@ function formatStreams(
   return lines.join("\n");
 }
 
-function shellArtifactResultData(
-  artifact: ShellOutputArtifact | undefined,
-): Record<string, unknown> {
-  if (!artifact) return {};
-  return {
-    output_artifact_handle: artifact.handle,
-    output_artifact_created_at: artifact.createdAt,
-    output_artifact_expires_at: artifact.expiresAt,
-    output_artifact_retention_ms: artifact.retentionMs,
-    output_artifact_retrieval: {
-      action: "read_output_artifact",
-      handle: artifact.handle,
-      streams: ["stdout", "stderr"],
-      max_characters_per_page: 20_000,
-    },
-    output_truncation: {
-      model_character_limit: MODEL_FACING_SHELL_OUTPUT_CHARS,
-      stdout: artifact.stdout,
-      stderr: artifact.stderr,
-    },
-  };
-}
-
-function truncateToHardLimit(
-  text: string,
-  maxCharacters: number,
-): { text: string; truncated: boolean } {
-  if (maxCharacters <= 0) {
-    return { text: "", truncated: text.length > 0 };
-  }
-  let prefixBudget = maxCharacters;
-  let result = truncate(text, prefixBudget);
-  while (result.text.length > maxCharacters && prefixBudget > 0) {
-    prefixBudget = Math.max(
-      0,
-      prefixBudget - (result.text.length - maxCharacters),
-    );
-    result = truncate(text, prefixBudget);
-  }
-  return result.text.length <= maxCharacters
-    ? result
-    : { text: "", truncated: text.length > 0 };
-}
-
-export function boundedShellText(
-  fullText: string,
-  artifact: ShellOutputArtifact | undefined,
-): { text: string; truncated: boolean } {
-  if (!artifact) {
-    return truncateToHardLimit(fullText, MODEL_FACING_SHELL_OUTPUT_CHARS);
-  }
-  const notice = [
-    `[output truncated; complete redacted artifact ${artifact.handle}]`,
-    `retrieve: SHELL action=read_output_artifact handle=${artifact.handle} artifact_stream=stdout artifact_offset=0`,
-    `stdout: ${artifact.stdout.bytes} bytes, ${artifact.stdout.lines} lines`,
-    `stderr: ${artifact.stderr.bytes} bytes, ${artifact.stderr.lines} lines`,
-    `expires: ${artifact.expiresAt}`,
-  ].join("\n");
-  // Bound the notice independently so even future opaque-handle formats cannot
-  // consume the planner's entire model-facing shell-output budget.
-  const boundedNotice = truncateToHardLimit(
-    notice,
-    Math.floor(MODEL_FACING_SHELL_OUTPUT_CHARS / 2),
-  );
-  const preview = truncateToHardLimit(
-    fullText,
-    MODEL_FACING_SHELL_OUTPUT_CHARS - boundedNotice.text.length - 1,
-  );
-  return {
-    text: preview.text
-      ? `${preview.text}\n${boundedNotice.text}`
-      : boundedNotice.text,
-    truncated: true,
-  };
-}
-
 export const shellAction: Action = {
   name: "SHELL",
   contexts: [...CODING_TOOLS_CONTEXTS],
@@ -1242,7 +1160,7 @@ export const shellAction: Action = {
   contextGate: { anyOf: ["code", "terminal", "automation"] },
   similes: ["BASH", "EXEC", "RUN_COMMAND"],
   description:
-    "Run shell commands, retrieve complete redacted foreground output by artifact handle, manage per-conversation background shell sessions, or view/clear shell history. Each run starts a fresh shell, so prefix any required environment variables on every command. Use bounded commands; default to the session cwd unless the user supplied an exact cwd or the session moved.",
+    "Run shell commands with complete accepted redacted foreground output, retrieve unexpired scoped legacy output artifacts, manage per-conversation background shell sessions, or view/clear shell history. Each run starts a fresh shell, so prefix any required environment variables on every command. Use bounded commands; default to the session cwd unless the user supplied an exact cwd or the session moved.",
   descriptionCompressed:
     "Run shell commands; page output artifacts; start/poll/write/kill/list background sessions; clear/view history.",
   parameters: [
@@ -2044,38 +1962,11 @@ export const shellAction: Action = {
     const streams = formatStreams(redactedStdout, redactedStderr, {
       showEmptyStreams: !result.stdout && !result.stderr,
     });
-    const fullText = streams.length > 0 ? `${head}\n${streams}` : head;
-    let artifact: ShellOutputArtifact | undefined;
-    if (fullText.length > MODEL_FACING_SHELL_OUTPUT_CHARS) {
-      try {
-        artifact = await persistShellOutputArtifact({
-          command: redactedCommand,
-          cwd: redactedCwd,
-          stdout: redactedStdout,
-          stderr: redactedStderr,
-          exitCode: result.exitCode,
-          timedOut,
-          signal,
-          modelCharacterLimit: MODEL_FACING_SHELL_OUTPUT_CHARS,
-          modelCharacters: MODEL_FACING_SHELL_OUTPUT_CHARS,
-          ownerAgentId: String(runtime.agentId),
-          ownerConversationId: conversationId,
-        });
-      } catch (err) {
-        // error-policy:J1 artifact persistence is part of the SHELL result
-        // boundary: do not claim recoverable truncation when storage failed.
-        return failureToActionResult(
-          {
-            reason: "io_error",
-            message: `complete shell output could not be persisted: ${redactShellText(runtime, (err as Error).message)}`,
-          },
-          { command: redactedCommand, cwd: redactedCwd },
-        );
-      }
-    }
-    const bounded = boundedShellText(fullText, artifact);
-    const text = bounded.text;
-    const artifactData = shellArtifactResultData(artifact);
+    // `runShell` rejects above the explicit complete-capture ceiling before
+    // this boundary. Every accepted result therefore remains complete after
+    // redaction; the planner must never receive a preview or optional handle
+    // in place of stdout/stderr it would otherwise reason over.
+    const text = streams.length > 0 ? `${head}\n${streams}` : head;
 
     const echoTranscript =
       process.env.ELIZA_SHELL_ECHO_TRANSCRIPT?.trim().toLowerCase();
@@ -2092,8 +1983,7 @@ export const shellAction: Action = {
           command: redactedCommand,
           cwd: redactedCwd,
           output: text,
-          output_truncated: bounded.truncated,
-          ...artifactData,
+          output_truncated: false,
         },
       );
     }
@@ -2108,8 +1998,7 @@ export const shellAction: Action = {
           exit_code: result.exitCode,
           cwd: redactedCwd,
           output: text,
-          output_truncated: bounded.truncated,
-          ...artifactData,
+          output_truncated: false,
         },
       );
     }
@@ -2120,8 +2009,7 @@ export const shellAction: Action = {
       execution_route: result.sandbox === "host" ? "host" : "sandbox",
       sandbox_backend: result.sandbox,
       signal,
-      output_truncated: bounded.truncated,
-      ...artifactData,
+      output_truncated: false,
     });
     // The crypto / disk / memory / status projections are CHAT conveniences
     // keyed on the *message text*, and the coding sub-agent's message text is

--- a/plugins/plugin-coding-tools/src/lib/shell-output-artifact.ts
+++ b/plugins/plugin-coding-tools/src/lib/shell-output-artifact.ts
@@ -1,7 +1,7 @@
 /**
- * Persists complete redacted foreground-shell streams when the planner-facing
- * transcript is truncated. Artifacts live in the shared elizaOS state root,
- * inherit the shell job retention window, and are swept opportunistically.
+ * Reads and writes scoped legacy foreground-shell artifacts without exposing
+ * their state-root paths. Current SHELL runs return accepted output directly;
+ * this compatibility store keeps already-issued handles readable until expiry.
  */
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";


### PR DESCRIPTION
# Relates to

Fix-forward for #24526 (authored by @lalalune), which implemented the explicit complete-capture ceiling and scoped artifact retrieval. This preserves that work while correcting the merged 50,000-character planner-output cap identified during review. Related scope: #24299.

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `3daae2d17930eafa378211546c26b59c999ba17f` with zero conflicts.
- [x] Install/verification results and unrelated environment/baseline failures are recorded below.
- [x] The regression test exercises the real shell process and asserts the exact planner-visible result.

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Exact unrelated `bun run verify` blocker is documented below.

# Risks

Low. Accepted foreground shell results between the former 50,000-character cap and the existing 1,000,000-character complete-capture ceiling now consume their full intended model context. Results beyond the ceiling still fail explicitly before any partial output reaches the action result. Scoped artifact reads remain available only for unexpired handles issued by earlier runtimes.

# Background

## What does this PR do?

- Removes the 50,000-character planner-facing preview and automatic artifact substitution from `SHELL action=run`.
- Returns complete redacted stdout and stderr for every result accepted by `runShell`.
- Keeps the existing explicit one-million-character rejection with no partial payload.
- Retains scoped legacy artifact retrieval for already-issued handles and updates stale package guides, including the complete `SHELL_HISTORY` contract.
- Adds a real-process regression covering more than 50,000 characters of mixed Unicode stdout/stderr, secret redaction, exact stream equality, and absence of artifact indirection.

## What kind of change is this?

Bug fix (prompt-integrity regression).

# Documentation changes needed?

Updated `README.md`, `CLAUDE.md`, and paired `AGENTS.md` to describe the complete-result and legacy-artifact contracts.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/actions/bash.test.ts`, test: `returns complete redacted Unicode stdout and stderr above the former model cap`.

## Detailed testing steps

Run with the pinned toolchain:

```bash
mise exec node@24.15.0 bun@1.3.14 -- bun run --cwd plugins/plugin-coding-tools test -- src/actions/bash.test.ts
mise exec node@24.15.0 bun@1.3.14 -- bun run --cwd plugins/plugin-coding-tools test
mise exec node@24.15.0 bun@1.3.14 -- bun run --cwd plugins/plugin-coding-tools typecheck
mise exec node@24.15.0 bun@1.3.14 -- bun run --cwd plugins/plugin-coding-tools lint:check
mise exec node@24.15.0 bun@1.3.14 -- bun run check:agents-claude
```

Observed: 152/152 focused tests, 942/942 package tests, typecheck, lint, and all 160 guide pairs pass.

# Evidence Gate

<!-- evidence-head:b8865e23a66c60d84fec581dd152ba14f5066c09 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - the boundary is covered by a real child-process regression; no deployed backend is required.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this is a deterministic action-result boundary fix; the regression asserts the complete value supplied to the planner without requiring a model call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifacts are created; current runs deliberately stop substituting shell-output artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic shell action boundary; the exact `ActionResult.text` and data are asserted directly.

## Backend + frontend logs

N/A - no frontend or deployed-backend surface. Focused Vitest output: 1 file passed, 152 tests passed. Full package output: 41 files passed, 942 tests passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- `bun install --frozen-lockfile` was attempted with the pinned toolchain but the isolated `/tmp` worktree hit `EDQUOT: Disk quota exceeded` while linking dependencies. Verification used the existing repository dependency tree with the same pinned Bun 1.3.14 and Node 24.15.0.
- `bun run verify` reaches the repository-wide workspace-resolution audit, then fails on current `origin/develop` because 16 packages cannot resolve `@elizaos/capacitor-secure-store` from `packages/ui/src/bridge/storage-bridge.ts`. This PR does not touch UI, package manifests, or TypeScript resolution. All owning-package and changed-file gates pass.

## Maintainer CI exception record

N/A - no exception requested.

AI assistance: OpenAI Codex (GPT-5.6) reviewed and implemented this fix-forward; no external skill package was used.
