### PR TITLE
chore(cloud): apply Biome formatting to bounded transport files

### DIFF
--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
@@ -62,20 +62,18 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
 
   test("preserves caller cancellation (composed)", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = vi
-      .fn()
-      .mockImplementation(
-        (_input: RequestInfo | URL, init?: RequestInit) =>
-          new Promise<Response>((resolve, reject) => {
-            seen = init?.signal ?? undefined;
-            seen?.addEventListener("abort", () => {
-              reject(
-                new DOMException("The operation was aborted.", "AbortError"),
-              );
-            });
-            setTimeout(() => resolve(new Response("{}", { status: 200 })), 500);
-          }),
-      ) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          seen = init?.signal ?? undefined;
+          seen?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+          setTimeout(() => resolve(new Response("{}", { status: 200 })), 500);
+        }),
+    ) as unknown as typeof fetch;
 
     const { blooioFetch } = await import("./blooio");
     const controller = new AbortController();

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -16,8 +16,8 @@ import {
 } from "../../../db/repositories/phone-metadata-readers";
 import { agentPhoneContacts } from "../../../db/schemas/agent-phone-contacts";
 import { agentPhoneNumbers, type PhoneMessageLog } from "../../../db/schemas/agent-phone-numbers";
-import { logger } from "../../utils/logger";
 import { boundedProviderFetch } from "../../utils/bounded-provider-fetch";
+import { logger } from "../../utils/logger";
 
 import { normalizePhoneNumber } from "../../utils/phone-normalization";
 import {
@@ -47,7 +47,6 @@ export function messageRouterTwilioFetch(
     maxResponseBytes: MESSAGE_ROUTER_TWILIO_RESPONSE_MAX_BYTES,
   });
 }
-
 
 function isUndefinedTableError(error: unknown): boolean {
   return isPostgresUndefinedTableError(error);

--- a/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
+++ b/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
@@ -14,10 +14,7 @@ import { ElizaError } from "@elizaos/core";
 
 const MAX_TIMER_MS = 2_147_483_647;
 
-function cancelBodyDetached(
-  body: ReadableStream<Uint8Array> | null,
-  reason: unknown,
-): void {
+function cancelBodyDetached(body: ReadableStream<Uint8Array> | null, reason: unknown): void {
   if (!body) return;
   try {
     // error-policy:J6 The request has already failed; cancellation is detached


### PR DESCRIPTION
#24274 was merged at head 080aae72 while its "All Tests Passed" check was red on Biome formatting (run 32604509174). This applies the pinned Biome's `check --write` output to the three files it flagged — `gateway-webhook/src/adapters/blooio.fetch.test.ts`, `cloud/shared/src/lib/services/message-router/index.ts`, `cloud/shared/src/lib/utils/bounded-provider-fetch.ts` — restoring green `lint:check` for both packages. Formatting + import-sort only, no behavior change.

Verified locally at this head:
- `bunx @biomejs/biome check` clean in `packages/cloud/services/gateway-webhook` (52 files) and `packages/cloud/shared` (2322 files)
- `gateway-webhook-deadline.test.ts` + `blooio.fetch.test.ts`: 18 pass / 0 fail
- `message-router-deadline.test.ts`: 9 pass / 0 fail (pre-format head)
- typecheck clean in both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)