### PR TITLE
fix(core): restore authorized complete action surfaces

### DIFF
--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -293,8 +293,13 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 			contexts: ["files"],
 			handler: async () => ({ success: true }),
 		});
+		const buildGraphAction = makeMockAction({
+			name: "INSPECT_BUILD_GRAPH",
+			contexts: ["code"],
+			handler: async () => ({ success: true }),
+		});
 		const runtime = makeRuntime({
-			actions: [fileAction, mediaAction],
+			actions: [fileAction, mediaAction, buildGraphAction],
 			owner: true,
 			responses: [
 				{
@@ -358,6 +363,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		// The action passes the ordinary coding-context/role gates, so a fixed
 		// legacy name allowlist must not silently remove it from the model surface.
 		expect(plannerTools).toContain("GENERATE_MEDIA");
+		expect(plannerTools).toContain("INSPECT_BUILD_GRAPH");
 		const firstPlannerMessages = (
 			getCalls(runtime)[0]?.params as
 				| {

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -74,6 +74,7 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	],
 	"packages/core/src/services/message.ts": [
 		/slice\(0,\s*400\)[\s\S]{0,120}task_complete/,
+		/CODING_DIRECT_ACTIONS/,
 	],
 	"packages/core/src/services/relationships.ts": [
 		/MAX_INTERACTION_HISTORY/,

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -816,6 +816,56 @@ describe("v5 tiered action surface", () => {
 		);
 	});
 
+	it("does not disclose an unauthorized inline child through tools or prompt metadata", async () => {
+		const allowedChild = makeAction({
+			name: "SAFE_CHILD",
+			description: "Allowed child description.",
+			contexts: ["general" as AgentContext],
+			contextGate: { anyOf: ["general"] },
+		});
+		const deniedChild = makeAction({
+			name: "PRIVATE_CHILD",
+			description: "Private child description must never reach the model.",
+			contexts: ["general" as AgentContext],
+			contextGate: { anyOf: ["general"] },
+			roleGate: { minRole: "OWNER" },
+		});
+		const parent = makeAction({
+			name: "PARENT",
+			description: "Parent action.",
+			contexts: ["general" as AgentContext],
+			contextGate: { anyOf: ["general"] },
+			subActions: [allowedChild, deniedChild],
+		});
+		const runtime = makeRuntime({
+			actions: [parent, allowedChild, deniedChild],
+			responses: [
+				stage1Response({ contexts: ["general"] }),
+				plannerToolResponse("SAFE_CHILD"),
+				finishEvaluatorResponse("Allowed child completed."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("use the safe child"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const modelContext = [
+			availableActionsSection(runtime),
+			plannerUserContent(runtime),
+		].join("\n");
+		expect(plannerToolNames(runtime)).toContain("SAFE_CHILD");
+		expect(plannerToolNames(runtime)).not.toContain("PRIVATE_CHILD");
+		expect(modelContext).toContain("SAFE_CHILD");
+		expect(modelContext).not.toContain("PRIVATE_CHILD");
+		expect(modelContext).not.toContain(
+			"Private child description must never reach the model.",
+		);
+	});
+
 	it("lets a Tier B parent invoke its sub-planner and execute child actions", async () => {
 		let createEventCalls = 0;
 		const createEvent = makeAction({

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -747,6 +747,64 @@ describe("v5 tiered action surface", () => {
 		expect(prompt).toContain("MESSAGE_OP_9");
 	});
 
+	it("keeps a denied inline child's metadata out of model context (#24699)", async () => {
+		// The parent keeps inline metadata for every registered child, but this
+		// turn's gate denies one. Its name is not enough to check: the leak this
+		// guards is the denied child's DESCRIPTION reaching retrieval, tiering,
+		// and the rendered action section through the catalog.
+		process.env.ACTION_ROLE_POLICY = JSON.stringify({ FILES: "GUEST" });
+		_resetActionRolePolicyCacheForTests();
+
+		const allowedChild = makeAction({
+			name: "FILES_READ",
+			description: "Read a workspace file that the owner allowed.",
+		});
+		const deniedChild = makeAction({
+			name: "FILES_PURGE",
+			description: "Irreversibly purge every workspace file forever.",
+			roleGate: { minRole: "OWNER" },
+		});
+		const parent = makeAction({
+			name: "FILES",
+			description: "Workspace file management parent action.",
+			subActions: [allowedChild, deniedChild],
+		});
+		const runtime = makeRuntime({
+			actions: [parent, allowedChild],
+			responses: [
+				stage1Response({
+					contexts: ["general"],
+					intents: ["read a workspace file"],
+					candidateActionNames: ["FILES_READ"],
+				}),
+				plannerToolResponse("FILES_READ"),
+				finishEvaluatorResponse("Read the file."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("read the workspace file"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const plannerCall = getCalls(runtime).find(
+			(call) => call.modelType === ModelType.ACTION_PLANNER,
+		);
+		const tools = (
+			plannerCall?.params as { tools?: Array<{ name?: string }> } | undefined
+		)?.tools;
+		const toolNames = tools?.map((tool) => tool.name).filter(Boolean) ?? [];
+		expect(toolNames).toContain("FILES_READ");
+		expect(toolNames).not.toContain("FILES_PURGE");
+		// The description is the payload — a denied child must not describe
+		// itself to the model through the catalog either.
+		const prompt = availableActionsSection(runtime);
+		expect(prompt).toContain("FILES_READ");
+		expect(prompt).not.toContain("Irreversibly purge every workspace file");
+	});
+
 	it("omits planner tools that execution would reject for the selected context", async () => {
 		// ACTION_ROLE_POLICY authorizes by exact action name only — similes
 		// intentionally do not authorize (action-role-policy.ts), so the key must

--- a/packages/core/src/actions/__tests__/to-tool.test.ts
+++ b/packages/core/src/actions/__tests__/to-tool.test.ts
@@ -335,6 +335,35 @@ describe("buildPlannerToolsFromTieredActions", () => {
 		expect(tools.map((tool) => tool.name)).toEqual(["MUSIC", "PLAY_MUSIC"]);
 	});
 
+	it("does not expand inline children absent from an authorized lookup", () => {
+		const allowed = makeTieredAction({
+			name: "ALLOWED_CHILD",
+			description: "Allowed child.",
+		});
+		const denied = makeTieredAction({
+			name: "DENIED_CHILD",
+			description: "Private child schema.",
+		});
+		const parent = makeTieredAction({
+			name: "PARENT",
+			description: "Parent action.",
+			subActions: [allowed, denied],
+		});
+		const onUnresolved = vi.fn();
+
+		const tools = buildPlannerToolsFromTieredActions([parent, allowed], {
+			actionLookup: new Map([["ALLOWED_CHILD", allowed]]),
+			onUnresolvedSubAction: onUnresolved,
+		});
+
+		expect(tools.map((tool) => tool.name)).toEqual(["PARENT", "ALLOWED_CHILD"]);
+		expect(JSON.stringify(tools)).not.toContain("Private child schema");
+		expect(onUnresolved).toHaveBeenCalledWith({
+			parentName: "PARENT",
+			subActionName: "DENIED_CHILD",
+		});
+	});
+
 	it("expands children when legacy tierAParents is omitted", () => {
 		const playMusic = makeTieredAction({
 			name: "PLAY_MUSIC",

--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -471,8 +471,9 @@ function resolveActionLookup(
  * alongside the parent, so relevance metadata cannot hide a callable action.
  *
  * Sub-action resolution:
- *   - Inline `Action` sub-actions are expanded only when their exact name is
- *     present in `actionLookup` or the authorized top-level input.
+ *   - Inline `Action` sub-actions are resolved through an explicitly supplied
+ *     authorized lookup before expansion; standalone callers without a lookup
+ *     retain the inline object.
  *   - String-only sub-action references are resolved through `actionLookup`
  *     when provided; references that cannot be resolved are skipped silently
  *     (the parent's handler can still route to them).
@@ -487,8 +488,8 @@ export function buildPlannerToolsFromTieredActions(
 	actions: ReadonlyArray<PlannerToolActionShape>,
 	options: BuildPlannerToolsFromTieredActionsOptions = {},
 ): ToolDefinition[] {
-	const hasAuthoritativeActionLookup = options.actionLookup !== undefined;
 	const actionLookup = resolveActionLookup(options.actionLookup);
+	const requireAuthorizedChild = options.actionLookup !== undefined;
 
 	// Top up the lookup with anything already in `actions` so children that
 	// appear inline elsewhere in the input remain resolvable from a string ref.
@@ -524,18 +525,16 @@ export function buildPlannerToolsFromTieredActions(
 				subActionName = subAction;
 			} else if (subAction && typeof subAction === "object") {
 				subActionName = subAction.name;
-				child = hasAuthoritativeActionLookup
-					? actionLookup.has(subActionName)
-						? actionLookup.get(subActionName)
-						: undefined
+				child = requireAuthorizedChild
+					? actionLookup.get(subAction.name)
 					: subAction;
 			}
-			if (typeof subAction === "string") {
-				child = actionLookup.get(subAction);
+			if (typeof subAction === "string" || (requireAuthorizedChild && !child)) {
+				child = actionLookup.get(subActionName);
 				if (!child) {
 					onUnresolved({
 						parentName: action.name,
-						subActionName: subAction,
+						subActionName,
 					});
 					continue;
 				}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3382,8 +3382,22 @@ function buildV5PlannerActionSurface(params: {
 	}
 
 	const toolSearchStartedAt = Date.now();
+	const authorizedActionNames = new Set(
+		params.actions.map((action) => normalizeActionIdentifier(action.name)),
+	);
+	// A parent may retain inline metadata for every registered child even when
+	// this turn's action gate rejected one of those children. Build retrieval and
+	// tier metadata from the authorized view so a denied child's name,
+	// description, schema, or examples cannot influence or enter model context.
+	const authorizedCatalogActions = params.actions.map((action) => ({
+		...action,
+		subActions: action.subActions?.filter((child) => {
+			const childName = typeof child === "string" ? child : child.name;
+			return authorizedActionNames.has(normalizeActionIdentifier(childName));
+		}),
+	}));
 	const catalog = getCachedActionCatalog(
-		params.actions,
+		authorizedCatalogActions,
 		params.localizedExamples,
 	);
 	const measurementMode = process.env.ELIZA_RETRIEVAL_MEASUREMENT === "1";
@@ -3419,8 +3433,14 @@ function buildV5PlannerActionSurface(params: {
 		queryTokens: retrieval.query.tokens,
 	});
 	const toolSearchEndedAt = Date.now();
-	const exposedActionNames = new Set(
-		tieredSurface.exposedActionNames.map(normalizeActionIdentifier),
+	const exposedActionNames = authorizedActionNames;
+	const tierAChildrenByParent = Object.fromEntries(
+		tieredSurface.tierAParents.map((parent) => [
+			parent.name,
+			parent.childNames.filter((childName) =>
+				exposedActionNames.has(normalizeActionIdentifier(childName)),
+			),
+		]),
 	);
 	const exposedActionCount = params.actions.filter((action) =>
 		exposedActionNames.has(normalizeActionIdentifier(action.name)),
@@ -3489,12 +3509,7 @@ function buildV5PlannerActionSurface(params: {
 			catalogParentCount: catalog.parents.length,
 			exposedActionCount,
 			tierAParents: tieredSurface.sortedTierAParentNames,
-			tierAChildrenByParent: Object.fromEntries(
-				tieredSurface.tierAParents.map((parent) => [
-					parent.name,
-					[...parent.childNames],
-				]),
-			),
+			tierAChildrenByParent,
 			tierBParents: tieredSurface.sortedTierBParentNames,
 			omittedParentCount: tieredSurface.omittedParentNames.length,
 			omittedParentNamesPreview: tieredSurface.omittedParentNames,
@@ -8868,11 +8883,9 @@ export async function runV5MessageRuntimeStage1(args: {
 				elizaTrustedCodingMode: true,
 			};
 		}
-		// Full-surface mode (a focused coding sub-agent): skip the relevance/role
-		// narrowing entirely and hand the planner EVERY action whose execution gates
-		// pass. The narrowing is built for big chat catalogs (retrieve the relevant
-		// few); a coding agent's whole small tool set is relevant, and narrowing was
-		// returning zero candidates → planner got no native tools → model narrated.
+		// A focused coding turn receives every action whose ordinary execution gates
+		// pass for the coding contexts. Relevance or a fixed name list may order or
+		// describe the tools, but cannot hide a newly registered authorized action.
 		const useFullSurface = args.codingMode === true;
 		const plannerCandidateActions = useFullSurface
 			? (args.runtime.actions ?? []).filter((action) =>
@@ -8882,6 +8895,8 @@ export async function runV5MessageRuntimeStage1(args: {
 					canActionRun(action, {
 						activeContexts: CODING_SUB_AGENT_CONTEXTS,
 						userRoles: [senderRole],
+						// There is no concrete turn message in this static surface build;
+						// execution still enforces the private gate.
 						skipPrivateGate: true,
 					}),
 				)


### PR DESCRIPTION
Closes #24699

Follow-up to #24718: its final rebased head retained the complete-catalog work but accidentally dropped two reviewed authorization/completeness fixes before merge.

- removes the resurrected fixed `CODING_DIRECT_ACTIONS` name cap and exposes every coding-context action admitted by ordinary execution gates
- requires inline children to resolve through the authorized per-turn lookup before they become planner tools
- builds retrieval/tiering metadata from the authorized nested-child view so denied names, descriptions, schemas, examples, and hash inputs never enter model context
- adds prompt-boundary and source guards against both regressions

Verification on current `origin/develop`:
- 320 focused tests passed across Stage 1, planner, tiered surfaces, action retrieval/tiering, sub-planning, complete rendering, tool conversion, and prompt-integrity guards
- `bun run --cwd packages/core typecheck`
- Biome, guide parity (161 pairs), and `git diff --check`