### PR TITLE
test(scenarios): repair deterministic runtime contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -642,6 +642,7 @@
         "@discordjs/opus": "^0.10.0",
         "@discordjs/voice": "^0.19.2",
         "@elizaos/cloud-services-common": "workspace:*",
+        "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "@hono/node-server": "2.0.10",
         "@upstash/redis": "^1.37.0",

--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -74,11 +74,14 @@ const CORE_ACTION_SURFACE: Record<string, readonly string[]> = {
     "VIEWS",
   ],
   "@elizaos/plugin-coding-tools": [
+    "EDIT",
     "FILE",
+    "READ",
     "SHELL",
     "WEB_FETCH",
     "WEB_SEARCH",
     "WORKTREE",
+    "WRITE",
   ],
   "@elizaos/plugin-commands": [
     "ACCOUNTS_COMMAND",
@@ -195,6 +198,11 @@ const KNOWN_UNCOVERED: readonly string[] = [
   // current runtime action surface without registering them as top-level actions.
   "CLOSE_ALL_VIEWS",
   "CLOSE_VIEW",
+  // Direct coding-tools file aliases are registered alongside FILE but do not
+  // yet have their own strict keyless scenario turns.
+  "EDIT",
+  "READ",
+  "WRITE",
   // Coding-tools web actions are unit-covered but do not yet have a strict,
   // network-free scenario fixture. Keep them visible in the no-growth ledger.
   "WEB_FETCH",

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -39,6 +39,8 @@ import {
 import { shouldOptInScenarioTrajectoryLogging } from "./trajectory-opt-in.ts";
 import type { AggregateReport, ScenarioReport } from "./types.ts";
 
+captureHostExecutionBaseline();
+
 const SCENARIO_LANES: readonly ScenarioLane[] = [
   "pr-deterministic",
   "live-only",

--- a/packages/scenario-runner/src/legacy-deterministic-scenario.integration.test.ts
+++ b/packages/scenario-runner/src/legacy-deterministic-scenario.integration.test.ts
@@ -19,7 +19,7 @@ describe("legacy deterministic scenario compatibility", () => {
       useDeterministicModel: true,
       requiredPlugins: legacyScenario.requires?.plugins,
     });
-  }, 120_000);
+  }, 300_000);
 
   afterAll(async () => {
     await runtimeResult?.cleanup();
@@ -40,7 +40,7 @@ describe("legacy deterministic scenario compatibility", () => {
       scenarioId: legacyScenario.id,
       attemptId: "legacy-compatibility-test",
     });
-  }, 120_000);
+  }, 300_000);
 
   it("does not expose the migration fallback to a declared strict attempt", async () => {
     if (!runtimeResult) throw new Error("scenario runtime was not created");

--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -145,7 +145,7 @@ describe("scenario runtime deterministic model mode", () => {
       ),
     ).resolves.toBe("declared response");
     expect(plugin.models?.[ModelType.TEXT_EMBEDDING]).toBeUndefined();
-  });
+  }, 300_000);
 
   it("recognizes scheduled-dispatch render prompts and returns deterministic owner-facing text", () => {
     const prompt = [

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -58,13 +58,13 @@ async function loadTestMocks() {
     "../../../plugins/plugin-personal-assistant/test/support/helpers/seed-grants.ts",
     import.meta.url,
   ).href;
-  const [mockRuntime, lifeopsSimulator, benchmarkFixtures, grants] =
-    await Promise.all([
-      import(mockRuntimeSpecifier),
-      import(lifeopsSimulatorSpecifier),
-      import(benchmarkFixturesSpecifier),
-      import(grantsSpecifier),
-    ]);
+  // These helpers share a large module graph. Load them in sequence so test
+  // runners transform that graph once instead of contending across four
+  // concurrent dynamic imports.
+  const mockRuntime = await import(mockRuntimeSpecifier);
+  const lifeopsSimulator = await import(lifeopsSimulatorSpecifier);
+  const benchmarkFixtures = await import(benchmarkFixturesSpecifier);
+  const grants = await import(grantsSpecifier);
   return {
     prepareMockedTestEnvironment: mockRuntime.prepareMockedTestEnvironment,
     seedLifeOpsSimulatorRuntime: lifeopsSimulator.seedLifeOpsSimulatorRuntime,

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -628,12 +628,18 @@ export default scenario({
       text: "Open the settings view",
       actionName: "VIEWS",
       options: { action: "show", view: "settings", viewType: "gui" },
-      responseIncludesAny: ["Opened Settings"],
+      responseIncludesAny: ['"effect":"view_navigation"'],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "VIEWS",
           parameters: { action: "show", view: "settings", viewType: "gui" },
-          responseText: "Opened Settings.",
+          responseText: JSON.stringify({
+            effect: "view_navigation",
+            status: "accepted",
+            viewId: "settings",
+            label: "Settings",
+            path: "/settings",
+          }),
           resultFields: {
             "values.mode": "show",
             "values.viewId": "settings",
@@ -648,7 +654,7 @@ export default scenario({
       text: "Open the remote ledger view",
       actionName: "VIEWS",
       options: { action: "open", view: "remote-ledger", viewType: "gui" },
-      responseIncludesAny: ["Opened Remote Ledger"],
+      responseIncludesAny: ['"effect":"view_navigation"'],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "VIEWS",
@@ -657,7 +663,13 @@ export default scenario({
             view: "remote-ledger",
             viewType: "gui",
           },
-          responseText: "Opened Remote Ledger.",
+          responseText: JSON.stringify({
+            effect: "view_navigation",
+            status: "accepted",
+            viewId: "remote-ledger",
+            label: "Remote Ledger",
+            path: "/remote-ledger",
+          }),
           resultFields: {
             "values.mode": "show",
             "values.viewId": "remote-ledger",
@@ -864,12 +876,15 @@ export default scenario({
       text: "Launch the feed app",
       actionName: "APP",
       options: { action: "launch", app: "feed" },
-      responseIncludesAny: ["Launched Feed", "run-feed-launch-1"],
+      responseIncludesAny: ['"effect":"app_launch"'],
       assertTurn: (execution) =>
         expectActionTurn(execution, {
           actionName: "APP",
           parameters: { action: "launch", app: "feed" },
-          responseText: "Launched Feed. Run ID: run-feed-launch-1.",
+          responseText: JSON.stringify({
+            effect: "app_launch",
+            status: "completed",
+          }),
           resultFields: {
             "values.mode": "launch",
             "values.appName": "feed",
@@ -1137,7 +1152,6 @@ export default scenario({
         /"stop"/,
         /"load_from_directory"/,
         /"create"/,
-        /run-feed-launch-1/,
         /run-feed-relaunch-2/,
         /loaded-console/,
         /editTarget/,

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -30,10 +30,14 @@ type RuntimeWithScenarioModelFixtures = {
   deleteTask?: (taskId: string) => Promise<void>;
   getService?: (serviceType: string) => unknown;
   getTasks?: (query?: Record<string, unknown>) => Promise<unknown[]>;
+  evaluators: unknown[];
   scenarioModelFixtures?: {
     register: (...fixtures: Array<Record<string, unknown>>) => void;
   };
 };
+
+let previousEvaluators: unknown[] | null = null;
+let scenarioRuntime: RuntimeWithScenarioModelFixtures | null = null;
 
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -125,29 +129,42 @@ function plannerFixture(
   args: Record<string, unknown>,
   messageToUser: string,
 ) {
+  const plannedResponse = {
+    text: "",
+    thought: `Call ${actionName} for ${input}.`,
+    messageToUser,
+    completed: true,
+    finishReason: "tool-calls",
+    toolCalls: [
+      {
+        id: `call-${actionName.toLowerCase()}-${String(args.action)}`,
+        name: actionName,
+        type: "function",
+        arguments: args,
+      },
+    ],
+  };
   return {
     name: `route-${actionName.toLowerCase()}-planner-${input}`,
     match: {
       modelType: ModelType.ACTION_PLANNER,
       input: matchesScenarioInput(input),
-      toolName: actionName,
     },
-    response: {
-      text: "",
-      thought: `Call ${actionName} for ${input}.`,
-      messageToUser,
-      completed: true,
-      finishReason: "tool-calls",
-      toolCalls: [
-        {
-          id: `call-${actionName.toLowerCase()}-${String(args.action)}`,
-          name: actionName,
-          type: "function",
-          arguments: args,
-        },
-      ],
-    },
-    times: 1,
+    resolve: (call: {
+      latestUserText: string;
+      params: { toolChoice?: unknown };
+    }) =>
+      call.params.toolChoice === "required"
+        ? plannedResponse
+        : {
+            text: messageToUser,
+            thought: `Report the completed ${actionName} result.`,
+            messageToUser,
+            completed: true,
+            finishReason: "stop",
+            toolCalls: [],
+          },
+    times: { min: 1, max: 2 },
   };
 }
 
@@ -294,6 +311,9 @@ export default scenario({
         process.env.ELIZA_WORKSPACE_DIR = repoRoot;
         resetAppControlHttpLoopback();
         const runtime = ctx.runtime as RuntimeWithScenarioModelFixtures;
+        scenarioRuntime = runtime;
+        previousEvaluators = runtime.evaluators;
+        runtime.evaluators = [];
 
         await fs.rm(path.dirname(appLoadDirectory), {
           force: true,
@@ -567,6 +587,36 @@ export default scenario({
             },
             "Deleted Remote Ledger (@elizaos/plugin-remote-ledger). Plugin @elizaos/plugin-remote-ledger unloaded.",
           ),
+          {
+            name: "app-relaunch-result-rescue",
+            match: {
+              modelType: ModelType.TEXT_LARGE,
+              input: (input: string) =>
+                input.includes("Relaunched Feed. New run ID: run-feed-nl-2."),
+            },
+            response: "Relaunched Feed. New run ID: run-feed-nl-2.",
+            times: 1,
+          },
+          {
+            name: "app-load-result-rescue",
+            match: {
+              modelType: ModelType.TEXT_LARGE,
+              input: (input: string) =>
+                input.includes("Loaded Console (@scenario/app-loaded-console)"),
+            },
+            response: `Registered 1 app from ${appLoadDirectory}: Loaded Console (@scenario/app-loaded-console).`,
+            times: 1,
+          },
+          {
+            name: "app-create-cancel-result-rescue",
+            match: {
+              modelType: ModelType.TEXT_LARGE,
+              input: (input: string) =>
+                input.includes("Canceled. No app changes made."),
+            },
+            response: "Canceled. No app changes made.",
+            times: 1,
+          },
         );
 
         registerAppControlHttpHandler((request) => {
@@ -661,6 +711,11 @@ export default scenario({
       type: "custom",
       name: "remove app-control source fixtures",
       apply: async () => {
+        if (scenarioRuntime && previousEvaluators !== null) {
+          scenarioRuntime.evaluators = previousEvaluators;
+          previousEvaluators = null;
+        }
+        scenarioRuntime = null;
         await fs.rm(path.dirname(appLoadDirectory), {
           force: true,
           recursive: true,

--- a/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-coding-tools-actions.scenario.ts
@@ -77,6 +77,14 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Write the deterministic coding tools note file",
     messageToUser: `Wrote ${notePath}`,
+    plannerToolNames: [
+      "FILE",
+      "WEB_FETCH",
+      "START_CODING_TASK",
+      "REPLY",
+      "IGNORE",
+      "STOP",
+    ],
   },
   {
     actionName: "FILE",
@@ -84,6 +92,7 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Read the deterministic coding tools note file",
     messageToUser: "alpha coding-tools scenario",
+    plannerToolNames: ["FILE", "WEB_FETCH", "REPLY", "IGNORE", "STOP"],
   },
   {
     actionName: "SHELL",
@@ -92,6 +101,7 @@ const strictCodingToolRoutes = [
     input:
       "Run a shell command to count the deterministic coding tools note lines",
     messageToUser: "shell-ok:2",
+    plannerToolNames: ["SHELL", "WEB_FETCH", "REPLY", "IGNORE", "STOP"],
   },
   {
     actionName: "WORKTREE",
@@ -99,6 +109,7 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Enter an isolated repo worktree",
     messageToUser: `Entered worktree ${worktreeBranch}`,
+    plannerToolNames: ["SHELL", "WORKTREE", "REPLY", "IGNORE", "STOP"],
   },
   {
     actionName: "WORKTREE",
@@ -106,14 +117,9 @@ const strictCodingToolRoutes = [
     contextIds: ["code"],
     input: "Exit and clean up the isolated repo worktree",
     messageToUser: "Exited and removed worktree",
+    plannerToolNames: ["SHELL", "WORKTREE", "REPLY", "IGNORE", "STOP"],
   },
 ];
-
-const plannerToolNames: Record<string, readonly string[]> = {
-  FILE: ["FILE", "WEB_FETCH", "REPLY", "IGNORE", "STOP"],
-  SHELL: ["SHELL", "WEB_FETCH", "REPLY", "IGNORE", "STOP"],
-  WORKTREE: ["SHELL", "WORKTREE", "REPLY", "IGNORE", "STOP"],
-};
 
 function currentTurnInputPattern(input: string): string {
   const escaped = input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -147,7 +153,7 @@ const codingToolModelFixtures: ScenarioModelFixture[] = [
         match: {
           modelType: "ACTION_PLANNER" as const,
           input: { pattern: currentTurnInputPattern(route.input) },
-          toolNames: plannerToolNames[route.actionName],
+          toolNames: route.plannerToolNames,
         },
         response: {
           json: {
@@ -182,6 +188,7 @@ const codingToolModelFixtures: ScenarioModelFixture[] = [
     },
     response: {
       json: {
+        text: "alpha coding-tools scenario\nbeta strict e2e",
         thought: "Report the complete file contents returned by FILE.",
         messageToUser: "alpha coding-tools scenario\nbeta strict e2e",
         completed: true,
@@ -203,6 +210,7 @@ const codingToolModelFixtures: ScenarioModelFixture[] = [
     },
     response: {
       json: {
+        text: "Exited and removed worktree",
         thought: "Report the completed worktree cleanup.",
         messageToUser: "Exited and removed worktree",
         completed: true,

--- a/packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts
@@ -8,6 +8,7 @@
 import type { AgentRuntime } from "@elizaos/core";
 import companionPlugin from "@elizaos/plugin-companion";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { CompanionService } from "../../../../plugins/plugin-companion/src/service.ts";
 
 const PAIRING_TOKEN = "companion-scenario-token";
 const SET_MOOD = "SET_COMPANION_MOOD";

--- a/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
@@ -22,7 +22,7 @@ import mcpPlugin, {
   handleMcpRoutes,
   type McpRouteConfig,
 } from "../../../../plugins/plugin-mcp/src/index.ts";
-import type { McpService } from "../../../../plugins/plugin-mcp/src/service.ts";
+import { McpService } from "../../../../plugins/plugin-mcp/src/service.ts";
 import {
   MCP_SERVICE_NAME,
   type McpServer,
@@ -142,6 +142,27 @@ function unsupportedMcpEvaluationFixture(input: string, op: string) {
   };
 }
 
+function unsupportedMcpPostToolFixture(input: string, op: string) {
+  const text = `MCP op=${op} is only available in the cloud runtime.`;
+  return {
+    name: `mcp-unsupported-${op}-post-tool-${input}`,
+    match: {
+      modelType: ModelType.ACTION_PLANNER,
+      input: matchesScenarioInput(input),
+      toolNames: [],
+    },
+    response: {
+      text,
+      thought: `Report the ${op} local-runtime boundary.`,
+      messageToUser: text,
+      completed: true,
+      finishReason: "stop",
+      toolCalls: [],
+    },
+    times: 1,
+  };
+}
+
 type RuntimeWithMcpScenario = IAgentRuntime &
   RuntimeWithScenarioModelFixtures & {
     plugins?: Plugin[];
@@ -169,6 +190,9 @@ type RouteStatusBody = {
 };
 
 let scenarioRuntime: RuntimeWithMcpScenario | null = null;
+let scenarioMcpService: McpService | null = null;
+let restoreMcpGetService: (() => void) | null = null;
+let previousMcpEvaluators: RuntimeWithMcpScenario["evaluators"] | null = null;
 
 function isRecord(value: unknown): value is JsonRecord {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -504,11 +528,23 @@ async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
   const runtime = ctx.runtime as RuntimeWithMcpScenario | undefined;
   if (!runtime) return "scenario runtime was not available";
   scenarioRuntime = runtime;
+  previousMcpEvaluators = runtime.evaluators;
+  runtime.evaluators = [];
   if (!fixtureSource.includes(RESOURCE_TEXT)) {
     return `MCP fixture source does not contain ${RESOURCE_TEXT}`;
   }
 
   runtime.setSetting("mcp", mcpConfig().mcp, false);
+  const originalGetService = runtime.getService.bind(runtime);
+  await originalGetService<McpService>(MCP_SERVICE_NAME)?.stop();
+  scenarioMcpService = await McpService.start(runtime);
+  runtime.getService = ((serviceType: string) =>
+    serviceType === MCP_SERVICE_NAME
+      ? scenarioMcpService
+      : originalGetService(serviceType)) as typeof runtime.getService;
+  restoreMcpGetService = () => {
+    runtime.getService = originalGetService as typeof runtime.getService;
+  };
   registerStrictActionRouteFixtures(runtime, strictMcpRoutes);
   runtime.scenarioModelFixtures?.register(
     {
@@ -579,6 +615,12 @@ async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
     ),
     unsupportedMcpEvaluationFixture(searchActionsInput, "search_actions"),
     unsupportedMcpEvaluationFixture(listConnectionsInput, "list_connections"),
+    unsupportedMcpPostToolFixture(
+      parentListConnectionsInput,
+      "list_connections",
+    ),
+    unsupportedMcpPostToolFixture(searchActionsInput, "search_actions"),
+    unsupportedMcpPostToolFixture(listConnectionsInput, "list_connections"),
   );
 
   const registered = (runtime.plugins ?? []).some(
@@ -587,10 +629,7 @@ async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
   if (!registered) {
     await runtime.registerPlugin(mcpPlugin);
   }
-  const service =
-    ((await runtime.getServiceLoadPromise?.(MCP_SERVICE_NAME)) as
-      | McpService
-      | undefined) ?? runtime.getService<McpService>(MCP_SERVICE_NAME);
+  const service = scenarioMcpService;
   await service?.waitForInitialization?.();
   const server = service
     ?.getServers()
@@ -653,7 +692,6 @@ async function finalMcpCheck(
   if (readPath(server.resources?.[0], "uri") !== RESOURCE_URI) {
     return `expected MCP resource uri ${RESOURCE_URI}, saw ${stableStringify(server.resources)}`;
   }
-  await service.stop();
   return undefined;
 }
 
@@ -765,6 +803,22 @@ export default scenario({
       type: "custom",
       name: "real MCP stdio service discovered the fixture tool and resource",
       predicate: finalMcpCheck,
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "stop scenario MCP service and restore runtime service lookup",
+      apply: async () => {
+        if (scenarioRuntime && previousMcpEvaluators !== null) {
+          scenarioRuntime.evaluators = previousMcpEvaluators;
+          previousMcpEvaluators = null;
+        }
+        await scenarioMcpService?.stop();
+        scenarioMcpService = null;
+        restoreMcpGetService?.();
+        restoreMcpGetService = null;
+      },
     },
   ],
 });

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
@@ -84,9 +84,23 @@ function expectShowTurn(
   execution: ScenarioTurnExecution,
   view: CoveredView,
 ): string | undefined {
-  const expectedText = `Opened ${view.label}.`;
-  if (execution.responseText !== expectedText) {
-    return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
+  let effect: Record<string, unknown>;
+  try {
+    effect = toRecord(JSON.parse(execution.responseText));
+  } catch {
+    return `expected a JSON view-navigation effect, saw ${JSON.stringify(execution.responseText)}`;
+  }
+  const expectedEffect = {
+    effect: "view_navigation",
+    status: "accepted",
+    viewId: view.id,
+    label: view.label,
+    path: view.path,
+  };
+  for (const [key, expected] of Object.entries(expectedEffect)) {
+    if (effect[key] !== expected) {
+      return `expected navigation effect ${key}=${JSON.stringify(expected)}, saw ${JSON.stringify(effect[key])}`;
+    }
   }
   const action = execution.actionsCalled.find(
     (candidate) => candidate.actionName === "VIEWS",
@@ -186,7 +200,7 @@ export default scenario({
       text: entry.phrase,
       actionName: "VIEWS",
       options: { action: "show", viewType: "gui" },
-      responseIncludesAny: [`Opened ${view.label}`],
+      responseIncludesAny: ['"effect":"view_navigation"'],
       assertTurn: (execution: ScenarioTurnExecution) =>
         expectShowTurn(execution, view),
     };

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
@@ -73,9 +73,23 @@ function expectShowTurn(
   execution: ScenarioTurnExecution,
   view: BuiltinView,
 ): string | undefined {
-  const expectedText = `Opened ${view.navigationLabel ?? view.label}.`;
-  if (execution.responseText !== expectedText) {
-    return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
+  let effect: Record<string, unknown>;
+  try {
+    effect = toRecord(JSON.parse(execution.responseText));
+  } catch {
+    return `expected a JSON view-navigation effect, saw ${JSON.stringify(execution.responseText)}`;
+  }
+  const expectedEffect = {
+    effect: "view_navigation",
+    status: "accepted",
+    viewId: view.id,
+    label: view.navigationLabel ?? view.label,
+    path: view.path,
+  };
+  for (const [key, expected] of Object.entries(expectedEffect)) {
+    if (effect[key] !== expected) {
+      return `expected navigation effect ${key}=${JSON.stringify(expected)}, saw ${JSON.stringify(effect[key])}`;
+    }
   }
   const action = execution.actionsCalled.find(
     (candidate) => candidate.actionName === "VIEWS",
@@ -159,7 +173,7 @@ export default scenario({
     text: `Open the ${view.label} view`,
     actionName: "VIEWS",
     options: { action: "show", view: view.id, viewType: "gui" },
-    responseIncludesAny: [`Opened ${view.navigationLabel ?? view.label}`],
+    responseIncludesAny: ['"effect":"view_navigation"'],
     assertTurn: (execution: ScenarioTurnExecution) =>
       expectShowTurn(execution, view),
   })),

--- a/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
@@ -108,9 +108,23 @@ function expectVoiceTurn(
   execution: ScenarioTurnExecution,
   view: VoiceView,
 ): string | undefined {
-  const expectedText = `Opened ${view.navigationLabel ?? view.label}.`;
-  if (execution.responseText !== expectedText) {
-    return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
+  let effect: Record<string, unknown>;
+  try {
+    effect = toRecord(JSON.parse(execution.responseText));
+  } catch {
+    return `expected a JSON view-navigation effect, saw ${JSON.stringify(execution.responseText)}`;
+  }
+  const expectedEffect = {
+    effect: "view_navigation",
+    status: "accepted",
+    viewId: view.id,
+    label: view.navigationLabel ?? view.label,
+    path: view.path,
+  };
+  for (const [key, expected] of Object.entries(expectedEffect)) {
+    if (effect[key] !== expected) {
+      return `expected navigation effect ${key}=${JSON.stringify(expected)}, saw ${JSON.stringify(effect[key])}`;
+    }
   }
   const action = execution.actionsCalled.find(
     (candidate) => candidate.actionName === "VIEWS",
@@ -202,7 +216,7 @@ export default scenario({
     text: view.noun,
     actionName: "VIEWS",
     options: { action: "show", viewType: "gui" },
-    responseIncludesAny: [`Opened ${view.navigationLabel ?? view.label}`],
+    responseIncludesAny: ['"effect":"view_navigation"'],
     assertTurn: (execution: ScenarioTurnExecution) =>
       expectVoiceTurn(execution, view),
   })),


### PR DESCRIPTION
## Summary
- repair deterministic scenario fixtures after runtime action and synthesis contract drift
- isolate unrelated post-turn evaluators in strict APP and MCP scenarios
- align coding-tools per-turn action surfaces and register the direct file aliases in the action inventory
- preserve the current companion plugin registration path while validating the real loopback service

Follow-up to #23150. Contributes to #22901.

## Exact-head validation
- 10 repaired/current contract scenarios: 10 passed, 0 failed (run d092369b-0c35-48a0-958c-a59d8d6b729b)
- deterministic action coverage: 18 passed
- scenario mock tests: 21 passed
- scenario-runner build: passed
- bun install: passed

## Repository gate hold
bun run verify reached 212/214 Turbo tasks, then stopped in unrelated @elizaos/cloud-shared typecheck because @elizaos/plugin-doordash declarations could not be resolved. The repaired scenario matrix and package-scoped gates above pass on this head. The broader deterministic lane also contains pre-existing failures in browser, documents, GitHub, and LifeOps fixtures caused by unmatched background evaluator/model calls; those are outside this focused repair.