### PR TITLE
agent: stop the v1 backup JSON writer hanging on client disconnect during backpressure

### DIFF
--- a/packages/agent/src/api/backup-json-response.test.ts
+++ b/packages/agent/src/api/backup-json-response.test.ts
@@ -4,7 +4,8 @@
  */
 
 import http from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import net from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentBackupStateData } from "../services/agent-backup.ts";
 import { writeAgentBackupJsonResponse } from "./backup-json-response.ts";
 
@@ -101,6 +102,79 @@ describe("writeAgentBackupJsonResponse", () => {
       text: `${boundaryPrefix}😀\n"done`,
       array: [null, null, true],
       date: "2026-08-13T00:00:00.000Z",
+    });
+  });
+
+  it("settles with a typed rejection when the client disconnects during backpressure", async () => {
+    // Real transport: the client reads a few KB, pauses while the server is
+    // backpressured (write() returned false), then destroys its socket. The
+    // drain event never arrives after 'close', so the writer must reject via
+    // the close race instead of parking on `once(res, "drain")` forever.
+    const snapshot = snapshotWithConfig({
+      blob: "0123456789abcdef".repeat(1024 * 1024),
+    });
+    const server = http.createServer((_req, res) => {
+      void writeAgentBackupJsonResponse(res, snapshot).then(
+        () => outcome.resolve({ kind: "resolved" }),
+        (err: unknown) =>
+          outcome.resolve({
+            kind: "rejected",
+            name: (err as Error)?.name,
+            code: (err as { code?: string })?.code,
+          }),
+      );
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("No test port");
+
+    const outcome = Promise.withResolvers<{
+      kind: "resolved" | "rejected";
+      name?: string;
+      code?: string;
+    }>();
+
+    const socket = net.connect(address.port, "127.0.0.1");
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.write(
+      "POST /api/snapshot HTTP/1.1\r\nHost: test\r\nContent-Length: 0\r\n\r\n",
+    );
+
+    let received = 0;
+    let backpressured = false;
+    socket.on("data", (chunk) => {
+      received += chunk.length;
+      // Stop reading so the server's write buffer fills and res.write()
+      // starts returning false — a genuine backpressure state.
+      if (received > 16 * 1024) {
+        backpressured = true;
+        socket.pause();
+      }
+    });
+
+    await vi.waitFor(
+      () => {
+        if (!backpressured) throw new Error("backpressure not reached yet");
+      },
+      { timeout: 10_000, interval: 50 },
+    );
+    socket.destroy();
+
+    await expect(
+      Promise.race([
+        outcome.promise,
+        new Promise<"hang">((resolve) =>
+          setTimeout(() => resolve("hang"), 5_000),
+        ),
+      ]),
+    ).resolves.toEqual({
+      kind: "rejected",
+      name: "AgentBackupClientDisconnectedError",
+      code: "AGENT_BACKUP_CLIENT_DISCONNECTED",
     });
   });
 });

--- a/packages/agent/src/api/backup-json-response.ts
+++ b/packages/agent/src/api/backup-json-response.ts
@@ -3,11 +3,29 @@
  * Node's response writer to materialize one giant outgoing buffer.
  */
 
-import { once } from "node:events";
 import type http from "node:http";
+import { ElizaError } from "@elizaos/core";
 import type { AgentBackupStateData } from "../services/agent-backup.ts";
 
 const STRING_CHUNK_CODE_UNITS = 256 * 1024;
+
+/**
+ * Thrown when the backup download transport dies mid-stream (client disconnect
+ * or socket error) instead of parking forever on a `drain` that can never
+ * arrive. Mirrors the v2 capture writer's AGENT_BACKUP_V2_CLIENT_DISCONNECTED
+ * policy: ephemeral, not a server fault.
+ */
+export class AgentBackupClientDisconnectedError extends ElizaError {
+  override readonly name = "AgentBackupClientDisconnectedError";
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, {
+      code: "AGENT_BACKUP_CLIENT_DISCONNECTED",
+      cause: options?.cause,
+      severity: "ephemeral",
+    });
+  }
+}
 
 function isUnsupportedJsonValue(value: unknown): boolean {
   return (
@@ -106,6 +124,45 @@ async function* encodeJsonValue(
   }
 }
 
+/**
+ * Resolves on `drain`; rejects with a typed error if the transport closes or
+ * errors first, so an aborted download can never park this writer forever on
+ * a backpressure wait that will never complete (the v2 capture writer in
+ * backup-v2-stream-response.ts applies the same close/error racing).
+ */
+function waitForDrain(res: http.ServerResponse): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      res.off("drain", onDrain);
+      res.off("close", onClose);
+      res.off("error", onError);
+    };
+    const onDrain = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onClose = (): void => {
+      cleanup();
+      reject(
+        new AgentBackupClientDisconnectedError(
+          "Agent backup client disconnected while the JSON snapshot was backpressured",
+        ),
+      );
+    };
+    const onError = (error: unknown): void => {
+      cleanup();
+      reject(
+        error instanceof Error
+          ? error
+          : new Error("Agent backup response stream failed", { cause: error }),
+      );
+    };
+    res.once("drain", onDrain);
+    res.once("close", onClose);
+    res.once("error", onError);
+  });
+}
+
 /** Writes a restorable snapshot as chunked JSON while honoring backpressure. */
 export async function writeAgentBackupJsonResponse(
   res: http.ServerResponse,
@@ -113,8 +170,29 @@ export async function writeAgentBackupJsonResponse(
 ): Promise<void> {
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
-  for await (const chunk of encodeJsonValue(snapshot, new Set())) {
-    if (!res.write(chunk)) await once(res, "drain");
+  // Capture transport errors raised outside the drain wait (a write can emit
+  // "error" asynchronously between chunks) instead of letting them surface as
+  // an unhandled stream event; the loop checks the capture after every write.
+  let streamError: unknown;
+  const captureStreamError = (error: unknown): void => {
+    streamError ??=
+      error instanceof Error
+        ? error
+        : new Error("Agent backup response stream failed", { cause: error });
+  };
+  res.on("error", captureStreamError);
+  try {
+    for await (const chunk of encodeJsonValue(snapshot, new Set())) {
+      if (!res.write(chunk)) await waitForDrain(res);
+      if (streamError) throw streamError;
+      if (res.destroyed) {
+        throw new AgentBackupClientDisconnectedError(
+          "Agent backup response transport closed mid-stream",
+        );
+      }
+    }
+  } finally {
+    res.off("error", captureStreamError);
   }
   res.end();
 }

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -68,7 +68,10 @@ import {
 import { parseClampedInteger } from "@elizaos/shared/utils/number-parsing";
 import { type WebSocket, WebSocketServer } from "ws";
 import { installPlugin as installPluginDirect } from "../services/plugin-installer.ts";
-import { writeAgentBackupJsonResponse } from "./backup-json-response.ts";
+import {
+  AgentBackupClientDisconnectedError,
+  writeAgentBackupJsonResponse,
+} from "./backup-json-response.ts";
 import { handleAgentBackupV2SnapshotRequest } from "./backup-v2-stream-response.ts";
 import { handleStandaloneCloudPairRoute } from "./cloud-pair-route.ts";
 import { resolveConnectorHealthIntervalMs } from "./connector-health.ts";
@@ -1908,6 +1911,20 @@ async function handleRequest(
       await writeAgentBackupJsonResponse(res, snapshot);
     } catch (err) {
       const message = formatError(err);
+      if (
+        err instanceof AgentBackupClientDisconnectedError ||
+        message === "Agent backup response stream failed"
+      ) {
+        // The download transport died mid-stream (client abort or socket
+        // error). The response is already committed and the socket is gone;
+        // treat it like the v2 capture boundary's 499/ephemeral path rather
+        // than logging a server fault.
+        logger.warn(
+          { err: message },
+          "[agent-backup] Snapshot download aborted",
+        );
+        return;
+      }
       if (message === PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT) {
         // Transient teardown race (PGlite closing) — 503 so the caller retries
         // or defers instead of tripping the fail-closed restart gate on a 500


### PR DESCRIPTION

## Summary

`writeAgentBackupJsonResponse` — the v1 `/api/snapshot` stream writer — parked forever on
`once(res, "drain")` when the download client aborted mid-stream while backpressured. Node emits
`'close'` and never `'drain'` in that state, so the writer's promise never settled, the route
handler never settled, and every aborted download retained the fully materialized snapshot plus the
suspended generator.

Fix: race the drain wait against `close`/`error` (the same pattern the v2 capture writer already
applies in `backup-v2-stream-response.ts`), reject with a typed ephemeral
`AGENT_BACKUP_CLIENT_DISCONNECTED`, capture stream errors raised between chunks instead of letting
them surface unhandled, and treat a mid-stream disconnect in the `POST /api/snapshot` catch as a
warn-level transport abort rather than a server fault.

Closes the issue linked below; no content is ever truncated or rewritten by this change — an
aborted download now rejects loudly instead of hanging silently.

## Containment analysis

The caller wraps the writer in try/catch (`server.ts`), but nothing rejects on the defect path: the
failure is a non-settling `once(res, "drain")` promise, which no catch can observe. The v2 writer's
own close-race (`AGENT_BACKUP_V2_CLIENT_DISCONNECTED`) documents that this repo treats mid-stream
disconnects as real boundary events.

## Evidence (all commands executed locally; fork PR — hosted CI does not run here)

1. Origin reproduction, byte-identical file verified via
   `git show origin/develop:<path> | diff - <path>` → identical. Real HTTP transport, 64 MiB
   snapshot, client aborts during genuine backpressure:

   ```
   client bytes so far: 393441; destroying socket
   OBSERVATION WINDOW ENDED — backpressure engaged before destroy: true
   WRITER PROMISE NEVER SETTLED -> HANG CONFIRMED
   ```

2. Load-bearing revert (copy-aside): with the new committed regression test against **origin**
   source:

   ```
   Test Files  1 failed (1)
         Tests  1 failed | 2 skipped (3)      <- hangs, race resolves "hang", assertion fails
   ```

   With the fix restored:

   ```
   Test Files  1 passed (1)
         Tests  3 passed (3)
   ```

3. No over-rejection. Valid downloads are byte-for-byte unchanged: streamed body vs native
   `JSON.stringify` over a corpus with multibyte text, surrogate-pair chunk boundaries,
   NaN/Infinity/null holes:

   ```
   branch: 200 application/json 2248950 bytes
   native JSON.stringify reference: 2248950 bytes
   BYTE-IDENTICAL to native JSON.stringify -> no behavior change on valid inputs
   ```

   The two pre-existing round-trip/escaping tests in `backup-json-response.test.ts` pass unchanged.

4. Typecheck against untouched control, error sets diffed (line numbers normalized):
   `ZERO ADDED ERRORS`. The only shared entry is a pre-existing unresolved-module error for
   `@elizaos/plugin-wallet/diagnostic`.

5. `bunx biome check` clean on all changed files.

## Known gaps

- The memory-retention claim (snapshot + generator retained per aborted download) follows from the
  suspended closure/generator holding the input; I did not take a heap snapshot to measure it.
- `snapshot-route-transient.test.ts` / `restore-route-restart.test.ts` fail to collect in this
  worktree because `@elizaos/plugin-agent-skills` is not built here — reproduced identically on
  untouched origin, so pre-existing environment, not this change.
- Writes after a client disconnect while *not* backpressured previously could emit an unobserved
  stream `'error'`; this fix adds capture only for the writer's own duration.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openrouter/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f9b248a9a5972ee53d39016b0877f3d38c82d462 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openrouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [oxalpha-backup-hang]
<!-- slop-contribution-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NGQZGHFDC41KS5AE8WCH8W","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T19:56:41.361Z","completed_at":"2026-08-22T19:58:09.054Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T19:56:42.674Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6001e6a41f4035157e0647411b4a7d8aa5e683803d3f2361ccd8dd48ff1c6a90","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b85ccad0-321e-4ee7-a01c-062cb8224803","object_id":"sha256:6001e6a41f4035157e0647411b4a7d8aa5e683803d3f2361ccd8dd48ff1c6a90","sha256":"6001e6a41f4035157e0647411b4a7d8aa5e683803d3f2361ccd8dd48ff1c6a90"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"cujCT_Gghsfd_VqAvxxNvBZLy2v_nCIJZMuE3X9gIb6G2lknNzRqtIAdwDgzVpNrWkxP33fk-AYz0tOghZ32BA"}} -->
