### PR TITLE
fix(core): preserve authorized planner surface

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -355,7 +355,9 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 			),
 		);
 		expect(plannerTools).toContain("READ");
-		expect(plannerTools).not.toContain("GENERATE_MEDIA");
+		// The action passes the ordinary coding-context/role gates, so a fixed
+		// legacy name allowlist must not silently remove it from the model surface.
+		expect(plannerTools).toContain("GENERATE_MEDIA");
 		const firstPlannerMessages = (
 			getCalls(runtime)[0]?.params as
 				| {

--- a/packages/core/src/actions/__tests__/to-tool.test.ts
+++ b/packages/core/src/actions/__tests__/to-tool.test.ts
@@ -348,6 +348,29 @@ describe("buildPlannerToolsFromTieredActions", () => {
 		expect(tiered.map((tool) => tool.name)).toEqual(["MUSIC", "PLAY_MUSIC"]);
 	});
 
+	it("expands only inline children in the authorized action lookup", () => {
+		const allowedChild = makeTieredAction({
+			name: "PLAY_MUSIC",
+			description: "Allowed child.",
+		});
+		const deniedChild = makeTieredAction({
+			name: "DELETE_PRIVATE_PLAYLIST",
+			description: "Private child that must not reach the model.",
+		});
+		const parent = makeTieredAction({
+			name: "MUSIC",
+			description: "Music parent.",
+			subActions: [allowedChild, deniedChild],
+		});
+
+		const tools = buildPlannerToolsFromTieredActions([parent], {
+			actionLookup: new Map([[allowedChild.name, allowedChild]]),
+		});
+
+		expect(tools.map((tool) => tool.name)).toEqual(["MUSIC", "PLAY_MUSIC"]);
+		expect(JSON.stringify(tools)).not.toContain("Private child");
+	});
+
 	it("rejects sub-action names that are not strict native tool names", () => {
 		const badChild = makeTieredAction({
 			name: "lowercaseChild",

--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -346,8 +346,9 @@ export interface BuildPlannerToolsFromTieredActionsOptions {
 	 * skipped silently — string refs are advisory and the parent's handler
 	 * can still dispatch to them internally if the planner picks the parent.
 	 *
-	 * Inline-Action sub-actions (where `parent.subActions[i]` is an Action
-	 * object, not a string) are always expanded regardless of this map.
+	 * When provided, inline-Action sub-actions must also resolve through this
+	 * map. Runtime callers pass the already-authorized per-turn action set, so
+	 * expanding an absent inline object would disclose a rejected child.
 	 */
 	actionLookup?:
 		| ReadonlyMap<string, PlannerToolActionShape>
@@ -470,7 +471,8 @@ function resolveActionLookup(
  * alongside the parent, so relevance metadata cannot hide a callable action.
  *
  * Sub-action resolution:
- *   - Inline `Action` sub-actions on `parent.subActions` are always expanded.
+ *   - Inline `Action` sub-actions are expanded only when their exact name is
+ *     present in `actionLookup` or the authorized top-level input.
  *   - String-only sub-action references are resolved through `actionLookup`
  *     when provided; references that cannot be resolved are skipped silently
  *     (the parent's handler can still route to them).
@@ -485,6 +487,7 @@ export function buildPlannerToolsFromTieredActions(
 	actions: ReadonlyArray<PlannerToolActionShape>,
 	options: BuildPlannerToolsFromTieredActionsOptions = {},
 ): ToolDefinition[] {
+	const hasAuthoritativeActionLookup = options.actionLookup !== undefined;
 	const actionLookup = resolveActionLookup(options.actionLookup);
 
 	// Top up the lookup with anything already in `actions` so children that
@@ -521,7 +524,11 @@ export function buildPlannerToolsFromTieredActions(
 				subActionName = subAction;
 			} else if (subAction && typeof subAction === "object") {
 				subActionName = subAction.name;
-				child = subAction;
+				child = hasAuthoritativeActionLookup
+					? actionLookup.has(subActionName)
+						? actionLookup.get(subActionName)
+						: undefined
+					: subAction;
 			}
 			if (typeof subAction === "string") {
 				child = actionLookup.get(subAction);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3170,32 +3170,6 @@ const CODING_SUB_AGENT_CONTEXTS: readonly AgentContext[] = [
 	"automation",
 ];
 
-/**
- * Exact action surface for a direct coding turn. Context overlap is too broad:
- * attachment and media actions also carry file/automation contexts, and each
- * extra tool schema enlarges the request. A large tool set + a large file
- * generation is exactly what makes weaker hosted models (Cerebras glm-4.7)
- * intermittently reject the request (server_error / 400) or narrate instead of
- * emitting FILE. Keep the surface aligned with the tools that actually do the
- * work (FILE/SHELL/WORKTREE/WEB plus terminal controls).
- */
-const CODING_DIRECT_ACTIONS: ReadonlySet<string> = new Set(
-	// Stored in normalizeActionIdentifier() form (uppercase, underscores
-	// stripped), since that is what the filter compares against.
-	[
-		"READ",
-		"WRITE",
-		"EDIT",
-		"SHELL",
-		"WORKTREE",
-		"WEBFETCH",
-		"WEBSEARCH",
-		"REPLY",
-		"STOP",
-		"IGNORE",
-	],
-);
-
 function actionNameTokenKey(name: string): string {
 	return normalizeActionName(name).split("_").filter(Boolean).sort().join("_");
 }
@@ -8901,29 +8875,15 @@ export async function runV5MessageRuntimeStage1(args: {
 		// returning zero candidates → planner got no native tools → model narrated.
 		const useFullSurface = args.codingMode === true;
 		const plannerCandidateActions = useFullSurface
-			? (args.runtime.actions ?? []).filter(
-					(action) =>
-						// Full-surface = a trusted coding turn. It must NOT receive the
-						// whole chat action catalog (MESSAGE_*/POST_*/…) — 40 tools drowns
-						// the model and it never calls FILE. Instead treat the coding
-						// contexts (code/files/terminal/automation) as active and run the
-						// normal execution gates: that admits the coding tools
-						// (FILE/SHELL/WORKTREE, which gate on a coding context) plus
-						// context-free control actions (REPLY/STOP/…) and drops the
-						// messaging/social chat actions. Role still applies (FILE=ADMIN,
-						// SHELL=OWNER; the coding sub-agent runs as OWNER). UI/orchestration
-						// parents that pass the gate but a coder never needs are dropped
-						// too (see CODING_DIRECT_ACTIONS) to keep the request
-						// small enough for weaker hosted models to handle large builds.
-						CODING_DIRECT_ACTIONS.has(normalizeActionIdentifier(action.name)) &&
-						// Static candidate-action set for a coding sub-agent — no concrete
-						// turn message here, so skip the private-action gate; the eventual
-						// execution still enforces it through the executor.
-						canActionRun(action, {
-							activeContexts: CODING_SUB_AGENT_CONTEXTS,
-							userRoles: [senderRole],
-							skipPrivateGate: true,
-						}),
+			? (args.runtime.actions ?? []).filter((action) =>
+					// The execution gates are the authority for a focused coding turn.
+					// Names may rank tools but cannot form a second fixed allowlist that
+					// silently hides newly registered coding capabilities.
+					canActionRun(action, {
+						activeContexts: CODING_SUB_AGENT_CONTEXTS,
+						userRoles: [senderRole],
+						skipPrivateGate: true,
+					}),
 				)
 			: await collectV5PlannerCandidateActions({
 					runtime: args.runtime,


### PR DESCRIPTION
Fixes #24699

## Summary

- resolve planner child actions only from the authorized runtime action lookup
- preserve exact registered-action identity before normalized alias fallback
- remove the stale coding-action allowlist so newly registered authorized coding actions remain callable
- add regressions for private inline child metadata and newly registered coding actions

This is a narrow follow-up to #24718, which merged while its independent review was still running. The merged completeness change retained two authorization/completeness gaps that this patch closes.

## Verification

- focused planner/tool suites — 51 passed on the rebased exact tree
- `bun run --cwd packages/core typecheck` — passed
- Biome on all four changed files — passed
- `git diff --check origin/develop...HEAD` — passed

<!-- evidence-head:0f61180c8fb33725615f41996eabaeb2c13bbeb1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - planner authorization has no interactive UI flow

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic planner/tool suites exercise the in-process authorization boundary without external transport

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - the regression is catalog admission before model dispatch; tests prove denied metadata is absent and authorized actions are present without invoking a model

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by catalog construction

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes
