### PR TITLE
fix(orchestrator): harden subscription ACP execution

### DIFF
--- a/packages/shared/src/contracts/coding-agent-capabilities.test.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.test.ts
@@ -91,7 +91,7 @@ describe("coding-agent capability mapping", () => {
         discoveryPolicy: "configured-command-or-path",
         commandConfigKey: "ELIZA_GROK_ACP_COMMAND",
         commandResolution: "literal",
-        defaultCommand: "grok agent stdio",
+        defaultCommand: "grok --no-auto-update agent stdio",
       },
     });
     for (const backend of CODING_AGENT_BACKENDS) {

--- a/packages/shared/src/contracts/coding-agent-capabilities.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.ts
@@ -97,7 +97,7 @@ export const CODING_AGENT_BACKEND_PREFLIGHTS = {
     discoveryPolicy: "configured-command-or-path",
     commandConfigKey: "ELIZA_GROK_ACP_COMMAND",
     commandResolution: "literal",
-    defaultCommand: "grok agent stdio",
+    defaultCommand: "grok --no-auto-update agent stdio",
   },
 } as const satisfies Readonly<
   Record<CodingAgentBackend, CodingAgentBackendPreflight>

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -288,7 +288,7 @@ README → "GitHub credentials".
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_KIMI_ACP_COMMAND` | `kimi acp` | Official Kimi Code subscription ACP command. Interactive message, HTTP, and task-control boundaries mint attendance authorization and persist it for recovery; scheduled, agent-authored, and unspecified spawns fail before workspace creation. The adapter validates that the effective default model selects the managed OAuth provider. Login is `kimi login`; logout is the interactive `/logout` because there is no top-level logout/status command. |
-| `ELIZA_GROK_ACP_COMMAND` | `grok agent stdio` | Official Grok Build subscription ACP command. Login is `grok login` or `grok login --device-auth`; status/models is `grok models`; logout is `grok logout`. |
+| `ELIZA_GROK_ACP_COMMAND` | `grok --no-auto-update agent stdio` | Official Grok Build subscription ACP command with provider-recommended update suppression. Login is `grok login` or `grok login --device-auth`; status/models is `grok models`; logout is `grok logout`. |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
 | `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
@@ -331,6 +331,13 @@ README → "GitHub credentials".
 | `ELIZA_MODEL_GATEWAY_TOKEN` | unset | Gateway credential injected into the sub-agent (as `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`) in place of raw provider keys. In lease mode this is the parent-only, mint-capable token — never forwarded to the child. |
 | `ELIZA_MODEL_GATEWAY_LEASE_URL` | unset | Broker lease endpoint (#11536 E2 residual). When set (with gateway mode on), each spawn mints a per-spawn, TTL-bound, revocable lease (`POST` → `{ token, expiresAt, leaseId }`; revoke `POST <url>/<leaseId>/revoke`) and the child gets the leased token, not the static one. Unset ⇒ static-token fallback. |
 | `ELIZA_MODEL_GATEWAY_STRICT` | unset | `1`/`true` fails a spawn closed rather than hand a sub-agent a static long-lived gateway token when a lease broker is expected but absent or the mint fails. |
+
+Kimi children receive `KIMI_CODE_NO_AUTO_UPDATE=1` so the executable cannot
+change during an orchestrated task, and `KIMI_DISABLE_CRON=1` so the provider
+CLI cannot create a scheduler outside core `TaskService` and plugin-scheduling.
+Kimi's primary billing source is membership quota, but provider-managed Extra
+Usage can charge a prepaid balance when the account owner enabled that fallback;
+inventory consumers must preserve the billing disclosure.
 
 ## How to extend
 

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -288,7 +288,7 @@ README → "GitHub credentials".
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_KIMI_ACP_COMMAND` | `kimi acp` | Official Kimi Code subscription ACP command. Interactive message, HTTP, and task-control boundaries mint attendance authorization and persist it for recovery; scheduled, agent-authored, and unspecified spawns fail before workspace creation. The adapter validates that the effective default model selects the managed OAuth provider. Login is `kimi login`; logout is the interactive `/logout` because there is no top-level logout/status command. |
-| `ELIZA_GROK_ACP_COMMAND` | `grok agent stdio` | Official Grok Build subscription ACP command. Login is `grok login` or `grok login --device-auth`; status/models is `grok models`; logout is `grok logout`. |
+| `ELIZA_GROK_ACP_COMMAND` | `grok --no-auto-update agent stdio` | Official Grok Build subscription ACP command with provider-recommended update suppression. Login is `grok login` or `grok login --device-auth`; status/models is `grok models`; logout is `grok logout`. |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
 | `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |
@@ -331,6 +331,13 @@ README → "GitHub credentials".
 | `ELIZA_MODEL_GATEWAY_TOKEN` | unset | Gateway credential injected into the sub-agent (as `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`) in place of raw provider keys. In lease mode this is the parent-only, mint-capable token — never forwarded to the child. |
 | `ELIZA_MODEL_GATEWAY_LEASE_URL` | unset | Broker lease endpoint (#11536 E2 residual). When set (with gateway mode on), each spawn mints a per-spawn, TTL-bound, revocable lease (`POST` → `{ token, expiresAt, leaseId }`; revoke `POST <url>/<leaseId>/revoke`) and the child gets the leased token, not the static one. Unset ⇒ static-token fallback. |
 | `ELIZA_MODEL_GATEWAY_STRICT` | unset | `1`/`true` fails a spawn closed rather than hand a sub-agent a static long-lived gateway token when a lease broker is expected but absent or the mint fails. |
+
+Kimi children receive `KIMI_CODE_NO_AUTO_UPDATE=1` so the executable cannot
+change during an orchestrated task, and `KIMI_DISABLE_CRON=1` so the provider
+CLI cannot create a scheduler outside core `TaskService` and plugin-scheduling.
+Kimi's primary billing source is membership quota, but provider-managed Extra
+Usage can charge a prepaid balance when the account owner enabled that fallback;
+inventory consumers must preserve the billing disclosure.
 
 ## How to extend
 

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -164,7 +164,7 @@ second credential broker, and child trajectories retain their session join key.
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false`. |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |
 | `ELIZA_KIMI_ACP_COMMAND` | `kimi acp` | Official Kimi Code subscription ACP command. Requires explicit user-attended execution authority. |
-| `ELIZA_GROK_ACP_COMMAND` | `grok agent stdio` | Official Grok Build subscription ACP stdio command. |
+| `ELIZA_GROK_ACP_COMMAND` | `grok --no-auto-update agent stdio` | Official Grok Build subscription ACP stdio command with provider-recommended update suppression. |
 | `ELIZA_ACP_DEFAULT_APPROVAL` | `autonomous` | Approval preset (`read-only`, `auto`, `permissive`, `autonomous`, `full-access`). |
 | `ELIZA_ACP_PROMPT_TIMEOUT_MS` / `ACPX_DEFAULT_TIMEOUT_MS` | `300000` (5m) | Per-prompt timeout. |
 | `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` | `5000` (5s) | Maximum adapter-availability preflight wait. Values must be exact decimal integers from `250` through `2147483647`; missing/blank uses the default, and invalid values fail before the adapter probe starts. |
@@ -183,6 +183,12 @@ second credential broker, and child trajectories retain their session join key.
 | `SMITHERS_DB_PROVIDER` | `sqlite` | Smithers task storage: `sqlite`, `postgres`, or `pglite`. |
 | `SMITHERS_DB_URL` | unset | Required PostgreSQL connection string when `SMITHERS_DB_PROVIDER=postgres`. |
 | `SMITHERS_DB_DATA_DIR` | unset | Required persistent data root when `SMITHERS_DB_PROVIDER=pglite`; each durable tenant/task/run gets an isolated subdirectory because embedded PGlite directories cannot be shared by concurrent workers. |
+
+Kimi ACP children disable the CLI's updater and built-in cron surface. This
+keeps executable versions stable during a task and leaves scheduled work under
+the repository's canonical `TaskService`/plugin-scheduling path. Kimi inventory
+also discloses that provider-managed Extra Usage may charge a prepaid balance
+after membership quota is exhausted when the account owner enabled it.
 
 ### Native transport status
 

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -247,7 +247,7 @@
         "type": "string",
         "description": "Official Grok Build subscription ACP stdio command. Authentication comes from grok login state under GROK_HOME, never XAI_API_KEY.",
         "required": false,
-        "default": "grok agent stdio",
+        "default": "grok --no-auto-update agent stdio",
         "sensitive": false
       },
       "ELIZA_ACP_FORMAT": {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/subscription-coding-adapters.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/subscription-coding-adapters.test.ts
@@ -124,7 +124,7 @@ describe("subscription coding adapter descriptors", () => {
       defaultAcpCommand: "kimi acp",
       loginCommands: [{ mode: "device", command: "kimi login" }],
       requiresUserAttended: true,
-      billingSource: { kind: "included-plan" },
+      billingSource: { kind: "included-plan", mayUsePaidOverage: true },
     });
     expect(SUBSCRIPTION_CODING_ADAPTERS.kimi.statusCommand).toBeUndefined();
     expect(SUBSCRIPTION_CODING_ADAPTERS.kimi.logoutCommand).toBeUndefined();
@@ -133,11 +133,11 @@ describe("subscription coding adapter descriptors", () => {
     );
 
     expect(SUBSCRIPTION_CODING_ADAPTERS.grok).toMatchObject({
-      defaultAcpCommand: "grok agent stdio",
+      defaultAcpCommand: "grok --no-auto-update agent stdio",
       statusCommand: "grok models",
       logoutCommand: "grok logout",
       requiresUserAttended: false,
-      billingSource: { kind: "included-plan" },
+      billingSource: { kind: "included-plan", mayUsePaidOverage: false },
     });
     expect(SUBSCRIPTION_CODING_ADAPTERS.grok.loginCommands).toEqual([
       { mode: "browser", command: "grok login" },
@@ -180,7 +180,7 @@ describe("subscription coding adapter probes", () => {
       installed: true,
       authenticated: true,
       spawnable: true,
-      billingSource: { kind: "included-plan" },
+      billingSource: { kind: "included-plan", mayUsePaidOverage: true },
     });
     expect(JSON.stringify(probe)).not.toContain("secret-access-token");
     expect(JSON.stringify(probe)).not.toContain("secret-refresh-token");
@@ -544,7 +544,11 @@ describe("subscription billing and error isolation", () => {
     ).buildEnv.bind(service);
 
     const kimiEnv = buildEnv(
-      { KIMI_CODE_HOME: "/caller-controlled/kimi" },
+      {
+        KIMI_CODE_HOME: "/caller-controlled/kimi",
+        KIMI_CODE_NO_AUTO_UPDATE: "0",
+        KIMI_DISABLE_CRON: "0",
+      },
       {},
       undefined,
       "kimi",
@@ -562,6 +566,8 @@ describe("subscription billing and error isolation", () => {
     );
 
     expect(kimiEnv.KIMI_CODE_HOME).toBe("/tenant-a/kimi");
+    expect(kimiEnv.KIMI_CODE_NO_AUTO_UPDATE).toBe("1");
+    expect(kimiEnv.KIMI_DISABLE_CRON).toBe("1");
     expect(grokEnv.GROK_HOME).toBe("/tenant-a/grok");
     expect(grokEnv.GROK_DISABLE_API_KEY_AUTH).toBe("1");
     expect(grokEnv.GROK_AUTH_PATH).toBeUndefined();
@@ -578,13 +584,19 @@ describe("subscription billing and error isolation", () => {
         billingSource: {
           kind: "included-plan",
           label: "Kimi Code included plan",
+          mayUsePaidOverage: true,
+          disclosure: expect.stringContaining("Extra Usage"),
         },
         executionPolicy: { requiresUserAttended: true },
       },
     );
     expect(available.find((agent) => agent.agentType === "grok")).toMatchObject(
       {
-        billingSource: { kind: "included-plan", label: "Grok included plan" },
+        billingSource: {
+          kind: "included-plan",
+          label: "Grok included plan",
+          mayUsePaidOverage: false,
+        },
         executionPolicy: { requiresUserAttended: false },
       },
     );

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -5071,6 +5071,13 @@ export class AcpService extends Service {
         // disables env, auth.json, and per-model API-key precedence so an OAuth
         // preflight cannot silently execute as pay-as-you-go API billing.
         env.GROK_DISABLE_API_KEY_AUTH = "1";
+      } else {
+        // Kimi checks for and installs updates by default. An orchestrated ACP
+        // child must not mutate its own runtime version mid-task, and its
+        // built-in CronCreate surface must not establish a scheduler beside
+        // core TaskService and plugin-scheduling.
+        env.KIMI_CODE_NO_AUTO_UPDATE = "1";
+        env.KIMI_DISABLE_CRON = "1";
       }
       const removed = stripSubscriptionApiEnvironment(normalizedAgentType, env);
       if (removed.length > 0) {

--- a/plugins/plugin-agent-orchestrator/src/services/subscription-coding-adapters.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/subscription-coding-adapters.ts
@@ -21,6 +21,8 @@ export type { SubscriptionExecutionMode } from "./types.js";
 export interface SubscriptionBillingSource {
   kind: "included-plan";
   label: string;
+  mayUsePaidOverage: boolean;
+  disclosure?: string;
 }
 
 export interface SubscriptionLoginCommand {
@@ -66,6 +68,9 @@ export const SUBSCRIPTION_CODING_ADAPTERS: Readonly<
     billingSource: {
       kind: "included-plan",
       label: "Kimi Code included plan",
+      mayUsePaidOverage: true,
+      disclosure:
+        "Kimi uses membership quota first and may charge the account's Extra Usage balance when that provider-managed fallback is enabled.",
     },
     loginCommands: [{ mode: "device", command: "kimi login" }],
     logoutInstructions:
@@ -101,11 +106,12 @@ export const SUBSCRIPTION_CODING_ADAPTERS: Readonly<
     binary: "grok",
     commandSetting: "ELIZA_GROK_ACP_COMMAND",
     homeEnvironmentKey: "GROK_HOME",
-    defaultAcpCommand: "grok agent stdio",
+    defaultAcpCommand: "grok --no-auto-update agent stdio",
     supportedPlatforms: SUPPORTED_DESKTOP_PLATFORMS,
     billingSource: {
       kind: "included-plan",
       label: "Grok included plan",
+      mayUsePaidOverage: false,
     },
     loginCommands: [
       { mode: "browser", command: "grok login" },

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -316,6 +316,8 @@ export interface AvailableAgentInfo {
   billingSource?: {
     kind: "included-plan" | "api-payg";
     label: string;
+    mayUsePaidOverage?: boolean;
+    disclosure?: string;
   };
   executionPolicy?: {
     requiresUserAttended: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #24205 after its reviewed feature head was merged.

- run Grok ACP with the provider-documented `--no-auto-update` flag
- force Kimi child processes to disable self-update and the built-in cron surface
- disclose that Kimi Extra Usage may consume paid balance when provider-side fallback is enabled
- remove the stale route-test assumption that HTTP task control can persist user-attendance authorization
- strengthen child-environment regression coverage against caller overrides

The Kimi cron clamp preserves elizaOS's single scheduler boundary: core `TaskService` and `plugin-scheduling` remain authoritative.

## Verification

- orchestrator subscription adapter tests: 19 passed
- orchestrator route tests: 26 passed
- shared capability-contract tests: 16 passed
- account UI tests: 19 passed
- plugin typecheck: passed
- plugin build: passed
- Biome (7 touched source/test files): passed
- CLAUDE.md / AGENTS.md parity: 161 pairs passed
- `git diff --check`: passed

## Provider references

- Kimi environment controls: https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/env-vars
- Kimi membership and Extra Usage: https://www.kimi.com/code/docs/en/kimi-code/membership.html
- Grok headless/ACP guidance: https://docs.x.ai/build/cli/headless-scripting

No live paid-account certification is claimed by this follow-up.
