### PR TITLE
fix(cloud): restore shared transport type and lint baseline

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
@@ -62,20 +62,18 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
 
   test("preserves caller cancellation (composed)", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = vi
-      .fn()
-      .mockImplementation(
-        (_input: RequestInfo | URL, init?: RequestInit) =>
-          new Promise<Response>((resolve, reject) => {
-            seen = init?.signal ?? undefined;
-            seen?.addEventListener("abort", () => {
-              reject(
-                new DOMException("The operation was aborted.", "AbortError"),
-              );
-            });
-            setTimeout(() => resolve(new Response("{}", { status: 200 })), 500);
-          }),
-      ) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          seen = init?.signal ?? undefined;
+          seen?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+          setTimeout(() => resolve(new Response("{}", { status: 200 })), 500);
+        }),
+    ) as unknown as typeof fetch;
 
     const { blooioFetch } = await import("./blooio");
     const controller = new AbortController();

--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -208,7 +208,7 @@ function nodeResponseBodyStream(res: IncomingMessage): ReadableStream<Uint8Array
     },
     {
       highWaterMark: NODE_RESPONSE_QUEUE_HIGH_WATER_MARK_BYTES,
-      size: (chunk) => chunk?.byteLength ?? 0,
+      size: (chunk) => (chunk === undefined ? 0 : chunk.byteLength),
     },
   );
 }

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -16,8 +16,8 @@ import {
 } from "../../../db/repositories/phone-metadata-readers";
 import { agentPhoneContacts } from "../../../db/schemas/agent-phone-contacts";
 import { agentPhoneNumbers, type PhoneMessageLog } from "../../../db/schemas/agent-phone-numbers";
-import { logger } from "../../utils/logger";
 import { boundedProviderFetch } from "../../utils/bounded-provider-fetch";
+import { logger } from "../../utils/logger";
 
 import { normalizePhoneNumber } from "../../utils/phone-normalization";
 import {
@@ -47,7 +47,6 @@ export function messageRouterTwilioFetch(
     maxResponseBytes: MESSAGE_ROUTER_TWILIO_RESPONSE_MAX_BYTES,
   });
 }
-
 
 function isUndefinedTableError(error: unknown): boolean {
   return isPostgresUndefinedTableError(error);

--- a/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
+++ b/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
@@ -14,10 +14,7 @@ import { ElizaError } from "@elizaos/core";
 
 const MAX_TIMER_MS = 2_147_483_647;
 
-function cancelBodyDetached(
-  body: ReadableStream<Uint8Array> | null,
-  reason: unknown,
-): void {
+function cancelBodyDetached(body: ReadableStream<Uint8Array> | null, reason: unknown): void {
   if (!body) return;
   try {
     // error-policy:J6 The request has already failed; cancellation is detached


### PR DESCRIPTION
Closes #24802.

Current `develop` fails the affected Cloud typecheck because the Web Streams queuing-strategy callback accepts an optional chunk, while `safe-fetch` did not explicitly narrow that optional value before reading `byteLength`. This one-line repair returns queue size zero for the absent callback case and preserves exact `Uint8Array.byteLength` accounting otherwise. The existing 256 KiB backpressure high-water mark, pinned socket behavior, response completeness, and cancellation semantics are unchanged.

Exact head: `601bd9a11017782ae046c452ccd6da881bbbd075`

Verification:
- `safe-fetch.test.ts`: 24/24 pass, including fast-response backpressure, unconsumed bounded queue, premature close, redirect destruction, request streaming, and cancellation
- changed-file Biome: clean
- cloud-shared typecheck no longer reports `safe-fetch.ts`; the local isolated worktree continues into unrelated missing optional workspace/dependency declarations
- `git diff --check`: clean

No prompt/model payload, transport limit, external request, or response data is changed. Exact hosted CI is required before merge.