### PR TITLE
fix(ci): pin authority artifact download to the producing attempt

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1918,6 +1918,11 @@ jobs:
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     outputs:
       pages_deployed: ${{ steps.pages-deploy.outputs.deployed }}
+      # Attempt-pinned artifact name. rerun --failed re-runs the verify job at a
+      # new run_attempt while this job's attempt-1 artifact keeps its old name,
+      # so the consumer must download by the producer's name, never its own
+      # github.run_attempt.
+      pages_authority_artifact: pages-deployment-authority-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Reclaim disk from leaked checkouts of prior runs
         continue-on-error: true
@@ -2585,7 +2590,7 @@ jobs:
       - name: Download exact Pages deployment authority
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: pages-deployment-authority-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ needs.deploy-app.outputs.pages_authority_artifact }}
           path: ${{ runner.temp }}/deployed-renderer-proof-${{ github.run_id }}-${{ github.run_attempt }}/authority
 
       - name: Verify public deployment before browser auth


### PR DESCRIPTION
@lalalune — fourth link in the renderer-verify chain. Run 32603111801 attempt 2 (a `rerun --failed`) died instantly:

```
Unable to download artifact(s): Artifact not found for name: pages-deployment-authority-32603111801-2
```

The download name is templated with the CONSUMER's `github.run_attempt`, but on `rerun --failed` the successful `deploy-app` job doesn't re-run — its artifact only exists under attempt 1's name. Net effect: a failed renderer verify can never be rerun, which matters because the verify's live smoke has real timing sensitivity (attempt 1's only failure was a 120s history-anchor timeout in `cloud-live.spec.ts`, everything else green).

Fix: `deploy-app` exposes its attempt-pinned artifact name as a job output; the verify job downloads by that output. Job outputs are read from the successful prior attempt on reruns, so the pin follows the producer.

Workflow-only change. PR CI dead; the yaml parses (actionlint-clean shape, mirrors existing output usage `needs.deploy-app.outputs.pages_deployed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)