### PR TITLE
agent: make GET /api/memories/stats report exact per-table counts

### DIFF
--- a/packages/agent/src/api/memories-stats-exact-count.test.ts
+++ b/packages/agent/src/api/memories-stats-exact-count.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Exercises GET /api/memories/stats at the real route boundary against a real
+ * InMemoryDatabaseAdapter, pinning the exact-count invariant: the route must
+ * report true per-table counts even past any fetch window, never a capped
+ * getMemories(limit).length, and must signal exactness like its sibling
+ * browse/by-entity routes signal inexactness.
+ */
+
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../../core/src/database/inMemoryAdapter.ts";
+import {
+  handleMemoryRoutes,
+  MEMORY_TABLE_NAMES,
+  type MemoryRouteContext,
+} from "./memory-routes.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const OTHER_AGENT = "00000000-0000-0000-0000-0000000000c2" as UUID;
+
+function makeRuntime(adapter: InMemoryDatabaseAdapter): AgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    async ensureConnection() {
+      /* connection bookkeeping is irrelevant to the count invariant */
+    },
+    getMemories(params: Parameters<InMemoryDatabaseAdapter["getMemories"]>[0]) {
+      return adapter.getMemories(params);
+    },
+    countMemories(
+      params: Parameters<InMemoryDatabaseAdapter["countMemories"]>[0],
+    ) {
+      return adapter.countMemories(params);
+    },
+  } as unknown as AgentRuntime;
+}
+
+async function insertMessages(
+  adapter: InMemoryDatabaseAdapter,
+  count: number,
+  agentId: UUID = AGENT_ID,
+): Promise<void> {
+  const batch = Array.from({ length: count }, (_, i) => {
+    const memory = {
+      id: `00000000-0000-4000-8000-${String(i).padStart(12, "0")}` as UUID,
+      entityId: "22222222-2222-4222-8222-222222222222" as UUID,
+      roomId: "44444444-4444-4444-8444-444444444444" as UUID,
+      agentId,
+      createdAt: 2_000_000 - i,
+      content: { text: `note ${i}` },
+    } satisfies Partial<Memory> as Memory;
+    return { memory, tableName: "messages" };
+  });
+  await adapter.createMemories(batch);
+}
+
+async function stats(runtime: AgentRuntime): Promise<{
+  total: number;
+  byType: Record<string, number>;
+  totalIsExact?: boolean;
+}> {
+  let output: unknown;
+  const context: MemoryRouteContext = {
+    req: {} as never,
+    res: {} as never,
+    method: "GET",
+    pathname: "/api/memories/stats",
+    url: new URL("https://agent.test/api/memories/stats"),
+    runtime,
+    agentName: "Eliza",
+    json: (_res, value) => {
+      output = value;
+    },
+    error: (_res, message, status) => {
+      throw new Error(`unexpected ${status}: ${message}`);
+    },
+    readJsonBody: async <T extends object>() => ({}) as T,
+  };
+  const handled = await handleMemoryRoutes(context);
+  if (!handled) throw new Error("stats route not handled");
+  return output as {
+    total: number;
+    byType: Record<string, number>;
+    totalIsExact?: boolean;
+  };
+}
+
+describe("GET /api/memories/stats", () => {
+  it("counts exactly past the previous 10,000-row fetch cap", async () => {
+    const adapter = new InMemoryDatabaseAdapter();
+    await insertMessages(adapter, 10_050);
+
+    const body = await stats(makeRuntime(adapter));
+
+    expect(body.byType.messages).toBe(10_050);
+    expect(body.total).toBe(10_050);
+  });
+
+  it("reports identical totals to the origin implementation on sub-cap corpora", async () => {
+    // No-over-rejection corpus: mixed tables and a foreign-agent partition,
+    // all under the old 10,000 fetch cap where both implementations must
+    // agree with the store's ground truth.
+    const adapter = new InMemoryDatabaseAdapter();
+    await insertMessages(adapter, 137);
+    await insertMessages(adapter, 23, OTHER_AGENT);
+    await adapter.createMemories([
+      {
+        memory: {
+          id: "00000000-0000-4000-8000-000000099999" as UUID,
+          entityId: "22222222-2222-4222-8222-222222222222" as UUID,
+          roomId: "44444444-4444-4444-8444-444444444444" as UUID,
+          agentId: AGENT_ID,
+          createdAt: 1_000_000,
+          content: { text: "fact" },
+        } satisfies Partial<Memory> as Memory,
+        tableName: "facts",
+      },
+    ]);
+
+    const body = await stats(makeRuntime(adapter));
+
+    const groundTruth = await adapter.countMemories({
+      agentId: AGENT_ID,
+      tableName: "messages",
+    });
+    expect(groundTruth).toBe(137);
+    // The old implementation returned memories.length for
+    // getMemories({limit:10000}) — identical on every sub-cap corpus.
+    expect(body.byType.messages).toBe(137);
+    expect(body.byType.facts).toBe(1);
+    for (const table of MEMORY_TABLE_NAMES) {
+      const exact = await adapter.countMemories({
+        agentId: AGENT_ID,
+        tableName: table,
+      });
+      expect(body.byType[table]).toBe(exact);
+    }
+    expect(body.total).toBe(
+      MEMORY_TABLE_NAMES.reduce(
+        (sum, table) => sum + (body.byType[table] ?? 0),
+        0,
+      ),
+    );
+  });
+
+  it("signals exactness explicitly like sibling browse routes signal inexactness", async () => {
+    const adapter = new InMemoryDatabaseAdapter();
+    await insertMessages(adapter, 3);
+
+    const body = await stats(makeRuntime(adapter));
+    expect(body.totalIsExact).toBe(true);
+  });
+});

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -66,7 +66,7 @@ const MEMORY_BROWSE_MAX_LIMIT = 200;
 const MEMORY_BROWSE_MAX_SCAN_ROWS = 25_000;
 const MEMORY_FEED_DEFAULT_LIMIT = 50;
 const MEMORY_FEED_MAX_LIMIT = 100;
-const MEMORY_TABLE_NAMES = [
+export const MEMORY_TABLE_NAMES = [
   "messages",
   "memories",
   "facts",
@@ -1419,17 +1419,20 @@ export async function handleMemoryRoutes(
     let total = 0;
 
     for (const tableName of MEMORY_TABLE_NAMES) {
-      const memories = await runtime.getMemories({
+      // Exact count straight from the store. The previous implementation
+      // fetched getMemories({ limit: 10000 }).length per table, which capped
+      // every larger table at exactly 10,000 and reported the truncated value
+      // as success — a silent window that violates the repo's no-silent-drop
+      // invariant once any table exceeds the cap.
+      const count = await runtime.countMemories({
         agentId: runtime.agentId as UUID,
         tableName,
-        limit: 10000,
-        includeEmbedding: false, // stats only counts memories.length
       });
-      counts[tableName] = memories.length;
-      total += memories.length;
+      counts[tableName] = count;
+      total += count;
     }
 
-    json(res, { total, byType: counts });
+    json(res, { total, byType: counts, totalIsExact: true });
     return true;
   }
 


### PR DESCRIPTION

## Summary

`GET /api/memories/stats` counted each table with `getMemories({ limit: 10000 }).length`, which
newest-first slices at the fetch cap: any table with more than 10,000 rows reported exactly 10000
with HTTP 200 and no inexactness marker. Measured against the real `InMemoryDatabaseAdapter`:
10,050 stored rows → route reported 10,000, silently dropping 50.

Fix: count via `runtime.countMemories` — an exact store-side count available on every adapter
(abstract on `DatabaseAdapter`; agentId-filtered in both the SQL and in-memory implementations) —
and signal `totalIsExact: true` explicitly, matching the sibling convention where `/browse` and
`/by-entity` annotate `totalIsExact: false`. The existing `total`/`byType` fields are unchanged for
consumers. As a side benefit the route no longer materializes full memory rows (content included)
just to read `.length`.

## Evidence (all commands executed locally; fork PR — hosted CI does not run here)

1. Origin reproduction, byte-identical file verified via
   `git show origin/develop:<path> | diff - <path>` → identical. Real adapter, real route seam:

   ```
   rows actually stored:            10050
   getMemories(limit:10000).length: 10000   <- what /api/memories/stats reports today
   countMemories():                 10050   <- exact
   DEFECT CONFIRMED on real adapter
   ```

2. Load-bearing revert (copy-aside): committed regression test suite against **origin** source:

   ```
    × counts exactly past the previous 10,000-row fetch cap
    × reports identical totals to the origin implementation on sub-cap corpora
    × signals exactness explicitly like sibling browse routes signal inexactness
   Test Files  1 failed (1)      Tests  3 failed (3)
   ```

   With the fix restored: `Test Files  1 passed (1)   Tests  3 passed (3)`.

3. No over-rejection. The committed sub-cap corpus test pins that every table's reported count
   equals the store's ground truth (`adapter.countMemories`) across mixed tables and a foreign-agent
   partition — i.e. identical numbers to the old `getMemories(...).length` on every corpus under
   the cap, where the two implementations agree by construction. Additionally, the full existing
   memory-route surface passes unchanged:

   ```
   Test Files  6 passed (6)      Tests  64 passed (64)
   ```

   (`memory-browse-pagination`, `memory-feed-cursor`, `memory-remember-idempotency`,
   `memory-search-cache`, `memory-routes.encoding`, plus the new stats suite.)

4. Typecheck against untouched control, error sets diffed (line numbers normalized):
   `ZERO ADDED ERRORS`.

5. `bunx biome check` clean on all changed files.

## Known gaps

- `totalIsExact: true` is a new response field; consumers reading only `total`/`byType` see no
  change, but I could not run the packaged mobile/dashboard consumers to confirm none assert an
  exact response shape.
- Verified against `InMemoryDatabaseAdapter` and the SQL adapter source; I did not execute a live
  Postgres instance.

# Relates to\n\n- Fixes #24636\n
# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openrouter/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b142276a8a0b14bb796fd5c8ca679762afa258b7 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openrouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [oxalpha-stats-exact]
<!-- slop-contribution-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NHPHFQPPBZWBEG2ZZ01R79","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T20:13:22.808Z","completed_at":"2026-08-22T20:21:49.275Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T20:13:24.820Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2d80ab35bb3b13397d22cee604ab726d62639e670851780b95b102f9445caaa0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5c8aab8a-5053-46ed-b2ee-8a2d007a6ecc","object_id":"sha256:2d80ab35bb3b13397d22cee604ab726d62639e670851780b95b102f9445caaa0","sha256":"2d80ab35bb3b13397d22cee604ab726d62639e670851780b95b102f9445caaa0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"PuLifUTeZX5pesWYXbLgKDDl4LNiE77v65t63H9NPkpEanvl7UmDWWccF5ZjiRjgUoYc7n7z6XidpiG89z4pAw"}} -->
