### PR TITLE
fix(ui): drain remote host revocation cleanup

### DIFF
--- a/packages/ui/src/api/remote-control-cloud-client.test.ts
+++ b/packages/ui/src/api/remote-control-cloud-client.test.ts
@@ -1,4 +1,5 @@
 /** Contract validation for owner-scoped remote host and pairing responses. */
+import { ElizaError } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -213,6 +214,83 @@ describe("RemoteControlCloudClient", () => {
     await expect(client.listSessions(HOST_ID)).rejects.toThrow(
       "different host",
     );
+  });
+
+  it("drains every host revocation cleanup page before resolving", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          id: HOST_ID,
+          status: "revoked",
+          cleanup: { sessions: 100, commands: 500, more: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          id: HOST_ID,
+          status: "revoked",
+          cleanup: { sessions: 2, commands: 7, more: false },
+        }),
+      );
+    const client = new RemoteControlCloudClient({
+      baseUrl: "https://cloud.example",
+      authToken: "token",
+      request,
+    });
+
+    await expect(client.revokeHost(HOST_ID)).resolves.toBeUndefined();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      `https://cloud.example/api/v1/remote/hosts/${HOST_ID}/revoke`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      `https://cloud.example/api/v1/remote/hosts/${HOST_ID}/revoke`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejects missing cleanup progress instead of finalizing locally", async () => {
+    const client = new RemoteControlCloudClient({
+      baseUrl: "https://cloud.example",
+      authToken: "token",
+      request: vi
+        .fn()
+        .mockResolvedValue(response({ id: HOST_ID, status: "revoked" })),
+    });
+
+    const failure = await client.revokeHost(HOST_ID).catch((cause) => cause);
+    expect(failure).toBeInstanceOf(ElizaError);
+    expect(failure).toMatchObject({
+      code: "REMOTE_HOST_CLEANUP_PROGRESS_INVALID",
+      context: { hostId: HOST_ID, reason: "malformed_response" },
+    });
+  });
+
+  it("rejects a non-progressing continuation instead of looping", async () => {
+    const request = vi.fn().mockResolvedValue(
+      response({
+        id: HOST_ID,
+        status: "revoked",
+        cleanup: { sessions: 0, commands: 0, more: true },
+      }),
+    );
+    const client = new RemoteControlCloudClient({
+      baseUrl: "https://cloud.example",
+      authToken: "token",
+      request,
+    });
+
+    const failure = await client.revokeHost(HOST_ID).catch((cause) => cause);
+    expect(failure).toBeInstanceOf(ElizaError);
+    expect(failure).toMatchObject({
+      code: "REMOTE_HOST_CLEANUP_PROGRESS_INVALID",
+      context: { hostId: HOST_ID, reason: "non_progressing_page" },
+    });
+    expect(request).toHaveBeenCalledTimes(1);
   });
 
   it("rejects relay envelopes that are malformed or bound to another command", async () => {

--- a/packages/ui/src/api/remote-control-cloud-client.ts
+++ b/packages/ui/src/api/remote-control-cloud-client.ts
@@ -3,6 +3,7 @@
  * command relay envelopes. It validates every untrusted Cloud response before
  * exposing it to Settings or the agent transport.
  */
+import { ElizaError } from "@elizaos/core";
 import type {
   EncryptedRemoteControlEnvelope,
   RemoteControllerPlatform,
@@ -425,12 +426,39 @@ export class RemoteControlCloudClient {
   }
 
   async revokeHost(hostId: string): Promise<void> {
-    await this.request(
-      `/api/v1/remote/hosts/${encodeURIComponent(hostId)}/revoke`,
-      {
+    const path = `/api/v1/remote/hosts/${encodeURIComponent(hostId)}/revoke`;
+    while (true) {
+      const data = await this.request<Record<string, unknown>>(path, {
         method: "POST",
-      },
-    );
+      });
+      const cleanup = record(data.cleanup);
+      if (
+        !cleanup ||
+        typeof cleanup.more !== "boolean" ||
+        !Number.isSafeInteger(cleanup.sessions) ||
+        (cleanup.sessions as number) < 0 ||
+        !Number.isSafeInteger(cleanup.commands) ||
+        (cleanup.commands as number) < 0
+      ) {
+        throw new ElizaError(
+          "Cloud response contains invalid host cleanup progress.",
+          {
+            code: "REMOTE_HOST_CLEANUP_PROGRESS_INVALID",
+            context: { hostId, reason: "malformed_response" },
+          },
+        );
+      }
+      if (!cleanup.more) return;
+      if (cleanup.sessions === 0 && cleanup.commands === 0) {
+        throw new ElizaError(
+          "Cloud host cleanup reported more work without making progress.",
+          {
+            code: "REMOTE_HOST_CLEANUP_PROGRESS_INVALID",
+            context: { hostId, reason: "non_progressing_page" },
+          },
+        );
+      }
+    }
   }
 
   async enqueueCommand(input: {


### PR DESCRIPTION
Fixes #24725.

Fix-forward for #24414. Remote host revocation is deliberately page-bounded in Cloud, but the owner client discarded `cleanup.more` and the settings flow could delete the local bearer/private state after only one page. This change follows the explicit continuation contract until Cloud reports complete, and fails visibly on malformed/missing progress so local finalization cannot run on fabricated success. No item/page cap abandons cleanup.

Attribution: preserves and repairs the secure remote runtime work authored by @NubsCarson in #24414.

Verification:
- `bun test packages/ui/src/api/remote-control-cloud-client.test.ts`: 9 pass, including two-page drain and malformed-progress rejection.
- Biome changed-file check: pass.
- Package typecheck attempted in isolated linked worktree; unavailable due unrelated missing workspace dependency resolution (`drizzle-orm`/plugin packages), with no changed-file diagnostics. Exact hosted CI required before merge.