### PR TITLE
fix(core): zero-delivery recovery must not fabricate a failed-steps report on a toolless turn

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -4036,9 +4036,11 @@ describe("runV5MessageRuntimeStage1", () => {
 	it("keeps the planner prompt byte-identical on an addressed group turn (no ambient policy, no terminal conversion)", async () => {
 		// Addressed branch pin (same pattern as the memory-surface branch
 		// tests): a platform mention makes the turn addressed, so the
-		// ambient-turn policy must not render and a planner IGNORE keeps
-		// today's planned-reply "none" outcome instead of the ambient terminal
-		// conversion.
+		// ambient-turn policy must not render and the ambient silent-terminal
+		// conversion must not fire. The addressed turn-delivery floor
+		// (#23223) still answers: a toolless planner IGNORE recovers with the
+		// honest zero-action fallback — never silence, and never a fabricated
+		// "I ran the steps … they failed" report for steps that never ran.
 		const runtime = makeRuntime([
 			stage1Response({
 				thought: "Addressed follow-up; see if the planner has anything.",
@@ -4071,8 +4073,12 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(plannerContent).not.toContain("ambient_turn_policy");
 		expect(result.kind).toBe("planned_reply");
 		if (result.kind === "planned_reply") {
-			expect(result.result.responseContent).toBeNull();
-			expect(result.result.mode).toBe("none");
+			const text = result.result.responseContent?.text ?? "";
+			expect(text).toBe(
+				"I don't have a useful answer to that right now — ask again and I will retry.",
+			);
+			// Effect honesty: nothing ran this turn, so no failure narrative.
+			expect(text).not.toMatch(/ran the steps|failed/i);
 		}
 	});
 
@@ -5135,6 +5141,36 @@ describe("runV5MessageRuntimeStage1", () => {
 		// Pure decision seam: the exact source precedence, ack suppression,
 		// failure-aware wording, and the async-handoff silence gate.
 		describe("resolveZeroDeliveryRecovery", () => {
+			it("never fabricates a failed-steps report on a toolless turn", () => {
+				// Effect honesty: with no action results at all, the fallback must
+				// not claim "I ran the steps … they failed".
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [],
+					stageOneAck: "",
+					earlyReplySent: false,
+				});
+				expect(decision.recover).toBe(true);
+				expect(decision.source).toBe("fallbackText");
+				expect(decision.text).toBe(
+					"I don't have a useful answer to that right now — ask again and I will retry.",
+				);
+				expect(decision.text).not.toMatch(/ran the steps|failed/i);
+			});
+
+			it("keeps the failed-steps fallback when failed steps actually ran", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: false }],
+					stageOneAck: "",
+					earlyReplySent: false,
+				});
+				expect(decision.recover).toBe(true);
+				expect(decision.text).toContain(
+					"I ran the steps for that but they failed",
+				);
+			});
+
 			it("prefers surviving planner text over everything else", () => {
 				const decision = resolveZeroDeliveryRecovery({
 					plannedText: "The check passed on retry.",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1855,17 +1855,19 @@ export type ZeroDeliveryRecoverySource =
 	| "fallbackText";
 
 /**
- * Decides whether — and with what text — a RESPOND turn that ran tools but
- * delivered nothing terminal recovers instead of ending silent (#20083,
- * corrected by #20086). Source precedence: the planner's surviving terminal
- * text, then the last explicit action-owned `userFacingText`, then the
- * Stage-1 ack ONLY when no early ack already shipped it, then a hardcoded
- * fallback whose wording is failure-aware — it claims completion only when at
- * least one tool actually succeeded. After an early progress ack the turn
- * recovers only when grounded text exists or any tool failed: a successful
- * async handoff reports through a later completion relay, so manufacturing a
- * "finished" line behind its ack would be a lie, while a failed handoff will
- * never relay anything and the ack's promise must be corrected.
+ * Decides whether — and with what text — a turn that owes the user a terminal
+ * response but delivered nothing recovers instead of ending silent (#20083,
+ * corrected by #20086). The turn may have run tools or may be an addressed,
+ * toolless turn covered by the delivery floor. Source precedence is the
+ * planner's surviving terminal text, then the last explicit action-owned
+ * `userFacingText`, then the Stage-1 ack ONLY when no early ack already shipped
+ * it, then a hardcoded fallback. Fallback wording is effect-aware: it claims
+ * completion only when a tool succeeded, failure only when a tool ran, and
+ * otherwise gives a neutral no-answer response. After an early progress ack,
+ * the turn recovers only when grounded text exists or any tool failed: a
+ * successful async handoff reports through a later completion relay, so
+ * manufacturing a "finished" line behind its ack would be a lie, while a failed
+ * handoff will never relay anything and the ack's promise must be corrected.
  * `plannedText` must arrive pre-blanked when it merely repeats the early ack.
  */
 export function resolveZeroDeliveryRecovery(args: {
@@ -1898,12 +1900,19 @@ export function resolveZeroDeliveryRecovery(args: {
 			.filter((ownedText) => ownedText.length > 0)
 			.at(-1) ?? "";
 	const ackRecoveryText = args.earlyReplySent ? "" : args.stageOneAck;
+	const ranAnySteps = args.actionResults.length > 0;
+	// Effect honesty: the failure-flavored fallbacks may only describe steps
+	// that actually ran. A toolless turn (planner ended with no tool calls —
+	// e.g. a deliberate IGNORE on an addressed turn the delivery floor still
+	// answers) must not fabricate "I ran the steps … they failed".
 	const fallbackRecoveryText =
 		actionSuccessCount > 0 && actionFailureCount > 0
 			? "Some steps completed and some failed, but I could not produce a reliable summary. Check the current state before deciding whether to retry."
 			: actionSuccessCount > 0
 				? "The requested steps completed, but I could not produce a reliable summary. Check the current state before retrying."
-				: "I ran the steps for that but they failed, and I could not compose a useful report — ask again and I will retry.";
+				: ranAnySteps
+					? "I ran the steps for that but they failed, and I could not compose a useful report — ask again and I will retry."
+					: "I don't have a useful answer to that right now — ask again and I will retry.";
 	const text =
 		args.plannedText ||
 		lastActionUserFacingText ||


### PR DESCRIPTION
Companion to #24603 (the other develop-gate breakage in `message-runtime-stage1.test.ts` was behavioral, so it gets its own PR):

#23223's never-silent zero-delivery recovery answers an addressed turn that reached the reply gate with zero deliveries. When **no actions ran at all** — e.g. a toolless planner IGNORE that the addressed delivery floor still answers — the fallback claimed *"I ran the steps for that but they failed, and I could not compose a useful report"*: a fabricated failure report for steps that never existed.

- `resolveZeroDeliveryRecovery` now uses an honest zero-action fallback ("I don't have a useful answer to that right now — ask again and I will retry."); the failure-flavored copy is reserved for turns where failed steps actually ran.
- The stale addressed-group-turn pin (it still expected the pre-floor silent `mode: "none"` outcome and fails on develop) now asserts the delivery floor answers with the honest fallback and never a failure narrative.
- Direct unit pins for both `resolveZeroDeliveryRecovery` branches.

`message-runtime-stage1.test.ts`: 164/164 green (was 2 failing on develop, one of them order-polluting a third).

cc @lalalune

🤖 Generated with [Claude Code](https://claude.com/claude-code)
