### PR TITLE
fix(agent): remove hard-coded action and trajectory completion caps

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -750,7 +750,6 @@ async function rewriteDirectActionCallbackText(args: {
           error: args.content?.error,
         })}`,
       ].join("\n"),
-      maxTokens: 260,
       signal: args.abortSignal,
       providerOptions: { eliza: { thinking: "off" } },
     });

--- a/packages/agent/src/api/fallback-action-helpers.test.ts
+++ b/packages/agent/src/api/fallback-action-helpers.test.ts
@@ -63,6 +63,7 @@ describe("executeFallbackParsedActions", () => {
         expect(String((params as { prompt?: string }).prompt)).toContain(
           "stdout: block active for example.com",
         );
+        expect(params).not.toHaveProperty("maxTokens");
         return JSON.stringify({
           response: "I turned on the block for example.com.",
         });

--- a/packages/agent/src/api/fallback-action-helpers.ts
+++ b/packages/agent/src/api/fallback-action-helpers.ts
@@ -74,7 +74,6 @@ async function rewriteFallbackActionText(args: {
           error: args.content?.error,
         })}`,
       ].join("\n"),
-      maxTokens: 260,
       signal: args.abortSignal,
       providerOptions: { eliza: { thinking: "off" } },
     });

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -643,7 +643,6 @@ export async function flushObservationBuffer(
 
     const result = await runtime.useModel(ModelType.TEXT_SMALL, {
       prompt,
-      maxTokens: 512,
       temperature: 0,
     });
 

--- a/packages/agent/src/runtime/trajectory-observability.test.ts
+++ b/packages/agent/src/runtime/trajectory-observability.test.ts
@@ -101,6 +101,24 @@ describe("trajectory observability", () => {
     );
   });
 
+  it("does not cap observation-extraction model output", async () => {
+    const { runtime } = createRuntime();
+    const useModel = vi.mocked(runtime.useModel);
+    useModel.mockImplementation(async (_modelType, params) => {
+      expect(params).not.toHaveProperty("maxTokens");
+      return JSON.stringify([`HEAD${"x".repeat(2_000)}TAIL`]);
+    });
+    pushChatExchange(runtime, {
+      userPrompt: "extract complete observations",
+      response: "complete response",
+      trajectoryId: "trajectory-complete-output",
+      timestamp: Date.now(),
+    });
+
+    await expect(flushObservationBuffer(runtime)).resolves.toEqual([]);
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects source aggregation failures instead of fabricating an empty result", async () => {
     const { runtime, warn } = createRuntime();
 

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -258,7 +258,11 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"packages/core/src/features/advanced-capabilities/providers/facts.ts": [
 		/EVIDENCE_TEXT_CHAR_CAP/,
 	],
-	"packages/agent/src/api/chat-routes.ts": [/\.slice\(-50\)/],
+	"packages/agent/src/api/chat-routes.ts": [
+		/\.slice\(-50\)/,
+		/maxTokens:\s*260/,
+	],
+	"packages/agent/src/api/fallback-action-helpers.ts": [/maxTokens:\s*260/],
 	"packages/agent/src/api/interactions-routes.ts": [
 		/truncateWellFormed/,
 		/MAX_CONTEXT_CHARS/,
@@ -286,6 +290,7 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/actionCompactionEnabled/,
 	],
 	"packages/agent/src/runtime/trajectory-internals.ts": [
+		/maxTokens:\s*512/,
 		/truncateField/,
 		/truncateRecord/,
 		/\[\^\\n\]\{1,1024\}/,


### PR DESCRIPTION
Part of #24704.

Removes the hard-coded `maxTokens: 260` completion caps from both direct/fallback action-result rewrite paths and the `maxTokens: 512` cap from trajectory observation extraction. These caps could cut strict JSON, silently trigger generic fallback text, or discard observations. Caller/provider admission remains responsible for explicit hard boundaries; these call sites no longer request partial output.

Adds production-path assertions that the model params omit `maxTokens`, exercises an observation above the former boundary, and adds root prompt-integrity guards for all three paths.

Exact head: `0669e0606`. Focused fallback + trajectory suites: 10/10 passed. Changed-file Biome and diff-check passed. Hosted exact-head CI remains required.

The vision-provider portion of #24704 remains open for a provider-specific follow-up: OpenAI/xAI/Ollama can omit defaults, while Anthropic requires a model-authoritative maximum plus `stop_reason=max_tokens` rejection.