### PR TITLE
fix(agent): reject unsupported vision output requests

### DIFF
--- a/packages/agent/src/providers/media-provider.test.ts
+++ b/packages/agent/src/providers/media-provider.test.ts
@@ -615,6 +615,44 @@ describe("media vision provider input validation", () => {
     ]);
     expect(calls[1].body.max_tokens).toBe(128_000);
   });
+
+  it("rejects an explicit Anthropic output request above the model maximum before dispatch", async () => {
+    const calls: FetchCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push({
+          url: href,
+          init,
+          body:
+            typeof init?.body === "string"
+              ? (JSON.parse(init.body) as Record<string, unknown>)
+              : {},
+        });
+        return Response.json({ max_tokens: 128_000 });
+      }),
+    );
+    const provider = createVisionProvider(
+      {
+        mode: "own-key",
+        provider: "anthropic",
+        anthropic: { apiKey: "anthropic-key", model: "claude-opus-4-7" },
+      },
+      { cloudMediaDisabled: true },
+    );
+
+    await expect(
+      provider.analyze({ imageBase64: "AQID", maxTokens: 128_001 }),
+    ).resolves.toMatchObject({
+      success: false,
+      errorCode: "VISION_OUTPUT_BUDGET_UNSUPPORTED",
+      error: expect.stringMatching(/supports at most 128000 output tokens/),
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.anthropic.com/v1/models/claude-opus-4-7",
+    ]);
+  });
 });
 
 /**

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -13,7 +13,9 @@
  */
 
 import {
+  ElizaError,
   fetchRemoteMedia,
+  isElizaError,
   logger,
   nodeLookupFn,
   nodePinnedFetch,
@@ -53,10 +55,12 @@ async function withProviderErrorBoundary<T>(
   try {
     return await run();
   } catch (err) {
+    // error-policy:J1 provider boundary returns an explicit failed result.
     const message = err instanceof Error ? err.message : String(err);
     return {
       success: false,
       error: `[${providerName}] Network error: ${message}`,
+      ...(isElizaError(err) ? { errorCode: err.code } : {}),
     };
   }
 }
@@ -153,6 +157,7 @@ export interface MediaProviderResult<T> {
   success: boolean;
   data?: T;
   error?: string;
+  errorCode?: string;
 }
 
 export interface ImageGenerationResult {
@@ -1343,6 +1348,22 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
 
     return withProviderErrorBoundary(this.name, async () => {
       const modelMaxOutputTokens = await this.resolveModelMaxOutputTokens();
+      if (
+        options.maxTokens !== undefined &&
+        options.maxTokens > modelMaxOutputTokens
+      ) {
+        throw new ElizaError(
+          `Anthropic model ${this.model} supports at most ${modelMaxOutputTokens} output tokens`,
+          {
+            code: "VISION_OUTPUT_BUDGET_UNSUPPORTED",
+            context: {
+              model: this.model,
+              requestedMaxTokens: options.maxTokens,
+              supportedMaxTokens: modelMaxOutputTokens,
+            },
+          },
+        );
+      }
       const response = await fetchWithTimeout(
         "https://api.anthropic.com/v1/messages",
         {
@@ -1354,10 +1375,7 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
           },
           body: JSON.stringify({
             model: this.model,
-            max_tokens: Math.min(
-              options.maxTokens ?? modelMaxOutputTokens,
-              modelMaxOutputTokens,
-            ),
+            max_tokens: options.maxTokens ?? modelMaxOutputTokens,
             messages: [
               {
                 role: "user",


### PR DESCRIPTION
Fixes #24719

## Summary
- reject explicit Anthropic vision `maxTokens` requests above the model-authoritative maximum before message dispatch
- surface the failure with stable `VISION_OUTPUT_BUDGET_UNSUPPORTED` classification
- preserve accepted explicit requests and the model-authoritative default without clamping
- add a no-dispatch regression for the oversized request

## Verification
- `bunx vitest run packages/agent/src/providers/media-provider.test.ts` — 22 passed
- Biome on both changed files
- `git diff --check origin/develop...HEAD`
- package-wide typecheck attempted; blocked by the isolated dependency overlay across unrelated cloud/UI/wallet packages, with no changed-file diagnostic observed

Exact head: `a77c9b83739b5f3d5025fa5933b3c768ca0dd7d0`