### PR TITLE
fix(cloud): suppress ambient Discord typing effects

### DIFF
--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -40,7 +40,10 @@ import { pollTrackedDiscordDms, type TrackedDiscordDm } from "./dm-polling";
 import { tryConfirmDiscordIdentityLink } from "./identity-link";
 import { invalidIntegerEnvError, parseIntegerEnvValue } from "./integer-env";
 import { logger } from "./logger";
-import { managedGuildMessageTurn } from "./managed-guild-message-policy";
+import {
+  type ManagedGuildInvocation,
+  managedGuildMessageTurn,
+} from "./managed-guild-message-policy";
 import {
   createManagedGuildVoiceCloudBridge,
   MANAGED_GUILD_VOICE_INTENT,
@@ -2535,7 +2538,7 @@ export class GatewayManager {
       );
       return;
     }
-    await this.routeManagedAgentMessage(message, trimmedContent);
+    await this.routeManagedAgentMessage(message, trimmedContent, "dm");
   }
 
   private async handleManagedAgentGuildMessage(
@@ -2562,12 +2565,13 @@ export class GatewayManager {
       return;
     }
 
-    await this.routeManagedAgentMessage(message, turn.content);
+    await this.routeManagedAgentMessage(message, turn.content, turn.invocation);
   }
 
   private async routeManagedAgentMessage(
     message: Message,
     content: string,
+    invocation: ManagedGuildInvocation | "dm",
   ): Promise<void> {
     try {
       // Egress health (proven dropped-turn class, E2E 2026-08-05): a single
@@ -2616,8 +2620,15 @@ export class GatewayManager {
             });
           },
         });
+      // Ambient guild traffic must reach the runtime's contextual
+      // respond-or-ignore decision without producing a visible side effect
+      // first. In particular, unauthorized ambient speakers and turns the
+      // runtime ignores must never make the bot appear to be typing. Explicit
+      // DMs, mentions and replies retain their progress heartbeat.
       const typingChannel =
-        "sendTyping" in message.channel ? message.channel : null;
+        invocation !== "ambient" && "sendTyping" in message.channel
+          ? message.channel
+          : null;
       const outcome = typingChannel
         ? await withManagedTypingHeartbeat(
             {

--- a/packages/cloud/services/gateway-discord/tests/managed-guild-ambient-effects.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/managed-guild-ambient-effects.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Verifies the managed Discord gateway does not emit visible pre-decision
+ * effects for ambient guild turns. The real manager routing boundary posts the
+ * turn to Cloud, while deterministic responses model downstream authorization
+ * denial and runtime ignore decisions.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { Message } from "discord.js";
+import { GatewayManager } from "../src/gateway-manager";
+
+const originalFetch = globalThis.fetch;
+const BOT_ID = "100000000000000001";
+const SENDER_ID = "200000000000000002";
+
+interface ManagedGuildHarness {
+  accessToken: string | null;
+  tokenExpiresAt: Date | null;
+  elizaAppClient: { user: { id: string } } | null;
+  handleManagedAgentGuildMessage(message: Message): Promise<void>;
+}
+
+function createHarness() {
+  const manager = new GatewayManager({
+    podName: "test-pod",
+    elizaCloudUrl: "https://cloud.test",
+    gatewayBootstrapSecret: "test-secret",
+    project: "test",
+  });
+  const harness = manager as unknown as ManagedGuildHarness;
+  harness.accessToken = "test-token";
+  harness.tokenExpiresAt = new Date(Date.now() + 60_000);
+  harness.elizaAppClient = { user: { id: BOT_ID } };
+  return harness;
+}
+
+function guildMessage(options: { mentionBot?: boolean } = {}) {
+  let typingCalls = 0;
+  let replyCalls = 0;
+  const mentionedUserIds = options.mentionBot ? [BOT_ID] : [];
+  const message = {
+    id: "message-1",
+    guildId: "guild-1",
+    channelId: "channel-1",
+    content: options.mentionBot ? `<@${BOT_ID}> hello` : "ambient hello",
+    author: {
+      id: SENDER_ID,
+      username: "speaker",
+      bot: false,
+      globalName: "Speaker",
+      displayAvatarURL: () => "",
+    },
+    member: { displayName: "Speaker" },
+    mentions: {
+      users: {
+        map: (select: (user: { id: string }) => string) =>
+          mentionedUserIds.map((id) => select({ id })),
+      },
+      repliedUser: null,
+      everyone: false,
+    },
+    channel: {
+      sendTyping: async () => {
+        typingCalls += 1;
+      },
+    },
+    reply: async () => {
+      replyCalls += 1;
+      return null;
+    },
+  } as unknown as Message;
+  return {
+    message,
+    typingCalls: () => typingCalls,
+    replyCalls: () => replyCalls,
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("managed guild ambient pre-decision effects", () => {
+  test.each([
+    ["authorization denial", "sender_not_guild_owner"],
+    ["runtime ignore", "ignored"],
+  ])("%s emits no typing or reply", async (_label, reason) => {
+    let routedCalls = 0;
+    globalThis.fetch = mock(async () => {
+      routedCalls += 1;
+      return Response.json({ handled: false, reason });
+    }) as typeof fetch;
+    const harness = createHarness();
+    const turn = guildMessage();
+
+    await harness.handleManagedAgentGuildMessage(turn.message);
+
+    expect(routedCalls).toBe(1);
+    expect(turn.typingCalls()).toBe(0);
+    expect(turn.replyCalls()).toBe(0);
+  });
+
+  test("an explicit mention retains its pre-decision typing heartbeat", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({ handled: false, reason: "ignored" }),
+    ) as typeof fetch;
+    const harness = createHarness();
+    const turn = guildMessage({ mentionBot: true });
+
+    await harness.handleManagedAgentGuildMessage(turn.message);
+
+    expect(turn.typingCalls()).toBe(1);
+    expect(turn.replyCalls()).toBe(0);
+  });
+});


### PR DESCRIPTION
Fix-forward for #24670. The merged ambient-turn routing correctly preserves downstream owner authorization and GROUP respond-or-ignore evaluation, but it started Discord typing before either decision. That let unauthorized ambient speakers and runtime-ignored ambient turns produce a visible bot effect.

This change propagates the managed invocation classification into routing. Ambient turns still reach the authenticated Cloud/runtime decision, but bypass the pre-decision typing heartbeat. DMs, direct mentions, and direct replies retain their existing heartbeat behavior.

Attribution: preserves and completes the ambient managed-Discord work in #24670.

## Verification

- focused real GatewayManager boundary: 15 tests passed (ambient authorization denial and runtime-ignore both route internally with zero typing and zero replies; explicit mention still types)
- package typecheck: passed
- package lint: passed
- package build: passed
- full package lane: 174 passed; one unrelated Redis mock test timed out at 5s, then passed alone in 35ms and passed again in the exact focused rerun

<!-- evidence-head:0e04be21340791e2e8f8cb6d6595802b14cdedb7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — gateway-only behavior, no UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A — gateway-only behavior, no UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no rendered surface.
<!-- evidence-row:backend-logs -->
- [x] Real GatewayManager boundary tests prove one internal route call and zero Discord effects for ambient deny/ignore outcomes.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — downstream outcomes are deterministic authorization/ignore fixtures; the change is pre-decision transport behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Assertions cover routing count, typing count, and reply count.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered surface.

<!-- contribution-attribution:v1 -->
- Original ambient-turn implementation: #24670
- Fix-forward implementation: OpenAI Codex
- AI assistance: yes