### PR TITLE
fix(gateway): build gateway-webhook image from repository root

### DIFF
--- a/packages/cloud/services/gateway-webhook/package.json
+++ b/packages/cloud/services/gateway-webhook/package.json
@@ -16,7 +16,7 @@
     "start": "PORT=3002 bun run src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "docker:build": "docker build -t gateway-webhook:local ."
+    "docker:build": "docker build -f Dockerfile -t gateway-webhook:local ../../../.."
   },
   "dependencies": {
     "@elizaos/cloud-services-common": "workspace:*",


### PR DESCRIPTION
# Fix gateway-webhook local Docker build context

## What changed

The package-local `docker:build` command now supplies the repository root as Docker context, matching the Dockerfile's workspace-relative `COPY packages/cloud/services/...` paths.

## Proof

- `gateway-webhook` typecheck: passed.
- Repository-root Docker-context contract: passed.
- Real local `docker build`: passed; image `gateway-webhook:local` produced.
- Stable patch ID exactly matches preserved checkpoint `d4b57ca8fe`.
- Biome, `git diff --check`, and gitleaks: passed with no leaks.
- The broader package run was 221 passed / 1 unrelated current-develop failure in the gateway-discord Dockerfile workspace-dependency assertion. This PR deliberately does not touch gateway-discord.

## Scope and rollout

One manifest line only. No gateway runtime, provider, Auth, Deletion, Cloudflare, Railway, workflow, or frozen-WIP change. After normal review/merge, deploy Railway staging only after Worker + Pages certify the final canonical SHA, and require Railway to use that identical SHA.

@lalalune please review this focused build-context correction.
