### PR TITLE
fix(cli-inference): fail closed on invalid timeout settings

### DIFF
--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -147,7 +147,8 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-8` | claude large-tier model (`--model` / SDK large tier) |
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
 | `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default / allowlist lookup) | path to the claude executable: drives the `claude-sdk` session AND pins the cold `claude` spawn (deploys outside the SOC2 launcher allowlist) |
-| `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |
+| `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk` / `codex-sdk`: restart a warm session after a positive safe-integer number of turns (bounds context) |
+| `ELIZA_CLI_SDK_TURN_TIMEOUT_MS` | No | `90000` | `claude-sdk`: positive safe-integer per-turn timeout; falls back to `ELIZA_CLI_TIMEOUT_MS` when unset; the exact literal `0` is the only unbounded-turn opt-out |
 | `ELIZA_CLI_CLAUDE_EFFORT` | No | (SDK default: high) | `claude-sdk`: reasoning effort forwarded to the SDK `effort` option (`low`/`medium`/`high`/`xhigh`/`max`); an unsupported level for the model is silently downgraded by the SDK |
 | `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` | No | (falls back to `ELIZA_CLI_CLAUDE_EFFORT`) | `claude-sdk`: effort for the ROUTE-mode planner tier, so routing depth tunes independently of reply depth |
 | `ELIZA_CLI_CLAUDE_ALL_TIERS` | No | (unset = large tiers only) | `claude-sdk`: also serve the high-frequency triage tiers (TEXT_SMALL/NANO/MEDIUM) on this route so the ENTIRE text brain runs on the one subscription (no cerebras/gemma fallthrough). Higher subscription usage; triage defaults to the cheaper large-tier model, not the planner tier |
@@ -156,11 +157,13 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |
 | `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled / allowlist lookup) | path to the system codex binary: REQUIRED for `codex-sdk` (bundled 0.80.0 rejects current models); also pins the cold `codex` spawn |
-| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout (SIGTERM on expiry; CLI backends) |
+| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | positive safe-integer per-call spawn timeout (SIGTERM on expiry; cold CLI backends), also the `claude-sdk` turn-timeout fallback when its dedicated setting is absent |
 
 ## Errors
 
 Handlers THROW on non-zero exit / timeout (`+SIGTERM`) / empty stdout so `useModel` + AccountPool failover treat them as provider failures — never swallow-and-return-empty. stderr is redacted via `SENSITIVE_ENV_RE` before it reaches the error message or log.
+
+For the active backend, an explicitly present numeric timeout/restart setting must satisfy the contract above. Blank, malformed, non-safe, zero (except the exact SDK turn-timeout opt-out), and negative values throw `CLI_INFERENCE_INVALID_CONFIGURATION` before any process or warm session is created. Only a truly absent setting selects a fallback/default; settings unused by the active backend are ignored. Each warm-cache entry records its effective bounds; a configuration change disposes and replaces the session under the same logical cache/rotation identity, so stale lifecycle or account-affinity state cannot be reused or accumulated.
 
 ## Commands
 

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -147,7 +147,8 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CLAUDE_MODEL` | No | `claude-opus-4-8` | claude large-tier model (`--model` / SDK large tier) |
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
 | `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default / allowlist lookup) | path to the claude executable: drives the `claude-sdk` session AND pins the cold `claude` spawn (deploys outside the SOC2 launcher allowlist) |
-| `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk`: restart a warm session after N turns (bounds context) |
+| `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk` / `codex-sdk`: restart a warm session after a positive safe-integer number of turns (bounds context) |
+| `ELIZA_CLI_SDK_TURN_TIMEOUT_MS` | No | `90000` | `claude-sdk`: positive safe-integer per-turn timeout; falls back to `ELIZA_CLI_TIMEOUT_MS` when unset; the exact literal `0` is the only unbounded-turn opt-out |
 | `ELIZA_CLI_CLAUDE_EFFORT` | No | (SDK default: high) | `claude-sdk`: reasoning effort forwarded to the SDK `effort` option (`low`/`medium`/`high`/`xhigh`/`max`); an unsupported level for the model is silently downgraded by the SDK |
 | `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` | No | (falls back to `ELIZA_CLI_CLAUDE_EFFORT`) | `claude-sdk`: effort for the ROUTE-mode planner tier, so routing depth tunes independently of reply depth |
 | `ELIZA_CLI_CLAUDE_ALL_TIERS` | No | (unset = large tiers only) | `claude-sdk`: also serve the high-frequency triage tiers (TEXT_SMALL/NANO/MEDIUM) on this route so the ENTIRE text brain runs on the one subscription (no cerebras/gemma fallthrough). Higher subscription usage; triage defaults to the cheaper large-tier model, not the planner tier |
@@ -156,11 +157,13 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |
 | `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled / allowlist lookup) | path to the system codex binary: REQUIRED for `codex-sdk` (bundled 0.80.0 rejects current models); also pins the cold `codex` spawn |
-| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout (SIGTERM on expiry; CLI backends) |
+| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | positive safe-integer per-call spawn timeout (SIGTERM on expiry; cold CLI backends), also the `claude-sdk` turn-timeout fallback when its dedicated setting is absent |
 
 ## Errors
 
 Handlers THROW on non-zero exit / timeout (`+SIGTERM`) / empty stdout so `useModel` + AccountPool failover treat them as provider failures — never swallow-and-return-empty. stderr is redacted via `SENSITIVE_ENV_RE` before it reaches the error message or log.
+
+For the active backend, an explicitly present numeric timeout/restart setting must satisfy the contract above. Blank, malformed, non-safe, zero (except the exact SDK turn-timeout opt-out), and negative values throw `CLI_INFERENCE_INVALID_CONFIGURATION` before any process or warm session is created. Only a truly absent setting selects a fallback/default; settings unused by the active backend are ignored. Each warm-cache entry records its effective bounds; a configuration change disposes and replaces the session under the same logical cache/rotation identity, so stale lifecycle or account-affinity state cannot be reused or accumulated.
 
 ## Commands
 

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -7,10 +7,17 @@
  * `claude`/`codex` resolve through the SOC2 allowlist on this box.
  */
 import { readFileSync } from "node:fs";
-import type { ChatMessage, IAgentRuntime, PluginAutoEnableContext } from "@elizaos/core";
+import type {
+  ChatMessage,
+  GenerateTextParams,
+  IAgentRuntime,
+  PluginAutoEnableContext,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldEnable } from "../auto-enable";
 import {
+  __setClaudeSdkSessionFactoryForTests,
+  __setCodexSdkSessionFactoryForTests,
   buildCleanRoutingParams,
   buildCleanRoutingSystemPrompt,
   buildEnvelopeBody,
@@ -19,8 +26,10 @@ import {
   buildRouterBody,
   ClaudeCli,
   ClaudeSdkSession,
+  CliInferenceConfigurationError,
   CodexSdkSession,
   cliInferencePlugin,
+  disposeSdkSessions,
   findHandleResponseTool,
   LARGE_TIER_MODEL_TYPES,
   parseTimeout,
@@ -97,9 +106,40 @@ function recordingSpawn(result: Partial<SpawnResult>) {
   return { calls, fn };
 }
 
-afterEach(() => {
+type TestBackend = "claude" | "claude-sdk" | "codex" | "codex-sdk";
+type TestModelHandler = (runtime: IAgentRuntime, params: GenerateTextParams) => Promise<string>;
+
+function textLargeHandler(backend: TestBackend): TestModelHandler {
+  const models = buildModels({ ELIZA_CHAT_VIA_CLI: backend }) as Record<string, TestModelHandler>;
+  return models.TEXT_LARGE;
+}
+
+function modelRuntime(
+  backend: TestBackend,
+  settings: Record<string, string | boolean | number | null | undefined> = {}
+): IAgentRuntime {
+  return {
+    getSetting: (key: string) => (key === "ELIZA_CHAT_VIA_CLI" ? backend : (settings[key] ?? null)),
+  } as IAgentRuntime;
+}
+
+const sessionFactoryRestores: Array<() => void> = [];
+
+function trackSessionFactoryRestore(restore: () => void): () => void {
+  sessionFactoryRestores.push(restore);
+  return restore;
+}
+
+afterEach(async () => {
+  while (sessionFactoryRestores.length > 0) {
+    sessionFactoryRestores.pop()?.();
+  }
+  await disposeSdkSessions();
   delete process.env.ELIZA_CHAT_VIA_CLI;
   delete process.env.ELIZA_PLANNER_NATIVE_TOOLS;
+  delete process.env.ELIZA_CLI_TIMEOUT_MS;
+  delete process.env.ELIZA_CLI_SDK_RESTART_AFTER_TURNS;
+  delete process.env.ELIZA_CLI_SDK_TURN_TIMEOUT_MS;
   vi.restoreAllMocks();
 });
 
@@ -542,9 +582,455 @@ describe("models map gating (large-tier only)", () => {
       const argv = calls[0].argv;
       expect(argv[0]).toBe(FAKE_CLAUDE);
       expect(argv[argv.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+      expect(calls[0].opts.timeoutMs).toBe(120_000);
     } finally {
       restore();
     }
+  });
+
+  it.each(["", "abc", "1.5", "9007199254740993", "0", "-1", "-0"])(
+    "rejects an explicitly invalid cold timeout %j before any spawn",
+    async (invalid) => {
+      const { calls, fn } = recordingSpawn({ stdout: "must not run" });
+      const restore = __setClaudeSpawn(fn);
+      try {
+        const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude" }) as Record<
+          string,
+          (
+            runtime: { getSetting: (key: string) => string | undefined },
+            params: unknown
+          ) => Promise<string>
+        >;
+        const runtime = {
+          getSetting: (key: string) =>
+            key === "ELIZA_CHAT_VIA_CLI"
+              ? "claude"
+              : key === "ELIZA_CLI_TIMEOUT_MS"
+                ? invalid
+                : key === "ELIZA_CLI_CLAUDE_BIN"
+                  ? FAKE_CLAUDE
+                  : undefined,
+        };
+
+        const error = await models.TEXT_LARGE(runtime, { prompt: "hello" }).then(
+          () => undefined,
+          (cause: unknown) => cause
+        );
+        expect(error).toBeInstanceOf(CliInferenceConfigurationError);
+        expect(error).toMatchObject({
+          code: "CLI_INFERENCE_INVALID_CONFIGURATION",
+          setting: "ELIZA_CLI_TIMEOUT_MS",
+        });
+        expect(calls).toHaveLength(0);
+      } finally {
+        restore();
+      }
+    }
+  );
+
+  it("rejects an invalid cold Codex timeout before any spawn", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "must not run" });
+    const restoreSpawn = __setCodexSpawn(fn);
+    try {
+      const error = await textLargeHandler("codex")(
+        modelRuntime("codex", {
+          ELIZA_CLI_TIMEOUT_MS: "broken",
+          ELIZA_CLI_CODEX_BIN: FAKE_CODEX,
+        }),
+        { prompt: "hello" }
+      ).then(
+        () => undefined,
+        (cause: unknown) => cause
+      );
+
+      expect(error).toBeInstanceOf(CliInferenceConfigurationError);
+      expect(error).toMatchObject({ setting: "ELIZA_CLI_TIMEOUT_MS" });
+      expect(calls).toHaveLength(0);
+    } finally {
+      restoreSpawn();
+    }
+  });
+
+  it("validates only the general timeout for a cold backend", async () => {
+    const { calls, fn } = recordingSpawn({ stdout: "from claude" });
+    const restoreSpawn = __setClaudeSpawn(fn);
+    try {
+      await expect(
+        textLargeHandler("claude")(
+          modelRuntime("claude", {
+            ELIZA_CLI_TIMEOUT_MS: "2500",
+            ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "invalid-but-unused",
+            ELIZA_CLI_SDK_TURN_TIMEOUT_MS: "invalid-but-unused",
+            ELIZA_CLI_CLAUDE_BIN: FAKE_CLAUDE,
+          }),
+          { prompt: "hello" }
+        )
+      ).resolves.toBe("from claude");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].opts.timeoutMs).toBe(2_500);
+    } finally {
+      restoreSpawn();
+    }
+  });
+
+  it("prefers a valid runtime timeout over an invalid environment timeout", async () => {
+    process.env.ELIZA_CLI_TIMEOUT_MS = "invalid-env";
+    const { calls, fn } = recordingSpawn({
+      stdout: '{"type":"agent_message","message":"from codex"}',
+    });
+    const restoreSpawn = __setCodexSpawn(fn);
+    try {
+      await expect(
+        textLargeHandler("codex")(
+          modelRuntime("codex", {
+            ELIZA_CLI_TIMEOUT_MS: 3_500,
+            ELIZA_CLI_CODEX_BIN: FAKE_CODEX,
+          }),
+          { prompt: "hello" }
+        )
+      ).resolves.toBe("from codex");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].opts.timeoutMs).toBe(3_500);
+    } finally {
+      restoreSpawn();
+    }
+  });
+
+  it("rejects an env-only invalid timeout with a bounded typed diagnostic", async () => {
+    process.env.ELIZA_CLI_TIMEOUT_MS = `not-a-number-${"x".repeat(10_000)}`;
+    const { calls, fn } = recordingSpawn({ stdout: "must not run" });
+    const restoreSpawn = __setClaudeSpawn(fn);
+    try {
+      const error = await textLargeHandler("claude")(
+        modelRuntime("claude", { ELIZA_CLI_CLAUDE_BIN: FAKE_CLAUDE }),
+        { prompt: "hello" }
+      ).then(
+        () => undefined,
+        (cause: unknown) => cause
+      );
+
+      expect(error).toBeInstanceOf(CliInferenceConfigurationError);
+      expect(error).toMatchObject({
+        code: "CLI_INFERENCE_INVALID_CONFIGURATION",
+        setting: "ELIZA_CLI_TIMEOUT_MS",
+        context: { valueType: "string" },
+      });
+      expect((error as Error).message.length).toBeLessThan(260);
+      expect(
+        String((error as CliInferenceConfigurationError).context?.valuePreview).length
+      ).toBeLessThanOrEqual(96);
+      expect(calls).toHaveLength(0);
+    } finally {
+      restoreSpawn();
+    }
+  });
+
+  it.each([
+    ["ELIZA_CLI_SDK_RESTART_AFTER_TURNS", ""],
+    ["ELIZA_CLI_SDK_RESTART_AFTER_TURNS", "0"],
+    ["ELIZA_CLI_SDK_RESTART_AFTER_TURNS", "-0"],
+    ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "abc"],
+    ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "0.5"],
+    ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "-0"],
+    ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "+0"],
+  ] as const)("rejects invalid warm setting %s=%j before session creation", async (key, value) => {
+    let sessionCreations = 0;
+    const restoreFactory = trackSessionFactoryRestore(
+      __setClaudeSdkSessionFactoryForTests(() => {
+        sessionCreations += 1;
+        throw new Error("warm session constructor must not be reached");
+      })
+    );
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" }) as Record<
+        string,
+        (
+          runtime: { getSetting: (setting: string) => string | undefined },
+          params: unknown
+        ) => Promise<string>
+      >;
+      const runtime = {
+        getSetting: (setting: string) =>
+          setting === "ELIZA_CHAT_VIA_CLI" ? "claude-sdk" : setting === key ? value : undefined,
+      };
+
+      const error = await models.TEXT_LARGE(runtime, { prompt: "hello" }).then(
+        () => undefined,
+        (cause: unknown) => cause
+      );
+      expect(error).toBeInstanceOf(CliInferenceConfigurationError);
+      expect(error).toMatchObject({
+        code: "CLI_INFERENCE_INVALID_CONFIGURATION",
+        setting: key,
+      });
+      expect(sessionCreations).toBe(0);
+    } finally {
+      restoreFactory();
+    }
+  });
+
+  it("rejects an invalid Codex SDK restart before session creation", async () => {
+    let sessionCreations = 0;
+    trackSessionFactoryRestore(
+      __setCodexSdkSessionFactoryForTests(() => {
+        sessionCreations += 1;
+        throw new Error("Codex warm session constructor must not be reached");
+      })
+    );
+
+    const error = await textLargeHandler("codex-sdk")(
+      modelRuntime("codex-sdk", { ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "" }),
+      { prompt: "hello" }
+    ).then(
+      () => undefined,
+      (cause: unknown) => cause
+    );
+
+    expect(error).toBeInstanceOf(CliInferenceConfigurationError);
+    expect(error).toMatchObject({ setting: "ELIZA_CLI_SDK_RESTART_AFTER_TURNS" });
+    expect(sessionCreations).toBe(0);
+  });
+
+  it("Codex SDK ignores unrelated timeout settings and propagates a valid restart", async () => {
+    const createdConfigs: Array<ConstructorParameters<typeof CodexSdkSession>[0]> = [];
+    trackSessionFactoryRestore(
+      __setCodexSdkSessionFactoryForTests((config) => {
+        createdConfigs.push(config);
+        return new CodexSdkSession(config);
+      })
+    );
+    vi.spyOn(CodexSdkSession.prototype, "generate").mockResolvedValue("from codex sdk");
+
+    await expect(
+      textLargeHandler("codex-sdk")(
+        modelRuntime("codex-sdk", {
+          ELIZA_CLI_TIMEOUT_MS: "invalid-but-unused",
+          ELIZA_CLI_SDK_TURN_TIMEOUT_MS: "invalid-but-unused",
+          ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "+9",
+        }),
+        { prompt: "hello" }
+      )
+    ).resolves.toBe("from codex sdk");
+
+    expect(createdConfigs).toHaveLength(1);
+    expect(createdConfigs[0].restartAfterTurns).toBe(9);
+  });
+
+  it("does not let a valid SDK turn timeout mask an invalid general timeout", async () => {
+    let sessionCreations = 0;
+    const restoreFactory = trackSessionFactoryRestore(
+      __setClaudeSdkSessionFactoryForTests(() => {
+        sessionCreations += 1;
+        throw new Error("warm session constructor must not be reached");
+      })
+    );
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" }) as Record<
+        string,
+        (
+          runtime: { getSetting: (key: string) => string | undefined },
+          params: unknown
+        ) => Promise<string>
+      >;
+      const runtime = {
+        getSetting: (key: string) =>
+          key === "ELIZA_CHAT_VIA_CLI"
+            ? "claude-sdk"
+            : key === "ELIZA_CLI_TIMEOUT_MS"
+              ? "broken"
+              : key === "ELIZA_CLI_SDK_TURN_TIMEOUT_MS"
+                ? "45000"
+                : undefined,
+      };
+
+      const error = await models.TEXT_LARGE(runtime, { prompt: "hello" }).then(
+        () => undefined,
+        (cause: unknown) => cause
+      );
+      expect(error).toMatchObject({
+        code: "CLI_INFERENCE_INVALID_CONFIGURATION",
+        setting: "ELIZA_CLI_TIMEOUT_MS",
+      });
+      expect(sessionCreations).toBe(0);
+    } finally {
+      restoreFactory();
+    }
+  });
+
+  it("does not let an invalid SDK turn timeout fall through to a valid general timeout", async () => {
+    let sessionCreations = 0;
+    const restoreFactory = trackSessionFactoryRestore(
+      __setClaudeSdkSessionFactoryForTests(() => {
+        sessionCreations += 1;
+        throw new Error("warm session constructor must not be reached");
+      })
+    );
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" }) as Record<
+        string,
+        (
+          runtime: { getSetting: (key: string) => string | undefined },
+          params: unknown
+        ) => Promise<string>
+      >;
+      const runtime = {
+        getSetting: (key: string) =>
+          key === "ELIZA_CHAT_VIA_CLI"
+            ? "claude-sdk"
+            : key === "ELIZA_CLI_TIMEOUT_MS"
+              ? "45000"
+              : key === "ELIZA_CLI_SDK_TURN_TIMEOUT_MS"
+                ? "broken"
+                : undefined,
+      };
+
+      const error = await models.TEXT_LARGE(runtime, { prompt: "hello" }).then(
+        () => undefined,
+        (cause: unknown) => cause
+      );
+      expect(error).toMatchObject({
+        code: "CLI_INFERENCE_INVALID_CONFIGURATION",
+        setting: "ELIZA_CLI_SDK_TURN_TIMEOUT_MS",
+      });
+      expect(sessionCreations).toBe(0);
+    } finally {
+      restoreFactory();
+    }
+  });
+
+  it.each([
+    [undefined, undefined, undefined, 20, 90_000],
+    ["45000", undefined, undefined, 20, 45_000],
+    [undefined, "0", undefined, 20, 0],
+    [undefined, "+45000", "7", 7, 45_000],
+  ] as const)(
+    "keeps warm defaults/fallbacks for general=%j turn=%j restart=%j",
+    async (generalTimeout, turnTimeout, restart, expectedRestart, expectedTurnTimeout) => {
+      let created: ClaudeSdkSession | undefined;
+      const restoreFactory = trackSessionFactoryRestore(
+        __setClaudeSdkSessionFactoryForTests((config) => {
+          created = new ClaudeSdkSession(config);
+          return created;
+        })
+      );
+      vi.spyOn(ClaudeSdkSession.prototype, "send").mockResolvedValue("from sdk");
+      try {
+        const models = buildModels({ ELIZA_CHAT_VIA_CLI: "claude-sdk" }) as Record<
+          string,
+          (
+            runtime: { getSetting: (key: string) => string | undefined },
+            params: unknown
+          ) => Promise<string>
+        >;
+        const runtime = {
+          getSetting: (key: string) =>
+            key === "ELIZA_CHAT_VIA_CLI"
+              ? "claude-sdk"
+              : key === "ELIZA_CLI_TIMEOUT_MS"
+                ? generalTimeout
+                : key === "ELIZA_CLI_SDK_TURN_TIMEOUT_MS"
+                  ? turnTimeout
+                  : key === "ELIZA_CLI_SDK_RESTART_AFTER_TURNS"
+                    ? restart
+                    : undefined,
+        };
+
+        await expect(models.TEXT_LARGE(runtime, { prompt: "hello" })).resolves.toBe("from sdk");
+        expect(created).toBeDefined();
+        expect(
+          (created as unknown as { restartAfterTurns: number; turnTimeoutMs: number })
+            .restartAfterTurns
+        ).toBe(expectedRestart);
+        expect(
+          (created as unknown as { restartAfterTurns: number; turnTimeoutMs: number }).turnTimeoutMs
+        ).toBe(expectedTurnTimeout);
+      } finally {
+        restoreFactory();
+      }
+    }
+  );
+
+  it("replaces the logical Claude session when effective lifecycle config changes", async () => {
+    const sessions: Array<{
+      config: ConstructorParameters<typeof ClaudeSdkSession>[0];
+      dispose: ReturnType<typeof vi.fn>;
+    }> = [];
+    trackSessionFactoryRestore(
+      __setClaudeSdkSessionFactoryForTests((config) => {
+        const session = {
+          config,
+          send: vi.fn().mockResolvedValue("from sdk"),
+          dispose: vi.fn().mockResolvedValue(undefined),
+        };
+        sessions.push(session);
+        return session as unknown as ClaudeSdkSession;
+      })
+    );
+    const settings: Record<string, string | undefined> = {
+      ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "3",
+      ELIZA_CLI_SDK_TURN_TIMEOUT_MS: "0",
+    };
+    const runtime = modelRuntime("claude-sdk", settings);
+    const handler = textLargeHandler("claude-sdk");
+
+    await handler(runtime, { prompt: "same prompt" });
+    settings.ELIZA_CLI_SDK_TURN_TIMEOUT_MS = "45000";
+    await handler(runtime, { prompt: "same prompt" });
+    settings.ELIZA_CLI_SDK_TURN_TIMEOUT_MS = "0";
+    await handler(runtime, { prompt: "same prompt" });
+    delete settings.ELIZA_CLI_SDK_TURN_TIMEOUT_MS;
+    await handler(runtime, { prompt: "same prompt" });
+    settings.ELIZA_CLI_SDK_RESTART_AFTER_TURNS = "4";
+    await handler(runtime, { prompt: "same prompt" });
+
+    expect(sessions.map(({ config }) => [config.restartAfterTurns, config.turnTimeoutMs])).toEqual([
+      [3, 0],
+      [3, 45_000],
+      [3, 0],
+      [3, 90_000],
+      [4, 90_000],
+    ]);
+    for (const stale of sessions.slice(0, -1)) {
+      expect(stale.dispose).toHaveBeenCalledTimes(1);
+    }
+    expect(sessions.at(-1)?.dispose).not.toHaveBeenCalled();
+  });
+
+  it("replaces the logical Codex session when effective restart config changes", async () => {
+    const sessions: Array<{
+      config: ConstructorParameters<typeof CodexSdkSession>[0];
+      dispose: ReturnType<typeof vi.fn>;
+    }> = [];
+    trackSessionFactoryRestore(
+      __setCodexSdkSessionFactoryForTests((config) => {
+        const session = {
+          config,
+          generate: vi.fn().mockResolvedValue("from codex sdk"),
+          dispose: vi.fn(),
+        };
+        sessions.push(session);
+        return session as unknown as CodexSdkSession;
+      })
+    );
+    const settings: Record<string, string | undefined> = {
+      ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "3",
+    };
+    const runtime = modelRuntime("codex-sdk", settings);
+    const handler = textLargeHandler("codex-sdk");
+
+    await handler(runtime, { prompt: "same prompt" });
+    settings.ELIZA_CLI_SDK_RESTART_AFTER_TURNS = "4";
+    await handler(runtime, { prompt: "same prompt" });
+    settings.ELIZA_CLI_SDK_RESTART_AFTER_TURNS = "3";
+    await handler(runtime, { prompt: "same prompt" });
+    delete settings.ELIZA_CLI_SDK_RESTART_AFTER_TURNS;
+    await handler(runtime, { prompt: "same prompt" });
+
+    expect(sessions.map(({ config }) => config.restartAfterTurns)).toEqual([3, 4, 3, 20]);
+    for (const stale of sessions.slice(0, -1)) {
+      expect(stale.dispose).toHaveBeenCalledTimes(1);
+    }
+    expect(sessions.at(-1)?.dispose).not.toHaveBeenCalled();
   });
 
   it("routes warm Claude SDK handlers through the current default Opus model", async () => {
@@ -1292,6 +1778,12 @@ describe("parseTurnTimeout (#16553)", () => {
 
   it("preserves the previously accepted explicit plus sign", () => {
     expect(parseTurnTimeout("+120000")).toBe(120_000);
+  });
+
+  it("rejects alternate spellings of zero so only the documented literal opts out", () => {
+    expect(parseTurnTimeout("-0")).toBeUndefined();
+    expect(parseTurnTimeout("+0")).toBeUndefined();
+    expect(parseTurnTimeout("00")).toBeUndefined();
   });
 });
 

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -1784,6 +1784,7 @@ describe("parseTurnTimeout (#16553)", () => {
     expect(parseTurnTimeout("-0")).toBeUndefined();
     expect(parseTurnTimeout("+0")).toBeUndefined();
     expect(parseTurnTimeout("00")).toBeUndefined();
+    expect(parseTurnTimeout(" 0 ")).toBeUndefined();
   });
 });
 

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { GenerateTextParams, IAgentRuntime, Plugin, ToolDefinition } from "@elizaos/core";
 import {
+  ElizaError,
   HANDLE_RESPONSE_TOOL_NAME,
   isTruthyEnvValue,
   logger,
@@ -15,6 +16,7 @@ import {
 import { ClaudeCli } from "./src/claude-cli";
 import {
   ClaudeSdkSession,
+  type ClaudeSdkSessionConfig,
   type EnvelopeFieldSchemas,
   type SdkSessionMode,
 } from "./src/claude-sdk-session";
@@ -28,7 +30,7 @@ import {
   STAGE1_ENVELOPE_SYSTEM_PROMPT,
 } from "./src/clean-routing-planner";
 import { CodexCli } from "./src/codex-cli-exec";
-import { CodexSdkSession } from "./src/codex-sdk-session";
+import { CodexSdkSession, type CodexSdkSessionConfig } from "./src/codex-sdk-session";
 import { flattenPrompt } from "./src/prompt-flatten";
 
 /**
@@ -185,9 +187,17 @@ export function resolveCliBackend(source: { ELIZA_CHAT_VIA_CLI?: string }): CliB
 // system prompt and each mode (text vs native router) gets its own warm process.
 // Keying by model ALONE would share one frozen-system opus session across
 // RESPONSE_HANDLER/TEXT_LARGE/TEXT_MEGA, bleeding context between tiers/rooms and
-// intermittently returning empty turns. Lives for the plugin's lifetime; torn
-// down in dispose().
-const sdkSessions = new Map<string, ClaudeSdkSession>();
+// intermittently returning empty turns. Each cache entry also records its
+// effective restart/turn budgets; a runtime configuration change replaces the
+// session under the same logical key instead of reusing stale lifecycle state
+// or fragmenting account-rotation affinity. Lives for the plugin's lifetime;
+// torn down in dispose().
+interface CachedClaudeSdkSession {
+  session: ClaudeSdkSession;
+  lifecycleFingerprint: string;
+}
+
+const sdkSessions = new Map<string, CachedClaudeSdkSession>();
 
 /**
  * Upper bound on concurrently-cached warm sessions. Each session is a live
@@ -199,6 +209,34 @@ const sdkSessions = new Map<string, ClaudeSdkSession>();
  * order; a cache hit re-inserts to mark it most-recently-used).
  */
 const MAX_SDK_SESSIONS = 8;
+const DEFAULT_SDK_RESTART_AFTER_TURNS = 20;
+const DEFAULT_CLAUDE_SDK_TURN_TIMEOUT_MS = 90_000;
+
+type ClaudeSdkSessionFactory = (config: ClaudeSdkSessionConfig) => ClaudeSdkSession;
+
+let createClaudeSdkSession: ClaudeSdkSessionFactory = (config) => new ClaudeSdkSession(config);
+
+/** Replace the warm-session constructor for deterministic boundary tests. */
+export function __setClaudeSdkSessionFactoryForTests(factory: ClaudeSdkSessionFactory): () => void {
+  const previous = createClaudeSdkSession;
+  createClaudeSdkSession = factory;
+  return () => {
+    createClaudeSdkSession = previous;
+  };
+}
+
+type CodexSdkSessionFactory = (config: CodexSdkSessionConfig) => CodexSdkSession;
+
+let createCodexSdkSession: CodexSdkSessionFactory = (config) => new CodexSdkSession(config);
+
+/** Replace the warm Codex-session constructor for deterministic boundary tests. */
+export function __setCodexSdkSessionFactoryForTests(factory: CodexSdkSessionFactory): () => void {
+  const previous = createCodexSdkSession;
+  createCodexSdkSession = factory;
+  return () => {
+    createCodexSdkSession = previous;
+  };
+}
 
 /** The Claude model for a given tier (planner/small can differ from large). */
 function resolveSdkModel(runtime: IAgentRuntime, modelType: string): string {
@@ -224,6 +262,7 @@ function shortHash(value: string): string {
 
 /**
  * Lazily create + cache a warm SDK session for a (model, mode, systemPrompt).
+ * A lifecycle-config change replaces the entry under that stable logical key.
  * "route" builds the native `route_action` MCP-tool session (the planner);
  * "envelope" builds the native `handle_response` session (Stage-1 routing);
  * "text" builds a plain text-generation session (reply/large tiers).
@@ -239,6 +278,10 @@ function claudeSessionKey(
   // shapes compose different sets; registry plugins add more).
   const fieldsPart = envelopeFields ? shortHash(Object.keys(envelopeFields).sort().join(",")) : "";
   return `${model}\u001f${mode}\u001f${shortHash(systemPrompt)}\u001f${fieldsPart}`;
+}
+
+function claudeLifecycleFingerprint(config: ClaudeSdkTimeoutConfiguration): string {
+  return `${config.sdkRestartAfterTurns}\u001f${config.sdkTurnTimeoutMs}`;
 }
 
 /**
@@ -267,7 +310,7 @@ function evictSdkSession(key: string): void {
   const existing = sdkSessions.get(key);
   if (!existing) return;
   sdkSessions.delete(key);
-  void existing.dispose();
+  void existing.session.dispose();
 }
 
 function getSdkSession(
@@ -275,31 +318,38 @@ function getSdkSession(
   model: string,
   systemPrompt: string,
   mode: SdkSessionMode,
+  timeoutConfiguration: ClaudeSdkTimeoutConfiguration,
   subprocessEnv?: RotationSubprocessEnv,
   envelopeFields?: EnvelopeFieldSchemas
 ): ClaudeSdkSession {
   const key = claudeSessionKey(model, systemPrompt, mode, envelopeFields);
+  const lifecycleFingerprint = claudeLifecycleFingerprint(timeoutConfiguration);
   const existing = sdkSessions.get(key);
-  if (existing) {
+  if (existing?.lifecycleFingerprint === lifecycleFingerprint) {
     // Mark most-recently-used: delete + re-insert moves it to the Map's tail.
     sdkSessions.delete(key);
     sdkSessions.set(key, existing);
-    return existing;
+    return existing.session;
   }
-  const session = new ClaudeSdkSession({
+  if (existing) {
+    // Configuration is part of the cached value rather than the logical key so
+    // account-rotation state keeps one stable affinity per session. Never retain
+    // or resurrect a process created with stale lifecycle bounds.
+    sdkSessions.delete(key);
+    void existing.session.dispose();
+  }
+  const session = createClaudeSdkSession({
     model,
     systemPrompt,
     mode,
     envelopeFields,
     claudeExecutablePath: getSetting(runtime, "ELIZA_CLI_CLAUDE_BIN"),
-    restartAfterTurns: parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_RESTART_AFTER_TURNS")),
-    turnTimeoutMs:
-      parseTurnTimeout(getSetting(runtime, "ELIZA_CLI_SDK_TURN_TIMEOUT_MS")) ??
-      parseTurnTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+    restartAfterTurns: timeoutConfiguration.sdkRestartAfterTurns,
+    turnTimeoutMs: timeoutConfiguration.sdkTurnTimeoutMs,
     effort: resolveSdkEffort(runtime, mode),
     subprocessEnv,
   });
-  sdkSessions.set(key, session);
+  sdkSessions.set(key, { session, lifecycleFingerprint });
   // Evict least-recently-used past the cap (each session is a live process).
   // dispose() is best-effort fire-and-forget — the new session is already
   // cached and returned synchronously.
@@ -308,25 +358,30 @@ function getSdkSession(
     if (lruKey === undefined) break;
     const lru = sdkSessions.get(lruKey);
     sdkSessions.delete(lruKey);
-    void lru?.dispose();
+    void lru?.session.dispose();
   }
   return session;
 }
 
 /** Tear down all warm SDK sessions (plugin dispose). */
 export async function disposeSdkSessions(): Promise<void> {
-  const all = [...sdkSessions.values()];
+  const all = [...sdkSessions.values()].map(({ session }) => session);
   sdkSessions.clear();
   await Promise.all(all.map((s) => s.dispose()));
-  const codex = [...codexSdkSessions.values()];
+  const codex = [...codexSdkSessions.values()].map(({ session }) => session);
   codexSdkSessions.clear();
   for (const s of codex) s.dispose();
 }
 
-// Warm Codex SDK threads, keyed by (model, mode). codex-sdk has no thread-level
-// system prompt (it's folded into the body), so ONE warm thread per (model, mode)
-// serves every system prompt — simpler than the claude cache.
-const codexSdkSessions = new Map<string, CodexSdkSession>();
+// Warm Codex SDK threads use one stable (model, mode) key. The effective restart
+// cadence is stored beside the session so a change disposes/replaces the thread
+// without leaking cache or account-rotation entries.
+interface CachedCodexSdkSession {
+  session: CodexSdkSession;
+  lifecycleFingerprint: string;
+}
+
+const codexSdkSessions = new Map<string, CachedCodexSdkSession>();
 
 /** The codex model for a given tier (planner/small can differ from large). */
 function resolveCodexModel(runtime: IAgentRuntime, modelType: string): string {
@@ -340,6 +395,10 @@ function codexSessionKey(model: string, router: boolean): string {
   return `${model}\u001f${router ? "route" : "text"}`;
 }
 
+function codexLifecycleFingerprint(config: CodexSdkTimeoutConfiguration): string {
+  return String(config.sdkRestartAfterTurns);
+}
+
 /**
  * Evict + dispose a warm Codex SDK thread by its cache key so the next
  * `getCodexSdkSession` re-starts it — re-reading the (rotated) per-account
@@ -349,29 +408,36 @@ function evictCodexSdkSession(key: string): void {
   const existing = codexSdkSessions.get(key);
   if (!existing) return;
   codexSdkSessions.delete(key);
-  existing.dispose();
+  existing.session.dispose();
 }
 
-/** Lazily create + cache a warm Codex SDK thread for a (model, mode). */
+/** Lazily cache a warm Codex SDK thread for a (model, mode, restart cadence). */
 function getCodexSdkSession(
   runtime: IAgentRuntime,
   model: string,
   router: boolean,
+  timeoutConfiguration: CodexSdkTimeoutConfiguration,
   subprocessEnv?: RotationSubprocessEnv
 ): CodexSdkSession {
   const key = codexSessionKey(model, router);
-  let session = codexSdkSessions.get(key);
-  if (!session) {
-    session = new CodexSdkSession({
-      model,
-      router,
-      reasoningEffort: getSetting(runtime, "ELIZA_CLI_CODEX_REASONING_EFFORT"),
-      codexBinPath: getSetting(runtime, "ELIZA_CLI_CODEX_BIN"),
-      restartAfterTurns: parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_RESTART_AFTER_TURNS")),
-      subprocessEnv,
-    });
-    codexSdkSessions.set(key, session);
+  const lifecycleFingerprint = codexLifecycleFingerprint(timeoutConfiguration);
+  const existing = codexSdkSessions.get(key);
+  if (existing?.lifecycleFingerprint === lifecycleFingerprint) {
+    return existing.session;
   }
+  if (existing) {
+    codexSdkSessions.delete(key);
+    existing.session.dispose();
+  }
+  const session = createCodexSdkSession({
+    model,
+    router,
+    reasoningEffort: getSetting(runtime, "ELIZA_CLI_CODEX_REASONING_EFFORT"),
+    codexBinPath: getSetting(runtime, "ELIZA_CLI_CODEX_BIN"),
+    restartAfterTurns: timeoutConfiguration.sdkRestartAfterTurns,
+    subprocessEnv,
+  });
+  codexSdkSessions.set(key, { session, lifecycleFingerprint });
   return session;
 }
 
@@ -389,8 +455,9 @@ export function parseTimeout(value: string | undefined): number | undefined {
 
 /** Turn-timeout parse (#16553): like {@link parseTimeout}, but an explicit
  *  `"0"` passes through as 0 — the documented operator opt-out to an
- *  unbounded turn. Unset/invalid still return undefined so the session's
- *  bounded default applies. Exported for tests. */
+ *  unbounded turn. The parser returns undefined for unset/invalid input; the
+ *  backend-aware resolver below distinguishes those states and rejects a
+ *  present-invalid value before session lookup. Exported for tests. */
 export function parseTurnTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
   // Same prefix-parse hole, and it matters more here: `0` is the documented
@@ -398,9 +465,130 @@ export function parseTurnTimeout(value: string | undefined): number | undefined 
   // silently REMOVED the turn timeout rather than falling back to the bounded
   // default. An explicit "0" is still honoured.
   const trimmed = value.trim();
-  const n = /^[+-]?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
-  if (!Number.isSafeInteger(n) || n < 0) return undefined;
-  return n;
+  if (trimmed === "0") return 0;
+  return parseTimeout(trimmed);
+}
+
+type TimeoutSettingKey =
+  | "ELIZA_CLI_TIMEOUT_MS"
+  | "ELIZA_CLI_SDK_RESTART_AFTER_TURNS"
+  | "ELIZA_CLI_SDK_TURN_TIMEOUT_MS";
+
+interface ColdTimeoutConfiguration {
+  cliTimeoutMs?: number;
+}
+
+interface ClaudeSdkTimeoutConfiguration {
+  sdkRestartAfterTurns: number;
+  sdkTurnTimeoutMs: number;
+}
+
+interface CodexSdkTimeoutConfiguration {
+  sdkRestartAfterTurns: number;
+}
+
+const MAX_RENDERED_INVALID_SETTING_LENGTH = 96;
+
+function renderInvalidSettingValue(value: string | boolean | number): {
+  rendered: string;
+  valueType: string;
+} {
+  const serialized = typeof value === "string" ? JSON.stringify(value) : String(value);
+  return {
+    rendered:
+      serialized.length <= MAX_RENDERED_INVALID_SETTING_LENGTH
+        ? serialized
+        : `${serialized.slice(0, MAX_RENDERED_INVALID_SETTING_LENGTH - 3)}...`,
+    valueType: typeof value,
+  };
+}
+
+/** Typed failure for an explicitly present but invalid CLI inference setting. */
+export class CliInferenceConfigurationError extends ElizaError {
+  override readonly name = "CliInferenceConfigurationError";
+  readonly setting: TimeoutSettingKey;
+
+  constructor(setting: TimeoutSettingKey, value: string | boolean | number, expected: string) {
+    const { rendered, valueType } = renderInvalidSettingValue(value);
+    super(`[cli-inference] Invalid ${setting}: expected ${expected}; received ${rendered}`, {
+      code: "CLI_INFERENCE_INVALID_CONFIGURATION",
+      context: { setting, valueType, valuePreview: rendered, expected },
+      severity: "fatal",
+    });
+    this.setting = setting;
+  }
+}
+
+function readRawSetting(
+  runtime: IAgentRuntime,
+  key: TimeoutSettingKey
+): string | boolean | number | undefined {
+  const runtimeValue = runtime.getSetting(key);
+  return runtimeValue === undefined || runtimeValue === null ? readEnv(key) : runtimeValue;
+}
+
+function resolveNumericSetting(
+  runtime: IAgentRuntime,
+  key: TimeoutSettingKey,
+  parser: (value: string | undefined) => number | undefined,
+  expected: string
+): number | undefined {
+  const raw = readRawSetting(runtime, key);
+  if (raw === undefined) return undefined;
+  const parsed = Object.is(raw, -0) ? undefined : parser(String(raw));
+  if (parsed === undefined) {
+    throw new CliInferenceConfigurationError(key, raw, expected);
+  }
+  return parsed;
+}
+
+function resolveColdTimeoutConfiguration(runtime: IAgentRuntime): ColdTimeoutConfiguration {
+  return {
+    cliTimeoutMs: resolveNumericSetting(
+      runtime,
+      "ELIZA_CLI_TIMEOUT_MS",
+      parseTimeout,
+      "a positive safe integer"
+    ),
+  };
+}
+
+/** Resolve every timeout consumed by Claude SDK before session lookup/creation. */
+function resolveClaudeSdkTimeoutConfiguration(
+  runtime: IAgentRuntime
+): ClaudeSdkTimeoutConfiguration {
+  const cliTimeoutMs = resolveColdTimeoutConfiguration(runtime).cliTimeoutMs;
+  const sdkRestartAfterTurns =
+    resolveNumericSetting(
+      runtime,
+      "ELIZA_CLI_SDK_RESTART_AFTER_TURNS",
+      parseTimeout,
+      "a positive safe integer"
+    ) ?? DEFAULT_SDK_RESTART_AFTER_TURNS;
+  const explicitSdkTurnTimeoutMs = resolveNumericSetting(
+    runtime,
+    "ELIZA_CLI_SDK_TURN_TIMEOUT_MS",
+    parseTurnTimeout,
+    'the exact literal "0" opt-out or a positive safe integer'
+  );
+  return {
+    sdkRestartAfterTurns,
+    sdkTurnTimeoutMs:
+      explicitSdkTurnTimeoutMs ?? cliTimeoutMs ?? DEFAULT_CLAUDE_SDK_TURN_TIMEOUT_MS,
+  };
+}
+
+/** Resolve the only numeric setting consumed by the warm Codex backend. */
+function resolveCodexSdkTimeoutConfiguration(runtime: IAgentRuntime): CodexSdkTimeoutConfiguration {
+  return {
+    sdkRestartAfterTurns:
+      resolveNumericSetting(
+        runtime,
+        "ELIZA_CLI_SDK_RESTART_AFTER_TURNS",
+        parseTimeout,
+        "a positive safe integer"
+      ) ?? DEFAULT_SDK_RESTART_AFTER_TURNS,
+  };
 }
 
 // One binary setting covers both warm and cold backends so container images can
@@ -411,18 +599,24 @@ function resolveBinaryPin(runtime: IAgentRuntime, key: string): string | undefin
   return value ? value : undefined;
 }
 
-function buildClaude(runtime: IAgentRuntime): ClaudeCli {
+function buildClaude(
+  runtime: IAgentRuntime,
+  timeoutConfiguration: ColdTimeoutConfiguration
+): ClaudeCli {
   return new ClaudeCli({
     model: getSetting(runtime, "ELIZA_CLI_CLAUDE_MODEL"),
-    timeoutMs: parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+    timeoutMs: timeoutConfiguration.cliTimeoutMs,
     binaryPath: resolveBinaryPin(runtime, "ELIZA_CLI_CLAUDE_BIN"),
   });
 }
 
-function buildCodex(runtime: IAgentRuntime): CodexCli {
+function buildCodex(
+  runtime: IAgentRuntime,
+  timeoutConfiguration: ColdTimeoutConfiguration
+): CodexCli {
   return new CodexCli({
     model: getSetting(runtime, "ELIZA_CLI_CODEX_MODEL"),
-    timeoutMs: parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
+    timeoutMs: timeoutConfiguration.cliTimeoutMs,
     binaryPath: resolveBinaryPin(runtime, "ELIZA_CLI_CODEX_BIN"),
   });
 }
@@ -454,6 +648,7 @@ async function generateViaCli(
       ? findHandleResponseTool(params.tools)
       : undefined;
   if (backend === "claude-sdk" && handleResponseTool) {
+    const timeoutConfiguration = resolveClaudeSdkTimeoutConfiguration(runtime);
     // Stage-1 routing envelope via the native `handle_response` MCP tool.
     // Every other Stage-1 lane structurally forces the envelope (anthropic
     // native tool_use, cloud tool_choice:required, local GBNF); serving it as
@@ -469,9 +664,15 @@ async function generateViaCli(
     const key = claudeSessionKey(model, STAGE1_ENVELOPE_SYSTEM_PROMPT, "envelope", fields);
     return withAccountRotation(
       (env) =>
-        getSdkSession(runtime, model, STAGE1_ENVELOPE_SYSTEM_PROMPT, "envelope", env, fields).send(
-          envelopeBody
-        ),
+        getSdkSession(
+          runtime,
+          model,
+          STAGE1_ENVELOPE_SYSTEM_PROMPT,
+          "envelope",
+          timeoutConfiguration,
+          env,
+          fields
+        ).send(envelopeBody),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -481,6 +682,7 @@ async function generateViaCli(
     );
   }
   if (backend === "claude-sdk") {
+    const timeoutConfiguration = resolveClaudeSdkTimeoutConfiguration(runtime);
     // Warm, persistent Agent SDK session. The SDK freezes `systemPrompt` at start,
     // so we flatten system+messages here and hand the session a STABLE system
     // (so all turns of a tier share one warm process) plus a self-contained body.
@@ -500,7 +702,10 @@ async function generateViaCli(
     // the warm session so it re-auths as the new account), then retry; fall
     // through to provider failover only when the pool is exhausted.
     return withAccountRotation(
-      (env) => getSdkSession(runtime, model, framedSystem, "text", env).send(framedBody),
+      (env) =>
+        getSdkSession(runtime, model, framedSystem, "text", timeoutConfiguration, env).send(
+          framedBody
+        ),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -510,6 +715,7 @@ async function generateViaCli(
     );
   }
   if (backend === "codex-sdk") {
+    const timeoutConfiguration = resolveCodexSdkTimeoutConfiguration(runtime);
     // Warm Codex SDK thread. codex-sdk folds the system into the body, so frame
     // the body the same way (the SDK model is agentic too) and run TEXT mode.
     const model = resolveCodexModel(runtime, modelType);
@@ -517,7 +723,8 @@ async function generateViaCli(
     const framedBody = appendTextDirective(`${frameTextSystemPrompt(system)}\n\n${body}`);
     const key = codexSessionKey(model, false);
     return withAccountRotation(
-      (env) => getCodexSdkSession(runtime, model, false, env).generate(framedBody),
+      (env) =>
+        getCodexSdkSession(runtime, model, false, timeoutConfiguration, env).generate(framedBody),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -526,7 +733,11 @@ async function generateViaCli(
       }
     );
   }
-  const cli = backend === "claude" ? buildClaude(runtime) : buildCodex(runtime);
+  const timeoutConfiguration = resolveColdTimeoutConfiguration(runtime);
+  const cli =
+    backend === "claude"
+      ? buildClaude(runtime, timeoutConfiguration)
+      : buildCodex(runtime, timeoutConfiguration);
   return cli.generate(generateParams);
 }
 
@@ -556,11 +767,20 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
     ELIZA_CHAT_VIA_CLI: getSetting(runtime, "ELIZA_CHAT_VIA_CLI"),
   });
   if (backend === "claude-sdk") {
+    const timeoutConfiguration = resolveClaudeSdkTimeoutConfiguration(runtime);
     const model = resolveSdkModel(runtime, ModelType.ACTION_PLANNER);
     const routerBody = buildRouterBody(params);
     const key = claudeSessionKey(model, ROUTER_SYSTEM_PROMPT, "route");
     return withAccountRotation(
-      (env) => getSdkSession(runtime, model, ROUTER_SYSTEM_PROMPT, "route", env).send(routerBody),
+      (env) =>
+        getSdkSession(
+          runtime,
+          model,
+          ROUTER_SYSTEM_PROMPT,
+          "route",
+          timeoutConfiguration,
+          env
+        ).send(routerBody),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -570,6 +790,7 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
     );
   }
   if (backend === "codex-sdk") {
+    const timeoutConfiguration = resolveCodexSdkTimeoutConfiguration(runtime);
     // codex routes via NATIVE structured output (outputSchema) for a reliable
     // {action, params} shape. The clean-routing prompt (menu + transcript +
     // persona) is folded into the body (codex-sdk has no thread-level system
@@ -579,7 +800,7 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
     const routeBody = `${clean.system ?? ""}\n\n${clean.prompt ?? ""}`;
     const key = codexSessionKey(model, true);
     return withAccountRotation(
-      (env) => getCodexSdkSession(runtime, model, true, env).route(routeBody),
+      (env) => getCodexSdkSession(runtime, model, true, timeoutConfiguration, env).route(routeBody),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -464,9 +464,8 @@ export function parseTurnTimeout(value: string | undefined): number | undefined 
   // opt-out to an unbounded turn, so "0junk" and "0.5" both truncated to 0 and
   // silently REMOVED the turn timeout rather than falling back to the bounded
   // default. An explicit "0" is still honoured.
-  const trimmed = value.trim();
-  if (trimmed === "0") return 0;
-  return parseTimeout(trimmed);
+  if (value === "0") return 0;
+  return parseTimeout(value);
 }
 
 type TimeoutSettingKey =

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -110,14 +110,14 @@
       },
       "ELIZA_CLI_SDK_RESTART_AFTER_TURNS": {
         "type": "number",
-        "description": "Restart each warm Claude SDK session after this many turns. Defaults to 20.",
+        "description": "Restart each warm SDK session after this many turns. Must be a strictly positive safe integer when a warm backend is active; empty or invalid values are rejected. Defaults to 20.",
         "required": false,
         "default": 20,
         "sensitive": false
       },
       "ELIZA_CLI_SDK_TURN_TIMEOUT_MS": {
         "type": "number",
-        "description": "Per-turn Claude SDK timeout in milliseconds. Defaults to 90000 and falls back to ELIZA_CLI_TIMEOUT_MS when set.",
+        "description": "Per-turn Claude SDK timeout in milliseconds. Accepts a positive safe integer or the exact literal 0 to opt out; empty, alternate zero spellings, and invalid values are rejected. Defaults to 90000 and falls back to a valid ELIZA_CLI_TIMEOUT_MS when set.",
         "required": false,
         "default": 90000,
         "sensitive": false
@@ -131,7 +131,7 @@
       },
       "ELIZA_CLI_TIMEOUT_MS": {
         "type": "number",
-        "description": "Per-call CLI spawn timeout in milliseconds (SIGTERM on expiry). Defaults to 120000.",
+        "description": "Per-call CLI spawn timeout in milliseconds (SIGTERM on expiry), also used as the Claude SDK turn fallback. Must be a strictly positive safe integer when consumed; empty or invalid values are rejected. Defaults to 120000.",
         "required": false,
         "default": 120000,
         "sensitive": false

--- a/plugins/plugin-cli-inference/registry-entry.json
+++ b/plugins/plugin-cli-inference/registry-entry.json
@@ -44,9 +44,9 @@
       "sensitive": false,
       "default": "120000",
       "label": "Timeout",
-      "help": "Per-call CLI spawn timeout in milliseconds.",
+      "help": "Per-call CLI spawn timeout in milliseconds. Must be a strictly positive integer when configured.",
       "advanced": true,
-      "min": 0,
+      "min": 1,
       "unit": "ms"
     }
   },


### PR DESCRIPTION
# Relates to

Relates to #24511. This is the narrow fix-forward for the timeout-configuration regression merged in #24517; it does not close or claim the other recovery items in #24511.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (`91a2cf76737f823af8c4f2d2d4f250c3548ec42b`) with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` succeeded and `bun run verify` was run after sync; its exact unrelated baseline blocker is recorded below.
- [x] A reviewer can confirm the change from the deterministic public-boundary tests and exact-head command transcript below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Exact affected-package tests, typecheck, lint, and build pass post-sync; the unrelated root-verify blocker is documented in **Known gaps / failures**.

# Risks

**Medium.** The change is confined to `plugin-cli-inference` configuration handling. An explicitly present invalid timeout/restart setting now fails with `CLI_INFERENCE_INVALID_CONFIGURATION` before a process or warm session is created instead of silently selecting a default. Warm sessions are replaced when effective lifecycle bounds change, while stable logical cache keys preserve account-rotation affinity. Unset settings and documented defaults remain unchanged; `ELIZA_CLI_SDK_TURN_TIMEOUT_MS=0` remains the only unbounded-turn opt-out.

# Background

## What does this PR do?

- Distinguishes truly absent timeout settings from present malformed, unsafe, zero/out-of-range values.
- Validates only settings consumed by the active backend: cold Claude/Codex use the general timeout, Claude SDK uses all three settings with the documented fallback, and Codex SDK uses restart cadence only.
- Throws a bounded typed configuration error before cold spawn or warm-session creation.
- Records effective warm-session lifecycle bounds and disposes/replaces a cached session when they change, without fragmenting cache or rotation identity.
- Aligns package metadata, registry minimums, and operator guides with the enforced contract.
- Adds boundary coverage for Claude and Codex, runtime-over-env precedence, env-only invalid values, defaults/fallbacks, exact zero, zero process/session creation, and `0 → 45000 → 0` non-resurrection.

## What kind of change is this?

Bug fix (non-breaking for valid configuration; intentionally fail-closed for invalid explicit configuration).

# Documentation changes needed?

Documentation was required and has been updated in the package metadata, registry entry, `AGENTS.md`, and byte-identical `CLAUDE.md` guide.

# Testing

## Where should a reviewer start?

Start with the timeout resolver and cached-session fingerprint replacement in `plugins/plugin-cli-inference/index.ts`, then the public `TEXT_LARGE` boundary cases in `plugins/plugin-cli-inference/__tests__/cli-inference.test.ts`.

## Detailed testing steps

Exact PR head: `1a264ea04d1a6cc3774ac841dea9e80950f29acb`

```text
bun install --frozen-lockfile --ignore-scripts
  PASS — 6,879 packages installed; lockfile unchanged

node packages/shared/scripts/generate-keywords.mjs
(cd packages/cloud/routing && bun run build)
(cd packages/core && bun run build.ts --node-only --skip-testing)
(cd plugins/plugin-cli-inference && bun run test)
  PASS — 8 files, 198 tests
(cd plugins/plugin-cli-inference && bun run typecheck)
  PASS
(cd plugins/plugin-cli-inference && bun run lint:check)
  PASS — 21 files, no fixes
(cd plugins/plugin-cli-inference && bun run build)
  PASS
git diff --check origin/develop...HEAD
  PASS
cmp -s plugins/plugin-cli-inference/AGENTS.md plugins/plugin-cli-inference/CLAUDE.md
  PASS
```

No real Claude/Codex CLI, SDK provider, credential, model, or account-rotation backend was invoked; process/session factories are deterministic test seams.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1a264ea04d1a6cc3774ac841dea9e80950f29acb -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing visual flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - local pre-dispatch configuration boundary; exact mocked zero-spawn and zero-session results are in Testing, and no live provider was invoked.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, console, network, or state path changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/model/output behavior changes; invalid configuration prevents model dispatch.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, task, wallet, generated-file, or persisted-domain changes.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - this change validates configuration before any model call and does not alter prompts, responses, tools, or model selection.

## Backend + frontend logs

Backend: N/A - deterministic zero-spawn/zero-session tests are the relevant boundary evidence; a real provider call would bypass the invalid-configuration path under test.

Frontend: N/A - no frontend code or request flow changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path changed.

## Known gaps / failures

`bun run verify` was run after the final sync and stopped at the existing root `audit:tsconfig-workspace-resolution` baseline: 16 unrelated plugins resolve `packages/ui/src/bridge/storage-bridge.ts` without `@elizaos/capacitor-secure-store`. The preceding `check:agents-claude`, Biome-version, i18n, Bun/Turbo contract, workspace-dependency, plugin-test-convention, and alias-read checks completed; the audit reported zero changed guarded source files for this branch. This diff touches only `plugins/plugin-cli-inference`, and its exact-head test/typecheck/lint/build suite is green as shown above.

The first post-rebase core declaration attempt through Bun's standalone workspace install also could not resolve the unrelated local workspace package `@elizaos/logger`; the repository's established targeted dependency bootstrap resolved it, after which core build and every affected-package command passed. No product code or lockfile was changed to paper over either workspace baseline.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

