### PR TITLE
fix(ui): surface connector mutation failures

### DIFF
--- a/packages/ui/src/api/client-agent-connector-accounts.test.ts
+++ b/packages/ui/src/api/client-agent-connector-accounts.test.ts
@@ -1,0 +1,68 @@
+/** Verifies connector-account transport normalization against canonical server payloads. */
+
+import { describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client";
+
+function clientReturning(body: unknown): ElizaClient {
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  client.setRequestTransport({
+    request: vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ),
+  });
+  return client;
+}
+
+describe("connector-account OAuth response normalization", () => {
+  it("accepts the agent's canonical nested OAuth flow response", async () => {
+    const result = await clientReturning({
+      provider: "google-workspace",
+      flow: {
+        id: "flow-1",
+        provider: "google-workspace",
+        status: "pending",
+        authUrl: "https://accounts.google.example/authorize",
+      },
+    }).startConnectorAccountOAuth("google-workspace", undefined);
+
+    expect(result).toMatchObject({
+      ok: true,
+      authUrl: "https://accounts.google.example/authorize",
+      status: "pending",
+    });
+  });
+
+  it("does not turn a nested flow error into success", async () => {
+    const result = await clientReturning({
+      provider: "google-workspace",
+      flow: {
+        id: "flow-1",
+        status: "error",
+        authUrl: "https://accounts.google.example/authorize",
+        error: "OAuth setup failed",
+      },
+    }).startConnectorAccountOAuth("google-workspace", undefined);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "OAuth setup failed",
+    });
+  });
+
+  it("preserves an explicit rejected result even when it carries a URL", async () => {
+    const result = await clientReturning({
+      ok: false,
+      authUrl: "https://accounts.google.example/authorize",
+      error: "Authorization rejected",
+    }).startConnectorAccountOAuth("google-workspace", undefined);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "Authorization rejected",
+    });
+  });
+});

--- a/packages/ui/src/api/client-agent-connector-accounts.ts
+++ b/packages/ui/src/api/client-agent-connector-accounts.ts
@@ -243,12 +243,18 @@ export function normalizeConnectorAccountActionResult(
   const account =
     record.account ?? (typeof record.id === "string" ? record : null);
   const flow = recordFromUnknown(record.flow);
+  const authUrl =
+    nonEmptyString(record.authUrl) ?? nonEmptyString(flow.authUrl) ?? undefined;
+  const flowError = nonEmptyString(flow.error) ?? undefined;
   return {
     ...(record as Partial<ConnectorAccountActionResult>),
     ok:
       typeof record.ok === "boolean"
         ? record.ok
-        : record.deleted === true || (!("error" in record) && account !== null),
+        : record.deleted === true ||
+          (!("error" in record) &&
+            flowError === undefined &&
+            (account !== null || authUrl !== undefined)),
     account: account
       ? normalizeConnectorAccountRecord(provider, connectorId, account)
       : undefined,
@@ -262,19 +268,14 @@ export function normalizeConnectorAccountActionResult(
         ? record.defaultAccountId
         : null,
     flow: Object.keys(flow).length > 0 ? flow : undefined,
-    authUrl:
-      typeof record.authUrl === "string"
-        ? record.authUrl
-        : typeof flow.authUrl === "string"
-          ? flow.authUrl
-          : undefined,
+    authUrl,
     status:
       typeof record.status === "string"
         ? normalizeStatus(record.status)
         : typeof flow.status === "string"
           ? normalizeStatus(flow.status)
           : undefined,
-    error: typeof record.error === "string" ? record.error : undefined,
+    error: nonEmptyString(record.error) ?? flowError,
   };
 }
 

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -322,14 +322,17 @@ describe("MessageContent sensitive requests", () => {
       "will not be sent",
     );
     // The card states its security contract in fixed copy: a masked-input
-    // explainer in the header and a storage note under the submit button. Both
+    // explainer in the header and a delivery note under the submit button. Both
     // must be visible before the user types a value.
     expect(screen.getByTestId("sensitive-request").textContent).toContain(
       "Masked input. It never lands in the transcript.",
     );
     expect(
       screen.getByTestId("sensitive-request-security-note").textContent,
-    ).toContain("never posted to chat");
+    ).toContain("Sent directly to the agent — never posted to chat");
+    expect(
+      screen.getByTestId("sensitive-request-security-note").textContent,
+    ).not.toContain("encrypted");
   });
 
   it("labels the submit button 'Save securely' when the form omits submitLabel", () => {

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1179,7 +1179,7 @@ export function SensitiveRequestBlock({
               <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden />
               {tunnel
                 ? "Sent once to the waiting session — never stored, never posted to chat."
-                : "Stored encrypted in the agent's secret store — never posted to chat."}
+                : "Sent directly to the agent — never posted to chat."}
             </div>
           )}
         </form>

--- a/packages/ui/src/components/chat/widgets/connector-card.test.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-card.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo } from "../../../api/client-types-config";
+import en from "../../../i18n/locales/en.json";
 import { __setAppValueForTests } from "../../../state/app-store";
 
 const { clientMock, loadPluginsMock, modesMock } = vi.hoisted(() => ({
@@ -55,6 +56,12 @@ function pluginInfo(overrides: Partial<PluginInfo> = {}): PluginInfo {
 }
 
 describe("ConnectorCardWidget", () => {
+  it("keeps the production security note aligned with the transport contract", () => {
+    expect(en["connectorcard.StorageNote"]).toBe(
+      "Sent directly to the agent — never posted to chat.",
+    );
+  });
+
   afterEach(() => {
     cleanup();
     __setAppValueForTests(null);

--- a/packages/ui/src/components/chat/widgets/connector-card.test.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-card.test.tsx
@@ -19,13 +19,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInfo } from "../../../api/client-types-config";
 import { __setAppValueForTests } from "../../../state/app-store";
 
-const { clientMock, modesMock } = vi.hoisted(() => ({
+const { clientMock, loadPluginsMock, modesMock } = vi.hoisted(() => ({
   clientMock: {
     getPlugins: vi.fn(),
     startConnectorAccountOAuth: vi.fn(),
     updateSecrets: vi.fn(),
     updatePlugin: vi.fn(),
   },
+  loadPluginsMock: vi.fn(),
   modesMock: vi.fn(),
 }));
 
@@ -64,6 +65,8 @@ describe("ConnectorCardWidget", () => {
     clientMock.startConnectorAccountOAuth.mockReset();
     clientMock.updateSecrets.mockReset();
     clientMock.updatePlugin.mockReset();
+    loadPluginsMock.mockReset();
+    loadPluginsMock.mockResolvedValue(undefined);
     modesMock.mockReset();
     modesMock.mockReturnValue([]);
     // Interpolating `t` matching the app contract, so assertions read the
@@ -75,7 +78,7 @@ describe("ConnectorCardWidget", () => {
           (_m, name: string) => String(vars?.[name] ?? ""),
         ),
       elizaCloudConnected: false,
-      loadPlugins: vi.fn().mockResolvedValue(undefined),
+      loadPlugins: loadPluginsMock,
     } as never);
   });
 
@@ -104,6 +107,7 @@ describe("ConnectorCardWidget", () => {
       { id: "oauth", label: "OAuth", description: "", kind: "oauth" },
     ]);
     clientMock.startConnectorAccountOAuth.mockResolvedValue({
+      ok: true,
       authUrl: "https://accounts.example.test/consent?state=s1",
     });
     const openSpy = vi
@@ -139,6 +143,7 @@ describe("ConnectorCardWidget", () => {
       { id: "oauth", label: "OAuth", description: "", kind: "oauth" },
     ]);
     clientMock.startConnectorAccountOAuth.mockResolvedValue({
+      ok: true,
       // A javascript: URL must never reach window.open.
       authUrl: "javascript:alert(1)",
     });
@@ -158,6 +163,38 @@ describe("ConnectorCardWidget", () => {
       );
     });
     expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("does not open or poll when OAuth returns ok:false with an https URL", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [pluginInfo({ id: "google" })],
+    });
+    modesMock.mockReturnValue([
+      { id: "oauth", label: "OAuth", description: "", kind: "oauth" },
+    ]);
+    clientMock.startConnectorAccountOAuth.mockResolvedValue({
+      ok: false,
+      authUrl: "https://accounts.example.test/consent?state=failed",
+      error: "OAuth is unavailable for this connector.",
+    });
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue(null as unknown as Window);
+
+    render(<ConnectorCardWidget pluginId="google" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card-authorize")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("connector-card-authorize"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card").textContent).toContain(
+        "OAuth is unavailable for this connector.",
+      );
+    });
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(clientMock.getPlugins).toHaveBeenCalledTimes(1);
     openSpy.mockRestore();
   });
 
@@ -197,6 +234,12 @@ describe("ConnectorCardWidget", () => {
     expect(
       screen.getByTestId("connector-card-token-form").textContent,
     ).toContain("Masked input. It never lands in the transcript.");
+    expect(
+      screen.getByTestId("connector-card-token-form").textContent,
+    ).toContain("Sent directly to the agent — never posted to chat.");
+    expect(
+      screen.getByTestId("connector-card-token-form").textContent,
+    ).not.toContain("encrypted");
 
     fireEvent.change(input, { target: { value: rawToken } });
     fireEvent.click(screen.getByTestId("connector-card-token-submit"));
@@ -213,6 +256,139 @@ describe("ConnectorCardWidget", () => {
       expect(screen.getByTestId("connector-card-connected")).toBeTruthy();
     });
     expect(container.textContent?.includes(rawToken)).toBe(false);
+  });
+
+  it("keeps the token form and does not enable when secret saving returns ok:false", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [
+        pluginInfo({
+          parameters: [
+            {
+              key: "SLACK_BOT_TOKEN",
+              type: "string",
+              description: "Bot token",
+              required: true,
+              sensitive: true,
+              currentValue: null,
+              isSet: false,
+            },
+          ],
+        }),
+      ],
+    });
+    clientMock.updateSecrets.mockResolvedValue({ ok: false, updated: [] });
+    const rawToken = "xoxb-save-rejected";
+
+    render(<ConnectorCardWidget pluginId="slack" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card-add-token")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("connector-card-add-token"));
+    fireEvent.change(screen.getByLabelText("SLACK_BOT_TOKEN"), {
+      target: { value: rawToken },
+    });
+    fireEvent.click(screen.getByTestId("connector-card-token-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card").textContent).toContain(
+        "The token could not be saved",
+      );
+    });
+    expect(clientMock.updatePlugin).not.toHaveBeenCalled();
+    expect(loadPluginsMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("connector-card-connected")).toBeNull();
+    expect(
+      (screen.getByLabelText("SLACK_BOT_TOKEN") as HTMLInputElement).value,
+    ).toBe(rawToken);
+  });
+
+  it("does not enable when the agent omits a required key from the saved-key receipt", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [
+        pluginInfo({
+          parameters: [
+            {
+              key: "SLACK_BOT_TOKEN",
+              type: "string",
+              description: "Bot token",
+              required: true,
+              sensitive: true,
+              currentValue: null,
+              isSet: false,
+            },
+          ],
+        }),
+      ],
+    });
+    clientMock.updateSecrets.mockResolvedValue({ ok: true, updated: [] });
+
+    render(<ConnectorCardWidget pluginId="slack" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card-add-token")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("connector-card-add-token"));
+    fireEvent.change(screen.getByLabelText("SLACK_BOT_TOKEN"), {
+      target: { value: "xoxb-unconfirmed" },
+    });
+    fireEvent.click(screen.getByTestId("connector-card-token-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card").textContent).toContain(
+        "did not confirm saving every required token",
+      );
+    });
+    expect(clientMock.updatePlugin).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("connector-card-connected")).toBeNull();
+  });
+
+  it("surfaces partial success and preserves retry input when enabling returns ok:false", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [
+        pluginInfo({
+          parameters: [
+            {
+              key: "SLACK_BOT_TOKEN",
+              type: "string",
+              description: "Bot token",
+              required: true,
+              sensitive: true,
+              currentValue: null,
+              isSet: false,
+            },
+          ],
+        }),
+      ],
+    });
+    clientMock.updateSecrets.mockResolvedValue({
+      ok: true,
+      updated: ["SLACK_BOT_TOKEN"],
+    });
+    clientMock.updatePlugin.mockResolvedValue({
+      ok: false,
+      error: "Plugin validation failed.",
+    });
+    const rawToken = "xoxb-enable-rejected";
+
+    render(<ConnectorCardWidget pluginId="slack" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card-add-token")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("connector-card-add-token"));
+    fireEvent.change(screen.getByLabelText("SLACK_BOT_TOKEN"), {
+      target: { value: rawToken },
+    });
+    fireEvent.click(screen.getByTestId("connector-card-token-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connector-card").textContent).toContain(
+        "The token was saved, but the connector could not be enabled: Plugin validation failed.",
+      );
+    });
+    expect(loadPluginsMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("connector-card-connected")).toBeNull();
+    expect(
+      (screen.getByLabelText("SLACK_BOT_TOKEN") as HTMLInputElement).value,
+    ).toBe(rawToken);
   });
 
   it("renders a passive Connected state for an already-connected connector", async () => {

--- a/packages/ui/src/components/chat/widgets/connector-card.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-card.tsx
@@ -192,6 +192,14 @@ export const ConnectorCardWidget = memo(function ConnectorCardWidget({
         pluginId,
         {},
       );
+      if (result.ok !== true) {
+        throw new Error(
+          result.error?.trim() ||
+            t("connectorcard.AuthorizeRejected", {
+              defaultValue: "The connector could not start authorization.",
+            }),
+        );
+      }
       if (!isHttpsUrl(result.authUrl)) {
         throw new Error(
           result.error ??
@@ -234,9 +242,41 @@ export const ConnectorCardWidget = memo(function ConnectorCardWidget({
           const value = tokenValues[field.key];
           if (value != null && value !== "") secrets[field.key] = value;
         }
-        await client.updateSecrets(secrets);
-        await client.updatePlugin(pluginId, { enabled: true });
-        await loadPlugins();
+        const secretResult = await client.updateSecrets(secrets);
+        if (secretResult.ok !== true) {
+          throw new Error(
+            t("connectorcard.SecretSaveRejected", {
+              defaultValue: "The token could not be saved. Try again.",
+            }),
+          );
+        }
+        const missingSecretKeys = Object.keys(secrets).filter(
+          (key) => !secretResult.updated.includes(key),
+        );
+        if (missingSecretKeys.length > 0) {
+          throw new Error(
+            t("connectorcard.SecretSaveUnconfirmed", {
+              defaultValue:
+                "The agent did not confirm saving every required token. Try again.",
+            }),
+          );
+        }
+
+        const enableResult = await client.updatePlugin(pluginId, {
+          enabled: true,
+        });
+        if (enableResult.ok !== true) {
+          const detail =
+            enableResult.error?.trim() || enableResult.message?.trim();
+          throw new Error(
+            t("connectorcard.EnableRejectedAfterSave", {
+              defaultValue: detail
+                ? `The token was saved, but the connector could not be enabled: ${detail}`
+                : "The token was saved, but the connector could not be enabled. Try again.",
+            }),
+          );
+        }
+
         if (mountedRef.current) {
           setTokenValues({});
           setTokenFormOpen(false);
@@ -244,6 +284,20 @@ export const ConnectorCardWidget = memo(function ConnectorCardWidget({
           setPlugin((prev) =>
             prev ? { ...prev, enabled: true, configured: true } : prev,
           );
+        }
+        try {
+          await loadPlugins();
+        } catch {
+          // error-policy:J4 both mutations succeeded, but global status refresh
+          // failed; keep the successful local state and make reconciliation visible.
+          if (mountedRef.current) {
+            setError(
+              t("connectorcard.RefreshFailedAfterSave", {
+                defaultValue:
+                  "Connected, but the connector list could not be refreshed.",
+              }),
+            );
+          }
         }
         pollTimerRef.current = setTimeout(
           () => void fetchPlugin(),
@@ -403,7 +457,7 @@ export const ConnectorCardWidget = memo(function ConnectorCardWidget({
             <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden />
             {t("connectorcard.StorageNote", {
               defaultValue:
-                "Stored encrypted in the agent's secret store — never posted to chat.",
+                "Sent directly to the agent — never posted to chat.",
             })}
           </div>
         </form>

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8571,7 +8571,7 @@
   "connectorcard.SaveFailed": "Couldn't save the token.",
   "connectorcard.SaveSecurely": "Save securely",
   "connectorcard.Saving": "Saving...",
-  "connectorcard.StorageNote": "Stored encrypted in the agent's secret store — never posted to chat.",
+  "connectorcard.StorageNote": "Sent directly to the agent — never posted to chat.",
   "browserworkspace.NativeSurfaceUnavailable": "Browser view unavailable",
   "browserworkspace.NativeSurfaceUnavailableDescription": "The secure browser surface could not connect. Retry without losing your tabs.",
   "browserworkspace.NativeSurfaceUnsupported": "Secure browsing not supported here",


### PR DESCRIPTION
Closes #24794.

## Scope

Makes the in-chat connector setup path treat mutation response bodies as authoritative instead of treating every resolved HTTP request as success.

- OAuth opens/polls only after a normalized successful start result.
- Canonical nested OAuth responses (`{ flow: { authUrl, ... } }`) remain accepted; explicit or nested failures stay rejected.
- Secret saves require `ok: true` and confirmation for every submitted key.
- Plugin enable requires `ok: true`; token-saved/enable-failed is shown as a truthful partial success.
- A post-success plugin-list refresh failure preserves the connected local state and surfaces reconciliation failure.
- Retry inputs remain masked and populated after rejected mutations.
- User copy no longer claims connector tokens are encrypted at rest when this UI cannot establish that contract.

## Exact source

- Head: `22b253d6cc7c99148dc06cf874798ab288add93d`
- Base: `cbb400ddbcc21117505275557dd4f8505b2ccd1a`
- Two rebases were checked with `git range-diff`; all three commits remained patch-identical.

## Verification

- Focused UI tests: 32/32 pass
  - canonical nested OAuth success
  - nested/explicit OAuth rejection with an HTTPS URL
  - secret rejection and missing-key confirmation
  - enable rejection after a confirmed save
  - refresh failure after successful mutations
  - masked-value retry preservation
  - production English security-copy contract
- `packages/ui` typecheck: pass
- Biome on all seven changed files: pass
- `git diff --check`: pass
- Exact affected app audit at the rebased patch: `builtin-chat mobile-landscape` passes with `broken=0`, `needs-work=0`, `good=1`.
- Full app audit on the same patch series: 223/227. The first chat mobile-landscape attempt stalled in the static preboot shell; the exact targeted rerun passed. The other three failures were unrelated existing audit/lifecycle debt (`builtin-experience`, `builtin-trajectories`, and the final wallet gate reporting Settings density verdicts).

## Visual inspection

The production chat harness was captured after the production catalog repair, at desktop and mobile widths, for rest, hover, populated masked form, and rejected-mutation retry states.

- No card overflow in desktop or mobile captures.
- Secret input remained `type=password`; the submitted value was not present in visible body text.
- Secret-save and enable-after-save failures were visibly distinct and actionable.
- The corrected “Sent directly to the agent — never posted to chat” copy rendered from the production English catalog.
- Frontend console/page errors: none after mocking the gallery's unrelated orchestrator-task and native-permission requests.

The harness uses deterministic transport fixtures; this change does not claim a live connector credential or provider run. No live-model trajectory is applicable because connector mutation handling and transport normalization do not alter agent/model behavior.
