### PR TITLE
fix(core): require distinctive address tokens

### DIFF
--- a/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
+++ b/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
@@ -1,6 +1,6 @@
 /**
- * Stage-1 prompt rendering: every channel and addressing state receives the
- * complete canonical instruction block, context catalog, and field docs.
+ * Stage-1 prompt rendering and structural addressing use complete canonical
+ * instructions while keeping generic name tokens ambient.
  */
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -14,7 +14,10 @@ import {
 } from "../runtime/builtin-field-evaluators";
 import { ContextRegistry } from "../runtime/context-registry";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
-import { runV5MessageRuntimeStage1 } from "../services/message";
+import {
+	runV5MessageRuntimeStage1,
+	textContainsAgentName,
+} from "../services/message";
 import { isUnaddressedTextGroupTurn } from "../services/message/stage1-prompt-tier";
 import type { ContextDefinition } from "../types/contexts";
 import type { Memory } from "../types/memory";
@@ -296,17 +299,29 @@ describe("Stage-1 complete prompt rendering", () => {
 		expect(systemContent).toContain("Sticky Notes -> NOTES");
 	});
 
-	it("a single TOKEN of a multi-word agent name counts as addressed (live 2026-08-22)", async () => {
-		// "nubilio whats the setting …" was classified ambient because only the
-		// full phrase "remilio nubilio" matched; any distinctive name token
-		// (>= 4 chars) must structurally address the agent.
-		const { systemContent } = await renderedSystemPrompt(
-			makeMessage({
-				channelType: String(ChannelType.GROUP),
-				text: "Agent whats the setting we use to make u always respond",
-			}),
+	it.each([
+		"agent whats the setting we use to make u always respond",
+		"test the build before release",
+	])("keeps generic multi-word-name tokens ambient: %s", (text) => {
+		const message = makeMessage({
+			channelType: String(ChannelType.GROUP),
+			text,
+		});
+		const addressed = textContainsAgentName(text, ["Test Agent"]);
+		expect(addressed).toBe(false);
+		expect(isUnaddressedTextGroupTurn(message, addressed)).toBe(true);
+	});
+
+	it("preserves full names, explicit aliases, and distinctive name tokens", () => {
+		expect(textContainsAgentName("Test Agent check this", ["Test Agent"])).toBe(
+			true,
 		);
-		expect(systemContent).toContain(FULL_TEMPLATE_MARKER);
+		expect(
+			textContainsAgentName("@test_agent check this", ["test_agent"]),
+		).toBe(true);
+		expect(
+			textContainsAgentName("nubilio whats the setting", ["remilio nubilio"]),
+		).toBe(true);
 	});
 
 	it("renders the full rule block when channel type is missing (fail-open)", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -470,7 +470,20 @@ function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function textContainsAgentName(
+const NON_DISTINCTIVE_AGENT_NAME_TOKENS = new Set([
+	"agent",
+	"assistant",
+	"bot",
+	"chatbot",
+	"demo",
+	"helper",
+	"system",
+	"test",
+]);
+
+/** Returns whether text names the agent through a complete configured alias or
+ * a distinctive token from a multi-word alias. */
+export function textContainsAgentName(
 	text: string | undefined,
 	names: Array<string | null | undefined>,
 ): boolean {
@@ -482,15 +495,22 @@ function textContainsAgentName(
 	// "remilio nubilio" answers to "nubilio …" (live 2026-08-22: the full-phrase
 	// match classified "nubilio whats the setting …" as ambient, arming the
 	// engagement gate on a message that literally opens with the agent's name).
-	// Tokens under 4 characters stay excluded — short fragments ("al", "bot")
-	// would match ordinary prose.
+	// Short fragments and generic role/test words stay excluded because length
+	// alone does not make "agent", "assistant", or "test" an identity signal.
+	// The complete configured name/username remains authoritative even when one
+	// of its component words is generic.
 	const candidates = new Set<string>();
 	for (const name of names) {
 		const candidate = name?.trim();
 		if (!candidate) continue;
 		candidates.add(candidate);
 		for (const token of candidate.split(/\s+/u)) {
-			if (token.length >= 4) candidates.add(token);
+			if (
+				token.length >= 4 &&
+				!NON_DISTINCTIVE_AGENT_NAME_TOKENS.has(token.toLowerCase())
+			) {
+				candidates.add(token);
+			}
 		}
 	}
 
@@ -8762,16 +8782,12 @@ export async function runV5MessageRuntimeStage1(args: {
 							message: args.message,
 						})
 				).catch((error) => {
-					// error-policy:J4 an unresolved addressee must not suppress a
-					// response, but the failed room lookup remains observable.
-					// (optional-call: fail-open diagnostics on partial runtimes.)
-					args.runtime.reportError?.(
-						"MessageService.resolveAddressees",
-						error,
-						{
-							roomId: args.message.roomId,
-						},
-					);
+					// error-policy:J7 addressee-resolution diagnostics must not kill
+					// the message loop or suppress a response, but the required runtime
+					// error stream still owns the failure.
+					args.runtime.reportError("MessageService.resolveAddressees", error, {
+						roomId: args.message.roomId,
+					});
 					return false;
 				})
 			: false;


### PR DESCRIPTION
Fixes #24723. Follow-up to #24663.

- Preserve complete configured agent names/usernames as authoritative aliases.
- Permit multi-word-name token addressing only for non-generic distinctive tokens; `agent`, `assistant`, `bot`, `chatbot`, `demo`, `helper`, `system`, and `test` no longer turn ambient prose into an explicit agent address solely by length.
- Add ambient group regressions for `agent whats...` and `test the build`, plus full-name, explicit-alias, and `nubilio` coverage.
- Use required `runtime.reportError` with J7 classification for fail-open addressee-resolution diagnostics.

Exact-head local verification:
- addressed-to + Stage-1 prompt/addressing suites: 42/42 passed
- core typecheck passed
- changed-file Biome and diff check passed
- hosted exact-head CI required before merge.