### PR TITLE
fix(cloud): parse Wrangler session deployment record

### DIFF
--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -21,6 +21,14 @@ const buildId = "a".repeat(64);
 const indexHtmlSha256 = "b".repeat(64);
 
 function wranglerRecord(overrides: Record<string, unknown> = {}): string {
+  const session = {
+    type: "wrangler-session",
+    version: 1,
+    wrangler_version: "4.100.0",
+    command_line_args: ["pages", "deploy", "dist"],
+    log_file_path: "/tmp/wrangler.log",
+    timestamp: "2026-08-21T19:59:59.999Z",
+  };
   const summary = {
     type: "pages-deploy",
     version: 1,
@@ -42,7 +50,7 @@ function wranglerRecord(overrides: Record<string, unknown> = {}): string {
     timestamp: "2026-08-21T20:00:00.001Z",
     ...overrides,
   };
-  return `${JSON.stringify(summary)}\n${JSON.stringify(detailed)}\n`;
+  return `${JSON.stringify(session)}\n${JSON.stringify(summary)}\n${JSON.stringify(detailed)}\n`;
 }
 
 function authority() {
@@ -148,7 +156,7 @@ function continuity() {
 }
 
 describe("Pages deployment authority", () => {
-  test("closes exactly the two Wrangler v1 records and hashes the UUID", () => {
+  test("closes exactly the three Wrangler v1 records and hashes the UUID", () => {
     const parsed = authority();
     expect(parsed).toEqual({
       schema: PAGES_AUTHORITY_SCHEMA,
@@ -178,7 +186,7 @@ describe("Pages deployment authority", () => {
         runId: "1",
         runAttempt: "1",
       }),
-    ).toThrow("exactly two");
+    ).toThrow("exactly three");
     expect(() =>
       parseWranglerPagesDeploymentOutput(
         wranglerRecord({ deployment_id: "other" }),

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -2,10 +2,11 @@
  * Closes Cloudflare Pages deployment output into a privacy-safe release proof.
  *
  * Wrangler's append-only NDJSON is accepted only at the deployment boundary.
- * This module validates both v1 records, removes the raw deployment UUID, and
- * binds subsequent public and browser observations to one source SHA, alias,
- * workflow run, and renderer build before a staging receipt can claim that the
- * deployed renderer was tested.
+ * This module validates Wrangler's session record and both deployment records,
+ * removes the raw deployment UUID and local session metadata, and binds later
+ * public and browser observations to one source SHA, alias, workflow run, and
+ * renderer build before a staging receipt can claim that the deployed renderer
+ * was tested.
  */
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
@@ -201,10 +202,10 @@ function parseNdjson(raw) {
   }
   const lines = raw.slice(0, -1).split("\n");
   if (
-    lines.length !== 2 ||
+    lines.length !== 3 ||
     lines.some((line) => !line || line.includes("\r"))
   ) {
-    fail("Wrangler output must contain exactly two non-empty NDJSON records");
+    fail("Wrangler output must contain exactly three non-empty NDJSON records");
   }
   return lines.map((line, index) =>
     parseJson(line, `Wrangler record ${index + 1}`),
@@ -223,7 +224,7 @@ function parseWorkflow(value, label = "workflow") {
 }
 
 /**
- * Validates the two records emitted by Wrangler 4.100.0 and returns only the
+ * Validates the three records emitted by Wrangler 4.100.0 and returns only the
  * closed, publishable identity needed by later release jobs.
  */
 export function parseWranglerPagesDeploymentOutput(
@@ -239,7 +240,19 @@ export function parseWranglerPagesDeploymentOutput(
     runAttempt,
   },
 ) {
-  const [summaryValue, detailedValue] = parseNdjson(raw);
+  const [sessionValue, summaryValue, detailedValue] = parseNdjson(raw);
+  const session = requireExactKeys(
+    sessionValue,
+    [
+      "command_line_args",
+      "log_file_path",
+      "timestamp",
+      "type",
+      "version",
+      "wrangler_version",
+    ],
+    "wrangler-session record",
+  );
   const summary = requireExactKeys(
     summaryValue,
     ["deployment_id", "pages_project", "timestamp", "type", "url", "version"],
@@ -261,11 +274,28 @@ export function parseWranglerPagesDeploymentOutput(
     ],
     "pages-deploy-detailed record",
   );
+  if (session.type !== "wrangler-session" || session.version !== 1) {
+    fail("first Wrangler record must be wrangler-session/v1");
+  }
+  if (session.wrangler_version !== "4.100.0") {
+    fail("Wrangler session version does not match the pinned release version");
+  }
+  if (
+    !Array.isArray(session.command_line_args) ||
+    session.command_line_args.length === 0 ||
+    session.command_line_args.some(
+      (argument) => typeof argument !== "string" || !argument,
+    )
+  ) {
+    fail("Wrangler session command_line_args are invalid");
+  }
+  requireString(session.log_file_path, "Wrangler session log_file_path");
+  requireIsoTimestamp(session.timestamp, "wrangler-session timestamp");
   if (summary.type !== "pages-deploy" || summary.version !== 1) {
-    fail("first Wrangler record must be pages-deploy/v1");
+    fail("second Wrangler record must be pages-deploy/v1");
   }
   if (detailed.type !== "pages-deploy-detailed" || detailed.version !== 1) {
-    fail("second Wrangler record must be pages-deploy-detailed/v1");
+    fail("third Wrangler record must be pages-deploy-detailed/v1");
   }
   requireIsoTimestamp(summary.timestamp, "pages-deploy timestamp");
   requireIsoTimestamp(detailed.timestamp, "pages-deploy-detailed timestamp");


### PR DESCRIPTION
## Summary

- accept the exact three-record NDJSON stream emitted by pinned `wrangler@4.100.0`: `wrangler-session/v1`, `pages-deploy/v1`, and `pages-deploy-detailed/v1`
- validate and discard local session metadata before publishing the closed Pages authority receipt
- preserve fail-closed exact schemas, record ordering, pinned Wrangler version, cross-record identity, and deployment ownership checks

## Root cause

Staging run [32593200158](https://github.com/elizaOS/eliza/actions/runs/32593200158) successfully uploaded and deployed the Pages renderer, then the authority parser rejected the output as not exactly two records. Wrangler 4.100.0 writes a `wrangler-session/v1` entry at command startup before Pages deploy writes the two deployment entries. Our fixture modeled only the final two entries.

Primary-source contract at the pinned tag:

- session write: [`packages/wrangler/src/index.ts`](https://github.com/cloudflare/workers-sdk/blob/wrangler%404.100.0/packages/wrangler/src/index.ts#L608-L615)
- deployment writes: [`packages/wrangler/src/pages/deploy.ts`](https://github.com/cloudflare/workers-sdk/blob/wrangler%404.100.0/packages/wrangler/src/pages/deploy.ts#L567-L590)

## Verification

- `bun test packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts` — 7 pass, 0 fail, 17 expectations
- `bunx @biomejs/biome@2.5.8 check packages/cloud/scripts/pages-deployment-authority.mjs packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts` — clean
- `git diff --check origin/develop...HEAD` — clean
- mutation discrimination: the real three-record fixture fails against the pre-fix parser because it requires exactly two records

## Evidence matrix

- UI screenshots/video: N/A — release parser only; no rendered UI change
- browser/network: N/A — no browser behavior change
- backend evidence: real staging deploy completed before the parser false-negative; linked run above
- production mutation: none

Fixes #24597. Related staging Auth acceptance: #24390.