### PR TITLE
fix(cloud): preserve MCP info pricing contract

### DIFF
--- a/packages/cloud/api/__tests__/mcp-info-inventory.test.ts
+++ b/packages/cloud/api/__tests__/mcp-info-inventory.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { PLATFORM_MCP_TOOL_PRICING } from "@elizaos/cloud-shared/billing";
 
 import { listPlatformCloudMcpTools } from "@/lib/mcp/platform-cloud-tools";
 
@@ -33,6 +34,7 @@ type InfoBody = {
     type: string;
     description: string;
     creditUnit: string;
+    rates: Record<string, string>;
   };
   authentication: { type: string; header: string; description: string };
   status: string;
@@ -83,6 +85,12 @@ describe("GET /api/mcp/info advertises exactly the served inventory", () => {
     expect(body.authRequired).toBe(true);
     expect(body.status).toBe("live");
     expect(body.pricing.creditUnit).toBe("USD");
+    expect(body.pricing.rates.save_memory).toBe(
+      PLATFORM_MCP_TOOL_PRICING.save_memory.label,
+    );
+    expect(body.pricing.rates.retrieve_memories).toBe(
+      PLATFORM_MCP_TOOL_PRICING.retrieve_memories.label,
+    );
     expect(body.authentication.type).toBe("Bearer");
     expect(body.authentication.header).toBe("Authorization");
   });

--- a/packages/cloud/api/mcp/info/route.ts
+++ b/packages/cloud/api/mcp/info/route.ts
@@ -11,6 +11,10 @@
  * unauthenticated and requires no DB or env access.
  */
 
+import {
+  MCP_USAGE_BASED_COST_LABEL,
+  PLATFORM_MCP_TOOL_PRICING,
+} from "@elizaos/cloud-shared/billing";
 import { Hono } from "hono";
 
 import { listPlatformCloudMcpTools } from "@/lib/mcp/platform-cloud-tools";
@@ -48,6 +52,18 @@ app.get("/", (c) => {
       description:
         "Uses your organization's USD-denominated cloud-credit balance",
       creditUnit: "USD",
+      // Stable compatibility metadata consumed independently of the executable
+      // `tools` inventory. Prices come from the billing authority rather than
+      // being inferred from the current platform registry.
+      rates: {
+        generate_text: "Varies by model and tokens",
+        generate_image: MCP_USAGE_BASED_COST_LABEL,
+        search_web: MCP_USAGE_BASED_COST_LABEL,
+        extract_page: MCP_USAGE_BASED_COST_LABEL,
+        browser_session: MCP_USAGE_BASED_COST_LABEL,
+        save_memory: PLATFORM_MCP_TOOL_PRICING.save_memory.label,
+        retrieve_memories: PLATFORM_MCP_TOOL_PRICING.retrieve_memories.label,
+      },
     },
     authentication: {
       type: "Bearer",


### PR DESCRIPTION
## Summary

Immediate compatibility follow-up to #24653. The inventory endpoint remains derived from the executable platform MCP registry, while the stable `pricing.rates` discovery contract is restored from the canonical billing authority.

- restore `pricing.rates` for the existing public discovery shape
- derive memory prices from `PLATFORM_MCP_TOOL_PRICING`
- retain the established usage-based labels for metered non-memory tools
- assert the stable memory-rate fields in the inventory regression suite

## Verification

Exact head: `5f9a03aca5b8d441fcc28c4235f3674781d90f02`

- `mcp-info-inventory.test.ts`: 6/6 assertions passed
- `mcp-pricing-contract.test.ts`: 3/3 passed
- `mcp-memory-pricing-contract.test.ts`: 1/1 passed
- changed-file Biome: clean
- package typecheck reaches an unrelated current-workspace missing dependency: `@elizaos/plugin-doordash` from `packages/cloud/shared/src/lib/eliza/runtime/initializer.ts`

The focused Bun assertions pass after the rebase. The inventory invocation subsequently hit Bun coverage reporter `WriteFailed` while printing monorepo-wide coverage; no test assertion failed.

Fixes the compatibility regression introduced by #24653. Related: #24645.
