### PR TITLE
fix(cloud): let managed Discord agents evaluate ambient turns

### DIFF
--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -40,6 +40,7 @@ import { pollTrackedDiscordDms, type TrackedDiscordDm } from "./dm-polling";
 import { tryConfirmDiscordIdentityLink } from "./identity-link";
 import { invalidIntegerEnvError, parseIntegerEnvValue } from "./integer-env";
 import { logger } from "./logger";
+import { managedGuildMessageTurn } from "./managed-guild-message-policy";
 import {
   createManagedGuildVoiceCloudBridge,
   MANAGED_GUILD_VOICE_INTENT,
@@ -2545,31 +2546,14 @@ export class GatewayManager {
       return;
     }
 
-    const trimmedContent = message.content.trim();
-    if (!trimmedContent) {
-      return;
-    }
-
-    const botMentionRegex = new RegExp(`<@!?${botUserId}>`, "g");
-    const botMentioned =
-      message.mentions.users.has(botUserId) ||
-      botMentionRegex.test(trimmedContent);
-    if (!botMentioned) {
-      return;
-    }
-
-    const mentionedOtherUser = message.mentions.users.some(
-      (user: { id: string }) => user.id !== botUserId,
-    );
-    const repliedUserId = message.mentions.repliedUser?.id;
-    const repliedToAnotherUser = Boolean(
-      repliedUserId && repliedUserId !== botUserId,
-    );
-    if (
-      mentionedOtherUser ||
-      message.mentions.everyone ||
-      repliedToAnotherUser
-    ) {
+    const turn = managedGuildMessageTurn({
+      botUserId,
+      content: message.content,
+      mentionedUserIds: message.mentions.users.map((user) => user.id),
+      repliedUserId: message.mentions.repliedUser?.id,
+      mentionsEveryone: message.mentions.everyone,
+    });
+    if (!turn) {
       logger.debug("Ignoring managed guild message that targets someone else", {
         guildId: message.guildId,
         channelId: message.channelId,
@@ -2578,12 +2562,7 @@ export class GatewayManager {
       return;
     }
 
-    const sanitizedContent = trimmedContent.replace(botMentionRegex, "").trim();
-    if (!sanitizedContent) {
-      return;
-    }
-
-    await this.routeManagedAgentMessage(message, sanitizedContent);
+    await this.routeManagedAgentMessage(message, turn.content);
   }
 
   private async routeManagedAgentMessage(

--- a/packages/cloud/services/gateway-discord/src/managed-guild-message-policy.ts
+++ b/packages/cloud/services/gateway-discord/src/managed-guild-message-policy.ts
@@ -1,0 +1,57 @@
+/**
+ * Decides which managed Discord guild messages reach an Eliza runtime. The
+ * gateway excludes turns explicitly aimed only at someone else, while leaving
+ * ambient conversation to the runtime's contextual respond-or-ignore gate.
+ */
+
+export type ManagedGuildInvocation = "mention" | "reply" | "ambient";
+
+export interface ManagedGuildMessageInput {
+  botUserId: string;
+  content: string;
+  mentionedUserIds: readonly string[];
+  repliedUserId?: string | null;
+  mentionsEveryone?: boolean;
+}
+
+export interface ManagedGuildMessageTurn {
+  content: string;
+  invocation: ManagedGuildInvocation;
+}
+
+/**
+ * Returns the transport-clean turn to route, or `null` when Discord facts prove
+ * the message belongs only to another participant (or contains no usable text).
+ */
+export function managedGuildMessageTurn(
+  input: ManagedGuildMessageInput,
+): ManagedGuildMessageTurn | null {
+  const trimmedContent = input.content.trim();
+  if (!trimmedContent || !input.botUserId) return null;
+
+  const escapedBotUserId = input.botUserId.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    "\\$&",
+  );
+  const botMentionRegex = new RegExp(`<@!?${escapedBotUserId}>`, "g");
+  const botMentioned =
+    input.mentionedUserIds.includes(input.botUserId) ||
+    botMentionRegex.test(trimmedContent);
+  const repliedToBot = input.repliedUserId === input.botUserId;
+  const targetsOtherParticipant =
+    input.mentionedUserIds.some((userId) => userId !== input.botUserId) ||
+    Boolean(input.mentionsEveryone) ||
+    Boolean(input.repliedUserId && !repliedToBot);
+
+  // A deliberate call to Eliza wins over a co-mention: role calls commonly
+  // name several agents at once, and each named agent should receive the turn.
+  if (!botMentioned && !repliedToBot && targetsOtherParticipant) return null;
+
+  const content = trimmedContent.replace(botMentionRegex, "").trim();
+  if (!content) return null;
+
+  return {
+    content,
+    invocation: botMentioned ? "mention" : repliedToBot ? "reply" : "ambient",
+  };
+}

--- a/packages/cloud/services/gateway-discord/tests/managed-guild-message-policy.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/managed-guild-message-policy.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Verifies managed Discord guild ingress with deterministic platform facts.
+ * The harness is pure and covers direct, ambient, and other-target routing.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { managedGuildMessageTurn } from "../src/managed-guild-message-policy";
+
+const BOT_ID = "100000000000000001";
+const OTHER_ID = "200000000000000002";
+
+function turn(
+  overrides: Partial<Parameters<typeof managedGuildMessageTurn>[0]> = {},
+) {
+  return managedGuildMessageTurn({
+    botUserId: BOT_ID,
+    content: "what's going on",
+    mentionedUserIds: [],
+    ...overrides,
+  });
+}
+
+describe("managedGuildMessageTurn", () => {
+  test("routes ambient follow-ups for contextual runtime evaluation", () => {
+    expect(turn()).toEqual({
+      content: "what's going on",
+      invocation: "ambient",
+    });
+  });
+
+  test("routes textual by-name messages without requiring a native tag", () => {
+    expect(turn({ content: "Eliza, are you awake?" })).toEqual({
+      content: "Eliza, are you awake?",
+      invocation: "ambient",
+    });
+  });
+
+  test("routes a native mention and removes only the bot pointer", () => {
+    expect(
+      turn({
+        content: `<@${BOT_ID}> gm`,
+        mentionedUserIds: [BOT_ID],
+      }),
+    ).toEqual({ content: "gm", invocation: "mention" });
+  });
+
+  test("routes role calls that mention Eliza alongside other participants", () => {
+    expect(
+      turn({
+        content: `<@${BOT_ID}> <@${OTHER_ID}> role call, who's awake`,
+        mentionedUserIds: [BOT_ID, OTHER_ID],
+      }),
+    ).toEqual({
+      content: `<@${OTHER_ID}> role call, who's awake`,
+      invocation: "mention",
+    });
+  });
+
+  test("routes a direct reply to Eliza without requiring another mention", () => {
+    expect(turn({ content: "what about now?", repliedUserId: BOT_ID })).toEqual(
+      {
+        content: "what about now?",
+        invocation: "reply",
+      },
+    );
+  });
+
+  test.each([
+    { label: "mentions another user", mentionedUserIds: [OTHER_ID] },
+    {
+      label: "replies to another user",
+      mentionedUserIds: [],
+      repliedUserId: OTHER_ID,
+    },
+    {
+      label: "mentions everyone",
+      mentionedUserIds: [],
+      mentionsEveryone: true,
+    },
+  ])(
+    "ignores a message that only $label",
+    ({ label: _label, ...targeting }) => {
+      expect(turn(targeting)).toBeNull();
+    },
+  );
+
+  test.each([
+    { label: "empty text", content: "" },
+    {
+      label: "bare mention",
+      content: `<@${BOT_ID}>`,
+      mentionedUserIds: [BOT_ID],
+    },
+  ])("ignores $label", ({ label: _label, ...message }) => {
+    expect(turn(message)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- let managed Shared and Dedicated/VPS Discord agents receive ambient guild turns so the runtime can make the contextual respond-or-ignore decision
- recognize direct replies and native co-mentions, including multi-agent role calls
- continue suppressing turns explicitly aimed only at another user or `@everyone`, and reject empty/bare-pointer messages

## Verification

- `bun run test` in `packages/cloud/services/gateway-discord` — 172 pass, 0 fail
- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run build` — pass
- `bun run verify` — blocked by 16 pre-existing `@elizaos/capacitor-secure-store` workspace-resolution violations, reproduced on clean `origin/develop` at `c753f28052bb4`

## Evidence

| Surface | Evidence |
| --- | --- |
| Managed Discord routing | deterministic tests cover ambient follow-up, textual by-name input, native mention, co-mention role call, and direct reply |
| Other-target suppression | deterministic tests cover another-user mention/reply and `@everyone` |
| UI screenshots/video | N/A — gateway-only change with no UI surface |
| Live Discord | Pending deployment of the merged gateway revision; no production deploy performed from this PR |

Fixes #24647
