### PR TITLE
fix(core): align batch capability with embedding pin

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -6305,7 +6305,20 @@ export class AgentRuntime implements IAgentRuntime {
 				params: Record<string, JsonValue | object>,
 		  ) => Promise<JsonValue | object>)
 		| undefined {
-		const resolvedModel = this.resolveModelRegistration(modelType);
+		const requestedModelKey = String(modelType);
+		// Keep capability probes aligned with useModel dispatch: once the
+		// embedding dimension probe pins a provider, another provider's BATCH
+		// handler is not usable because it may emit a different vector width.
+		const requestedProvider =
+			(requestedModelKey === ModelType.TEXT_EMBEDDING ||
+				requestedModelKey === ModelType.TEXT_EMBEDDING_BATCH) &&
+			this.pinnedEmbeddingProvider !== undefined
+				? this.pinnedEmbeddingProvider
+				: undefined;
+		const resolvedModel = this.resolveModelRegistration(
+			requestedModelKey,
+			requestedProvider,
+		);
 		if (!resolvedModel) {
 			return undefined;
 		}

--- a/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
+++ b/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
@@ -435,6 +435,40 @@ describe("AgentRuntime.ensureEmbeddingDimension provider failover", () => {
 		expect(localBatch).toHaveBeenCalledTimes(1);
 		expect(vectors[0]).toHaveLength(384);
 	});
+
+	it("does not advertise or retry another provider's batch handler when the pinned provider lacks one", async () => {
+		const runtime = makeRuntime();
+		const localEmbed = vi.fn(async () => new Array(384).fill(0));
+		const cloudBatch = vi.fn(
+			async (_runtime: AgentRuntime, params: { texts: string[] }) =>
+				params.texts.map(() => new Array(1536).fill(1)),
+		);
+		runtime.registerModel(ModelType.TEXT_EMBEDDING, localEmbed, "local", 100);
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING_BATCH,
+			cloudBatch,
+			"cloud",
+			100,
+		);
+
+		// Before the dimension probe chooses an owner, the cloud registration is
+		// discoverable. Afterwards, capability lookup must reflect the same pin as
+		// dispatch rather than selecting an incompatible provider.
+		expect(runtime.getModel(ModelType.TEXT_EMBEDDING_BATCH)).toBeDefined();
+		await runtime.ensureEmbeddingDimension();
+		expect(runtime.getModel(ModelType.TEXT_EMBEDDING_BATCH)).toBeUndefined();
+
+		for (let attempt = 0; attempt < 2; attempt++) {
+			await expect(
+				runtime.useModel(ModelType.TEXT_EMBEDDING_BATCH, {
+					texts: ["hello"],
+				}),
+			).rejects.toThrow(
+				`No handler found for delegate type: ${ModelType.TEXT_EMBEDDING_BATCH}`,
+			);
+		}
+		expect(cloudBatch).not.toHaveBeenCalled();
+	});
 });
 
 describe("AgentRuntime.initialize with a broken TEXT_EMBEDDING provider (#10702)", () => {


### PR DESCRIPTION
Fix-forward for #24467, preserving and completing @ss251’s embedding-provider pin work.

The merged dispatch fix pinned `useModel(TEXT_EMBEDDING_BATCH)`, but capability probes still used an unqualified `getModel(TEXT_EMBEDDING_BATCH)`. If the pinned provider lacked BATCH while another provider exposed it, services enabled batching even though dispatch could not use that provider. This change makes `getModel` apply the same embedding pin as dispatch, so capability detection and execution agree.

The regression proves that a cloud-only BATCH registration is discoverable before the local TEXT_EMBEDDING probe, unavailable after local is pinned, and never selected across repeated dispatch attempts.

Fixes #24466.

## Verification

- `bun run --cwd packages/core test -- src/runtime/__tests__/embedding-dimension.test.ts` — 15/15 passed
- `bun run --cwd packages/core typecheck` — passed
- `bunx biome check packages/core/src/runtime.ts packages/core/src/runtime/__tests__/embedding-dimension.test.ts` — passed

<!-- evidence-head:048e83a889411ee74da48899e55d8d04518efcc9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — core model routing only.
<!-- evidence-row:after-screenshots -->
- [x] N/A — core model routing only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no UI surface.
<!-- evidence-row:backend-logs -->
- [x] Focused real AgentRuntime regression: 15 tests passed.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — deterministic canned embedding handlers; no live model call.
<!-- evidence-row:domain-artifacts -->
- [x] Regression asserts pinned capability is absent and the incompatible handler remains at zero calls.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered surface.

<!-- contribution-attribution:v1 -->
- Original defect analysis and dispatch pin: @ss251 in #24467
- Fix-forward implementation: OpenAI Codex
- AI assistance: yes