### PR TITLE
fix(agent): preserve E2B initialization failures

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -720,11 +720,12 @@ describe("E2BRemoteCapabilityRouterService", () => {
       entry("/workspace/README.md", "README.md", FILE_ENTRY),
     ]);
     let attempts = 0;
+    const transientError = new Error("transient sandbox provisioning failure");
     const factory: E2BSandboxFactory = {
       create: async () => {
         attempts += 1;
         if (attempts === 1) {
-          throw new Error("transient sandbox provisioning failure");
+          throw transientError;
         }
         return sandbox;
       },
@@ -735,9 +736,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
       factory,
     );
 
-    await expect(service.fs.list({})).rejects.toThrow(
-      "transient sandbox provisioning failure",
-    );
+    await expect(service.fs.list({})).rejects.toBe(transientError);
 
     const result = await service.fs.list({});
     expect(result.entries.map((item) => item.name)).toEqual(["README.md"]);
@@ -751,13 +750,14 @@ describe("E2BRemoteCapabilityRouterService", () => {
     const factory = new FakeFactory(sandbox);
     const runCommand = sandbox.commands.run.bind(sandbox.commands);
     let preparationAttempts = 0;
+    const transientError = new Error("transient workspace preparation failure");
     vi.spyOn(sandbox.commands, "run").mockImplementation(async (cmd, opts) => {
       const result = await runCommand(cmd, opts);
       if (cmd.startsWith("mkdir ")) {
         preparationAttempts += 1;
         if (preparationAttempts === 1) {
           // Model a lost response after mkdir has already mutated the workspace.
-          throw new Error("transient workspace preparation failure");
+          throw transientError;
         }
       }
       return result;
@@ -768,9 +768,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
       factory,
     );
 
-    await expect(service.fs.list({})).rejects.toThrow(
-      "transient workspace preparation failure",
-    );
+    await expect(service.fs.list({})).rejects.toBe(transientError);
     expect(factory.configs).toHaveLength(1);
     expect(preparationAttempts).toBe(1);
     expect(sandbox.files.listCalls).toHaveLength(0);

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -945,28 +945,24 @@ export class E2BRemoteCapabilityRouterService
    */
   private async getSandbox(): Promise<E2BSandboxClient> {
     if (!this.sandboxPromise) {
-      const pending: Promise<E2BSandboxClient> = this.factory
-        .create(this.routerConfig)
-        .catch((error: unknown) => {
-          // error-policy:J2 clears the memoized attempt and rethrows the original create/prepare failure unchanged.
-          if (this.sandboxPromise === pending) this.sandboxPromise = null;
-          throw error;
-        });
+      const pending = this.factory.create(this.routerConfig);
       this.sandboxPromise = pending;
+      // error-policy:J5 every caller observes this rejection by awaiting `pending`; this sidecar only evicts the failed cache entry.
+      void pending.then(undefined, () => {
+        if (this.sandboxPromise === pending) this.sandboxPromise = null;
+      });
       this.createdSandbox = !this.routerConfig.sandboxId;
     }
     const sandbox = await this.sandboxPromise;
     if (!this.preparePromise) {
-      const pendingPrepare: Promise<void> = this.prepareSandbox(sandbox).catch(
-        (error: unknown) => {
-          // error-policy:J2 clears the memoized attempt and rethrows the original create/prepare failure unchanged.
-          if (this.preparePromise === pendingPrepare) {
-            this.preparePromise = null;
-          }
-          throw error;
-        },
-      );
+      const pendingPrepare = this.prepareSandbox(sandbox);
       this.preparePromise = pendingPrepare;
+      // error-policy:J5 every caller observes this rejection by awaiting `pendingPrepare`; this sidecar only evicts the failed cache entry.
+      void pendingPrepare.then(undefined, () => {
+        if (this.preparePromise === pendingPrepare) {
+          this.preparePromise = null;
+        }
+      });
     }
     await this.preparePromise;
     return sandbox;


### PR DESCRIPTION
## Summary

Follow-up to merged #24678. The retry behavior is already correct; this preserves the exact rejected promise/error while classifying the cache-eviction observers under the repository's J5 policy instead of falsely labeling unchanged rethrows as J2 context-wrapping.

- observes create/prepare rejection in a sidecar handler that only evicts the matching failed cache entry
- leaves every caller awaiting the original promise, so rejection identity is preserved
- adds identity assertions for both transient create and transient prepare failures

Fixes #24052.

## Verification

- `e2b-capability-router.test.ts`: 54/54 passed
- Biome: 2 changed files clean
- `git diff --check`: passed

No UI, provider, live-model, or deployment evidence applies to this error-policy and regression-test follow-up.
