### PR TITLE
fix(agent): expire settled idempotency before fingerprint check

### DIFF
--- a/packages/agent/src/services/chat-idempotency-service.test.ts
+++ b/packages/agent/src/services/chat-idempotency-service.test.ts
@@ -147,4 +147,92 @@ describe("chat idempotency store", () => {
       store.admit("principal-b:room", "id", { fingerprint: "request" }).kind,
     ).toBe("owner");
   });
+
+  // `settle` stamps `settledAt` from the real clock while `admit` accepts an
+  // injected `now`. The suite's other expiry cases pass `now: 3`, which makes
+  // `now - settledAt` hugely negative, so the retention branch can never fire
+  // there. These cases derive `now` from the real clock so it actually does.
+  it("re-admits a key reused after the retention window with new content", () => {
+    const store = createChatIdempotencyStore<{ value: string }>({
+      retentionMs: 10,
+    });
+    const owner = store.admit("principal:room", "id", {
+      fingerprint: "request-a",
+    });
+    if (owner.kind !== "owner") throw new Error("fixture admission failed");
+    store.settle("principal:room", "id", { value: "done" }, owner.reservation);
+
+    const afterRetention = Date.now() + store.retentionMs + 1;
+    const replacement = store.admit("principal:room", "id", {
+      fingerprint: "request-b",
+      now: afterRetention,
+    });
+    expect(replacement.kind).toBe("owner");
+    if (replacement.kind !== "owner") throw new Error("re-admission failed");
+
+    store.settle(
+      "principal:room",
+      "id",
+      { value: "second" },
+      replacement.reservation,
+    );
+    expect(store.outcome("principal:room", "id")).toEqual({ value: "second" });
+  });
+
+  it("still conflicts and still replays inside the retention window", () => {
+    const store = createChatIdempotencyStore<{ value: string }>({
+      retentionMs: 60_000,
+    });
+    const owner = store.admit("principal:room", "id", {
+      fingerprint: "request-a",
+    });
+    if (owner.kind !== "owner") throw new Error("fixture admission failed");
+    store.settle("principal:room", "id", { value: "done" }, owner.reservation);
+
+    const inWindow = Date.now() + 1_000;
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-b",
+        now: inWindow,
+      }),
+    ).toMatchObject({
+      kind: "conflict",
+      error: { code: "CHAT_IDEMPOTENCY_CONFLICT" },
+    });
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-a",
+        now: inWindow,
+      }),
+    ).toMatchObject({ kind: "settled", outcome: { value: "done" } });
+  });
+
+  it("does not retire an ACTIVE turn no matter how old it is", () => {
+    const store = createChatIdempotencyStore<{ value: string }>({
+      retentionMs: 10,
+    });
+    const owner = store.admit("principal:room", "id", {
+      fingerprint: "request-a",
+    });
+    if (owner.kind !== "owner") throw new Error("fixture admission failed");
+
+    // Never settled, so retention does not apply: a long-running generation
+    // keeps its reservation and a different payload still conflicts.
+    const muchLater = Date.now() + 60 * 60_000;
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-a",
+        now: muchLater,
+      }).kind,
+    ).toBe("duplicate");
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-b",
+        now: muchLater,
+      }),
+    ).toMatchObject({
+      kind: "conflict",
+      error: { code: "CHAT_IDEMPOTENCY_CONFLICT" },
+    });
+  });
 });

--- a/packages/agent/src/services/chat-idempotency-service.ts
+++ b/packages/agent/src/services/chat-idempotency-service.ts
@@ -139,7 +139,23 @@ export function createChatIdempotencyStore<Outcome>(options?: {
     const key = keyFor(scope, clientMessageId);
     const current = entries.get(key);
     if (current) {
-      if (
+      // Retire a settled entry that has outlived the retention window BEFORE
+      // comparing fingerprints. Past `retentionMs` the reservation no longer
+      // exists as far as this contract is concerned, so a client reusing the
+      // same `clientMessageId` for genuinely new content is a fresh request.
+      // Comparing fingerprints first pinned the key to its original content
+      // permanently — the caller got CHAT_IDEMPOTENCY_CONFLICT forever, and
+      // the route layer hands that value straight to the client as an SSE
+      // error. It also returned before the opportunistic sweep below, so the
+      // dead entry was never collected either. `reserve()` already retires the
+      // expired entry first; this makes `admit()` agree with it.
+      const settledAndExpired =
+        current.status === "settled" &&
+        current.settledAt !== undefined &&
+        now - current.settledAt > retentionMs;
+      if (settledAndExpired) {
+        entries.delete(key);
+      } else if (
         current.fingerprint !== undefined &&
         options.fingerprint !== current.fingerprint
       ) {
@@ -147,13 +163,6 @@ export function createChatIdempotencyStore<Outcome>(options?: {
           kind: "conflict",
           error: new ChatIdempotencyConflictError(scope, clientMessageId),
         };
-      }
-      if (
-        current.status === "settled" &&
-        current.settledAt !== undefined &&
-        now - current.settledAt > retentionMs
-      ) {
-        entries.delete(key);
       } else if (
         current.status === "settled" &&
         current.outcome !== undefined


### PR DESCRIPTION
## Summary

- replaces #24137 on current `develop`
- retires settled chat-idempotency entries after their retention window before comparing request fingerprints
- preserves conflict/replay behavior inside retention and duplicate protection for active turns

Previously, a reused client message ID with new content conflicted forever because fingerprint comparison returned before the expired settled entry could be removed. The admission path now matches the existing reservation expiry contract.

## Verification

- focused Vitest: 1 file, 11 tests passed
- changed-file Biome: 2 files clean
- tests cover post-retention reuse, in-window replay/conflict, and old-but-active turns

No UI, connector, model, or schema changes. Supersedes #24137.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-pr-audit]
