### PR TITLE
fix(core): enforce exact action identity at authorization boundary

### DIFF
--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -874,9 +874,9 @@ describe("v5 tiered action surface", () => {
 		);
 	});
 
-	it("does not disclose an unauthorized inline child through tools or prompt metadata", async () => {
+	it("does not disclose an unauthorized inline child whose normalized name collides", async () => {
 		const allowedChild = makeAction({
-			name: "SAFE_CHILD",
+			name: "PRIVATECHILD",
 			description: "Allowed child description.",
 			contexts: ["general" as AgentContext],
 			contextGate: { anyOf: ["general"] },
@@ -899,7 +899,7 @@ describe("v5 tiered action surface", () => {
 			actions: [parent, allowedChild, deniedChild],
 			responses: [
 				stage1Response({ contexts: ["general"] }),
-				plannerToolResponse("SAFE_CHILD"),
+				plannerToolResponse("PRIVATECHILD"),
 				finishEvaluatorResponse("Allowed child completed."),
 			],
 		});
@@ -915,9 +915,11 @@ describe("v5 tiered action surface", () => {
 			availableActionsSection(runtime),
 			plannerUserContent(runtime),
 		].join("\n");
-		expect(plannerToolNames(runtime)).toContain("SAFE_CHILD");
+		// PRIVATECHILD and PRIVATE_CHILD deliberately collide under the lenient
+		// retrieval normalizer but remain distinct native tool identities.
+		expect(plannerToolNames(runtime)).toContain("PRIVATECHILD");
 		expect(plannerToolNames(runtime)).not.toContain("PRIVATE_CHILD");
-		expect(modelContext).toContain("SAFE_CHILD");
+		expect(modelContext).toContain("PRIVATECHILD");
 		expect(modelContext).not.toContain("PRIVATE_CHILD");
 		expect(modelContext).not.toContain(
 			"Private child description must never reach the model.",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3382,6 +3382,9 @@ function buildV5PlannerActionSurface(params: {
 	}
 
 	const toolSearchStartedAt = Date.now();
+	const authorizedActionIdentities = new Set(
+		params.actions.map((action) => action.name.trim()),
+	);
 	const authorizedActionNames = new Set(
 		params.actions.map((action) => normalizeActionIdentifier(action.name)),
 	);
@@ -3393,7 +3396,10 @@ function buildV5PlannerActionSurface(params: {
 		...action,
 		subActions: action.subActions?.filter((child) => {
 			const childName = typeof child === "string" ? child : child.name;
-			return authorizedActionNames.has(normalizeActionIdentifier(childName));
+			// Authorization uses the exact native tool identity. The retrieval
+			// normalizer intentionally collapses separators, so using it here would
+			// let an allowed FOO_BAR disclose a denied FOOBAR child (or vice versa).
+			return authorizedActionIdentities.has(childName.trim());
 		}),
 	}));
 	const catalog = getCachedActionCatalog(
@@ -3438,7 +3444,7 @@ function buildV5PlannerActionSurface(params: {
 		tieredSurface.tierAParents.map((parent) => [
 			parent.name,
 			parent.childNames.filter((childName) =>
-				exposedActionNames.has(normalizeActionIdentifier(childName)),
+				authorizedActionIdentities.has(childName.trim()),
 			),
 		]),
 	);


### PR DESCRIPTION
Closes #24800.

Narrow fix-forward for merged #24782 / #24718. The final #24782 head was force-updated after exact review and dropped this repair.

- uses exact trimmed native tool identity for authorized inline-child catalog membership
- keeps lenient identifier normalization limited to retrieval/exposure diagnostics
- adds an adversarial `PRIVATECHILD` allowed vs `PRIVATE_CHILD` denied collision regression proving the denied child name, description, and schema do not reach planner tools or model context

Exact local verification on `6cbe561e3f`:
- 70/70 focused tests passed (1,031 assertions): tiered surface, planner happy path, tool conversion, prompt-integrity policy
- `bun run --cwd packages/core typecheck`
- Biome on both changed files
- `git diff --check origin/develop...HEAD`

Hold merge until required hosted CI is green on the exact head.