### PR TITLE
fix(shared): fence late sandbox heartbeat renewal

### DIFF
--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -35,12 +35,33 @@ const recorded: Recorded[] = [];
 const store = new Map<string, string>();
 let failNextFetch = false;
 let nextPipelineResponse: unknown = null;
+let nextPipelineDelay: {
+  started: () => void;
+  wait: Promise<void>;
+} | null = null;
+
+function delayNextPipeline(): {
+  started: Promise<void>;
+  release: () => void;
+} {
+  let markStarted: () => void = () => {};
+  let release: () => void = () => {};
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  nextPipelineDelay = { started: markStarted, wait };
+  return { started, release };
+}
 
 function installFetch(): void {
   recorded.length = 0;
   store.clear();
   failNextFetch = false;
   nextPipelineResponse = null;
+  nextPipelineDelay = null;
   global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     if (failNextFetch) {
       failNextFetch = false;
@@ -51,6 +72,12 @@ function installFetch(): void {
     recorded.push({ url, body });
 
     if (url.endsWith("/pipeline")) {
+      const delay = nextPipelineDelay;
+      if (delay) {
+        nextPipelineDelay = null;
+        delay.started();
+        await delay.wait;
+      }
       if (nextPipelineResponse !== null) {
         return {
           ok: true,
@@ -201,6 +228,101 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
 
     reg.stopHeartbeat();
+  });
+
+  it("does not overlap heartbeat refreshes when a tick is still in flight", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    recorded.length = 0;
+
+    const delayed = delayNextPipeline();
+    reg.startHeartbeat(30_000);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+
+    delayed.release();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(2);
+
+    reg.stopHeartbeat();
+  });
+
+  it("unregister() drains an in-flight heartbeat before deleting its keys", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    recorded.length = 0;
+
+    const delayed = delayNextPipeline();
+    reg.startHeartbeat(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+
+    const unregistering = reg.unregister();
+    await Promise.resolve();
+    expect(
+      recorded.some(
+        (request) => Array.isArray(request.body) && request.body[0] === "EVAL",
+      ),
+    ).toBe(false);
+
+    delayed.release();
+    await unregistering;
+    expect(store.has("agent:char-123:server")).toBe(false);
+    expect(store.has("server:sandbox-abc:url")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+  });
+
+  it("unregister() falls back within the shutdown margin without deleting keys", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    recorded.length = 0;
+
+    const delayed = delayNextPipeline();
+    reg.startHeartbeat(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+
+    const unregistering = reg.unregister();
+    const outcome = unregistering.then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    let settled = false;
+    const observed = outcome.then((result) => {
+      settled = true;
+      return result;
+    });
+
+    // The dev supervisor allows 15s while runtime service teardown may use
+    // 13s. Registry cleanup must settle well inside the remaining 2s margin.
+    await vi.advanceTimersByTimeAsync(999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(observed).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
+    });
+
+    expect(
+      recorded.some(
+        (request) => Array.isArray(request.body) && request.body[0] === "EVAL",
+      ),
+    ).toBe(false);
+    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
+    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
+    await vi.advanceTimersByTimeAsync(90_000);
+    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+
+    delayed.release();
+    await vi.advanceTimersByTimeAsync(0);
   });
 
   it("stopHeartbeat() halts the timer", async () => {

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -34,7 +34,7 @@ interface Recorded {
 const recorded: Recorded[] = [];
 const store = new Map<string, string>();
 let failNextFetch = false;
-let nextPipelineResponse: unknown = null;
+let nextCommandError: string | null = null;
 let nextWriteDelay: {
   started: () => void;
   wait: Promise<void>;
@@ -60,7 +60,7 @@ function installFetch(): void {
   recorded.length = 0;
   store.clear();
   failNextFetch = false;
-  nextPipelineResponse = null;
+  nextCommandError = null;
   nextWriteDelay = null;
   global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     if (failNextFetch) {
@@ -72,28 +72,13 @@ function installFetch(): void {
     recorded.push({ url, body });
 
     const command = Array.isArray(body) ? body[0] : undefined;
-    if (nextWriteDelay && (url.endsWith("/pipeline") || command === "EVAL")) {
+    if (nextWriteDelay && command === "EVAL") {
       const delay = nextWriteDelay;
       nextWriteDelay = null;
       delay.started();
       await delay.wait;
     }
 
-    if (url.endsWith("/pipeline")) {
-      if (nextPipelineResponse !== null) {
-        return {
-          ok: true,
-          json: async () => nextPipelineResponse,
-        } as unknown as Response;
-      }
-      for (const cmd of body as string[][]) {
-        if (cmd[0] === "SET") store.set(cmd[1], cmd[2]);
-      }
-      return {
-        ok: true,
-        json: async () => (body as unknown[]).map(() => ({ result: "OK" })),
-      } as unknown as Response;
-    }
     const cmd = body as string[];
     if (cmd[0] === "GET") {
       return {
@@ -109,24 +94,56 @@ function installFetch(): void {
       } as unknown as Response;
     }
     if (cmd[0] === "EVAL") {
-      const [, , , key1, key2, expected1, expected2] = cmd;
-      if (cmd.length === 8) {
-        const ttl = cmd[7];
+      if (nextCommandError !== null) {
+        const error = nextCommandError;
+        nextCommandError = null;
+        return {
+          ok: true,
+          json: async () => ({ error }),
+        } as Response;
+      }
+      const [
+        ,
+        script,
+        ,
+        key1,
+        key2,
+        generationKey,
+        value1,
+        value2,
+        generation,
+      ] = cmd;
+      if (script.includes("-- register")) {
+        store.set(key1, value1);
+        store.set(key2, value2);
+        store.set(generationKey, generation);
+        return { ok: true, json: async () => ({ result: 1 }) } as Response;
+      }
+      if (script.includes("-- refresh")) {
         const owned =
-          store.get(key1) === expected1 && store.get(key2) === expected2;
+          store.get(key1) === value1 &&
+          store.get(key2) === value2 &&
+          store.get(generationKey) === generation;
         if (owned) {
-          store.set(key1, expected1);
-          store.set(key2, expected2);
+          store.set(key1, value1);
+          store.set(key2, value2);
+          store.set(generationKey, generation);
         }
-        expect(Number(ttl)).toBeGreaterThan(0);
         return {
           ok: true,
           json: async () => ({ result: owned ? 1 : 0 }),
         } as Response;
       }
-      if (store.get(key1) === expected1) store.delete(key1);
-      if (store.get(key2) === expected2) store.delete(key2);
-      return { ok: true, json: async () => ({ result: 1 }) } as Response;
+      const owned = store.get(generationKey) === generation;
+      if (owned) {
+        if (store.get(key1) === value1) store.delete(key1);
+        if (store.get(key2) === value2) store.delete(key2);
+        store.delete(generationKey);
+      }
+      return {
+        ok: true,
+        json: async () => ({ result: owned ? 1 : 0 }),
+      } as Response;
     }
     return { ok: true, json: async () => ({ result: null }) } as Response;
   }) as unknown as typeof fetch;
@@ -148,36 +165,33 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     vi.restoreAllMocks();
   });
 
-  it("register() writes both keys with TTL via the pipeline endpoint", async () => {
+  it("register() writes public keys and a private generation fence atomically", async () => {
     const reg = new SandboxRegistry(baseConfig);
     await reg.register();
 
-    const pipe = recorded.find((r) => r.url.endsWith("/pipeline"));
-    expect(pipe).toBeTruthy();
-    const cmds = pipe?.body as string[][];
-    expect(cmds).toContainEqual([
-      "SET",
+    expect(recorded).toHaveLength(1);
+    const command = recorded[0]?.body as string[];
+    expect(command.slice(0, 6)).toEqual([
+      "EVAL",
+      expect.stringContaining("-- register"),
+      "3",
       "server:sandbox-abc:url",
-      "http://1.2.3.4:1999/api",
-      "EX",
-      "90",
-    ]);
-    expect(cmds).toContainEqual([
-      "SET",
       "agent:char-123:server",
-      "sandbox-abc",
-      "EX",
-      "90",
+      "server:sandbox-abc:registration",
     ]);
+    expect(command.slice(6, 8)).toEqual([
+      "http://1.2.3.4:1999/api",
+      "sandbox-abc",
+    ]);
+    expect(command[8]).toEqual(expect.any(String));
+    expect(command[9]).toBe("90");
   });
 
-  it("rejects a top-level Upstash pipeline error response", async () => {
-    nextPipelineResponse = { error: "pipeline unavailable" };
+  it("rejects a top-level Upstash registration error response", async () => {
+    nextCommandError = "registration unavailable";
     const reg = new SandboxRegistry(baseConfig);
 
-    await expect(reg.register()).rejects.toThrow(
-      "Upstash pipeline returned an invalid response",
-    );
+    await expect(reg.register()).rejects.toThrow("registration unavailable");
   });
 
   it("unregister() deletes keys only when they still point at this sandbox", async () => {
@@ -194,9 +208,13 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     // Simulate another sandbox claiming the agent.
     store.set("agent:char-123:server", "sandbox-other");
     store.set("server:sandbox-abc:url", "http://9.9.9.9:1/api");
+    store.set("server:sandbox-abc:registration", "successor-generation");
     await reg.unregister();
     expect(store.get("agent:char-123:server")).toBe("sandbox-other");
     expect(store.get("server:sandbox-abc:url")).toBe("http://9.9.9.9:1/api");
+    expect(store.get("server:sandbox-abc:registration")).toBe(
+      "successor-generation",
+    );
   });
 
   it("unregister() does not delete keys another sandbox claims in the same instant it decides to delete", async () => {
@@ -215,6 +233,7 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
         if (verb === "DEL" || verb === "EVAL") {
           store.set("agent:char-123:server", "sandbox-other");
           store.set("server:sandbox-abc:url", "http://9.9.9.9:1/api");
+          store.set("server:sandbox-abc:registration", "successor-generation");
         }
         return realFetch(input, init);
       },
@@ -224,6 +243,9 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
 
     expect(store.get("agent:char-123:server")).toBe("sandbox-other");
     expect(store.get("server:sandbox-abc:url")).toBe("http://9.9.9.9:1/api");
+    expect(store.get("server:sandbox-abc:registration")).toBe(
+      "successor-generation",
+    );
   });
 
   it("startHeartbeat() refreshes on the interval; errors do not kill the timer", async () => {
@@ -332,10 +354,11 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     expect(recorded).toHaveLength(2);
   });
 
-  it("a late heartbeat cannot replace a successor instance after drain timeout", async () => {
+  it("a late heartbeat cannot refresh or delete a same-identity successor", async () => {
     vi.useFakeTimers();
     const oldRegistry = new SandboxRegistry(baseConfig);
     await oldRegistry.register();
+    const oldGeneration = store.get("server:sandbox-abc:registration");
     recorded.length = 0;
 
     const delayed = delayNextRegistryWrite();
@@ -350,21 +373,19 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
       code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT",
     });
 
-    const successor = new SandboxRegistry({
-      ...baseConfig,
-      serverName: "sandbox-successor",
-      serverUrl: "http://5.6.7.8:2999/api",
-    });
+    const successor = new SandboxRegistry(baseConfig);
     await successor.register();
+    const successorGeneration = store.get("server:sandbox-abc:registration");
+    expect(successorGeneration).not.toBe(oldGeneration);
 
     delayed.release();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(store.get("agent:char-123:server")).toBe("sandbox-successor");
-    expect(store.get("server:sandbox-successor:url")).toBe(
-      "http://5.6.7.8:2999/api",
+    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
+    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
+    expect(store.get("server:sandbox-abc:registration")).toBe(
+      successorGeneration,
     );
-    expect(store.has("server:sandbox-abc:url")).toBe(false);
   });
 
   it("stopHeartbeat() halts the timer", async () => {
@@ -405,13 +426,10 @@ describe("buildSandboxRegistryFromEnv", () => {
     });
     expect(reg).not.toBeNull();
     await reg?.register();
-    const pipe = recorded.find((r) => r.url.endsWith("/pipeline"));
-    const cmds = pipe?.body as string[][];
+    const command = recorded[0]?.body as string[];
     // Must register under the routing character_id, not the sandbox id.
-    expect(cmds.some((c) => c[1] === "agent:char-a1f08a41:server")).toBe(true);
-    expect(cmds.some((c) => c[1] === "agent:sandbox-id-2facbf59:server")).toBe(
-      false,
-    );
+    expect(command).toContain("agent:char-a1f08a41:server");
+    expect(command).not.toContain("agent:sandbox-id-2facbf59:server");
   });
 
   it("falls back to SANDBOX_AGENT_ID when no route id is injected", () => {
@@ -564,21 +582,42 @@ async function startFakeRedis(opts?: {
           for (const k of cmd.slice(1)) if (store.delete(k)) n++;
           send(`:${n}\r\n`);
         } else if (verb === "EVAL") {
-          const [, , , key1, key2, expected1, expected2] = cmd;
-          if (cmd.length === 8) {
+          const [
+            ,
+            script,
+            ,
+            key1,
+            key2,
+            generationKey,
+            value1,
+            value2,
+            generation,
+          ] = cmd;
+          if (script.includes("-- register")) {
+            store.set(key1, value1);
+            store.set(key2, value2);
+            store.set(generationKey, generation);
+            send(":1\r\n");
+          } else if (script.includes("-- refresh")) {
             const owned =
-              store.get(key1) === expected1 && store.get(key2) === expected2;
+              store.get(key1) === value1 &&
+              store.get(key2) === value2 &&
+              store.get(generationKey) === generation;
             if (owned) {
-              store.set(key1, expected1);
-              store.set(key2, expected2);
+              store.set(key1, value1);
+              store.set(key2, value2);
+              store.set(generationKey, generation);
             }
             send(`:${owned ? 1 : 0}\r\n`);
-            cmd = tryParseCommand();
-            continue;
+          } else {
+            const owned = store.get(generationKey) === generation;
+            if (owned) {
+              if (store.get(key1) === value1) store.delete(key1);
+              if (store.get(key2) === value2) store.delete(key2);
+              store.delete(generationKey);
+            }
+            send(`:${owned ? 1 : 0}\r\n`);
           }
-          if (store.get(key1) === expected1) store.delete(key1);
-          if (store.get(key2) === expected2) store.delete(key2);
-          send(":1\r\n");
         } else {
           send("-ERR unknown command\r\n");
         }
@@ -644,6 +683,30 @@ describe("SandboxRegistry (native TCP transport)", () => {
     expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-successor");
     expect(fake.store.get("server:sandbox-tcp:url")).toBe(
       "http://5.6.7.8:1999/api",
+    );
+  });
+
+  it("a stale same-identity instance cannot refresh or unregister its TCP successor", async () => {
+    fake = await startFakeRedis();
+    const stale = new SandboxRegistry(tcpConfig(fake.port));
+    const successor = new SandboxRegistry(tcpConfig(fake.port));
+    await stale.register();
+    const staleGeneration = fake.store.get("server:sandbox-tcp:registration");
+    await successor.register();
+    const successorGeneration = fake.store.get(
+      "server:sandbox-tcp:registration",
+    );
+    expect(successorGeneration).not.toBe(staleGeneration);
+
+    await stale.refresh();
+    await stale.unregister();
+
+    expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");
+    expect(fake.store.get("server:sandbox-tcp:url")).toBe(
+      "http://5.6.7.8:1999/api",
+    );
+    expect(fake.store.get("server:sandbox-tcp:registration")).toBe(
+      successorGeneration,
     );
   });
 

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -120,10 +120,15 @@ function installFetch(): void {
         return { ok: true, json: async () => ({ result: 1 }) } as Response;
       }
       if (script.includes("-- refresh")) {
+        // Honor the script rather than assume it: each guard is applied only
+        // when the Lua actually carries it, so deleting a check from the real
+        // script makes this double stop enforcing it and the ownership tests
+        // fail. Otherwise the script — the thing Redis runs — is untested.
         const owned =
-          store.get(key1) === value1 &&
-          store.get(key2) === value2 &&
-          store.get(generationKey) === generation;
+          (!script.includes("u==ARGV[1]") || store.get(key1) === value1) &&
+          (!script.includes("s==ARGV[2]") || store.get(key2) === value2) &&
+          (!script.includes("g==ARGV[3]") ||
+            store.get(generationKey) === generation);
         if (owned) {
           store.set(key1, value1);
           store.set(key2, value2);
@@ -134,10 +139,14 @@ function installFetch(): void {
           json: async () => ({ result: owned ? 1 : 0 }),
         } as Response;
       }
-      const owned = store.get(generationKey) === generation;
+      const owned =
+        !script.includes("KEYS[3])~=ARGV[3]") ||
+        store.get(generationKey) === generation;
       if (owned) {
-        if (store.get(key1) === value1) store.delete(key1);
-        if (store.get(key2) === value2) store.delete(key2);
+        if (!script.includes("KEYS[1])==ARGV[1]") || store.get(key1) === value1)
+          store.delete(key1);
+        if (!script.includes("KEYS[2])==ARGV[2]") || store.get(key2) === value2)
+          store.delete(key2);
         store.delete(generationKey);
       }
       return {

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -113,8 +113,7 @@ function installFetch(): void {
       if (cmd.length === 8) {
         const ttl = cmd[7];
         const owned =
-          (store.get(key1) === expected1 && store.get(key2) === expected2) ||
-          (!store.has(key1) && !store.has(key2));
+          store.get(key1) === expected1 && store.get(key2) === expected2;
         if (owned) {
           store.set(key1, expected1);
           store.set(key2, expected2);
@@ -568,9 +567,7 @@ async function startFakeRedis(opts?: {
           const [, , , key1, key2, expected1, expected2] = cmd;
           if (cmd.length === 8) {
             const owned =
-              (store.get(key1) === expected1 &&
-                store.get(key2) === expected2) ||
-              (!store.has(key1) && !store.has(key2));
+              store.get(key1) === expected1 && store.get(key2) === expected2;
             if (owned) {
               store.set(key1, expected1);
               store.set(key2, expected2);

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -35,12 +35,12 @@ const recorded: Recorded[] = [];
 const store = new Map<string, string>();
 let failNextFetch = false;
 let nextPipelineResponse: unknown = null;
-let nextPipelineDelay: {
+let nextWriteDelay: {
   started: () => void;
   wait: Promise<void>;
 } | null = null;
 
-function delayNextPipeline(): {
+function delayNextRegistryWrite(): {
   started: Promise<void>;
   release: () => void;
 } {
@@ -52,7 +52,7 @@ function delayNextPipeline(): {
   const wait = new Promise<void>((resolve) => {
     release = resolve;
   });
-  nextPipelineDelay = { started: markStarted, wait };
+  nextWriteDelay = { started: markStarted, wait };
   return { started, release };
 }
 
@@ -61,7 +61,7 @@ function installFetch(): void {
   store.clear();
   failNextFetch = false;
   nextPipelineResponse = null;
-  nextPipelineDelay = null;
+  nextWriteDelay = null;
   global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     if (failNextFetch) {
       failNextFetch = false;
@@ -71,13 +71,15 @@ function installFetch(): void {
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
     recorded.push({ url, body });
 
+    const command = Array.isArray(body) ? body[0] : undefined;
+    if (nextWriteDelay && (url.endsWith("/pipeline") || command === "EVAL")) {
+      const delay = nextWriteDelay;
+      nextWriteDelay = null;
+      delay.started();
+      await delay.wait;
+    }
+
     if (url.endsWith("/pipeline")) {
-      const delay = nextPipelineDelay;
-      if (delay) {
-        nextPipelineDelay = null;
-        delay.started();
-        await delay.wait;
-      }
       if (nextPipelineResponse !== null) {
         return {
           ok: true,
@@ -107,9 +109,22 @@ function installFetch(): void {
       } as unknown as Response;
     }
     if (cmd[0] === "EVAL") {
-      // Simulates the registry's compare-and-delete script: EVAL, script,
-      // numkeys, key1, key2, expected1, expected2.
       const [, , , key1, key2, expected1, expected2] = cmd;
+      if (cmd.length === 8) {
+        const ttl = cmd[7];
+        const owned =
+          (store.get(key1) === expected1 && store.get(key2) === expected2) ||
+          (!store.has(key1) && !store.has(key2));
+        if (owned) {
+          store.set(key1, expected1);
+          store.set(key2, expected2);
+        }
+        expect(Number(ttl)).toBeGreaterThan(0);
+        return {
+          ok: true,
+          json: async () => ({ result: owned ? 1 : 0 }),
+        } as Response;
+      }
       if (store.get(key1) === expected1) store.delete(key1);
       if (store.get(key2) === expected2) store.delete(key2);
       return { ok: true, json: async () => ({ result: 1 }) } as Response;
@@ -222,10 +237,10 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
 
     failNextFetch = true;
     await vi.advanceTimersByTimeAsync(30_000);
-    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(0);
+    expect(recorded).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(30_000);
-    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+    expect(recorded).toHaveLength(1);
 
     reg.stopHeartbeat();
   });
@@ -236,17 +251,17 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     await reg.register();
     recorded.length = 0;
 
-    const delayed = delayNextPipeline();
+    const delayed = delayNextRegistryWrite();
     reg.startHeartbeat(30_000);
 
     await vi.advanceTimersByTimeAsync(30_000);
     await delayed.started;
     await vi.advanceTimersByTimeAsync(90_000);
-    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+    expect(recorded).toHaveLength(1);
 
     delayed.release();
     await vi.advanceTimersByTimeAsync(30_000);
-    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(2);
+    expect(recorded).toHaveLength(2);
 
     reg.stopHeartbeat();
   });
@@ -257,18 +272,14 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     await reg.register();
     recorded.length = 0;
 
-    const delayed = delayNextPipeline();
+    const delayed = delayNextRegistryWrite();
     reg.startHeartbeat(30_000);
     await vi.advanceTimersByTimeAsync(30_000);
     await delayed.started;
 
     const unregistering = reg.unregister();
     await Promise.resolve();
-    expect(
-      recorded.some(
-        (request) => Array.isArray(request.body) && request.body[0] === "EVAL",
-      ),
-    ).toBe(false);
+    expect(recorded).toHaveLength(1);
 
     delayed.release();
     await unregistering;
@@ -276,7 +287,7 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     expect(store.has("server:sandbox-abc:url")).toBe(false);
 
     await vi.advanceTimersByTimeAsync(90_000);
-    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+    expect(recorded).toHaveLength(2);
   });
 
   it("unregister() falls back within the shutdown margin without deleting keys", async () => {
@@ -285,7 +296,7 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     await reg.register();
     recorded.length = 0;
 
-    const delayed = delayNextPipeline();
+    const delayed = delayNextRegistryWrite();
     reg.startHeartbeat(30_000);
     await vi.advanceTimersByTimeAsync(30_000);
     await delayed.started;
@@ -311,18 +322,50 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
       error: { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
     });
 
-    expect(
-      recorded.some(
-        (request) => Array.isArray(request.body) && request.body[0] === "EVAL",
-      ),
-    ).toBe(false);
+    expect(recorded).toHaveLength(1);
     expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
     expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
     await vi.advanceTimersByTimeAsync(90_000);
-    expect(recorded.filter((r) => r.url.endsWith("/pipeline"))).toHaveLength(1);
+    expect(recorded).toHaveLength(1);
 
     delayed.release();
     await vi.advanceTimersByTimeAsync(0);
+    expect(recorded).toHaveLength(2);
+  });
+
+  it("a late heartbeat cannot replace a successor instance after drain timeout", async () => {
+    vi.useFakeTimers();
+    const oldRegistry = new SandboxRegistry(baseConfig);
+    await oldRegistry.register();
+    recorded.length = 0;
+
+    const delayed = delayNextRegistryWrite();
+    oldRegistry.startHeartbeat(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await delayed.started;
+
+    const unregistering = oldRegistry.unregister();
+    const outcome = unregistering.catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(outcome).resolves.toMatchObject({
+      code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT",
+    });
+
+    const successor = new SandboxRegistry({
+      ...baseConfig,
+      serverName: "sandbox-successor",
+      serverUrl: "http://5.6.7.8:2999/api",
+    });
+    await successor.register();
+
+    delayed.release();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(store.get("agent:char-123:server")).toBe("sandbox-successor");
+    expect(store.get("server:sandbox-successor:url")).toBe(
+      "http://5.6.7.8:2999/api",
+    );
+    expect(store.has("server:sandbox-abc:url")).toBe(false);
   });
 
   it("stopHeartbeat() halts the timer", async () => {
@@ -522,9 +565,20 @@ async function startFakeRedis(opts?: {
           for (const k of cmd.slice(1)) if (store.delete(k)) n++;
           send(`:${n}\r\n`);
         } else if (verb === "EVAL") {
-          // Simulates the registry's compare-and-delete script: EVAL, script,
-          // numkeys, key1, key2, expected1, expected2.
           const [, , , key1, key2, expected1, expected2] = cmd;
+          if (cmd.length === 8) {
+            const owned =
+              (store.get(key1) === expected1 &&
+                store.get(key2) === expected2) ||
+              (!store.has(key1) && !store.has(key2));
+            if (owned) {
+              store.set(key1, expected1);
+              store.set(key2, expected2);
+            }
+            send(`:${owned ? 1 : 0}\r\n`);
+            cmd = tryParseCommand();
+            continue;
+          }
           if (store.get(key1) === expected1) store.delete(key1);
           if (store.get(key2) === expected2) store.delete(key2);
           send(":1\r\n");
@@ -580,6 +634,20 @@ describe("SandboxRegistry (native TCP transport)", () => {
     await reg.register();
     expect(fake.authedWith).toContainEqual(["default", "s3cret"]);
     expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");
+  });
+
+  it("refresh() does not reclaim an agent key owned by a successor", async () => {
+    fake = await startFakeRedis();
+    const reg = new SandboxRegistry(tcpConfig(fake.port));
+    await reg.register();
+    fake.store.set("agent:char-tcp:server", "sandbox-successor");
+
+    await reg.refresh();
+
+    expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-successor");
+    expect(fake.store.get("server:sandbox-tcp:url")).toBe(
+      "http://5.6.7.8:1999/api",
+    );
   });
 
   it("unregister() deletes only keys still pointing at this sandbox", async () => {

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -32,6 +32,12 @@ import { ElizaError, logger } from "@elizaos/core";
 
 /** Hard cap on a single TCP register/refresh round-trip. */
 const REGISTRY_TCP_TIMEOUT_MS = 10_000;
+/**
+ * Maximum graceful-shutdown wait before falling back to Redis key expiry.
+ * Runtime service teardown may use 13s of the dev supervisor's 15s ceiling,
+ * so registry cleanup must leave that path enough headroom to finish.
+ */
+const REGISTRY_HEARTBEAT_DRAIN_TIMEOUT_MS = 1_000;
 const MAX_REGISTRY_TCP_BYTES = 1_048_576;
 
 function formatErr(err: unknown): string {
@@ -80,6 +86,7 @@ export interface SandboxRegistryConfig {
 
 export class SandboxRegistry {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatInFlight: Promise<void> | null = null;
   private readonly tcp: boolean;
 
   constructor(private readonly config: SandboxRegistryConfig) {
@@ -98,6 +105,32 @@ export class SandboxRegistry {
   }
 
   async unregister(): Promise<void> {
+    this.stopHeartbeat();
+    const heartbeat = this.heartbeatInFlight;
+    if (heartbeat) {
+      let drainTimer: ReturnType<typeof setTimeout> | null = null;
+      try {
+        await Promise.race([
+          heartbeat,
+          new Promise<never>((_resolve, reject) => {
+            drainTimer = setTimeout(() => {
+              reject(
+                new ElizaError(
+                  "Timed out draining sandbox registry heartbeat; routing keys will expire through their TTL",
+                  { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
+                ),
+              );
+            }, REGISTRY_HEARTBEAT_DRAIN_TIMEOUT_MS);
+            if (typeof drainTimer === "object" && "unref" in drainTimer) {
+              drainTimer.unref();
+            }
+          }),
+        ]);
+      } finally {
+        if (drainTimer !== null) clearTimeout(drainTimer);
+      }
+    }
+
     const { serverName, serverUrl, agentId } = this.config;
     const serverUrlKey = `server:${serverName}:url`;
     const agentServerKey = `agent:${agentId}:server`;
@@ -126,11 +159,7 @@ export class SandboxRegistry {
     if (this.heartbeatTimer) return;
 
     this.heartbeatTimer = setInterval(() => {
-      void this.refresh().catch((err) => {
-        logger.warn(
-          `[sandbox-registry] Heartbeat refresh failed: ${formatErr(err)}`,
-        );
-      });
+      this.runHeartbeat();
     }, intervalMs);
 
     if (
@@ -146,6 +175,25 @@ export class SandboxRegistry {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }
+  }
+
+  private runHeartbeat(): void {
+    if (this.heartbeatInFlight) return;
+
+    const heartbeat = this.refresh()
+      .catch((err) => {
+        // error-policy:J7 a transient heartbeat failure is warned without
+        // terminating the recurring liveness loop; the next tick retries.
+        logger.warn(
+          `[sandbox-registry] Heartbeat refresh failed: ${formatErr(err)}`,
+        );
+      })
+      .finally(() => {
+        if (this.heartbeatInFlight === heartbeat) {
+          this.heartbeatInFlight = null;
+        }
+      });
+    this.heartbeatInFlight = heartbeat;
   }
 
   /**

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -94,14 +94,14 @@ export class SandboxRegistry {
   }
 
   async register(): Promise<void> {
-    await this.writeKeys();
+    await this.registerKeys();
     logger.info(
       `[sandbox-registry] Registered ${this.config.serverName} -> ${this.config.serverUrl} (agent ${this.config.agentId}, ttl ${this.config.ttlSeconds}s, transport ${this.tcp ? "tcp" : "rest"})`,
     );
   }
 
   async refresh(): Promise<void> {
-    await this.writeKeys();
+    await this.refreshOwnedKeys();
   }
 
   async unregister(): Promise<void> {
@@ -109,17 +109,13 @@ export class SandboxRegistry {
     const heartbeat = this.heartbeatInFlight;
     if (heartbeat) {
       let drainTimer: ReturnType<typeof setTimeout> | null = null;
+      let drained = false;
       try {
-        await Promise.race([
-          heartbeat,
-          new Promise<never>((_resolve, reject) => {
+        drained = await Promise.race([
+          heartbeat.then(() => true),
+          new Promise<false>((resolve) => {
             drainTimer = setTimeout(() => {
-              reject(
-                new ElizaError(
-                  "Timed out draining sandbox registry heartbeat; routing keys will expire through their TTL",
-                  { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
-                ),
-              );
+              resolve(false);
             }, REGISTRY_HEARTBEAT_DRAIN_TIMEOUT_MS);
             if (typeof drainTimer === "object" && "unref" in drainTimer) {
               drainTimer.unref();
@@ -129,8 +125,27 @@ export class SandboxRegistry {
       } finally {
         if (drainTimer !== null) clearTimeout(drainTimer);
       }
+      if (!drained) {
+        void heartbeat
+          .then(() => this.deleteOwnedKeys())
+          .catch((err) => {
+            // error-policy:J6 teardown already failed closed; warn if the
+            // handled late-write cleanup cannot remove this instance's keys.
+            logger.warn(
+              `[sandbox-registry] Late heartbeat cleanup failed: ${formatErr(err)}`,
+            );
+          });
+        throw new ElizaError(
+          "Timed out draining sandbox registry heartbeat; late-write cleanup remains attached",
+          { code: "SANDBOX_REGISTRY_HEARTBEAT_DRAIN_TIMEOUT" },
+        );
+      }
     }
 
+    await this.deleteOwnedKeys();
+  }
+
+  private async deleteOwnedKeys(): Promise<void> {
     const { serverName, serverUrl, agentId } = this.config;
     const serverUrlKey = `server:${serverName}:url`;
     const agentServerKey = `agent:${agentId}:server`;
@@ -202,12 +217,30 @@ export class SandboxRegistry {
    * value or miss a routing entry whose other half was just renewed. REST uses
    * the Upstash pipeline endpoint; TCP pipelines both commands on one socket.
    */
-  private async writeKeys(): Promise<void> {
+  private async registerKeys(): Promise<void> {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
     const ttl = String(ttlSeconds);
     await this.pipeline([
       ["SET", `server:${serverName}:url`, serverUrl, "EX", ttl],
       ["SET", `agent:${agentId}:server`, serverName, "EX", ttl],
+    ]);
+  }
+
+  /** Renew only while both routing keys are still owned by this instance. */
+  private async refreshOwnedKeys(): Promise<void> {
+    const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
+    await this.command([
+      "EVAL",
+      "local u=redis.call('GET',KEYS[1]) local s=redis.call('GET',KEYS[2]) " +
+        "if (u==ARGV[1] and s==ARGV[2]) or (not u and not s) then " +
+        "redis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[3]) " +
+        "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[3]) return 1 end return 0",
+      "2",
+      `server:${serverName}:url`,
+      `agent:${agentId}:server`,
+      serverUrl,
+      serverName,
+      String(ttlSeconds),
     ]);
   }
 

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -14,8 +14,8 @@
  *
  * Two transports are supported, selected by the URL scheme so the same registry
  * works before and after the managed Redis is migrated off Upstash:
- *   - `http(s)://` — Upstash REST API via `fetch` (the pipeline endpoint applies
- *     both SET-with-EX commands atomically server-side).
+ *   - `http(s)://` — Upstash REST API via `fetch` (Lua applies the routing and
+ *     private generation keys atomically server-side).
  *   - `redis(s)://` — native RESP over a TCP socket (e.g. a Railway Redis public
  *     proxy). Auth is carried inline in the URL, so no separate token is
  *     required. This mirrors what the gateways already do (`gateway-discord` /
@@ -26,6 +26,7 @@
  * instead of concatenating until the 10s socket timeout.
  */
 
+import { randomUUID } from "node:crypto";
 import net from "node:net";
 
 import { ElizaError, logger } from "@elizaos/core";
@@ -85,6 +86,7 @@ export interface SandboxRegistryConfig {
 }
 
 export class SandboxRegistry {
+  private readonly generation = randomUUID();
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private heartbeatInFlight: Promise<void> | null = null;
   private readonly tcp: boolean;
@@ -149,6 +151,7 @@ export class SandboxRegistry {
     const { serverName, serverUrl, agentId } = this.config;
     const serverUrlKey = `server:${serverName}:url`;
     const agentServerKey = `agent:${agentId}:server`;
+    const generationKey = `server:${serverName}:registration`;
     // Compare-and-delete inside a single Lua script so the ownership check and
     // the delete are one atomic Redis operation. A read-then-delete over two
     // round-trips leaves a window where another sandbox's register()/refresh()
@@ -156,14 +159,18 @@ export class SandboxRegistry {
     // delete that fresh registration instead of its own stale one.
     await this.command([
       "EVAL",
-      "if redis.call('GET',KEYS[1])==ARGV[1] then redis.call('DEL',KEYS[1]) end " +
+      "-- unregister\nif redis.call('GET',KEYS[3])~=ARGV[3] then return 0 end " +
+        "if redis.call('GET',KEYS[1])==ARGV[1] then redis.call('DEL',KEYS[1]) end " +
         "if redis.call('GET',KEYS[2])==ARGV[2] then redis.call('DEL',KEYS[2]) end " +
+        "redis.call('DEL',KEYS[3]) " +
         "return 1",
-      "2",
+      "3",
       serverUrlKey,
       agentServerKey,
+      generationKey,
       serverUrl,
       serverName,
+      this.generation,
     ]);
     logger.info(
       `[sandbox-registry] Unregistered ${serverName} (agent ${agentId})`,
@@ -212,17 +219,26 @@ export class SandboxRegistry {
   }
 
   /**
-   * Atomic two-key write. Both keys must succeed together — partial state
+   * Atomic registration write. Both public keys and the private generation
+   * fence must succeed together — partial state
    * would let gateways resolve `agent:X:server` to a stale `server:Y:url`
-   * value or miss a routing entry whose other half was just renewed. REST uses
-   * the Upstash pipeline endpoint; TCP pipelines both commands on one socket.
+   * value or miss a routing entry whose other half was just renewed.
    */
   private async registerKeys(): Promise<void> {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
-    const ttl = String(ttlSeconds);
-    await this.pipeline([
-      ["SET", `server:${serverName}:url`, serverUrl, "EX", ttl],
-      ["SET", `agent:${agentId}:server`, serverName, "EX", ttl],
+    await this.command([
+      "EVAL",
+      "-- register\nredis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[4]) " +
+        "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[4]) " +
+        "redis.call('SET',KEYS[3],ARGV[3],'EX',ARGV[4]) return 1",
+      "3",
+      `server:${serverName}:url`,
+      `agent:${agentId}:server`,
+      `server:${serverName}:registration`,
+      serverUrl,
+      serverName,
+      this.generation,
+      String(ttlSeconds),
     ]);
   }
 
@@ -231,15 +247,19 @@ export class SandboxRegistry {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
     await this.command([
       "EVAL",
-      "local u=redis.call('GET',KEYS[1]) local s=redis.call('GET',KEYS[2]) " +
-        "if u==ARGV[1] and s==ARGV[2] then " +
-        "redis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[3]) " +
-        "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[3]) return 1 end return 0",
-      "2",
+      "-- refresh\nlocal u=redis.call('GET',KEYS[1]) local s=redis.call('GET',KEYS[2]) " +
+        "local g=redis.call('GET',KEYS[3]) " +
+        "if u==ARGV[1] and s==ARGV[2] and g==ARGV[3] then " +
+        "redis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[4]) " +
+        "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[4]) " +
+        "redis.call('SET',KEYS[3],ARGV[3],'EX',ARGV[4]) return 1 end return 0",
+      "3",
       `server:${serverName}:url`,
       `agent:${agentId}:server`,
+      `server:${serverName}:registration`,
       serverUrl,
       serverName,
+      this.generation,
       String(ttlSeconds),
     ]);
   }
@@ -265,43 +285,6 @@ export class SandboxRegistry {
     const json = (await res.json()) as { result?: unknown; error?: string };
     if (json.error) throw new Error(`Upstash error: ${json.error}`);
     return json.result;
-  }
-
-  private async pipeline(commands: string[][]): Promise<void> {
-    if (this.tcp) {
-      await this.tcpExec(commands);
-      return;
-    }
-    const res = await fetch(`${this.config.redisUrl}/pipeline`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.config.redisToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(commands),
-    });
-    if (!res.ok) {
-      throw new Error(
-        `Upstash pipeline failed: ${res.status} ${await res.text()}`,
-      );
-    }
-    const json: unknown = await res.json();
-    if (!Array.isArray(json) || json.length !== commands.length) {
-      throw new Error("Upstash pipeline returned an invalid response");
-    }
-    for (const entry of json) {
-      if (typeof entry !== "object" || entry === null) {
-        throw new Error("Upstash pipeline returned an invalid response");
-      }
-      const result = Reflect.get(entry, "result");
-      const error = Reflect.get(entry, "error");
-      if (typeof error === "string" && error.length > 0) {
-        throw new Error(`Upstash error: ${error}`);
-      }
-      if (result !== "OK") {
-        throw new Error("Upstash pipeline returned an invalid response");
-      }
-    }
   }
 
   /**

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -232,7 +232,7 @@ export class SandboxRegistry {
     await this.command([
       "EVAL",
       "local u=redis.call('GET',KEYS[1]) local s=redis.call('GET',KEYS[2]) " +
-        "if (u==ARGV[1] and s==ARGV[2]) or (not u and not s) then " +
+        "if u==ARGV[1] and s==ARGV[2] then " +
         "redis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[3]) " +
         "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[3]) return 1 end return 0",
       "2",


### PR DESCRIPTION
Closes #24470. Supersedes closed #24473 while preserving @startrack3r's implementation as the first authored commit.

## What changed

- Keeps heartbeat ticks single-flight and drains an active heartbeat before unregistering.
- Gives each registry instance a private random generation token. Registration atomically writes the two unchanged gateway-facing values plus a TTL-matched private generation key.
- Heartbeat renewal requires exact public-value and generation ownership; it cannot recreate expired routes or refresh any successor.
- Unregister and handled post-timeout cleanup require the same generation before deleting anything.
- Adds the hostile same-identity sequence: A's heartbeat stalls, A unregister times out, B registers the same agent ID, server name, and URL, then A completes late. B's public keys and private generation remain unchanged.
- Covers stale same-identity refresh and unregister over the real TCP/RESP harness as well as deterministic REST ordering.

This resolves both P1s found on prior head f696: absent-key route recreation and public-name/URL identity aliasing across generations. Gateway key names and public values are unchanged.

## Exact-head evidence

Head: `6cf881d1e6fe0597c3c039576a7226b0b842761d`
Base: `aa702d6ab6463fbc6d46f2f48afe5c910335db5a`

- Frozen install: passed.
- Focused sandbox registry: 26/26 passed.
- Full `@elizaos/shared` suite: 169 files, 2,252 tests passed at this exact head.
- `@elizaos/shared` typecheck: passed.
- Biome 2.5.8 on both changed files: clean.
- `git diff --check origin/develop...HEAD`: clean.
- Complete open-PR file scan: no other open PR touches either sandbox-registry file.

The first full-suite retry hit an environment-level temp-write error (`Unknown system error -122`) across 83 unrelated imports after earlier exact suites had passed. Re-running with a worktree-local TMPDIR passed all 2,252 tests; focused tests and typecheck were independently green.

Backend lifecycle only; visual, frontend, model/trajectory, and audio evidence are N/A.
