### PR TITLE
fix(app-core): align NativeKeyringLoader with the validated keyring module

### DIFF
--- a/packages/app-core/src/security/platform-secure-store-node.test.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   createNodePlatformSecureStore,
+  type NativeKeyringModule,
   resolveBundledKeyringPath,
 } from "./platform-secure-store-node";
 
@@ -190,7 +191,7 @@ describe("platform secure-store behavioral outcomes", () => {
       loadNativeKeyring: async () =>
         ({
           AsyncEntry: FakeAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+        }) as unknown as NativeKeyringModule,
     });
 
     await expect(
@@ -222,7 +223,7 @@ describe("platform secure-store behavioral outcomes", () => {
       loadNativeKeyring: async () =>
         ({
           AsyncEntry: DeniedAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+        }) as unknown as NativeKeyringModule,
     });
 
     await expect(
@@ -246,7 +247,7 @@ describe("platform secure-store behavioral outcomes", () => {
       loadNativeKeyring: async () =>
         ({
           AsyncEntry: UnverifiedAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+        }) as unknown as NativeKeyringModule,
     });
 
     await expect(

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -27,7 +27,7 @@ import type {
 const execFileAsync = promisify(execFile);
 const LINUX_SECRET_WIRE_PREFIX = "eliza-v1:";
 
-type NativeKeyringLoader = () => Promise<typeof import("@napi-rs/keyring")>;
+type NativeKeyringLoader = () => Promise<NativeKeyringModule>;
 type SecretToolCommandRunner = (
   executable: string,
   args: string[],
@@ -211,7 +211,7 @@ type NativeKeyringEntryConstructor = new (
   account: string,
 ) => NativeKeyringEntry;
 
-interface NativeKeyringModule {
+export interface NativeKeyringModule {
   AsyncEntry: NativeKeyringEntryConstructor;
 }
 


### PR DESCRIPTION
Repairs a `develop` typecheck baseline break that is currently failing the required `All Tests Passed` gate on every open PR whose affected-workspace closure includes `@elizaos/app-core`.

## The break

```
@elizaos/app-core:typecheck: src/security/platform-secure-store-node.ts(296,5):
error TS2322: Type "() => Promise<NativeKeyringModule>" is not assignable to type "NativeKeyringLoader".
```

`importNativeKeyring` and `loadBundledNativeKeyring` both validate the imported binding through `isNativeKeyringModule` and return the narrowed `NativeKeyringModule`, but `NativeKeyringLoader` (line 30) still described the raw `typeof import("@napi-rs/keyring")` module namespace. `loadNativeKeyring` is therefore not assignable to the `keyringLoader` parameter it is the default for.

## The change

- `NativeKeyringLoader` now returns `Promise<NativeKeyringModule>` — the shape every loader on this path actually produces and the shape the constructor consumes.
- `NativeKeyringModule` is exported so the three injection sites in `platform-secure-store-node.test.ts` can cast to it directly instead of to the package namespace.

No runtime behavior changes: the validation, the bundled-addon fallback, and the `AggregateError` wrapping are all untouched.

## Verification

- `tsc --noEmit -p packages/app-core/tsconfig.json` — the TS2322 at line 296 is gone. (Locally one `TS2307: Cannot find module "@napi-rs/keyring"` remains at line 269 because the optional native dependency is not installed for this platform; CI resolves it, which is why the hosted failure was TS2322 and not TS2307.)
- `biome check` on both changed files — clean.

## Why this is urgent

CI lints and typechecks the *affected workspace closure*, so this single break fails PRs that do not touch `app-core` at all. It was observed failing e.g. #24043 (a two-line agent change) and #24055 (inbox routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)