### PR TITLE
fix(trajectory): surface incomplete experience context

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -681,6 +681,12 @@ export async function flushObservationBuffer(
 
     return observations;
   } catch (err) {
+    // error-policy:J7 observation extraction is diagnostic enrichment, but its
+    // failures must remain visible to the runtime error stream without killing
+    // the surrounding message loop.
+    runtime.reportError("TrajectoryPersistence.flushObservationBuffer", err, {
+      agentId: runtime.agentId,
+    });
     warnRuntime(
       runtime,
       "[trajectory-persistence] observation flush failed",

--- a/packages/agent/src/runtime/trajectory-observability.test.ts
+++ b/packages/agent/src/runtime/trajectory-observability.test.ts
@@ -16,16 +16,18 @@ import {
 
 function createRuntime() {
   const warn = vi.fn();
+  const reportError = vi.fn();
   const runtime = {
     agentId: "trajectory-observability-test",
     actions: [],
     adapter: { db: undefined },
     logger: { warn },
+    reportError,
     useModel: vi.fn(async () => {
       throw new Error("model down");
     }),
   } as unknown as IAgentRuntime;
-  return { runtime, warn };
+  return { runtime, reportError, warn };
 }
 
 describe("trajectory observability", () => {
@@ -82,7 +84,7 @@ describe("trajectory observability", () => {
   });
 
   it("logs observation flush failures before returning an empty result", async () => {
-    const { runtime, warn } = createRuntime();
+    const { runtime, reportError, warn } = createRuntime();
     pushChatExchange(runtime, {
       userPrompt: "hello",
       response: "hi",
@@ -98,6 +100,11 @@ describe("trajectory observability", () => {
         subsystem: "trajectory-db",
       }),
       "[trajectory-persistence] observation flush failed",
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "TrajectoryPersistence.flushObservationBuffer",
+      expect.any(Error),
+      { agentId: "trajectory-observability-test" },
     );
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
@@ -201,6 +201,35 @@ describe("queryPastExperience complete traversal", () => {
     });
   });
 
+  it.each([
+    ["missing detail", null, "detail_missing"],
+    ["missing steps", { trajectoryId: "legacy" }, "steps_missing"],
+  ])(
+    "rejects %s instead of omitting legacy context",
+    async (_label, detail, reason) => {
+      const runtime = makeRuntime({
+        listTrajectories: async () => ({
+          trajectories: [
+            {
+              id: "legacy",
+              source: "orchestrator",
+              startTime: 1,
+              llmCallCount: 1,
+              createdAt: new Date(1).toISOString(),
+            },
+          ],
+          total: 1,
+        }),
+        getTrajectoryDetail: async () => detail,
+      });
+
+      await expect(queryPastExperience(runtime)).rejects.toMatchObject({
+        code: "TRAJECTORY_EXPERIENCE_DETAIL_UNAVAILABLE",
+        context: { trajectoryId: "legacy", reason },
+      });
+    },
+  );
+
   it("traverses every storage page without treating page size as a content cap", async () => {
     const summaries = Array.from({ length: 501 }, (_, index) => ({
       id: `trajectory-${index}`,

--- a/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
@@ -338,7 +338,18 @@ export async function queryPastExperience(
         logger.getTrajectoryDetail(summary.id),
         QUERY_TIMEOUT_MS,
       );
-      if (!detail?.steps) continue;
+      if (!detail || !Array.isArray(detail.steps)) {
+        throw new ElizaError(
+          "Trajectory detail is unavailable for complete experience loading",
+          {
+            code: "TRAJECTORY_EXPERIENCE_DETAIL_UNAVAILABLE",
+            context: {
+              trajectoryId: summary.id,
+              reason: detail ? "steps_missing" : "detail_missing",
+            },
+          },
+        );
+      }
 
       for (const step of detail.steps) {
         if (!step.llmCalls) continue;


### PR DESCRIPTION
Fixes #24714. Follow-up to #24662.

- Reject missing legacy trajectory detail or steps with typed `TRAJECTORY_EXPERIENCE_DETAIL_UNAVAILABLE`, including trajectory id and exact unavailable reason, instead of silently omitting context.
- Report non-fatal observation-extraction failures through `runtime.reportError` under the J7 contract before retaining the existing structured warning/degrade behavior.
- Add deterministic missing-detail, missing-steps, and diagnostic-reporting regressions.

Exact-head local verification:
- focused agent + orchestrator suites: 16/16 passed
- changed-file Biome and diff check passed
- orchestrator package typecheck passed after building its workspace dependencies
- agent package typecheck reaches unrelated missing optional plugin trees (`plugin-capacitor-bridge`, `plugin-wallet`, `plugin-video`, `plugin-vision`, `plugin-notes`, `plugin-todos`); no diagnostic points at changed files; hosted exact-head CI is required.