### PR TITLE
fix(remote): require authoritative native host revoke

### DIFF
--- a/packages/app-core/platforms/electrobun/src/remote-target-boundaries.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-boundaries.test.ts
@@ -250,4 +250,63 @@ describe("remote target native boundaries", () => {
     store.values.set("target-test", JSON.stringify(stored));
     await expect(vault.load()).rejects.toThrow("corrupt");
   });
+
+  it("binds native host revocation to its stored bearer and exact response host", async () => {
+    const store = new MemorySecureStore();
+    const vault = new RemoteTargetVault(store, "revoke-target-test");
+    const pending = await vault.prepare({
+      ownerId: "owner-1",
+      displayName: "Linux target",
+      now: 2_000_000_000_000,
+    });
+    if (pending.status !== "pending") throw new Error("expected pending");
+    const enrollment = await vault.commitEnrollment({
+      apiBaseUrl: "https://api.example.test",
+      hostId: "11111111-1111-4111-8111-111111111111",
+      hostToken: `rhost_v1_${"A".repeat(43)}`,
+      runtimeKeyId: pending.keyId,
+      createdAt: 2_000_000_000_001,
+    });
+    const requests: Request[] = [];
+    const transport = new HttpRemoteTargetRelayTransport(
+      async (input, init) => {
+        requests.push(new Request(input, init));
+        return jsonResponse({
+          success: true,
+          data: {
+            id: enrollment.identity.runtimeId,
+            status: "revoked",
+            alreadyRevoked: false,
+            cleanup: { sessions: 1, commands: 2, more: false },
+          },
+        });
+      },
+    );
+    await expect(transport.revokeHost({ enrollment })).resolves.toMatchObject({
+      hostId: enrollment.identity.runtimeId,
+      status: "revoked",
+      cleanup: { more: false },
+    });
+    expect(requests[0]?.headers.get("authorization")).toBe(
+      `Bearer ${enrollment.hostToken}`,
+    );
+    expect(requests[0]?.headers.get("x-remote-host-id")).toBe(
+      enrollment.identity.runtimeId,
+    );
+
+    const substituted = new HttpRemoteTargetRelayTransport(async () =>
+      jsonResponse({
+        success: true,
+        data: {
+          id: "22222222-2222-4222-8222-222222222222",
+          status: "revoked",
+          alreadyRevoked: false,
+          cleanup: { sessions: 0, commands: 0, more: false },
+        },
+      }),
+    );
+    await expect(substituted.revokeHost({ enrollment })).rejects.toThrow(
+      "response is invalid",
+    );
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
@@ -4,6 +4,7 @@
  * the host bearer and private JWKs never cross this boundary.
  */
 import { createHash } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import type { RemoteTargetPublicIdentity } from "@elizaos/shared/contracts/remote-control";
 import {
   LoopbackRemoteTargetExecutor,
@@ -260,23 +261,45 @@ export class RemoteTargetDesktopService {
   async finalizeHostRevoke(params: unknown): Promise<{ cleaned: true }> {
     const value = requireObject(params);
     const hostId = requireString(value.hostId, "host id", 256);
-    if (value.cloudRevoked !== true) {
-      throw new Error(
-        "Cloud host revocation must complete before local cleanup.",
+    const enrollment = await this.vault.load();
+    if (enrollment?.status !== "enrolled") {
+      throw new ElizaError("Remote host enrollment is unavailable", {
+        code: "REMOTE_HOST_ENROLLMENT_UNAVAILABLE",
+        context: { hostId },
+      });
+    }
+    if (enrollment.identity.runtimeId !== hostId) {
+      throw new ElizaError(
+        "Remote host cleanup target does not match this device",
+        {
+          code: "REMOTE_HOST_CLEANUP_TARGET_MISMATCH",
+          context: { hostId, enrolledHostId: enrollment.identity.runtimeId },
+        },
       );
     }
-    const enrollment = await this.vault.load();
-    if (
-      enrollment?.status === "enrolled" &&
-      enrollment.identity.runtimeId !== hostId
-    ) {
-      throw new Error("Remote host cleanup target does not match this device.");
+    while (true) {
+      const page = await this.transport.revokeHost({ enrollment });
+      if (!page.cleanup.more) break;
+      if (page.cleanup.sessions === 0 && page.cleanup.commands === 0) {
+        throw new ElizaError(
+          "Remote host revocation made no cleanup progress",
+          {
+            code: "REMOTE_HOST_CLEANUP_PROGRESS_INVALID",
+            context: { hostId, reason: "non_progressing_page" },
+          },
+        );
+      }
     }
     await this.stop();
     this.runner = null;
     this.loopbackConfigurationKey = null;
     await this.stateStore.clear();
-    await this.vault.delete();
+    if (!(await this.vault.delete())) {
+      throw new ElizaError("Remote host credentials could not be deleted", {
+        code: "REMOTE_HOST_CREDENTIAL_DELETE_FAILED",
+        context: { hostId },
+      });
+    }
     return { cleaned: true };
   }
 

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
@@ -89,6 +89,12 @@ class FakeRelay implements RemoteTargetRelayTransport {
   }[] = [];
   startFailure: Error | null = null;
   completionFailure: Error | null = null;
+  readonly revocations: Array<{
+    hostId: string;
+    status: "revoked";
+    alreadyRevoked: boolean;
+    cleanup: { sessions: number; commands: number; more: boolean };
+  }> = [];
 
   async enroll(
     _input: RemoteTargetEnrollmentRequest,
@@ -128,6 +134,17 @@ class FakeRelay implements RemoteTargetRelayTransport {
       throw error;
     }
     this.completions.push(input);
+  }
+
+  async revokeHost(): Promise<{
+    hostId: string;
+    status: "revoked";
+    alreadyRevoked: boolean;
+    cleanup: { sessions: number; commands: number; more: boolean };
+  }> {
+    const page = this.revocations.shift();
+    if (!page) throw new Error("authoritative revocation unavailable");
+    return page;
   }
 }
 
@@ -755,5 +772,83 @@ describe("remote target durable runner", () => {
     await service.configureLoopback(secondConfiguration);
     expect((await service.status()).running).toBe(true);
     await service.stop();
+  });
+
+  it("requires authoritative host revocation before deleting native credentials", async () => {
+    const harness = await createHarness();
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      harness.relay,
+      () => NOW,
+    );
+
+    await expect(
+      service.finalizeHostRevoke({ hostId: HOST_ID, cloudRevoked: true }),
+    ).rejects.toThrow("authoritative revocation unavailable");
+    await expect(harness.vault.load()).resolves.toMatchObject({
+      status: "enrolled",
+    });
+  });
+
+  it("drains authoritative revoke pages before clearing the journal and vault", async () => {
+    const harness = await createHarness();
+    await createRunner(harness, () => undefined);
+    harness.relay.revocations.push(
+      {
+        hostId: HOST_ID,
+        status: "revoked",
+        alreadyRevoked: false,
+        cleanup: { sessions: 100, commands: 500, more: true },
+      },
+      {
+        hostId: HOST_ID,
+        status: "revoked",
+        alreadyRevoked: true,
+        cleanup: { sessions: 1, commands: 0, more: false },
+      },
+    );
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      harness.relay,
+      () => NOW,
+    );
+
+    await expect(
+      service.finalizeHostRevoke({ hostId: HOST_ID }),
+    ).resolves.toEqual({ cleaned: true });
+    await expect(harness.vault.load()).resolves.toBeNull();
+    await expect(harness.state.read()).resolves.toEqual({
+      version: 1,
+      sessions: {},
+      commands: {},
+    });
+    expect(harness.relay.revocations).toHaveLength(0);
+  });
+
+  it("rejects non-progressing revoke continuation without local cleanup", async () => {
+    const harness = await createHarness();
+    harness.relay.revocations.push({
+      hostId: HOST_ID,
+      status: "revoked",
+      alreadyRevoked: true,
+      cleanup: { sessions: 0, commands: 0, more: true },
+    });
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      harness.relay,
+      () => NOW,
+    );
+
+    await expect(
+      service.finalizeHostRevoke({ hostId: HOST_ID }),
+    ).rejects.toMatchObject({
+      code: "REMOTE_HOST_CLEANUP_PROGRESS_INVALID",
+    });
+    await expect(harness.vault.load()).resolves.toMatchObject({
+      status: "enrolled",
+    });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/remote-target-transport.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-transport.ts
@@ -3,6 +3,8 @@
  * process. Host and owner bearers are placed in request headers, never URLs or
  * returned diagnostics, and response bodies are rejected above a fixed limit.
  */
+
+import { ElizaError } from "@elizaos/core";
 import {
   canonicalizeRemoteControlValue,
   type EncryptedRemoteControlEnvelope,
@@ -79,6 +81,13 @@ export interface RemoteTargetClaim {
   claimExpiresAt: number;
 }
 
+export interface RemoteTargetHostRevocationPage {
+  hostId: string;
+  status: "revoked";
+  alreadyRevoked: boolean;
+  cleanup: { sessions: number; commands: number; more: boolean };
+}
+
 export interface RemoteTargetRelayTransport {
   enroll(
     input: RemoteTargetEnrollmentRequest,
@@ -108,6 +117,9 @@ export interface RemoteTargetRelayTransport {
     claimToken: string;
     envelope: EncryptedRemoteControlEnvelope;
   }): Promise<void>;
+  revokeHost(input: {
+    enrollment: EnrolledRemoteTargetVaultRecord;
+  }): Promise<RemoteTargetHostRevocationPage>;
 }
 
 function requireObject(value: unknown): Record<string, unknown> {
@@ -502,6 +514,48 @@ export class HttpRemoteTargetRelayTransport
     envelope: EncryptedRemoteControlEnvelope;
   }): Promise<void> {
     await this.commandMutation("complete", input);
+  }
+
+  async revokeHost(input: {
+    enrollment: EnrolledRemoteTargetVaultRecord;
+  }): Promise<RemoteTargetHostRevocationPage> {
+    const hostId = requireUuid(input.enrollment.identity.runtimeId);
+    const data = requireObject(
+      await this.request(
+        input.enrollment.apiBaseUrl,
+        `/api/v1/remote/hosts/${encodeURIComponent(hostId)}/revoke`,
+        {
+          method: "POST",
+          headers: this.hostHeaders(input.enrollment),
+        },
+      ),
+    );
+    const cleanup = requireObject(data.cleanup);
+    if (
+      data.id !== hostId ||
+      data.status !== "revoked" ||
+      typeof data.alreadyRevoked !== "boolean" ||
+      !Number.isSafeInteger(cleanup.sessions) ||
+      (cleanup.sessions as number) < 0 ||
+      !Number.isSafeInteger(cleanup.commands) ||
+      (cleanup.commands as number) < 0 ||
+      typeof cleanup.more !== "boolean"
+    ) {
+      throw new ElizaError("Remote host revocation response is invalid", {
+        code: "REMOTE_HOST_REVOCATION_RESPONSE_INVALID",
+        context: { hostId },
+      });
+    }
+    return {
+      hostId,
+      status: "revoked",
+      alreadyRevoked: data.alreadyRevoked,
+      cleanup: {
+        sessions: cleanup.sessions as number,
+        commands: cleanup.commands as number,
+        more: cleanup.more,
+      },
+    };
   }
 
   private async commandMutation(

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -2334,7 +2334,7 @@ export type ElizaDesktopRPCSchema = {
         response: { revoked: true };
       };
       remoteTargetFinalizeHostRevoke: {
-        params: { hostId: string; cloudRevoked: true };
+        params: { hostId: string };
         response: { cleaned: true };
       };
 

--- a/packages/cloud/api/v1/remote/hosts/[id]/revoke/route.ts
+++ b/packages/cloud/api/v1/remote/hosts/[id]/revoke/route.ts
@@ -6,21 +6,34 @@ import { remoteHostsRepository } from "@/db/repositories/remote-hosts";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { parseRemoteHostCredential } from "../../../host-auth";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
     const id = c.req.param("id")?.trim() ?? "";
     if (!isRemotePairingUuid(id)) {
       return c.json({ success: false, error: "Host id must be a UUID" }, 400);
     }
-    const result = await remoteHostsRepository.revoke(
-      id,
-      user.organization_id,
-      user.id,
-    );
+    const credential = parseRemoteHostCredential(c.req.raw);
+    let result: Awaited<ReturnType<typeof remoteHostsRepository.revoke>>;
+    if (credential) {
+      result =
+        credential.hostId === id
+          ? await remoteHostsRepository.revokeAuthenticated(
+              id,
+              credential.token,
+            )
+          : undefined;
+    } else {
+      const user = await requireUserOrApiKeyWithOrg(c);
+      result = await remoteHostsRepository.revoke(
+        id,
+        user.organization_id,
+        user.id,
+      );
+    }
     if (!result)
       return c.json({ success: false, error: "Host not found" }, 404);
     return c.json({

--- a/packages/cloud/api/v1/remote/relay-routes.test.ts
+++ b/packages/cloud/api/v1/remote/relay-routes.test.ts
@@ -37,6 +37,7 @@ const createOwned = mock();
 const recoverHostCredential = mock();
 const listOwned = mock();
 const revokeHost = mock();
+const revokeAuthenticatedHost = mock();
 const createPendingForOwnedAgent = mock();
 const createPendingForOwnedHost = mock();
 const activatePendingHost = mock();
@@ -58,6 +59,7 @@ mock.module("@/db/repositories/remote-hosts", () => ({
     recoverCredential: recoverHostCredential,
     listOwned,
     revoke: revokeHost,
+    revokeAuthenticated: revokeAuthenticatedHost,
   },
 }));
 mock.module("@/db/repositories/remote-sessions", () => ({
@@ -182,6 +184,7 @@ beforeEach(() => {
     recoverHostCredential,
     listOwned,
     revokeHost,
+    revokeAuthenticatedHost,
     createPendingForOwnedAgent,
     createPendingForOwnedHost,
     activatePendingHost,
@@ -606,5 +609,31 @@ describe("secure remote relay routes", () => {
       },
     });
     expect(revokeHost).toHaveBeenCalledWith(hostId, organizationId, ownerId);
+  });
+
+  test("lets a host bearer revoke only its bound host for native cleanup", async () => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    revokeAuthenticatedHost.mockResolvedValue({
+      host: { id: hostId, status: "revoked" },
+      alreadyRevoked: false,
+      cleanup: { sessions: 1, commands: 2, more: false },
+    });
+    const response = await request(
+      `/api/v1/remote/hosts/${hostId}/revoke`,
+      {},
+      hostHeaders(),
+    );
+    expect(response.status).toBe(200);
+    expect(revokeAuthenticatedHost).toHaveBeenCalledWith(hostId, hostToken);
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+
+    const wrongHost = "40000000-0000-4000-8000-000000000002";
+    const rejected = await request(
+      `/api/v1/remote/hosts/${wrongHost}/revoke`,
+      {},
+      hostHeaders(),
+    );
+    expect(rejected.status).toBe(404);
+    expect(revokeAuthenticatedHost).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts
@@ -206,8 +206,8 @@ beforeAll(async () => {
   for (const migration of [
     "0068_add_remote_sessions",
     "0275_remote_sessions_first_class_expiry",
-    "0300_secure_remote_hosts",
-    "0301_secure_remote_command_relay",
+    "0305_secure_remote_hosts",
+    "0306_secure_remote_command_relay",
   ]) {
     await applyMigration(migration);
   }
@@ -524,6 +524,27 @@ describe("secure remote relay repositories", () => {
     const [stored] = await database.select().from(remoteCommandEnvelopes);
     expect(stored?.status).toBe("execution_ambiguous");
     expect((await commands.claimNext({ sessionId, hostId, hostToken })).kind).toBe("not_found");
+  });
+
+  it("lets the exact host bearer revoke and continue its own bounded cleanup", async () => {
+    await enrollAndPair();
+    await expect(
+      hosts.revokeAuthenticated(hostId, `rhost_v1_${"B".repeat(43)}`),
+    ).resolves.toBeUndefined();
+    await expect(hosts.authenticate(hostId, hostToken)).resolves.toMatchObject({
+      status: "active",
+    });
+
+    await expect(hosts.revokeAuthenticated(hostId, hostToken)).resolves.toMatchObject({
+      alreadyRevoked: false,
+      host: { id: hostId, status: "revoked" },
+      cleanup: { sessions: 1, more: false },
+    });
+    await expect(hosts.revokeAuthenticated(hostId, hostToken)).resolves.toMatchObject({
+      alreadyRevoked: true,
+      host: { id: hostId, status: "revoked" },
+      cleanup: { sessions: 0, commands: 0, more: false },
+    });
   });
 
   it("serializes revoke against enqueue and leaves no executable command", async () => {

--- a/packages/cloud/shared/src/db/repositories/remote-hosts.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-hosts.ts
@@ -6,7 +6,7 @@
 
 import { ElizaError } from "@elizaos/core";
 import { canonicalizeRemoteControlValue } from "@elizaos/shared/contracts/remote-control";
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, type SQL } from "drizzle-orm";
 import type { Database } from "../client";
 import { hashRemoteHostToken } from "../crypto/remote-host-token";
 import { dbWrite } from "../helpers";
@@ -202,19 +202,45 @@ export class RemoteHostsRepository {
     organizationId: string,
     userId: string,
   ): Promise<RevokeRemoteHostResult | undefined> {
+    return this.revokeMatching(
+      hostId,
+      and(eq(remoteHosts.organization_id, organizationId), eq(remoteHosts.user_id, userId)),
+    );
+  }
+
+  /**
+   * Lets an enrolled native host revoke only itself with its one-time bearer.
+   * The token hash remains usable for bounded cleanup continuation after the
+   * first page changes the host status to revoked.
+   */
+  async revokeAuthenticated(
+    hostId: string,
+    token: string,
+  ): Promise<RevokeRemoteHostResult | undefined> {
+    let tokenHash: string;
+    try {
+      tokenHash = await hashRemoteHostToken(token);
+    } catch {
+      // error-policy:J3 malformed bearer material is an explicit auth miss.
+      return undefined;
+    }
+    return this.revokeMatching(hostId, eq(remoteHosts.host_token_hash, tokenHash));
+  }
+
+  private async revokeMatching(
+    hostId: string,
+    ownership: SQL<unknown> | undefined,
+  ): Promise<RevokeRemoteHostResult | undefined> {
     return this.database.transaction(async (tx) => {
       const [current] = await tx
         .select()
         .from(remoteHosts)
-        .where(
-          and(
-            eq(remoteHosts.id, hostId),
-            eq(remoteHosts.organization_id, organizationId),
-            eq(remoteHosts.user_id, userId),
-          ),
-        )
+        .where(and(eq(remoteHosts.id, hostId), ownership))
         .for("update");
       if (!current) return undefined;
+
+      const organizationId = current.organization_id;
+      const userId = current.user_id;
 
       const now = await readPostLockDatabaseNow(tx);
       const alreadyRevoked = current.status === "revoked";

--- a/packages/ui/src/platform/remote-target.ts
+++ b/packages/ui/src/platform/remote-target.ts
@@ -117,7 +117,7 @@ export async function finalizeRemoteTargetHostRevoke(
   const result = await invokeDesktopBridgeRequest<{ cleaned: true }>({
     rpcMethod: "remoteTargetFinalizeHostRevoke",
     ipcChannel: "remoteTarget:finalizeHostRevoke",
-    params: { hostId, cloudRevoked: true },
+    params: { hostId },
   });
   return result?.cleaned ?? false;
 }


### PR DESCRIPTION
Closes #24738.\n\n## What changed\n\n- native Linux cleanup authenticates with the enrolled host bearer and revokes the exact host itself\n- the Cloud repository accepts that bearer only for the bound host and preserves it across bounded cleanup continuation\n- native cleanup drains every page, rejects non-progress, validates exact host/status/counts, and deletes local state only after authoritative completion\n- renderer `cloudRevoked` assertions no longer authorize key deletion\n\n## Verification\n\n- `bun test packages/cloud/api/v1/remote/relay-routes.test.ts` — 14 passed\n- `bun test packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts` — 12 passed on real PGlite\n- `bun x vitest run --config vitest.electrobun.config.ts src/remote-target-runner.test.ts src/remote-target-boundaries.test.ts` — 25 passed\n- targeted Biome — clean\n- `packages/app-core`, Cloud API, and Cloud shared typechecks are blocked only by pre-existing unavailable optional workspaces (plugin-doordash / optional plugins / Capacitor packages); no changed-file diagnostic.\n\n## Evidence\n\nN/A - security/native boundary fix with deterministic HTTP, secure-store, and real PGlite tests; no rendered UI change.