### PR TITLE
fix(core): stop SETUP_MISSING misreading a missing world as a load failure

### DIFF
--- a/packages/core/src/providers/setup-progress.test.ts
+++ b/packages/core/src/providers/setup-progress.test.ts
@@ -1,9 +1,19 @@
 /**
- * Tests for setup-progress provider and lossless Unicode normalization.
+ * Tests for the setup-progress providers and lossless Unicode normalization.
+ * Provider cases drive the real exported providers through a minimal typed
+ * runtime stub (getRoom/getWorld/reportError) — no harness stands in for the
+ * module under test.
  */
 
 import { describe, expect, it } from "vitest";
-import { normalizeSetupProgressText } from "./setup-progress";
+import type { Channel, IAgentRuntime, Memory, State, World } from "../types";
+import { ChannelType } from "../types/primitives";
+import type { SerializedSetupState, SetupContext } from "../types/setup";
+import {
+	normalizeSetupProgressText,
+	type SetupStep,
+	setupMissingProvider,
+} from "./setup-progress";
 
 function isWellFormed(value: string): boolean {
 	for (let index = 0; index < value.length; index += 1) {
@@ -49,5 +59,121 @@ describe("normalizeSetupProgressText Unicode boundaries", () => {
 		const out = normalizeSetupProgressText(lone);
 		expect(out).toBe("setup progress \uFFFD current");
 		expect(isWellFormed(out)).toBe(true);
+	});
+});
+
+describe("setupMissingProvider world resolution", () => {
+	const roomId = "00000000-0000-0000-0000-000000000001" as Memory["roomId"];
+	const message = { roomId } as Memory;
+	const state = {} as State;
+
+	function setupContext(overrides: Partial<SetupContext> = {}): SetupContext {
+		return {
+			currentStep: "WELCOME",
+			completedSteps: [],
+			settings: {},
+			errors: [],
+			startedAt: Date.now(),
+			lastActivityAt: Date.now(),
+			platform: "test",
+			mode: "conversational",
+			sessionId: "session-1",
+			...overrides,
+		};
+	}
+
+	function runtimeWith(
+		room: Channel | null,
+		world: World | null,
+	): { runtime: IAgentRuntime; reportCalls: unknown[] } {
+		const reportCalls: unknown[] = [];
+		const runtime = {
+			getRoom: async () => room,
+			getWorld: async () => world,
+			character: { name: "Agent" },
+			reportError: (...args: unknown[]) => {
+				reportCalls.push(args);
+			},
+		} as unknown as IAgentRuntime;
+		return { runtime, reportCalls };
+	}
+
+	function dmRoom(worldId?: string): Channel {
+		return {
+			id: roomId,
+			source: "test",
+			type: ChannelType.DM,
+			worldId,
+		} as Channel;
+	}
+
+	function worldWithSetup(): World {
+		const metadata: { setupStateMachine: SerializedSetupState } = {
+			setupStateMachine: {
+				version: 1,
+				context: setupContext({
+					currentStep: "RISK_ACK" as SetupStep,
+				}),
+			},
+		};
+		return {
+			id: "00000000-0000-0000-0000-0000000000aa",
+			agentId: "00000000-0000-0000-0000-0000000000bb",
+			metadata,
+		} as unknown as World;
+	}
+
+	it("renders the missing list for a DM whose world carries setup state", async () => {
+		const { runtime, reportCalls } = runtimeWith(
+			dmRoom("00000000-0000-0000-0000-0000000000aa"),
+			worldWithSetup(),
+		);
+		const result = await setupMissingProvider.get(runtime, message, state);
+		expect(result.text).toContain("Still needs configuration:");
+		expect(result.text).toContain("Risk acknowledgement");
+		expect(reportCalls).toHaveLength(0);
+	});
+
+	it("returns designed-empty — not unavailable — when the world no longer exists", async () => {
+		// getWorld legitimately returns null (world deleted between getRoom and
+		// getWorld). The old code read `.setupStateMachine` off undefined and
+		// misrouted this healthy state into reportError + "unavailable".
+		const { runtime, reportCalls } = runtimeWith(dmRoom("w"), null);
+		const result = await setupMissingProvider.get(runtime, message, state);
+		expect(result.text).toBe("");
+		expect(result.values?.setupMissing).toBe("");
+		expect(result.data).toEqual({ missing: [] });
+		expect(reportCalls).toHaveLength(0);
+	});
+
+	it("returns designed-empty when the world has no metadata", async () => {
+		// A plain world without metadata is normal, not a failure.
+		const world = {
+			id: "00000000-0000-0000-0000-0000000000aa",
+			agentId: "00000000-0000-0000-0000-0000000000bb",
+		} as World;
+		const { runtime, reportCalls } = runtimeWith(
+			dmRoom(world.id as string),
+			world,
+		);
+		const result = await setupMissingProvider.get(runtime, message, state);
+		expect(result.text).toBe("");
+		expect(reportCalls).toHaveLength(0);
+	});
+
+	it("stays silent in non-DM rooms, matching SETUP_PROGRESS", async () => {
+		// SETUP_PROGRESS gates on ChannelType.DM before touching world metadata;
+		// SETUP_MISSING skipped that gate and would narrate setup state into a
+		// group room.
+		const room = {
+			id: roomId,
+			source: "test",
+			type: ChannelType.GROUP,
+			worldId: "00000000-0000-0000-0000-0000000000aa",
+		} as Channel;
+		const { runtime, reportCalls } = runtimeWith(room, worldWithSetup());
+		const result = await setupMissingProvider.get(runtime, message, state);
+		expect(result.text).toBe("");
+		expect(reportCalls).toHaveLength(0);
 	});
 });

--- a/packages/core/src/providers/setup-progress.ts
+++ b/packages/core/src/providers/setup-progress.ts
@@ -312,8 +312,29 @@ export const setupMissingProvider: Provider = {
 				};
 			}
 
+			// Same gates as SETUP_PROGRESS above: setup state is a DM-only
+			// surface, and a missing world or a world without metadata is a
+			// normal designed-empty case — not a load failure. Reading
+			// `.setupStateMachine` off an undefined metadata object here used
+			// to throw and misroute every such turn into reportError plus a
+			// fabricated "unavailable" state.
+			if (room.type !== ChannelType.DM) {
+				return {
+					data: { missing: [] },
+					values: { setupMissing: "" },
+					text: "",
+				};
+			}
+
 			const world = await runtime.getWorld(room.worldId);
-			const metadata = world?.metadata as {
+			if (!world?.metadata) {
+				return {
+					data: { missing: [] },
+					values: { setupMissing: "" },
+					text: "",
+				};
+			}
+			const metadata = world.metadata as {
 				setupStateMachine?: SerializedSetupState;
 			};
 


### PR DESCRIPTION
Closes #24617.


Closes #24617

## The defect

`setupMissingProvider` reads `.setupStateMachine` off `world?.metadata` without the guard its sibling has:

```ts
const world = await runtime.getWorld(room.worldId);   // returns null when the world is gone
const metadata = world?.metadata as { … };            // World.metadata is optional → undefined
if (!metadata.setupStateMachine) {                    // TypeError on undefined
```

The provider's own `catch` (J4) contains the throw — no crash — but it then **fabricates an error state out of a healthy one**: every DM whose world is deleted, or simply has no metadata (the normal case), produces a spurious `runtime.reportError("SetupMissingProvider.get", …)` per evaluated turn plus `"Setup requirements are unavailable."` text. The report feeds `ERROR_REPORTED`, owner escalation, and the `RECENT_ERRORS` ring, so the fabricated failure is narrated into prompts. That is the "wrong value passes through unchanged" shape: nothing escapes, but the observable state and side effects are wrong. `SETUP_PROGRESS` handles the identical situation as designed-empty (`if (!world?.metadata)`), which is the intended contract.

Secondary: `SETUP_PROGRESS` gates non-DM rooms out before touching world metadata; `SETUP_MISSING` skipped that gate.

## The fix

- Guard `!world?.metadata` before the cast, mirroring `SETUP_PROGRESS`.
- Add the same DM-room gate so setup requirements are never narrated into group rooms.
- Regression tests drive the real exported providers through a minimal typed runtime stub (`getRoom`/`getWorld`/`reportError`) — the module's actual seams.

## Evidence

Origin reproduction on unmodified code (both files byte-identical to `origin/develop`, verified with `git show origin/develop:<path> | diff - <path>`):

```
bun vitest run packages/core/src/providers/setup-progress.test.ts --root packages/core
Tests  3 failed | 5 passed (8)
FAIL … > returns designed-empty — not unavailable — when the world no longer exists
AssertionError: expected 'Setup requirements are unavailable.' to be ''
```

Load-bearing revert (copy-aside): fix removed, origin file restored under the new tests → 3 failed | 5 passed; fix restored → all green:

```
bun vitest run packages/core/src/providers/setup-progress.test.ts --root packages/core
Tests  8 passed (8)
```

| Check | Result |
| --- | --- |
| No over-rejection | Positive control in the same suite — a DM world carrying setup state still renders `"Still needs configuration:"` with zero `reportError` calls; pre-existing Unicode tests untouched and passing |
| Typecheck | `bun run --cwd packages/core typecheck` → 0 errors at head 37e22fde0 |
| Biome | `bunx biome check` on both changed files — clean |
| Hosted CI | N/A — fork contributor, CI does not run on our PRs; every command above ran locally and is quoted |

## Known gaps

- These providers are public exports of `@elizaos/core`; no in-repo caller registers them today, so the reproduction drives the module seam directly rather than through a host wiring.
- The evidence trajectory slice covers only this defect's session segment (the earlier segment belongs to the separate recent-errors PR); both slices are genuine, non-overlapping records of the same session.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:37e22fde07bf3dbed84d4198ba65b7495ee90520 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openrouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [ox-alpha-cr24033-defect2]
<!-- slop-contribution-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NGMWPVCNFQGWZJB914Z5FX","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T19:55:00.187Z","completed_at":"2026-08-22T19:57:21.134Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T19:55:01.602Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"783eb0cf60d744c6065fb1e0ca207d92c9ada154b450088397ecf3f5fc6c2821","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ffba881f-1451-4160-9e7d-4d31b6de12dd","object_id":"sha256:783eb0cf60d744c6065fb1e0ca207d92c9ada154b450088397ecf3f5fc6c2821","sha256":"783eb0cf60d744c6065fb1e0ca207d92c9ada154b450088397ecf3f5fc6c2821"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"x8k1stixekZjO1oOhTs30U_6CPknHK3E6ZH7F8O0v4gO3_prXgNcrn6POl1WMU9kvh7qsSvfUSxLmbKEJ5fYCw"}} -->
