### PR TITLE
fix(agent): remove default vision completion caps

### DIFF
--- a/packages/agent/src/providers/media-provider.test.ts
+++ b/packages/agent/src/providers/media-provider.test.ts
@@ -494,6 +494,126 @@ describe("media vision provider input validation", () => {
         },
       ],
     });
+    expect(calls[0].body).not.toHaveProperty("max_tokens");
+  });
+
+  it("omits OpenAI's output cap by default and preserves an explicit caller limit", async () => {
+    const calls: FetchCall[] = [];
+    fakeMediaFetch(
+      Response.json({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "complete image" },
+          },
+        ],
+      }),
+      calls,
+    );
+    const provider = createVisionProvider(
+      {
+        mode: "own-key",
+        provider: "openai",
+        openai: { apiKey: "openai-key" },
+      },
+      { cloudMediaDisabled: true },
+    );
+
+    await provider.analyze({ imageBase64: "AQID" });
+    await provider.analyze({ imageBase64: "AQID", maxTokens: 4096 });
+
+    expect(calls[0].body).not.toHaveProperty("max_tokens");
+    expect(calls[1].body.max_tokens).toBe(4096);
+  });
+
+  it.each([
+    {
+      provider: "openai" as const,
+      config: { openai: { apiKey: "openai-key" } },
+      response: {
+        choices: [
+          {
+            finish_reason: "length",
+            message: { content: "partial OpenAI description" },
+          },
+        ],
+      },
+    },
+    {
+      provider: "xai" as const,
+      config: { xai: { apiKey: "xai-key" } },
+      response: {
+        choices: [
+          {
+            finish_reason: "length",
+            message: { content: "partial xAI description" },
+          },
+        ],
+      },
+    },
+  ])("rejects $provider length-stopped descriptions", async (fixture) => {
+    const calls: FetchCall[] = [];
+    fakeMediaFetch(Response.json(fixture.response), calls);
+    const provider = createVisionProvider(
+      {
+        mode: "own-key",
+        provider: fixture.provider,
+        ...fixture.config,
+      },
+      { cloudMediaDisabled: true },
+    );
+
+    const result = await provider.analyze({ imageBase64: "AQID" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/incomplete vision description/);
+    expect(result.data).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+
+  it("uses Anthropic's model-authoritative maximum and rejects max_tokens stops", async () => {
+    const calls: FetchCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push({
+          url: href,
+          init,
+          body:
+            typeof init?.body === "string"
+              ? (JSON.parse(init.body) as Record<string, unknown>)
+              : {},
+        });
+        if (href.includes("/v1/models/")) {
+          return Response.json({ max_tokens: 128_000 });
+        }
+        return Response.json({
+          stop_reason: "max_tokens",
+          content: [{ type: "text", text: "partial Anthropic description" }],
+        });
+      }),
+    );
+    const provider = createVisionProvider(
+      {
+        mode: "own-key",
+        provider: "anthropic",
+        anthropic: { apiKey: "anthropic-key", model: "claude-opus-4-7" },
+      },
+      { cloudMediaDisabled: true },
+    );
+
+    const result = await provider.analyze({ imageBase64: "AQID" });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringMatching(/incomplete vision description/),
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.anthropic.com/v1/models/claude-opus-4-7",
+      "https://api.anthropic.com/v1/messages",
+    ]);
+    expect(calls[1].body.max_tokens).toBe(128_000);
   });
 });
 
@@ -590,5 +710,46 @@ describe("Ollama vision image fetching (W5-020)", () => {
     expect(
       calls.find((call) => call.url.endsWith("/api/chat")),
     ).toBeUndefined();
+  });
+
+  it("requests unlimited generation and rejects a length-stopped response", async () => {
+    const calls: FetchCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push({
+          url: href,
+          init,
+          body:
+            typeof init?.body === "string"
+              ? (JSON.parse(init.body) as Record<string, unknown>)
+              : {},
+        });
+        if (href.endsWith("/api/tags")) {
+          return Response.json({ models: [{ name: "llava" }] });
+        }
+        return Response.json({
+          done_reason: "length",
+          message: { content: "partial Ollama description" },
+        });
+      }),
+    );
+    const provider = createVisionProvider(
+      { mode: "own-key", provider: "ollama", ollama: {} },
+      { cloudMediaDisabled: true },
+    );
+
+    const result = await provider.analyze({
+      imageBase64: "AQID",
+      prompt: "describe",
+    });
+
+    const chatCall = calls.find((call) => call.url.endsWith("/api/chat"));
+    expect(chatCall?.body.options).toEqual({ num_predict: -1 });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringMatching(/incomplete vision description/),
+    });
   });
 });

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -595,7 +595,7 @@ export class OpenAIVisionProvider implements VisionAnalysisProvider {
   name = "openai";
   private apiKey: string;
   private model: string;
-  private maxTokens: number;
+  private maxTokens?: number;
 
   constructor(config: NonNullable<VisionConfig["openai"]>) {
     if (!config.apiKey) {
@@ -604,7 +604,7 @@ export class OpenAIVisionProvider implements VisionAnalysisProvider {
     this.apiKey = config.apiKey;
     // Mirrors plugin-openai's IMAGE_DESCRIPTION default (utils/config.ts).
     this.model = config.model ?? "gpt-5-mini";
-    this.maxTokens = config.maxTokens ?? 1024;
+    this.maxTokens = config.maxTokens;
   }
 
   async analyze(
@@ -634,7 +634,9 @@ export class OpenAIVisionProvider implements VisionAnalysisProvider {
           },
           body: JSON.stringify({
             model: this.model,
-            max_tokens: options.maxTokens ?? this.maxTokens,
+            ...((options.maxTokens ?? this.maxTokens) !== undefined
+              ? { max_tokens: options.maxTokens ?? this.maxTokens }
+              : {}),
             messages: [
               {
                 role: "user",
@@ -657,8 +659,18 @@ export class OpenAIVisionProvider implements VisionAnalysisProvider {
       }
 
       const data = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
+        choices?: Array<{
+          finish_reason?: string;
+          message?: { content?: string };
+        }>;
       };
+      if (data.choices?.[0]?.finish_reason === "length") {
+        return {
+          success: false,
+          error:
+            "OpenAI returned an incomplete vision description after reaching an output limit",
+        };
+      }
       const description = data.choices?.[0]?.message?.content;
       if (!description) {
         return {
@@ -1026,7 +1038,9 @@ export class XAIVisionProvider implements VisionAnalysisProvider {
           },
           body: JSON.stringify({
             model: this.model,
-            max_tokens: options.maxTokens ?? 1024,
+            ...(options.maxTokens !== undefined
+              ? { max_tokens: options.maxTokens }
+              : {}),
             messages: [
               {
                 role: "user",
@@ -1049,8 +1063,18 @@ export class XAIVisionProvider implements VisionAnalysisProvider {
       }
 
       const data = (await response.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
+        choices?: Array<{
+          finish_reason?: string;
+          message?: { content?: string };
+        }>;
       };
+      if (data.choices?.[0]?.finish_reason === "length") {
+        return {
+          success: false,
+          error:
+            "xAI returned an incomplete vision description after reaching an output limit",
+        };
+      }
       const description = data.choices?.[0]?.message?.content;
       if (!description) {
         return { success: false, error: "No description returned from xAI" };
@@ -1076,14 +1100,14 @@ class OllamaVisionProvider implements VisionAnalysisProvider {
   name = "ollama";
   private baseUrl: string;
   private model: string;
-  private maxTokens: number;
+  private maxTokens?: number;
   private autoDownload: boolean;
   private modelChecked = false;
 
   constructor(config: NonNullable<VisionConfig["ollama"]>) {
     this.baseUrl = config.baseUrl ?? "http://localhost:11434";
     this.model = config.model ?? "llava";
-    this.maxTokens = config.maxTokens ?? 1024;
+    this.maxTokens = config.maxTokens;
     this.autoDownload = config.autoDownload ?? true;
   }
 
@@ -1215,7 +1239,7 @@ class OllamaVisionProvider implements VisionAnalysisProvider {
             ],
             stream: false,
             options: {
-              num_predict: this.maxTokens,
+              num_predict: options.maxTokens ?? this.maxTokens ?? -1,
             },
           }),
         },
@@ -1228,8 +1252,16 @@ class OllamaVisionProvider implements VisionAnalysisProvider {
       }
 
       const data = (await response.json()) as {
+        done_reason?: string;
         message?: { content?: string };
       };
+      if (data.done_reason === "length") {
+        return {
+          success: false,
+          error:
+            "Ollama returned an incomplete vision description after reaching an output limit",
+        };
+      }
       const description = data.message?.content;
       if (!description) {
         return { success: false, error: "No description returned from Ollama" };
@@ -1251,6 +1283,7 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
   name = "anthropic";
   private apiKey: string;
   private model: string;
+  private modelMaxOutputTokens?: number;
 
   constructor(config: NonNullable<VisionConfig["anthropic"]>) {
     if (!config.apiKey) {
@@ -1258,6 +1291,40 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
     }
     this.apiKey = config.apiKey;
     this.model = config.model ?? "claude-opus-4-7";
+  }
+
+  private async resolveModelMaxOutputTokens(): Promise<number> {
+    if (this.modelMaxOutputTokens !== undefined) {
+      return this.modelMaxOutputTokens;
+    }
+    const response = await fetchWithTimeout(
+      `https://api.anthropic.com/v1/models/${encodeURIComponent(this.model)}`,
+      {
+        method: "GET",
+        headers: {
+          "x-api-key": this.apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+      },
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Anthropic model metadata error: ${response.status} ${text}`,
+      );
+    }
+    const data = (await response.json()) as { max_tokens?: unknown };
+    if (
+      typeof data.max_tokens !== "number" ||
+      !Number.isSafeInteger(data.max_tokens) ||
+      data.max_tokens <= 0
+    ) {
+      throw new Error(
+        `Anthropic model metadata omitted max_tokens for ${this.model}`,
+      );
+    }
+    this.modelMaxOutputTokens = data.max_tokens;
+    return data.max_tokens;
   }
 
   async analyze(
@@ -1275,6 +1342,7 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
         : { type: "url" as const, url: imageInput.value };
 
     return withProviderErrorBoundary(this.name, async () => {
+      const modelMaxOutputTokens = await this.resolveModelMaxOutputTokens();
       const response = await fetchWithTimeout(
         "https://api.anthropic.com/v1/messages",
         {
@@ -1286,7 +1354,10 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
           },
           body: JSON.stringify({
             model: this.model,
-            max_tokens: options.maxTokens ?? 1024,
+            max_tokens: Math.min(
+              options.maxTokens ?? modelMaxOutputTokens,
+              modelMaxOutputTokens,
+            ),
             messages: [
               {
                 role: "user",
@@ -1310,7 +1381,15 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
 
       const data = (await response.json()) as {
         content?: Array<{ type: string; text?: string }>;
+        stop_reason?: string;
       };
+      if (data.stop_reason === "max_tokens") {
+        return {
+          success: false,
+          error:
+            "Anthropic returned an incomplete vision description after reaching max_tokens",
+        };
+      }
       const textBlock = data.content?.find((c) => c.type === "text");
       if (!textBlock?.text) {
         return {

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -111,6 +111,11 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/applyTrajectoryFieldCap/,
 		/capBytes\?:/,
 	],
+	"packages/agent/src/providers/media-provider.ts": [
+		/max_tokens:\s*options\.maxTokens\s*\?\?\s*1024/,
+		/this\.maxTokens\s*=\s*config\.maxTokens\s*\?\?\s*1024/,
+		/num_predict:\s*this\.maxTokens/,
+	],
 	"plugins/plugin-coding-tools/src/actions/summaries.ts": [
 		/compactSummaryText/,
 		/truncateWellFormed/,


### PR DESCRIPTION
Closes #24704

Removes hidden 1,024-token defaults from OpenAI, xAI, Ollama, and Anthropic vision analysis. OpenAI and xAI omit the output bound unless a caller explicitly supplies one. Ollama requests its documented unlimited mode. Anthropic requires max_tokens, so the provider resolves the selected model authoritative max_tokens from the Models API instead of guessing a constant. Every provider length-stop signal is treated as an incomplete failure; partial descriptions are never returned as success.

Verification:
- bunx biome check on all changed files
- focused media-provider suite: 21/21
- prompt-integrity guard new media patterns; full guard is sparse-checkout blocked by unrelated omitted plugin sources
- package typecheck has no changed-file diagnostics; aggregate is blocked by missing isolated-clone database dependencies and the existing PluginRouteContext.applySignalQrOverride error