### PR TITLE
fix(cloud): restore remote migration journal order

### DIFF
--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2021,14 +2021,14 @@
     {
       "idx": 288,
       "version": "7",
-      "when": 1794081600000,
+      "when": 1794168000001,
       "tag": "0305_secure_remote_hosts",
       "breakpoints": true
     },
     {
       "idx": 289,
       "version": "7",
-      "when": 1794081600001,
+      "when": 1794168000002,
       "tag": "0306_secure_remote_command_relay",
       "breakpoints": true
     }

--- a/packages/cloud/shared/src/db/secure-remote-relay-migration.pglite.test.ts
+++ b/packages/cloud/shared/src/db/secure-remote-relay-migration.pglite.test.ts
@@ -115,11 +115,17 @@ describe("secure remote relay migrations", () => {
 
       const journal = JSON.parse(
         await readFile(new URL("./migrations/meta/_journal.json", import.meta.url), "utf8"),
-      ) as { entries: Array<{ tag: string }> };
-      expect(journal.entries.slice(-2).map((entry) => entry.tag)).toEqual([
+      ) as { entries: Array<{ idx: number; tag: string; when: number }> };
+      const relayEntries = journal.entries.slice(-3);
+      expect(relayEntries.map((entry) => entry.tag)).toEqual([
+        "0304_personal_shared_group_delivery_lease",
         "0305_secure_remote_hosts",
         "0306_secure_remote_command_relay",
       ]);
+      expect(relayEntries.map((entry) => entry.idx)).toEqual([287, 288, 289]);
+      expect(relayEntries[1]!.when).toBeGreaterThan(relayEntries[0]!.when);
+      expect(relayEntries[2]!.when).toBeGreaterThan(relayEntries[1]!.when);
+      expect(new Set(journal.entries.map((entry) => entry.when)).size).toBe(journal.entries.length);
     } finally {
       await database.close();
     }


### PR DESCRIPTION
Fixes #24717.

Fix-forward for the secure remote relay migrations introduced by #24414. The merged journal gave 0305 the same `when` identity as 0303 and placed 0305/0306 before 0304, so `validateAppliedMigrationLedger` rejected the duplicate `created_at` before deployment. This preserves the Linux desktop and secure remote runtime implementation and changes only the migration identities plus its real PGlite regression.

Attribution: preserves and repairs the remote relay work authored by @NubsCarson in #24414.

Verification at `3466fe42d8` on base `3841ec6389`:
- `bun test packages/cloud/shared/src/db/secure-remote-relay-migration.pglite.test.ts packages/cloud/shared/src/db/migration-journal-registration.test.ts`: 6 pass, 0 fail; real PGlite applies 0068/0275/0305/0306 and enforces target/authority/lifecycle constraints.
- New order assertion reproduces the merged defect before the fix (`Received 1794081600000`, expected greater than 0304 `1794168000000`).
- Biome check of both changed files: pass.
- Package typecheck was attempted but is not valid in this linked isolated worktree because unrelated workspace packages are not installed/resolved (`plugin-doordash`, `drizzle-orm`, plugin-elizacloud dependencies); no errors referenced either changed file. Hosted exact-head CI is required before merge.

The exact merged delta audit also confirmed #24414 did not modify scheduling, personal-assistant, or notification production sources; the earlier suspected effective reversion is not present in the final landed commit.