### PR TITLE
feat(documents): add bounded indexed source reads

### DIFF
--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -429,10 +429,17 @@ export function validateDocumentRevisionReplacement(
 		});
 	}
 	const ids = new Set<string>();
+	let sourcePosition = 0;
+	let embeddingPosition = 0;
 	for (let index = 0; index < params.fragments.length; index++) {
 		const fragment = params.fragments[index];
 		const fragmentId = fragment.id;
 		const metadata = fragment.metadata as Record<string, unknown> | undefined;
+		const fragmentRole = metadata?.fragmentRole;
+		const expectedPosition =
+			fragmentRole === "source-segment"
+				? sourcePosition++
+				: embeddingPosition++;
 		if (
 			!isUuid(fragmentId) ||
 			fragmentId === params.documentId ||
@@ -444,7 +451,10 @@ export function validateDocumentRevisionReplacement(
 			metadata?.type !== MemoryType.FRAGMENT ||
 			metadata.documentId !== params.documentId ||
 			metadata.documentRevision !== revision ||
-			metadata.position !== index ||
+			(fragmentRole !== undefined &&
+				fragmentRole !== "source-segment" &&
+				fragmentRole !== "embedding-chunk") ||
+			metadata.position !== expectedPosition ||
 			typeof fragment.content.text !== "string" ||
 			(fragment.embedding !== undefined &&
 				(!Array.isArray(fragment.embedding) ||
@@ -1007,6 +1017,12 @@ export function queryDocumentFragmentsInMemory(
 			if (
 				memory.agentId !== params.agentId ||
 				memory.metadata?.type !== MemoryType.FRAGMENT
+			) {
+				return false;
+			}
+			if (
+				(memory.metadata as unknown as Record<string, unknown>).fragmentRole ===
+				"source-segment"
 			) {
 				return false;
 			}

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -125,6 +125,50 @@ function roomTableKey(tableName: string, roomId: UUID): string {
 	return `${tableName}:${String(roomId)}`;
 }
 
+function documentSourceIndexKey(args: {
+	agentId: UUID;
+	documentId: UUID | string;
+	documentRevision: number;
+	revisionAttemptId?: string;
+}): string {
+	return JSON.stringify([
+		String(args.agentId),
+		String(args.documentId),
+		args.documentRevision,
+		args.revisionAttemptId ?? "",
+	]);
+}
+
+function sourceSegmentIndexKey(memory: Memory): string | null {
+	const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
+	if (
+		typeof memory.agentId !== "string" ||
+		metadata.type !== MemoryType.FRAGMENT ||
+		metadata.fragmentRole !== "source-segment" ||
+		metadata.sourceSegmentVersion !== 1 ||
+		typeof metadata.documentId !== "string" ||
+		!Number.isSafeInteger(metadata.documentRevision) ||
+		(metadata.revisionAttemptId !== undefined &&
+			typeof metadata.revisionAttemptId !== "string")
+	) {
+		return null;
+	}
+	return documentSourceIndexKey({
+		agentId: memory.agentId as UUID,
+		documentId: metadata.documentId,
+		documentRevision: metadata.documentRevision as number,
+		revisionAttemptId: metadata.revisionAttemptId as string | undefined,
+	});
+}
+
+function sourceSegmentPosition(memory: Memory): number {
+	const position = (memory.metadata as Record<string, unknown> | undefined)
+		?.position;
+	return typeof position === "number" && Number.isSafeInteger(position)
+		? position
+		: Number.MAX_SAFE_INTEGER;
+}
+
 function memoryMatchesMetadata(
 	memory: Memory,
 	filter: Record<string, unknown>,
@@ -323,9 +367,37 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 
 	private memoriesById = new Map<string, Memory>();
 	private memoriesByRoom = new Map<string, Memory[]>();
+	private sourceSegmentsByGeneration = new Map<string, Memory[]>();
 	private cache = new Map<string, string>();
 	/** Width last passed to {@link ensureEmbeddingDimension}; used to reclaim stale vectors. */
 	private embeddingDimension: number | undefined;
+
+	private addSourceSegmentToIndex(memory: Memory): void {
+		const key = sourceSegmentIndexKey(memory);
+		if (!key) return;
+		const segments = this.sourceSegmentsByGeneration.get(key) ?? [];
+		const position = sourceSegmentPosition(memory);
+		let low = 0;
+		let high = segments.length;
+		while (low < high) {
+			const middle = low + Math.floor((high - low) / 2);
+			if (sourceSegmentPosition(segments[middle]) <= position) low = middle + 1;
+			else high = middle;
+		}
+		segments.splice(low, 0, memory);
+		this.sourceSegmentsByGeneration.set(key, segments);
+	}
+
+	private removeSourceSegmentFromIndex(memory: Memory): void {
+		const key = sourceSegmentIndexKey(memory);
+		if (!key) return;
+		const segments = this.sourceSegmentsByGeneration.get(key);
+		if (!segments) return;
+		const id = String(memory.id);
+		const next = segments.filter((segment) => String(segment.id) !== id);
+		if (next.length === 0) this.sourceSegmentsByGeneration.delete(key);
+		else this.sourceSegmentsByGeneration.set(key, next);
+	}
 
 	private participantsByRoom = new Map<string, Set<string>>();
 	private roomsByParticipant = new Map<string, Set<string>>();
@@ -943,6 +1015,16 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				: params.unit === "line"
 					? parent.sourceLineCount
 					: parent.sourceFragmentCount;
+		if (params.offset > total) {
+			throw new ElizaError("Document range offset exceeds the source length", {
+				code: "DOCUMENT_READ_INVALID_RANGE",
+				context: {
+					documentId: params.documentId,
+					offset: params.offset,
+					total,
+				},
+			});
+		}
 		const requestedEnd = Math.min(params.offset + params.limit, total);
 		const coordinateName =
 			params.unit === "byte"
@@ -952,44 +1034,46 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 					: "Fragment";
 		const startKey = `source${coordinateName}Start`;
 		const endKey = `source${coordinateName}End`;
+		const indexKey = documentSourceIndexKey({
+			agentId: params.agentId,
+			documentId: params.documentId,
+			documentRevision: parent.documentRevision,
+			revisionAttemptId: parent.revisionAttemptId,
+		});
+		const indexed = this.sourceSegmentsByGeneration.get(indexKey) ?? [];
+		let examinedSourceSegments = 0;
+		let low = 0;
+		let high = indexed.length;
+		while (low < high) {
+			const middle = low + Math.floor((high - low) / 2);
+			const end = (
+				indexed[middle].metadata as Record<string, unknown> | undefined
+			)?.[endKey];
+			examinedSourceSegments += 1;
+			if (typeof end === "number" && end > params.offset) high = middle;
+			else low = middle + 1;
+		}
 		const sourceSegments: Memory[] = [];
-		for (const candidate of this.memoriesById.values()) {
-			const candidateMetadata = (candidate.metadata ?? {}) as Record<
-				string,
-				unknown
-			>;
-			const start = candidateMetadata[startKey];
-			const end = candidateMetadata[endKey];
-			if (
-				candidate.agentId === params.agentId &&
-				candidateMetadata.type === MemoryType.FRAGMENT &&
-				candidateMetadata.fragmentRole === "source-segment" &&
-				candidateMetadata.documentId === params.documentId &&
-				candidateMetadata.sourceSegmentVersion === 1 &&
-				candidateMetadata.documentRevision === parent.documentRevision &&
-				(parent.revisionAttemptId === undefined ||
-					candidateMetadata.revisionAttemptId === parent.revisionAttemptId) &&
-				typeof start === "number" &&
-				typeof end === "number" &&
-				end > params.offset &&
-				start < requestedEnd
-			) {
-				sourceSegments.push(candidate);
-				sourceSegments.sort(
-					(left, right) =>
-						Number((left.metadata as Record<string, unknown>)?.position) -
-						Number((right.metadata as Record<string, unknown>)?.position),
-				);
-				if (sourceSegments.length > DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS) {
-					sourceSegments.pop();
-				}
-			}
+		for (
+			let index = low;
+			index < indexed.length &&
+			sourceSegments.length < DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS;
+			index += 1
+		) {
+			const candidate = indexed[index];
+			const start = (
+				candidate.metadata as Record<string, unknown> | undefined
+			)?.[startKey];
+			examinedSourceSegments += 1;
+			if (typeof start !== "number" || start >= requestedEnd) break;
+			sourceSegments.push(candidate);
 		}
 		return readDocumentSourceProjection({
 			segments: sourceSegments,
 			params,
 			parent,
 			documentId: params.documentId,
+			examinedSourceSegments,
 			sourceQueryCount: 2,
 		});
 	}
@@ -1119,7 +1203,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				});
 			}
 		}
-		for (const id of oldFragmentIds) this.memoriesById.delete(id);
+		for (const id of oldFragmentIds) {
+			const fragment = this.memoriesById.get(id);
+			if (fragment) this.removeSourceSegmentFromIndex(fragment);
+			this.memoriesById.delete(id);
+		}
 		for (const [key, list] of this.memoriesByRoom) {
 			this.memoriesByRoom.set(
 				key,
@@ -1142,6 +1230,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		}
 		for (const fragment of params.fragments) {
 			this.memoriesById.set(String(fragment.id), fragment);
+			this.addSourceSegmentToIndex(fragment);
 			const key = roomTableKey("document_fragments", fragment.roomId);
 			this.memoriesByRoom.set(key, [
 				...(this.memoriesByRoom.get(key) ?? []),
@@ -1534,7 +1623,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				id: asUuid(id),
 				unique: unique ?? memory.unique ?? true,
 			};
+			const existing = this.memoriesById.get(id);
+			if (existing) this.removeSourceSegmentFromIndex(existing);
 			this.memoriesById.set(id, stored);
+			this.addSourceSegmentToIndex(stored);
 			const roomId = memory.roomId;
 			const key = roomTableKey(tableName, roomId);
 			const list = this.memoriesByRoom.get(key) ?? [];
@@ -1556,7 +1648,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				continue;
 			}
 			const merged: Memory = { ...existing, ...memory };
+			this.removeSourceSegmentFromIndex(existing);
 			this.memoriesById.set(String(memory.id), merged);
+			this.addSourceSegmentToIndex(merged);
 			// Update reference in memoriesByRoom to keep consistency
 			const oldRoomId = existing.roomId;
 			const newRoomId = merged.roomId;
@@ -1600,6 +1694,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	async deleteMemories(memoryIds: UUID[]): Promise<void> {
 		const idSet = new Set(memoryIds.map(String));
 		for (const id of memoryIds) {
+			const memory = this.memoriesById.get(String(id));
+			if (memory) this.removeSourceSegmentFromIndex(memory);
 			this.memoriesById.delete(String(id));
 		}
 		// Clean up memoriesByRoom references
@@ -1618,6 +1714,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			const key = roomTableKey(tableName, roomId);
 			const memories = this.memoriesByRoom.get(key) ?? [];
 			for (const mem of memories) {
+				this.removeSourceSegmentFromIndex(mem);
 				this.memoriesById.delete(String(mem.id));
 			}
 			this.memoriesByRoom.delete(key);

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -21,6 +21,11 @@ import {
 	validateTaskQueryPagination,
 } from "../database";
 import { ElizaError } from "../errors";
+import {
+	DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+	readDocumentSourceProjection,
+	requireDocumentSourceReadMetadata,
+} from "../features/documents/source-segments";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
@@ -85,7 +90,6 @@ import type {
 import { MemoryType } from "../types";
 import { normalizePairingPageOptions } from "../types/pairing";
 import { DEFAULT_UUID } from "../types/primitives";
-import { createHash } from "../utils/crypto-compat";
 import { isPlainObject } from "../utils/type-guards";
 import {
 	cloneConnectorJsonObject,
@@ -301,7 +305,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	Record<string, never>
 > {
 	readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
-	readonly documentRangeReadCapability = 1 as const;
+	readonly documentRangeReadCapability = 2 as const;
 	db: Record<string, never> = {};
 
 	private ready = false;
@@ -911,42 +915,79 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	async readDocumentRange(
 		params: DocumentRangeReadParams,
 	): Promise<DocumentRangeReadResult | null> {
+		if (
+			!(["line", "fragment", "byte"] as const).includes(params.unit) ||
+			!Number.isSafeInteger(params.offset) ||
+			params.offset < 0 ||
+			!Number.isSafeInteger(params.limit) ||
+			params.limit < 1 ||
+			params.offset > Number.MAX_SAFE_INTEGER - params.limit
+		) {
+			throw new ElizaError(
+				"Document range read requires a valid unit and bounded safe-integer range",
+				{
+					code: "DOCUMENT_READ_INVALID_RANGE",
+				},
+			);
+		}
 		const memory = await this.getDocument(params);
 		if (!memory) return null;
-		const source = memory.content.text ?? "";
-		const lines = source.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+$/gu) ?? [];
-		const units =
-			params.unit === "line"
-				? lines
-				: lines
-						.reduce<string[]>((fragments, line) => {
-							const last = fragments.length - 1;
-							if (last < 0) fragments.push(line);
-							else fragments[last] += line;
-							if (line.replace(/[\r\n]/gu, "").trim().length === 0) {
-								fragments.push("");
-							}
-							return fragments;
-						}, [])
-						.filter((fragment) => fragment.length > 0);
-		const text = units
-			.slice(params.offset, params.offset + params.limit)
-			.join("");
 		const metadata = (memory.metadata ?? {}) as Record<string, unknown>;
-		return {
-			text,
-			start: params.offset,
-			end: Math.min(params.offset + params.limit, units.length),
-			total: units.length,
-			documentRevision:
-				typeof metadata.documentRevision === "number"
-					? metadata.documentRevision
-					: 0,
-			...(typeof metadata.revisionAttemptId === "string"
-				? { revisionAttemptId: metadata.revisionAttemptId }
-				: {}),
-			sourceFingerprint: `md5:${createHash("md5").update(source).digest("hex")}`,
-		};
+		const parent = requireDocumentSourceReadMetadata(
+			metadata,
+			params.documentId,
+		);
+		const total =
+			params.unit === "byte"
+				? parent.sourceByteLength
+				: params.unit === "line"
+					? parent.sourceLineCount
+					: parent.sourceFragmentCount;
+		const requestedEnd = Math.min(params.offset + params.limit, total);
+		const coordinateName =
+			params.unit === "byte"
+				? "Byte"
+				: params.unit === "line"
+					? "Line"
+					: "Fragment";
+		const startKey = `source${coordinateName}Start`;
+		const endKey = `source${coordinateName}End`;
+		const sourceSegments = Array.from(this.memoriesById.values())
+			.filter((candidate) => {
+				const candidateMetadata = (candidate.metadata ?? {}) as Record<
+					string,
+					unknown
+				>;
+				const start = candidateMetadata[startKey];
+				const end = candidateMetadata[endKey];
+				return (
+					candidate.agentId === params.agentId &&
+					candidateMetadata.type === MemoryType.FRAGMENT &&
+					candidateMetadata.fragmentRole === "source-segment" &&
+					candidateMetadata.documentId === params.documentId &&
+					candidateMetadata.sourceSegmentVersion === 1 &&
+					candidateMetadata.documentRevision === parent.documentRevision &&
+					(parent.revisionAttemptId === undefined ||
+						candidateMetadata.revisionAttemptId === parent.revisionAttemptId) &&
+					typeof start === "number" &&
+					typeof end === "number" &&
+					end > params.offset &&
+					start < requestedEnd
+				);
+			})
+			.sort(
+				(left, right) =>
+					Number((left.metadata as Record<string, unknown>)?.position) -
+					Number((right.metadata as Record<string, unknown>)?.position),
+			)
+			.slice(0, DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS);
+		return readDocumentSourceProjection({
+			segments: sourceSegments,
+			params,
+			parent,
+			documentId: params.documentId,
+			sourceQueryCount: 2,
+		});
 	}
 
 	async queryDocumentFragments(
@@ -964,15 +1005,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				typeof documentId === "string"
 					? this.memoriesById.get(documentId)
 					: undefined;
-			const source = parent?.content.text;
-			return typeof source === "string"
+			const sourceFingerprint = (
+				parent?.metadata as Record<string, unknown> | undefined
+			)?.sourceFingerprint;
+			return typeof sourceFingerprint === "string"
 				? {
 						...fragment,
 						metadata: {
 							...(fragment.metadata ?? {}),
-							sourceFingerprint: `md5:${createHash("md5")
-								.update(source)
-								.digest("hex")}`,
+							sourceFingerprint,
 						} as Memory["metadata"],
 					}
 				: fragment;

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -135,7 +135,7 @@ function documentSourceIndexKey(args: {
 		String(args.agentId),
 		String(args.documentId),
 		args.documentRevision,
-		args.revisionAttemptId ?? "",
+		args.revisionAttemptId ?? null,
 	]);
 }
 

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -952,35 +952,39 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 					: "Fragment";
 		const startKey = `source${coordinateName}Start`;
 		const endKey = `source${coordinateName}End`;
-		const sourceSegments = Array.from(this.memoriesById.values())
-			.filter((candidate) => {
-				const candidateMetadata = (candidate.metadata ?? {}) as Record<
-					string,
-					unknown
-				>;
-				const start = candidateMetadata[startKey];
-				const end = candidateMetadata[endKey];
-				return (
-					candidate.agentId === params.agentId &&
-					candidateMetadata.type === MemoryType.FRAGMENT &&
-					candidateMetadata.fragmentRole === "source-segment" &&
-					candidateMetadata.documentId === params.documentId &&
-					candidateMetadata.sourceSegmentVersion === 1 &&
-					candidateMetadata.documentRevision === parent.documentRevision &&
-					(parent.revisionAttemptId === undefined ||
-						candidateMetadata.revisionAttemptId === parent.revisionAttemptId) &&
-					typeof start === "number" &&
-					typeof end === "number" &&
-					end > params.offset &&
-					start < requestedEnd
+		const sourceSegments: Memory[] = [];
+		for (const candidate of this.memoriesById.values()) {
+			const candidateMetadata = (candidate.metadata ?? {}) as Record<
+				string,
+				unknown
+			>;
+			const start = candidateMetadata[startKey];
+			const end = candidateMetadata[endKey];
+			if (
+				candidate.agentId === params.agentId &&
+				candidateMetadata.type === MemoryType.FRAGMENT &&
+				candidateMetadata.fragmentRole === "source-segment" &&
+				candidateMetadata.documentId === params.documentId &&
+				candidateMetadata.sourceSegmentVersion === 1 &&
+				candidateMetadata.documentRevision === parent.documentRevision &&
+				(parent.revisionAttemptId === undefined ||
+					candidateMetadata.revisionAttemptId === parent.revisionAttemptId) &&
+				typeof start === "number" &&
+				typeof end === "number" &&
+				end > params.offset &&
+				start < requestedEnd
+			) {
+				sourceSegments.push(candidate);
+				sourceSegments.sort(
+					(left, right) =>
+						Number((left.metadata as Record<string, unknown>)?.position) -
+						Number((right.metadata as Record<string, unknown>)?.position),
 				);
-			})
-			.sort(
-				(left, right) =>
-					Number((left.metadata as Record<string, unknown>)?.position) -
-					Number((right.metadata as Record<string, unknown>)?.position),
-			)
-			.slice(0, DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS);
+				if (sourceSegments.length > DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS) {
+					sourceSegments.pop();
+				}
+			}
+		}
 		return readDocumentSourceProjection({
 			segments: sourceSegments,
 			params,

--- a/packages/core/src/features/documents/__tests__/actions-progressive-read.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-progressive-read.test.ts
@@ -45,8 +45,35 @@ function harness(text: string) {
 		readDocumentRange: vi.fn(
 			async (
 				_documentId: UUID,
-				params: { unit: "line" | "fragment"; offset: number; limit: number },
+				params: {
+					unit: "line" | "fragment" | "byte";
+					offset: number;
+					limit: number;
+				},
 			) => {
+				if (params.unit === "byte") {
+					const bytes = Buffer.from(currentText, "utf8");
+					const text = bytes
+						.subarray(params.offset, params.offset + params.limit)
+						.toString("utf8");
+					return {
+						unit: "byte" as const,
+						text,
+						start: params.offset,
+						end: params.offset + Buffer.byteLength(text, "utf8"),
+						total: bytes.length,
+						documentRevision: currentRevision,
+						revisionAttemptId: `native-secret-${currentRevision}`,
+						sourceFingerprint: `sha256:${createHash("sha256")
+							.update(currentText)
+							.digest("hex")}`,
+						examinedSourceSegments: 1,
+						returnedSourceSegments: 1,
+						sourceBytesRead: text.length,
+						returnedSourceBytes: text.length,
+						sourceQueryCount: 2,
+					};
+				}
 				const lines =
 					currentText.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+$/gu) ?? [];
 				const units =
@@ -63,10 +90,12 @@ function harness(text: string) {
 									return fragments;
 								}, [])
 								.filter(Boolean);
+				const pageText = units
+					.slice(params.offset, params.offset + params.limit)
+					.join("");
 				return {
-					text: units
-						.slice(params.offset, params.offset + params.limit)
-						.join(""),
+					unit: params.unit,
+					text: pageText,
 					start: params.offset,
 					end: Math.min(params.offset + params.limit, units.length),
 					total: units.length,
@@ -75,6 +104,11 @@ function harness(text: string) {
 					sourceFingerprint: `sha256:${createHash("sha256")
 						.update(currentText)
 						.digest("hex")}`,
+					examinedSourceSegments: 1,
+					returnedSourceSegments: 1,
+					sourceBytesRead: Buffer.byteLength(pageText, "utf8"),
+					returnedSourceBytes: Buffer.byteLength(pageText, "utf8"),
+					sourceQueryCount: 2,
 				};
 			},
 		),
@@ -192,6 +226,42 @@ describe("DOCUMENT progressive read", () => {
 			offset = view.slice.nextOffset as number;
 		}
 		expect(pages.join("")).toBe(source);
+	});
+
+	it("exposes giant-unit fallback as an advancing partial byte page", async () => {
+		const { runtime, service } = harness("unused");
+		service.readDocumentRange.mockResolvedValueOnce({
+			unit: "byte",
+			text: "bounded prefix",
+			start: 0,
+			end: 14,
+			total: 1_000_000,
+			documentRevision: 7,
+			revisionAttemptId: "native-secret-7",
+			sourceFingerprint: `sha256:${"a".repeat(64)}`,
+			examinedSourceSegments: 5,
+			returnedSourceSegments: 3,
+			sourceBytesRead: 256 * 1024,
+			returnedSourceBytes: 14,
+			sourceQueryCount: 2,
+		});
+		const result = await documentAction.handler?.(
+			runtime,
+			request(),
+			undefined,
+			options({ action: "read", documentId: DOCUMENT_ID, unit: "line" }),
+		);
+		expect(result?.text).toBe("bounded prefix");
+		expect(result?.data).toMatchObject({
+			readView: {
+				slice: {
+					range: { unit: "byte", start: 0, end: 14, total: 1_000_000 },
+					completeness: "partial-recoverable",
+					hasMore: true,
+					nextOffset: 14,
+				},
+			},
+		});
 	});
 
 	it("fails explicitly when the source changes between pages", async () => {

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -768,7 +768,7 @@ async function handleSearch(
 
 const DOCUMENT_READ_DEFAULT_LIMIT = 100;
 
-type DocumentReadUnit = "line" | "fragment";
+type DocumentReadUnit = "line" | "fragment" | "byte";
 
 function opaqueDocumentRevision(metadata: Record<string, unknown>): string {
 	const declaredRevision =
@@ -871,7 +871,7 @@ async function handleRead(
 	}
 
 	const unit: DocumentReadUnit =
-		params.unit === "fragment" ? "fragment" : "line";
+		params.unit === "fragment" || params.unit === "byte" ? params.unit : "line";
 	const offset = requiredReadInteger(params.offset, "offset", 0);
 	const limit = requiredReadInteger(
 		params.limit,
@@ -893,7 +893,7 @@ async function handleRead(
 			context: { field: "offset", total: bounded.total },
 		});
 	}
-	const page = documentReadPage(bounded, documentId, unit);
+	const page = documentReadPage(bounded, documentId, bounded.unit);
 	if (
 		page.view.slice.range.start > 0 &&
 		(typeof params.expectedRevision !== "string" ||
@@ -1547,7 +1547,7 @@ export const documentAction: Action = {
 		{
 			name: "limit",
 			description:
-				"Maximum number of results or listed documents (1-100). Use 0 when this field is not applicable to the selected action.",
+				"Maximum results for list/search or exact units for one explicitly paged read (1-100). Omitting it on read requests the first bounded 100-unit page; follow readView.nextOffset until readView.completeness is complete. Use 0 when this field is not applicable.",
 			required: false,
 			schema: { type: "number", minimum: 0, maximum: 100 },
 		},
@@ -1598,16 +1598,16 @@ export const documentAction: Action = {
 		{
 			name: "offset",
 			description:
-				"Pagination offset for list, or the zero-based line/fragment offset for read.",
+				"Pagination offset for list, or the zero-based line/fragment/UTF-8-byte offset for read. Continuations must use readView.nextOffset and expectedRevision.",
 			required: false,
 			schema: { type: "number", minimum: 0 },
 		},
 		{
 			name: "unit",
 			description:
-				"Exact read unit for action=read: line or fragment. Defaults to line.",
+				"Exact read unit for action=read: line, fragment, or UTF-8 byte. Defaults to line; oversized logical units continue as bounded byte pages.",
 			required: false,
-			schema: { type: "string", enum: ["line", "fragment"] },
+			schema: { type: "string", enum: ["line", "fragment", "byte"] },
 		},
 		{
 			name: "expectedRevision",

--- a/packages/core/src/features/documents/document-processor.ts
+++ b/packages/core/src/features/documents/document-processor.ts
@@ -130,6 +130,7 @@ async function persistKeywordOnlyFragments(args: {
 		const metadata: DocumentFragmentMemoryMetadata = {
 			...(args.documentMetadata ?? {}),
 			type: MemoryType.FRAGMENT,
+			fragmentRole: "embedding-chunk",
 			documentId: args.documentId,
 			position,
 			timestamp: Date.now(),
@@ -454,6 +455,7 @@ export async function preparePreChunkedFragmentMemories({
 			...(documentMetadata ?? {}),
 			...metadata,
 			type: MemoryType.FRAGMENT,
+			fragmentRole: "embedding-chunk",
 			documentId,
 			position,
 			timestamp: Date.now(),
@@ -600,6 +602,7 @@ async function processAndSaveFragments({
 				const fragmentMetadata: DocumentFragmentMemoryMetadata = {
 					...(documentMetadata ?? {}),
 					type: MemoryType.FRAGMENT,
+					fragmentRole: "embedding-chunk",
 					documentId,
 					position: originalChunkIndex,
 					timestamp: Date.now(),

--- a/packages/core/src/features/documents/index.ts
+++ b/packages/core/src/features/documents/index.ts
@@ -64,6 +64,15 @@ export type {
 	SearchMode,
 } from "./service";
 export { DocumentService, resolveDocumentRequester } from "./service";
+export type { DocumentSourceReadMetadata } from "./source-segments";
+export {
+	DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+	DOCUMENT_SOURCE_READ_MAX_SEGMENTS,
+	DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+	DOCUMENT_SOURCE_SEGMENT_VERSION,
+	readDocumentSourceProjection,
+	requireDocumentSourceReadMetadata,
+} from "./source-segments";
 export * from "./types";
 export type {
 	FetchDocumentFromUrlOptions,

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -21,6 +21,12 @@ import {
 import { documentAction } from "./actions.ts";
 import { documentsProvider } from "./provider.ts";
 import { DocumentService } from "./service.ts";
+import {
+	buildDocumentSourceProjection,
+	DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+	DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+} from "./source-segments.ts";
+import type { DocumentMemoryMetadata } from "./types.ts";
 
 const USER_ID = "f4300000-0000-4000-8000-000000000001" as UUID;
 const OTHER_USER_ID = "f4300000-0000-4000-8000-000000000007" as UUID;
@@ -120,6 +126,34 @@ function documentFragment(document: Memory, text: string, id: UUID): Memory {
 	};
 }
 
+function sourceBackedRecords(document: Memory): Array<{
+	memory: Memory;
+	tableName: "documents" | "document_fragments";
+}> {
+	const projection = buildDocumentSourceProjection({
+		text: document.content.text ?? "",
+		documentId: document.id as UUID,
+		agentId: document.agentId,
+		roomId: document.roomId as UUID,
+		entityId: document.entityId as UUID,
+		worldId: document.worldId,
+		documentMetadata: document.metadata as DocumentMemoryMetadata,
+	});
+	return [
+		{
+			memory: {
+				...document,
+				metadata: { ...document.metadata, ...projection.metadata },
+			},
+			tableName: "documents",
+		},
+		...projection.segments.map((memory) => ({
+			memory,
+			tableName: "document_fragments" as const,
+		})),
+	];
+}
+
 beforeAll(async () => {
 	({ runtime, cleanup } = await createTestRuntime({
 		characterName: "DocumentAuthorizationTest",
@@ -202,37 +236,31 @@ beforeAll(async () => {
 			title: "HIDDEN_FOREIGN_TENANT_DOCUMENT",
 		},
 	);
+	const privateGrantDocument = userPrivateDocument(
+		PRIVATE_GRANT_DOCUMENT_ID,
+		"Private grantable body",
+	);
+	const globalGrantDocument = {
+		...userPrivateDocument(GRANT_DOCUMENT_ID, "Grantable global body"),
+		metadata: {
+			...userPrivateDocument(GRANT_DOCUMENT_ID, "Grantable global body")
+				.metadata,
+			scope: "global",
+			scopedToEntityId: undefined,
+		},
+	} as Memory;
 	await runtime.createMemories([
-		{
-			memory: userPrivateDocument(
-				PRIVATE_GRANT_DOCUMENT_ID,
-				"Private grantable body",
-			),
-			tableName: "documents",
-		},
-		{
-			memory: {
-				...userPrivateDocument(GRANT_DOCUMENT_ID, "Grantable global body"),
-				metadata: {
-					...userPrivateDocument(GRANT_DOCUMENT_ID, "Grantable global body")
-						.metadata,
-					scope: "global",
-					scopedToEntityId: undefined,
-				},
-			},
-			tableName: "documents",
-		},
-		{
-			memory: userPrivateDocument(UPDATE_DOCUMENT_ID, "Original update body"),
-			tableName: "documents",
-		},
-		{
-			memory: userPrivateDocument(DELETE_DOCUMENT_ID, "Original delete body"),
-			tableName: "documents",
-		},
-		{ memory: visibleDocument, tableName: "documents" },
-		{ memory: hiddenUserDocument, tableName: "documents" },
-		{ memory: foreignDocument, tableName: "documents" },
+		...sourceBackedRecords(privateGrantDocument),
+		...sourceBackedRecords(globalGrantDocument),
+		...sourceBackedRecords(
+			userPrivateDocument(UPDATE_DOCUMENT_ID, "Original update body"),
+		),
+		...sourceBackedRecords(
+			userPrivateDocument(DELETE_DOCUMENT_ID, "Original delete body"),
+		),
+		...sourceBackedRecords(visibleDocument),
+		...sourceBackedRecords(hiddenUserDocument),
+		...sourceBackedRecords(foreignDocument),
 		{
 			memory: documentFragment(
 				visibleDocument,
@@ -363,17 +391,46 @@ describe("DocumentService requester authorization", () => {
 	});
 
 	it("reads a late page from a 10 MiB PGLite document without returning a source-sized projection", async () => {
+		const raw = (
+			runtime.adapter as unknown as {
+				getRawConnection?: () => {
+					query: (
+						statement: string,
+					) => Promise<{ rows: Array<Record<string, unknown>> }>;
+				};
+			}
+		).getRawConnection?.();
+		if (!raw)
+			throw new Error("bounded source test requires the PGLite adapter");
+		const indexRows = await raw.query(`
+			SELECT indexname, indexdef
+			FROM pg_indexes
+			WHERE indexname IN (
+				'idx_document_source_byte_seek',
+				'idx_document_source_line_seek',
+				'idx_document_source_fragment_seek'
+			)
+			ORDER BY indexname
+		`);
+		expect(indexRows.rows.map((row) => row.indexname)).toEqual([
+			"idx_document_source_byte_seek",
+			"idx_document_source_fragment_seek",
+			"idx_document_source_line_seek",
+		]);
+		for (const row of indexRows.rows) {
+			expect(String(row.indexdef)).toContain("documentId");
+			expect(String(row.indexdef)).toContain("source-segment");
+		}
 		const ordinaryLine = `${"x".repeat(1_023)}\n`;
 		const lateLine = `${"LATE-EVIDENCE".padEnd(1_023, "z")}\n`;
 		const source = ordinaryLine.repeat(10_239) + lateLine;
 		expect(Buffer.byteLength(source)).toBe(10 * 1024 * 1024);
 		await runtime.createMemories([
-			{
-				memory: userPrivateDocument(LARGE_DOCUMENT_ID, source, {
+			...sourceBackedRecords(
+				userPrivateDocument(LARGE_DOCUMENT_ID, source, {
 					title: "Large bounded-read document",
 				}),
-				tableName: "documents",
-			},
+			),
 		]);
 		const wholeRead = vi
 			.spyOn(runtime.adapter, "getDocument")
@@ -439,6 +496,27 @@ describe("DocumentService requester authorization", () => {
 					},
 				},
 			});
+			const directPage = await runtime.adapter.readDocumentRange?.({
+				agentId: runtime.agentId,
+				documentId: LARGE_DOCUMENT_ID,
+				requesterEntityId: USER_ID,
+				requesterRoomIds: [ROOM_ID],
+				requesterRole: "USER",
+				unit: "line",
+				offset: 10_239,
+				limit: 1,
+			});
+			expect(directPage).toMatchObject({
+				text: lateLine,
+				sourceQueryCount: 2,
+			});
+			expect(directPage?.examinedSourceSegments).toBeLessThanOrEqual(
+				DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+			);
+			expect(directPage?.sourceBytesRead).toBeLessThanOrEqual(
+				DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS *
+					DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+			);
 		} finally {
 			getService.mockRestore();
 			wholeRead.mockRestore();
@@ -542,6 +620,18 @@ describe("DocumentService requester authorization", () => {
 		await expect(
 			runtime.adapter.getMemoryById(oldFragmentId),
 		).resolves.toMatchObject({ content: { text: "Failure old fragment" } });
+		await expect(
+			runtime.adapter.readDocumentRange?.({
+				agentId: runtime.agentId,
+				documentId: FAILED_UPDATE_DOCUMENT_ID,
+				requesterEntityId: USER_ID,
+				requesterRoomIds: [ROOM_ID],
+				requesterRole: "USER",
+				unit: "line",
+				offset: 0,
+				limit: 1,
+			}),
+		).rejects.toMatchObject({ code: "DOCUMENT_REINDEX_REQUIRED" });
 	});
 
 	it("commits a parent and its replacement fragments as one revision", async () => {
@@ -595,6 +685,19 @@ describe("DocumentService requester authorization", () => {
 		expect(replacementFragments[0]).toMatchObject({
 			content: { text: "Atomic replacement body" },
 			metadata: { documentRevision: 1, position: 0 },
+		});
+		await expect(
+			runtime.adapter.readDocumentRange?.({
+				...context,
+				documentId: ATOMIC_UPDATE_DOCUMENT_ID,
+				unit: "line",
+				offset: 0,
+				limit: 1,
+			}),
+		).resolves.toMatchObject({
+			text: "Atomic replacement body",
+			documentRevision: 1,
+			sourceQueryCount: 2,
 		});
 		await expect(
 			runtime.adapter.getMemoryById(oldFragmentId),

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -481,8 +481,8 @@ describe("DocumentService requester authorization", () => {
 			}
 			expect(result?.text).toBe(lateLine);
 			expect(wholeRead).not.toHaveBeenCalled();
-			// Query/result-byte oracle: the adapter may scan the source inside the DB,
-			// but only the requested page and continuation metadata cross into JS.
+			// Query/result-byte oracle: indexed source segments keep the complete
+			// parent body out of both the database read path and the JS projection.
 			expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThan(16 * 1024);
 			expect(result?.data).toMatchObject({
 				readView: {

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -517,6 +517,30 @@ describe("DocumentService requester authorization", () => {
 				DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS *
 					DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
 			);
+			await expect(
+				runtime.adapter.readDocumentRange?.({
+					agentId: runtime.agentId,
+					documentId: LARGE_DOCUMENT_ID,
+					requesterEntityId: USER_ID,
+					requesterRoomIds: [ROOM_ID],
+					requesterRole: "USER",
+					unit: "line",
+					offset: 10_240,
+					limit: 1,
+				}),
+			).resolves.toMatchObject({ text: "", start: 10_240, end: 10_240 });
+			await expect(
+				runtime.adapter.readDocumentRange?.({
+					agentId: runtime.agentId,
+					documentId: LARGE_DOCUMENT_ID,
+					requesterEntityId: USER_ID,
+					requesterRoomIds: [ROOM_ID],
+					requesterRole: "USER",
+					unit: "line",
+					offset: 10_241,
+					limit: 1,
+				}),
+			).rejects.toMatchObject({ code: "DOCUMENT_READ_INVALID_RANGE" });
 		} finally {
 			getService.mockRestore();
 			wholeRead.mockRestore();

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -48,6 +48,7 @@ const GRANT_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000022" as UUID;
 const PRIVATE_GRANT_DOCUMENT_ID =
 	"f4300000-0000-4000-8000-000000000030" as UUID;
 const LARGE_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000029" as UUID;
+const PLAN_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000031" as UUID;
 
 let runtime: AgentRuntime;
 let cleanup: () => Promise<void>;
@@ -432,6 +433,116 @@ describe("DocumentService requester authorization", () => {
 				}),
 			),
 		]);
+		const planSource = `${"p".repeat(1_022)}\n\n`.repeat(2_048);
+		const planRecords = sourceBackedRecords(
+			userPrivateDocument(PLAN_DOCUMENT_ID, planSource, {
+				title: "Coordinate seek plan document",
+			}),
+		);
+		await runtime.createMemories(planRecords);
+		const planMetadata = planRecords[0].memory.metadata as Record<
+			string,
+			unknown
+		>;
+		type ExplainNode = {
+			"Node Type"?: string;
+			"Index Name"?: string;
+			Alias?: string;
+			"Actual Rows"?: number;
+			"Rows Removed by Filter"?: number;
+			"Rows Removed by Index Recheck"?: number;
+			Plans?: ExplainNode[];
+		};
+		const flattenPlan = (node: ExplainNode): ExplainNode[] => [
+			node,
+			...(node.Plans ?? []).flatMap(flattenPlan),
+		];
+		const explainSeek = async (args: {
+			unit: "Byte" | "Line" | "Fragment";
+			offset: number;
+			total: number;
+			indexName: string;
+		}) => {
+			const explained = await raw.query(`
+				EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+				SELECT source_segment.id
+				FROM memories AS source_parent
+				LEFT JOIN memories AS source_segment ON (
+					source_segment.type = 'document_fragments'
+					AND source_segment.agent_id = '${runtime.agentId}'::uuid
+					AND source_segment.metadata->>'type' = 'fragment'
+					AND source_segment.metadata->>'fragmentRole' = 'source-segment'
+					AND source_segment.metadata->>'sourceSegmentVersion' = '1'
+					AND source_segment.metadata->>'documentId' = '${PLAN_DOCUMENT_ID}'
+					AND (source_segment.metadata->>'documentRevision')::bigint = 0
+					AND NOT (source_segment.metadata ? 'revisionAttemptId')
+					AND (source_segment.metadata->>'source${args.unit}End')::bigint > ${args.offset}
+					AND (source_segment.metadata->>'source${args.unit}Start')::bigint < ${args.total}
+				)
+				WHERE source_parent.id = '${PLAN_DOCUMENT_ID}'::uuid
+					AND source_parent.type = 'documents'
+					AND source_parent.agent_id = '${runtime.agentId}'::uuid
+					AND source_parent.metadata->>'type' = 'document'
+				ORDER BY (source_segment.metadata->>'position')::bigint ASC NULLS LAST
+				LIMIT ${DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS}
+			`);
+			const rawPlan = explained.rows[0]?.["QUERY PLAN"];
+			const envelope = Array.isArray(rawPlan) ? rawPlan[0] : rawPlan;
+			const root = (envelope as { Plan?: ExplainNode } | undefined)?.Plan;
+			if (!root)
+				throw new Error(
+					`PGLite returned an invalid EXPLAIN plan for ${args.unit}`,
+				);
+			const nodes = flattenPlan(root);
+			expect(nodes.some((node) => node["Index Name"] === args.indexName)).toBe(
+				true,
+			);
+			expect(
+				nodes.some(
+					(node) =>
+						node.Alias === "source_segment" && node["Node Type"] === "Seq Scan",
+				),
+			).toBe(false);
+			const sourceScans = nodes.filter(
+				(node) =>
+					node.Alias === "source_segment" &&
+					node["Node Type"]?.includes("Scan"),
+			);
+			expect(sourceScans.length).toBeGreaterThan(0);
+			for (const node of sourceScans) {
+				const visited =
+					(node["Actual Rows"] ?? 0) +
+					(node["Rows Removed by Filter"] ?? 0) +
+					(node["Rows Removed by Index Recheck"] ?? 0);
+				expect(visited).toBeLessThanOrEqual(
+					DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+				);
+			}
+		};
+		await raw.query("ANALYZE memories");
+		await raw.query("SET enable_seqscan = off");
+		try {
+			await explainSeek({
+				unit: "Byte",
+				offset: Number(planMetadata.sourceByteLength) - 1,
+				total: Number(planMetadata.sourceByteLength),
+				indexName: "idx_document_source_byte_seek",
+			});
+			await explainSeek({
+				unit: "Line",
+				offset: Number(planMetadata.sourceLineCount) - 1,
+				total: Number(planMetadata.sourceLineCount),
+				indexName: "idx_document_source_line_seek",
+			});
+			await explainSeek({
+				unit: "Fragment",
+				offset: Number(planMetadata.sourceFragmentCount) - 1,
+				total: Number(planMetadata.sourceFragmentCount),
+				indexName: "idx_document_source_fragment_seek",
+			});
+		} finally {
+			await raw.query("RESET enable_seqscan");
+		}
 		const wholeRead = vi
 			.spyOn(runtime.adapter, "getDocument")
 			.mockRejectedValue(

--- a/packages/core/src/features/documents/service-character-ingest.test.ts
+++ b/packages/core/src/features/documents/service-character-ingest.test.ts
@@ -185,18 +185,30 @@ describe("DocumentService character document ingestion boot races", () => {
 		});
 
 		expect(result.fragmentCount).toBe(2);
-		expect(createMemories).toHaveBeenCalledTimes(1);
-		expect(createMemories.mock.calls[0]?.[0]).toHaveLength(2);
+		expect(createMemories).toHaveBeenCalledTimes(2);
+		expect(createMemories.mock.calls[0]?.[0]).toHaveLength(1);
+		expect(
+			createMemories.mock.calls[0]?.[0]?.[0]?.memory.metadata,
+		).toMatchObject({
+			fragmentRole: "source-segment",
+			position: 0,
+		});
+		expect(createMemories.mock.calls[1]?.[0]).toHaveLength(2);
 		const documents = await getStoredMemories(runtime, DOCUMENTS_TABLE);
 		const fragments = await getStoredMemories(
 			runtime,
 			DOCUMENT_FRAGMENTS_TABLE,
 		);
 		expect(documents).toHaveLength(1);
-		expect(fragments).toHaveLength(2);
+		expect(fragments).toHaveLength(3);
 		expect(
 			fragments.every((fragment) => fragment.embedding === undefined),
 		).toBe(true);
+		expect(
+			fragments.filter(
+				(fragment) => fragment.metadata?.fragmentRole === "source-segment",
+			),
+		).toHaveLength(1);
 		expect(fragments).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -168,12 +168,20 @@ describe("DocumentService list semantics", () => {
 			roomId: ROOM_A,
 			count: 10,
 		});
-		expect(fragments).toHaveLength(1);
-		expect(fragments[0]).toMatchObject({
+		const embeddingFragments = fragments.filter(
+			(fragment) => fragment.metadata?.fragmentRole !== "source-segment",
+		);
+		expect(embeddingFragments).toHaveLength(1);
+		expect(embeddingFragments[0]).toMatchObject({
 			content: { text: "Revised keyword-only standing draft" },
 			metadata: { documentId: added.storedDocumentMemoryId },
 		});
-		expect(fragments[0]?.embedding).toBeUndefined();
+		expect(embeddingFragments[0]?.embedding).toBeUndefined();
+		expect(
+			fragments.filter(
+				(fragment) => fragment.metadata?.fragmentRole === "source-segment",
+			),
+		).toHaveLength(1);
 	});
 
 	it("filters and paginates through one bounded adapter query", async () => {

--- a/packages/core/src/features/documents/service-orphan-compensation.test.ts
+++ b/packages/core/src/features/documents/service-orphan-compensation.test.ts
@@ -37,7 +37,7 @@ async function fragmentsFor(documentId: string): Promise<number> {
 	return memories.filter(
 		(memory) =>
 			(memory.metadata as { documentId?: string } | undefined)?.documentId ===
-			documentId,
+				documentId && memory.metadata?.fragmentRole !== "source-segment",
 	).length;
 }
 

--- a/packages/core/src/features/documents/service-update-atomic-revision.test.ts
+++ b/packages/core/src/features/documents/service-update-atomic-revision.test.ts
@@ -1,9 +1,9 @@
 /**
  * Proves updateDocument publishes document revisions atomically (#16021): the
- * replacement fragment generation is staged reader-invisible before the parent
- * compare-and-swap commits, every failure (embed outage, Nth insert, CAS
- * conflict, discard outage) preserves the complete prior committed revision,
- * and readers never observe zero, partial, or mixed fragment generations.
+ * source segments and embedding chunks are prepared reader-invisible before the
+ * adapter transaction commits them with the parent. Embed, insertion, and CAS
+ * failures preserve the prior complete revision, and readers never observe a
+ * zero, partial, or mixed fragment generation.
  * Integration-backed: a real AgentRuntime over a real PGLite SQL adapter
  * (plugin-sql); only the embedding model handler is injected.
  */
@@ -70,6 +70,18 @@ async function rawFragmentsFor(documentId: UUID): Promise<Memory[]> {
 		(memory) =>
 			(memory.metadata as { documentId?: string } | undefined)?.documentId ===
 			documentId,
+	);
+}
+
+function embeddingRows(memories: Memory[]): Memory[] {
+	return memories.filter(
+		(memory) => memory.metadata?.fragmentRole !== "source-segment",
+	);
+}
+
+function sourceRows(memories: Memory[]): Memory[] {
+	return memories.filter(
+		(memory) => memory.metadata?.fragmentRole === "source-segment",
 	);
 }
 
@@ -157,9 +169,9 @@ describe("updateDocument atomic revision publication (#16021)", () => {
 		expect(visible.join(" ")).toContain("Version two alpha");
 		expect(visible.join(" ")).not.toContain("Version one");
 		// Superseded generation is physically gone, not just invisible.
-		expect(await rawFragmentsFor(documentId)).toHaveLength(
-			updated.fragmentCount,
-		);
+		const raw = await rawFragmentsFor(documentId);
+		expect(embeddingRows(raw)).toHaveLength(updated.fragmentCount);
+		expect(sourceRows(raw).length).toBeGreaterThan(0);
 	}, 120_000);
 
 	it("preserves the complete old revision when embedding fails mid-update", async () => {
@@ -168,7 +180,7 @@ describe("updateDocument atomic revision publication (#16021)", () => {
 		try {
 			await expect(
 				service.updateDocument({ documentId, content: V2_TEXT }),
-			).rejects.toThrow(/stage replacement fragments/);
+			).rejects.toThrow("injected embedding provider outage");
 		} finally {
 			embedShouldFail = false;
 		}
@@ -188,26 +200,43 @@ describe("updateDocument atomic revision publication (#16021)", () => {
 			{ length: 200 },
 			(_, i) => `Version two long paragraph ${i}: ${V2_TEXT}`,
 		).join("\n\n");
-		const realCreateMemory = runtime.createMemory.bind(runtime);
+		const adapterRecord = runtime.adapter as unknown as Record<string, unknown>;
+		const insertMemory = Reflect.get(
+			adapterRecord,
+			"insertMemoryInTransaction",
+		);
+		if (typeof insertMemory !== "function") {
+			throw new Error("SQL adapter insertion seam is unavailable");
+		}
+		const realInsertMemory = insertMemory.bind(runtime.adapter) as (
+			...args: unknown[]
+		) => Promise<unknown>;
 		let fragmentWrites = 0;
-		runtime.createMemory = async (memory, tableName, unique) => {
-			if (
-				tableName === DOCUMENT_FRAGMENTS_TABLE &&
-				memory.content.text?.includes("Version two")
-			) {
-				fragmentWrites += 1;
-				if (fragmentWrites >= 2) {
-					throw new Error("injected Nth fragment insert outage");
+		Reflect.set(
+			adapterRecord,
+			"insertMemoryInTransaction",
+			async (...args: unknown[]) => {
+				const memory = args[1] as Memory | undefined;
+				const tableName = args[2];
+				if (
+					tableName === DOCUMENT_FRAGMENTS_TABLE &&
+					memory?.metadata?.documentId === documentId &&
+					memory.metadata.documentRevision === 1
+				) {
+					fragmentWrites += 1;
+					if (fragmentWrites >= 2) {
+						throw new Error("injected Nth fragment insert outage");
+					}
 				}
-			}
-			return realCreateMemory(memory, tableName, unique);
-		};
+				return realInsertMemory(...args);
+			},
+		);
 		try {
 			await expect(
 				service.updateDocument({ documentId, content: longV2 }),
-			).rejects.toThrow(/stage replacement fragments/);
+			).rejects.toThrow("injected Nth fragment insert outage");
 		} finally {
-			runtime.createMemory = realCreateMemory;
+			Reflect.set(adapterRecord, "insertMemoryInTransaction", insertMemory);
 		}
 		expect(fragmentWrites).toBeGreaterThanOrEqual(2);
 		await expectCommittedV1(documentId);
@@ -220,14 +249,14 @@ describe("updateDocument atomic revision publication (#16021)", () => {
 	it("keeps the old revision committed when a concurrent writer wins the CAS", async () => {
 		const documentId = await seedDocument();
 		const adapter = runtime.adapter;
-		const realCompareAndSwap = adapter.compareAndSwapDocument.bind(adapter);
-		adapter.compareAndSwapDocument = async () => ({ status: "conflict" });
+		const realReplace = adapter.replaceDocumentRevision.bind(adapter);
+		adapter.replaceDocumentRevision = async () => ({ status: "conflict" });
 		try {
 			await expect(
 				service.updateDocument({ documentId, content: V2_TEXT }),
 			).rejects.toThrow(/authorization changed before update/);
 		} finally {
-			adapter.compareAndSwapDocument = realCompareAndSwap;
+			adapter.replaceDocumentRevision = realReplace;
 		}
 		await expectCommittedV1(documentId);
 		const raw = await rawFragmentsFor(documentId);
@@ -271,42 +300,35 @@ describe("updateDocument atomic revision publication (#16021)", () => {
 		expect(after.join(" ")).not.toContain("Version one");
 	}, 120_000);
 
-	it("leaves discard leftovers invisible when staged cleanup is unavailable", async () => {
+	it("leaves no replacement rows when the atomic publication loses its CAS", async () => {
 		const documentId = await seedDocument();
-		const realDeleteMemory = runtime.deleteMemory.bind(runtime);
-		const realCompareAndSwap = runtime.adapter.compareAndSwapDocument.bind(
+		const realReplace = runtime.adapter.replaceDocumentRevision.bind(
 			runtime.adapter,
 		);
-		runtime.adapter.compareAndSwapDocument = async () => ({
+		runtime.adapter.replaceDocumentRevision = async () => ({
 			status: "conflict",
 		});
-		runtime.deleteMemory = async () => {
-			throw new Error("injected discard outage");
-		};
 		try {
 			await expect(
 				service.updateDocument({ documentId, content: V2_TEXT }),
 			).rejects.toThrow(/authorization changed before update/);
 		} finally {
-			runtime.deleteMemory = realDeleteMemory;
-			runtime.adapter.compareAndSwapDocument = realCompareAndSwap;
+			runtime.adapter.replaceDocumentRevision = realReplace;
 		}
-		// Leftover staged rows exist in storage but never reach readers: the
-		// committed parent still declares revision 0 with no attempt token.
 		const raw = await rawFragmentsFor(documentId);
 		expect(
-			raw.filter((memory) => memory.content.text?.includes("Version two"))
-				.length,
-		).toBeGreaterThan(0);
+			raw.filter((memory) => memory.content.text?.includes("Version two")),
+		).toHaveLength(0);
 		await expectCommittedV1(documentId);
 
-		// The next successful update sweeps the stale staged generation.
+		// The next successful update replaces both source and embedding views.
 		const recovered = await service.updateDocument({
 			documentId,
 			content: V2_TEXT,
 		});
 		const swept = await rawFragmentsFor(documentId);
-		expect(swept).toHaveLength(recovered.fragmentCount);
+		expect(embeddingRows(swept)).toHaveLength(recovered.fragmentCount);
+		expect(sourceRows(swept).length).toBeGreaterThan(0);
 		const visible = await visibleFragmentTexts(documentId);
 		expect(visible).toHaveLength(recovered.fragmentCount);
 		expect(visible.join(" ")).not.toContain("Version one");

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -62,6 +62,7 @@ import {
 	processFragmentsSynchronously,
 } from "./document-processor.ts";
 import { embedRecallQuery } from "./recall-embed.ts";
+import { buildDocumentSourceProjection } from "./source-segments.ts";
 import type {
 	AddDocumentOptions,
 	DocumentAddedFrom,
@@ -726,7 +727,7 @@ export class DocumentService extends Service {
 	): Promise<DocumentRangeReadResult | null> {
 		const adapter = this.runtime.adapter;
 		if (
-			adapter.documentRangeReadCapability !== 1 ||
+			adapter.documentRangeReadCapability !== 2 ||
 			typeof adapter.readDocumentRange !== "function"
 		) {
 			throw new ElizaError(
@@ -1492,6 +1493,8 @@ export class DocumentService extends Service {
 				addedAt: Date.now(),
 				ingestionAttemptId,
 				ingestionState: "pending" as const,
+				documentRevision: 0,
+				revisionAttemptId: ingestionAttemptId,
 				pinned,
 			};
 
@@ -1509,7 +1512,7 @@ export class DocumentService extends Service {
 				customMetadata: scopedMetadata,
 			});
 
-			const memoryWithScope = {
+			const memoryWithScope: Memory = {
 				...documentMemory,
 				id: clientDocumentId,
 				agentId: agentId,
@@ -1518,11 +1521,34 @@ export class DocumentService extends Service {
 				roomId: roomId || agentId,
 				entityId: targetEntityId,
 			};
+			const canonicalSourceText =
+				fragments !== undefined
+					? this.runtime.redactSecrets(extractedText)
+					: extractedText;
 			if (fragments !== undefined) {
 				memoryWithScope.content = {
 					...memoryWithScope.content,
-					text: this.runtime.redactSecrets(extractedText),
+					text: canonicalSourceText,
 				};
+			}
+			const sourceProjection = buildDocumentSourceProjection({
+				text: canonicalSourceText,
+				documentId: clientDocumentId,
+				agentId,
+				roomId: roomId || agentId,
+				entityId: targetEntityId,
+				worldId: worldId ?? agentId,
+				documentMetadata: memoryWithScope.metadata as DocumentMemoryMetadata,
+			});
+			memoryWithScope.metadata = {
+				...(memoryWithScope.metadata ?? {}),
+				...sourceProjection.metadata,
+			} as Metadata;
+			for (const segment of sourceProjection.segments) {
+				segment.metadata = {
+					...(segment.metadata ?? {}),
+					...sourceProjection.metadata,
+				} as Metadata;
 			}
 
 			await this.runtime.createMemory(memoryWithScope, DOCUMENTS_TABLE);
@@ -1563,6 +1589,13 @@ export class DocumentService extends Service {
 
 			let fragmentCount: number;
 			try {
+				await this.runtime.createMemories(
+					sourceProjection.segments.map((memory) => ({
+						memory,
+						tableName: DOCUMENT_FRAGMENTS_TABLE,
+						unique: false,
+					})),
+				);
 				if (fragments !== undefined) {
 					const fragmentMemories = await preparePreChunkedFragmentMemories({
 						runtime: this.runtime,
@@ -1576,7 +1609,8 @@ export class DocumentService extends Service {
 						worldId: worldId ?? agentId,
 						documentTitle: originalFilename,
 						documentMetadata:
-							(documentMemory.metadata as Record<string, unknown>) ?? undefined,
+							(memoryWithScope.metadata as Record<string, unknown>) ??
+							undefined,
 					});
 					await this.runtime.createMemories(
 						fragmentMemories.map((memory) => ({
@@ -1598,7 +1632,8 @@ export class DocumentService extends Service {
 						worldId: worldId ?? agentId,
 						documentTitle: originalFilename,
 						documentMetadata:
-							(documentMemory.metadata as Record<string, unknown>) ?? undefined,
+							(memoryWithScope.metadata as Record<string, unknown>) ??
+							undefined,
 					});
 				}
 				if (fragmentCount === 0) {
@@ -2525,6 +2560,16 @@ export class DocumentService extends Service {
 			// same revision number, so readers additionally match this token.
 			revisionAttemptId: this.runtime.createRunId(),
 		};
+		const sourceProjection = buildDocumentSourceProjection({
+			text: options.content,
+			documentId: options.documentId,
+			agentId: this.runtime.agentId,
+			roomId: existingDocument.roomId,
+			entityId: existingDocument.entityId,
+			worldId: existingDocument.worldId ?? this.runtime.agentId,
+			documentMetadata: updatedMetadata,
+		});
+		Object.assign(updatedMetadata, sourceProjection.metadata);
 
 		const replacement: Memory = {
 			id: options.documentId,
@@ -2536,7 +2581,7 @@ export class DocumentService extends Service {
 			metadata: updatedMetadata,
 			createdAt: existingDocument.createdAt,
 		};
-		const fragments = await this.splitAndCreateFragments(
+		const embeddingFragments = await this.splitAndCreateFragments(
 			{
 				id: options.documentId,
 				content: { text: options.content },
@@ -2553,7 +2598,8 @@ export class DocumentService extends Service {
 				entityId: existingDocument.entityId,
 			},
 		);
-		await this.prepareDocumentFragmentEmbeddings(fragments);
+		await this.prepareDocumentFragmentEmbeddings(embeddingFragments);
+		const fragments = [...sourceProjection.segments, ...embeddingFragments];
 		const mutation = await this.runtime.adapter.replaceDocumentRevision({
 			...requestContext,
 			documentId: options.documentId,
@@ -2575,7 +2621,7 @@ export class DocumentService extends Service {
 
 		return {
 			documentId: options.documentId,
-			fragmentCount: fragments.length,
+			fragmentCount: embeddingFragments.length,
 		};
 	}
 
@@ -2928,6 +2974,7 @@ export class DocumentService extends Service {
 				...(document.metadata || {}),
 				type: MemoryType.FRAGMENT,
 				documentId: document.id,
+				fragmentRole: "embedding-chunk",
 				position: index,
 				timestamp: Date.now(),
 			};

--- a/packages/core/src/features/documents/source-segments.test.ts
+++ b/packages/core/src/features/documents/source-segments.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Proves the canonical document source projection with deterministic in-memory
+ * adapter storage. The suite exercises exact UTF-8 reassembly, giant logical
+ * unit continuation, bounded source-work counters, authorization, legacy
+ * migration failure, and corruption-sensitive invariants.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import type { DocumentRangeReadParams, Memory, UUID } from "../../types";
+import { MemoryType } from "../../types";
+import {
+	buildDocumentSourceProjection,
+	DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+	DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+	readDocumentSourceProjection,
+	requireDocumentSourceReadMetadata,
+} from "./source-segments";
+import type { DocumentMemoryMetadata } from "./types";
+
+const AGENT_ID = "d1000000-0000-4000-8000-000000000001" as UUID;
+const USER_ID = "d1000000-0000-4000-8000-000000000002" as UUID;
+const OTHER_ID = "d1000000-0000-4000-8000-000000000003" as UUID;
+const ROOM_ID = "d1000000-0000-4000-8000-000000000004" as UUID;
+const WORLD_ID = "d1000000-0000-4000-8000-000000000005" as UUID;
+const DOCUMENT_ID = "d1000000-0000-4000-8000-000000000006" as UUID;
+const ATTEMPT_ID = "d1000000-0000-4000-8000-000000000007" as UUID;
+
+function parentDocument(text: string, documentId = DOCUMENT_ID): Memory {
+	return {
+		id: documentId,
+		agentId: AGENT_ID,
+		entityId: USER_ID,
+		roomId: ROOM_ID,
+		worldId: WORLD_ID,
+		content: { text },
+		metadata: {
+			type: MemoryType.DOCUMENT,
+			documentId,
+			documentRevision: 3,
+			revisionAttemptId: ATTEMPT_ID,
+			scope: "global",
+			timestamp: 1_000,
+		},
+	};
+}
+
+function projection(text: string, documentId = DOCUMENT_ID) {
+	const parent = parentDocument(text, documentId);
+	const source = buildDocumentSourceProjection({
+		text,
+		documentId,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		entityId: USER_ID,
+		worldId: WORLD_ID,
+		documentMetadata: parent.metadata as DocumentMemoryMetadata,
+	});
+	return {
+		parent: {
+			...parent,
+			metadata: { ...parent.metadata, ...source.metadata },
+		} as Memory,
+		segments: source.segments,
+	};
+}
+
+function intersectingSegments(
+	segments: Memory[],
+	params: Pick<DocumentRangeReadParams, "unit" | "offset" | "limit">,
+	total: number,
+): Memory[] {
+	const coordinate =
+		params.unit === "byte"
+			? "Byte"
+			: params.unit === "line"
+				? "Line"
+				: "Fragment";
+	const startKey = `source${coordinate}Start`;
+	const endKey = `source${coordinate}End`;
+	const end = Math.min(params.offset + params.limit, total);
+	return segments
+		.filter((segment) => {
+			const metadata = segment.metadata as unknown as Record<string, unknown>;
+			return (
+				Number(metadata[endKey]) > params.offset &&
+				Number(metadata[startKey]) < end
+			);
+		})
+		.slice(0, DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS);
+}
+
+function readProjection(
+	projected: ReturnType<typeof projection>,
+	params: Pick<DocumentRangeReadParams, "unit" | "offset" | "limit">,
+) {
+	const metadata = requireDocumentSourceReadMetadata(
+		projected.parent.metadata as unknown as Record<string, unknown>,
+		projected.parent.id as UUID,
+	);
+	const total =
+		params.unit === "byte"
+			? metadata.sourceByteLength
+			: params.unit === "line"
+				? metadata.sourceLineCount
+				: metadata.sourceFragmentCount;
+	return readDocumentSourceProjection({
+		segments: intersectingSegments(projected.segments, params, total),
+		params,
+		parent: metadata,
+		documentId: projected.parent.id as UUID,
+		sourceQueryCount: 2,
+	});
+}
+
+describe("canonical document source segments", () => {
+	it("stores non-overlapping UTF-8 ranges and reconstructs mixed newline pages exactly", () => {
+		const source = `${"a".repeat(DOCUMENT_SOURCE_SEGMENT_MAX_BYTES - 2)}😀\r\nβeta\n\ngamma`;
+		const projected = projection(source);
+		expect(projected.segments.length).toBeGreaterThan(1);
+		let nextByte = 0;
+		for (const [position, segment] of projected.segments.entries()) {
+			const metadata = segment.metadata as unknown as Record<string, unknown>;
+			expect(metadata.position).toBe(position);
+			expect(metadata.sourceByteStart).toBe(nextByte);
+			nextByte = Number(metadata.sourceByteEnd);
+			expect(Buffer.byteLength(segment.content.text ?? "", "utf8")).toBe(
+				nextByte - Number(metadata.sourceByteStart),
+			);
+			expect(segment.content.text).not.toContain("�");
+		}
+		expect(nextByte).toBe(Buffer.byteLength(source, "utf8"));
+
+		const fragmentTexts: string[] = [];
+		let offset = 0;
+		for (;;) {
+			const page = readProjection(projected, {
+				unit: "fragment",
+				offset,
+				limit: 1,
+			});
+			fragmentTexts.push(page.text);
+			if (page.end === page.total) break;
+			offset = page.end;
+		}
+		expect(fragmentTexts.join("")).toBe(source);
+	});
+
+	it("converts a giant line to bounded byte continuation without loss or no-progress pages", () => {
+		const source = `${"x".repeat(DOCUMENT_SOURCE_SEGMENT_MAX_BYTES * 6)}😀\nlast\n`;
+		const projected = projection(source);
+		const first = readProjection(projected, {
+			unit: "line",
+			offset: 0,
+			limit: 1,
+		});
+		expect(first).toMatchObject({
+			unit: "byte",
+			start: 0,
+			sourceQueryCount: 2,
+			examinedSourceSegments: DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+		});
+		expect(first.end).toBeGreaterThan(first.start);
+		expect(first.sourceBytesRead).toBeLessThanOrEqual(
+			DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS *
+				DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+		);
+
+		const pages = [first.text];
+		let offset = first.end;
+		while (offset < first.total) {
+			const page = readProjection(projected, {
+				unit: "byte",
+				offset,
+				limit: 100,
+			});
+			expect(page.end).toBeGreaterThan(offset);
+			expect(page.returnedSourceSegments).toBeLessThanOrEqual(2);
+			pages.push(page.text);
+			offset = page.end;
+		}
+		expect(pages.join("")).toBe(source);
+	});
+
+	it("rejects byte ranges that split a multibyte code point", () => {
+		const projected = projection("😀tail");
+		expect(() =>
+			readProjection(projected, { unit: "byte", offset: 1, limit: 4 }),
+		).toThrowError(
+			expect.objectContaining({ code: "DOCUMENT_READ_INVALID_UTF8_BOUNDARY" }),
+		);
+		expect(() =>
+			readProjection(projected, { unit: "byte", offset: 0, limit: 1 }),
+		).toThrowError(
+			expect.objectContaining({ code: "DOCUMENT_READ_INVALID_UTF8_BOUNDARY" }),
+		);
+	});
+
+	it("kills coordinate and same-length payload mutations", () => {
+		const projected = projection(
+			"z".repeat(DOCUMENT_SOURCE_SEGMENT_MAX_BYTES * 2 + 8),
+		);
+		const params = {
+			unit: "byte" as const,
+			offset: DOCUMENT_SOURCE_SEGMENT_MAX_BYTES - 1,
+			limit: 10,
+		};
+		const metadata = requireDocumentSourceReadMetadata(
+			projected.parent.metadata as unknown as Record<string, unknown>,
+			DOCUMENT_ID,
+		);
+		const rows = intersectingSegments(
+			projected.segments,
+			params,
+			metadata.sourceByteLength,
+		);
+		const corrupted = rows.map((row) => ({
+			...row,
+			metadata: { ...row.metadata },
+		}));
+		(
+			corrupted[1].metadata as unknown as Record<string, unknown>
+		).sourceByteStart =
+			Number(
+				(corrupted[1].metadata as unknown as Record<string, unknown>)
+					.sourceByteStart,
+			) + 1;
+		expect(() =>
+			readDocumentSourceProjection({
+				segments: corrupted,
+				params,
+				parent: metadata,
+				documentId: DOCUMENT_ID,
+				sourceQueryCount: 2,
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "DOCUMENT_SOURCE_CORRUPT" }),
+		);
+		const payloadMutated = rows.map((row) => ({
+			...row,
+			content: { ...row.content },
+		}));
+		payloadMutated[0].content.text = `q${payloadMutated[0].content.text?.slice(1)}`;
+		expect(() =>
+			readDocumentSourceProjection({
+				segments: payloadMutated,
+				params,
+				parent: metadata,
+				documentId: DOCUMENT_ID,
+				sourceQueryCount: 2,
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "DOCUMENT_SOURCE_CORRUPT" }),
+		);
+	});
+});
+
+describe("in-memory document source adapter", () => {
+	it("reads bounded late pages, reauthorizes, and rejects authorized legacy parents", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const source = Array.from(
+			{ length: 4_000 },
+			(_, index) => `line-${index}😀\n`,
+		).join("");
+		const projected = projection(source);
+		await adapter.createMemories([
+			{ memory: projected.parent, tableName: "documents" },
+			...projected.segments.map((memory) => ({
+				memory,
+				tableName: "document_fragments",
+			})),
+		]);
+		const page = await adapter.readDocumentRange({
+			agentId: AGENT_ID,
+			documentId: DOCUMENT_ID,
+			requesterEntityId: USER_ID,
+			requesterRoomIds: [ROOM_ID],
+			requesterRole: "USER",
+			unit: "line",
+			offset: 3_999,
+			limit: 1,
+		});
+		expect(page).toMatchObject({
+			text: "line-3999😀\n",
+			total: 4_000,
+			sourceQueryCount: 2,
+		});
+		expect(page?.examinedSourceSegments).toBeLessThanOrEqual(
+			DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+		);
+		await expect(
+			adapter.readDocumentRange({
+				agentId: AGENT_ID,
+				documentId: DOCUMENT_ID,
+				requesterEntityId: OTHER_ID,
+				requesterRoomIds: [],
+				requesterRole: "GUEST",
+				unit: "line",
+				offset: 0,
+				limit: 1,
+			}),
+		).resolves.toBeNull();
+
+		const legacyId = "d1000000-0000-4000-8000-000000000008" as UUID;
+		await adapter.createMemories([
+			{
+				memory: parentDocument("legacy body", legacyId),
+				tableName: "documents",
+			},
+		]);
+		await expect(
+			adapter.readDocumentRange({
+				agentId: AGENT_ID,
+				documentId: legacyId,
+				requesterEntityId: USER_ID,
+				requesterRoomIds: [ROOM_ID],
+				requesterRole: "USER",
+				unit: "line",
+				offset: 0,
+				limit: 1,
+			}),
+		).rejects.toMatchObject({ code: "DOCUMENT_REINDEX_REQUIRED" });
+	});
+});

--- a/packages/core/src/features/documents/source-segments.test.ts
+++ b/packages/core/src/features/documents/source-segments.test.ts
@@ -252,6 +252,48 @@ describe("canonical document source segments", () => {
 			expect.objectContaining({ code: "DOCUMENT_SOURCE_CORRUPT" }),
 		);
 	});
+
+	it("rejects a surviving giant-line prefix instead of fabricating completeness", () => {
+		const projected = projection(
+			`${"g".repeat(DOCUMENT_SOURCE_SEGMENT_MAX_BYTES * 6)}\n`,
+		);
+		const metadata = requireDocumentSourceReadMetadata(
+			projected.parent.metadata as unknown as Record<string, unknown>,
+			DOCUMENT_ID,
+		);
+		expect(() =>
+			readDocumentSourceProjection({
+				segments: projected.segments.slice(0, 3),
+				params: { unit: "line", offset: 0, limit: 1 },
+				parent: metadata,
+				documentId: DOCUMENT_ID,
+				sourceQueryCount: 2,
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "DOCUMENT_SOURCE_CORRUPT" }),
+		);
+	});
+
+	it("rejects a giant-line continuation when its leading segment is missing", () => {
+		const projected = projection(
+			`${"g".repeat(DOCUMENT_SOURCE_SEGMENT_MAX_BYTES * 6)}\n`,
+		);
+		const metadata = requireDocumentSourceReadMetadata(
+			projected.parent.metadata as unknown as Record<string, unknown>,
+			DOCUMENT_ID,
+		);
+		expect(() =>
+			readDocumentSourceProjection({
+				segments: projected.segments.slice(1, 6),
+				params: { unit: "line", offset: 0, limit: 1 },
+				parent: metadata,
+				documentId: DOCUMENT_ID,
+				sourceQueryCount: 2,
+			}),
+		).toThrowError(
+			expect.objectContaining({ code: "DOCUMENT_SOURCE_CORRUPT" }),
+		);
+	});
 });
 
 describe("in-memory document source adapter", () => {

--- a/packages/core/src/features/documents/source-segments.test.ts
+++ b/packages/core/src/features/documents/source-segments.test.ts
@@ -4,6 +4,7 @@
  * unit continuation, bounded source-work counters, authorization, legacy
  * migration failure, and corruption-sensitive invariants.
  */
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import type { DocumentRangeReadParams, Memory, UUID } from "../../types";
@@ -361,5 +362,190 @@ describe("in-memory document source adapter", () => {
 				limit: 1,
 			}),
 		).rejects.toMatchObject({ code: "DOCUMENT_REINDEX_REQUIRED" });
+	});
+
+	it("seeks logarithmically through a high-cardinality source index", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const segmentCount = 10_000;
+		const segmentText = "x\n";
+		const source = segmentText.repeat(segmentCount);
+		const segmentSha256 = createHash("sha256")
+			.update(segmentText)
+			.digest("hex");
+		const parent = parentDocument(source);
+		parent.metadata = {
+			...parent.metadata,
+			sourceFingerprint: `sha256:${createHash("sha256").update(source).digest("hex")}`,
+			sourceByteLength: Buffer.byteLength(source, "utf8"),
+			sourceLineCount: segmentCount,
+			sourceFragmentCount: segmentCount,
+			sourceSegmentCount: segmentCount,
+			sourceSegmentVersion: 1,
+		};
+		const segments = Array.from({ length: segmentCount }, (_, position) => {
+			const byteStart = position * 2;
+			return {
+				id: `d2000000-0000-4000-8000-${position.toString(16).padStart(12, "0")}` as UUID,
+				agentId: AGENT_ID,
+				entityId: USER_ID,
+				roomId: ROOM_ID,
+				worldId: WORLD_ID,
+				content: { text: segmentText },
+				metadata: {
+					...parent.metadata,
+					type: MemoryType.FRAGMENT,
+					fragmentRole: "source-segment",
+					sourceSegmentVersion: 1,
+					documentId: DOCUMENT_ID,
+					position,
+					sourceSegmentSha256: segmentSha256,
+					sourceByteStart: byteStart,
+					sourceByteEnd: byteStart + 2,
+					sourceLineStart: position,
+					sourceLineEnd: position + 1,
+					sourceLineStartBoundary: true,
+					sourceLineEndBoundary: true,
+					sourceFragmentStart: position,
+					sourceFragmentEnd: position + 1,
+					sourceFragmentStartBoundary: true,
+					sourceFragmentEndBoundary: true,
+				},
+			} satisfies Memory;
+		});
+		await adapter.createMemories([
+			{ memory: parent, tableName: "documents" },
+			...segments.map((memory) => ({
+				memory,
+				tableName: "document_fragments",
+			})),
+		]);
+
+		const page = await adapter.readDocumentRange({
+			agentId: AGENT_ID,
+			documentId: DOCUMENT_ID,
+			requesterEntityId: USER_ID,
+			requesterRoomIds: [ROOM_ID],
+			requesterRole: "USER",
+			unit: "line",
+			offset: segmentCount - 1,
+			limit: 1,
+		});
+		expect(page).toMatchObject({
+			text: segmentText,
+			returnedSourceSegments: 1,
+		});
+		expect(page?.examinedSourceSegments).toBeGreaterThan(
+			page?.returnedSourceSegments ?? 0,
+		);
+		expect(page?.examinedSourceSegments).toBeLessThanOrEqual(
+			Math.ceil(Math.log2(segmentCount)) + 2,
+		);
+
+		const empty = await adapter.readDocumentRange({
+			agentId: AGENT_ID,
+			documentId: DOCUMENT_ID,
+			requesterEntityId: USER_ID,
+			requesterRoomIds: [ROOM_ID],
+			requesterRole: "USER",
+			unit: "line",
+			offset: segmentCount,
+			limit: 1,
+		});
+		expect(empty).toMatchObject({
+			text: "",
+			start: segmentCount,
+			end: segmentCount,
+		});
+
+		const index = Reflect.get(adapter, "sourceSegmentsByGeneration");
+		Reflect.set(adapter, "sourceSegmentsByGeneration", {
+			get: () => {
+				throw new Error(
+					"source index must not be touched for an invalid offset",
+				);
+			},
+		});
+		try {
+			await expect(
+				adapter.readDocumentRange({
+					agentId: AGENT_ID,
+					documentId: DOCUMENT_ID,
+					requesterEntityId: USER_ID,
+					requesterRoomIds: [ROOM_ID],
+					requesterRole: "USER",
+					unit: "line",
+					offset: segmentCount + 1,
+					limit: 1,
+				}),
+			).rejects.toMatchObject({ code: "DOCUMENT_READ_INVALID_RANGE" });
+		} finally {
+			Reflect.set(adapter, "sourceSegmentsByGeneration", index);
+		}
+	});
+
+	it("keeps adversarial generation keys and legacy source rows isolated", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const firstId = "x:1" as UUID;
+		const secondId = "x" as UUID;
+		const first = projection("first\n", firstId);
+		const second = projection("second\n", secondId);
+		const retag = (
+			projected: ReturnType<typeof projection>,
+			documentRevision: number,
+			revisionAttemptId: string,
+		) => {
+			projected.parent.metadata = {
+				...projected.parent.metadata,
+				documentRevision,
+				revisionAttemptId,
+			};
+			projected.segments = projected.segments.map((segment) => ({
+				...segment,
+				metadata: {
+					...segment.metadata,
+					documentRevision,
+					revisionAttemptId,
+				},
+			}));
+		};
+		// These tuples collide under delimiter concatenation:
+		// ["x:1", 2, "3"] and ["x", 1, "2:3"].
+		retag(first, 2, "3");
+		retag(second, 1, "2:3");
+		const legacy = {
+			...first.segments[0],
+			id: "d3000000-0000-4000-8000-000000000001" as UUID,
+			metadata: {
+				...first.segments[0].metadata,
+				sourceSegmentVersion: 0,
+			},
+		};
+		await adapter.createMemories([
+			{ memory: first.parent, tableName: "documents" },
+			{ memory: second.parent, tableName: "documents" },
+			...first.segments.map((memory) => ({
+				memory,
+				tableName: "document_fragments",
+			})),
+			...second.segments.map((memory) => ({
+				memory,
+				tableName: "document_fragments",
+			})),
+			{ memory: legacy, tableName: "document_fragments" },
+		]);
+
+		const read = (documentId: UUID) =>
+			adapter.readDocumentRange({
+				agentId: AGENT_ID,
+				documentId,
+				requesterEntityId: USER_ID,
+				requesterRoomIds: [ROOM_ID],
+				requesterRole: "USER",
+				unit: "line",
+				offset: 0,
+				limit: 1,
+			});
+		await expect(read(firstId)).resolves.toMatchObject({ text: "first\n" });
+		await expect(read(secondId)).resolves.toMatchObject({ text: "second\n" });
 	});
 });

--- a/packages/core/src/features/documents/source-segments.ts
+++ b/packages/core/src/features/documents/source-segments.ts
@@ -73,8 +73,14 @@ function intersectingUnitRange(
 	segmentStart: number,
 	segmentEnd: number,
 ): { start: number; end: number } {
-	let start = units.findIndex((unit) => unit.end > segmentStart);
-	if (start < 0) start = units.length;
+	let low = 0;
+	let high = units.length;
+	while (low < high) {
+		const middle = low + Math.floor((high - low) / 2);
+		if (units[middle].end <= segmentStart) low = middle + 1;
+		else high = middle;
+	}
+	const start = low;
 	let end = start;
 	while (end < units.length && units[end].start < segmentEnd) end++;
 	return { start, end };

--- a/packages/core/src/features/documents/source-segments.ts
+++ b/packages/core/src/features/documents/source-segments.ts
@@ -117,6 +117,11 @@ export function buildDocumentSourceProjection(args: {
 		const end = safeUtf8End(bytes, start);
 		const line = intersectingUnitRange(lineRanges, start, end);
 		const fragment = intersectingUnitRange(fragmentRanges, start, end);
+		const lineStartBoundary = lineRanges[line.start]?.start === start;
+		const lineEndBoundary = lineRanges[line.end - 1]?.end === end;
+		const fragmentStartBoundary =
+			fragmentRanges[fragment.start]?.start === start;
+		const fragmentEndBoundary = fragmentRanges[fragment.end - 1]?.end === end;
 		const metadata: DocumentFragmentMemoryMetadata = {
 			...args.documentMetadata,
 			type: MemoryType.FRAGMENT,
@@ -131,8 +136,12 @@ export function buildDocumentSourceProjection(args: {
 			sourceByteEnd: end,
 			sourceLineStart: line.start,
 			sourceLineEnd: line.end,
+			sourceLineStartBoundary: lineStartBoundary,
+			sourceLineEndBoundary: lineEndBoundary,
 			sourceFragmentStart: fragment.start,
 			sourceFragmentEnd: fragment.end,
+			sourceFragmentStartBoundary: fragmentStartBoundary,
+			sourceFragmentEndBoundary: fragmentEndBoundary,
 			timestamp: Date.now(),
 		};
 		segments.push({
@@ -429,6 +438,20 @@ export function readDocumentSourceProjection(args: {
 		const firstMetadata = (first.metadata ?? {}) as Record<string, unknown>;
 		const firstUnit =
 			sourceCoordinate(firstMetadata, unit, "Start") ?? args.params.offset;
+		const boundaryPrefix = unit === "line" ? "sourceLine" : "sourceFragment";
+		if (
+			firstUnit === args.params.offset &&
+			firstMetadata[`${boundaryPrefix}StartBoundary`] !== true
+		) {
+			throw new ElizaError("Document source unit prefix is missing", {
+				code: "DOCUMENT_SOURCE_CORRUPT",
+				context: {
+					documentId: args.documentId,
+					unit,
+					offset: args.params.offset,
+				},
+			});
+		}
 		const units = sourceUnits(first.content.text ?? "", unit);
 		const skipped = units.slice(0, args.params.offset - firstUnit).join("");
 		const firstByte = safeNumber(firstMetadata.sourceByteStart) ?? 0;
@@ -455,6 +478,31 @@ export function readDocumentSourceProjection(args: {
 				"Start",
 			) ?? args.params.offset)
 		: args.params.offset;
+	const firstMetadata = (rows[0]?.metadata ?? {}) as Record<string, unknown>;
+	const lastMetadata = (rows.at(-1)?.metadata ?? {}) as Record<string, unknown>;
+	const lastUnit = rows.length
+		? sourceCoordinate(lastMetadata, unit, "End")
+		: args.params.offset;
+	const boundaryPrefix = unit === "line" ? "sourceLine" : "sourceFragment";
+	if (
+		rows.length > 0 &&
+		((firstUnit === args.params.offset &&
+			firstMetadata[`${boundaryPrefix}StartBoundary`] !== true) ||
+			lastUnit === null ||
+			lastUnit < requestedEnd ||
+			(lastUnit === requestedEnd &&
+				lastMetadata[`${boundaryPrefix}EndBoundary`] !== true))
+	) {
+		throw new ElizaError("Document source unit range is incomplete", {
+			code: "DOCUMENT_SOURCE_CORRUPT",
+			context: {
+				documentId: args.documentId,
+				unit,
+				offset: args.params.offset,
+				requestedEnd,
+			},
+		});
+	}
 	const units = sourceUnits(
 		rows.map((row) => row.content.text ?? "").join(""),
 		unit,

--- a/packages/core/src/features/documents/source-segments.ts
+++ b/packages/core/src/features/documents/source-segments.ts
@@ -1,0 +1,469 @@
+/**
+ * Builds the canonical, lossless UTF-8 source projection used by bounded
+ * document reads. Source segments are immutable, non-overlapping byte ranges;
+ * embedding chunks remain a separate derived projection.
+ */
+import { v4 as uuidv4 } from "uuid";
+import { ElizaError } from "../../errors";
+import type {
+	DocumentRangeReadParams,
+	DocumentRangeReadResult,
+	Memory,
+	UUID,
+} from "../../types";
+import { MemoryType } from "../../types";
+import { createHash } from "../../utils/crypto-compat";
+import type {
+	DocumentFragmentMemoryMetadata,
+	DocumentMemoryMetadata,
+} from "./types";
+
+export const DOCUMENT_SOURCE_SEGMENT_VERSION = 1 as const;
+export const DOCUMENT_SOURCE_SEGMENT_MAX_BYTES = 64 * 1024;
+export const DOCUMENT_SOURCE_READ_MAX_SEGMENTS = 4;
+export const DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS =
+	DOCUMENT_SOURCE_READ_MAX_SEGMENTS + 1;
+
+export interface DocumentSourceProjection {
+	metadata: Pick<
+		DocumentMemoryMetadata,
+		| "sourceSegmentVersion"
+		| "sourceSegmentCount"
+		| "sourceByteLength"
+		| "sourceLineCount"
+		| "sourceFragmentCount"
+		| "sourceSha256"
+		| "sourceFingerprint"
+	>;
+	segments: Memory[];
+}
+
+interface UnitRange {
+	start: number;
+	end: number;
+}
+
+function sourceUnits(text: string, unit: "line" | "fragment"): string[] {
+	const lines = text.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+$/gu) ?? [];
+	if (unit === "line") return lines;
+	return lines
+		.reduce<string[]>((fragments, line) => {
+			const last = fragments.length - 1;
+			if (last < 0) fragments.push(line);
+			else fragments[last] += line;
+			if (line.replace(/[\r\n]/gu, "").trim().length === 0) {
+				fragments.push("");
+			}
+			return fragments;
+		}, [])
+		.filter((fragment) => fragment.length > 0);
+}
+
+function unitRanges(text: string, unit: "line" | "fragment"): UnitRange[] {
+	let byteOffset = 0;
+	return sourceUnits(text, unit).map((value) => {
+		const start = byteOffset;
+		byteOffset += Buffer.byteLength(value, "utf8");
+		return { start, end: byteOffset };
+	});
+}
+
+function intersectingUnitRange(
+	units: UnitRange[],
+	segmentStart: number,
+	segmentEnd: number,
+): { start: number; end: number } {
+	let start = units.findIndex((unit) => unit.end > segmentStart);
+	if (start < 0) start = units.length;
+	let end = start;
+	while (end < units.length && units[end].start < segmentEnd) end++;
+	return { start, end };
+}
+
+function safeUtf8End(bytes: Buffer, start: number): number {
+	let end = Math.min(start + DOCUMENT_SOURCE_SEGMENT_MAX_BYTES, bytes.length);
+	while (end > start && end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+		end--;
+	}
+	if (end === start) {
+		throw new Error(
+			"Unable to find a UTF-8 boundary inside source segment limit",
+		);
+	}
+	return end;
+}
+
+export function buildDocumentSourceProjection(args: {
+	text: string;
+	documentId: UUID;
+	agentId: UUID;
+	roomId: UUID;
+	entityId: UUID;
+	worldId?: UUID;
+	documentMetadata: DocumentMemoryMetadata;
+}): DocumentSourceProjection {
+	const bytes = Buffer.from(args.text, "utf8");
+	const lineRanges = unitRanges(args.text, "line");
+	const fragmentRanges = unitRanges(args.text, "fragment");
+	const sha256 = createHash("sha256").update(bytes).digest("hex");
+	const segments: Memory[] = [];
+	for (let start = 0, ordinal = 0; start < bytes.length; ordinal++) {
+		const end = safeUtf8End(bytes, start);
+		const line = intersectingUnitRange(lineRanges, start, end);
+		const fragment = intersectingUnitRange(fragmentRanges, start, end);
+		const metadata: DocumentFragmentMemoryMetadata = {
+			...args.documentMetadata,
+			type: MemoryType.FRAGMENT,
+			documentId: args.documentId,
+			fragmentRole: "source-segment",
+			position: ordinal,
+			sourceSegmentVersion: DOCUMENT_SOURCE_SEGMENT_VERSION,
+			sourceSegmentSha256: createHash("sha256")
+				.update(bytes.subarray(start, end))
+				.digest("hex"),
+			sourceByteStart: start,
+			sourceByteEnd: end,
+			sourceLineStart: line.start,
+			sourceLineEnd: line.end,
+			sourceFragmentStart: fragment.start,
+			sourceFragmentEnd: fragment.end,
+			timestamp: Date.now(),
+		};
+		segments.push({
+			id: uuidv4() as UUID,
+			agentId: args.agentId,
+			roomId: args.roomId,
+			entityId: args.entityId,
+			worldId: args.worldId,
+			content: { text: bytes.subarray(start, end).toString("utf8") },
+			metadata,
+		});
+		start = end;
+	}
+	return {
+		metadata: {
+			sourceSegmentVersion: DOCUMENT_SOURCE_SEGMENT_VERSION,
+			sourceSegmentCount: segments.length,
+			sourceByteLength: bytes.length,
+			sourceLineCount: lineRanges.length,
+			sourceFragmentCount: fragmentRanges.length,
+			sourceSha256: sha256,
+			sourceFingerprint: `sha256:${sha256}`,
+		},
+		segments,
+	};
+}
+
+export function splitDocumentSourceUnits(
+	text: string,
+	unit: "line" | "fragment",
+): string[] {
+	return sourceUnits(text, unit);
+}
+
+function safeNumber(value: unknown): number | null {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+		? value
+		: null;
+}
+
+export interface DocumentSourceReadMetadata {
+	documentRevision: number;
+	revisionAttemptId?: string;
+	sourceByteLength: number;
+	sourceLineCount: number;
+	sourceFragmentCount: number;
+	sourceFingerprint: string;
+}
+
+/**
+ * Validates the parent-only metadata required for bounded reads. An authorized
+ * legacy row receives an actionable migration error; malformed segmented rows
+ * are reported separately as corruption rather than being scanned as legacy.
+ */
+export function requireDocumentSourceReadMetadata(
+	metadata: Record<string, unknown>,
+	documentId: UUID,
+): DocumentSourceReadMetadata {
+	if (metadata.sourceSegmentVersion !== DOCUMENT_SOURCE_SEGMENT_VERSION) {
+		throw new ElizaError("Document must be reindexed before bounded reading", {
+			code: "DOCUMENT_REINDEX_REQUIRED",
+			context: {
+				documentId,
+				sourceSegmentVersion: metadata.sourceSegmentVersion ?? null,
+			},
+		});
+	}
+	const documentRevision = safeNumber(metadata.documentRevision);
+	const sourceByteLength = safeNumber(metadata.sourceByteLength);
+	const sourceLineCount = safeNumber(metadata.sourceLineCount);
+	const sourceFragmentCount = safeNumber(metadata.sourceFragmentCount);
+	const sourceSegmentCount = safeNumber(metadata.sourceSegmentCount);
+	if (
+		documentRevision === null ||
+		sourceByteLength === null ||
+		sourceLineCount === null ||
+		sourceFragmentCount === null ||
+		sourceSegmentCount === null ||
+		typeof metadata.sourceFingerprint !== "string" ||
+		!/^sha256:[a-f0-9]{64}$/u.test(metadata.sourceFingerprint) ||
+		(sourceByteLength > 0 && sourceSegmentCount === 0)
+	) {
+		throw new ElizaError("Canonical document source metadata is invalid", {
+			code: "DOCUMENT_SOURCE_CORRUPT",
+			context: { documentId },
+		});
+	}
+	return {
+		documentRevision,
+		...(typeof metadata.revisionAttemptId === "string"
+			? { revisionAttemptId: metadata.revisionAttemptId }
+			: {}),
+		sourceByteLength,
+		sourceLineCount,
+		sourceFragmentCount,
+		sourceFingerprint: metadata.sourceFingerprint,
+	};
+}
+
+function sourceCoordinate(
+	metadata: Record<string, unknown>,
+	unit: "line" | "fragment",
+	boundary: "Start" | "End",
+): number | null {
+	return safeNumber(
+		metadata[`source${unit === "line" ? "Line" : "Fragment"}${boundary}`],
+	);
+}
+
+/**
+ * Reassembles one bounded read from already-authorized source rows. Callers
+ * must pass no more than MAX+1 coordinate-intersecting rows; the extra row is
+ * the bounded overflow probe that triggers byte-coordinate continuation.
+ */
+export function readDocumentSourceProjection(args: {
+	segments: Memory[];
+	params: Pick<DocumentRangeReadParams, "unit" | "offset" | "limit">;
+	parent: DocumentSourceReadMetadata;
+	documentId: UUID;
+	/** Number of rows returned by the bounded storage query, including lookahead. */
+	examinedSourceSegments?: number;
+	/** Constant storage-query count reported by the adapter. */
+	sourceQueryCount: number;
+}): DocumentRangeReadResult {
+	const byteTotal = args.parent.sourceByteLength;
+	const lineTotal = args.parent.sourceLineCount;
+	const fragmentTotal = args.parent.sourceFragmentCount;
+	const fingerprint = args.parent.sourceFingerprint;
+	const ordered = [...args.segments].sort((left, right) => {
+		const leftStart =
+			safeNumber((left.metadata as Record<string, unknown>)?.sourceByteStart) ??
+			-1;
+		const rightStart =
+			safeNumber(
+				(right.metadata as Record<string, unknown>)?.sourceByteStart,
+			) ?? -1;
+		return leftStart - rightStart;
+	});
+	if (ordered.length > DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS) {
+		throw new ElizaError("Document source read exceeded bounded lookahead", {
+			code: "DOCUMENT_SOURCE_CORRUPT",
+			context: { documentId: args.documentId, rows: ordered.length },
+		});
+	}
+	let previousEnd: number | undefined;
+	let previousPosition: number | undefined;
+	for (const segment of ordered) {
+		const rowMetadata = (segment.metadata ?? {}) as Record<string, unknown>;
+		const rowStart = safeNumber(rowMetadata.sourceByteStart);
+		const rowEnd = safeNumber(rowMetadata.sourceByteEnd);
+		const position = safeNumber(rowMetadata.position);
+		const segmentSha256 = rowMetadata.sourceSegmentSha256;
+		const text = segment.content.text;
+		if (
+			rowMetadata.fragmentRole !== "source-segment" ||
+			rowMetadata.sourceSegmentVersion !== DOCUMENT_SOURCE_SEGMENT_VERSION ||
+			rowStart === null ||
+			rowEnd === null ||
+			rowEnd <= rowStart ||
+			position === null ||
+			typeof text !== "string" ||
+			Buffer.byteLength(text, "utf8") !== rowEnd - rowStart ||
+			typeof segmentSha256 !== "string" ||
+			!/^[a-f0-9]{64}$/u.test(segmentSha256) ||
+			createHash("sha256").update(text).digest("hex") !== segmentSha256 ||
+			(previousEnd !== undefined && rowStart !== previousEnd) ||
+			(previousPosition !== undefined && position !== previousPosition + 1)
+		) {
+			throw new ElizaError("Canonical document source segments are invalid", {
+				code: "DOCUMENT_SOURCE_CORRUPT",
+				context: { documentId: args.documentId, position },
+			});
+		}
+		previousEnd = rowEnd;
+		previousPosition = position;
+	}
+	const examinedSourceSegments = args.examinedSourceSegments ?? ordered.length;
+	const sourceBytesRead = ordered.reduce(
+		(total, row) => total + Buffer.byteLength(row.content.text ?? "", "utf8"),
+		0,
+	);
+	const common = {
+		documentRevision: args.parent.documentRevision,
+		...(args.parent.revisionAttemptId
+			? { revisionAttemptId: args.parent.revisionAttemptId }
+			: {}),
+		sourceFingerprint: fingerprint,
+		examinedSourceSegments,
+		sourceQueryCount: args.sourceQueryCount,
+		sourceBytesRead,
+	};
+	const bytePage = (
+		start: number,
+		requestedLimit: number,
+	): DocumentRangeReadResult => {
+		const requestedEnd = Math.min(start + requestedLimit, byteTotal);
+		const rows = ordered.filter((segment) => {
+			const rowMetadata = (segment.metadata ?? {}) as Record<string, unknown>;
+			const rowStart = safeNumber(rowMetadata.sourceByteStart);
+			const rowEnd = safeNumber(rowMetadata.sourceByteEnd);
+			return (
+				rowStart !== null &&
+				rowEnd !== null &&
+				rowEnd > start &&
+				rowStart < requestedEnd
+			);
+		});
+		if (start < byteTotal && rows.length === 0) {
+			throw new ElizaError("Document source byte range is missing", {
+				code: "DOCUMENT_SOURCE_CORRUPT",
+				context: { documentId: args.documentId, start },
+			});
+		}
+		const complete = rows.map((row) => row.content.text ?? "").join("");
+		const firstStart =
+			safeNumber(
+				(rows[0]?.metadata as Record<string, unknown> | undefined)
+					?.sourceByteStart,
+			) ?? start;
+		const localStart = start - firstStart;
+		if (localStart < 0) {
+			throw new ElizaError(
+				"Document source byte range begins after its offset",
+				{
+					code: "DOCUMENT_SOURCE_CORRUPT",
+					context: { documentId: args.documentId, start, firstStart },
+				},
+			);
+		}
+		const bytes = Buffer.from(complete, "utf8");
+		let localEnd = Math.min(localStart + (requestedEnd - start), bytes.length);
+		if (localStart < bytes.length && (bytes[localStart] & 0xc0) === 0x80) {
+			throw new ElizaError("Document byte offset splits a UTF-8 sequence", {
+				code: "DOCUMENT_READ_INVALID_UTF8_BOUNDARY",
+				context: { documentId: args.documentId, offset: start },
+			});
+		}
+		while (
+			localEnd > localStart &&
+			localEnd < bytes.length &&
+			(bytes[localEnd] & 0xc0) === 0x80
+		) {
+			localEnd--;
+		}
+		if (localEnd === localStart && start < byteTotal) {
+			throw new ElizaError("Document byte limit splits a UTF-8 sequence", {
+				code: "DOCUMENT_READ_INVALID_UTF8_BOUNDARY",
+				context: { documentId: args.documentId, offset: start, requestedLimit },
+			});
+		}
+		const pageBytes = bytes.subarray(localStart, localEnd);
+		let text: string;
+		try {
+			text = new TextDecoder("utf-8", { fatal: true }).decode(pageBytes);
+		} catch (cause) {
+			// error-policy:J2 Preserve the decoder failure behind a typed range error.
+			throw new ElizaError("Document byte range is not valid UTF-8", {
+				code: "DOCUMENT_READ_INVALID_UTF8_BOUNDARY",
+				context: { documentId: args.documentId, offset: start },
+				cause,
+			});
+		}
+		const returnedSourceBytes = pageBytes.length;
+		return {
+			unit: "byte",
+			text,
+			start,
+			end: start + returnedSourceBytes,
+			total: byteTotal,
+			...common,
+			returnedSourceSegments: rows.length,
+			returnedSourceBytes,
+		};
+	};
+	const unit = args.params.unit;
+	if (unit === "byte") {
+		return bytePage(args.params.offset, args.params.limit);
+	}
+	const total = unit === "line" ? lineTotal : fragmentTotal;
+	const requestedEnd = Math.min(args.params.offset + args.params.limit, total);
+	const rows = ordered.filter((segment) => {
+		const rowMetadata = (segment.metadata ?? {}) as Record<string, unknown>;
+		const start = sourceCoordinate(rowMetadata, unit, "Start");
+		const end = sourceCoordinate(rowMetadata, unit, "End");
+		return (
+			start !== null &&
+			end !== null &&
+			end > args.params.offset &&
+			start < requestedEnd
+		);
+	});
+	if (rows.length > DOCUMENT_SOURCE_READ_MAX_SEGMENTS) {
+		const first = rows[0];
+		const firstMetadata = (first.metadata ?? {}) as Record<string, unknown>;
+		const firstUnit =
+			sourceCoordinate(firstMetadata, unit, "Start") ?? args.params.offset;
+		const units = sourceUnits(first.content.text ?? "", unit);
+		const skipped = units.slice(0, args.params.offset - firstUnit).join("");
+		const firstByte = safeNumber(firstMetadata.sourceByteStart) ?? 0;
+		return bytePage(
+			firstByte + Buffer.byteLength(skipped, "utf8"),
+			(DOCUMENT_SOURCE_READ_MAX_SEGMENTS - 1) *
+				DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+		);
+	}
+	if (args.params.offset < total && rows.length === 0) {
+		throw new ElizaError("Document source unit range is missing", {
+			code: "DOCUMENT_SOURCE_CORRUPT",
+			context: {
+				documentId: args.documentId,
+				unit,
+				offset: args.params.offset,
+			},
+		});
+	}
+	const firstUnit = rows.length
+		? (sourceCoordinate(
+				(rows[0].metadata ?? {}) as Record<string, unknown>,
+				unit,
+				"Start",
+			) ?? args.params.offset)
+		: args.params.offset;
+	const units = sourceUnits(
+		rows.map((row) => row.content.text ?? "").join(""),
+		unit,
+	);
+	const pageText = units
+		.slice(args.params.offset - firstUnit, requestedEnd - firstUnit)
+		.join("");
+	return {
+		unit,
+		text: pageText,
+		start: args.params.offset,
+		end: requestedEnd,
+		total,
+		...common,
+		returnedSourceSegments: rows.length,
+		returnedSourceBytes: Buffer.byteLength(pageText, "utf8"),
+	};
+}

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -291,8 +291,14 @@ export interface DocumentFragmentMemoryMetadata
 	sourceByteEnd?: number;
 	sourceLineStart?: number;
 	sourceLineEnd?: number;
+	/** True only when this segment edge is also an exact logical-line edge. */
+	sourceLineStartBoundary?: boolean;
+	sourceLineEndBoundary?: boolean;
 	sourceFragmentStart?: number;
 	sourceFragmentEnd?: number;
+	/** True only when this segment edge is also an exact paragraph-fragment edge. */
+	sourceFragmentStartBoundary?: boolean;
+	sourceFragmentEndBoundary?: boolean;
 	source?: string;
 	documentTitle?: string;
 	timestamp?: number;

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -259,6 +259,14 @@ export interface DocumentMemoryMetadata
 	mediaHash?: string;
 	/** Served original-bytes file (content-addressed) linked to this document. */
 	mediaFileName?: string;
+	/** Versioned canonical source-segment projection available for bounded reads. */
+	sourceSegmentVersion?: 1;
+	sourceSegmentCount?: number;
+	sourceByteLength?: number;
+	sourceLineCount?: number;
+	sourceFragmentCount?: number;
+	sourceSha256?: string;
+	sourceFingerprint?: string;
 }
 export interface DocumentFragmentMemoryMetadata
 	extends FragmentMetadata,
@@ -274,6 +282,17 @@ export interface DocumentFragmentMemoryMetadata
 	/** Update attempt that staged this fragment; must match the parent's committed token to be readable. */
 	revisionAttemptId?: UUID;
 	position: number;
+	/** Source segments are canonical; embedding chunks are derived retrieval views. */
+	fragmentRole?: "source-segment" | "embedding-chunk";
+	sourceSegmentVersion?: 1;
+	/** SHA-256 of this bounded source segment, verified before returning content. */
+	sourceSegmentSha256?: string;
+	sourceByteStart?: number;
+	sourceByteEnd?: number;
+	sourceLineStart?: number;
+	sourceLineEnd?: number;
+	sourceFragmentStart?: number;
+	sourceFragmentEnd?: number;
 	source?: string;
 	documentTitle?: string;
 	timestamp?: number;

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -54,14 +54,21 @@ export * from "./env-utils";
 export * from "./errors";
 export * from "./features/advanced-memory";
 export { AutonomyService } from "./features/autonomy/index";
+export type { DocumentSourceReadMetadata } from "./features/documents/index";
 export {
 	__setDocumentUrlFetchImplForTests,
+	DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
+	DOCUMENT_SOURCE_READ_MAX_SEGMENTS,
+	DOCUMENT_SOURCE_SEGMENT_MAX_BYTES,
+	DOCUMENT_SOURCE_SEGMENT_VERSION,
 	type FetchDocumentFromUrlOptions,
 	type FetchedDocumentUrl,
 	type FetchedDocumentUrlKind,
 	fetchDocumentFromUrl,
 	isYouTubeUrl,
 	normalizeDocumentContentType,
+	readDocumentSourceProjection,
+	requireDocumentSourceReadMetadata,
 } from "./features/documents/index";
 export type {
 	DeferredMessageScheduleCommit,

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -121,6 +121,57 @@ export const memorySchema: SchemaTable = {
 			],
 			isUnique: false,
 		},
+		idx_document_source_byte_seek: {
+			name: "idx_document_source_byte_seek",
+			columns: [
+				{ expression: "((metadata->>'documentId'))", isExpression: true },
+				{
+					expression: "((metadata->>'sourceByteEnd')::bigint)",
+					isExpression: true,
+				},
+				{
+					expression: "((metadata->>'position')::bigint)",
+					isExpression: true,
+				},
+			],
+			isUnique: false,
+			where:
+				"type = 'document_fragments' AND metadata->>'fragmentRole' = 'source-segment'",
+		},
+		idx_document_source_line_seek: {
+			name: "idx_document_source_line_seek",
+			columns: [
+				{ expression: "((metadata->>'documentId'))", isExpression: true },
+				{
+					expression: "((metadata->>'sourceLineEnd')::bigint)",
+					isExpression: true,
+				},
+				{
+					expression: "((metadata->>'position')::bigint)",
+					isExpression: true,
+				},
+			],
+			isUnique: false,
+			where:
+				"type = 'document_fragments' AND metadata->>'fragmentRole' = 'source-segment'",
+		},
+		idx_document_source_fragment_seek: {
+			name: "idx_document_source_fragment_seek",
+			columns: [
+				{ expression: "((metadata->>'documentId'))", isExpression: true },
+				{
+					expression: "((metadata->>'sourceFragmentEnd')::bigint)",
+					isExpression: true,
+				},
+				{
+					expression: "((metadata->>'position')::bigint)",
+					isExpression: true,
+				},
+			],
+			isUnique: false,
+			where:
+				"type = 'document_fragments' AND metadata->>'fragmentRole' = 'source-segment'",
+		},
 	},
 	foreignKeys: {
 		fk_room: {

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -103,7 +103,7 @@ export interface DocumentGetQueryParams extends DocumentRequesterContext {
 }
 
 /** Exact unit used by an authorized bounded document read. */
-export type DocumentRangeUnit = "line" | "fragment";
+export type DocumentRangeUnit = "line" | "fragment" | "byte";
 
 /**
  * Authorized bounded document read. Offsets and limits count exact retained
@@ -122,6 +122,7 @@ export interface DocumentRangeReadParams extends DocumentRequesterContext {
  * opaque public revision before it leaves DocumentService.
  */
 export interface DocumentRangeReadResult {
+	unit: DocumentRangeUnit;
 	text: string;
 	start: number;
 	end: number;
@@ -129,6 +130,14 @@ export interface DocumentRangeReadResult {
 	documentRevision: number;
 	revisionAttemptId?: string;
 	sourceFingerprint: string;
+	/** Physical source rows examined and returned by the bounded storage read. */
+	examinedSourceSegments: number;
+	returnedSourceSegments: number;
+	/** Source payload transferred into the adapter and returned to the caller. */
+	sourceBytesRead: number;
+	returnedSourceBytes: number;
+	/** Constant number of storage queries used for the authorized page. */
+	sourceQueryCount: number;
 }
 
 /**
@@ -1162,7 +1171,7 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	 */
 	readonly documentListQueryCapability: 4;
 	/** Native bounded source projection; absent adapters must fail explicitly. */
-	readonly documentRangeReadCapability?: 1;
+	readonly documentRangeReadCapability?: 2;
 	queryDocuments(
 		params: DocumentListQueryParams,
 	): Promise<DocumentListQueryResult>;

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2269,6 +2269,12 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           : params.unit === "line"
             ? parent.sourceLineCount
             : parent.sourceFragmentCount;
+      if (params.offset > total) {
+        throw new ElizaError("Document range offset exceeds the source length", {
+          code: "DOCUMENT_READ_INVALID_RANGE",
+          context: { documentId: params.documentId, offset: params.offset, total },
+        });
+      }
       const requestedEnd = Math.min(params.offset + params.limit, total);
       const sourceParent = alias(memoryTable, "document_source_parent");
       const sourceSegment = alias(memoryTable, "document_source_segment");

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -28,6 +28,7 @@ import {
   DatabaseAdapter,
   type DeleteConnectorAccountParams,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION,
+  DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS,
   type DocumentCompareAndSwapParams,
   type DocumentDeleteParams,
   type DocumentDirectGrantUpdateParams,
@@ -77,6 +78,8 @@ import {
   type Relationship,
   type Room,
   type RunStatus,
+  readDocumentSourceProjection,
+  requireDocumentSourceReadMetadata,
   type SetConnectorAccountCredentialRefParams,
   type Task,
   type TaskMetadata,
@@ -558,7 +561,7 @@ import type { DrizzleDatabase } from "./types";
 
 export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase> {
   readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
-  readonly documentRangeReadCapability = 1 as const;
+  readonly documentRangeReadCapability = 2 as const;
   protected readonly maxRetries: number = 3;
   protected readonly baseDelay: number = 1000;
   protected readonly maxDelay: number = 10000;
@@ -2232,13 +2235,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   ): Promise<DocumentRangeReadResult | null> {
     validateDocumentRequesterContext(params);
     if (
+      !(["line", "fragment", "byte"] as const).includes(params.unit) ||
       !Number.isSafeInteger(params.offset) ||
       params.offset < 0 ||
       !Number.isSafeInteger(params.limit) ||
-      params.limit < 1
+      params.limit < 1 ||
+      params.offset > Number.MAX_SAFE_INTEGER - params.limit
     ) {
       throw new ElizaError(
-        "Document range read requires a non-negative offset and positive limit",
+        "Document range read requires a valid unit and bounded safe-integer range",
         {
           code: "DOCUMENT_READ_INVALID_RANGE",
         }
@@ -2248,81 +2253,65 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       ? params.agentId
       : params.requesterEntityId;
     return this.withEntityContext(entityContext, async (tx) => {
-      const linePattern = "([^\\r\\n]*(?:\\r\\n|\\r|\\n)|[^\\r\\n]+$)";
-      const units =
-        params.unit === "line"
-          ? sql`line_units AS (
-              SELECT matched[1] AS unit_text, ordinal - 1 AS unit_index
-              FROM authorized
-              CROSS JOIN LATERAL regexp_matches(source_text, ${linePattern}, 'g')
-                WITH ORDINALITY AS matches(matched, ordinal)
-            )`
-          : sql`raw_lines AS (
-              SELECT matched[1] AS unit_text, ordinal - 1 AS line_index
-              FROM authorized
-              CROSS JOIN LATERAL regexp_matches(source_text, ${linePattern}, 'g')
-                WITH ORDINALITY AS matches(matched, ordinal)
-            ), grouped_lines AS (
-              SELECT unit_text, line_index,
-                COALESCE(SUM(
-                  CASE WHEN btrim(regexp_replace(unit_text, E'[\\r\\n]', '', 'g')) = ''
-                    THEN 1 ELSE 0 END
-                ) OVER (
-                  ORDER BY line_index
-                  ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-                ), 0) AS unit_index
-              FROM raw_lines
-            ), line_units AS (
-              SELECT string_agg(unit_text, '' ORDER BY line_index) AS unit_text, unit_index
-              FROM grouped_lines
-              GROUP BY unit_index
-            )`;
-      const result = await tx.execute(sql`
-        WITH authorized AS (
-          SELECT content->>'text' AS source_text, metadata
-          FROM ${memoryTable}
-          WHERE ${and(...this.documentReadConditions(params))}
-          LIMIT 1
-        ), ${units}
-        SELECT
-          COALESCE(
-            string_agg(unit_text, '' ORDER BY unit_index)
-              FILTER (
-                WHERE unit_index >= ${params.offset}
-                  AND unit_index < ${params.offset + params.limit}
-              ),
-            ''
-          ) AS text,
-          COUNT(*)::integer AS total,
-          (SELECT COALESCE((metadata->>'documentRevision')::integer, 0) FROM authorized)
-            AS document_revision,
-          (SELECT metadata->>'revisionAttemptId' FROM authorized) AS revision_attempt_id,
-          (SELECT md5(source_text) FROM authorized) AS source_fingerprint
-        FROM line_units
-      `);
-      const row = result.rows[0] as
-        | {
-            text?: unknown;
-            total?: unknown;
-            document_revision?: unknown;
-            revision_attempt_id?: unknown;
-            source_fingerprint?: unknown;
-          }
-        | undefined;
-      if (!row || typeof row.source_fingerprint !== "string") return null;
-      const total = Number(row.total);
-      const start = params.offset;
-      return {
-        text: typeof row.text === "string" ? row.text : "",
-        start,
-        end: Math.min(start + params.limit, total),
-        total,
-        documentRevision: Number(row.document_revision ?? 0),
-        ...(typeof row.revision_attempt_id === "string"
-          ? { revisionAttemptId: row.revision_attempt_id }
-          : {}),
-        sourceFingerprint: `md5:${row.source_fingerprint}`,
-      };
+      const parentRows = await tx
+        .select({ metadata: memoryTable.metadata })
+        .from(memoryTable)
+        .where(and(...this.documentReadConditions(params)))
+        .limit(1);
+      const parentRow = parentRows[0];
+      if (!parentRow) return null;
+      const parentMetadata = (parentRow.metadata ?? {}) as Record<string, unknown>;
+      const parent = requireDocumentSourceReadMetadata(parentMetadata, params.documentId);
+      const total =
+        params.unit === "byte"
+          ? parent.sourceByteLength
+          : params.unit === "line"
+            ? parent.sourceLineCount
+            : parent.sourceFragmentCount;
+      const requestedEnd = Math.min(params.offset + params.limit, total);
+      const coordinateStart =
+        params.unit === "byte"
+          ? sql`(${memoryTable.metadata}->>'sourceByteStart')::bigint`
+          : params.unit === "line"
+            ? sql`(${memoryTable.metadata}->>'sourceLineStart')::bigint`
+            : sql`(${memoryTable.metadata}->>'sourceFragmentStart')::bigint`;
+      const coordinateEnd =
+        params.unit === "byte"
+          ? sql`(${memoryTable.metadata}->>'sourceByteEnd')::bigint`
+          : params.unit === "line"
+            ? sql`(${memoryTable.metadata}->>'sourceLineEnd')::bigint`
+            : sql`(${memoryTable.metadata}->>'sourceFragmentEnd')::bigint`;
+      const revisionAttemptCondition = parent.revisionAttemptId
+        ? sql`${memoryTable.metadata}->>'revisionAttemptId' = ${parent.revisionAttemptId}`
+        : sql`NOT (${memoryTable.metadata} ? 'revisionAttemptId')`;
+      const rows = await tx
+        .select()
+        .from(memoryTable)
+        .where(
+          and(
+            eq(memoryTable.type, "document_fragments"),
+            eq(memoryTable.agentId, params.agentId),
+            sql`${memoryTable.metadata}->>'type' = 'fragment'`,
+            sql`${memoryTable.metadata}->>'fragmentRole' = 'source-segment'`,
+            sql`${memoryTable.metadata}->>'sourceSegmentVersion' = '1'`,
+            sql`${memoryTable.metadata}->>'documentId' = ${params.documentId}`,
+            validDocumentRevision(memoryTable.metadata),
+            sql`${documentRevisionExpression(memoryTable.metadata)} = ${parent.documentRevision}`,
+            revisionAttemptCondition,
+            sql`${coordinateEnd} > ${params.offset}`,
+            sql`${coordinateStart} < ${requestedEnd}`
+          )
+        )
+        .orderBy(sql`(${memoryTable.metadata}->>'position')::bigint ASC`)
+        .limit(DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS);
+      const segments = rows.map((row) => memoryFromRow(row));
+      return readDocumentSourceProjection({
+        segments,
+        params,
+        parent,
+        documentId: params.documentId,
+        sourceQueryCount: 2,
+      });
     });
   }
 
@@ -2345,6 +2334,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         eq(fragment.type, "document_fragments"),
         eq(fragment.agentId, params.agentId),
         sql`${fragment.metadata}->>'type' = 'fragment'`,
+        sql`COALESCE(${fragment.metadata}->>'fragmentRole', 'embedding-chunk')
+          = 'embedding-chunk'`,
         validDocumentRevision(fragment.metadata),
         sql`${documentRevisionExpression(fragment.metadata)}
           = ${documentRevisionExpression(parent.metadata)}`,
@@ -2379,7 +2370,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         const rows = await tx
           .select({
             memory: fragment,
-            sourceFingerprint: sql<string>`md5(${parent.content}->>'text')`,
+            sourceFingerprint: sql<string | null>`${parent.metadata}->>'sourceFingerprint'`,
           })
           .from(fragment)
           .innerJoin(parent, parentJoin)
@@ -2389,13 +2380,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .offset(params.offset ?? 0);
         return rows.map((row) => {
           const memory = memoryFromRow(row.memory);
-          return {
-            ...memory,
-            metadata: {
-              ...(memory.metadata ?? {}),
-              sourceFingerprint: `md5:${row.sourceFingerprint}`,
-            } as Memory["metadata"],
-          };
+          return row.sourceFingerprint
+            ? {
+                ...memory,
+                metadata: {
+                  ...(memory.metadata ?? {}),
+                  sourceFingerprint: row.sourceFingerprint,
+                } as Memory["metadata"],
+              }
+            : memory;
         });
       }
 
@@ -2411,7 +2404,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           memory: fragment,
           embedding: activeColumn,
           similarity,
-          sourceFingerprint: sql<string>`md5(${parent.content}->>'text')`,
+          sourceFingerprint: sql<string | null>`${parent.metadata}->>'sourceFingerprint'`,
         })
         .from(embeddingTable)
         .innerJoin(fragment, eq(fragment.id, embeddingTable.memoryId))
@@ -2426,13 +2419,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           row.embedding ? Array.from(row.embedding) : undefined,
           row.similarity
         );
-        return {
-          ...memory,
-          metadata: {
-            ...(memory.metadata ?? {}),
-            sourceFingerprint: `md5:${row.sourceFingerprint}`,
-          } as Memory["metadata"],
-        };
+        return row.sourceFingerprint
+          ? {
+              ...memory,
+              metadata: {
+                ...(memory.metadata ?? {}),
+                sourceFingerprint: row.sourceFingerprint,
+              } as Memory["metadata"],
+            }
+          : memory;
       });
     });
   }

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2257,6 +2257,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .select({ metadata: memoryTable.metadata })
         .from(memoryTable)
         .where(and(...this.documentReadConditions(params)))
+        .for("share")
         .limit(1);
       const parentRow = parentRows[0];
       if (!parentRow) return null;
@@ -2269,42 +2270,68 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             ? parent.sourceLineCount
             : parent.sourceFragmentCount;
       const requestedEnd = Math.min(params.offset + params.limit, total);
+      const sourceParent = alias(memoryTable, "document_source_parent");
+      const sourceSegment = alias(memoryTable, "document_source_segment");
       const coordinateStart =
         params.unit === "byte"
-          ? sql`(${memoryTable.metadata}->>'sourceByteStart')::bigint`
+          ? sql`(${sourceSegment.metadata}->>'sourceByteStart')::bigint`
           : params.unit === "line"
-            ? sql`(${memoryTable.metadata}->>'sourceLineStart')::bigint`
-            : sql`(${memoryTable.metadata}->>'sourceFragmentStart')::bigint`;
+            ? sql`(${sourceSegment.metadata}->>'sourceLineStart')::bigint`
+            : sql`(${sourceSegment.metadata}->>'sourceFragmentStart')::bigint`;
       const coordinateEnd =
         params.unit === "byte"
-          ? sql`(${memoryTable.metadata}->>'sourceByteEnd')::bigint`
+          ? sql`(${sourceSegment.metadata}->>'sourceByteEnd')::bigint`
           : params.unit === "line"
-            ? sql`(${memoryTable.metadata}->>'sourceLineEnd')::bigint`
-            : sql`(${memoryTable.metadata}->>'sourceFragmentEnd')::bigint`;
+            ? sql`(${sourceSegment.metadata}->>'sourceLineEnd')::bigint`
+            : sql`(${sourceSegment.metadata}->>'sourceFragmentEnd')::bigint`;
       const revisionAttemptCondition = parent.revisionAttemptId
-        ? sql`${memoryTable.metadata}->>'revisionAttemptId' = ${parent.revisionAttemptId}`
-        : sql`NOT (${memoryTable.metadata} ? 'revisionAttemptId')`;
+        ? sql`${sourceSegment.metadata}->>'revisionAttemptId' = ${parent.revisionAttemptId}`
+        : sql`NOT (${sourceSegment.metadata} ? 'revisionAttemptId')`;
+      const hasGlobalVisibility = documentRoleHasGlobalVisibility(params.requesterRole);
+      const parentConditions: SQL[] = [
+        eq(sourceParent.id, params.documentId),
+        eq(sourceParent.type, "documents"),
+        eq(sourceParent.agentId, params.agentId),
+        isNotNull(sourceParent.roomId),
+        isNotNull(sourceParent.entityId),
+        sql`${sourceParent.metadata}->>'type' = 'document'`,
+        documentVisibilityCondition(params, sourceParent.metadata),
+      ];
+      if (!hasGlobalVisibility) {
+        parentConditions.push(
+          documentRoomOrDirectGrantCondition(
+            params,
+            params.requesterRoomIds.length > 0
+              ? inArray(sourceParent.roomId, params.requesterRoomIds)
+              : sql`false`,
+            sourceParent.metadata
+          )
+        );
+      }
       const rows = await tx
-        .select()
-        .from(memoryTable)
-        .where(
+        .select({ parentId: sourceParent.id, segment: sourceSegment })
+        .from(sourceParent)
+        .leftJoin(
+          sourceSegment,
           and(
-            eq(memoryTable.type, "document_fragments"),
-            eq(memoryTable.agentId, params.agentId),
-            sql`${memoryTable.metadata}->>'type' = 'fragment'`,
-            sql`${memoryTable.metadata}->>'fragmentRole' = 'source-segment'`,
-            sql`${memoryTable.metadata}->>'sourceSegmentVersion' = '1'`,
-            sql`${memoryTable.metadata}->>'documentId' = ${params.documentId}`,
-            validDocumentRevision(memoryTable.metadata),
-            sql`${documentRevisionExpression(memoryTable.metadata)} = ${parent.documentRevision}`,
+            eq(sourceSegment.type, "document_fragments"),
+            eq(sourceSegment.agentId, params.agentId),
+            sql`${sourceSegment.metadata}->>'type' = 'fragment'`,
+            sql`${sourceSegment.metadata}->>'fragmentRole' = 'source-segment'`,
+            sql`${sourceSegment.metadata}->>'sourceSegmentVersion' = '1'`,
+            sql`${sourceSegment.metadata}->>'documentId' = ${params.documentId}`,
+            validDocumentRevision(sourceSegment.metadata),
+            sql`${documentRevisionExpression(sourceSegment.metadata)} = ${parent.documentRevision}`,
             revisionAttemptCondition,
             sql`${coordinateEnd} > ${params.offset}`,
             sql`${coordinateStart} < ${requestedEnd}`
           )
         )
-        .orderBy(sql`(${memoryTable.metadata}->>'position')::bigint ASC`)
+        .where(and(...parentConditions))
+        .orderBy(sql`(${sourceSegment.metadata}->>'position')::bigint ASC NULLS LAST`)
         .limit(DOCUMENT_SOURCE_READ_LOOKAHEAD_SEGMENTS);
-      const segments = rows.map((row) => memoryFromRow(row));
+      if (rows.length === 0) return null;
+      const segments = rows.flatMap((row) => (row.segment ? [memoryFromRow(row.segment)] : []));
       return readDocumentSourceProjection({
         segments,
         params,

--- a/plugins/plugin-sql/src/schema/memory.ts
+++ b/plugins/plugin-sql/src/schema/memory.ts
@@ -88,6 +88,33 @@ export const memoryTable = pgTable(
       sql`((metadata->>'documentId'))`,
       sql`((metadata->>'position'))`
     ),
+    index("idx_document_source_byte_seek")
+      .on(
+        sql`((metadata->>'documentId'))`,
+        sql`((metadata->>'sourceByteEnd')::bigint)`,
+        sql`((metadata->>'position')::bigint)`
+      )
+      .where(
+        sql`${table.type} = 'document_fragments' AND ${table.metadata}->>'fragmentRole' = 'source-segment'`
+      ),
+    index("idx_document_source_line_seek")
+      .on(
+        sql`((metadata->>'documentId'))`,
+        sql`((metadata->>'sourceLineEnd')::bigint)`,
+        sql`((metadata->>'position')::bigint)`
+      )
+      .where(
+        sql`${table.type} = 'document_fragments' AND ${table.metadata}->>'fragmentRole' = 'source-segment'`
+      ),
+    index("idx_document_source_fragment_seek")
+      .on(
+        sql`((metadata->>'documentId'))`,
+        sql`((metadata->>'sourceFragmentEnd')::bigint)`,
+        sql`((metadata->>'position')::bigint)`
+      )
+      .where(
+        sql`${table.type} = 'document_fragments' AND ${table.metadata}->>'fragmentRole' = 'source-segment'`
+      ),
     check(
       "fragment_metadata_check",
       sql`


### PR DESCRIPTION
# Relates to

Follow-up to #24286 and the progressive-content specification under `docs/design/context-content/`.

- [x] This PR targets `develop` and is rebased onto `origin/develop` `3841ec6389126ccc9218367d7d87f13115e4dc0d` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run in this sparse isolated worktree; exact package gates and the reproduced `develop` blockers are recorded below.
- [x] A reviewer can confirm the storage and action contracts from the real-PGLite tests below.

# Sync with develop

- [x] Rebased onto `origin/develop` `3841ec6389126ccc9218367d7d87f13115e4dc0d`; zero conflicts.
- [ ] Root verify is pending the integrated coordinator; focused exact-head gates pass and baseline failures are documented below.

# Risks

Medium. This changes document persistence, the public database-adapter range capability, SQL indexes, authorization queries, revision replacement, and DOCUMENT read continuation. Legacy unsegmented parents deliberately fail with `DOCUMENT_REINDEX_REQUIRED` instead of scanning the parent body.

# Background

## What does this PR do?

- Adds immutable, non-overlapping 64 KiB UTF-8 source segments alongside derived embedding chunks.
- Adds indexed byte, line, and fragment seeks with at most four returned segments plus one bounded lookahead row.
- Computes the source SHA/revision once at ingestion or atomic update instead of rescanning and hashing the parent JSON body on each page.
- Reauthorizes each SQL segment read through the current parent entitlement and locks the selected parent generation, closing the parent-query/segment-query revocation race.
- Returns exact advancing `ReadSlice` pages, falls back from oversized logical units to byte continuation, rejects invalid UTF-8 boundaries, and requires revision-bound continuation.
- Records logical-unit edge boundaries and rejects missing giant-line prefixes or suffixes instead of presenting a surviving partial segment sequence as complete.
- Gives the in-memory conformance adapter a collision-safe, generation-keyed ordered source index; late reads use a logarithmic coordinate seek plus at most five range candidates instead of scanning all memories.
- Rejects `offset > total` with `DOCUMENT_READ_INVALID_RANGE` after parent authorization but before any source-index or SQL segment query; `offset == total` remains a valid empty page.
- Keeps source segments out of semantic fragment search and preserves parent plus source/embedding projections atomically on update.
- Returns typed `DOCUMENT_REINDEX_REQUIRED` for authorized legacy rows rather than silently materializing them.

## What kind of change is this?

Feature and security/correctness improvement; additive adapter capability version 2.

# Documentation changes needed?

The governing spec/report/goal already describe indexed document source segments, bounded lookahead, authorization on continuation, and typed legacy reindex failure. No additional documentation file is required in this lane.

# Testing

## Where should a reviewer start?

1. `packages/core/src/features/documents/source-segments.ts`
2. `plugins/plugin-sql/src/base.ts` (`readDocumentRange`)
3. `packages/core/src/features/documents/source-segments.test.ts`
4. `packages/core/src/features/documents/service-authorization.real.test.ts`
5. `packages/core/src/features/documents/service-update-atomic-revision.test.ts`

## Detailed testing steps

Exact head: `4d9e2bec20a163b29e800d182bdf38a6c3ef24d1`

- Focused Vitest runs using the owning core config — 5 files, 39 tests passed: source/index projection 9, progressive action 10, character ingest 5, orphan compensation 8, and atomic revision 7. The 10,000-row in-memory test reads the last logical unit after inspecting no more than `ceil(log2(10000)) + 2` candidates, proves the inspection count exceeds returned rows, and injects an index trap proving `offset > total` rejects before index access.
- `VITEST_LANE=post-merge bun run --cwd packages/core test -- src/features/documents/service-authorization.real.test.ts` — 1 real-PGLite file, 6 tests passed, including a 10 MiB late-page read, direct-grant revocation, bounded row/byte counters, legacy failure, and atomic replacement. `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` over the actual parent/source join shape proves byte, line, and fragment late seeks choose `idx_document_source_*_seek`, never sequential-scan the source alias, and visit at most the five-row lookahead bound.
- `bun run --cwd packages/core test -- src/features/documents/service-list.test.ts -t 'adds and updates keyword-searchable documents'` — 1 passed, 15 skipped; proves both physical projections without changing the public embedding-fragment count.
- `bun run --cwd plugins/plugin-sql test` — 28 files passed, 1 skipped; 178 tests passed, 3 skipped.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run --cwd plugins/plugin-sql typecheck` — passed after the required core build.
- `bun run --cwd packages/core build` — Node, browser, edge, testing bundles, declarations, and packed consumers passed.
- `bun run --cwd plugins/plugin-sql build` — Node ESM, browser ESM, CJS, and declarations passed.
- Changed-file Biome check, plugin-sql `lint:check`, plugin-sql `format:check`, and `git diff --check` — passed.
- Core and plugin-sql `CLAUDE.md` / `AGENTS.md` pairs compare byte-for-byte identical.

# Evidence Gate

<!-- evidence-head:4d9e2bec20a163b29e800d182bdf38a6c3ef24d1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:backend-logs -->
- [x] The exact commands and terminal results above exercise the real PGLite adapter and production DocumentService/action path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this isolated lane proves deterministic source/storage/action contracts; live-model continuation planning remains an integrated rollout gate and is not claimed here.
<!-- evidence-row:domain-artifacts -->
- [x] Real-PGLite tests inspect the three source-seek indexes, authorized parent/source rows, bounded source-work counters, exact 10 MiB late-page output, revision replacement, and rollback after the injected Nth fragment insert failure.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic native paging and persistence lane. A live-model trajectory is still required by the overall progressive-content rollout before default enablement; this PR does not claim autonomous planning acceptance.

## Backend + frontend logs

Backend evidence is the real-PGLite Vitest output summarized above. Frontend is N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio or voice surface changed.

## Known gaps / failures

- `bun install` was not run because this isolated sparse worktree intentionally uses read-only dependency symlinks while another task owns cleanup of the shared checkout. No dependency or lockfile changed.
- `bun run check:agents-claude` cannot execute because the sparse checkout omits `scripts/assert-agents-claude-identical.mjs`; both touched-package guide pairs were compared directly and are identical.
- `bun run --cwd packages/core test -- src/features/documents` reports 315 passed and six failures. Five are reproduced unchanged on clean `origin/develop`: three `service-list.test.ts` role/visibility expectations and two `action-context-gate.test.ts` mocks that lack `readDocumentRange`. The sixth is a sparse-checkout-only missing PDF fixture under `packages/app-core/test/contracts/`. All lane-owned failures discovered in the first full run were repaired and pass in the focused commands above.
- Root `bun run verify`, live-model planning, shared corpus conformance, Postgres, and soak/evidence-bundle gates belong to the integrated progressive-content wave and remain required before merge/default rollout.
- Local Node is `v24.5.0` rather than the repository-pinned `24.15.0`; Bun is the pinned `1.3.14`. Hosted CI must confirm the pinned Node environment.

## Maintainer CI exception record

N/A - no exception requested.
