### PR TITLE
fix(core): count all retained messages for summaries

### DIFF
--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
@@ -147,6 +147,7 @@ describe("summaryEvaluator.shouldRun — dialogue count matches canonical MESSAG
 		metadataType: string,
 		count: number,
 		extraMemories: Memory[] = [],
+		existingSummary: { lastMessageOffset: number } | null = null,
 	) {
 		const memories = [
 			...Array.from({ length: count }, (_v, i) =>
@@ -159,14 +160,16 @@ describe("summaryEvaluator.shouldRun — dialogue count matches canonical MESSAG
 				shortTermSummarizationThreshold: 16,
 				shortTermSummarizationInterval: 8,
 			}),
-			getCurrentSessionSummary: async () => null,
+			getCurrentSessionSummary: async () => existingSummary,
 		};
 		return createMockRuntime({
 			agentId: "agent-1",
 			character: { name: "Agent" },
 			getService: (name: string) =>
 				name === "memory" ? (memoryService as never) : null,
-			getMemories: async () => memories,
+			countMemories: async () => memories.length,
+			getMemories: async ({ limit }: { limit: number }) =>
+				memories.slice(0, limit),
 		} as never);
 	}
 
@@ -230,5 +233,21 @@ describe("summaryEvaluator.shouldRun — dialogue count matches canonical MESSAG
 		// 12 real dialogue rows < 16 threshold; the 8 action_result rows must
 		// not push the count over.
 		expect(run).toBe(false);
+	});
+
+	it("continues after the first 100 retained dialogue rows", async () => {
+		const rt = runtimeWithMessages("message", 110, [], {
+			lastMessageOffset: 100,
+		});
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+
+		// 10 retained dialogue rows are newer than the prior summary offset,
+		// exceeding the configured interval of 8.
+		expect(run).toBe(true);
 	});
 });

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -135,6 +135,11 @@ async function getDialogueMessageCount(
 		roomId,
 		limit: Math.max(1, retainedMessageCount),
 		unique: false,
+		// The dialogue predicate reads only `metadata.type` and `content.type`.
+		// This fetch is now sized by the room, so pulling vectors for every
+		// retained message would make a long room's memory cost the dominant
+		// one for a value that is just a count.
+		includeEmbedding: false,
 	});
 	return messages.filter(isDialogueMessage).length;
 }

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -125,10 +125,15 @@ async function getDialogueMessageCount(
 	runtime: IAgentRuntime,
 	roomId: UUID,
 ): Promise<number> {
+	const retainedMessageCount = await runtime.countMemories({
+		roomIds: [roomId],
+		unique: false,
+		tableName: "messages",
+	});
 	const messages = await runtime.getMemories({
 		tableName: "messages",
 		roomId,
-		limit: 100,
+		limit: Math.max(1, retainedMessageCount),
 		unique: false,
 	});
 	return messages.filter(isDialogueMessage).length;


### PR DESCRIPTION
Closes #24756.


## Summary

- count the room's full retained message cardinality before fetching rows for summary eligibility
- apply the existing dialogue filter only after retrieving that complete retained set
- add an adapter-faithful regression for rolling summaries beyond the first 100 dialogue rows

## Why

The eligibility path previously fixed `getMemories({ limit: 100 })`. After a rolling summary stored `lastMessageOffset: 100`, a room with 110 or more retained dialogue rows was still observed as having exactly 100. `newDialogueCount` remained zero and the evaluator returned `false` forever, so rolling-summary cleanup silently stopped.

The replacement mirrors `prepareSummary()`: count retained message rows, fetch that complete cardinality, then filter canonical and legacy dialogue while excluding action results and synthetic artifacts. It does not clamp, window, rewrite, or silently discard rows.

## Verification

- Copy-aside control using exact `origin/develop` production bytes and the committed regression test: **1 failed, 7 passed**; `shouldRun` returned `false` for ten unsummarized rows beyond offset 100.
- Restored fixed source: **8 passed** in `memory-items.test.ts`.
- No-overrejection/adjacent corpus: threshold behavior, below-threshold behavior, canonical `message`, legacy metadata, and action-result exclusion all passed.
- `bun run --cwd packages/core typecheck`: passed on control and fixed source; both produced zero TypeScript errors.
- `bunx @biomejs/biome check` on both changed files: passed.
- `git diff --check`: passed.
- `bun install --frozen-lockfile`: passed locally with no changes.
- Full `bun run verify`: failed at the unchanged i18n gate because `connector-card.tsx` references 14 keys missing from `en.json`; the branch changes only the two core memory files listed above.

Hosted CI does not execute tests for this fork PR. All results above are local and bound to the exact pushed commit through the proof ledger.

## Known gaps

- I did not run an adapter-specific database integration suite; the regression mock enforces the adapter's requested `limit`, which is the behavior required to expose this bug.
- I did not load-test very large retained rooms. This change removes the fixed 100-row eligibility cap and matches the already-shipped exhaustive retrieval used by `prepareSummary()`.
- The full repository verifier is not green locally because the unchanged connector-card UI references 14 English i18n keys missing from `en.json`; no UI or locale file is changed here.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cfe9c648dfaa39f697d1ff035ce8625d3aa0045f -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-memory-summary-count]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NS8PAA1TVCQ7T32TB2XQYP","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T22:25:37.611Z","completed_at":"2026-08-22T22:38:24.787Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T22:25:38.735Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f71376dc98abf1439e02f0ea9e5a856512e14779aa6fbb96745e636e39871932","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a36fefc7-18c1-4ca5-8a40-cc77258214f2","object_id":"sha256:f71376dc98abf1439e02f0ea9e5a856512e14779aa6fbb96745e636e39871932","sha256":"f71376dc98abf1439e02f0ea9e5a856512e14779aa6fbb96745e636e39871932"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"j71-2fnOjLdI768hSYVY-uw80NhMdqh2sykNVy8hsOMBDHkxn0f7lIbYDJipHsJH_NCs_HEhqIDVFZffqzceAA"}} -->
