### PR TITLE
fix(auth): reject partial provider diagnostics

### DIFF
--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -45,6 +45,9 @@ subpath export.
   an independent provider-local lock.
 - Keep provider protocol details at the boundary and return the shared typed
   account/credential contracts to consumers.
+- Preserve complete direct-provider failure bodies when they fit the explicit
+  diagnostic boundary. If a response body exceeds that boundary, reject the
+  body as unavailable; never return a prefix labeled as the provider error.
 
 ## Commands
 

--- a/packages/auth/CLAUDE.md
+++ b/packages/auth/CLAUDE.md
@@ -45,6 +45,9 @@ subpath export.
   an independent provider-local lock.
 - Keep provider protocol details at the boundary and return the shared typed
   account/credential contracts to consumers.
+- Preserve complete direct-provider failure bodies when they fit the explicit
+  diagnostic boundary. If a response body exceeds that boundary, reject the
+  body as unavailable; never return a prefix labeled as the provider error.
 
 ## Commands
 

--- a/packages/auth/src/direct-api-probe.test.ts
+++ b/packages/auth/src/direct-api-probe.test.ts
@@ -35,7 +35,7 @@ describe("probeDirectApiKey", () => {
     });
   });
 
-  it("marks an over-limit body instead of trimming it silently", async () => {
+  it("rejects an over-limit body without retaining a misleading prefix", async () => {
     // The base URL is operator-configurable via *_BASE_URL, so the diagnostic
     // read is bounded. A reader must be able to tell a complete body from a cut
     // one — that is the whole point of dropping the old silent slice(0, 200).
@@ -47,11 +47,10 @@ describe("probeDirectApiKey", () => {
 
     const result = await probeDirectApiKey("openai-api", "provider-key");
 
-    // Exactly the cap is retained, then the marker — assert on the kept body
-    // itself, since the marker and status prefix are added on top of it.
     expect(result.error).toBe(
-      `openai-api 500: ${"y".repeat(64 * 1024)}[truncated: ${64 * 1024 + 10} bytes exceeded the ${64 * 1024}-byte probe diagnostic limit]`,
+      `openai-api 500: [response body rejected: more than ${64 * 1024} bytes exceeds the probe diagnostic limit]`,
     );
+    expect(result.error).not.toContain("y".repeat(100));
   });
 
   it("keeps the HTTP status when the provider body cannot be read", async () => {

--- a/packages/auth/src/direct-api-probe.ts
+++ b/packages/auth/src/direct-api-probe.ts
@@ -49,21 +49,47 @@ export interface DirectApiProbeResult {
  * Ceiling on the provider error body kept for diagnostics. Orders of magnitude
  * above any real provider error, so in practice nothing is lost — but the base
  * URL is operator-configurable through the `*_BASE_URL` overrides, so the read
- * must not be unbounded. Exceeding it is reported in the text rather than
- * silently trimmed: a truncation the reader cannot see is the failure mode this
- * function exists to avoid.
+ * must not be unbounded. Exceeding it rejects the optional body as a whole;
+ * partial provider text is never presented as the provider's diagnostic.
  */
 const MAX_PROBE_FAILURE_BODY_BYTES = 64 * 1024;
 
 async function readProbeFailureBody(response: Response): Promise<string> {
   try {
-    const body = await response.text();
-    const bytes = new TextEncoder().encode(body);
-    if (bytes.length <= MAX_PROBE_FAILURE_BODY_BYTES) return body;
-    const kept = new TextDecoder().decode(
-      bytes.subarray(0, MAX_PROBE_FAILURE_BODY_BYTES),
-    );
-    return `${kept}[truncated: ${bytes.length} bytes exceeded the ${MAX_PROBE_FAILURE_BODY_BYTES}-byte probe diagnostic limit]`;
+    const declaredLength = Number(response.headers?.get?.("content-length"));
+    if (
+      Number.isFinite(declaredLength) &&
+      declaredLength > MAX_PROBE_FAILURE_BODY_BYTES
+    ) {
+      return `[response body rejected: ${declaredLength} bytes exceeds the ${MAX_PROBE_FAILURE_BODY_BYTES}-byte probe diagnostic limit]`;
+    }
+    if (!response.body) {
+      const body = await response.text();
+      const bytes = new TextEncoder().encode(body);
+      if (bytes.length <= MAX_PROBE_FAILURE_BODY_BYTES) return body;
+      return `[response body rejected: ${bytes.length} bytes exceeds the ${MAX_PROBE_FAILURE_BODY_BYTES}-byte probe diagnostic limit]`;
+    }
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let byteLength = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > MAX_PROBE_FAILURE_BODY_BYTES) {
+        await reader.cancel();
+        return `[response body rejected: more than ${MAX_PROBE_FAILURE_BODY_BYTES} bytes exceeds the probe diagnostic limit]`;
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(byteLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(bytes);
   } catch (cause) {
     // error-policy:J4 explicit diagnostic degrade — the HTTP status remains the
     // authoritative failed probe; only the optional provider body is unavailable.


### PR DESCRIPTION
## Summary

- preserve complete direct-provider failure bodies inside the explicit 64 KiB diagnostic boundary
- stream the failure body only up to that boundary and cancel larger reads
- reject an oversized body as unavailable instead of returning a prefix labeled as the provider error
- document and test the no-partial-diagnostic contract

Fixes #24602.

## Verification

Exact head: `4c8925fd425c3582261c720cd4de98b4c0219cd8`

- focused auth Vitest: 1 file / 4 tests passed
- `bun run --cwd packages/auth typecheck` — passed
- changed-file Biome — passed
- `bun run check:agents-claude` — 161 pairs passed
- `git diff --check origin/develop...HEAD` — passed

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-content-budget-review]
<!-- evidence-head:4c8925fd425c3582261c720cd4de98b4c0219cd8 -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop"} -->