### PR TITLE
fix(agent): drain Apple Container startup output

### DIFF
--- a/packages/agent/src/services/sandbox-engine-run-container.harness.ts
+++ b/packages/agent/src/services/sandbox-engine-run-container.harness.ts
@@ -1,3 +1,5 @@
+/** Drives Apple Container startup in a subprocess for inherited-stdio boundary tests. */
+
 import { ElizaError } from "@elizaos/core";
 import {
   AppleContainerEngine,


### PR DESCRIPTION
## Summary

- replaces #24068 on current `develop`
- gives Apple Container an inherited stdout/stderr path so a chatty startup cannot fill an unread child pipe and wedge
- rejects immediate exits and spawn failures with typed `ElizaError` codes and bounded structured context
- keeps the detached running process unreferenced after startup
- adds the required source header to the subprocess harness found during review

## Verification

- process-boundary Vitest: 1 file, 2 tests passed
- changed-file Biome: 3 files clean
- exercised 300,000-byte stdout forwarding and 300,000-byte immediate-exit stderr forwarding byte-for-byte
- immediate exit produced `SANDBOX_APPLE_CONTAINER_START_EXITED` without copying unbounded stderr into the error

No UI or live container runtime was available; the test runs the real spawn/stdio logic against an executable `container` stub at the host-execution boundary. Supersedes #24068.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-pr-audit]
