### PR TITLE
fix(ci): use --project=chromium so the spec path stays positional

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -2645,7 +2645,7 @@ jobs:
           set +e
           bunx playwright test \
             --config playwright.cloud-deployed.config.ts \
-            --project chromium \
+            --project=chromium \
             test/ui-smoke/cloud-live.spec.ts
           smoke_status=$?
           set -e


### PR DESCRIPTION
@lalalune — one-line unblock for the new deployed-renderer verify leg (same harness-fix lane as #24412; PR CI dead, receipts below).

Run 32599078212's `Verify deployed staging renderer (Pages alias)` failed with:

```
Error: Project(s) "test/ui-smoke/cloud-live.spec.ts" not found. Available projects: "chromium"
```

Playwright's `--project <name...>` is **variadic** — the space-separated form consumes the following positional spec path as a second project name. `--project=chromium` keeps the spec path positional. This leg is the current Certify blocker (frontend NDJSON parse is green since your #24619; renderer verify is next in the chain).

Receipts: identical `--project=chromium` equals form already proven in `app-live-e2e.yml` lines 306/422; change is workflow-only, no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)