### PR TITLE
fix(app-core): write steward credentials metadata atomically

### DIFF
--- a/packages/app-core/src/services/steward-credentials.test.ts
+++ b/packages/app-core/src/services/steward-credentials.test.ts
@@ -9,7 +9,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   PlatformSecureStore,
   SecureStoreDeleteResult,
@@ -283,5 +283,99 @@ describe("steward credentials", () => {
 
     const loaded = await loadStewardCredentials({ secureStore });
     expect(loaded).toMatchObject({ apiKey: "", agentToken: "" });
+  });
+
+  it("writes the metadata file atomically with owner-only permissions and no leftover temp file", async () => {
+    const secureStore = new MemorySecureStore();
+
+    await saveStewardCredentials(
+      {
+        apiUrl: "https://steward.local",
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        apiKey: "tenant-api-key",
+        agentToken: "agent-token",
+      },
+      { secureStore },
+    );
+
+    const stat = fs.statSync(credentialsPath(stateDir));
+    expect(stat.mode & 0o777).toBe(0o600);
+    const parsed = JSON.parse(
+      fs.readFileSync(credentialsPath(stateDir), "utf8"),
+    );
+    expect(parsed.apiUrl).toBe("https://steward.local");
+    const leftovers = fs
+      .readdirSync(stateDir)
+      .filter((name) => name.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+
+  it("keeps the previously saved credentials readable when a metadata write is interrupted mid-write", async () => {
+    const secureStore = new MemorySecureStore();
+    await saveStewardCredentials(
+      {
+        apiUrl: "https://steward.local",
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        apiKey: "tenant-api-key",
+        agentToken: "agent-token",
+        agentName: "Agent",
+      },
+      { secureStore },
+    );
+
+    // Simulate the process dying halfway through writing the metadata file:
+    // flush half of the payload, then crash. The real module must route the
+    // write through a temp file so this interruption cannot tear the live
+    // steward-credentials.json.
+    const realWriteFileSync = fs.writeFileSync;
+    const interrupted = vi.spyOn(fs, "writeFileSync").mockImplementationOnce(((
+      target: fs.PathOrFileDescriptor,
+      data,
+    ) => {
+      const text =
+        typeof data === "string" ? data : Buffer.from(data).toString();
+      realWriteFileSync(target, text.slice(0, Math.floor(text.length / 2)), {
+        mode: 0o600,
+      });
+      throw new Error("simulated crash mid-write");
+    }) as typeof fs.writeFileSync);
+
+    let failed = false;
+    try {
+      await saveStewardCredentials(
+        {
+          apiUrl: "https://steward.local",
+          tenantId: "tenant-2",
+          agentId: "agent-2",
+          apiKey: "tenant-api-key",
+          agentToken: "agent-token",
+          agentName: "Renamed",
+        },
+        { secureStore },
+      );
+    } catch {
+      failed = true;
+    } finally {
+      interrupted.mockRestore();
+    }
+    expect(failed).toBe(true);
+
+    // The torn write must never be observable: the original setup survives.
+    const loaded = await loadStewardCredentials({ secureStore });
+    expect(loaded).toMatchObject({
+      apiUrl: "https://steward.local",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      agentName: "Agent",
+    });
+    expect(
+      JSON.parse(fs.readFileSync(credentialsPath(stateDir), "utf8")),
+    ).toMatchObject({ tenantId: "tenant-1" });
+    const leftovers = fs
+      .readdirSync(stateDir)
+      .filter((name) => name.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
   });
 });

--- a/packages/app-core/src/services/steward-credentials.test.ts
+++ b/packages/app-core/src/services/steward-credentials.test.ts
@@ -334,8 +334,16 @@ describe("steward credentials", () => {
       target: fs.PathOrFileDescriptor,
       data,
     ) => {
+      // `data` widens to ArrayBufferView, which includes BigInt64Array —
+      // decode through the underlying bytes so every view type is accepted.
       const text =
-        typeof data === "string" ? data : Buffer.from(data).toString();
+        typeof data === "string"
+          ? data
+          : Buffer.from(
+              data.buffer,
+              data.byteOffset,
+              data.byteLength,
+            ).toString();
       realWriteFileSync(target, text.slice(0, Math.floor(text.length / 2)), {
         mode: 0o600,
       });

--- a/packages/app-core/src/services/steward-credentials.ts
+++ b/packages/app-core/src/services/steward-credentials.ts
@@ -7,7 +7,7 @@
  * Environment variables always override persisted values.
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -109,6 +109,19 @@ function readCredentialsFile():
   }
 }
 
+function fsyncMetadataDirectory(directory: string): void {
+  if (process.platform === "win32") return;
+  const descriptor = fs.openSync(
+    directory,
+    fs.constants.O_RDONLY | (fs.constants.O_DIRECTORY ?? 0),
+  );
+  try {
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
 function writeCredentialsMetadata(
   credentials: PersistedStewardCredentials | StewardCredentialsMetadata,
 ): void {
@@ -126,7 +139,31 @@ function writeCredentialsMetadata(
   if (credentials.tenantId) data.tenantId = credentials.tenantId;
   if (credentials.agentId) data.agentId = credentials.agentId;
 
-  fs.writeFileSync(credPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  // Write to a private temporary file and rename into place so an interrupted
+  // process can never leave a truncated steward-credentials.json behind: the
+  // loader treats unparseable metadata as "steward not configured", silently
+  // discarding the saved setup. Mirrors writeMetaStore() in account-pool.ts.
+  const tmp = `${credPath}.${process.pid}.${randomUUID()}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(
+      tmp,
+      fs.constants.O_WRONLY |
+        fs.constants.O_CREAT |
+        fs.constants.O_EXCL |
+        (fs.constants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    fs.writeFileSync(descriptor, JSON.stringify(data, null, 2), "utf-8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(tmp, credPath);
+    fsyncMetadataDirectory(dir);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    fs.rmSync(tmp, { force: true });
+  }
 }
 
 async function readStewardSecret(


### PR DESCRIPTION
# Relates to

Fixes #24611

# Summary

`writeCredentialsMetadata()` wrote `<state-dir>/steward-credentials.json` **in place** with one `fs.writeFileSync(credPath, ...)`. An interrupted process (crash, SIGKILL, power loss) leaves a truncated JSON file, and the loader's `error-policy:J3` catch converts that torn file into "steward not configured" — `loadStewardCredentials()` returns `null` and the saved setup silently disappears. Nothing throws; nothing reports data loss.

This PR routes the write through the repository's established crash-atomic pattern (same shape as `writeMetaStore()` in `packages/core/src/services/account-pool.ts`):

1. create a unique temp file with `O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW`, mode `0600`
2. write, then `fsync` the file descriptor
3. atomic `renameSync(tmp, credPath)`
4. `fsync` the containing directory (skipped on win32, matching account-pool)
5. on any failure: close the fd if open and remove the temp file in `finally`

The previous file therefore survives any interrupted attempt byte-for-byte; no truncation, windowing, or content rewriting is introduced anywhere — complete metadata is either fully replaced or not at all.

# Evidence Gate

## 1. Origin reproduction

- Branch point: origin/develop @ `c57445392a6e`.
- Pre-change byte-identity verified before any run:
  `git show origin/develop:packages/app-core/src/services/steward-credentials.ts | diff - <file>` → identical.
- Defect demonstrated by driving the real module (`saveStewardCredentials` → interrupted metadata write → `loadStewardCredentials`) through its real seam: on the origin source the previously saved credentials load as `null`.

## 2. No over-rejection (previously-valid inputs unchanged)

All 3 pre-existing tests pass unmodified alongside the new ones. The writer still produces exactly the same JSON document (`JSON.stringify(data, null, 2)`), same fields, same selection logic; only the durability mechanism changed. Verified outputs are byte-comparable for the happy path (test asserts parsed equality of `apiUrl` plus existing assertions cover field presence and secret-scrubbing).

## 3. Load-bearing revert (copy-aside)

- `cp` fixed source aside; restore origin `steward-credentials.ts`; run new suite against it:

```
Test Files  1 failed (1)
Tests  1 failed | 4 passed (5)
AssertionError: expected null to match object { …(4) }
```

(the interrupted-write test fails: origin loses the saved setup)
- Restore fix:

```
Test Files  1 passed (1)
Tests  5 passed (5)
```

## 4. Committed test actually executed

`packages/app-core/src/services/steward-credentials.test.ts` — two new tests:

- "keeps the previously saved credentials readable when a metadata write is interrupted mid-write" — injects a mid-write death at the real fs seam and proves the old setup still loads and no `.tmp` files remain.
- "writes the metadata file atomically with owner-only permissions and no leftover temp file" — asserts `0600`, complete parse, empty tmp leftovers.

Final recorded run at head sha `a9119201dd49` (exit 0): `5 passed (5)`.

## 5. Typecheck

`tsc --noEmit` error sets diffed branch vs untouched control (both files reverted to origin): identical error set (one pre-existing unrelated `TS2307` in `@elizaos/cloud-shared` from an unbuilt workspace dep). **Zero added errors.**

## 6. Biome

`bunx biome check src/services/steward-credentials.ts src/services/steward-credentials.test.ts` → clean ("Checked 2 files... No fixes applied" after `--write` normalization).

## Known gaps

- The same non-atomic pattern exists in `services/steward-sidecar/wallet-setup.ts` (`persistCredentials`). That file is already occupied by open PR #24416, so this PR deliberately does not touch it; it should get the same treatment once #24416 resolves.
- Real SIGKILL/power-loss timing was simulated deterministically via fault injection at the fs boundary rather than by racing a real kill signal; a real kill lands mid-write only probabilistically.
- Hosted CI does not run on fork PRs; all evidence above is from local execution of the real module and real test runner.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openrouter/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openrouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [ox-steward-cred-atomic]
<!-- slop-contribution-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NCEHC4WKV78FDPKPGFXW1F","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T18:41:37.668Z","completed_at":"2026-08-22T19:47:44.270Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T18:41:38.614Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0208af3d94f0ac263dd7475f3260a03877c020330167ec0d33d684d6096c60c8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"978e7d8f-2d80-4c62-8ee0-064dab3916c4","object_id":"sha256:0208af3d94f0ac263dd7475f3260a03877c020330167ec0d33d684d6096c60c8","sha256":"0208af3d94f0ac263dd7475f3260a03877c020330167ec0d33d684d6096c60c8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"1Wlcyh779mSGppeRDcwB4C8B1lmB4axSkz6FSZ6Ae3d9r237Rmg-5yxFOnWTLwc8C2bqxMd4sRc9Gk3Q1qefCw"}} -->
