### PR TITLE
fix(cloud): require Blooio configuration in production

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -647,13 +647,13 @@ jobs:
             require_exact RELAY_ORIGIN "$RELAY_ORIGIN" "https://relay-staging.eliza.app"
           fi
 
-      - name: Validate protected staging Blooio configuration
-        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
+      - name: Validate protected Blooio configuration
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         env:
           DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
-          ELIZA_APP_BLOOIO_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
-          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
-          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
+          ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
+          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
+          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           required_names=(
@@ -669,10 +669,10 @@ jobs:
             fi
           done
           if [ "${#missing[@]}" -gt 0 ]; then
-            echo "::error::Missing required protected staging Blooio secret name(s): ${missing[*]}"
+            echo "::error::Missing required protected $DEPLOY_ENVIRONMENT Blooio secret name(s): ${missing[*]}"
             exit 1
           fi
-          echo "Verified ${#required_names[@]} protected staging Blooio secret names; values were not printed."
+          echo "Verified ${#required_names[@]} protected $DEPLOY_ENVIRONMENT Blooio secret names; values were not printed."
 
       - name: Disable staging session exchange before cutover
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' && steps.env.outputs.deploy_environment == 'staging'
@@ -838,13 +838,12 @@ jobs:
           # activation is a separate protected, live-proven rollout.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
           ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
-          # Personal Shared Blooio is a staging acceptance surface. These
-          # protected values are mandatory in staging and are committed with
-          # the exact Worker source through the atomic secrets file below.
-          # Production keeps its existing bindings and never queues this source.
-          ELIZA_APP_BLOOIO_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
-          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
-          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
+          # Personal Shared Blooio is the public-number messaging surface in
+          # both protected environments. Commit the environment-specific
+          # values atomically with the exact Worker source below.
+          ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
+          ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
+          ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
           # Personal Shared APNs stays dormant unless the complete protected
           # environment config is present. Topic/environment are explicit so a
           # signed development build cannot silently receive production pushes.
@@ -1224,19 +1223,17 @@ jobs:
             queue_secret "$name" || exit 1
           done
 
-          if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
-            for name in \
-              ELIZA_APP_BLOOIO_API_KEY \
-              ELIZA_APP_BLOOIO_PHONE_NUMBER \
-              ELIZA_APP_BLOOIO_WEBHOOK_SECRET
-            do
-              if ! has_nonblank_value "${!name:-}"; then
-                echo "::error::Required protected staging Blooio secret is absent or blank: $name"
-                exit 1
-              fi
-              queue_secret "$name" || exit 1
-            done
-          fi
+          for name in \
+            ELIZA_APP_BLOOIO_API_KEY \
+            ELIZA_APP_BLOOIO_PHONE_NUMBER \
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET
+          do
+            if ! has_nonblank_value "${!name:-}"; then
+              echo "::error::Required protected $DEPLOY_ENVIRONMENT Blooio secret is absent or blank: $name"
+              exit 1
+            fi
+            queue_secret "$name" || exit 1
+          done
 
           for name in \
             OPENROUTER_API_KEY \
@@ -1461,12 +1458,12 @@ jobs:
             ];
             if (process.env.DEPLOY_ENVIRONMENT === "staging") {
               required.push("LOCAL_EMBEDDINGS_API_KEY");
-              required.push(
-                "ELIZA_APP_BLOOIO_API_KEY",
-                "ELIZA_APP_BLOOIO_PHONE_NUMBER",
-                "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
-              );
             }
+            required.push(
+              "ELIZA_APP_BLOOIO_API_KEY",
+              "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+              "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+            );
             if (
               process.env.DEPLOY_ENVIRONMENT === "production" &&
               process.env.VOICE_REALTIME_WS_ENABLED === "true"

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -202,9 +202,9 @@ jobs:
           # place both sides of the Blooio webhook contract are observable, so
           # a Worker/Railway value divergence is caught before deploy instead
           # of as a 401 on every live webhook.
-          WORKER_ELIZA_APP_BLOOIO_API_KEY: ${{ inputs.environment == 'staging' && secrets.ELIZA_APP_BLOOIO_API_KEY || '' }}
-          WORKER_ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ inputs.environment == 'staging' && secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER || '' }}
-          WORKER_ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ inputs.environment == 'staging' && secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET || '' }}
+          WORKER_ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
+          WORKER_ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
+          WORKER_ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           umask 077
@@ -221,7 +221,7 @@ jobs:
               AGENT_ROUTER_ORIGIN_HOST: .AGENT_ROUTER_ORIGIN_HOST,
               ELIZA_CLOUD_AGENT_BASE_DOMAIN: .ELIZA_CLOUD_AGENT_BASE_DOMAIN
             },
-            staging_blooio_nonblank_names: [
+            blooio_nonblank_names: [
               to_entries[] |
               select(.key == "ELIZA_APP_BLOOIO_API_KEY" or
                      .key == "ELIZA_APP_BLOOIO_PHONE_NUMBER" or
@@ -246,18 +246,16 @@ jobs:
               cut -d' ' -f1
           }
           declare -A railway_blooio_digests=()
-          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
-            for name in \
-              ELIZA_APP_BLOOIO_API_KEY \
-              ELIZA_APP_BLOOIO_PHONE_NUMBER \
-              ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
-              railway_value="$(jq -r --arg name "$name" \
-                'if (.[$name] | type) == "string" then .[$name] else "" end' \
-                "$variables_raw_path")"
-              railway_blooio_digests["$name"]="$(blooio_digest "$railway_value")"
-              railway_value=""
-            done
-          fi
+          for name in \
+            ELIZA_APP_BLOOIO_API_KEY \
+            ELIZA_APP_BLOOIO_PHONE_NUMBER \
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
+            railway_value="$(jq -r --arg name "$name" \
+              'if (.[$name] | type) == "string" then .[$name] else "" end' \
+              "$variables_raw_path")"
+            railway_blooio_digests["$name"]="$(blooio_digest "$railway_value")"
+            railway_value=""
+          done
           shred -u "$variables_raw_path"
 
           require_exact_variable() {
@@ -278,12 +276,12 @@ jobs:
               exit 1
             fi
           }
-          require_staging_blooio_name() {
+          require_blooio_name() {
             local name="$1"
             if ! jq -e --arg name "$name" \
-              '.staging_blooio_nonblank_names | index($name) != null' \
+              '.blooio_nonblank_names | index($name) != null' \
               "$variables_path" >/dev/null; then
-              echo "::error::Required staging Blooio Railway variable name is absent or blank: $name"
+              echo "::error::Required protected $TARGET_ENVIRONMENT Blooio Railway variable name is absent or blank: $name"
               exit 1
             fi
           }
@@ -298,36 +296,34 @@ jobs:
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET; do
             require_sensitive_name "$name"
           done
-          if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
-            for name in \
-              ELIZA_APP_BLOOIO_API_KEY \
-              ELIZA_APP_BLOOIO_PHONE_NUMBER \
-              ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
-              require_staging_blooio_name "$name"
-            done
-            # Name presence on both sides still permits Worker secret A and
-            # Railway secret B, which passes every names-only check and then
-            # 401s every live Blooio webhook. Compare salted digests so the
-            # values must actually agree without either value being read,
-            # printed, or written anywhere.
-            for name in \
-              ELIZA_APP_BLOOIO_API_KEY \
-              ELIZA_APP_BLOOIO_PHONE_NUMBER \
-              ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
-              worker_name="WORKER_$name"
-              worker_value="${!worker_name:-}"
-              if [ -z "${worker_value//[[:space:]]/}" ]; then
-                echo "::error::Required protected staging Blooio GitHub environment secret is absent or blank: $name"
-                exit 1
-              fi
-              if [ "$(blooio_digest "$worker_value")" != "${railway_blooio_digests[$name]:-}" ]; then
-                echo "::error::Protected staging Blooio value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: $name (compared by salted digest; values were not printed)"
-                exit 1
-              fi
-              worker_value=""
-            done
-            echo "Verified 3 protected staging Blooio Worker/Railway value matches by salted digest; values were not printed."
-          fi
+          for name in \
+            ELIZA_APP_BLOOIO_API_KEY \
+            ELIZA_APP_BLOOIO_PHONE_NUMBER \
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
+            require_blooio_name "$name"
+          done
+          # Name presence on both sides still permits Worker secret A and
+          # Railway secret B, which passes every names-only check and then
+          # 401s every live Blooio webhook. Compare salted digests so the
+          # values must actually agree without either value being read,
+          # printed, or written anywhere.
+          for name in \
+            ELIZA_APP_BLOOIO_API_KEY \
+            ELIZA_APP_BLOOIO_PHONE_NUMBER \
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET; do
+            worker_name="WORKER_$name"
+            worker_value="${!worker_name:-}"
+            if [ -z "${worker_value//[[:space:]]/}" ]; then
+              echo "::error::Required protected $TARGET_ENVIRONMENT Blooio GitHub environment secret is absent or blank: $name"
+              exit 1
+            fi
+            if [ "$(blooio_digest "$worker_value")" != "${railway_blooio_digests[$name]:-}" ]; then
+              echo "::error::Protected $TARGET_ENVIRONMENT Blooio value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: $name (compared by salted digest; values were not printed)"
+              exit 1
+            fi
+            worker_value=""
+          done
+          echo "Verified 3 protected $TARGET_ENVIRONMENT Blooio Worker/Railway value matches by salted digest; values were not printed."
           if ! jq -e '.nonblank_sensitive_names as $names |
             (($names | index("REDIS_URL")) != null or
              ((($names | index("KV_REST_API_URL")) != null) and

--- a/packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts
@@ -1,6 +1,6 @@
 /**
- * Guards staging-only Blooio secret sourcing, atomic Worker publication, and
- * names-only post-deploy verification in the protected Cloud release.
+ * Guards protected-environment Blooio secret sourcing, atomic Worker
+ * publication, and names-only post-deploy verification in the Cloud release.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -31,7 +31,7 @@ const blooioNames = [
   "ELIZA_APP_BLOOIO_PHONE_NUMBER",
   "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
 ] as const;
-const stagingValues: Record<(typeof blooioNames)[number], string> = {
+const blooioValues: Record<(typeof blooioNames)[number], string> = {
   ELIZA_APP_BLOOIO_API_KEY: "api-key-private-canary",
   ELIZA_APP_BLOOIO_PHONE_NUMBER: "+15555550199",
   ELIZA_APP_BLOOIO_WEBHOOK_SECRET: "webhook-secret-private-canary",
@@ -52,14 +52,15 @@ function githubExpression(body: string): string {
 }
 
 function runValidation(
-  overrides: Partial<typeof stagingValues> = {},
+  target: "staging" | "production",
+  overrides: Partial<typeof blooioValues> = {},
 ): ReturnType<typeof Bun.spawnSync> {
-  const validation = step("Validate protected staging Blooio configuration");
+  const validation = step("Validate protected Blooio configuration");
   return Bun.spawnSync(["bash", "-c", validation.run ?? ""], {
     env: {
       ...process.env,
-      DEPLOY_ENVIRONMENT: "staging",
-      ...stagingValues,
+      DEPLOY_ENVIRONMENT: target,
+      ...blooioValues,
       ...overrides,
     },
     stderr: "pipe",
@@ -67,57 +68,55 @@ function runValidation(
   });
 }
 
-describe("protected Cloud staging Blooio configuration", () => {
+describe("protected Cloud Blooio configuration", () => {
   test("fails closed before Worker mutation without exposing protected values", () => {
-    const validation = step("Validate protected staging Blooio configuration");
-    expect(validation.if).toContain(
-      "steps.env.outputs.deploy_environment == 'staging'",
-    );
+    const validation = step("Validate protected Blooio configuration");
+    expect(validation.if).not.toContain("deploy_environment == 'staging'");
     expect(index("Validate canonical routing contract")).toBeLessThan(
-      index("Validate protected staging Blooio configuration"),
+      index("Validate protected Blooio configuration"),
     );
-    expect(
-      index("Validate protected staging Blooio configuration"),
-    ).toBeLessThan(index("Disable staging session exchange before cutover"));
-
-    const complete = runValidation();
-    expect(complete.exitCode).toBe(0);
-    expect(complete.stdout.toString()).toContain(
-      "Verified 3 protected staging Blooio secret names",
+    expect(index("Validate protected Blooio configuration")).toBeLessThan(
+      index("Disable staging session exchange before cutover"),
     );
-    const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
-    for (const value of Object.values(stagingValues)) {
-      expect(completeOutput).not.toContain(value);
-    }
 
-    for (const name of blooioNames) {
-      for (const missingValue of ["", " \t "]) {
-        const missing = runValidation({ [name]: missingValue });
-        expect(missing.exitCode).toBe(1);
-        const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
-        expect(output).toContain(name);
-        for (const value of Object.values(stagingValues)) {
-          expect(output).not.toContain(value);
+    for (const target of ["staging", "production"] as const) {
+      const complete = runValidation(target);
+      expect(complete.exitCode).toBe(0);
+      expect(complete.stdout.toString()).toContain(
+        `Verified 3 protected ${target} Blooio secret names`,
+      );
+      const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
+      for (const value of Object.values(blooioValues)) {
+        expect(completeOutput).not.toContain(value);
+      }
+
+      for (const name of blooioNames) {
+        for (const missingValue of ["", " \t "]) {
+          const missing = runValidation(target, { [name]: missingValue });
+          expect(missing.exitCode).toBe(1);
+          const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
+          expect(output).toContain(name);
+          expect(output).toContain(`protected ${target} Blooio`);
+          for (const value of Object.values(blooioValues)) {
+            expect(output).not.toContain(value);
+          }
         }
       }
     }
   });
 
-  test("sources only protected staging values and commits them atomically", () => {
-    const validation = step("Validate protected staging Blooio configuration");
+  test("sources protected environment values and commits them atomically", () => {
+    const validation = step("Validate protected Blooio configuration");
     const prepare = step("Prepare Worker secrets for atomic deploy");
     const deploy = step("Deploy to Cloudflare Workers");
     const cleanup = step("Remove atomic Worker secrets file");
 
     for (const name of blooioNames) {
-      const expected = githubExpression(
-        `steps.env.outputs.deploy_environment == 'staging' && secrets.${name} || ''`,
-      );
+      const expected = githubExpression(`secrets.${name}`);
       expect(validation.env?.[name]).toBe(expected);
       expect(prepare.env?.[name]).toBe(expected);
-      expect(prepare.run).toContain(`\n    ${name}`);
+      expect(prepare.run).toContain(name);
     }
-    expect(prepare.run).toContain('if [ "$DEPLOY_ENVIRONMENT" = "staging" ]');
     expect(prepare.run).toContain('queue_secret "$name" || exit 1');
     expect(prepare.run).toContain("worker-secrets-file.mjs");
     expect(prepare.run).toContain('create "$RUNNER_TEMP"');
@@ -127,25 +126,11 @@ describe("protected Cloud staging Blooio configuration", () => {
     expect(cleanup.run).toContain('remove-all "$RUNNER_TEMP"');
   });
 
-  test("verifies staging names after deploy while leaving production isolated", () => {
+  test("verifies Blooio names after every protected deploy", () => {
     const verify = step("Verify required Worker secret binding names");
-    expect(verify.run).toContain(
-      'process.env.DEPLOY_ENVIRONMENT === "staging"',
-    );
     for (const name of blooioNames) {
       expect(verify.run).toContain(`"${name}"`);
     }
     expect(verify.run).toContain("values were not read");
-
-    const validation = step("Validate protected staging Blooio configuration");
-    expect(validation.if).not.toContain("production");
-    for (const name of blooioNames) {
-      expect(validation.env?.[name]).not.toContain(
-        `deploy_environment == 'production' && secrets.${name}`,
-      );
-      expect(
-        step("Prepare Worker secrets for atomic deploy").env?.[name],
-      ).not.toContain(`deploy_environment == 'production' && secrets.${name}`);
-    }
   });
 });

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -167,18 +167,16 @@ function verifyRailwayVariableInventory(
     AGENT_SERVER_SHARED_SECRET: "server-private-canary",
     ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "forwarder-private-canary",
     REDIS_URL: "redis-private-canary",
-    ...(target === "staging" ? blooioValues : {}),
+    ...blooioValues,
     ...overrides,
   };
   // The Worker side receives these as GitHub Environment secrets; by default
   // they agree with Railway, so only an explicit override models divergence.
   const workerEnvironment: Record<string, string> = {};
-  if (target === "staging") {
-    for (const name of blooioNames) {
-      const value =
-        name in workerOverrides ? workerOverrides[name] : blooioValues[name];
-      if (value !== undefined) workerEnvironment[`WORKER_${name}`] = value;
-    }
+  for (const name of blooioNames) {
+    const value =
+      name in workerOverrides ? workerOverrides[name] : blooioValues[name];
+    if (value !== undefined) workerEnvironment[`WORKER_${name}`] = value;
   }
   writeFileSync(
     join(binRoot, "railway"),
@@ -437,8 +435,7 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(variables.run).toContain("KV_REST_API_TOKEN");
     expect(variables.run).toContain("AGENT_ROUTER_ORIGIN_HOST");
     expect(variables.run).toContain("ELIZA_CLOUD_AGENT_BASE_DOMAIN");
-    expect(variables.run).toContain("staging_blooio_nonblank_names");
-    expect(variables.run).toContain('if [ "$TARGET_ENVIRONMENT" = "staging" ]');
+    expect(variables.run).toContain("blooio_nonblank_names");
     for (const name of blooioNames) {
       expect(variables.run).toContain(name);
     }
@@ -447,51 +444,43 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(source).not.toContain('echo "$RAILWAY_TOKEN"');
   });
 
-  test("requires the complete staging Blooio set without changing production", () => {
-    const complete = verifyRailwayVariableInventory("staging");
-    expect(complete.exitCode).toBe(0);
-    expect(complete.stdout.toString()).toContain(
-      "required sensitive variable names are present",
-    );
-    const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
-    for (const value of Object.values(blooioValues)) {
-      expect(completeOutput).not.toContain(value);
-    }
+  test("requires the complete protected-environment Blooio set", () => {
+    for (const target of ["staging", "production"] as const) {
+      const complete = verifyRailwayVariableInventory(target);
+      expect(complete.exitCode).toBe(0);
+      expect(complete.stdout.toString()).toContain(
+        "required sensitive variable names are present",
+      );
+      const completeOutput = `${complete.stdout.toString()}${complete.stderr.toString()}`;
+      for (const value of Object.values(blooioValues)) {
+        expect(completeOutput).not.toContain(value);
+      }
 
-    for (const name of blooioNames) {
-      for (const missingValue of [undefined, "", " \t "]) {
-        const missing = verifyRailwayVariableInventory("staging", {
-          [name]: missingValue,
-        });
-        expect(missing.exitCode).toBe(1);
-        const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
-        // The staging-only gate must name itself so an operator reading a red
-        // run can tell it apart from the shared sensitive-name gate.
-        expect(output).toContain(
-          `Required staging Blooio Railway variable name is absent or blank: ${name}`,
-        );
-        for (const value of Object.values(blooioValues)) {
-          expect(output).not.toContain(value);
+      for (const name of blooioNames) {
+        for (const missingValue of [undefined, "", " \t "]) {
+          const missing = verifyRailwayVariableInventory(target, {
+            [name]: missingValue,
+          });
+          expect(missing.exitCode).toBe(1);
+          const output = `${missing.stdout.toString()}${missing.stderr.toString()}`;
+          expect(output).toContain(
+            `Required protected ${target} Blooio Railway variable name is absent or blank: ${name}`,
+          );
+          for (const value of Object.values(blooioValues)) {
+            expect(output).not.toContain(value);
+          }
         }
       }
     }
-
-    const production = verifyRailwayVariableInventory("production");
-    expect(production.exitCode).toBe(0);
-    expect(production.stdout.toString()).toContain(
-      "required sensitive variable names are present",
-    );
   }, 15_000);
 
-  test("requires the staging Worker and Railway Blooio values to actually match", () => {
+  test("requires protected Worker and Railway Blooio values to actually match", () => {
     const variables = step(
       "Verify canonical Railway variables and sensitive names",
     );
     for (const name of blooioNames) {
       expect(variables.env?.[`WORKER_${name}`]).toBe(
-        githubExpression(
-          `inputs.environment == 'staging' && secrets.${name} || ''`,
-        ),
+        githubExpression(`secrets.${name}`),
       );
     }
     // Equality is proven by digest; the values themselves must never be
@@ -513,51 +502,47 @@ describe("protected gateway-webhook deployment workflow", () => {
       ...Object.values(workerValues),
     ];
 
-    const matched = verifyRailwayVariableInventory("staging");
-    expect(matched.exitCode).toBe(0);
-    expect(matched.stdout.toString()).toContain(
-      "protected staging Blooio Worker/Railway value matches by salted digest",
-    );
-
-    for (const name of blooioNames) {
-      // A divergent-but-nonblank Worker secret is precisely the case a
-      // names-only inventory accepts and a live webhook then rejects with 401.
-      const divergent = verifyRailwayVariableInventory(
-        "staging",
-        {},
-        { [name]: workerValues[name] },
+    for (const target of ["staging", "production"] as const) {
+      const matched = verifyRailwayVariableInventory(target);
+      expect(matched.exitCode).toBe(0);
+      expect(matched.stdout.toString()).toContain(
+        `protected ${target} Blooio Worker/Railway value matches by salted digest`,
       );
-      expect(divergent.exitCode).toBe(1);
-      const divergentOutput = `${divergent.stdout.toString()}${divergent.stderr.toString()}`;
-      expect(divergentOutput).toContain(
-        `Protected staging Blooio value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: ${name}`,
-      );
-      for (const value of allSecretValues) {
-        expect(divergentOutput).not.toContain(value);
-      }
 
-      for (const absentWorkerValue of [undefined, "", " \t "]) {
-        const absent = verifyRailwayVariableInventory(
-          "staging",
+      for (const name of blooioNames) {
+        // A divergent-but-nonblank Worker secret is precisely the case a
+        // names-only inventory accepts and a live webhook then rejects with 401.
+        const divergent = verifyRailwayVariableInventory(
+          target,
           {},
-          { [name]: absentWorkerValue },
+          { [name]: workerValues[name] },
         );
-        expect(absent.exitCode).toBe(1);
-        const absentOutput = `${absent.stdout.toString()}${absent.stderr.toString()}`;
-        expect(absentOutput).toContain(
-          `Required protected staging Blooio GitHub environment secret is absent or blank: ${name}`,
+        expect(divergent.exitCode).toBe(1);
+        const divergentOutput = `${divergent.stdout.toString()}${divergent.stderr.toString()}`;
+        expect(divergentOutput).toContain(
+          `Protected ${target} Blooio value differs between the Cloudflare Worker GitHub environment secret and the Railway variable: ${name}`,
         );
         for (const value of allSecretValues) {
-          expect(absentOutput).not.toContain(value);
+          expect(divergentOutput).not.toContain(value);
+        }
+
+        for (const absentWorkerValue of [undefined, "", " \t "]) {
+          const absent = verifyRailwayVariableInventory(
+            target,
+            {},
+            { [name]: absentWorkerValue },
+          );
+          expect(absent.exitCode).toBe(1);
+          const absentOutput = `${absent.stdout.toString()}${absent.stderr.toString()}`;
+          expect(absentOutput).toContain(
+            `Required protected ${target} Blooio GitHub environment secret is absent or blank: ${name}`,
+          );
+          for (const value of allSecretValues) {
+            expect(absentOutput).not.toContain(value);
+          }
         }
       }
     }
-
-    // Production never sources the Worker secrets, so the value gate must not
-    // fire there even with every Worker secret absent.
-    const production = verifyRailwayVariableInventory("production");
-    expect(production.exitCode).toBe(0);
-    expect(production.stdout.toString()).not.toContain("salted digest");
   }, 30_000);
 
   test("binds the exact root source and manifest to its new deployment id", () => {


### PR DESCRIPTION
## Outcome

- sources the protected Blooio API key, sender, and webhook secret for both staging and production Cloudflare Worker releases
- requires the same complete set on the production Railway gateway
- compares Worker and Railway values with per-run salted digests without printing or persisting secret values
- makes a missing, blank, or divergent production binding fail before deploy instead of accepting a live 401-only webhook path

Relates to #24247.

## Live diagnosis

- Blooio v4 and the existing gateway adapter are channel-aware: inbound events preserve `channel_id`, `channel_type`, `protocol`, and `chat_id`; replies use the v4 chat endpoint, while non-chat sends use `/v4/messages` with `from: ch_...`.
- The current Blooio organization exposes one operational dedicated `+18087881821` number and an active v4 webhook, but no verified `whatsapp` or `whatsapp_business` channel yet.
- The public WhatsApp CTA remains disabled. Activation still requires `GET /v4/channels` proof plus a real handset inbound-to-agent-to-reply round trip.

## Evidence

- `bun test packages/scripts/__tests__/cloud-cf-blooio-deploy-workflow.test.ts packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts` — 11 passed, 0 failed
- `git diff --check origin/develop...HEAD` — passed
- Blooio adapter runtime tests could not start in this fresh worktree because the workspace install is missing `zod`; the channel-aware behavior is unchanged by this workflow-only diff.

## UI evidence

N/A — no rendered UI files changed. Production connector and Blooio dashboard state were inspected live.