### PR TITLE
test(plugin-x): preserve explicit account isolation

### DIFF
--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -201,7 +201,7 @@ describe("XService account status", () => {
     });
   });
 
-  it("reports accountId-first env capabilities without making a network call", async () => {
+  it("reports default-account env capabilities without making a network call", async () => {
     const service = serviceWithRuntime({
       TWITTER_AUTH_MODE: "env",
       TWITTER_API_KEY: "api-key",
@@ -210,12 +210,32 @@ describe("XService account status", () => {
       TWITTER_ACCESS_TOKEN_SECRET: "access-secret",
     });
 
-    await expect(service.getAccountStatus("primary")).resolves.toMatchObject({
-      accountId: "primary",
+    await expect(service.getAccountStatus("default")).resolves.toMatchObject({
+      accountId: "default",
       configured: true,
       connected: true,
       reason: "connected",
       grantedCapabilities: ["x.read", "x.write", "x.dm.read", "x.dm.write"],
+      authMode: "env",
+    });
+  });
+
+  it("does not leak default env credentials to an unknown explicit account", async () => {
+    const service = serviceWithRuntime({
+      TWITTER_AUTH_MODE: "env",
+      TWITTER_API_KEY: "api-key",
+      TWITTER_API_SECRET_KEY: "api-secret",
+      TWITTER_ACCESS_TOKEN: "access-token",
+      TWITTER_ACCESS_TOKEN_SECRET: "access-secret",
+    });
+
+    await expect(service.getAccountStatus("secondary")).resolves.toMatchObject({
+      accountId: "secondary",
+      configured: false,
+      connected: false,
+      reason: "config_missing",
+      grantedCapabilities: [],
+      grantedScopes: [],
       authMode: "env",
     });
   });
@@ -228,10 +248,8 @@ describe("XService account status", () => {
       TWITTER_SCOPES: "tweet.read users.read dm.read",
     });
 
-    await expect(
-      service.getAccountStatus("oauth-account"),
-    ).resolves.toMatchObject({
-      accountId: "oauth-account",
+    await expect(service.getAccountStatus("default")).resolves.toMatchObject({
+      accountId: "default",
       configured: true,
       connected: true,
       grantedCapabilities: ["x.read", "x.dm.read"],


### PR DESCRIPTION
## Summary

- align X account-status tests with the fail-closed explicit-account isolation contract
- exercise env and OAuth capabilities through the resolved default account
- prove an unknown explicit account cannot inherit owner credentials

Closes #24589

## Validation

- focused XService account-status suite: 18/18 passed
- full plugin-x lane: 36 files passed, 322 tests passed, 13 skipped
- plugin-x typecheck passed
- plugin-x build passed
- changed-file Biome and `git diff --check` passed

Exact reviewed SHA: `03b94e92f2b3474c646aa58d23aef160138fe5d8`

UI evidence and LLM trajectories are N/A because this repairs deterministic account-isolation assertions only. Hosted exact-head static smoke remains the merge gate.
