### PR TITLE
fix(cloud): backpressure pinned Node response streams

### DIFF
--- a/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
@@ -25,6 +25,8 @@ const { resolveSafeOutboundTarget } = await import("./outbound-url");
 
 type FakeIncomingMessage = IncomingMessage & {
   destroy: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
 };
 
 type FakeClientRequest = ClientRequest & {
@@ -35,12 +37,48 @@ type FakeClientRequest = ClientRequest & {
 function createFakeIncomingMessage(
   overrides: Partial<Pick<IncomingMessage, "headers" | "statusCode" | "statusMessage">> = {},
 ): FakeIncomingMessage {
-  return Object.assign(new EventEmitter(), {
+  const message = Object.assign(new EventEmitter(), {
     destroy: vi.fn(),
     headers: overrides.headers ?? {},
+    pause: vi.fn(),
+    resume: vi.fn(),
     statusCode: overrides.statusCode ?? 200,
     statusMessage: overrides.statusMessage ?? "OK",
   }) as FakeIncomingMessage;
+  message.pause.mockImplementation(() => message);
+  message.resume.mockImplementation(() => message);
+  return message;
+}
+
+function createBurstingIncomingMessage(totalChunks: number, chunkSize: number) {
+  const res = createFakeIncomingMessage();
+  let emittedChunks = 0;
+  let paused = false;
+  const pump = () => {
+    while (!paused && emittedChunks < totalChunks) {
+      emittedChunks += 1;
+      res.emit("data", Buffer.alloc(chunkSize));
+    }
+    if (!paused && emittedChunks === totalChunks) {
+      res.emit("end");
+    }
+  };
+  res.pause.mockImplementation(() => {
+    paused = true;
+    return res;
+  });
+  res.resume.mockImplementation(() => {
+    paused = false;
+    pump();
+    return res;
+  });
+  return {
+    res,
+    pump,
+    get emittedChunks() {
+      return emittedChunks;
+    },
+  };
 }
 
 function createFakeClientRequest(onEnd?: (req: FakeClientRequest) => void): FakeClientRequest {
@@ -267,6 +305,99 @@ describe("safeFetch fail-closed", () => {
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("hello world");
     expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("pauses a fast Node response when the web stream queue is full", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const chunkSize = 20 * 1024;
+    const totalChunks = 100;
+    let upstream!: ReturnType<typeof createBurstingIncomingMessage>;
+    requestMock.mockImplementation((_options, onResponse) => {
+      const req = createFakeClientRequest(() => {
+        upstream = createBurstingIncomingMessage(totalChunks, chunkSize);
+        onResponse(upstream.res);
+        // A real IncomingMessage begins flowing when a data listener is added.
+        // Drive that transition explicitly so this fixture also fails against
+        // an adapter that never pauses its push source.
+        upstream.pump();
+      });
+      return req;
+    });
+
+    const response = await safeFetch("http://example.com/fast-stream");
+    await Promise.resolve();
+
+    expect(upstream.emittedChunks * chunkSize).toBeLessThanOrEqual(64 * 1024 + chunkSize);
+    expect(upstream.emittedChunks).toBeLessThan(totalChunks);
+    expect(upstream.res.pause).toHaveBeenCalled();
+    expect(upstream.res.resume).toHaveBeenCalledTimes(1);
+    await response.body?.cancel();
+    expect(upstream.res.destroy).toHaveBeenCalledTimes(1);
+    upstream.res.emit("close");
+    expect(upstream.res.listenerCount("error")).toBe(0);
+    expect(upstream.res.listenerCount("close")).toBe(0);
+  });
+
+  test("lets an unconsumed small Node response finish within the bounded queue", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    let upstream!: ReturnType<typeof createBurstingIncomingMessage>;
+    requestMock.mockImplementation((_options, onResponse) => {
+      const req = createFakeClientRequest(() => {
+        upstream = createBurstingIncomingMessage(2, 16 * 1024);
+        onResponse(upstream.res);
+        upstream.pump();
+      });
+      return req;
+    });
+
+    const response = await safeFetch("http://example.com/status-only");
+    await Promise.resolve();
+
+    expect(upstream.emittedChunks).toBe(2);
+    expect(upstream.res.listenerCount("data")).toBe(0);
+    expect(upstream.res.destroy).not.toHaveBeenCalled();
+    await response.body?.cancel();
+  });
+
+  test("errors a pinned response that closes before the body ends", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    let responseMessage: FakeIncomingMessage | null = null;
+    requestMock.mockImplementation((_options, onResponse) => {
+      const req = createFakeClientRequest(() => {
+        responseMessage = createFakeIncomingMessage();
+        onResponse(responseMessage);
+      });
+      return req;
+    });
+
+    const response = await safeFetch("http://example.com/premature-close");
+    const pendingRead = response.body?.getReader().read();
+    responseMessage?.emit("close");
+
+    await expect(pendingRead).rejects.toThrow("closed before its body completed");
+    expect(responseMessage?.listenerCount("data")).toBe(0);
+    expect(responseMessage?.listenerCount("close")).toBe(0);
+  });
+
+  test("destroys a backpressured redirect body before rejecting redirects", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    let responseMessage: FakeIncomingMessage | null = null;
+    requestMock.mockImplementation((_options, onResponse) => {
+      const req = createFakeClientRequest(() => {
+        responseMessage = createFakeIncomingMessage({
+          headers: { location: "http://redirect.example/next" },
+          statusCode: 302,
+          statusMessage: "Found",
+        });
+        onResponse(responseMessage);
+      });
+      return req;
+    });
+
+    await expect(safeFetch("http://example.com/redirect", { redirect: "error" })).rejects.toThrow(
+      "redirects are not allowed",
+    );
+    expect(responseMessage?.destroy).toHaveBeenCalledTimes(1);
   });
 
   test("writes ReadableStream request bodies to pinned Node requests", async () => {

--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -10,6 +10,9 @@ import { isForbiddenIpAddress, normalizeHostname, resolveSafeOutboundTarget } fr
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const DEFAULT_MAX_REDIRECTS = 5;
+// Preserve eager completion for ordinary status-only responses while bounding
+// an unread Node body to this queue plus at most one transport chunk.
+const NODE_RESPONSE_QUEUE_HIGH_WATER_MARK_BYTES = 64 * 1024;
 
 type LookupCallback = (
   err: NodeJS.ErrnoException | null,
@@ -140,32 +143,74 @@ function toUint8ArrayChunk(chunk: unknown): Uint8Array {
 }
 
 function nodeResponseBodyStream(res: IncomingMessage): ReadableStream<Uint8Array> {
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      const cleanup = () => {
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  let settled = false;
+
+  const cleanup = () => {
+    res.off("data", onData);
+    res.off("end", onEnd);
+    res.off("error", onError);
+    res.off("close", onClose);
+  };
+  const onData = (chunk: unknown) => {
+    if (settled) return;
+    controller.enqueue(toUint8ArrayChunk(chunk));
+    if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+      res.pause();
+    }
+  };
+  const onEnd = () => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    controller.close();
+  };
+  const onError = (error: Error) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    controller.error(error);
+  };
+  const onClose = () => {
+    if (settled) {
+      cleanup();
+      return;
+    }
+    settled = true;
+    cleanup();
+    controller.error(new Error("Pinned response closed before its body completed"));
+  };
+
+  // Adding a `data` listener normally switches an IncomingMessage into flowing
+  // mode. Pause first so the WHATWG stream owns the bounded producer demand.
+  res.pause();
+  return new ReadableStream<Uint8Array>(
+    {
+      start(nextController) {
+        controller = nextController;
+        res.on("data", onData);
+        res.on("end", onEnd);
+        res.on("error", onError);
+        res.on("close", onClose);
+      },
+      pull() {
+        if (!settled) res.resume();
+      },
+      cancel() {
+        if (settled) return;
+        settled = true;
+        // Keep terminal listeners until destroy emits close so any already
+        // scheduled Node error remains handled. onClose performs final cleanup.
         res.off("data", onData);
         res.off("end", onEnd);
-        res.off("error", onError);
-      };
-      const onData = (chunk: unknown) => {
-        controller.enqueue(toUint8ArrayChunk(chunk));
-      };
-      const onEnd = () => {
-        cleanup();
-        controller.close();
-      };
-      const onError = (error: Error) => {
-        cleanup();
-        controller.error(error);
-      };
-      res.on("data", onData);
-      res.on("end", onEnd);
-      res.on("error", onError);
+        res.destroy();
+      },
     },
-    cancel() {
-      res.destroy();
+    {
+      highWaterMark: NODE_RESPONSE_QUEUE_HIGH_WATER_MARK_BYTES,
+      size: (chunk) => chunk.byteLength,
     },
-  });
+  );
 }
 
 async function writeRequestBody(
@@ -285,6 +330,14 @@ export async function safeFetch(rawUrl: string, init: RequestInit = {}): Promise
       return response;
     }
 
+    // A redirect response is never returned to the caller. Dispose it before
+    // every follow/error path so the backpressured Node bridge cannot strand a
+    // paused socket while this request moves on or rejects.
+    await response.body?.cancel().catch(() => {
+      // error-policy:J6 Redirect handling is already authoritative; disposal
+      // is best-effort teardown of the unused response connection.
+    });
+
     if (redirectMode === "error") {
       throw new Error(
         `Outbound request was redirected (${response.status}) but redirects are not allowed`,
@@ -299,9 +352,6 @@ export async function safeFetch(rawUrl: string, init: RequestInit = {}): Promise
     if (!location) {
       throw new Error("Redirect response missing Location header");
     }
-
-    // Free the socket before re-issuing the request.
-    await response.body?.cancel().catch(() => {});
 
     currentUrl = new URL(location, currentUrl).toString();
     currentInit = nextRedirectInit(currentInit, response.status);

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -6387,16 +6387,28 @@ export class ProvisioningJobService {
         body: rawBody,
         signal: AbortSignal.timeout(10_000),
       });
+      const responseOk = response.ok;
+      const responseStatus = response.status;
+      try {
+        await response.body?.cancel();
+      } catch (error) {
+        // error-policy:J6 The webhook status is already authoritative; response
+        // disposal is best-effort teardown of the pinned outbound connection.
+        logger.warn("[provisioning-jobs] Failed to release webhook response body", {
+          jobId: job.id,
+          error: jobErrorText(error),
+        });
+      }
 
       await jobsRepository.update(job.id, {
-        webhook_status: response.ok ? "delivered" : `failed_${response.status}`,
+        webhook_status: responseOk ? "delivered" : `failed_${responseStatus}`,
       });
 
-      if (!response.ok) {
+      if (!responseOk) {
         logger.warn("[provisioning-jobs] Webhook delivery failed", {
           jobId: job.id,
           webhookUrl: safeWebhookUrl.toString(),
-          status: response.status,
+          status: responseStatus,
         });
       }
     } catch (err) {


### PR DESCRIPTION
# Relates to

Follow-up to merged PR [#23961](https://github.com/elizaOS/eliza/pull/23961) and the scoped public [follow-up claim](https://github.com/elizaOS/eliza/pull/23961#issuecomment-5382766164).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact
      unrelated baseline blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the
      deterministic backpressure, teardown, and compatibility evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop@237dfceaba7503f7c9d931378c8c843842eb5cda`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Medium.** This changes the Node/Bun response-stream bridge used by `safeFetch`: unread pinned responses now retain at most 64 KiB plus one transport chunk and pause their socket until consumed or canceled. A cancellation/terminal-event mistake could leak a listener or prematurely close a response. Workerd behavior is unchanged. The explicit daemon status-only webhook consumer now cancels after snapshotting status so large or persistent bodies cannot strand a paused socket.

# Background

## What does this PR do?

The Node `IncomingMessage` adapter added by #23961 attached a `data` listener and enqueued every pushed chunk without consulting WHATWG stream demand. A fast or unbounded peer could therefore fill process memory before the downstream 64 KiB payout cap had a chance to read and reject it.

This follow-up:

- pauses the Node response before attaching listeners and resumes only from the stream's `pull()`;
- uses a byte-aware 64 KiB queue high-water mark and pauses again when demand is exhausted;
- handles end, error, premature close, cancellation, and listener teardown explicitly;
- cancels every unused redirect body before following or rejecting;
- cancels the provisioning daemon's status-only webhook response after snapshotting `ok` and `status`;
- adds a flow-aware fast producer fixture proving the adapter stops the source instead of merely limiting a pull-based test stream.

## What kind of change is this?

Bug fix (non-breaking cloud transport hardening).

# Documentation changes needed?

No project documentation change is needed. This preserves the public `safeFetch` contract and hardens its internal Node stream adapter.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/security/safe-fetch.test.ts`, especially “pauses a fast Node response when the web stream queue is full”, then inspect `nodeResponseBodyStream` in `safe-fetch.ts`.

## Detailed testing steps

On exact head `70f2740f4c8d491d9685cfefb76389aea181d1fc`:

1. `bun install --frozen-lockfile`
2. `bunx vitest run packages/cloud/shared/src/lib/security/safe-fetch.test.ts`
   - 1 file, 24/24 tests passed.
3. `bun test packages/cloud/shared/src/lib/services/payout-alerts.test.ts`
   - 18/18 tests passed, 41 assertions.
4. `bunx biome check packages/cloud/shared/src/lib/security/safe-fetch.ts packages/cloud/shared/src/lib/security/safe-fetch.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs.ts`
   - clean.
5. `bunx tsc --ignoreConfig --noEmit --pretty false --target ES2022 --module ESNext --moduleResolution Bundler --lib ESNext,DOM --types node --skipLibCheck packages/cloud/shared/src/lib/security/safe-fetch.ts`
   - passed.
6. `git diff --check origin/develop...HEAD`
   - passed.
7. `bun run verify`
   - reached 210/214 successful tasks, then stopped only on the unchanged missing `@elizaos/plugin-doordash` module detailed below.

Mutation proof during test design: with the adapter's queue-full `pause()` neutralized, the fast push source emitted 1,638,400 bytes and the bounded-queue assertion failed against its 65,536-byte ceiling. Restoring `pause()` makes the exact flow-aware regression pass.

# Evidence Gate

<!-- evidence-head:70f2740f4c8d491d9685cfefb76389aea181d1fc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only TypeScript transport change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only TypeScript transport change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive or visual user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live external service was contacted; deterministic Node transport fixtures execute the exact adapter path without production cloud or webhook traffic.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, task, wallet, generated-file, or audio artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - the diff has no rendered visual surface or user-facing text.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic Node stream transport change; no LLM path is involved.

## Backend + frontend logs

Backend live logs: N/A - exercising an arbitrary real webhook would add external/prod traffic and is unnecessary for this deterministic transport seam. The exact adapter path is covered by the 24-test `safe-fetch` suite, including a push-driven producer, premature close, cancellation, redirect disposal, and small unconsumed response compatibility.

Frontend logs: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI or interactive flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice path changed.

## Known gaps / failures

- Exact-head `bun run verify` fails in the unchanged `packages/cloud/shared/src/lib/eliza/runtime/initializer.ts:14:32` with `TS2307: Cannot find module '@elizaos/plugin-doordash'`. That file and dependency metadata are absent from this diff. Turbo reports 210 successful / 214 total and terminates the in-flight UI build after the cloud-shared typecheck failure.
- Package-wide `bun run --cwd packages/cloud/shared typecheck` reaches the same unchanged missing-module error.
- Live backend logs, UI artifacts, LLM evidence, domain artifacts, OCR, and audio are N/A for the concrete reasons recorded above. No production Cloudflare, infrastructure, credential, billing, or webhook operation was performed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@4f4a78be4a97d9fd42d5b2342d7343c7cebcfeed:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [standujar/safe-fetch-node-backpressure-follow-up]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@4f4a78be4a97d9fd42d5b2342d7343c7cebcfeed:packages/skills/skills/contribute-to-eliza"} -->
