### PR TITLE
test(core): align RECENT_ERRORS suite and docs with the uncapped lossless contract

### DIFF
--- a/packages/core/src/providers/recent-errors.test.ts
+++ b/packages/core/src/providers/recent-errors.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for the RECENT_ERRORS provider: renders nothing when clean, dedupes by
- * code (newest wins), caps the list, and ages out stale entries. Uses a fake
+ * code (newest wins), ages out stale entries, and surfaces every distinct code
+ * in the window uncapped. Uses a fake
  * runtime that returns a controlled reported-error ring — except the W5-025
  * case, which drives a real AgentRuntime so the redactSecrets scrub under test
  * is the production one.
@@ -62,8 +63,11 @@ describe("RECENT_ERRORS provider", () => {
 		expect(result.text).not.toContain("old dup");
 	});
 
-	it("caps the surfaced list at 5 distinct codes (newest-first)", async () => {
+	it("surfaces every distinct code uncapped, newest-first (#24134)", async () => {
 		const now = Date.now();
+		// The surfaced block is model context: an item-count window here is
+		// forbidden by the prompt-integrity contract. All 8 distinct codes must
+		// arrive, ordered newest-first, with none dropped.
 		const entries: ReportedError[] = Array.from({ length: 8 }, (_, i) => ({
 			scope: "S",
 			code: `C${i}`,
@@ -76,10 +80,21 @@ describe("RECENT_ERRORS provider", () => {
 			state,
 		);
 		const surfaced = result.data?.recentErrors as ReportedError[];
-		expect(surfaced).toHaveLength(5);
-		// Newest (C0) first, oldest kept is C4.
-		expect(surfaced[0].code).toBe("C0");
-		expect(surfaced.at(-1)?.code).toBe("C4");
+		expect(surfaced).toHaveLength(8);
+		expect(surfaced.map((e) => e.code)).toEqual([
+			"C0",
+			"C1",
+			"C2",
+			"C3",
+			"C4",
+			"C5",
+			"C6",
+			"C7",
+		]);
+		// Every dropped code would be silent data loss in the prompt.
+		for (const entry of entries) {
+			expect(result.text).toContain(`${entry.code}: ${entry.message}`);
+		}
 	});
 
 	it("ages out entries older than 30 minutes", async () => {
@@ -307,7 +322,7 @@ describe("serializeContext well-formed Unicode boundaries", () => {
 		expect(isWellFormed(res)).toBe(true);
 	});
 
-	it("sanitizes lone surrogates without truncation when fitting under limit", () => {
+	it("sanitizes lone surrogates without truncation", () => {
 		const payload = "ok \uD800 end";
 		const res = serializeContext({ payload }) ?? "";
 		expect(res).toBe(JSON.stringify({ payload: "ok \uFFFD end" }));

--- a/packages/core/src/providers/recent-errors.ts
+++ b/packages/core/src/providers/recent-errors.ts
@@ -4,8 +4,8 @@
  *
  * Failures outside the action path (providers, services, background jobs, event
  * handlers) do not otherwise reach the model. This provider reads the runtime's
- * in-memory reported-error ring, dedupes by `code`, ages out stale entries, caps
- * the list, and appends a short instruction so the agent can attempt a fix or
+ * in-memory reported-error ring, dedupes by `code`, ages out stale entries, and
+ * appends a short instruction so the agent can attempt a fix or
  * tell the owner. It renders nothing (and costs no prompt tokens) when there are
  * no recent errors — no prompt bloat on the healthy path.
  *
@@ -30,7 +30,6 @@ import {
 	toWellFormedUnicode,
 } from "../utils/well-formed.ts";
 
-/** Newest N distinct-by-code errors surfaced into the prompt. */
 /** Entries older than this are ignored (stale failures shouldn't linger). */
 const ERROR_MAX_AGE_MS = 30 * 60 * 1000;
 
@@ -80,7 +79,9 @@ export function serializeContext(
 
 /**
  * Reduce the raw ring to the newest entry per `code` within the age window,
- * ordered newest-first, capped at {@link MAX_RECENT_ERRORS}.
+ * ordered newest-first. Deliberately uncapped: the surfaced block is model
+ * context, and item-count windows into model context are forbidden by the
+ * prompt-integrity contract (#24134).
  */
 function selectRecentErrors(
 	entries: ReportedError[],


### PR DESCRIPTION
Closes #24604.


Closes #24604

## What happened

#24134 ("preserve complete model context") removed `MAX_RECENT_ERRORS` and `MAX_CONTEXT_CHARS` from `recent-errors.ts` — but left the old contract behind in two places:

1. **The committed test is red on develop.** `caps the surfaced list at 5 distinct codes (newest-first)` fails because the provider now correctly surfaces all distinct codes:

```
$ git show origin/develop:packages/core/src/providers/recent-errors.ts | diff - packages/core/src/providers/recent-errors.ts
IDENTICAL   # origin reproduction on unmodified code
$ bun vitest run packages/core/src/providers/recent-errors.test.ts --root packages/core
Test Files  1 failed (1)
Tests  1 failed | 14 passed (15)
× caps the surfaced list at 5 distinct codes (newest-first)
  - Expected  5
  + Received  8
```

2. **Stale docstrings document a cap that no longer exists** — the module header says "caps the list", an orphaned `/** Newest N distinct-by-code errors surfaced into the prompt. */` comment survives, and `selectRecentErrors`'s JSDoc carries a `{@link MAX_RECENT_ERRORS}` reference that no longer resolves.

## The fix

- Rewrite the cap test as an uncapped-completeness regression: 8 distinct codes must all surface newest-first, and every entry must appear in the rendered text — proving no item-count window silently drops model context (#24134's invariant).
- Delete the orphaned constant comment; restate both JSDoc blocks to name the deliberate uncapped behavior.
- Drop a stale "when fitting under limit" phrase from one Unicode test title (no limit exists).

## Evidence

| Check | Result |
| --- | --- |
| Origin reproduction | Both files byte-identical to `origin/develop` (`git show … \| diff -`) before any edit |
| Load-bearing revert (copy-aside) | Old test restored → `1 failed \| 14 passed`; fixed test restored → `15 passed (15)` |
| Committed tests executed | `bun vitest run packages/core/src/providers --root packages/core` → `Tests 19 passed (19)` at head b0c704ea7 |
| No over-rejection | Neighbors untouched and green: providers dir + `prompt-integrity-policy.test.ts` → `3 passed (3)`, `23 passed (23)` |
| Typecheck vs control | `bun run --cwd packages/core typecheck`: control (origin bytes) and branch error sets both empty — zero added errors |
| Biome | `bunx biome check` on both changed files — clean |
| Hosted CI | Not applicable: fork contributor, CI does not run on our PRs; all commands above were executed locally and are quoted verbatim |

## Known gaps

- The uploaded evidence trajectory excludes the session's initial user event (a ~9.8 MB ambient-context dump over the trace uploader's 8 MiB per-line limit); the remaining 94 events are unmodified. Declared rather than silent.
- `setup-progress.test.ts` has an identical stale "under limit" title phrase; left alone here because this PR deliberately touches only the recent-errors family (one file family per PR).

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b0c704ea7c66a4a44b8e151c6c379251105e29af -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openrouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [ox-alpha-cr24033-defect1]
<!-- slop-contribution-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NEDQQE670TZT0220RJ3VB8","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T19:16:08.559Z","completed_at":"2026-08-22T19:36:32.534Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T19:16:09.766Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"458f87e81ba965fb99b68c3ed6d18ede794f1c91c1710dcdb761489bb394162b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f4c697c9-21fb-4da1-bb65-c4a4ed41293a","object_id":"sha256:458f87e81ba965fb99b68c3ed6d18ede794f1c91c1710dcdb761489bb394162b","sha256":"458f87e81ba965fb99b68c3ed6d18ede794f1c91c1710dcdb761489bb394162b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"U5TZ0KGrNZrRn9uby66XCLPk7l9w57n2n9G5h7l4ewvSKs3Xzn0EfgeF3SErZ1JTJlV0I6hbhNUDImVNLCZoDA"}} -->
