### PR TITLE
fix(cloud): guard optional chunk in node-stream queuing strategy size

### DIFF
--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -208,7 +208,7 @@ function nodeResponseBodyStream(res: IncomingMessage): ReadableStream<Uint8Array
     },
     {
       highWaterMark: NODE_RESPONSE_QUEUE_HIGH_WATER_MARK_BYTES,
-      size: (chunk) => chunk.byteLength,
+      size: (chunk) => chunk?.byteLength ?? 0,
     },
   );
 }


### PR DESCRIPTION
@lalalune — one-line typecheck unblock on your #24731 (merged with PR CI dead, so the break rode straight onto the deploy train — same class as #24412).

Run 32602630117 `Deploy API Worker`:
```
../shared/src/lib/security/safe-fetch.ts(211,24): error TS18048: 'chunk' is possibly 'undefined'.
```

TS's lib types `QueuingStrategySize<T>` as `(chunk?: T) => number`, so the strict cloud-api typecheck rejects the bare `chunk.byteLength`. Guarded form counts undefined as zero bytes — behavior unchanged for every real chunk.

Receipts (PR CI dead): `bun run --cwd packages/cloud/api typecheck` → exit 0 at this branch.

Good news from that same run: migrations recovered (#24737's DB-side window has passed) and everything upstream of the worker leg is green — this is the last blocker before the renderer verify + first Certify mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)