### PR TITLE
fix(agent): serialize registry cache invalidation

### DIFF
--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -115,6 +115,28 @@ describe("refreshRegistry", () => {
     expect(second).toBe(third);
   });
 
+  it("shares one refresh between concurrent refresh callers", async () => {
+    let releaseFetch: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    fetchImpl = async () => {
+      await fetchGate;
+      return PAYLOAD_A();
+    };
+    const { refreshRegistry } = await loadModule();
+
+    const first = refreshRegistry();
+    while (fetchCalls === 0) await sleep(1);
+    const second = refreshRegistry();
+    expect(fetchCalls).toBe(1);
+    releaseFetch?.();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(fetchCalls).toBe(1);
+    expect(firstResult).toBe(secondResult);
+  });
+
   it("still serves a fresh file cache without a network call", async () => {
     await fsp.mkdir(path.join(stateDir, "cache"), { recursive: true });
     await fsp.writeFile(
@@ -271,5 +293,47 @@ describe("refreshRegistry", () => {
     expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
       "plugin-b",
     ]);
+  });
+
+  it("does not let an older generation finish its cache write after refresh", async () => {
+    let signalWriteStarted: (() => void) | undefined;
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve;
+    });
+    let releaseWrite: (() => void) | undefined;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    const writeFile = fsp.writeFile.bind(fsp);
+    vi.spyOn(fsp, "writeFile").mockImplementationOnce(async (...args) => {
+      signalWriteStarted?.();
+      await writeGate;
+      return writeFile(...args);
+    });
+    const registry = await loadModule();
+
+    await registry.refreshRegistry();
+    await writeStarted;
+
+    fetchImpl = async () => PAYLOAD_B();
+    const refresh = registry.refreshRegistry();
+    await sleep(20);
+    expect(fetchCalls).toBe(1);
+
+    releaseWrite?.();
+    await refresh;
+
+    const cachePath = path.join(stateDir, "cache", "registry.json");
+    let cached = "";
+    while (!cached.includes("plugin-b")) {
+      cached = await fsp.readFile(cachePath, "utf8").catch(() => "");
+      await sleep(1);
+    }
+
+    const restarted = await loadModule();
+    expect([...(await restarted.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-b",
+    ]);
+    expect(fetchCalls).toBe(2);
   });
 });

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -80,6 +80,9 @@ let memoryCache: {
   ttlMs?: number;
 } | null = null;
 let registryLoadPromise: Promise<Map<string, RegistryPluginInfo>> | null = null;
+let registryFileWritePromise: Promise<void> | null = null;
+let registryRefreshPromise: Promise<Map<string, RegistryPluginInfo>> | null =
+  null;
 /**
  * Bumped every time the registry caches are invalidated. A load that started
  * before the bump carries a pre-invalidation snapshot, so it must not publish
@@ -161,6 +164,18 @@ async function writeFileCache(
     }),
     "utf-8",
   );
+}
+
+function persistFileCache(plugins: Map<string, RegistryPluginInfo>): void {
+  // error-policy:J6 The registry file is a derived cache; persistence failure
+  // is warned while the complete in-memory network snapshot remains usable.
+  const write = writeFileCache(plugins).catch((err) => {
+    logger.warn(`[registry-client] Cache write failed: ${String(err)}`);
+  });
+  registryFileWritePromise = write;
+  void write.then(() => {
+    if (registryFileWritePromise === write) registryFileWritePromise = null;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -312,9 +327,7 @@ async function loadRegistryPlugins(
       ttlMs: usedLocalFallback ? LOCAL_FALLBACK_CACHE_TTL_MS : CACHE_TTL_MS,
     };
     if (!usedLocalFallback) {
-      writeFileCache(plugins).catch((err) =>
-        logger.warn(`[registry-client] Cache write failed: ${String(err)}`),
-      );
+      persistFileCache(plugins);
     }
 
     return plugins;
@@ -357,6 +370,10 @@ function hasFilesystemErrorCode(error: unknown, code: string): boolean {
 }
 
 async function removeRegistryFileCache(): Promise<void> {
+  // A prior generation publishes memory before its best-effort file write
+  // finishes. Drain that write before unlinking so it cannot recreate stale
+  // disk state after this refresh has installed a newer snapshot.
+  if (registryFileWritePromise) await registryFileWritePromise;
   const filePath = cacheFilePath();
   try {
     await fs.unlink(filePath);
@@ -374,11 +391,19 @@ async function removeRegistryFileCache(): Promise<void> {
 export async function refreshRegistry(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  // Removal is useful persistent cleanup but is not required for correctness:
-  // the refresh explicitly bypasses the file tier even when unlink is denied.
-  await removeRegistryFileCache();
-  invalidateRegistryCaches();
-  return loadRegistryPlugins(true);
+  if (registryRefreshPromise) return registryRefreshPromise;
+
+  const refresh = (async () => {
+    // Removal is useful persistent cleanup but is not required for correctness:
+    // the refresh explicitly bypasses the file tier even when unlink is denied.
+    await removeRegistryFileCache();
+    invalidateRegistryCaches();
+    return loadRegistryPlugins(true);
+  })().finally(() => {
+    if (registryRefreshPromise === refresh) registryRefreshPromise = null;
+  });
+  registryRefreshPromise = refresh;
+  return refresh;
 }
 
 /** Look up a plugin by name (exact → @elizaos/ prefix → bare suffix). */


### PR DESCRIPTION
Fixes #24115.

## Summary

- serializes the derived registry cache write with refresh invalidation
- drains the pending write before unlinking stale disk state
- coalesces concurrent refresh callers onto one invalidation/load cycle
- prevents an older generation from overwriting `registry.json` after a newer refresh has already published

This repairs the restart race found while auditing merged #24118/#24673. Their in-memory generation fence is correct, but the fire-and-forget file write could still finish out of order and resurrect stale plugin metadata after restart.

## Verification

- Node 24.15.0 and Bun 1.3.14
- registry refresh suite - PASS: 11/11
- `bun run --cwd packages/agent build` - PASS
- changed-file Biome - PASS
- `git diff --check` - PASS

<!-- evidence-head:ae3c63952024d3c94418bd4efa9e56a039fcfe7d -->

<!-- evidence-row:before-screenshots -->
N/A - agent registry cache concurrency repair with no rendered visual surface.

<!-- evidence-row:after-screenshots -->
N/A - agent registry cache concurrency repair with no rendered visual surface.

<!-- evidence-row:walkthrough-video -->
N/A - no user-interface flow changed.

<!-- evidence-row:backend-logs -->
N/A - no deployed backend was invoked; deterministic restart and concurrent-refresh receipts are recorded as domain artifacts.

<!-- evidence-row:frontend-logs -->
N/A - no frontend request, response, or state changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, model dispatch, provider output, action result, or agent response changed.

<!-- evidence-row:domain-artifacts -->
<details>
<summary>Exact-head cache-generation artifact</summary>

```text
Delayed generation A write, refresh generation B, then release A: a simulated restart loads B, never stale A.
Two concurrent refresh callers share the same invalidation/load promise and publish one derived cache generation.
Focused registry refresh suite passed 11/11; agent package build and changed-file Biome also passed.
```
</details>

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface changed.

<!-- ai-attribution: codex -->
