### PR TITLE
feat(ui): state the security contract on the sensitive-request card

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -318,12 +318,44 @@ describe("MessageContent sensitive requests", () => {
     const input = screen.getByLabelText("OPENAI_API_KEY") as HTMLInputElement;
     expect(input.type).toBe("password");
     expect(screen.getByRole("button", { name: "Save secret" })).toBeTruthy();
-    // Trust-signage copy lives only on the OAuth panel where the user is
-    // navigating to a third-party origin. For a password field, the
-    // `type="password"` input is the signal — chatty reassurance copy was
-    // intentionally removed.
     expect(screen.getByTestId("sensitive-request").textContent).not.toContain(
       "will not be sent",
+    );
+    // The card states its security contract in fixed copy: a masked-input
+    // explainer in the header and a storage note under the submit button. Both
+    // must be visible before the user types a value.
+    expect(screen.getByTestId("sensitive-request").textContent).toContain(
+      "Masked input. It never lands in the transcript.",
+    );
+    expect(
+      screen.getByTestId("sensitive-request-security-note").textContent,
+    ).toContain("never posted to chat");
+  });
+
+  it("labels the submit button 'Save securely' when the form omits submitLabel", () => {
+    const request = pendingOwnerInlineSecretRequest();
+    if (request?.form) request.form.submitLabel = undefined;
+    render(
+      <MessageContent message={baseMessage({ secretRequest: request })} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Save securely" })).toBeTruthy();
+  });
+
+  it("describes the tunnel delivery (send-once, not stored) on tunneled requests", () => {
+    render(
+      <MessageContent
+        message={baseMessage({ secretRequest: pendingTunnelSecretRequest() })}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("sensitive-request-security-note").textContent,
+    ).toContain("Sent once to the waiting session");
+    // The header explainer describes long-term storage semantics, which do not
+    // apply to a one-shot tunnel delivery — it must not render here.
+    expect(screen.getByTestId("sensitive-request").textContent).not.toContain(
+      "Masked input. It never lands in the transcript.",
     );
   });
 

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -16,6 +16,7 @@
 
 import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
 import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
+import { Check, ShieldCheck } from "lucide-react";
 import {
   type FormEvent,
   memo,
@@ -34,6 +35,7 @@ import type { UiSpec } from "../../config/ui-spec";
 import { dispatchConnectRequest } from "../../events";
 import { normalizeRemoteAgentUrl } from "../../first-run/adopt-remote-first-run";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
+import { cn } from "../../lib/utils";
 import { isDesktopPlatform, isNative } from "../../platform";
 import {
   createMobileSignalsPermissionsRegistry,
@@ -949,6 +951,8 @@ export function SensitiveRequestBlock({
 
   const tunnel = request.delivery?.tunnel;
   const requestLabel = sensitiveRequestTitleLabel(request.key);
+  const isSaved =
+    status === "saved" || status === "submitted" || status === "fulfilled";
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -1035,14 +1039,25 @@ export function SensitiveRequestBlock({
   return (
     <div
       data-testid="sensitive-request"
-      className="my-2 py-1.5 text-sm space-y-3"
+      className="my-2 rounded-sm border border-border/50 bg-card/40 px-3 py-2.5 text-sm space-y-3"
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 break-words font-medium">{requestLabel}</div>
+        <div className="min-w-0">
+          <div className="break-words font-medium">{requestLabel}</div>
+          {canCollectSecret && !tunnel && !isRemoteConnect && (
+            <div className="mt-0.5 text-xs text-muted">
+              Masked input. It never lands in the transcript.
+            </div>
+          )}
+        </div>
         <div
           data-testid="sensitive-request-status"
-          className="shrink-0 text-xs text-muted"
+          className={cn(
+            "flex shrink-0 items-center gap-1 text-xs",
+            isSaved ? "text-ok" : "text-muted",
+          )}
         >
+          {isSaved && <Check className="h-3.5 w-3.5" aria-hidden />}
           {sensitiveRequestStatusLabel(status)}
         </div>
       </div>
@@ -1151,8 +1166,22 @@ export function SensitiveRequestBlock({
             disabled={saving || !canSubmit}
             data-testid="sensitive-request-submit"
           >
-            {saving ? "Saving..." : (request.form?.submitLabel ?? "Save")}
+            {saving
+              ? "Saving..."
+              : (request.form?.submitLabel ??
+                (isRemoteConnect ? "Connect" : "Save securely"))}
           </Button>
+          {!isRemoteConnect && (
+            <div
+              className="flex items-center gap-1.5 text-xs text-muted"
+              data-testid="sensitive-request-security-note"
+            >
+              <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              {tunnel
+                ? "Sent once to the waiting session — never stored, never posted to chat."
+                : "Stored encrypted in the agent's secret store — never posted to chat."}
+            </div>
+          )}
         </form>
       )}
       {canStartOAuth && request.form?.kind === "oauth" && (
@@ -1305,7 +1334,8 @@ function OAuthRequestPanel({
       >
         {authorizing ? "Authorizing..." : label}
       </Button>
-      <div className="text-xs text-muted">
+      <div className="flex items-center gap-1.5 text-xs text-muted">
+        <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden />
         Authorization happens on the provider's secure page. The token is stored
         securely and is never shown in chat.
       </div>


### PR DESCRIPTION
# Relates to

Grok-parity inline secrets/connector UX initiative (stack 1/3; see #24632, #24633). No pre-existing issue — plan discussed and executed in-session.

# What this does

Polishes `SensitiveRequestBlock` — the in-chat masked secret card — so it states its own security contract, matching the product bar set by Grok Bot's secure secret request:

- Card chrome (border + surface) instead of a bare block.
- Header explainer under the title for storable secret forms: **"Masked input. It never lands in the transcript."**
- Shield-icon security note under the submit button, distinguishing the two delivery paths: long-term (**"Stored encrypted in the agent's secret store — never posted to chat."**) vs one-shot tunnel (**"Sent once to the waiting session — never stored, never posted to chat."**).
- Default submit label is now **"Save securely"** (explicit `submitLabel` still wins; remote-connect defaults to "Connect").
- Saved status gains a green check.
- The OAuth panel's existing trust copy gains the same shield treatment.

No transport or storage behavior changed — the card already saved via `PUT /api/secrets` / `POST /api/credential-tunnel`; this PR is presentation + regression tests.

# How it was tested

- `packages/ui`: `MessageContent.sensitive-request.test.tsx` (18 tests — 3 new: header explainer + storage note, default "Save securely" label, tunnel note incl. absence of the storage explainer), `render-parity.contract.test.tsx`, `parser-parity.contract.test.ts` — all green.
- Existing tests assert the submitted value never renders back into the DOM (unchanged, still green).
- `bun run --cwd packages/ui typecheck` and `lint` clean.

# Evidence

- Tests: 38/38 passing across the three suites above.
- Visual: covered in the stacked follow-ups' app audit pass (shared card chrome).