### PR TITLE
fix(core): remove planner and evaluator output caps

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -47,6 +47,9 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"packages/core/src/runtime/evaluator.ts": [
 		/MAX_EVALUATOR_INPUT_CHARS/,
 		/chars truncated/,
+		/DEFAULT_EVALUATOR_MAX_TOKENS/,
+		/maxTokens\s*:/,
+		/retryMaxTokens/,
 	],
 	"packages/core/src/runtime/message-handler.ts": [
 		/normalizeStringHints/,
@@ -63,6 +66,8 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/maybeCompactPlannerTrajectory/,
 		/CONTEXT_COMPACTION/,
 		/projectStepForFinalSynthesis/,
+		/DEFAULT_(?:CODING_)?PLANNER_MAX_TOKENS/,
+		/maxTokens:\s*\d+/,
 	],
 	"packages/core/src/services/message/bot-noise-triage.ts": [
 		/MAX_HISTORY_MESSAGES/,

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -199,7 +199,7 @@ df -h / /home
 		const evaluatorParams = runtime.useModel.mock.calls[0][1];
 		// Wire-shape contract: evaluator emits ONLY `messages`.
 		expect(evaluatorParams.prompt).toBeUndefined();
-		expect(evaluatorParams.maxTokens).toBe(2048);
+		expect(evaluatorParams.maxTokens).toBeUndefined();
 		expect(evaluatorParams.messages.map((message) => message.role)).toEqual([
 			"system",
 			"user",
@@ -1356,12 +1356,10 @@ describe("fabricated marker invocations are rejected, real widgets pass", () => 
 	});
 });
 
-describe("completion-truncation guard: one bounded retry, never a loop", () => {
-	// Bidirectional contract for the 2026-08-17 truncation spiral: an envelope
-	// cut off at the completion cap must trigger EXACTLY ONE retry at a doubled
-	// cap. Without the guard (the old behavior) the truncated JSON parsed as a
-	// protocol failure and the planner burned extra full-prompt rounds; with it,
-	// the second (complete) envelope is used directly.
+describe("provider-owned evaluator output boundaries", () => {
+	// Core never chooses a completion ceiling. If a provider still reports that
+	// its own hard length boundary was reached, reject the partial envelope as a
+	// typed failure instead of parsing or silently retrying it.
 	const truncatedEnvelope = {
 		// A JSON envelope cut mid-string — unparseable by construction.
 		text: '{"success": true, "decision": "FINISH", "thought": "long reasoning that got cut o',
@@ -1441,75 +1439,60 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 		expect(evaluatorHitCompletionLimit("plain text", 2048)).toBe(false);
 	});
 
-	it("retries ONCE with a doubled cap when the truncated envelope is unparseable, then uses the retry result", async () => {
+	it("rejects an incomplete envelope once without imposing or doubling a cap", async () => {
 		const useModel = vi
 			.fn()
 			.mockResolvedValueOnce(truncatedEnvelope)
 			.mockResolvedValueOnce(completeEnvelope);
 
-		const result = await runEvaluator(baseParams(useModel));
-
-		expect(useModel).toHaveBeenCalledTimes(2);
-		const firstCap = useModel.mock.calls[0][1].maxTokens;
-		const secondCap = useModel.mock.calls[1][1].maxTokens;
-		expect(firstCap).toBe(2048);
-		expect(secondCap).toBe(4096);
-		expect(result.decision).toBe("FINISH");
-		expect(result.success).toBe(true);
-		expect(result.protocolFailure).toBeUndefined();
+		await expect(runEvaluator(baseParams(useModel))).rejects.toMatchObject({
+			code: "EVALUATOR_OUTPUT_INCOMPLETE",
+		});
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(useModel.mock.calls[0][1].maxTokens).toBeUndefined();
 	});
 
-	it("reports usage for both the truncated attempt and its successful retry", async () => {
+	it("reports usage for the rejected provider response", async () => {
 		const useModel = vi
 			.fn()
 			.mockResolvedValueOnce(truncatedEnvelope)
 			.mockResolvedValueOnce(completeEnvelope);
 		const onUsage = vi.fn();
 
-		await runEvaluator({ ...baseParams(useModel), onUsage });
+		await expect(
+			runEvaluator({ ...baseParams(useModel), onUsage }),
+		).rejects.toMatchObject({ code: "EVALUATOR_OUTPUT_INCOMPLETE" });
 
-		expect(onUsage).toHaveBeenCalledTimes(2);
-		expect(onUsage).toHaveBeenNthCalledWith(1, {
+		expect(onUsage).toHaveBeenCalledTimes(1);
+		expect(onUsage).toHaveBeenCalledWith({
 			promptTokens: 100,
 			completionTokens: 2048,
 		});
-		expect(onUsage).toHaveBeenNthCalledWith(2, {
-			promptTokens: 100,
-			completionTokens: 40,
-		});
 	});
 
-	it("records both billable model calls when the truncation retry succeeds", async () => {
+	it("records the typed incomplete-output failure", async () => {
 		const stages: RecordedStage[] = [];
 		const useModel = vi
 			.fn()
 			.mockResolvedValueOnce(truncatedEnvelope)
 			.mockResolvedValueOnce(completeEnvelope);
 
-		await runEvaluator({
-			...baseParams(useModel),
-			recorder: captureRecorder(stages),
-			trajectoryId: "trajectory-evaluator-retry",
-		});
+		await expect(
+			runEvaluator({
+				...baseParams(useModel),
+				recorder: captureRecorder(stages),
+				trajectoryId: "trajectory-evaluator-incomplete",
+			}),
+		).rejects.toMatchObject({ code: "EVALUATOR_OUTPUT_INCOMPLETE" });
 
-		expect(stages).toHaveLength(2);
-		expect(stages.map((stage) => stage.stageId)).toEqual([
-			expect.stringContaining("-attempt-1"),
-			expect.stringContaining("-attempt-2"),
-		]);
-		expect(stages[0]?.model?.response).toBe(truncatedEnvelope.text);
-		expect(stages[0]?.model?.usage).toMatchObject({
-			promptTokens: 100,
-			completionTokens: 2048,
-		});
-		expect(stages[1]?.model?.response).toBe(completeEnvelope.text);
-		expect(stages[1]?.model?.usage).toMatchObject({
-			promptTokens: 100,
-			completionTokens: 40,
-		});
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(stages).toHaveLength(1);
+		expect(stages[0]?.model?.response).toContain(
+			"Evaluator provider returned an incomplete output",
+		);
 	});
 
-	it("keeps first-attempt provenance when a differently routed retry fails", async () => {
+	it("keeps selected-provider provenance for an incomplete output", async () => {
 		const stages: RecordedStage[] = [];
 		const providerError = Object.assign(new Error("retry rate limited"), {
 			status: 429,
@@ -1544,26 +1527,26 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 			},
 		);
 
-		const result = await runEvaluator({
-			...baseParams(useModel),
-			runtime: {
-				useModel,
-				supportsModelAttemptPreparation: true,
-				reportError: vi.fn(),
-			},
-			recorder: captureRecorder(stages),
-			trajectoryId: "trajectory-evaluator-retry",
-		});
+		await expect(
+			runEvaluator({
+				...baseParams(useModel),
+				runtime: {
+					useModel,
+					supportsModelAttemptPreparation: true,
+					reportError: vi.fn(),
+				},
+				recorder: captureRecorder(stages),
+				trajectoryId: "trajectory-evaluator-incomplete",
+			}),
+		).rejects.toMatchObject({ code: "EVALUATOR_OUTPUT_INCOMPLETE" });
 
-		expect(result.protocolFailure).toBe(true);
-		expect(stages).toHaveLength(2);
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(stages).toHaveLength(1);
 		expect(stages[0]?.model?.provider).toBe("initial-provider");
-		expect(stages[0]?.model?.response).toBe(truncatedEnvelope.text);
-		expect(stages[1]?.model?.provider).toBe("retry-provider");
-		expect(stages[1]?.model?.response).toContain("retry rate limited");
+		expect(stages[0]?.model?.response).toContain("incomplete output");
 	});
 
-	it("rejects the original partial response when the retry throws", async () => {
+	it("does not make a second model call after an incomplete output", async () => {
 		const providerError = Object.assign(new Error("retry rate limited"), {
 			status: 429,
 		});
@@ -1575,27 +1558,17 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 		const reportError = vi.fn();
 		const onUsage = vi.fn();
 
-		const result = await runEvaluator({
-			...baseParams(useModel),
-			runtime: { useModel, logger: { warn }, reportError },
-			onUsage,
-		});
+		await expect(
+			runEvaluator({
+				...baseParams(useModel),
+				runtime: { useModel, logger: { warn }, reportError },
+				onUsage,
+			}),
+		).rejects.toMatchObject({ code: "EVALUATOR_OUTPUT_INCOMPLETE" });
 
-		expect(useModel).toHaveBeenCalledTimes(2);
-		expect(result).toMatchObject({
-			decision: "CONTINUE",
-			success: false,
-			protocolFailure: true,
-		});
-		expect(warn).toHaveBeenCalledWith(
-			expect.objectContaining({ retryMaxTokens: 4096 }),
-			"[evaluator] output-limit retry failed; rejecting the original partial response",
-		);
-		expect(reportError).toHaveBeenCalledWith(
-			"Evaluator.truncationRetry",
-			providerError,
-			expect.objectContaining({ retryMaxTokens: 4096 }),
-		);
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(warn).not.toHaveBeenCalled();
+		expect(reportError).not.toHaveBeenCalled();
 		expect(onUsage).toHaveBeenCalledTimes(1);
 		expect(onUsage).toHaveBeenCalledWith({
 			promptTokens: 100,
@@ -1603,7 +1576,7 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 		});
 	});
 
-	it("records a retry budget rejection and falls back to the initial response", async () => {
+	it("rejects a complete input that cannot fit the selected provider", async () => {
 		vi.stubEnv("MODEL_CONTEXT_WINDOWS_JSON", '{"tiny-evaluator":8000}');
 		try {
 			const stages: RecordedStage[] = [];
@@ -1643,55 +1616,48 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 			);
 			const reportError = vi.fn();
 
-			const result = await runEvaluator({
-				...baseParams(useModel),
-				runtime: {
-					useModel,
-					supportsModelAttemptPreparation: true,
-					getModelRegistrations: () => [
-						{
-							modelType: ModelType.RESPONSE_HANDLER,
-							provider: "tiny",
-							metadata: { displayModel: "tiny-evaluator" },
-						},
-					],
-					reportError,
-				},
-				context: {
-					...baseParams(useModel).context,
-					staticPrefix: {
-						characterPrompt: {
-							content: `agent_name: Eliza\n${"x".repeat(10_000)}`,
-							stable: true,
+			await expect(
+				runEvaluator({
+					...baseParams(useModel),
+					runtime: {
+						useModel,
+						supportsModelAttemptPreparation: true,
+						getModelRegistrations: () => [
+							{
+								modelType: ModelType.RESPONSE_HANDLER,
+								provider: "tiny",
+								metadata: { displayModel: "tiny-evaluator" },
+							},
+						],
+						reportError,
+					},
+					context: {
+						...baseParams(useModel).context,
+						staticPrefix: {
+							characterPrompt: {
+								content: `agent_name: Eliza\n${"x".repeat(40_000)}`,
+								stable: true,
+							},
 						},
 					},
-				},
-				recorder: captureRecorder(stages),
-				trajectoryId: "trajectory-evaluator-retry-budget",
-			});
+					recorder: captureRecorder(stages),
+					trajectoryId: "trajectory-evaluator-input-budget",
+				}),
+			).rejects.toMatchObject({ code: "EVALUATOR_INPUT_OVER_BUDGET" });
 
-			expect(useModel).toHaveBeenCalledTimes(2);
-			expect(completedCalls).toBe(1);
-			expect(result).toMatchObject({
-				decision: "CONTINUE",
-				success: false,
-				protocolFailure: true,
-			});
-			expect(stages).toHaveLength(2);
-			expect(stages[1]?.model?.response).toContain(
+			expect(useModel).toHaveBeenCalledTimes(1);
+			expect(completedCalls).toBe(0);
+			expect(stages).toHaveLength(1);
+			expect(stages[0]?.model?.response).toContain(
 				"EVALUATOR_INPUT_OVER_BUDGET",
 			);
-			expect(reportError).toHaveBeenCalledWith(
-				"Evaluator.truncationRetry",
-				expect.objectContaining({ code: "EVALUATOR_INPUT_OVER_BUDGET" }),
-				expect.objectContaining({ retryMaxTokens: 4096 }),
-			);
+			expect(reportError).not.toHaveBeenCalled();
 		} finally {
 			vi.unstubAllEnvs();
 		}
 	});
 
-	it("propagates non-provider failures from the bounded retry", async () => {
+	it("does not invoke a second-call adapter after incomplete output", async () => {
 		const programmerError = new TypeError("retry result adapter is broken");
 		const useModel = vi
 			.fn()
@@ -1701,7 +1667,8 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 
 		await expect(
 			runEvaluator({ ...baseParams(useModel), onUsage }),
-		).rejects.toBe(programmerError);
+		).rejects.toMatchObject({ code: "EVALUATOR_OUTPUT_INCOMPLETE" });
+		expect(useModel).toHaveBeenCalledTimes(1);
 		expect(onUsage).toHaveBeenCalledTimes(1);
 		expect(onUsage).toHaveBeenCalledWith({
 			promptTokens: 100,
@@ -1709,7 +1676,7 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 		});
 	});
 
-	it("does NOT retry when the completion hit the cap but still parsed", async () => {
+	it("does not infer a cap from usage when none was requested", async () => {
 		const parseableAtCap = {
 			text: '{"success": true, "decision": "FINISH", "thought": "Fits exactly."}',
 			finishReason: "stop",
@@ -1723,17 +1690,12 @@ describe("completion-truncation guard: one bounded retry, never a loop", () => {
 		expect(result.decision).toBe("FINISH");
 	});
 
-	it("never loops: a still-truncated retry proceeds to parse-recovery with exactly two calls total", async () => {
+	it("never parses or retries an incomplete provider response", async () => {
 		const useModel = vi.fn().mockResolvedValue(truncatedEnvelope);
 
-		const result = await runEvaluator(baseParams(useModel));
-
-		// One initial call + one retry. NEVER a third.
-		expect(useModel).toHaveBeenCalledTimes(2);
-		// The unparseable envelope routes through the existing protocol-failure
-		// path (CONTINUE + replan), not an exception and not a user-visible leak.
-		expect(result.decision).toBe("CONTINUE");
-		expect(result.success).toBe(false);
-		expect(result.messageToUser).toBeUndefined();
+		await expect(runEvaluator(baseParams(useModel))).rejects.toMatchObject({
+			code: "EVALUATOR_OUTPUT_INCOMPLETE",
+		});
+		expect(useModel).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -505,7 +505,7 @@ describe("v5 planner loop skeleton", () => {
 			reserveTokens: 10_000,
 			shouldCompact: false,
 		});
-		expect(plannerParams.maxTokens).toBe(4096);
+		expect(plannerParams.maxTokens).toBeUndefined();
 		expect(plannerParams.providerOptions.eliza.thinking).toBe("off");
 		expect(executeToolCall).toHaveBeenCalledWith(
 			{ id: "call-1", name: "LOOKUP", params: { query: "status" } },
@@ -517,11 +517,9 @@ describe("v5 planner loop skeleton", () => {
 		expect(result.finalMessage).toBe("Done.");
 	});
 
-	// #10132: in chat mode the planner's 1024-token output cap is fine, but a
-	// coding sub-agent (selected through per-turn codingMode) must emit a whole
-	// file as a single FILE/WRITE tool-call argument — a real single-file app is
-	// ~4.6k+ tokens once JSON-escaped, so 1024 truncates it mid-stream and the
-	// build silently fails. Coding mode lifts the cap.
+	// A coding sub-agent may need to emit a whole file as one FILE/WRITE call.
+	// Core therefore leaves output uncapped unless an operator explicitly sets a
+	// ceiling that the selected provider validates before dispatch.
 	const buildCodingPlannerRuntime = () => ({
 		useModel: vi.fn(async () => ({
 			text: "",
@@ -578,7 +576,7 @@ describe("v5 planner loop skeleton", () => {
 		}
 	};
 
-	it("raises the planner output-token cap in coding/full-surface mode (#10132)", async () => {
+	it("does not impose a coding planner output-token cap", async () => {
 		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 		delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
 		try {
@@ -596,7 +594,7 @@ describe("v5 planner loop skeleton", () => {
 				})),
 			});
 			const plannerParams = runtime.useModel.mock.calls[0][1];
-			expect(plannerParams.maxTokens).toBe(16384);
+			expect(plannerParams.maxTokens).toBeUndefined();
 		} finally {
 			if (prevMax === undefined)
 				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -26,10 +26,7 @@ import {
 	ModelType,
 	type PromptSegment,
 } from "../types/model";
-import {
-	isModelProviderError,
-	modelProviderErrorDetail,
-} from "../utils/model-errors";
+import { modelProviderErrorDetail } from "../utils/model-errors";
 import { stripReasoningPrefixes } from "../utils/reasoning-tags";
 import { resolveSetting } from "../utils/resolve-setting";
 import { toWellFormedUnicode } from "../utils/well-formed.js";
@@ -117,25 +114,13 @@ const EVALUATOR_ENVELOPE_KEYS = new Set([
 ]);
 
 /**
- * Base completion budget for the evaluator envelope. Raised from 1024 after a
- * live incident (sol-dev 2026-08-17): fable completions hitting exactly 1024
- * truncated the JSON envelope mid-string, the parse failed with "unparseable
- * output", and the planner burned 1-2 extra full-prompt rounds per affected
- * turn recovering. Observed envelopes are 100-450 tokens; 2048 gives 4x
- * headroom while the single doubled retry below covers pathological ramblers.
- */
-const DEFAULT_EVALUATOR_MAX_TOKENS = 2048;
-
-/**
- * Whether an evaluator model result was cut off by the completion-token cap:
- * the provider's finish reason names a length/token limit, or the reported
- * completion usage reached the requested cap. String results carry no
- * finish/usage metadata and are never treated as truncated. Exported for
- * regression coverage of the single-retry truncation guard.
+ * Whether the provider reports an incomplete evaluator result. Core does not
+ * impose an evaluator output cap; a provider length stop is therefore a typed
+ * failure rather than a partial envelope that may be parsed as a decision.
  */
 export function evaluatorHitCompletionLimit(
 	raw: EvaluatorModelResult,
-	maxTokens: number,
+	requestedMaxTokens?: number,
 ): boolean {
 	if (typeof raw === "string") return false;
 	const finishReason = raw.finishReason?.toLowerCase() ?? "";
@@ -147,9 +132,10 @@ export function evaluatorHitCompletionLimit(
 		return true;
 	}
 	return (
+		requestedMaxTokens !== undefined &&
 		typeof raw.usage?.completionTokens === "number" &&
 		Number.isFinite(raw.usage.completionTokens) &&
-		raw.usage.completionTokens >= maxTokens
+		raw.usage.completionTokens >= requestedMaxTokens
 	);
 }
 
@@ -257,25 +243,18 @@ function resolveEvaluatorBudget(
 	};
 }
 
-function evaluatorBudgetOptions(
-	contextWindowTokens: number,
-	minOutputReserveTokens = DEFAULT_EVALUATOR_MAX_TOKENS,
-): {
+function evaluatorBudgetOptions(contextWindowTokens: number): {
 	contextWindowTokens: number;
 	reserveTokens: number;
 } {
 	const desiredReserve = Math.max(
 		DEFAULT_COMPACTION_RESERVE_TOKENS,
 		Math.floor(contextWindowTokens * MODEL_WINDOW_RESERVE_FRACTION),
-		minOutputReserveTokens,
 	);
 	// Custom/local model windows can be smaller than the global 10k reserve.
-	// Keep enough room for input and the requested evaluator output instead of
+	// Keep enough room for both input and provider-owned evaluator output instead of
 	// turning such models into an unconditional one-token bottom-out.
-	const smallWindowCap = Math.max(
-		minOutputReserveTokens,
-		Math.floor(contextWindowTokens * 0.4),
-	);
+	const smallWindowCap = Math.floor(contextWindowTokens * 0.4);
 	return {
 		contextWindowTokens,
 		reserveTokens: Math.min(
@@ -508,15 +487,11 @@ export async function runEvaluator(
 			promptSegments?: PromptSegment[];
 			providerOptions?: Record<string, unknown>;
 		},
-		maxOutputTokens = DEFAULT_EVALUATOR_MAX_TOKENS,
 	): Promise<void> => {
 		const modelName = modelNameFromMetadata(params.runtime, attempt.metadata);
 		const resolvedBudget = buildModelInputBudget({ modelName });
 		const attemptWindow = resolvedBudget.contextWindowTokens;
-		const attemptBudgetOptions = evaluatorBudgetOptions(
-			attemptWindow,
-			maxOutputTokens,
-		);
+		const attemptBudgetOptions = evaluatorBudgetOptions(attemptWindow);
 		const attemptBaselineInput = renderEvaluatorModelInput({
 			context: params.context,
 			trajectory: params.trajectory,
@@ -612,58 +587,12 @@ export async function runEvaluator(
 	let selectedCall: EvaluatorModelCall | undefined;
 	let activeCallStartedAt = startedAt;
 	let activeAttempt: number | undefined;
-	let initialCallRecorded = false;
-	let fellBackToInitialCall = false;
 	try {
-		const callEvaluatorModel = async (
-			maxTokens: number,
-		): Promise<EvaluatorModelCall> => {
+		const callEvaluatorModel = async (): Promise<EvaluatorModelCall> => {
 			preparedAttempt = undefined;
 			const callStartedAt = Date.now();
 			activeCallStartedAt = callStartedAt;
 			const callInput = renderedInput;
-			let callProviderOptions = providerOptions;
-			if (
-				maxTokens > DEFAULT_EVALUATOR_MAX_TOKENS &&
-				params.runtime.supportsModelAttemptPreparation !== true &&
-				budgetResolution.contextWindowTokens
-			) {
-				const retryBudget = buildModelInputBudget({
-					messages: callInput.messages,
-					promptSegments: callInput.promptSegments,
-					...evaluatorBudgetOptions(
-						budgetResolution.contextWindowTokens,
-						maxTokens,
-					),
-				});
-				const retryOptions = buildAttemptProviderOptions(
-					callInput,
-					retryBudget,
-					params.provider,
-					buildContentProjectionDiagnostics({
-						enabled: projectionEnabled,
-						baselineBudget: retryBudget,
-						...(projectionBudget ? { projectionBudget } : {}),
-						stats: callInput.projectionStats,
-					}),
-				);
-				callProviderOptions = retryOptions.providerOptions;
-				preparedAttempt = {
-					input: callInput,
-					providerOptions: callProviderOptions,
-					prefixHashes: retryOptions.prefixHashes,
-					prefixHash: retryOptions.prefixHash,
-					provider: params.provider,
-				};
-				if (retryBudget.shouldCompact) {
-					throw buildInputBudgetError({
-						input: callInput,
-						budget: retryBudget,
-						resolvedModelNames: budgetResolution.modelNames,
-						unknownReachableModel: budgetResolution.unknownReachableModel,
-					});
-				}
-			}
 			const callRaw = await runWithStreamingContext(
 				streamingContext
 					? {
@@ -674,10 +603,9 @@ export async function runEvaluator(
 				() => {
 					const modelRequest = {
 						messages: callInput.messages,
-						maxTokens,
 						responseSchema: evaluatorSchema,
 						promptSegments: callInput.promptSegments,
-						providerOptions: callProviderOptions,
+						providerOptions,
 						prepareModelAttempt: (
 							attempt: ModelAttemptContext,
 							attemptParams: {
@@ -685,7 +613,7 @@ export async function runEvaluator(
 								promptSegments?: PromptSegment[];
 								providerOptions?: Record<string, unknown>;
 							},
-						) => prepareModelAttempt(attempt, attemptParams, maxTokens),
+						) => prepareModelAttempt(attempt, attemptParams),
 					};
 					return params.runtime.useModel(
 						modelType,
@@ -701,163 +629,23 @@ export async function runEvaluator(
 				endedAt: Date.now(),
 			};
 		};
-		const recordCompletedCall = async (
-			call: EvaluatorModelCall,
-			output: EvaluatorOutput,
-			attempt?: number,
-		): Promise<void> => {
-			const snapshot = call.preparedAttempt;
-			await recordEvaluationStage({
-				runtime: params.runtime,
-				recorder: params.recorder,
-				trajectoryId: params.trajectoryId,
-				parentStageId: params.parentStageId,
-				iteration: params.iteration ?? 1,
-				attempt,
-				modelType: String(modelType),
-				provider: snapshot?.provider ?? params.provider,
-				messages: (snapshot?.input ?? renderedInput).messages,
-				providerOptions: snapshot?.providerOptions ?? providerOptions,
-				raw: call.raw,
-				output,
-				startedAt: attempt === undefined ? startedAt : call.startedAt,
-				endedAt: call.endedAt,
-				segmentHashes: (snapshot?.prefixHashes ?? prefixHashes).map(
-					(entry) => entry.segmentHash,
-				),
-				prefixHash: snapshot?.prefixHash ?? prefixHash,
-				logger: params.runtime.logger,
-			});
-		};
 		activeAttempt = undefined;
-		const initialCall = await callEvaluatorModel(DEFAULT_EVALUATOR_MAX_TOKENS);
+		const initialCall = await callEvaluatorModel();
 		selectedCall = initialCall;
 		raw = initialCall.raw;
 		reportEvaluatorUsage(raw, params.onUsage);
-		// Truncation guard: a completion cut off at the cap yields an unparseable
-		// envelope, and each unparseable evaluation costs the planner a full extra
-		// replan round (live sol-dev 2026-08-17: 1024-cap truncations chained into
-		// 30-117s turns). Retry exactly ONCE with a doubled budget — never loop —
-		// and only when the truncated output actually failed to parse; a result
-		// that happens to be both complete-and-parseable at the cap stands.
-		if (
-			evaluatorHitCompletionLimit(raw, DEFAULT_EVALUATOR_MAX_TOKENS) &&
-			parseEvaluatorOutput(raw).protocolFailure === true
-		) {
-			const retryMaxTokens = DEFAULT_EVALUATOR_MAX_TOKENS * 2;
-			// A retry is a second billable model call. Persist the truncated first
-			// attempt before starting it so trajectories retain every request,
-			// response, usage record, and provider selection even if the retry fails.
-			await recordCompletedCall(
-				initialCall,
-				finalizeEvaluatorOutput(raw, params.context, params.trajectory),
-				1,
-			);
-			initialCallRecorded = true;
-			params.runtime.logger?.warn?.(
+		if (evaluatorHitCompletionLimit(raw)) {
+			throw new ElizaError(
+				"Evaluator provider returned an incomplete output at its length boundary",
 				{
-					modelType: String(modelType),
-					maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
-					retryMaxTokens,
-				},
-				"[evaluator] completion truncated at token cap and unparseable; retrying once with a doubled cap",
-			);
-			try {
-				activeAttempt = 2;
-				const retryCall = await callEvaluatorModel(retryMaxTokens);
-				reportEvaluatorUsage(retryCall.raw, params.onUsage);
-				selectedCall = retryCall;
-				raw = retryCall.raw;
-				if (evaluatorHitCompletionLimit(raw, retryMaxTokens)) {
-					params.runtime.logger?.warn?.(
-						{ modelType: String(modelType), retryMaxTokens },
-						"[evaluator] retry completion still hit its output limit; rejecting the partial response",
-					);
-					raw = "";
-				}
-			} catch (retryError) {
-				// error-policy:J4 The retry is an optional recovery attempt. Preserve
-				// the original truncated response so the established protocol-failure
-				// path can request another planner round for expected provider or
-				// retry-budget failures; programmer failures still propagate.
-				const retryBudgetError =
-					retryError instanceof ElizaError &&
-					retryError.code === "EVALUATOR_INPUT_OVER_BUDGET";
-				if (!retryBudgetError && !isModelProviderError(retryError)) {
-					throw retryError;
-				}
-				const retrySnapshot = preparedAttempt;
-				const retryDetail = retryBudgetError
-					? undefined
-					: modelProviderErrorDetail(retryError);
-				if (retryBudgetError) {
-					await recordInputBudgetFailure({
-						error: retryError,
-						input: retrySnapshot?.input ?? renderedInput,
-						provider: retrySnapshot?.provider ?? params.provider,
-						providerOptions: retrySnapshot?.providerOptions ?? providerOptions,
-						attempt: 2,
-						failureStartedAt: activeCallStartedAt,
-					});
-				} else {
-					await recordEvaluationStage({
-						runtime: params.runtime,
-						recorder: params.recorder,
-						trajectoryId: params.trajectoryId,
-						parentStageId: params.parentStageId,
-						iteration: params.iteration ?? 1,
-						attempt: 2,
+					code: "EVALUATOR_OUTPUT_INCOMPLETE",
+					context: {
 						modelType: String(modelType),
-						provider: retrySnapshot?.provider ?? params.provider,
-						messages: (retrySnapshot?.input ?? renderedInput).messages,
-						providerOptions: retrySnapshot?.providerOptions ?? providerOptions,
-						raw: `[evaluator truncation retry failed] ${
-							retryError instanceof Error
-								? retryError.message
-								: String(retryError)
-						}${retryDetail?.providerMessage ? ` | provider: ${retryDetail.providerMessage}` : ""}${
-							retryDetail?.status !== undefined
-								? ` | status: ${retryDetail.status}`
-								: ""
-						}`,
-						output: {
-							success: false,
-							decision: "CONTINUE",
-							thought:
-								"Evaluator truncation retry failed before producing output.",
-							protocolFailure: true,
-							raw: {},
-						},
-						startedAt: activeCallStartedAt,
-						endedAt: Date.now(),
-						segmentHashes: (retrySnapshot?.prefixHashes ?? prefixHashes).map(
-							(entry) => entry.segmentHash,
-						),
-						prefixHash: retrySnapshot?.prefixHash ?? prefixHash,
-						logger: params.runtime.logger,
-					});
-				}
-				// Keep the initial attempt for trajectory attribution, but never parse
-				// its partial response as a completed evaluation.
-				selectedCall = initialCall;
-				raw = "";
-				fellBackToInitialCall = true;
-				params.runtime.logger?.warn?.(
-					{
-						err:
-							retryError instanceof Error
-								? retryError.message
-								: String(retryError),
-						modelType: String(modelType),
-						retryMaxTokens,
+						finishReason:
+							typeof raw === "string" ? undefined : raw.finishReason,
 					},
-					"[evaluator] output-limit retry failed; rejecting the original partial response",
-				);
-				params.runtime.reportError?.("Evaluator.truncationRetry", retryError, {
-					modelType: String(modelType),
-					retryMaxTokens,
-				});
-			}
+				},
+			);
 		}
 	} catch (error) {
 		if (
@@ -934,36 +722,27 @@ export async function runEvaluator(
 	});
 	await applyEvaluatorEffects(output, params.effects);
 
-	// The first call was already persisted before the retry. When a provider
-	// failure makes us fall back to that same response, do not append a duplicate
-	// stage; the failed retry has its own attempt-2 stage above.
-	if (!fellBackToInitialCall) {
-		const snapshot = selectedCall?.preparedAttempt;
-		await recordEvaluationStage({
-			runtime: params.runtime,
-			recorder: params.recorder,
-			trajectoryId: params.trajectoryId,
-			parentStageId: params.parentStageId,
-			iteration: params.iteration ?? 1,
-			attempt: initialCallRecorded ? 2 : undefined,
-			modelType: String(modelType),
-			provider: snapshot?.provider ?? params.provider,
-			messages: (snapshot?.input ?? renderedInput).messages,
-			providerOptions: snapshot?.providerOptions ?? providerOptions,
-			raw,
-			output,
-			startedAt:
-				initialCallRecorded && selectedCall
-					? selectedCall.startedAt
-					: startedAt,
-			endedAt: selectedCall?.endedAt ?? Date.now(),
-			segmentHashes: (snapshot?.prefixHashes ?? prefixHashes).map(
-				(entry) => entry.segmentHash,
-			),
-			prefixHash: snapshot?.prefixHash ?? prefixHash,
-			logger: params.runtime.logger,
-		});
-	}
+	const snapshot = selectedCall?.preparedAttempt;
+	await recordEvaluationStage({
+		runtime: params.runtime,
+		recorder: params.recorder,
+		trajectoryId: params.trajectoryId,
+		parentStageId: params.parentStageId,
+		iteration: params.iteration ?? 1,
+		modelType: String(modelType),
+		provider: snapshot?.provider ?? params.provider,
+		messages: (snapshot?.input ?? renderedInput).messages,
+		providerOptions: snapshot?.providerOptions ?? providerOptions,
+		raw,
+		output,
+		startedAt,
+		endedAt: selectedCall?.endedAt ?? Date.now(),
+		segmentHashes: (snapshot?.prefixHashes ?? prefixHashes).map(
+			(entry) => entry.segmentHash,
+		),
+		prefixHash: snapshot?.prefixHash ?? prefixHash,
+		logger: params.runtime.logger,
+	});
 
 	return output;
 }

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -187,34 +187,6 @@ trajectory:
 {{trajectory}}`;
 
 /**
- * Chat-lane planner output budget. Reasoning models spend completion tokens on
- * deliberation BEFORE the tool call, and with `toolChoice: required` a budget
- * exhausted mid-reasoning means the required call is never emitted — Cerebras
- * then terminates the stream with an in-stream "server error", which reads as
- * a transient provider failure but reproduces 100% on any ask ambiguous
- * enough to burn the budget (live 2026-08-03: nine identical failures on one
- * build-and-host ask; wire capture showed the entire old 1024-token budget
- * consumed by reasoning deltas with no tool call). 4096 leaves deliberation
- * headroom while staying chat-sized; `ELIZA_PLANNER_MAX_TOKENS` overrides.
- * The coding lane's larger budget below exists for the same failure class
- * (#10132).
- */
-const DEFAULT_PLANNER_MAX_TOKENS = 4096;
-
-/**
- * Default per-call output-token ceiling for a coding planner turn. A single
- * FILE/WRITE tool call must carry the entire file as a JSON-escaped argument —
- * a real single-file app (the reference `tetris.html` is ~4.6k tokens once
- * escaped) blows straight past the chat default of {@link DEFAULT_PLANNER_MAX_TOKENS}
- * (1024), which truncates the tool-call argument mid-stream so the model either
- * narrates without ever completing the call or the provider 400s. Coding CLIs
- * on the same Cerebras `zai-glm-4.7` build the same app reliably precisely
- * because they do not clamp the file-emitting completion to a chat-sized budget.
- * Overridable via `ELIZA_CODING_PLANNER_MAX_TOKENS`. See issue #10132.
- */
-const DEFAULT_CODING_PLANNER_MAX_TOKENS = 16384;
-
-/**
  * Canonical form for an operator-facing positive-integer budget knob: a
  * positive decimal integer with no sign, whitespace, leading zero, decimal
  * point, or exponent. Matches the fail-fast precedent for numeric env config
@@ -256,25 +228,18 @@ export function resolvePositivePlannerInt(
 }
 
 /**
- * Resolve the planner's per-call `maxTokens`: the small chat default, or — in
- * coding/full-surface mode — a budget large enough to emit a full file in one
- * tool call ({@link DEFAULT_CODING_PLANNER_MAX_TOKENS}, overridable via
- * `ELIZA_CODING_PLANNER_MAX_TOKENS`). A set-but-malformed override throws via
- * {@link resolvePositivePlannerInt} rather than silently defaulting.
+ * Resolve an explicitly configured planner output ceiling. Unset settings do
+ * not impose a core-owned cap: the selected provider owns its real output
+ * boundary and must reject an unsupported explicit override before dispatch.
+ * A set-but-malformed override throws rather than silently defaulting.
  */
-function resolvePlannerMaxTokens(codingMode: boolean): number {
-	if (!codingMode) {
-		return resolvePositivePlannerInt(
-			"ELIZA_PLANNER_MAX_TOKENS",
-			process.env.ELIZA_PLANNER_MAX_TOKENS,
-			DEFAULT_PLANNER_MAX_TOKENS,
-		);
-	}
-	return resolvePositivePlannerInt(
-		"ELIZA_CODING_PLANNER_MAX_TOKENS",
-		process.env.ELIZA_CODING_PLANNER_MAX_TOKENS,
-		DEFAULT_CODING_PLANNER_MAX_TOKENS,
-	);
+function resolvePlannerMaxTokens(codingMode: boolean): number | undefined {
+	const envVarName = codingMode
+		? "ELIZA_CODING_PLANNER_MAX_TOKENS"
+		: "ELIZA_PLANNER_MAX_TOKENS";
+	const rawValue = process.env[envVarName];
+	if (rawValue === undefined || rawValue === "") return undefined;
+	return resolvePositivePlannerInt(envVarName, rawValue, 1);
 }
 
 /**
@@ -2611,11 +2576,13 @@ async function callPlanner(params: {
 			}),
 			modelInputBudget,
 		),
-		// Chat planner turns stay at the small DEFAULT_PLANNER_MAX_TOKENS; a coding
-		// turn must be able to emit a whole file in one tool call, so coding mode
-		// raises the cap (see resolvePlannerMaxTokens / issue #10132).
-		maxTokens: resolvePlannerMaxTokens(params.trajectory.codingMode === true),
 	};
+	const configuredMaxTokens = resolvePlannerMaxTokens(
+		params.trajectory.codingMode === true,
+	);
+	if (configuredMaxTokens !== undefined) {
+		modelParams.maxTokens = configuredMaxTokens;
+	}
 	modelParams.providerOptions = {
 		...modelParams.providerOptions,
 		eliza: {
@@ -5146,7 +5113,6 @@ async function rescueReplyFromSuccessfulResults(
 				{ role: "system", content: instructions.join("\n") },
 				{ role: "user", content: excerpts.join("\n\n") },
 			],
-			maxTokens: 1024,
 		});
 		const usage = extractUsage(raw);
 		if (


### PR DESCRIPTION
Closes #24790

## What changed
- omit `maxTokens` from planner, evaluator, and rescue-synthesis model calls by default
- retain validated planner output ceilings only when an operator explicitly configures them
- reject provider-reported evaluator length stops with typed `EVALUATOR_OUTPUT_INCOMPLETE` instead of parsing or retrying partial envelopes
- reserve evaluator input-window headroom without coupling it to a core-owned output ceiling
- add source guards that prevent restoration of the removed defaults/literal caps

## Verification
- `bun run --cwd packages/core test -- src/runtime/__tests__/planner-loop.test.ts src/runtime/__tests__/evaluator.test.ts src/__tests__/message-runtime-stage1.test.ts src/__tests__/prompt-integrity-policy.test.ts` (422 passed)
- `bun run --cwd packages/core typecheck`
- Biome check on all five touched files

No prompt or partial model output is silently shortened. Providers remain responsible for validating explicit output requests against their real model limits before dispatch.