### PR TITLE
test(orchestrator): assert task-control routes never mint attendance

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
@@ -851,14 +851,12 @@ describe("orchestrator routes — room, telemetry, agents", () => {
     expect(added.status).toBe(201);
     const sessions = added.json.sessions as Array<Record<string, unknown>>;
     expect(sessions).toHaveLength(1);
-    expect(sessions[0]?.metadata).toMatchObject({
-      subscriptionExecutionAuthorization: {
-        version: 1,
-        mode: "user-attended",
-        source: "interactive-task-control",
-        requestId: expect.any(String),
-      },
-    });
+    // Task-control routes must never mint the user-attendance capability;
+    // it is minted only while handling a concrete user-authored message
+    // (see subscriptionAuthorizationForMessage in actions/tasks.ts).
+    expect(sessions[0]?.metadata ?? {}).not.toHaveProperty(
+      "subscriptionExecutionAuthorization",
+    );
 
     const stopped = await call(
       service,


### PR DESCRIPTION
Follow-up to #24205. The final hardening commit removed subscription execution-authorization minting from `POST /api/orchestrator/tasks/:id/agents` (per the review: attendance is minted only from a concrete user-authored message), but `orchestrator-routes.test.ts` still asserted the removed `interactive-task-control` minting, leaving develop deterministically red on that test. This updates the test to assert the fail-closed contract: task-control routes never attach `subscriptionExecutionAuthorization`.

Verified: `bunx vitest run __tests__/unit/orchestrator-routes.test.ts` 26/26 passed; plugin `lint:check` and `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)