### PR TITLE
test(agent): replace forbidden update checker module mocks

### DIFF
--- a/packages/agent/src/services/update-checker.test.ts
+++ b/packages/agent/src/services/update-checker.test.ts
@@ -3,40 +3,52 @@
  * config-mutating channel changes clear those fields, but `resolveChannel` also
  * honours `ELIZA_UPDATE_CHANNEL`, which writes nothing — so the cache has to
  * record which channel produced it or it will be served under another one.
+ *
+ * Deterministic: real config reads/writes are isolated in a temp state dir and
+ * the npm registry response is supplied by a fetch stub; no module mocks.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadElizaConfig, saveElizaConfig } from "../config/config.ts";
 import type { ElizaConfig } from "../config/types.eliza.ts";
-
-const state: { config: ElizaConfig; saved: ElizaConfig | null } = {
-  config: {} as ElizaConfig,
-  saved: null,
-};
-
-vi.mock("../config/config.ts", () => ({
-  loadElizaConfig: () => state.config,
-  saveElizaConfig: (next: ElizaConfig) => {
-    state.saved = next;
-  },
-}));
-
-vi.mock("../runtime/version.ts", () => ({ VERSION: "2.0.0" }));
-
+import { VERSION } from "../runtime/version.ts";
 import { checkForUpdate } from "./update-checker.ts";
 
 const DIST_TAGS = {
-  latest: "9.9.9",
-  beta: "9.9.9-beta.1",
-  nightly: "9.9.9-nightly.1",
+  latest: "9999.9.9",
+  beta: "9999.9.9-beta.1",
+  nightly: "9999.9.9-nightly.1",
 };
 
 let fetchCalls = 0;
+let tempStateDir: string;
 const originalFetch = globalThis.fetch;
-const originalChannelEnv = process.env.ELIZA_UPDATE_CHANNEL;
+const originalEnv = {
+  ELIZA_CONFIG_PATH: process.env.ELIZA_CONFIG_PATH,
+  ELIZA_PERSIST_CONFIG_PATH: process.env.ELIZA_PERSIST_CONFIG_PATH,
+  ELIZA_STATE_DIR: process.env.ELIZA_STATE_DIR,
+  ELIZA_UPDATE_CHANNEL: process.env.ELIZA_UPDATE_CHANNEL,
+};
+
+function restoreEnv(
+  key: keyof typeof originalEnv,
+  value: string | undefined,
+): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
 
 beforeEach(() => {
   fetchCalls = 0;
-  state.saved = null;
+  tempStateDir = mkdtempSync(join(tmpdir(), "eliza-update-checker-"));
+  const configPath = join(tempStateDir, "eliza.json");
+  process.env.ELIZA_STATE_DIR = tempStateDir;
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+  delete process.env.ELIZA_UPDATE_CHANNEL;
   globalThis.fetch = (async () => {
     fetchCalls += 1;
     return {
@@ -48,11 +60,10 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  if (originalChannelEnv === undefined) {
-    delete process.env.ELIZA_UPDATE_CHANNEL;
-  } else {
-    process.env.ELIZA_UPDATE_CHANNEL = originalChannelEnv;
+  for (const [key, value] of Object.entries(originalEnv)) {
+    restoreEnv(key as keyof typeof originalEnv, value);
   }
+  rmSync(tempStateDir, { recursive: true, force: true });
 });
 
 function freshStableCache(): ElizaConfig {
@@ -60,7 +71,7 @@ function freshStableCache(): ElizaConfig {
     update: {
       channel: "stable",
       lastCheckAt: new Date().toISOString(),
-      lastCheckVersion: "9.9.9",
+      lastCheckVersion: DIST_TAGS.latest,
       lastCheckChannel: "stable",
     },
   } as ElizaConfig;
@@ -68,40 +79,40 @@ function freshStableCache(): ElizaConfig {
 
 describe("checkForUpdate release-channel cache", () => {
   it("does not serve a stable cache under ELIZA_UPDATE_CHANNEL=beta", async () => {
-    state.config = freshStableCache();
+    saveElizaConfig(freshStableCache());
     process.env.ELIZA_UPDATE_CHANNEL = "beta";
 
     const result = await checkForUpdate();
 
+    expect(result.currentVersion).toBe(VERSION);
     expect(result.channel).toBe("beta");
     expect(result.distTag).toBe("beta");
     // The bug returns the stable dist-tag's version under channel "beta".
-    expect(result.latestVersion).toBe("9.9.9-beta.1");
+    expect(result.latestVersion).toBe(DIST_TAGS.beta);
     expect(result.cached).toBe(false);
     expect(fetchCalls).toBe(1);
   });
 
   it("still serves a fresh cache for the channel that produced it", async () => {
-    state.config = freshStableCache();
-    delete process.env.ELIZA_UPDATE_CHANNEL;
+    saveElizaConfig(freshStableCache());
 
     const result = await checkForUpdate();
 
     expect(result.channel).toBe("stable");
-    expect(result.latestVersion).toBe("9.9.9");
+    expect(result.latestVersion).toBe(DIST_TAGS.latest);
     expect(result.cached).toBe(true);
     expect(fetchCalls).toBe(0);
   });
 
   it("records the channel a live check was made for", async () => {
-    state.config = { update: { channel: "beta" } } as ElizaConfig;
-    delete process.env.ELIZA_UPDATE_CHANNEL;
+    saveElizaConfig({ update: { channel: "beta" } } as ElizaConfig);
 
     const result = await checkForUpdate();
+    const saved = loadElizaConfig();
 
     expect(result.cached).toBe(false);
-    expect(result.latestVersion).toBe("9.9.9-beta.1");
-    expect(state.saved?.update?.lastCheckChannel).toBe("beta");
-    expect(state.saved?.update?.lastCheckVersion).toBe("9.9.9-beta.1");
+    expect(result.latestVersion).toBe(DIST_TAGS.beta);
+    expect(saved.update?.lastCheckChannel).toBe("beta");
+    expect(saved.update?.lastCheckVersion).toBe(DIST_TAGS.beta);
   });
 });


### PR DESCRIPTION
# Relates to

Closes #24700. Follow-up to merged PR #24085; @lalalune's merge-verification review identified the forbidden test mocks.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact result is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `799d9b3467e2923b7a1ed16a84ea9e2417dad137`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact result is documented in **Known gaps / failures** below.

# Risks

Low. This changes one test file only. The main risk is leaking environment or temporary filesystem state between tests; `afterEach` restores every changed variable and `globalThis.fetch`, then removes the per-test directory.

# Background

## What does this PR do?

Removes the two `vi.mock(...)` calls added by #24085. The tests now exercise the real config persistence and real `VERSION` module against an isolated temporary config file. The npm registry boundary remains a deterministic fetch stub and is disclosed in the test header.

## What kind of change is this?

Bug fix to test-integrity policy compliance. The target file now has zero `vi.mock(...)` and zero `vi.fn(...)` matches.

# Documentation changes needed?

No project documentation change is needed; this is a test-harness correction.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/update-checker.test.ts`

## Detailed testing steps

At exact head `e5f283fb2ce3aef543c878073c65d174b543dd93`:

```text
bunx vitest run packages/agent/src/services/update-checker.test.ts --coverage.enabled=false
Test Files  1 passed (1)
Tests       3 passed (3)

bun run --cwd packages/agent typecheck
exit 0

bunx @biomejs/biome check packages/agent/src/services/update-checker.test.ts
Checked 1 file. No fixes applied.

rg -n 'vi\.(mock|fn)\(' packages/agent/src/services/update-checker.test.ts
target forbidden-pattern matches: 0
```

The focused Vitest command was recorded through `scripts/proof-run.mjs` at this exact commit.

# Evidence Gate

<!-- evidence-head:e5f283fb2ce3aef543c878073c65d174b543dd93 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change with no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused test output above is the applicable execution evidence; no deployed backend changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

N/A - test-only change; exact focused-suite output is included above.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

This is a fork contribution, so hosted CI does not run contributor tests. The commands above are local exact-head evidence and must not be read as hosted-CI results.

The repository-wide `lint-no-vi-mocks` ratchet remains red from pre-existing debt; this PR removes both violations in its target file and does not claim the global audit passes.

`bun run verify` reached 212/214 successful tasks, then failed in the unrelated `@elizaos/cloud-shared#typecheck` task because `src/lib/eliza/runtime/initializer.ts:14` could not resolve `@elizaos/plugin-doordash` (`TS2307`). The changed agent test is outside that package; its focused suite, package typecheck, and Biome check all pass.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [followup-24085-mocks-r2]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NPX94MYQ6D338STBXTPAFW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T21:44:26.517Z","completed_at":"2026-08-22T21:45:19.054Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T21:44:27.953Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cbe0d99849db0c4ab7846886062d298216c05657b0a1121c31704b05f7cc197a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"dac2cd7d-d447-4f56-89c3-89094113317b","object_id":"sha256:cbe0d99849db0c4ab7846886062d298216c05657b0a1121c31704b05f7cc197a","sha256":"cbe0d99849db0c4ab7846886062d298216c05657b0a1121c31704b05f7cc197a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"oKmcLHv2IW8LUFYLRIKiNQSLnqS6kX0oGSv4Hn1KlEJvfQGwHiQvzhSoRGwEJ9-JpKJfjMcW5qYMxmBohsFEAw"}} -->
