### PR TITLE
test(cloud): prove Workerd upload-cancel response

### DIFF
--- a/packages/cloud/api/__tests__/storage-r2-workerd.test.ts
+++ b/packages/cloud/api/__tests__/storage-r2-workerd.test.ts
@@ -1,6 +1,7 @@
 /**
- * Exercises the native R2 generation contract inside genuine Workerd: an
- * immutable conditional write, strongly consistent HEAD/GET, and delete.
+ * Exercises genuine Workerd contracts through Miniflare: native R2 generation
+ * semantics and delivery of an early response after cancelling an unfinished
+ * inbound streaming request body. This does not exercise Hono or module mocks.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Miniflare } from "miniflare";
@@ -18,6 +19,13 @@ describe("native storage R2 contract in Workerd", () => {
           contents: `
             export default {
               async fetch(request, env) {
+                if (new URL(request.url).pathname === "/reject-unbounded-upload") {
+                  if (request.body === null) {
+                    return new Response("missing request body", { status: 500 });
+                  }
+                  await request.body.cancel();
+                  return new Response("length required", { status: 411 });
+                }
                 const key = "__eliza_storage_authority/v2/org/test/object/1";
                 if (request.method === "PUT") {
                   const digest = request.headers.get("x-content-sha256");
@@ -82,4 +90,64 @@ describe("native storage R2 contract in Workerd", () => {
       (await miniflare.dispatchFetch("https://storage.test/")).status,
     ).toBe(404);
   });
+
+  test("flushes 411 after cancelling an unfinished streaming upload", async () => {
+    let uploadFinished = false;
+    let releaseUpload: (() => void) | undefined;
+    const uploadRelease = new Promise<void>((resolve) => {
+      releaseUpload = resolve;
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial upload"));
+      },
+      async pull(controller) {
+        await uploadRelease;
+        controller.close();
+        uploadFinished = true;
+      },
+    });
+
+    const timeout = Symbol("timeout");
+    const withinDeadline = async <T>(
+      promise: Promise<T>,
+      milliseconds = 5_000,
+    ) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<typeof timeout>((resolve) => {
+        timeoutId = setTimeout(() => resolve(timeout), milliseconds);
+      });
+      try {
+        return await Promise.race([promise, deadline]);
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    };
+    const response = miniflare.dispatchFetch(
+      "https://storage.test/reject-unbounded-upload",
+      { method: "PUT", body },
+    );
+    try {
+      const result = await withinDeadline(response);
+
+      expect(result).not.toBe(timeout);
+      if (result === timeout) return;
+      expect(result.status).toBe(411);
+      expect(await result.text()).toBe("length required");
+      expect(uploadFinished).toBe(false);
+
+      // Miniflare does not currently forward Workerd's body cancellation to
+      // the host ReadableStream cancel hook. The observable transport proof is
+      // therefore the completed 411 while this producer is still unfinished.
+    } finally {
+      releaseUpload?.();
+      await withinDeadline(
+        response.then(
+          () => undefined,
+          () => undefined,
+        ),
+        1_000,
+      );
+    }
+  }, 10_000);
 });


### PR DESCRIPTION
# Relates to

Closes #24728. Follow-up to merged PR #24041; @lalalune's merge-verification review identified the missing real-Workerd transport proof.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact result is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `afaad559dd80dd33fbae0f381b16941c2a1f95fa`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact result is documented in **Known gaps / failures** below.

# Risks

Low. This changes one Workerd test file only. The test uses bounded deadlines and releases its deliberately blocked upload producer in `finally`.

# Background

## What does this PR do?

Adds the transport proof missing from #24041. A Miniflare-dispatched streaming PUT crosses genuine Workerd transport. The worker rejects a null body, non-optionally awaits `request.body.cancel()`, and only then returns 411. The test proves the complete 411 reaches the client while the host upload producer is still unfinished.

This does not use Hono `app.request()` or module mocks. Miniflare does not propagate the Workerd cancellation to the host stream's `cancel` hook, so the observable host-side invariant is response completion before upload EOF; the awaited non-optional cancellation remains inside Workerd.

## What kind of change is this?

Test coverage for a real-runtime transport contract.

# Documentation changes needed?

No project documentation change is needed; the test header documents the harness boundary.

# Testing

## Where should a reviewer start?

`packages/cloud/api/__tests__/storage-r2-workerd.test.ts`

## Detailed testing steps

At exact head `ea317a05b81c10d5cf8bdd6940d3663531761758`:

```text
bun test packages/cloud/api/__tests__/storage-r2-workerd.test.ts
2 pass
0 fail
9 expect() calls
Ran 2 tests across 1 file.

bunx @biomejs/biome check packages/cloud/api/__tests__/storage-r2-workerd.test.ts
Checked 1 file. No fixes applied.
```

The focused Bun command was recorded through `scripts/proof-run.mjs` at this exact commit. Independent repeated review also ran the new case five times without failure.

# Evidence Gate

<!-- evidence-head:ea317a05b81c10d5cf8bdd6940d3663531761758 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend test-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend test-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow.
<!-- evidence-row:backend-logs -->
- [x] The exact Workerd-focused test output is included above; it runs the real transport contract under Miniflare.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Backend: the exact Workerd suite result is included under **Testing**. Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

This is a fork contribution, so hosted CI does not run contributor tests. The commands above are local exact-head evidence and must not be read as hosted-CI results.

`bun run --cwd packages/cloud/api typecheck` fails before reaching this test because `packages/cloud/shared/src/lib/eliza/runtime/initializer.ts:14` cannot resolve `@elizaos/plugin-doordash` (`TS2307`). This is unrelated to the one-file test diff.

`bun run verify` reached 211/214 successful tasks, then failed in the same unrelated `@elizaos/cloud-shared#typecheck` task because `src/lib/eliza/runtime/initializer.ts:14` could not resolve `@elizaos/plugin-doordash` (`TS2307`). The changed Workerd test is outside that package and its focused suite passes.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [followup-24041-workerd-r2]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NRMR3N6KRJPMBA1Y3K2QQ8","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T22:14:44.086Z","completed_at":"2026-08-22T22:20:22.247Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T22:14:45.218Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a4d806d67f4b63aaa4dd753a7a92447fd0b7d176c370e6903b63d2e1c98849d8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0f69b19b-bc6a-48f7-92a9-eda8d0196f19","object_id":"sha256:a4d806d67f4b63aaa4dd753a7a92447fd0b7d176c370e6903b63d2e1c98849d8","sha256":"a4d806d67f4b63aaa4dd753a7a92447fd0b7d176c370e6903b63d2e1c98849d8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"0sBYEtKmY5UtWkiDljUhUqgC6Ws-WaVK0THqxeXaEEBHfTk4oWPdc2q7Wo85_GQ_4-CrB0Me_ujpNHhXhEZYDQ"}} -->
