### PR TITLE
fix(ci): bound Bun release fetch attempts

### DIFF
--- a/packages/scripts/__tests__/ci-fetch-bun-release.test.ts
+++ b/packages/scripts/__tests__/ci-fetch-bun-release.test.ts
@@ -1,10 +1,19 @@
 /**
- * Exercises Bun release URL selection, AVX2 variant choice, GitHub-to-npm
- * fallback, and zip cache hits. Network is a deterministic fetch stub.
+ * Exercises Bun release selection, caching, bounded downloads, mirror fallback,
+ * and local serving. Timeout coverage runs the production downloader in Node
+ * against a real loopback HTTP connection; other remote-network paths use
+ * deterministic fetch stubs.
  */
 import { describe, expect, it } from "bun:test";
-import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -22,6 +31,117 @@ import {
 
 const BUN_VERSION = "1.3.14";
 
+const NODE_DOWNLOAD_HARNESS = `
+const spec = JSON.parse(process.env.ELIZA_BUN_TIMEOUT_TEST_SPEC);
+const { readFile } = await import("node:fs/promises");
+const downloader = await import(spec.moduleUrl);
+const asset = downloader.resolveBunAsset(spec.host);
+const [githubUrl, npmUrl] = downloader.bunReleaseUrls(spec.version, asset);
+const seen = [];
+const realFetch = globalThis.fetch.bind(globalThis);
+const result = await downloader.ensureBunReleaseZip({
+  outDir: spec.outDir,
+  version: spec.version,
+  host: spec.host,
+  attempts: 2,
+  retryDelayMs: 0,
+  requestTimeoutMs: 150,
+  fetchImpl: (url, init) => {
+    const remoteUrl = String(url);
+    seen.push(remoteUrl);
+    if (remoteUrl === githubUrl) return realFetch(spec.baseUrl + "/stall", init);
+    if (remoteUrl === npmUrl) return realFetch(spec.baseUrl + "/ok", init);
+    throw new Error("unexpected Bun release URL: " + remoteUrl);
+  },
+});
+const zip = await readFile(result.zipPath);
+process.stdout.write(JSON.stringify({
+  source: result.source,
+  seen,
+  zipBase64: zip.toString("base64"),
+}));
+`;
+
+type NodeDownloadHarnessResult = {
+  source: string;
+  seen: string[];
+  zipBase64: string;
+};
+
+function runNodeDownloadHarness(spec: {
+  moduleUrl: string;
+  baseUrl: string;
+  outDir: string;
+  version: string;
+  host: { platform: string; arch: string; hasAvx2: boolean };
+}): Promise<NodeDownloadHarnessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "node",
+      ["--input-type=module", "--eval", NODE_DOWNLOAD_HARNESS],
+      {
+        env: {
+          ...process.env,
+          ELIZA_BUN_TIMEOUT_TEST_SPEC: JSON.stringify(spec),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    let spawnError: Error | undefined;
+    let timedOut = false;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, 5_000);
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      if (spawnError) {
+        reject(spawnError);
+        return;
+      }
+      if (timedOut) {
+        reject(new Error("Node Bun release fallback exceeded 5 seconds"));
+        return;
+      }
+      if (code !== 0) {
+        reject(
+          new Error(
+            `Node Bun release harness exited with code ${String(code)} and signal ${String(signal)}: ${stderr}`,
+          ),
+        );
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (error) {
+        // error-policy:J2 preserve the parse failure while adding child output
+        reject(
+          new Error(
+            `Node Bun release harness returned invalid JSON: ${stdout}`,
+            {
+              cause: error,
+            },
+          ),
+        );
+      }
+    });
+  });
+}
+
 function fakeZip() {
   const bytes = Buffer.alloc(2048, 0);
   bytes[0] = 0x50;
@@ -29,6 +149,24 @@ function fakeZip() {
   bytes[2] = 0x03;
   bytes[3] = 0x04;
   return bytes;
+}
+
+async function withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 describe("resolveBunAsset", () => {
@@ -146,10 +284,221 @@ describe("ensureBunReleaseZip", () => {
     expect(result.source).toContain("registry.npmjs.org/@oven/bun-linux-x64");
   });
 
+  it("rejects invalid request deadlines before fetching", async () => {
+    const invalidValues = [
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      2_147_483_648,
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+    let fetches = 0;
+    for (const requestTimeoutMs of invalidValues) {
+      const outDir = mkdtempSync(join(tmpdir(), "bun-zip-timeout-invalid-"));
+      try {
+        await expect(
+          ensureBunReleaseZip({
+            outDir,
+            host: { platform: "linux", arch: "x64", hasAvx2: true },
+            attempts: 1,
+            requestTimeoutMs,
+            fetchImpl: async () => {
+              fetches += 1;
+              return { ok: true, arrayBuffer: async () => fakeZip() };
+            },
+          }),
+        ).rejects.toThrow("requestTimeoutMs must be an integer between 1 and");
+      } finally {
+        rmSync(outDir, { force: true, recursive: true });
+      }
+    }
+    expect(fetches).toBe(0);
+  });
+
+  it("accepts the timer deadline boundaries", async () => {
+    for (const requestTimeoutMs of [1, 2_147_483_647]) {
+      const outDir = mkdtempSync(join(tmpdir(), "bun-zip-timeout-valid-"));
+      let fetches = 0;
+      try {
+        const result = await ensureBunReleaseZip({
+          outDir,
+          host: { platform: "linux", arch: "x64", hasAvx2: true },
+          attempts: 1,
+          requestTimeoutMs,
+          fetchImpl: async () => {
+            fetches += 1;
+            return { ok: true, arrayBuffer: async () => fakeZip() };
+          },
+        });
+        expect(fetches).toBe(1);
+        expect(result.source).toContain(
+          "github.com/oven-sh/bun/releases/download",
+        );
+      } finally {
+        rmSync(outDir, { force: true, recursive: true });
+      }
+    }
+  });
+
+  it("reports the final mirror and deadline after retries are exhausted", async () => {
+    const outDir = mkdtempSync(join(tmpdir(), "bun-zip-timeout-error-"));
+    const asset = resolveBunAsset({
+      platform: "linux",
+      arch: "x64",
+      hasAvx2: true,
+    });
+    const [, npmUrl] = bunReleaseUrls(BUN_VERSION, asset);
+    const timeoutError = new Error("simulated body timeout");
+    timeoutError.name = "TimeoutError";
+    try {
+      await expect(
+        ensureBunReleaseZip({
+          outDir,
+          host: { platform: "linux", arch: "x64", hasAvx2: true },
+          attempts: 1,
+          fetchImpl: async () => {
+            throw timeoutError;
+          },
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          `after 1 attempt(s) with a 30000ms deadline: ${npmUrl}`,
+        ),
+        cause: expect.objectContaining({ name: "TimeoutError" }),
+      });
+    } finally {
+      rmSync(outDir, { force: true, recursive: true });
+    }
+  });
+
+  it("times out a stalled Node response body and advances to the npm mirror", async () => {
+    const sockets = new Set<import("node:net").Socket>();
+    const stalledSockets: import("node:net").Socket[] = [];
+    const stalledSocketCloses: Promise<void>[] = [];
+    const serverPaths: string[] = [];
+    const server = createServer((req, res) => {
+      serverPaths.push(req.url ?? "");
+      if (req.url === "/stall") {
+        stalledSockets.push(req.socket);
+        stalledSocketCloses.push(
+          new Promise<void>((resolve) => req.socket.once("close", resolve)),
+        );
+        res.writeHead(200, {
+          "content-length": String(fakeZip().length),
+          "content-type": "application/zip",
+        });
+        res.flushHeaders();
+        res.write(fakeZip().subarray(0, 64));
+        return;
+      }
+      if (req.url === "/ok") {
+        res.writeHead(200, { "content-type": "application/zip" });
+        res.end(fakeZip());
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+    });
+    const outDir = mkdtempSync(join(tmpdir(), "bun-zip-timeout-real-"));
+    let listening = false;
+    let downloadPromise: ReturnType<typeof runNodeDownloadHarness> | undefined;
+
+    const operationResults = await Promise.allSettled([
+      (async () => {
+        await new Promise<void>((resolve, reject) => {
+          const onError = (error: Error) => reject(error);
+          server.once("error", onError);
+          server.listen(0, "127.0.0.1", () => {
+            server.off("error", onError);
+            listening = true;
+            resolve();
+          });
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("loopback test server did not bind a TCP port");
+        }
+        const baseUrl = `http://127.0.0.1:${address.port}`;
+        const asset = resolveBunAsset({
+          platform: "linux",
+          arch: "x64",
+          hasAvx2: true,
+        });
+        const [githubUrl, npmUrl] = bunReleaseUrls(BUN_VERSION, asset);
+        downloadPromise = runNodeDownloadHarness({
+          moduleUrl: new URL("../ci-fetch-bun-release.mjs", import.meta.url)
+            .href,
+          baseUrl,
+          outDir,
+          version: BUN_VERSION,
+          host: { platform: "linux", arch: "x64", hasAvx2: true },
+        });
+        const result = await downloadPromise;
+
+        expect(stalledSocketCloses).toHaveLength(2);
+        await withDeadline(
+          Promise.all(stalledSocketCloses),
+          2_000,
+          "stalled sockets did not close after request aborts",
+        );
+
+        expect(result.seen).toEqual([githubUrl, githubUrl, npmUrl]);
+        expect(serverPaths).toEqual(["/stall", "/stall", "/ok"]);
+        expect(stalledSockets.every((socket) => socket.destroyed)).toBe(true);
+        expect(result.source).toBe(npmUrl);
+        expect(Buffer.from(result.zipBase64, "base64")).toEqual(fakeZip());
+      })(),
+    ]);
+
+    const teardownChecks: Promise<unknown>[] = [];
+    if (listening) {
+      const serverClosed = new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+      for (const socket of sockets) socket.destroy();
+      teardownChecks.push(
+        withDeadline(
+          serverClosed,
+          2_000,
+          "loopback server did not close during teardown",
+        ),
+      );
+    }
+    if (downloadPromise) {
+      teardownChecks.push(
+        withDeadline(
+          Promise.allSettled([downloadPromise]),
+          2_000,
+          "Node Bun release download did not settle during teardown",
+        ),
+      );
+    }
+    const teardownResults = await Promise.allSettled(teardownChecks);
+    const remainingSockets = sockets.size;
+    for (const socket of sockets) socket.destroy();
+    rmSync(outDir, { force: true, recursive: true });
+
+    for (const result of [...operationResults, ...teardownResults]) {
+      if (result.status === "rejected") throw result.reason;
+    }
+    expect(remainingSockets).toBe(0);
+  });
+
   it("converts an npm tarball into a GitHub-layout zip without the zip CLI", async () => {
     const staging = mkdtempSync(join(tmpdir(), "bun-npm-src-"));
     mkdirSync(join(staging, "package"), { recursive: true });
-    writeFileSync(join(staging, "package", "bun"), Buffer.alloc(2048, 0x61));
+    const bunName = process.platform === "win32" ? "bun.exe" : "bun";
+    writeFileSync(join(staging, "package", bunName), Buffer.alloc(2048, 0x61));
     const tgzPath = join(staging, "bun.tgz");
     execFileSync("tar", ["-czf", tgzPath, "-C", staging, "package"]);
     const tgz = readFileSync(tgzPath);
@@ -176,7 +525,7 @@ describe("ensureBunReleaseZip", () => {
     const zip = readFileSync(result.zipPath);
     expect(zip[0]).toBe(0x50);
     expect(zip[1]).toBe(0x4b);
-    expect(zip.includes(Buffer.from("bun-linux-x64/bun"))).toBe(true);
+    expect(zip.includes(Buffer.from(`bun-linux-x64/${bunName}`))).toBe(true);
   });
 });
 

--- a/packages/scripts/ci-fetch-bun-release.mjs
+++ b/packages/scripts/ci-fetch-bun-release.mjs
@@ -31,6 +31,9 @@ import { crc32 } from "node:zlib";
 const BUN_VERSION = "1.3.14";
 const ZIP_NAME = "bun.zip";
 const DEFAULT_ATTEMPTS = 6;
+// Six deadlines plus the existing 22.5s backoff still leave 5m jobs time to use npm.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
  * @typedef {{
@@ -145,14 +148,34 @@ function tgzLooksValid(bytes) {
   return bytes.length > 20 && bytes[0] === 0x1f && bytes[1] === 0x8b;
 }
 
+function validateRequestTimeoutMs(value) {
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_TIMER_DELAY_MS
+  ) {
+    throw new TypeError(
+      `requestTimeoutMs must be an integer between 1 and ${MAX_TIMER_DELAY_MS}; received ${String(value)}`,
+    );
+  }
+}
+
 async function downloadBytes(
   url,
-  { fetchImpl, attempts, retryDelayMs = 1500 },
+  {
+    fetchImpl,
+    attempts,
+    retryDelayMs = 1500,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  },
 ) {
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
-      const response = await fetchImpl(url, { redirect: "follow" });
+      const response = await fetchImpl(url, {
+        redirect: "follow",
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
       if (!response.ok) {
         throw new Error(`${url} -> HTTP ${response.status}`);
       }
@@ -170,7 +193,12 @@ async function downloadBytes(
       );
     }
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  const cause =
+    lastError instanceof Error ? lastError : new Error(String(lastError));
+  throw new Error(
+    `Bun release request failed after ${attempts} attempt(s) with a ${requestTimeoutMs}ms deadline: ${url}: ${cause.message}`,
+    { cause },
+  );
 }
 
 /**
@@ -267,7 +295,9 @@ export async function ensureBunReleaseZip(options) {
     fetchImpl = globalThis.fetch,
     attempts = DEFAULT_ATTEMPTS,
     retryDelayMs = 1500,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
   } = options;
+  validateRequestTimeoutMs(requestTimeoutMs);
   mkdirSync(outDir, { recursive: true });
   const zipPath = join(outDir, ZIP_NAME);
   if (existsSync(zipPath)) {
@@ -285,6 +315,7 @@ export async function ensureBunReleaseZip(options) {
         fetchImpl,
         attempts,
         retryDelayMs,
+        requestTimeoutMs,
       });
       if (zipLooksValid(bytes)) {
         writeFileSync(zipPath, bytes);


### PR DESCRIPTION
# Relates to

Fixes #24575

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      Windows blockers are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      exact-head production-Node loopback evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `240af7833ca2aee8b04f32b5c792cfd9ee9fa326`; zero conflicts.
- [x] `bun run verify` was run post-sync; exact unrelated Windows blockers are
      documented in **Known gaps / failures** below.

# Risks

Low. A single transfer that makes no progress for 30 seconds is aborted, but
the existing six-attempt policy remains and npm is still tried after GitHub.
The bound leaves a five-minute workflow about 97.5 seconds after worst-case
GitHub deadlines and backoff to complete the npm fallback.

# Background

## What does this PR do?

- Gives every GitHub/npm HTTP attempt a fresh 30-second `AbortSignal` that
  covers both headers and complete body consumption.
- Rejects invalid, fractional, non-safe, zero/negative, and timer-overflow
  deadlines before cache or network work.
- Preserves retry and mirror order while adding terminal URL, attempt-count,
  deadline, and underlying-cause context.
- Adds a production-runtime regression: Bun's test runner starts a loopback
  server, then a real Node child imports the downloader. Two GitHub responses
  flush headers, send a partial body, and stall; Node times them out, closes
  both sockets, and downloads the exact zip bytes from npm.
- Makes the pre-existing npm-tarball fixture platform-correct on Windows.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. The new option and its behavior are
internal to the CI download helper and are covered by executable tests.

# Testing

## Where should a reviewer start?

Start with `downloadBytes()` in
`packages/scripts/ci-fetch-bun-release.mjs`, then the stalled-body Node test in
`packages/scripts/__tests__/ci-fetch-bun-release.test.ts`.

## Detailed testing steps

On exact head `a89342acb6a6dc1166fddf3620fac74298dec425`:

1. Put Node `24.15.0` and Bun `1.3.14` on `PATH`.
2. Run
   `bun test packages/scripts/__tests__/ci-fetch-bun-release.test.ts`.
   Expected: `19 pass`, `0 fail`, `64 expect() calls`; the real Node
   stalled-body fallback test passes.
3. Run `node --check packages/scripts/ci-fetch-bun-release.mjs`.
   Expected: exit 0.
4. Run
   `bunx @biomejs/biome@2.5.8 check packages/scripts/ci-fetch-bun-release.mjs packages/scripts/__tests__/ci-fetch-bun-release.test.ts`.
   Expected: exit 0 (the command reports two pre-existing environment-variable
   warnings in the script).
5. Run `bun install --frozen-lockfile`, then `bun run verify`. The install
   completes; the exact unrelated Windows verification blockers are below.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a89342acb6a6dc1166fddf3620fac74298dec425 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI-only downloader change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI-only downloader change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - this standalone CI helper has no structured backend logger; exact-head production-Node TAP proof is pasted inline below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, console, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the generated zip is a temporary fixture asserted byte-for-byte in the production-Node test below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

N/A - this CI helper has neither a structured backend logger nor a frontend.
The exact production-runtime test transcript is:

<details>
<summary>Node 24.15.0 + Bun 1.3.14 exact-head proof</summary>

```text
bun test v1.3.14 (0d9b296a)
(pass) ensureBunReleaseZip > rejects invalid request deadlines before fetching
(pass) ensureBunReleaseZip > accepts the timer deadline boundaries
(pass) ensureBunReleaseZip > reports the final mirror and deadline after retries are exhausted
(pass) ensureBunReleaseZip > times out a stalled Node response body and advances to the npm mirror

19 pass
0 fail
64 expect() calls
```

The loopback assertion proves exact request order `[GitHub, GitHub, npm]`,
server paths `[/stall, /stall, /ok]`, closure of both stalled sockets, npm as
the retained production source URL, and byte-for-byte equality of the output
zip.

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- `bun install --frozen-lockfile` completed with exit 0 (`3709 installs across
  3992 packages`). On this non-Developer-Mode Windows host, the repository's
  workspace-symlink helper reported `EPERM`; disposable junction/declaration
  generation was used only inside ignored install output so the workspace
  resolution audit could run. No source file changed.
- Post-sync `bun run verify` passed the repository contracts and workspace
  resolution audit and launched the 150-package Turbo typecheck/lint graph. It
  then exited 1 on unrelated Windows-only checkout/tooling findings:
  - `packages/app/src/shims/solana-wallet-adapter-react-ui.css` is checked out
    with CRLF and Biome requests LF.
  - `packages/app-core/platforms/electrobun` invokes POSIX `find` in its lint
    script; Windows `find.exe` reports `File not found - *.tsx`, after which
    generated `src/preload.js` and `.generated/brand-config.json` are scanned.
  - Standalone `packages/shared` lint likewise reports CRLF-only formatting in
    `src/brand-classic/brand.css` and `src/brand/brand.css`.
- None of those paths are in this PR. `git diff --name-only
  origin/develop...HEAD` contains only the downloader and its test. Focused
  exact-head tests, syntax, Biome, and `git diff --check` all pass.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a89342acb6a6dc1166fddf3620fac74298dec425:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [implementation-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a89342acb6a6dc1166fddf3620fac74298dec425:packages/skills/skills/contribute-to-eliza"} -->
