### PR TITLE
fix(agent): retry failed E2B sandbox initialization

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -715,6 +715,95 @@ describe("E2BRemoteCapabilityRouterService", () => {
     });
   });
 
+  it("retries sandbox creation after a transient failure instead of caching the rejection", async () => {
+    const sandbox = new FakeSandbox([
+      entry("/workspace/README.md", "README.md", FILE_ENTRY),
+    ]);
+    let attempts = 0;
+    const factory: E2BSandboxFactory = {
+      create: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("transient sandbox provisioning failure");
+        }
+        return sandbox;
+      },
+    };
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig(),
+      factory,
+    );
+
+    await expect(service.fs.list({})).rejects.toThrow(
+      "transient sandbox provisioning failure",
+    );
+
+    const result = await service.fs.list({});
+    expect(result.entries.map((item) => item.name)).toEqual(["README.md"]);
+    expect(attempts).toBe(2);
+  });
+
+  it("retries preparation on the same sandbox after a transient workspace failure", async () => {
+    const sandbox = new FakeSandbox([
+      entry("/workspace/README.md", "README.md", FILE_ENTRY),
+    ]);
+    const factory = new FakeFactory(sandbox);
+    const runCommand = sandbox.commands.run.bind(sandbox.commands);
+    let preparationAttempts = 0;
+    vi.spyOn(sandbox.commands, "run").mockImplementation(async (cmd, opts) => {
+      const result = await runCommand(cmd, opts);
+      if (cmd.startsWith("mkdir ")) {
+        preparationAttempts += 1;
+        if (preparationAttempts === 1) {
+          // Model a lost response after mkdir has already mutated the workspace.
+          throw new Error("transient workspace preparation failure");
+        }
+      }
+      return result;
+    });
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig(),
+      factory,
+    );
+
+    await expect(service.fs.list({})).rejects.toThrow(
+      "transient workspace preparation failure",
+    );
+    expect(factory.configs).toHaveLength(1);
+    expect(preparationAttempts).toBe(1);
+    expect(sandbox.files.listCalls).toHaveLength(0);
+
+    const retried = await service.fs.list({});
+    expect(retried.entries.map((item) => item.name)).toEqual(["README.md"]);
+
+    await service.fs.list({});
+    await Promise.all([service.fs.list({}), service.fs.list({})]);
+
+    expect(factory.configs).toHaveLength(1);
+    expect(preparationAttempts).toBe(2);
+    expect(sandbox.files.listCalls).toHaveLength(4);
+  });
+
+  it("creates the sandbox once across many successful operations", async () => {
+    const sandbox = new FakeSandbox([
+      entry("/workspace/README.md", "README.md", FILE_ENTRY),
+    ]);
+    const factory = new FakeFactory(sandbox);
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig(),
+      factory,
+    );
+
+    await service.fs.list({});
+    await service.fs.list({});
+    await Promise.all([service.fs.list({}), service.fs.list({})]);
+
+    expect(factory.configs).toHaveLength(1);
+  });
+
   it("lists E2B remote runner files with hidden and ignore filtering", async () => {
     const sandbox = new FakeSandbox([
       entry("/workspace/src", "src", DIR_ENTRY),

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -934,14 +934,39 @@ export class E2BRemoteCapabilityRouterService
     });
   }
 
+  /**
+   * Caches the sandbox and its one-time preparation, but only caches SUCCESS.
+   * A rejected promise left in either field would be re-awaited by every later
+   * call — one transient create/prepare failure would take `fs.*`, `pty.*` and
+   * `git.*` down for the service's lifetime, with `stop()` the only reset. Each
+   * attempt clears its own field on failure (and only if it is still the
+   * current attempt, so a concurrent retry is never discarded), so the next
+   * call starts a fresh one.
+   */
   private async getSandbox(): Promise<E2BSandboxClient> {
     if (!this.sandboxPromise) {
-      this.sandboxPromise = this.factory.create(this.routerConfig);
+      const pending: Promise<E2BSandboxClient> = this.factory
+        .create(this.routerConfig)
+        .catch((error: unknown) => {
+          // error-policy:J2 clears the memoized attempt and rethrows the original create/prepare failure unchanged.
+          if (this.sandboxPromise === pending) this.sandboxPromise = null;
+          throw error;
+        });
+      this.sandboxPromise = pending;
       this.createdSandbox = !this.routerConfig.sandboxId;
     }
     const sandbox = await this.sandboxPromise;
     if (!this.preparePromise) {
-      this.preparePromise = this.prepareSandbox(sandbox);
+      const pendingPrepare: Promise<void> = this.prepareSandbox(sandbox).catch(
+        (error: unknown) => {
+          // error-policy:J2 clears the memoized attempt and rethrows the original create/prepare failure unchanged.
+          if (this.preparePromise === pendingPrepare) {
+            this.preparePromise = null;
+          }
+          throw error;
+        },
+      );
+      this.preparePromise = pendingPrepare;
     }
     await this.preparePromise;
     return sandbox;


### PR DESCRIPTION
## Summary

- replaces #24054 on current `develop`
- caches successful E2B sandbox creation/preparation, but clears the matching memoized promise after a rejected attempt
- retries preparation on the same successfully created sandbox and preserves one-time creation across successful sequential/concurrent operations
- rethrows the original failure to the caller; only a later operation retries

## Verification

- focused Vitest: 1 file, 54 tests passed
- changed-file Biome: 2 files clean
- regressions cover transient factory failure, mutation-then-lost-response preparation failure, and sequential/concurrent cache reuse

No live E2B credentials were used; the contract is exercised at the injected sandbox-factory and command seams. Supersedes #24054.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-pr-audit]
