### PR TITLE
fix(cloud): accept Wrangler session authority record

### DIFF
--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -32,7 +32,9 @@ function wranglerRecord(
       "pages",
       "deploy",
       "--project-name=eliza-app",
+      "--branch=develop",
       `--commit-hash=${sourceSha}`,
+      "--commit-dirty=false",
     ],
     log_file_path: "/tmp/wrangler.log",
     timestamp: "2026-08-21T19:59:59.999Z",
@@ -262,6 +264,52 @@ describe("Pages deployment authority", () => {
           },
         ),
       ).toThrow();
+    }
+  });
+
+  test("binds the Wrangler command exactly to the attested release", () => {
+    const validArgs = [
+      "pages",
+      "deploy",
+      "--project-name=eliza-app",
+      "--branch=develop",
+      `--commit-hash=${sourceSha}`,
+      "--commit-dirty=false",
+    ];
+    const mutations = [
+      validArgs.map((argument) =>
+        argument.startsWith("--commit-hash=")
+          ? `--commit-hash=${"c".repeat(40)}`
+          : argument,
+      ),
+      validArgs.map((argument) =>
+        argument === "--project-name=eliza-app"
+          ? "--project-name=other-app"
+          : argument,
+      ),
+      validArgs.map((argument) =>
+        argument === "--branch=develop" ? "--branch=main" : argument,
+      ),
+      validArgs.slice(0, -1),
+      [...validArgs, "--skip-caching"],
+    ];
+
+    for (const commandLineArgs of mutations) {
+      expect(() =>
+        parseWranglerPagesDeploymentOutput(
+          wranglerRecord({}, { command_line_args: commandLineArgs }),
+          {
+            expectedProject: "eliza-app",
+            expectedCommit: sourceSha,
+            expectedBranch: "develop",
+            expectedAlias: aliasUrl,
+            expectedEnvironment: "preview",
+            expectedProductionBranch: "main",
+            runId: "1",
+            runAttempt: "1",
+          },
+        ),
+      ).toThrow("command_line_args do not match the release");
     }
   });
 

--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -20,7 +20,24 @@ const apiOrigin = "https://api-staging.eliza.app";
 const buildId = "a".repeat(64);
 const indexHtmlSha256 = "b".repeat(64);
 
-function wranglerRecord(overrides: Record<string, unknown> = {}): string {
+function wranglerRecord(
+  overrides: Record<string, unknown> = {},
+  sessionOverrides: Record<string, unknown> = {},
+): string {
+  const session = {
+    type: "wrangler-session",
+    version: 1,
+    wrangler_version: "4.100.0",
+    command_line_args: [
+      "pages",
+      "deploy",
+      "--project-name=eliza-app",
+      `--commit-hash=${sourceSha}`,
+    ],
+    log_file_path: "/tmp/wrangler.log",
+    timestamp: "2026-08-21T19:59:59.999Z",
+    ...sessionOverrides,
+  };
   const summary = {
     type: "pages-deploy",
     version: 1,
@@ -42,7 +59,7 @@ function wranglerRecord(overrides: Record<string, unknown> = {}): string {
     timestamp: "2026-08-21T20:00:00.001Z",
     ...overrides,
   };
-  return `${JSON.stringify(summary)}\n${JSON.stringify(detailed)}\n`;
+  return `${JSON.stringify(session)}\n${JSON.stringify(summary)}\n${JSON.stringify(detailed)}\n`;
 }
 
 function authority() {
@@ -148,7 +165,7 @@ function continuity() {
 }
 
 describe("Pages deployment authority", () => {
-  test("closes exactly the two Wrangler v1 records and hashes the UUID", () => {
+  test("closes the exact Wrangler session and deployment records without publishing local metadata", () => {
     const parsed = authority();
     expect(parsed).toEqual({
       schema: PAGES_AUTHORITY_SCHEMA,
@@ -164,6 +181,8 @@ describe("Pages deployment authority", () => {
         "eb251bd0455144d0f3c6642e81b5ad148ffbc82522239e94028b9154159222fc",
     });
     expect(JSON.stringify(parsed)).not.toContain(deploymentId);
+    expect(JSON.stringify(parsed)).not.toContain("command_line_args");
+    expect(JSON.stringify(parsed)).not.toContain("/tmp/wrangler.log");
   });
 
   test("rejects extra records, unexpected fields, and cross-record drift", () => {
@@ -178,7 +197,7 @@ describe("Pages deployment authority", () => {
         runId: "1",
         runAttempt: "1",
       }),
-    ).toThrow("exactly two");
+    ).toThrow("exactly three");
     expect(() =>
       parseWranglerPagesDeploymentOutput(
         wranglerRecord({ deployment_id: "other" }),
@@ -206,6 +225,44 @@ describe("Pages deployment authority", () => {
         runAttempt: "1",
       }),
     ).toThrow("exact closed schema");
+  });
+
+  test("rejects missing or malformed Wrangler session records", () => {
+    const withoutSession = wranglerRecord().split("\n").slice(1).join("\n");
+    expect(() =>
+      parseWranglerPagesDeploymentOutput(withoutSession, {
+        expectedProject: "eliza-app",
+        expectedCommit: sourceSha,
+        expectedBranch: "develop",
+        expectedAlias: aliasUrl,
+        expectedEnvironment: "preview",
+        expectedProductionBranch: "main",
+        runId: "1",
+        runAttempt: "1",
+      }),
+    ).toThrow("exactly three");
+
+    for (const sessionOverrides of [
+      { wrangler_version: "4.99.0" },
+      { command_line_args: ["deploy"] },
+      { unexpected: true },
+    ]) {
+      expect(() =>
+        parseWranglerPagesDeploymentOutput(
+          wranglerRecord({}, sessionOverrides),
+          {
+            expectedProject: "eliza-app",
+            expectedCommit: sourceSha,
+            expectedBranch: "develop",
+            expectedAlias: aliasUrl,
+            expectedEnvironment: "preview",
+            expectedProductionBranch: "main",
+            runId: "1",
+            runAttempt: "1",
+          },
+        ),
+      ).toThrow();
+    }
   });
 
   test("requires exact commit, alias, environment, and production branch", () => {

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -2,10 +2,11 @@
  * Closes Cloudflare Pages deployment output into a privacy-safe release proof.
  *
  * Wrangler's append-only NDJSON is accepted only at the deployment boundary.
- * This module validates both v1 records, removes the raw deployment UUID, and
- * binds subsequent public and browser observations to one source SHA, alias,
- * workflow run, and renderer build before a staging receipt can claim that the
- * deployed renderer was tested.
+ * This module validates the session and both deployment records, removes the
+ * raw deployment UUID and local CLI metadata, and binds subsequent public and
+ * browser observations to one source SHA, alias, workflow run, and renderer
+ * build before a staging receipt can claim that the deployed renderer was
+ * tested.
  */
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
@@ -32,6 +33,16 @@ const SHA256 = /^[0-9a-f]{64}$/;
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const PROJECT = /^[a-z0-9][a-z0-9-]{0,57}[a-z0-9]$/;
+const WRANGLER_VERSION = "4.100.0";
+
+const WRANGLER_SESSION_KEYS = [
+  "command_line_args",
+  "log_file_path",
+  "timestamp",
+  "type",
+  "version",
+  "wrangler_version",
+];
 
 const AUTHORITY_KEYS = [
   "aliasUrl",
@@ -146,6 +157,17 @@ function requirePositiveInteger(value, label) {
   return parsed;
 }
 
+function requireStringArray(value, label) {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((entry) => typeof entry !== "string" || !entry)
+  ) {
+    fail(`${label} must be a non-empty string array`);
+  }
+  return value;
+}
+
 function requireHttpsUrl(value, label) {
   const raw = requireString(value, label);
   let parsed;
@@ -201,14 +223,37 @@ function parseNdjson(raw) {
   }
   const lines = raw.slice(0, -1).split("\n");
   if (
-    lines.length !== 2 ||
+    lines.length !== 3 ||
     lines.some((line) => !line || line.includes("\r"))
   ) {
-    fail("Wrangler output must contain exactly two non-empty NDJSON records");
+    fail("Wrangler output must contain exactly three non-empty NDJSON records");
   }
   return lines.map((line, index) =>
     parseJson(line, `Wrangler record ${index + 1}`),
   );
+}
+
+function parseWranglerSession(value) {
+  const session = requireExactKeys(
+    value,
+    WRANGLER_SESSION_KEYS,
+    "wrangler-session record",
+  );
+  if (session.type !== "wrangler-session" || session.version !== 1) {
+    fail("first Wrangler record must be wrangler-session/v1");
+  }
+  if (session.wrangler_version !== WRANGLER_VERSION) {
+    fail(`wrangler-session must report pinned Wrangler ${WRANGLER_VERSION}`);
+  }
+  requireIsoTimestamp(session.timestamp, "wrangler-session timestamp");
+  requireString(session.log_file_path, "wrangler-session log_file_path");
+  const commandLineArgs = requireStringArray(
+    session.command_line_args,
+    "wrangler-session command_line_args",
+  );
+  if (commandLineArgs[0] !== "pages" || commandLineArgs[1] !== "deploy") {
+    fail("wrangler-session must describe a Pages deploy command");
+  }
 }
 
 function parseWorkflow(value, label = "workflow") {
@@ -223,8 +268,9 @@ function parseWorkflow(value, label = "workflow") {
 }
 
 /**
- * Validates the two records emitted by Wrangler 4.100.0 and returns only the
- * closed, publishable identity needed by later release jobs.
+ * Validates the three records emitted by Wrangler 4.100.0 and returns only the
+ * closed, publishable identity needed by later release jobs. Session-local CLI
+ * arguments and log paths are deliberately validated and discarded.
  */
 export function parseWranglerPagesDeploymentOutput(
   raw,
@@ -239,7 +285,8 @@ export function parseWranglerPagesDeploymentOutput(
     runAttempt,
   },
 ) {
-  const [summaryValue, detailedValue] = parseNdjson(raw);
+  const [sessionValue, summaryValue, detailedValue] = parseNdjson(raw);
+  parseWranglerSession(sessionValue);
   const summary = requireExactKeys(
     summaryValue,
     ["deployment_id", "pages_project", "timestamp", "type", "url", "version"],
@@ -262,10 +309,10 @@ export function parseWranglerPagesDeploymentOutput(
     "pages-deploy-detailed record",
   );
   if (summary.type !== "pages-deploy" || summary.version !== 1) {
-    fail("first Wrangler record must be pages-deploy/v1");
+    fail("second Wrangler record must be pages-deploy/v1");
   }
   if (detailed.type !== "pages-deploy-detailed" || detailed.version !== 1) {
-    fail("second Wrangler record must be pages-deploy-detailed/v1");
+    fail("third Wrangler record must be pages-deploy-detailed/v1");
   }
   requireIsoTimestamp(summary.timestamp, "pages-deploy timestamp");
   requireIsoTimestamp(detailed.timestamp, "pages-deploy-detailed timestamp");

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -233,7 +233,10 @@ function parseNdjson(raw) {
   );
 }
 
-function parseWranglerSession(value) {
+function parseWranglerSession(
+  value,
+  { expectedProject, expectedBranch, expectedCommit },
+) {
   const session = requireExactKeys(
     value,
     WRANGLER_SESSION_KEYS,
@@ -251,8 +254,21 @@ function parseWranglerSession(value) {
     session.command_line_args,
     "wrangler-session command_line_args",
   );
-  if (commandLineArgs[0] !== "pages" || commandLineArgs[1] !== "deploy") {
-    fail("wrangler-session must describe a Pages deploy command");
+  const expectedCommandLineArgs = [
+    "pages",
+    "deploy",
+    `--project-name=${requireString(expectedProject, "expected project", PROJECT)}`,
+    `--branch=${requireString(expectedBranch, "expected branch", PROJECT)}`,
+    `--commit-hash=${requireString(expectedCommit, "expected commit", SHA40)}`,
+    "--commit-dirty=false",
+  ];
+  if (
+    commandLineArgs.length !== expectedCommandLineArgs.length ||
+    commandLineArgs.some(
+      (argument, index) => argument !== expectedCommandLineArgs[index],
+    )
+  ) {
+    fail("wrangler-session command_line_args do not match the release");
   }
 }
 
@@ -286,7 +302,11 @@ export function parseWranglerPagesDeploymentOutput(
   },
 ) {
   const [sessionValue, summaryValue, detailedValue] = parseNdjson(raw);
-  parseWranglerSession(sessionValue);
+  parseWranglerSession(sessionValue, {
+    expectedProject,
+    expectedBranch,
+    expectedCommit,
+  });
   const summary = requireExactKeys(
     summaryValue,
     ["deployment_id", "pages_project", "timestamp", "type", "url", "version"],


### PR DESCRIPTION
Fixes #24596

## Summary
- require the pinned Wrangler 4.100.0 wrangler-session/v1 preamble
- validate its closed key set, timestamp, version, and log path without publishing local metadata
- bind command_line_args by exact ordered equality to pages deploy, project, branch, commit, and commit-dirty=false
- require exactly one session, one pages-deploy/v1 record, and one pages-deploy-detailed/v1 record; reject missing, duplicate, extra, unknown, or drifting records
- add the real three-record Wrangler regression plus adversarial session and command mutation cases

## Validation
- bun install (Bun 1.3.14)
- bun test packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts packages/scripts/__tests__/staging-cloud-receipt.test.ts — 25 pass, 0 fail, 159 expectations
- mutation coverage rejects wrong commit/project/branch, missing commit-dirty=false, and extra command args
- bunx biome check packages/cloud/scripts/pages-deployment-authority.mjs packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts — pass
- git diff --check — pass
- bun run verify — reaches audit:tsconfig-workspace-resolution, then fails on 16 unresolved @elizaos/capacitor-secure-store references in untouched UI/plugin paths; the exact develop parent 4462c779dcb0 reproduces the identical 16 violations

## Deployment evidence
Staging run 32593200158 deployed Worker and Pages successfully, then failed only because the authority parser expected two records while pinned Wrangler emitted the session plus two Pages records. This change repairs that fail-closed parser. After merge, the canonical staging workflow must rerun and certify routing, renderer authority, browser proof, and session exchange before this is treated as deployed acceptance.