### PR TITLE
fix(auth): recognize current Codex API key mode

### DIFF
--- a/packages/auth/src/subscription-auth/builtin-providers.test.ts
+++ b/packages/auth/src/subscription-auth/builtin-providers.test.ts
@@ -117,12 +117,18 @@ describe("built-in Codex CLI credential discovery", () => {
     expect(discoverCodexCredential()).toBeNull();
   });
 
-  it("omits a valid direct API-key-only login", () => {
-    writeCodexAuth(
-      home,
-      JSON.stringify({ auth_mode: "api-key", OPENAI_API_KEY: "sk-fixture" }),
-    );
+  it.each(["apikey", "api-key"])(
+    "omits a valid direct API-key-only login using %s auth mode",
+    (authMode) => {
+      writeCodexAuth(
+        home,
+        JSON.stringify({
+          auth_mode: authMode,
+          OPENAI_API_KEY: "sk-fixture",
+        }),
+      );
 
-    expect(discoverCodexCredential()).toBeNull();
-  });
+      expect(discoverCodexCredential()).toBeNull();
+    },
+  );
 });

--- a/packages/auth/src/subscription-auth/builtin-providers.ts
+++ b/packages/auth/src/subscription-auth/builtin-providers.ts
@@ -85,7 +85,10 @@ function codexCliSubscriptionState(): CodexCliSubscriptionState {
 
   const authMode =
     typeof data.auth_mode === "string" ? data.auth_mode.trim() : "";
-  if (authMode.toLowerCase() === "api-key") return "absent";
+  const normalizedAuthMode = authMode.toLowerCase();
+  if (normalizedAuthMode === "apikey" || normalizedAuthMode === "api-key") {
+    return "absent";
+  }
   if (data.OPENAI_API_KEY !== undefined || data.auth_mode !== undefined) {
     return typeof data.OPENAI_API_KEY === "string" &&
       data.OPENAI_API_KEY.trim() &&


### PR DESCRIPTION
Relates to #24580 and fixes forward the invariant that was omitted from the landed #24599 squash.

Codex CLI writes direct API-key authentication as `auth_mode: "apikey"`. The landed classifier recognized only the legacy spelling `"api-key"`, so a valid direct-key-only file was still projected as a configured subscription. This accepts both exact spellings as the explicit non-subscription state; malformed or subscription-bearing files retain #24599 behavior.

Exact head `67f8c92675` verification:
- real filesystem/registry focused suite: 9/9 passed
- table-driven `apikey` and `api-key` controls
- changed-file Biome clean
- `git diff --check` clean

No UI, model, prompt, provider egress, or credential bytes change.