### PR TITLE
fix(agent-orchestrator): normalize quoted single-token ELIZA_ACP_CLI

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -573,6 +573,53 @@ describe("AcpService", () => {
     await service.stop();
   });
 
+  it("spawns a quoted single-token ELIZA_ACP_CLI as the parsed executable (#24684)", async () => {
+    const reg = nextProc();
+    // A quoted single token is quote-stripped by the availability walker and by
+    // missingCliMessage(), but cliPath previously kept the raw literal, so
+    // spawn() received `"acpx"` with the quotes and ENOENTed (there is no shell
+    // to strip them). Asserting the spawn argv pins the actual defect site:
+    // restoring the old normalization makes this expectation see '"acpx"'.
+    const service = new AcpService(runtime({ ELIZA_ACP_CLI: '"acpx"' }));
+    await service.start();
+
+    const promise = service.spawnSession({
+      name: "quoted",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(reg);
+    reg.proc.stdout.emit(
+      "data",
+      Buffer.from(
+        '{"jsonrpc":"2.0","method":"session_started","params":{"sessionId":"quoted"}}\n',
+      ),
+    );
+    closeOk(reg);
+    await promise;
+
+    expect(spawnMock.mock.calls[0]?.[0]).toBe("acpx");
+    await service.stop();
+  });
+
+  it("rejects a whitespace-only ELIZA_ACP_CLI instead of spawning the empty string (#24684)", async () => {
+    // An empty parsed command previously fell through to spawn() as a PATH
+    // lookup of "" instead of failing closed.
+    const service = new AcpService(runtime({ ELIZA_ACP_CLI: "   " }));
+    await service.start();
+
+    await expect(
+      service.spawnSession({
+        name: "empty-cli",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      }),
+    ).rejects.toThrow(/No executable command is configured/);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    await service.stop();
+  });
+
   it("spawns a session, emits ready, and stores the session", async () => {
     const reg = nextProc();
     const service = new AcpService(runtime());

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -980,10 +980,20 @@ export class AcpService extends Service {
     );
     const configuredCli = this.setting("ELIZA_ACP_CLI") ?? "acpx";
     const parsedCli = splitCommandLine(configuredCli);
+    // A zero-argument value must normalize to the PARSED token, not the raw
+    // literal: the availability walker and missingCliMessage() both parse
+    // (quote-stripping) while spawn() consumes this.cliPath verbatim and gets
+    // no shell. Keeping the raw literal let a quoted single token such as
+    // `"acpx"` report installed and then ENOENT at spawn time (#24684).
+    // Only a token that actually looks like a path is resolved to an absolute
+    // path; a bare command name stays bare so PATH lookup still works. An
+    // empty parsed command is preserved verbatim so it is rejected as
+    // unavailable instead of becoming a PATH lookup of the empty string.
     this.cliPath =
-      parsedCli.args.length === 0 &&
-      (parsedCli.command.includes("/") || parsedCli.command.includes("\\"))
-        ? resolve(parsedCli.command)
+      parsedCli.args.length === 0 && parsedCli.command !== ""
+        ? parsedCli.command.includes("/") || parsedCli.command.includes("\\")
+          ? resolve(parsedCli.command)
+          : parsedCli.command
         : configuredCli;
     this.transportMode =
       normalizeTransportMode(
@@ -5366,8 +5376,15 @@ export class AcpService extends Service {
   }
 
   private missingCliMessage(): string | undefined {
-    if (splitCommandLine(this.cliPath).args.length > 0) {
+    const parsed = splitCommandLine(this.cliPath);
+    if (parsed.args.length > 0) {
       return "ELIZA_ACP_CLI must name one executable path; command arguments are not supported.";
+    }
+    // An empty or whitespace-only value must fail closed here rather than
+    // reaching spawn() as a PATH lookup of the empty string (#24684). The
+    // availability walker already rejects this with the same wording.
+    if (parsed.command === "") {
+      return "No executable command is configured.";
     }
     if (!this.cliPath.includes("/") || existsSync(this.cliPath)) {
       return undefined;


### PR DESCRIPTION
Closes #24684

## Summary

The `ELIZA_ACP_CLI` constructor normalization in `AcpService` only replaced the
configured value with the parsed command when it had zero args **and** contained
a path separator. A quoted single token such as `"acpx"` is quote-stripped by the
availability walker and by `missingCliMessage()`, but `this.cliPath` kept the raw
literal — so availability reported `installed: true` while
`spawn(this.cliPath, …)` received `"acpx"` **with the quotes** and ENOENTed
(there is no shell to strip them).

## Change

`plugins/plugin-agent-orchestrator/src/services/acp-service.ts` only:

1. Normalize every zero-argument value to the **parsed** token. Resolve to an
   absolute path only when the token actually looks like a path, so a bare
   command name still goes through PATH lookup.
2. Reject an empty / whitespace-only parsed command in `missingCliMessage()`
   instead of falling through to a PATH lookup of the empty string, reusing the
   wording the availability walker already returns
   (`No executable command is configured.`).

The transport contract, adapter selection, and argv construction are unchanged.

## Behavior table

Verified against the real `splitCommandLine` from `acp-native-transport.ts`:

| `ELIZA_ACP_CLI` | before → `spawn()` | after → `spawn()` |
| --- | --- | --- |
| `"acpx"` (quoted token) | `"acpx"` → **ENOENT** | `acpx` → executes |
| `acpx` | `acpx` | `acpx` (unchanged) |
| `/no/acpx` | resolved abs path | resolved abs path (unchanged) |
| `"/tmp/acpx"` (quoted path) | resolved abs path | resolved abs path (unchanged) |
| `"   "` (whitespace) | PATH lookup of `""` | fails closed before spawn |
| `acpx --flag` | verbatim, rejected downstream | verbatim, rejected downstream (unchanged) |

Only the first and fifth rows change. Availability and `spawn()` now agree on
the executable for every row.

## Tests

Two regression cases added to
`plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts`:

- **`spawns a quoted single-token ELIZA_ACP_CLI as the parsed executable (#24684)`**
  — asserts the argv handed to `spawn()` is `acpx`, pinning the actual defect
  site. Restoring the old normalization makes this expectation observe
  `"acpx"` and fail.
- **`rejects a whitespace-only ELIZA_ACP_CLI instead of spawning the empty string (#24684)`**
  — asserts `spawnSession` rejects with `No executable command is configured.`
  and that `spawn()` is never called.

Both use the file's existing deterministic `spawn` double and its `runtime()`
settings helper; no new mocking style, no new dependency, and no reliance on a
real `acpx` being installed.

I deliberately did **not** add a "quoted path" test: quoted paths already
normalized correctly before this change, so such a test would pass on
`develop` and prove nothing.

## Verification

- Reproduced the defect and confirmed the repair by executing the verbatim
  `splitCommandLine` implementation against both the old and new normalization
  over all six rows above (the table is that run's output). Sabotage check
  included: with the old logic restored, `"acpx"` does **not** normalize to
  `acpx`, which is the reported failure.
- `git diff --check` — clean.
- Test file parses cleanly under Node 24 type-stripping.

## Risks

Low, and confined to how a zero-argument `ELIZA_ACP_CLI` is stored. A bare
command name, an absolute path, a quoted path, and a value carrying arguments
all keep their existing behavior (table above). The one intentional behavior
change beyond the fix is that whitespace-only now fails closed with an explicit
message instead of attempting an empty-string PATH lookup — the previous
behavior could not have succeeded.

## Known gaps / failures

I could not run the package's hosted Vitest lane locally: `bun` is not
installed on this host and the sandbox blocked installing it, so
`node_modules` is absent and `bunx vitest run --root plugins/plugin-agent-orchestrator`
could not execute. The two new tests are written against the patterns already
proven in this file (the sibling `ELIZA_ACP_CLI: "/no/acpx"` case uses the same
`spawnSession` rejection + `spawnMock` shape), and the behavioral claim is
backed by the direct execution described above, but hosted CI is the
authoritative run for the suite itself. Flagging this explicitly rather than
implying a green local suite.

AI provider/model: meituan / longcat-2.0
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-longcat]
<!-- eliza-computer-attribution:v1 {"provider":"meituan","model":"longcat-2.0","client":"Hermes Agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
