### PR TITLE
fix(cloud): type queue strategy chunks defensively

### DIFF
--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -208,7 +208,7 @@ function nodeResponseBodyStream(res: IncomingMessage): ReadableStream<Uint8Array
     },
     {
       highWaterMark: NODE_RESPONSE_QUEUE_HIGH_WATER_MARK_BYTES,
-      size: (chunk) => chunk.byteLength,
+      size: (chunk) => chunk?.byteLength ?? 0,
     },
   );
 }


### PR DESCRIPTION
# Relates to

Follow-up to merged PR [#24731](https://github.com/elizaOS/eliza/pull/24731), its public [repair claim](https://github.com/elizaOS/eliza/pull/24731#issuecomment-5382914095), and the exact [failing Static Smoke](https://github.com/elizaOS/eliza/actions/runs/32601782706/job/97101038744).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; exact unrelated
      baseline blockers are recorded below.
- [x] A reviewer can confirm the change from the one-line diff, the prior exact
      compiler diagnostic, and the new exact-head static smoke.

# Sync with develop

- [x] Based on `origin/develop@527a2efb2e5a28fd20eb57396cbcf62ad5a651bf`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is
      documented in **Known gaps / failures**.

# Risks

**Low.** This is a one-line type-totality fix for the byte-length queuing strategy merged in #24731. Runtime-enqueued chunks remain `Uint8Array`; the nullish fallback only satisfies the shared strategy signature's optional parameter and returns zero if a caller ever invokes it without a chunk.

# Background

## What does this PR do?

#24731 merged before its Static Smoke completed. The affected `cloud-api` typecheck then reported:

```
../shared/src/lib/security/safe-fetch.ts(211,24): error TS18048: 'chunk' is possibly 'undefined'.
```

This changes `chunk.byteLength` to `chunk?.byteLength ?? 0`, making the queuing strategy callback total under the consumer package's TypeScript view while preserving byte-aware sizing for every real response chunk.

## What kind of change is this?

Bug fix (non-breaking post-merge compiler repair).

# Documentation changes needed?

No documentation change is needed; there is no public API or behavioral contract change.

# Testing

## Where should a reviewer start?

The entire diff is the `size` callback in `packages/cloud/shared/src/lib/security/safe-fetch.ts`.

## Detailed testing steps

On exact head `8da3ac948f6dafa28cbc350383e6739002d424e3`:

1. `bun install --frozen-lockfile` — passed.
2. `bunx vitest run packages/cloud/shared/src/lib/security/safe-fetch.test.ts` — 1 file, 24/24 tests passed.
3. `bunx biome check packages/cloud/shared/src/lib/security/safe-fetch.ts` — clean.
4. `git diff --check origin/develop...HEAD` — passed.
5. `bun run --cwd packages/cloud/api typecheck` — the #24731 `TS18048` diagnostic is gone; local resolution then reports only the unchanged missing `@elizaos/plugin-doordash` module described below.
6. `bun run --cwd packages/cloud/shared typecheck` — same unchanged missing-module blocker, with no queue-strategy diagnostic.
7. `bun run verify` — stops earlier on unchanged missing connector-card English i18n keys from current `develop`, detailed below.

# Evidence Gate

<!-- evidence-head:8da3ac948f6dafa28cbc350383e6739002d424e3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - one-line backend TypeScript fix with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - one-line backend TypeScript fix with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - this repairs a compile-time signature; the exact compiler diagnostic and deterministic tests are the applicable evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, provider, prompt, model, or action path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, task, memory, wallet, file, or audio artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface or user-facing text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - compile-time transport typing repair; no LLM path exists.

## Backend + frontend logs

Backend live logs: N/A - compile-time callback signature repair. The predecessor CI diagnostic is linked above and the new exact-head Static Smoke exercises the same affected-package typecheck.

Frontend logs: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI or interactive flow changed.

## Audio / voice walkthrough

N/A - no voice or audio path changed.

## Known gaps / failures

- Exact-head `bun run verify` stops in `check:i18n`: current `develop` uses 14 missing English `connectorcard.*` keys in `packages/ui/src/components/chat/widgets/connector-card.tsx`. No UI/i18n file is in this one-line diff.
- Local `cloud-api` and `cloud-shared` typechecks no longer report `TS18048`; they report only the unchanged `packages/cloud/shared/src/lib/eliza/runtime/initializer.ts:14:32` missing `@elizaos/plugin-doordash` module. That file and dependency metadata are absent from this diff. The GitHub workspace setup resolved that package in the predecessor run, so the new Static Smoke is the authoritative reproduction of the affected typecheck.
- All UI, live-service, LLM, domain, OCR, and audio evidence is N/A for the concrete reasons above. No production Cloudflare, infrastructure, credential, billing, or webhook operation was performed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@4f4a78be4a97d9fd42d5b2342d7343c7cebcfeed:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [standujar/safe-fetch-queue-size-typecheck-follow-up]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@4f4a78be4a97d9fd42d5b2342d7343c7cebcfeed:packages/skills/skills/contribute-to-eliza"} -->
