### PR TITLE
fix(agent): isolate escalation state by agent

### DIFF
--- a/packages/agent/src/providers/escalation-trigger.ts
+++ b/packages/agent/src/providers/escalation-trigger.ts
@@ -89,10 +89,13 @@ async function findLastOwnerMessageTimestamp(
 // Trigger checks
 // ---------------------------------------------------------------------------
 
-async function checkActiveEscalation(triggers: Trigger[]): Promise<void> {
+async function checkActiveEscalation(
+  runtime: IAgentRuntime,
+  triggers: Trigger[],
+): Promise<void> {
   try {
     const { EscalationService } = await import("../services/escalation.ts");
-    const active = EscalationService.getActiveEscalationSync();
+    const active = EscalationService.getActiveEscalationSync(runtime);
     if (active && !active.resolved) {
       triggers.push({
         type: "active_escalation",
@@ -195,7 +198,7 @@ export function createEscalationTriggerProvider(): Provider {
 
       if (isAdminViewer) {
         await Promise.all([
-          checkActiveEscalation(triggers),
+          checkActiveEscalation(runtime, triggers),
           checkOwnerInactivity(runtime, message, triggers),
           checkPendingVerifications(runtime, message, triggers),
         ]);

--- a/packages/agent/src/runtime/error-escalation.test.ts
+++ b/packages/agent/src/runtime/error-escalation.test.ts
@@ -374,6 +374,8 @@ describe("EscalationService coalescing (real service)", () => {
     expect(second.id).toBe(first.id);
     expect(second.text).toContain("first burst");
     expect(second.text).toContain("second burst");
-    expect(EscalationService.getActiveEscalationSync()?.id).toBe(first.id);
+    expect(EscalationService.getActiveEscalationSync(runtime)?.id).toBe(
+      first.id,
+    );
   });
 });

--- a/packages/agent/src/services/escalation-agent-isolation.test.ts
+++ b/packages/agent/src/services/escalation-agent-isolation.test.ts
@@ -1,0 +1,246 @@
+/**
+ * EscalationService keeps its in-memory state in module-level maps while the
+ * cache key it persists under is agent-scoped. A process holding more than one
+ * runtime — a multi-agent boot, or a runtime rebuilt in-process — must not let
+ * one agent's escalation absorb another's: these tests pin per-agent isolation
+ * of the active escalation, of the persisted cache row, and of resolution,
+ * while keeping same-agent coalescing (the documented behaviour) intact. They
+ * also pin that empty per-agent buckets are never retained — timer buckets are
+ * deleted on both timer-fire and resolve, and a read-only lookup for an unknown
+ * escalation allocates nothing — so a long-lived process does not retain one
+ * Map per agent id.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { EscalationService } from "./escalation.ts";
+
+type CacheStore = Map<string, unknown>;
+
+function makeRuntime(agentId: string, cache: CacheStore): IAgentRuntime {
+  return {
+    agentId,
+    character: { name: `agent-${agentId}` },
+    getRoomsForParticipant: async () => [],
+    getRoom: async () => null,
+    getWorld: async () => null,
+    getService: () => null,
+    getEntityById: async () => null,
+    getMemoriesByRoomIds: async () => [],
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    },
+    getCache: async (key: string) => cache.get(key) ?? null,
+    deleteCache: async (key: string) => {
+      cache.delete(key);
+      return true;
+    },
+    sendMessageToTarget: async () => {},
+  } as unknown as IAgentRuntime;
+}
+
+const keyFor = (agentId: string) => `agent:escalation:active:${agentId}`;
+
+describe("EscalationService per-agent isolation", () => {
+  afterEach(() => {
+    EscalationService._reset();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  test("a second agent gets its own escalation instead of coalescing into the first", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+    const second = await EscalationService.startEscalation(
+      runtimeB,
+      "reason B",
+      "agent B private text",
+    );
+
+    expect(second.id).not.toBe(first.id);
+    expect(first.text).toBe("agent A private text");
+    expect(first.reason).toBe("reason A");
+    expect(second.text).toBe("agent B private text");
+    expect(second.reason).toBe("reason B");
+  });
+
+  test("each agent's cache row holds that agent's own escalation", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+    const second = await EscalationService.startEscalation(
+      runtimeB,
+      "reason B",
+      "agent B private text",
+    );
+
+    const storedA = cache.get(keyFor("agent-a")) as
+      | { id: string; text: string }
+      | undefined;
+    const storedB = cache.get(keyFor("agent-b")) as
+      | { id: string; text: string }
+      | undefined;
+
+    expect(storedA?.id).toBe(first.id);
+    expect(storedA?.text).toBe("agent A private text");
+    expect(storedB?.id).toBe(second.id);
+    expect(storedB?.text).toBe("agent B private text");
+  });
+
+  test("getActiveEscalationSync only reports the calling agent's escalation", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+
+    expect(EscalationService.getActiveEscalationSync(runtimeA)?.id).toBe(
+      first.id,
+    );
+    expect(EscalationService.getActiveEscalationSync(runtimeB)).toBeNull();
+  });
+
+  test("resolving one agent's escalation leaves the other's active", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+    const second = await EscalationService.startEscalation(
+      runtimeB,
+      "reason B",
+      "agent B private text",
+    );
+
+    await EscalationService.resolveEscalation(first.id, runtimeA);
+
+    expect(EscalationService.getActiveEscalationSync(runtimeA)).toBeNull();
+    expect(EscalationService.getActiveEscalationSync(runtimeB)?.id).toBe(
+      second.id,
+    );
+  });
+
+  test("same-agent coalescing still folds a second reason into the active escalation", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "reason 1",
+      "first burst",
+    );
+    const second = await EscalationService.startEscalation(
+      runtime,
+      "reason 2",
+      "second burst",
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.reason).toBe("reason 1; reason 2");
+    expect(second.text).toContain("first burst");
+    expect(second.text).toContain("second burst");
+    expect(EscalationService.getActiveEscalationSync(runtime)?.id).toBe(
+      first.id,
+    );
+  });
+
+  test("resolveEscalation deletes the per-agent timer bucket instead of leaving it empty", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "reason A",
+      "agent A private text",
+    );
+
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(true);
+
+    await EscalationService.resolveEscalation(first.id, runtime);
+
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+    expect(EscalationService.getActiveEscalationSync(runtime)).toBeNull();
+  });
+
+  test("timer fire deletes the per-agent timer bucket when the check does not reschedule", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const check = vi
+      .spyOn(EscalationService, "checkEscalation")
+      .mockResolvedValue();
+
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    await EscalationService.startEscalation(
+      runtime,
+      "reason A",
+      "agent A private text",
+    );
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(true);
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+  });
+
+  test("resolveEscalation does not allocate a timer bucket when none exists", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    vi.spyOn(EscalationService, "checkEscalation").mockResolvedValue();
+
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "reason A",
+      "agent A private text",
+    );
+    await vi.runOnlyPendingTimersAsync();
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+
+    // Still active because the check was stubbed. Resolve must read with
+    // pendingTimers.get(), not timersFor(), or this recreates an empty bucket.
+    await EscalationService.resolveEscalation(first.id, runtime);
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+  });
+
+  test("checkEscalation does not allocate an escalation bucket for an unknown id", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    await EscalationService.checkEscalation(runtime, "unknown-id");
+
+    expect(EscalationService._hasActiveEscalationBucket("agent-a")).toBe(false);
+  });
+
+  test("rehydrating an agent without persisted state retains no empty bucket", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    await EscalationService.rehydrateFromDb(runtime);
+
+    expect(EscalationService._hasActiveEscalationBucket("agent-a")).toBe(false);
+  });
+});

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -2,11 +2,12 @@
  * EscalationService — escalates an unacknowledged agent message to the owner
  * across the configured ordered channels (client_chat first, then paired
  * connectors), retrying on a wait/backoff timer until the owner responds or the
- * retry budget is exhausted. State is module-level (one active escalation at a
- * time, coalescing new reasons into it) and persisted to the runtime cache so it
- * survives restarts; owner-contact config and routing hints resolve the delivery
- * target per channel. `registerEscalationChannel` appends newly paired channels
- * to the escalation order in eliza.json.
+ * retry budget is exhausted. State is module-level but partitioned per agent
+ * (one active escalation at a time PER AGENT, coalescing new reasons into it)
+ * and persisted to the runtime cache under an agent-scoped key so it survives
+ * restarts; owner-contact config and routing hints resolve the delivery target
+ * per channel. `registerEscalationChannel` appends newly paired channels to the
+ * escalation order in eliza.json.
  */
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import {
@@ -50,8 +51,85 @@ const DEFAULT_WAIT_MINUTES = 5;
 const DEFAULT_MAX_RETRIES = 3;
 const ESCALATION_CACHE_KEY_PREFIX = "agent:escalation:active";
 
-const activeEscalations = new Map<string, EscalationState>();
-const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+/**
+ * In-memory escalation state, partitioned by `runtime.agentId`.
+ *
+ * These maps used to be flat (`escalationId -> state`) while
+ * {@link escalationCacheKey} was already agent-scoped. A process that holds
+ * more than one runtime — a multi-agent boot (one service instance per runtime
+ * over the same data dir) or a runtime rebuilt in-process by PGLite recovery —
+ * then shared one "active escalation" across agents: agent B's
+ * `startEscalation` found agent A's state, appended B's reason/text to it, and
+ * persisted A's mutated state under B's cache key. B never got its own
+ * escalation and A's timer went on to deliver text that belonged to B.
+ * Partitioning both maps the same way the cache key is partitioned keeps each
+ * agent's escalation to itself.
+ */
+const activeEscalations = new Map<string, Map<string, EscalationState>>();
+const pendingTimers = new Map<
+  string,
+  Map<string, ReturnType<typeof setTimeout>>
+>();
+
+function agentIdOf(runtime: IAgentRuntime): string {
+  return runtime.agentId as string;
+}
+
+function escalationsFor(agentId: string): Map<string, EscalationState> {
+  let bucket = activeEscalations.get(agentId);
+  if (!bucket) {
+    bucket = new Map<string, EscalationState>();
+    activeEscalations.set(agentId, bucket);
+  }
+  return bucket;
+}
+
+function timersFor(
+  agentId: string,
+): Map<string, ReturnType<typeof setTimeout>> {
+  let bucket = pendingTimers.get(agentId);
+  if (!bucket) {
+    bucket = new Map<string, ReturnType<typeof setTimeout>>();
+    pendingTimers.set(agentId, bucket);
+  }
+  return bucket;
+}
+
+/**
+ * Drop one pending timer without allocating a bucket. Empty inner maps are
+ * removed so a long-lived process that boots many agents does not retain one
+ * Map per agent id after the last timer fires or the escalation resolves.
+ */
+function releaseTimer(agentId: string, escalationId: string): void {
+  const timers = pendingTimers.get(agentId);
+  if (!timers) return;
+  const existing = timers.get(escalationId);
+  if (existing) {
+    clearTimeout(existing);
+    timers.delete(escalationId);
+  }
+  if (timers.size === 0) pendingTimers.delete(agentId);
+}
+
+/**
+ * Locate an escalation by id. `resolveEscalation` may be called without a
+ * runtime, so fall back to a scan across agents when no runtime is supplied.
+ */
+function findEscalation(
+  escalationId: string,
+  runtime?: IAgentRuntime,
+): { agentId: string; state: EscalationState } | null {
+  if (runtime) {
+    const agentId = agentIdOf(runtime);
+    const state = activeEscalations.get(agentId)?.get(escalationId);
+    return state ? { agentId, state } : null;
+  }
+  for (const [agentId, bucket] of activeEscalations) {
+    const state = bucket.get(escalationId);
+    if (state) return { agentId, state };
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Persistence helpers -- owned by agent state instead of app-lifeops storage.
@@ -383,11 +461,11 @@ function scheduleCheck(
   escalationId: string,
   delayMs: number,
 ): void {
-  const existing = pendingTimers.get(escalationId);
-  if (existing) clearTimeout(existing);
+  const agentId = agentIdOf(runtime);
+  releaseTimer(agentId, escalationId);
 
   const timer = setTimeout(async () => {
-    pendingTimers.delete(escalationId);
+    releaseTimer(agentId, escalationId);
     try {
       await EscalationService.checkEscalation(runtime, escalationId);
     } catch (err) {
@@ -398,7 +476,7 @@ function scheduleCheck(
     }
   }, delayMs);
 
-  pendingTimers.set(escalationId, timer);
+  timersFor(agentId).set(escalationId, timer);
 }
 
 let idCounter = 0;
@@ -410,7 +488,7 @@ export class EscalationService {
     reason: string,
     text: string,
   ): Promise<EscalationState> {
-    const existing = EscalationService.getActiveEscalationSync();
+    const existing = EscalationService.getActiveEscalationSync(runtime);
     if (existing) {
       existing.reason = `${existing.reason}; ${reason}`;
       existing.text = `${existing.text}\n---\n${text}`;
@@ -450,7 +528,7 @@ export class EscalationService {
       resolved: false,
     };
 
-    activeEscalations.set(escalationId, state);
+    escalationsFor(agentIdOf(runtime)).set(escalationId, state);
 
     // Initial delivery falls through failed channels immediately: a channel
     // whose send throws (dashboard with no conversation, missing handler) is
@@ -490,7 +568,9 @@ export class EscalationService {
     runtime: IAgentRuntime,
     escalationId: string,
   ): Promise<void> {
-    const state = activeEscalations.get(escalationId);
+    // Read-only: escalationsFor() would allocate an empty bucket for an
+    // unknown escalation id.
+    const state = activeEscalations.get(agentIdOf(runtime))?.get(escalationId);
     if (!state || state.resolved) return;
 
     const config = loadEscalationConfig();
@@ -561,17 +641,16 @@ export class EscalationService {
     escalationId: string,
     runtime?: IAgentRuntime,
   ): Promise<void> {
-    const state = activeEscalations.get(escalationId);
-    if (!state || state.resolved) return;
+    const found = findEscalation(escalationId, runtime);
+    if (!found) return;
+    const { agentId, state } = found;
+    if (state.resolved) return;
 
     state.resolved = true;
     state.resolvedAt = Date.now();
 
-    const timer = pendingTimers.get(escalationId);
-    if (timer) {
-      clearTimeout(timer);
-      pendingTimers.delete(escalationId);
-    }
+    // Read-only: timersFor() would allocate an empty bucket on a no-timer path.
+    releaseTimer(agentId, escalationId);
 
     logger.info(`[escalation] Resolved ${escalationId}`);
 
@@ -582,11 +661,18 @@ export class EscalationService {
     // Drop the resolved escalation from the in-memory map. getActiveEscalationSync
     // ignores resolved entries and the resolved state is persisted to cache, so
     // retaining it only grows the map one entry per escalation ever created.
-    activeEscalations.delete(escalationId);
+    const bucket = activeEscalations.get(agentId);
+    bucket?.delete(escalationId);
+    if (bucket?.size === 0) activeEscalations.delete(agentId);
   }
 
-  static getActiveEscalationSync(): EscalationState | null {
-    for (const state of activeEscalations.values()) {
+  /** The calling agent's own active escalation, if any. */
+  static getActiveEscalationSync(
+    runtime: IAgentRuntime,
+  ): EscalationState | null {
+    const bucket = activeEscalations.get(agentIdOf(runtime));
+    if (!bucket) return null;
+    for (const state of bucket.values()) {
       if (!state.resolved) return state;
     }
     return null;
@@ -595,12 +681,12 @@ export class EscalationService {
   static async getActiveEscalation(
     runtime: IAgentRuntime,
   ): Promise<EscalationState | null> {
-    const cached = EscalationService.getActiveEscalationSync();
+    const cached = EscalationService.getActiveEscalationSync(runtime);
     if (cached) return cached;
 
     const persisted = await loadActiveFromCache(runtime);
     if (persisted) {
-      activeEscalations.set(persisted.id, persisted);
+      escalationsFor(agentIdOf(runtime)).set(persisted.id, persisted);
       return persisted;
     }
     return null;
@@ -608,8 +694,10 @@ export class EscalationService {
 
   static async rehydrateFromDb(runtime: IAgentRuntime): Promise<void> {
     const persisted = await loadActiveFromCache(runtime);
-    if (persisted && !activeEscalations.has(persisted.id)) {
-      activeEscalations.set(persisted.id, persisted);
+    if (!persisted) return;
+    const bucket = escalationsFor(agentIdOf(runtime));
+    if (!bucket.has(persisted.id)) {
+      bucket.set(persisted.id, persisted);
       logger.info(
         `[escalation] Rehydrated unresolved escalation ${persisted.id} from cache`,
       );
@@ -617,10 +705,29 @@ export class EscalationService {
   }
 
   static _reset(): void {
-    for (const timer of pendingTimers.values()) clearTimeout(timer);
+    for (const bucket of pendingTimers.values()) {
+      for (const timer of bucket.values()) clearTimeout(timer);
+    }
     pendingTimers.clear();
     activeEscalations.clear();
     idCounter = 0;
+  }
+
+  /**
+   * Test-only: whether `pendingTimers` still holds a bucket for this agent,
+   * including an empty one. Production cleanup must delete the outer entry
+   * when the last timer is released.
+   */
+  static _hasPendingTimerBucket(agentId: string): boolean {
+    return pendingTimers.has(agentId);
+  }
+
+  /**
+   * Test-only: whether `activeEscalations` still holds a bucket for this agent,
+   * including an empty one. Read-only lookups must not allocate one.
+   */
+  static _hasActiveEscalationBucket(agentId: string): boolean {
+    return activeEscalations.has(agentId);
   }
 
   static async _resetDb(runtime: IAgentRuntime): Promise<void> {


### PR DESCRIPTION
## Summary

- replaces #24160 on current `develop`, preserving the original contributor's per-agent escalation isolation fix
- partitions active escalation and timer state by agent and updates the trigger/provider callers
- removes empty per-agent timer buckets on fire and resolution
- fixes an additional review finding: rehydrating an agent with no persisted escalation no longer allocates an empty retained bucket

## Verification

Exact pre-push head: `c68b8166b601ab655e1a40da57a5693b5d5a9563`

- focused Vitest: 2 files, 41 tests passed
- changed-file Biome: 4 files clean
- `git diff --check`: passed before rebase; no whitespace changes introduced by the clean rebase
- full agent typecheck was attempted but this reused worktree lacks built exports for several unrelated optional workspace plugins; hosted CI is the authoritative full workspace closure

No UI, external connector, or live-model path changes. The executable evidence uses two runtime identities, independent cache rows, same-agent coalescing, timer cleanup, resolution isolation, and empty rehydration.

Supersedes #24160.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-pr-audit]
