### PR TITLE
fix(cloud-shared): resolve @elizaos/plugin-doordash in typecheck without a prebuilt dist

### DIFF
--- a/packages/cloud/shared/tsconfig.json
+++ b/packages/cloud/shared/tsconfig.json
@@ -39,6 +39,8 @@
       "@elizaos/shared/*": ["../../../packages/shared/src/*"],
       "@elizaos/plugin-cloud-apps": ["../../../plugins/plugin-cloud-apps/src/index.ts"],
       "@elizaos/plugin-cloud-apps/*": ["../../../plugins/plugin-cloud-apps/src/*"],
+      "@elizaos/plugin-doordash": ["../../../plugins/plugin-doordash/src/index.ts"],
+      "@elizaos/plugin-doordash/*": ["../../../plugins/plugin-doordash/src/*"],
       "@elizaos/plugin-elizacloud": ["../../../plugins/plugin-elizacloud/src/index.ts"],
       "@elizaos/plugin-elizacloud/*": ["../../../plugins/plugin-elizacloud/src/*"],
       "@elizaos/plugin-scheduling/edge": ["../../../plugins/plugin-scheduling/src/edge.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -248,6 +248,7 @@
     "@elizaos/cloud-shared#typecheck": {
       "dependsOn": [
         "@elizaos/plugin-cloud-apps#build",
+        "@elizaos/plugin-doordash#build",
         "@elizaos/plugin-scheduling#build",
         "@elizaos/plugin-todos#build",
         "@elizaos/plugin-web-search#build"


### PR DESCRIPTION
## Problem
On a clean checkout of `develop` (`bun install --frozen-lockfile` + `bun run build:core`), `@elizaos/cloud-shared` typecheck fails:

```
src/lib/eliza/runtime/initializer.ts(14,32): error TS2307: Cannot find module '@elizaos/plugin-doordash' or its corresponding type declarations.
```

`@elizaos/plugin-doordash` resolves through its package `types` field at `dist/index.d.ts`, which does not exist until the plugin is built. cloud-shared's tsconfig has explicit source path aliases for every other `@elizaos/*` dependency (plugin-cloud-apps, plugin-elizacloud, plugin-sql, edge subpaths of scheduling/todos/web-search, core, shared, logger, cloud-sdk, cloud-routing) — doordash was the only one missing. The explicit `@elizaos/cloud-shared#typecheck` turbo task in root `turbo.json` also omits `@elizaos/plugin-doordash#build` from its `dependsOn`, so the CI-equivalent `node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/cloud-shared` never builds the dist either. It only passes when something else (e.g. building `@elizaos/agent`) happens to have produced the dist first — several fresh workers hit the TS2307.

## Fix (3 lines)
- `packages/cloud/shared/tsconfig.json`: add `@elizaos/plugin-doordash` → `plugins/plugin-doordash/src/index.ts` path alias (same pattern as plugin-cloud-apps). doordash src imports only `@elizaos/core`, already aliased to source.
- `turbo.json`: add `@elizaos/plugin-doordash#build` to `@elizaos/cloud-shared#typecheck.dependsOn` for parity with the sibling plugin deps.

## Verification (fresh worktree at origin/develop 4425ebd3e733f)
- Repro: `rm -rf plugins/plugin-doordash/dist` → both `run-turbo.mjs run typecheck --filter=@elizaos/cloud-shared --force` and bare `bun run --cwd packages/cloud/shared typecheck` fail with the TS2307 above.
- With fix, dist still deleted: bare typecheck passes (source alias); turbo typecheck now schedules `@elizaos/plugin-doordash#build` and passes (12/12 tasks).
- `biome check` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)