### PR TITLE
perf(cloud): thin-path passkey bootstrap auth

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -12,6 +12,7 @@ import cloudApiWorker, {
   isInternalDiscordGatewayPath,
   isThinInferenceEnabled,
   isThinStewardEmailAuthPath,
+  isThinStewardPasskeyLoginOptionsPath,
   isThinStewardPath,
   isThinStewardPublicPath,
   isUnsupportedLegacyWildcardHostname,
@@ -402,18 +403,41 @@ describe("thin Steward public path dispatch (#18049)", () => {
     expect(isThinStewardPublicPath("/api/v1/oauth/providers")).toBe(false);
   });
 
-  test("POST Magic Link email legs are thin-eligible; other mutations are not", () => {
+  test("only exact pre-auth email and passkey-bootstrap POSTs are thin-eligible", () => {
     expect(isThinStewardEmailAuthPath("/steward/auth/email/send")).toBe(true);
     expect(isThinStewardEmailAuthPath("/steward/auth/email/code/verify")).toBe(
       true,
     );
     expect(isThinStewardEmailAuthPath("/steward/auth/email/status")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/otp/send")).toBe(
+      true,
+    );
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/otp/verify")).toBe(
+      true,
+    );
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/login/options",
+      ),
+    ).toBe(true);
     expect(isThinStewardEmailAuthPath("/steward/vault/keys")).toBe(false);
     expect(isThinStewardPath("POST", "/steward/auth/email/send")).toBe(true);
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/login/options"),
+    ).toBe(true);
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/login/verify"),
+    ).toBe(false);
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/register/options"),
+    ).toBe(false);
     expect(isThinStewardPath("POST", "/steward/auth/providers")).toBe(false);
     expect(isThinStewardPath("GET", "/steward/auth/email/send")).toBe(false);
     expect(isThinStewardPath("DELETE", "/steward/auth/email/send")).toBe(false);
     expect(isThinStewardPath("OPTIONS", "/steward/auth/email/send")).toBe(true);
+    expect(
+      isThinStewardPath("OPTIONS", "/steward/auth/passkey/login/options"),
+    ).toBe(true);
   });
 
   test("dispatches POST /steward/auth/email/send through the thin shell", async () => {
@@ -460,6 +484,99 @@ describe("thin Steward public path dispatch (#18049)", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test.each([
+    [
+      "/steward/auth/passkey/login/options",
+      404,
+      { email: "new-user@example.com" },
+    ],
+    ["/steward/auth/email/otp/send", 200, { email: "new-user@example.com" }],
+    [
+      "/steward/auth/email/otp/verify",
+      200,
+      { email: "new-user@example.com", code: "123456" },
+    ],
+  ] as const)(
+    "dispatches POST %s through the thin shell with thin telemetry",
+    async (path, upstreamStatus, requestBody) => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        expect(url).toBe(
+          `https://steward.example.test${path.slice("/steward".length)}`,
+        );
+        return Response.json(
+          upstreamStatus === 404
+            ? {
+                success: false,
+                error: "Passkey authentication is unavailable",
+              }
+            : { ok: true, data: { accepted: true } },
+          { status: upstreamStatus },
+        );
+      }) as unknown as typeof fetch;
+
+      try {
+        const response = await cloudApiWorker.fetch(
+          new Request(`https://api.eliza.app${path}`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              origin: "https://cloud.eliza.app",
+            },
+            body: JSON.stringify(requestBody),
+          }),
+          stewardEnv,
+          executionCtx,
+        );
+
+        expect(response.status).toBe(upstreamStatus);
+        expect(response.headers.get("x-eliza-steward-path")).toBe("thin");
+        expect(response.headers.get("server-timing")).toMatch(
+          /entry_dispatch;dur=\d+(?:\.\d+)?/,
+        );
+        expect(response.headers.get("server-timing")).not.toContain(
+          "full_app_dispatch",
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
+  test.each([
+    "/steward/auth/passkey/login/options",
+    "/steward/auth/email/otp/send",
+    "/steward/auth/email/otp/verify",
+  ])("dispatches OPTIONS %s through the thin shell", async (path) => {
+    const response = await cloudApiWorker.fetch(
+      new Request(`https://api.eliza.app${path}`, {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://cloud.eliza.app",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "content-type",
+        },
+      }),
+      stewardEnv,
+      executionCtx,
+    );
+
+    expect(response.status).toBeLessThan(500);
+    expect(response.headers.get("x-eliza-steward-path")).toBe("thin");
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://cloud.eliza.app",
+    );
+    expect(response.headers.get("server-timing")).toContain("entry_dispatch");
+    expect(response.headers.get("server-timing")).not.toContain(
+      "full_app_dispatch",
+    );
   });
 
   test("dispatches GET /steward/auth/providers through the thin shell", async () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -51,6 +51,7 @@ export { PersonalTelegramDelivery } from "./personal-telegram-delivery";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";
 export {
   isThinStewardEmailAuthPath,
+  isThinStewardPasskeyLoginOptionsPath,
   isThinStewardPath,
   isThinStewardPublicPath,
 } from "./steward/public-paths";
@@ -65,7 +66,7 @@ export { TwitterOAuthRefreshCoordinator } from "./twitter-oauth-refresh-coordina
 const fullAppPromises = new Map<string | null, Promise<Hono<AppEnv>>>();
 const knownRouteShards = new Set(KNOWN_ROUTE_SHARD_KEYS);
 const inferenceAppPromises = new Map<string, Promise<Hono<AppEnv>>>();
-/** Lazy thin shell for login-critical Steward GETs (#18049). */
+/** Lazy thin shell for login-critical Steward pre-auth requests (#18049). */
 let stewardThinAppPromise: Promise<Hono<AppEnv>> | undefined;
 /** Lazy thin shell for the CLI-session login hot path (#22948). */
 let cliSessionThinAppPromise: Promise<Hono<AppEnv>> | undefined;

--- a/packages/cloud/api/src/steward/public-paths.ts
+++ b/packages/cloud/api/src/steward/public-paths.ts
@@ -28,8 +28,8 @@ export function isThinStewardPublicPath(pathname: string): boolean {
 }
 
 /**
- * Login-critical pre-auth Steward email mutations (Magic Link) that must not
- * wait on full-app bootstrap either.
+ * Login-critical pre-auth Steward email mutations (Magic Link and passkey
+ * fallback) that must not wait on full-app bootstrap either.
  *
  * Every one of these is a serial, user-blocking leg of the email sign-in
  * flow, and each was paying the monolithic bootstrap as multi-second cold
@@ -42,8 +42,12 @@ export function isThinStewardPublicPath(pathname: string): boolean {
  * - POST /steward/auth/email/code/verify — fires on six-digit-code submit;
  *   gates login completion.
  * - POST /steward/auth/email/status — the companion-code 3s status poll.
+ * - POST /steward/auth/email/otp/send — sends the six-digit fallback code
+ *   when the typed account has no passkey.
+ * - POST /steward/auth/email/otp/verify — verifies that code before passkey
+ *   enrollment begins.
  *
- * All three are pre-auth by design: the full app applies no additional
+ * All five are pre-auth by design: the full app applies no additional
  * protection to them — `authMiddleware` and the cookie-mutation CSRF guard
  * both pass every non-`/api/` path straight through — so the thin shell's
  * replicated stack (CORS, secure headers, Redis fail-closed guard, global IP
@@ -62,13 +66,32 @@ export function isThinStewardEmailAuthPath(pathname: string): boolean {
   return (
     normalized === "/steward/auth/email/send" ||
     normalized === "/steward/auth/email/code/verify" ||
-    normalized === "/steward/auth/email/status"
+    normalized === "/steward/auth/email/status" ||
+    normalized === "/steward/auth/email/otp/send" ||
+    normalized === "/steward/auth/email/otp/verify"
+  );
+}
+
+/**
+ * The one pre-auth passkey mutation needed before WebAuthn starts.
+ *
+ * Login options decides whether the typed account has a credential. Unknown
+ * or no-passkey accounts receive Steward's generic 404 and immediately fall
+ * back to the email OTP paths above. Registration options and both WebAuthn
+ * verification endpoints deliberately stay on the full app.
+ */
+export function isThinStewardPasskeyLoginOptionsPath(
+  pathname: string,
+): boolean {
+  return (
+    removeTrailingSlashes(pathname) === "/steward/auth/passkey/login/options"
   );
 }
 
 /**
  * Method-aware eligibility for the thin Steward shell: read-only for the
- * public discovery paths, POST (+ preflight) for the login email mutations.
+ * public discovery paths, POST (+ preflight) for the exact pre-auth login
+ * mutations.
  */
 export function isThinStewardPath(method: string, pathname: string): boolean {
   const upper = method.toUpperCase();
@@ -76,11 +99,16 @@ export function isThinStewardPath(method: string, pathname: string): boolean {
     return isThinStewardPublicPath(pathname);
   }
   if (upper === "POST") {
-    return isThinStewardEmailAuthPath(pathname);
+    return (
+      isThinStewardEmailAuthPath(pathname) ||
+      isThinStewardPasskeyLoginOptionsPath(pathname)
+    );
   }
   if (upper === "OPTIONS") {
     return (
-      isThinStewardPublicPath(pathname) || isThinStewardEmailAuthPath(pathname)
+      isThinStewardPublicPath(pathname) ||
+      isThinStewardEmailAuthPath(pathname) ||
+      isThinStewardPasskeyLoginOptionsPath(pathname)
     );
   }
   return false;

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./embedded";
 import {
   isThinStewardEmailAuthPath,
+  isThinStewardPasskeyLoginOptionsPath,
   isThinStewardPath,
   isThinStewardPublicPath,
 } from "./public-paths";
@@ -105,13 +106,19 @@ describe("isThinStewardPublicPath", () => {
 });
 
 describe("isThinStewardEmailAuthPath", () => {
-  test("matches only the three Magic Link email legs", () => {
+  test("matches only the five email pre-auth legs", () => {
     expect(isThinStewardEmailAuthPath("/steward/auth/email/send")).toBe(true);
     expect(isThinStewardEmailAuthPath("/steward/auth/email/send/")).toBe(true);
     expect(isThinStewardEmailAuthPath("/steward/auth/email/code/verify")).toBe(
       true,
     );
     expect(isThinStewardEmailAuthPath("/steward/auth/email/status")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/otp/send")).toBe(
+      true,
+    );
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/otp/verify")).toBe(
+      true,
+    );
     expect(isThinStewardEmailAuthPath("/steward/auth/providers")).toBe(false);
     expect(isThinStewardEmailAuthPath("/steward/auth/email/verify")).toBe(
       false,
@@ -128,6 +135,36 @@ describe("isThinStewardEmailAuthPath", () => {
   });
 });
 
+describe("isThinStewardPasskeyLoginOptionsPath", () => {
+  test("matches only the pre-WebAuthn login-options request", () => {
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/login/options",
+      ),
+    ).toBe(true);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/login/options/",
+      ),
+    ).toBe(true);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/login/verify",
+      ),
+    ).toBe(false);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/register/options",
+      ),
+    ).toBe(false);
+    expect(
+      isThinStewardPasskeyLoginOptionsPath(
+        "/steward/auth/passkey/register/verify",
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("isThinStewardPath", () => {
   test("GET/HEAD only for public reads", () => {
     expect(isThinStewardPath("GET", "/steward/auth/providers")).toBe(true);
@@ -135,12 +172,30 @@ describe("isThinStewardPath", () => {
     expect(isThinStewardPath("GET", "/steward/auth/email/send")).toBe(false);
   });
 
-  test("POST only for the Magic Link email legs", () => {
+  test("POST only for the exact pre-auth email and passkey-bootstrap legs", () => {
     expect(isThinStewardPath("POST", "/steward/auth/email/send")).toBe(true);
     expect(isThinStewardPath("POST", "/steward/auth/email/code/verify")).toBe(
       true,
     );
     expect(isThinStewardPath("POST", "/steward/auth/email/status")).toBe(true);
+    expect(isThinStewardPath("POST", "/steward/auth/email/otp/send")).toBe(
+      true,
+    );
+    expect(isThinStewardPath("POST", "/steward/auth/email/otp/verify")).toBe(
+      true,
+    );
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/login/options"),
+    ).toBe(true);
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/login/verify"),
+    ).toBe(false);
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/register/options"),
+    ).toBe(false);
+    expect(
+      isThinStewardPath("POST", "/steward/auth/passkey/register/verify"),
+    ).toBe(false);
     expect(isThinStewardPath("POST", "/steward/auth/providers")).toBe(false);
     expect(isThinStewardPath("POST", "/steward/vault/keys")).toBe(false);
     expect(isThinStewardPath("PUT", "/steward/auth/email/send")).toBe(false);
@@ -150,6 +205,18 @@ describe("isThinStewardPath", () => {
   test("OPTIONS eligible for both path families", () => {
     expect(isThinStewardPath("OPTIONS", "/steward/auth/providers")).toBe(true);
     expect(isThinStewardPath("OPTIONS", "/steward/auth/email/send")).toBe(true);
+    expect(isThinStewardPath("OPTIONS", "/steward/auth/email/otp/send")).toBe(
+      true,
+    );
+    expect(isThinStewardPath("OPTIONS", "/steward/auth/email/otp/verify")).toBe(
+      true,
+    );
+    expect(
+      isThinStewardPath("OPTIONS", "/steward/auth/passkey/login/options"),
+    ).toBe(true);
+    expect(
+      isThinStewardPath("OPTIONS", "/steward/auth/passkey/register/options"),
+    ).toBe(false);
     expect(isThinStewardPath("OPTIONS", "/steward/vault/keys")).toBe(false);
   });
 });

--- a/packages/cloud/api/src/steward/thin-app.ts
+++ b/packages/cloud/api/src/steward/thin-app.ts
@@ -1,5 +1,5 @@
 /**
- * Thin Hono shell for login-critical Steward GETs (#18049).
+ * Thin Hono shell for login-critical Steward pre-auth requests (#18049).
  *
  * The monolithic bootstrap loads ~580 routes and service singletons (e.g.
  * PayoutAlerts) before the embedded Steward proxy runs. Cold isolates then
@@ -9,7 +9,9 @@
  * This shell mirrors the dependency-light protections already used by the thin
  * inference entry (`inference-app.ts`) plus the production Redis fail-closed
  * rate-limit config guard from `bootstrap-app.ts`, without evaluating
- * `_router.generated`. Mutating Steward auth still uses the full app.
+ * `_router.generated`. Only the exact pre-auth mutations selected by
+ * `public-paths.ts` enter this shell; all other mutating Steward auth still
+ * uses the full app.
  */
 
 import { Hono } from "hono";
@@ -170,7 +172,7 @@ export function createStewardThinApp(): Hono<AppEnv> {
   });
 
   // Global IP backstop (600/min) — same ceiling/namespace as bootstrap-app and
-  // inference-app so thin login GETs are not unmetered.
+  // inference-app so thin login requests are not unmetered.
   app.use(
     "*",
     rateLimit(


### PR DESCRIPTION
## Summary

- route only the three serial passkey-bootstrap POSTs (`/steward/auth/passkey/login/options`, `/steward/auth/email/otp/send`, and `/steward/auth/email/otp/verify`) through the existing thin Steward shell
- send their OPTIONS preflights through the same shell while keeping WebAuthn registration/verification and every broader Steward mutation on the full app
- cover the unknown/no-passkey 404 fallback and assert thin-path telemetry never reports `full_app_dispatch`

This removes the Worker bootstrap from a flow where edge requests were spiking around 3.1s while direct Steward calls were roughly 0.21–0.26s.

## Validation

- `bun --conditions=eliza-source test packages/cloud/api/src/steward/thin-app.test.ts packages/cloud/api/src/index.test.ts` (pass)
- `bun x @biomejs/biome check` on all five changed files (pass)
- `git diff --check origin/develop...HEAD` (pass)
- package typecheck was run; it reaches the existing unrelated develop error at `packages/cloud/shared/src/lib/security/safe-fetch.ts:211` (`chunk` is possibly undefined). This branch does not change that file.

No deployment is included.