### PR TITLE
fix(cloud): reject foreign Telegram group commands

### DIFF
--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -137,6 +137,13 @@ function entityText(
   return text.slice(entity.offset, entity.offset + entity.length);
 }
 
+const TELEGRAM_COMMAND_TEXT_PREFIX =
+  /^\/[a-z0-9_]{1,32}(?:@([a-z0-9_]{5,32}))?(?=$|\s)/i;
+
+function telegramCommandTarget(value: string): string | null {
+  return value.match(/@([a-z0-9_]{5,32})$/i)?.[1] ?? null;
+}
+
 /**
  * Default group policy: respond only to a command delivered to the bot, an
  * explicit @mention of this bot, or a reply to one of its messages. Ambient
@@ -149,14 +156,8 @@ export function classifyTelegramGroupInvocation(
 ): TelegramConnectorEvent["groupInvocation"] | null {
   const botUsername = normalizedTelegramUsername(policy.botUsername);
   if (!botUsername) return null;
-  if (
-    message.reply_to_message?.from?.is_bot &&
-    normalizedTelegramUsername(message.reply_to_message.from.username ?? "") ===
-      botUsername
-  ) {
-    return "reply";
-  }
   const entities = message.text ? message.entities : message.caption_entities;
+  const validEntities: Array<{ type: string; value: string }> = [];
   for (const entity of entities ?? []) {
     if (
       !Number.isInteger(entity.offset) ||
@@ -167,20 +168,47 @@ export function classifyTelegramGroupInvocation(
     ) {
       continue;
     }
-    const value = entityText(text, entity);
+    validEntities.push({ type: entity.type, value: entityText(text, entity) });
+  }
+
+  const textCommandMatch = text.trim().match(TELEGRAM_COMMAND_TEXT_PREFIX);
+  const textCommandTarget = textCommandMatch?.[1];
+  if (
+    textCommandTarget &&
+    normalizedTelegramUsername(textCommandTarget) !== botUsername
+  ) {
+    return null;
+  }
+  for (const entity of validEntities) {
+    if (entity.type !== "bot_command") continue;
+    const target = telegramCommandTarget(entity.value);
+    if (target && normalizedTelegramUsername(target) !== botUsername) {
+      return null;
+    }
+  }
+
+  if (
+    message.reply_to_message?.from?.is_bot &&
+    normalizedTelegramUsername(message.reply_to_message.from.username ?? "") ===
+      botUsername
+  ) {
+    return "reply";
+  }
+  for (const entity of validEntities) {
     if (
       entity.type === "mention" &&
-      normalizedTelegramUsername(value) === botUsername
+      normalizedTelegramUsername(entity.value) === botUsername
     ) {
       return "mention";
     }
     if (entity.type === "bot_command") {
-      const target = value.match(/@([a-z0-9_]{5,32})$/i)?.[1];
+      const target = telegramCommandTarget(entity.value);
       if (!target || normalizedTelegramUsername(target) === botUsername) {
         return "command";
       }
     }
   }
+  if (textCommandMatch) return "command";
   return policy.allowAmbient ? "ambient" : null;
 }
 

--- a/packages/cloud/services/_common/tests/telegram-connector-groups.test.ts
+++ b/packages/cloud/services/_common/tests/telegram-connector-groups.test.ts
@@ -83,6 +83,75 @@ describe("parseTelegramWebhook group policy", () => {
     ).toBeNull();
   });
 
+  test.each([
+    [
+      "ambient before a reply",
+      {
+        text: "  /eliza_ambient@AnotherBot on\n",
+        entities: [{ type: "bot_command", offset: 2, length: 25 }],
+        reply_to_message: {
+          message_id: 77,
+          from: { is_bot: true, username: "ElizaIsNotABot" },
+        },
+      },
+    ],
+    [
+      "leave before a mention",
+      {
+        text: "\t/eliza_leave@AnotherBot @ElizaIsNotABot  ",
+        entities: [
+          { type: "bot_command", offset: 1, length: 23 },
+          { type: "mention", offset: 25, length: 15 },
+        ],
+      },
+    ],
+    [
+      "link before ambient fallback with a misaligned entity",
+      {
+        text: "  /eliza_link@AnotherBot 23456789  ",
+        entities: [{ type: "bot_command", offset: 0, length: 22 }],
+      },
+    ],
+  ])("rejects a foreign %s", (_case, message) => {
+    expect(
+      parseTelegramWebhook(update(message), undefined, {
+        ...policy,
+        allowAmbient: true,
+      }),
+    ).toBeNull();
+  });
+
+  test.each([
+    ["current-bot ambient", "  /eliza_ambient@ElizaIsNotABot on\n"],
+    ["unqualified ambient", "\t/eliza_ambient off  "],
+    ["current-bot leave", "\n/eliza_leave@ElizaIsNotABot  "],
+    ["unqualified leave", "  /eliza_leave\t"],
+    ["current-bot link", "\t/eliza_link@ElizaIsNotABot 23456789  "],
+    ["unqualified link", "  /eliza_link 23456789\n"],
+  ])("recognizes a trimmed %s command without entities", (_case, text) => {
+    expect(
+      parseTelegramWebhook(update({ text }), undefined, {
+        ...policy,
+        allowAmbient: true,
+      }),
+    ).toMatchObject({ groupInvocation: "command", text });
+  });
+
+  test.each([
+    ["unqualified", " /eliza_leave "],
+    ["suffixed", " /eliza_link@ElizaIsNotABot 23456789 "],
+  ])(
+    "keeps a trimmed %s command fail-closed without bot identity",
+    (_case, text) => {
+      expect(
+        parseTelegramWebhook(update({ text }), undefined, {
+          botUsername: "  ",
+          allowAmbient: true,
+        }),
+      ).toBeNull();
+    },
+  );
+
   test("accepts a reply to this bot but not an arbitrary bot", () => {
     expect(
       parseTelegramWebhook(

--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts
@@ -40,6 +40,9 @@ describe("telegram group-link authority", () => {
     ["slash", "/eliza_link 23456789"],
     ["natural language", "Eliza link 23456789"],
     ["bot-suffixed slash", "/eliza_link@ElizaBot 23456789"],
+    ["trimmed slash", "  /eliza_link 23456789\n"],
+    ["trimmed natural language", "\tEliza link 23456789  "],
+    ["trimmed bot-suffixed slash", "\n/eliza_link@ElizaBot 23456789\t"],
   ])("verifies %s syntax through current membership", async (_case, text) => {
     const requests: Request[] = [];
     globalThis.fetch = (async (input, init) => {
@@ -60,6 +63,7 @@ describe("telegram group-link authority", () => {
     expect(event).toMatchObject({
       chatId: "-100123456789",
       senderId: "42",
+      text,
       groupActorRole: "administrator",
     });
     expect(requests).toHaveLength(1);
@@ -104,18 +108,53 @@ describe("telegram group-link authority", () => {
     expect(requests).toBe(0);
   });
 
+  test.each([
+    ["ambient", "  /eliza_ambient@OtherBot on\n"],
+    ["leave", "\t/eliza_leave@OtherBot  "],
+  ])(
+    "drops a foreign %s command at the adapter boundary",
+    async (_case, text) => {
+      let requests = 0;
+      globalThis.fetch = (async () => {
+        requests += 1;
+        return Response.json({ ok: true, result: {} });
+      }) as typeof fetch;
+
+      const event = await telegramAdapter.extractEvent(
+        groupUpdate(text),
+        config,
+      );
+
+      expect(event).toBeNull();
+      expect(requests).toBe(0);
+    },
+  );
+
+  test("drops a whitespace-padded link command addressed to another bot", async () => {
+    let requests = 0;
+    globalThis.fetch = (async () => {
+      requests += 1;
+      return Response.json({ ok: true, result: { status: "creator" } });
+    }) as typeof fetch;
+    const text = "  /eliza_link@OtherBot 23456789\n";
+
+    const event = await telegramAdapter.extractEvent(groupUpdate(text), config);
+
+    expect(event).toBeNull();
+    expect(requests).toBe(0);
+  });
+
   test("drops a suffixed link command when bot identity is unavailable", async () => {
     let requests = 0;
     globalThis.fetch = (async () => {
       requests += 1;
       throw new Error("Telegram unavailable");
     }) as typeof fetch;
-    const text = "/eliza_link@ElizaBot 23456789";
+    const text = " \t/eliza_link@ElizaBot 23456789\n";
 
-    const event = await telegramAdapter.extractEvent(
-      groupUpdate(text, text.indexOf(" ")),
-      { botToken: "telegram-test-token" },
-    );
+    const event = await telegramAdapter.extractEvent(groupUpdate(text), {
+      botToken: "telegram-test-token",
+    });
 
     expect(event).toBeNull();
     expect(requests).toBe(1);

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -32,7 +32,7 @@ function telegramGroupLinkTarget(
   text: string,
   botUsername: string,
 ): "not-link" | "this-bot" | "other-bot" {
-  const match = text.match(TELEGRAM_GROUP_LINK_COMMAND);
+  const match = text.trim().match(TELEGRAM_GROUP_LINK_COMMAND);
   if (!match) return "not-link";
   const target = match[1];
   if (!target) return "this-bot";


### PR DESCRIPTION
# Relates to

Follow-up to merged PR [#24695](https://github.com/elizaOS/eliza/pull/24695), the exact-head [changes-requested review](https://github.com/elizaOS/eliza/pull/24695#pullrequestreview-5001113925), the [post-merge revalidation](https://github.com/elizaOS/eliza/pull/24695#issuecomment-5382882611), and the public [follow-up claim](https://github.com/elizaOS/eliza/pull/24695#issuecomment-5382930913).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; exact unrelated
      baseline blockers are recorded below.
- [x] A reviewer can confirm the behavior from provider-shaped parser and
      adapter fixtures covering every affected command class.

# Sync with develop

- [x] Rebased onto `origin/develop@3c12334e5775bdc60f9df65d44a1f774d7a1c85f`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is
      documented in **Known gaps / failures**.

# Risks

**Medium.** This changes the Telegram group ingress classification boundary. An explicitly foreign `@bot` command now vetoes the whole update before reply, mention, or ambient fallbacks, even if the same message also replies to or mentions this bot. That fail-closed precedence prevents another bot's control command from mutating this bot's group state. The text fallback also recognizes command prefixes when Telegram entities are absent or misaligned; unqualified and current-bot commands remain accepted, while unavailable bot identity remains fail-closed. Original event text is preserved.

# Background

## What does this PR do?

The merged #24695 filtered only one raw link shape. Two gaps remained:

1. `/eliza_ambient@OtherBot on` and `/eliza_leave@OtherBot` missed the target match, fell through as ambient because the gateway enables `allowAmbient`, and could reach downstream policy or binding mutations.
2. `/eliza_link@OtherBot 23456789 ` missed the adapter's anchored raw regex, then matched after the Cloud route trimmed the message.

This repair:

- collects valid Telegram entities, rejects every explicitly foreign `bot_command` before reply/mention/ambient classification, and preserves valid current-bot or unqualified commands;
- parses a trimmed command prefix as a fallback when entities are missing or malformed, matching the downstream normalization boundary;
- matches group-link commands against a trimmed copy in the gateway without changing `event.text`;
- adds shared and adapter regressions for foreign ambient/leave/link commands, reply/mention precedence, leading/trailing whitespace, current-bot/unqualified commands, membership lookup behavior, and unavailable bot identity.

The internal Cloud route is intentionally unchanged because it does not receive the trusted Telegram bot identity or provider entities; the gateway classifier is the correct trust boundary.

## What kind of change is this?

Bug fix (non-breaking Cloud Telegram routing hardening).

# Documentation changes needed?

No project documentation change is needed. The public command syntax is preserved; only foreign-target filtering and normalization parity are corrected.

# Testing

## Where should a reviewer start?

Start with `classifyTelegramGroupInvocation` in `packages/cloud/services/_common/src/telegram-connector.ts`, then the provider-shaped matrix in `telegram-connector-groups.test.ts` and adapter integration cases in `telegram-group-link.test.ts`.

## Detailed testing steps

On exact head `ad418e4f15e555fa2afa847b6c37ee6179a47446`:

1. `bun install --frozen-lockfile` — passed with no changes.
2. `bun test packages/cloud/services/_common/tests/telegram-connector-groups.test.ts packages/cloud/services/gateway-webhook/__tests__/telegram-group-link.test.ts` — 33/33 passed, 64 assertions.
3. `bun run --cwd packages/cloud/services/_common test` — 54/54 passed, 112 assertions.
4. `bun run --cwd packages/cloud/services/gateway-webhook test` — 227 passed / 228 total; the single unchanged Dockerfile baseline failure is detailed below.
5. `bun run --cwd packages/cloud/services/_common typecheck` — passed.
6. `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — passed.
7. `bunx @biomejs/biome check packages/cloud/services/_common packages/cloud/services/gateway-webhook` — 69 files clean.
8. `git diff --check origin/develop...HEAD` — passed.
9. `bun run verify` — stops on the unchanged connector-card i18n baseline detailed below.

# Evidence Gate

<!-- evidence-head:ad418e4f15e555fa2afa847b6c37ee6179a47446 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend webhook classification change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend webhook classification change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Telegram or Cloud traffic was generated; deterministic provider-shaped updates execute the exact parser and adapter paths.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider-model, prompt, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - rejected ingress produces no database, binding, policy, memory, task, wallet, file, or audio artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or user-facing text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic Telegram transport classification; no LLM path is involved.

## Backend + frontend logs

Backend live logs: N/A - a live provider/Cloud round trip would require secrets and external state. Provider-shaped Telegram updates exercise the exact shared classifier and gateway adapter locally; the regressions assert rejected foreign commands return `null` before any Telegram API request.

Frontend logs: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI or interactive flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- Exact-head `bun run verify` stops in `check:i18n`: current `develop` uses 14 missing English `connectorcard.*` keys in `packages/ui/src/components/chat/widgets/connector-card.tsx`. No UI or i18n file is in this diff.
- The full gateway suite reports 227 pass / 1 fail. The unchanged `dockerfile-workspace-context.test.ts` expects `packages/cloud/services/gateway-discord/Dockerfile` to copy `@elizaos/core`; it currently does not. The other 8 tests in that file pass, and neither the gateway-discord Dockerfile nor its dependency metadata is in this diff.
- Live provider/Cloud logs and UI, LLM, domain, OCR, and audio artifacts are N/A for the concrete reasons above. No production Cloudflare, Railway, Kubernetes, credential, billing, deployment, or webhook mutation was performed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@4f4a78be4a97d9fd42d5b2342d7343c7cebcfeed:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [standujar/telegram-foreign-command-routing-follow-up]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@4f4a78be4a97d9fd42d5b2342d7343c7cebcfeed:packages/skills/skills/contribute-to-eliza"} -->
