### PR TITLE
fix(agent): validate refresh/default connector-account patches before provider callbacks

### DIFF
--- a/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
+++ b/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
@@ -17,7 +17,9 @@
  * These tests pin both bounded layers: route-walk failures and the stricter
  * connector-storage projection are rejected with a 400 before provider
  * callbacks run, an over-budget stored value is served with an explicit
- * marker, and honest nested metadata is untouched.
+ * marker, and honest nested metadata is untouched. The refresh/default
+ * routes build patches from stored rows rather than caller bodies, so their
+ * tests seed a budget-edge row through the validated POST path first.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
@@ -42,6 +44,8 @@ const OVERFLOW_DEPTH = 60_000;
 const STORAGE_OVERFLOW_DEPTH = 17;
 /** Wide enough to exceed core's storage-node budget but not the route budget. */
 const STORAGE_OVERFLOW_WIDTH = 2_100;
+/** Root + 1,023 key/value pairs = 2,047 storage nodes: one below core's cap. */
+const STORAGE_EDGE_KEYS = 1_023;
 
 function deepChain(depth: number): Record<string, unknown> {
   const root: Record<string, unknown> = {};
@@ -158,6 +162,84 @@ describe("connector account metadata walk bounds (real route handler)", () => {
     const { ctx, captured } = createContext(runtime, "PATCH", pathname, {
       metadata: wideObject(STORAGE_OVERFLOW_WIDTH),
     });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(patchAccount).not.toHaveBeenCalled();
+  });
+
+  it("rejects a budget-edge refresh patch before a provider patch side effect", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    // Seed through the validated POST path: a row whose stored metadata sits
+    // one node below core's durable-storage cap (root + 1,023 pairs).
+    const seed = createContext(
+      runtime,
+      "POST",
+      `/api/connectors/${PROVIDER}/accounts`,
+      {
+        label: "edge@example.com",
+        metadata: wideObject(STORAGE_EDGE_KEYS),
+      },
+    );
+    expect(await handleConnectorAccountRoutes(seed.ctx)).toBe(true);
+    expect(seed.captured.status).toBe(201);
+    const seededId = (seed.captured.body as { id: string }).id;
+
+    const patchAccount = vi.fn(
+      async (_accountId: string, patch: ConnectorAccountPatch) => patch,
+    );
+    manager.registerProvider({ provider: PROVIDER, patchAccount });
+    // lastSyncedAt adds one more key/value pair: the merged patch now exceeds
+    // the storage budget and must be rejected before patchAccount runs.
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${seededId}/refresh`;
+    const { ctx, captured } = createContext(runtime, "POST", pathname);
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(patchAccount).not.toHaveBeenCalled();
+  });
+
+  it("rejects a budget-edge default patch before a provider patch side effect", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    const seed = createContext(
+      runtime,
+      "POST",
+      `/api/connectors/${PROVIDER}/accounts`,
+      {
+        label: "edge@example.com",
+        metadata: wideObject(STORAGE_EDGE_KEYS),
+      },
+    );
+    expect(await handleConnectorAccountRoutes(seed.ctx)).toBe(true);
+    expect(seed.captured.status).toBe(201);
+    const seededId = (seed.captured.body as { id: string }).id;
+
+    const patchAccount = vi.fn(
+      async (_accountId: string, patch: ConnectorAccountPatch) => patch,
+    );
+    manager.registerProvider({ provider: PROVIDER, patchAccount });
+    // Setting isDefault on the seeded row adds one key/value pair past the
+    // storage budget; rejection must precede the provider callback.
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${seededId}/default`;
+    const { ctx, captured } = createContext(runtime, "POST", pathname);
 
     const handled = await handleConnectorAccountRoutes(ctx);
 

--- a/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
+++ b/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
@@ -253,6 +253,77 @@ describe("connector account metadata walk bounds (real route handler)", () => {
     expect(patchAccount).not.toHaveBeenCalled();
   });
 
+  it("rejects a two-account default plan before any effect: over-budget second account means zero provider callbacks and zero row writes", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    // Seed the over-budget target FIRST so it has the older updatedAt; the
+    // storage adapter lists accounts newest-updated-first, so the valid old
+    // default is visited by the mutation loop before the invalid target.
+    const targetSeed = createContext(
+      runtime,
+      "POST",
+      `/api/connectors/${PROVIDER}/accounts`,
+      {
+        label: "edge@example.com",
+        metadata: wideObject(STORAGE_EDGE_KEYS),
+      },
+    );
+    expect(await handleConnectorAccountRoutes(targetSeed.ctx)).toBe(true);
+    expect(targetSeed.captured.status).toBe(201);
+    const targetId = (targetSeed.captured.body as { id: string }).id;
+
+    const firstSeed = createContext(
+      runtime,
+      "POST",
+      `/api/connectors/${PROVIDER}/accounts`,
+      { label: "old-default@example.com", metadata: {} },
+    );
+    expect(await handleConnectorAccountRoutes(firstSeed.ctx)).toBe(true);
+    expect(firstSeed.captured.status).toBe(201);
+    const firstId = (firstSeed.captured.body as { id: string }).id;
+    // Make it the current default; the manager-level patch also bumps its
+    // updatedAt so it sorts ahead of the target in listAccounts.
+    await manager.patchAccount(PROVIDER, firstId, {
+      metadata: { isDefault: true },
+    });
+
+    // Ordering precondition: without this, the invalid target would be
+    // visited first and the test would pass without exercising the
+    // validate-early-then-flip-later ordering the maintainer asked about.
+    const preOrder = await manager.listAccounts(PROVIDER);
+    expect(preOrder[0]?.id).toBe(firstId);
+    expect(preOrder[1]?.id).toBe(targetId);
+
+    const patchAccount = vi.fn(
+      async (_accountId: string, patch: ConnectorAccountPatch) => patch,
+    );
+    manager.registerProvider({ provider: PROVIDER, patchAccount });
+
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${targetId}/default`;
+    const { ctx, captured } = createContext(runtime, "POST", pathname);
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    // The structured 400 is the whole outcome: the plan (flip the old default
+    // off, flip the new one on) must be validated before the first provider
+    // callback or row write, so a later-account rejection leaves the earlier
+    // account untouched.
+    expect(handled).toBe(true);
+    expect(captured).toEqual({
+      status: 400,
+      body: {
+        error: "Connector account metadata exceeds the bounded walk budget",
+      },
+    });
+    expect(patchAccount).not.toHaveBeenCalled();
+    const rows = await manager.listAccounts(PROVIDER);
+    const firstRow = rows.find((row) => row.id === firstId);
+    const targetRow = rows.find((row) => row.id === targetId);
+    expect(firstRow?.metadata?.isDefault).toBe(true);
+    expect(targetRow?.metadata?.isDefault).toBeUndefined();
+  });
+
   it("rejects an over-deep POST body with a 400 instead of escaping the handler", async () => {
     const runtime = createRuntime(await newAdapter());
     const pathname = `/api/connectors/${PROVIDER}/accounts`;

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -902,12 +902,28 @@ export async function handleConnectorAccountRoutes(
       }
 
       if (action === "refresh") {
-        const refreshed = await manager.patchAccount(provider, accountId, {
-          metadata: {
-            ...(account.metadata ?? {}),
-            lastSyncedAt: Date.now(),
-          },
-        });
+        let refreshPatch: ConnectorAccountPatch;
+        try {
+          // error-policy:J1 route boundary — the stored row may already sit at
+          // the durable-storage node budget; adding lastSyncedAt tips it over,
+          // and the rejection must land before any registered provider
+          // patchAccount callback fires. Every other error is rethrown.
+          refreshPatch = validatePatchMetadataForStorage({
+            metadata: {
+              ...(account.metadata ?? {}),
+              lastSyncedAt: Date.now(),
+            },
+          });
+        } catch (err) {
+          if (!isUnboundedMetadataGraph(err)) throw err;
+          error(res, UNBOUNDED_METADATA_MESSAGE, 400);
+          return true;
+        }
+        const refreshed = await manager.patchAccount(
+          provider,
+          accountId,
+          refreshPatch,
+        );
         json(res, {
           ok: true,
           provider,
@@ -932,12 +948,23 @@ export async function handleConnectorAccountRoutes(
         for (const item of accounts) {
           const isTarget = item.id === accountId;
           if (item.metadata?.isDefault === isTarget) continue;
-          await manager.patchAccount(provider, item.id, {
-            metadata: {
-              ...(item.metadata ?? {}),
-              isDefault: isTarget,
-            },
-          });
+          let defaultPatch: ConnectorAccountPatch;
+          try {
+            // error-policy:J1 route boundary — same pre-provider validation as
+            // refresh: a listed row near the storage budget must be rejected
+            // here, before its provider callback can run. Rethrow otherwise.
+            defaultPatch = validatePatchMetadataForStorage({
+              metadata: {
+                ...(item.metadata ?? {}),
+                isDefault: isTarget,
+              },
+            });
+          } catch (err) {
+            if (!isUnboundedMetadataGraph(err)) throw err;
+            error(res, UNBOUNDED_METADATA_MESSAGE, 400);
+            return true;
+          }
+          await manager.patchAccount(provider, item.id, defaultPatch);
         }
         const updatedAccounts = await manager.listAccounts(provider);
         const updatedAccount =

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -945,6 +945,14 @@ export async function handleConnectorAccountRoutes(
           return true;
         }
         const accounts = await manager.listAccounts(provider);
+        // Plan-then-execute: construct and validate EVERY affected account's
+        // patch before the first provider callback or row write. A later
+        // over-budget row must not 400 after earlier rows have already
+        // flipped — that would leave the provider's account set in a
+        // partially mutated, zero-or-two-default state. Provider/DB failures
+        // during execution still follow the manager's explicit partial-failure
+        // contract; only deterministic validation is hoisted here.
+        const plan: Array<{ id: string; patch: ConnectorAccountPatch }> = [];
         for (const item of accounts) {
           const isTarget = item.id === accountId;
           if (item.metadata?.isDefault === isTarget) continue;
@@ -952,7 +960,7 @@ export async function handleConnectorAccountRoutes(
           try {
             // error-policy:J1 route boundary — same pre-provider validation as
             // refresh: a listed row near the storage budget must be rejected
-            // here, before its provider callback can run. Rethrow otherwise.
+            // here, before ANY provider callback can run. Rethrow otherwise.
             defaultPatch = validatePatchMetadataForStorage({
               metadata: {
                 ...(item.metadata ?? {}),
@@ -964,7 +972,10 @@ export async function handleConnectorAccountRoutes(
             error(res, UNBOUNDED_METADATA_MESSAGE, 400);
             return true;
           }
-          await manager.patchAccount(provider, item.id, defaultPatch);
+          plan.push({ id: item.id, patch: defaultPatch });
+        }
+        for (const step of plan) {
+          await manager.patchAccount(provider, step.id, step.patch);
         }
         const updatedAccounts = await manager.listAccounts(provider);
         const updatedAccount =


### PR DESCRIPTION
## Summary

- Fixes #24710
- `POST /api/connectors/:provider/accounts/:id/refresh` and `POST /api/connectors/:provider/accounts/:id/default` built metadata patches from **stored rows** (`{ ...account.metadata, lastSyncedAt }` / `{ ...item.metadata, isDefault }`) and passed them straight to `manager.patchAccount` without the durable-storage validation that #24410 added to the POST/PATCH paths.
- Consequence pre-fix: a stored row one node below the connector-storage budget (2,048 nodes) tips over when the route merge adds its key. The registered provider `patchAccount` callback fired **before** the rejection (side-effect-before-reject), and the storage-layer throw then escaped `handleConnectorAccountRoutes` entirely — no `json()`/`error()` ran, so the client got no HTTP response.
- Fix: both constructed patches now go through `validatePatchMetadataForStorage` with the same `error-policy:J1` boundary shape as POST/PATCH — over-budget metadata becomes a clean `400` ("Connector account metadata exceeds the bounded walk budget") **before** any provider callback; every other error is rethrown. All four `manager.createAccount`/`manager.patchAccount` call sites in the route are now validated.

## Behavior matrix (executed at the branch head)

| Scenario | develop | this PR |
|---|---|---|
| refresh on budget-edge row (2,047 stored nodes + `lastSyncedAt` = 2,049 > 2,048) | provider callback runs, then throw escapes handler (no HTTP response) | `400` unbounded-metadata message, provider spy **not invoked** |
| default on budget-edge row (`isDefault` added) | same escape, mid-loop | `400` unbounded-metadata message, provider spy **not invoked** |
| refresh on a normal row | `ok: true`, `lastSyncedAt` written | identical (executed: response shape, `lastSyncedAt` number, prior metadata keys preserved) |
| default on normal rows | flags flipped, full payload | identical (executed vs develop control) |

Known pre-existing behavior (not changed by this PR, verified against develop): the default loop is not transactional — if a later row's patch is rejected, earlier rows already flipped stay flipped. Develop had the same partial-mutation window (the storage throw escaped mid-loop); this PR surfaces it as a structured 400 instead of an escaped error.

## Tests

Two new tests in `packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts` (real route handler + real core manager over `InMemoryDatabaseAdapter`, no system-under-test mocks):

- **rejects a budget-edge refresh patch before a provider patch side effect** — seeds a 1,023-key metadata row through the validated POST path (root + 1,023 keys + 1,023 values = 2,047 storage nodes, one below the cap), registers a provider `patchAccount` spy, calls refresh, asserts `400` + `patchAccount` NOT called.
- **rejects a budget-edge default patch before a provider patch side effect** — same seed; `isDefault` merge tips it to 2,049; asserts `400` + spy NOT called.

RED control: with only the route file stashed (tests kept), exactly these 2 tests fail and the other 8 pass; unstashed, all 10 pass.

Node arithmetic (independently recomputed by a second reviewer agent): seed = 1 + 1,023 + 1,023 = 2,047; merge adds key + value = 2,049 > 2,048.

## Verification

- `npx vitest run src/api/connector-account-routes.metadata-bounds.test.ts` — 10/10 pass (2 new)
- Sibling suites `connector-account-routes.test.ts` / `.durable.test.ts` / `.limit.test.ts` — 28/28 pass (38 total with the bounds suite, re-run after rebase)
- `bun run --cwd packages/agent typecheck` — 19 errors at head vs 19 at pristine-develop control, sorted error sets byte-identical (pre-existing unbuilt optional-plugin type imports; none introduced)
- `npx biome check` on both changed files — clean
- Branch rebased on latest `origin/develop` (8329afb4760) before final runs

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-UI change; no rendered surface is affected

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-UI change; no rendered surface is affected

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-UI change; the executed behavior matrix in the Summary is the behavioral equivalent

<!-- evidence-row:backend-logs -->
<details>
<summary>Backend logs: focused-suite + RED control + adversarial probes at head 67ee225c015</summary>

```
$ npx vitest run src/api/connector-account-routes.metadata-bounds.test.ts   # head 67ee225c015
 RUN  v4.1.10
 Test Files  1 passed (1)
      Tests  11 passed (11)   # incl. new two-account default-plan regression

RED control (mid-loop shape at parent 91746d3ecd0, before the fix): the two-account
regression FAILED with exactly 1 provider patchAccount call observed before the 400 —
the partial mutation the maintainer flagged.

Adversarial probes (bun, real route handler + real core manager over InMemoryDatabaseAdapter):
- three-account plan rejection (valid old default + neutral visited BEFORE invalid target):
  400, 0 provider calls, all three rows unchanged (old default still default)
- happy-path two-account default switch: 200, 2 provider callbacks, old flipped false, new flipped true
- provider callback throws mid-execution (plan already validated): error propagates
  (rethrow, no spurious 400) — execution-time partial-failure stays on the manager's
  explicit contract, per the blocker's own framing

$ npx vitest run src/api/connector-account-routes.test.ts src/api/connector-account-routes.durable.test.ts src/api/connector-account-routes.limit.test.ts
 Test Files  3 passed (3)
      Tests  28 passed (28)

typecheck: error set IDENTICAL to pristine develop control (19 pre-existing
environmental module-resolution errors in both head and control; zero new).
biome check on both changed files: clean.
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - non-UI change; no frontend console or network surface is involved

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - pure HTTP route validation change; no model path is involved, so no live-model trajectory exists

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain effect is the HTTP 400 + provider-not-invoked ordering asserted by the new real-handler tests above

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface is touched by this change

<!-- evidence-head:67ee225c015717f51da07d3597d464f113559b4b -->

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

