### PR TITLE
test(app-core): cover CLI name resolution

### DIFF
--- a/packages/app-core/src/cli/__tests__/cli-name.test.ts
+++ b/packages/app-core/src/cli/__tests__/cli-name.test.ts
@@ -1,34 +1,60 @@
-import { describe, expect, it } from "vitest";
-import { CLI_PREFIX_RE, replaceCliName, resolveCliName } from "./cli-name.ts";
+/**
+ * Deterministic unit coverage for CLI display-name resolution and command
+ * rewriting, with module reloads isolating the import-time environment value.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadCliName() {
+  return import("../cli-name.ts");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
 
 describe("resolveCliName", () => {
-  it("returns the resolved CLI name (default eliza)", () => {
-    expect(resolveCliName()).toBe(process.env.APP_CLI_NAME?.trim() || "eliza");
+  it("uses the default for an empty environment value", async () => {
+    vi.stubEnv("APP_CLI_NAME", "");
+    const { resolveCliName } = await loadCliName();
+    expect(resolveCliName()).toBe("eliza");
+  });
+
+  it("trims the configured environment value", async () => {
+    vi.stubEnv("APP_CLI_NAME", "  mycli  ");
+    const { resolveCliName } = await loadCliName();
+    expect(resolveCliName()).toBe("mycli");
   });
 });
 
 describe("replaceCliName", () => {
-  it("replaces a leading eliza token", () => {
+  it("replaces a leading eliza token", async () => {
+    const { replaceCliName } = await loadCliName();
     expect(replaceCliName("eliza start", "mycli")).toBe("mycli start");
     expect(replaceCliName("elizaos run", "mycli")).toBe("mycli run");
   });
 
-  it("preserves the runner prefix", () => {
+  it("preserves the runner prefix", async () => {
+    const { replaceCliName } = await loadCliName();
     expect(replaceCliName("bun eliza start", "mycli")).toBe("bun mycli start");
     expect(replaceCliName("npx elizaos dev", "mycli")).toBe("npx mycli dev");
   });
 
-  it("leaves unrelated commands untouched", () => {
+  it("leaves unrelated commands untouched", async () => {
+    const { replaceCliName } = await loadCliName();
     expect(replaceCliName("git commit", "mycli")).toBe("git commit");
     expect(replaceCliName("", "mycli")).toBe("");
   });
 
-  it("uses the default name when not passed", () => {
-    const out = replaceCliName("eliza start");
-    expect(out.startsWith("eliza")).toBe(true);
+  it("uses the configured name when an override is not passed", async () => {
+    vi.stubEnv("APP_CLI_NAME", "mycli");
+    const { replaceCliName } = await loadCliName();
+    expect(replaceCliName("eliza start")).toBe("mycli start");
   });
 
-  it("CLI_PREFIX_RE matches runner + eliza forms", () => {
+  it("CLI_PREFIX_RE matches runner and eliza forms", async () => {
+    const { CLI_PREFIX_RE } = await loadCliName();
     expect(CLI_PREFIX_RE.test("eliza start")).toBe(true);
     expect(CLI_PREFIX_RE.test("bunx elizaos x")).toBe(true);
     expect(CLI_PREFIX_RE.test("other eliza")).toBe(false);

--- a/packages/app-core/src/cli/__tests__/cli-name.test.ts
+++ b/packages/app-core/src/cli/__tests__/cli-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { CLI_PREFIX_RE, replaceCliName, resolveCliName } from "./cli-name.ts";
+
+describe("resolveCliName", () => {
+  it("returns the resolved CLI name (default eliza)", () => {
+    expect(resolveCliName()).toBe(process.env.APP_CLI_NAME?.trim() || "eliza");
+  });
+});
+
+describe("replaceCliName", () => {
+  it("replaces a leading eliza token", () => {
+    expect(replaceCliName("eliza start", "mycli")).toBe("mycli start");
+    expect(replaceCliName("elizaos run", "mycli")).toBe("mycli run");
+  });
+
+  it("preserves the runner prefix", () => {
+    expect(replaceCliName("bun eliza start", "mycli")).toBe("bun mycli start");
+    expect(replaceCliName("npx elizaos dev", "mycli")).toBe("npx mycli dev");
+  });
+
+  it("leaves unrelated commands untouched", () => {
+    expect(replaceCliName("git commit", "mycli")).toBe("git commit");
+    expect(replaceCliName("", "mycli")).toBe("");
+  });
+
+  it("uses the default name when not passed", () => {
+    const out = replaceCliName("eliza start");
+    expect(out.startsWith("eliza")).toBe(true);
+  });
+
+  it("CLI_PREFIX_RE matches runner + eliza forms", () => {
+    expect(CLI_PREFIX_RE.test("eliza start")).toBe(true);
+    expect(CLI_PREFIX_RE.test("bunx elizaos x")).toBe(true);
+    expect(CLI_PREFIX_RE.test("other eliza")).toBe(false);
+  });
+});


### PR DESCRIPTION
# Summary

Supersedes #24571 because the maintainer-enabled fork rejected updates. The original implementation commit remains authored by @HarukaMa and preserved as the first commit.

Adds deterministic coverage for CLI display-name resolution, leading-token replacement, package-runner preservation, unrelated-command passthrough, configured implicit names, and the exported prefix matcher.

The restack repairs the original test import, which targeted a nonexistent `__tests__/cli-name.ts`, adds the required test header, and replaces an environment-dependent tautology with isolated module reloads that prove both the default and a trimmed configured value.

# Verification

Exact head: `0afd28cdb7e43d394ffc755bb9cdaa60a7632c46`
Restack base: `6831cbb714d9977671c00aa52b55b31d5d2d33c3`

- `bun install --frozen-lockfile`: passed
- `node packages/shared/scripts/generate-keywords.mjs`: passed
- `bunx vitest run src/cli/__tests__/cli-name.test.ts` from `packages/app-core`: 1 file, 7 tests passed
- `bunx @biomejs/biome check src/cli/__tests__/cli-name.test.ts`: clean
- direct package typecheck reached existing unbuilt-workspace declaration failures across agent plugins, Capacitor bridges, cloud routing, and native secure-store types; no error referenced the changed test. Hosted affected-workspace CI is required before merge.
- `git diff --check`: passed

No production, UI, prompt/model/action, persistence, transport, or security behavior changes. Screenshots, video, runtime logs, and LLM trajectories are N/A.

Original contributor disclosure from #24571: Hermes Agent; deepseek/deepseek-v4-flash. Maintainer restack used OpenAI Codex.