### PR TITLE
fix(computeruse): preserve complete Android trajectory errors

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -134,6 +134,10 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/maxHistoryPerConversation/,
 		/history\.shift\(\)/,
 	],
+	"plugins/plugin-computeruse/src/mobile/android-trajectory.ts": [
+		/MAX_ERROR_MSG/,
+		/errorMessage\s*=\s*[^;]*\.slice\(/,
+	],
 	"plugins/plugin-cli-inference/src/prompt-flatten.ts": [
 		/MAX_TOOL_PAYLOAD_(?:DEPTH|NODES|CHARS)/,
 		/TOOL_PAYLOAD_.*MARKER/,

--- a/plugins/plugin-computeruse/AGENTS.md
+++ b/plugins/plugin-computeruse/AGENTS.md
@@ -10,6 +10,8 @@ Adds real desktop control to an Eliza agent: taking screenshots, clicking/typing
 
 File operations belong to the FILE action; shell/terminal access belongs to the SHELL action — this plugin does not expose them.
 
+Android action and agent-step trajectory fields are complete audit records. Do not clip error text, goals, rationales, references, or other emitted fields; logging transport failures must reject explicitly rather than produce a shortened trajectory.
+
 ## Plugin surface
 
 ### Actions

--- a/plugins/plugin-computeruse/CLAUDE.md
+++ b/plugins/plugin-computeruse/CLAUDE.md
@@ -10,6 +10,8 @@ Adds real desktop control to an Eliza agent: taking screenshots, clicking/typing
 
 File operations belong to the FILE action; shell/terminal access belongs to the SHELL action — this plugin does not expose them.
 
+Android action and agent-step trajectory fields are complete audit records. Do not clip error text, goals, rationales, references, or other emitted fields; logging transport failures must reject explicitly rather than produce a shortened trajectory.
+
 ## Plugin surface
 
 ### Actions

--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
@@ -40,7 +40,7 @@ describe("emitAndroidAction", () => {
     }
   });
 
-  it("trims error messages over 256 chars", () => {
+  it("preserves complete long error messages in the payload and structured log", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
     try {
       const long = "x".repeat(2_000);
@@ -50,13 +50,14 @@ describe("emitAndroidAction", () => {
         errorCode: "accessibility_unavailable",
         errorMessage: long,
       });
-      expect(payload.errorMessage?.length).toBe(256);
+      expect(payload.errorMessage).toBe(long);
       expect(spy.mock.calls[0]?.[0]).toMatchObject({
         evt: "computeruse.android.action",
         platform: "android",
         kind: "tap",
         success: false,
         errorCode: "accessibility_unavailable",
+        errorMessage: long,
       });
     } finally {
       spy.mockRestore();
@@ -96,6 +97,27 @@ describe("emitAndroidAgentStep", () => {
       expect(obj.step).toBe(3);
       expect(obj.actionKind).toBe("click");
       expect(obj.success).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("preserves complete long agent-step errors", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      const error = "android bridge failure ".repeat(200);
+      const payload = emitAndroidAgentStep({
+        step: 4,
+        goal: "save the document",
+        actionKind: "click",
+        displayId: 0,
+        rois: 1,
+        success: false,
+        error,
+        rationale: "tap save",
+      });
+      expect(payload.error).toBe(error);
+      expect(spy.mock.calls[0]?.[0]).toMatchObject({ error });
     } finally {
       spy.mockRestore();
     }

--- a/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
+++ b/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
@@ -41,7 +41,7 @@ export interface AndroidTrajectoryActionEvent {
   success: boolean;
   /** Bridge error code (only on failure). */
   errorCode?: string;
-  /** Free-form error message; trimmed for log hygiene. */
+  /** Complete free-form error message. */
   errorMessage?: string;
   /** Display-local pixel coords for tap/swipe (optional). */
   x?: number;
@@ -66,8 +66,6 @@ export interface AndroidTrajectoryStepEvent {
   rationale: string;
 }
 
-const MAX_ERROR_MSG = 256;
-
 /**
  * Emit a `computeruse.android.action` log entry. Returns the payload so
  * callers can also forward it elsewhere (e.g. in-memory replay buffer).
@@ -75,19 +73,16 @@ const MAX_ERROR_MSG = 256;
 export function emitAndroidAction(
   event: AndroidTrajectoryActionEvent,
 ): AndroidTrajectoryActionEvent {
-  const trimmed: AndroidTrajectoryActionEvent = { ...event };
-  if (trimmed.errorMessage) {
-    trimmed.errorMessage = trimmed.errorMessage.slice(0, MAX_ERROR_MSG);
-  }
+  const payload: AndroidTrajectoryActionEvent = { ...event };
   logger.info(
     {
       evt: "computeruse.android.action",
       platform: "android" as const,
-      ...trimmed,
+      ...payload,
     },
-    `[computeruse/android] ${trimmed.kind}${trimmed.success ? "" : ` failed (${trimmed.errorCode ?? "?"})`}`,
+    `[computeruse/android] ${payload.kind}${payload.success ? "" : ` failed (${payload.errorCode ?? "?"})`}`,
   );
-  return trimmed;
+  return payload;
 }
 
 /**


### PR DESCRIPTION
Closes #24452
Closes #23969

Android direct-action trajectories still clipped `errorMessage` to 256 code units even though agent-step errors were complete. This removes the final Android trajectory clip, preserves complete action and agent-step errors in both returned payloads and structured logs, updates the package invariant, and adds a root reversion guard.

Verification:
- Android trajectory + root prompt-integrity suites: 10/10 passed
- changed-file Biome and `git diff --check`
- AGENTS/CLAUDE content updated identically

Package typecheck is environment-blocked in this isolated sparse worktree by missing optional Drizzle/UI/Capacitor/puppeteer/nut-js dependencies; the focused production-path tests compile and pass.