### PR TITLE
fix(cloud-shared): restore biome lint:check on develop (import sort + format drift)

### DIFF
--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -16,8 +16,8 @@ import {
 } from "../../../db/repositories/phone-metadata-readers";
 import { agentPhoneContacts } from "../../../db/schemas/agent-phone-contacts";
 import { agentPhoneNumbers, type PhoneMessageLog } from "../../../db/schemas/agent-phone-numbers";
-import { logger } from "../../utils/logger";
 import { boundedProviderFetch } from "../../utils/bounded-provider-fetch";
+import { logger } from "../../utils/logger";
 
 import { normalizePhoneNumber } from "../../utils/phone-normalization";
 import {
@@ -47,7 +47,6 @@ export function messageRouterTwilioFetch(
     maxResponseBytes: MESSAGE_ROUTER_TWILIO_RESPONSE_MAX_BYTES,
   });
 }
-
 
 function isUndefinedTableError(error: unknown): boolean {
   return isPostgresUndefinedTableError(error);

--- a/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
+++ b/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
@@ -14,10 +14,7 @@ import { ElizaError } from "@elizaos/core";
 
 const MAX_TIMER_MS = 2_147_483_647;
 
-function cancelBodyDetached(
-  body: ReadableStream<Uint8Array> | null,
-  reason: unknown,
-): void {
+function cancelBodyDetached(body: ReadableStream<Uint8Array> | null, reason: unknown): void {
   if (!body) return;
   try {
     // error-policy:J6 The request has already failed; cancellation is detached


### PR DESCRIPTION
origin/develop (37f92987eeddd) fails `@elizaos/cloud-shared` lint:check:

- `src/lib/services/message-router/index.ts` — import order (`bounded-provider-fetch` before `logger`) + stray blank line
- `src/lib/utils/bounded-provider-fetch.ts` — `cancelBodyDetached` signature formatting

Fix is `biome check --write` on those two files only. Formatting only; zero code-token changes.

Verified:
- `cd packages/cloud/shared && bunx @biomejs/biome check .` → clean (2320 files)
- `node packages/scripts/run-turbo.mjs run lint:check --filter=@elizaos/cloud-shared` → 1 successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)