### PR TITLE
fix(cloud): recover orphaned committed group delivery leases after a lost token

### DIFF
--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.integration.test.ts
@@ -66,12 +66,14 @@ beforeAll(async () => {
     new URL("../migrations/0297_personal_shared_group_bindings.sql", import.meta.url),
   ).text();
   await database.exec(migration);
+  // Repair: these migrations were renumbered to 0303/0304 when #24356 landed,
+  // but the references below were left stale, breaking this entire test file.
   const authorityMigration = await Bun.file(
-    new URL("../migrations/0300_personal_shared_group_authority_version.sql", import.meta.url),
+    new URL("../migrations/0303_personal_shared_group_authority_version.sql", import.meta.url),
   ).text();
   await database.exec(authorityMigration);
   const leaseMigration = await Bun.file(
-    new URL("../migrations/0301_personal_shared_group_delivery_lease.sql", import.meta.url),
+    new URL("../migrations/0304_personal_shared_group_delivery_lease.sql", import.meta.url),
   ).text();
   await database.exec(leaseMigration);
 });
@@ -659,4 +661,100 @@ describe("personalSharedGroupsRepository", () => {
       }),
     ).resolves.toEqual({ recorded: true, inserted: 1 });
   });
+
+  test("recovers a group whose committed lease was orphaned with its lost token", async () => {
+    await issue({
+      codeHash: "claim-orphan-initial",
+      organizationId: ORG_A,
+      ownerUserId: USER_A,
+      personalAgentId: "personal:owner-a",
+      platformUserId: "+155****0001",
+    });
+    const initial = await consume("claim-orphan-initial", "+155****0001");
+    if (initial.status !== "bound") throw new Error("expected initial binding");
+    const delivery = {
+      authority: {
+        bindingId: initial.binding.id,
+        ownerUserId: USER_A,
+        personalAgentId: "personal:owner-a",
+        version: initial.binding.authority_version,
+      },
+      platform: "blooio" as const,
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      providerChatId: CHAT_ID,
+      invocation: "mention" as const,
+      sourceMessageId: "incoming-orphaned-commit",
+      leaseToken: "71000000-0000-4000-8000-0000000000a1",
+    };
+    expect(await repository.authorizeDelivery(delivery)).toMatchObject({ authorized: true });
+    expect(await repository.commitDelivery(delivery)).toBe(true);
+
+    // At this point the sending process dies before persisting any receipt.
+    // Nothing can ever present this exact leaseToken again, so no
+    // recordDeliveryReceipts call can clear the committed lease below.
+
+    // Fresh deliveries stay fenced while the orphaned commit is recent — the
+    // provider send may still be in flight and must not be duplicated.
+    const fresh = {
+      authority: { ...delivery.authority },
+      platform: "blooio" as const,
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      providerChatId: CHAT_ID,
+      invocation: "mention" as const,
+      sourceMessageId: "incoming-too-soon",
+      leaseToken: "71000000-0000-4000-8000-0000000000a2",
+    };
+    expect(await repository.authorizeDelivery(fresh)).toMatchObject({ authorized: false });
+
+    // Past the recovery horizon (COMMITTED_LEASE_RECOVERY_MS = 600s) the slot
+    // frees up without knowing the token; age it 60s beyond for determinism.
+    await getPgliteClientForTests().exec(`
+      UPDATE personal_shared_group_bindings
+      SET delivery_lease_committed_at = now() - interval '660 seconds'
+      WHERE id = '${initial.binding.id}';
+    `);
+    expect(await repository.authorizeDelivery(fresh)).toMatchObject({
+      authorized: true,
+      leaseToken: fresh.leaseToken,
+    });
+    const recovered = await repository.resolveBinding({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      providerChatId: CHAT_ID,
+    });
+    if (!recovered) throw new Error("expected recovered binding");
+    // The takeover must not inherit the orphaned lease's committed marker...
+    expect(recovered.delivery_lease_committed_at).toBeNull();
+    expect(recovered.delivery_lease_source_id).toBe(fresh.sourceMessageId);
+    // ...and the new reservation commits and reconciles normally end-to-end.
+    expect(await repository.commitDelivery(fresh)).toBe(true);
+    expect(
+      await repository.recordDeliveryReceipts({
+        ...fresh,
+        providerMessageIds: ["outgoing-recovered"],
+      }),
+    ).toEqual({ recorded: true, inserted: 1 });
+    const settled = await repository.resolveBinding({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      providerChatId: CHAT_ID,
+    });
+    expect(settled?.delivery_lease_source_id).toBeNull();
+    expect(settled?.delivery_lease_token).toBeNull();
+    expect(settled?.delivery_lease_expires_at).toBeNull();
+    expect(settled?.delivery_lease_committed_at).toBeNull();
+
+    // The late receipt of the original orphaned send can no longer hijack or
+    // clear anything: its token was overwritten by the recovered delivery.
+    expect(
+      await repository.recordDeliveryReceipts({
+        ...delivery,
+        providerMessageIds: ["outgoing-late-orphan"],
+      }),
+    ).toEqual({ recorded: false, inserted: 0 });
+  }, 10_000);
 });

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -53,6 +53,17 @@ export interface PersonalSharedGroupDeliveryLease {
 const DELIVERY_LEASE_MS = 90_000;
 const DELIVERY_LEASE_POLL_MS = 25;
 const AUTHORITY_MUTATION_WAIT_MS = 5_000;
+/**
+ * Recovery horizon for an orphaned committed lease. A committed lease whose
+ * exact leaseToken was lost (process crash, pod kill, or deploy between the
+ * delivery_commit response and receipt persistence) can never be cleared by
+ * its owner, so beyond this horizon the sending process is assumed dead — no
+ * legitimate provider send stays in flight this long — and the delivery slot
+ * recovers automatically instead of silencing the group until manual DB
+ * surgery. Far exceeding DELIVERY_LEASE_MS, which already treats workers as
+ * gone after 90s of an uncommitted reservation.
+ */
+const COMMITTED_LEASE_RECOVERY_MS = 10 * 60_000;
 
 export class PersonalSharedGroupDeliveryPendingError extends ElizaError {
   constructor() {
@@ -69,6 +80,14 @@ function deliveryLeaseAvailable(now: Date) {
     and(
       isNull(personalSharedGroupBindings.delivery_lease_committed_at),
       lte(personalSharedGroupBindings.delivery_lease_expires_at, now),
+    ),
+    // An orphaned committed lease — the exact leaseToken was lost to a crash,
+    // pod kill, or deploy before its receipt was persisted — can never be
+    // cleared by its owner. Past the recovery horizon the sending process is
+    // assumed dead and the slot recovers instead of silencing the group.
+    lte(
+      personalSharedGroupBindings.delivery_lease_committed_at,
+      new Date(now.getTime() - COMMITTED_LEASE_RECOVERY_MS),
     ),
   );
 }
@@ -467,6 +486,12 @@ export const personalSharedGroupsRepository = {
         delivery_lease_source_id: input.sourceMessageId,
         delivery_lease_token: input.leaseToken,
         delivery_lease_expires_at: new Date(now.getTime() + DELIVERY_LEASE_MS),
+        // A recovered slot may still carry the orphaned lease's committed
+        // marker; clear it unless this exact pair is already the committed
+        // authorization being re-authorized.
+        delivery_lease_committed_at: sql`CASE WHEN ${personalSharedGroupBindings.delivery_lease_source_id} = ${input.sourceMessageId}
+          AND ${personalSharedGroupBindings.delivery_lease_token} = ${input.leaseToken}
+          THEN ${personalSharedGroupBindings.delivery_lease_committed_at} ELSE NULL END`,
       })
       .where(
         and(
@@ -522,7 +547,9 @@ export const personalSharedGroupsRepository = {
    * Commits the exact reserved delivery immediately before provider egress.
    * Once committed, the source/token pair is the immutable authorization
    * point. Authority may change afterward, but another delivery cannot take
-   * over this slot until its exact provider receipt is reconciled.
+   * over this slot until its exact provider receipt is reconciled — or until
+   * the committed lease is orphaned past COMMITTED_LEASE_RECOVERY_MS, because
+   * a lost token could otherwise never be reconciled at all.
    */
   async commitDelivery(input: {
     authority: PersonalSharedGroupDeliveryAuthority;


### PR DESCRIPTION
## Summary

Fixes #24557.

A committed delivery lease whose `leaseToken` was lost to a crash, pod kill,
or deploy between the `delivery_commit` response and receipt persistence
could never be cleared:

- `deliveryLeaseAvailable` required `delivery_lease_committed_at IS NULL`, so
  committed leases never expired (`personal-shared-groups.ts`);
- the only clearing path is `recordDeliveryReceipts` with the exact
  in-memory `leaseToken` — a `crypto.randomUUID()` that died with the sending
  process;
- authority mutations do not clear leases and owner rebind deliberately
  preserves committed lease columns, so revoke + re-link did not recover.

Every future `authorizeDelivery` returned `authorized: false` forever and the
Personal Shared group went permanently silent pending manual DB surgery.

### What changed

- Add `COMMITTED_LEASE_RECOVERY_MS` (10 minutes). Past that horizon the
  sending process is assumed dead — no legitimate provider send stays in
  flight that long, and the uncommitted path already gives up at 90s — so
  `deliveryLeaseAvailable` recovers the slot automatically.
- `authorizeDelivery` clears the stale `delivery_lease_committed_at` marker
  when taking over a recovered slot (`CASE` on the exact source/token pair),
  so a new reservation never inherits an orphaned commit state while exact
  re-authorization of the live committed pair still preserves it.
- Repairs this test file's stale migration references (`0300`/`0301` ->
  `0303`/`0304`) left behind when #24356 renumbered them; every test in this
  file failed on current develop before this repair.

### Verification

- [Exact-head validation transcript](https://github.com/sharkwon/eliza/releases/download/pr-evidence-24557/validation-clean.log)
- repository integration suite `personal-shared-groups.integration.test.ts`: 9/9 pass, including the new end-to-end orphaned-lease recovery case (fresh deliveries stay fenced while the orphaned commit is recent; slot recovers past the horizon without knowing the token; recovered reservation does not inherit the committed marker; full authorize -> commit -> reconcile cycle settles cleanly; late orphan receipt cannot hijack)
- consumer route suite `internal/eliza-app/personal-shared/messages/route.test.ts`: 51 pass
- gateway-webhook `webhook-handler.e2e.test.ts`: 34 pass
- `bun run --cwd packages/cloud/shared typecheck`: clean
- Biome on both changed files: clean
- `git diff --check`: clean

<!-- evidence-head:aee75c4b71125d1ca2b7274292b72a0ba035c381 -->

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is database lease recovery semantics.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; the changed surface is database lease recovery semantics.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow change; pure recovery-path repair verified by integration tests.
<!-- evidence-row:backend-logs -->
- [x] https://github.com/sharkwon/eliza/releases/download/pr-evidence-24557/validation-clean.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic database logic; no LLM execution involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; repository integration coverage proves the behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or scanned artifacts in this change.

## Attribution

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2

<!-- attribution-row:models -->
z.ai/glm-5.2

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
self-reported
