### PR TITLE
fix(app-core): align native keyring loader with the validated module surface

### DIFF
--- a/packages/app-core/src/security/platform-secure-store-node.test.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.test.ts
@@ -187,10 +187,7 @@ describe("platform secure-store behavioral outcomes", () => {
     }
     const store = createNodePlatformSecureStore({
       platform: "darwin",
-      loadNativeKeyring: async () =>
-        ({
-          AsyncEntry: FakeAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+      loadNativeKeyring: async () => ({ AsyncEntry: FakeAsyncEntry }),
     });
 
     await expect(
@@ -219,10 +216,7 @@ describe("platform secure-store behavioral outcomes", () => {
     }
     const store = createNodePlatformSecureStore({
       platform: "darwin",
-      loadNativeKeyring: async () =>
-        ({
-          AsyncEntry: DeniedAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+      loadNativeKeyring: async () => ({ AsyncEntry: DeniedAsyncEntry }),
     });
 
     await expect(
@@ -243,10 +237,7 @@ describe("platform secure-store behavioral outcomes", () => {
     }
     const store = createNodePlatformSecureStore({
       platform: "darwin",
-      loadNativeKeyring: async () =>
-        ({
-          AsyncEntry: UnverifiedAsyncEntry,
-        }) as unknown as typeof import("@napi-rs/keyring"),
+      loadNativeKeyring: async () => ({ AsyncEntry: UnverifiedAsyncEntry }),
     });
 
     await expect(

--- a/packages/app-core/src/security/platform-secure-store-node.ts
+++ b/packages/app-core/src/security/platform-secure-store-node.ts
@@ -27,7 +27,7 @@ import type {
 const execFileAsync = promisify(execFile);
 const LINUX_SECRET_WIRE_PREFIX = "eliza-v1:";
 
-type NativeKeyringLoader = () => Promise<typeof import("@napi-rs/keyring")>;
+type NativeKeyringLoader = () => Promise<NativeKeyringModule>;
 type SecretToolCommandRunner = (
   executable: string,
   args: string[],


### PR DESCRIPTION
# Relates to

Fixes #24621 (app-core typecheck fails on develop: `NativeKeyringLoader` promises the full `@napi-rs/keyring` module while both production loaders validate and return only the `AsyncEntry` surface).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` — the `audit:tsconfig-workspace-resolution` step fails with 16 pre-existing `@elizaos/capacitor-secure-store` violations reproduced identically on clean develop (from #23068); unrelated to this diff.

# Risks

Low. Type-level narrowing only: `NativeKeyringLoader` now promises `NativeKeyringModule` (the `AsyncEntry` surface the adapter actually consumes and that `isNativeKeyringModule` validates), instead of `typeof import("@napi-rs/keyring")`. No runtime code changes; the three test stubs drop casts that the old wider type forced.

# Background

## What does this PR do?

`584c49f095` (#24455) introduced the validated `NativeKeyringModule` return type for both native-keyring loaders (`importNativeKeyring` and the packaged bundled fallback), but left `NativeKeyringLoader` promising the full module typing. TS2322 at `platform-secure-store-node.ts:296` now fails `bun run --cwd packages/app-core typecheck` on every develop-based branch whose CI reaches app-core in the affected closure.

## What kind of change is this?

Bug fix (type-contract mismatch breaking develop typecheck).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/security/platform-secure-store-node.ts:30` — the one-line contract change — then the three test-stub cast removals it enables.

## Detailed testing steps

- Before: `node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/app-core` fails with TS2322 on develop.
- After: same command — 73/73 tasks successful.
- `bun run --cwd packages/app-core lint` — clean.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:replace-with-current-40-character-head-sha -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - type-only fix; no rendered visual surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - type-only fix; no rendered visual surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - type-only fix; no user flow exists to walk through.
<!-- evidence-row:backend-logs -->
- [ ] Typecheck transcript before/after attached below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface; compile-time contract only.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] Turbo typecheck result (73/73 successful) attached below.
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.
