### PR TITLE
fix(agent): traverse complete conversation suffixes

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -172,6 +172,10 @@ Connector health monitoring (`api/connector-health.ts`): the interval is validat
 - `core-plugins.ts` splits plugins into blocking vs deferred boot phases; slow feature/provider plugins must stay in the deferred set or boot regresses.
 - Several barrel re-exports avoid duplicate-symbol (`TS2308`) collisions and lazy-load heavy plugins (wallet, app-manager, elizacloud) — read the inline comments in `index.ts`/`api/index.ts`/`services/index.ts` before adding broad `export *` lines.
 - `lint`/`lint:check` and `format` cover the complete `src/` tree.
+- Conversation suffix deletion walks the complete room with stable keyset pages,
+  validates forward progress, resolves every target before mutation, and requires
+  a bulk deletion contract for multi-row changes. Never restore a fixed scan cap
+  or per-row partial deletion fallback.
 - Provider-neutral TEE policy and key release are gated behind `services/tee-boot-gate*`; the hardware-free trust pipeline is exercised by `scripts/tee-full-stack-local.ts`. Concrete attestation providers and hardware validation belong to their deployment; see `docs/tee-agent-implementation-plan.md`.
 - **Files / media storage.** Attachment bytes live in one content-addressed store, `api/media-store.ts` (`${STATE_DIR}/media/<sha256>.<ext>`, served pre-auth at `/api/media/<sha256>.<ext>` with `nosniff` and a download `Content-Disposition` for SVG/active types). `services/file-storage.ts` (`LocalFileStorageService`, fills `ServiceType.REMOTE_FILES`) is the contract the rest of the system resolves through `runtime.getService(ServiceType.REMOTE_FILES)` for `store`/`getUrl`/`list`/`delete`; authenticated `api/files-routes.ts` (`GET`/`DELETE /api/files`) and the `actions/files.ts` `FILES` tool both use it. `api/media-runtime.ts` rehosts inline `data:` and remote generated-media URLs on authenticated outgoing paths through the SSRF guard and runs the reference-aware orphan GC. Do not add a second file store, a `files` table, or a second refcount/GC engine; see issue #8876 and the root media invariant.
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -172,6 +172,10 @@ Connector health monitoring (`api/connector-health.ts`): the interval is validat
 - `core-plugins.ts` splits plugins into blocking vs deferred boot phases; slow feature/provider plugins must stay in the deferred set or boot regresses.
 - Several barrel re-exports avoid duplicate-symbol (`TS2308`) collisions and lazy-load heavy plugins (wallet, app-manager, elizacloud) — read the inline comments in `index.ts`/`api/index.ts`/`services/index.ts` before adding broad `export *` lines.
 - `lint`/`lint:check` and `format` cover the complete `src/` tree.
+- Conversation suffix deletion walks the complete room with stable keyset pages,
+  validates forward progress, resolves every target before mutation, and requires
+  a bulk deletion contract for multi-row changes. Never restore a fixed scan cap
+  or per-row partial deletion fallback.
 - Provider-neutral TEE policy and key release are gated behind `services/tee-boot-gate*`; the hardware-free trust pipeline is exercised by `scripts/tee-full-stack-local.ts`. Concrete attestation providers and hardware validation belong to their deployment; see `docs/tee-agent-implementation-plan.md`.
 - **Files / media storage.** Attachment bytes live in one content-addressed store, `api/media-store.ts` (`${STATE_DIR}/media/<sha256>.<ext>`, served pre-auth at `/api/media/<sha256>.<ext>` with `nosniff` and a download `Content-Disposition` for SVG/active types). `services/file-storage.ts` (`LocalFileStorageService`, fills `ServiceType.REMOTE_FILES`) is the contract the rest of the system resolves through `runtime.getService(ServiceType.REMOTE_FILES)` for `store`/`getUrl`/`list`/`delete`; authenticated `api/files-routes.ts` (`GET`/`DELETE /api/files`) and the `actions/files.ts` `FILES` tool both use it. `api/media-runtime.ts` rehosts inline `data:` and remote generated-media URLs on authenticated outgoing paths through the SSRF guard and runs the reference-aware orphan GC. Do not add a second file store, a `files` table, or a second refcount/GC engine; see issue #8876 and the root media invariant.
 

--- a/packages/agent/src/services/conversation-message-service.test.ts
+++ b/packages/agent/src/services/conversation-message-service.test.ts
@@ -19,6 +19,15 @@ function runtime(methods: Record<string, unknown>): AgentRuntime {
   } as unknown as AgentRuntime;
 }
 
+function message(index: number): Memory {
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}` as UUID,
+    roomId,
+    createdAt: index,
+    content: { text: `message ${index}` },
+  } as Memory;
+}
+
 describe("conversation message service", () => {
   it("uses the runtime bulk deletion contract", async () => {
     const deleteManyMemories = vi.fn(async () => undefined);
@@ -54,5 +63,67 @@ describe("conversation message service", () => {
       truncateConversationMessages(target, conversation, ids[1]),
     ).resolves.toEqual({ deletedCount: 1 });
     expect(deleteManyMemories).toHaveBeenCalledWith([ids[2]]);
+  });
+
+  it("traverses every page before deleting a suffix beyond 1,000 messages", async () => {
+    const messages = Array.from({ length: 1_205 }, (_, index) =>
+      message(index + 1),
+    );
+    const deleteManyMemories = vi.fn(async () => undefined);
+    const getMemories = vi.fn(
+      async ({
+        cursor,
+        limit,
+      }: {
+        cursor?: { createdAt: number };
+        limit: number;
+      }) => {
+        const start = cursor
+          ? messages.findIndex(
+              (entry) => entry.createdAt === cursor.createdAt,
+            ) + 1
+          : 0;
+        return messages.slice(start, start + limit);
+      },
+    );
+    const target = runtime({ deleteManyMemories, getMemories });
+
+    await expect(
+      truncateConversationMessages(
+        target,
+        conversation,
+        String(messages[999]?.id),
+      ),
+    ).resolves.toEqual({ deletedCount: 205 });
+    expect(getMemories).toHaveBeenCalledTimes(3);
+    expect(deleteManyMemories).toHaveBeenCalledWith(
+      messages.slice(1_000).map((entry) => entry.id),
+    );
+  });
+
+  it("rejects a non-advancing adapter before deleting anything", async () => {
+    const page = Array.from({ length: 500 }, (_, index) => message(index + 1));
+    const deleteManyMemories = vi.fn(async () => undefined);
+    const target = runtime({
+      deleteManyMemories,
+      getMemories: vi.fn(async () => page),
+    });
+
+    await expect(
+      truncateConversationMessages(target, conversation, String(page[0]?.id)),
+    ).rejects.toMatchObject({ code: "CONVERSATION_TRAVERSAL_UNSTABLE" });
+    expect(deleteManyMemories).not.toHaveBeenCalled();
+  });
+
+  it("requires a bulk deletion contract for multi-message suffixes", async () => {
+    const target = runtime({
+      getMemories: async () => [message(1), message(2), message(3)],
+    });
+    await expect(
+      truncateConversationMessages(target, conversation, String(message(1).id)),
+    ).rejects.toMatchObject({
+      code: "CONVERSATION_BULK_DELETE_UNAVAILABLE",
+      status: 501,
+    });
   });
 });

--- a/packages/agent/src/services/conversation-message-service.ts
+++ b/packages/agent/src/services/conversation-message-service.ts
@@ -3,7 +3,12 @@
  * persistence contract. HTTP routes supply an authorized conversation and
  * translate the service's status-bearing not-found error at their boundary.
  */
-import type { AgentRuntime, UUID } from "@elizaos/core";
+import {
+  type AgentRuntime,
+  ElizaError,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import type { ConversationMeta } from "../api/server-types.ts";
 
 type DeletableRuntime = AgentRuntime & {
@@ -40,6 +45,16 @@ export async function deleteConversationMemories(
     return memoryIds.length;
   }
 
+  if (memoryIds.length > 1) {
+    throw Object.assign(
+      new ElizaError(
+        "Atomic conversation message deletion is not supported by this adapter",
+        { code: "CONVERSATION_BULK_DELETE_UNAVAILABLE" },
+      ),
+      { status: 501 },
+    );
+  }
+
   for (const memoryId of memoryIds) {
     if (typeof deletable.deleteMemory === "function") {
       await deletable.deleteMemory(memoryId);
@@ -57,6 +72,74 @@ export async function deleteConversationMemories(
     }
   }
   return memoryIds.length;
+}
+
+const CONVERSATION_SCAN_PAGE_SIZE = 500;
+
+function memoryCursor(memory: Memory): { createdAt: number; id: UUID } {
+  if (
+    typeof memory.id !== "string" ||
+    memory.id.length === 0 ||
+    !Number.isFinite(memory.createdAt)
+  ) {
+    throw new ElizaError("Conversation traversal returned an unpageable row", {
+      code: "CONVERSATION_TRAVERSAL_INVALID_ROW",
+    });
+  }
+  return { createdAt: memory.createdAt as number, id: memory.id };
+}
+
+function cursorFollows(
+  next: { createdAt: number; id: UUID },
+  previous: { createdAt: number; id: UUID },
+): boolean {
+  return (
+    next.createdAt > previous.createdAt ||
+    (next.createdAt === previous.createdAt && next.id > previous.id)
+  );
+}
+
+async function getCompleteConversationMemories(
+  runtime: AgentRuntime,
+  roomId: UUID,
+): Promise<Memory[]> {
+  const complete: Memory[] = [];
+  let cursor: { createdAt: number; id: UUID } | undefined;
+
+  while (true) {
+    const page = await runtime.getMemories({
+      roomId,
+      tableName: "messages",
+      limit: CONVERSATION_SCAN_PAGE_SIZE,
+      orderBy: "createdAt",
+      orderDirection: "asc",
+      ...(cursor ? { cursor } : {}),
+    });
+    if (page.length > CONVERSATION_SCAN_PAGE_SIZE) {
+      throw new ElizaError(
+        "Conversation traversal exceeded its requested page",
+        {
+          code: "CONVERSATION_TRAVERSAL_INVALID_PAGE",
+          context: {
+            requested: CONVERSATION_SCAN_PAGE_SIZE,
+            received: page.length,
+          },
+        },
+      );
+    }
+    for (const memory of page) {
+      const next = memoryCursor(memory);
+      if (cursor && !cursorFollows(next, cursor)) {
+        throw new ElizaError("Conversation traversal did not advance", {
+          code: "CONVERSATION_TRAVERSAL_UNSTABLE",
+          context: { previousId: cursor.id, nextId: next.id },
+        });
+      }
+      complete.push(memory);
+      cursor = next;
+    }
+    if (page.length < CONVERSATION_SCAN_PAGE_SIZE) return complete;
+  }
 }
 
 export async function deleteConversationMessage(
@@ -86,13 +169,9 @@ export async function truncateConversationMessages(
   messageId: string,
   options?: { inclusive?: boolean },
 ): Promise<{ deletedCount: number }> {
-  const memories = await runtime.getMemories({
-    roomId: conversation.roomId,
-    tableName: "messages",
-    limit: 1_000,
-  });
-  memories.sort(
-    (left, right) => (left.createdAt ?? 0) - (right.createdAt ?? 0),
+  const memories = await getCompleteConversationMemories(
+    runtime,
+    conversation.roomId,
   );
   const targetIndex = memories.findIndex((memory) => memory.id === messageId);
   if (targetIndex < 0) throw conversationMessageNotFound();


### PR DESCRIPTION
Fixes #24651. Replaces the fixed 1,000-message retrieval window with exhaustive ordered keyset pagination, detects invalid or non-advancing adapter pages before mutation, and requires atomic bulk deletion for multi-message suffixes so partial success cannot be reported. Verified: focused suite passes 6/6 including a 1,205-message boundary, non-advancing pagination, and bulk-delete rejection; Biome, diff check, and CLAUDE/AGENTS parity pass. Attribution: OpenAI gpt-5.6-sol via Codex Desktop.