### PR TITLE
fix(ui): validate account deletion receipt fields

### DIFF
--- a/packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts
+++ b/packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts
@@ -107,4 +107,36 @@ describe("submitAccountDeletion", () => {
       "Account deletion receipt was malformed",
     );
   });
+
+  it("rejects unknown receipt statuses and invalid timestamps", async () => {
+    const request = {
+      requestId: "request-2",
+      status: "scheduled",
+      requestedAt: "2026-08-19T00:00:00.000Z",
+      scheduledDeletionAt: "2026-09-18T00:00:00.000Z",
+      identityDeactivated: true,
+      completedAt: null,
+    };
+
+    apiMock.mockResolvedValueOnce({
+      request: { ...request, status: "unexpected" },
+    });
+    await expect(submitAccountDeletion()).rejects.toThrow(
+      "Account deletion receipt was malformed",
+    );
+
+    apiMock.mockResolvedValueOnce({
+      request: { ...request, scheduledDeletionAt: "not-a-date" },
+    });
+    await expect(submitAccountDeletion()).rejects.toThrow(
+      "Account deletion receipt was malformed",
+    );
+
+    apiMock.mockResolvedValueOnce({
+      request: { ...request, completedAt: "2026-09-18" },
+    });
+    await expect(submitAccountDeletion()).rejects.toThrow(
+      "Account deletion receipt was malformed",
+    );
+  });
 });

--- a/packages/ui/src/cloud/account-security/data/account-deletion-client.ts
+++ b/packages/ui/src/cloud/account-security/data/account-deletion-client.ts
@@ -5,12 +5,23 @@ import { api } from "../../lib/api-client";
 
 export interface AccountDeletionRequestDto {
   requestId: string;
-  status: string;
+  status: AccountDeletionRequestStatus;
   requestedAt: string;
   scheduledDeletionAt: string;
   identityDeactivated: boolean;
   completedAt: string | null;
 }
+
+export type AccountDeletionRequestStatus =
+  | "requested"
+  | "scheduled"
+  | "processing"
+  | "completed"
+  | "action_required";
+
+const ACCOUNT_DELETION_REQUEST_STATUSES = new Set<AccountDeletionRequestStatus>(
+  ["requested", "scheduled", "processing", "completed", "action_required"],
+);
 
 export type AccountDeletionStatusDto =
   | { state: "available"; request: null }
@@ -32,17 +43,32 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isAccountDeletionRequestStatus(
+  value: unknown,
+): value is AccountDeletionRequestStatus {
+  return (
+    typeof value === "string" &&
+    ACCOUNT_DELETION_REQUEST_STATUSES.has(value as AccountDeletionRequestStatus)
+  );
+}
+
+function isServerTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+}
+
 function parseRequest(value: unknown): AccountDeletionRequestDto {
   if (!isRecord(value))
     throw new Error("Account deletion receipt was malformed");
   const completedAt = value.completedAt;
   if (
     typeof value.requestId !== "string" ||
-    typeof value.status !== "string" ||
-    typeof value.requestedAt !== "string" ||
-    typeof value.scheduledDeletionAt !== "string" ||
+    !isAccountDeletionRequestStatus(value.status) ||
+    !isServerTimestamp(value.requestedAt) ||
+    !isServerTimestamp(value.scheduledDeletionAt) ||
     typeof value.identityDeactivated !== "boolean" ||
-    (completedAt !== null && typeof completedAt !== "string")
+    (completedAt !== null && !isServerTimestamp(completedAt))
   ) {
     throw new Error("Account deletion receipt was malformed");
   }


### PR DESCRIPTION
## Summary
- restrict account-deletion receipts to the five database-supported lifecycle statuses
- require canonical server ISO timestamps before the UI trusts a successful deletion receipt
- cover unknown status and invalid scheduled/completed timestamps

Follow-up to #24202 and merged #24256.

## Verification
- `bun run --cwd packages/ui test --run src/cloud/account-security/data/account-deletion-client.test.ts` — 6/6 passed
- `bun run --cwd packages/ui typecheck` — passed
- `bunx @biomejs/biome check packages/ui/src/cloud/account-security/data/account-deletion-client.ts packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts` — passed
- `git diff --check` — passed
- `bun run verify` — blocked on the pre-existing repository-wide i18n backlog at base `aa7578ae9e` (missing translations and connectorcard English keys); no changed file adds or consumes an i18n key

## Evidence
- Before/after screenshots: N/A — transport validation only; no rendered layout or styling changes
- MP4 walkthrough: N/A — the change rejects malformed 2xx payloads before navigation and adds no user-visible success path
- Console/network/backend logs: N/A — deterministic client boundary unit coverage exercises the changed contract without a server mutation
- `audit:app`: attempted; capture failed before Playwright config load with host filesystem write error `Unknown system error -122`, after prerequisite view/core/shared builds passed
