### PR TITLE
[cloud][billing][e2e] Prove snapshot UI recovery from backend faults

### DIFF
--- a/packages/cloud/e2e/src/fixtures/backend-fault-proxy.ts
+++ b/packages/cloud/e2e/src/fixtures/backend-fault-proxy.ts
@@ -1,0 +1,416 @@
+/**
+ * Test-only reverse proxy that can inject a deterministic JSON response before
+ * forwarding a frontend request to the real local cloud-api.
+ */
+
+import {
+  type ClientRequest,
+  createServer,
+  request as httpRequest,
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { type AddressInfo, createConnection } from "node:net";
+import type { Duplex } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
+
+export interface BackendFault {
+  /** Exact URL pathname to fault. Query parameters are ignored. */
+  path: string;
+  /** Optional HTTP method. When omitted, every method matches. */
+  method?: string;
+  status: number;
+  /** JSON-serializable response body. */
+  body?: unknown;
+  headers?: Readonly<Record<string, string>>;
+  delayMs?: number;
+  /** Number of matching requests to fault. Omit to fault until clearFault(). */
+  times?: number;
+}
+
+export interface BackendPathRewrite {
+  /** Exact incoming URL pathname. Query parameters are preserved. */
+  path: string;
+  /** Exact upstream pathname substituted before forwarding. */
+  targetPath: string;
+  /** Optional HTTP method. When omitted, every method matches. */
+  method?: string;
+}
+
+export interface RunningBackendFaultProxy {
+  url: string;
+  port: number;
+  setFault(fault: BackendFault): void;
+  clearFault(): void;
+  /** Route selected HTTP requests to another real endpoint on the same Worker. */
+  setPathRewrites(rewrites: readonly BackendPathRewrite[]): void;
+  clearPathRewrites(): void;
+  /** Number of responses injected for the current/most-recent fault. */
+  readonly faultHits: number;
+  stop(): Promise<void>;
+}
+
+export interface StartBackendFaultProxyOptions {
+  targetUrl: string;
+  port?: number;
+  hostname?: string;
+}
+
+interface ActiveFault extends BackendFault {
+  method?: string;
+  remaining?: number;
+  serializedBody?: string;
+}
+
+interface ActivePathRewrite extends BackendPathRewrite {
+  method?: string;
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function assertTestEnvironment(): void {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "[backend-fault-proxy] Refusing to start with NODE_ENV=production",
+    );
+  }
+  if (process.env.NODE_ENV === "test" || process.env.CLOUD_E2E === "1") return;
+  throw new Error(
+    "[backend-fault-proxy] Refusing to start outside NODE_ENV=test/CLOUD_E2E=1",
+  );
+}
+
+function validateFault(fault: BackendFault): ActiveFault {
+  if (!fault.path.startsWith("/")) {
+    throw new Error("[backend-fault-proxy] fault.path must start with '/'");
+  }
+  if (
+    !Number.isInteger(fault.status) ||
+    fault.status < 100 ||
+    fault.status > 599
+  ) {
+    throw new Error(
+      "[backend-fault-proxy] fault.status must be an integer from 100 to 599",
+    );
+  }
+  if (
+    fault.delayMs !== undefined &&
+    (!Number.isFinite(fault.delayMs) || fault.delayMs < 0)
+  ) {
+    throw new Error(
+      "[backend-fault-proxy] fault.delayMs must be a non-negative number",
+    );
+  }
+  if (
+    fault.times !== undefined &&
+    (!Number.isInteger(fault.times) || fault.times < 1)
+  ) {
+    throw new Error(
+      "[backend-fault-proxy] fault.times must be a positive integer",
+    );
+  }
+
+  let serializedBody: string | undefined;
+  if (fault.body !== undefined) {
+    serializedBody = JSON.stringify(fault.body);
+    if (serializedBody === undefined) {
+      throw new Error(
+        "[backend-fault-proxy] fault.body must be JSON-serializable",
+      );
+    }
+  }
+
+  return {
+    ...fault,
+    method: fault.method?.toUpperCase(),
+    headers: fault.headers ? { ...fault.headers } : undefined,
+    remaining: fault.times,
+    serializedBody,
+  };
+}
+
+function requestPathname(request: IncomingMessage): string {
+  return new URL(request.url ?? "/", "http://backend-fault-proxy.test")
+    .pathname;
+}
+
+function validatePathRewrites(
+  rewrites: readonly BackendPathRewrite[],
+): ActivePathRewrite[] {
+  return rewrites.map((rewrite) => {
+    if (!rewrite.path.startsWith("/") || !rewrite.targetPath.startsWith("/")) {
+      throw new Error(
+        "[backend-fault-proxy] rewrite paths must start with '/'",
+      );
+    }
+    if (/[?#]/.test(rewrite.targetPath)) {
+      throw new Error(
+        "[backend-fault-proxy] rewrite.targetPath must not contain a query or hash",
+      );
+    }
+    return {
+      ...rewrite,
+      method: rewrite.method?.toUpperCase(),
+    };
+  });
+}
+
+function forwardedRequestPath(
+  request: IncomingMessage,
+  rewrites: readonly ActivePathRewrite[],
+): string {
+  const incoming = new URL(
+    request.url ?? "/",
+    "http://backend-fault-proxy.test",
+  );
+  const method = request.method?.toUpperCase();
+  const rewrite = rewrites.find(
+    (candidate) =>
+      candidate.path === incoming.pathname &&
+      (candidate.method === undefined || candidate.method === method),
+  );
+  return `${rewrite?.targetPath ?? incoming.pathname}${incoming.search}`;
+}
+
+function copyForwardHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  const forwarded = { ...headers };
+  for (const header of HOP_BY_HOP_HEADERS) delete forwarded[header];
+  return forwarded;
+}
+
+function copyUpstreamHeaders(
+  upstream: IncomingMessage,
+  response: ServerResponse,
+): void {
+  for (const [name, value] of Object.entries(upstream.headers)) {
+    if (value === undefined || HOP_BY_HOP_HEADERS.has(name)) continue;
+    response.setHeader(name, value);
+  }
+}
+
+function writeFaultResponse(
+  request: IncomingMessage,
+  response: ServerResponse,
+  fault: ActiveFault,
+): void {
+  const suppliedHeaders = fault.headers ?? {};
+  for (const [name, value] of Object.entries(suppliedHeaders)) {
+    response.setHeader(name, value);
+  }
+
+  const body = fault.serializedBody;
+  const hasContentType = Object.keys(suppliedHeaders).some(
+    (name) => name.toLowerCase() === "content-type",
+  );
+  if (body !== undefined && !hasContentType) {
+    response.setHeader("Content-Type", "application/json; charset=utf-8");
+  }
+  if (body !== undefined) {
+    response.setHeader("Content-Length", Buffer.byteLength(body));
+  }
+
+  response.statusCode = fault.status;
+  response.end(request.method === "HEAD" ? undefined : body);
+}
+
+function forwardHttpRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  target: URL,
+  upstreamRequests: Set<ClientRequest>,
+  path: string,
+): void {
+  const upstream = httpRequest(
+    {
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path,
+      method: request.method,
+      headers: copyForwardHeaders(request.headers),
+    },
+    (upstreamResponse) => {
+      response.statusCode = upstreamResponse.statusCode ?? 502;
+      if (upstreamResponse.statusMessage) {
+        response.statusMessage = upstreamResponse.statusMessage;
+      }
+      copyUpstreamHeaders(upstreamResponse, response);
+      upstreamResponse.pipe(response);
+    },
+  );
+  upstreamRequests.add(upstream);
+  upstream.once("close", () => upstreamRequests.delete(upstream));
+  upstream.once("error", (error) => {
+    if (response.headersSent || response.destroyed) {
+      response.destroy(error);
+      return;
+    }
+    const body = JSON.stringify({
+      error: "Backend unavailable",
+      code: "backend_proxy_error",
+    });
+    response.writeHead(502, {
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Length": Buffer.byteLength(body),
+    });
+    response.end(body);
+  });
+  request.once("aborted", () => upstream.destroy());
+  response.once("close", () => {
+    if (!response.writableEnded) upstream.destroy();
+  });
+  request.pipe(upstream);
+}
+
+function forwardWebSocket(
+  request: IncomingMessage,
+  browserSocket: Duplex,
+  head: Buffer,
+  target: URL,
+  sockets: Set<Duplex>,
+): void {
+  const upstreamSocket = createConnection({
+    host: target.hostname,
+    port: Number(target.port || 80),
+  });
+  sockets.add(upstreamSocket);
+  upstreamSocket.once("close", () => sockets.delete(upstreamSocket));
+  browserSocket.once("close", () => upstreamSocket.destroy());
+  upstreamSocket.once("error", () => browserSocket.destroy());
+  browserSocket.once("error", () => upstreamSocket.destroy());
+
+  upstreamSocket.once("connect", () => {
+    upstreamSocket.write(
+      `${request.method ?? "GET"} ${request.url ?? "/"} HTTP/${request.httpVersion}\r\n`,
+    );
+    for (let index = 0; index < request.rawHeaders.length; index += 2) {
+      upstreamSocket.write(
+        `${request.rawHeaders[index]}: ${request.rawHeaders[index + 1]}\r\n`,
+      );
+    }
+    upstreamSocket.write("\r\n");
+    if (head.length > 0) upstreamSocket.write(head);
+    browserSocket.pipe(upstreamSocket).pipe(browserSocket);
+  });
+}
+
+/** Start the opt-in fault boundary used only by the Cloud Playwright stack. */
+export async function startBackendFaultProxy(
+  options: StartBackendFaultProxyOptions,
+): Promise<RunningBackendFaultProxy> {
+  assertTestEnvironment();
+  const target = new URL(options.targetUrl);
+  if (target.protocol !== "http:") {
+    throw new Error(
+      "[backend-fault-proxy] targetUrl must use http for the local E2E stack",
+    );
+  }
+
+  let activeFault: ActiveFault | undefined;
+  let pathRewrites: ActivePathRewrite[] = [];
+  let faultHits = 0;
+  let stopped = false;
+  const stopController = new AbortController();
+  const sockets = new Set<Duplex>();
+  const upstreamRequests = new Set<ClientRequest>();
+
+  const server = createServer(async (request, response) => {
+    const fault = activeFault;
+    const matches =
+      fault !== undefined &&
+      requestPathname(request) === fault.path &&
+      (fault.method === undefined ||
+        fault.method === request.method?.toUpperCase()) &&
+      (fault.remaining === undefined || fault.remaining > 0);
+
+    if (!matches || !fault) {
+      forwardHttpRequest(
+        request,
+        response,
+        target,
+        upstreamRequests,
+        forwardedRequestPath(request, pathRewrites),
+      );
+      return;
+    }
+
+    faultHits += 1;
+    if (fault.remaining !== undefined) fault.remaining -= 1;
+    request.resume();
+    if ((fault.delayMs ?? 0) > 0) {
+      try {
+        await delay(fault.delayMs, undefined, {
+          signal: stopController.signal,
+        });
+      } catch {
+        if (stopController.signal.aborted) return;
+        throw new Error("[backend-fault-proxy] fault delay failed");
+      }
+    }
+    if (!response.destroyed) writeFaultResponse(request, response, fault);
+  });
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, socket, head) => {
+    // WebSockets are always transparent. Rewriting `/ws` would fabricate a
+    // shared-adapter endpoint that the real Worker deliberately does not own.
+    forwardWebSocket(request, socket, head, target, sockets);
+  });
+
+  const hostname = options.hostname ?? "127.0.0.1";
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, hostname, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://${hostname}:${address.port}`,
+    port: address.port,
+    setFault(fault) {
+      activeFault = validateFault(fault);
+      faultHits = 0;
+    },
+    clearFault() {
+      activeFault = undefined;
+    },
+    setPathRewrites(rewrites) {
+      pathRewrites = validatePathRewrites(rewrites);
+    },
+    clearPathRewrites() {
+      pathRewrites = [];
+    },
+    get faultHits() {
+      return faultHits;
+    },
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      activeFault = undefined;
+      pathRewrites = [];
+      stopController.abort();
+      for (const upstream of upstreamRequests) upstream.destroy();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}

--- a/packages/cloud/e2e/src/fixtures/stack.ts
+++ b/packages/cloud/e2e/src/fixtures/stack.ts
@@ -30,6 +30,10 @@ import {
   type RunningStewardMock,
   startStewardMock,
 } from "@elizaos/cloud-test-mocks/steward";
+import {
+  type RunningBackendFaultProxy,
+  startBackendFaultProxy,
+} from "./backend-fault-proxy";
 import { buildSharedEnv } from "./env";
 import { type RunningMockLlm, startMockLlm } from "./mock-llm";
 
@@ -86,6 +90,8 @@ export interface StackHandle {
     controlPlane: RunningControlPlaneMock;
     steward: RunningStewardMock;
     mockLlm?: RunningMockLlm;
+    /** Present only when started with `backendFaults: true`. */
+    backendFaults?: RunningBackendFaultProxy;
   };
   dataDir: string;
   logDir: string;
@@ -268,6 +274,11 @@ export interface StartCloudStackOptions {
    */
   mockLlmEchoContext?: boolean;
   /**
+   * Put a test-only programmable fault proxy between the Vite frontend and the
+   * real local cloud-api. Defaults to false, leaving frontend routing unchanged.
+   */
+  backendFaults?: boolean;
+  /**
    * Test-only subprocess environment overrides. Values are scoped to this
    * stack's local PGlite/Worker/frontend processes and never mutate the parent
    * runner, so specs can exercise configuration boundaries without changing
@@ -417,6 +428,12 @@ export async function startCloudStack(
     label: "cloud-api",
   });
 
+  const backendFaults = opts.backendFaults
+    ? await startBackendFaultProxy({ targetUrl: apiUrl })
+    : undefined;
+  const frontendApiUrl = backendFaults?.url ?? apiUrl;
+  const frontendApiPort = backendFaults?.port ?? apiPort;
+
   // 3. console (apex) frontend Vite dev (skipped for API-only stacks).
   // The apex moved to packages/app in the cloud-frontend→packages/app cutover.
   // packages/app's vite dev does NOT honour VITE_API_PROXY_TARGET; it computes
@@ -438,10 +455,10 @@ export async function startCloudStack(
       ...stackEnv,
       // packages/app vite dev: UI listen port + /api proxy target.
       ELIZA_UI_PORT: String(frontendPort),
-      ELIZA_API_PORT: String(apiPort),
-      ELIZA_PORT: String(apiPort),
-      VITE_API_BASE_URL: apiUrl,
-      NEXT_PUBLIC_API_BASE_URL: apiUrl,
+      ELIZA_API_PORT: String(frontendApiPort),
+      ELIZA_PORT: String(frontendApiPort),
+      VITE_API_BASE_URL: frontendApiUrl,
+      NEXT_PUBLIC_API_BASE_URL: frontendApiUrl,
     };
     procs.push(
       spawnLogged(
@@ -498,6 +515,7 @@ export async function startCloudStack(
     await hetzner.stop().catch(() => undefined);
     await steward.stop().catch(() => undefined);
     await mockLlm?.stop().catch(() => undefined);
+    await backendFaults?.stop().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
     if (dbCloseError) {
       throw dbCloseError;
@@ -523,7 +541,13 @@ export async function startCloudStack(
     },
     frontendSkipped: frontendSkipReason !== undefined,
     frontendSkipReason,
-    mocks: { hetzner, controlPlane, steward, ...(mockLlm ? { mockLlm } : {}) },
+    mocks: {
+      hetzner,
+      controlPlane,
+      steward,
+      ...(mockLlm ? { mockLlm } : {}),
+      ...(backendFaults ? { backendFaults } : {}),
+    },
     dataDir,
     logDir: LOG_DIR,
   };

--- a/packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts
+++ b/packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * Proves the Billing snapshot UI distinguishes pending, failed, recovered, and
+ * designed-empty states against the real local Worker and database. The only
+ * injected failure lives at the stack's server-side proxy boundary; the
+ * browser transport is never intercepted or fulfilled by Playwright.
+ */
+
+import {
+  createCloudAgent,
+  getPersistedAgentSummary,
+} from "../src/helpers/provisioning";
+import { expect, test } from "../src/helpers/test-fixtures";
+
+const BILLING_SNAPSHOT_PATH = "/api/v1/billing/limits";
+const LEGACY_BILLING_PAGE_PATH = "/dashboard/billing";
+const CANONICAL_BILLING_PAGE_PATH = "/cloud/billing";
+
+test.use({ stackOptions: { backendFaults: true } });
+
+test.describe("billing snapshot — backend failure recovery", () => {
+  test.beforeEach(async ({ authenticatedPage, seededUser, stack }) => {
+    const backendFaults = stack.mocks.backendFaults;
+    if (!backendFaults) throw new Error("backend fault controller unavailable");
+    backendFaults.clearFault();
+
+    // The combined app expects an agent API for its startup coordinator. Create
+    // a real, non-billable shared agent and route only those exact shell paths
+    // to its real Worker adapter; Cloud account APIs remain at the Worker root.
+    const agentId = await createCloudAgent(
+      { apiUrl: stack.urls.api },
+      seededUser.apiKey,
+      `billing-snapshot-e2e-${Date.now().toString(36)}`,
+    );
+    const shellRuntime = await getPersistedAgentSummary(
+      agentId,
+      seededUser.organizationId,
+    );
+    expect(shellRuntime.executionTier).toBe("shared");
+    const sharedAdapterPrefix = `/api/v1/eliza/agents/${encodeURIComponent(agentId)}`;
+    backendFaults.setPathRewrites(
+      [
+        "/api/health",
+        "/api/status",
+        "/api/auth/status",
+        "/api/auth/me",
+        "/api/conversations",
+        "/api/character",
+        "/api/first-run/status",
+        "/api/first-run",
+        "/api/views",
+        "/api/config",
+        "/api/runtime/mode",
+        "/api/commands",
+        "/api/custom-actions",
+        "/api/agent/events",
+        "/api/agent/start",
+        "/api/apps/overlay-presence",
+        "/api/lifeops/activity-signals",
+        "/api/stream/settings",
+      ].map((path) => ({
+        path,
+        targetPath: `${sharedAdapterPrefix}${path}`,
+      })),
+    );
+
+    // This suite exercises the authenticated Billing route, not the unrelated
+    // device first-run overlay. Restore the real persisted runtime shape before
+    // the app bootstraps so it can pass startup against that shared adapter.
+    await authenticatedPage.addInitScript(
+      ({ agentId, apiBase, apiKey }) => {
+        window.localStorage.setItem("eliza:first-run-complete", "1");
+        window.localStorage.setItem(
+          "elizaos:active-server",
+          JSON.stringify({
+            id: `cloud:${agentId}`,
+            kind: "cloud",
+            label: "Billing E2E shared runtime",
+            apiBase,
+            accessToken: apiKey,
+            cloudRuntimeAgentId: agentId,
+            cloudRuntime: "shared",
+          }),
+        );
+      },
+      {
+        agentId,
+        apiBase: stack.urls.frontend,
+        apiKey: seededUser.apiKey,
+      },
+    );
+
+    // Warm the app shell once so startup and lazy private-route registration
+    // settle before either test installs its Billing-specific observation.
+    const runtimeReady = authenticatedPage.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === "/api/status" &&
+        response.status() === 200,
+    );
+    await authenticatedPage.goto(stack.urls.frontend, { timeout: 60_000 });
+    await runtimeReady;
+    await expect(
+      authenticatedPage.getByTestId("home-launcher-surface"),
+    ).toBeVisible();
+  });
+
+  test("renders an unavailable server observation without inferring an empty snapshot", async ({
+    authenticatedPage,
+    stack,
+    seededUser,
+  }) => {
+    const { organizationsRepository } = await import(
+      "@elizaos/cloud-shared/db/repositories/organizations"
+    );
+    const original = await organizationsRepository.findBalanceSnapshotForWrite(
+      seededUser.organizationId,
+    );
+    expect(original, "expected the seeded billing authority").toBeDefined();
+    const originalRevision = Number(original?.balance_revision);
+    expect(Number.isSafeInteger(originalRevision)).toBe(true);
+    expect(originalRevision).toBeGreaterThanOrEqual(0);
+
+    const snapshotStatuses: number[] = [];
+    authenticatedPage.on("response", (response) => {
+      if (new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH) {
+        snapshotStatuses.push(response.status());
+      }
+    });
+
+    await organizationsRepository.update(seededUser.organizationId, {
+      balance_revision: -1,
+    });
+    try {
+      await authenticatedPage.goto(
+        `${stack.urls.frontend}${LEGACY_BILLING_PAGE_PATH}`,
+        { timeout: 60_000 },
+      );
+      await expect(authenticatedPage).not.toHaveURL(/\/login(?:\?|$)/);
+      await expect(authenticatedPage).toHaveURL(
+        new RegExp(`${CANONICAL_BILLING_PAGE_PATH}$`),
+      );
+
+      await expect(
+        authenticatedPage.getByText("Balance unavailable", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByRole("heading", { name: "Active compute" }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(
+          "Active resources cannot be shown from this observation. No empty state is inferred.",
+          { exact: true },
+        ),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText("No active billable compute", {
+          exact: true,
+        }),
+      ).toBeHidden();
+      await expect(
+        authenticatedPage.getByRole("button", {
+          name: "Retry balance",
+        }),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByRole("button", {
+          name: "Retry",
+          exact: true,
+        }),
+      ).toBeVisible();
+      expect(snapshotStatuses.length).toBeGreaterThanOrEqual(1);
+      expect(snapshotStatuses.every((status) => status === 200)).toBe(true);
+    } finally {
+      await organizationsRepository.update(seededUser.organizationId, {
+        balance_revision: originalRevision,
+      });
+    }
+
+    const recoveredResponse = authenticatedPage.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH &&
+        response.status() === 200,
+    );
+    await authenticatedPage
+      .getByRole("button", { name: "Retry balance" })
+      .click();
+    await recoveredResponse;
+
+    await expect(
+      authenticatedPage.getByText("$1,000.00", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByText("No active billable compute", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    expect(snapshotStatuses.length).toBeGreaterThanOrEqual(2);
+    expect(snapshotStatuses.every((status) => status === 200)).toBe(true);
+  });
+
+  test("renders loading and failure honestly, then retries into the real empty snapshot", async ({
+    authenticatedPage,
+    stack,
+  }) => {
+    const backendFaults = stack.mocks.backendFaults;
+    expect(
+      backendFaults,
+      "stackOptions.backendFaults must expose the server-side fault controller",
+    ).toBeDefined();
+    if (!backendFaults) throw new Error("backend fault controller unavailable");
+
+    backendFaults.setFault({
+      path: BILLING_SNAPSHOT_PATH,
+      method: "GET",
+      status: 503,
+      body: {
+        success: false,
+        error: "Billing snapshot temporarily unavailable",
+        code: "billing_snapshot_unavailable",
+        retryable: true,
+      },
+      headers: { "Retry-After": "1" },
+      delayMs: 10_000,
+    });
+
+    const snapshotStatuses: number[] = [];
+    authenticatedPage.on("response", (response) => {
+      if (new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH) {
+        snapshotStatuses.push(response.status());
+      }
+    });
+
+    await authenticatedPage.goto(
+      `${stack.urls.frontend}${LEGACY_BILLING_PAGE_PATH}`,
+      {
+        timeout: 60_000,
+        waitUntil: "domcontentloaded",
+      },
+    );
+    await expect(authenticatedPage).not.toHaveURL(/\/login(?:\?|$)/);
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`${CANONICAL_BILLING_PAGE_PATH}$`),
+    );
+
+    await Promise.all([
+      expect(
+        authenticatedPage.getByRole("status", { name: "Loading balance" }),
+      ).toBeVisible(),
+      expect(
+        authenticatedPage.getByRole("status", {
+          name: "Loading active compute",
+        }),
+      ).toBeVisible(),
+    ]);
+
+    await expect(
+      authenticatedPage.getByText("Balance unavailable", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", {
+        name: "Active compute unavailable",
+      }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByText("No active billable compute", {
+        exact: true,
+      }),
+    ).toBeHidden();
+    await expect(
+      authenticatedPage.getByRole("button", {
+        name: "Retry balance",
+      }),
+    ).toBeHidden();
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Retry", exact: true }),
+    ).toBeVisible();
+    expect(snapshotStatuses.length).toBeGreaterThanOrEqual(1);
+    expect(snapshotStatuses.every((status) => status === 503)).toBe(true);
+    expect(backendFaults.faultHits).toBe(snapshotStatuses.length);
+
+    backendFaults.clearFault();
+    const recoveredResponse = authenticatedPage.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === BILLING_SNAPSHOT_PATH &&
+        response.status() === 200,
+    );
+    await authenticatedPage
+      .getByRole("button", { name: "Retry", exact: true })
+      .click();
+    await recoveredResponse;
+
+    await expect(
+      authenticatedPage.getByText("$1,000.00", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Active compute" }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByText("No active billable compute", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByText(
+        "No containers or agent sandboxes are currently reported as billable.",
+        { exact: true },
+      ),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByText("Active compute unavailable", {
+        exact: true,
+      }),
+    ).toBeHidden();
+    const first503 = snapshotStatuses.indexOf(503);
+    const first200AfterFailure = snapshotStatuses.findIndex(
+      (status, index) => index > first503 && status === 200,
+    );
+    expect(first503).toBeGreaterThanOrEqual(0);
+    expect(first200AfterFailure).toBeGreaterThan(first503);
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #24736.

This is the first bounded adversarial Billing snapshot slice. It does not claim
that the broader recurring-billing/refund suite is complete.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto
      `origin/develop@37f92987eeddd06620ce6ba35c414a6caa56bc19` with zero
      conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync;
      the exact unrelated `develop` failures are recorded below.
- [x] A reviewer can confirm the behavior from the exact-head video, trace,
      backend excerpt, and test results below.

# Sync with develop

- [x] Rebased onto `origin/develop@37f92987eeddd06620ce6ba35c414a6caa56bc19`;
      zero conflicts.
- [x] `bun run verify` was run at PR head
      `d31408732d682b854136ac4dcc8ec8a9c3fb5dad`; its unrelated i18n
      blocker is documented in **Known gaps / failures**.

# Risks

Low. Production and default E2E behavior are unchanged. The new proxy is
opt-in, test-only, bound to loopback, forwards unmatched HTTP/WebSocket traffic,
and refuses to start whenever `NODE_ENV=production` (including when
`CLOUD_E2E=1`). The main risk is E2E harness lifecycle/socket leakage; explicit
teardown and the focused real-stack run cover it.

# Background

## What does this PR do?

- Adds an opt-in server-side fault proxy to the local Cloud E2E stack with
  exact method/path faults, delay/status/body controls, hit counts, transparent
  forwarding, and deterministic teardown.
- Opens `/dashboard/billing` in the real combined app and asserts
  canonicalization to `/cloud/billing`, without `page.route` or browser-side
  response mocks.
- Uses a real same-org `shared` shell agent, explicitly asserts that persisted
  non-billable tier, and leaves all Billing account requests on the real Worker.
- Proves distinct pending and unavailable UI states, no inferred empty state,
  visible retry, an observed `503 -> 200` transition, server-owned balance, and
  the designed fresh-billable-resource empty state.
- Corrupts one PGlite balance revision for the unavailable-observation case and
  restores it in `finally`.

No Stripe/provider call, payment, refund, subscription, entitlement, quota
policy, migration, deploy, staging, production, or product UI behavior changes.

## What kind of change is this?

Improvement: adversarial end-to-end coverage and local test infrastructure.

# Documentation changes needed?

No project documentation change is needed. The proxy is private to the Cloud
E2E fixture and its contract is documented inline.

# Testing

## Where should a reviewer start?

Start with
`packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts`, then review
`packages/cloud/e2e/src/fixtures/backend-fault-proxy.ts` and the opt-in wiring in
`packages/cloud/e2e/src/fixtures/stack.ts`.

Independent exact-head review: no findings on
`d31408732d682b854136ac4dcc8ec8a9c3fb5dad`.

## Detailed testing steps

All passing commands below ran locally with Bun `1.3.14` at exact PR head
`d31408732d682b854136ac4dcc8ec8a9c3fb5dad`:

```bash
bun install --frozen-lockfile
# PASS: no changes

ELIZA_NODE_PATH=/opt/homebrew/bin/node E2E_RECORD=1 \
  bun run --cwd packages/cloud/e2e test \
  tests/billing-snapshot-adversarial.spec.ts
# PASS: 2 passed (44.2s)

bun run --cwd packages/cloud/e2e typecheck
# PASS

bun run --cwd packages/ui test \
  src/cloud/billing/components/active-compute-card.test.tsx \
  src/cloud/billing/data/billing-snapshot.test.tsx \
  src/cloud/billing/components/billing-tab.test.tsx
# PASS: 3 files, 51 tests

bunx @biomejs/biome check \
  packages/cloud/e2e/src/fixtures/backend-fault-proxy.ts \
  packages/cloud/e2e/src/fixtures/stack.ts \
  packages/cloud/e2e/tests/billing-snapshot-adversarial.spec.ts
# PASS

NODE_ENV=production CLOUD_E2E=1 bun -e '<production guard probe>'
# PASS: Error: [backend-fault-proxy] Refusing to start with NODE_ENV=production

git diff --check origin/develop...HEAD
# PASS
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d31408732d682b854136ac4dcc8ec8a9c3fb5dad -->

No rendered product file changes in this PR. A recorded walkthrough is still
provided because the new spec is frontend-testable. Every artifact below was
captured at the exact PR head and is not committed to the repository.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only Cloud E2E TypeScript diff; no rendered product UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only Cloud E2E TypeScript diff; the exact-head walkthrough demonstrates the existing surface.
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24819-billing-snapshot-recovery-d314087.mp4
<!-- evidence-row:backend-logs -->
- [x] [24819-billing-snapshot-backend-d314087.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24819-billing-snapshot-backend-d314087.log)
<!-- evidence-row:frontend-logs -->
- [x] [24819-billing-snapshot-frontend-d314087.jsonl](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24819-billing-snapshot-frontend-d314087.jsonl)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, provider, prompt, model, or LLM behavior change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - PGlite org and shared-agent state is ephemeral; the corrupted revision is restored in finally and the stack is removed at teardown.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI file or visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent action/provider/prompt/model behavior changes and no LLM call.

## Backend + frontend logs

The backend row contains a sanitized real-Worker excerpt showing stack health,
real agent creation, and real Billing snapshot `200` responses. The fault proxy
terminates the programmed `503`, so the attached Playwright trace is the source
of truth for the browser-visible `503 -> 200` network transition and UI state
change. The test also asserts the proxy hit count and ordered statuses.

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only `.ts` diff; no rendered product UI was changed.

### After

N/A - test-only `.ts` diff; no rendered product UI was changed. The recorded
walkthrough shows the existing Billing surface at the exact head.

### Walkthrough video

Attached in the evidence row as MP4. It covers loading, the injected 503,
unavailable states, visible Retry, real Worker recovery, and the designed empty
snapshot.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio change.

## Known gaps / failures

- `bun run verify` exits 1 at the pre-existing `check:i18n` gate before reaching
  this PR's checks: `en.json` is missing 14 `connectorcard.*` keys and the
  non-English locale catalogs have broad existing gaps. This PR changes no UI
  source or locale file; the focused E2E/typecheck/Biome lanes pass.
- Continuing the verification chain directly with monorepo typecheck/lint exits
  1 in the upstream-only
  `packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts`:
  Biome reports one formatting error. That path is absent from this PR diff.
- `bun run audit:scripts` independently exits 1 because the existing root
  `linux:bootstrap` script is orphaned. This PR changes no root scripts.
- One capture attempt used the ambient Node `22.20.0` and failed before any test
  because `packages/app` now requires Node 24+. The exact-head rerun explicitly
  selected `/opt/homebrew/bin/node` (`v25.5.0`) and passed 2/2 with artifacts.
- Repository `develop` workflow runs are systematically cancelled by the shared
  concurrency behavior, so no green `develop` claim is made. Evidence here is
  the local exact-head execution with real exit codes.

None of these failures intersects the three changed Cloud E2E files.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

