### PR TITLE
fix(agent): preserve vision budget rejection context

### DIFF
--- a/packages/agent/src/providers/media-provider.test.ts
+++ b/packages/agent/src/providers/media-provider.test.ts
@@ -647,11 +647,91 @@ describe("media vision provider input validation", () => {
     ).resolves.toMatchObject({
       success: false,
       errorCode: "VISION_OUTPUT_BUDGET_UNSUPPORTED",
-      error: expect.stringMatching(/supports at most 128000 output tokens/),
+      error: expect.stringMatching(
+        /Requested 128001 output tokens.*supports at most 128000/,
+      ),
+      errorContext: {
+        model: "claude-opus-4-7",
+        requestedMaxTokens: 128_001,
+        supportedMaxTokens: 128_000,
+      },
     });
     expect(calls.map((call) => call.url)).toEqual([
       "https://api.anthropic.com/v1/models/claude-opus-4-7",
     ]);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects malformed Anthropic output budget %s before any provider request",
+    async (maxTokens) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const provider = createVisionProvider(
+        {
+          mode: "own-key",
+          provider: "anthropic",
+          anthropic: { apiKey: "anthropic-key", model: "claude-opus-4-7" },
+        },
+        { cloudMediaDisabled: true },
+      );
+
+      await expect(
+        provider.analyze({ imageBase64: "AQID", maxTokens }),
+      ).resolves.toMatchObject({
+        success: false,
+        errorCode: "VISION_OUTPUT_BUDGET_INVALID",
+        error: expect.stringMatching(/must be a positive safe integer/),
+        errorContext: {
+          model: "claude-opus-4-7",
+          requestedMaxTokens: maxTokens,
+        },
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves an accepted explicit Anthropic output request", async () => {
+    const calls: FetchCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url);
+        calls.push({
+          url: href,
+          init,
+          body:
+            typeof init?.body === "string"
+              ? (JSON.parse(init.body) as Record<string, unknown>)
+              : {},
+        });
+        return href.includes("/v1/models/")
+          ? Response.json({ max_tokens: 128_000 })
+          : Response.json({
+              stop_reason: "end_turn",
+              content: [{ type: "text", text: "complete image" }],
+            });
+      }),
+    );
+    const provider = createVisionProvider(
+      {
+        mode: "own-key",
+        provider: "anthropic",
+        anthropic: { apiKey: "anthropic-key", model: "claude-opus-4-7" },
+      },
+      { cloudMediaDisabled: true },
+    );
+
+    await expect(
+      provider.analyze({ imageBase64: "AQID", maxTokens: 4096 }),
+    ).resolves.toMatchObject({
+      success: true,
+      data: { description: "complete image" },
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.anthropic.com/v1/models/claude-opus-4-7",
+      "https://api.anthropic.com/v1/messages",
+    ]);
+    expect(calls[1].body.max_tokens).toBe(4096);
   });
 });
 

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -57,10 +57,16 @@ async function withProviderErrorBoundary<T>(
   } catch (err) {
     // error-policy:J1 provider boundary returns an explicit failed result.
     const message = err instanceof Error ? err.message : String(err);
+    const structuredError = isElizaError(err) ? err : undefined;
     return {
       success: false,
-      error: `[${providerName}] Network error: ${message}`,
-      ...(isElizaError(err) ? { errorCode: err.code } : {}),
+      error: `[${providerName}] ${structuredError ? message : `Network error: ${message}`}`,
+      ...(structuredError
+        ? {
+            errorCode: structuredError.code,
+            errorContext: structuredError.context,
+          }
+        : {}),
     };
   }
 }
@@ -158,6 +164,7 @@ export interface MediaProviderResult<T> {
   data?: T;
   error?: string;
   errorCode?: string;
+  errorContext?: Record<string, unknown>;
 }
 
 export interface ImageGenerationResult {
@@ -1347,13 +1354,28 @@ export class AnthropicVisionProvider implements VisionAnalysisProvider {
         : { type: "url" as const, url: imageInput.value };
 
     return withProviderErrorBoundary(this.name, async () => {
+      if (
+        options.maxTokens !== undefined &&
+        (!Number.isSafeInteger(options.maxTokens) || options.maxTokens <= 0)
+      ) {
+        throw new ElizaError(
+          `Requested Anthropic output tokens must be a positive safe integer; received ${options.maxTokens}`,
+          {
+            code: "VISION_OUTPUT_BUDGET_INVALID",
+            context: {
+              model: this.model,
+              requestedMaxTokens: options.maxTokens,
+            },
+          },
+        );
+      }
       const modelMaxOutputTokens = await this.resolveModelMaxOutputTokens();
       if (
         options.maxTokens !== undefined &&
         options.maxTokens > modelMaxOutputTokens
       ) {
         throw new ElizaError(
-          `Anthropic model ${this.model} supports at most ${modelMaxOutputTokens} output tokens`,
+          `Requested ${options.maxTokens} output tokens for Anthropic model ${this.model}, which supports at most ${modelMaxOutputTokens}`,
           {
             code: "VISION_OUTPUT_BUDGET_UNSUPPORTED",
             context: {


### PR DESCRIPTION
Fixes #24719

## Summary

- validate explicit Anthropic vision `maxTokens` as a positive safe integer before any provider metadata or message request
- reject unsupported output budgets with `VISION_OUTPUT_BUDGET_UNSUPPORTED` while preserving requested/supported context
- distinguish typed policy rejection from network failure at the provider boundary
- preserve accepted explicit values and the model-authoritative default exactly

This is a narrow follow-up to #24722. That PR merged while review was still in progress and did not preserve the typed error context or reject malformed explicit budgets.

## Verification

- `bunx vitest run packages/agent/src/providers/media-provider.test.ts --config packages/agent/vitest.config.ts` — 28 passed
- `bun run --cwd packages/agent build` — passed
- Biome on both changed files — passed
- `git diff --check origin/develop...HEAD` — passed

<!-- evidence-head:95cf47dafddee872b5384d8315e64975cd9b3c26 -->
<!-- evidence-row: walkthrough=N/A - provider-boundary validation has no UI surface -->
<!-- evidence-row: backend-logs=Focused provider suite passed 28 of 28 tests, including five malformed-budget zero-fetch cases, structured typed rejection context, and accepted explicit 4096 forwarding. -->
<!-- evidence-row: frontend-console=N/A - no frontend code or browser path changes -->
<!-- evidence-row: frontend-network=N/A - no frontend code or browser path changes -->
<!-- evidence-row: llm-trajectory=N/A - invalid requests are rejected before model dispatch; accepted-value behavior is asserted at the provider messages boundary -->
<!-- evidence-row: screenshots=N/A - no visual surface changes -->
<!-- evidence-row: domain-artifacts=The focused test receipt proves requested and supported values survive the boundary and malformed values perform zero provider fetches. -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - provider-boundary validation has no interactive UI flow

<!-- evidence-row:backend-logs -->
- [ ] N/A - the invalid requests are rejected before provider network dispatch; focused tests prove zero provider fetches

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - malformed and unsupported budgets must reject before model dispatch; accepted exact forwarding is asserted at the provider messages boundary

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by a rejected provider request

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes
