### PR TITLE
test(agent): cover overlay-app presence heartbeat

### DIFF
--- a/packages/agent/src/services/__tests__/overlay-app-presence.test.ts
+++ b/packages/agent/src/services/__tests__/overlay-app-presence.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OVERLAY_APP_PRESENCE_TTL_MS,
+  isOverlayAppPresenceActive,
+  setOverlayAppPresence,
+} from "./overlay-app-presence.ts";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setOverlayAppPresence(null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("overlay-app-presence", () => {
+  it("reports active for the same app within TTL", () => {
+    vi.setSystemTime(1_000_000);
+    setOverlayAppPresence("companion");
+    vi.setSystemTime(1_000_000 + OVERLAY_APP_PRESENCE_TTL_MS - 1);
+    expect(isOverlayAppPresenceActive("companion")).toBe(true);
+  });
+
+  it("expires after the TTL", () => {
+    vi.setSystemTime(1_000_000);
+    setOverlayAppPresence("companion");
+    vi.setSystemTime(1_000_000 + OVERLAY_APP_PRESENCE_TTL_MS + 1);
+    expect(isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("is inactive for a different app name", () => {
+    setOverlayAppPresence("companion");
+    expect(isOverlayAppPresenceActive("other")).toBe(false);
+  });
+
+  it("is inactive with no presence reported", () => {
+    expect(isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("clearing presence (null) makes it inactive", () => {
+    setOverlayAppPresence("companion");
+    setOverlayAppPresence(null);
+    expect(isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("blank names are treated as cleared", () => {
+    setOverlayAppPresence("   ");
+    expect(isOverlayAppPresenceActive("companion")).toBe(false);
+  });
+
+  it("honors a custom max age", () => {
+    vi.setSystemTime(1_000_000);
+    setOverlayAppPresence("companion");
+    vi.setSystemTime(1_000_000 + 5_000);
+    expect(isOverlayAppPresenceActive("companion", 10_000)).toBe(true);
+    expect(isOverlayAppPresenceActive("companion", 1_000)).toBe(false);
+  });
+});

--- a/packages/agent/src/services/__tests__/overlay-app-presence.test.ts
+++ b/packages/agent/src/services/__tests__/overlay-app-presence.test.ts
@@ -1,9 +1,14 @@
+/**
+ * Deterministic unit coverage for the in-memory overlay-app heartbeat state.
+ * Fake time isolates TTL boundaries without exercising the HTTP route.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  OVERLAY_APP_PRESENCE_TTL_MS,
   isOverlayAppPresenceActive,
+  OVERLAY_APP_PRESENCE_TTL_MS,
   setOverlayAppPresence,
-} from "./overlay-app-presence.ts";
+} from "../overlay-app-presence.ts";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -18,7 +23,7 @@ describe("overlay-app-presence", () => {
   it("reports active for the same app within TTL", () => {
     vi.setSystemTime(1_000_000);
     setOverlayAppPresence("companion");
-    vi.setSystemTime(1_000_000 + OVERLAY_APP_PRESENCE_TTL_MS - 1);
+    vi.setSystemTime(1_000_000 + OVERLAY_APP_PRESENCE_TTL_MS);
     expect(isOverlayAppPresenceActive("companion")).toBe(true);
   });
 


### PR DESCRIPTION
# Summary

Supersedes #24581 because the maintainer-enabled fork rejected updates. The original implementation commit remains authored by @HarukaMa and preserved as the first commit.

Adds deterministic unit coverage for overlay-app presence state: active TTL, exact inclusive boundary, expiry, different app, empty state, null/blank clearing, and custom maximum age.

The restack repairs two blockers in the original head: its import targeted a nonexistent module inside `__tests__`, and Biome rejected its import order. It also adds the repository-required test header.

# Verification

Exact head: `dc492489ec89a54fad8392974b7288621760998e`
Restack base: `4822e0331de69b1cc714e6e9a13f7b4ac171493f`

- `bun install --frozen-lockfile`: passed
- `node packages/shared/scripts/generate-keywords.mjs`: passed
- `bunx vitest run src/services/__tests__/overlay-app-presence.test.ts` from `packages/agent`: 1 file, 7 tests passed
- `bunx @biomejs/biome check src/services/__tests__/overlay-app-presence.test.ts`: clean
- full `packages/agent` lint completed successfully with unrelated existing warnings only
- direct package typecheck reached existing unbuilt-workspace declaration failures in capacitor bridge, wallet, optional plugins, cloud routing, and todos; no error referenced the changed test. Hosted affected-workspace CI is required before merge.
- `git diff --check`: passed

No UI, prompt/model/action, persistence, transport, or production behavior changes. Screenshots, video, runtime logs, and LLM trajectories are N/A.

Original contributor disclosure from #24581: Hermes Agent; deepseek/deepseek-v4-flash. Maintainer restack used OpenAI Codex.