### PR TITLE
fix(ui): unify chat panel and drawer typography on the semantic type scale

### DIFF
--- a/packages/ui/src/components/chat/AccountRequiredCard.tsx
+++ b/packages/ui/src/components/chat/AccountRequiredCard.tsx
@@ -84,7 +84,7 @@ function ReconnectProgressLine({
 }) {
   if (phase === "reconnecting") {
     return (
-      <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-muted">
+      <div className="mt-1.5 flex items-center gap-1.5 text-2xs text-muted">
         <Spinner className="h-3 w-3" />
         Waiting for sign-in to finish...
       </div>
@@ -92,7 +92,7 @@ function ReconnectProgressLine({
   }
   if (phase === "retrying") {
     return (
-      <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-muted">
+      <div className="mt-1.5 flex items-center gap-1.5 text-2xs text-muted">
         <Spinner className="h-3 w-3" />
         Reconnected. Retrying...
       </div>
@@ -100,7 +100,7 @@ function ReconnectProgressLine({
   }
   if (phase === "success") {
     return (
-      <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-ok">
+      <div className="mt-1.5 flex items-center gap-1.5 text-2xs text-ok">
         <CheckCircle2 className="h-3 w-3" />
         Reconnected and sent.
       </div>
@@ -108,7 +108,7 @@ function ReconnectProgressLine({
   }
   if (phase === "failed") {
     return (
-      <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-destructive">
+      <div className="mt-1.5 flex items-center gap-1.5 text-2xs text-destructive">
         <span className="min-w-0 flex-1 truncate">
           {error ?? "Reconnect failed."}
         </span>
@@ -117,7 +117,7 @@ function ReconnectProgressLine({
             type="button"
             variant="ghost"
             size="sm"
-            className="h-6 shrink-0 gap-1 px-1.5 text-[10px]"
+            className="h-6 shrink-0 gap-1 px-1.5 text-2xs"
             onClick={onRetry}
           >
             <RefreshCw className="h-3 w-3" />
@@ -242,10 +242,10 @@ export function AccountRequiredCard({
                       <StatusBadge
                         label={status.label}
                         tone={status.tone}
-                        className="px-1.5 py-0 text-[9px]"
+                        className="px-1.5 py-0 text-3xs"
                       />
                       {account.handle || account.externalId ? (
-                        <span className="truncate text-[10px] text-muted">
+                        <span className="truncate text-2xs text-muted">
                           {account.handle ?? account.externalId}
                         </span>
                       ) : null}
@@ -256,7 +256,7 @@ export function AccountRequiredCard({
                       type="button"
                       variant="outline"
                       size="sm"
-                      className="h-7 shrink-0 gap-1 px-2 text-[10px]"
+                      className="h-7 shrink-0 gap-1 px-2 text-2xs"
                       disabled={reconnectBusy}
                       onClick={() => handleReconnect(account.id)}
                     >

--- a/packages/ui/src/components/chat/ConnectorAccountPicker.tsx
+++ b/packages/ui/src/components/chat/ConnectorAccountPicker.tsx
@@ -102,7 +102,7 @@ export function ConnectorAccountPicker({
             variant="outline"
             size="sm"
             disabled={disabled || loading}
-            className="h-7 max-w-full rounded-full px-2 text-[11px] shadow-none"
+            className="h-7 max-w-full rounded-full px-2 text-xs-tight shadow-none"
             data-testid="connector-account-picker-trigger"
           >
             {loading ? (
@@ -165,7 +165,7 @@ export function ConnectorAccountPicker({
                       {connectorAccountDisplayName(account)}
                     </span>
                     {account.isDefault ? (
-                      <span className="rounded-sm border border-border/40 px-1 py-0 text-[9px] uppercase text-muted">
+                      <span className="rounded-sm border border-border/40 px-1 py-0 text-3xs uppercase tracking-wider text-muted">
                         Default
                       </span>
                     ) : null}
@@ -174,9 +174,9 @@ export function ConnectorAccountPicker({
                     <StatusBadge
                       label={status.label}
                       tone={status.tone}
-                      className="px-1.5 py-0 text-[9px]"
+                      className="px-1.5 py-0 text-3xs"
                     />
-                    <span className="truncate text-[10px] text-muted">
+                    <span className="truncate text-2xs text-muted">
                       {accountSecondaryText(account)}
                     </span>
                   </span>
@@ -220,7 +220,7 @@ export function ConnectorAccountPicker({
         </DropdownMenuContent>
       </DropdownMenu>
       {selectedAccount && !isConnectorAccountUsable(selectedAccount) ? (
-        <span className="truncate text-[11px] text-warn">
+        <span className="truncate text-xs-tight text-warn">
           Account needs attention
         </span>
       ) : null}

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -542,7 +542,7 @@ function PdfTile({
             <span className="block truncate text-xs-tight font-medium">
               {label}
             </span>
-            <span className="block text-2xs uppercase tracking-wide text-muted">
+            <span className="block text-2xs uppercase tracking-wider text-muted">
               {t("messageattachments.pdfLabel")}
             </span>
           </span>
@@ -825,7 +825,7 @@ function CodeTile({
             <span className="block truncate text-xs-tight font-medium">
               {label}
             </span>
-            <span className="block text-2xs uppercase tracking-wide text-muted">
+            <span className="block text-2xs uppercase tracking-wider text-muted">
               {t("messageattachments.textLabel")}
             </span>
           </span>
@@ -847,7 +847,7 @@ function CodeTile({
         <span className="min-w-0 flex-1 truncate text-xs-tight font-medium text-txt">
           {label}
         </span>
-        <span className="shrink-0 text-2xs uppercase tracking-wide text-muted">
+        <span className="shrink-0 text-2xs uppercase tracking-wider text-muted">
           {language}
         </span>
         <TileButton

--- a/packages/ui/src/components/chat/TasksEventsPanel.tsx
+++ b/packages/ui/src/components/chat/TasksEventsPanel.tsx
@@ -301,7 +301,7 @@ export function TasksEventsPanel({
                 data-testid="chat-widgets-edit-inline"
                 variant="ghost"
                 size="sm"
-                className="h-5 shrink-0 gap-1 bg-transparent px-1 text-[10px] leading-none font-semibold uppercase tracking-[0.1em] text-muted transition-colors hover:bg-transparent hover:text-txt"
+                className="h-5 shrink-0 gap-1 bg-transparent px-1 text-2xs leading-none font-semibold uppercase tracking-wider text-muted transition-colors hover:bg-transparent hover:text-txt"
                 aria-label="Edit widgets"
                 onClick={() => setEditOpen(true)}
               >

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -596,7 +596,7 @@ export function TranscriptViewerOverlay({
                     placeholder="Entity ID"
                     density="compact"
                     data-testid="transcript-share-target"
-                    className="font-mono text-[11px]"
+                    className="font-mono text-xs-tight"
                   />
                 </label>
                 <div className="grid content-end gap-1">

--- a/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
+++ b/packages/ui/src/components/chat/message-search/MessageSearchPanel.tsx
@@ -200,7 +200,7 @@ export function MessageSearchPanel({
                   : "flex h-auto w-full flex-col items-start gap-0.5 whitespace-normal rounded-md px-2 py-1.5 text-left font-normal hover:bg-muted/60"
               }
             >
-              <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <span className="text-xs-tight uppercase tracking-wider text-muted-foreground">
                 {result.role === "assistant" ? "Agent" : "You"} ·{" "}
                 {formatTimestamp(result.createdAt)}
               </span>

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -116,7 +116,7 @@ export const ChoiceWidget = memo(function ChoiceWidget({
           data-testid={`choice-${soleOption.value}`}
           // The locked (selected) state stays at full opacity: it is the
           // confirmation the user just acted on, not a faded leftover.
-          className="h-auto min-h-10 w-full justify-center whitespace-normal rounded-md border border-white/30 bg-[#2c2f3a] px-4 py-2 text-[14px] font-semibold text-[#f0f2f7] transition-colors hover:bg-[#363a46] disabled:bg-[#2c2f3a] disabled:text-[#f0f2f7] disabled:opacity-100"
+          className="h-auto min-h-10 w-full justify-center whitespace-normal rounded-md border border-white/30 bg-[#2c2f3a] px-4 py-2 text-sm font-semibold text-[#f0f2f7] transition-colors hover:bg-[#363a46] disabled:bg-[#2c2f3a] disabled:text-[#f0f2f7] disabled:opacity-100"
           onClick={() => handleChoose(soleOption)}
         >
           <span className="flex w-full min-w-0 items-center justify-center gap-2">
@@ -139,7 +139,7 @@ export const ChoiceWidget = memo(function ChoiceWidget({
         // Plain muted text, no pill chrome: the theme text token stays
         // readable on every surface (chat-native de-slop, supersedes the
         // #15144 pill-background fix by removing the pill).
-        <span className="text-[11px] font-medium text-muted">
+        <span className="text-xs-tight font-medium text-muted">
           {selected ? "Selected" : `${options.length} options`}
         </span>
       }

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-accounts-view.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-accounts-view.tsx
@@ -41,7 +41,7 @@ function UsageBar({ label, pct }: { label: string; pct?: number }) {
   const clamped = Math.max(0, Math.min(100, Math.round(pct)));
   return (
     <div className="flex items-center gap-1.5">
-      <span className="w-9 shrink-0 text-3xs uppercase tracking-wide text-muted">
+      <span className="w-9 shrink-0 text-3xs uppercase tracking-wider text-muted">
         {label}
       </span>
       <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted/20">
@@ -225,7 +225,7 @@ export function OrchestratorAccountsView({
             className="space-y-1.5 border-t border-border/40 pt-1.5"
             data-testid="orchestrator-room-roster"
           >
-            <div className="text-3xs font-medium uppercase tracking-wide text-muted">
+            <div className="text-3xs font-medium uppercase tracking-wider text-muted">
               {t("agentorchestrator.taskRooms", { defaultValue: "Task rooms" })}
             </div>
             {activeRooms.map((room) => (

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
@@ -107,7 +107,7 @@ function ParticipantRow({
       <span className="relative inline-flex shrink-0">
         <Icon
           className={`h-3.5 w-3.5 ${
-            isSubAgent ? (live ? "text-txt" : "text-muted/50") : "text-muted"
+            isSubAgent ? (live ? "text-txt" : "text-muted") : "text-muted"
           }`}
         />
         {isSubAgent ? (

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -630,7 +630,7 @@ function AppRunsWidget({
           </div>
           {attentionRuns.length > 0 ? (
             <div className="p-2 text-warn">
-              <div className="mb-1.5 flex items-center gap-1.5 text-3xs font-semibold uppercase tracking-[0.08em] text-warn">
+              <div className="mb-1.5 flex items-center gap-1.5 text-3xs font-semibold uppercase tracking-wider text-warn">
                 <AlertTriangle className="h-3 w-3" />
                 {t("agentorchestrator.recovery", { defaultValue: "Recovery" })}
               </div>

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -177,7 +177,7 @@ export const FormRequest = memo(function FormRequest({
     <ChatWidgetShell
       title={form.title ?? "Form"}
       status={
-        <span className="text-[11px] font-medium text-muted">
+        <span className="text-xs-tight font-medium text-muted">
           {submitted ? "Submitted" : `${form.fields.length} fields`}
         </span>
       }
@@ -192,7 +192,7 @@ export const FormRequest = memo(function FormRequest({
         onSubmit={handleSubmit}
       >
         {form.description ? (
-          <div className="text-xs text-txt/80">{form.description}</div>
+          <div className="text-xs text-muted-strong">{form.description}</div>
         ) : null}
 
         {form.fields.map((field) => {
@@ -236,7 +236,7 @@ export const FormRequest = memo(function FormRequest({
                     className={getConfigInputClassName({
                       density: "compact",
                       hasError: !!fieldErrors?.length,
-                      className: "text-txt placeholder:text-txt/70",
+                      className: "text-txt placeholder:text-muted",
                     })}
                     aria-label={label}
                   >
@@ -270,7 +270,7 @@ export const FormRequest = memo(function FormRequest({
                 className={getConfigInputClassName({
                   density: "compact",
                   hasError: !!fieldErrors?.length,
-                  className: "text-txt placeholder:text-txt/70",
+                  className: "text-txt placeholder:text-muted",
                 })}
                 type={htmlInputTypeForField(field.type)}
                 name={field.name}

--- a/packages/ui/src/components/chat/widgets/home-widget-card.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.tsx
@@ -142,7 +142,7 @@ export function HomeWidgetCard({
           read as a real dashboard), with the single high-priority datum below
           it. When a widget supplies no datum, the label carries the row alone. */}
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-xs-tight font-medium uppercase tracking-[0.08em] text-[color:color-mix(in_srgb,var(--brand-white)_68%,transparent)]">
+        <span className="truncate text-xs-tight font-medium uppercase tracking-wider text-[color:color-mix(in_srgb,var(--brand-white)_68%,transparent)]">
           {label}
         </span>
         {value != null ? (

--- a/packages/ui/src/components/chat/widgets/shared.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.tsx
@@ -94,7 +94,7 @@ export function EmptyWidgetState({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col items-center justify-center gap-2 py-5 text-center">
-        <span className="text-muted/50">{icon}</span>
+        <span className="text-muted">{icon}</span>
         <p className="text-2xs text-muted">{title}</p>
         {description ? (
           <p className="text-3xs text-muted">{description}</p>

--- a/packages/ui/src/components/chat/widgets/task-pipeline.tsx
+++ b/packages/ui/src/components/chat/widgets/task-pipeline.tsx
@@ -152,7 +152,7 @@ export const PlanChecklist = memo(function PlanChecklist({
                   ? "text-muted line-through"
                   : isActive
                     ? "text-txt"
-                    : "text-txt/80"
+                    : "text-muted-strong"
               }`}
             >
               <Icon
@@ -190,7 +190,7 @@ export const ChecklistWidget = memo(function ChecklistWidget({
     <ChatWidgetShell
       title={resolvedTitle}
       status={
-        <span className="text-[11px] font-medium tabular-nums text-muted">
+        <span className="text-xs-tight font-medium tabular-nums text-muted">
           {done}/{entries.length}
         </span>
       }

--- a/packages/ui/src/components/chat/widgets/task-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/task-widget.tsx
@@ -310,7 +310,7 @@ export const TaskWidget = memo(function TaskWidget({
               </span>
               {sessionCount > 0 ? (
                 <>
-                  <span className="text-muted/40">·</span>
+                  <span className="text-muted">·</span>
                   <span>
                     {activeSessionCount}/{sessionCount} agents
                   </span>
@@ -318,13 +318,13 @@ export const TaskWidget = memo(function TaskWidget({
               ) : null}
               {relative ? (
                 <>
-                  <span className="text-muted/40">·</span>
+                  <span className="text-muted">·</span>
                   <span>{relative}</span>
                 </>
               ) : null}
               {tokens ? (
                 <>
-                  <span className="text-muted/40">·</span>
+                  <span className="text-muted">·</span>
                   <span className="tabular-nums">{tokens}</span>
                 </>
               ) : null}

--- a/packages/ui/src/components/chat/widgets/topic-chips-bar.tsx
+++ b/packages/ui/src/components/chat/widgets/topic-chips-bar.tsx
@@ -84,7 +84,7 @@ export function TopicChipsBar({
             data-testid={`topic-chip-${topic.id}`}
             className={cn(
               appearance === "overlay"
-                ? "h-auto shrink-0 whitespace-nowrap rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors"
+                ? "h-auto shrink-0 whitespace-nowrap rounded-full border px-2.5 py-0.5 text-xs-tight font-medium transition-colors"
                 : "h-7 gap-1.5 px-3 text-xs",
               appearance === "overlay" &&
                 (isActive

--- a/packages/ui/src/components/chat/widgets/workflow-steps.tsx
+++ b/packages/ui/src/components/chat/widgets/workflow-steps.tsx
@@ -109,7 +109,7 @@ export const WorkflowSteps = memo(function WorkflowSteps({
       title={title}
       status={
         <span
-          className={`text-[11px] font-medium tabular-nums ${
+          className={`text-xs-tight font-medium tabular-nums ${
             failed ? "text-danger" : "text-muted"
           }`}
         >
@@ -162,12 +162,12 @@ export const WorkflowSteps = memo(function WorkflowSteps({
               <span className="text-xs font-medium text-txt">
                 {widget.title}
               </span>
-              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[9px] uppercase text-primary">
+              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-3xs uppercase tracking-wider text-primary">
                 {widget.component}
               </span>
             </div>
             {execution?.output !== undefined ? (
-              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap text-[11px] text-muted">
+              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap text-xs-tight text-muted">
                 {JSON.stringify(execution.output, null, 2)}
               </pre>
             ) : null}

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
@@ -348,7 +348,7 @@ export function ChatVoiceStatusBar({
 
       <span
         className={cn(
-          "inline-flex items-center gap-1 rounded-sm border px-2 py-0.5 text-[10px] font-medium",
+          "inline-flex items-center gap-1 rounded-sm border px-2 py-0.5 text-2xs font-medium",
           TONE_CLASS[tone],
         )}
         data-testid="chat-voice-latency-badge"
@@ -364,7 +364,9 @@ export function ChatVoiceStatusBar({
       >
         {formatLatency(primaryLatency)}
         {cached ? (
-          <span className="text-[9px] uppercase opacity-70">cached</span>
+          <span className="text-3xs uppercase tracking-wider opacity-70">
+            cached
+          </span>
         ) : null}
       </span>
 

--- a/packages/ui/src/components/composites/chat/chat-bubble.tsx
+++ b/packages/ui/src/components/composites/chat/chat-bubble.tsx
@@ -65,7 +65,7 @@ export function ChatBubble({
         className={cn(
           // whitespace-pre-wrap keeps newlines; overflow-wrap breaks long URLs /
           // hashes / paths so they can't blow out the bubble width on a phone.
-          "relative w-fit max-w-full whitespace-pre-wrap text-[14px] leading-relaxed [overflow-wrap:anywhere]",
+          "relative w-fit max-w-full whitespace-pre-wrap text-chat-body [overflow-wrap:anywhere]",
           // Message text must remain selectable for normal highlight/copy.
           "select-text [-webkit-touch-callout:default]",
           bare

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -626,10 +626,10 @@ export function ChatComposer({
           density={isInline ? null : undefined}
           className={
             isGameModal
-              ? "w-full min-w-0 min-h-0 h-[46px] resize-none overflow-y-hidden max-h-[200px] outline-none     font-[var(--font-chat)] disabled:opacity-50 rounded-sm border border-transparent bg-transparent px-4 pb-[13px] pt-[13px] text-[15px] leading-[1.55] text-txt-strong placeholder:text-muted pointer-coarse:text-[16px]"
+              ? "w-full min-w-0 min-h-0 h-[46px] resize-none overflow-y-hidden max-h-[200px] outline-none     font-chat disabled:opacity-50 rounded-sm border border-transparent bg-transparent px-4 pb-[13px] pt-[13px] text-chat-body leading-[1.55] text-txt-strong placeholder:text-muted pointer-coarse:text-[16px]"
               : isInline
                 ? inlineTextareaClass
-                : "w-full min-w-0 min-h-0 h-[38px] resize-none overflow-y-hidden max-h-[200px] outline-none     font-[var(--font-chat)] disabled:opacity-50 rounded-sm border-0 bg-card/40 px-4 py-[8px] text-[15px] leading-[1.55] text-txt placeholder:text-muted pointer-coarse:text-[16px]"
+                : "w-full min-w-0 min-h-0 h-[38px] resize-none overflow-y-hidden max-h-[200px] outline-none     font-chat disabled:opacity-50 rounded-sm border-0 bg-card/40 px-4 py-[8px] text-chat-body leading-[1.55] text-txt placeholder:text-muted pointer-coarse:text-[16px]"
           }
           placeholder={placeholder ?? defaultTextareaPlaceholder}
           rows={1}

--- a/packages/ui/src/components/composites/chat/chat-empty-state.tsx
+++ b/packages/ui/src/components/composites/chat/chat-empty-state.tsx
@@ -68,7 +68,7 @@ export function ChatEmptyState({
           <h3 className="mb-2 text-lg font-semibold text-txt-strong">
             {labels.startConversation ?? "Start a Conversation"}
           </h3>
-          <p className="mb-6 max-w-sm font-[var(--font-chat)] text-sm text-muted">
+          <p className="mb-6 max-w-sm font-chat text-sm text-muted">
             {labels.sendMessageTo ?? "Send a message to"} {agentName}{" "}
             {labels.toBeginChatting ?? "to begin chatting."}
           </p>

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -313,7 +313,7 @@ function ReactionEmoji({ emoji }: { emoji: string }) {
   if (rendered) {
     return rendered;
   }
-  return <span className="text-[15px] leading-none">{emoji}</span>;
+  return <span className="text-chat-body leading-none">{emoji}</span>;
 }
 
 function ReactionStrip({
@@ -906,10 +906,9 @@ export const ChatMessage = memo(function ChatMessage({
         className={cn(
           "field-sizing-content min-h-0 max-h-40 w-full resize-none overflow-y-auto rounded-none border-0 bg-transparent p-0 shadow-none outline-none transition-opacity duration-200 disabled:cursor-default",
           glass
-            ? "text-[14px] leading-relaxed text-white caret-white"
-            : "text-[15px] leading-[1.7] text-txt-strong caret-txt-strong",
+            ? "font-chat text-chat-body text-white caret-white"
+            : "font-chat text-chat-body text-txt-strong caret-txt-strong",
         )}
-        style={{ fontFamily: "var(--font-chat)" }}
         disabled={savingEdit}
       />
       {glass ? null : inlineEditControls}
@@ -971,7 +970,7 @@ export const ChatMessage = memo(function ChatMessage({
           ts={message.timestamp}
           short
           data-testid="thread-line-timestamp"
-          className="inline-block min-w-[3ch] whitespace-nowrap text-left text-[11px] tabular-nums text-white/45"
+          className="inline-block min-w-[3ch] whitespace-nowrap text-left text-xs-tight tabular-nums text-white/45"
         />
       ) : null;
     const trailingAccessory =
@@ -1030,7 +1029,7 @@ export const ChatMessage = memo(function ChatMessage({
             // ("Do it") + dismiss. stopPropagation keeps these taps from
             // toggling the bubble's click-to-reveal action row.
             <div className="mb-1.5 flex items-center justify-between gap-2">
-              <span className="inline-flex items-center gap-1 text-[12px] font-medium text-[rgb(255,148,84)]">
+              <span className="inline-flex items-center gap-1 text-xs font-medium text-[rgb(255,148,84)]">
                 <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
                 Suggestion
               </span>
@@ -1046,7 +1045,7 @@ export const ChatMessage = memo(function ChatMessage({
                       e.stopPropagation();
                       onAcceptSuggestion(message);
                     }}
-                    className="h-auto rounded-full bg-white/10 px-2.5 py-0.5 text-[12px] font-medium text-[rgb(255,148,84)] transition-colors hover:bg-white/20"
+                    className="h-auto rounded-full bg-white/10 px-2.5 py-0.5 text-xs font-medium text-[rgb(255,148,84)] transition-colors hover:bg-white/20"
                   >
                     Do it
                   </Button>
@@ -1074,7 +1073,7 @@ export const ChatMessage = memo(function ChatMessage({
             data-chat-selectable="true"
             className={cn(
               isFirstRun &&
-                "flex w-full flex-col gap-4 whitespace-normal text-[17px] leading-relaxed text-white",
+                "flex w-full flex-col gap-4 whitespace-normal text-chat-lead text-white",
             )}
           >
             {renderContent?.(message, renderContext) ??
@@ -1284,7 +1283,7 @@ export const ChatMessage = memo(function ChatMessage({
                 e.stopPropagation();
                 onRetry?.(message.id);
               }}
-              className="h-auto gap-1.5 rounded-full bg-white/10 px-3 py-1 text-[13px] font-medium text-white/80 transition-colors hover:bg-white/20"
+              className="h-auto gap-1.5 rounded-full bg-white/10 px-3 py-1 text-sm-tight font-medium text-white/80 transition-colors hover:bg-white/20"
             >
               <RotateCcw className="h-3.5 w-3.5" aria-hidden />
               Retry
@@ -1402,18 +1401,17 @@ export const ChatMessage = memo(function ChatMessage({
           tone={isUser ? "user" : "assistant"}
           source={normalizedSource}
           className={cn(
-            "relative group py-1 text-[15px] leading-[1.7] whitespace-pre-wrap break-words",
+            "relative group py-1 font-chat text-chat-body whitespace-pre-wrap break-words",
             // Suggestion treatment: subtle accent tint + dashed accent border so
             // a proactive offer reads as a suggestion, not a normal reply.
             isSuggestion &&
               "border border-dashed border-accent/45 bg-accent/[0.06]",
           )}
-          style={{
-            fontFamily: "var(--font-chat)",
-            ...(isEditing && editBubbleWidth
+          style={
+            isEditing && editBubbleWidth
               ? { width: editBubbleWidth, maxWidth: "100%" }
-              : {}),
-          }}
+              : undefined
+          }
           data-chat-message-bubble="true"
           data-proactive-suggestion={isSuggestion ? "true" : undefined}
         >

--- a/packages/ui/src/components/composites/chat/chat-source.tsx
+++ b/packages/ui/src/components/composites/chat/chat-source.tsx
@@ -70,7 +70,7 @@ export function ChatVoiceSpeakerBadge({
       data-testid={dataTestId ?? "chat-voice-speaker"}
       data-owner={isOwner ? "true" : undefined}
       className={cn(
-        "inline-flex items-center gap-1 rounded-sm border border-border bg-card px-1.5 py-0.5 text-[10px] font-medium text-muted",
+        "inline-flex items-center gap-1 rounded-sm border border-border bg-card px-1.5 py-0.5 text-2xs font-medium text-muted",
         className,
       )}
       title={isOwner ? `${label} (OWNER)` : label}

--- a/packages/ui/src/components/composites/chat/chat-transcript.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.tsx
@@ -202,14 +202,11 @@ export const ChatTranscript = memo(function ChatTranscript({
             >
               <ChatBubble
                 tone={isUser ? "user" : "assistant"}
-                className={`max-w-[min(85%,24rem)] rounded-sm px-4 py-3 text-[15px] leading-relaxed ${
+                className={`max-w-[min(85%,24rem)] rounded-sm px-4 py-3 text-chat-body ${
                   isUser ? "rounded-br-none" : "rounded-bl-none"
                 }`}
               >
-                <div
-                  className="break-words"
-                  style={{ fontFamily: "var(--font-chat)" }}
-                >
+                <div className="break-words font-chat">
                   {renderTranscriptMessageContent(
                     message,
                     renderMessageContent,
@@ -229,14 +226,11 @@ export const ChatTranscript = memo(function ChatTranscript({
             >
               <ChatBubble
                 tone={isUser ? "user" : "assistant"}
-                className={`max-w-[min(85%,24rem)] rounded-sm px-4 py-3 text-[15px] leading-relaxed ${
+                className={`max-w-[min(85%,24rem)] rounded-sm px-4 py-3 text-chat-body ${
                   isUser ? "rounded-br-none" : "rounded-bl-none"
                 }`}
               >
-                <div
-                  className="break-words"
-                  style={{ fontFamily: "var(--font-chat)" }}
-                >
+                <div className="break-words font-chat">
                   {renderTranscriptMessageContent(
                     message,
                     renderMessageContent,

--- a/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
+++ b/packages/ui/src/components/composites/chat/chat-typing-indicator.tsx
@@ -257,7 +257,7 @@ export function TurnStatus({
         aria-live="polite"
       >
         <MarkerContent
-          className="shimmer inline-flex min-h-[1.4375rem] items-center text-[13px] font-medium leading-[1.4375rem] motion-reduce:shimmer-none"
+          className="shimmer inline-flex min-h-[1.4375rem] items-center text-sm-tight font-medium leading-[1.4375rem] motion-reduce:shimmer-none"
           data-testid="turn-status-label"
           data-current-label={label}
         >
@@ -282,7 +282,7 @@ export function TurnStatus({
           className="text-white/70 motion-reduce:animate-none"
         />
       </MarkerIcon>
-      <MarkerContent className="inline-flex items-baseline text-[13px] font-medium tabular-nums">
+      <MarkerContent className="inline-flex items-baseline text-sm-tight font-medium tabular-nums">
         <span
           className="shimmer motion-reduce:shimmer-none"
           data-testid="turn-status-label"

--- a/packages/ui/src/components/composites/chat/permission-card.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.tsx
@@ -200,7 +200,7 @@ export function PermissionCard({
     >
       <header className="mb-1 flex items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-txt-strong">{title}</h3>
-        <span className="rounded-full border border-border/50 px-2 py-0.5 text-[10px] font-medium uppercase text-muted">
+        <span className="rounded-full border border-border/50 px-2 py-0.5 text-2xs font-medium uppercase tracking-wider text-muted">
           {statusLabel(state)}
         </span>
       </header>

--- a/packages/ui/src/components/shell/BuildBadge.tsx
+++ b/packages/ui/src/components/shell/BuildBadge.tsx
@@ -382,7 +382,7 @@ export function BuildBadge() {
             <span
               data-testid="build-badge-geom"
               title="Live viewport geometry (ih=innerHeight vv=visualViewport ce=docEl.clientHeight sh=screen.height rc=reclaim-var rcw=reclaim-wiring lv=100lvh dv=100dvh)"
-              className="font-mono tracking-tight text-3xs text-muted/80"
+              className="font-mono tracking-tight text-3xs text-muted"
             >
               {geom}
             </span>

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -6119,7 +6119,7 @@ export function ChatOverlay({
                 {transcriptionComposerActive ? (
                   <div
                     data-testid="chat-transcribing-badge"
-                    className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full bg-white/10 px-2.5 py-0.5 text-[11px] font-medium text-white/75"
+                    className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full bg-white/10 px-2.5 py-0.5 text-xs-tight font-medium text-white/75"
                   >
                     {transcriptionFinishing
                       ? "Finishing transcription…"

--- a/packages/ui/src/components/shell/ChatSurface.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.tsx
@@ -190,7 +190,7 @@ export function ChatSurface({
           aria-label={t("chatsurface.messageLabel", {
             defaultValue: "Message {{appName}}",
           })}
-          className="min-w-0 flex-1 border-0 bg-transparent px-2 py-1.5 text-sm text-txt placeholder:text-txt/50 disabled:opacity-50"
+          className="min-w-0 flex-1 border-0 bg-transparent px-2 py-1.5 text-sm text-txt placeholder:text-muted disabled:opacity-50"
         />
         <GlassIconButton
           icon="mic"

--- a/packages/ui/src/components/shell/LoadingScreen.tsx
+++ b/packages/ui/src/components/shell/LoadingScreen.tsx
@@ -111,7 +111,7 @@ export function LoadingScreen({
   return (
     <div className="flex items-center justify-center h-dvh bg-bg relative overflow-hidden">
       <div className="flex flex-col items-start gap-3.5 w-[420px] max-w-[90vw]">
-        <div className="font-mono text-sm font-normal tracking-[0.35em] uppercase text-txt/70 select-none">
+        <div className="font-mono text-sm font-normal tracking-[0.35em] uppercase text-muted-strong select-none">
           {t("common.loading", { defaultValue: "Loading" })}
           <span className="loading-screen__dots" />
         </div>

--- a/packages/ui/src/components/shell/PairingCommandHint.tsx
+++ b/packages/ui/src/components/shell/PairingCommandHint.tsx
@@ -102,7 +102,7 @@ export function PairingCommandHint({ remoteUrl }: { remoteUrl?: string }) {
         />
       ))}
 
-      <div className="mt-3 space-y-1 text-[11px] leading-relaxed text-muted">
+      <div className="mt-3 space-y-1 text-xs-tight leading-relaxed text-muted">
         {commandInfo.sshTarget ? (
           <p>
             {t("pairingcommandhint.editSshTargetPrefix", {
@@ -139,7 +139,7 @@ function CommandLine({
             style={{
               fontFamily: "'Poppins', Arial, system-ui, sans-serif",
             }}
-            className="text-[10px] font-semibold uppercase text-muted"
+            className="text-2xs font-semibold uppercase tracking-wider text-muted"
           >
             {label}
           </p>
@@ -155,7 +155,7 @@ function CommandLine({
           {copyLabel}
         </Button>
       </div>
-      <code className="block max-w-full select-all overflow-x-auto whitespace-pre rounded-sm border border-border/60 bg-bg/80 px-3 py-2 font-mono text-[11px] leading-relaxed text-txt">
+      <code className="block max-w-full select-all overflow-x-auto whitespace-pre rounded-sm border border-border/60 bg-bg/80 px-3 py-2 font-mono text-xs-tight leading-relaxed text-txt">
         {command}
       </code>
     </div>

--- a/packages/ui/src/components/shell/PairingView.tsx
+++ b/packages/ui/src/components/shell/PairingView.tsx
@@ -83,7 +83,7 @@ export function PairingView() {
         <CardHeader className="pb-6 pt-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0 space-y-1.5">
-              <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/80">
+              <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted">
                 {branding.appName}
               </div>
               <CardTitle className="text-xl text-txt-strong">
@@ -195,7 +195,7 @@ export function PairingView() {
               </p>
 
               <div className="space-y-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted">
+                <p className="text-xs font-semibold uppercase tracking-wider text-muted">
                   {t("pairingview.NextSteps")}
                 </p>
                 <ol className="list-decimal space-y-2 pl-5 text-sm leading-relaxed text-txt">

--- a/packages/ui/src/components/shell/ShortcutsOverlay.tsx
+++ b/packages/ui/src/components/shell/ShortcutsOverlay.tsx
@@ -88,7 +88,7 @@ export function ShortcutsOverlay() {
           {Object.entries(grouped).map(([scope, shortcuts]) => (
             <div key={scope}>
               <h3
-                className="text-xs-tight uppercase tracking-wide font-medium mb-2"
+                className="text-xs-tight uppercase tracking-wider font-medium mb-2"
                 style={{ color: "var(--muted)" }}
               >
                 {scope}

--- a/packages/ui/src/components/shell/SlashCommandMenu.tsx
+++ b/packages/ui/src/components/shell/SlashCommandMenu.tsx
@@ -294,7 +294,7 @@ export function SlashCommandMenu({
     >
       <div
         className={cn(
-          "px-3.5 pb-1 pt-0.5 text-[10px] font-medium uppercase tracking-wider",
+          "px-3.5 pb-1 pt-0.5 text-2xs font-medium uppercase tracking-wider",
           WALLPAPER_TEXT.muted,
           WALLPAPER_FLOAT_SHADOW,
         )}
@@ -308,7 +308,7 @@ export function SlashCommandMenu({
       {error ? (
         <div
           className={cn(
-            "mx-2 mb-1 rounded-lg border border-amber-400/25 bg-amber-400/5 px-2.5 py-1 text-[10px] text-amber-200/80",
+            "mx-2 mb-1 rounded-lg border border-amber-400/25 bg-amber-400/5 px-2.5 py-1 text-2xs text-amber-200/80",
             WALLPAPER_FLOAT_SHADOW,
           )}
           role="status"
@@ -348,7 +348,7 @@ export function SlashCommandMenu({
           >
             <span
               className={cn(
-                "min-w-0 shrink-0 font-mono text-[13px]",
+                "min-w-0 shrink-0 font-mono text-sm-tight",
                 WALLPAPER_TEXT.strong,
                 WALLPAPER_FLOAT_SHADOW,
               )}
@@ -358,7 +358,7 @@ export function SlashCommandMenu({
             {item.secondary ? (
               <span
                 className={cn(
-                  "min-w-0 flex-1 truncate text-[12px]",
+                  "min-w-0 flex-1 truncate text-xs",
                   WALLPAPER_TEXT.soft,
                   WALLPAPER_FLOAT_SHADOW,
                 )}
@@ -371,7 +371,7 @@ export function SlashCommandMenu({
             {item.isCommand && item.hasArgs ? (
               <span
                 aria-hidden="true"
-                className="shrink-0 text-[11px] text-white/35"
+                className="shrink-0 text-xs-tight text-white/35"
               >
                 ⇥
               </span>

--- a/packages/ui/src/components/shell/TopicGroup.tsx
+++ b/packages/ui/src/components/shell/TopicGroup.tsx
@@ -108,8 +108,8 @@ function TitledTopicGroup({
             className="h-1.5 w-1.5 shrink-0 rounded-full bg-white/60"
             aria-hidden
           />
-          <span className="truncate text-[13px] font-medium">{label}</span>
-          <span className="ml-auto shrink-0 text-[11px] text-white/45">
+          <span className="truncate text-sm-tight font-medium">{label}</span>
+          <span className="ml-auto shrink-0 text-xs-tight tabular-nums text-white/45">
             {count} {count === 1 ? "message" : "messages"}
           </span>
         </Button>
@@ -128,7 +128,7 @@ function TitledTopicGroup({
           )}
         >
           <span className="h-px flex-1 bg-white/10" aria-hidden />
-          <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide">
+          <span className="shrink-0 text-2xs font-medium uppercase tracking-wider">
             {label}
           </span>
           <span className="h-px flex-1 bg-white/10" aria-hidden />

--- a/packages/ui/src/components/shell/chat-overlay-transcript.tsx
+++ b/packages/ui/src/components/shell/chat-overlay-transcript.tsx
@@ -117,10 +117,10 @@ export function renderOverlayMessageBody(
           WALLPAPER_FLOAT_SHADOW,
         )}
       >
-        <div className="mb-1 text-[14px] font-medium">
+        <div className="mb-1 text-sm font-medium">
           Connect a provider to chat
         </div>
-        <div className="mb-2.5 whitespace-pre-wrap text-[13px] leading-relaxed text-muted-strong [overflow-wrap:anywhere]">
+        <div className="mb-2.5 whitespace-pre-wrap text-sm-tight leading-relaxed text-muted-strong [overflow-wrap:anywhere]">
           {message.text}
         </div>
         <Button
@@ -128,7 +128,7 @@ export function renderOverlayMessageBody(
           size="sm"
           data-testid="chat-no-provider-settings"
           onClick={() => onOpenSettings?.()}
-          className="h-auto rounded-full border border-border-strong bg-surface px-3 py-1.5 text-[13px] font-medium text-txt transition-colors hover:bg-bg-hover"
+          className="h-auto rounded-full border border-border-strong bg-surface px-3 py-1.5 text-sm-tight font-medium text-txt transition-colors hover:bg-bg-hover"
         >
           Open Settings
         </Button>
@@ -147,8 +147,8 @@ export function renderOverlayMessageBody(
           WALLPAPER_FLOAT_SHADOW,
         )}
       >
-        <div className="mb-1 text-[14px] font-medium">Out of credits</div>
-        <div className="mb-2.5 whitespace-pre-wrap text-[13px] leading-relaxed text-muted-strong [overflow-wrap:anywhere]">
+        <div className="mb-1 text-sm font-medium">Out of credits</div>
+        <div className="mb-2.5 whitespace-pre-wrap text-sm-tight leading-relaxed text-muted-strong [overflow-wrap:anywhere]">
           {message.text}
         </div>
         <Button
@@ -156,7 +156,7 @@ export function renderOverlayMessageBody(
           size="sm"
           data-testid="chat-insufficient-credits-add"
           onClick={() => onOpenSettings?.()}
-          className="h-auto rounded-full border border-border-strong bg-surface px-3 py-1.5 text-[13px] font-medium text-txt transition-colors hover:bg-bg-hover"
+          className="h-auto rounded-full border border-border-strong bg-surface px-3 py-1.5 text-sm-tight font-medium text-txt transition-colors hover:bg-bg-hover"
         >
           Add credits
         </Button>

--- a/packages/ui/src/components/shell/notification-shade-content.tsx
+++ b/packages/ui/src/components/shell/notification-shade-content.tsx
@@ -215,7 +215,7 @@ function NotificationSourceIcon({
           }
           aria-hidden
           style={{ opacity: countVisibility }}
-          className="eliza-notif-shade-transition absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-[11px] font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
+          className="eliza-notif-shade-transition absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-white/90 px-1.5 text-center text-xs-tight font-semibold leading-none tabular-nums text-black shadow-[0_0_0_2px_rgba(0,0,0,0.7),0_1px_4px_rgba(0,0,0,0.45)]"
         >
           {decorative ? null : count > 99 ? "99+" : count}
         </span>

--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -27,7 +27,7 @@ const FieldLabel = React.forwardRef<
     ref={ref}
     className={cn(
       variant === "form"
-        ? "mb-2 block text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted/80"
+        ? "mb-2 block text-xs-tight font-semibold uppercase tracking-[0.14em] text-muted"
         : variant === "kicker"
           ? "text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted"
           : "text-sm font-medium text-txt-strong",

--- a/packages/ui/src/lib/utils.test.ts
+++ b/packages/ui/src/lib/utils.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Locks the cn() tailwind-merge contract for the custom font-size utilities
+ * registered in tailwind-theme.css. Without the classGroups registration,
+ * tailwind-merge parses `text-xs-tight` / `text-2xs` / `text-3xs` as text
+ * COLORS and silently drops them whenever a real color class appears in the
+ * same cn() call. Real merge library, no mocks.
+ */
+import { describe, expect, it } from "vitest";
+
+import { cn } from "./utils";
+
+const CUSTOM_SIZES = [
+  "text-3xs",
+  "text-2xs",
+  "text-xs-tight",
+  "text-sm-tight",
+  "text-chat-body",
+  "text-chat-lead",
+] as const;
+
+describe("cn() custom font-size merge contract", () => {
+  it.each(CUSTOM_SIZES)("%s survives a following text color", (size) => {
+    expect(cn(size, "text-muted")).toBe(`${size} text-muted`);
+  });
+
+  it.each(CUSTOM_SIZES)("%s survives a preceding text color", (size) => {
+    expect(cn("text-muted", size)).toBe(`text-muted ${size}`);
+  });
+
+  it("keeps a custom size alongside arbitrary-value and opacity-suffixed colors", () => {
+    expect(cn("text-chat-body", "text-white/80")).toBe(
+      "text-chat-body text-white/80",
+    );
+    expect(cn("text-xs-tight", "text-[color:var(--brand-white)]")).toBe(
+      "text-xs-tight text-[color:var(--brand-white)]",
+    );
+  });
+
+  it("resolves custom-size vs custom-size conflicts last-wins", () => {
+    expect(cn("text-2xs", "text-xs-tight")).toBe("text-xs-tight");
+    expect(cn("text-chat-body", "text-chat-lead")).toBe("text-chat-lead");
+  });
+
+  it("resolves custom-size vs built-in-size conflicts last-wins in both directions", () => {
+    expect(cn("text-sm", "text-chat-body")).toBe("text-chat-body");
+    expect(cn("text-chat-body", "text-sm")).toBe("text-sm");
+    expect(cn("text-xs", "text-2xs")).toBe("text-2xs");
+    expect(cn("text-3xs", "text-[16px]")).toBe("text-[16px]");
+  });
+
+  it("does not merge a size across a variant boundary", () => {
+    // The composer pattern: base size + coarse-pointer override must coexist.
+    expect(cn("text-chat-body", "pointer-coarse:text-[16px]")).toBe(
+      "text-chat-body pointer-coarse:text-[16px]",
+    );
+  });
+
+  it("leaves ordinary Tailwind size and color merging undisturbed", () => {
+    expect(cn("text-sm", "text-lg")).toBe("text-lg");
+    expect(cn("text-muted", "text-warn")).toBe("text-warn");
+    expect(cn("text-sm", "text-muted")).toBe("text-sm text-muted");
+    expect(cn("px-2", "px-4")).toBe("px-4");
+  });
+});

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,9 +1,33 @@
 /**
  * cn(): the tailwind-merge + clsx class combiner. Browser-safe; prefer this over
  * the utils barrel when bundling the kit (see package CLAUDE.md).
+ *
+ * The merge config must know the project's custom font-size utilities
+ * (tailwind-theme.css `--text-*`). Without registration tailwind-merge parses
+ * `text-xs-tight` as a text *color* and silently drops it when a real color
+ * class follows in the same cn() call.
  */
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "3xs",
+            "2xs",
+            "xs-tight",
+            "sm-tight",
+            "chat-body",
+            "chat-lead",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -145,6 +145,12 @@
   --text-3xs: 0.5625rem;
   --text-2xs: 0.625rem;
   --text-xs-tight: 0.6875rem;
+  /* Between xs and sm (replaces arbitrary text-[13px]) */
+  --text-sm-tight: 0.8125rem;
+  /* Chat message body + composer (replaces the text-[14px]/text-[15px] split)
+     and the larger first-run/lead conversational size (was text-[17px]). */
+  --text-chat-body: 0.9375rem;
+  --text-chat-lead: 1.0625rem;
 
   /* Touch target minimum (Apple HIG 44px) */
   --min-touch-target: 2.75rem;
@@ -313,6 +319,9 @@
   --text-3xs: 0.5625rem;
   --text-2xs: 0.625rem;
   --text-xs-tight: 0.6875rem;
+  --text-sm-tight: 0.8125rem;
+  --text-chat-body: 0.9375rem;
+  --text-chat-lead: 1.0625rem;
   --min-touch-target: 2.75rem;
 
   /* Plugin UI */

--- a/packages/ui/src/styles/tailwind-theme.css
+++ b/packages/ui/src/styles/tailwind-theme.css
@@ -144,6 +144,16 @@
   --text-2xs--line-height: 1rem;
   --text-xs-tight: var(--text-xs-tight);
   --text-xs-tight--line-height: 1rem;
+  --text-sm-tight: var(--text-sm-tight);
+  --text-sm-tight--line-height: 1.125rem;
+  /* Chat conversation body: one size for bubbles, composers, and inline edit
+     (was a 14px/15px split across surfaces). Lead is the larger first-run
+     conversational size. Both keep the body line-height comfortable for
+     multi-line replies. */
+  --text-chat-body: var(--text-chat-body);
+  --text-chat-body--line-height: 1.625;
+  --text-chat-lead: var(--text-chat-lead);
+  --text-chat-lead--line-height: 1.625;
 
   --spacing-touch: var(--min-touch-target);
 }


### PR DESCRIPTION
# Relates to

Fixes #24638 — chat panel / drawer typography split across two systems (arbitrary px vs semantic scale). The issue holds the audit findings and scoped acceptance criteria; this PR implements them.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low–medium. Pure presentation change (class names + token registrations, no logic), but it touches 41 files across every chat surface. Two deliberate visual deltas: the message body unifies on 15px/1.625 (glass bubbles were 14px, some rows 1.7 leading), and uppercase micro-labels gain `tracking-wider`. The `cn()` tailwind-merge config change is behavioral: custom `text-*` size utilities were previously parsed as text *colors* and silently dropped when merged against a color class; they now merge as font sizes. Story-gate pixel diff bounds the blast radius: 163 of 1,547 stories changed, all inspected classes of change (label tracking, body size unification, muted-tier contrast).

# Background

## What does this PR do?

Unifies chat panel / drawer typography on the repo's semantic type scale, finishing the migration `base.css` already started ("replaces arbitrary text-[9px]…"):

- **Migrates ~60 call sites** in `chat/`, `chat/widgets/`, `composites/chat/`, `shell/`, and `pages/ChatView.tsx` off arbitrary `text-[9px]`–`text-[15px]` classes onto `text-3xs` / `text-2xs` / `text-xs-tight` / `text-xs`. The arbitrary px classes silently skipped the coarse-pointer mobile up-sizing in `base.css` (9–10px is unreadable at arm's length on a handset); the semantic utilities restore it.
- **Registers three new scale steps**: `text-sm-tight` (13px — a de-facto step used 7+ times but never named), `text-chat-body` (15px/1.625 — one size for message bubbles, transcripts, composers, and inline edit, replacing a 14px/15px split across surfaces), and `text-chat-lead` (17px first-run conversational size).
- **Fixes a real `cn()` bug**: `tailwind-merge` did not know the custom font-size utilities, so it classified `text-xs-tight`/`text-2xs`/`text-3xs` as text colors and dropped them whenever a color class followed in the same `cn()` call. Registered via `extendTailwindMerge` classGroups.
- **Letter-spacing**: all uppercase micro-labels now carry `tracking-wider` (previously: none, `tracking-wide`, `0.08em`, `0.1em`, or `0.14em` for the same visual role).
- **Contrast**: replaces opacity-suffixed text classes (`text-muted/40–80`, `text-txt/50–80`) with the named muted tiers, per the `CHAT_OVERLAY_DESIGN_SPEC.md` #16418 rule. The `field.tsx` form-label change (`text-muted/80` → `text-muted`) also clears a story-gate color-contrast axe violation.
- **Misc**: `tabular-nums` on the topic message counter; `font-chat` utility instead of inline `style={{fontFamily}}` / `font-[var(--font-chat)]` spellings.
- **Merge-contract regression tests** (`src/lib/utils.test.ts`, 17 tests, real tailwind-merge, no mocks): every registered custom size survives an adjacent text color in **both orderings** (including arbitrary-value and opacity-suffixed colors), custom-vs-custom and custom-vs-built-in size conflicts resolve last-wins in both directions, variant-prefixed sizes (`pointer-coarse:text-[16px]`) are not merged across the boundary, and ordinary Tailwind size/color/spacing merging is undisturbed.

## What kind of change is this?

Improvements (visual-consistency fix, no functional change).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The token registrations: `packages/ui/src/styles/base.css` (scale values + mobile up-size block), `packages/ui/src/styles/tailwind-theme.css` (Tailwind v4 `--text-*` registration), and `packages/ui/src/lib/utils.ts` (tailwind-merge classGroups). Then any migrated component, e.g. `composites/chat/chat-message.tsx`.

## Detailed testing steps

- `bun run --cwd packages/ui typecheck` — passes.
- `bun run --cwd packages/ui lint:check` — passes (5 pre-existing warnings in untouched cloud test files).
- `bun run --cwd packages/ui test` — failure set byte-identical to clean `origin/develop` (27 pre-existing failures, zero new; verified by diffing sorted FAIL lists from both runs).
- Story gate (`test/story-gate/run-story-gate.mjs`, 1,607 stories): totals identical to develop's baseline — and one **fewer** a11y violation (the field label contrast fix). 163/1,547 screenshot-stable stories changed pixels; all changes are the intended label tracking / body-size unification.
- `bun run --cwd packages/app audit:app` (with `ELIZA_NODE_PATH` pointing at Node 24): **227 passed, 0 broken, 0 needs-work, 0 OCR regressions** — run twice, at `979561f800` and again at the exact head `1172642609` (pre-rebase; rendering identical at `b4c6574805` — the rebase picked up only non-UI develop commits and the keyring type fix).
- `bunx vitest run src/lib/utils.test.ts` — 17/17 merge-contract tests pass.
- **Five audit/inspection/iteration cycles** documented with dispositions in [audit-cycles.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-audit-cycles.md): (1) implementation + first gate run surfaced a new a11y contrast violation, (2) `field.tsx` fix + gate rerun back to baseline-minus-one-violation, (3) byte-wise pixel diff of all 1,547 stable stories against develop + visual inspection of the changed pairs, (4) full `audit:app` at `979561f800`, (5) full `audit:app` at exact head `1172642609` (pre-rebase; rendering identical at `b4c6574805` — the rebase picked up only non-UI develop commits and the keyring type fix) plus manual review of **all 13 needs-eyeball views** (26 captures opened and dispositioned individually, not waved through on baseline status) — head OCR reports: [ocr-triage-head-1172642.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-ocr-triage-head-1172642.json) and, after the rebase onto develop, [ocr-triage-head-b4c6574.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-ocr-triage-head-b4c6574.json) at the current head (cycle 6: same clean result — 224 views, 211 verified, 0 broken, 0 regressions).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b4c6574805c89e6e7f634fe15033eda401261a4c -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: each pair image below is before (left) / after (right) at identical viewport — see the inline gallery in **Evidence Details**. [chatview](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-pages-chatview--default--before-after.jpg) · [chat message](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-composites-chat-chatmessage--assistant--before-after.jpg) · [transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-composites-chat-chattranscript--default--before-after.jpg) · [form widget](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-chat-widgets-formrequest--default--before-after.jpg) · [topic group](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-topicgroup--expanded--before-after.jpg)
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: right half of every pair, plus live `audit:app` captures — [desktop chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-audit-app-builtin-chat-desktop.jpg) · [mobile chat](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-audit-app-builtin-chat-mobile.jpg) · [slash menu](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-slashcommandmenu--open--before-after.jpg) · [permission card](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-composites-chat-permissioncard--default--before-after.jpg) · [first-run overlay](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-chatoverlay--first-run-onboarding--before-after.jpg) · [pairing hint](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-pairingcommandhint--loopback--before-after.jpg) · [skill sidebar](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-composites-skills-skillsidebaritem--default--before-after.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video (slideshow through all 10 before/after story pairs): [typography-before-after-walkthrough.mp4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-typography-walkthrough-faststart.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - renderer-only class-name/token change; no backend code path exists to log.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: story-gate per-story console/network capture, 0 new console errors vs develop baseline — [frontend-logs.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-frontend-logs.json)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; CSS classes and design tokens only.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: story-gate report (totals identical to develop, one fewer a11y violation) — [story-gate-report-after.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-story-gate-report-after.json) · pixel-diff list of the 163 changed stories — [changed-stories.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-changed-stories.txt)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: packaged-engine ocr-triage report from `audit:app` — 224 views, 211 verified, 0 broken, 0 regressions — [ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-ocr-triage.json)

# Evidence Details

Every pair below is **before (left) / after (right)** at the same viewport, from the deterministic story-gate capture (frozen clock, seeded RNG, animations off), so any pixel delta is caused by this diff.

**Assistant message body — 15px unified (was 15px here; glass surfaces were 14px):**

![chat message](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-composites-chat-chatmessage--assistant--before-after.jpg)

**Game-modal transcript — bubbles unified on `text-chat-body`:**

![transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-composites-chat-chattranscript--default--before-after.jpg)

**Topic drawer group — 10px/11px → `text-2xs`/`text-xs-tight`, counter gains `tabular-nums`, header gains `tracking-wider`:**

![topic group](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-topicgroup--expanded--before-after.jpg)

**Slash-command menu — section header and hints on the semantic scale:**

![slash menu](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-slashcommandmenu--open--before-after.jpg)

**Form-request widget — kicker labels tracked, helper text on named muted tier:**

![form widget](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-chat-widgets-formrequest--default--before-after.jpg)

**First-run overlay — 17px → `text-chat-lead`:**

![first-run](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-shell-chatoverlay--first-run-onboarding--before-after.jpg)

**Live `audit:app` chat captures (desktop landscape / mobile portrait), post-change:**

![audit desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-audit-app-builtin-chat-desktop.jpg)
![audit mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24612-audit-app-builtin-chat-mobile.jpg)

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; this PR only renames CSS utility classes and registers design tokens.

## Known gaps / failures

- `bun run verify` fails at `audit:tsconfig-workspace-resolution` with 16 pre-existing violations (`@elizaos/capacitor-secure-store` unresolved from `packages/ui/src/bridge/storage-bridge.ts` in 16 plugin tsconfigs). Reproduced identically on a clean `origin/develop` detached checkout — introduced by the Vault workspace merge (#23068), unrelated to this diff.
- `bun run --cwd packages/ui test` has 27 pre-existing failures on clean develop; this PR's failure set is byte-identical (diffed sorted FAIL lists).
