### PR TITLE
fix(app-core): align native keyring loader contract

### DIFF
--- a/packages/app-core/src/security/platform-secure-store-node.test.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.test.ts
@@ -187,10 +187,7 @@ describe("platform secure-store behavioral outcomes", () => {
     }
     const store = createNodePlatformSecureStore({
       platform: "darwin",
-      loadNativeKeyring: async () =>
-        ({
-          AsyncEntry: FakeAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+      loadNativeKeyring: async () => ({ AsyncEntry: FakeAsyncEntry }),
     });
 
     await expect(
@@ -219,10 +216,7 @@ describe("platform secure-store behavioral outcomes", () => {
     }
     const store = createNodePlatformSecureStore({
       platform: "darwin",
-      loadNativeKeyring: async () =>
-        ({
-          AsyncEntry: DeniedAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+      loadNativeKeyring: async () => ({ AsyncEntry: DeniedAsyncEntry }),
     });
 
     await expect(
@@ -243,10 +237,7 @@ describe("platform secure-store behavioral outcomes", () => {
     }
     const store = createNodePlatformSecureStore({
       platform: "darwin",
-      loadNativeKeyring: async () =>
-        ({
-          AsyncEntry: UnverifiedAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+      loadNativeKeyring: async () => ({ AsyncEntry: UnverifiedAsyncEntry }),
     });
 
     await expect(

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -27,7 +27,7 @@ import type {
 const execFileAsync = promisify(execFile);
 const LINUX_SECRET_WIRE_PREFIX = "eliza-v1:";
 
-type NativeKeyringLoader = () => Promise<typeof import("@napi-rs/keyring")>;
+type NativeKeyringLoader = () => Promise<NativeKeyringModule>;
 type SecretToolCommandRunner = (
   executable: string,
   args: string[],


### PR DESCRIPTION
Closes #24621.

## Summary

- make the injectable native keyring loader promise the validated `AsyncEntry` capability that production actually consumes
- remove three test-only casts that falsely claimed minimal fakes implemented every `@napi-rs/keyring` export
- restore the app-core typecheck past the native keyring boundary without changing runtime behavior

## Verification

<!-- evidence-head:1bcdf4f2e771caf03d2d46f5fa77b388d2d4dd29 -->

- `bun test packages/app-core/src/security/platform-secure-store-node.test.ts`: 15 pass, 0 fail, 60 assertions
- Biome on both changed files: clean
- `git diff --check`: clean
- app-core dependency-closure typecheck advances past the prior `platform-secure-store-node.ts(296,5)` mismatch; it currently stops on the separate pre-existing `plugin-todos` declaration gap in `packages/agent/src/api/todo-cutover-import.ts`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head secure-store validation log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24627-validation-1bcdf4f2.log) - 15 tests, Biome, and diff check pass.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - behavior-neutral TypeScript contract repair; native loading implementation is unchanged.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface.


