### PR TITLE
fix(plugin-x): retry reads without duplicating writes

### DIFF
--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -148,13 +148,23 @@ export function resolveMaxAuthRetries(raw: string | undefined): number {
  * Class representing a request queue for handling asynchronous requests in a controlled manner.
  */
 
-type QueuedRequest = () => Promise<unknown>;
+type QueuedItem = {
+  run: () => Promise<void>;
+  reject: (error: unknown) => void;
+};
 
-class RequestQueue {
-  private queue: QueuedRequest[] = [];
+export class RequestQueue {
+  private queue: QueuedItem[] = [];
   private processing = false;
   private maxRetries = 3;
-  private retryAttempts = new Map<QueuedRequest, number>();
+  private retryAttempts = new Map<QueuedItem, number>();
+
+  constructor(
+    private readonly waits: {
+      backoff?: (retryCount: number) => Promise<void>;
+      jitter?: () => Promise<void>;
+    } = {},
+  ) {}
 
   /**
    * Asynchronously adds a request to the queue, then processes the queue.
@@ -165,15 +175,14 @@ class RequestQueue {
    */
   async add<T>(request: () => Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
-      this.queue.push(async () => {
-        try {
+      this.queue.push({
+        run: async () => {
           const result = await request();
           resolve(result);
-        } catch (error) {
-          reject(error);
-        }
+        },
+        reject,
       });
-      this.processQueue();
+      void this.processQueue();
     });
   }
 
@@ -189,38 +198,35 @@ class RequestQueue {
     this.processing = true;
 
     while (this.queue.length > 0) {
-      const request = this.queue.shift();
-      if (!request) break;
+      const item = this.queue.shift();
+      if (!item) break;
       try {
-        await request();
-        // Clear retry count on success
-        this.retryAttempts.delete(request);
+        await item.run();
+        this.retryAttempts.delete(item);
       } catch (error) {
         logger.error("Error processing request:", errorDetail(error));
 
-        const retryCount = (this.retryAttempts.get(request) || 0) + 1;
+        const retryCount = (this.retryAttempts.get(item) || 0) + 1;
 
         if (retryCount < this.maxRetries) {
-          this.retryAttempts.set(request, retryCount);
-          this.queue.unshift(request);
+          this.retryAttempts.set(item, retryCount);
+          this.queue.unshift(item);
           await this.exponentialBackoff(retryCount);
-          // Break the loop to allow exponential backoff to take effect
-          break;
-        } else {
-          logger.error(
-            `Max retries (${this.maxRetries}) exceeded for request, skipping`,
-          );
-          this.retryAttempts.delete(request);
+          continue;
         }
+        logger.error(
+          `Max retries (${this.maxRetries}) exceeded for request, skipping`,
+        );
+        this.retryAttempts.delete(item);
+        item.reject(error);
       }
       await this.randomDelay();
     }
 
     this.processing = false;
 
-    // If there are still items in the queue, restart processing
     if (this.queue.length > 0) {
-      this.processQueue();
+      void this.processQueue();
     }
   }
 
@@ -230,6 +236,10 @@ class RequestQueue {
    * @returns {Promise<void>} - A promise that resolves after a delay based on the retry count.
    */
   private async exponentialBackoff(retryCount: number): Promise<void> {
+    if (this.waits.backoff) {
+      await this.waits.backoff(retryCount);
+      return;
+    }
     const delay = 2 ** retryCount * 1000;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
@@ -240,6 +250,10 @@ class RequestQueue {
    * @returns A Promise that resolves after the random delay has passed.
    */
   private async randomDelay(): Promise<void> {
+    if (this.waits.jitter) {
+      await this.waits.jitter();
+      return;
+    }
     const delay = Math.floor(Math.random() * 2000) + 1500;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -151,7 +151,12 @@ export function resolveMaxAuthRetries(raw: string | undefined): number {
 type QueuedItem = {
   run: () => Promise<void>;
   reject: (error: unknown) => void;
+  shouldRetry: (error: unknown, retryCount: number) => boolean;
 };
+
+export interface RequestQueueRetryOptions {
+  shouldRetry?: (error: unknown, retryCount: number) => boolean;
+}
 
 export class RequestQueue {
   private queue: QueuedItem[] = [];
@@ -173,7 +178,10 @@ export class RequestQueue {
    * @param {() => Promise<T>} request - The request to be added to the queue
    * @returns {Promise<T>} - A promise that resolves with the result of the request or rejects with an error
    */
-  async add<T>(request: () => Promise<T>): Promise<T> {
+  async add<T>(
+    request: () => Promise<T>,
+    options: RequestQueueRetryOptions = {},
+  ): Promise<T> {
     return new Promise((resolve, reject) => {
       this.queue.push({
         run: async () => {
@@ -181,6 +189,7 @@ export class RequestQueue {
           resolve(result);
         },
         reject,
+        shouldRetry: options.shouldRetry ?? (() => true),
       });
       void this.processQueue();
     });
@@ -208,7 +217,10 @@ export class RequestQueue {
 
         const retryCount = (this.retryAttempts.get(item) || 0) + 1;
 
-        if (retryCount < this.maxRetries) {
+        if (
+          retryCount < this.maxRetries &&
+          item.shouldRetry(error, retryCount)
+        ) {
           this.retryAttempts.set(item, retryCount);
           this.queue.unshift(item);
           await this.exponentialBackoff(retryCount);

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -42,6 +42,7 @@ import type {
 } from "./types";
 import { TwitterEventTypes } from "./types";
 import { parseActionResponseFromText, sendTweet } from "./utils";
+import { shouldRetryTwitterWrite } from "./utils/error-handler";
 import { describeTweetPhotos } from "./utils/image-descriptions";
 import {
   buildTwitterMessageMetadata,
@@ -740,8 +741,13 @@ ${tweet.text}`;
       }
 
       this.assertCurrentSession(session);
-      await this.client.requestQueue.add(() =>
-        this.client.twitterClient.sendQuoteTweet(post, tweet.id),
+      await this.client.requestQueue.add(
+        () => this.client.twitterClient.sendQuoteTweet(post, tweet.id),
+        {
+          // A 429 is an explicit pre-acceptance rejection. Retrying an
+          // ambiguous transport failure could publish the quote twice.
+          shouldRetry: shouldRetryTwitterWrite,
+        },
       );
       logger.info(`Quoted tweet ${tweet.id}`);
       return true;

--- a/plugins/plugin-x/src/request-queue.test.ts
+++ b/plugins/plugin-x/src/request-queue.test.ts
@@ -1,30 +1,26 @@
 /**
- * Real `ClientBase.requestQueue` coverage: a swallowed wrapper catch used to
+ * Real `RequestQueue` coverage: a swallowed wrapper catch used to
  * reject `add()` on the first failure and skip retry/backoff. The queue now
- * retries, then rejects only after the budget is exhausted.
+ * retries, then rejects only after the budget is exhausted. Per-call retry
+ * policy keeps ambiguous non-idempotent writes from being repeated.
  */
-import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
-import { ClientBase } from "./base";
-import type { TwitterClientState } from "./types";
+import { describe, expect, it, vi } from "vitest";
+import { RequestQueue } from "./base";
+import { shouldRetryTwitterWrite } from "./utils/error-handler";
 
-function makeClient(): ClientBase {
-  return new ClientBase(
-    {
-      agentId: "00000000-0000-0000-0000-000000000001",
-      character: { name: "Agent" },
-      getSetting: () => undefined,
-    } as unknown as IAgentRuntime,
-    { accountId: "default" } as TwitterClientState,
-  );
+function makeQueue(): RequestQueue {
+  return new RequestQueue({
+    backoff: async () => undefined,
+    jitter: async () => undefined,
+  });
 }
 
 describe("RequestQueue retries provider failures", () => {
   it("retries a failed request and resolves when a later attempt succeeds", async () => {
-    const client = makeClient();
+    const queue = makeQueue();
     let calls = 0;
     await expect(
-      client.requestQueue.add(async () => {
+      queue.add(async () => {
         calls += 1;
         if (calls < 2) {
           throw new Error("HTTP 429 rate limited");
@@ -36,10 +32,10 @@ describe("RequestQueue retries provider failures", () => {
   }, 20_000);
 
   it("rejects after the retry budget instead of hanging or skipping", async () => {
-    const client = makeClient();
+    const queue = makeQueue();
     let calls = 0;
     await expect(
-      client.requestQueue.add(async () => {
+      queue.add(async () => {
         calls += 1;
         throw new Error("HTTP 429 rate limited");
       }),
@@ -48,14 +44,63 @@ describe("RequestQueue retries provider failures", () => {
   }, 20_000);
 
   it("still resolves a first-try success without extra attempts", async () => {
-    const client = makeClient();
+    const queue = makeQueue();
     let calls = 0;
     await expect(
-      client.requestQueue.add(async () => {
+      queue.add(async () => {
         calls += 1;
         return 42;
       }),
     ).resolves.toBe(42);
     expect(calls).toBe(1);
+  });
+
+  it("does not retry when a non-idempotent caller rejects the error", async () => {
+    const queue = makeQueue();
+    let calls = 0;
+    const shouldRetry = vi.fn(() => false);
+
+    await expect(
+      queue.add(
+        async () => {
+          calls += 1;
+          throw new Error("ambiguous network failure");
+        },
+        { shouldRetry },
+      ),
+    ).rejects.toThrow("ambiguous network failure");
+
+    expect(calls).toBe(1);
+    expect(shouldRetry).toHaveBeenCalledOnce();
+  });
+
+  it("honors a per-call policy that permits an explicit rejection retry", async () => {
+    const queue = makeQueue();
+    let calls = 0;
+
+    await expect(
+      queue.add(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw new Error("HTTP 429 rate limited");
+          return "ok";
+        },
+        { shouldRetry: (error) => String(error).includes("429") },
+      ),
+    ).resolves.toBe("ok");
+
+    expect(calls).toBe(2);
+  });
+
+  it("retries only explicit rate-limit write rejections", () => {
+    expect(shouldRetryTwitterWrite({ status: 429 })).toBe(true);
+    expect(shouldRetryTwitterWrite(new Error("rate limit exceeded"))).toBe(
+      true,
+    );
+    expect(shouldRetryTwitterWrite(new Error("network timeout"))).toBe(false);
+    expect(shouldRetryTwitterWrite({ status: 500 })).toBe(false);
+    expect(
+      shouldRetryTwitterWrite(new Error("unknown transport failure")),
+    ).toBe(false);
   });
 });

--- a/plugins/plugin-x/src/request-queue.test.ts
+++ b/plugins/plugin-x/src/request-queue.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Real `ClientBase.requestQueue` coverage: a swallowed wrapper catch used to
+ * reject `add()` on the first failure and skip retry/backoff. The queue now
+ * retries, then rejects only after the budget is exhausted.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { ClientBase } from "./base";
+import type { TwitterClientState } from "./types";
+
+function makeClient(): ClientBase {
+  return new ClientBase(
+    {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+    } as unknown as IAgentRuntime,
+    { accountId: "default" } as TwitterClientState,
+  );
+}
+
+describe("RequestQueue retries provider failures", () => {
+  it("retries a failed request and resolves when a later attempt succeeds", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        if (calls < 2) {
+          throw new Error("HTTP 429 rate limited");
+        }
+        return "ok";
+      }),
+    ).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  }, 20_000);
+
+  it("rejects after the retry budget instead of hanging or skipping", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        throw new Error("HTTP 429 rate limited");
+      }),
+    ).rejects.toThrow("HTTP 429 rate limited");
+    expect(calls).toBe(3);
+  }, 20_000);
+
+  it("still resolves a first-try success without extra attempts", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        return 42;
+      }),
+    ).resolves.toBe(42);
+    expect(calls).toBe(1);
+  });
+});

--- a/plugins/plugin-x/src/timeline.ts
+++ b/plugins/plugin-x/src/timeline.ts
@@ -28,6 +28,7 @@ import {
 } from "./templates";
 import type { ActionResponse, TwitterClientState } from "./types";
 import { parseActionResponseFromText, sendTweet } from "./utils";
+import { shouldRetryTwitterWrite } from "./utils/error-handler";
 import {
   buildTwitterMessageMetadata,
   createMemorySafe,
@@ -654,13 +655,20 @@ ${tweet.text}${mediaDescriptions}`;
         }
 
         const sendQuote = () =>
-          this.client.requestQueue.add(async () => {
-            if (session) this.assertCurrentSession(session);
-            return await this.twitterClient.sendQuoteTweet(
-              String(responseObject.post),
-              tweet.id,
-            );
-          });
+          this.client.requestQueue.add(
+            async () => {
+              if (session) this.assertCurrentSession(session);
+              return await this.twitterClient.sendQuoteTweet(
+                String(responseObject.post),
+                tweet.id,
+              );
+            },
+            {
+              // Do not duplicate a provider-accepted write after an ambiguous
+              // network failure; only explicit rate-limit rejection is safe.
+              shouldRetry: shouldRetryTwitterWrite,
+            },
+          );
         const result = await sendQuote();
 
         try {

--- a/plugins/plugin-x/src/utils/error-handler.ts
+++ b/plugins/plugin-x/src/utils/error-handler.ts
@@ -114,6 +114,15 @@ export function getErrorType(error: unknown): TwitterErrorType {
   return TwitterErrorType.UNKNOWN;
 }
 
+/**
+ * A write may be retried only when the provider explicitly rejected it for
+ * rate limiting. Network and unknown failures are ambiguous: the provider may
+ * already have accepted the write, so retrying could publish a duplicate.
+ */
+export function shouldRetryTwitterWrite(error: unknown): boolean {
+  return getErrorType(error) === TwitterErrorType.RATE_LIMIT;
+}
+
 export function handleTwitterError(
   context: string,
   error: unknown,


### PR DESCRIPTION
Closes #24522. Supersedes #24524 because the external fork cannot be rebased through the current queue with the available OAuth scope.

This carries the original queue retry repair by @ss251 onto current `develop` and fixes the non-idempotent write risk found during review.

## Scope

- let queued request failures reach the retry loop instead of rejecting and swallowing on attempt one
- reject the caller after the three-attempt budget instead of hanging or silently skipping
- add deterministic injected wait seams so retry tests do not sleep
- add a per-call retry policy
- keep read requests retryable, but retry quote-tweet writes only for explicit rate-limit rejection; ambiguous network/unknown failures fail without repeating a potentially accepted write

## Validation

- queue, auth-retry, and real interaction-action suites: 3 files, 16/16 passed
- plugin-x typecheck passed
- plugin-x build passed
- changed-file Biome and `git diff --check` passed
- full plugin lane reached 338/340; the only two failures are stale current-develop account-status assertions tracked separately in #24589

Exact reviewed SHA: `e3de58b7dca3778fff21121f436e2eab48f7e42c`

UI evidence and LLM trajectories are N/A because this is a deterministic transport queue contract. Hosted exact-head static smoke remains the merge gate.

Attribution: original queue retry implementation by @ss251 in #24524; write-idempotency policy, deterministic tests, current-base migration, and independent execution by Codex.

<!-- evidence-head:e3de58b7dca3778fff21121f436e2eab48f7e42c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered user flow changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic transport queue contract covered by focused tests; no deployed backend is required.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact; no live X write was issued.



