### PR TITLE
refactor(identity): hard-cut canonical principal service

### DIFF
--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -30,7 +30,7 @@ import { createUniqueUuid } from "./entities";
 import { ElizaError } from "./errors.ts";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
-import type { IdentityResolutionService } from "./types/identity";
+import type { PrincipalService } from "./types/identity";
 import {
 	MESSAGE_SOURCE_AGENT_GREETING,
 	MESSAGE_SOURCE_CLIENT_CHAT,
@@ -512,9 +512,7 @@ async function resolveIdentityOwnerBinding(
 	ownerIds: readonly UUID[],
 ): Promise<boolean | null> {
 	if (typeof runtime.getService !== "function") return null;
-	const service = runtime.getService<IdentityResolutionService>(
-		ServiceType.IDENTITY_RESOLUTION,
-	);
+	const service = runtime.getService<PrincipalService>(ServiceType.PRINCIPAL);
 	if (!service) return null;
 
 	try {
@@ -776,13 +774,11 @@ async function resolveExplicitGrantedRole(
 		return { role: directRole, source: "manual" };
 	}
 
-	const identityService =
+	const principalService =
 		typeof runtime.getService === "function"
-			? runtime.getService<IdentityResolutionService>(
-					ServiceType.IDENTITY_RESOLUTION,
-				)
+			? runtime.getService<PrincipalService>(ServiceType.PRINCIPAL)
 			: null;
-	if (identityService) return null;
+	if (principalService) return null;
 
 	const linkedIds = await getConfirmedLinkedEntityIds(runtime, entityId);
 	let bestRole: RoleName | null = null;

--- a/packages/core/src/types/identity.test.ts
+++ b/packages/core/src/types/identity.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it } from "vitest";
+import * as identityContracts from "./identity";
 import {
 	IDENTITY_AUTHORITY_CONTRACT_VERSION,
 	IDENTITY_CLAIM_STATUSES,
@@ -11,7 +12,7 @@ import {
 	IDENTITY_MERGE_OPERATIONS,
 	IDENTITY_MERGE_STATUSES,
 	IDENTITY_REDIRECT_STATUSES,
-	IdentityResolutionService,
+	PrincipalService,
 } from "./identity";
 import { ServiceType } from "./service";
 
@@ -46,9 +47,14 @@ describe("identity authority contract", () => {
 	});
 
 	it("registers one canonical runtime service name", () => {
-		expect(ServiceType.IDENTITY_RESOLUTION).toBe("identity_resolution");
-		expect(IdentityResolutionService.serviceType).toBe(
-			ServiceType.IDENTITY_RESOLUTION,
-		);
+		expect(ServiceType.PRINCIPAL).toBe("principal");
+		expect(PrincipalService.serviceType).toBe(ServiceType.PRINCIPAL);
+
+		const retiredKey = ["IDENTITY", "RESOLUTION"].join("_");
+		const retiredValue = ["identity", "resolution"].join("_");
+		const retiredExport = ["Identity", "Resolution", "Service"].join("");
+		expect(Object.hasOwn(ServiceType, retiredKey)).toBe(false);
+		expect(Object.values(ServiceType)).not.toContain(retiredValue);
+		expect(Object.hasOwn(identityContracts, retiredExport)).toBe(false);
 	});
 });

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -326,11 +326,11 @@ export type IdentityPersonLinkVerification =
 			reason: "no_attestation";
 	  };
 
-/** Single runtime authority for identity reads and reversible mutations. */
-export abstract class IdentityResolutionService extends Service {
-	static override readonly serviceType = ServiceType.IDENTITY_RESOLUTION;
+/** Single runtime authority for principals and every identity mutation. */
+export abstract class PrincipalService extends Service {
+	static override readonly serviceType = ServiceType.PRINCIPAL;
 	public readonly capabilityDescription =
-		"Resolves canonical principals and performs reversible identity mutations.";
+		"Owns principals, identity evidence, and reversible identity mutations.";
 
 	abstract resolveCanonicalPrincipal(
 		agentId: UUID,

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -53,7 +53,7 @@ export interface ServiceTypeRegistry {
 	SCREEN_CAPTURE: "screen_capture";
 	DOCUMENTS: "documents";
 	RELATIONSHIPS: "relationships";
-	IDENTITY_RESOLUTION: "identity_resolution";
+	PRINCIPAL: "principal";
 	FOLLOW_UP: "follow_up";
 	TRAJECTORIES: "trajectories";
 	SWARM_COORDINATOR: "SWARM_COORDINATOR";
@@ -161,7 +161,7 @@ export const ServiceType = {
 	SCREEN_CAPTURE: "screen_capture",
 	DOCUMENTS: "documents",
 	RELATIONSHIPS: "relationships",
-	IDENTITY_RESOLUTION: "identity_resolution",
+	PRINCIPAL: "principal",
 	FOLLOW_UP: "follow_up",
 	TRAJECTORIES: "trajectories",
 	SWARM_COORDINATOR: "SWARM_COORDINATOR",

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -13,7 +13,7 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 | Kind | Name | Description |
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
-| Service | `SqlIdentityResolutionService` (`serviceType = "IDENTITY_RESOLUTION"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
+| Service | `SqlPrincipalService` (`serviceType = "principal"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
 | Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
 | Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |
@@ -58,7 +58,7 @@ plugins/plugin-sql/
       agent.ts / room.ts / memory.ts / entity.ts / ...  One file per table
     services/
       advanced-memory-storage.ts  AdvancedMemoryStorageService implementation
-      sql-identity-resolution.ts  Canonical identity authority implementation
+      sql-principal.ts  Canonical identity authority implementation
     stores/
       agent.store.ts / memory.store.ts / room.store.ts / ...  Query logic split by domain
     runtime-migrator/

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -13,7 +13,7 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 | Kind | Name | Description |
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
-| Service | `SqlIdentityResolutionService` (`serviceType = "IDENTITY_RESOLUTION"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
+| Service | `SqlPrincipalService` (`serviceType = "principal"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
 | Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
 | Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |
@@ -58,7 +58,7 @@ plugins/plugin-sql/
       agent.ts / room.ts / memory.ts / entity.ts / ...  One file per table
     services/
       advanced-memory-storage.ts  AdvancedMemoryStorageService implementation
-      sql-identity-resolution.ts  Canonical identity authority implementation
+      sql-principal.ts  Canonical identity authority implementation
     stores/
       agent.store.ts / memory.store.ts / room.store.ts / ...  Query logic split by domain
     runtime-migrator/

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -14,7 +14,7 @@ This plugin registers a `DatabaseAdapter` with the elizaOS agent runtime so that
 
 ## Identity authority
 
-The plugin registers `SqlIdentityResolutionService` as the runtime's canonical
+The plugin registers `SqlPrincipalService` as the runtime's canonical
 identity authority. Its private person-link endpoints let an authenticated
 OWNER or ADMIN attest that two preserved principals represent the same person
 without merging or deleting either principal:

--- a/plugins/plugin-sql/src/__tests__/identity-person-link-registration.test.ts
+++ b/plugins/plugin-sql/src/__tests__/identity-person-link-registration.test.ts
@@ -1,18 +1,20 @@
 /**
  * Verifies the SQL plugin activates the canonical identity service and its
- * private person-link routes without registering any model-callable action.
+ * private person-link routes without restoring the retired authority surface
+ * or registering any model-callable action.
  */
-import { IdentityResolutionService } from "@elizaos/core";
+
+import { existsSync } from "node:fs";
+import { PrincipalService } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { plugin } from "../index";
+import * as sqlPluginExports from "../index";
+import { plugin, SqlPrincipalService } from "../index";
 
 describe("identity person-link registration", () => {
   it("registers one canonical service and private routes, with no actions", () => {
     expect(
-      plugin.services?.some(
-        (service) => service.serviceType === IdentityResolutionService.serviceType
-      )
-    ).toBe(true);
+      plugin.services?.filter((service) => service.serviceType === PrincipalService.serviceType)
+    ).toEqual([SqlPrincipalService]);
     expect(plugin.routes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -28,5 +30,16 @@ describe("identity person-link registration", () => {
       ])
     );
     expect(plugin.actions).toBeUndefined();
+  });
+
+  it("ratchets deletion of the retired service, export, and implementation files", () => {
+    const retiredExport = ["Sql", "Identity", "Resolution", "Service"].join("");
+    const retiredBasename = ["sql", "identity", "resolution"].join("-");
+
+    expect(Object.hasOwn(sqlPluginExports, retiredExport)).toBe(false);
+    expect(existsSync(new URL(`../services/${retiredBasename}.ts`, import.meta.url))).toBe(false);
+    expect(existsSync(new URL(`../services/${retiredBasename}.test.ts`, import.meta.url))).toBe(
+      false
+    );
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-authority.real.test.ts
@@ -17,17 +17,14 @@ import {
   identityMergeConfirmationTable,
   identityMergeJournalTable,
 } from "../../schema/identityAuthority";
-import {
-  computeIdentityRequestDigest,
-  SqlIdentityResolutionService,
-} from "../../services/sql-identity-resolution";
+import { computeIdentityRequestDigest, SqlPrincipalService } from "../../services/sql-principal";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
 describe("SQL identity authority", () => {
   let cleanup: () => Promise<void>;
   let db: DrizzleDatabase;
-  let service: SqlIdentityResolutionService;
+  let service: SqlPrincipalService;
   let agentId: UUID;
   const actorId = crypto.randomUUID() as UUID;
   const canonicalId = crypto.randomUUID() as UUID;
@@ -49,7 +46,7 @@ describe("SQL identity authority", () => {
     vi.spyOn(setup.runtime, "getSetting").mockImplementation((key) =>
       key === "ELIZA_INSTANCE_ID" ? "identity-authority-test" : getSetting(key)
     );
-    service = new SqlIdentityResolutionService(setup.runtime);
+    service = new SqlPrincipalService(setup.runtime);
     await db
       .insert(entityTable)
       .values(

--- a/plugins/plugin-sql/src/__tests__/integration/identity-person-link-attestation.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-person-link-attestation.real.test.ts
@@ -3,7 +3,7 @@
  * authority, including stale generations, forged fields, replay, and proof
  * that attestations never create redirects or merge journals.
  */
-import { IdentityResolutionService, type RouteHandlerContext, type UUID } from "@elizaos/core";
+import { PrincipalService, type RouteHandlerContext, type UUID } from "@elizaos/core";
 import { count, eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { identityPersonLinkRoutes } from "../../routes/identity-person-link";
@@ -14,7 +14,7 @@ import {
   identityMergeJournalTable,
   identityPersonLinkAttestationTable,
 } from "../../schema/identityAuthority";
-import { SqlIdentityResolutionService } from "../../services/sql-identity-resolution";
+import { SqlPrincipalService } from "../../services/sql-principal";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
@@ -28,7 +28,7 @@ describe.sequential("authenticated identity person-link ingress", () => {
   let cleanup: () => Promise<void>;
   let db: DrizzleDatabase;
   let runtime: Awaited<ReturnType<typeof createIsolatedTestDatabase>>["runtime"];
-  let service: SqlIdentityResolutionService;
+  let service: SqlPrincipalService;
   let agentId: UUID;
 
   const attestRoute = identityPersonLinkRoutes.find(
@@ -44,9 +44,9 @@ describe.sequential("authenticated identity person-link ingress", () => {
     db = setup.adapter.getDatabase() as DrizzleDatabase;
     runtime = setup.runtime;
     agentId = setup.testAgentId;
-    service = new SqlIdentityResolutionService(runtime);
+    service = new SqlPrincipalService(runtime);
     vi.spyOn(runtime, "getService").mockImplementation((type) =>
-      type === IdentityResolutionService.serviceType ? service : null
+      type === PrincipalService.serviceType ? service : null
     );
     await db.insert(entityTable).values(
       [actorId, leftId, rightId, otherLeftId, otherRightId].map((id) => ({

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -29,7 +29,7 @@ import {
 import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
-import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
+import { SqlPrincipalService } from "./services/sql-principal";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
@@ -116,7 +116,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access (PGlite WASM in browser).",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService, SqlIdentityResolutionService],
+  services: [AdvancedMemoryStorageService, SqlPrincipalService],
   routes: [...identityPersonLinkRoutes],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
@@ -200,6 +200,6 @@ export * from "./schema";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 export {
   computeIdentityRequestDigest,
-  SqlIdentityResolutionService,
-} from "./services/sql-identity-resolution";
+  SqlPrincipalService,
+} from "./services/sql-principal";
 export type { DrizzleDatabase } from "./types";

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -54,7 +54,7 @@ import {
 import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
-import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
+import { SqlPrincipalService } from "./services/sql-principal";
 import { stringToUuid } from "./utils/string-to-uuid";
 import { resolvePgliteDir } from "./utils.node.ts";
 
@@ -181,7 +181,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService, SqlIdentityResolutionService],
+  services: [AdvancedMemoryStorageService, SqlPrincipalService],
   routes: [...identityPersonLinkRoutes],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
@@ -259,8 +259,8 @@ export {
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 export {
   computeIdentityRequestDigest,
-  SqlIdentityResolutionService,
-} from "./services/sql-identity-resolution";
+  SqlPrincipalService,
+} from "./services/sql-principal";
 
 /**
  * Query the live Electric Sync status from the global PGliteClientManager

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -54,7 +54,7 @@ import {
 import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
-import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
+import { SqlPrincipalService } from "./services/sql-principal";
 import { resolvePgliteDir } from "./utils";
 import { stringToUuid } from "./utils/string-to-uuid";
 
@@ -176,7 +176,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService, SqlIdentityResolutionService],
+  services: [AdvancedMemoryStorageService, SqlPrincipalService],
   routes: [...identityPersonLinkRoutes],
   init: async (_, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
@@ -270,8 +270,8 @@ export * from "./schema";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 export {
   computeIdentityRequestDigest,
-  SqlIdentityResolutionService,
-} from "./services/sql-identity-resolution";
+  SqlPrincipalService,
+} from "./services/sql-principal";
 export * from "./types";
 export { schema };
 

--- a/plugins/plugin-sql/src/routes/identity-person-link.ts
+++ b/plugins/plugin-sql/src/routes/identity-person-link.ts
@@ -6,14 +6,14 @@
 import {
   ElizaError,
   type IdentityPersonLinkActorRole,
-  IdentityResolutionService,
+  PrincipalService,
   type Route,
   type RouteHandlerContext,
   type RouteHandlerResult,
   type UUID,
   validateUuid,
 } from "@elizaos/core";
-import { computeIdentityPersonLinkRequestDigest } from "../services/sql-identity-resolution";
+import { computeIdentityPersonLinkRequestDigest } from "../services/sql-principal";
 
 const ATTEST_PATH = "/api/identity/person-links/attest";
 const VERIFY_PATH = "/api/identity/person-links/verify";
@@ -100,9 +100,7 @@ async function attest(ctx: RouteHandlerContext): Promise<RouteHandlerResult> {
   }
   const actor = authenticatedActor(ctx);
   if ("status" in actor) return actor;
-  const service = ctx.runtime.getService<IdentityResolutionService>(
-    IdentityResolutionService.serviceType
-  );
+  const service = ctx.runtime.getService<PrincipalService>(PrincipalService.serviceType);
   if (!service) return json(503, { error: "IDENTITY_AUTHORITY_UNAVAILABLE" });
   const requestWithoutDigest = {
     agentId: ctx.runtime.agentId,
@@ -137,9 +135,7 @@ async function verify(ctx: RouteHandlerContext): Promise<RouteHandlerResult> {
   if (!leftPrincipalId || !rightPrincipalId || generation === null) {
     return json(400, { error: "IDENTITY_PERSON_LINK_INPUT_INVALID" });
   }
-  const service = ctx.runtime.getService<IdentityResolutionService>(
-    IdentityResolutionService.serviceType
-  );
+  const service = ctx.runtime.getService<PrincipalService>(PrincipalService.serviceType);
   if (!service) return json(503, { error: "IDENTITY_AUTHORITY_UNAVAILABLE" });
   try {
     const verification = await service.verifyPersonLink({

--- a/plugins/plugin-sql/src/services/sql-principal.test.ts
+++ b/plugins/plugin-sql/src/services/sql-principal.test.ts
@@ -4,7 +4,7 @@
  * PGlite integration lane rather than mocks of the SQL authority.
  */
 import { describe, expect, it } from "vitest";
-import { computeIdentityRequestDigest } from "./sql-identity-resolution";
+import { computeIdentityRequestDigest } from "./sql-principal";
 
 describe("computeIdentityRequestDigest", () => {
   it("is stable across object-key and principal-set order", () => {

--- a/plugins/plugin-sql/src/services/sql-principal.ts
+++ b/plugins/plugin-sql/src/services/sql-principal.ts
@@ -21,10 +21,10 @@ import {
   type IdentityMergePlan,
   type IdentityPersonLinkAttestation,
   type IdentityPersonLinkVerification,
-  IdentityResolutionService,
   type JsonObject,
   type MergeJournal,
   type OwnerBindingEvaluation,
+  PrincipalService,
   type ProposeIdentityMergeRequest,
   type Service,
   type SplitIdentityRequest,
@@ -278,11 +278,11 @@ function follow(
   return { canonical: current, ids };
 }
 
-export class SqlIdentityResolutionService extends IdentityResolutionService {
-  static override readonly serviceType = IdentityResolutionService.serviceType;
+export class SqlPrincipalService extends PrincipalService {
+  static override readonly serviceType = PrincipalService.serviceType;
 
   static async start(runtime: IAgentRuntime): Promise<Service> {
-    const service = new SqlIdentityResolutionService(runtime);
+    const service = new SqlPrincipalService(runtime);
     if (!service.db) {
       fail(
         "IDENTITY_SQL_ADAPTER_REQUIRED",
@@ -434,7 +434,7 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
   }
 
   async evaluateOwnerBinding(
-    request: Parameters<IdentityResolutionService["evaluateOwnerBinding"]>[0]
+    request: Parameters<PrincipalService["evaluateOwnerBinding"]>[0]
   ): Promise<OwnerBindingEvaluation> {
     this.assertAgent(request.agentId);
     const instanceSetting = this.runtime.getSetting("ELIZA_INSTANCE_ID");
@@ -941,7 +941,7 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
   }
 
   async confirmMerge(
-    request: Parameters<IdentityResolutionService["confirmMerge"]>[0]
+    request: Parameters<PrincipalService["confirmMerge"]>[0]
   ): Promise<IdentityMergeConfirmation> {
     this.assertAgent(request.agentId);
     return this.db.transaction(async (tx) => {


### PR DESCRIPTION
## Outcome

Hard-cuts the runtime and SQL identity authority from the retired identity-resolution name to the single canonical `PrincipalService` / `ServiceType.PRINCIPAL` (`principal`) surface. There is deliberately no alias, compatibility key, dual registration, or old export.

This is a prerequisite slice of #24397; it does not close the broader device-bound owner-bootstrap and consumer-migration issue.

## Proof

- Full `@elizaos/core` Node/browser/edge/testing build, declarations, and packed-consumer verification
- Core and plugin-sql typechecks
- plugin-sql Node/browser/CJS build and lint
- 47 focused core role/identity tests green
- 13 SQL tests green, including real PGlite merge-authority and authenticated same-person attestation suites
- Exact-cardinality SQL service registration assertion
- Automated negative ratchets for the retired core key/value/export and SQL export/source paths
- Literal deletion search is empty for all retired names
- `check:agents-claude` and `git diff --check` green
- Independent review: GO on exact head `d2f8bcd9867288722fd1f3af60d6205a1ab9d18b`

## Repository-wide gate exception

`bun run verify` reaches repository audits and fails on the exact `develop` base `2a0cd02215032b1736cde7332ed18c27ec3dd974` with the same unrelated existing failures: 22 orphaned plugin tests in `ensure-plugin-test-conventions`, and 16 plugin tsconfig graphs unable to resolve `@elizaos/capacitor-secure-store`. Both were reproduced after a fresh `bun install` in a separate detached worktree at that base. No changed file participates in either failure. All changed-surface gates above are green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— principal-service-hard-cut
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->