### PR TITLE
fix(plugin-discord): wire speaking listeners once per voice connection

### DIFF
--- a/plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts
+++ b/plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts
@@ -127,6 +127,8 @@ describe("VoiceManager voice-connection lifecycle", () => {
 		// `error` is not asserted: each still-pending `entersState` loser from
 		// `Promise.race` holds one of its own until its 20s deadline.
 		expect(connection.listenerCount("stateChange")).toBe(1);
+		expect(connection.receiver.speaking.listenerCount("start")).toBe(1);
+		expect(connection.receiver.speaking.listenerCount("end")).toBe(1);
 
 		closeWithoutReconnect(connection);
 		await afterReconnectProbe();

--- a/plugins/plugin-discord/__tests__/voice.test.ts
+++ b/plugins/plugin-discord/__tests__/voice.test.ts
@@ -263,4 +263,65 @@ describe("VoiceManager", () => {
 
 		expect(connection.receiver.subscribe).toHaveBeenCalledTimes(1);
 	});
+
+	it("routes a reused connection's speaking events through its latest channel", async () => {
+		const receiveStream = new PassThrough();
+		const connection = makeConnection(receiveStream);
+		voiceModule.joinVoiceChannel.mockImplementation(
+			(options: { channelId: string }) => {
+				connection.joinConfig.channelId = options.channelId;
+				return connection;
+			},
+		);
+		voiceModule.entersState.mockResolvedValue(connection);
+
+		const client = new EventEmitter() as EventEmitter & {
+			user?: { id: string };
+		};
+		client.user = { id: "bot-1" };
+		const userStream = vi.fn();
+		client.on("userStream", userStream);
+		const member = {
+			displayName: "Owner",
+			guild: { id: "guild-1" },
+			id: "user-1",
+			user: { bot: false, displayName: "Owner", username: "owner" },
+		};
+		const firstChannel = makeChannel();
+		const latestChannel = {
+			...makeChannel(member),
+			id: "voice-2",
+			name: "Latest Room",
+		};
+		const registerVoiceTarget = vi.fn();
+		const manager = new VoiceManager(
+			{
+				accountId: "test",
+				client: client as never,
+				registerVoiceTarget,
+			},
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+
+		await Promise.all([
+			manager.joinChannel(firstChannel as never),
+			manager.joinChannel(latestChannel as never),
+		]);
+		connection.receiver.speaking.emit("start", "user-1");
+
+		await vi.waitFor(() => {
+			expect(connection.receiver.subscribe).toHaveBeenCalledTimes(1);
+			expect(registerVoiceTarget).toHaveBeenCalledTimes(1);
+			expect(registerVoiceTarget).toHaveBeenCalledWith(
+				expect.objectContaining({ channel: latestChannel }),
+			);
+			expect(userStream).toHaveBeenCalledWith(
+				"user-1",
+				"Owner",
+				"owner",
+				latestChannel,
+				expect.any(Transform),
+			);
+		});
+	});
 });

--- a/plugins/plugin-discord/__tests__/voice.test.ts
+++ b/plugins/plugin-discord/__tests__/voice.test.ts
@@ -209,4 +209,58 @@ describe("VoiceManager", () => {
 			);
 		});
 	});
+
+	it("wires speaking start/end once when two joins share a connection", async () => {
+		const connection = makeConnection();
+		voiceModule.joinVoiceChannel.mockReturnValue(connection);
+		voiceModule.entersState.mockResolvedValue(connection);
+		const manager = new VoiceManager(
+			{ accountId: "test", client: new EventEmitter() as never },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+		const channel = makeChannel();
+
+		await Promise.all([
+			manager.joinChannel(channel as never),
+			manager.joinChannel(channel as never),
+		]);
+
+		expect(connection.receiver.speaking.listenerCount("start")).toBe(1);
+		expect(connection.receiver.speaking.listenerCount("end")).toBe(1);
+	});
+
+	it("does not resubscribe a member on a second speaking start", async () => {
+		const receiveStream = new PassThrough();
+		const connection = makeConnection(receiveStream);
+		voiceModule.joinVoiceChannel.mockReturnValue(connection);
+		voiceModule.entersState.mockResolvedValue(connection);
+
+		const client = new EventEmitter() as EventEmitter & {
+			user?: { id: string };
+		};
+		client.user = { id: "bot-1" };
+		const member = {
+			displayName: "Owner",
+			guild: { id: "guild-1" },
+			id: "user-1",
+			user: { bot: false, displayName: "Owner", username: "owner" },
+		};
+		const channel = makeChannel(member);
+		const manager = new VoiceManager(
+			{ accountId: "test", client: client as never },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+
+		await manager.joinChannel(channel as never);
+		connection.receiver.speaking.emit("start", "user-1");
+		await vi.waitFor(() => {
+			expect(connection.receiver.subscribe).toHaveBeenCalledTimes(1);
+		});
+
+		connection.receiver.speaking.emit("start", "user-1");
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(connection.receiver.subscribe).toHaveBeenCalledTimes(1);
+	});
 });

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -374,12 +374,35 @@ export class VoiceManager extends EventEmitter {
 	 * subscribe the same member twice.
 	 */
 	private wiredConnections = new WeakSet<VoiceConnection>();
+	/** Latest Discord channel associated with each reusable voice connection. */
+	private connectionChannels = new WeakMap<
+		VoiceConnection,
+		BaseGuildVoiceChannel
+	>();
 	private audioLanes = new Map<string, DiscordAudioLaneConfig>();
 	private lanePlayers = new Map<string, LanePlayerState>();
 	private activeMonitors: Map<
 		string,
 		{ channel: BaseGuildVoiceChannel; monitor: AudioMonitor }
 	> = new Map();
+
+	private getConnectionChannel(
+		connection: VoiceConnection,
+		event: string,
+	): BaseGuildVoiceChannel | undefined {
+		const channel = this.connectionChannels.get(connection);
+		if (!channel) {
+			this.runtime.logger.error(
+				{
+					src: "plugin:discord:service:voice",
+					agentId: this.runtime.agentId,
+					event,
+				},
+				"Voice connection event has no channel binding",
+			);
+		}
+		return channel;
+	}
 	private ready: boolean;
 	/** channelId → live voice-channel transcription session. */
 	private meetingSessions: Map<string, DiscordVoiceMeetingSession> = new Map();
@@ -641,6 +664,7 @@ export class VoiceManager extends EventEmitter {
 			selfMute: false,
 			group: this.client?.user?.id ?? "default-group",
 		});
+		this.connectionChannels.set(connection, channel);
 
 		try {
 			// Wait for either Ready or Signalling state
@@ -648,6 +672,17 @@ export class VoiceManager extends EventEmitter {
 				entersState(connection, VoiceConnectionStatus.Ready, 20_000),
 				entersState(connection, VoiceConnectionStatus.Signalling, 20_000),
 			]);
+			if (this.connectionChannels.get(connection) !== channel) {
+				this.runtime.logger.debug(
+					{
+						src: "plugin:discord:service:voice",
+						agentId: this.runtime.agentId,
+						channelId: channel.id,
+					},
+					"Voice join was superseded by a newer channel",
+				);
+				return;
+			}
 
 			// Log connection success
 			this.runtime.logger.info(
@@ -722,38 +757,61 @@ export class VoiceManager extends EventEmitter {
 								},
 								"Disconnection confirmed - cleaning up",
 							);
-							const isCurrent = this.connections.get(channel.id) === connection;
+							const activeChannel = this.getConnectionChannel(
+								connection,
+								"stateChange:disconnected",
+							);
+							if (!activeChannel) {
+								return;
+							}
+							const isCurrent =
+								this.connections.get(activeChannel.id) === connection;
 							if (connection.state.status !== VoiceConnectionStatus.Destroyed) {
 								connection.destroy();
 							}
 							if (isCurrent) {
-								this.connections.delete(channel.id);
+								this.connections.delete(activeChannel.id);
 								this.unregisterVoiceTarget?.(
 									this.accountId,
-									channel.guild.id,
-									channel.id,
+									activeChannel.guild.id,
+									activeChannel.id,
 								);
 							}
 						}
 					} else if (newState.status === VoiceConnectionStatus.Destroyed) {
+						const activeChannel = this.getConnectionChannel(
+							connection,
+							"stateChange:destroyed",
+						);
+						if (!activeChannel) {
+							return;
+						}
 						// Only the connection that currently owns this channel entry may
 						// clear it; a superseded connection cleans up itself and nothing
 						// else.
-						if (this.connections.get(channel.id) === connection) {
-							this.connections.delete(channel.id);
+						if (this.connections.get(activeChannel.id) === connection) {
+							this.connections.delete(activeChannel.id);
 							this.unregisterVoiceTarget?.(
 								this.accountId,
-								channel.guild.id,
-								channel.id,
+								activeChannel.guild.id,
+								activeChannel.id,
 							);
-							void this.stopVoiceTranscription(channel.id, "normal_completion");
+							void this.stopVoiceTranscription(
+								activeChannel.id,
+								"normal_completion",
+							);
 						}
 					} else if (
-						!this.connections.has(channel.id) &&
-						(newState.status === VoiceConnectionStatus.Ready ||
-							newState.status === VoiceConnectionStatus.Signalling)
+						newState.status === VoiceConnectionStatus.Ready ||
+						newState.status === VoiceConnectionStatus.Signalling
 					) {
-						this.connections.set(channel.id, connection);
+						const activeChannel = this.getConnectionChannel(
+							connection,
+							"stateChange:ready",
+						);
+						if (activeChannel && !this.connections.has(activeChannel.id)) {
+							this.connections.set(activeChannel.id, connection);
+						}
 					}
 				});
 
@@ -777,10 +835,17 @@ export class VoiceManager extends EventEmitter {
 				});
 
 				connection.receiver.speaking.on("start", async (entityId: string) => {
-					let user = channel.members.get(entityId);
+					const activeChannel = this.getConnectionChannel(
+						connection,
+						"speaking:start",
+					);
+					if (!activeChannel) {
+						return;
+					}
+					let user = activeChannel.members.get(entityId);
 					if (!user) {
 						try {
-							user = await channel.guild.members.fetch(entityId);
+							user = await activeChannel.guild.members.fetch(entityId);
 						} catch (error) {
 							this.runtime.logger.error(
 								{
@@ -796,7 +861,7 @@ export class VoiceManager extends EventEmitter {
 
 					const userUser = user?.user;
 					if (user && userUser && !userUser.bot) {
-						await this.monitorMember(user as GuildMember, channel);
+						await this.monitorMember(user as GuildMember, activeChannel);
 						const entityStream = this.streams.get(entityId);
 						if (entityStream) {
 							entityStream.emit("speakingStarted");
@@ -805,7 +870,14 @@ export class VoiceManager extends EventEmitter {
 				});
 
 				connection.receiver.speaking.on("end", async (entityId: string) => {
-					const user = channel.members.get(entityId);
+					const activeChannel = this.getConnectionChannel(
+						connection,
+						"speaking:end",
+					);
+					if (!activeChannel) {
+						return;
+					}
+					const user = activeChannel.members.get(entityId);
 					const userUser = user?.user;
 					if (user && userUser && !userUser.bot) {
 						const entityStream = this.streams.get(entityId);
@@ -813,7 +885,7 @@ export class VoiceManager extends EventEmitter {
 							entityStream.emit("speakingStopped");
 						}
 						// Speaking end = utterance boundary for the meeting pipeline.
-						this.meetingSessions.get(channel.id)?.flushSpeaker(entityId);
+						this.meetingSessions.get(activeChannel.id)?.flushSpeaker(entityId);
 					}
 				});
 			}

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -369,8 +369,9 @@ export class VoiceManager extends EventEmitter {
 	 * Connections this manager has already wired lifecycle listeners onto.
 	 * `joinVoiceChannel()` returns the connection it is *already* tracking for the
 	 * same (group, guildId) instead of creating a new one, so two overlapping
-	 * joins would otherwise stack a second copy of the `stateChange`/`error`
-	 * listeners onto a single connection and run its teardown twice.
+	 * joins would otherwise stack a second copy of the `stateChange`/`error`/
+	 * `speaking` listeners onto a single connection and run teardown twice /
+	 * subscribe the same member twice.
 	 */
 	private wiredConnections = new WeakSet<VoiceConnection>();
 	private audioLanes = new Map<string, DiscordAudioLaneConfig>();
@@ -774,6 +775,47 @@ export class VoiceManager extends EventEmitter {
 						"Will attempt to recover",
 					);
 				});
+
+				connection.receiver.speaking.on("start", async (entityId: string) => {
+					let user = channel.members.get(entityId);
+					if (!user) {
+						try {
+							user = await channel.guild.members.fetch(entityId);
+						} catch (error) {
+							this.runtime.logger.error(
+								{
+									src: "plugin:discord:service:voice",
+									agentId: this.runtime.agentId,
+									entityId,
+									error: error instanceof Error ? error.message : String(error),
+								},
+								"Failed to fetch user",
+							);
+						}
+					}
+
+					const userUser = user?.user;
+					if (user && userUser && !userUser.bot) {
+						await this.monitorMember(user as GuildMember, channel);
+						const entityStream = this.streams.get(entityId);
+						if (entityStream) {
+							entityStream.emit("speakingStarted");
+						}
+					}
+				});
+
+				connection.receiver.speaking.on("end", async (entityId: string) => {
+					const user = channel.members.get(entityId);
+					const userUser = user?.user;
+					if (user && userUser && !userUser.bot) {
+						const entityStream = this.streams.get(entityId);
+						if (entityStream) {
+							entityStream.emit("speakingStopped");
+						}
+						// Speaking end = utterance boundary for the meeting pipeline.
+						this.meetingSessions.get(channel.id)?.flushSpeaker(entityId);
+					}
+				});
 			}
 
 			// Store the connection
@@ -834,47 +876,6 @@ export class VoiceManager extends EventEmitter {
 					// Continue even if this fails
 				}
 			}
-
-			connection.receiver.speaking.on("start", async (entityId: string) => {
-				let user = channel.members.get(entityId);
-				if (!user) {
-					try {
-						user = await channel.guild.members.fetch(entityId);
-					} catch (error) {
-						this.runtime.logger.error(
-							{
-								src: "plugin:discord:service:voice",
-								agentId: this.runtime.agentId,
-								entityId,
-								error: error instanceof Error ? error.message : String(error),
-							},
-							"Failed to fetch user",
-						);
-					}
-				}
-
-				const userUser = user?.user;
-				if (user && userUser && !userUser.bot) {
-					this.monitorMember(user as GuildMember, channel);
-					const entityStream = this.streams.get(entityId);
-					if (entityStream) {
-						entityStream.emit("speakingStarted");
-					}
-				}
-			});
-
-			connection.receiver.speaking.on("end", async (entityId: string) => {
-				const user = channel.members.get(entityId);
-				const userUser = user?.user;
-				if (user && userUser && !userUser.bot) {
-					const entityStream = this.streams.get(entityId);
-					if (entityStream) {
-						entityStream.emit("speakingStopped");
-					}
-					// Speaking end = utterance boundary for the meeting pipeline.
-					this.meetingSessions.get(channel.id)?.flushSpeaker(entityId);
-				}
-			});
 		} catch (error) {
 			this.runtime.logger.error(
 				{
@@ -1012,6 +1013,9 @@ export class VoiceManager extends EventEmitter {
 		const name = memberUser?.displayName;
 		const memberGuild = member?.guild;
 		const memberGuildId = memberGuild?.id;
+		if (entityId && this.streams.has(entityId)) {
+			return;
+		}
 		const connection = this.getVoiceConnection(memberGuildId);
 
 		const connectionReceiver = connection?.receiver;


### PR DESCRIPTION
# Relates to

Closes #24519.
Supersedes #24520 because the maintained fork branch could not accept the current `develop` workflow history with the available OAuth scope.

# Contribution provenance

The original implementation commit remains authored by @ss251 and is preserved as the first commit in this branch. Original self-reported provenance and evidence are retained on #24520. The maintainer restack and race repair used OpenAI Codex; exact backend model identifier is unavailable in this client.

# What changed

This preserves the contributor fix that wires `stateChange`, `error`, and speaking listeners once per reusable Discord voice connection and prevents duplicate member subscriptions.

During restack, exact concurrency review found that moving handlers under the one-time guard made them retain the first overlapping channel. The follow-up binds each reusable connection to its latest channel, resolves that binding for lifecycle and speaking events, and stops a superseded join from registering a stale voice target or transcription session.

# Exact-head verification

Evidence head: `9b0faa98742d5589769392c8378ce86e217d84c8`
Base: `62ae175f89d5602cc61275d8136494acadc9c473`

- `bun install --frozen-lockfile`: passed
- `node packages/shared/scripts/generate-keywords.mjs`: passed (required generated source in isolated worktree)
- `bun run --cwd plugins/plugin-discord test __tests__/voice.test.ts __tests__/voice-connection-lifecycle.test.ts __tests__/voice-meetings.test.ts __tests__/voice-target-registry.test.ts`: 4 files, 33 tests passed
- `bun run --cwd plugins/plugin-discord typecheck`: passed after building required workspace declarations for `@elizaos/cloud-routing`, `@elizaos/vault`, and `@elizaos/plugin-commands`
- `bun run --cwd plugins/plugin-discord lint:check`: 169 files clean
- `git diff --check`: passed

# Evidence gate

- Before/after screenshots: N/A, no rendered UI.
- Walkthrough video: N/A, no rendered UI.
- Backend/frontend logs: N/A, unit-level voice lifecycle change; exact command results above.
- LLM trajectory: N/A, no prompt/model/action/provider path.
- Domain artifact: deterministic mocked Discord voice connection lifecycle tests; no live Discord bot token or guild was available.
- Audio walkthrough: N/A, the change is connection/listener lifecycle behavior, not audio rendering.

The new regression overlaps joins to different channels sharing one connection, then proves only the latest channel is registered and receives speaker attribution. Existing lifecycle tests cover disconnect teardown, leave during reconnect probes, meeting cleanup, and target registry behavior.