### PR TITLE
test(core): cover sandbox policy

### DIFF
--- a/packages/core/src/__tests__/sandbox-policy.test.ts
+++ b/packages/core/src/__tests__/sandbox-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+const variant = vi.hoisted(() => ({
+  value: "direct" as "direct" | "store",
+}));
+
+vi.mock("./build-variant.js", () => ({
+  getBuildVariant: () => variant.value,
+  getDirectDownloadUrl: () => "https://eliza.so/download",
+}));
+
+import {
+  buildStoreVariantBlockedMessage,
+  isLocalCodeExecutionAllowed,
+} from "./sandbox-policy.ts";
+
+describe("isLocalCodeExecutionAllowed", () => {
+  it("allows on direct builds", () => {
+    variant.value = "direct";
+    expect(isLocalCodeExecutionAllowed()).toBe(true);
+  });
+
+  it("blocks on store builds", () => {
+    variant.value = "store";
+    expect(isLocalCodeExecutionAllowed()).toBe(false);
+  });
+});
+
+describe("buildStoreVariantBlockedMessage", () => {
+  it("mentions the feature, the sandbox, and the download URL", () => {
+    const message = buildStoreVariantBlockedMessage("Code execution");
+    expect(message).toContain("Code execution");
+    expect(message).toContain("direct download");
+    expect(message).toContain("https://eliza.so/download");
+  });
+});

--- a/packages/core/src/__tests__/sandbox-policy.test.ts
+++ b/packages/core/src/__tests__/sandbox-policy.test.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it, vi } from "vitest";
 
 const variant = vi.hoisted(() => ({
-  value: "direct" as "direct" | "store",
+	value: "direct" as "direct" | "store",
 }));
 
-vi.mock("./build-variant.js", () => ({
-  getBuildVariant: () => variant.value,
-  getDirectDownloadUrl: () => "https://eliza.so/download",
+vi.mock("../build-variant.js", () => ({
+	getBuildVariant: () => variant.value,
+	getDirectDownloadUrl: () => "https://eliza.so/download",
 }));
 
 import {
-  buildStoreVariantBlockedMessage,
-  isLocalCodeExecutionAllowed,
-} from "./sandbox-policy.ts";
+	buildStoreVariantBlockedMessage,
+	isLocalCodeExecutionAllowed,
+} from "../sandbox-policy.ts";
 
 describe("isLocalCodeExecutionAllowed", () => {
-  it("allows on direct builds", () => {
-    variant.value = "direct";
-    expect(isLocalCodeExecutionAllowed()).toBe(true);
-  });
+	it("allows on direct builds", () => {
+		variant.value = "direct";
+		expect(isLocalCodeExecutionAllowed()).toBe(true);
+	});
 
-  it("blocks on store builds", () => {
-    variant.value = "store";
-    expect(isLocalCodeExecutionAllowed()).toBe(false);
-  });
+	it("blocks on store builds", () => {
+		variant.value = "store";
+		expect(isLocalCodeExecutionAllowed()).toBe(false);
+	});
 });
 
 describe("buildStoreVariantBlockedMessage", () => {
-  it("mentions the feature, the sandbox, and the download URL", () => {
-    const message = buildStoreVariantBlockedMessage("Code execution");
-    expect(message).toContain("Code execution");
-    expect(message).toContain("direct download");
-    expect(message).toContain("https://eliza.so/download");
-  });
+	it("mentions the feature, the sandbox, and the download URL", () => {
+		const message = buildStoreVariantBlockedMessage("Code execution");
+		expect(message).toContain("Code execution");
+		expect(message).toContain("direct download");
+		expect(message).toContain("https://eliza.so/download");
+	});
 });


### PR DESCRIPTION
## Summary

Unit coverage for `packages/core/src/sandbox-policy.ts`.

## Coverage (3 cases)

- `isLocalCodeExecutionAllowed`: direct-build allow, store-build block
- `buildStoreVariantBlockedMessage`: feature + sandbox + URL composition

## Evidence

- `packages/core/src/__tests__/sandbox-policy.test.ts`: **3 passed** (verified in isolation with vitest)

## Scope

Test-only; no production change.

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash