### PR TITLE
fix(shared): recover expired sandbox registration

### DIFF
--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -129,14 +129,19 @@ function installFetch(): void {
           (!script.includes("s==ARGV[2]") || store.get(key2) === value2) &&
           (!script.includes("g==ARGV[3]") ||
             store.get(generationKey) === generation);
-        if (owned) {
+        const unclaimed =
+          script.includes("not u and not s and not g") &&
+          !store.has(key1) &&
+          !store.has(key2) &&
+          !store.has(generationKey);
+        if (owned || unclaimed) {
           store.set(key1, value1);
           store.set(key2, value2);
           store.set(generationKey, generation);
         }
         return {
           ok: true,
-          json: async () => ({ result: owned ? 1 : 0 }),
+          json: async () => ({ result: owned || unclaimed ? 1 : 0 }),
         } as Response;
       }
       const owned =
@@ -273,6 +278,35 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     expect(recorded).toHaveLength(1);
 
     reg.stopHeartbeat();
+  });
+
+  it("recovers a transient initial registration failure on heartbeat", async () => {
+    vi.useFakeTimers();
+    const reg = new SandboxRegistry(baseConfig);
+
+    failNextFetch = true;
+    await expect(reg.register()).rejects.toThrow("simulated upstash failure");
+
+    reg.startHeartbeat(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
+    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
+    expect(store.get("server:sandbox-abc:registration")).toBeDefined();
+
+    reg.stopHeartbeat();
+  });
+
+  it("recovers after all registration keys expire", async () => {
+    const reg = new SandboxRegistry(baseConfig);
+    await reg.register();
+    store.clear();
+
+    await reg.refresh();
+
+    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
+    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
+    expect(store.get("server:sandbox-abc:registration")).toBeDefined();
   });
 
   it("does not overlap heartbeat refreshes when a tick is still in flight", async () => {
@@ -612,12 +646,17 @@ async function startFakeRedis(opts?: {
               store.get(key1) === value1 &&
               store.get(key2) === value2 &&
               store.get(generationKey) === generation;
-            if (owned) {
+            const unclaimed =
+              script.includes("not u and not s and not g") &&
+              !store.has(key1) &&
+              !store.has(key2) &&
+              !store.has(generationKey);
+            if (owned || unclaimed) {
               store.set(key1, value1);
               store.set(key2, value2);
               store.set(generationKey, generation);
             }
-            send(`:${owned ? 1 : 0}\r\n`);
+            send(`:${owned || unclaimed ? 1 : 0}\r\n`);
           } else {
             const owned = store.get(generationKey) === generation;
             if (owned) {
@@ -687,7 +726,9 @@ describe("SandboxRegistry (native TCP transport)", () => {
     await reg.register();
     fake.store.set("agent:char-tcp:server", "sandbox-successor");
 
-    await reg.refresh();
+    await expect(reg.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
 
     expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-successor");
     expect(fake.store.get("server:sandbox-tcp:url")).toBe(
@@ -707,7 +748,9 @@ describe("SandboxRegistry (native TCP transport)", () => {
     );
     expect(successorGeneration).not.toBe(staleGeneration);
 
-    await stale.refresh();
+    await expect(stale.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
     await stale.unregister();
 
     expect(fake.store.get("agent:char-tcp:server")).toBe("sandbox-tcp");

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -242,14 +242,20 @@ export class SandboxRegistry {
     ]);
   }
 
-  /** Renew only while both routing keys are still owned by this instance. */
+  /**
+   * Renew exact ownership, or recover only when the complete registration has
+   * expired. Mixed or foreign state belongs to another lifecycle generation
+   * and must never be overwritten by this instance.
+   */
   private async refreshOwnedKeys(): Promise<void> {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
-    await this.command([
+    const refreshed = await this.command([
       "EVAL",
       "-- refresh\nlocal u=redis.call('GET',KEYS[1]) local s=redis.call('GET',KEYS[2]) " +
         "local g=redis.call('GET',KEYS[3]) " +
-        "if u==ARGV[1] and s==ARGV[2] and g==ARGV[3] then " +
+        "local owned=u==ARGV[1] and s==ARGV[2] and g==ARGV[3] " +
+        "local unclaimed=not u and not s and not g " +
+        "if owned or unclaimed then " +
         "redis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[4]) " +
         "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[4]) " +
         "redis.call('SET',KEYS[3],ARGV[3],'EX',ARGV[4]) return 1 end return 0",
@@ -262,6 +268,16 @@ export class SandboxRegistry {
       this.generation,
       String(ttlSeconds),
     ]);
+    if (refreshed !== 1) {
+      throw new ElizaError(
+        "Sandbox registry heartbeat refused because the route is owned by another lifecycle generation",
+        {
+          code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+          context: { agentId, serverName },
+          severity: "ephemeral",
+        },
+      );
+    }
   }
 
   private async command(args: string[]): Promise<unknown> {


### PR DESCRIPTION
Fixes #24470.

## Summary

- lets a sandbox heartbeat atomically reclaim its route only when every authoritative registration key is absent
- preserves generation fencing: mixed, foreign, and successor-owned state is never overwritten
- surfaces lost ownership as typed `SANDBOX_REGISTRY_OWNERSHIP_LOST` so the caller can report and retry instead of silently remaining unroutable
- adds transient initial-registration and complete-TTL-expiry recovery coverage across the real registry boundary

This repairs the post-merge gap found while auditing #24675. That PR prevented stale heartbeats from overwriting a successor, but a failed initial registration or full Redis expiry could never recover.

## Verification

- Node 24.15.0 and Bun 1.3.14
- `bunx vitest run packages/shared/src/sandbox-registry.test.ts --config packages/shared/vitest.config.ts` - PASS: 28/28
- changed-file Biome - PASS
- `git diff --check` - PASS
- full shared lane: 2,255 passed; four unrelated baseline failures recorded during audit

<!-- evidence-head:5b88e36bb6e5525b790985e67412dd7b1403d4be -->

<!-- evidence-row:before-screenshots -->
N/A - Redis registry authority repair with no rendered visual surface.

<!-- evidence-row:after-screenshots -->
N/A - Redis registry authority repair with no rendered visual surface.

<!-- evidence-row:walkthrough-video -->
N/A - no user-interface flow changed.

<!-- evidence-row:backend-logs -->
N/A - no deployed backend was invoked; deterministic Redis REST and real TCP/RESP contract receipts are recorded in the domain-artifacts row.

<!-- evidence-row:frontend-logs -->
N/A - no frontend request, response, or state changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, provider, action, model dispatch, or agent response behavior changed.

<!-- evidence-row:domain-artifacts -->
<details>
<summary>Redis authority artifact</summary>

```text
Absent authoritative key trio: atomic claim succeeds and all route keys are restored.
Exact URL, agent, and generation: heartbeat renews the existing registration.
Mixed, foreign, or successor state: no key is overwritten and SANDBOX_REGISTRY_OWNERSHIP_LOST is raised.
```
</details>

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface changed.

<!-- ai-attribution: codex -->

