### PR TITLE
fix(orchestrator): reject partial trajectory details

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
@@ -204,6 +204,11 @@ describe("queryPastExperience complete traversal", () => {
   it.each([
     ["missing detail", null, "detail_missing"],
     ["missing steps", { trajectoryId: "legacy" }, "steps_missing"],
+    [
+      "empty steps for a non-empty summary",
+      { trajectoryId: "legacy", steps: [] },
+      "steps_missing",
+    ],
   ])(
     "rejects %s instead of omitting legacy context",
     async (_label, detail, reason) => {
@@ -229,6 +234,37 @@ describe("queryPastExperience complete traversal", () => {
       });
     },
   );
+
+  it("rejects a partial model-call inventory instead of returning partial context", async () => {
+    const runtime = makeRuntime({
+      listTrajectories: async () => ({
+        trajectories: [
+          {
+            id: "legacy",
+            source: "orchestrator",
+            startTime: 1,
+            llmCallCount: 2,
+            createdAt: new Date(1).toISOString(),
+          },
+        ],
+        total: 1,
+      }),
+      getTrajectoryDetail: async () => ({
+        trajectoryId: "legacy",
+        steps: [{ llmCalls: [{ response: "DECISION: only one call" }] }],
+      }),
+    });
+
+    await expect(queryPastExperience(runtime)).rejects.toMatchObject({
+      code: "TRAJECTORY_EXPERIENCE_DETAIL_UNAVAILABLE",
+      context: {
+        trajectoryId: "legacy",
+        reason: "llm_calls_incomplete",
+        expectedLlmCallCount: 2,
+        observedLlmCallCount: 1,
+      },
+    });
+  });
 
   it("traverses every storage page without treating page size as a content cap", async () => {
     const summaries = Array.from({ length: 501 }, (_, index) => ({

--- a/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
@@ -338,7 +338,11 @@ export async function queryPastExperience(
         logger.getTrajectoryDetail(summary.id),
         QUERY_TIMEOUT_MS,
       );
-      if (!detail || !Array.isArray(detail.steps)) {
+      if (
+        !detail ||
+        !Array.isArray(detail.steps) ||
+        (summary.llmCallCount > 0 && detail.steps.length === 0)
+      ) {
         throw new ElizaError(
           "Trajectory detail is unavailable for complete experience loading",
           {
@@ -346,6 +350,26 @@ export async function queryPastExperience(
             context: {
               trajectoryId: summary.id,
               reason: detail ? "steps_missing" : "detail_missing",
+            },
+          },
+        );
+      }
+
+      const detailLlmCallCount = detail.steps.reduce(
+        (count, step) =>
+          count + (Array.isArray(step.llmCalls) ? step.llmCalls.length : 0),
+        0,
+      );
+      if (detailLlmCallCount !== summary.llmCallCount) {
+        throw new ElizaError(
+          "Trajectory detail does not contain its complete model-call inventory",
+          {
+            code: "TRAJECTORY_EXPERIENCE_DETAIL_UNAVAILABLE",
+            context: {
+              trajectoryId: summary.id,
+              reason: "llm_calls_incomplete",
+              expectedLlmCallCount: summary.llmCallCount,
+              observedLlmCallCount: detailLlmCallCount,
             },
           },
         );


### PR DESCRIPTION
Fixes #24714

## Summary

- reject trajectory details whose empty step list contradicts a nonzero authoritative model-call count
- reject details that expose fewer model calls than the summary reports
- preserve typed expected/observed context instead of returning complete-looking empty or partial experience context
- add regressions for both inconsistent detail shapes

This is a narrow follow-up to #24715. That PR merged while review was in progress and still treated these summary/detail contradictions as healthy context.

## Verification

- focused trajectory-feedback suite — 11 passed on the rebased exact tree
- orchestrator typecheck — passed
- orchestrator build — passed
- Biome on both changed files and diff integrity — passed

<!-- evidence-head:ed031ed4c6cb498ab8f3c6d4e2f871f7b2a8ea92 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - trajectory validation has no interactive UI flow

<!-- evidence-row:backend-logs -->
- [ ] N/A - focused service tests exercise authoritative summary and detail reconciliation without an external transport

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this correction rejects inconsistent stored trajectory metadata before it can become model context; it does not invoke a model

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - deterministic service fixtures are the changed persistence-read boundary; no production trajectory store is available in this environment

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes
