### PR TITLE
fix(plugin-fish-audio): sanitize provider-controlled error text and centralize socket cleanup

### DIFF
--- a/plugins/plugin-fish-audio/AGENTS.md
+++ b/plugins/plugin-fish-audio/AGENTS.md
@@ -27,3 +27,6 @@ bun run --cwd plugins/plugin-fish-audio build
   Fish receives submitted text and the reference ID, so credentials and the
   feature flag alone must never authorize provider egress.
 - Keep live tests skipped unless a caller explicitly provides `FISH_AUDIO_API_KEY` and a consented `FISH_AUDIO_REFERENCE_ID`/`FISH_AUDIO_VOICE_ID`.
+- Classify authentication, rate limit, timeout, cancellation, transport,
+  malformed response, and provider failures explicitly so caller-owned retry
+  policy never retries permanent failures.

--- a/plugins/plugin-fish-audio/CLAUDE.md
+++ b/plugins/plugin-fish-audio/CLAUDE.md
@@ -27,3 +27,6 @@ bun run --cwd plugins/plugin-fish-audio build
   Fish receives submitted text and the reference ID, so credentials and the
   feature flag alone must never authorize provider egress.
 - Keep live tests skipped unless a caller explicitly provides `FISH_AUDIO_API_KEY` and a consented `FISH_AUDIO_REFERENCE_ID`/`FISH_AUDIO_VOICE_ID`.
+- Classify authentication, rate limit, timeout, cancellation, transport,
+  malformed response, and provider failures explicitly so caller-owned retry
+  policy never retries permanent failures.

--- a/plugins/plugin-fish-audio/__tests__/streaming.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/streaming.test.ts
@@ -66,9 +66,9 @@ class FakeFishSocket {
     }
   }
 
-  close(_code?: number, reason?: string): void {
+  close(code?: number, reason?: string): void {
     this.readyState = 3;
-    this.fire("close", { reason });
+    this.fire("close", { code, reason });
   }
 
   addEventListener(type: string, listener: (event: never) => void): void {
@@ -88,6 +88,10 @@ class FakeFishSocket {
     this.fire("message", { data: encode({ event: "finish", reason: "stop" }) });
   }
 
+  emitError(message: string, error: unknown): void {
+    this.fire("error", { message, error });
+  }
+
   private fire(type: string, event: unknown): void {
     for (const listener of this.listeners.get(type) ?? []) listener(event);
   }
@@ -100,6 +104,12 @@ function runtime(
     getSetting: (key: string) => settings[key],
     registerModel: vi.fn(),
   } as unknown as IAgentRuntime;
+}
+
+function useFakeSocket(): void {
+  configureFishAudioWebSocketFactory(
+    (url, options) => new FakeFishSocket(url, undefined, options),
+  );
 }
 
 function wrapPcm16MonoAsWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
@@ -182,10 +192,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("returns AudioStreamResult when audioStream is true and sends MessagePack frames", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const rt = runtime({
       ELIZA_TTS_FISH_ENABLED: "true",
       FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
@@ -245,10 +252,7 @@ describe("fishAudioPlugin", () => {
 
   test("rejects when Fish closes before a finish frame", async () => {
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -263,16 +267,92 @@ describe("fishAudioPlugin", () => {
     FakeFishSocket.instances.at(-1)?.close(1011, "provider failed");
 
     await expect(result.bytes).rejects.toThrow(
-      "Fish Audio WebSocket closed before finish: provider failed",
+      "Fish Audio WebSocket closed before synthesis completed",
     );
+  });
+
+  test("does not preserve provider-controlled WebSocket error text or causes", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const result = await handleFishAudioTextToSpeech(
+      runtime({
+        ELIZA_TTS_FISH_ENABLED: "true",
+        FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+        FISH_AUDIO_API_KEY: "key",
+        FISH_AUDIO_REFERENCE_ID: "voice",
+      }),
+      { text: "transport error", audioStream: true },
+    );
+    if (!("bytes" in result)) throw new Error("Expected streaming result");
+    await Promise.resolve();
+    const secret = "WS_CAUSE_SECRET_do-not-reflect_88fd";
+    FakeFishSocket.instances
+      .at(-1)
+      ?.emitError(
+        "Unexpected server response: 401",
+        new Error(`cause ${secret}`),
+      );
+
+    const failure = await result.bytes.catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      code: "FISH_AUDIO_AUTH_FAILED",
+      message: "Fish Audio authentication failed",
+      context: { retryable: false, statusCode: 401 },
+    });
+    const error = failure as Error & {
+      cause?: unknown;
+      context?: Record<string, unknown>;
+    };
+    expect(error.cause).toBeUndefined();
+    expect(
+      [
+        String(error),
+        error.stack,
+        JSON.stringify(error),
+        JSON.stringify(error.context),
+        String(error.cause),
+      ].join("\n"),
+    ).not.toContain(secret);
+  });
+
+  test("does not classify injected status digits as an upgrade status", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const result = await handleFishAudioTextToSpeech(
+      runtime({
+        ELIZA_TTS_FISH_ENABLED: "true",
+        FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+        FISH_AUDIO_API_KEY: "key",
+        FISH_AUDIO_REFERENCE_ID: "voice",
+      }),
+      { text: "ambiguous transport error", audioStream: true },
+    );
+    if (!("bytes" in result)) throw new Error("Expected streaming result");
+    await Promise.resolve();
+    const secret = "WS_STATUS_SECRET_429_then_401_778a";
+    FakeFishSocket.instances
+      .at(-1)
+      ?.emitError(
+        `provider text ${secret}`,
+        new Error(`Unexpected server response: 401 ${secret}`),
+      );
+
+    const failure = await result.bytes.catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      code: "FISH_AUDIO_WEBSOCKET_ERROR",
+      message: "Fish Audio WebSocket transport failed",
+      context: { retryable: true },
+    });
+    const error = failure as Error & { cause?: unknown };
+    expect(error.cause).toBeUndefined();
+    expect(
+      [String(error), error.stack, JSON.stringify(error)].join("\n"),
+    ).not.toContain(secret);
   });
 
   test("rejects a provider finish frame whose reason is error", async () => {
     FakeFishSocket.finishReason = "error";
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -285,15 +365,12 @@ describe("fishAudioPlugin", () => {
     if (!("bytes" in result)) throw new Error("Expected streaming result");
 
     await expect(result.bytes).rejects.toThrow(
-      "Fish Audio TTS failed to finish synthesis",
+      "Fish Audio provider reported a synthesis failure",
     );
   });
 
   test("rejects an already-aborted request", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const controller = new AbortController();
     controller.abort();
     const result = await handleFishAudioTextToSpeech(
@@ -311,10 +388,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("detaches the abort listener once synthesis finishes on its own", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const controller = new AbortController();
     const remove = vi.spyOn(controller.signal, "removeEventListener");
 
@@ -334,10 +408,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("buffers bytes when audioStream is false", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const rt = runtime({
       ELIZA_TTS_FISH_ENABLED: "true",
       FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
@@ -352,10 +423,7 @@ describe("fishAudioPlugin", () => {
 
   test("accepts audio exactly at the configured buffer ceiling", async () => {
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -378,10 +446,7 @@ describe("fishAudioPlugin", () => {
 
   test("rejects both result surfaces and closes when audio exceeds the buffer ceiling", async () => {
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -415,10 +480,7 @@ describe("fishAudioPlugin", () => {
   test("rejects and closes a stalled synthesis at the wall-clock deadline", async () => {
     vi.useFakeTimers();
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -441,10 +503,7 @@ describe("fishAudioPlugin", () => {
   test("suppresses provider frames and deadline work after cancellation", async () => {
     vi.useFakeTimers();
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const controller = new AbortController();
     const result = await handleFishAudioTextToSpeech(
       runtime({

--- a/plugins/plugin-fish-audio/index.browser.ts
+++ b/plugins/plugin-fish-audio/index.browser.ts
@@ -9,7 +9,9 @@ configureFishAudioWebSocketFactory(() => {
   );
 });
 
+export type { FishAudioFailureClassification } from "./src/index";
 export {
+  classifyFishAudioFailure,
   default,
   fishAudioPlugin,
   handleFishAudioTextToSpeech,

--- a/plugins/plugin-fish-audio/index.node.ts
+++ b/plugins/plugin-fish-audio/index.node.ts
@@ -1,12 +1,14 @@
 /** Node entrypoint for the Fish Audio plugin. */
-import WebSocket from "ws";
+
+import { createFishAudioNodeWebSocketFactory } from "./node-transport";
 import { configureFishAudioWebSocketFactory } from "./src/index";
 
-configureFishAudioWebSocketFactory(
-  (url, options) => new WebSocket(url, { headers: options.headers }),
-);
+configureFishAudioWebSocketFactory(createFishAudioNodeWebSocketFactory());
 
+export { createFishAudioNodeWebSocketFactory } from "./node-transport";
+export type { FishAudioFailureClassification } from "./src/index";
 export {
+  classifyFishAudioFailure,
   default,
   fishAudioPlugin,
   handleFishAudioTextToSpeech,

--- a/plugins/plugin-fish-audio/index.ts
+++ b/plugins/plugin-fish-audio/index.ts
@@ -1,12 +1,14 @@
 /** Exposes the Fish Audio plugin from the package root. */
-import WebSocket from "ws";
+
+import { createFishAudioNodeWebSocketFactory } from "./node-transport";
 import { configureFishAudioWebSocketFactory } from "./src/index";
 
-configureFishAudioWebSocketFactory(
-  (url, options) => new WebSocket(url, { headers: options.headers }),
-);
+configureFishAudioWebSocketFactory(createFishAudioNodeWebSocketFactory());
 
+export { createFishAudioNodeWebSocketFactory } from "./node-transport";
+export type { FishAudioFailureClassification } from "./src/index";
 export {
+  classifyFishAudioFailure,
   default,
   fishAudioPlugin,
   handleFishAudioTextToSpeech,

--- a/plugins/plugin-fish-audio/node-transport.ts
+++ b/plugins/plugin-fish-audio/node-transport.ts
@@ -1,0 +1,13 @@
+/** Provides the authenticated Node WebSocket transport used by Fish Audio. */
+
+import WebSocket from "ws";
+
+interface FishAudioNodeTransportOptions {
+  readonly headers: Record<string, string>;
+}
+
+/** Creates the production Node transport, optionally targeting a test upstream. */
+export function createFishAudioNodeWebSocketFactory(endpointOverride?: string) {
+  return (url: string, options: FishAudioNodeTransportOptions) =>
+    new WebSocket(endpointOverride ?? url, { headers: options.headers });
+}

--- a/plugins/plugin-fish-audio/src/index.ts
+++ b/plugins/plugin-fish-audio/src/index.ts
@@ -41,6 +41,51 @@ type TtsInput =
       synthesisTimeoutMs?: number;
     });
 
+export interface FishAudioFailureClassification {
+  category:
+    | "auth"
+    | "rate_limit"
+    | "timeout"
+    | "cancelled"
+    | "provider"
+    | "transport"
+    | "invalid_response"
+    | "configuration";
+  retryable: boolean;
+}
+
+/** Classifies Fish failures for bounded caller-owned retry policy. */
+export function classifyFishAudioFailure(
+  error: unknown,
+): FishAudioFailureClassification {
+  const code = error instanceof ElizaError ? error.code : "";
+  if (code === "FISH_AUDIO_AUTH_FAILED") {
+    return { category: "auth", retryable: false };
+  }
+  if (code === "FISH_AUDIO_RATE_LIMITED") {
+    return { category: "rate_limit", retryable: true };
+  }
+  if (code === "FISH_AUDIO_SYNTHESIS_TIMEOUT") {
+    return { category: "timeout", retryable: true };
+  }
+  if (code === "FISH_AUDIO_STREAM_ABORTED") {
+    return { category: "cancelled", retryable: false };
+  }
+  if (code === "FISH_AUDIO_PROVIDER_MESSAGE_INVALID") {
+    return { category: "invalid_response", retryable: false };
+  }
+  if (
+    code === "FISH_AUDIO_WEBSOCKET_ERROR" ||
+    code === "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY"
+  ) {
+    return { category: "transport", retryable: true };
+  }
+  if (code.startsWith("FISH_AUDIO_PROVIDER_")) {
+    return { category: "provider", retryable: false };
+  }
+  return { category: "configuration", retryable: false };
+}
+
 interface FishAudioWebSocketLike {
   readonly readyState: number;
   binaryType?: string;
@@ -249,6 +294,10 @@ function createFishAudioStream(
     resolveBytes = resolve;
     rejectBytes = reject;
   });
+  // error-policy:J5 stream-only consumers observe the same failure through
+  // iterator.next(); this handler prevents the parallel bytes view from
+  // becoming an unhandled rejection when they intentionally never await it.
+  void bytes.catch(() => undefined);
   const socket = openSocket(config.apiKey, config.model);
   socket.binaryType = "arraybuffer";
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
@@ -259,16 +308,22 @@ function createFishAudioStream(
     done = true;
     if (deadlineTimer) clearTimeout(deadlineTimer);
     unlistenAbort?.();
+    socket.close(1000, "synthesis complete");
     resolveBytes(concatBytes(bufferedChunks, totalBytes));
     while (waiters.length > 0) {
       waiters.shift()?.({ done: true, value: undefined });
     }
   };
-  const fail = (error: unknown) => {
+  const fail = (
+    error: unknown,
+    closeCode = 1011,
+    closeReason = "synthesis failed",
+  ) => {
     if (done) return;
     done = true;
     if (deadlineTimer) clearTimeout(deadlineTimer);
     unlistenAbort?.();
+    socket.close(closeCode, closeReason);
     failure = error;
     rejectBytes(error);
     while (waiters.length > 0) {
@@ -286,8 +341,9 @@ function createFishAudioStream(
             receivedBytes: totalBytes + chunk.byteLength,
           },
         }),
+        1009,
+        "audio limit exceeded",
       );
-      socket.close(1009, "audio limit exceeded");
       return;
     }
     bufferedChunks.push(chunk);
@@ -305,8 +361,9 @@ function createFishAudioStream(
         code: "FISH_AUDIO_SYNTHESIS_TIMEOUT",
         context: { synthesisTimeoutMs: config.synthesisTimeoutMs },
       }),
+      1013,
+      "synthesis timeout",
     );
-    socket.close(1013, "synthesis timeout");
   }, config.synthesisTimeoutMs);
 
   socket.addEventListener("open", () => {
@@ -335,12 +392,9 @@ function createFishAudioStream(
       if (frame.event === "finish") {
         if (frame.reason === "error") {
           fail(
-            new ElizaError(
-              String(
-                frame.message ?? "Fish Audio TTS failed to finish synthesis",
-              ),
-              { code: "FISH_AUDIO_PROVIDER_FINISH_ERROR" },
-            ),
+            new ElizaError("Fish Audio provider reported a synthesis failure", {
+              code: "FISH_AUDIO_PROVIDER_FINISH_ERROR",
+            }),
           );
         } else {
           finish();
@@ -348,10 +402,9 @@ function createFishAudioStream(
       }
       if (frame.event === "error" || frame.error) {
         fail(
-          new ElizaError(
-            String(frame.message ?? frame.error ?? "Fish Audio TTS failed"),
-            { code: "FISH_AUDIO_PROVIDER_ERROR" },
-          ),
+          new ElizaError("Fish Audio provider reported an error", {
+            code: "FISH_AUDIO_PROVIDER_ERROR",
+          }),
         );
       }
     } catch (error) {
@@ -360,27 +413,40 @@ function createFishAudioStream(
       fail(error);
     }
   });
-  socket.addEventListener("error", (event) =>
+  socket.addEventListener("error", (event) => {
+    const statusCode = /^Unexpected server response: (401|429)$/.exec(
+      event.message ?? "",
+    )?.[1];
+    const code =
+      statusCode === "401"
+        ? "FISH_AUDIO_AUTH_FAILED"
+        : statusCode === "429"
+          ? "FISH_AUDIO_RATE_LIMITED"
+          : "FISH_AUDIO_WEBSOCKET_ERROR";
+    const publicMessage =
+      statusCode === "401"
+        ? "Fish Audio authentication failed"
+        : statusCode === "429"
+          ? "Fish Audio rate limit exceeded"
+          : "Fish Audio WebSocket transport failed";
     fail(
-      new ElizaError(
-        event.message ??
-          (event.error instanceof Error
-            ? event.error.message
-            : "Fish Audio WebSocket error"),
-        {
-          code: "FISH_AUDIO_WEBSOCKET_ERROR",
-          cause: event.error,
+      new ElizaError(publicMessage, {
+        code,
+        severity: statusCode === "401" ? "fatal" : "ephemeral",
+        context: {
+          retryable: statusCode !== "401",
+          ...(statusCode ? { statusCode: Number(statusCode) } : {}),
         },
-      ),
-    ),
-  );
+      }),
+    );
+  });
   socket.addEventListener("close", (event) => {
     if (done) return;
-    const detail = event.reason ? `: ${event.reason}` : "";
     fail(
-      new ElizaError(`Fish Audio WebSocket closed before finish${detail}`, {
+      new ElizaError("Fish Audio WebSocket closed before synthesis completed", {
         code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
-        context: { statusCode: event.code, reason: event.reason },
+        context:
+          typeof event.code === "number" ? { closeCode: event.code } : {},
       }),
     );
   });
@@ -389,8 +455,9 @@ function createFishAudioStream(
       new ElizaError("Fish Audio TTS aborted", {
         code: "FISH_AUDIO_STREAM_ABORTED",
       }),
+      1000,
+      "aborted",
     );
-    socket.close(1000, "aborted");
   };
   if (config.signal?.aborted) {
     abort();
@@ -412,6 +479,10 @@ function createFishAudioStream(
               failure ? reject(failure) : resolve(result),
             );
           });
+        },
+        return(): Promise<IteratorResult<Uint8Array>> {
+          if (!done) abort();
+          return Promise.resolve({ done: true, value: undefined });
         },
       };
     },
@@ -436,40 +507,32 @@ function openSocket(
   if (configuredWebSocketFactory) {
     return configuredWebSocketFactory(FISH_AUDIO_TTS_WEBSOCKET_URL, options);
   }
-  const WebSocketCtor = (
-    globalThis as {
-      WebSocket?: new (
-        url: string,
-        protocolsOrOptions?:
-          | string
-          | string[]
-          | { headers?: Record<string, string> },
-        options?: { headers?: Record<string, string> },
-      ) => FishAudioWebSocketLike;
-    }
-  ).WebSocket;
-  if (!WebSocketCtor) {
-    throw new ElizaError("WebSocket is not available for Fish Audio TTS", {
-      code: "FISH_AUDIO_WEBSOCKET_UNAVAILABLE",
-    });
-  }
-  try {
-    return new WebSocketCtor(FISH_AUDIO_TTS_WEBSOCKET_URL, undefined, options);
-  } catch {
-    // error-policy:J1 boundary translation — runtimes differ on whether WS
-    // headers are accepted as the second or third constructor argument.
-    return new WebSocketCtor(FISH_AUDIO_TTS_WEBSOCKET_URL, options);
-  }
+  throw new ElizaError(
+    "Fish Audio requires the authenticated platform WebSocket transport",
+    { code: "FISH_AUDIO_WEBSOCKET_UNAVAILABLE" },
+  );
 }
 
 function decodeFrame(data: unknown): Record<string, unknown> {
-  const frame =
-    data instanceof ArrayBuffer
-      ? decode(new Uint8Array(data))
-      : ArrayBuffer.isView(data)
-        ? decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
-        : decode(data as Uint8Array);
-  if (typeof frame !== "object" || frame === null) {
+  let frame: unknown;
+  try {
+    frame =
+      data instanceof ArrayBuffer
+        ? decode(new Uint8Array(data))
+        : ArrayBuffer.isView(data)
+          ? decode(
+              new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+            )
+          : decode(data as Uint8Array);
+  } catch {
+    // error-policy:J1 malformed provider bytes are translated at the transport
+    // boundary and never reach callers as an unclassified decoder exception.
+    throw new ElizaError("Fish Audio returned an invalid MessagePack frame", {
+      code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
+      severity: "fatal",
+    });
+  }
+  if (typeof frame !== "object" || frame === null || Array.isArray(frame)) {
     throw new ElizaError("Fish Audio frame must be an object", {
       code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
     });


### PR DESCRIPTION
# Relates to

Supersedes the production slice of #24228 (author @lalalune). #24228 was closed with the abandoned synthetic-world mock program (#24092 / #22896 / #22899, all closed not planned); its closure comment invited landing the independently valuable production correction as a focused change without the mock framework. This PR is that slice — the `packages/cloud/test-mocks` Fish protocol harness and its integration test are intentionally excluded.

# Risks

Low. Scope is Fish Audio TTS transport/error behavior only. No other package imports `plugin-fish-audio/src` directly; all entrypoints configure a transport factory, so removing the implicit `globalThis.WebSocket` fallback is safe.

# Background

## What does this PR do?

- Provider-controlled frame text (`frame.message`/`frame.error`), peer close reasons, and WebSocket `event.message`/`event.error` objects no longer flow into public `ElizaError` messages, contexts, or causes. Failures use stable public messages/codes with numeric allowlisted metadata only (`closeCode`, `statusCode`, `retryable`).
- 401/429 upgrade classification is anchored to the exact Node `ws` `Unexpected server response: <status>` event-message shape, so injected digits in provider text cannot alter retry policy.
- New `classifyFishAudioFailure()` export gives callers explicit retryable/permanent categories (auth, rate_limit, timeout, cancelled, provider, transport, invalid_response, configuration).
- Terminal paths (finish, fail, timeout, abort, iterator `return()`) centralize WebSocket cleanup; abandoning a streaming iterator now aborts synthesis instead of leaking the socket.
- `decodeFrame` translates malformed MessagePack at the boundary (`FISH_AUDIO_PROVIDER_MESSAGE_INVALID`) instead of leaking decoder exceptions.
- Node transport moves to `createFishAudioNodeWebSocketFactory` (`node-transport.ts`); the browser entrypoint keeps its explicit unsupported error.

## What kind of change is this?

Bug fix / hardening (error sanitization + resource cleanup).

# Documentation changes needed?

`AGENTS.md`/`CLAUDE.md` gain the failure-classification guidance (mock-harness references removed); pair is byte-identical.

# Testing

## Where should a reviewer start?

`plugins/plugin-fish-audio/__tests__/streaming.test.ts` — including the two new adversarial tests: provider-controlled WS error text/causes are absent from every public error surface, and injected status digits do not reclassify a generic transport failure.

## Detailed testing steps

Verified locally at this head (branched from current `origin/develop`):

```text
bun run --cwd plugins/plugin-fish-audio test        # 17 passed, 1 opt-in live skipped
bun run --cwd plugins/plugin-fish-audio typecheck   # PASS
bun run --cwd plugins/plugin-fish-audio lint:check  # PASS (12 files)
bun run --cwd plugins/plugin-fish-audio build       # PASS (Node, Browser, declarations)
```

Load-bearing check: re-attaching `cause: event.error` in the WebSocket error handler makes the redaction regression fail; restoring the fix turns it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)