### PR TITLE
fix(cli-inference): cap timer-backed timeout configuration

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -704,9 +704,10 @@
           "sensitive": false,
           "default": "120000",
           "label": "Timeout",
-          "help": "Per-call CLI spawn timeout in milliseconds.",
+          "help": "Per-call CLI spawn timeout in milliseconds. Must be an integer from 1 through 2147483647 when configured.",
           "advanced": true,
-          "min": 0,
+          "min": 1,
+          "max": 2147483647,
           "unit": "ms"
         }
       },

--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -148,7 +148,7 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
 | `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default / allowlist lookup) | path to the claude executable: drives the `claude-sdk` session AND pins the cold `claude` spawn (deploys outside the SOC2 launcher allowlist) |
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk` / `codex-sdk`: restart a warm session after a positive safe-integer number of turns (bounds context) |
-| `ELIZA_CLI_SDK_TURN_TIMEOUT_MS` | No | `90000` | `claude-sdk`: positive safe-integer per-turn timeout; falls back to `ELIZA_CLI_TIMEOUT_MS` when unset; the exact literal `0` is the only unbounded-turn opt-out |
+| `ELIZA_CLI_SDK_TURN_TIMEOUT_MS` | No | `90000` | `claude-sdk`: per-turn timeout from `1` through `2147483647` ms; falls back to `ELIZA_CLI_TIMEOUT_MS` when unset; the exact literal `0` is the only unbounded-turn opt-out |
 | `ELIZA_CLI_CLAUDE_EFFORT` | No | (SDK default: high) | `claude-sdk`: reasoning effort forwarded to the SDK `effort` option (`low`/`medium`/`high`/`xhigh`/`max`); an unsupported level for the model is silently downgraded by the SDK |
 | `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` | No | (falls back to `ELIZA_CLI_CLAUDE_EFFORT`) | `claude-sdk`: effort for the ROUTE-mode planner tier, so routing depth tunes independently of reply depth |
 | `ELIZA_CLI_CLAUDE_ALL_TIERS` | No | (unset = large tiers only) | `claude-sdk`: also serve the high-frequency triage tiers (TEXT_SMALL/NANO/MEDIUM) on this route so the ENTIRE text brain runs on the one subscription (no cerebras/gemma fallthrough). Higher subscription usage; triage defaults to the cheaper large-tier model, not the planner tier |
@@ -157,13 +157,13 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |
 | `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled / allowlist lookup) | path to the system codex binary: REQUIRED for `codex-sdk` (bundled 0.80.0 rejects current models); also pins the cold `codex` spawn |
-| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | positive safe-integer per-call spawn timeout (SIGTERM on expiry; cold CLI backends), also the `claude-sdk` turn-timeout fallback when its dedicated setting is absent |
+| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout from `1` through `2147483647` ms (SIGTERM on expiry; cold CLI backends), also the `claude-sdk` turn-timeout fallback when its dedicated setting is absent |
 
 ## Errors
 
 Handlers THROW on non-zero exit / timeout (`+SIGTERM`) / empty stdout so `useModel` + AccountPool failover treat them as provider failures — never swallow-and-return-empty. stderr is redacted via `SENSITIVE_ENV_RE` before it reaches the error message or log.
 
-For the active backend, an explicitly present numeric timeout/restart setting must satisfy the contract above. Blank, malformed, non-safe, zero (except the exact SDK turn-timeout opt-out), and negative values throw `CLI_INFERENCE_INVALID_CONFIGURATION` before any process or warm session is created. Only a truly absent setting selects a fallback/default; settings unused by the active backend are ignored. Each warm-cache entry records its effective bounds; a configuration change disposes and replaces the session under the same logical cache/rotation identity, so stale lifecycle or account-affinity state cannot be reused or accumulated.
+For the active backend, an explicitly present numeric timeout/restart setting must satisfy the contract above. Blank, malformed, non-safe, zero (except the exact SDK turn-timeout opt-out), and negative values throw `CLI_INFERENCE_INVALID_CONFIGURATION` before any process or warm session is created. Timer-backed general and SDK turn timeouts also reject values above `2147483647`, which Node would otherwise clamp to about 1 ms; the turn-count restart cadence remains a positive safe integer. Only a truly absent setting selects a fallback/default; settings unused by the active backend are ignored. Each warm-cache entry records its effective bounds; a configuration change disposes and replaces the session under the same logical cache/rotation identity, so stale lifecycle or account-affinity state cannot be reused or accumulated.
 
 ## Commands
 

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -148,7 +148,7 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CLAUDE_PLANNER_MODEL` | No | (falls back to large) | `claude-sdk` small/planner tier model (e.g. sonnet) |
 | `ELIZA_CLI_CLAUDE_BIN` | No | (SDK default / allowlist lookup) | path to the claude executable: drives the `claude-sdk` session AND pins the cold `claude` spawn (deploys outside the SOC2 launcher allowlist) |
 | `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` | No | `20` | `claude-sdk` / `codex-sdk`: restart a warm session after a positive safe-integer number of turns (bounds context) |
-| `ELIZA_CLI_SDK_TURN_TIMEOUT_MS` | No | `90000` | `claude-sdk`: positive safe-integer per-turn timeout; falls back to `ELIZA_CLI_TIMEOUT_MS` when unset; the exact literal `0` is the only unbounded-turn opt-out |
+| `ELIZA_CLI_SDK_TURN_TIMEOUT_MS` | No | `90000` | `claude-sdk`: per-turn timeout from `1` through `2147483647` ms; falls back to `ELIZA_CLI_TIMEOUT_MS` when unset; the exact literal `0` is the only unbounded-turn opt-out |
 | `ELIZA_CLI_CLAUDE_EFFORT` | No | (SDK default: high) | `claude-sdk`: reasoning effort forwarded to the SDK `effort` option (`low`/`medium`/`high`/`xhigh`/`max`); an unsupported level for the model is silently downgraded by the SDK |
 | `ELIZA_CLI_CLAUDE_PLANNER_EFFORT` | No | (falls back to `ELIZA_CLI_CLAUDE_EFFORT`) | `claude-sdk`: effort for the ROUTE-mode planner tier, so routing depth tunes independently of reply depth |
 | `ELIZA_CLI_CLAUDE_ALL_TIERS` | No | (unset = large tiers only) | `claude-sdk`: also serve the high-frequency triage tiers (TEXT_SMALL/NANO/MEDIUM) on this route so the ENTIRE text brain runs on the one subscription (no cerebras/gemma fallthrough). Higher subscription usage; triage defaults to the cheaper large-tier model, not the planner tier |
@@ -157,13 +157,13 @@ plugins/plugin-cli-inference/
 | `ELIZA_CLI_CODEX_PLANNER_MODEL` | No | (falls back to large) | `codex-sdk` small/planner tier model |
 | `ELIZA_CLI_CODEX_REASONING_EFFORT` | No | (sdk default) | `codex-sdk`: `modelReasoningEffort` (minimal..xhigh) |
 | `ELIZA_CLI_CODEX_BIN` | No | (sdk bundled / allowlist lookup) | path to the system codex binary: REQUIRED for `codex-sdk` (bundled 0.80.0 rejects current models); also pins the cold `codex` spawn |
-| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | positive safe-integer per-call spawn timeout (SIGTERM on expiry; cold CLI backends), also the `claude-sdk` turn-timeout fallback when its dedicated setting is absent |
+| `ELIZA_CLI_TIMEOUT_MS` | No | `120000` | per-call spawn timeout from `1` through `2147483647` ms (SIGTERM on expiry; cold CLI backends), also the `claude-sdk` turn-timeout fallback when its dedicated setting is absent |
 
 ## Errors
 
 Handlers THROW on non-zero exit / timeout (`+SIGTERM`) / empty stdout so `useModel` + AccountPool failover treat them as provider failures — never swallow-and-return-empty. stderr is redacted via `SENSITIVE_ENV_RE` before it reaches the error message or log.
 
-For the active backend, an explicitly present numeric timeout/restart setting must satisfy the contract above. Blank, malformed, non-safe, zero (except the exact SDK turn-timeout opt-out), and negative values throw `CLI_INFERENCE_INVALID_CONFIGURATION` before any process or warm session is created. Only a truly absent setting selects a fallback/default; settings unused by the active backend are ignored. Each warm-cache entry records its effective bounds; a configuration change disposes and replaces the session under the same logical cache/rotation identity, so stale lifecycle or account-affinity state cannot be reused or accumulated.
+For the active backend, an explicitly present numeric timeout/restart setting must satisfy the contract above. Blank, malformed, non-safe, zero (except the exact SDK turn-timeout opt-out), and negative values throw `CLI_INFERENCE_INVALID_CONFIGURATION` before any process or warm session is created. Timer-backed general and SDK turn timeouts also reject values above `2147483647`, which Node would otherwise clamp to about 1 ms; the turn-count restart cadence remains a positive safe integer. Only a truly absent setting selects a fallback/default; settings unused by the active backend are ignored. Each warm-cache entry records its effective bounds; a configuration change disposes and replaces the session under the same logical cache/rotation identity, so stale lifecycle or account-affinity state cannot be reused or accumulated.
 
 ## Commands
 

--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -588,7 +588,7 @@ describe("models map gating (large-tier only)", () => {
     }
   });
 
-  it.each(["", "abc", "1.5", "9007199254740993", "0", "-1", "-0"])(
+  it.each(["", "abc", "1.5", "2147483648", "9007199254740993", "0", "-1", "-0"])(
     "rejects an explicitly invalid cold timeout %j before any spawn",
     async (invalid) => {
       const { calls, fn } = recordingSpawn({ stdout: "must not run" });
@@ -683,14 +683,14 @@ describe("models map gating (large-tier only)", () => {
       await expect(
         textLargeHandler("codex")(
           modelRuntime("codex", {
-            ELIZA_CLI_TIMEOUT_MS: 3_500,
+            ELIZA_CLI_TIMEOUT_MS: 2_147_483_647,
             ELIZA_CLI_CODEX_BIN: FAKE_CODEX,
           }),
           { prompt: "hello" }
         )
       ).resolves.toBe("from codex");
       expect(calls).toHaveLength(1);
-      expect(calls[0].opts.timeoutMs).toBe(3_500);
+      expect(calls[0].opts.timeoutMs).toBe(2_147_483_647);
     } finally {
       restoreSpawn();
     }
@@ -726,6 +726,7 @@ describe("models map gating (large-tier only)", () => {
   });
 
   it.each([
+    ["ELIZA_CLI_TIMEOUT_MS", "2147483648"],
     ["ELIZA_CLI_SDK_RESTART_AFTER_TURNS", ""],
     ["ELIZA_CLI_SDK_RESTART_AFTER_TURNS", "0"],
     ["ELIZA_CLI_SDK_RESTART_AFTER_TURNS", "-0"],
@@ -733,6 +734,7 @@ describe("models map gating (large-tier only)", () => {
     ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "0.5"],
     ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "-0"],
     ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "+0"],
+    ["ELIZA_CLI_SDK_TURN_TIMEOUT_MS", "2147483648"],
   ] as const)("rejects invalid warm setting %s=%j before session creation", async (key, value) => {
     let sessionCreations = 0;
     const restoreFactory = trackSessionFactoryRestore(
@@ -791,7 +793,7 @@ describe("models map gating (large-tier only)", () => {
     expect(sessionCreations).toBe(0);
   });
 
-  it("Codex SDK ignores unrelated timeout settings and propagates a valid restart", async () => {
+  it("Codex SDK accepts a counter-only restart above the Node timer ceiling", async () => {
     const createdConfigs: Array<ConstructorParameters<typeof CodexSdkSession>[0]> = [];
     trackSessionFactoryRestore(
       __setCodexSdkSessionFactoryForTests((config) => {
@@ -806,14 +808,14 @@ describe("models map gating (large-tier only)", () => {
         modelRuntime("codex-sdk", {
           ELIZA_CLI_TIMEOUT_MS: "invalid-but-unused",
           ELIZA_CLI_SDK_TURN_TIMEOUT_MS: "invalid-but-unused",
-          ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "+9",
+          ELIZA_CLI_SDK_RESTART_AFTER_TURNS: "2147483648",
         }),
         { prompt: "hello" }
       )
     ).resolves.toBe("from codex sdk");
 
     expect(createdConfigs).toHaveLength(1);
-    expect(createdConfigs[0].restartAfterTurns).toBe(9);
+    expect(createdConfigs[0].restartAfterTurns).toBe(2_147_483_648);
   });
 
   it("does not let a valid SDK turn timeout mask an invalid general timeout", async () => {
@@ -902,6 +904,7 @@ describe("models map gating (large-tier only)", () => {
     [undefined, undefined, undefined, 20, 90_000],
     ["45000", undefined, undefined, 20, 45_000],
     [undefined, "0", undefined, 20, 0],
+    [undefined, "2147483647", undefined, 20, 2_147_483_647],
     [undefined, "+45000", "7", 7, 45_000],
   ] as const)(
     "keeps warm defaults/fallbacks for general=%j turn=%j restart=%j",
@@ -1764,6 +1767,7 @@ describe("parseTurnTimeout (#16553)", () => {
 
   it("parses a positive budget and rejects junk/negatives to undefined (bounded default applies)", () => {
     expect(parseTurnTimeout("120000")).toBe(120_000);
+    expect(parseTurnTimeout("2147483647")).toBe(2_147_483_647);
     expect(parseTurnTimeout(undefined)).toBeUndefined();
     expect(parseTurnTimeout("abc")).toBeUndefined();
     expect(parseTurnTimeout("-5")).toBeUndefined();
@@ -1773,6 +1777,7 @@ describe("parseTurnTimeout (#16553)", () => {
     expect(parseTurnTimeout("0junk")).toBeUndefined();
     expect(parseTurnTimeout("0.5")).toBeUndefined();
     expect(parseTurnTimeout("120000junk")).toBeUndefined();
+    expect(parseTurnTimeout("2147483648")).toBeUndefined();
     expect(parseTurnTimeout("9007199254740993")).toBeUndefined();
   });
 
@@ -1793,6 +1798,7 @@ describe("parseTimeout", () => {
     expect(parseTimeout("120000")).toBe(120_000);
     expect(parseTimeout("+120000")).toBe(120_000);
     expect(parseTimeout(" 120000 ")).toBe(120_000);
+    expect(parseTimeout("2147483648")).toBe(2_147_483_648);
     expect(parseTimeout(undefined)).toBeUndefined();
     expect(parseTimeout("0")).toBeUndefined();
     expect(parseTimeout("-5")).toBeUndefined();

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -441,7 +441,9 @@ function getCodexSdkSession(
   return session;
 }
 
-/** Parse a strictly positive timeout or restart cadence. Exported for tests. */
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
+
+/** Parse a strictly positive safe-integer lifecycle setting. Exported for tests. */
 export function parseTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
   // `Number.parseInt` stops at the first non-digit, so "300junk" parsed to 300
@@ -453,10 +455,16 @@ export function parseTimeout(value: string | undefined): number | undefined {
   return Number.isSafeInteger(n) && n > 0 ? n : undefined;
 }
 
-/** Turn-timeout parse (#16553): like {@link parseTimeout}, but an explicit
- *  `"0"` passes through as 0 — the documented operator opt-out to an
- *  unbounded turn. The parser returns undefined for unset/invalid input; the
- *  backend-aware resolver below distinguishes those states and rejects a
+/** Parse a positive delay that Node timers can represent without clamping. */
+function parseTimerTimeout(value: string | undefined): number | undefined {
+  const parsed = parseTimeout(value);
+  return parsed !== undefined && parsed <= MAX_NODE_TIMER_DELAY_MS ? parsed : undefined;
+}
+
+/** Turn-timeout parse (#16553): positive values must fit the Node timer range,
+ *  while an explicit `"0"` passes through as the documented operator opt-out
+ *  to an unbounded turn. The parser returns undefined for unset/invalid input;
+ *  the backend-aware resolver below distinguishes those states and rejects a
  *  present-invalid value before session lookup. Exported for tests. */
 export function parseTurnTimeout(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
@@ -465,7 +473,7 @@ export function parseTurnTimeout(value: string | undefined): number | undefined 
   // silently REMOVED the turn timeout rather than falling back to the bounded
   // default. An explicit "0" is still honoured.
   if (value === "0") return 0;
-  return parseTimeout(value);
+  return parseTimerTimeout(value);
 }
 
 type TimeoutSettingKey =
@@ -546,8 +554,8 @@ function resolveColdTimeoutConfiguration(runtime: IAgentRuntime): ColdTimeoutCon
     cliTimeoutMs: resolveNumericSetting(
       runtime,
       "ELIZA_CLI_TIMEOUT_MS",
-      parseTimeout,
-      "a positive safe integer"
+      parseTimerTimeout,
+      `a positive integer no greater than ${MAX_NODE_TIMER_DELAY_MS}`
     ),
   };
 }
@@ -568,7 +576,7 @@ function resolveClaudeSdkTimeoutConfiguration(
     runtime,
     "ELIZA_CLI_SDK_TURN_TIMEOUT_MS",
     parseTurnTimeout,
-    'the exact literal "0" opt-out or a positive safe integer'
+    `the exact literal "0" opt-out or a positive integer no greater than ${MAX_NODE_TIMER_DELAY_MS}`
   );
   return {
     sdkRestartAfterTurns,

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -117,9 +117,11 @@
       },
       "ELIZA_CLI_SDK_TURN_TIMEOUT_MS": {
         "type": "number",
-        "description": "Per-turn Claude SDK timeout in milliseconds. Accepts a positive safe integer or the exact literal 0 to opt out; empty, alternate zero spellings, and invalid values are rejected. Defaults to 90000 and falls back to a valid ELIZA_CLI_TIMEOUT_MS when set.",
+        "description": "Per-turn Claude SDK timeout in milliseconds. Accepts an integer from 1 through 2147483647 or the exact literal 0 to opt out; empty, alternate zero spellings, and invalid values are rejected. Defaults to 90000 and falls back to a valid ELIZA_CLI_TIMEOUT_MS when set.",
         "required": false,
         "default": 90000,
+        "min": 0,
+        "max": 2147483647,
         "sensitive": false
       },
       "ELIZA_CLI_CODEX_MODEL": {
@@ -131,9 +133,11 @@
       },
       "ELIZA_CLI_TIMEOUT_MS": {
         "type": "number",
-        "description": "Per-call CLI spawn timeout in milliseconds (SIGTERM on expiry), also used as the Claude SDK turn fallback. Must be a strictly positive safe integer when consumed; empty or invalid values are rejected. Defaults to 120000.",
+        "description": "Per-call CLI spawn timeout in milliseconds (SIGTERM on expiry), also used as the Claude SDK turn fallback. Must be an integer from 1 through 2147483647 when consumed; empty or invalid values are rejected. Defaults to 120000.",
         "required": false,
         "default": 120000,
+        "min": 1,
+        "max": 2147483647,
         "sensitive": false
       }
     }

--- a/plugins/plugin-cli-inference/registry-entry.json
+++ b/plugins/plugin-cli-inference/registry-entry.json
@@ -44,9 +44,10 @@
       "sensitive": false,
       "default": "120000",
       "label": "Timeout",
-      "help": "Per-call CLI spawn timeout in milliseconds. Must be a strictly positive integer when configured.",
+      "help": "Per-call CLI spawn timeout in milliseconds. Must be an integer from 1 through 2147483647 when configured.",
       "advanced": true,
       "min": 1,
+      "max": 2147483647,
       "unit": "ms"
     }
   },


### PR DESCRIPTION
## Summary

Follow-up to #24615 and the scoped claim in #24511.

Node clamps `setTimeout` delays above `2_147_483_647` ms to about 1 ms. The merged timeout validator still accepted larger positive safe integers for `ELIZA_CLI_TIMEOUT_MS` and `ELIZA_CLI_SDK_TURN_TIMEOUT_MS`, so an operator asking for a long deadline could get an immediate timeout.

This change:

- rejects timer-backed values above `2_147_483_647` before any cold spawn or warm-session creation;
- preserves only the exact `"0"` Claude SDK turn-timeout opt-out merged in #24615;
- keeps `ELIZA_CLI_SDK_RESTART_AFTER_TURNS` on its counter-only positive-safe-integer contract;
- synchronizes package metadata, plugin registry metadata, both package guides, and the generated first-party catalog.

## Exact-head validation

Head: `2a5dab4c723dbb86dbd58cbb9321c43c0c5a8f55`
Validated base: `6f4cf4d1005b96d6bff940a65a76be9a78d25a3f`

- `bun run --cwd plugins/plugin-cli-inference test`: 8 files, 202 passed
- `bun run --cwd plugins/plugin-cli-inference typecheck`: pass
- `bun run --cwd plugins/plugin-cli-inference lint:check`: pass
- `bun run --cwd plugins/plugin-cli-inference build`: pass
- `bun run --cwd packages/registry test`: 7 files, 40 passed
- `bun run --cwd packages/registry typecheck`: pass
- `bun run check:agents-claude`: 161 tracked pairs pass
- targeted first-party generation check for the existing 84-entry catalog: pass
- `git diff --check`: pass

The regressions prove overflow fails with zero cold spawns and zero warm-session creations, the maximum timer value remains inclusive, and a restart counter above the timer ceiling remains accepted.

## Baseline gates

- The unfiltered `generate:first-party:check` stops before this entry on the unchanged `plugins/plugin-doordash/registry-entry.json` (`features.doordash` has the wrong shape and subtype `connector` is outside the current schema). The committed generated diff is mechanically produced and changes only the `cli-inference` timeout fields.
- Root `bun run verify` reaches `audit:tsconfig-workspace-resolution` and fails on 16 unrelated plugin configs resolving `@elizaos/capacitor-secure-store` through `packages/ui/src/bridge/storage-bridge.ts`. None of those files is in this diff.

UI/native/live-model evidence: N/A — configuration-boundary change with deterministic mocked process/session seams; no rendered or live-provider surface.

<!-- evidence-head:2a5dab4c723dbb86dbd58cbb9321c43c0c5a8f55 -->

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2a5dab4c723dbb86dbd58cbb9321c43c0c5a8f55:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [standujar/cli-timeout-overflow-follow-up]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2a5dab4c723dbb86dbd58cbb9321c43c0c5a8f55:packages/skills/skills/contribute-to-eliza"} -->