### PR TITLE
fix(vault): verify protected credential writes

### DIFF
--- a/packages/agent/src/runtime/operations/vault-bridge.ts
+++ b/packages/agent/src/runtime/operations/vault-bridge.ts
@@ -15,7 +15,12 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { createManager, type SecretsManager, type Vault } from "@elizaos/vault";
+import {
+  createManager,
+  type SecretsManager,
+  type Vault,
+  writeSensitiveValueVerified,
+} from "@elizaos/vault";
 import type { OperationErrorCode } from "./types.ts";
 
 export class VaultResolveError extends Error {
@@ -205,8 +210,7 @@ export async function persistProviderApiKey(opts: {
   caller: string;
 }): Promise<string> {
   const ref = vaultKeyForProviderApiKey(opts.normalizedProvider);
-  await opts.secrets.vault.set(ref, opts.apiKey, {
-    sensitive: true,
+  await writeSensitiveValueVerified(opts.secrets.vault, ref, opts.apiKey, {
     caller: opts.caller,
   });
   return ref;

--- a/packages/agent/test/runtime/operations/vault-integration.test.ts
+++ b/packages/agent/test/runtime/operations/vault-integration.test.ts
@@ -37,6 +37,8 @@ import {
   createTestVault,
   type SecretsManager,
   type TestVault,
+  type Vault,
+  VaultWriteVerificationError,
 } from "@elizaos/vault";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { defaultClassifier } from "../../../src/runtime/operations/classifier.js";
@@ -181,8 +183,8 @@ describe("vault × runtime-ops — accepted operation persists ref, never plaint
     const desc = await testVault.vault.describe(apiKeyRef);
     expect(desc?.sensitive).toBe(true);
 
-    // Invariant 4: the audit log records the route's set call by name and
-    // never contains the plaintext.
+    // Invariant 4: the audit log records the route's set plus exact read-back
+    // by name and never contains the plaintext.
     const audit = await testVault.getAuditRecords();
     const routeSet = audit.find(
       (a) =>
@@ -191,8 +193,40 @@ describe("vault × runtime-ops — accepted operation persists ref, never plaint
         a.caller === "provider-switch-route",
     );
     expect(routeSet).toBeDefined();
+    expect(
+      audit.find(
+        (a) =>
+          a.action === "reveal" &&
+          a.key === "providers.openai.api-key" &&
+          a.caller === "provider-switch-route:verify",
+      ),
+    ).toBeDefined();
     const auditRaw = readFileSync(testVault.auditLogPath, "utf8");
     expect(auditRaw).not.toContain(apiKey);
+  });
+
+  test("does not return a provider ref when protected read-back cannot be verified", async () => {
+    const unreadableVault = new Proxy(testVault.vault, {
+      get(target, property, receiver) {
+        if (property === "reveal") {
+          return async () => {
+            throw new Error("simulated protected read failure");
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Vault;
+    const unreadableSecrets = createManager({ vault: unreadableVault });
+
+    await expect(
+      persistProviderApiKey({
+        secrets: unreadableSecrets,
+        normalizedProvider: "cerebras",
+        apiKey: "disposable-provider-fixture",
+        caller: "provider-switch-route",
+      }),
+    ).rejects.toBeInstanceOf(VaultWriteVerificationError);
   });
 });
 

--- a/packages/app-core/src/services/vault-bootstrap.test.ts
+++ b/packages/app-core/src/services/vault-bootstrap.test.ts
@@ -158,4 +158,61 @@ describe("runVaultBootstrap", () => {
       ]),
     );
   });
+
+  it("reuses an identical protected winner before replacing plaintext with a sentinel", async () => {
+    const values = new Map([["CEREBRAS_API_KEY", "same-secret"]]);
+    const config = { env: { CEREBRAS_API_KEY: "same-secret" } };
+
+    const result = await migrateElizaJsonSecretsForTesting(
+      config as unknown as ElizaConfig,
+      createRecordingVault(values),
+    );
+
+    expect(result).toMatchObject({
+      migrated: ["CEREBRAS_API_KEY"],
+      failed: [],
+      mutated: true,
+    });
+    expect(config.env.CEREBRAS_API_KEY).toBe("vault://CEREBRAS_API_KEY");
+    expect(values.get("CEREBRAS_API_KEY")).toBe("same-secret");
+  });
+
+  it("preserves a different protected row and its plaintext recovery source", async () => {
+    const values = new Map([["CEREBRAS_API_KEY", "protected-winner"]]);
+    const config = { env: { CEREBRAS_API_KEY: "plaintext-recovery" } };
+
+    const result = await migrateElizaJsonSecretsForTesting(
+      config as unknown as ElizaConfig,
+      createRecordingVault(values),
+    );
+
+    expect(result).toMatchObject({
+      migrated: [],
+      failed: ["CEREBRAS_API_KEY"],
+      mutated: false,
+    });
+    expect(config.env.CEREBRAS_API_KEY).toBe("plaintext-recovery");
+    expect(values.get("CEREBRAS_API_KEY")).toBe("protected-winner");
+  });
+
+  it("does not replace plaintext when protected read-back is unavailable", async () => {
+    const values = new Map<string, string>();
+    const vault = createRecordingVault(values);
+    vault.reveal = async () => {
+      throw new Error("protected read failed");
+    };
+    const config = { env: { CARTESIA_API_KEY: "plaintext-recovery" } };
+
+    const result = await migrateElizaJsonSecretsForTesting(
+      config as unknown as ElizaConfig,
+      vault,
+    );
+
+    expect(result).toMatchObject({
+      migrated: [],
+      failed: ["CARTESIA_API_KEY"],
+      mutated: false,
+    });
+    expect(config.env.CARTESIA_API_KEY).toBe("plaintext-recovery");
+  });
 });

--- a/packages/app-core/src/services/vault-bootstrap.ts
+++ b/packages/app-core/src/services/vault-bootstrap.ts
@@ -11,10 +11,11 @@
  *   5. `process.env[KEY]` for keys flagged sensitive in any registered plugin
  *      (does not mutate process.env — only mirrors to the vault).
  *
- * Idempotent by `vault.has(key)` per-key checks — no separate marker
- * file. Re-running the bootstrap after a partial run is safe and cheap;
- * only keys not already in the vault get re-attempted. Per-key
- * failures are isolated; if every write fails the function throws.
+ * Idempotent through atomic set-if-absent plus exact protected read-back — no
+ * separate marker file. An identical protected winner is reused; an unreadable
+ * or different existing row is never overwritten, and its plaintext recovery
+ * source is retained. Per-key failures are isolated; if every persistent write
+ * fails the function throws.
  */
 
 // `@elizaos/app-core` is the host layer ABOVE `@elizaos/agent`, so importing
@@ -31,7 +32,10 @@ import {
 } from "@elizaos/agent/runtime/operations/vault-bridge";
 import { logger } from "@elizaos/core";
 import { loadRegistry } from "@elizaos/registry/first-party";
-import type { Vault } from "@elizaos/vault";
+import {
+  type Vault,
+  writeSensitiveValueIfAbsentVerified,
+} from "@elizaos/vault";
 import {
   CONNECTOR_SECRET_FIELDS,
   connectorVaultKey,
@@ -147,7 +151,9 @@ async function migrateElizaJson(
     if (!isSensitive) return;
     const vaultKey = options.vaultKey ?? key;
     try {
-      await vault.set(vaultKey, value, { sensitive: true });
+      await writeSensitiveValueIfAbsentVerified(vault, vaultKey, value, {
+        caller: "vault-bootstrap:eliza-json",
+      });
       container[key] = bridge.formatVaultRef(vaultKey);
       migrated.push(vaultKey);
       mutated = true;
@@ -247,7 +253,9 @@ async function migrateConfigEnvFile(
       sensitiveKeys.has(key) || inferSensitiveByHeuristic(key);
     if (!isSensitive) continue;
     try {
-      await vault.set(key, value, { sensitive: true });
+      await writeSensitiveValueIfAbsentVerified(vault, key, value, {
+        caller: "vault-bootstrap:config-env",
+      });
       await bridge.persistConfigEnv(key, bridge.formatVaultRef(key), {
         stateDir,
       });
@@ -281,10 +289,16 @@ async function mirrorProcessEnvSensitive(
     const isSensitive =
       sensitiveKeys.has(key) || inferSensitiveByHeuristic(key);
     if (!isSensitive) continue;
-    if (await vault.has(key)) continue;
     try {
-      await vault.set(key, rawValue, { sensitive: true });
-      migrated.push(key);
+      const inserted = await writeSensitiveValueIfAbsentVerified(
+        vault,
+        key,
+        rawValue,
+        {
+          caller: "vault-bootstrap:process-env",
+        },
+      );
+      if (inserted) migrated.push(key);
     } catch (err) {
       failed.push(key);
       logger.error(

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -155,3 +155,8 @@ export {
   VaultDecryptionError,
   VaultMissError,
 } from "./vault.js";
+export {
+  VaultWriteVerificationError,
+  writeSensitiveValueIfAbsentVerified,
+  writeSensitiveValueVerified,
+} from "./verified-write.js";

--- a/packages/vault/src/verified-write.ts
+++ b/packages/vault/src/verified-write.ts
@@ -36,8 +36,10 @@ async function serializeVaultKeyWrite<T>(
     writeQueues.set(vault, queue);
   }
 
+  // Queue entries are normalized below and cannot reject; direct chaining
+  // preserves per-key ordering.
   const previous = queue.get(key) ?? Promise.resolve();
-  const current = previous.catch(() => {}).then(operation);
+  const current = previous.then(operation);
   const settled = current.then(
     () => {},
     () => {},

--- a/packages/vault/src/verified-write.ts
+++ b/packages/vault/src/verified-write.ts
@@ -1,0 +1,109 @@
+/**
+ * Verified sensitive-value writes.
+ *
+ * Callers that are about to discard a plaintext recovery source must not
+ * treat a successful storage call as proof that the protected value is
+ * usable. These helpers serialize writes per vault/key, perform an audited
+ * exact read-back, and surface a redacted error on any mismatch or read
+ * failure.
+ */
+
+import type { SetOptions, Vault } from "./vault-types.js";
+
+const writeQueues = new WeakMap<Vault, Map<string, Promise<void>>>();
+
+export class VaultWriteVerificationError extends Error {
+  constructor(
+    readonly key: string,
+    options: { cause?: unknown } = {},
+  ) {
+    super(
+      `vault: protected write verification failed for ${JSON.stringify(key)}`,
+    );
+    this.name = "VaultWriteVerificationError";
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+async function serializeVaultKeyWrite<T>(
+  vault: Vault,
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let queue = writeQueues.get(vault);
+  if (!queue) {
+    queue = new Map();
+    writeQueues.set(vault, queue);
+  }
+
+  const previous = queue.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(operation);
+  const settled = current.then(
+    () => {},
+    () => {},
+  );
+  queue.set(key, settled);
+
+  try {
+    return await current;
+  } finally {
+    if (queue.get(key) === settled) {
+      queue.delete(key);
+      if (queue.size === 0) writeQueues.delete(vault);
+    }
+  }
+}
+
+function verificationCaller(caller: string | undefined): string {
+  return caller ? `${caller}:verify` : "vault:verified-write";
+}
+
+async function verifyExactReadBack(
+  vault: Vault,
+  key: string,
+  expected: string,
+  caller: string | undefined,
+): Promise<void> {
+  let actual: string;
+  try {
+    actual = await vault.reveal(key, verificationCaller(caller));
+  } catch (cause) {
+    throw new VaultWriteVerificationError(key, { cause });
+  }
+  if (actual !== expected) throw new VaultWriteVerificationError(key);
+}
+
+/** Overwrite a sensitive value, then prove the exact protected read-back. */
+export async function writeSensitiveValueVerified(
+  vault: Vault,
+  key: string,
+  value: string,
+  opts: Omit<SetOptions, "sensitive"> = {},
+): Promise<void> {
+  await serializeVaultKeyWrite(vault, key, async () => {
+    await vault.set(key, value, { ...opts, sensitive: true });
+    await verifyExactReadBack(vault, key, value, opts.caller);
+  });
+}
+
+/**
+ * Atomically establish a sensitive value without replacing an existing row,
+ * then prove that the winning protected value exactly matches the caller's
+ * recovery source. An unreadable or different existing value is left intact
+ * and fails closed.
+ */
+export async function writeSensitiveValueIfAbsentVerified(
+  vault: Vault,
+  key: string,
+  value: string,
+  opts: Omit<SetOptions, "sensitive"> = {},
+): Promise<boolean> {
+  return serializeVaultKeyWrite(vault, key, async () => {
+    const inserted = await vault.setIfAbsent(key, value, {
+      ...opts,
+      sensitive: true,
+    });
+    await verifyExactReadBack(vault, key, value, opts.caller);
+    return inserted;
+  });
+}

--- a/packages/vault/test/verified-write.test.ts
+++ b/packages/vault/test/verified-write.test.ts
@@ -1,3 +1,5 @@
+/** Verifies serialized protected writes with exact read-back against mocked and real PGlite vaults. */
+
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/vault/test/verified-write.test.ts
+++ b/packages/vault/test/verified-write.test.ts
@@ -1,0 +1,124 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { generateMasterKey } from "../src/crypto.js";
+import { inMemoryMasterKey } from "../src/master-key.js";
+import { PgliteVaultImpl } from "../src/pglite-vault.js";
+import type { Vault } from "../src/vault-types.js";
+import {
+  VaultWriteVerificationError,
+  writeSensitiveValueIfAbsentVerified,
+  writeSensitiveValueVerified,
+} from "../src/verified-write.js";
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanup
+      .splice(0)
+      .map((path) => fs.rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("verified sensitive writes", () => {
+  it("serializes same-key writes through each exact read-back", async () => {
+    let value = "";
+    let activeWrites = 0;
+    let maxActiveWrites = 0;
+    const vault = {
+      set: async (_key: string, next: string) => {
+        activeWrites += 1;
+        maxActiveWrites = Math.max(maxActiveWrites, activeWrites);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        value = next;
+      },
+      reveal: async () => {
+        const readBack = value;
+        activeWrites -= 1;
+        return readBack;
+      },
+    } as unknown as Vault;
+
+    await Promise.all([
+      writeSensitiveValueVerified(vault, "providers.test.api-key", "first"),
+      writeSensitiveValueVerified(vault, "providers.test.api-key", "second"),
+    ]);
+
+    expect(maxActiveWrites).toBe(1);
+    expect(value).toBe("second");
+  });
+
+  it("fails closed on a read-back mismatch without exposing either value", async () => {
+    const vault = {
+      set: async () => {},
+      reveal: async () => "different",
+    } as unknown as Vault;
+
+    const error = await writeSensitiveValueVerified(
+      vault,
+      "providers.test.api-key",
+      "expected-secret",
+    ).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(VaultWriteVerificationError);
+    expect(String(error)).not.toMatch(/expected-secret|different/);
+  });
+
+  it("preserves an existing unreadable row when using the migration helper", async () => {
+    let setCalls = 0;
+    const unreadable = new Error("unreadable ciphertext");
+    const vault = {
+      setIfAbsent: async () => {
+        setCalls += 1;
+        return false;
+      },
+      reveal: async () => {
+        throw unreadable;
+      },
+    } as unknown as Vault;
+
+    await expect(
+      writeSensitiveValueIfAbsentVerified(
+        vault,
+        "CEREBRAS_API_KEY",
+        "recovery-source",
+      ),
+    ).rejects.toMatchObject({
+      name: "VaultWriteVerificationError",
+      cause: unreadable,
+    });
+    expect(setCalls).toBe(1);
+  });
+
+  it("survives a real PGlite close and restart with the same master key", async () => {
+    const workDir = await fs.mkdtemp(join(tmpdir(), "vault-verified-restart-"));
+    cleanup.push(workDir);
+    const dataDir = join(workDir, ".vault-pglite");
+    const auditPath = join(workDir, "audit", "vault.jsonl");
+    const masterKey = generateMasterKey();
+    const first = new PgliteVaultImpl({
+      dataDir,
+      auditPath,
+      masterKey: inMemoryMasterKey(Buffer.from(masterKey)),
+    });
+
+    await writeSensitiveValueIfAbsentVerified(
+      first,
+      "providers.cerebras.api-key",
+      "disposable-fixture",
+      { caller: "test:repair" },
+    );
+    await first.close();
+
+    const restarted = new PgliteVaultImpl({
+      dataDir,
+      auditPath,
+      masterKey: inMemoryMasterKey(Buffer.from(masterKey)),
+    });
+    expect(await restarted.get("providers.cerebras.api-key")).toBe(
+      "disposable-fixture",
+    );
+    await restarted.close();
+  });
+});


### PR DESCRIPTION
# Relates to

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto latest `origin/develop`
      `cc387aaeef976675bf1e28d1b4ddb17efa06b159` with zero conflicts.
- [ ] `bun install` completed. Focused exact-head suites and Vault typecheck
      pass; full `bun run verify` was not run, with exact unrelated typecheck
      blockers recorded below.
- [x] A reviewer can confirm the change from the deterministic test and
      names-only encrypted-snapshot evidence below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` was not run; exact scoped evidence and unrelated
      clean-checkout type-dependency blockers are documented below.

# Risks

Medium, limited to protected Vault credential persistence and bootstrap
migration. Writes are now serialized per Vault instance/key and verified by an
audited exact read-back. Bootstrap no longer overwrites a different or
unreadable protected row; it retains the plaintext recovery source and reports
the key as failed. Explicit provider switches still overwrite intentionally,
but do not return a reference until the new protected value reads back exactly.

# Background

## What does this PR do?

- Adds reusable verified sensitive-write helpers with per-key serialization,
  redacted failures, audited read-back, and an atomic set-if-absent variant.
- Uses verified overwrite for provider-switch credential persistence.
- Uses verified set-if-absent for boot-time plaintext migration, preserving an
  existing unreadable/different row instead of destroying forensic ciphertext.
- Adds real PGlite restart, concurrency, mismatch, unreadable-row,
  plaintext-retention, and runtime bridge coverage.

## What kind of change is this?

Bug fix (non-breaking secure-storage correctness change).

# Documentation changes needed?

No external documentation change is required. The bootstrap and helper source
comments document the new fail-closed behavior.

# Testing

## Where should a reviewer start?

Start with `packages/vault/src/verified-write.ts`, then the two call sites in
`packages/agent/src/runtime/operations/vault-bridge.ts` and
`packages/app-core/src/services/vault-bootstrap.ts`.

## Detailed testing steps

At exact head `9abb7fe9c244677bdfbced7ac3a200e9f23ec26e`:

1. `bun run --cwd packages/vault test` — 14 files, 212 tests pass.
2. `bun run --cwd packages/vault typecheck` — pass.
3. Root Vitest focused run for the runtime provider bridge and app-core Vault
   bootstrap — 2 files, 13 tests pass.
4. Broader focused Vault/PGlite/bridge/bootstrap run — 5 files, 71 tests pass.
5. Biome on all seven changed files and `git diff --check` — pass.
6. Isolated encrypted-copy rehearsal with the current OS-Keychain master key:
   canonical Cerebras and Cartesia keys both report protected readiness after
   exact read-back; both unreadable legacy ciphertext rows remain unchanged.
   No value was printed or copied, and no paid provider call was made.

# Evidence Gate

<!-- evidence-head:9abb7fe9c244677bdfbced7ac3a200e9f23ec26e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI files or surfaces changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI files or surfaces changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - secure-storage backend change with no rendered UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - live app mutation was intentionally excluded because another
      owner holds the single-writer PGlite process; deterministic PGlite and
      encrypted-copy evidence is provided instead.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network request changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model behavior changed and paid provider calls were
      intentionally not performed.
<!-- evidence-row:domain-artifacts -->
- [x] Names-only encrypted-copy proof: `providers.cerebras.api-key` and
      `providers.cartesia.api-key` each returned `ready: true`, source
      `keychain-encrypted`, with `legacyForensicRowPreserved: true`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is credential persistence, not LLM behavior; no paid call was
needed or made.

## Backend + frontend logs

Names-only isolated proof output:

```json
{"repairProof":"pass","results":[{"key":"providers.cerebras.api-key","ready":true,"source":"keychain-encrypted","legacyForensicRowPreserved":true},{"key":"providers.cartesia.api-key","ready":true,"source":"keychain-encrypted","legacyForensicRowPreserved":true}]}
```

No credential value, length, ciphertext, or native error payload is included.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- The full agent and app-core typechecks in this fresh worktree currently fail
  on unrelated missing optional/private workspace package declarations such as
  `@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-wallet/diagnostic`,
  `@elizaos/plugin-scheduling`, and `@elizaos/capacitor-bun-runtime`. No
  changed-file TypeScript error was reported; the focused source-aliased tests
  pass.
- Live canonical provider rows are not mutated in this PR evidence run because
  the accepted macOS candidate owns the live PGlite single writer. The secure
  repair was rehearsed against an encrypted copy only. Live handoff requires a
  clean owner-controlled app stop, then the same protected write/read-back,
  names-only verification, and only then plaintext-source scrubbing.
- No build, app launch, port access, paid provider call, signing, deployment,
  or production action was performed.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
