### PR TITLE
fix(ci): build core+shared dists before the deployed-renderer smoke

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -2610,6 +2610,14 @@ jobs:
       - name: Install Playwright Chromium
         run: .github/scripts/install-playwright-browsers.sh chromium
 
+      - name: Generate shared i18n assets
+        run: bun run --cwd packages/shared build:i18n
+
+      # cloud-live-origin.ts imports @elizaos/shared/dist/elizacloud; a fresh
+      # checkout has no dist, so build the same bundles app-live-e2e.yml does.
+      - name: Build @elizaos/core + @elizaos/shared browser bundles
+        run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+
       - name: Run deployed Personal identity, chat, and continuity trajectory
         id: deployed-browser
         working-directory: packages/app


### PR DESCRIPTION
@lalalune — third and hopefully last link in the renderer-verify chain (after your #24619 and my #24696). Run 32599975784 attempt 2:

```
Error: Cannot find module '.../packages/app/node_modules/@elizaos/shared/dist/elizacloud/index.js' imported from packages/app/test/cloud-live-origin.ts
Error: No tests found.
```

The verify job checks out exact released source and installs deps but never builds workspace dists; `cloud-live-origin.ts` (imported by `cloud-live.spec.ts`) needs `@elizaos/shared/dist/elizacloud`. Fix mirrors the exact build pair the working `app-live-e2e.yml` lane runs before the same spec (`build:i18n` + turbo build core+shared).

Everything upstream is green on that run: migrations, API worker (after one known group-c 500 flake rerun), Pages deploy + NDJSON authority, routing verify. This leg is the last thing between us and the first Certify mint under the new pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)