### PR TITLE
fix(shared): contain stale sandbox route reclaim

### DIFF
--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -129,7 +129,14 @@ function installFetch(): void {
           (!script.includes("s==ARGV[2]") || store.get(key2) === value2) &&
           (!script.includes("g==ARGV[3]") ||
             store.get(generationKey) === generation);
-        if (owned) {
+        // Only honored when the script actually offers the unclaimed-reclaim
+        // branch, so reintroducing it to the Lua fails the containment test.
+        const unclaimed =
+          script.includes("unclaimed") &&
+          !store.has(key1) &&
+          !store.has(key2) &&
+          !store.has(generationKey);
+        if (owned || unclaimed) {
           store.set(key1, value1);
           store.set(key2, value2);
           store.set(generationKey, generation);
@@ -655,7 +662,12 @@ async function startFakeRedis(opts?: {
               store.get(key1) === value1 &&
               store.get(key2) === value2 &&
               store.get(generationKey) === generation;
-            if (owned) {
+            const unclaimed =
+              script.includes("unclaimed") &&
+              !store.has(key1) &&
+              !store.has(key2) &&
+              !store.has(generationKey);
+            if (owned || unclaimed) {
               store.set(key1, value1);
               store.set(key2, value2);
               store.set(generationKey, generation);

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -129,19 +129,14 @@ function installFetch(): void {
           (!script.includes("s==ARGV[2]") || store.get(key2) === value2) &&
           (!script.includes("g==ARGV[3]") ||
             store.get(generationKey) === generation);
-        const unclaimed =
-          script.includes("not u and not s and not g") &&
-          !store.has(key1) &&
-          !store.has(key2) &&
-          !store.has(generationKey);
-        if (owned || unclaimed) {
+        if (owned) {
           store.set(key1, value1);
           store.set(key2, value2);
           store.set(generationKey, generation);
         }
         return {
           ok: true,
-          json: async () => ({ result: owned || unclaimed ? 1 : 0 }),
+          json: async () => ({ result: owned ? 1 : 0 }),
         } as Response;
       }
       const owned =
@@ -280,33 +275,47 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     reg.stopHeartbeat();
   });
 
-  it("recovers a transient initial registration failure on heartbeat", async () => {
-    vi.useFakeTimers();
+  it("reports ownership loss after a transient initial registration failure", async () => {
     const reg = new SandboxRegistry(baseConfig);
 
     failNextFetch = true;
     await expect(reg.register()).rejects.toThrow("simulated upstash failure");
-
-    reg.startHeartbeat(30_000);
-    await vi.advanceTimersByTimeAsync(30_000);
-
-    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
-    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
-    expect(store.get("server:sandbox-abc:registration")).toBeDefined();
-
-    reg.stopHeartbeat();
+    await expect(reg.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    expect(store).toEqual(new Map());
   });
 
-  it("recovers after all registration keys expire", async () => {
-    const reg = new SandboxRegistry(baseConfig);
-    await reg.register();
+  it("does not let stale-first ordering reclaim a fully expired route", async () => {
+    const stale = new SandboxRegistry(baseConfig);
+    const successor = new SandboxRegistry(baseConfig);
+    await stale.register();
+    await successor.register();
     store.clear();
 
-    await reg.refresh();
+    await expect(stale.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    await expect(successor.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    expect(store).toEqual(new Map());
+  });
 
-    expect(store.get("agent:char-123:server")).toBe("sandbox-abc");
-    expect(store.get("server:sandbox-abc:url")).toBe("http://1.2.3.4:1999/api");
-    expect(store.get("server:sandbox-abc:registration")).toBeDefined();
+  it("does not let successor-first ordering guess after full route expiry", async () => {
+    const stale = new SandboxRegistry(baseConfig);
+    const successor = new SandboxRegistry(baseConfig);
+    await stale.register();
+    await successor.register();
+    store.clear();
+
+    await expect(successor.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    await expect(stale.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    expect(store).toEqual(new Map());
   });
 
   it("does not overlap heartbeat refreshes when a tick is still in flight", async () => {
@@ -646,17 +655,12 @@ async function startFakeRedis(opts?: {
               store.get(key1) === value1 &&
               store.get(key2) === value2 &&
               store.get(generationKey) === generation;
-            const unclaimed =
-              script.includes("not u and not s and not g") &&
-              !store.has(key1) &&
-              !store.has(key2) &&
-              !store.has(generationKey);
-            if (owned || unclaimed) {
+            if (owned) {
               store.set(key1, value1);
               store.set(key2, value2);
               store.set(generationKey, generation);
             }
-            send(`:${owned || unclaimed ? 1 : 0}\r\n`);
+            send(`:${owned ? 1 : 0}\r\n`);
           } else {
             const owned = store.get(generationKey) === generation;
             if (owned) {
@@ -760,6 +764,40 @@ describe("SandboxRegistry (native TCP transport)", () => {
     expect(fake.store.get("server:sandbox-tcp:registration")).toBe(
       successorGeneration,
     );
+  });
+
+  it("does not let stale-first TCP ordering reclaim a fully expired route", async () => {
+    fake = await startFakeRedis();
+    const stale = new SandboxRegistry(tcpConfig(fake.port));
+    const successor = new SandboxRegistry(tcpConfig(fake.port));
+    await stale.register();
+    await successor.register();
+    fake.store.clear();
+
+    await expect(stale.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    await expect(successor.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    expect(fake.store).toEqual(new Map());
+  });
+
+  it("does not let successor-first TCP ordering guess after full route expiry", async () => {
+    fake = await startFakeRedis();
+    const stale = new SandboxRegistry(tcpConfig(fake.port));
+    const successor = new SandboxRegistry(tcpConfig(fake.port));
+    await stale.register();
+    await successor.register();
+    fake.store.clear();
+
+    await expect(successor.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    await expect(stale.refresh()).rejects.toMatchObject({
+      code: "SANDBOX_REGISTRY_OWNERSHIP_LOST",
+    });
+    expect(fake.store).toEqual(new Map());
   });
 
   it("unregister() deletes only keys still pointing at this sandbox", async () => {

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -243,9 +243,10 @@ export class SandboxRegistry {
   }
 
   /**
-   * Renew exact ownership, or recover only when the complete registration has
-   * expired. Mixed or foreign state belongs to another lifecycle generation
-   * and must never be overwritten by this instance.
+   * Renew only exact ownership. Missing state is not authority: after complete
+   * expiry an older live generation and its successor are indistinguishable,
+   * so recovery must wait for the provisioner-owned handshake tracked in
+   * #24767 rather than letting whichever heartbeat arrives first take over.
    */
   private async refreshOwnedKeys(): Promise<void> {
     const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
@@ -254,8 +255,7 @@ export class SandboxRegistry {
       "-- refresh\nlocal u=redis.call('GET',KEYS[1]) local s=redis.call('GET',KEYS[2]) " +
         "local g=redis.call('GET',KEYS[3]) " +
         "local owned=u==ARGV[1] and s==ARGV[2] and g==ARGV[3] " +
-        "local unclaimed=not u and not s and not g " +
-        "if owned or unclaimed then " +
+        "if owned then " +
         "redis.call('SET',KEYS[1],ARGV[1],'EX',ARGV[4]) " +
         "redis.call('SET',KEYS[2],ARGV[2],'EX',ARGV[4]) " +
         "redis.call('SET',KEYS[3],ARGV[3],'EX',ARGV[4]) return 1 end return 0",


### PR DESCRIPTION
## Outcome

- removes the merged #24721 absent-trio reclaim path, because Redis absence cannot distinguish an older live sandbox generation from its successor
- retains typed `SANDBOX_REGISTRY_OWNERSHIP_LOST` failure when refresh cannot prove exact ownership
- covers complete route expiry with stale-first and successor-first ordering over both REST and the real TCP/RESP harness
- keeps the durable provisioner/DB-owned authority handshake scoped in #24767

Fix-forward for #24721. Relates to #24470 and #24767.

## Why containment is required

After all three TTL-backed keys expire, an old process and its successor can both observe the same empty state. The merged `unclaimed` branch lets whichever heartbeat reaches Redis first recreate the route. That can resurrect the stale process and reverses the generation fence added in #24675.

A runtime-created persistent key is not sufficient: an old delayed `register()` can complete after successor registration. #24767 therefore owns the durable control-plane handshake. Until that exists, missing state fails closed instead of guessing.

## Exact-head verification

Base before rebase: `3c12334e5775bdc60f9df65d44a1f774d7a1c85f`

- `bun run --cwd packages/shared test -- src/sandbox-registry.test.ts` — 31/31 passed
- `bun run --cwd packages/shared typecheck` — passed
- `bunx biome check packages/shared/src/sandbox-registry.ts packages/shared/src/sandbox-registry.test.ts` — passed, no fixes
- `git diff --check HEAD^..HEAD` — passed

No UI, model, prompt, transport schema, or public gateway key changes.

<!-- evidence-head:1b8dadcf0d5a8967f6a020aba195bd1f2a4eb8bd -->

<!-- evidence-row:before-screenshots -->
N/A - Redis lifecycle containment with no rendered UI.

<!-- evidence-row:after-screenshots -->
N/A - Redis lifecycle containment with no rendered UI.

<!-- evidence-row:walkthrough-video -->
N/A - no user-interface flow changed.

<!-- evidence-row:backend-logs -->
N/A - deterministic REST and real TCP/RESP receipts are recorded below; no deployed credential-bearing environment was mutated.

<!-- evidence-row:frontend-logs -->
N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, provider, action, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
<details><summary>Registry ordering receipt</summary>

```text
REST: stale-first full expiry -> both generations receive SANDBOX_REGISTRY_OWNERSHIP_LOST; route remains absent.
REST: successor-first full expiry -> both generations receive SANDBOX_REGISTRY_OWNERSHIP_LOST; route remains absent.
TCP/RESP: stale-first full expiry -> same result over a real socket.
TCP/RESP: successor-first full expiry -> same result over a real socket.
Focused suite: 31 passed, 0 failed.
```
</details>

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface changed.
