### PR TITLE
fix(cloud): ignore foreign Telegram link commands

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts
@@ -87,7 +87,7 @@ describe("telegram group-link authority", () => {
     expect(requests).toBe(0);
   });
 
-  test("does not authorize a link command addressed to another bot", async () => {
+  test("drops a link command addressed to another bot", async () => {
     let requests = 0;
     globalThis.fetch = (async () => {
       requests += 1;
@@ -100,14 +100,25 @@ describe("telegram group-link authority", () => {
       config,
     );
 
-    // Ambient forwarding is enabled for groups, so the provider event remains
-    // available; it must not be upgraded into a link-authority operation.
-    expect(event).toMatchObject({
-      text,
-      groupInvocation: "ambient",
-    });
-    expect(event?.groupActorRole).toBeUndefined();
+    expect(event).toBeNull();
     expect(requests).toBe(0);
+  });
+
+  test("drops a suffixed link command when bot identity is unavailable", async () => {
+    let requests = 0;
+    globalThis.fetch = (async () => {
+      requests += 1;
+      throw new Error("Telegram unavailable");
+    }) as typeof fetch;
+    const text = "/eliza_link@ElizaBot 23456789";
+
+    const event = await telegramAdapter.extractEvent(
+      groupUpdate(text, text.indexOf(" ")),
+      { botToken: "telegram-test-token" },
+    );
+
+    expect(event).toBeNull();
+    expect(requests).toBe(1);
   });
 
   test("fails a link command closed when current membership lookup fails", async () => {

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -28,11 +28,17 @@ export {
 const TELEGRAM_GROUP_LINK_COMMAND =
   /^(?:\/eliza_link(?:@([a-z0-9_]{5,32}))?|eliza\s+link)\s+[2-9A-HJ-NP-Z]{8}$/i;
 
-function isTelegramGroupLinkForBot(text: string, botUsername: string): boolean {
+function telegramGroupLinkTarget(
+  text: string,
+  botUsername: string,
+): "not-link" | "this-bot" | "other-bot" {
   const match = text.match(TELEGRAM_GROUP_LINK_COMMAND);
-  if (!match) return false;
+  if (!match) return "not-link";
   const target = match[1];
-  return !target || target.toLowerCase() === botUsername.toLowerCase();
+  if (!target) return "this-bot";
+  return botUsername && target.toLowerCase() === botUsername.toLowerCase()
+    ? "this-bot"
+    : "other-bot";
 }
 
 function asTelegramEvent(event: ChatEvent): TelegramConnectorEvent {
@@ -115,7 +121,14 @@ export const telegramAdapter: PlatformAdapter = {
       // may enter the model. Telegram privacy mode may still hide them.
       allowAmbient: true,
     });
-    if (event && isTelegramGroupLinkForBot(event.text, botUsername)) {
+    if (!event) return null;
+    const linkTarget = telegramGroupLinkTarget(event.text, botUsername);
+    // Telegram may deliver commands addressed to another bot when this bot is
+    // an administrator. Do not forward those commands as ambient text: the
+    // trusted Cloud route also recognizes the command grammar and would
+    // otherwise emit a control reply despite the foreign @username suffix.
+    if (linkTarget === "other-bot") return null;
+    if (linkTarget === "this-bot") {
       try {
         event.groupActorRole = await resolveTelegramGroupActorRole(
           config ?? {},


### PR DESCRIPTION
# Relates to

Fixes #24691. Corrective follow-up to #24402.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto exact `origin/develop` `8c8c2a3441f0d627696af078d5e3dd1c510bdcf3` with zero conflicts.
- [x] Focused and owning-package gates ran at exact head; the unrelated current-`develop` full-suite failure and sparse-install limitation are recorded below.
- [x] The provider-shaped regression proves the foreign command is dropped before dedupe, Cloud forwarding, or provider egress.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Exact post-sync focused test, typecheck, lint, and diff checks pass.

# Risks

Low. The change only suppresses a syntactically valid `/eliza_link@username CODE` group command when `username` does not match the resolved configured Telegram bot. Unsuffixed commands, natural-language commands, and commands addressed to this bot retain the existing membership-authority flow. A suffixed command also fails closed when bot identity is unavailable.

# Background

## What does this PR do?

The Telegram adapter previously recognized that `/eliza_link@OtherBot …` was not addressed to Eliza and skipped its membership lookup, but still returned the event as ambient group text. Personal Shared independently recognizes bot-suffixed link syntax, so it reclassified that forwarded event as an Eliza control command and emitted `group_admin_required` into a conversation addressed to another bot.

This patch classifies link commands as `not-link`, `this-bot`, or `other-bot` at the provider boundary and returns `null` for the foreign/unknown-target cases. The webhook handler's established null-event contract acknowledges the provider update without dedupe, Cloud forwarding, typing, or reply egress.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change. This restores Telegram's documented `@botusername` command-targeting semantics at the adapter boundary.

# Testing

## Where should a reviewer start?

- `packages/cloud/services/gateway-webhook/src/adapters/telegram.ts`
- `packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts`

## Detailed testing steps

At exact head `1c6b7d14fe8b4a9e4859394ab97d8f8730779750` with Bun `1.3.14`:

- `bun test ./packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts` — 8 passed, 0 failed.
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — passed.
- `bun run --cwd packages/cloud/services/gateway-webhook lint:check` — 48 files clean.
- `git diff --check origin/develop...HEAD` — passed.
- Full gateway package suite — 213 passed, 1 unrelated current-`develop` failure: the Dockerfile workspace-context ratchet detects that `gateway-discord` declares `@elizaos/core` but its Dockerfile does not copy `packages/core`.

# Evidence Gate

<!-- evidence-head:1c6b7d14fe8b4a9e4859394ab97d8f8730779750 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI or interactive client flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no production Telegram credential was used; the provider-shaped deterministic fixture exercises the exact adapter boundary and asserts zero membership egress for the foreign command.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, or rendering changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, model, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no durable domain state changes; the relevant artifact is the provider-shaped Telegram update covered by the regression test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path is involved.

## Backend + frontend logs

Focused exact-head result: 8 Telegram group-link authority tests passed, including foreign-target silence and bot-identity-unavailable fail-closed behavior. Frontend logs are N/A because no frontend surface is touched.

## Screenshots (before / after) + video walkthrough

N/A - backend provider-boundary change only.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior.

## Known gaps / failures

- The inherited sparse checkout cannot complete root `bun install`: the root manifest references workspaces omitted from that checkout (`packages/app-core/deploy/cloud-agent-template`). The exact package used the repository's pinned Bun `1.3.14` dependency installation; no manifest or lockfile changed.
- `bun run verify` is not representable in the sparse checkout. All affected-package checks pass.
- The complete owning-package test run has one unrelated baseline failure on current `develop`: `gateway-discord copies every workspace package it depends on`; this PR does not touch Discord, its manifest, or Dockerfiles. The other 213 tests pass.
- No live Telegram bot credential was used. The provider-shaped fixture directly exercises the command target and verifies that no Telegram membership request occurs.

## Maintainer CI exception record

N/A - no exception requested.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8c8c2a3441f0d627696af078d5e3dd1c510bdcf3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8c8c2a3441f0d627696af078d5e3dd1c510bdcf3:packages/skills/skills/contribute-to-eliza"} -->
