### PR TITLE
fix(plugin-personal-assistant): gate relative-schedule onDays on the anchor's local day

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts
@@ -3,7 +3,11 @@
  * branch. Pins the invariant the workflow scheduler loop depends on: the
  * resolved instant is strictly AFTER the cursor, including for negative-offset
  * schedules (during_night / "before bedtime") whose fire instant precedes the
- * projected anchor. Deterministic vitest, no runtime.
+ * projected anchor. Also pins the anchor-day weekday gate for the direct-anchor
+ * branch (regression for #24739): `onDays` filters on the anchor's local day,
+ * not the offsetted fire instant, so a negative offset that crosses local
+ * midnight cannot fire on an unrequested weekday or drop a requested one.
+ * Deterministic vitest, no runtime.
  */
 import { describe, expect, it } from "vitest";
 import { resolveNextRelativeScheduleInstant } from "./relative-schedule-resolver.js";
@@ -85,5 +89,160 @@ describe("resolveNextRelativeScheduleInstant — negative-offset projection", ()
       nowMs,
     });
     expect(resolved).toBe("2026-07-01T12:00:00.000Z");
+  });
+});
+
+type Schedule = Parameters<
+  typeof resolveNextRelativeScheduleInstant
+>[0]["schedule"];
+
+/**
+ * Direct-anchor branch with live sleep-cycle anchors and no baseline fallback:
+ * `baseline: null` forces the resolver through the direct-anchor path only, so
+ * a null result means the weekday gate rejected the occurrence rather than the
+ * projection branch producing a different day.
+ */
+function anchorState(overrides: {
+  bedtimeTargetAt?: string | null;
+  wakeAt?: string | null;
+}): LifeOpsScheduleMergedStateRecord {
+  return {
+    timezone: "America/New_York",
+    circadianState: "awake",
+    regularity: { regularityClass: "very_regular" },
+    baseline: null,
+    relativeTime: { bedtimeTargetAt: overrides.bedtimeTargetAt ?? null },
+    wakeAt: overrides.wakeAt ?? null,
+  } as unknown as LifeOpsScheduleMergedStateRecord;
+}
+
+describe("resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739)", () => {
+  // bedtimeTargetAt 2026-01-06T06:00Z = Tue 01:00 EST (anchor local weekday =
+  // Tuesday / 2). offset -120m => fire instant 2026-01-06T04:00Z = Mon 23:00
+  // EST (offset weekday = Monday / 1). The gate must match on the ANCHOR day.
+  const bedtimeState = anchorState({
+    bedtimeTargetAt: "2026-01-06T06:00:00.000Z",
+  });
+  const nowBeforeFire = Date.parse("2026-01-06T01:00:00.000Z"); // Mon 20:00 EST
+
+  it("relative_to_bedtime negative offset gates on the anchor's local day, not the fire instant", () => {
+    const onAnchorDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_bedtime",
+        timezone: "America/New_York",
+        offsetMinutes: -120,
+        onDays: [2], // Tuesday — the anchor's local day
+      } as Schedule,
+      state: bedtimeState,
+      cursorIso: null,
+      nowMs: nowBeforeFire,
+    });
+    expect(onAnchorDay).toBe("2026-01-06T04:00:00.000Z");
+
+    const onFireInstantDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_bedtime",
+        timezone: "America/New_York",
+        offsetMinutes: -120,
+        onDays: [1], // Monday — the offset fire-instant's local day
+      } as Schedule,
+      state: bedtimeState,
+      cursorIso: null,
+      nowMs: nowBeforeFire,
+    });
+    expect(onFireInstantDay).toBeNull();
+  });
+
+  it("during_night window crossing midnight gates on the bedtime anchor's local day", () => {
+    // window 120m before Tue 01:00 EST bedtime target => fire Mon 23:00 EST.
+    const onAnchorDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "during_night",
+        timezone: "America/New_York",
+        windowMinutesBeforeSleepTarget: 120,
+        onDays: [2], // Tuesday anchor
+      } as Schedule,
+      state: bedtimeState,
+      cursorIso: null,
+      nowMs: nowBeforeFire,
+    });
+    expect(onAnchorDay).toBe("2026-01-06T04:00:00.000Z");
+
+    const onFireInstantDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "during_night",
+        timezone: "America/New_York",
+        windowMinutesBeforeSleepTarget: 120,
+        onDays: [1], // Monday fire instant
+      } as Schedule,
+      state: bedtimeState,
+      cursorIso: null,
+      nowMs: nowBeforeFire,
+    });
+    expect(onFireInstantDay).toBeNull();
+  });
+
+  it("relative_to_wake large positive offset gates on the wake anchor's local day when the fire crosses into the next day", () => {
+    // wakeAt 2026-01-06T15:00Z = Tue 10:00 EST (anchor Tuesday / 2). offset
+    // +900m (15h) => fire 2026-01-07T06:00Z = Wed 01:00 EST (Wednesday / 3).
+    const wakeState = anchorState({ wakeAt: "2026-01-06T15:00:00.000Z" });
+    const now = Date.parse("2026-01-06T16:00:00.000Z"); // Tue 11:00 EST
+    const onAnchorDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_wake",
+        timezone: "America/New_York",
+        offsetMinutes: 900,
+        onDays: [2], // Tuesday wake anchor
+      } as Schedule,
+      state: wakeState,
+      cursorIso: null,
+      nowMs: now,
+    });
+    expect(onAnchorDay).toBe("2026-01-07T06:00:00.000Z");
+
+    const onFireInstantDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_wake",
+        timezone: "America/New_York",
+        offsetMinutes: 900,
+        onDays: [3], // Wednesday fire instant
+      } as Schedule,
+      state: wakeState,
+      cursorIso: null,
+      nowMs: now,
+    });
+    expect(onFireInstantDay).toBeNull();
+  });
+
+  it("does not regress the common same-day case where anchor and fire share a weekday", () => {
+    // wakeAt 2026-01-06T13:00Z = Tue 08:00 EST, offset +240m => Tue 12:00 EST;
+    // anchor and fire are both Tuesday, so onDays=[2] fires and onDays=[3] not.
+    const wakeState = anchorState({ wakeAt: "2026-01-06T13:00:00.000Z" });
+    const now = Date.parse("2026-01-06T14:00:00.000Z"); // Tue 09:00 EST
+    const sameDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_wake",
+        timezone: "America/New_York",
+        offsetMinutes: 240,
+        onDays: [2],
+      } as Schedule,
+      state: wakeState,
+      cursorIso: null,
+      nowMs: now,
+    });
+    expect(sameDay).toBe("2026-01-06T17:00:00.000Z");
+
+    const otherDay = resolveNextRelativeScheduleInstant({
+      schedule: {
+        kind: "relative_to_wake",
+        timezone: "America/New_York",
+        offsetMinutes: 240,
+        onDays: [3],
+      } as Schedule,
+      state: wakeState,
+      cursorIso: null,
+      nowMs: now,
+    });
+    expect(otherDay).toBeNull();
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.ts
@@ -163,9 +163,15 @@ export function resolveNextRelativeScheduleInstant(args: {
 
   if (anchorMs !== null) {
     const targetMs = anchorMs + offsetMinutes * 60_000;
+    // Weekday restrictions apply to the anchor's local day (the sleep-day the
+    // occurrence belongs to), not the offsetted fire instant. A negative
+    // offset (relative_to_bedtime / during_night) can push the fire instant
+    // across local midnight onto the previous weekday; gating on `targetMs`
+    // there fires on a day the owner did not request or silently drops a day
+    // they did. This mirrors the anchor-day rule in `nextProjectedLocalInstant`.
     if (
       targetMs > cursorMs &&
-      weekdayMatches(targetMs, state.timezone, args.schedule.onDays)
+      weekdayMatches(anchorMs, state.timezone, args.schedule.onDays)
     ) {
       return new Date(targetMs).toISOString();
     }


### PR DESCRIPTION
# Relates to

Closes #24739

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Package `test`, `typecheck`, and `lint:check` pass; the repo-wide `bun run verify` was not run to completion on this constrained machine (see **Known gaps**).
- [x] A reviewer can confirm the change works from the before/after test evidence below without reading the code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused package checks pass post-sync; repo-wide `bun run verify` blocker documented in **Known gaps / failures**.

# Risks

Low. One-line production change to a single weekday-gate expression in
`resolveNextRelativeScheduleInstant`, plus additive tests. It aligns the
direct-anchor branch with the anchor-day rule the projection branch already
documents and enforces, so behavior converges rather than diverges. The
common same-day case (anchor and fire share a weekday) is unchanged and pinned
by a non-regression test.

# Background

## What does this PR do?

Fixes an inverted weekday filter in the LifeOps relative-schedule resolver
(`plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.ts`).

`resolveNextRelativeScheduleInstant` has two occurrence-placement paths. The
projected path (`nextProjectedLocalInstant`) documents and enforces the
invariant that *"weekday restrictions apply to the anchor's local day (the
sleep-day the occurrence belongs to), not the offsetted fire instant."* The
direct-anchor branch violated it: it checked
`weekdayMatches(targetMs, ...)` where `targetMs = anchorMs + offsetMinutes*60_000`.

For negative-offset schedules (`relative_to_bedtime` / `during_night`, and any
offset that crosses local midnight) the anchor and the fire instant fall on
different local weekdays. So an `onDays`-restricted workflow/reminder either
**fired on a day the owner did NOT request**, or was **silently dropped**
(resolver returns `null` with no baseline fallback) on a day they DID request.

The fix evaluates the gate on the anchor's local day
(`weekdayMatches(anchorMs, ...)`), keeping the `targetMs > cursorMs` future
guard. This makes the direct path consistent with `nextProjectedLocalInstant`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. Behavior now matches the already-documented in-file invariant; no public
surface or configuration changed.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts`
— the new `direct-anchor weekday gate (#24739)` describe block. It drives the
real resolver (no mocks) across `America/New_York`.

## Detailed testing steps

```bash
bun install
node packages/shared/scripts/generate-keywords.mjs   # one-time codegen for isolated run
cd plugins/plugin-personal-assistant
bun x vitest run --config vitest.config.ts src/lifeops/relative-schedule-resolver.test.ts --reporter=verbose
```

The three midnight-crossing cases fail on current `develop` (the requested
anchor day resolves to `null`) and pass after the one-line change; the same-day
case passes both, proving no regression. Verified before/after by reverting the
single expression:

- **Before (buggy):** `3 failed | 4 passed` — `onDays=[anchorWeekday]` returns
  `null` (owner's requested day silently dropped): `expected null to be
  '2026-01-06T04:00:00.000Z'`.
- **After (fixed):** `7 passed` — `onDays=[anchorWeekday]` resolves the correct
  instant and `onDays=[fireInstantWeekday]` correctly does not fire.

# Evidence Gate

<!-- evidence-head:6dce078f56168a7b0d71e1c3500ab246298fa969 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure scheduling-logic change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure scheduling-logic change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; behavior is a resolver return value proven by before/after unit output.
<!-- evidence-row:backend-logs -->
- [x] Focused vitest output (before failing / after passing) attached under **Backend + frontend logs**.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface in this change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; this is deterministic time-zone math.
<!-- evidence-row:domain-artifacts -->
- [x] Resolver before/after instants for the crossing-midnight fixture attached under **Domain artifacts**.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic time-zone/weekday arithmetic; no model call involved.

## Backend + frontend logs

Focused vitest, real resolver, no mocks. Full logs attached:

<details><summary>After fix — full vitest verbose output (7 passed)</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-24739

 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — negative-offset projection > never resolves a during_night instant at or before now 28ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — negative-offset projection > advances past the cursor when re-resolved from the previous dueAt 3ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — negative-offset projection > keeps a still-future positive-offset fire on today's anchor 1ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > relative_to_bedtime negative offset gates on the anchor's local day, not the fire instant 2ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > during_night window crossing midnight gates on the bedtime anchor's local day 2ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > relative_to_wake large positive offset gates on the wake anchor's local day when the fire crosses into the next day 1ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > does not regress the common same-day case where anchor and fire share a weekday 2ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  23:33:55
   Duration  15.54s (transform 12.26s, setup 419ms, import 14.77s, tests 46ms, environment 0ms)
```
</details>

<details><summary>Before fix — full vitest verbose output (3 failed | 4 passed)</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-24739

 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — negative-offset projection > never resolves a during_night instant at or before now 47ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — negative-offset projection > advances past the cursor when re-resolved from the previous dueAt 2ms
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — negative-offset projection > keeps a still-future positive-offset fire on today's anchor 1ms
 × plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > relative_to_bedtime negative offset gates on the anchor's local day, not the fire instant 9ms
   → expected null to be '2026-01-06T04:00:00.000Z' // Object.is equality
 × plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > during_night window crossing midnight gates on the bedtime anchor's local day 2ms
   → expected null to be '2026-01-06T04:00:00.000Z' // Object.is equality
 × plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > relative_to_wake large positive offset gates on the wake anchor's local day when the fire crosses into the next day 2ms
   → expected null to be '2026-01-07T06:00:00.000Z' // Object.is equality
 ✓ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > does not regress the common same-day case where anchor and fire share a weekday 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > relative_to_bedtime negative offset gates on the anchor's local day, not the fire instant
AssertionError: expected null to be '2026-01-06T04:00:00.000Z' // Object.is equality

- Expected:
"2026-01-06T04:00:00.000Z"

+ Received:
null

 ❯ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts:140:25
    138|       nowMs: nowBeforeFire,
    139|     });
    140|     expect(onAnchorDay).toBe("2026-01-06T04:00:00.000Z");
       |                         ^
    141|
    142|     const onFireInstantDay = resolveNextRelativeScheduleInstant({

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > during_night window crossing midnight gates on the bedtime anchor's local day
AssertionError: expected null to be '2026-01-06T04:00:00.000Z' // Object.is equality

- Expected:
"2026-01-06T04:00:00.000Z"

+ Received:
null

 ❯ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts:169:25
    167|       nowMs: nowBeforeFire,
    168|     });
    169|     expect(onAnchorDay).toBe("2026-01-06T04:00:00.000Z");
       |                         ^
    170|
    171|     const onFireInstantDay = resolveNextRelativeScheduleInstant({

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts > resolveNextRelativeScheduleInstant — direct-anchor weekday gate (#24739) > relative_to_wake large positive offset gates on the wake anchor's local day when the fire crosses into the next day
AssertionError: expected null to be '2026-01-07T06:00:00.000Z' // Object.is equality

- Expected:
"2026-01-07T06:00:00.000Z"

+ Received:
null

 ❯ plugins/plugin-personal-assistant/src/lifeops/relative-schedule-resolver.test.ts:201:25
    199|       nowMs: now,
    200|     });
    201|     expect(onAnchorDay).toBe("2026-01-07T06:00:00.000Z");
       |                         ^
    202|
    203|     const onFireInstantDay = resolveNextRelativeScheduleInstant({

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 4 passed (7)
   Start at  23:34:46
   Duration  15.55s (transform 12.30s, setup 403ms, import 14.83s, tests 70ms, environment 0ms)
```
</details>

Before-fix assertion excerpt (owner's requested anchor day dropped to null):

```
AssertionError: expected null to be '2026-01-06T04:00:00.000Z' // Object.is equality
AssertionError: expected null to be '2026-01-06T04:00:00.000Z' // Object.is equality
AssertionError: expected null to be '2026-01-07T06:00:00.000Z' // Object.is equality
 Tests  3 failed | 4 passed (7)
```

After-fix summary:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Screenshots (before / after) + video walkthrough

### Before
N/A - no UI change.
### After
N/A - no UI change.
### Walkthrough video
N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Domain artifacts

Resolver output for the crossing-midnight fixture
(`America/New_York`, `relative_to_bedtime`, `bedtimeTargetAt = 2026-01-06T06:00Z`
= Tue 01:00 EST anchor, `offsetMinutes = -120` = Mon 23:00 EST fire instant,
`baseline = null`):

| onDays | meaning | before fix | after fix |
|---|---|---|---|
| `[2]` (Tuesday) | anchor's local day (correct per invariant) | `null` (dropped) | `2026-01-06T04:00:00.000Z` |
| `[1]` (Monday) | offset fire-instant day (wrong day) | `2026-01-06T04:00:00.000Z` (fires) | `null` |

Full before/after captures are inline under **Backend + frontend logs** above.

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this 16 GB Raspberry Pi
  host (full Turbo build/verify of all workspaces exceeds practical resources
  here). Mitigation: built the personal-assistant dependency graph via Turbo,
  then ran the owning package's `typecheck` (exit 0), Biome `lint:check`/
  `format` (no fixes), and the resolver + related scheduling/recurrence suites
  (all green). The change is one expression in a pure, dependency-light module.
- `bun install` required a one-time `node packages/shared/scripts/generate-keywords.mjs`
  codegen for the isolated vitest run (normally produced by the core `prebuild`);
  no source or lockfile change.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@8329afb4760592d27e6d67a3e39001283ca79711:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@8329afb4760592d27e6d67a3e39001283ca79711:packages/skills/skills/contribute-to-eliza"} -->
