### PR TITLE
fix(ui): wait for session recovery before phone login

### DIFF
--- a/packages/app/test/ui-smoke/phone-login-session-recovery.spec.ts
+++ b/packages/app/test/ui-smoke/phone-login-session-recovery.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Real-browser proof that stale Steward session recovery cannot overtake a
+ * fresh phone OTP login. HTTP authority is fixed at the network boundary; the
+ * shipped /login route, storage client, and React state machine run unchanged.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { expect, type Page, type TestInfo, test } from "@playwright/test";
+import { saveBrowserVideoArtifact } from "./helpers/video-artifacts";
+
+test.use({ video: "on" });
+
+const VIEWPORTS = [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+] as const;
+
+const PROVIDERS = {
+  passkey: false,
+  email: true,
+  sms: true,
+  siwe: false,
+  siws: false,
+  google: true,
+  discord: false,
+  github: false,
+  twitter: false,
+  oauth: ["google"],
+};
+
+async function screenshot(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const path = testInfo.outputPath(`${name}.jpg`);
+  await mkdir(testInfo.outputDir, { recursive: true });
+  await page.screenshot({ path, type: "jpeg", quality: 90, fullPage: true });
+  await testInfo.attach(name, { path, contentType: "image/jpeg" });
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`phone OTP waits for stale-session recovery at ${viewport.name}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize(viewport);
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "steward_session_token",
+        "older-session-token",
+      );
+    });
+
+    const frontendEvents: string[] = [];
+    page.on("console", (message) =>
+      frontendEvents.push(`console:${message.type()}:${message.text()}`),
+    );
+    page.on("requestfailed", (request) =>
+      frontendEvents.push(
+        `requestfailed:${request.method()}:${request.url()}:${request.failure()?.errorText ?? "unknown"}`,
+      ),
+    );
+    page.on("response", (response) =>
+      frontendEvents.push(
+        `response:${response.request().method()}:${response.status()}:${response.url()}`,
+      ),
+    );
+
+    await page.route("**/auth/providers", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(PROVIDERS),
+      }),
+    );
+
+    let releaseRecovery: (() => void) | undefined;
+    const recoveryGate = new Promise<void>((resolve) => {
+      releaseRecovery = resolve;
+    });
+    let sessionRequests = 0;
+    await page.route("**/api/auth/steward-session", async (route) => {
+      sessionRequests += 1;
+      await recoveryGate;
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          error: "Older session expired",
+          code: "invalid_steward_token",
+        }),
+      });
+    });
+
+    let smsSendRequests = 0;
+    await page.route("**/auth/sms/send", async (route) => {
+      smsSendRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          expiresAt: "2099-01-01T00:05:00.000Z",
+        }),
+      });
+    });
+    let smsVerifyRequests = 0;
+    await page.route("**/auth/sms/verify", async (route) => {
+      smsVerifyRequests += 1;
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "Unexpected verify" }),
+      });
+    });
+
+    await page.goto("/login");
+    await expect(
+      page.getByRole("status", { name: "Loading sign-in options" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Phone number" }),
+    ).toHaveCount(0);
+    await screenshot(page, testInfo, `${viewport.name}-1-recovery-pending`);
+
+    releaseRecovery?.();
+    await expect(page.getByText("Older session expired")).toBeVisible();
+    const phone = page.getByRole("textbox", { name: "Phone number" });
+    await expect(phone).toBeVisible();
+    await phone.fill("4155552671");
+    await page.getByRole("button", { name: "Text me a code" }).click();
+
+    await expect(page.getByText("Enter the text code")).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Six-digit code" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+    expect(sessionRequests).toBe(1);
+    expect(smsSendRequests).toBe(1);
+    expect(smsVerifyRequests).toBe(0);
+    await screenshot(page, testInfo, `${viewport.name}-2-code-required`);
+
+    const logPath = testInfo.outputPath(`${viewport.name}-frontend.log`);
+    await writeFile(logPath, `${frontendEvents.join("\n")}\n`, "utf8");
+    await testInfo.attach(`${viewport.name}-frontend-log`, {
+      path: logPath,
+      contentType: "text/plain",
+    });
+
+    const video = page.video();
+    if (video) {
+      await page.close();
+      const artifact = await saveBrowserVideoArtifact({
+        video,
+        testInfo,
+        basename: `${viewport.name}-phone-login-recovery-walkthrough`,
+      });
+      await testInfo.attach(`${viewport.name}-walkthrough`, artifact);
+    }
+  });
+}

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
@@ -325,6 +325,35 @@ describe("StewardLoginSection phone login", () => {
     expect(screen.queryByText("Enter the text code")).toBeNull();
   });
 
+  it("does not expose phone login while an older session is still recovering", async () => {
+    let failRecovery: ((error: Error) => void) | undefined;
+    sessionSpies.storedToken = "older-session-token";
+    sessionSpies.sync.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        failRecovery = reject;
+      }),
+    );
+    renderSection();
+
+    await waitFor(() =>
+      expect(sessionSpies.sync).toHaveBeenCalledWith(
+        "older-session-token",
+        null,
+      ),
+    );
+    expect(screen.queryByLabelText("Phone number")).toBeNull();
+    expect(screen.getByLabelText("Loading sign-in options")).toBeTruthy();
+
+    await act(async () => failRecovery?.(new Error("Older session expired")));
+    expect(await screen.findByText("Older session expired")).toBeTruthy();
+
+    await sendPhoneCode();
+    expect(screen.getByText("Enter the text code")).toBeTruthy();
+    expect(screen.getByLabelText("Six-digit code")).toBeTruthy();
+    expect(sessionSpies.write).not.toHaveBeenCalled();
+    expect(returnToSpies.resolve).not.toHaveBeenCalled();
+  });
+
   it("verifies six digits through the existing session completion authority", async () => {
     renderSection("/login?returnTo=%2Fdashboard%2Fagents");
     await sendPhoneCode();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -572,6 +572,12 @@ export default function StewardLoginSection() {
   const walletOptionsRegionRef = useRef<HTMLDivElement>(null);
   const [callbackError, setCallbackError] = useState<string | null>(null);
   const [redirectTo, setRedirectTo] = useState<string | null>(null);
+  // Do not expose fresh-login controls while an older session is still being
+  // restored. Otherwise a delayed restore can overtake an OTP request and make
+  // requesting a code look like successful authentication.
+  const [sessionRecoveryComplete, setSessionRecoveryComplete] = useState(
+    PLAYWRIGHT_TEST_AUTH_ENABLED,
+  );
   const [externalSuccessDestination, setExternalSuccessDestination] = useState<
     string | null
   >(null);
@@ -827,8 +833,10 @@ export default function StewardLoginSection() {
 
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;
-    if (searchParams.get("code")) return;
-    if (searchParams.get("error")) return;
+    if (searchParams.get("code") || searchParams.get("error")) {
+      setSessionRecoveryComplete(true);
+      return;
+    }
 
     let cancelled = false;
 
@@ -872,6 +880,8 @@ export default function StewardLoginSection() {
             ),
           );
         }
+      } finally {
+        if (!cancelled) setSessionRecoveryComplete(true);
       }
     };
 
@@ -1891,7 +1901,7 @@ export default function StewardLoginSection() {
   // Provider discovery in flight: a pulsing skeleton with the final option
   // stack's exact geometry, so the real options materialize in place with no
   // card resize (#18256) instead of replacing a short spinner block.
-  if (!providersLoaded) {
+  if (!providersLoaded || !sessionRecoveryComplete) {
     return (
       <div
         role="status"


### PR DESCRIPTION
# Relates to

Production phone login report: requesting an SMS code could be overtaken by delayed restoration of an older Steward session, redirecting into Cloud before OTP verification and producing a 401/503 cascade.

- [x] This PR targets `develop` and was rebased onto `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and the focused exact-head checks were run after sync; the most recent root verification failure is recorded below.
- [x] The focused regression test demonstrates the state transition without requiring code inspection.

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Focused unit and production-renderer browser checks were rerun post-sync; the most recent root verification blocker is documented below.

# Risks

Low. The login options skeleton remains visible until existing-session recovery finishes. Valid recovered sessions still redirect normally; failed or absent recovery reveals the unchanged login form.

# Background

## What does this PR do?

Serializes existing-session recovery ahead of fresh login controls so a delayed old-token exchange cannot overtake phone OTP login. Adds a regression test that holds recovery pending, proves the phone form is unavailable during that authority decision, then rejects the old session and proves SMS login advances only to six-digit verification without creating or redirecting a session.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects an internal login state race without changing the documented authentication contract.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx`

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx` — 11/11 passed at exact head `1a1f73bf118bebb561d0270c12eac459d8104a60`.
- `E2E_RECORD=1 node packages/app/scripts/run-ui-playwright.mjs --config packages/app/playwright.ui-smoke.config.ts --project=chromium packages/app/test/ui-smoke/phone-login-session-recovery.spec.ts` — desktop and mobile passed against the production renderer build at the same exact head.
- `bun run --cwd packages/ui lint:check` — passed with five pre-existing `noDocumentCookie` warnings in unrelated SSO tests.
- `bun run --cwd packages/ui typecheck` — passed after the required generated i18n/core build artifacts were created.
- Live read-only probes: `https://eliza.steward.fi/health` returned 200; both `https://eliza.app/steward/auth/providers` and the direct Steward provider endpoint returned 200 with `sms: true`.

# Evidence Gate

<!-- evidence-head:1a1f73bf118bebb561d0270c12eac459d8104a60 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-before-contact-sheet.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-after-contact-sheet.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-desktop-phone-login-recovery-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - No backend code changed; the stale-session 401 is a deterministic browser fixture at the HTTP authority boundary.
<!-- evidence-row:frontend-logs -->
- [x] [24701-desktop-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-desktop-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No LLM behavior is involved in the authentication state machine.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No domain or rendering artifact beyond the browser evidence applies.
<!-- evidence-row:ocr-review -->
- [x] [24701-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-ocr-review.txt)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, prompt, provider, or model behavior changed.

## Backend + frontend logs

Desktop and mobile frontend network logs: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-desktop-frontend.log), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-mobile-frontend.log). No backend code changed.

## Screenshots (before / after) + video walkthrough

Before and after contact sheets cover desktop and mobile. Walkthroughs: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-desktop-phone-login-recovery-walkthrough.mp4), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24701-mobile-phone-login-recovery-walkthrough.mp4).

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Root `bun run verify` reaches `audit:tsconfig-workspace-resolution` and fails on 16 existing consumers that cannot resolve `@elizaos/capacitor-secure-store` through `packages/ui/src/bridge/storage-bridge.ts`. This branch does not modify that file or dependency; focused UI test, UI lint, and UI typecheck pass.
- Production deployment and a real SMS receipt/verification round trip require merge and release; they are not claimed by this draft.

## Maintainer CI exception record

N/A - no exception requested.


