### PR TITLE
fix(agent): supersede stale registry loads on refresh

### DIFF
--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -1,0 +1,275 @@
+/**
+ * `refreshRegistry` clears the caches and then delegates to
+ * `getRegistryPlugins`, which returns any load that is already in flight. That
+ * load carries a pre-refresh snapshot, so a force-refresh must not adopt it —
+ * nor let it stamp a fresh TTL over the refreshed result afterwards.
+ *
+ * The registry caches are module-level, so every case re-imports the module
+ * through `vi.resetModules()`. The listing-route case uses the real refresh
+ * function so cache teardown failures are covered at the HTTP boundary too.
+ */
+
+import fsp from "node:fs/promises";
+import type http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleRegistryRoutes,
+  type RegistryRouteContext,
+} from "../api/registry-routes.ts";
+
+let stateDir: string;
+let fetchImpl: () => Promise<Map<string, unknown>>;
+let fetchCalls = 0;
+
+vi.mock("../config/paths.ts", () => ({
+  resolveStateDir: () => stateDir,
+}));
+
+vi.mock("../config/config.ts", () => ({
+  loadElizaConfig: () => ({}),
+  saveElizaConfig: () => {},
+}));
+
+vi.mock("./registry-client-local.ts", () => ({
+  applyLocalWorkspaceApps: async () => {},
+  applyNodeModulePlugins: async () => {},
+}));
+
+vi.mock("./registry-client-network.ts", () => ({
+  fetchFromNetwork: async () => {
+    fetchCalls += 1;
+    return fetchImpl();
+  },
+  isExpectedRegistryNetworkFallback: () => true,
+}));
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const PAYLOAD_A = () =>
+  new Map([["plugin-a", { name: "plugin-a", npm: { v2Version: null } }]]);
+const PAYLOAD_B = () =>
+  new Map([["plugin-b", { name: "plugin-b", npm: { v2Version: null } }]]);
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./registry-client.ts");
+}
+
+beforeEach(async () => {
+  stateDir = await fsp.mkdtemp(path.join(os.tmpdir(), "registry-refresh-"));
+  fetchCalls = 0;
+  fetchImpl = async () => PAYLOAD_A();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fsp.rm(stateDir, { recursive: true, force: true });
+});
+
+describe("refreshRegistry", () => {
+  it("does not adopt a load that started before the refresh", async () => {
+    fetchImpl = async () => {
+      await sleep(200);
+      return PAYLOAD_A();
+    };
+    const { getRegistryPlugins, refreshRegistry } = await loadModule();
+
+    const inFlight = getRegistryPlugins();
+    await sleep(20);
+    fetchImpl = async () => PAYLOAD_B();
+
+    const refreshed = await refreshRegistry();
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+
+    // The refreshed snapshot must also survive the older load completing.
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-b"]);
+    await inFlight;
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-b"]);
+  });
+
+  it("still refetches when no load is in flight", async () => {
+    const { refreshRegistry } = await loadModule();
+
+    const refreshed = await refreshRegistry();
+
+    expect([...refreshed.keys()]).toEqual(["plugin-a"]);
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("still shares one load between concurrent callers", async () => {
+    fetchImpl = async () => {
+      await sleep(50);
+      return PAYLOAD_A();
+    };
+    const { getRegistryPlugins } = await loadModule();
+
+    const [first, second, third] = await Promise.all([
+      getRegistryPlugins(),
+      getRegistryPlugins(),
+      getRegistryPlugins(),
+    ]);
+
+    expect(fetchCalls).toBe(1);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it("still serves a fresh file cache without a network call", async () => {
+    await fsp.mkdir(path.join(stateDir, "cache"), { recursive: true });
+    await fsp.writeFile(
+      path.join(stateDir, "cache", "registry.json"),
+      JSON.stringify({
+        fetchedAt: Date.now(),
+        plugins: [["plugin-file", { name: "plugin-file" }]],
+      }),
+    );
+    const { getRegistryPlugins } = await loadModule();
+
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-file"]);
+    expect(fetchCalls).toBe(0);
+  });
+
+  it.each(["EACCES", "EROFS"] as const)(
+    "still returns fresh network data when cache removal fails with %s",
+    async (code) => {
+      const cachePath = path.join(stateDir, "cache", "registry.json");
+      await fsp.mkdir(path.dirname(cachePath), { recursive: true });
+      await fsp.writeFile(
+        cachePath,
+        JSON.stringify({
+          fetchedAt: Date.now(),
+          plugins: [...PAYLOAD_A().entries()],
+        }),
+      );
+      fetchImpl = async () => PAYLOAD_B();
+      const cause = Object.assign(new Error(`unlink failed: ${code}`), {
+        code,
+      });
+      vi.spyOn(fsp, "unlink").mockRejectedValueOnce(cause);
+      const registry = await loadModule();
+
+      const refreshed = await registry.refreshRegistry();
+
+      expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+      expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
+        "plugin-b",
+      ]);
+      expect(fetchCalls).toBe(1);
+    },
+  );
+
+  it("keeps GET /api/registry/plugins available when cache removal fails", async () => {
+    const cachePath = path.join(stateDir, "cache", "registry.json");
+    await fsp.mkdir(path.dirname(cachePath), { recursive: true });
+    await fsp.writeFile(
+      cachePath,
+      JSON.stringify({
+        fetchedAt: Date.now(),
+        plugins: [...PAYLOAD_A().entries()],
+      }),
+    );
+    fetchImpl = async () => PAYLOAD_B();
+    vi.spyOn(fsp, "unlink").mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    );
+    const registry = await loadModule();
+    const json = vi.fn();
+    const error = vi.fn();
+    const res = {} as http.ServerResponse;
+    const ctx = {
+      req: { method: "GET", url: "/api/registry/plugins" },
+      res,
+      method: "GET",
+      pathname: "/api/registry/plugins",
+      url: new URL("http://localhost/api/registry/plugins"),
+      json,
+      error,
+      getPluginManager: () => ({
+        refreshRegistry: registry.refreshRegistry,
+        listInstalledPlugins: async () => [],
+        getRegistryPlugin: async () => null,
+        searchRegistry: async () => [],
+      }),
+      getLoadedPluginNames: () => [],
+      getBundledPluginIds: () => new Set<string>(),
+      classifyRegistryPluginRelease: () => ({ status: "compatible" }),
+    } as unknown as RegistryRouteContext;
+
+    await expect(handleRegistryRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(res, {
+      count: 1,
+      plugins: [expect.objectContaining({ name: "plugin-b" })],
+    });
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("still supersedes an in-flight load when cache removal fails", async () => {
+    let releaseFetch: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    fetchImpl = async () => {
+      await fetchGate;
+      return PAYLOAD_A();
+    };
+    const registry = await loadModule();
+    const first = registry.getRegistryPlugins();
+    while (fetchCalls === 0) await sleep(1);
+    fetchImpl = async () => PAYLOAD_B();
+
+    const cause = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+    });
+    vi.spyOn(fsp, "unlink").mockRejectedValueOnce(cause);
+    const refreshed = await registry.refreshRegistry();
+
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+    expect(fetchCalls).toBe(2);
+    releaseFetch?.();
+
+    expect([...(await first).keys()]).toEqual(["plugin-a"]);
+    expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-b",
+    ]);
+  });
+
+  it("does not publish a file-cache read that began before refresh", async () => {
+    const cachePath = path.join(stateDir, "cache", "registry.json");
+    const staleCache = JSON.stringify({
+      fetchedAt: Date.now(),
+      plugins: [...PAYLOAD_A().entries()],
+    });
+    await fsp.mkdir(path.dirname(cachePath), { recursive: true });
+    await fsp.writeFile(cachePath, staleCache);
+
+    let signalReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      signalReadStarted = resolve;
+    });
+    let releaseRead: (() => void) | undefined;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    vi.spyOn(fsp, "readFile").mockImplementationOnce(async () => {
+      signalReadStarted?.();
+      await readGate;
+      return staleCache;
+    });
+    fetchImpl = async () => PAYLOAD_B();
+    const registry = await loadModule();
+
+    const staleCaller = registry.getRegistryPlugins();
+    await readStarted;
+    const refreshed = await registry.refreshRegistry();
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+
+    releaseRead?.();
+    expect([...(await staleCaller).keys()]).toEqual(["plugin-a"]);
+    expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-b",
+    ]);
+  });
+});

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -80,6 +80,12 @@ let memoryCache: {
   ttlMs?: number;
 } | null = null;
 let registryLoadPromise: Promise<Map<string, RegistryPluginInfo>> | null = null;
+/**
+ * Bumped every time the registry caches are invalidated. A load that started
+ * before the bump carries a pre-invalidation snapshot, so it must not publish
+ * that snapshot (or stamp a fresh TTL over it) once it finally resolves.
+ */
+let registryGeneration = 0;
 
 const LOCAL_FALLBACK_CACHE_TTL_MS = 5 * 60_000;
 
@@ -239,10 +245,9 @@ export function isDefaultEndpoint(url: string): boolean {
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Get all plugins. Resolution: memory → file → network. */
-export async function getRegistryPlugins(): Promise<
-  Map<string, RegistryPluginInfo>
-> {
+async function loadRegistryPlugins(
+  skipFileCache: boolean,
+): Promise<Map<string, RegistryPluginInfo>> {
   if (
     memoryCache &&
     Date.now() - memoryCache.fetchedAt < (memoryCache.ttlMs ?? CACHE_TTL_MS)
@@ -250,20 +255,30 @@ export async function getRegistryPlugins(): Promise<
     return memoryCache.plugins;
   }
 
-  const fromFile = await readFileCache();
-  if (fromFile) {
-    await applyLocalWorkspaceApps(fromFile);
-    await applyNodeModulePlugins(fromFile);
-    await mergeCustomEndpoints(fromFile, getConfiguredEndpoints());
-    memoryCache = { plugins: fromFile, fetchedAt: Date.now() };
-    return fromFile;
+  if (!skipFileCache) {
+    const fileReadGeneration = registryGeneration;
+    const fromFile = await readFileCache();
+    if (fromFile) {
+      await applyLocalWorkspaceApps(fromFile);
+      await applyNodeModulePlugins(fromFile);
+      await mergeCustomEndpoints(fromFile, getConfiguredEndpoints());
+
+      // A refresh can unlink the cache while an earlier read still owns an open
+      // file handle. Return that snapshot only to its original caller; publishing
+      // it would replace the post-refresh memory cache with stale disk state.
+      if (fileReadGeneration !== registryGeneration) return fromFile;
+
+      memoryCache = { plugins: fromFile, fetchedAt: Date.now() };
+      return fromFile;
+    }
   }
 
   if (registryLoadPromise) {
     return registryLoadPromise;
   }
 
-  registryLoadPromise = (async () => {
+  const generation = registryGeneration;
+  const load: Promise<Map<string, RegistryPluginInfo>> = (async () => {
     logger.info("[registry-client] Fetching plugin registry...");
     let plugins: Map<string, RegistryPluginInfo>;
     let usedLocalFallback = false;
@@ -286,6 +301,11 @@ export async function getRegistryPlugins(): Promise<
     await mergeCustomEndpoints(plugins, getConfiguredEndpoints());
     logger.info(`[registry-client] Loaded ${plugins.size} plugins`);
 
+    // The caches were invalidated after this load started, so this snapshot is
+    // already known to be stale. Hand it to the callers that are awaiting it,
+    // but never publish it.
+    if (generation !== registryGeneration) return plugins;
+
     memoryCache = {
       plugins,
       fetchedAt: Date.now(),
@@ -299,23 +319,66 @@ export async function getRegistryPlugins(): Promise<
 
     return plugins;
   })().finally(() => {
-    registryLoadPromise = null;
+    // Only clear the slot if it is still this load's; an invalidation may have
+    // already replaced it with a newer one.
+    if (registryLoadPromise === load) registryLoadPromise = null;
   });
+  registryLoadPromise = load;
 
-  return registryLoadPromise;
+  return load;
+}
+
+/** Get all plugins. Resolution: memory → file → network. */
+export async function getRegistryPlugins(): Promise<
+  Map<string, RegistryPluginInfo>
+> {
+  return loadRegistryPlugins(false);
+}
+
+/**
+ * Drop every cached registry snapshot, including one that is still loading.
+ * Clearing `memoryCache` alone is not enough: an in-flight load returns its
+ * pre-invalidation snapshot to the refresher and then republishes it with a
+ * fresh TTL, which suppresses later refreshes for the full cache lifetime.
+ */
+function invalidateRegistryCaches(): void {
+  memoryCache = null;
+  registryLoadPromise = null;
+  registryGeneration += 1;
+}
+
+function hasFilesystemErrorCode(error: unknown, code: string): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+async function removeRegistryFileCache(): Promise<void> {
+  const filePath = cacheFilePath();
+  try {
+    await fs.unlink(filePath);
+  } catch (error) {
+    if (hasFilesystemErrorCode(error, "ENOENT")) return;
+    // error-policy:J6 File-cache removal is best-effort teardown. The refresh
+    // below bypasses the retained file and obtains a complete network snapshot.
+    logger.warn(
+      `[registry-client] Cache removal failed at ${filePath}; forcing an uncached refresh: ${String(error)}`,
+    );
+  }
 }
 
 /** Force-refresh from network. */
 export async function refreshRegistry(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  memoryCache = null;
-  try {
-    await fs.unlink(cacheFilePath());
-  } catch {
-    // Missing cache files are fine; the network refresh below repopulates it.
-  }
-  return getRegistryPlugins();
+  // Removal is useful persistent cleanup but is not required for correctness:
+  // the refresh explicitly bypasses the file tier even when unlink is denied.
+  await removeRegistryFileCache();
+  invalidateRegistryCaches();
+  return loadRegistryPlugins(true);
 }
 
 /** Look up a plugin by name (exact → @elizaos/ prefix → bare suffix). */


### PR DESCRIPTION
## Summary

- replaces #24118 on current `develop`
- gives registry cache loads a generation so pre-refresh file/network snapshots cannot overwrite refreshed state
- makes forced refresh bypass the file cache even when cache-file deletion is unavailable
- preserves shared concurrent loads and fresh file-cache behavior outside explicit refresh

## Verification

- focused Vitest: 1 file, 9 tests passed
- changed-file Biome: 2 files clean
- coverage includes in-flight network loads, in-flight file reads, concurrent callers, unlink failures, and the registry HTTP listing boundary

No UI, model, schema, or external mutation changes. Supersedes #24118.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-pr-audit]
