### PR TITLE
fix(plugin-x): page mentions losslessly to the watermark

### DIFF
--- a/plugins/plugin-x/src/client/client.ts
+++ b/plugins/plugin-x/src/client/client.ts
@@ -49,6 +49,7 @@ import {
   searchProfiles,
   searchQuotedTweets,
   searchTweets,
+  searchTweetsPage,
 } from "./search";
 
 import {
@@ -330,27 +331,17 @@ export class Client {
     query: string,
     maxTweets: number,
     searchMode: SearchMode,
-    _cursor?: string,
+    cursor?: string,
   ): Promise<QueryTweetsResponse> {
-    return this.withAuthenticatedSession(async () => {
-      const tweets: Tweet[] = [];
-      const generator = searchTweets(
+    return this.withAuthenticatedSession(() =>
+      searchTweetsPage(
         query,
         maxTweets,
         searchMode,
         this.requireAuth(),
-      );
-
-      for await (const tweet of generator) {
-        tweets.push(tweet);
-      }
-
-      return {
-        tweets,
-        // v2 API doesn't provide cursor-based pagination for search
-        next: undefined,
-      };
-    });
+        cursor,
+      ),
+    );
   }
 
   /**

--- a/plugins/plugin-x/src/client/fetch-search-tweets.test.ts
+++ b/plugins/plugin-x/src/client/fetch-search-tweets.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Real-module tests for `Client.fetchSearchTweets` page cursors. The v2
+ * recent-search paginator is the injected transport; conversion and cursor
+ * plumbing run unmocked.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { TwitterAuth } from "./auth";
+import { Client } from "./client";
+import { SearchMode } from "./search";
+
+function fakeAuth(v2: Record<string, unknown>): TwitterAuth {
+  const session = {
+    client: {},
+    profile: { userId: "1", username: "bot", name: "Bot" },
+    revision: 1,
+  };
+  return {
+    getV2Client: async () => ({ v2 }),
+    withAuthenticatedSession: async <T>(
+      operation: (session: typeof session) => Promise<T>,
+    ) => operation(session),
+    getAuthenticatedSession: async () => session,
+    isAuthenticatedSessionCurrent: () => true,
+    deferUntil: () => undefined,
+    logout: async () => undefined,
+  } as unknown as TwitterAuth;
+}
+
+function tweetPage(ids: string[], next?: string) {
+  const tweets = ids.map((id) => ({
+    id,
+    text: `tweet-${id}`,
+    author_id: "u1",
+    created_at: "2026-01-01T00:00:00.000Z",
+    conversation_id: id,
+  }));
+  const paginator = {
+    tweets,
+    includes: { users: [{ id: "u1", name: "User", username: "user" }] },
+    meta: { next_token: next },
+    async *[Symbol.asyncIterator]() {
+      yield* tweets;
+    },
+  };
+  return paginator;
+}
+
+describe("Client.fetchSearchTweets pagination", () => {
+  it("returns the v2 next_token and forwards a resume cursor", async () => {
+    const search = vi.fn(
+      async (_query: string, options: { next_token?: string }) => {
+        if (options.next_token === "page-2") {
+          return tweetPage(["8", "9"]);
+        }
+        return tweetPage(["10", "11"], "page-2");
+      },
+    );
+    const client = new Client();
+    client.updateAuth(fakeAuth({ search }));
+
+    const first = await client.fetchSearchTweets(
+      "from:user",
+      20,
+      SearchMode.Latest,
+    );
+    expect(first.tweets.map((tweet) => tweet.id)).toEqual(["10", "11"]);
+    expect(first.next).toBe("page-2");
+    expect(search.mock.calls[0]?.[1]).not.toHaveProperty("next_token");
+
+    const second = await client.fetchSearchTweets(
+      "from:user",
+      20,
+      SearchMode.Latest,
+      "page-2",
+    );
+    expect(second.tweets.map((tweet) => tweet.id)).toEqual(["8", "9"]);
+    expect(second.next).toBeUndefined();
+    expect(search.mock.calls[1]?.[1]).toMatchObject({ next_token: "page-2" });
+  });
+
+  it("does not send a blank cursor as next_token", async () => {
+    const search = vi.fn(async () => tweetPage(["1"]));
+    const client = new Client();
+    client.updateAuth(fakeAuth({ search }));
+
+    await client.fetchSearchTweets("hello", 20, SearchMode.Latest, "  ");
+    expect(search.mock.calls[0]?.[1]).not.toHaveProperty("next_token");
+  });
+
+  it("keeps first-page tweet ids stable for previously valid uncursored searches", async () => {
+    const ids = ["a", "b", "c", "d", "e"];
+    const search = vi.fn(async () => tweetPage(ids, "more"));
+    const client = new Client();
+    client.updateAuth(fakeAuth({ search }));
+
+    const result = await client.fetchSearchTweets(
+      "javascript",
+      5,
+      SearchMode.Latest,
+    );
+    expect(result.tweets.map((tweet) => tweet.id)).toEqual(ids);
+    expect(result.tweets.map((tweet) => tweet.username)).toEqual(
+      Array(5).fill("user"),
+    );
+  });
+});

--- a/plugins/plugin-x/src/client/search.ts
+++ b/plugins/plugin-x/src/client/search.ts
@@ -1,5 +1,10 @@
+/**
+ * X recent-search helpers: one-page `searchTweetsPage` (honors `next_token`)
+ * and the `searchTweets` generator that walks those pages up to `maxTweets`.
+ */
 import { ElizaError } from "@elizaos/core";
-import type { TweetV2 } from "twitter-api-v2";
+import type { TweetV2, Tweetv2SearchParams, UserV2 } from "twitter-api-v2";
+import type { QueryTweetsResponse } from "./api-types";
 import type { TwitterAuth } from "./auth";
 import type { Profile } from "./profile";
 import type { Tweet } from "./tweets";
@@ -20,6 +25,162 @@ export enum SearchMode {
   Users = 4,
 }
 
+type SearchIncludes = {
+  users?: UserV2[];
+  tweets?: TweetV2[];
+};
+
+type SearchPaginator = {
+  tweets?: TweetV2[];
+  includes?: SearchIncludes;
+  meta?: { next_token?: string };
+};
+
+const SEARCH_TWEET_QUERY: Partial<Tweetv2SearchParams> = {
+  "tweet.fields": [
+    "id",
+    "text",
+    "conversation_id",
+    "created_at",
+    "author_id",
+    "referenced_tweets",
+    "entities",
+    "public_metrics",
+    "attachments",
+  ],
+  "user.fields": ["id", "name", "username", "profile_image_url"],
+  "media.fields": ["url", "preview_image_url", "type"],
+  expansions: [
+    "author_id",
+    "attachments.media_keys",
+    "referenced_tweets.id",
+    "referenced_tweets.id.author_id",
+  ],
+};
+
+function applySearchMode(query: string, searchMode: SearchMode): string {
+  switch (searchMode) {
+    case SearchMode.Photos:
+      return `${query} has:media has:images`;
+    case SearchMode.Videos:
+      return `${query} has:media has:videos`;
+    default:
+      return query;
+  }
+}
+
+function currentPageTweets(paginator: SearchPaginator): TweetV2[] {
+  return Array.isArray(paginator.tweets) ? paginator.tweets : [];
+}
+
+function convertSearchTweet(tweet: TweetV2, includes?: SearchIncludes): Tweet {
+  const author = includes?.users?.find((user) => user.id === tweet.author_id);
+  const inReplyToStatusId = tweet.referenced_tweets?.find(
+    (rt) => rt.type === "replied_to",
+  )?.id;
+  const inReplyToStatus = inReplyToStatusId
+    ? includes?.tweets?.find(
+        (includedTweet) => includedTweet.id === inReplyToStatusId,
+      )
+    : undefined;
+  const inReplyToAuthor = inReplyToStatus?.author_id
+    ? includes?.users?.find((user) => user.id === inReplyToStatus.author_id)
+    : undefined;
+
+  return {
+    id: tweet.id,
+    text: tweet.text || "",
+    timestamp: tweet.created_at
+      ? new Date(tweet.created_at).getTime()
+      : Date.now(),
+    timeParsed: tweet.created_at ? new Date(tweet.created_at) : new Date(),
+    userId: tweet.author_id || "",
+    name: author?.name || "",
+    username: author?.username || "",
+    conversationId: tweet.conversation_id || tweet.id,
+    hashtags: tweet.entities?.hashtags?.map((h) => h.tag) || [],
+    mentions:
+      tweet.entities?.mentions?.map((m) => ({
+        id: m.id || "",
+        username: m.username || "",
+        name: "",
+      })) || [],
+    inReplyToStatusId,
+    inReplyToStatus: inReplyToStatus
+      ? {
+          id: inReplyToStatus.id,
+          text: inReplyToStatus.text || "",
+          userId: inReplyToStatus.author_id || "",
+          name: inReplyToAuthor?.name || "",
+          username: inReplyToAuthor?.username || "",
+          hashtags: [],
+          mentions: [],
+          photos: [],
+          thread: [],
+          urls: [],
+          videos: [],
+        }
+      : undefined,
+    photos: [],
+    thread: [],
+    urls: tweet.entities?.urls?.map((u) => u.expanded_url || u.url) || [],
+    videos: [],
+    isRetweet:
+      tweet.referenced_tweets?.some((rt) => rt.type === "retweeted") || false,
+    isReply:
+      tweet.referenced_tweets?.some((rt) => rt.type === "replied_to") || false,
+    isQuoted:
+      tweet.referenced_tweets?.some((rt) => rt.type === "quoted") || false,
+    isPin: false,
+    sensitiveContent: false,
+    likes: tweet.public_metrics?.like_count || undefined,
+    replies: tweet.public_metrics?.reply_count || undefined,
+    retweets: tweet.public_metrics?.retweet_count || undefined,
+    views: tweet.public_metrics?.impression_count || undefined,
+    quotes: tweet.public_metrics?.quote_count || undefined,
+  };
+}
+
+/**
+ * Fetch one page of v2 recent-search results, honoring `next_token` and
+ * returning the provider's next cursor so callers can resume.
+ */
+export async function searchTweetsPage(
+  query: string,
+  maxTweets: number,
+  searchMode: SearchMode,
+  auth: TwitterAuth,
+  cursor?: string,
+): Promise<QueryTweetsResponse> {
+  const client = await auth.getV2Client();
+  const finalQuery = applySearchMode(query, searchMode);
+  const paginationToken = cursor?.trim() ? cursor.trim() : undefined;
+
+  try {
+    const paginator = (await client.v2.search(finalQuery, {
+      max_results: Math.min(maxTweets, 100),
+      ...SEARCH_TWEET_QUERY,
+      ...(paginationToken ? { next_token: paginationToken } : {}),
+    })) as SearchPaginator;
+
+    const converted = currentPageTweets(paginator)
+      .slice(0, maxTweets)
+      .map((tweet) => convertSearchTweet(tweet, paginator.includes));
+
+    return {
+      tweets: converted,
+      next: paginator.meta?.next_token,
+    };
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — attach the query that faulted.
+    throw new ElizaError("Tweet search failed", {
+      code: "X_SEARCH_FAILED",
+      cause: error,
+      context: { query, searchMode },
+    });
+  }
+}
+
 /**
  * Search for tweets using Twitter API v2
  *
@@ -36,123 +197,18 @@ export async function* searchTweets(
   auth: TwitterAuth,
 ): AsyncGenerator<Tweet, void> {
   const client = await auth.getV2Client();
-
-  // Build query based on search mode
-  let finalQuery = query;
-  switch (searchMode) {
-    case SearchMode.Photos:
-      finalQuery = `${query} has:media has:images`;
-      break;
-    case SearchMode.Videos:
-      finalQuery = `${query} has:media has:videos`;
-      break;
-  }
+  const finalQuery = applySearchMode(query, searchMode);
 
   try {
-    const searchIterator = await client.v2.search(finalQuery, {
+    const searchIterator = (await client.v2.search(finalQuery, {
       max_results: Math.min(maxTweets, 100),
-      "tweet.fields": [
-        "id",
-        "text",
-        "conversation_id",
-        "created_at",
-        "author_id",
-        "referenced_tweets",
-        "entities",
-        "public_metrics",
-        "attachments",
-      ],
-      "user.fields": ["id", "name", "username", "profile_image_url"],
-      "media.fields": ["url", "preview_image_url", "type"],
-      expansions: [
-        "author_id",
-        "attachments.media_keys",
-        "referenced_tweets.id",
-        "referenced_tweets.id.author_id",
-      ],
-    });
+      ...SEARCH_TWEET_QUERY,
+    })) as SearchPaginator & AsyncIterable<TweetV2>;
 
     let count = 0;
     for await (const tweet of searchIterator) {
       if (count >= maxTweets) break;
-
-      const author = searchIterator.includes?.users?.find(
-        (u) => u.id === tweet.author_id,
-      );
-      const inReplyToStatusId = tweet.referenced_tweets?.find(
-        (rt) => rt.type === "replied_to",
-      )?.id;
-      const referencedTweets = (
-        searchIterator.includes as { tweets?: TweetV2[] }
-      )?.tweets;
-      const inReplyToStatus = inReplyToStatusId
-        ? referencedTweets?.find(
-            (includedTweet) => includedTweet.id === inReplyToStatusId,
-          )
-        : undefined;
-      const inReplyToAuthor = inReplyToStatus?.author_id
-        ? searchIterator.includes?.users?.find(
-            (u) => u.id === inReplyToStatus.author_id,
-          )
-        : undefined;
-
-      // Convert to Tweet format
-      const convertedTweet: Tweet = {
-        id: tweet.id,
-        text: tweet.text || "",
-        timestamp: tweet.created_at
-          ? new Date(tweet.created_at).getTime()
-          : Date.now(),
-        timeParsed: tweet.created_at ? new Date(tweet.created_at) : new Date(),
-        userId: tweet.author_id || "",
-        name: author?.name || "",
-        username: author?.username || "",
-        conversationId: tweet.conversation_id || tweet.id,
-        hashtags: tweet.entities?.hashtags?.map((h) => h.tag) || [],
-        mentions:
-          tweet.entities?.mentions?.map((m) => ({
-            id: m.id || "",
-            username: m.username || "",
-            name: "",
-          })) || [],
-        inReplyToStatusId,
-        inReplyToStatus: inReplyToStatus
-          ? {
-              id: inReplyToStatus.id,
-              text: inReplyToStatus.text || "",
-              userId: inReplyToStatus.author_id || "",
-              name: inReplyToAuthor?.name || "",
-              username: inReplyToAuthor?.username || "",
-              hashtags: [],
-              mentions: [],
-              photos: [],
-              thread: [],
-              urls: [],
-              videos: [],
-            }
-          : undefined,
-        photos: [],
-        thread: [],
-        urls: tweet.entities?.urls?.map((u) => u.expanded_url || u.url) || [],
-        videos: [],
-        isRetweet:
-          tweet.referenced_tweets?.some((rt) => rt.type === "retweeted") ||
-          false,
-        isReply:
-          tweet.referenced_tweets?.some((rt) => rt.type === "replied_to") ||
-          false,
-        isQuoted:
-          tweet.referenced_tweets?.some((rt) => rt.type === "quoted") || false,
-        isPin: false,
-        sensitiveContent: false,
-        likes: tweet.public_metrics?.like_count || undefined,
-        replies: tweet.public_metrics?.reply_count || undefined,
-        retweets: tweet.public_metrics?.retweet_count || undefined,
-        views: tweet.public_metrics?.impression_count || undefined,
-        quotes: tweet.public_metrics?.quote_count || undefined,
-      };
-
-      yield convertedTweet;
+      yield convertSearchTweet(tweet, searchIterator.includes);
       count++;
     }
   } catch (error) {

--- a/plugins/plugin-x/src/interactions-mention-pagination.test.ts
+++ b/plugins/plugin-x/src/interactions-mention-pagination.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Real `TwitterInteractionClient.handleTwitterInteractions` coverage for mention
+ * paging: a live next_token is followed until the snowflake watermark, so
+ * mentions past the first page are not dropped.
+ */
+import { type IAgentRuntime, logger, type UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientBase } from "./base";
+import type { Tweet } from "./client";
+import { TwitterInteractionClient } from "./interactions";
+import type { TwitterClientState } from "./types";
+
+vi.mock("@elizaos/core", async () => {
+  const node = await import("@elizaos/core/node");
+  return node;
+});
+
+const PROFILE_ID = "bot-user";
+
+function createRuntime() {
+  const cache = new Map<string, unknown>();
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+    character: { name: "Agent", templates: {} },
+    composeState: vi.fn(async () => ({ values: {}, data: {}, text: "" })),
+    createMemory: vi.fn(async () => undefined),
+    emitEvent: vi.fn(),
+    ensureConnection: vi.fn(async () => undefined),
+    ensureRoomExists: vi.fn(async () => undefined),
+    ensureWorldExists: vi.fn(async () => undefined),
+    updateWorld: vi.fn(async () => undefined),
+    cache,
+    getCache: vi.fn(async (key: string) => cache.get(key)),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    }),
+    deleteCache: vi.fn(async (key: string) => cache.delete(key)),
+    getMemoryById: vi.fn(async () => null),
+    getMemories: vi.fn(async () => []),
+    getSetting: vi.fn((key: string) =>
+      key === "TWITTER_ENABLE_REPLIES" ? "true" : undefined,
+    ),
+    reportError: vi.fn(),
+    useModel: vi.fn(async () => ""),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    messageService: {
+      handleMessage: vi.fn(async () => ({ responseMessages: [] })),
+    },
+  };
+  return runtime as unknown as IAgentRuntime & typeof runtime;
+}
+
+function mention(id: string): Tweet {
+  return {
+    id,
+    userId: "user-1",
+    username: "alice",
+    name: "Alice",
+    conversationId: id,
+    text: `@bot mention ${id}`,
+    timestamp: Date.now(),
+    thread: [],
+    permanentUrl: `https://x.com/alice/status/${id}`,
+  } as Tweet;
+}
+
+describe("mention search pagination", () => {
+  beforeEach(() => {
+    logger.log = vi.fn();
+    logger.info = vi.fn();
+    logger.warn = vi.fn();
+    logger.error = vi.fn();
+  });
+
+  it("follows every next_token past five pages until the lastChecked watermark", async () => {
+    const runtime = createRuntime();
+    const pages = Array.from({ length: 7 }, (_, page) =>
+      Array.from({ length: 20 }, (_, index) =>
+        mention(String(1000 - page * 20 - index)),
+      ),
+    );
+    const fetchSearchTweets = vi.fn(
+      async (_query: string, _max: number, _mode: unknown, cursor?: string) => {
+        const pageIndex = cursor ? Number(cursor.slice("page-".length)) - 1 : 0;
+        return {
+          tweets: pages[pageIndex] ?? [],
+          next:
+            pageIndex + 1 < pages.length ? `page-${pageIndex + 2}` : undefined,
+        };
+      },
+    );
+
+    let lastChecked: bigint | null = 875n;
+    const profile = {
+      id: PROFILE_ID,
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    };
+    const client = {
+      accountId: "default",
+      runtime,
+      profile,
+      twitterClient: { getTweetsV2: vi.fn(async () => []) },
+      withAuthenticatedSession: vi.fn(
+        async (operation: (session: unknown) => Promise<unknown>) =>
+          operation({ client: {}, profile, revision: 1 }),
+      ),
+      isAuthenticatedSessionCurrent: vi.fn(() => true),
+      getLatestCheckedTweetId: vi.fn((profileId: string) =>
+        profileId === PROFILE_ID ? lastChecked : null,
+      ),
+      recordLatestCheckedTweetId: vi.fn((profileId: string, id: bigint) => {
+        if (profileId !== PROFILE_ID) return;
+        if (lastChecked !== null && id <= lastChecked) return;
+        lastChecked = id;
+      }),
+      cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+      getIdentityCache: vi.fn(async () => undefined),
+      setIdentityCache: vi.fn(async () => undefined),
+      fetchSearchTweets,
+    };
+
+    const interactions = new TwitterInteractionClient(
+      client as unknown as ClientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+    const collected: Tweet[][] = [];
+    Object.assign(interactions, {
+      processMentionTweetsForSession: async (candidates: Tweet[]) => {
+        collected.push(candidates);
+      },
+    });
+
+    await interactions.handleTwitterInteractions();
+
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(7);
+    expect(fetchSearchTweets.mock.calls[0]?.[3]).toBeUndefined();
+    expect(fetchSearchTweets.mock.calls[1]?.[3]).toBe("page-2");
+    expect(fetchSearchTweets.mock.calls[6]?.[3]).toBe("page-7");
+    expect(collected).toHaveLength(1);
+    expect(collected[0]?.map((tweet) => tweet.id)).toEqual(
+      pages.flat().map((tweet) => tweet.id),
+    );
+  });
+
+  it("does not request a second page when the first page has no next_token", async () => {
+    const runtime = createRuntime();
+    const fetchSearchTweets = vi.fn(async () => ({
+      tweets: [mention("50")],
+    }));
+    const profile = {
+      id: PROFILE_ID,
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    };
+    const client = {
+      accountId: "default",
+      runtime,
+      profile,
+      twitterClient: { getTweetsV2: vi.fn(async () => []) },
+      withAuthenticatedSession: vi.fn(
+        async (operation: (session: unknown) => Promise<unknown>) =>
+          operation({ client: {}, profile, revision: 1 }),
+      ),
+      isAuthenticatedSessionCurrent: vi.fn(() => true),
+      getLatestCheckedTweetId: vi.fn(() => null),
+      recordLatestCheckedTweetId: vi.fn(),
+      cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+      getIdentityCache: vi.fn(async () => undefined),
+      setIdentityCache: vi.fn(async () => undefined),
+      fetchSearchTweets,
+    };
+    const interactions = new TwitterInteractionClient(
+      client as unknown as ClientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+    Object.assign(interactions, {
+      processMentionTweetsForSession: async () => undefined,
+    });
+
+    await interactions.handleTwitterInteractions();
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a repeated provider cursor instead of looping or returning a partial page set", async () => {
+    const runtime = createRuntime();
+    const fetchSearchTweets = vi.fn(async () => ({
+      tweets: [mention("50")],
+      next: "repeated-cursor",
+    }));
+    const profile = {
+      id: PROFILE_ID,
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    };
+    const client = {
+      accountId: "default",
+      runtime,
+      profile,
+      twitterClient: { getTweetsV2: vi.fn(async () => []) },
+      withAuthenticatedSession: vi.fn(
+        async (operation: (session: unknown) => Promise<unknown>) =>
+          operation({ client: {}, profile, revision: 1 }),
+      ),
+      isAuthenticatedSessionCurrent: vi.fn(() => true),
+      getLatestCheckedTweetId: vi.fn(() => null),
+      recordLatestCheckedTweetId: vi.fn(),
+      cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+      getIdentityCache: vi.fn(async () => undefined),
+      setIdentityCache: vi.fn(async () => undefined),
+      fetchSearchTweets,
+    };
+    const interactions = new TwitterInteractionClient(
+      client as unknown as ClientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+    const processMentions = vi.fn(async () => undefined);
+    Object.assign(interactions, {
+      processMentionTweetsForSession: processMentions,
+    });
+
+    await interactions.handleTwitterInteractions();
+
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(2);
+    expect(processMentions).not.toHaveBeenCalled();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "XInteractionClient.handleInteractions",
+      expect.objectContaining({ code: "X_MENTION_CURSOR_CYCLE" }),
+    );
+  });
+});

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -273,6 +273,8 @@ export class TwitterInteractionClient {
         logger.log("Finished checking Twitter interactions");
       });
     } catch (error) {
+      // error-policy:J7 polling diagnostics must remain visible without killing
+      // the recurring interaction loop.
       this.runtime.reportError("XInteractionClient.handleInteractions", error);
     }
   }
@@ -283,36 +285,47 @@ export class TwitterInteractionClient {
   private async handleMentions(session: TwitterAccountSession) {
     const { profile } = session;
     const twitterUsername = profile.username;
-    const cachedCursor =
-      (await this.client.getIdentityCache<string>(profile, "mention_cursor")) ??
-      "";
-
-    const searchResult = await this.client.fetchSearchTweets(
-      `@${twitterUsername}`,
-      20,
-      SearchMode.Latest,
-      String(cachedCursor),
-    );
-
-    const mentionCandidates = searchResult.tweets;
+    const lastCheckedTweetId = this.client.getLatestCheckedTweetId(profile.id);
+    const mentionCandidates: ClientTweet[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+    // Stay inside the recent-search window without silently dropping mentions
+    // that sit past the first page. Stop at the snowflake watermark so already
+    // processed ids are not re-fetched on later pages.
+    while (true) {
+      const searchResult = await this.client.fetchSearchTweets(
+        `@${twitterUsername}`,
+        20,
+        SearchMode.Latest,
+        cursor,
+      );
+      let hitWatermark = false;
+      for (const tweet of searchResult.tweets) {
+        mentionCandidates.push(tweet);
+        if (
+          lastCheckedTweetId !== null &&
+          typeof tweet.id === "string" &&
+          tweet.id.length > 0 &&
+          BigInt(tweet.id) <= lastCheckedTweetId
+        ) {
+          hitWatermark = true;
+        }
+      }
+      const nextCursor = searchResult.next;
+      if (hitWatermark || !nextCursor) {
+        break;
+      }
+      if (seenCursors.has(nextCursor)) {
+        throw new ElizaError("X mention pagination repeated a cursor", {
+          code: "X_MENTION_CURSOR_CYCLE",
+          context: { cursor: nextCursor, accountId: this.client.accountId },
+        });
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
 
     await this.processMentionTweetsForSession(mentionCandidates, session);
-    this.assertCurrentSession(session);
-    if (mentionCandidates.length > 0 && searchResult.previous) {
-      await this.client.setIdentityCache(
-        profile,
-        "mention_cursor",
-        searchResult.previous,
-        session,
-      );
-    } else if (!searchResult.previous && !searchResult.next) {
-      await this.client.setIdentityCache(
-        profile,
-        "mention_cursor",
-        "",
-        session,
-      );
-    }
   }
 
   /**


### PR DESCRIPTION
Replacement for #24515; preserves and credits its v2 next_token implementation while removing the hidden five-page loss. Relates to #24509.

What changed:
- forwards and returns v2 recent-search cursors;
- follows every page until the stored snowflake watermark or provider exhaustion, with no item-count/page cap;
- detects repeated provider cursors and reports typed `X_MENTION_CURSOR_CYCLE` instead of looping or admitting a partial candidate set;
- keeps ordinary one-page behavior unchanged.

Validation (Bun 1.3.14):
- focused client/pagination/error/cursor suites: 3 files, 8/8 passed
- the regression crosses seven pages and proves all 140 candidates reach processing
- `bun run --cwd plugins/plugin-x typecheck` — passed
- `bun run --cwd plugins/plugin-x lint:check` — 96 files clean
- `git diff --check` — passed

Original implementation authorship remains attributed to ss251 through the preserved commit author and cherry-pick provenance. No live X credential was available; tests drive the installed twitter-api-v2 paginator contract.