### PR TITLE
fix(interactions): generation-fence file-store locks

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -64,7 +64,10 @@ context. If publication sees a transition marker after linking its complete
 owner, no transaction starts. Offline recovery must additionally verify the
 reported owner token/inode, remove both the exact marker and owner paths, fsync
 the parent directory, and restart. Owner-candidate cleanup failure is likewise
-typed as pre-mutation and safely detaches its published owner when possible.
+typed as pre-mutation (`INTERACTION_STORE_OWNER_CANDIDATE_CLEANUP_FAILED`,
+`committed: false`) whether or not the candidate was published; a published
+owner is safely detached when possible and `context.published` records which
+case occurred.
 After the state temp is renamed, a parent-directory sync failure reports
 `INTERACTION_STORE_COMMIT_AMBIGUOUS` with `committed: "unknown"`; a close
 failure after successful sync uses the same code with `committed: true`.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -36,8 +36,13 @@ boot/process generation, and generation-fences stale takeover and release with
 an atomically published transition marker. A complete owner inode is fsynced
 before no-replace hardlink publication; malformed owners have a bounded
 recovery ceiling, while a live PID that cannot be generation-qualified fails
-closed. Its boundary
-is one machine and one state directory. Multi-host deployments must supply a
+closed. An abandoned transition marker also fails closed because portable
+filesystems cannot conditionally unlink a pathname generation; an operator may
+remove it only after stopping every store user and verifying that no host
+process owns the store. Operations report
+`INTERACTION_STORE_RECOVERY_REQUIRED` and do not mutate state while that marker
+remains; this state has no bounded automatic recovery. Its boundary is one
+machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -47,16 +47,24 @@ reported in `error.context.markerPath`; with the default filename it is
 Recovery requires stopping every process that uses the store, verifying that
 none owns the adjacent `.lock` owner file, removing that exact `.transition`
 path, fsyncing the state directory, and only then restarting store users. Its
-boundary is one machine and one state directory. Multi-host deployments must supply a
-transactional database implementation of `MessageInteractionSessionStore` and
-use the session replay key as the effect or outbox idempotency key.
+boundary is one machine and one state directory. Multi-host deployments must
+supply a transactional database implementation of
+`MessageInteractionSessionStore` and use the session replay key as the effect or
+outbox idempotency key.
 
 Transition cleanup reports machine-distinct retry outcomes. A failure during
 pre-operation stale recovery is
 `INTERACTION_STORE_RECOVERY_CLEANUP_FAILED` with `committed: false`; a failure
 after the durable transaction commit is
 `INTERACTION_STORE_COMMITTED_CLEANUP_FAILED` with `committed: true`, so callers
-must not retry the mutation.
+must not retry the mutation. Every other release failure after the durable write
+is `INTERACTION_STORE_COMMITTED_RELEASE_FAILED` with the same no-retry contract;
+combined operation/release failures retain the release code and recovery
+context. If publication sees a transition marker after linking its complete
+owner, no transaction starts. Offline recovery must additionally verify the
+reported owner token/inode, remove both the exact marker and owner paths, fsync
+the parent directory, and restart. Owner-candidate cleanup failure is likewise
+typed as pre-mutation and safely detaches its published owner when possible.
 
 The file authority durably commits an effect before dispatch. If the process
 dies after that commit but before retaining the receipt, the session remains

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -46,6 +46,13 @@ machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 
+Transition cleanup reports machine-distinct retry outcomes. A failure during
+pre-operation stale recovery is
+`INTERACTION_STORE_RECOVERY_CLEANUP_FAILED` with `committed: false`; a failure
+after the durable transaction commit is
+`INTERACTION_STORE_COMMITTED_CLEANUP_FAILED` with `committed: true`, so callers
+must not retry the mutation.
+
 The file authority durably commits an effect before dispatch. If the process
 dies after that commit but before retaining the receipt, the session remains
 `committed` for operator reconciliation; it is never lease-transferred,

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -33,9 +33,10 @@ core's message-interaction session authority. It serializes independent local
 processes, writes a 0600 regular file through same-filesystem fsync and atomic
 rename, fails fast on corruption and symlinks, qualifies Linux lock owners by
 boot/process generation, and generation-fences stale takeover and release with
-an atomically published transition marker. An unpublished owner has a bounded
-recovery ceiling;
-a live PID that cannot be generation-qualified fails closed. Its boundary
+an atomically published transition marker. A complete owner inode is fsynced
+before no-replace hardlink publication; malformed owners have a bounded
+recovery ceiling, while a live PID that cannot be generation-qualified fails
+closed. Its boundary
 is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -65,6 +65,13 @@ owner, no transaction starts. Offline recovery must additionally verify the
 reported owner token/inode, remove both the exact marker and owner paths, fsync
 the parent directory, and restart. Owner-candidate cleanup failure is likewise
 typed as pre-mutation and safely detaches its published owner when possible.
+After the state temp is renamed, a parent-directory sync failure reports
+`INTERACTION_STORE_COMMIT_AMBIGUOUS` with `committed: "unknown"`; a close
+failure after successful sync uses the same code with `committed: true`.
+Both are non-retryable and require reading the reported state file to reconcile
+the persisted session outcome. If lock unlink and transition cleanup both fail,
+the committed cleanup error retains the unlink cause, cleanup error, marker,
+lock identity/token, and exact offline recovery authority.
 
 The file authority durably commits an effect before dispatch. If the process
 dies after that commit but before retaining the receipt, the session remains

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -41,8 +41,13 @@ filesystems cannot conditionally unlink a pathname generation; an operator may
 remove it only after stopping every store user and verifying that no host
 process owns the store. Operations report
 `INTERACTION_STORE_RECOVERY_REQUIRED` and do not mutate state while that marker
-remains; this state has no bounded automatic recovery. Its boundary is one
-machine and one state directory. Multi-host deployments must supply a
+remains; this state has no bounded automatic recovery. The marker path is
+reported in `error.context.markerPath`; with the default filename it is
+`<stateDirectory>/message-interaction-sessions.v1.json.lock.transition`.
+Recovery requires stopping every process that uses the store, verifying that
+none owns the adjacent `.lock` owner file, removing that exact `.transition`
+path, fsyncing the state directory, and only then restarting store users. Its
+boundary is one machine and one state directory. Multi-host deployments must supply a
 transactional database implementation of `MessageInteractionSessionStore` and
 use the session replay key as the effect or outbox idempotency key.
 

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -351,6 +351,10 @@ describe("FileMessageInteractionSessionStore", () => {
         afterLockPublishBeforeCandidateCleanup: async () => markPublished(),
       },
     }).deleteExpired(now);
+    const creatorError = creator.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
     await afterCheck.entered;
 
     const recoveryCleanup = barrier();
@@ -364,16 +368,20 @@ describe("FileMessageInteractionSessionStore", () => {
         },
       },
     }).deleteExpired(now);
+    const recovererError = recoverer.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
     await recoveryCleanup.entered;
     afterCheck.release();
     await published;
     recoveryCleanup.release();
 
-    await expect(recoverer).rejects.toMatchObject({
+    await expect(recovererError).resolves.toMatchObject({
       code: "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED",
       context: { committed: false },
     });
-    await expect(creator).rejects.toMatchObject({
+    await expect(creatorError).resolves.toMatchObject({
       code: "INTERACTION_STORE_RECOVERY_REQUIRED",
       context: {
         committed: false,

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -443,6 +443,79 @@ describe("FileMessageInteractionSessionStore", () => {
     });
   });
 
+  it("marks a visible post-rename sync failure as an ambiguous commit", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { store, created, now } = await seed(stateDirectory);
+    await store.claimIfCurrent({
+      ...bindings,
+      reference: created.session.reference,
+      replayKey: "replay-sync-failure",
+      claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      now,
+      claimTtlMs: 30_000,
+    });
+    const failing = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeStateDirectorySync: async () => {
+          throw new Error("simulated directory sync failure");
+        },
+      },
+    });
+    await expect(
+      failing.commitIfClaimed({
+        reference: created.session.reference,
+        replayKey: "replay-sync-failure",
+        claimId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: "INTERACTION_STORE_COMMIT_AMBIGUOUS",
+      context: {
+        committed: "unknown",
+        reconciliationRequired: true,
+        retrySafe: false,
+      },
+    });
+    const reopened = new FileMessageInteractionSessionStore({ stateDirectory });
+    await expect(
+      reopened.get(created.session.reference),
+    ).resolves.toMatchObject({
+      consume: {
+        state: "committed",
+        replayKey: "replay-sync-failure",
+      },
+    });
+  });
+
+  it("marks post-sync directory close failure as committed and non-retryable", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created, now } = await seed(stateDirectory);
+    const reference = "abcdefabcdefabcdefabcdefabcdefab";
+    const failing = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        afterStateDirectoryClose: async () => {
+          throw new Error("simulated directory close failure");
+        },
+      },
+    });
+    await expect(
+      failing.create({ ...created.session, reference }),
+    ).rejects.toMatchObject({
+      code: "INTERACTION_STORE_COMMIT_AMBIGUOUS",
+      context: {
+        committed: true,
+        reconciliationRequired: true,
+        retrySafe: false,
+      },
+    });
+    const reopened = new FileMessageInteractionSessionStore({ stateDirectory });
+    await expect(reopened.get(reference)).resolves.toMatchObject({ reference });
+  });
+
   it("fails fast on corruption instead of fabricating an empty store", async () => {
     const stateDirectory = await temporaryDirectory();
     const filePath = path.join(
@@ -947,6 +1020,44 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(fs.lstat(`${lockPath}.transition`)).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  it("preserves lock unlink and marker cleanup failures together", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeLockUnlink: async () => {
+          throw new Error("primary lock unlink failure");
+        },
+        beforeTransitionAbortCleanup: async () => {
+          throw new Error("secondary marker cleanup failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
+      context: {
+        cleanupError: "secondary marker cleanup failure",
+        committed: true,
+        lockIdentity: expect.any(String),
+        lockPath,
+        markerPath: `${lockPath}.transition`,
+        ownerToken: expect.any(String),
+        recovery:
+          "Stop all store users, verify lockPath still has lockIdentity and ownerToken when reported, remove markerPath and lockPath, fsync their parent directory, then restart.",
+        releaseErrorCode: "INTERACTION_STORE_RELEASE_CLEANUP_FAILED",
+        retrySafeAfterRecovery: false,
+      },
+    });
+    expect(await fs.lstat(lockPath)).toBeDefined();
+    expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
   });
 
   it("marks stale-recovery cleanup failure as uncommitted and retryable after recovery", async () => {

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -321,6 +321,111 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(successorTransaction).resolves.toBe(0);
   });
 
+  it("does not start a transaction when recovery claims after the publish check", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-owner-before-publish-check",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
+
+    const afterCheck = barrier();
+    let markPublished: () => void = () => {};
+    const published = new Promise<void>((resolve) => {
+      markPublished = resolve;
+    });
+    const creator = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 50,
+      pollMs: 1,
+      lockRaceHooks: {
+        afterTransitionCheckBeforeLockPublish: afterCheck.hook,
+        afterLockPublishBeforeCandidateCleanup: async () => markPublished(),
+      },
+    }).deleteExpired(now);
+    await afterCheck.entered;
+
+    const recoveryCleanup = barrier();
+    const recoverer = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeTransitionMarkerCleanup: async () => {
+          await recoveryCleanup.hook();
+          throw new Error("simulated stale-recovery marker cleanup failure");
+        },
+      },
+    }).deleteExpired(now);
+    await recoveryCleanup.entered;
+    afterCheck.release();
+    await published;
+    recoveryCleanup.release();
+
+    await expect(recoverer).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED",
+      context: { committed: false },
+    });
+    await expect(creator).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+      context: {
+        committed: false,
+        lockPath,
+        markerPath: `${lockPath}.transition`,
+        recovery:
+          "Stop all store users, verify lockPath still has lockIdentity and ownerToken, remove markerPath and lockPath, fsync their parent directory, then restart.",
+        retrySafeAfterRecovery: true,
+      },
+    });
+    await expect(
+      fs.lstat(
+        path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("cleans a published lock when owner candidate cleanup fails", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeOwnerCandidateCleanup: async () => {
+          throw new Error("simulated owner candidate cleanup failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_OWNER_CANDIDATE_CLEANUP_FAILED",
+      context: {
+        committed: false,
+        lockPath,
+        markerPath: `${lockPath}.transition`,
+        recoveryRequired: false,
+        retrySafeAfterRecovery: true,
+        retrySafeNow: true,
+      },
+    });
+    await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.lstat(
+        path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("writes a 0600 regular file and retains state across store instances", async () => {
     const stateDirectory = await temporaryDirectory();
     const { created } = await seed(stateDirectory);
@@ -806,7 +911,12 @@ describe("FileMessageInteractionSessionStore", () => {
 
     oldRelease.release();
     await expect(oldTransaction).rejects.toMatchObject({
-      code: "INTERACTION_STORE_LOCK_LOST",
+      code: "INTERACTION_STORE_COMMITTED_RELEASE_FAILED",
+      context: {
+        committed: true,
+        releaseErrorCode: "INTERACTION_STORE_LOCK_LOST",
+        retrySafeAfterRecovery: false,
+      },
     });
     expect(await lockIdentity(lockPath)).toBe(successorIdentity);
     successorRelease.release();
@@ -829,9 +939,10 @@ describe("FileMessageInteractionSessionStore", () => {
         },
       },
     });
-    await expect(store.deleteExpired(now)).rejects.toThrow(
-      "simulated lock unlink failure",
-    );
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_COMMITTED_RELEASE_FAILED",
+      context: { committed: true, retrySafeAfterRecovery: false },
+    });
     expect(await fs.lstat(lockPath)).toBeDefined();
     await expect(fs.lstat(`${lockPath}.transition`)).rejects.toMatchObject({
       code: "ENOENT",
@@ -989,7 +1100,7 @@ describe("FileMessageInteractionSessionStore", () => {
     ).rejects.toMatchObject({
       code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
       message:
-        "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
+        "Interaction transaction committed but lock release failed; do not retry the mutation.",
       context: {
         committed: true,
         markerPath: `${lockPath}.transition`,
@@ -1016,6 +1127,32 @@ describe("FileMessageInteractionSessionStore", () => {
       context: { markerPath: `${lockPath}.transition` },
     });
     expect(await fs.readFile(filePath, "utf8")).toBe(committedState);
+  });
+
+  it("preserves structured release recovery beside an operation failure", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created, now } = await seed(stateDirectory);
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const failing = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeTransitionMarkerCleanup: async () => {
+          throw new Error("simulated release cleanup failure");
+        },
+      },
+    });
+    await expect(failing.create(created.session)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_TRANSACTION_AND_RELEASE_FAILED",
+      cause: { code: "MESSAGE_INTERACTION_REFERENCE_COLLISION" },
+      context: {
+        releaseErrorCode: "INTERACTION_STORE_RELEASE_CLEANUP_FAILED",
+        releaseErrorContext: { markerPath: `${lockPath}.transition` },
+      },
+    });
   });
 
   it("collects expired sessions through the explicit retention/GC boundary", async () => {

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -755,7 +755,9 @@ describe("FileMessageInteractionSessionStore", () => {
       code: "INTERACTION_STORE_LOCK_TIMEOUT",
     });
 
-    await fs.utimes(lockPath, new Date(now - 101), new Date(now - 101));
+    // Stay well beyond the ceiling so filesystem timestamp precision cannot
+    // turn this into a boundary assertion on platforms with rounded mtimes.
+    await fs.utimes(lockPath, new Date(now - 1_000), new Date(now - 1_000));
     await expect(store.deleteExpired(now)).resolves.toBe(0);
   });
 

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -285,6 +285,89 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(Promise.all([publisher, contender])).resolves.toEqual([0, 0]);
   });
 
+  it("re-observes the lock after a publisher completes and releases inside the two-link read window", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const publication = barrier();
+    const publisher = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        afterLockPublishBeforeCandidateCleanup: publication.hook,
+      },
+    }).deleteExpired(now);
+    await publication.entered;
+
+    const candidateValidation = barrier();
+    const contender = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforePublicationCandidateValidation: candidateValidation.hook,
+      },
+    }).deleteExpired(now);
+    await candidateValidation.entered;
+    publication.release();
+    await expect(publisher).resolves.toBe(0);
+    await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    candidateValidation.release();
+    await expect(contender).resolves.toBe(0);
+  });
+
+  it("re-observes a successor lock linked inside the two-link read window", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const publication = barrier();
+    const publisher = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        afterLockPublishBeforeCandidateCleanup: publication.hook,
+      },
+    }).deleteExpired(now);
+    await publication.entered;
+
+    const candidateValidation = barrier();
+    const contender = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforePublicationCandidateValidation: candidateValidation.hook,
+      },
+    }).deleteExpired(now);
+    await candidateValidation.entered;
+    publication.release();
+    await expect(publisher).resolves.toBe(0);
+
+    const successorRelease = barrier();
+    const successor = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: { beforeReleaseRetire: successorRelease.hook },
+    }).deleteExpired(now);
+    await successorRelease.entered;
+    const successorIdentity = await lockIdentity(lockPath);
+
+    candidateValidation.release();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await lockIdentity(lockPath)).toBe(successorIdentity);
+    successorRelease.release();
+    await expect(Promise.all([successor, contender])).resolves.toEqual([0, 0]);
+  });
+
   it("a delayed creator cannot publish over a successor owner", async () => {
     const stateDirectory = await temporaryDirectory();
     const now = Date.parse("2026-08-21T00:00:00.000Z");
@@ -421,11 +504,121 @@ describe("FileMessageInteractionSessionStore", () => {
         committed: false,
         lockPath,
         markerPath: `${lockPath}.transition`,
+        published: true,
         recoveryRequired: false,
         retrySafeAfterRecovery: true,
         retrySafeNow: true,
       },
     });
+    await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.lstat(
+        path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("types candidate cleanup failure when an existing lock blocks publication", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const holderRelease = barrier();
+    const holder = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: { beforeReleaseRetire: holderRelease.hook },
+    }).deleteExpired(now);
+    await holderRelease.entered;
+    const holderIdentity = await lockIdentity(lockPath);
+
+    const contender = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforeOwnerCandidateCleanup: async () => {
+          throw new Error("simulated owner candidate cleanup failure");
+        },
+      },
+    });
+    const failure = await contender.deleteExpired(now).then(
+      () => {
+        throw new Error("contender must not acquire the held lock");
+      },
+      (error: unknown) => error,
+    );
+    expect(failure).toMatchObject({
+      code: "INTERACTION_STORE_OWNER_CANDIDATE_CLEANUP_FAILED",
+      context: {
+        committed: false,
+        lockPath,
+        markerPath: `${lockPath}.transition`,
+        published: false,
+        recoveryRequired: false,
+        retrySafeAfterRecovery: true,
+        retrySafeNow: true,
+      },
+    });
+    const candidatePath = (failure as { context: { candidatePath: string } })
+      .context.candidatePath;
+    expect(candidatePath.startsWith(`${lockPath}.owner-${process.pid}-`)).toBe(
+      true,
+    );
+    expect((failure as { cause?: unknown }).cause).toMatchObject({
+      message: "simulated owner candidate cleanup failure",
+    });
+    expect(await lockIdentity(lockPath)).toBe(holderIdentity);
+
+    holderRelease.release();
+    await expect(holder).resolves.toBe(0);
+  });
+
+  it("types candidate cleanup failure when a transition marker defers publication", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await fs.mkdir(stateDirectory, { recursive: true });
+    await fs.writeFile(
+      `${lockPath}.transition`,
+      JSON.stringify({
+        pid: 2_000_000_000,
+        processIdentity: null,
+        token: "in-flight-transition",
+      }),
+      { mode: 0o600 },
+    );
+    const marker = await fs.readFile(`${lockPath}.transition`, "utf8");
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforeOwnerCandidateCleanup: async () => {
+          throw new Error("simulated owner candidate cleanup failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_OWNER_CANDIDATE_CLEANUP_FAILED",
+      context: {
+        committed: false,
+        lockPath,
+        markerPath: `${lockPath}.transition`,
+        published: false,
+        recoveryRequired: false,
+        retrySafeAfterRecovery: true,
+        retrySafeNow: true,
+      },
+    });
+    expect(await fs.readFile(`${lockPath}.transition`, "utf8")).toBe(marker);
     await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(
       fs.lstat(
@@ -758,7 +951,17 @@ describe("FileMessageInteractionSessionStore", () => {
     // Stay well beyond the ceiling so filesystem timestamp precision cannot
     // turn this into a boundary assertion on platforms with rounded mtimes.
     await fs.utimes(lockPath, new Date(now - 1_000), new Date(now - 1_000));
-    await expect(store.deleteExpired(now)).resolves.toBe(0);
+    // Recovery publishes and fsyncs a transition marker before the retry, so
+    // the acquiring store needs a timeout that is not bounded by disk latency.
+    const recoverer = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      staleLockMs: 1,
+      hardStaleLockMs: 100,
+      pollMs: 1,
+    });
+    await expect(recoverer.deleteExpired(now)).resolves.toBe(0);
   });
 
   it("fences two delayed stale recoverers from the fresh winner generation", async () => {

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -39,6 +39,29 @@ async function lockIdentity(lockPath: string): Promise<string> {
   return `${entry.dev}-${entry.ino}`;
 }
 
+async function writeLock(
+  lockPath: string,
+  owner: Omit<
+    {
+      pid: number;
+      processIdentity: string | null;
+      lockIdentity: string;
+      token: string;
+      createdAt: number;
+      expiresAt: number;
+    },
+    "lockIdentity"
+  >,
+): Promise<string> {
+  await fs.writeFile(lockPath, "{}", { mode: 0o600, flag: "wx" });
+  const identity = await lockIdentity(lockPath);
+  await fs.writeFile(
+    lockPath,
+    JSON.stringify({ ...owner, lockIdentity: identity }),
+  );
+  return identity;
+}
+
 function barrier(): {
   entered: Promise<void>;
   hook: () => Promise<void>;
@@ -200,6 +223,102 @@ describe("FileMessageInteractionSessionStore", () => {
     ).toHaveLength(7);
   });
 
+  it("treats the exact two-link owner publication window as in progress", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const publication = barrier();
+    const publisher = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        afterLockPublishBeforeCandidateCleanup: publication.hook,
+      },
+    }).deleteExpired(now);
+    await publication.entered;
+    const contender = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 20,
+      pollMs: 1,
+    }).deleteExpired(now);
+    await expect(contender).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+
+    publication.release();
+    await expect(publisher).resolves.toBe(0);
+  });
+
+  it("accepts candidate cleanup after observing the two-link window", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const publication = barrier();
+    const publisherRelease = barrier();
+    const publisher = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        afterLockPublishBeforeCandidateCleanup: publication.hook,
+        beforeReleaseRetire: publisherRelease.hook,
+      },
+    }).deleteExpired(now);
+    await publication.entered;
+
+    const candidateValidation = barrier();
+    const contender = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 1_000,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforePublicationCandidateValidation: candidateValidation.hook,
+      },
+    }).deleteExpired(now);
+    await candidateValidation.entered;
+    publication.release();
+    await publisherRelease.entered;
+    candidateValidation.release();
+    publisherRelease.release();
+
+    await expect(Promise.all([publisher, contender])).resolves.toEqual([0, 0]);
+  });
+
+  it("a delayed creator cannot publish over a successor owner", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const oldPublication = barrier();
+    const oldCreator = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 30,
+      pollMs: 1,
+      lockRaceHooks: { beforeLockPublish: oldPublication.hook },
+    }).deleteExpired(now);
+    await oldPublication.entered;
+
+    const successorRelease = barrier();
+    const successor = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: { beforeReleaseRetire: successorRelease.hook },
+    });
+    const successorTransaction = successor.deleteExpired(now);
+    await successorRelease.entered;
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const successorIdentity = await lockIdentity(lockPath);
+
+    oldPublication.release();
+    await expect(oldCreator).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+    expect(await lockIdentity(lockPath)).toBe(successorIdentity);
+    successorRelease.release();
+    await expect(successorTransaction).resolves.toBe(0);
+  });
+
   it("writes a 0600 regular file and retains state across store instances", async () => {
     const stateDirectory = await temporaryDirectory();
     const { created } = await seed(stateDirectory);
@@ -319,19 +438,13 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: 2_000_000_000,
-        processIdentity: null,
-        lockIdentity: await lockIdentity(lockPath),
-        token: "dead-owner",
-        createdAt: now - 10_000,
-        expiresAt: now - 1,
-      }),
-      { mode: 0o600 },
-    );
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-owner",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
     const { created } = await seed(stateDirectory, { now });
     expect(created.session.reference).toBe("0123456789abcdef0123456789abcdef");
   });
@@ -343,19 +456,13 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: process.pid,
-        processIdentity: null,
-        lockIdentity: await lockIdentity(lockPath),
-        token: "live-owner",
-        createdAt: now - 10_000,
-        expiresAt: now - 1,
-      }),
-      { mode: 0o600 },
-    );
+    await writeLock(lockPath, {
+      pid: process.pid,
+      processIdentity: null,
+      token: "live-owner",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
     const store = new FileMessageInteractionSessionStore({
       stateDirectory,
       clock: () => now,
@@ -368,6 +475,30 @@ describe("FileMessageInteractionSessionStore", () => {
     expect(await fs.lstat(lockPath)).toBeDefined();
   });
 
+  it("rejects a steady lock hardlink outside the publication candidate", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await writeLock(lockPath, {
+      pid: process.pid,
+      processIdentity: null,
+      token: "hardlinked-owner",
+      createdAt: now,
+      expiresAt: now + 30_000,
+    });
+    await fs.link(lockPath, `${lockPath}.unexpected-link`);
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "UNSAFE_INTERACTION_STORE_LOCK",
+    });
+  });
+
   it("recovers an expired lock after the recorded PID is reused", async () => {
     if (process.platform !== "linux") return;
     const stateDirectory = await temporaryDirectory();
@@ -376,19 +507,13 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: process.pid,
-        processIdentity: "different-boot:different-start",
-        lockIdentity: await lockIdentity(lockPath),
-        token: "reused-pid-owner",
-        createdAt: now - 10_000,
-        expiresAt: now - 1,
-      }),
-      { mode: 0o600 },
-    );
+    await writeLock(lockPath, {
+      pid: process.pid,
+      processIdentity: "different-boot:different-start",
+      token: "reused-pid-owner",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
     const { created } = await seed(stateDirectory, { now });
     expect(created.session.reference).toBe("0123456789abcdef0123456789abcdef");
   });
@@ -400,19 +525,13 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: process.pid,
-        processIdentity: null,
-        lockIdentity: await lockIdentity(lockPath),
-        token: "unqualified-owner",
-        createdAt: now - 101,
-        expiresAt: now - 100,
-      }),
-      { mode: 0o600 },
-    );
+    await writeLock(lockPath, {
+      pid: process.pid,
+      processIdentity: null,
+      token: "unqualified-owner",
+      createdAt: now - 101,
+      expiresAt: now - 100,
+    });
     const store = new FileMessageInteractionSessionStore({
       stateDirectory,
       clock: () => now,
@@ -434,7 +553,7 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
+    await fs.writeFile(lockPath, "", { mode: 0o600, flag: "wx" });
     await fs.utimes(lockPath, new Date(now - 50), new Date(now - 50));
     const store = new FileMessageInteractionSessionStore({
       stateDirectory,
@@ -459,20 +578,13 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    const staleIdentity = await lockIdentity(lockPath);
-    await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: 2_000_000_000,
-        processIdentity: null,
-        lockIdentity: staleIdentity,
-        token: "stale-generation",
-        createdAt: now - 10_000,
-        expiresAt: now - 1,
-      }),
-      { mode: 0o600 },
-    );
+    const staleIdentity = await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "stale-generation",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
 
     let staleObservers = 0;
     let releaseObservers: () => void = () => {};
@@ -525,20 +637,13 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    const staleIdentity = await lockIdentity(lockPath);
-    await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: 2_000_000_000,
-        processIdentity: null,
-        lockIdentity: staleIdentity,
-        token: "departing-generation",
-        createdAt: now - 10_000,
-        expiresAt: now - 1,
-      }),
-      { mode: 0o600 },
-    );
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "departing-generation",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
     const recovererGate = barrier();
     const recovering = new FileMessageInteractionSessionStore({
       stateDirectory,
@@ -549,7 +654,7 @@ describe("FileMessageInteractionSessionStore", () => {
     }).deleteExpired(now);
     await recovererGate.entered;
 
-    await fs.rm(lockPath, { recursive: true });
+    await fs.rm(lockPath);
     const successorRelease = barrier();
     const successor = new FileMessageInteractionSessionStore({
       stateDirectory,
@@ -576,22 +681,15 @@ describe("FileMessageInteractionSessionStore", () => {
       stateDirectory,
       "message-interaction-sessions.v1.json.lock",
     );
-    await fs.mkdir(lockPath, { mode: 0o700 });
-    const identity = await lockIdentity(lockPath);
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-lock-owner",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
     await fs.writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: 2_000_000_000,
-        processIdentity: null,
-        lockIdentity: identity,
-        token: "dead-lock-owner",
-        createdAt: now - 10_000,
-        expiresAt: now - 1,
-      }),
-      { mode: 0o600 },
-    );
-    await fs.writeFile(
-      path.join(lockPath, ".transition"),
+      `${lockPath}.transition`,
       JSON.stringify({
         pid: 2_000_000_000,
         processIdentity: null,
@@ -607,6 +705,79 @@ describe("FileMessageInteractionSessionStore", () => {
       pollMs: 1,
     });
     await expect(store.deleteExpired(now)).resolves.toBe(0);
+  });
+
+  it("two clearers cannot remove a replacement live transition marker", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-lock-owner",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
+    await fs.writeFile(
+      `${lockPath}.transition`,
+      JSON.stringify({
+        pid: 2_000_000_000,
+        processIdentity: null,
+        token: "dead-transition-owner",
+      }),
+      { mode: 0o600 },
+    );
+
+    const firstBeforeRetire = barrier();
+    const secondBeforeRetire = barrier();
+    const firstAfterRetire = barrier();
+    const first = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 30,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforeAbandonedTransitionRetire: firstBeforeRetire.hook,
+        afterAbandonedTransitionRetire: firstAfterRetire.hook,
+      },
+    }).deleteExpired(now);
+    const second = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 30,
+      pollMs: 1,
+      lockRaceHooks: {
+        beforeAbandonedTransitionRetire: secondBeforeRetire.hook,
+      },
+    }).deleteExpired(now);
+    await Promise.all([firstBeforeRetire.entered, secondBeforeRetire.entered]);
+
+    firstBeforeRetire.release();
+    await firstAfterRetire.entered;
+    await fs.writeFile(
+      `${lockPath}.transition`,
+      JSON.stringify({
+        pid: process.pid,
+        processIdentity: null,
+        token: "live-replacement-transition",
+      }),
+      { mode: 0o600, flag: "wx" },
+    );
+    secondBeforeRetire.release();
+    await expect(second).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
+    expect(
+      JSON.parse(await fs.readFile(`${lockPath}.transition`, "utf8")),
+    ).toMatchObject({ token: "live-replacement-transition" });
+
+    firstAfterRetire.release();
+    await expect(first).rejects.toMatchObject({
+      code: "INTERACTION_STORE_LOCK_TIMEOUT",
+    });
   });
 
   it("a delayed release cannot detach a replacement lock generation", async () => {
@@ -645,6 +816,31 @@ describe("FileMessageInteractionSessionStore", () => {
     expect(await lockIdentity(lockPath)).toBe(successorIdentity);
     successorRelease.release();
     await expect(successorTransaction).resolves.toBe(0);
+  });
+
+  it("cleans its transition marker when lock unlink fails", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeLockUnlink: async () => {
+          throw new Error("simulated lock unlink failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toThrow(
+      "simulated lock unlink failure",
+    );
+    expect(await fs.lstat(lockPath)).toBeDefined();
+    await expect(fs.lstat(`${lockPath}.transition`)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("collects expired sessions through the explicit retention/GC boundary", async () => {

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -709,6 +709,7 @@ describe("FileMessageInteractionSessionStore", () => {
     });
     await expect(store.deleteExpired(now)).rejects.toMatchObject({
       code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+      context: { markerPath: `${lockPath}.transition` },
     });
     expect(await fs.readFile(`${lockPath}.transition`, "utf8")).toBe(marker);
     await expect(
@@ -758,11 +759,17 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(Promise.allSettled([first, second])).resolves.toMatchObject([
       {
         status: "rejected",
-        reason: { code: "INTERACTION_STORE_RECOVERY_REQUIRED" },
+        reason: {
+          code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+          context: { markerPath: `${lockPath}.transition` },
+        },
       },
       {
         status: "rejected",
-        reason: { code: "INTERACTION_STORE_RECOVERY_REQUIRED" },
+        reason: {
+          code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+          context: { markerPath: `${lockPath}.transition` },
+        },
       },
     ]);
     expect(await fs.readFile(`${lockPath}.transition`, "utf8")).toBe(marker);
@@ -856,7 +863,11 @@ describe("FileMessageInteractionSessionStore", () => {
     });
     await expect(store.deleteExpired(now)).rejects.toMatchObject({
       code: "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED",
-      context: { committed: false, retrySafeAfterRecovery: true },
+      context: {
+        committed: false,
+        markerPath: `${lockPath}.transition`,
+        retrySafeAfterRecovery: true,
+      },
     });
     await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
@@ -865,6 +876,91 @@ describe("FileMessageInteractionSessionStore", () => {
         path.join(stateDirectory, "message-interaction-sessions.v1.json"),
       ),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves validation failure when transition cleanup also fails", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-owner-validation-error",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeTransitionValidation: async () => {
+          throw new Error("primary validation failure");
+        },
+        beforeTransitionAbortCleanup: async () => {
+          throw new Error("secondary marker cleanup failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED",
+      cause: { message: "primary validation failure" },
+      context: {
+        cleanupError: "secondary marker cleanup failure",
+        committed: false,
+        markerPath: `${lockPath}.transition`,
+        retrySafeAfterRecovery: true,
+      },
+    });
+    expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
+  });
+
+  it("types cleanup failure after transition validation mismatch", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const staleIdentity = await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-owner-validation-mismatch",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
+    let replacementIdentity = "";
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeTransitionValidation: async () => {
+          await fs.rename(lockPath, `${lockPath}.retired-${staleIdentity}`);
+          replacementIdentity = await writeLock(lockPath, {
+            pid: process.pid,
+            processIdentity: null,
+            token: "replacement-owner",
+            createdAt: now,
+            expiresAt: now + 30_000,
+          });
+        },
+        beforeTransitionAbortCleanup: async () => {
+          throw new Error("mismatch marker cleanup failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED",
+      context: {
+        cleanupError: "mismatch marker cleanup failure",
+        committed: false,
+        markerPath: `${lockPath}.transition`,
+      },
+    });
+    expect(await lockIdentity(lockPath)).toBe(replacementIdentity);
+    expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
   });
 
   it("reports a committed mutation whose transition cleanup fails", async () => {
@@ -894,7 +990,11 @@ describe("FileMessageInteractionSessionStore", () => {
       code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
       message:
         "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
-      context: { committed: true, retrySafeAfterRecovery: false },
+      context: {
+        committed: true,
+        markerPath: `${lockPath}.transition`,
+        retrySafeAfterRecovery: false,
+      },
     });
     await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
@@ -913,6 +1013,7 @@ describe("FileMessageInteractionSessionStore", () => {
       }),
     ).rejects.toMatchObject({
       code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+      context: { markerPath: `${lockPath}.transition` },
     });
     expect(await fs.readFile(filePath, "utf8")).toBe(committedState);
   });

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -223,7 +223,7 @@ describe("FileMessageInteractionSessionStore", () => {
     ).toHaveLength(7);
   });
 
-  it("treats the exact two-link owner publication window as in progress", async () => {
+  it("does not retire a live publisher paused past the recovery ceiling", async () => {
     const stateDirectory = await temporaryDirectory();
     const now = Date.parse("2026-08-21T00:00:00.000Z");
     const publication = barrier();
@@ -237,7 +237,9 @@ describe("FileMessageInteractionSessionStore", () => {
     await publication.entered;
     const contender = new FileMessageInteractionSessionStore({
       stateDirectory,
-      clock: () => now,
+      clock: () => now + 10_000,
+      staleLockMs: 1,
+      hardStaleLockMs: 2,
       lockTimeoutMs: 20,
       pollMs: 1,
     }).deleteExpired(now);
@@ -674,7 +676,7 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(successorTransaction).resolves.toBe(0);
   });
 
-  it("recovers a transition marker abandoned by a dead lock owner", async () => {
+  it("fails closed on a transition marker abandoned by a dead owner", async () => {
     const stateDirectory = await temporaryDirectory();
     const now = Date.parse("2026-08-21T00:00:00.000Z");
     const lockPath = path.join(
@@ -698,16 +700,25 @@ describe("FileMessageInteractionSessionStore", () => {
       { mode: 0o600 },
     );
 
+    const marker = await fs.readFile(`${lockPath}.transition`, "utf8");
     const store = new FileMessageInteractionSessionStore({
       stateDirectory,
       clock: () => now,
-      lockTimeoutMs: 1_000,
+      lockTimeoutMs: 20,
       pollMs: 1,
     });
-    await expect(store.deleteExpired(now)).resolves.toBe(0);
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+    });
+    expect(await fs.readFile(`${lockPath}.transition`, "utf8")).toBe(marker);
+    await expect(
+      fs.lstat(
+        path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("two clearers cannot remove a replacement live transition marker", async () => {
+  it("two contenders leave an abandoned transition marker untouched", async () => {
     const stateDirectory = await temporaryDirectory();
     const now = Date.parse("2026-08-21T00:00:00.000Z");
     const lockPath = path.join(
@@ -731,53 +742,30 @@ describe("FileMessageInteractionSessionStore", () => {
       { mode: 0o600 },
     );
 
-    const firstBeforeRetire = barrier();
-    const secondBeforeRetire = barrier();
-    const firstAfterRetire = barrier();
+    const marker = await fs.readFile(`${lockPath}.transition`, "utf8");
     const first = new FileMessageInteractionSessionStore({
       stateDirectory,
       clock: () => now,
-      lockTimeoutMs: 30,
+      lockTimeoutMs: 20,
       pollMs: 1,
-      lockRaceHooks: {
-        beforeAbandonedTransitionRetire: firstBeforeRetire.hook,
-        afterAbandonedTransitionRetire: firstAfterRetire.hook,
-      },
     }).deleteExpired(now);
     const second = new FileMessageInteractionSessionStore({
       stateDirectory,
       clock: () => now,
-      lockTimeoutMs: 30,
+      lockTimeoutMs: 20,
       pollMs: 1,
-      lockRaceHooks: {
-        beforeAbandonedTransitionRetire: secondBeforeRetire.hook,
-      },
     }).deleteExpired(now);
-    await Promise.all([firstBeforeRetire.entered, secondBeforeRetire.entered]);
-
-    firstBeforeRetire.release();
-    await firstAfterRetire.entered;
-    await fs.writeFile(
-      `${lockPath}.transition`,
-      JSON.stringify({
-        pid: process.pid,
-        processIdentity: null,
-        token: "live-replacement-transition",
-      }),
-      { mode: 0o600, flag: "wx" },
-    );
-    secondBeforeRetire.release();
-    await expect(second).rejects.toMatchObject({
-      code: "INTERACTION_STORE_LOCK_TIMEOUT",
-    });
-    expect(
-      JSON.parse(await fs.readFile(`${lockPath}.transition`, "utf8")),
-    ).toMatchObject({ token: "live-replacement-transition" });
-
-    firstAfterRetire.release();
-    await expect(first).rejects.toMatchObject({
-      code: "INTERACTION_STORE_LOCK_TIMEOUT",
-    });
+    await expect(Promise.allSettled([first, second])).resolves.toMatchObject([
+      {
+        status: "rejected",
+        reason: { code: "INTERACTION_STORE_RECOVERY_REQUIRED" },
+      },
+      {
+        status: "rejected",
+        reason: { code: "INTERACTION_STORE_RECOVERY_REQUIRED" },
+      },
+    ]);
+    expect(await fs.readFile(`${lockPath}.transition`, "utf8")).toBe(marker);
   });
 
   it("a delayed release cannot detach a replacement lock generation", async () => {
@@ -841,6 +829,55 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(fs.lstat(`${lockPath}.transition`)).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  it("reports a committed mutation whose transition cleanup fails", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const { created, now } = await seed(stateDirectory, { retentionMs: 0 });
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    const filePath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json",
+    );
+    const failing = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      retentionMs: 0,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeTransitionMarkerCleanup: async () => {
+          throw new Error("simulated transition cleanup failure");
+        },
+      },
+    });
+    await expect(
+      failing.deleteExpired(Date.parse(created.session.expiresAt)),
+    ).rejects.toMatchObject({
+      code: "INTERACTION_STORE_TRANSITION_CLEANUP_FAILED",
+      message:
+        "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
+    });
+    await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
+    const committedState = await fs.readFile(filePath, "utf8");
+
+    const contender = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockTimeoutMs: 20,
+      pollMs: 1,
+    });
+    await expect(
+      contender.create({
+        ...created.session,
+        reference: "fedcba9876543210fedcba9876543210",
+      }),
+    ).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_REQUIRED",
+    });
+    expect(await fs.readFile(filePath, "utf8")).toBe(committedState);
   });
 
   it("collects expired sessions through the explicit retention/GC boundary", async () => {

--- a/packages/agent/src/services/message-interaction-session-store.test.ts
+++ b/packages/agent/src/services/message-interaction-session-store.test.ts
@@ -831,6 +831,42 @@ describe("FileMessageInteractionSessionStore", () => {
     });
   });
 
+  it("marks stale-recovery cleanup failure as uncommitted and retryable after recovery", async () => {
+    const stateDirectory = await temporaryDirectory();
+    const now = Date.parse("2026-08-21T00:00:00.000Z");
+    const lockPath = path.join(
+      stateDirectory,
+      "message-interaction-sessions.v1.json.lock",
+    );
+    await writeLock(lockPath, {
+      pid: 2_000_000_000,
+      processIdentity: null,
+      token: "dead-owner-before-operation",
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    });
+    const store = new FileMessageInteractionSessionStore({
+      stateDirectory,
+      clock: () => now,
+      lockRaceHooks: {
+        beforeTransitionMarkerCleanup: async () => {
+          throw new Error("simulated recovery cleanup failure");
+        },
+      },
+    });
+    await expect(store.deleteExpired(now)).rejects.toMatchObject({
+      code: "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED",
+      context: { committed: false, retrySafeAfterRecovery: true },
+    });
+    await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();
+    await expect(
+      fs.lstat(
+        path.join(stateDirectory, "message-interaction-sessions.v1.json"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("reports a committed mutation whose transition cleanup fails", async () => {
     const stateDirectory = await temporaryDirectory();
     const { created, now } = await seed(stateDirectory, { retentionMs: 0 });
@@ -855,9 +891,10 @@ describe("FileMessageInteractionSessionStore", () => {
     await expect(
       failing.deleteExpired(Date.parse(created.session.expiresAt)),
     ).rejects.toMatchObject({
-      code: "INTERACTION_STORE_TRANSITION_CLEANUP_FAILED",
+      code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
       message:
         "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
+      context: { committed: true, retrySafeAfterRecovery: false },
     });
     await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await fs.lstat(`${lockPath}.transition`)).toBeDefined();

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -45,6 +45,8 @@ interface LockRaceHooks {
   beforePublicationCandidateValidation?: () => Promise<void>;
   beforeStaleRetire?: () => Promise<void>;
   beforeReleaseRetire?: () => Promise<void>;
+  beforeTransitionValidation?: () => Promise<void>;
+  beforeTransitionAbortCleanup?: () => Promise<void>;
   beforeLockUnlink?: () => Promise<void>;
   beforeTransitionMarkerCleanup?: () => Promise<void>;
 }
@@ -455,6 +457,39 @@ export class FileMessageInteractionSessionStore
     return `${entry.dev}-${entry.ino}`;
   }
 
+  private transitionRecoveryContext(marker: string): Record<string, unknown> {
+    return {
+      markerPath: marker,
+      recovery:
+        "Stop all store users, verify no process owns the lock, remove markerPath, fsync its parent directory, then restart.",
+    };
+  }
+
+  private transitionCleanupError(
+    marker: string,
+    phase: "recovery" | "release",
+    cleanupError: unknown,
+    primaryError?: unknown,
+  ): ElizaError {
+    return new ElizaError("Interaction transition marker cleanup failed.", {
+      code:
+        phase === "recovery"
+          ? "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED"
+          : "INTERACTION_STORE_RELEASE_CLEANUP_FAILED",
+      cause: primaryError ?? cleanupError,
+      context: {
+        ...this.transitionRecoveryContext(marker),
+        ...(phase === "recovery"
+          ? { committed: false, retrySafeAfterRecovery: true }
+          : {}),
+        cleanupError:
+          cleanupError instanceof Error
+            ? cleanupError.message
+            : String(cleanupError),
+      },
+    });
+  }
+
   private async beginLockTransition(
     lockIdentity: string,
   ): Promise<string | null> {
@@ -510,13 +545,33 @@ export class FileMessageInteractionSessionStore
     if (!marker) return false;
     let valid: boolean;
     try {
+      await this.lockRaceHooks.beforeTransitionValidation?.();
       valid = await validate();
-    } catch (error) {
-      await fs.rm(marker, { force: true });
-      throw error;
+    } catch (primaryError) {
+      try {
+        await this.lockRaceHooks.beforeTransitionAbortCleanup?.();
+        await fs.rm(marker, { force: true });
+      } catch (cleanupError) {
+        // error-policy:J2 Preserve the validation failure while exposing the
+        // fail-closed marker and its exact offline recovery procedure.
+        throw this.transitionCleanupError(
+          marker,
+          phase,
+          cleanupError,
+          primaryError,
+        );
+      }
+      throw primaryError;
     }
     if (!valid) {
-      await fs.rm(marker, { force: true });
+      try {
+        await this.lockRaceHooks.beforeTransitionAbortCleanup?.();
+        await fs.rm(marker, { force: true });
+      } catch (cleanupError) {
+        // error-policy:J2 A failed validation grants no detach authority; an
+        // uncleared marker is a typed outage rather than a raw teardown error.
+        throw this.transitionCleanupError(marker, phase, cleanupError);
+      }
       return false;
     }
     try {
@@ -537,20 +592,7 @@ export class FileMessageInteractionSessionStore
     } catch (error) {
       // error-policy:J2 The lock is already detached, so acquisition or release
       // must surface the fail-closed marker instead of permitting a successor.
-      throw new ElizaError(
-        "Interaction lock detached but transition cleanup failed.",
-        {
-          code:
-            phase === "recovery"
-              ? "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED"
-              : "INTERACTION_STORE_RELEASE_CLEANUP_FAILED",
-          cause: error,
-          context:
-            phase === "recovery"
-              ? { committed: false, retrySafeAfterRecovery: true }
-              : undefined,
-        },
-      );
+      throw this.transitionCleanupError(marker, phase, error);
     }
     return true;
   }
@@ -818,9 +860,11 @@ export class FileMessageInteractionSessionStore
       }
     }
     if (await existsLstat(`${this.lockPath}.transition`)) {
+      const marker = `${this.lockPath}.transition`;
       storeError(
         "INTERACTION_STORE_RECOVERY_REQUIRED",
         "Interaction store recovery requires all users to stop before the abandoned transition marker is removed.",
+        this.transitionRecoveryContext(marker),
       );
     }
     return storeError(
@@ -855,9 +899,11 @@ export class FileMessageInteractionSessionStore
       await delay(this.pollMs);
     }
     if (await existsLstat(`${this.lockPath}.transition`)) {
+      const marker = `${this.lockPath}.transition`;
       storeError(
         "INTERACTION_STORE_RECOVERY_REQUIRED",
         "Interaction store recovery requires all users to stop before the abandoned transition marker is removed.",
+        this.transitionRecoveryContext(marker),
       );
     }
     storeError(
@@ -1090,7 +1136,11 @@ export class FileMessageInteractionSessionStore
         {
           code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
           cause: releaseError,
-          context: { committed: true, retrySafeAfterRecovery: false },
+          context: {
+            ...releaseError.context,
+            committed: true,
+            retrySafeAfterRecovery: false,
+          },
         },
       );
     }

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -44,6 +44,8 @@ interface LockRaceHooks {
   afterTransitionCheckBeforeLockPublish?: () => Promise<void>;
   afterLockPublishBeforeCandidateCleanup?: () => Promise<void>;
   beforeOwnerCandidateCleanup?: () => Promise<void>;
+  beforeStateDirectorySync?: () => Promise<void>;
+  afterStateDirectoryClose?: () => Promise<void>;
   beforePublicationCandidateValidation?: () => Promise<void>;
   beforeStaleRetire?: () => Promise<void>;
   beforeReleaseRetire?: () => Promise<void>;
@@ -546,6 +548,7 @@ export class FileMessageInteractionSessionStore
     lockIdentity: string,
     validate: () => Promise<boolean>,
     phase: "recovery" | "release",
+    ownerToken?: string,
   ): Promise<boolean> {
     const marker = await this.beginLockTransition(lockIdentity, phase);
     if (!marker) return false;
@@ -583,14 +586,41 @@ export class FileMessageInteractionSessionStore
     try {
       await this.lockRaceHooks.beforeLockUnlink?.();
       await fs.rm(this.lockPath);
-    } catch (error) {
+    } catch (unlinkError) {
       try {
+        await this.lockRaceHooks.beforeTransitionAbortCleanup?.();
         await fs.rm(marker, { force: true });
-      } catch {
-        // error-policy:J6 preserve the authoritative unlink failure.
+      } catch (cleanupError) {
+        // error-policy:J2 Preserve both failures and the exact offline
+        // authority needed to recover the still-published owner generation.
+        throw new ElizaError(
+          "Interaction lock unlink and transition cleanup both failed.",
+          {
+            code:
+              phase === "recovery"
+                ? "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED"
+                : "INTERACTION_STORE_RELEASE_CLEANUP_FAILED",
+            cause: unlinkError,
+            context: {
+              ...this.transitionRecoveryContext(marker),
+              lockPath: this.lockPath,
+              lockIdentity,
+              ...(ownerToken ? { ownerToken } : {}),
+              cleanupError:
+                cleanupError instanceof Error
+                  ? cleanupError.message
+                  : String(cleanupError),
+              recovery:
+                "Stop all store users, verify lockPath still has lockIdentity and ownerToken when reported, remove markerPath and lockPath, fsync their parent directory, then restart.",
+              ...(phase === "recovery"
+                ? { committed: false, retrySafeAfterRecovery: true }
+                : {}),
+            },
+          },
+        );
       }
-      if (isErrno(error, "ENOENT")) return false;
-      throw error;
+      if (isErrno(unlinkError, "ENOENT")) return false;
+      throw unlinkError;
     }
     try {
       await this.lockRaceHooks.beforeTransitionMarkerCleanup?.();
@@ -954,6 +984,7 @@ export class FileMessageInteractionSessionStore
             return Boolean(current && current.token === owner.token);
           },
           "release",
+          owner.token,
         )
       ) {
         return;
@@ -1136,15 +1167,40 @@ export class FileMessageInteractionSessionStore
       );
     }
     const temp = `${this.filePath}.tmp-${process.pid}-${newToken()}`;
+    let renameCommitted = false;
+    let directorySynced = false;
     try {
       await this.writeAndSync(temp, document);
       await fs.rename(temp, this.filePath);
+      renameCommitted = true;
       const directoryHandle = await fs.open(this.directory, constants.O_RDONLY);
       try {
+        await this.lockRaceHooks.beforeStateDirectorySync?.();
         await directoryHandle.sync();
+        directorySynced = true;
       } finally {
         await directoryHandle.close();
+        await this.lockRaceHooks.afterStateDirectoryClose?.();
       }
+    } catch (error) {
+      if (renameCommitted) {
+        // error-policy:J2 The new row is visible after rename; failed directory
+        // durability/teardown makes retry unsafe and requires state inspection.
+        throw new ElizaError(
+          "Interaction store commit requires reconciliation after a post-rename failure.",
+          {
+            code: "INTERACTION_STORE_COMMIT_AMBIGUOUS",
+            cause: error,
+            context: {
+              committed: directorySynced ? true : "unknown",
+              filePath: this.filePath,
+              reconciliationRequired: true,
+              retrySafe: false,
+            },
+          },
+        );
+      }
+      throw error;
     } finally {
       try {
         await fs.rm(temp, { force: true });
@@ -1185,6 +1241,12 @@ export class FileMessageInteractionSessionStore
           code: "INTERACTION_STORE_TRANSACTION_AND_RELEASE_FAILED",
           cause: operationError,
           context: {
+            ...(operationError instanceof ElizaError
+              ? {
+                  operationErrorCode: operationError.code,
+                  operationErrorContext: operationError.context,
+                }
+              : {}),
             releaseError:
               releaseError instanceof Error
                 ? releaseError.message

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -38,8 +38,14 @@ interface LockOwner {
 }
 
 interface LockRaceHooks {
+  beforeLockPublish?: () => Promise<void>;
+  afterLockPublishBeforeCandidateCleanup?: () => Promise<void>;
+  beforePublicationCandidateValidation?: () => Promise<void>;
   beforeStaleRetire?: () => Promise<void>;
   beforeReleaseRetire?: () => Promise<void>;
+  beforeAbandonedTransitionRetire?: () => Promise<void>;
+  afterAbandonedTransitionRetire?: () => Promise<void>;
+  beforeLockUnlink?: () => Promise<void>;
 }
 
 interface LockTransitionOwner {
@@ -457,9 +463,9 @@ export class FileMessageInteractionSessionStore
   private async beginLockTransition(
     lockIdentity: string,
   ): Promise<string | null> {
-    const marker = path.join(this.lockPath, ".transition");
+    const marker = `${this.lockPath}.transition`;
     const token = newToken();
-    const candidate = path.join(this.lockPath, `.transition-${token}.tmp`);
+    const candidate = `${marker}-${token}.tmp`;
     try {
       await this.writeAndSync(candidate, {
         pid: process.pid,
@@ -488,7 +494,7 @@ export class FileMessageInteractionSessionStore
     }
     const current = await existsLstat(this.lockPath);
     if (
-      !current?.isDirectory() ||
+      !current?.isFile() ||
       current.isSymbolicLink() ||
       this.lockIdentity(current) !== lockIdentity
     ) {
@@ -505,11 +511,27 @@ export class FileMessageInteractionSessionStore
   private async clearAbandonedTransition(lockIdentity: string): Promise<void> {
     const current = await existsLstat(this.lockPath);
     if (!current || this.lockIdentity(current) !== lockIdentity) return;
-    const marker = path.join(this.lockPath, ".transition");
+    const marker = `${this.lockPath}.transition`;
+    let markerEntry: Awaited<ReturnType<typeof fs.lstat>>;
     let value: Partial<LockTransitionOwner>;
     try {
-      const raw = await fs.readFile(marker, "utf8");
-      value = JSON.parse(raw) as Partial<LockTransitionOwner>;
+      markerEntry = await fs.lstat(marker);
+      if (!markerEntry.isFile() || markerEntry.isSymbolicLink()) return;
+      const handle = await fs.open(
+        marker,
+        constants.O_RDONLY | constants.O_NOFOLLOW,
+      );
+      try {
+        const opened = await handle.stat();
+        if (opened.dev !== markerEntry.dev || opened.ino !== markerEntry.ino) {
+          return;
+        }
+        value = JSON.parse(
+          await handle.readFile("utf8"),
+        ) as Partial<LockTransitionOwner>;
+      } finally {
+        await handle.close();
+      }
     } catch (error) {
       if (isErrno(error, "ENOENT")) return;
       // error-policy:J3 malformed transition ownership fails closed.
@@ -536,10 +558,27 @@ export class FileMessageInteractionSessionStore
     ) {
       return;
     }
-    const rechecked = await existsLstat(this.lockPath);
-    if (rechecked && this.lockIdentity(rechecked) === lockIdentity) {
-      await fs.rm(marker, { force: true });
+    await this.lockRaceHooks.beforeAbandonedTransitionRetire?.();
+    const retiredMarker = path.join(
+      this.directory,
+      `${path.basename(this.lockPath)}.transition-retired-${this.lockIdentity(markerEntry)}`,
+    );
+    try {
+      await fs.link(marker, retiredMarker);
+    } catch (error) {
+      if (isErrno(error, "ENOENT") || isErrno(error, "EEXIST")) return;
+      throw error;
     }
+    const retiredEntry = await fs.lstat(retiredMarker);
+    if (
+      retiredEntry.dev !== markerEntry.dev ||
+      retiredEntry.ino !== markerEntry.ino
+    ) {
+      await fs.rm(retiredMarker, { force: true });
+      return;
+    }
+    await fs.rm(marker, { force: true });
+    await this.lockRaceHooks.afterAbandonedTransitionRetire?.();
   }
 
   /** The transition hardlink excludes release and all competing recoverers. */
@@ -560,29 +599,35 @@ export class FileMessageInteractionSessionStore
       await fs.rm(marker, { force: true });
       return false;
     }
-    const quarantine = `${this.lockPath}.retired-${process.pid}-${newToken()}`;
     try {
-      await fs.rename(this.lockPath, quarantine);
+      await this.lockRaceHooks.beforeLockUnlink?.();
+      await fs.rm(this.lockPath);
     } catch (error) {
+      try {
+        await fs.rm(marker, { force: true });
+      } catch {
+        // error-policy:J6 preserve the authoritative unlink failure.
+      }
       if (isErrno(error, "ENOENT")) return false;
       throw error;
     }
     try {
-      await fs.rm(quarantine, { recursive: true });
+      await fs.rm(marker, { force: true });
     } catch {
-      // error-policy:J6 the detached generation no longer blocks the store.
+      // error-policy:J6 an abandoned transition is generation-recoverable.
     }
     return true;
   }
 
   private async readLockOwner(): Promise<LockOwner | null> {
     try {
-      const ownerPath = path.join(this.lockPath, "owner.json");
+      const ownerPath = this.lockPath;
       const entry = await fs.lstat(ownerPath);
       if (
         !entry.isFile() ||
         entry.isSymbolicLink() ||
-        entry.nlink !== 1 ||
+        entry.nlink < 1 ||
+        entry.nlink > 2 ||
         (entry.mode & 0o077) !== 0 ||
         entry.size > 4_096
       ) {
@@ -603,12 +648,15 @@ export class FileMessageInteractionSessionStore
         constants.O_RDONLY | constants.O_NOFOLLOW,
       );
       let raw: string;
+      let openedNlink = 0;
       try {
         const opened = await handle.stat();
+        openedNlink = opened.nlink;
         if (
           opened.dev !== entry.dev ||
           opened.ino !== entry.ino ||
-          opened.nlink !== 1 ||
+          opened.nlink < 1 ||
+          opened.nlink > 2 ||
           opened.size > 4_096
         ) {
           // The prior owner may release and a contender may create a new lock
@@ -631,6 +679,59 @@ export class FileMessageInteractionSessionStore
         !Number.isSafeInteger(value.createdAt) ||
         !Number.isSafeInteger(value.expiresAt)
       ) {
+        return null;
+      }
+      if (entry.nlink === 2 || openedNlink === 2) {
+        await this.lockRaceHooks.beforePublicationCandidateValidation?.();
+        const expectedCandidate = `${path.basename(this.lockPath)}.owner-${String(value.pid)}-${value.token}.tmp`;
+        const names = await fs.readdir(this.directory);
+        if (!names.includes(expectedCandidate)) {
+          const completed = await existsLstat(this.lockPath);
+          if (
+            completed &&
+            completed.dev === entry.dev &&
+            completed.ino === entry.ino &&
+            completed.nlink === 1
+          ) {
+            return {
+              ...(value as LockOwner),
+              processIdentity: value.processIdentity ?? null,
+            };
+          }
+          storeError(
+            "UNSAFE_INTERACTION_STORE_LOCK",
+            "Interaction store lock has an unexpected hardlink.",
+          );
+        }
+        let candidate: Awaited<ReturnType<typeof fs.lstat>>;
+        try {
+          candidate = await fs.lstat(
+            path.join(this.directory, expectedCandidate),
+          );
+        } catch (error) {
+          if (!isErrno(error, "ENOENT")) throw error;
+          const completed = await existsLstat(this.lockPath);
+          if (
+            completed &&
+            completed.dev === entry.dev &&
+            completed.ino === entry.ino &&
+            completed.nlink === 1
+          ) {
+            return {
+              ...(value as LockOwner),
+              processIdentity: value.processIdentity ?? null,
+            };
+          }
+          return null;
+        }
+        if (candidate.dev !== entry.dev || candidate.ino !== entry.ino) {
+          storeError(
+            "UNSAFE_INTERACTION_STORE_LOCK",
+            "Interaction store lock publication hardlink changed.",
+          );
+        }
+        // The creator has not completed candidate cleanup and therefore has
+        // not returned the lease to a transaction yet.
         return null;
       }
       return {
@@ -690,10 +791,10 @@ export class FileMessageInteractionSessionStore
   private async recoverStaleLock(now: number): Promise<boolean> {
     const lockStat = await existsLstat(this.lockPath);
     if (!lockStat) return true;
-    if (!lockStat.isDirectory() || lockStat.isSymbolicLink()) {
+    if (!lockStat.isFile() || lockStat.isSymbolicLink()) {
       storeError(
         "UNSAFE_INTERACTION_STORE_LOCK",
-        "Interaction store lock is not a real directory.",
+        "Interaction store lock is not a regular file.",
       );
     }
     if (!(await this.lockIsStale(lockStat, now))) return false;
@@ -714,42 +815,45 @@ export class FileMessageInteractionSessionStore
     const startedAt = performance.now();
     while (performance.now() - startedAt <= this.lockTimeoutMs) {
       const now = this.clock();
+      const token = newToken();
+      const candidate = `${this.lockPath}.owner-${process.pid}-${token}.tmp`;
+      let owner: LockOwner;
       try {
-        await fs.mkdir(this.lockPath, { mode: 0o700 });
+        const handle = await fs.open(
+          candidate,
+          constants.O_CREAT |
+            constants.O_EXCL |
+            constants.O_WRONLY |
+            constants.O_NOFOLLOW,
+          0o600,
+        );
+        try {
+          const created = await handle.stat();
+          owner = {
+            pid: process.pid,
+            processIdentity: await this.readProcessIdentity(process.pid),
+            lockIdentity: this.lockIdentity(created),
+            token,
+            createdAt: now,
+            expiresAt: now + this.staleLockMs,
+          };
+          await handle.writeFile(JSON.stringify(owner, null, 2), "utf8");
+          await handle.sync();
+        } finally {
+          await handle.close();
+        }
+        // link(2) publishes the already complete owner inode with no-replace
+        // semantics. A delayed creator never writes through the shared path.
+        await this.lockRaceHooks.beforeLockPublish?.();
+        await fs.link(candidate, this.lockPath);
+        await this.lockRaceHooks.afterLockPublishBeforeCandidateCleanup?.();
+        return owner;
       } catch (error) {
         if (!isErrno(error, "EEXIST")) throw error;
         await this.recoverStaleLock(now);
         await delay(this.pollMs);
-        continue;
-      }
-
-      const created = await fs.lstat(this.lockPath);
-      const lockIdentity = this.lockIdentity(created);
-      try {
-        const owner: LockOwner = {
-          pid: process.pid,
-          processIdentity: await this.readProcessIdentity(process.pid),
-          lockIdentity,
-          token: newToken(),
-          createdAt: now,
-          expiresAt: now + this.staleLockMs,
-        };
-        const ownerTemp = path.join(
-          this.lockPath,
-          `.owner-${process.pid}-${owner.token}.tmp`,
-        );
-        await this.writeAndSync(ownerTemp, owner);
-        // Publish only the complete, synced lease. Contenders may inspect the
-        // lock directory immediately after mkdir and must never mistake an
-        // empty or partially written owner file for hostile state.
-        await fs.rename(ownerTemp, path.join(this.lockPath, "owner.json"));
-        return owner;
-      } catch (error) {
-        // A construction failure may race a hard-ceiling recovery of the
-        // unpublished owner. Retain its identity quarantine so delayed cleanup
-        // cannot detach a successor generation.
-        await this.retireObservedLock(lockIdentity, async () => true);
-        throw error;
+      } finally {
+        await fs.rm(candidate, { force: true });
       }
     }
     return storeError(

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -41,7 +41,9 @@ interface LockOwner {
 
 interface LockRaceHooks {
   beforeLockPublish?: () => Promise<void>;
+  afterTransitionCheckBeforeLockPublish?: () => Promise<void>;
   afterLockPublishBeforeCandidateCleanup?: () => Promise<void>;
+  beforeOwnerCandidateCleanup?: () => Promise<void>;
   beforePublicationCandidateValidation?: () => Promise<void>;
   beforeStaleRetire?: () => Promise<void>;
   beforeReleaseRetire?: () => Promise<void>;
@@ -492,6 +494,7 @@ export class FileMessageInteractionSessionStore
 
   private async beginLockTransition(
     lockIdentity: string,
+    phase: "recovery" | "release",
   ): Promise<string | null> {
     const marker = `${this.lockPath}.transition`;
     const token = newToken();
@@ -526,9 +529,12 @@ export class FileMessageInteractionSessionStore
       this.lockIdentity(current) !== lockIdentity
     ) {
       try {
+        await this.lockRaceHooks.beforeTransitionAbortCleanup?.();
         await fs.rm(marker, { force: true });
-      } catch {
-        // error-policy:J6 the mismatched generation cannot be retired by us.
+      } catch (cleanupError) {
+        // error-policy:J2 A marker targeting a replaced lock must remain a
+        // typed outage if its pathname cannot be cleared safely.
+        throw this.transitionCleanupError(marker, phase, cleanupError);
       }
       return null;
     }
@@ -541,7 +547,7 @@ export class FileMessageInteractionSessionStore
     validate: () => Promise<boolean>,
     phase: "recovery" | "release",
   ): Promise<boolean> {
-    const marker = await this.beginLockTransition(lockIdentity);
+    const marker = await this.beginLockTransition(lockIdentity, phase);
     if (!marker) return false;
     let valid: boolean;
     try {
@@ -802,6 +808,7 @@ export class FileMessageInteractionSessionStore
       const candidate = `${this.lockPath}.owner-${process.pid}-${token}.tmp`;
       let owner: LockOwner | null = null;
       let published = false;
+      let candidateCleanupError: unknown;
       try {
         const handle = await fs.open(
           candidate,
@@ -833,6 +840,7 @@ export class FileMessageInteractionSessionStore
           await delay(this.pollMs);
           continue;
         }
+        await this.lockRaceHooks.afterTransitionCheckBeforeLockPublish?.();
         await fs.link(candidate, this.lockPath);
         published = true;
         await this.lockRaceHooks.afterLockPublishBeforeCandidateCleanup?.();
@@ -841,9 +849,37 @@ export class FileMessageInteractionSessionStore
         await this.recoverStaleLock(now);
         await delay(this.pollMs);
       } finally {
-        await fs.rm(candidate, { force: true });
+        try {
+          await this.lockRaceHooks.beforeOwnerCandidateCleanup?.();
+          await fs.rm(candidate, { force: true });
+        } catch (error) {
+          candidateCleanupError = error;
+        }
       }
       if (published && owner) {
+        while (
+          (await existsLstat(`${this.lockPath}.transition`)) &&
+          performance.now() - startedAt <= this.lockTimeoutMs
+        ) {
+          await delay(this.pollMs);
+        }
+        if (await existsLstat(`${this.lockPath}.transition`)) {
+          const marker = `${this.lockPath}.transition`;
+          storeError(
+            "INTERACTION_STORE_RECOVERY_REQUIRED",
+            "Interaction store recovery requires all users to stop before the abandoned transition marker is removed.",
+            {
+              ...this.transitionRecoveryContext(marker),
+              lockPath: this.lockPath,
+              lockIdentity: owner.lockIdentity,
+              ownerToken: owner.token,
+              committed: false,
+              recovery:
+                "Stop all store users, verify lockPath still has lockIdentity and ownerToken, remove markerPath and lockPath, fsync their parent directory, then restart.",
+              retrySafeAfterRecovery: true,
+            },
+          );
+        }
         const canonical = await existsLstat(this.lockPath);
         const current = await this.readLockOwner();
         if (
@@ -856,8 +892,41 @@ export class FileMessageInteractionSessionStore
             "Interaction store lock ownership changed during publication.",
           );
         }
+        if (candidateCleanupError) {
+          let releaseError: unknown;
+          try {
+            await this.releaseLock(owner);
+          } catch (error) {
+            releaseError = error;
+          }
+          throw new ElizaError(
+            "Interaction lock owner candidate cleanup failed before mutation.",
+            {
+              code: "INTERACTION_STORE_OWNER_CANDIDATE_CLEANUP_FAILED",
+              cause: candidateCleanupError,
+              context: {
+                candidatePath: candidate,
+                committed: false,
+                lockPath: this.lockPath,
+                markerPath: `${this.lockPath}.transition`,
+                recoveryRequired: Boolean(releaseError),
+                retrySafeAfterRecovery: true,
+                retrySafeNow: !releaseError,
+                ...(releaseError instanceof ElizaError
+                  ? {
+                      releaseErrorCode: releaseError.code,
+                      releaseErrorContext: releaseError.context,
+                    }
+                  : releaseError
+                    ? { releaseError: String(releaseError) }
+                    : {}),
+              },
+            },
+          );
+        }
         return owner;
       }
+      if (candidateCleanupError) throw candidateCleanupError;
     }
     if (await existsLstat(`${this.lockPath}.transition`)) {
       const marker = `${this.lockPath}.transition`;
@@ -1120,31 +1189,47 @@ export class FileMessageInteractionSessionStore
               releaseError instanceof Error
                 ? releaseError.message
                 : String(releaseError),
+            ...(releaseError instanceof ElizaError
+              ? {
+                  releaseErrorCode: releaseError.code,
+                  releaseErrorContext: releaseError.context,
+                }
+              : {}),
           },
         },
       );
     }
     if (operationError) throw operationError;
-    if (
-      releaseError instanceof ElizaError &&
-      releaseError.code === "INTERACTION_STORE_RELEASE_CLEANUP_FAILED"
-    ) {
+    if (releaseError) {
       // error-policy:J2 The state rename and directory fsync completed before
-      // release began, so this is a committed mutation plus an operator outage.
+      // every release path, so no release failure is safe for caller retry.
       throw new ElizaError(
-        "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
+        "Interaction transaction committed but lock release failed; do not retry the mutation.",
         {
-          code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
+          code:
+            releaseError instanceof ElizaError &&
+            releaseError.code === "INTERACTION_STORE_RELEASE_CLEANUP_FAILED"
+              ? "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED"
+              : "INTERACTION_STORE_COMMITTED_RELEASE_FAILED",
           cause: releaseError,
           context: {
-            ...releaseError.context,
+            ...(releaseError instanceof ElizaError
+              ? {
+                  ...releaseError.context,
+                  releaseErrorCode: releaseError.code,
+                }
+              : {
+                  releaseError:
+                    releaseError instanceof Error
+                      ? releaseError.message
+                      : String(releaseError),
+                }),
             committed: true,
             retrySafeAfterRecovery: false,
           },
         },
       );
     }
-    if (releaseError) throw releaseError;
     return result as T;
   }
 

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -2,6 +2,8 @@
  * Persists message-interaction sessions for one host with cross-process atomic
  * transitions. Multi-host deployments should implement the same store contract
  * with a transactional database row or outbox rather than sharing this file.
+ * An abandoned lifecycle marker fails closed until an operator stops every
+ * store user, verifies no owner remains, and removes the marker.
  */
 
 import { constants } from "node:fs";
@@ -43,15 +45,8 @@ interface LockRaceHooks {
   beforePublicationCandidateValidation?: () => Promise<void>;
   beforeStaleRetire?: () => Promise<void>;
   beforeReleaseRetire?: () => Promise<void>;
-  beforeAbandonedTransitionRetire?: () => Promise<void>;
-  afterAbandonedTransitionRetire?: () => Promise<void>;
   beforeLockUnlink?: () => Promise<void>;
-}
-
-interface LockTransitionOwner {
-  pid: number;
-  processIdentity: string | null;
-  token: string;
+  beforeTransitionMarkerCleanup?: () => Promise<void>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -268,8 +263,8 @@ function newToken(): string {
 
 /**
  * A single-machine durable store. Atomic rename and directory fsync preserve a
- * complete prior or next revision across process/power loss; the lock directory
- * serializes independent host processes.
+ * complete prior or next revision across process/power loss; the lock owner
+ * inode and transition marker serialize independent host processes.
  */
 export class FileMessageInteractionSessionStore
   implements MessageInteractionSessionStore
@@ -479,9 +474,6 @@ export class FileMessageInteractionSessionStore
         isErrno(error, "EEXIST") ||
         isErrno(error, "ENOTEMPTY")
       ) {
-        if (isErrno(error, "EEXIST")) {
-          await this.clearAbandonedTransition(lockIdentity);
-        }
         return null;
       }
       throw error;
@@ -506,79 +498,6 @@ export class FileMessageInteractionSessionStore
       return null;
     }
     return marker;
-  }
-
-  private async clearAbandonedTransition(lockIdentity: string): Promise<void> {
-    const current = await existsLstat(this.lockPath);
-    if (!current || this.lockIdentity(current) !== lockIdentity) return;
-    const marker = `${this.lockPath}.transition`;
-    let markerEntry: Awaited<ReturnType<typeof fs.lstat>>;
-    let value: Partial<LockTransitionOwner>;
-    try {
-      markerEntry = await fs.lstat(marker);
-      if (!markerEntry.isFile() || markerEntry.isSymbolicLink()) return;
-      const handle = await fs.open(
-        marker,
-        constants.O_RDONLY | constants.O_NOFOLLOW,
-      );
-      try {
-        const opened = await handle.stat();
-        if (opened.dev !== markerEntry.dev || opened.ino !== markerEntry.ino) {
-          return;
-        }
-        value = JSON.parse(
-          await handle.readFile("utf8"),
-        ) as Partial<LockTransitionOwner>;
-      } finally {
-        await handle.close();
-      }
-    } catch (error) {
-      if (isErrno(error, "ENOENT")) return;
-      // error-policy:J3 malformed transition ownership fails closed.
-      if (error instanceof SyntaxError) return;
-      throw error;
-    }
-    if (
-      !Number.isSafeInteger(value.pid) ||
-      (value.processIdentity !== null &&
-        typeof value.processIdentity !== "string") ||
-      typeof value.token !== "string"
-    ) {
-      return;
-    }
-    const live = this.processAlive(value.pid as number);
-    const identity = live
-      ? await this.readProcessIdentity(value.pid as number)
-      : null;
-    if (
-      live &&
-      (!value.processIdentity ||
-        !identity ||
-        value.processIdentity === identity)
-    ) {
-      return;
-    }
-    await this.lockRaceHooks.beforeAbandonedTransitionRetire?.();
-    const retiredMarker = path.join(
-      this.directory,
-      `${path.basename(this.lockPath)}.transition-retired-${this.lockIdentity(markerEntry)}`,
-    );
-    try {
-      await fs.link(marker, retiredMarker);
-    } catch (error) {
-      if (isErrno(error, "ENOENT") || isErrno(error, "EEXIST")) return;
-      throw error;
-    }
-    const retiredEntry = await fs.lstat(retiredMarker);
-    if (
-      retiredEntry.dev !== markerEntry.dev ||
-      retiredEntry.ino !== markerEntry.ino
-    ) {
-      await fs.rm(retiredMarker, { force: true });
-      return;
-    }
-    await fs.rm(marker, { force: true });
-    await this.lockRaceHooks.afterAbandonedTransitionRetire?.();
   }
 
   /** The transition hardlink excludes release and all competing recoverers. */
@@ -612,9 +531,18 @@ export class FileMessageInteractionSessionStore
       throw error;
     }
     try {
-      await fs.rm(marker, { force: true });
-    } catch {
-      // error-policy:J6 an abandoned transition is generation-recoverable.
+      await this.lockRaceHooks.beforeTransitionMarkerCleanup?.();
+      await fs.rm(marker);
+    } catch (error) {
+      // error-policy:J2 The lock is already detached, so acquisition or release
+      // must surface the fail-closed marker instead of permitting a successor.
+      throw new ElizaError(
+        "Interaction lock detached but transition cleanup failed.",
+        {
+          code: "INTERACTION_STORE_TRANSITION_CLEANUP_FAILED",
+          cause: error,
+        },
+      );
     }
     return true;
   }
@@ -730,9 +658,10 @@ export class FileMessageInteractionSessionStore
             "Interaction store lock publication hardlink changed.",
           );
         }
-        // The creator has not completed candidate cleanup and therefore has
-        // not returned the lease to a transaction yet.
-        return null;
+        return {
+          ...(value as LockOwner),
+          processIdentity: value.processIdentity ?? null,
+        };
       }
       return {
         ...(value as LockOwner),
@@ -817,7 +746,8 @@ export class FileMessageInteractionSessionStore
       const now = this.clock();
       const token = newToken();
       const candidate = `${this.lockPath}.owner-${process.pid}-${token}.tmp`;
-      let owner: LockOwner;
+      let owner: LockOwner | null = null;
+      let published = false;
       try {
         const handle = await fs.open(
           candidate,
@@ -845,9 +775,13 @@ export class FileMessageInteractionSessionStore
         // link(2) publishes the already complete owner inode with no-replace
         // semantics. A delayed creator never writes through the shared path.
         await this.lockRaceHooks.beforeLockPublish?.();
+        if (await existsLstat(`${this.lockPath}.transition`)) {
+          await delay(this.pollMs);
+          continue;
+        }
         await fs.link(candidate, this.lockPath);
+        published = true;
         await this.lockRaceHooks.afterLockPublishBeforeCandidateCleanup?.();
-        return owner;
       } catch (error) {
         if (!isErrno(error, "EEXIST")) throw error;
         await this.recoverStaleLock(now);
@@ -855,6 +789,27 @@ export class FileMessageInteractionSessionStore
       } finally {
         await fs.rm(candidate, { force: true });
       }
+      if (published && owner) {
+        const canonical = await existsLstat(this.lockPath);
+        const current = await this.readLockOwner();
+        if (
+          !canonical ||
+          this.lockIdentity(canonical) !== owner.lockIdentity ||
+          current?.token !== owner.token
+        ) {
+          storeError(
+            "INTERACTION_STORE_LOCK_LOST",
+            "Interaction store lock ownership changed during publication.",
+          );
+        }
+        return owner;
+      }
+    }
+    if (await existsLstat(`${this.lockPath}.transition`)) {
+      storeError(
+        "INTERACTION_STORE_RECOVERY_REQUIRED",
+        "Interaction store recovery requires all users to stop before the abandoned transition marker is removed.",
+      );
     }
     return storeError(
       "INTERACTION_STORE_LOCK_TIMEOUT",
@@ -882,6 +837,12 @@ export class FileMessageInteractionSessionStore
         break;
       }
       await delay(this.pollMs);
+    }
+    if (await existsLstat(`${this.lockPath}.transition`)) {
+      storeError(
+        "INTERACTION_STORE_RECOVERY_REQUIRED",
+        "Interaction store recovery requires all users to stop before the abandoned transition marker is removed.",
+      );
     }
     storeError(
       "INTERACTION_STORE_LOCK_LOST",
@@ -1102,6 +1063,20 @@ export class FileMessageInteractionSessionStore
       );
     }
     if (operationError) throw operationError;
+    if (
+      releaseError instanceof ElizaError &&
+      releaseError.code === "INTERACTION_STORE_TRANSITION_CLEANUP_FAILED"
+    ) {
+      // error-policy:J2 The state rename and directory fsync completed before
+      // release began, so this is a committed mutation plus an operator outage.
+      throw new ElizaError(
+        "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
+        {
+          code: releaseError.code,
+          cause: releaseError,
+        },
+      );
+    }
     if (releaseError) throw releaseError;
     return result as T;
   }

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -504,6 +504,7 @@ export class FileMessageInteractionSessionStore
   private async retireObservedLock(
     lockIdentity: string,
     validate: () => Promise<boolean>,
+    phase: "recovery" | "release",
   ): Promise<boolean> {
     const marker = await this.beginLockTransition(lockIdentity);
     if (!marker) return false;
@@ -539,8 +540,15 @@ export class FileMessageInteractionSessionStore
       throw new ElizaError(
         "Interaction lock detached but transition cleanup failed.",
         {
-          code: "INTERACTION_STORE_TRANSITION_CLEANUP_FAILED",
+          code:
+            phase === "recovery"
+              ? "INTERACTION_STORE_RECOVERY_CLEANUP_FAILED"
+              : "INTERACTION_STORE_RELEASE_CLEANUP_FAILED",
           cause: error,
+          context:
+            phase === "recovery"
+              ? { committed: false, retrySafeAfterRecovery: true }
+              : undefined,
         },
       );
     }
@@ -729,14 +737,18 @@ export class FileMessageInteractionSessionStore
     if (!(await this.lockIsStale(lockStat, now))) return false;
     const observedIdentity = this.lockIdentity(lockStat);
     await this.lockRaceHooks.beforeStaleRetire?.();
-    return this.retireObservedLock(observedIdentity, async () => {
-      const current = await existsLstat(this.lockPath);
-      return Boolean(
-        current &&
-          this.lockIdentity(current) === observedIdentity &&
-          (await this.lockIsStale(current, now, lockStat.mtimeMs)),
-      );
-    });
+    return this.retireObservedLock(
+      observedIdentity,
+      async () => {
+        const current = await existsLstat(this.lockPath);
+        return Boolean(
+          current &&
+            this.lockIdentity(current) === observedIdentity &&
+            (await this.lockIsStale(current, now, lockStat.mtimeMs)),
+        );
+      },
+      "recovery",
+    );
   }
 
   private async acquireLock(): Promise<LockOwner> {
@@ -822,10 +834,14 @@ export class FileMessageInteractionSessionStore
     const startedAt = performance.now();
     while (performance.now() - startedAt <= this.lockTimeoutMs) {
       if (
-        await this.retireObservedLock(owner.lockIdentity, async () => {
-          const current = await this.readLockOwner();
-          return Boolean(current && current.token === owner.token);
-        })
+        await this.retireObservedLock(
+          owner.lockIdentity,
+          async () => {
+            const current = await this.readLockOwner();
+            return Boolean(current && current.token === owner.token);
+          },
+          "release",
+        )
       ) {
         return;
       }
@@ -1065,15 +1081,16 @@ export class FileMessageInteractionSessionStore
     if (operationError) throw operationError;
     if (
       releaseError instanceof ElizaError &&
-      releaseError.code === "INTERACTION_STORE_TRANSITION_CLEANUP_FAILED"
+      releaseError.code === "INTERACTION_STORE_RELEASE_CLEANUP_FAILED"
     ) {
       // error-policy:J2 The state rename and directory fsync completed before
       // release began, so this is a committed mutation plus an operator outage.
       throw new ElizaError(
         "Interaction transaction committed but transition cleanup failed; stop all store users before recovery.",
         {
-          code: releaseError.code,
+          code: "INTERACTION_STORE_COMMITTED_CLEANUP_FAILED",
           cause: releaseError,
+          context: { committed: true, retrySafeAfterRecovery: false },
         },
       );
     }

--- a/packages/agent/src/services/message-interaction-session-store.ts
+++ b/packages/agent/src/services/message-interaction-session-store.ts
@@ -702,11 +702,17 @@ export class FileMessageInteractionSessionStore
         if (!names.includes(expectedCandidate)) {
           const completed = await existsLstat(this.lockPath);
           if (
-            completed &&
-            completed.dev === entry.dev &&
-            completed.ino === entry.ino &&
-            completed.nlink === 1
+            !completed ||
+            completed.dev !== entry.dev ||
+            completed.ino !== entry.ino
           ) {
+            // The publisher finished its candidate cleanup, transaction, and
+            // release (and a successor may already have linked a new owner)
+            // inside the read window. The inode this reader opened grants no
+            // authority any more; the caller re-observes the current lock.
+            return null;
+          }
+          if (completed.nlink === 1) {
             return {
               ...(value as LockOwner),
               processIdentity: value.processIdentity ?? null,
@@ -715,6 +721,10 @@ export class FileMessageInteractionSessionStore
           storeError(
             "UNSAFE_INTERACTION_STORE_LOCK",
             "Interaction store lock has an unexpected hardlink.",
+            {
+              linkCount: completed.nlink,
+              lockPath: this.lockPath,
+            },
           );
         }
         let candidate: Awaited<ReturnType<typeof fs.lstat>>;
@@ -838,6 +848,8 @@ export class FileMessageInteractionSessionStore
       const candidate = `${this.lockPath}.owner-${process.pid}-${token}.tmp`;
       let owner: LockOwner | null = null;
       let published = false;
+      let transitionObserved = false;
+      let publicationError: unknown;
       let candidateCleanupError: unknown;
       try {
         const handle = await fs.open(
@@ -867,17 +879,26 @@ export class FileMessageInteractionSessionStore
         // semantics. A delayed creator never writes through the shared path.
         await this.lockRaceHooks.beforeLockPublish?.();
         if (await existsLstat(`${this.lockPath}.transition`)) {
-          await delay(this.pollMs);
-          continue;
+          // A transition is in flight; this candidate is discarded and a
+          // fresh one is written on the next attempt. Candidate cleanup still
+          // runs below so a cleanup failure cannot be swallowed by the retry.
+          transitionObserved = true;
+        } else {
+          await this.lockRaceHooks.afterTransitionCheckBeforeLockPublish?.();
+          await fs.link(candidate, this.lockPath);
+          published = true;
+          await this.lockRaceHooks.afterLockPublishBeforeCandidateCleanup?.();
         }
-        await this.lockRaceHooks.afterTransitionCheckBeforeLockPublish?.();
-        await fs.link(candidate, this.lockPath);
-        published = true;
-        await this.lockRaceHooks.afterLockPublishBeforeCandidateCleanup?.();
       } catch (error) {
-        if (!isErrno(error, "EEXIST")) throw error;
-        await this.recoverStaleLock(now);
-        await delay(this.pollMs);
+        // error-policy:J2 EEXIST is the designed contention signal and runs
+        // stale recovery; any other publication failure is rethrown after
+        // candidate cleanup so a cleanup failure is reported beside it.
+        if (!isErrno(error, "EEXIST")) {
+          publicationError = error;
+        } else {
+          await this.recoverStaleLock(now);
+          await delay(this.pollMs);
+        }
       } finally {
         try {
           await this.lockRaceHooks.beforeOwnerCandidateCleanup?.();
@@ -939,6 +960,7 @@ export class FileMessageInteractionSessionStore
                 committed: false,
                 lockPath: this.lockPath,
                 markerPath: `${this.lockPath}.transition`,
+                published: true,
                 recoveryRequired: Boolean(releaseError),
                 retrySafeAfterRecovery: true,
                 retrySafeNow: !releaseError,
@@ -956,7 +978,38 @@ export class FileMessageInteractionSessionStore
         }
         return owner;
       }
-      if (candidateCleanupError) throw candidateCleanupError;
+      if (candidateCleanupError) {
+        // The candidate never became the canonical owner, so nothing was
+        // mutated and no release is owed; the leftover candidate inode is the
+        // only residue and a retry publishes a fresh one.
+        throw new ElizaError(
+          "Interaction lock owner candidate cleanup failed before publication.",
+          {
+            code: "INTERACTION_STORE_OWNER_CANDIDATE_CLEANUP_FAILED",
+            cause: candidateCleanupError,
+            context: {
+              candidatePath: candidate,
+              committed: false,
+              lockPath: this.lockPath,
+              markerPath: `${this.lockPath}.transition`,
+              published: false,
+              recoveryRequired: false,
+              retrySafeAfterRecovery: true,
+              retrySafeNow: true,
+              ...(publicationError instanceof ElizaError
+                ? {
+                    publicationErrorCode: publicationError.code,
+                    publicationErrorContext: publicationError.context,
+                  }
+                : publicationError
+                  ? { publicationError: String(publicationError) }
+                  : {}),
+            },
+          },
+        );
+      }
+      if (publicationError) throw publicationError;
+      if (transitionObserved) await delay(this.pollMs);
     }
     if (await existsLstat(`${this.lockPath}.transition`)) {
       const marker = `${this.lockPath}.transition`;

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -127,6 +127,9 @@ abandoned transition marker reports `INTERACTION_STORE_RECOVERY_REQUIRED` and
 requires operator recovery after stopping every store user and verifying that
 no host process owns the store; it is never reclaimed through a racy pathname
 unlink and has no bounded automatic recovery.
+Cleanup failures distinguish pre-operation recovery (`committed: false`) from
+post-commit release (`committed: true`) with separate error codes so a caller
+never retries an already committed mutation.
 Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -138,6 +138,11 @@ the structured release code and recovery context. A publisher that finds a
 transition marker after linking its owner performs no mutation and reports both
 paths plus the owner token/inode: offline recovery must remove the verified
 marker and owner while all users are stopped, fsync the parent, then restart.
+Post-rename directory sync or close failures are non-retryable commit outcomes:
+the former reports `committed: "unknown"`, while a failure after successful
+sync reports `committed: true`; callers reconcile by reading the persisted
+session rather than repeating the transition. Dual lock-unlink/marker-cleanup
+failure preserves both errors and the exact owner/marker recovery authority.
 Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -126,7 +126,10 @@ have an absolute recovery ceiling and unqualified live PIDs fail closed. An
 abandoned transition marker reports `INTERACTION_STORE_RECOVERY_REQUIRED` and
 requires operator recovery after stopping every store user and verifying that
 no host process owns the store; it is never reclaimed through a racy pathname
-unlink and has no bounded automatic recovery.
+unlink and has no bounded automatic recovery. The typed error reports the exact
+marker in `context.markerPath`. Offline recovery is: stop every store user,
+verify no process owns the adjacent `.lock` file, remove exactly the reported
+`.transition` path, fsync its parent directory, then restart.
 Cleanup failures distinguish pre-operation recovery (`committed: false`) from
 post-commit release (`committed: true`) with separate error codes so a caller
 never retries an already committed mutation.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -121,8 +121,9 @@ processes. The agent host's `FileMessageInteractionSessionStore` is durable and
 cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
 commit and a boot/process-generation-qualified stale-owner lock whose atomic,
 shared transition marker prevents retirement from detaching a fresh successor.
-Unpublished owners have an absolute recovery ceiling; unqualified live PIDs
-fail closed. Multi-host deployments must implement the
+Complete owner inodes publish through a no-replace hardlink; malformed owners
+have an absolute recovery ceiling and unqualified live PIDs fail closed.
+Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.
 

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -122,7 +122,11 @@ cross-process safe on one machine. It uses a same-filesystem fsync-and-rename
 commit and a boot/process-generation-qualified stale-owner lock whose atomic,
 shared transition marker prevents retirement from detaching a fresh successor.
 Complete owner inodes publish through a no-replace hardlink; malformed owners
-have an absolute recovery ceiling and unqualified live PIDs fail closed.
+have an absolute recovery ceiling and unqualified live PIDs fail closed. An
+abandoned transition marker reports `INTERACTION_STORE_RECOVERY_REQUIRED` and
+requires operator recovery after stopping every store user and verifying that
+no host process owns the store; it is never reclaimed through a racy pathname
+unlink and has no bounded automatic recovery.
 Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.

--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -132,7 +132,12 @@ verify no process owns the adjacent `.lock` file, remove exactly the reported
 `.transition` path, fsync its parent directory, then restart.
 Cleanup failures distinguish pre-operation recovery (`committed: false`) from
 post-commit release (`committed: true`) with separate error codes so a caller
-never retries an already committed mutation.
+never retries an already committed mutation. All other post-write release
+errors also report `committed: true`; combined operation/release errors preserve
+the structured release code and recovery context. A publisher that finds a
+transition marker after linking its owner performs no mutation and reports both
+paths plus the owner token/inode: offline recovery must remove the verified
+marker and owner while all users are stopped, fsync the parent, then restart.
 Multi-host deployments must implement the
 same store interface with a transactional database and idempotent effect/outbox
 boundary; the JSON store does not claim distributed exactly-once semantics.


### PR DESCRIPTION
Follow-up safety remediation for merged #24363.

The merged directory-lock implementation retained check/use races in stale recovery, release, transition cleanup, and the mkdir-to-owner construction window. This hotfix publishes a fully written and fsynced regular owner inode with a no-replace hardlink, validates the exact publication candidate during the normal two-link window, and serializes release/recovery through an atomically published adjacent transition claim.

Portable filesystems do not provide conditional pathname unlink for safely reclaiming an abandoned reusable transition marker. The store therefore fails closed with `INTERACTION_STORE_RECOVERY_REQUIRED`; operators must stop every store user and verify that no owner remains before removing the marker. This degraded state has no bounded automatic recovery. Cleanup failures are machine-distinct: pre-operation stale recovery reports `INTERACTION_STORE_RECOVERY_CLEANUP_FAILED` with `committed: false`, while every post-write release failure reports a committed no-retry outcome. Validation plus cleanup failure preserves both structured outcomes. Every outage reports exact paths and an offline stop/verify/remove/fsync/restart procedure.

The persistence boundary also tracks the point at which the state temp was renamed. A directory-sync failure after rename reports `INTERACTION_STORE_COMMIT_AMBIGUOUS` with `committed: "unknown"`; a close failure after successful directory sync reports `committed: true`. Both require persisted-session reconciliation and forbid blind retry. Dual lock-unlink/marker-cleanup failure retains the unlink cause, cleanup error, exact owner generation, and offline recovery procedure.

Deterministic adversarial coverage includes:
- a live publisher paused beyond the hard recovery ceiling;
- creator candidate cleanup and canonical inode/token revalidation;
- candidate cleanup between the reader's two-link stat and lookup;
- unexpected steady hardlink rejection;
- two stale recoverers versus a fresh winner;
- old removal plus successor acquisition before delayed recovery;
- stale recovery claiming after the publisher's pre-link check, with no transaction allowed;
- published-owner candidate cleanup failure and safe owner detachment;
- delayed release versus replacement;
- an abandoned marker observed by two contenders with no deletion or state mutation;
- pre-unlink transition cleanup after injected lock-unlink failure; and
- post-lock-unlink marker cleanup failure, explicit committed outcome, and blocked successor mutation; and
- simultaneous operation/release failure with preserved structured release recovery;
- post-rename directory-sync ambiguity with the committed session row inspected; and
- post-sync directory-close failure with a confirmed committed/no-retry outcome.
- publisher release, or successor publication, inside a contender's two-link read window (contender re-observes instead of failing fatal); and
- typed uncommitted owner-candidate cleanup failure on the existing-lock and transition-marker paths.

Exact head: 13902114dc2d72851ccfafbc7f72be48e78058ce
Base: c770eb4aad53eca4b28be01ae09623f3f389f9e9

Verification at exact head: real-filesystem store suite 38/38 (4 new hook-driven regressions: publisher release and successor link inside the two-link read window, typed candidate-cleanup failure on the EEXIST and transition-marker paths); core typecheck; agent build:dist; changed-file Biome; git diff --check. All pass. Agent typecheck has no changed-file diagnostics; the repository still lacks unrelated optional plugin workspaces.

Backend filesystem lifecycle only; visual/model/connector evidence is N/A. The implementation is patch-equivalent to the CLEAN-reviewed 572169 head; subsequent commits only attach deterministic rejection observers and avoid an mtime precision boundary. Do not merge until exact-head hosted checks are green.

