### PR TITLE
fix(plugin-anthropic): validate every max-output-token entry before selecting one

### DIFF
--- a/plugins/plugin-anthropic/AGENTS.md
+++ b/plugins/plugin-anthropic/AGENTS.md
@@ -102,7 +102,7 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `ANTHROPIC_EFFORT_LARGE` | No | — | Effort for large-size models |
 | `ANTHROPIC_PROMPT_CACHE_TTL` | No | `5m` | Prompt cache TTL: `"5m"` or `"1h"` |
 | `ANTHROPIC_TEMPERATURE_LOCKED_MODELS` | No | — | Comma-separated model ids that only accept `temperature=1`, applied on top of the built-in `opus-4` name check |
-| `ANTHROPIC_MAX_OUTPUT_TOKENS` | No | — | Positive safe decimal integer, or comma-separated `model-id:tokens` pairs; malformed explicit entries fail before dispatch and unlisted models keep built-in caps. |
+| `ANTHROPIC_MAX_OUTPUT_TOKENS` | No | — | Positive safe decimal integer, or comma-separated `model-id:tokens` pairs. Every entry is validated before any is selected, so a malformed entry fails before dispatch regardless of its position in the list. The first entry matching the requested model wins, the last bare number is the fallback, and unlisted models keep built-in caps. |
 | `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_OAUTH_TOKEN` | No | — | OAuth bearer token for `ANTHROPIC_AUTH_MODE=oauth` |
 | `ANTHROPIC_SUBSCRIPTION_ACCOUNT_ID` | No | `default` | Account ID for app-managed subscription credentials |
 | `CLAUDE_CONFIG_DIR` | No | `~/.claude` | Override credential store directory (macOS keychain also checked) |

--- a/plugins/plugin-anthropic/CLAUDE.md
+++ b/plugins/plugin-anthropic/CLAUDE.md
@@ -102,7 +102,7 @@ All settings are read via `runtime.getSetting(key)` first, then `process.env[key
 | `ANTHROPIC_EFFORT_LARGE` | No | — | Effort for large-size models |
 | `ANTHROPIC_PROMPT_CACHE_TTL` | No | `5m` | Prompt cache TTL: `"5m"` or `"1h"` |
 | `ANTHROPIC_TEMPERATURE_LOCKED_MODELS` | No | — | Comma-separated model ids that only accept `temperature=1`, applied on top of the built-in `opus-4` name check |
-| `ANTHROPIC_MAX_OUTPUT_TOKENS` | No | — | Positive safe decimal integer, or comma-separated `model-id:tokens` pairs; malformed explicit entries fail before dispatch and unlisted models keep built-in caps. |
+| `ANTHROPIC_MAX_OUTPUT_TOKENS` | No | — | Positive safe decimal integer, or comma-separated `model-id:tokens` pairs. Every entry is validated before any is selected, so a malformed entry fails before dispatch regardless of its position in the list. The first entry matching the requested model wins, the last bare number is the fallback, and unlisted models keep built-in caps. |
 | `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_OAUTH_TOKEN` | No | — | OAuth bearer token for `ANTHROPIC_AUTH_MODE=oauth` |
 | `ANTHROPIC_SUBSCRIPTION_ACCOUNT_ID` | No | `default` | Account ID for app-managed subscription credentials |
 | `CLAUDE_CONFIG_DIR` | No | `~/.claude` | Override credential store directory (macOS keychain also checked) |

--- a/plugins/plugin-anthropic/__tests__/cot-budget.parsing.test.ts
+++ b/plugins/plugin-anthropic/__tests__/cot-budget.parsing.test.ts
@@ -87,6 +87,86 @@ describe("getMaxOutputTokensOverride entry parsing", () => {
     );
   });
 
+  it("rejects a malformed entry that follows the matching target", () => {
+    // The selector previously returned on the first target match, so a typo
+    // after it was never validated and the same setting threw or passed
+    // depending only on comma order.
+    const runtime = runtimeWith({
+      ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-sonnet-4:8192,claude-opus-4:8192junk",
+    });
+    expect(() => getMaxOutputTokensOverride(runtime, "claude-sonnet-4")).toThrow(
+      expect.objectContaining({
+        code: "ANTHROPIC_MAX_OUTPUT_TOKENS_INVALID",
+        context: expect.objectContaining({
+          value: "8192junk",
+          entry: "claude-opus-4:8192junk",
+        }),
+      })
+    );
+  });
+
+  it("rejects a malformed entry that precedes the matching target", () => {
+    const runtime = runtimeWith({
+      ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-opus-4:8192junk,claude-sonnet-4:8192",
+    });
+    expect(() => getMaxOutputTokensOverride(runtime, "claude-sonnet-4")).toThrow(
+      expect.objectContaining({
+        code: "ANTHROPIC_MAX_OUTPUT_TOKENS_INVALID",
+        context: expect.objectContaining({
+          value: "8192junk",
+          entry: "claude-opus-4:8192junk",
+        }),
+      })
+    );
+  });
+
+  it("rejects a malformed bare fallback that follows the matching target", () => {
+    const runtime = runtimeWith({
+      ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-sonnet-4:8192,4096junk",
+    });
+    expect(() => getMaxOutputTokensOverride(runtime, "claude-sonnet-4")).toThrow(
+      expect.objectContaining({
+        code: "ANTHROPIC_MAX_OUTPUT_TOKENS_INVALID",
+        context: expect.objectContaining({ value: "4096junk", entry: "4096junk" }),
+      })
+    );
+  });
+
+  it("keeps the first matching target entry when the target is duplicated", () => {
+    expect(
+      getMaxOutputTokensOverride(
+        runtimeWith({
+          ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-sonnet-4:8192,claude-sonnet-4:1024",
+        }),
+        "claude-sonnet-4"
+      )
+    ).toBe(8192);
+  });
+
+  it("keeps the last bare entry when the fallback is duplicated", () => {
+    expect(
+      getMaxOutputTokensOverride(
+        runtimeWith({ ANTHROPIC_MAX_OUTPUT_TOKENS: "4096,2048" }),
+        "claude-sonnet-4"
+      )
+    ).toBe(2048);
+  });
+
+  it("prefers the target entry over a bare fallback in either order", () => {
+    expect(
+      getMaxOutputTokensOverride(
+        runtimeWith({ ANTHROPIC_MAX_OUTPUT_TOKENS: "4096,claude-sonnet-4:8192" }),
+        "claude-sonnet-4"
+      )
+    ).toBe(8192);
+    expect(
+      getMaxOutputTokensOverride(
+        runtimeWith({ ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-sonnet-4:8192,4096" }),
+        "claude-sonnet-4"
+      )
+    ).toBe(8192);
+  });
+
   it("still honours a clean per-model cap and a bare fallback", () => {
     expect(
       getMaxOutputTokensOverride(

--- a/plugins/plugin-anthropic/utils/config.ts
+++ b/plugins/plugin-anthropic/utils/config.ts
@@ -287,7 +287,11 @@ export function getMaxOutputTokensOverride(
     return undefined;
   }
   const target = modelName.toLowerCase();
+  let selected: number | undefined;
   let fallback: number | undefined;
+  // Every entry is validated before any is returned. Returning on the first
+  // target match made the fail-fast contract depend on comma order:
+  // "target:8192,other:8192junk" was accepted while the reverse threw.
   for (const entry of raw.split(",")) {
     const trimmed = entry.trim();
     if (!trimmed) {
@@ -319,13 +323,15 @@ export function getMaxOutputTokensOverride(
       allowZero: false,
       entry: trimmed,
     });
-    if (separator === -1) {
+    if (modelSelector === undefined) {
+      // Last bare entry wins, as the previous unconditional assignment did.
       fallback = parsed;
-    } else if (modelSelector?.toLowerCase() === target) {
-      return parsed;
+    } else if (selected === undefined && modelSelector.toLowerCase() === target) {
+      // First explicit match wins, as the previous early return did.
+      selected = parsed;
     }
   }
-  return fallback;
+  return selected ?? fallback;
 }
 
 export function getAuthMode(runtime: IAgentRuntime): "cli" | "oauth" | "apikey" {


### PR DESCRIPTION
# Relates to

Closes #24658. Review follow-up to #24427 (merged), raised by @lalalune on that PR at head `0e06a170`: the strict entry parser that #24427 introduced is correct, but the surrounding selector short-circuits, so whether a malformed entry is caught depends on comma order.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Package tests, `typecheck`, and repository-pinned Biome 2.5.8 all run and quoted below.
- [x] A reviewer can confirm the change from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] `plugins/plugin-anthropic/utils/config.ts` was drift-checked against `develop` immediately before push; the only delta is this change.

# Risks

Low, and strictly narrowing. One function, one file. Every setting string that resolves today resolves to the same number. The only behaviour change is that a malformed entry which used to be skipped because of its position now throws, which is the contract #24427 already documented and shipped.

# Background

## What does this PR do?

`getMaxOutputTokensOverride` parses `ANTHROPIC_MAX_OUTPUT_TOKENS` — a comma-separated list of a bare fallback and/or `model-id:tokens` pairs — and returns as soon as an entry matches the requested model:

```ts
if (separator === -1) {
  fallback = parsed;
} else if (modelSelector?.toLowerCase() === target) {
  return parsed;          // entries after this are never parsed
}
```

Since #24427 made each entry throw on a malformed value, that early return makes the fail-fast contract depend on comma order alone:

| `ANTHROPIC_MAX_OUTPUT_TOKENS` | requested model | before | after |
| --- | --- | --- | --- |
| `claude-sonnet-4:8192,claude-opus-4:8192junk` | `claude-sonnet-4` | resolves `8192`, typo never seen | throws |
| `claude-opus-4:8192junk,claude-sonnet-4:8192` | `claude-sonnet-4` | throws | throws |

The same typo in the same setting surfaces or hides purely by where the operator happened to put it. The value is sent to a paid API on every request, so a silently skipped entry means a model quietly keeps a built-in cap the operator believed they had overridden.

## What is the fix?

Validate the whole list, then select. Selection precedence is unchanged and now stated in the package guides rather than left implicit in control flow:

- the **first** entry matching the requested model wins (what the early `return` did),
- the **last** bare entry is the fallback (what the unconditional `fallback =` assignment did).

Both rules were already the behaviour before #24427; this PR keeps them and writes them down.

# Documentation changes needed?

Yes, included. The `ANTHROPIC_MAX_OUTPUT_TOKENS` row in the paired `CLAUDE.md` / `AGENTS.md` now states the ordering guarantee and both precedence rules. The two files remain byte-for-byte identical (`bun run check:agents-claude` contract).

# Testing

## Where should a reviewer start?

The mutation block below. It shows the exact two configurations that the current `develop` accepts and this PR rejects.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| `cot-budget.parsing.test.ts` | 13 passed |
| full `plugin-anthropic` lane | **115 passed across 15 files** |
| `bun run --cwd plugins/plugin-anthropic typecheck` | clean (`tsc --noEmit`) |
| `biome check` (repository-pinned 2.5.8) | clean, no fixes applied |

Mutation resistance — reverting only the two-phase selection change and keeping every test:

```
 ❯ __tests__/cot-budget.parsing.test.ts (13 tests | 2 failed)
   × rejects a malformed entry that follows the matching target
   × rejects a malformed bare fallback that follows the matching target

AssertionError: expected function to throw an error, but it didn't
   ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-sonnet-4:8192,claude-opus-4:8192junk"
   ANTHROPIC_MAX_OUTPUT_TOKENS: "claude-sonnet-4:8192,4096junk"

 Tests  2 failed | 11 passed (13)
```

The four precedence tests (duplicate target, duplicate bare entry, target-over-fallback in both orders) pass in **both** directions by design — they pin the pre-existing selection rules this change deliberately preserves, so a future refactor cannot quietly flip them.

# Evidence Gate

<!-- evidence-head:6fc746c43b2d3018b9ee61276d07721016f8aa5e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only change to one setting parser, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only change to one setting parser, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the resolved cap value and the thrown ElizaError, both asserted directly in the tests above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started and no API call is made; the resolver is exercised directly by the unit suite quoted above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no live model call was made. This change only alters which setting STRINGS are accepted before a request is built; a live trajectory would exercise the Anthropic API rather than the parser, and the resolved values are asserted directly instead`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the observable output is the resolved max-output-token cap, asserted in the tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - the change has no rendered visual surface`.

# Attribution

- Defect reported by @lalalune in review of #24427.
- Fix, precedence analysis against the pre-#24427 baseline, regression suite, and mutation proof by Claude Code (`claude-opus-5`).

