### PR TITLE
fix(agent): make config updates atomic on persistence failure

### DIFF
--- a/packages/agent/src/api/config-routes.test.ts
+++ b/packages/agent/src/api/config-routes.test.ts
@@ -3,8 +3,12 @@
  * runtime-dependent, so structurally excessive patches are rejected by the
  * canonical blocked-object-key walker before those consumers run.
  */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type http from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ConfigRouteContext,
   configPatchExceedsBound,
@@ -24,7 +28,14 @@ function nest(depth: number): Record<string, unknown> {
 function makeCtx(
   body: Record<string, unknown>,
   strip: ConfigRouteContext["stripRedactedPlaceholderValuesDeep"],
-): { ctx: ConfigRouteContext; error: ReturnType<typeof vi.fn> } {
+  options: {
+    config?: ConfigRouteContext["config"];
+  } = {},
+): {
+  ctx: ConfigRouteContext;
+  error: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+} {
   const error = vi.fn();
   const json = vi.fn();
   const ctx: ConfigRouteContext = {
@@ -33,7 +44,7 @@ function makeCtx(
     method: "PUT",
     pathname: "/api/config",
     url: new URL("http://127.0.0.1/api/config"),
-    config: {},
+    config: options.config ?? {},
     runtime: null,
     json,
     error,
@@ -47,7 +58,7 @@ function makeCtx(
     resolveMcpServersRejection: async () => null,
     resolveMcpTerminalAuthorizationRejection: () => null,
   };
-  return { ctx, error };
+  return { ctx, error, json };
 }
 
 describe("config patch nest bound", () => {
@@ -81,5 +92,124 @@ describe("config patch nest bound", () => {
       400,
     );
     expect(strip).not.toHaveBeenCalled();
+  });
+});
+
+describe("config patch persistence", () => {
+  const envKey = "ELIZA_CONFIG_ROUTE_ATOMICITY_TEST";
+  const previousEnvValue = process.env[envKey];
+  const previousConfigPath = process.env.ELIZA_CONFIG_PATH;
+  let tempDir = "";
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "eliza-config-route-"));
+    process.env.ELIZA_CONFIG_PATH = path.join(tempDir, "eliza.json");
+  });
+
+  afterEach(() => {
+    if (previousEnvValue === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = previousEnvValue;
+    }
+    if (previousConfigPath === undefined) {
+      delete process.env.ELIZA_CONFIG_PATH;
+    } else {
+      process.env.ELIZA_CONFIG_PATH = previousConfigPath;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("rejects a failed save without changing live config or process.env", async () => {
+    process.env[envKey] = "before";
+    const config: ConfigRouteContext["config"] = {
+      ui: { theme: "eliza", seamColor: "#ffffff" },
+      env: { vars: { [envKey]: "before" } },
+    };
+    const before = structuredClone(config);
+    const blockedDirectory = path.join(tempDir, "not-a-directory");
+    writeFileSync(blockedDirectory, "file blocks config parent");
+    process.env.ELIZA_CONFIG_PATH = path.join(blockedDirectory, "eliza.json");
+    const { ctx, error, json } = makeCtx(
+      {
+        ui: { theme: "haxor" },
+        env: { vars: { [envKey]: "after" } },
+      },
+      vi.fn(),
+      { config },
+    );
+
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      "Config update could not be persisted",
+      500,
+    );
+    expect(json).not.toHaveBeenCalled();
+    expect(config).toEqual(before);
+    expect(process.env[envKey]).toBe("before");
+  });
+
+  it("preserves the successful response while committing staged state", async () => {
+    process.env[envKey] = "before";
+    const config: ConfigRouteContext["config"] = {
+      ui: { theme: "eliza", seamColor: "#ffffff" },
+      env: { vars: { [envKey]: "before" } },
+    };
+    const { ctx, error, json } = makeCtx(
+      {
+        ui: { theme: "haxor" },
+        env: { vars: { [envKey]: "after" } },
+      },
+      vi.fn(),
+      { config },
+    );
+
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    const expected = {
+      ui: { theme: "haxor", seamColor: "#ffffff" },
+      env: { vars: { [envKey]: "after" } },
+    };
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(ctx.res, expected);
+    expect(config).toEqual(expected);
+    expect(process.env[envKey]).toBe("after");
+    expect(
+      JSON.parse(readFileSync(process.env.ELIZA_CONFIG_PATH as string, "utf8")),
+    ).toEqual(expected);
+  });
+
+  it("keeps exact responses for two previously-valid patch shapes", async () => {
+    const corpus: Array<{
+      config: ConfigRouteContext["config"];
+      patch: Record<string, unknown>;
+      expected: Record<string, unknown>;
+    }> = [
+      {
+        config: { ui: { theme: "eliza", seamColor: "#ffffff" } },
+        patch: { ui: { theme: "haxor" } },
+        expected: { ui: { theme: "haxor", seamColor: "#ffffff" } },
+      },
+      {
+        config: {
+          ui: { theme: "eliza" },
+          env: { vars: { [envKey]: "before", EMPTY_VALUE: "" } },
+        },
+        patch: { env: { vars: { [envKey]: "after" } } },
+        expected: {
+          ui: { theme: "eliza" },
+          env: { vars: { [envKey]: "after" } },
+        },
+      },
+    ];
+
+    for (const entry of corpus) {
+      const { ctx, error, json } = makeCtx(entry.patch, vi.fn(), {
+        config: structuredClone(entry.config),
+      });
+      expect(await handleConfigRoutes(ctx)).toBe(true);
+      expect(error).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith(ctx.res, entry.expected);
+    }
   });
 });

--- a/packages/agent/src/api/config-routes.ts
+++ b/packages/agent/src/api/config-routes.ts
@@ -135,6 +135,23 @@ function asConfigRecord<T extends object>(
   return value as T & Record<string, unknown>;
 }
 
+/** Replace a live config in place so references held by callers stay valid. */
+function replaceConfigInPlace(state: ElizaConfig, next: ElizaConfig): void {
+  const stateRecord = asConfigRecord(state);
+  const nextRecord = asConfigRecord(next);
+  for (const key of Object.keys(stateRecord)) {
+    if (!(key in nextRecord)) {
+      delete stateRecord[key];
+    }
+  }
+  for (const [key, value] of Object.entries(nextRecord)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      continue;
+    }
+    stateRecord[key] = value;
+  }
+}
+
 /**
  * Compute which top-level keys differ between the current in-memory config
  * and a freshly-loaded copy from disk, and bucket them into hot-reloadable
@@ -185,19 +202,8 @@ async function applyReloadedConfig(params: {
   const { state, next, runtime, isBlockedEnvKey } = params;
 
   // Replace top-level keys in the live state.config with the loaded values.
-  const stateRecord = asConfigRecord(state);
+  replaceConfigInPlace(state, next);
   const nextRecord = asConfigRecord(next);
-  for (const key of Object.keys(stateRecord)) {
-    if (!(key in nextRecord)) {
-      delete stateRecord[key];
-    }
-  }
-  for (const [key, value] of Object.entries(nextRecord)) {
-    if (key === "__proto__" || key === "constructor" || key === "prototype") {
-      continue;
-    }
-    stateRecord[key] = value;
-  }
 
   // Sync provider API keys into process.env (the runtime reads them at
   // request time via getSetting → process.env).
@@ -553,11 +559,78 @@ export async function handleConfigRoutes(
       );
     }
 
-    safeMerge(config as Record<string, unknown>, filtered);
+    let nextConfig: ElizaConfig;
+    try {
+      // structuredClone preserves the complete config graph instead of using
+      // a JSON round-trip that would silently drop or rewrite values.
+      nextConfig = structuredClone(config);
+    } catch (err) {
+      logger.warn(
+        `[api] Config update staging failed: ${err instanceof Error ? err.message : err}`,
+      );
+      // error-policy:J1 route boundary translates an internal staging failure.
+      error(res, "Config update could not be staged", 500);
+      return true;
+    }
 
-    // If the client updated env vars, synchronise them into process.env so
-    // subsequent hot-restarts see the latest values (loadElizaConfig()
-    // only fills missing env vars and does not override existing ones).
+    safeMerge(asConfigRecord(nextConfig), filtered);
+
+    if (
+      filtered.env &&
+      typeof filtered.env === "object" &&
+      !Array.isArray(filtered.env)
+    ) {
+      // Keep the staged config clean: drop empty env.vars entries so we don't
+      // persist null/empty-string tombstones forever.
+      const cfgEnv = asConfigRecord(nextConfig).env;
+      if (cfgEnv && typeof cfgEnv === "object" && !Array.isArray(cfgEnv)) {
+        const cfgVars = (cfgEnv as Record<string, unknown>).vars;
+        if (cfgVars && typeof cfgVars === "object" && !Array.isArray(cfgVars)) {
+          for (const [k, v] of Object.entries(
+            cfgVars as Record<string, unknown>,
+          )) {
+            if (typeof v !== "string" || !v.trim()) {
+              delete (cfgVars as Record<string, unknown>)[k];
+            }
+          }
+        }
+      }
+    }
+
+    if (
+      canonicalDeploymentTargetRequested ||
+      canonicalLinkedAccountsRequested ||
+      canonicalServiceRoutingRequested
+    ) {
+      applyCanonicalFirstRunConfig(nextConfig, {
+        deploymentTarget: normalizedDeploymentTarget,
+        linkedAccounts: normalizedLinkedAccounts,
+        serviceRouting: normalizedServiceRouting,
+      });
+    }
+
+    try {
+      saveElizaConfig(nextConfig);
+      if (isElizaSettingsDebugEnabled()) {
+        const cfg = asConfigRecord(nextConfig);
+        const cloud = cfg.cloud as Record<string, unknown> | undefined;
+        logger.debug(
+          `[eliza][settings][api] PUT /api/config → saveElizaConfig OK cloud(after)=${JSON.stringify(settingsDebugCloudSummary(cloud))}`,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `[api] Config save failed: ${err instanceof Error ? err.message : err}`,
+      );
+      // error-policy:J1 route boundary translates a persistence failure.
+      error(res, "Config update could not be persisted", 500);
+      return true;
+    }
+
+    replaceConfigInPlace(config, nextConfig);
+
+    // Synchronise env only after persistence succeeds so a failed write cannot
+    // leave process.env ahead of durable and in-memory configuration.
     if (
       filtered.env &&
       typeof filtered.env === "object" &&
@@ -587,49 +660,6 @@ export async function handleConfigRoutes(
         if (v.trim()) process.env[k] = v;
         else delete process.env[k];
       }
-
-      // Keep config clean: drop empty env.vars entries so we don't persist
-      // null/empty-string tombstones forever.
-      const cfgEnv = (config as Record<string, unknown>).env;
-      if (cfgEnv && typeof cfgEnv === "object" && !Array.isArray(cfgEnv)) {
-        const cfgVars = (cfgEnv as Record<string, unknown>).vars;
-        if (cfgVars && typeof cfgVars === "object" && !Array.isArray(cfgVars)) {
-          for (const [k, v] of Object.entries(
-            cfgVars as Record<string, unknown>,
-          )) {
-            if (typeof v !== "string" || !v.trim()) {
-              delete (cfgVars as Record<string, unknown>)[k];
-            }
-          }
-        }
-      }
-    }
-
-    if (
-      canonicalDeploymentTargetRequested ||
-      canonicalLinkedAccountsRequested ||
-      canonicalServiceRoutingRequested
-    ) {
-      applyCanonicalFirstRunConfig(config, {
-        deploymentTarget: normalizedDeploymentTarget,
-        linkedAccounts: normalizedLinkedAccounts,
-        serviceRouting: normalizedServiceRouting,
-      });
-    }
-
-    try {
-      saveElizaConfig(config);
-      if (isElizaSettingsDebugEnabled()) {
-        const cfg = config as Record<string, unknown>;
-        const cloud = cfg.cloud as Record<string, unknown> | undefined;
-        logger.debug(
-          `[eliza][settings][api] PUT /api/config → saveElizaConfig OK cloud(after)=${JSON.stringify(settingsDebugCloudSummary(cloud))}`,
-        );
-      }
-    } catch (err) {
-      logger.warn(
-        `[api] Config save failed: ${err instanceof Error ? err.message : err}`,
-      );
     }
     json(res, redactConfigSecrets(asConfigRecord(config)));
     return true;


### PR DESCRIPTION

## Summary

- stage `PUT /api/config` updates on a complete `structuredClone` of the live config
- persist the staged candidate before changing live state or `process.env`
- translate saver failures to HTTP 500 instead of returning the normal success payload
- preserve the root config object's identity after a successful save

Closes #24742.

## Why this escapes containment

The handler's existing inner `try/catch` consumes `saveElizaConfig()` failures. Because nothing escapes to the server's outer route boundary, that boundary cannot translate the failure; the handler's normal 200 JSON response passes through unchanged. The same path had already mutated the live config and environment.

## Adjacent invariants

- Failed persistence leaves the full live config and `process.env` unchanged.
- Successful persistence updates disk first, then the existing live config object in place, then environment values.
- Staging uses `structuredClone`, not a lossy JSON round trip; staging failures are explicitly rejected rather than dropping, truncating, or rewriting values.

## Verification

- Origin reproduction: before editing, `config-routes.ts` was byte-identical to `origin/develop`. With that exact source restored, the real saver produced `ENOTDIR`; the regression reported `1 failed | 6 skipped` because the error responder was never called.
- Load-bearing fix: restored the fixed source under the same test; focused suite reported `1 file passed`, `7 tests passed`.
- No over-rejection: two previously valid patch shapes (partial UI merge and env tombstone cleanup) produced the same exact expected response objects on origin and branch. The origin corpus run reported `1 passed | 6 skipped`; the branch corpus is included in the 7/7 run.
- Biome: `Checked 2 files ... No fixes applied.`
- Typecheck comparison: untouched control and branch each reported 19 pre-existing missing-workspace-plugin errors; sorted error-set diff exit was 0, so this change adds zero errors.

## Known gaps

- `bun run verify` stops at the repository's existing i18n audit: `en.json` is missing 14 source keys and translated catalogs have broader pre-existing gaps. The focused route proof and Biome check pass at the submitted head.
- This is a fork contribution, so hosted CI does not run for this PR.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:8b0bd78f31f45d72c5276d8ec3c4349f7bedc985 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [api-config-persistence]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NQWQ09NBGYYW673EHJP8JR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T22:01:36.521Z","completed_at":"2026-08-22T22:20:15.369Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T22:01:36.872Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"be5838c4a7cf63758cd0075b02e8685d3f28a8daed7d93f92820549b92c4e67b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2666a4ba-133f-4440-bf57-e79ec693d941","object_id":"sha256:be5838c4a7cf63758cd0075b02e8685d3f28a8daed7d93f92820549b92c4e67b","sha256":"be5838c4a7cf63758cd0075b02e8685d3f28a8daed7d93f92820549b92c4e67b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"ZpmhPbZhh9aQarRIcs7Z5zyDMp0GFPgLpo1wk3yzcwI6YprdmlfmDI-5Pe2H4UpW9-_UTBxe23sxAncHkSDNCw"}} -->
