### PR TITLE
chore(gateway-webhook): apply biome formatting to blooio.fetch.test.ts

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
@@ -62,20 +62,18 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
 
   test("preserves caller cancellation (composed)", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = vi
-      .fn()
-      .mockImplementation(
-        (_input: RequestInfo | URL, init?: RequestInit) =>
-          new Promise<Response>((resolve, reject) => {
-            seen = init?.signal ?? undefined;
-            seen?.addEventListener("abort", () => {
-              reject(
-                new DOMException("The operation was aborted.", "AbortError"),
-              );
-            });
-            setTimeout(() => resolve(new Response("{}", { status: 200 })), 500);
-          }),
-      ) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          seen = init?.signal ?? undefined;
+          seen?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+          setTimeout(() => resolve(new Response("{}", { status: 200 })), 500);
+        }),
+    ) as unknown as typeof fetch;
 
     const { blooioFetch } = await import("./blooio");
     const controller = new AbortController();


### PR DESCRIPTION
Format-only. #24274 landed `src/adapters/blooio.fetch.test.ts` unformatted, turning `@elizaos/gateway-webhook#lint:check` red develop-wide (seen failing PR Static Smoke on unrelated PRs, e.g. run 32604736980). `bunx @biomejs/biome check --write` output, verified clean with `bun run lint:check` in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)