### PR TITLE
fix(openai): make direct API key metadata optional

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -3921,7 +3921,7 @@
       "config": {
         "OPENAI_API_KEY": {
           "type": "secret",
-          "required": true,
+          "required": false,
           "sensitive": true,
           "label": "Api Key",
           "help": "API key used to authenticate requests to the OpenAI API.",

--- a/plugins/plugin-openai/AGENTS.md
+++ b/plugins/plugin-openai/AGENTS.md
@@ -82,7 +82,7 @@ All settings are read via `getSetting(runtime, key)` (runtime config first, then
 
 | Var | Required | Default | Purpose |
 |---|---|---|---|
-| `OPENAI_API_KEY` | one-of | — | Auth for all OpenAI endpoints |
+| `OPENAI_API_KEY` | no | — | Direct auth for OpenAI endpoints; unnecessary for authenticated proxy mode or another compatible-provider key |
 | `CEREBRAS_API_KEY` | one-of | — | Auth when using Cerebras endpoint |
 | `EVOLINK_API_KEY` | one-of | — | Auth when using EvoLink endpoint |
 | `OPENAI_BASE_URL` | no | `https://api.openai.com/v1` | Override API endpoint |
@@ -121,7 +121,7 @@ All settings are read via `getSetting(runtime, key)` (runtime config first, then
 | `EVOLINK_BASE_URL` | no | `https://direct.evolink.ai/v1` | EvoLink API base |
 | `EVOLINK_MODEL` | no | `gpt-5.2` | Override model name in EvoLink mode |
 
-*Either `OPENAI_API_KEY`, `CEREBRAS_API_KEY`, or `EVOLINK_API_KEY` is required; the plugin will not auto-enable without one.
+*The plugin auto-enables when `OPENAI_API_KEY`, `CEREBRAS_API_KEY`, or `EVOLINK_API_KEY` is present. A manually enabled authenticated proxy can operate without any local provider key; direct provider calls still fail explicitly when their required credential is unavailable.
 
 ## How to extend
 

--- a/plugins/plugin-openai/CLAUDE.md
+++ b/plugins/plugin-openai/CLAUDE.md
@@ -82,7 +82,7 @@ All settings are read via `getSetting(runtime, key)` (runtime config first, then
 
 | Var | Required | Default | Purpose |
 |---|---|---|---|
-| `OPENAI_API_KEY` | one-of | — | Auth for all OpenAI endpoints |
+| `OPENAI_API_KEY` | no | — | Direct auth for OpenAI endpoints; unnecessary for authenticated proxy mode or another compatible-provider key |
 | `CEREBRAS_API_KEY` | one-of | — | Auth when using Cerebras endpoint |
 | `EVOLINK_API_KEY` | one-of | — | Auth when using EvoLink endpoint |
 | `OPENAI_BASE_URL` | no | `https://api.openai.com/v1` | Override API endpoint |
@@ -121,7 +121,7 @@ All settings are read via `getSetting(runtime, key)` (runtime config first, then
 | `EVOLINK_BASE_URL` | no | `https://direct.evolink.ai/v1` | EvoLink API base |
 | `EVOLINK_MODEL` | no | `gpt-5.2` | Override model name in EvoLink mode |
 
-*Either `OPENAI_API_KEY`, `CEREBRAS_API_KEY`, or `EVOLINK_API_KEY` is required; the plugin will not auto-enable without one.
+*The plugin auto-enables when `OPENAI_API_KEY`, `CEREBRAS_API_KEY`, or `EVOLINK_API_KEY` is present. A manually enabled authenticated proxy can operate without any local provider key; direct provider calls still fail explicitly when their required credential is unavailable.
 
 ## How to extend
 

--- a/plugins/plugin-openai/README.md
+++ b/plugins/plugin-openai/README.md
@@ -27,13 +27,16 @@ Add `@elizaos/plugin-openai` to your character's plugin list:
 
 The plugin auto-enables when `OPENAI_API_KEY`, `CEREBRAS_API_KEY`, or `EVOLINK_API_KEY` is present in the environment.
 
-## Required configuration
+## Authentication configuration
 
 ```
 OPENAI_API_KEY=sk-...
 ```
 
-That is the only required setting. All other settings are optional overrides.
+Use `OPENAI_API_KEY` for direct OpenAI calls, `CEREBRAS_API_KEY` or
+`EVOLINK_API_KEY` for those compatible providers, or configure an authenticated
+OpenAI proxy. No individual key is universally required in plugin metadata;
+direct calls still fail explicitly when their selected endpoint lacks auth.
 
 ## Full configuration reference
 

--- a/plugins/plugin-openai/__tests__/auth-metadata-optional.test.ts
+++ b/plugins/plugin-openai/__tests__/auth-metadata-optional.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Verifies that both published OpenAI plugin metadata surfaces keep direct API
+ * credentials optional because compatible providers and authenticated proxies
+ * are valid alternatives. The test reads the real JSON artifacts without mocks.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function readJson(relativePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(new URL(relativePath, import.meta.url), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("OpenAI authentication metadata", () => {
+  it("does not require OPENAI_API_KEY in package or registry metadata", () => {
+    const packageManifest = readJson("../package.json") as {
+      agentConfig?: {
+        pluginParameters?: Record<string, { required?: boolean }>;
+      };
+    };
+    const registryEntry = readJson("../registry-entry.json") as {
+      config?: Record<string, { required?: boolean }>;
+    };
+
+    expect(packageManifest.agentConfig?.pluginParameters?.OPENAI_API_KEY?.required).toBe(false);
+    expect(registryEntry.config?.OPENAI_API_KEY?.required).toBe(false);
+  });
+});

--- a/plugins/plugin-openai/package.json
+++ b/plugins/plugin-openai/package.json
@@ -109,7 +109,7 @@
       "OPENAI_API_KEY": {
         "type": "string",
         "description": "API key used to authenticate requests to the OpenAI API.",
-        "required": true,
+        "required": false,
         "sensitive": true
       },
       "OPENAI_BASE_URL": {

--- a/plugins/plugin-openai/registry-entry.json
+++ b/plugins/plugin-openai/registry-entry.json
@@ -13,7 +13,7 @@
   "config": {
     "OPENAI_API_KEY": {
       "type": "secret",
-      "required": true,
+      "required": false,
       "sensitive": true,
       "label": "Api Key",
       "help": "API key used to authenticate requests to the OpenAI API.",


### PR DESCRIPTION
Fixes #24758

## What changed
- mark OPENAI_API_KEY optional in package agentConfig metadata
- mark OPENAI_API_KEY optional in registry metadata
- document direct OpenAI keys, compatible-provider keys, and authenticated proxy mode
- retain explicit runtime failure for an unauthenticated direct provider call
- add a regression test reading both published JSON artifacts

## Exact-head verification
- auth-metadata-optional.test.ts: 1/1 passed
- changed-file Biome
- CLAUDE.md / AGENTS.md parity
- git diff --check

Exact head: abcc9949d0c03619a34690c8fa995f7a43a67756