### PR TITLE
fix(core): bound unverified coding completion loops

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -453,6 +453,79 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		).rejects.toThrow("queue empty");
 	});
 
+	it("marks an unverified coding mutation as a machine-readable turn failure", async () => {
+		const writeAction = makeMockAction({
+			name: "WRITE",
+			contexts: ["code", "files"],
+			parameters: [
+				{
+					name: "file_path",
+					description: "File path",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "content",
+					description: "File content",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			handler: async () => ({ success: true, text: "wrote config.go" }),
+		});
+		const runtime = makeRuntime({
+			actions: [writeAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								args: { file_path: "config.go", content: "package config" },
+							},
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								args: { text: "Implemented the change." },
+							},
+						],
+					},
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("change config.go"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+			plannerLoopConfig: { maxTerminalOnlyContinuations: 0 },
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") throw new Error("expected reply");
+		expect(result.result.responseContent).toMatchObject({
+			text: expect.stringContaining("coding task is incomplete"),
+			failureKind: "coding_verification_failed",
+			elizaSyntheticFailure: true,
+			transient: false,
+		});
+		expect(getCalls(runtime)).toHaveLength(2);
+	});
+
 	it("runs the full pipeline and records every stage to disk", async () => {
 		let webSearchCalls = 0;
 		const webSearch = makeMockAction({

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -779,6 +779,204 @@ describe("v5 planner loop skeleton", () => {
 		});
 	});
 
+	it("does not treat a successful inspection command as coding verification", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "file-write-1",
+								name: "FILE",
+								arguments: {
+									action: "write",
+									file_path: "config.go",
+									content: "package config",
+								},
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-grep-1",
+								name: "SHELL",
+								arguments: { command: "grep -R stringToEnvVarHookFunc ." },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-inspected", "Implemented the function."),
+					)
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-test-1",
+								name: "SHELL",
+								arguments: { command: "go test ./..." },
+							},
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply(
+							"reply-verified",
+							"Implemented and tested the function.",
+						),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async () => ({
+				success: true,
+				text: "succeeded",
+			}));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "FILE", description: "Operate on a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(runtime.useModel).toHaveBeenCalledTimes(5);
+			expect(executeToolCall).toHaveBeenCalledTimes(3);
+			expect(result.finalMessage).toBe("Implemented and tested the function.");
+			expect(
+				result.trajectory.evaluatorOutputs.filter(
+					(output) => output.decision === "CONTINUE",
+				),
+			).toHaveLength(1);
+		});
+	});
+
+	it("bounds repeated terminal replies while a coding mutation remains unverified", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const unverifiedReply = codingReply(
+				"reply-unverified",
+				"Implemented the change, but tests did not pass.",
+			);
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "draft" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-failed",
+								name: "SHELL",
+								arguments: { command: "test -s dice.html" },
+							},
+						],
+					})
+					.mockResolvedValue(unverifiedReply),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi
+				.fn()
+				.mockResolvedValueOnce({ success: true, text: "wrote draft" })
+				.mockResolvedValueOnce({ success: false, text: "test failed" });
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				config: { maxTerminalOnlyContinuations: 1 },
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(runtime.useModel).toHaveBeenCalledTimes(4);
+			expect(executeToolCall).toHaveBeenCalledTimes(2);
+			expect(result.evaluator).toMatchObject({
+				success: false,
+				decision: "FINISH",
+			});
+			expect(result.finalMessage).toContain("coding task is incomplete");
+			expect(
+				result.trajectory.evaluatorOutputs.filter(
+					(output) => output.decision === "CONTINUE",
+				),
+			).toHaveLength(1);
+			expect(runtime.logger.warn).toHaveBeenCalledWith(
+				expect.objectContaining({ codingVerificationDeferrals: 2 }),
+				expect.stringContaining("verification deferral limit"),
+			);
+		});
+	});
+
+	it("bounds repeated free-text terminals while a coding mutation remains unverified", async () => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "dice.html", content: "draft" },
+							},
+						],
+					})
+					.mockResolvedValue({
+						text: "Implemented the change, but verification is unavailable.",
+						toolCalls: [],
+					}),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async () => ({
+				success: true,
+				text: "wrote draft",
+			}));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				config: { maxTerminalOnlyContinuations: 1 },
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "SHELL", description: "Run a command." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(runtime.useModel).toHaveBeenCalledTimes(3);
+			expect(executeToolCall).toHaveBeenCalledTimes(1);
+			expect(result.evaluator).toMatchObject({
+				success: false,
+				decision: "FINISH",
+			});
+			expect(result.finalMessage).toContain("coding task is incomplete");
+		});
+	});
+
 	it("fails honestly instead of synthesizing success after repeated calls leave a mutation unverified", async () => {
 		await withCodingRequiredToolDefaults(async () => {
 			const readCall = {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -864,6 +864,7 @@ describe("v5 planner loop skeleton", () => {
 				"reply-unverified",
 				"Implemented the change, but tests did not pass.",
 			);
+			let plannerModelCalls = 0;
 			const runtime = {
 				useModel: vi
 					.fn()
@@ -887,7 +888,19 @@ describe("v5 planner loop skeleton", () => {
 							},
 						],
 					})
-					.mockResolvedValue(unverifiedReply),
+					// Bounded on purpose: without the deferral limit the loop spins
+					// forever, and an infinite mock hangs the runner instead of
+					// failing. The fix needs 4 calls, so this never trips while the
+					// bound holds — and trips immediately if the bound is removed.
+					.mockImplementation(async () => {
+						plannerModelCalls += 1;
+						if (plannerModelCalls > 12) {
+							throw new Error(
+								"planner loop exceeded 12 model calls: coding verification deferral is unbounded",
+							);
+						}
+						return unverifiedReply;
+					}),
 				logger: { warn: vi.fn() },
 			};
 			const executeToolCall = vi
@@ -930,6 +943,7 @@ describe("v5 planner loop skeleton", () => {
 
 	it("bounds repeated free-text terminals while a coding mutation remains unverified", async () => {
 		await withCodingRequiredToolDefaults(async () => {
+			let freeTextTerminalCalls = 0;
 			const runtime = {
 				useModel: vi
 					.fn()
@@ -943,9 +957,20 @@ describe("v5 planner loop skeleton", () => {
 							},
 						],
 					})
-					.mockResolvedValue({
-						text: "Implemented the change, but verification is unavailable.",
-						toolCalls: [],
+					// Bounded for the same reason as the deferral test above: an
+					// infinite mock turns a lost bound into a runner hang or OOM
+					// rather than a failure naming the cause.
+					.mockImplementation(async () => {
+						freeTextTerminalCalls += 1;
+						if (freeTextTerminalCalls > 12) {
+							throw new Error(
+								"planner loop exceeded 12 model calls: free-text terminal continuation is unbounded",
+							);
+						}
+						return {
+							text: "Implemented the change, but verification is unavailable.",
+							toolCalls: [],
+						};
 					}),
 				logger: { warn: vi.fn() },
 			};

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -434,6 +434,7 @@ async function runPlannerLoopIterations(
 	};
 	const failures: FailureLike[] = [];
 	let terminalOnlyContinuations = 0;
+	let codingVerificationDeferrals = 0;
 	let requiredToolMisses = 0;
 	let unavailableToolCallRetries = 0;
 	let silentFailedFinishRecoveries = 0;
@@ -519,6 +520,29 @@ async function runPlannerLoopIterations(
 		completionTokens: number;
 	}): void => {
 		params.onModelUsage?.(usage);
+	};
+	const stopAfterCodingVerificationDeferralLimit = async (
+		iteration: number,
+	): Promise<PlannerLoopResult | undefined> => {
+		codingVerificationDeferrals++;
+		if (codingVerificationDeferrals <= config.maxTerminalOnlyContinuations) {
+			return undefined;
+		}
+		params.runtime.logger?.warn?.(
+			{
+				iteration,
+				codingVerificationDeferrals,
+				maxTerminalOnlyContinuations: config.maxTerminalOnlyContinuations,
+			},
+			"[planner-loop] coding verification deferral limit reached; returning a typed unverified-mutation failure",
+		);
+		return finishWithForcedSynthesis({
+			loop: params,
+			config,
+			trajectory,
+			iteration,
+			onUsage: observePlannerUsage,
+		});
 	};
 	// Tracks the most recent planner output's *explicit* `messageToUser` so the
 	// post-tool evaluator gate can use it as the final response when the
@@ -1006,8 +1030,12 @@ async function runPlannerLoopIterations(
 						trajectory,
 						iteration,
 						redactDiagnosticText,
+						recordDiagnostic: codingVerificationDeferrals === 0,
 					})
 				) {
+					const limitResult =
+						await stopAfterCodingVerificationDeferralLimit(iteration);
+					if (limitResult) return limitResult;
 					continue;
 				}
 				if (trajectory.steps.some((step) => step.toolCall)) {
@@ -1265,8 +1293,12 @@ async function runPlannerLoopIterations(
 						trajectory,
 						iteration,
 						redactDiagnosticText,
+						recordDiagnostic: codingVerificationDeferrals === 0,
 					})
 				) {
+					const limitResult =
+						await stopAfterCodingVerificationDeferralLimit(iteration);
+					if (limitResult) return limitResult;
 					continue;
 				}
 				// The messageToUser fallback applies only when a REPLY call is
@@ -3738,29 +3770,32 @@ function deferCodingCompletionUntilMutationVerified(args: {
 	trajectory: PlannerTrajectory;
 	iteration: number;
 	redactDiagnosticText?: ToolDiagnosticTextRedactor;
+	recordDiagnostic?: boolean;
 }): boolean {
 	if (!codingMutationRequiresVerification(args.trajectory)) return false;
 
-	const evaluator: EvaluatorOutput = {
-		success: false,
-		decision: "CONTINUE",
-		thought:
-			"A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
-		messageToUser:
-			"Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
-	};
-	args.trajectory.evaluatorOutputs.push(
-		projectToolDiagnosticValue(
+	if (args.recordDiagnostic !== false) {
+		const evaluator: EvaluatorOutput = {
+			success: false,
+			decision: "CONTINUE",
+			thought:
+				"A successful WRITE or EDIT has not been followed by a successful SHELL verification.",
+			messageToUser:
+				"Run the narrowest relevant test, typecheck, lint, build, or diff check with SHELL before finishing.",
+		};
+		args.trajectory.evaluatorOutputs.push(
+			projectToolDiagnosticValue(
+				evaluator,
+				args.redactDiagnosticText ?? composeToolDiagnosticRedactor(),
+			) as EvaluatorOutput,
+		);
+		appendEvaluatorContextEvent(
+			args.trajectory,
 			evaluator,
-			args.redactDiagnosticText ?? composeToolDiagnosticRedactor(),
-		) as EvaluatorOutput,
-	);
-	appendEvaluatorContextEvent(
-		args.trajectory,
-		evaluator,
-		args.iteration,
-		args.redactDiagnosticText,
-	);
+			args.iteration,
+			args.redactDiagnosticText,
+		);
+	}
 	args.trajectory.plannedQueue.length = 0;
 	return true;
 }
@@ -3773,8 +3808,30 @@ function codingMutationRequiresVerification(
 	for (let index = 0; index < steps.length; index++) {
 		const step = steps[index];
 		const name = step?.toolCall?.name.toUpperCase();
+		const fileMutation =
+			name === "FILE" &&
+			[
+				"write",
+				"edit",
+				"create",
+				"delete",
+				"move",
+				"copy",
+				"mkdir",
+				"touch",
+			].includes(
+				String(
+					(step.toolCall?.params as Record<string, unknown> | undefined)
+						?.action ??
+						(step.toolCall?.params as Record<string, unknown> | undefined)
+							?.operation ??
+						"",
+				)
+					.trim()
+					.toLowerCase(),
+			);
 		if (
-			(name === "WRITE" || name === "EDIT") &&
+			(name === "WRITE" || name === "EDIT" || fileMutation) &&
 			step.result?.success === true
 		) {
 			latestMutationIndex = index;
@@ -3784,12 +3841,46 @@ function codingMutationRequiresVerification(
 
 	const verified = steps
 		.slice(latestMutationIndex + 1)
-		.some(
-			(step) =>
-				step.toolCall?.name.toUpperCase() === "SHELL" &&
-				step.result?.success === true,
-		);
+		.some((step) => isSuccessfulCodingVerificationStep(step));
 	return !verified;
+}
+
+/**
+ * Distinguishes a command that checks the changed program from a successful
+ * inspection command. A post-edit `grep`, `ls`, or `git status` proves only
+ * that the shell works; accepting it as verification lets a coding agent stop
+ * with syntax errors. The command families below are intentionally narrow and
+ * provider-independent. Tool implementations may additionally stamp the
+ * result with `verificationEvidence: true` when they have stronger typed
+ * evidence than command shape alone.
+ */
+function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
+	if (
+		step.toolCall?.name.toUpperCase() !== "SHELL" ||
+		step.result?.success !== true
+	) {
+		return false;
+	}
+	if (
+		(step.result.data as { verificationEvidence?: unknown } | undefined)
+			?.verificationEvidence === true
+	) {
+		return true;
+	}
+	const command = shellCommandParam(step.toolCall);
+	if (!command) return false;
+	return [
+		/(?:^|[;&|]\s*)(?:test|\[)\s+[^;&|]+/i,
+		/\bgit\s+diff\s+--check\b/i,
+		/\b(?:bun|npm|pnpm|yarn|deno)\b[^;&|\n]*\b(?:test|verify|check|lint|typecheck|build)\b/i,
+		/\b(?:vitest|jest|pytest|rspec|phpunit|mocha|ava)\b/i,
+		/\bgo\s+(?:test|vet|build)\b/i,
+		/\bcargo\s+(?:test|check|clippy|build)\b/i,
+		/\b(?:dotnet\s+test|mvn\s+(?:test|verify)|gradle\w*\s+(?:test|check|build))\b/i,
+		/\b(?:make|just)\b[^;&|\n]*\b(?:test|verify|check|lint|typecheck|build)\b/i,
+		/\b(?:tsc|eslint|biome)\b/i,
+		/\b(?:python\d*\s+-m\s+(?:compileall|py_compile)|ruby\s+-c|bash\s+-n|node\s+--check)\b/i,
+	].some((pattern) => pattern.test(command));
 }
 
 function getToolDefinitionName(tool: ToolDefinition): string | undefined {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2161,6 +2161,12 @@ function createV5ReplyStrategyResult(args: {
 	 * planner text so the gate can still rewrite canned strings.
 	 */
 	agentVoiced?: boolean;
+	/**
+	 * Machine-readable terminal failure for coding/CLI callers. The visible
+	 * text still reaches interactive surfaces, while adapters can return a
+	 * non-success process/result instead of treating any nonempty reply as done.
+	 */
+	codingFailureKind?: string;
 }): StrategyResult {
 	let responseContent: Content = {
 		thought: args.thought,
@@ -2169,6 +2175,13 @@ function createV5ReplyStrategyResult(args: {
 		simple: args.mode !== "actions",
 		responseId: args.responseId,
 		...(args.agentVoiced === true ? { agentVoiced: true } : {}),
+		...(args.codingFailureKind
+			? {
+					failureKind: args.codingFailureKind,
+					elizaSyntheticFailure: true,
+					transient: false,
+				}
+			: {}),
 		...(args.attachments?.length ? { attachments: args.attachments } : {}),
 		...(args.transcriptVisibility
 			? { transcriptVisibility: args.transcriptVisibility }
@@ -10247,6 +10260,10 @@ export async function runV5MessageRuntimeStage1(args: {
 			plannedTextRaw || effectiveReplyText,
 			actionResults,
 		);
+		const codingFailureKind =
+			args.codingMode === true && plannerResult.evaluator?.success === false
+				? "coding_verification_failed"
+				: undefined;
 
 		return {
 			kind: "planned_reply",
@@ -10268,6 +10285,7 @@ export async function runV5MessageRuntimeStage1(args: {
 								? { effectReceiptIds: effectiveReplyReceiptIds }
 								: {}),
 							...(transcriptVisibility ? { transcriptVisibility } : {}),
+							...(codingFailureKind ? { codingFailureKind } : {}),
 						}),
 						...(actionResults.length > 0 ? { actionResults } : {}),
 					}


### PR DESCRIPTION
Closes part of #24299.

## What changed
- Bound repeated REPLY and free-text completion attempts after an unverified coding mutation.
- Reuse the existing fail-closed forced-synthesis path, returning success=false without another model call.
- Deduplicate the synthetic verification diagnostic while preserving actual planner attempts.
- Treat FILE umbrella mutations like WRITE/EDIT.
- Require semantic verification command evidence; successful grep/ls/status inspection no longer proves correctness.
- Propagate the typed unverified terminal failure to coding/CLI callers.
- Match verification only when a recognized verifier is the executed shell command, not when verifier names merely occur in output/prose commands.
- Reject shell builtins such as `test -f` / `[ -f ]` as program verification.

## Exact-head evidence

Head: `5a42760e36ca942f620afcf3add201f3cf23189b` (rebased on current `develop`)

- `packages/core/src/runtime/__tests__/planner-loop.test.ts`: **147/147 passed**
- Adversarial coverage rejects `echo vitest`, `printf 'git diff --check'`, `test -f`, `[ -f ]`, quoted verifier text, and `npm exec echo test`.
- `bun run --cwd packages/core typecheck`: passed.
- Changed-file Biome: passed.
- Node/browser/edge/testing bundles and declaration generation completed. The later package smoke phase was blocked by a local tool shim issue: pinned Node attempted to parse the repository's shell-wrapper `npm` as JavaScript (`set -euo pipefail`); hosted CI is the authority for the package phase.

## Original evidence
- Live controlled env-task trajectory: successful grep was rejected as verification; bounded terminal attempts returned typed incomplete. Full trace SHA-256 `dcdb2c5bca438c880e7894f73986238a40032d13de34c7bf091e11e3fa9024c3`.
