### PR TITLE
fix(core): preserve complete handler and PII context

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -167,6 +167,9 @@ visible.
 - Three build targets share source — Node-only imports in shared modules break the browser/edge bundles. Verify with `build:node` vs full `build`.
 - The model-output contract is `<response>` XML (with `<actions>`/`<providers>`/`<text>`); plain text is tolerated and treated as a `REPLY`.
 - Action, provider, and analytics results preserve complete model-facing records. Detailed trust evaluation returns every evidence record, follow-up suggestions return every qualifying contact, relationship analytics page through every shared message, and channel-topic search returns every matching room. Do not silently slice without a lossless page or reference contract.
+- Response-handler hint arrays and PII scrub context packs preserve every record,
+  duplicate, and exact text value. Legacy count/character hints are ignored;
+  invalid candidates reject the complete pack instead of yielding partial context.
 - DB mutation methods on `IDatabaseAdapter` return `Promise<boolean>` so callers can distinguish success/failure (`types/database.ts`).
 - The task system (`services/task.ts`, `services/task-scheduler.ts`) is the single place scheduled work runs; only tasks tagged `queue` are polled. Three modes: local timer, per-daemon (`startTaskScheduler`), serverless (`{ serverless: true }` + `runDueTasks()`).
 - Document reads use `roomId` as the single room entitlement and join it to the requester's current room set inside the adapter. `directGrantEntityIds` is a bounded, validated read exception that remains valid without room membership; it never opens `agent-private` documents and never grants mutation authority. Only the dedicated adapter CAS may replace grants: OWNER on any valid document, or a current room ADMIN on global and user-private documents, with every grantee validated in the current agent tenant. Malformed or duplicate grant arrays make the parent unreadable.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -167,6 +167,9 @@ visible.
 - Three build targets share source — Node-only imports in shared modules break the browser/edge bundles. Verify with `build:node` vs full `build`.
 - The model-output contract is `<response>` XML (with `<actions>`/`<providers>`/`<text>`); plain text is tolerated and treated as a `REPLY`.
 - Action, provider, and analytics results preserve complete model-facing records. Detailed trust evaluation returns every evidence record, follow-up suggestions return every qualifying contact, relationship analytics page through every shared message, and channel-topic search returns every matching room. Do not silently slice without a lossless page or reference contract.
+- Response-handler hint arrays and PII scrub context packs preserve every record,
+  duplicate, and exact text value. Legacy count/character hints are ignored;
+  invalid candidates reject the complete pack instead of yielding partial context.
 - DB mutation methods on `IDatabaseAdapter` return `Promise<boolean>` so callers can distinguish success/failure (`types/database.ts`).
 - The task system (`services/task.ts`, `services/task-scheduler.ts`) is the single place scheduled work runs; only tasks tagged `queue` are polled. Three modes: local timer, per-daemon (`startTaskScheduler`), serverless (`{ serverless: true }` + `runDueTasks()`).
 - Document reads use `roomId` as the single room entitlement and join it to the requester's current room set inside the adapter. `directGrantEntityIds` is a bounded, validated read exception that remains valid without room membership; it never opens `agent-private` documents and never grants mutation authority. Only the dedicated adapter CAS may replace grants: OWNER on any valid document, or a current room ADMIN on global and user-private documents, with every grantee validated in the current agent tenant. Malformed or duplicate grant arrays make the parent unreadable.

--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -58,7 +58,7 @@ describe("message handler retrieval hint output", () => {
 		).toBe("To call a tool, the model emits <tool_call> followed by the name.");
 	});
 
-	it("parses, trims, dedupes, and caps canonical action hint arrays", () => {
+	it("preserves every canonical action hint exactly", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({
 				shouldRespond: "RESPOND",
@@ -84,7 +84,8 @@ describe("message handler retrieval hint output", () => {
 		);
 
 		expect(parsed?.plan.candidateActions).toEqual([
-			"send_email",
+			" send_email ",
+			"SEND_EMAIL",
 			"calendar_create_event",
 			"search_documents",
 			"play_music",
@@ -96,7 +97,25 @@ describe("message handler retrieval hint output", () => {
 			"health_steps",
 			"message_contact",
 			"settings_update",
+			"extra_after_cap",
 		]);
+	});
+
+	it("preserves every intent including duplicates and boundary whitespace", () => {
+		const intents = Array.from(
+			{ length: 11 },
+			(_, index) => ` intent-${index} `,
+		);
+		intents.push(intents[0] ?? "");
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "",
+				contexts: ["tasks"],
+				intents,
+			}),
+		);
+		expect(parsed?.plan.intents).toEqual(intents);
 	});
 
 	it("keeps missing hint arrays backward-compatible", () => {

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -11,7 +11,6 @@ import type {
 	MessageHandlerResult,
 } from "../types/components";
 import type { AgentContext } from "../types/contexts";
-import { normalizeTopics } from "./builtin-field-evaluators";
 import { parseJsonObject, stripJsonStructuralJunkReply } from "./json-output";
 import {
 	looksLikeRawFieldTranscript,
@@ -88,11 +87,8 @@ export function parseMessageHandlerOutput(
 		typeof parsed.replyText === "string"
 			? stripJsonStructuralJunkReply(parsed.replyText)
 			: undefined;
-	const candidateActions = normalizeStringHints(
-		parsed.candidateActionNames,
-		12,
-	);
-	const intents = normalizeStringHints(parsed.intents, 8);
+	const candidateActions = preserveStringHints(parsed.candidateActionNames);
+	const intents = preserveStringHints(parsed.intents);
 
 	const extract = parseExtract(parsed);
 
@@ -152,11 +148,10 @@ function parseMessageHandlerFieldTranscript(
 		typeof fields.replyText === "string"
 			? stripJsonStructuralJunkReply(fields.replyText)
 			: undefined;
-	const candidateActions = normalizeStringHints(
+	const candidateActions = preserveStringHints(
 		splitTranscriptList(fields.candidateActionNames),
-		12,
 	);
-	const intents = normalizeStringHints(splitTranscriptList(fields.intents), 8);
+	const intents = preserveStringHints(splitTranscriptList(fields.intents));
 
 	const extract = parseExtract({
 		facts: splitTranscriptList(fields.facts),
@@ -183,31 +178,10 @@ function parseMessageHandlerFieldTranscript(
 	};
 }
 
-function normalizeStringHints(raw: unknown, maxItems: number): string[] {
-	if (!Array.isArray(raw) || maxItems <= 0) {
-		return [];
-	}
-	const seen = new Set<string>();
-	const result: string[] = [];
-	for (const item of raw) {
-		if (typeof item !== "string") {
-			continue;
-		}
-		const value = item.trim();
-		if (!value) {
-			continue;
-		}
-		const dedupeKey = value.toLowerCase();
-		if (seen.has(dedupeKey)) {
-			continue;
-		}
-		seen.add(dedupeKey);
-		result.push(value);
-		if (result.length >= maxItems) {
-			break;
-		}
-	}
-	return result;
+function preserveStringHints(raw: unknown): string[] {
+	return Array.isArray(raw)
+		? raw.filter((item): item is string => typeof item === "string")
+		: [];
 }
 
 function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
@@ -244,7 +218,7 @@ function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
 				.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
 				.filter((entry): entry is string => entry.length > 0)
 		: [];
-	const topics = normalizeTopics(source.topics);
+	const topics = preserveStringHints(source.topics);
 	if (
 		facts.length === 0 &&
 		relationships.length === 0 &&

--- a/packages/core/src/security/pii-context-pack.test.ts
+++ b/packages/core/src/security/pii-context-pack.test.ts
@@ -131,7 +131,7 @@ describe("assembleContextPack", () => {
 		expect(pack.contextPack).not.toContain(pseudonym);
 	});
 
-	test("fragments are ranked by measured score and bounded; pack text is capped", async () => {
+	test("preserves every fragment in source order despite legacy caps", async () => {
 		const map = makeMap();
 		const fragments: PiiContextFragment[] = [
 			{ text: "low relevance", origin: "memory", score: 0.1 },
@@ -152,7 +152,10 @@ describe("assembleContextPack", () => {
 		);
 		expect(pack.contextPack).toContain("high relevance");
 		expect(pack.contextPack).toContain("mid relevance");
-		expect(pack.contextPack).not.toContain("low relevance");
+		expect(pack.contextPack).toContain("low relevance");
+		expect(pack.contextPack.indexOf("low relevance")).toBeLessThan(
+			pack.contextPack.indexOf("high relevance"),
+		);
 
 		const capped = await assembleContextPack(
 			{ searchDocuments: async () => fragments },
@@ -164,34 +167,47 @@ describe("assembleContextPack", () => {
 				maxChars: 32,
 			},
 		);
-		expect(capped.contextPack.length).toBeLessThanOrEqual(32);
+		expect(capped.contextPack).toContain("low relevance");
+		expect(capped.contextPack).toContain("high relevance");
+		expect(capped.contextPack).toContain("mid relevance");
 	});
 
-	test("absent sources are audited; empty candidates make zero source calls", async () => {
-		const map = makeMap();
-		const resolveEntity = vi.fn(async () => [] as PiiResolvedEntity[]);
-		const searchDocuments = vi.fn(async () => [] as PiiContextFragment[]);
+	test("preserves fragment whitespace and malformed Unicode as lossless JSON", async () => {
+		const exact = "  raw \ud800 context  ";
 		const pack = await assembleContextPack(
-			{ resolveEntity, searchDocuments },
+			{ searchDocuments: async () => [{ text: exact, origin: "document" }] },
 			{
-				chunk: "no candidates here",
-				candidates: [
-					{ surfaceForm: "", kind: "person" },
-					{ surfaceForm: "   ", kind: "person" },
-				],
-				map,
+				chunk: "Paris",
+				candidates: [{ surfaceForm: "Paris", kind: "person" }],
+				map: makeMap(),
 				rulesetVersion: RULESET,
 			},
 		);
-		expect(pack.candidateSpans).toEqual([]);
-		expect(pack.sourcesQueried).toEqual(["entities", "documents"]);
-		expect(resolveEntity).not.toHaveBeenCalled();
-		expect(searchDocuments).not.toHaveBeenCalled();
-		expect(pack.contextPack).toBe("");
-		expect(pack.assignments).toEqual([]);
+		expect(pack.contextPack).toContain("  raw ");
+		expect(pack.contextPack).toContain("\\ud800 context  ");
+		expect(pack.contextPack).not.toContain("�");
 	});
 
-	test("duplicate surface forms are deduped into one candidate span", async () => {
+	test("rejects empty candidates instead of assembling partial context", async () => {
+		const map = makeMap();
+		const resolveEntity = vi.fn(async () => [] as PiiResolvedEntity[]);
+		const searchDocuments = vi.fn(async () => [] as PiiContextFragment[]);
+		await expect(
+			assembleContextPack(
+				{ resolveEntity, searchDocuments },
+				{
+					chunk: "no candidates here",
+					candidates: [{ surfaceForm: "   ", kind: "person" }],
+					map,
+					rulesetVersion: RULESET,
+				},
+			),
+		).rejects.toMatchObject({ code: "PII_CONTEXT_CANDIDATE_INVALID" });
+		expect(resolveEntity).not.toHaveBeenCalled();
+		expect(searchDocuments).not.toHaveBeenCalled();
+	});
+
+	test("duplicate surface forms remain distinct and both are queried", async () => {
 		const map = makeMap();
 		const searchDocuments = vi.fn(async () => [] as PiiContextFragment[]);
 		const pack = await assembleContextPack(
@@ -206,8 +222,8 @@ describe("assembleContextPack", () => {
 				rulesetVersion: RULESET,
 			},
 		);
-		expect(pack.candidateSpans).toEqual(["John Smith"]);
-		expect(searchDocuments).toHaveBeenCalledTimes(1);
+		expect(pack.candidateSpans).toEqual(["John Smith", "John Smith"]);
+		expect(searchDocuments).toHaveBeenCalledTimes(2);
 	});
 
 	test("a wired source that throws propagates (fail-closed, rails retry)", async () => {
@@ -276,7 +292,7 @@ describe("entityResolverFromStore (EntityStore.resolve seam)", () => {
 		});
 	});
 
-	test("caps the number of candidates", async () => {
+	test("preserves every resolver candidate despite a legacy max hint", async () => {
 		const resolve = vi.fn(async () =>
 			Array.from({ length: 10 }, (_, i) => ({
 				...storeCandidate,
@@ -285,7 +301,7 @@ describe("entityResolverFromStore (EntityStore.resolve seam)", () => {
 		);
 		const resolver = entityResolverFromStore({ resolve }, { maxCandidates: 2 });
 		const resolved = await resolver({ surfaceForm: "Initech", kind: "org" });
-		expect(resolved).toHaveLength(2);
+		expect(resolved).toHaveLength(10);
 	});
 });
 

--- a/packages/core/src/security/pii-context-pack.ts
+++ b/packages/core/src/security/pii-context-pack.ts
@@ -39,6 +39,7 @@
  * to this chunk, never the whole secret artifact and never a real alias.
  */
 
+import { ElizaError } from "../errors.js";
 import type { PiiScrubRequestPayload } from "../types/events.js";
 import type { Memory, UUID } from "../types/index.js";
 import type {
@@ -48,7 +49,6 @@ import type {
 import { ModelType } from "../types/model.js";
 import type { IAgentRuntime } from "../types/runtime.js";
 import type { Service } from "../types/service.js";
-import { toWellFormedUnicode } from "../utils/well-formed.js";
 import { canonicalKind } from "./entity-recognizer.js";
 import type { CorpusPseudonymMap } from "./pii-pseudonym-map.js";
 
@@ -165,7 +165,7 @@ export interface PiiContextPack {
 	readonly assignments: readonly PiiPseudonymAssignment[];
 	/** Entity candidates that resolved with sufficient confidence. */
 	readonly resolvedEntities: readonly PiiResolvedEntity[];
-	/** Candidate surface forms, deduped — the seam's `candidateSpans`. */
+	/** Complete candidate surface forms in source order. */
 	readonly candidateSpans: readonly string[];
 	/** Which sources were queried vs structurally absent (audit). */
 	readonly sourcesQueried: readonly string[];
@@ -188,14 +188,13 @@ export interface AssembleContextPackRequest {
 	 * and leave fuzzy ones to the model.
 	 */
 	readonly minEntityConfidence?: number;
-	/** Max fragments folded into the pack (default 8). */
+	/** @deprecated Complete fragment inventories are always retained. */
 	readonly maxFragments?: number;
 	/** @deprecated Retained for source compatibility; pack text is never clipped. */
 	readonly maxChars?: number;
 }
 
 const DEFAULT_MIN_ENTITY_CONFIDENCE = 0.6;
-const DEFAULT_MAX_FRAGMENTS = 8;
 
 /**
  * Assemble the context pack + pseudonym-assignment slice for one chunk.
@@ -211,7 +210,7 @@ export async function assembleContextPack(
 		map,
 		rulesetVersion,
 		minEntityConfidence = DEFAULT_MIN_ENTITY_CONFIDENCE,
-		maxFragments = DEFAULT_MAX_FRAGMENTS,
+		maxFragments: _maxFragments,
 		maxChars: _maxChars,
 	} = request;
 
@@ -219,16 +218,16 @@ export async function assembleContextPack(
 	const resolvedEntities: PiiResolvedEntity[] = [];
 	const fragments: PiiContextFragment[] = [];
 
-	// Dedupe candidate surface forms (the seam's candidateSpans) while keeping
-	// first-seen order; drop empty/whitespace forms (adversarial input).
+	// Preserve the candidate-mining output exactly. Invalid empty forms reject
+	// the whole pack instead of producing a plausible partial context.
 	const candidateSpans: string[] = [];
-	const seenSpans = new Set<string>();
 	for (const candidate of candidates) {
-		const form = candidate.surfaceForm?.trim();
-		if (!form) continue;
-		if (seenSpans.has(form)) continue;
-		seenSpans.add(form);
-		candidateSpans.push(form);
+		if (!candidate.surfaceForm.trim()) {
+			throw new ElizaError("PII context candidate is empty", {
+				code: "PII_CONTEXT_CANDIDATE_INVALID",
+			});
+		}
+		candidateSpans.push(candidate.surfaceForm);
 	}
 
 	// 1. Entity resolution — the alias backbone. Confident resolutions are
@@ -236,13 +235,9 @@ export async function assembleContextPack(
 	// every other artifact got.
 	if (sources.resolveEntity) {
 		sourcesQueried.push("entities");
-		const seenClusters = new Set<string>();
 		for (const candidate of candidates) {
-			if (!candidate.surfaceForm?.trim()) continue;
 			const resolved = await sources.resolveEntity(candidate);
 			for (const entity of resolved) {
-				if (seenClusters.has(entity.clusterId)) continue;
-				seenClusters.add(entity.clusterId);
 				resolvedEntities.push(entity);
 				if (entity.confidence >= minEntityConfidence) {
 					map.assign({
@@ -273,17 +268,12 @@ export async function assembleContextPack(
 		for (const form of candidateSpans) {
 			const results = await search(form);
 			for (const fragment of results) {
-				if (typeof fragment.text === "string" && fragment.text.trim()) {
+				if (typeof fragment.text === "string") {
 					fragments.push(fragment);
 				}
 			}
 		}
 	}
-
-	// Rank (measured scores first, descending; unscored keep arrival order) and
-	// bound the pack.
-	fragments.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-	const kept = fragments.slice(0, maxFragments);
 
 	// 3. The per-chunk assignment slice: clusters whose aliases occur in the
 	// chunk, plus clusters resolved above. NEVER the whole map.
@@ -305,23 +295,15 @@ export async function assembleContextPack(
 			const mapped = map.assignmentFor(entity.clusterId)
 				? " [cluster already pseudonymized — reuse its assignment]"
 				: "";
-			const handles = entity.identities
-				.map((i) => `${i.platform}:${i.handle}`)
-				.join(", ");
-			return `- ${entity.clusterId} (${entity.kind}, confidence ${entity.confidence.toFixed(2)}${
-				handles ? `, identities: ${handles}` : ""
-			})${mapped}`;
+			return `- ${JSON.stringify(entity)}${mapped}`;
 		});
 		sections.push(`Resolved entity candidates:\n${lines.join("\n")}`);
 	}
-	if (kept.length > 0) {
-		const lines = kept.map(
-			(f) => `- [${f.origin}${f.ref ? ` ${f.ref}` : ""}] ${f.text.trim()}`,
-		);
+	if (fragments.length > 0) {
+		const lines = fragments.map((fragment) => `- ${JSON.stringify(fragment)}`);
 		sections.push(`Related context:\n${lines.join("\n")}`);
 	}
-	let contextPack = sections.join("\n\n");
-	contextPack = toWellFormedUnicode(contextPack);
+	const contextPack = sections.join("\n\n");
 
 	return {
 		contextPack,
@@ -340,9 +322,11 @@ export async function assembleContextPack(
  */
 export function entityResolverFromStore(
 	store: PiiEntityResolverStore,
-	options: { maxCandidates?: number } = {},
+	_options: {
+		/** @deprecated Complete resolver results are always retained. */
+		maxCandidates?: number;
+	} = {},
 ): (candidate: PiiScrubCandidate) => Promise<readonly PiiResolvedEntity[]> {
-	const maxCandidates = options.maxCandidates ?? 3;
 	return async (candidate) => {
 		const query: {
 			name?: string;
@@ -351,7 +335,7 @@ export function entityResolverFromStore(
 			? { identity: candidate.identity }
 			: { name: candidate.surfaceForm.trim() };
 		const resolved = await store.resolve(query);
-		return resolved.slice(0, maxCandidates).map((match) => {
+		return resolved.map((match) => {
 			const aliases = [
 				match.entity.preferredName,
 				...(match.entity.fullName ? [match.entity.fullName] : []),


### PR DESCRIPTION
Fixes #24650. Preserves complete ordered action and intent records in handler output, and complete ordered PII fragments and resolver candidates without caps, deduplication, whitespace normalization, or Unicode rewriting. Invalid empty candidates fail explicitly. Verified: 29 focused tests pass; core typecheck passes; Biome, diff check, and CLAUDE/AGENTS parity pass. Attribution: OpenAI gpt-5.6-sol via Codex Desktop.