### PR TITLE
fix(core): harden coding verification evidence

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -618,6 +618,81 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		});
 	});
 
+	it("preserves a typed coding-tool failure when callback delivery suppresses response content", async () => {
+		const failureMessage =
+			"The build failed because the source did not compile.";
+		const buildAction = makeMockAction({
+			name: "BROKEN_BUILD",
+			contexts: ["code"],
+			parameters: [],
+			handler: async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({ text: failureMessage }, "BROKEN_BUILD");
+				return {
+					success: false,
+					text: failureMessage,
+					userFacingText: failureMessage,
+					verifiedUserFacing: true,
+					failureProvenance: {
+						kind: "handler_error",
+						boundary: "handler",
+						code: "BUILD_FAILED",
+						retryable: false,
+					},
+				};
+			},
+		});
+		const runtime = makeRuntime({
+			actions: [buildAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [{ id: "build-1", name: "BROKEN_BUILD", args: {} }],
+					},
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								args: { text: failureMessage },
+							},
+						],
+					},
+				},
+			],
+		});
+		const deliveredVisibleTexts = new Set<string>();
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("build the project"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+			deliveredVisibleTexts,
+			callback: async (content) => {
+				if (content.text) deliveredVisibleTexts.add(content.text.toLowerCase());
+				return [];
+			},
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") throw new Error("expected reply");
+		expect(result.result.responseContent).toBeNull();
+		expect(result.result.terminalFailure).toEqual({
+			kind: "handler_error",
+			code: "BUILD_FAILED",
+			transient: false,
+			message: failureMessage,
+		});
+	});
+
 	it("runs the full pipeline and records every stage to disk", async () => {
 		let webSearchCalls = 0;
 		const webSearch = makeMockAction({

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -519,11 +519,103 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		if (result.kind !== "planned_reply") throw new Error("expected reply");
 		expect(result.result.responseContent).toMatchObject({
 			text: expect.stringContaining("coding task is incomplete"),
-			failureKind: "coding_verification_failed",
+			failureKind: "coding_mutation_unverified",
 			elizaSyntheticFailure: true,
 			transient: false,
 		});
+		expect(result.result.terminalFailure).toMatchObject({
+			kind: "coding_mutation_unverified",
+			transient: false,
+			message: expect.stringContaining("coding task is incomplete"),
+		});
 		expect(getCalls(runtime)).toHaveLength(2);
+	});
+
+	it("preserves an unverified-mutation failure when callback delivery suppresses response content", async () => {
+		const failureMessage =
+			"I changed files but could not complete the required command verification. The coding task is incomplete.";
+		const writeAction = makeMockAction({
+			name: "WRITE",
+			contexts: ["code", "files"],
+			parameters: [
+				{
+					name: "file_path",
+					description: "File path",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "content",
+					description: "File content",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			handler: async (_runtime, _message, _state, _options, callback) => {
+				await callback?.({
+					text: failureMessage,
+					source: "action",
+					action: "WRITE",
+				});
+				return { success: true, text: "wrote config.go" };
+			},
+		});
+		const runtime = makeRuntime({
+			actions: [writeAction],
+			owner: true,
+			responses: [
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								args: { file_path: "config.go", content: "package config" },
+							},
+						],
+					},
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: {
+						text: "",
+						toolCalls: [
+							{
+								id: "reply-1",
+								name: "REPLY",
+								args: { text: "Implemented the change." },
+							},
+						],
+					},
+				},
+			],
+		});
+		const deliveredVisibleTexts = new Set<string>();
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("change config.go"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+			codingMode: true,
+			plannerLoopConfig: { maxTerminalOnlyContinuations: 0 },
+			deliveredVisibleTexts,
+			callback: async (content) => {
+				if (content.text) deliveredVisibleTexts.add(content.text.toLowerCase());
+				return [];
+			},
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind !== "planned_reply") throw new Error("expected reply");
+		expect(result.result.responseContent).toBeNull();
+		expect(result.result.terminalFailure).toEqual({
+			kind: "coding_mutation_unverified",
+			transient: false,
+			message: failureMessage,
+		});
 	});
 
 	it("runs the full pipeline and records every stage to disk", async () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -738,7 +738,7 @@ describe("v5 planner loop skeleton", () => {
 							{
 								id: "shell-1",
 								name: "SHELL",
-								arguments: { command: "test -s dice.html" },
+								arguments: { command: "npm test -- dice.html" },
 							},
 						],
 					})
@@ -858,6 +858,156 @@ describe("v5 planner loop skeleton", () => {
 		});
 	});
 
+	it.each([
+		"echo vitest",
+		"printf 'git diff --check'",
+		"test -f config.go",
+		"[ -f config.go ]",
+		"echo 'bun test packages/core'",
+		"npm exec echo test",
+		"printf 'safe && vitest'",
+		"git diff --check",
+		"go test ./... || true",
+		"go test ./...; true",
+		"go test ./... | tee test.log",
+		"git diff --check || echo ignored",
+	])(
+		"does not treat verifier-looking shell text as coding verification: %s",
+		async (spoofCommand) => {
+			await withCodingRequiredToolDefaults(async () => {
+				const runtime = {
+					useModel: vi
+						.fn()
+						.mockResolvedValueOnce({
+							text: "",
+							toolCalls: [
+								{
+									id: "write-1",
+									name: "WRITE",
+									arguments: { path: "config.go", content: "package config" },
+								},
+							],
+						})
+						.mockResolvedValueOnce({
+							text: "",
+							toolCalls: [
+								{
+									id: "shell-spoof-1",
+									name: "SHELL",
+									arguments: { command: spoofCommand },
+								},
+							],
+						})
+						.mockResolvedValueOnce(
+							codingReply("reply-spoofed", "Implemented the change."),
+						)
+						.mockResolvedValueOnce({
+							text: "",
+							toolCalls: [
+								{
+									id: "shell-real-1",
+									name: "SHELL",
+									arguments: { command: "go test ./..." },
+								},
+							],
+						})
+						.mockResolvedValueOnce(
+							codingReply(
+								"reply-verified",
+								"Implemented and tested the change.",
+							),
+						),
+					logger: { warn: vi.fn() },
+				};
+				const executeToolCall = vi.fn(async () => ({
+					success: true,
+					text: "succeeded",
+				}));
+
+				const result = await runPlannerLoop({
+					runtime,
+					context: codingPlannerContext,
+					codingMode: true,
+					tools: [
+						{ name: "WRITE", description: "Write a file." },
+						{ name: "SHELL", description: "Run a command." },
+						{ name: "REPLY", description: "Reply to the user." },
+					],
+					executeToolCall,
+					evaluate: vi.fn(),
+				});
+
+				expect(runtime.useModel).toHaveBeenCalledTimes(5);
+				expect(executeToolCall).toHaveBeenCalledTimes(3);
+				expect(result.finalMessage).toBe("Implemented and tested the change.");
+				expect(
+					result.trajectory.evaluatorOutputs.filter(
+						(output) => output.decision === "CONTINUE",
+					),
+				).toHaveLength(1);
+			});
+		},
+	);
+
+	it.each([
+		"./gradlew test",
+		"npx vitest",
+		"bunx vitest",
+		"uv run pytest",
+		"poetry run pytest",
+		"bundle exec rspec",
+		"swift test",
+		"mix test",
+		"tox",
+	])("accepts a successful common coding verifier: %s", async (command) => {
+		await withCodingRequiredToolDefaults(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "write-1",
+								name: "WRITE",
+								arguments: { path: "config.go", content: "package config" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{ id: "verify-1", name: "SHELL", arguments: { command } },
+						],
+					})
+					.mockResolvedValueOnce(
+						codingReply("reply-verified", "Implemented and tested the change."),
+					),
+				logger: { warn: vi.fn() },
+			};
+			const executeToolCall = vi.fn(async () => ({
+				success: true,
+				text: "succeeded",
+			}));
+
+			const result = await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				codingMode: true,
+				tools: [
+					{ name: "WRITE", description: "Write a file." },
+					{ name: "SHELL", description: "Run a command." },
+					{ name: "REPLY", description: "Reply to the user." },
+				],
+				executeToolCall,
+				evaluate: vi.fn(),
+			});
+
+			expect(runtime.useModel).toHaveBeenCalledTimes(3);
+			expect(executeToolCall).toHaveBeenCalledTimes(2);
+			expect(result.finalMessage).toBe("Implemented and tested the change.");
+		});
+	});
 	it("bounds repeated terminal replies while a coding mutation remains unverified", async () => {
 		await withCodingRequiredToolDefaults(async () => {
 			const unverifiedReply = codingReply(
@@ -884,7 +1034,7 @@ describe("v5 planner loop skeleton", () => {
 							{
 								id: "shell-failed",
 								name: "SHELL",
-								arguments: { command: "test -s dice.html" },
+								arguments: { command: "npm test -- dice.html" },
 							},
 						],
 					})
@@ -927,6 +1077,11 @@ describe("v5 planner loop skeleton", () => {
 			expect(result.evaluator).toMatchObject({
 				success: false,
 				decision: "FINISH",
+			});
+			expect(result.terminalFailure).toMatchObject({
+				kind: "coding_mutation_unverified",
+				transient: false,
+				message: expect.stringContaining("coding task is incomplete"),
 			});
 			expect(result.finalMessage).toContain("coding task is incomplete");
 			expect(
@@ -1084,7 +1239,7 @@ describe("v5 planner loop skeleton", () => {
 							{
 								id: "shell-failed",
 								name: "SHELL",
-								arguments: { command: "test -s dice.html" },
+								arguments: { command: "npm test -- dice.html" },
 							},
 						],
 					})
@@ -1108,7 +1263,7 @@ describe("v5 planner loop skeleton", () => {
 							{
 								id: "shell-passed",
 								name: "SHELL",
-								arguments: { command: "test -s dice.html" },
+								arguments: { command: "npm test -- dice.html" },
 							},
 						],
 					})
@@ -1187,7 +1342,7 @@ describe("v5 planner loop skeleton", () => {
 							{
 								id: "verify-passed",
 								name: "SHELL",
-								arguments: { command: "test -s dice.html" },
+								arguments: { command: "npm test -- dice.html" },
 							},
 						],
 					})

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -867,10 +867,19 @@ describe("v5 planner loop skeleton", () => {
 		"npm exec echo test",
 		"printf 'safe && vitest'",
 		"git diff --check",
+		"go test ./... &",
 		"go test ./... || true",
 		"go test ./...; true",
 		"go test ./... | tee test.log",
 		"git diff --check || echo ignored",
+		"tsc --version",
+		"eslint --version",
+		"biome --version",
+		"pytest --help",
+		"go test -h",
+		"cargo test --help",
+		"tox --help",
+		"npx vitest --help",
 	])(
 		"does not treat verifier-looking shell text as coding verification: %s",
 		async (spoofCommand) => {
@@ -959,6 +968,20 @@ describe("v5 planner loop skeleton", () => {
 		"swift test",
 		"mix test",
 		"tox",
+		"cd pkg && go test ./...",
+		"go test ./... && tsc",
+		"go test ./... 2>&1",
+		"go test ./... &>test.log",
+		"python -m pytest",
+		"python -m unittest",
+		"pnpm exec vitest",
+		"npm exec vitest",
+		"npx --yes vitest",
+		"uv run python -m pytest",
+		"cargo nextest run",
+		"./gradlew :app:test",
+		"./mvnw test",
+		"export CGO_ENABLED=0 && go test ./...",
 	])("accepts a successful common coding verifier: %s", async (command) => {
 		await withCodingRequiredToolDefaults(async () => {
 			const runtime = {
@@ -1373,6 +1396,11 @@ describe("v5 planner loop skeleton", () => {
 
 			expect(result.finalMessage).toContain("failed");
 			expect(result.finalMessage).not.toContain("Built and deployed");
+			expect(result.terminalFailure).toMatchObject({
+				kind: "coding_tool_failure",
+				transient: false,
+				message: expect.stringContaining("failed"),
+			});
 		});
 	});
 

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -880,6 +880,11 @@ describe("v5 planner loop skeleton", () => {
 		"cargo test --help",
 		"tox --help",
 		"npx vitest --help",
+		"pytest '--help'",
+		'tsc "--version"',
+		"npx vitest '--help'",
+		"tsc --showConfig",
+		"jest --showConfig",
 	])(
 		"does not treat verifier-looking shell text as coding verification: %s",
 		async (spoofCommand) => {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -111,6 +111,7 @@ import type {
 	PlannerLoopResult,
 	PlannerRuntime,
 	PlannerStep,
+	PlannerTerminalFailure,
 	PlannerToolCall,
 	PlannerToolResult,
 	PlannerTrajectory,
@@ -1376,25 +1377,43 @@ async function runPlannerLoopIterations(
 						logger: params.runtime.logger,
 					});
 				}
+				const resolvedFinalMessage = terminalFollowsFailedTool
+					? hasReplyCall
+						? userSafeFinalMessage(terminalReplyMessage, trajectory)
+						: undefined
+					: pendingInteraction && hasReplyCall
+						? userSafeFinalMessage(terminalReplyMessage, trajectory)
+						: userSafeFinalMessage(
+								codingDrainQueue
+									? codingFinalMessage(trajectory, finalMessage)
+									: preferredFinalMessageFromToolOrModel(
+											trajectory,
+											finalMessage,
+										),
+								trajectory,
+							);
+				const terminalFailure =
+					trajectory.codingMode === true &&
+					terminalFollowsFailedTool &&
+					latestNonTerminalStep
+						? codingToolTerminalFailure(
+								latestNonTerminalStep,
+								resolvedFinalMessage ??
+									userSafeFinalMessage(
+										terminalMessageWithFailureAuthority(
+											trajectory,
+											finalMessage,
+										),
+										trajectory,
+									),
+							)
+						: undefined;
 				return {
 					status: "finished",
 					trajectory,
 					evaluator: terminalEvaluator,
-					finalMessage: terminalFollowsFailedTool
-						? hasReplyCall
-							? userSafeFinalMessage(terminalReplyMessage, trajectory)
-							: undefined
-						: pendingInteraction && hasReplyCall
-							? userSafeFinalMessage(terminalReplyMessage, trajectory)
-							: userSafeFinalMessage(
-									codingDrainQueue
-										? codingFinalMessage(trajectory, finalMessage)
-										: preferredFinalMessageFromToolOrModel(
-												trajectory,
-												finalMessage,
-											),
-									trajectory,
-								),
+					finalMessage: resolvedFinalMessage,
+					...(terminalFailure ? { terminalFailure } : {}),
 					// STOP/IGNORE-only terminals chose silence; a textless REPLY did
 					// not (the model tried to answer and failed to carry text).
 					// The silent terminal's name travels with the result so the
@@ -3869,39 +3888,53 @@ function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
 	}
 	const command = shellCommandParam(step.toolCall);
 	if (!command) return false;
-	const segments = splitShellCommandSegments(command);
-	// The SHELL result exposes only the aggregate exit status. Until the shell
-	// boundary returns per-command typed evidence, any control operator can mask
-	// a failed verifier (`test || true`, `test | tee`, or `test; true`).
-	if (segments.length !== 1) return false;
-	const segment = stripShellVerificationPrefix(segments[0]);
-	return [
+	const segments = splitSafeShellVerificationChain(command);
+	// The SHELL result exposes only the aggregate exit status. A foreground `&&`
+	// chain preserves verifier failure, but pipelines, background jobs, `||`, and
+	// sequential commands can mask it and therefore cannot serve as evidence.
+	if (!segments) return false;
+	const verificationPatterns = [
 		/^bun\s+(?:run\s+)?(?:(?:--cwd|-C)\s+\S+\s+)?(?:test|verify|check|lint|typecheck|build)(?:\s|$)/i,
 		/^npm\s+(?:test|(?:run|run-script)\s+(?:test|verify|check|lint|typecheck|build))(?:\s|$)/i,
 		/^(?:pnpm|yarn)\s+(?:run\s+)?(?:test|verify|check|lint|typecheck|build)(?:\s|$)/i,
-		/^(?:npx|bunx)\s+(?:vitest|jest|eslint|biome|tsc)(?:\s|$)/i,
+		/^(?:npm|pnpm)\s+exec\s+(?:vitest|jest|eslint|biome|tsc)(?:\s|$)/i,
+		/^(?:npx|bunx)\s+(?:--yes\s+)?(?:vitest|jest|eslint|biome|tsc)(?:\s|$)/i,
 		/^deno\s+(?:test|check|task\s+(?:test|verify|check|lint|typecheck|build))(?:\s|$)/i,
 		/^(?:vitest|jest|pytest|rspec|phpunit|mocha|ava)(?:\s|$)/i,
-		/^(?:uv|poetry)\s+run\s+(?:pytest|ruff|mypy)(?:\s|$)/i,
+		/^(?:uv|poetry)\s+run\s+(?:(?:python\d*\s+-m\s+)?pytest|ruff|mypy)(?:\s|$)/i,
 		/^bundle\s+exec\s+rspec(?:\s|$)/i,
 		/^go\s+(?:test|vet|build)(?:\s|$)/i,
-		/^cargo\s+(?:test|check|clippy|build)(?:\s|$)/i,
-		/^(?:dotnet\s+test|mvn\s+(?:test|verify)|gradle\w*\s+(?:test|check|build)|(?:\.\/)?gradlew\s+(?:test|check|build))(?:\s|$)/i,
+		/^cargo\s+(?:test|check|clippy|build|nextest\s+run)(?:\s|$)/i,
+		/^(?:dotnet\s+test|(?:mvn|\.\/mvnw)\s+(?:test|verify)|gradle\w*\s+(?:test|check|build)|(?:\.\/)?gradlew\s+(?:(?:\S*:)?(?:test|check|build)\w*))(?:\s|$)/i,
 		/^(?:swift|mix)\s+test(?:\s|$)/i,
 		/^tox(?:\s|$)/i,
 		/^(?:make|just)(?:\s+[^\s;&|]+)*\s+(?:test|verify|check|lint|typecheck|build)(?:\s|$)/i,
 		/^(?:tsc|eslint|biome)(?:\s|$)/i,
-		/^(?:python\d*\s+-m\s+(?:compileall|py_compile)|ruby\s+-c|bash\s+-n|node\s+--check)(?:\s|$)/i,
-	].some((pattern) => pattern.test(segment));
+		/^(?:python\d*\s+-m\s+(?:pytest|unittest|compileall|py_compile)|ruby\s+-c|bash\s+-n|node\s+--check)(?:\s|$)/i,
+	];
+	return segments.some((segment) => {
+		const commandSegment = stripShellVerificationPrefix(segment);
+		if (isNoopShellVerificationCommand(commandSegment)) return false;
+		return verificationPatterns.some((pattern) => pattern.test(commandSegment));
+	});
+}
+
+function isNoopShellVerificationCommand(command: string): boolean {
+	return (
+		/(?:^|\s)(?:--help|-h|--version|--list|--listTests|--collect-only|--co|--dry-run|--no-run|--showconfig)(?:=|\s|$)/.test(
+			command,
+		) || /(?:^|\s)-V(?:\s|$)/.test(command)
+	);
 }
 
 /**
- * Splits only on unquoted shell control operators. Verification recognition is
- * deliberately command-position based: diagnostic prose such as
- * `echo 'run vitest'` must never become proof merely because it names a test
- * runner.
+ * Parses the only untyped compound command whose aggregate zero exit status
+ * proves every verifier ran successfully: a foreground `&&` chain. Shell
+ * redirections containing `&` are retained inside their command. Every other
+ * unquoted control operator is rejected because it can hide, defer, or replace
+ * the verifier exit status.
  */
-function splitShellCommandSegments(command: string): string[] {
+function splitSafeShellVerificationChain(command: string): string[] | null {
 	const segments: string[] = [];
 	let start = 0;
 	let quote: "'" | '"' | undefined;
@@ -3920,21 +3953,25 @@ function splitShellCommandSegments(command: string): string[] {
 			quote = quote === character ? undefined : (quote ?? character);
 			continue;
 		}
-		if (
-			!quote &&
-			(character === ";" ||
-				character === "|" ||
-				character === "&" ||
-				character === "\n")
-		) {
+		if (quote) continue;
+		if (character === ";" || character === "|" || character === "\n") {
+			return null;
+		}
+		if (character === "&") {
+			if (command[index - 1] === ">" || command[index + 1] === ">") {
+				continue;
+			}
+			if (command[index + 1] !== "&") return null;
 			const segment = command.slice(start, index).trim();
-			if (segment) segments.push(segment);
-			while (command[index + 1] === character) index++;
+			if (!segment) return null;
+			segments.push(segment);
+			index++;
 			start = index + 1;
 		}
 	}
 	const tail = command.slice(start).trim();
-	if (tail) segments.push(tail);
+	if (!tail) return null;
+	segments.push(tail);
 	return segments;
 }
 
@@ -4182,6 +4219,25 @@ function terminalMessageWithFailureAuthority(
 	);
 	if (successEvidence.length === 0) return failureNote;
 	return `${failureNote}\n\nWork that did complete: ${successEvidence.join(" ")}`;
+}
+
+function codingToolTerminalFailure(
+	failedStep: PlannerStep,
+	message: string | undefined,
+): PlannerTerminalFailure {
+	const provenance = failedStep.result?.failureProvenance;
+	const retryableMarker = failedStep.result?.data?.retryable;
+	return {
+		kind: provenance?.kind ?? "coding_tool_failure",
+		...(provenance?.code ? { code: provenance.code } : {}),
+		transient:
+			provenance?.retryable ??
+			(typeof retryableMarker === "boolean" ? retryableMarker : false),
+		message:
+			message ??
+			groundedFailedToolMessage(failedStep) ??
+			"A required coding tool failed before the task could complete.",
+	};
 }
 
 /**

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3869,18 +3869,84 @@ function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
 	}
 	const command = shellCommandParam(step.toolCall);
 	if (!command) return false;
+	const segments = splitShellCommandSegments(command);
+	// The SHELL result exposes only the aggregate exit status. Until the shell
+	// boundary returns per-command typed evidence, any control operator can mask
+	// a failed verifier (`test || true`, `test | tee`, or `test; true`).
+	if (segments.length !== 1) return false;
+	const segment = stripShellVerificationPrefix(segments[0]);
 	return [
-		/(?:^|[;&|]\s*)(?:test|\[)\s+[^;&|]+/i,
-		/\bgit\s+diff\s+--check\b/i,
-		/\b(?:bun|npm|pnpm|yarn|deno)\b[^;&|\n]*\b(?:test|verify|check|lint|typecheck|build)\b/i,
-		/\b(?:vitest|jest|pytest|rspec|phpunit|mocha|ava)\b/i,
-		/\bgo\s+(?:test|vet|build)\b/i,
-		/\bcargo\s+(?:test|check|clippy|build)\b/i,
-		/\b(?:dotnet\s+test|mvn\s+(?:test|verify)|gradle\w*\s+(?:test|check|build))\b/i,
-		/\b(?:make|just)\b[^;&|\n]*\b(?:test|verify|check|lint|typecheck|build)\b/i,
-		/\b(?:tsc|eslint|biome)\b/i,
-		/\b(?:python\d*\s+-m\s+(?:compileall|py_compile)|ruby\s+-c|bash\s+-n|node\s+--check)\b/i,
-	].some((pattern) => pattern.test(command));
+		/^bun\s+(?:run\s+)?(?:(?:--cwd|-C)\s+\S+\s+)?(?:test|verify|check|lint|typecheck|build)(?:\s|$)/i,
+		/^npm\s+(?:test|(?:run|run-script)\s+(?:test|verify|check|lint|typecheck|build))(?:\s|$)/i,
+		/^(?:pnpm|yarn)\s+(?:run\s+)?(?:test|verify|check|lint|typecheck|build)(?:\s|$)/i,
+		/^(?:npx|bunx)\s+(?:vitest|jest|eslint|biome|tsc)(?:\s|$)/i,
+		/^deno\s+(?:test|check|task\s+(?:test|verify|check|lint|typecheck|build))(?:\s|$)/i,
+		/^(?:vitest|jest|pytest|rspec|phpunit|mocha|ava)(?:\s|$)/i,
+		/^(?:uv|poetry)\s+run\s+(?:pytest|ruff|mypy)(?:\s|$)/i,
+		/^bundle\s+exec\s+rspec(?:\s|$)/i,
+		/^go\s+(?:test|vet|build)(?:\s|$)/i,
+		/^cargo\s+(?:test|check|clippy|build)(?:\s|$)/i,
+		/^(?:dotnet\s+test|mvn\s+(?:test|verify)|gradle\w*\s+(?:test|check|build)|(?:\.\/)?gradlew\s+(?:test|check|build))(?:\s|$)/i,
+		/^(?:swift|mix)\s+test(?:\s|$)/i,
+		/^tox(?:\s|$)/i,
+		/^(?:make|just)(?:\s+[^\s;&|]+)*\s+(?:test|verify|check|lint|typecheck|build)(?:\s|$)/i,
+		/^(?:tsc|eslint|biome)(?:\s|$)/i,
+		/^(?:python\d*\s+-m\s+(?:compileall|py_compile)|ruby\s+-c|bash\s+-n|node\s+--check)(?:\s|$)/i,
+	].some((pattern) => pattern.test(segment));
+}
+
+/**
+ * Splits only on unquoted shell control operators. Verification recognition is
+ * deliberately command-position based: diagnostic prose such as
+ * `echo 'run vitest'` must never become proof merely because it names a test
+ * runner.
+ */
+function splitShellCommandSegments(command: string): string[] {
+	const segments: string[] = [];
+	let start = 0;
+	let quote: "'" | '"' | undefined;
+	let escaped = false;
+	for (let index = 0; index < command.length; index++) {
+		const character = command[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (character === "\\" && quote !== "'") {
+			escaped = true;
+			continue;
+		}
+		if (character === "'" || character === '"') {
+			quote = quote === character ? undefined : (quote ?? character);
+			continue;
+		}
+		if (
+			!quote &&
+			(character === ";" ||
+				character === "|" ||
+				character === "&" ||
+				character === "\n")
+		) {
+			const segment = command.slice(start, index).trim();
+			if (segment) segments.push(segment);
+			while (command[index + 1] === character) index++;
+			start = index + 1;
+		}
+	}
+	const tail = command.slice(start).trim();
+	if (tail) segments.push(tail);
+	return segments;
+}
+
+function stripShellVerificationPrefix(segment: string): string {
+	let command = segment.trim();
+	if (/^env(?:\s|$)/i.test(command)) {
+		command = command.replace(/^env\s+/i, "");
+	}
+	while (/^[A-Za-z_][A-Za-z0-9_]*=\S+\s+/.test(command)) {
+		command = command.replace(/^[A-Za-z_][A-Za-z0-9_]*=\S+\s+/, "");
+	}
+	return command;
 }
 
 function getToolDefinitionName(tool: ToolDefinition): string | undefined {
@@ -4537,6 +4603,11 @@ async function finishWithForcedSynthesis(params: {
 			trajectory,
 			evaluator,
 			finalMessage: message,
+			terminalFailure: {
+				kind: "coding_mutation_unverified",
+				transient: false,
+				message,
+			},
 		};
 	}
 	trajectory.context = appendContextEvent(trajectory.context, {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3921,9 +3921,9 @@ function isSuccessfulCodingVerificationStep(step: PlannerStep): boolean {
 
 function isNoopShellVerificationCommand(command: string): boolean {
 	return (
-		/(?:^|\s)(?:--help|-h|--version|--list|--listTests|--collect-only|--co|--dry-run|--no-run|--showconfig)(?:=|\s|$)/.test(
+		/(?:^|\s)["']?(?:--help|-h|--version|--list|--listTests|--collect-only|--co|--dry-run|--no-run|--showConfig)["']?(?:=|\s|$)/i.test(
 			command,
-		) || /(?:^|\s)-V(?:\s|$)/.test(command)
+		) || /(?:^|\s)["']?-V["']?(?:\s|$)/.test(command)
 	);
 }
 

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -240,6 +240,16 @@ export interface PlannerLoopResult {
 	evaluator?: EvaluatorOutput;
 	finalMessage?: string;
 	/**
+	 * Machine-readable terminal failure that survives independent text delivery.
+	 * The message service propagates this outside `responseContent`, so a host
+	 * cannot mistake a callback-delivered failure for a successful turn.
+	 */
+	terminalFailure?: {
+		kind: "coding_mutation_unverified";
+		transient: false;
+		message: string;
+	};
+	/**
 	 * Marks a turn whose empty `finalMessage` is a designed outcome — the
 	 * planner ended on STOP/IGNORE or a `suppressPlannerReply` terminal action —
 	 * so the tool-turn reply guarantee (`runPlannerLoop`'s post-pass) never

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -4,7 +4,10 @@
  * parameter and result envelopes. Consumed by planner-loop, the evaluator, and
  * the message handler that drives them.
  */
-import type { ActionFailureProvenance } from "../types/action-failure";
+import type {
+	ActionFailureKind,
+	ActionFailureProvenance,
+} from "../types/action-failure";
 import type { EvaluationResult } from "../types/components";
 import type { ContextObject } from "../types/context-object";
 import type { EffectReceipt } from "../types/effects";
@@ -234,6 +237,17 @@ export interface PlannerTrajectory {
 	evaluatorOutputs: EvaluatorOutput[];
 }
 
+export interface PlannerTerminalFailure {
+	kind:
+		| "coding_mutation_unverified"
+		| "coding_tool_failure"
+		| ActionFailureKind;
+	transient: boolean;
+	message: string;
+	/** Action boundary code when the failing tool supplied typed provenance. */
+	code?: string;
+}
+
 export interface PlannerLoopResult {
 	status: "finished" | "continued";
 	trajectory: PlannerTrajectory;
@@ -244,11 +258,7 @@ export interface PlannerLoopResult {
 	 * The message service propagates this outside `responseContent`, so a host
 	 * cannot mistake a callback-delivered failure for a successful turn.
 	 */
-	terminalFailure?: {
-		kind: "coding_mutation_unverified";
-		transient: false;
-		message: string;
-	};
+	terminalFailure?: PlannerTerminalFailure;
 	/**
 	 * Marks a turn whose empty `finalMessage` is a designed outcome — the
 	 * planner ended on STOP/IGNORE or a `suppressPlannerReply` terminal action —

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -267,6 +267,7 @@ import type {
 	IMessageService,
 	MessageProcessingOptions,
 	MessageProcessingResult,
+	MessageTerminalFailure,
 	ShouldRespondModelType,
 } from "../types/message-service";
 import {
@@ -1397,6 +1398,7 @@ interface StrategyResult {
 	responseContent: Content | null;
 	responseMessages: Memory[];
 	actionResults?: ActionResult[];
+	terminalFailure?: MessageTerminalFailure;
 	state: State;
 	mode: StrategyMode;
 }
@@ -2178,7 +2180,7 @@ function createV5ReplyStrategyResult(args: {
 	 * text still reaches interactive surfaces, while adapters can return a
 	 * non-success process/result instead of treating any nonempty reply as done.
 	 */
-	codingFailureKind?: string;
+	terminalFailure?: MessageTerminalFailure;
 }): StrategyResult {
 	let responseContent: Content = {
 		thought: args.thought,
@@ -2187,11 +2189,11 @@ function createV5ReplyStrategyResult(args: {
 		simple: args.mode !== "actions",
 		responseId: args.responseId,
 		...(args.agentVoiced === true ? { agentVoiced: true } : {}),
-		...(args.codingFailureKind
+		...(args.terminalFailure
 			? {
-					failureKind: args.codingFailureKind,
+					failureKind: args.terminalFailure.kind,
 					elizaSyntheticFailure: true,
-					transient: false,
+					transient: args.terminalFailure.transient,
 				}
 			: {}),
 		...(args.attachments?.length ? { attachments: args.attachments } : {}),
@@ -2225,6 +2227,7 @@ function createV5ReplyStrategyResult(args: {
 		],
 		state: args.state,
 		mode: args.mode ?? "simple",
+		...(args.terminalFailure ? { terminalFailure: args.terminalFailure } : {}),
 	};
 }
 
@@ -10289,10 +10292,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			plannedTextRaw || effectiveReplyText,
 			actionResults,
 		);
-		const codingFailureKind =
-			args.codingMode === true && plannerResult.evaluator?.success === false
-				? "coding_verification_failed"
-				: undefined;
+		const terminalFailure = plannerResult.terminalFailure;
 
 		return {
 			kind: "planned_reply",
@@ -10314,7 +10314,7 @@ export async function runV5MessageRuntimeStage1(args: {
 								? { effectReceiptIds: effectiveReplyReceiptIds }
 								: {}),
 							...(transcriptVisibility ? { transcriptVisibility } : {}),
-							...(codingFailureKind ? { codingFailureKind } : {}),
+							...(terminalFailure ? { terminalFailure } : {}),
 						}),
 						...(actionResults.length > 0 ? { actionResults } : {}),
 					}
@@ -10323,6 +10323,7 @@ export async function runV5MessageRuntimeStage1(args: {
 						responseMessages: [],
 						state: finalPlannerState,
 						mode: "none",
+						...(terminalFailure ? { terminalFailure } : {}),
 						...(actionResults.length > 0 ? { actionResults } : {}),
 					},
 		};
@@ -14221,6 +14222,7 @@ export class DefaultMessageService implements IMessageService {
 			Array.from(persistedEarlyReplyIds, (id) => id as UUID),
 		);
 		let actionResults: ActionResult[] | undefined;
+		let terminalFailure: MessageTerminalFailure | undefined;
 		let mode: StrategyMode = "none";
 
 		if (shouldRespondToMessage) {
@@ -14248,6 +14250,7 @@ export class DefaultMessageService implements IMessageService {
 					: result.responseMessages;
 			state = result.state;
 			actionResults = result.actionResults;
+			terminalFailure = result.terminalFailure;
 			mode = result.mode;
 
 			// Race check before we send anything.
@@ -14747,6 +14750,7 @@ export class DefaultMessageService implements IMessageService {
 					}
 				: {}),
 			...(actionResults ? { actionResults } : {}),
+			...(terminalFailure ? { terminalFailure } : {}),
 			state,
 			mode,
 		};

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -79,6 +79,8 @@ export interface MessageProcessingOptions {
 export interface MessageTerminalFailure {
 	/** Stable machine-readable category for adapters and orchestration hosts. */
 	kind: string;
+	/** Action boundary code when the failing tool supplied typed provenance. */
+	code?: string;
 	/** Whether retrying the same turn without user intervention may succeed. */
 	transient: boolean;
 	/** Complete user-facing explanation of why the turn did not complete. */

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -76,10 +76,25 @@ export interface MessageProcessingOptions {
 /**
  * Result of message processing
  */
+export interface MessageTerminalFailure {
+	/** Stable machine-readable category for adapters and orchestration hosts. */
+	kind: string;
+	/** Whether retrying the same turn without user intervention may succeed. */
+	transient: boolean;
+	/** Complete user-facing explanation of why the turn did not complete. */
+	message: string;
+}
+
 export interface MessageProcessingResult {
 	didRespond: boolean;
 	responseContent?: Content | null;
 	responseMessages: Memory[];
+	/**
+	 * Terminal failure independent of response delivery. Callback-delivered or
+	 * deduplicated text may leave `responseContent` null, but callers still need
+	 * an authoritative non-success result.
+	 */
+	terminalFailure?: MessageTerminalFailure;
 	/**
 	 * The returned delivery belongs to a live message-service run whose detached
 	 * task barrier will emit `RUN_ENDED`. Hosts must preserve this capability on

--- a/packages/examples/code/src/lib/agent-client.streaming.test.ts
+++ b/packages/examples/code/src/lib/agent-client.streaming.test.ts
@@ -6,6 +6,7 @@ import {
   type HandlerCallback,
   type IAgentRuntime,
   type Memory,
+  type MessageTerminalFailure,
   type StreamChunkCallback,
   stringToUuid,
 } from "@elizaos/core";
@@ -50,6 +51,7 @@ function makeRuntime(
     didRespond: boolean;
     responseContent?: Content | null;
     responseMessages: Memory[];
+    terminalFailure?: MessageTerminalFailure;
   }>,
 ): IAgentRuntime {
   return {
@@ -197,6 +199,40 @@ describe("AgentClient streaming", () => {
     ).rejects.toMatchObject({
       code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
       context: { failureKind: "transient_failure", transient: true },
+    });
+  });
+
+  it("rejects a terminal failure when callback delivery suppresses response content", async () => {
+    const message =
+      "I changed files but could not complete the required command verification.";
+    const runtime = makeRuntime(async (_runtime, _message, callback) => {
+      await callback?.({ text: message });
+      return {
+        didRespond: true,
+        responseContent: null,
+        responseMessages: [],
+        terminalFailure: {
+          kind: "coding_mutation_unverified",
+          transient: false,
+          message,
+        },
+      };
+    });
+
+    getAgentClient().setRuntime(runtime);
+    await expect(
+      getAgentClient().sendMessage({
+        room: makeRoom(),
+        text: "change a file",
+        identity: makeIdentity(),
+        codingMode: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+      context: {
+        failureKind: "coding_mutation_unverified",
+        transient: false,
+      },
     });
   });
 

--- a/packages/examples/code/src/lib/agent-client.ts
+++ b/packages/examples/code/src/lib/agent-client.ts
@@ -190,6 +190,9 @@ class AgentClient {
         code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
         context: {
           failureKind: result.terminalFailure.kind,
+          ...(result.terminalFailure.code
+            ? { failureCode: result.terminalFailure.code }
+            : {}),
           transient: result.terminalFailure.transient,
         },
         severity: result.terminalFailure.transient ? "ephemeral" : "fatal",

--- a/packages/examples/code/src/lib/agent-client.ts
+++ b/packages/examples/code/src/lib/agent-client.ts
@@ -185,6 +185,17 @@ class AgentClient {
       options,
     );
 
+    if (result.terminalFailure) {
+      throw new ElizaError(result.terminalFailure.message, {
+        code: "ELIZA_CODE_SYNTHETIC_TURN_FAILURE",
+        context: {
+          failureKind: result.terminalFailure.kind,
+          transient: result.terminalFailure.transient,
+        },
+        severity: result.terminalFailure.transient ? "ephemeral" : "fatal",
+      });
+    }
+
     const resultContent = result.responseContent;
     const resultRecord =
       resultContent && typeof resultContent === "object"


### PR DESCRIPTION
Closes #24702. Follow-up to #24654.

## What changed

- require one unmasked direct verifier command when SHELL provides only aggregate exit status;
- reject `|| true`, pipelines, multi-command masking, prose/inspection lookalikes, file-existence checks, and `git diff --check`;
- recognize common direct verifier families (`npx`/`bunx`, Gradle wrapper, uv/Poetry, RSpec, Swift, Mix, tox);
- carry `coding_mutation_unverified` as a typed top-level terminal failure independent of `responseContent`;
- make the Code client fail the turn even when callback delivery deduplicates response content;
- stop labeling every coding evaluator failure as a fatal verification failure.

## Local validation

- `bun test packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/__tests__/planner-happy-path.test.ts` — 193 pass
- `bun test packages/examples/code/src/lib/agent-client.streaming.test.ts` — 7 pass
- `bun run --cwd packages/core typecheck` — pass
- `bun run --cwd packages/core build` — pass
- `git diff --check` — pass

The Code example workspace typecheck additionally requires unrelated workspace outputs that are absent in this light checkout (`@elizaos/shared` first-run contracts, plugin-anthropic, and UI subpath builds). After rebuilding core, there are no errors from the changed terminal-failure API or Code client.