### PR TITLE
fix(plugin-x): retry only transient repeat-safe reads

### DIFF
--- a/plugins/plugin-x/src/base.read-retry-policy.test.ts
+++ b/plugins/plugin-x/src/base.read-retry-policy.test.ts
@@ -1,0 +1,205 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ClientBase, RequestQueue, type TwitterProfile } from "./base";
+import { SearchMode } from "./client";
+import type { TwitterAuth } from "./client/auth";
+import { getProfile } from "./client/profile";
+import type { TwitterClientState } from "./types";
+import { TwitterError, TwitterErrorType } from "./utils/error-handler";
+
+const PROFILE = {
+  userId: "user-1",
+  username: "alice",
+  name: "Alice",
+  biography: "",
+  location: "",
+};
+
+function makeClient() {
+  const reportError = vi.fn();
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    character: { name: "Agent" },
+    getSetting: () => undefined,
+    getCache: vi.fn(async () => undefined),
+    setCache: vi.fn(async () => true),
+    reportError,
+  } as unknown as IAgentRuntime;
+  const client = new ClientBase(runtime, {
+    accountId: "default",
+  } as TwitterClientState);
+  client.requestQueue = new RequestQueue({
+    backoff: async () => undefined,
+    jitter: async () => undefined,
+  });
+  return { client, reportError };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ClientBase typed read retry boundaries", () => {
+  it.each([
+    ["structured 429", { response: { status: 429 } }],
+    [
+      "network errno",
+      Object.assign(new Error("socket closed"), { code: "ECONNRESET" }),
+    ],
+  ])(
+    "retries a transient %s provider failure",
+    async (_label, providerError) => {
+      const { client } = makeClient();
+      const getProfileMock = vi
+        .fn()
+        .mockRejectedValueOnce(providerError)
+        .mockResolvedValue(PROFILE);
+      client.twitterClient = {
+        getProfile: getProfileMock,
+      } as unknown as ClientBase["twitterClient"];
+
+      await expect(client.fetchProfile("alice")).resolves.toMatchObject({
+        id: "user-1",
+      });
+      expect(getProfileMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([
+    ["authentication", { response: { status: 401 } }, TwitterErrorType.AUTH],
+    ["validation", { response: { status: 400 } }, TwitterErrorType.VALIDATION],
+  ])(
+    "types and does not retry a structured %s failure",
+    async (_label, providerError, errorType) => {
+      const { client } = makeClient();
+      const getProfileMock = vi.fn().mockRejectedValue(providerError);
+      client.twitterClient = {
+        getProfile: getProfileMock,
+      } as unknown as ClientBase["twitterClient"];
+
+      await expect(client.fetchProfile("alice")).rejects.toMatchObject({
+        type: errorType,
+      });
+      expect(getProfileMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not retry arbitrary prose that resembles a rate limit", async () => {
+    const { client } = makeClient();
+    const getProfileMock = vi
+      .fn()
+      .mockRejectedValue(new Error("HTTP 429 rate limited"));
+    client.twitterClient = {
+      getProfile: getProfileMock,
+    } as unknown as ClientBase["twitterClient"];
+
+    await expect(client.fetchProfile("alice")).rejects.toThrow(
+      "HTTP 429 rate limited",
+    );
+    expect(getProfileMock).toHaveBeenCalledOnce();
+  });
+
+  it("gives every provider retry its own timeout without overlapping a timed-out read", async () => {
+    vi.useFakeTimers();
+    const { client } = makeClient();
+    const fetchSearchTweets = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            setTimeout(
+              () =>
+                reject(
+                  new TwitterError(
+                    TwitterErrorType.NETWORK,
+                    "temporary network failure",
+                  ),
+                ),
+              10_000,
+            );
+          }),
+      )
+      .mockImplementationOnce(() => new Promise(() => undefined));
+    client.twitterClient = {
+      fetchSearchTweets,
+    } as unknown as ClientBase["twitterClient"];
+
+    const search = client.fetchSearchTweets("query", 10, SearchMode.Latest);
+    let settled = false;
+    void search.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(search).rejects.toMatchObject({ code: "X_SEARCH_TIMEOUT" });
+    expect(fetchSearchTweets).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports and throws an exhausted interactions read instead of returning an empty list", async () => {
+    const { client, reportError } = makeClient();
+    const providerError = new TwitterError(
+      TwitterErrorType.AUTH,
+      "credentials rejected",
+    );
+    client.twitterClient = {
+      fetchSearchTweets: vi.fn().mockRejectedValue(providerError),
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = vi.fn(async (operation) =>
+      operation({
+        profile: {
+          id: "bot-1",
+          username: "bot",
+          screenName: "Bot",
+          bio: "",
+          nicknames: [],
+        } satisfies TwitterProfile,
+      } as never),
+    );
+
+    await expect(client.fetchInteractions()).rejects.toMatchObject({
+      code: "X_INTERACTIONS_FAILED",
+      cause: providerError,
+    });
+    expect(reportError).toHaveBeenCalledWith(
+      "XClientBase.getInteractions",
+      providerError,
+    );
+  });
+});
+
+describe("profile provider error preservation", () => {
+  it("returns a typed error that retains the original structured provider failure", async () => {
+    const providerError = { response: { status: 429 }, detail: "quota" };
+    const auth = {
+      getV2Client: vi.fn(async () => ({
+        v2: {
+          userByUsername: vi.fn().mockRejectedValue(providerError),
+        },
+      })),
+    } as unknown as TwitterAuth;
+
+    const result = await getProfile("alice", auth);
+
+    expect(result).toMatchObject({
+      success: false,
+      err: {
+        type: TwitterErrorType.RATE_LIMIT,
+        originalError: providerError,
+      },
+    });
+    if (!result.success) {
+      expect(result.err).toBeInstanceOf(TwitterError);
+    }
+  });
+});

--- a/plugins/plugin-x/src/base.read-retry-policy.test.ts
+++ b/plugins/plugin-x/src/base.read-retry-policy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Exercises the real ClientBase read boundaries with typed provider failures,
+ * deterministic queue waits, and mocked X transport methods.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClientBase, RequestQueue, type TwitterProfile } from "./base";

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -38,6 +38,11 @@ import {
   type TwitterInteractionPayload,
 } from "./types";
 import {
+  getTwitterProviderStatus,
+  normalizeTwitterProviderError,
+  TwitterErrorType,
+} from "./utils/error-handler";
+import {
   buildTwitterMessageMetadata,
   createMemorySafe,
   reconcileTwitterWorld,
@@ -148,9 +153,17 @@ export function resolveMaxAuthRetries(raw: string | undefined): number {
  * Class representing a request queue for handling asynchronous requests in a controlled manner.
  */
 
+export type RequestRetryPolicy = { kind: "never" } | { kind: "transient-read" };
+
+export const NO_REQUEST_RETRY: RequestRetryPolicy = { kind: "never" };
+export const RETRY_TRANSIENT_X_READ: RequestRetryPolicy = {
+  kind: "transient-read",
+};
+
 type QueuedItem = {
   run: () => Promise<void>;
   reject: (error: unknown) => void;
+  retryPolicy: RequestRetryPolicy;
 };
 
 export class RequestQueue {
@@ -173,7 +186,10 @@ export class RequestQueue {
    * @param {() => Promise<T>} request - The request to be added to the queue
    * @returns {Promise<T>} - A promise that resolves with the result of the request or rejects with an error
    */
-  async add<T>(request: () => Promise<T>): Promise<T> {
+  async add<T>(
+    request: () => Promise<T>,
+    retryPolicy: RequestRetryPolicy = NO_REQUEST_RETRY,
+  ): Promise<T> {
     return new Promise((resolve, reject) => {
       this.queue.push({
         run: async () => {
@@ -181,6 +197,7 @@ export class RequestQueue {
           resolve(result);
         },
         reject,
+        retryPolicy,
       });
       void this.processQueue();
     });
@@ -197,36 +214,65 @@ export class RequestQueue {
     }
     this.processing = true;
 
-    while (this.queue.length > 0) {
-      const item = this.queue.shift();
-      if (!item) break;
-      try {
-        await item.run();
-        this.retryAttempts.delete(item);
-      } catch (error) {
-        logger.error("Error processing request:", errorDetail(error));
+    try {
+      while (this.queue.length > 0) {
+        const item = this.queue.shift();
+        if (!item) break;
+        try {
+          await item.run();
+          this.retryAttempts.delete(item);
+        } catch (error) {
+          logger.error("Error processing request:", errorDetail(error));
 
-        const retryCount = (this.retryAttempts.get(item) || 0) + 1;
+          const retryCount = (this.retryAttempts.get(item) || 0) + 1;
+          const typedProviderError =
+            item.retryPolicy.kind === "transient-read"
+              ? normalizeTwitterProviderError(error)
+              : null;
+          const requestError = typedProviderError ?? error;
+          const shouldRetry =
+            item.retryPolicy.kind === "transient-read" &&
+            (typedProviderError?.type === TwitterErrorType.RATE_LIMIT ||
+              typedProviderError?.type === TwitterErrorType.NETWORK);
 
-        if (retryCount < this.maxRetries) {
-          this.retryAttempts.set(item, retryCount);
-          this.queue.unshift(item);
-          await this.exponentialBackoff(retryCount);
-          continue;
+          if (shouldRetry && retryCount < this.maxRetries) {
+            this.retryAttempts.set(item, retryCount);
+            try {
+              await this.exponentialBackoff(retryCount);
+              this.queue.unshift(item);
+            } catch (delayError) {
+              this.retryAttempts.delete(item);
+              item.reject(
+                new ElizaError("X request retry delay failed", {
+                  code: "X_REQUEST_RETRY_DELAY_FAILED",
+                  cause: delayError,
+                }),
+              );
+            }
+            continue;
+          }
+          if (shouldRetry) {
+            logger.error(
+              `Max retries (${this.maxRetries}) exceeded for request`,
+            );
+          }
+          this.retryAttempts.delete(item);
+          item.reject(requestError);
         }
-        logger.error(
-          `Max retries (${this.maxRetries}) exceeded for request, skipping`,
-        );
-        this.retryAttempts.delete(item);
-        item.reject(error);
+        try {
+          await this.randomDelay();
+        } catch (delayError) {
+          logger.warn(
+            "Request queue pacing delay failed; continuing without delay:",
+            errorDetail(delayError),
+          );
+        }
       }
-      await this.randomDelay();
-    }
-
-    this.processing = false;
-
-    if (this.queue.length > 0) {
-      void this.processQueue();
+    } finally {
+      this.processing = false;
+      if (this.queue.length > 0) {
+        void this.processQueue();
+      }
     }
   }
 
@@ -350,8 +396,9 @@ export class ClientBase {
       return cachedTweet;
     }
 
-    const tweet = await this.requestQueue.add(() =>
-      this.twitterClient.getTweet(tweetId),
+    const tweet = await this.requestQueue.add(
+      () => this.twitterClient.getTweet(tweetId),
+      RETRY_TRANSIENT_X_READ,
     );
 
     if (!tweet) {
@@ -684,30 +731,34 @@ export class ClientBase {
     searchMode: SearchMode,
     cursor?: string,
   ): Promise<QueryTweetsResponse> {
-    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
-      const timeoutPromise = new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(
-          () =>
-            reject(
-              new ElizaError("X search timed out", {
-                code: "X_SEARCH_TIMEOUT",
-              }),
+      const result = await this.requestQueue.add(async () => {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(
+                new ElizaError("X search timed out", {
+                  code: "X_SEARCH_TIMEOUT",
+                }),
+              ),
+            15_000,
+          );
+        });
+        try {
+          return await Promise.race([
+            this.twitterClient.fetchSearchTweets(
+              query,
+              maxTweets,
+              searchMode,
+              cursor,
             ),
-          15_000,
-        );
-      });
-      const result = await this.requestQueue.add(() =>
-        Promise.race([
-          this.twitterClient.fetchSearchTweets(
-            query,
-            maxTweets,
-            searchMode,
-            cursor,
-          ),
-          timeoutPromise,
-        ]),
-      );
+            timeoutPromise,
+          ]);
+        } finally {
+          if (timeout) clearTimeout(timeout);
+        }
+      }, RETRY_TRANSIENT_X_READ);
       if (!result) {
         throw new ElizaError("X search returned no response", {
           code: "X_SEARCH_RESPONSE_INVALID",
@@ -722,8 +773,6 @@ export class ClientBase {
         code: "X_SEARCH_FAILED",
         cause: error,
       });
-    } finally {
-      if (timeout) clearTimeout(timeout);
     }
   }
 
@@ -1145,23 +1194,11 @@ export class ClientBase {
           bio: profile.biography || characterBio,
           nicknames: [],
         } satisfies TwitterProfile;
-      });
+      }, RETRY_TRANSIENT_X_READ);
 
       return profile;
     } catch (error) {
-      const candidate =
-        typeof error === "object" && error !== null
-          ? (error as {
-              code?: unknown;
-              status?: unknown;
-              statusCode?: unknown;
-            })
-          : null;
-      const status = [
-        candidate?.code,
-        candidate?.status,
-        candidate?.statusCode,
-      ].find((value): value is number => typeof value === "number");
+      const status = getTwitterProviderStatus(error);
       if (status === 404) {
         throw new ElizaError(`X profile @${username} was not found`, {
           code: "X_PROFILE_NOT_FOUND",
@@ -1181,12 +1218,14 @@ export class ClientBase {
     try {
       return await this.withAuthenticatedSession(async ({ profile }) => {
         // Use fetchSearchTweets to get mentions instead of the non-existent get method
-        const mentionsResponse = await this.requestQueue.add(() =>
-          this.twitterClient.fetchSearchTweets(
-            `@${profile.username}`,
-            100,
-            SearchMode.Latest,
-          ),
+        const mentionsResponse = await this.requestQueue.add(
+          () =>
+            this.twitterClient.fetchSearchTweets(
+              `@${profile.username}`,
+              100,
+              SearchMode.Latest,
+            ),
+          RETRY_TRANSIENT_X_READ,
         );
 
         // Process tweets directly into the expected interaction format
@@ -1195,11 +1234,14 @@ export class ClientBase {
         );
       });
     } catch (error) {
-      // error-policy:J7 a mentions/interactions fetch failure must surface to the
-      // agent rather than reading as no interactions; degrade to an empty list
-      // after reporting.
+      // A failed read is not an empty interaction set. Preserve the provider
+      // failure and reject explicitly so callers cannot advance on fabricated
+      // absence.
       this.runtime.reportError("XClientBase.getInteractions", error);
-      return [];
+      throw new ElizaError("Failed to fetch X interactions", {
+        code: "X_INTERACTIONS_FAILED",
+        cause: error,
+      });
     }
   }
 

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -148,13 +148,23 @@ export function resolveMaxAuthRetries(raw: string | undefined): number {
  * Class representing a request queue for handling asynchronous requests in a controlled manner.
  */
 
-type QueuedRequest = () => Promise<unknown>;
+type QueuedItem = {
+  run: () => Promise<void>;
+  reject: (error: unknown) => void;
+};
 
-class RequestQueue {
-  private queue: QueuedRequest[] = [];
+export class RequestQueue {
+  private queue: QueuedItem[] = [];
   private processing = false;
   private maxRetries = 3;
-  private retryAttempts = new Map<QueuedRequest, number>();
+  private retryAttempts = new Map<QueuedItem, number>();
+
+  constructor(
+    private readonly waits: {
+      backoff?: (retryCount: number) => Promise<void>;
+      jitter?: () => Promise<void>;
+    } = {},
+  ) {}
 
   /**
    * Asynchronously adds a request to the queue, then processes the queue.
@@ -165,15 +175,14 @@ class RequestQueue {
    */
   async add<T>(request: () => Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
-      this.queue.push(async () => {
-        try {
+      this.queue.push({
+        run: async () => {
           const result = await request();
           resolve(result);
-        } catch (error) {
-          reject(error);
-        }
+        },
+        reject,
       });
-      this.processQueue();
+      void this.processQueue();
     });
   }
 
@@ -189,38 +198,35 @@ class RequestQueue {
     this.processing = true;
 
     while (this.queue.length > 0) {
-      const request = this.queue.shift();
-      if (!request) break;
+      const item = this.queue.shift();
+      if (!item) break;
       try {
-        await request();
-        // Clear retry count on success
-        this.retryAttempts.delete(request);
+        await item.run();
+        this.retryAttempts.delete(item);
       } catch (error) {
         logger.error("Error processing request:", errorDetail(error));
 
-        const retryCount = (this.retryAttempts.get(request) || 0) + 1;
+        const retryCount = (this.retryAttempts.get(item) || 0) + 1;
 
         if (retryCount < this.maxRetries) {
-          this.retryAttempts.set(request, retryCount);
-          this.queue.unshift(request);
+          this.retryAttempts.set(item, retryCount);
+          this.queue.unshift(item);
           await this.exponentialBackoff(retryCount);
-          // Break the loop to allow exponential backoff to take effect
-          break;
-        } else {
-          logger.error(
-            `Max retries (${this.maxRetries}) exceeded for request, skipping`,
-          );
-          this.retryAttempts.delete(request);
+          continue;
         }
+        logger.error(
+          `Max retries (${this.maxRetries}) exceeded for request, skipping`,
+        );
+        this.retryAttempts.delete(item);
+        item.reject(error);
       }
       await this.randomDelay();
     }
 
     this.processing = false;
 
-    // If there are still items in the queue, restart processing
     if (this.queue.length > 0) {
-      this.processQueue();
+      void this.processQueue();
     }
   }
 
@@ -230,6 +236,10 @@ class RequestQueue {
    * @returns {Promise<void>} - A promise that resolves after a delay based on the retry count.
    */
   private async exponentialBackoff(retryCount: number): Promise<void> {
+    if (this.waits.backoff) {
+      await this.waits.backoff(retryCount);
+      return;
+    }
     const delay = 2 ** retryCount * 1000;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }
@@ -240,6 +250,10 @@ class RequestQueue {
    * @returns A Promise that resolves after the random delay has passed.
    */
   private async randomDelay(): Promise<void> {
+    if (this.waits.jitter) {
+      await this.waits.jitter();
+      return;
+    }
     const delay = Math.floor(Math.random() * 2000) + 1500;
     await new Promise((resolve) => setTimeout(resolve, delay));
   }

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -222,6 +222,8 @@ export class RequestQueue {
           await item.run();
           this.retryAttempts.delete(item);
         } catch (error) {
+          // error-policy:J1 The queue boundary either schedules an authorized
+          // retry or rejects the original caller with the classified failure.
           logger.error("Error processing request:", errorDetail(error));
 
           const retryCount = (this.retryAttempts.get(item) || 0) + 1;
@@ -241,6 +243,8 @@ export class RequestQueue {
               await this.exponentialBackoff(retryCount);
               this.queue.unshift(item);
             } catch (delayError) {
+              // error-policy:J1 A failed retry delay rejects this caller with
+              // a typed queue-boundary failure instead of stranding it.
               this.retryAttempts.delete(item);
               item.reject(
                 new ElizaError("X request retry delay failed", {
@@ -262,10 +266,19 @@ export class RequestQueue {
         try {
           await this.randomDelay();
         } catch (delayError) {
-          logger.warn(
-            "Request queue pacing delay failed; continuing without delay:",
-            errorDetail(delayError),
-          );
+          // error-policy:J1 The queue cannot preserve its pacing contract, so
+          // reject every pending caller rather than dispatching an unpaced
+          // burst or leaving promises stranded.
+          const pacingError = new ElizaError("X request pacing delay failed", {
+            code: "X_REQUEST_PACING_DELAY_FAILED",
+            cause: delayError,
+          });
+          let pending = this.queue.shift();
+          while (pending) {
+            this.retryAttempts.delete(pending);
+            pending.reject(pacingError);
+            pending = this.queue.shift();
+          }
         }
       }
     } finally {

--- a/plugins/plugin-x/src/client/profile.ts
+++ b/plugins/plugin-x/src/client/profile.ts
@@ -1,4 +1,5 @@
 import type { UserV2 } from "twitter-api-v2";
+import { normalizeTwitterProviderError } from "../utils/error-handler";
 import type { RequestApiResult } from "./api-types";
 import type { TwitterAuth } from "./auth";
 import type { TwitterApiErrorRaw } from "./errors";
@@ -263,7 +264,9 @@ export async function getProfile(
     const message = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      err: new Error(message || "Failed to fetch profile"),
+      err:
+        normalizeTwitterProviderError(error) ??
+        new Error(message || "Failed to fetch profile", { cause: error }),
     };
   }
 }

--- a/plugins/plugin-x/src/client/profile.ts
+++ b/plugins/plugin-x/src/client/profile.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves X user profiles through the authenticated API client and converts
+ * provider failures into typed connector errors without exposing credentials.
+ */
+import { ElizaError } from "@elizaos/core";
 import type { UserV2 } from "twitter-api-v2";
 import { normalizeTwitterProviderError } from "../utils/error-handler";
 import type { RequestApiResult } from "./api-types";
@@ -261,12 +266,17 @@ export async function getProfile(
       value: parseV2Profile(user.data),
     };
   } catch (error) {
+    // error-policy:J2 Preserve the provider cause and add profile-operation
+    // context when it is not already a classified X provider failure.
     const message = error instanceof Error ? error.message : String(error);
     return {
       success: false,
       err:
         normalizeTwitterProviderError(error) ??
-        new Error(message || "Failed to fetch profile", { cause: error }),
+        new ElizaError(message || "Failed to fetch profile", {
+          code: "X_PROFILE_FETCH_FAILED",
+          cause: error,
+        }),
     };
   }
 }

--- a/plugins/plugin-x/src/interactions-search-actions.test.ts
+++ b/plugins/plugin-x/src/interactions-search-actions.test.ts
@@ -1,7 +1,7 @@
 /** Unit tests for `TwitterInteractionClient` engagement on search-discovered tweets — like/retweet/quote/none per model choice, plus dry-run; mocked runtime. */
 import { type IAgentRuntime, logger, type UUID } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ClientBase } from "./base";
+import { type ClientBase, NO_REQUEST_RETRY } from "./base";
 import type { Tweet } from "./client";
 import { TwitterInteractionClient } from "./interactions";
 import type { TwitterClientState } from "./types";
@@ -70,6 +70,7 @@ function createClient(
     bio: "",
     nicknames: [],
   };
+  const requestQueueAdd = vi.fn(async (fn: () => Promise<unknown>) => fn());
   const client = {
     accountId: "default",
     runtime,
@@ -114,7 +115,7 @@ function createClient(
         runtime.setCache(`twitter/default/${profile.id}/${suffix}`, value),
     ),
     twitterClient,
-    requestQueue: { add: <T>(fn: () => Promise<T>) => fn() },
+    requestQueue: { add: requestQueueAdd },
     fetchSearchTweets: vi.fn(),
     fetchHomeTimeline: vi.fn(async () => []),
   };
@@ -215,6 +216,10 @@ describe("Twitter search engagement actions", () => {
     expect(twitterClient.sendQuoteTweet).toHaveBeenCalledWith(
       "sharp take, agreed",
       "500",
+    );
+    expect(clientBase.requestQueue.add).toHaveBeenCalledWith(
+      expect.any(Function),
+      NO_REQUEST_RETRY,
     );
     expect(twitterClient.likeTweet).not.toHaveBeenCalled();
     expect(twitterClient.retweet).not.toHaveBeenCalled();

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -21,7 +21,12 @@ import {
   ModelType,
   parseJSONObjectFromText,
 } from "@elizaos/core";
-import type { ClientBase, TwitterAccountSession, TwitterProfile } from "./base";
+import {
+  type ClientBase,
+  NO_REQUEST_RETRY,
+  type TwitterAccountSession,
+  type TwitterProfile,
+} from "./base";
 import { SearchMode } from "./client/index";
 import type { Tweet as ClientTweet } from "./client/tweets";
 import {
@@ -740,8 +745,9 @@ ${tweet.text}`;
       }
 
       this.assertCurrentSession(session);
-      await this.client.requestQueue.add(() =>
-        this.client.twitterClient.sendQuoteTweet(post, tweet.id),
+      await this.client.requestQueue.add(
+        () => this.client.twitterClient.sendQuoteTweet(post, tweet.id),
+        NO_REQUEST_RETRY,
       );
       logger.info(`Quoted tweet ${tweet.id}`);
       return true;

--- a/plugins/plugin-x/src/request-queue.test.ts
+++ b/plugins/plugin-x/src/request-queue.test.ts
@@ -3,13 +3,19 @@
  * reject `add()` on the first failure and skip retry/backoff. The queue now
  * retries, then rejects only after the budget is exhausted.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { ClientBase } from "./base";
+import {
+  ClientBase,
+  NO_REQUEST_RETRY,
+  RETRY_TRANSIENT_X_READ,
+  RequestQueue,
+} from "./base";
 import type { TwitterClientState } from "./types";
+import { TwitterError, TwitterErrorType } from "./utils/error-handler";
 
 function makeClient(): ClientBase {
-  return new ClientBase(
+  const client = new ClientBase(
     {
       agentId: "00000000-0000-0000-0000-000000000001",
       character: { name: "Agent" },
@@ -17,6 +23,11 @@ function makeClient(): ClientBase {
     } as unknown as IAgentRuntime,
     { accountId: "default" } as TwitterClientState,
   );
+  client.requestQueue = new RequestQueue({
+    backoff: async () => undefined,
+    jitter: async () => undefined,
+  });
+  return client;
 }
 
 describe("RequestQueue retries provider failures", () => {
@@ -27,10 +38,13 @@ describe("RequestQueue retries provider failures", () => {
       client.requestQueue.add(async () => {
         calls += 1;
         if (calls < 2) {
-          throw new Error("HTTP 429 rate limited");
+          throw new TwitterError(
+            TwitterErrorType.RATE_LIMIT,
+            "HTTP 429 rate limited",
+          );
         }
         return "ok";
-      }),
+      }, RETRY_TRANSIENT_X_READ),
     ).resolves.toBe("ok");
     expect(calls).toBe(2);
   }, 20_000);
@@ -41,8 +55,11 @@ describe("RequestQueue retries provider failures", () => {
     await expect(
       client.requestQueue.add(async () => {
         calls += 1;
-        throw new Error("HTTP 429 rate limited");
-      }),
+        throw new TwitterError(
+          TwitterErrorType.RATE_LIMIT,
+          "HTTP 429 rate limited",
+        );
+      }, RETRY_TRANSIENT_X_READ),
     ).rejects.toThrow("HTTP 429 rate limited");
     expect(calls).toBe(3);
   }, 20_000);
@@ -57,5 +74,149 @@ describe("RequestQueue retries provider failures", () => {
       }),
     ).resolves.toBe(42);
     expect(calls).toBe(1);
+  });
+
+  it("retries an explicitly retryable read only for a typed transient failure", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => undefined,
+      jitter: async () => undefined,
+    });
+    let calls = 0;
+
+    await expect(
+      queue.add(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new TwitterError(
+            TwitterErrorType.RATE_LIMIT,
+            "X read was rate limited",
+          );
+        }
+        return "ok";
+      }, RETRY_TRANSIENT_X_READ),
+    ).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  it("finds a typed transient provider failure through a contextual cause chain", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => undefined,
+      jitter: async () => undefined,
+    });
+    let calls = 0;
+
+    await expect(
+      queue.add(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new ElizaError("X search failed", {
+            code: "X_SEARCH_FAILED",
+            cause: new TwitterError(
+              TwitterErrorType.NETWORK,
+              "provider connection failed",
+            ),
+          });
+        }
+        return "ok";
+      }, RETRY_TRANSIENT_X_READ),
+    ).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  it("does not retry an untyped error that merely resembles a transient failure", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => undefined,
+      jitter: async () => undefined,
+    });
+    let calls = 0;
+
+    await expect(
+      queue.add(async () => {
+        calls += 1;
+        throw new Error("HTTP 429 rate limited");
+      }, RETRY_TRANSIENT_X_READ),
+    ).rejects.toThrow("HTTP 429 rate limited");
+    expect(calls).toBe(1);
+  });
+
+  it.each([TwitterErrorType.AUTH, TwitterErrorType.VALIDATION])(
+    "does not retry a permanent %s failure even for a read",
+    async (errorType) => {
+      const queue = new RequestQueue({
+        backoff: async () => undefined,
+        jitter: async () => undefined,
+      });
+      let calls = 0;
+
+      await expect(
+        queue.add(async () => {
+          calls += 1;
+          throw new TwitterError(errorType, `permanent ${errorType} failure`);
+        }, RETRY_TRANSIENT_X_READ),
+      ).rejects.toThrow(`permanent ${errorType} failure`);
+      expect(calls).toBe(1);
+    },
+  );
+
+  it("never replays a quote-tweet write after an ambiguous accepted-then-throw failure", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => undefined,
+      jitter: async () => undefined,
+    });
+    let publicPosts = 0;
+
+    await expect(
+      queue.add(async () => {
+        publicPosts += 1;
+        throw new TwitterError(
+          TwitterErrorType.NETWORK,
+          "connection reset after provider acceptance",
+        );
+      }, NO_REQUEST_RETRY),
+    ).rejects.toThrow("connection reset after provider acceptance");
+    expect(publicPosts).toBe(1);
+  });
+
+  it("fails closed when no retry policy is supplied", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => undefined,
+      jitter: async () => undefined,
+    });
+    let calls = 0;
+
+    await expect(
+      queue.add(async () => {
+        calls += 1;
+        throw new TwitterError(
+          TwitterErrorType.RATE_LIMIT,
+          "unclassified operation",
+        );
+      }),
+    ).rejects.toThrow("unclassified operation");
+    expect(calls).toBe(1);
+  });
+
+  it("rejects the affected read and continues the queue when retry scheduling fails", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => {
+        throw new Error("backoff unavailable");
+      },
+      jitter: async () => undefined,
+    });
+
+    const failedRead = queue.add(async () => {
+      throw new TwitterError(TwitterErrorType.NETWORK, "transient read");
+    }, RETRY_TRANSIENT_X_READ);
+    const followingRead = queue.add(async () => "next", RETRY_TRANSIENT_X_READ);
+
+    await expect(
+      Promise.race([
+        failedRead,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("queue stalled")), 100),
+        ),
+      ]),
+    ).rejects.toMatchObject({ code: "X_REQUEST_RETRY_DELAY_FAILED" });
+    await expect(followingRead).resolves.toBe("next");
   });
 });

--- a/plugins/plugin-x/src/request-queue.test.ts
+++ b/plugins/plugin-x/src/request-queue.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Real `ClientBase.requestQueue` coverage: a swallowed wrapper catch used to
+ * reject `add()` on the first failure and skip retry/backoff. The queue now
+ * retries, then rejects only after the budget is exhausted.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { ClientBase } from "./base";
+import type { TwitterClientState } from "./types";
+
+function makeClient(): ClientBase {
+  return new ClientBase(
+    {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+    } as unknown as IAgentRuntime,
+    { accountId: "default" } as TwitterClientState,
+  );
+}
+
+describe("RequestQueue retries provider failures", () => {
+  it("retries a failed request and resolves when a later attempt succeeds", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        if (calls < 2) {
+          throw new Error("HTTP 429 rate limited");
+        }
+        return "ok";
+      }),
+    ).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  }, 20_000);
+
+  it("rejects after the retry budget instead of hanging or skipping", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        throw new Error("HTTP 429 rate limited");
+      }),
+    ).rejects.toThrow("HTTP 429 rate limited");
+    expect(calls).toBe(3);
+  }, 20_000);
+
+  it("still resolves a first-try success without extra attempts", async () => {
+    const client = makeClient();
+    let calls = 0;
+    await expect(
+      client.requestQueue.add(async () => {
+        calls += 1;
+        return 42;
+      }),
+    ).resolves.toBe(42);
+    expect(calls).toBe(1);
+  });
+});

--- a/plugins/plugin-x/src/request-queue.test.ts
+++ b/plugins/plugin-x/src/request-queue.test.ts
@@ -219,4 +219,24 @@ describe("RequestQueue retries provider failures", () => {
     ).rejects.toMatchObject({ code: "X_REQUEST_RETRY_DELAY_FAILED" });
     await expect(followingRead).resolves.toBe("next");
   });
+
+  it("rejects pending callers when queue pacing cannot be enforced", async () => {
+    const queue = new RequestQueue({
+      backoff: async () => undefined,
+      jitter: async () => {
+        throw new Error("pacing unavailable");
+      },
+    });
+
+    const firstRead = queue.add(async () => "first", RETRY_TRANSIENT_X_READ);
+    const pendingRead = queue.add(
+      async () => "must not dispatch",
+      RETRY_TRANSIENT_X_READ,
+    );
+
+    await expect(firstRead).resolves.toBe("first");
+    await expect(pendingRead).rejects.toMatchObject({
+      code: "X_REQUEST_PACING_DELAY_FAILED",
+    });
+  });
 });

--- a/plugins/plugin-x/src/timeline.ts
+++ b/plugins/plugin-x/src/timeline.ts
@@ -18,7 +18,12 @@ import {
   type State,
   type UUID,
 } from "@elizaos/core";
-import type { ClientBase, TwitterAccountSession, TwitterProfile } from "./base";
+import {
+  type ClientBase,
+  NO_REQUEST_RETRY,
+  type TwitterAccountSession,
+  type TwitterProfile,
+} from "./base";
 import type { Client, Tweet } from "./client/index";
 import { parseTwitterInterval } from "./environment";
 import {
@@ -660,7 +665,7 @@ ${tweet.text}${mediaDescriptions}`;
               String(responseObject.post),
               tweet.id,
             );
-          });
+          }, NO_REQUEST_RETRY);
         const result = await sendQuote();
 
         try {

--- a/plugins/plugin-x/src/utils/error-handler.ts
+++ b/plugins/plugin-x/src/utils/error-handler.ts
@@ -40,6 +40,115 @@ interface ProbableErrorShape {
   response?: { status?: unknown };
 }
 
+const RETRYABLE_NETWORK_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+function nestedProviderError(error: unknown): unknown {
+  if (error instanceof TwitterError && error.originalError !== undefined) {
+    return error.originalError;
+  }
+  if (typeof error !== "object" || error === null || !("cause" in error)) {
+    return undefined;
+  }
+  return (error as { cause?: unknown }).cause;
+}
+
+function directProviderStatus(error: unknown): number | undefined {
+  const probed = probeError(error);
+  const candidate =
+    probed.data?.status ??
+    probed.response?.status ??
+    probed.status ??
+    probed.code;
+  if (typeof candidate === "number" && Number.isInteger(candidate)) {
+    return candidate;
+  }
+  if (typeof candidate === "string" && /^(?:[1-5]\d\d)$/.test(candidate)) {
+    return Number(candidate);
+  }
+  return undefined;
+}
+
+/** Returns the first structured HTTP status retained by an error/cause chain. */
+export function getTwitterProviderStatus(error: unknown): number | undefined {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    const status = directProviderStatus(current);
+    if (status !== undefined) return status;
+    current = nestedProviderError(current);
+  }
+  return undefined;
+}
+
+function structuredProviderErrorType(
+  error: unknown,
+): TwitterErrorType | undefined {
+  const status = directProviderStatus(error);
+  if (status === 401 || status === 403) return TwitterErrorType.AUTH;
+  if (status === 429) return TwitterErrorType.RATE_LIMIT;
+  if (status === 400 || status === 422) return TwitterErrorType.VALIDATION;
+  if (status !== undefined && status >= 400 && status < 500) {
+    return TwitterErrorType.API;
+  }
+  if (status !== undefined && status >= 500 && status < 600) {
+    return TwitterErrorType.NETWORK;
+  }
+
+  const code = probeError(error).code;
+  if (
+    typeof code === "string" &&
+    RETRYABLE_NETWORK_CODES.has(code.toUpperCase())
+  ) {
+    return TwitterErrorType.NETWORK;
+  }
+  return undefined;
+}
+
+/**
+ * Converts only structured provider evidence into a typed X error.
+ *
+ * Arbitrary prose is deliberately not classified: a message containing
+ * "rate limit" is not proof that a request was rejected before acceptance.
+ */
+export function normalizeTwitterProviderError(
+  error: unknown,
+): TwitterError | null {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    if (
+      current instanceof TwitterError &&
+      current.type !== TwitterErrorType.UNKNOWN
+    ) {
+      return current;
+    }
+
+    const type = structuredProviderErrorType(current);
+    if (type !== undefined) {
+      const message =
+        current instanceof Error && current.message.trim().length > 0
+          ? current.message
+          : `X provider request failed (${type})`;
+      return new TwitterError(type, message, current);
+    }
+    current = nestedProviderError(current);
+  }
+  return null;
+}
+
 function probeError(error: unknown): ProbableErrorShape {
   if (typeof error === "object" && error !== null) {
     return error as ProbableErrorShape;


### PR DESCRIPTION
Replacement for #24524 and closed draft #24583; preserves both contributor commits and authorship while rebasing the completed repair onto current `develop`.

What changed:
- queued callers settle correctly after retry success or budget exhaustion;
- retries require an explicit typed `transient-read` policy and only classified rate-limit/network provider failures qualify;
- auth, permanent, untyped, timeout, and ambiguous mutation failures remain single-attempt;
- quote-tweet and other public writes cannot be duplicated after a lost receipt;
- retry-delay failure is typed and visible;
- profile fallback failures use typed `ElizaError` with their cause.

Verification (Bun 1.3.14):
- focused queue/read-policy/pagination/interaction suites: 5 files, 31/31 passed
- `bun run --cwd plugins/plugin-x typecheck` — passed
- `bun run --cwd plugins/plugin-x lint:check` — 98 files clean
- `git diff --check` — passed

The two implementation commits remain authored by ss251. No live X write was issued.

<!-- evidence-head:875a06152929b082e779967916060e558e7030ad -->
- full plugin-x suite: 40 files passed, 1 skipped; 348 tests passed, 13 skipped
- plugin-x build — passed
- reviewer follow-up: queue pacing failure now rejects pending callers with typed X_REQUEST_PACING_DELAY_FAILED instead of dispatching an unpaced burst

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered user flow changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic connector queue and provider-classification boundaries are covered by focused and full package tests.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changes.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent artifact and no live X write was issued.

