### PR TITLE
fix(core): enforce cached request body byte budgets

### DIFF
--- a/packages/core/src/api/http-helpers.test.ts
+++ b/packages/core/src/api/http-helpers.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Exercises the shared HTTP body reader through real Node request streams,
+ * including per-reader byte budgets after the request body has been memoized.
+ */
+import http from "node:http";
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors.js";
+import { readJsonBody, readRequestBodyBuffer } from "./http-helpers.js";
+
+interface IncomingRequestResult<T> {
+	inspection: T;
+	responseBody: string;
+	status: number;
+}
+
+async function withIncomingRequest<T>(
+	body: string,
+	inspect: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<T>,
+): Promise<IncomingRequestResult<T>> {
+	let resolveInspection: (value: T) => void;
+	let rejectInspection: (reason: unknown) => void;
+	const inspection = new Promise<T>((resolve, reject) => {
+		resolveInspection = resolve;
+		rejectInspection = reject;
+	});
+
+	const server = http.createServer(async (req, res) => {
+		try {
+			resolveInspection(await inspect(req, res));
+			if (!res.writableEnded) res.end("ok");
+		} catch (error) {
+			rejectInspection(error);
+			res.statusCode = 500;
+			res.end("inspection failed");
+		}
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (address === null || typeof address === "string") {
+		throw new Error("HTTP test server did not expose a TCP address");
+	}
+
+	try {
+		const response = await fetch(`http://127.0.0.1:${address.port}`, {
+			body,
+			method: "POST",
+		});
+		const responseBody = await response.text();
+		return {
+			inspection: await inspection,
+			responseBody,
+			status: response.status,
+		};
+	} finally {
+		await new Promise<void>((resolve, reject) =>
+			server.close((error) => (error ? reject(error) : resolve())),
+		);
+	}
+}
+
+describe("readRequestBodyBuffer", () => {
+	it("rejects a cached body that exceeds a later reader's byte budget without rewriting it", async () => {
+		const { inspection: observation } = await withIncomingRequest(
+			"12345678",
+			async (req) => {
+				const first = await readRequestBodyBuffer(req, { maxBytes: 16 });
+				let strictError: unknown;
+				try {
+					await readRequestBodyBuffer(req, { maxBytes: 4 });
+				} catch (error) {
+					strictError = error;
+				}
+				const replay = await readRequestBodyBuffer(req, { maxBytes: 8 });
+				return { first, replay, strictError };
+			},
+		);
+
+		expect(observation.strictError).toBeInstanceOf(ElizaError);
+		expect(observation.strictError).toMatchObject({
+			code: "HTTP_REQUEST_BODY_TOO_LARGE",
+			context: { maxBytes: 4, observedBytes: 8 },
+		});
+		expect(observation.first?.toString("utf8")).toBe("12345678");
+		expect(observation.replay?.toString("utf8")).toBe("12345678");
+	});
+
+	it("returns null for an oversized cached body only when explicitly requested", async () => {
+		const { inspection: observation } = await withIncomingRequest(
+			"cached",
+			async (req) => {
+				await readRequestBodyBuffer(req, { maxBytes: 16 });
+				const strict = await readRequestBodyBuffer(req, {
+					maxBytes: 3,
+					returnNullOnTooLarge: true,
+				});
+				const replay = await readRequestBodyBuffer(req, { maxBytes: 6 });
+				return { replay, strict };
+			},
+		);
+
+		expect(observation.strict).toBeNull();
+		expect(observation.replay?.toString("utf8")).toBe("cached");
+	});
+
+	it("uses the same typed rejection for a first read over budget", async () => {
+		const { inspection: error } = await withIncomingRequest(
+			"uncached",
+			async (req) => {
+				try {
+					await readRequestBodyBuffer(req, { maxBytes: 4 });
+					return null;
+				} catch (caught) {
+					return caught;
+				}
+			},
+		);
+
+		expect(error).toBeInstanceOf(ElizaError);
+		expect(error).toMatchObject({
+			code: "HTTP_REQUEST_BODY_TOO_LARGE",
+			context: { maxBytes: 4, observedBytes: 8 },
+		});
+	});
+
+	it("rechecks a cached JSON body's byte budget before returning parsed data", async () => {
+		const outcome = await withIncomingRequest(
+			'{"message":"complete"}',
+			async (req, res) => {
+				const first = await readJsonBody(req, res, { maxBytes: 64 });
+				const strict = await readJsonBody(req, res, {
+					maxBytes: 4,
+					readErrorMessage: "Request body exceeds this route's limit",
+				});
+				return { first, strict };
+			},
+		);
+
+		expect(outcome.inspection.first).toEqual({ message: "complete" });
+		expect(outcome.inspection.strict).toBeNull();
+		expect(outcome.status).toBe(413);
+		expect(outcome.responseBody).toBe(
+			JSON.stringify({ error: "Request body exceeds this route's limit" }),
+		);
+	});
+});

--- a/packages/core/src/api/http-helpers.ts
+++ b/packages/core/src/api/http-helpers.ts
@@ -6,6 +6,7 @@
  * so several handlers can read one body without re-consuming the stream.
  */
 import type http from "node:http";
+import { ElizaError } from "../errors.js";
 import { logger } from "../logger.js";
 
 const CACHED_REQUEST_BODY = Symbol.for("eliza.http.cachedRequestBody");
@@ -41,6 +42,18 @@ function defaultTooLargeMessage(maxBytes: number, explicit?: string): string {
 	return explicit ?? `Request body exceeds maximum size (${maxBytes} bytes)`;
 }
 
+function requestBodyTooLargeError(
+	maxBytes: number,
+	observedBytes: number,
+	explicitMessage?: string,
+): ElizaError {
+	return new ElizaError(defaultTooLargeMessage(maxBytes, explicitMessage), {
+		code: "HTTP_REQUEST_BODY_TOO_LARGE",
+		context: { maxBytes, observedBytes },
+		severity: "ephemeral",
+	});
+}
+
 export async function readRequestBodyBuffer(
 	req: http.IncomingMessage,
 	{
@@ -53,6 +66,10 @@ export async function readRequestBodyBuffer(
 ): Promise<Buffer | null> {
 	const cached = (req as CachedRequest)[CACHED_REQUEST_BODY];
 	if (cached) {
+		if (cached.length > maxBytes) {
+			if (returnNullOnTooLarge) return null;
+			throw requestBodyTooLargeError(maxBytes, cached.length, tooLargeMessage);
+		}
 		return cached;
 	}
 
@@ -61,8 +78,6 @@ export async function readRequestBodyBuffer(
 		let totalBytes = 0;
 		let tooLarge = false;
 		let settled = false;
-
-		const message = defaultTooLargeMessage(maxBytes, tooLargeMessage);
 
 		const cleanup = (): void => {
 			req.off("data", onData);
@@ -98,7 +113,7 @@ export async function readRequestBodyBuffer(
 				}
 				if (destroyOnTooLarge) {
 					req.destroy();
-					fail(new Error(message));
+					fail(requestBodyTooLargeError(maxBytes, totalBytes, tooLargeMessage));
 					return;
 				}
 				return;
@@ -114,7 +129,7 @@ export async function readRequestBodyBuffer(
 					return;
 				}
 
-				fail(new Error(message));
+				fail(requestBodyTooLargeError(maxBytes, totalBytes, tooLargeMessage));
 				return;
 			}
 
@@ -249,18 +264,6 @@ export async function readJsonBody<T = Record<string, unknown>>(
 	}: ReadJsonBodyOptions = {},
 ): Promise<T | null> {
 	const cachedRequest = req as CachedRequest;
-	if (CACHED_JSON_BODY in cachedRequest) {
-		const parsed = cachedRequest[CACHED_JSON_BODY];
-		if (
-			requireObject &&
-			(parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
-		) {
-			await writeJsonError(res, nonObjectMessage, nonObjectStatus);
-			return null;
-		}
-		return parsed as T;
-	}
-
 	let raw: string;
 	try {
 		const body = await readRequestBody(req, readOptions);
@@ -274,6 +277,18 @@ export async function readJsonBody<T = Record<string, unknown>>(
 		// structured client response.
 		await writeJsonError(res, readErrorMessage, readErrorStatus);
 		return null;
+	}
+
+	if (CACHED_JSON_BODY in cachedRequest) {
+		const parsed = cachedRequest[CACHED_JSON_BODY];
+		if (
+			requireObject &&
+			(parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+		) {
+			await writeJsonError(res, nonObjectMessage, nonObjectStatus);
+			return null;
+		}
+		return parsed as T;
 	}
 
 	try {


### PR DESCRIPTION
# Relates to

Closes #24573.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated root-gate blocker is recorded below.
- [x] A reviewer can confirm the behavior from the real-HTTP regression and control evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `4462c779dcb0914de10088cd3b7a193fc53fe6b3`; zero conflicts.
- [x] `bun run verify` was run; its unrelated workspace-resolution blocker is documented in **Known gaps / failures**.

# Risks

Low. The change is confined to shared request-body readers. Routes that read the same request more than once now enforce each reader's declared byte budget; callers using the explicit `returnNullOnTooLarge` mode retain that behavior. Valid admitted bodies are neither truncated nor rewritten.

# Background

## What does this PR do?

`readRequestBodyBuffer` memoizes a consumed request so multiple helpers can safely reuse it. Before this change, a permissive first read authorized every later read: an 8-byte body cached under a 16-byte limit was returned unchanged to a reader declaring a 4-byte limit. `readJsonBody` had the same bypass because its parsed-value cache returned before the raw-body limit check.

This PR:

- enforces the current reader's `maxBytes` against memoized bytes;
- throws `ElizaError` with code `HTTP_REQUEST_BODY_TOO_LARGE` and `{ maxBytes, observedBytes }` for rejecting readers;
- preserves explicit `returnNullOnTooLarge` semantics;
- checks the raw-body budget before returning cached parsed JSON; and
- preserves the complete memoized body for any later reader whose budget admits it.

## What kind of change is this?

Bug fix (non-breaking security and correctness hardening).

# Documentation changes needed?

No. This restores the byte-limit contract already expressed by the helper options and does not add a public configuration surface.

# Testing

## Where should a reviewer start?

Start with `packages/core/src/api/http-helpers.test.ts`. Its real Node HTTP server exercises an actual `IncomingMessage`, not a request mock.

## Detailed testing steps

```bash
bun run --cwd packages/core test src/api/http-helpers.test.ts
bun run --cwd packages/core typecheck
bunx biome check packages/core/src/api/http-helpers.ts packages/core/src/api/http-helpers.test.ts
bun run --cwd packages/core build:node
bun run --cwd packages/core build
```

Expected exact-head results: 1 test file and 4 tests pass; typecheck and Biome pass; Node-only and complete Node/browser/edge/Vite packaging builds pass.

The load-bearing control restored the exact `origin/develop` implementation while retaining the new tests: 1 file failed and all 4 tests failed. Restoring this patch made all 4 pass. A six-case valid-input corpus (empty, one byte, exact limit, UTF-8, JSON, multiline) produced byte-identical full-body hex on origin and this branch.

# Evidence Gate

Evidence matches the exact commit below.
<!-- evidence-head:aa219da0414a7c32d2dd69fd1ad8f60a6b1e4ddd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a server-side request helper with no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the helper emits no success-path log; its real HTTP request/response observations are included below instead.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, model, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real HTTP regression and losslessness artifacts are included inline below.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text exists in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model path changed.

## Backend + frontend logs

Backend structured logs: N/A - this low-level reader does not log successful reads. The deterministic real-server observations were:

```text
origin: first read (max 16) = 8 bytes; second read (max 4) = resolved 8 bytes
patched: first read (max 16) = 8 bytes; second read (max 4) = HTTP_REQUEST_BODY_TOO_LARGE
patched replay (max 8) = original 8 bytes unchanged
patched cached JSON strict read = HTTP 413 with the route's configured error message
```

Frontend logs: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Domain artifacts

```text
origin source + new tests: 1 file failed, 4 tests failed
patched exact head:          1 file passed, 4 tests passed
valid-body corpus:           6/6 origin/branch outputs byte-identical
package typecheck:           exit 0
Biome (2 touched files):     exit 0
Node-only build:             exit 0
Node/browser/edge/Vite build: exit 0
```

## Known gaps / failures

- `bun run verify` was run post-sync and exited 1 in `audit:tsconfig-workspace-resolution`: 16 unrelated plugin workspaces cannot resolve `@elizaos/capacitor-secure-store`, imported by `packages/ui/src/bridge/storage-bridge.ts`. No reported violation touches `packages/core/src/api`.
- The full `packages/core` suite exposed numerous unrelated baseline failures (including Stage1 snapshots, action retrieval, provider cancellation, trajectory sanitization, document access-control, and prompt suites) and then remained open; it was stopped. The new focused real-HTTP suite, package typecheck, Biome, and both package builds pass at the exact PR head.
- This is a fork contribution, so hosted CI does not run on the PR. No claim of hosted-CI success is made.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [core-api-http-body-cache-budget]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0ND1W0V3W7ST5TRCWXG2VQB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T18:52:11.164Z","completed_at":"2026-08-22T19:42:20.641Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T18:52:25.252Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c7fbf9c885df057b20a0e6f599c1e6ef4a341307de9f487b54aea3d7cad9020b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"96aa4f71-c547-4f08-bd24-620b2a100d5f","object_id":"sha256:c7fbf9c885df057b20a0e6f599c1e6ef4a341307de9f487b54aea3d7cad9020b","sha256":"c7fbf9c885df057b20a0e6f599c1e6ef4a341307de9f487b54aea3d7cad9020b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"MasJd7NAPajoolv3ubkrYJXkYRWxQuN2CDm9RR8leaFScfqMhijUwASr4eUg1T2zgb7-ejXTrRsVDO7-E1kzBA"}} -->
