### PR TITLE
fix(computeruse): preserve complete Brain ROI output

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -337,6 +337,15 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/result\.length\s*>=\s*50/,
 		/textContent\.trim\(\)\.slice\(/,
 	],
+	"plugins/plugin-computeruse/src/actor/brain.ts": [
+		/BRAIN_MAX_ROIS/,
+		/Cap ROIs to/,
+		/roi\s*=\s*[^;]*\.slice\(0,/,
+	],
+	"plugins/plugin-computeruse/src/actor/cascade.ts": [
+		/BRAIN_MAX_ROIS/,
+		/brainOut\.roi\.slice\(0,/,
+	],
 	"packages/browser-bridge-extension/src/page-extract.ts": [
 		/normalizeText\([^\n]+,\s*\d/,
 		/currentLength\s*>=/,

--- a/plugins/plugin-computeruse/src/__tests__/brain.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/brain.test.ts
@@ -9,14 +9,13 @@
  *   - The retry uses the *strict* prompt variant; on a second failure a
  *     `BrainParseError` surfaces so the cascade can return a structured
  *     error result instead of crashing.
- *   - ROI extraction is preserved through enforcement of the cap.
+ *   - Every valid ROI from the model is preserved.
  *   - The model receives a `data:image/png;base64,...` URL (no resizing
  *     happens client-side — adapters do that downstream).
  */
 
 import { describe, expect, it } from "vitest";
 import {
-  BRAIN_MAX_ROIS,
   Brain,
   BrainParseError,
   brainPromptFor,
@@ -179,9 +178,9 @@ describe("brainPromptFor", () => {
     expect(b).toContain("MUST emit ONLY a JSON");
   });
 
-  it("documents the ROI cap in the prompt", () => {
+  it("does not ask the model to discard ROIs", () => {
     const p = brainPromptFor("{}", "g", false);
-    expect(p).toContain(`Cap ROIs to ${BRAIN_MAX_ROIS}`);
+    expect(p).not.toMatch(/cap rois|maximum rois|first two rois/i);
   });
 });
 
@@ -264,8 +263,8 @@ describe("Brain.observeAndPlan", () => {
     ).rejects.toBeInstanceOf(BrainParseError);
   });
 
-  it("enforces the ROI cap", async () => {
-    const tooMany = Array.from({ length: BRAIN_MAX_ROIS + 3 }, (_, i) => ({
+  it("preserves every valid ROI", async () => {
+    const completeRois = Array.from({ length: 7 }, (_, i) => ({
       displayId: 0,
       bbox: [i, i, 1, 1] as [number, number, number, number],
       reason: `r${i}`,
@@ -275,7 +274,7 @@ describe("Brain.observeAndPlan", () => {
         JSON.stringify({
           scene_summary: "S",
           target_display_id: 0,
-          roi: tooMany,
+          roi: completeRois,
           proposed_action: { kind: "wait", rationale: "" },
         }),
     });
@@ -284,7 +283,7 @@ describe("Brain.observeAndPlan", () => {
       goal: "g",
       captures: captures(),
     });
-    expect(out.roi.length).toBe(BRAIN_MAX_ROIS);
+    expect(out.roi).toEqual(completeRois);
   });
 
   it("accepts an ImageDescriptionResult with `description` payload", async () => {

--- a/plugins/plugin-computeruse/src/__tests__/cascade.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/cascade.test.ts
@@ -320,7 +320,7 @@ describe("Cascade — click grounding paths", () => {
     expect(res.proposed.y).toBe(220);
   });
 
-  it("rois are truncated to the cascade cap in the result", async () => {
+  it("preserves all Brain ROIs in the cascade result", async () => {
     const cascade = new Cascade({
       brain: fakeBrain({
         scene_summary: "S",
@@ -338,7 +338,8 @@ describe("Cascade — click grounding paths", () => {
       goal: "g",
       captures: captures(),
     });
-    expect(res.rois.length).toBeLessThanOrEqual(2);
+    expect(res.rois).toHaveLength(3);
+    expect(res.rois.map((roi) => roi.reason)).toEqual(["r1", "r2", "r3"]);
   });
 
   it("no ref and no roi → can't resolve a click", async () => {

--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -51,7 +51,6 @@ import { resolveReference } from "./actor.js";
 import type { BrainOutput, BrainProposedAction, BrainRoi } from "./types.js";
 
 export const BRAIN_MAX_PIXELS = 1_310_720; // 1280 * 32 * 32 ≈ 1.3 MP cap
-export const BRAIN_MAX_ROIS = 2;
 /** Bound on the per-Brain dHash→BrainOutput cache (LRU-ish, oldest evicted). */
 export const BRAIN_DHASH_CACHE_MAX = 16;
 /**
@@ -387,16 +386,15 @@ export class Brain {
       if (imageless !== null) {
         const parsedImageless = tryParse(extractText(imageless));
         if (parsedImageless) {
-          const capped = enforceCaps(parsedImageless);
           // Keep the imageless plan when its target is grounded against the
           // OCR/AX boxes (or it needs no coordinate at all), OR when the policy
           // forbids ever attaching pixels. Otherwise fall through to escalation.
           if (
             this.imagePolicy === "never" ||
-            this.resolvesWithoutImage(input.scene, capped)
+            this.resolvesWithoutImage(input.scene, parsedImageless)
           ) {
             this.recordImageless(targetCapture.frame);
-            return this.rememberOutput(key, capped);
+            return this.rememberOutput(key, parsedImageless);
           }
         } else if (this.imagePolicy === "never") {
           // No pixels available to escalate to — strict-retry imageless once.
@@ -410,7 +408,7 @@ export class Brain {
           const parsedStrict = tryParse(rawStrict);
           if (parsedStrict) {
             this.recordImageless(targetCapture.frame);
-            return this.rememberOutput(key, enforceCaps(parsedStrict));
+            return this.rememberOutput(key, parsedStrict);
           }
           throw new BrainParseError(
             "Brain output is not valid JSON conforming to BrainOutput after retry",
@@ -431,7 +429,7 @@ export class Brain {
       displayId,
     });
     const parsed = tryParse(extractText(first));
-    if (parsed) return this.rememberOutput(key, enforceCaps(parsed));
+    if (parsed) return this.rememberOutput(key, parsed);
     // Strict retry — same image, stricter prompt.
     this.invocations += 1;
     const second = await this.invoke({
@@ -441,7 +439,7 @@ export class Brain {
     });
     const rawSecond = extractText(second);
     const parsedRetry = tryParse(rawSecond);
-    if (parsedRetry) return this.rememberOutput(key, enforceCaps(parsedRetry));
+    if (parsedRetry) return this.rememberOutput(key, parsedRetry);
     throw new BrainParseError(
       "Brain output is not valid JSON conforming to BrainOutput after retry",
       rawSecond,
@@ -536,7 +534,7 @@ export function brainPromptFor(
     "  }",
     "}",
     "",
-    `Cap ROIs to ${BRAIN_MAX_ROIS}. Use action kind "finish" when the goal is already accomplished, "wait" when the screen is mid-transition.`,
+    'Use action kind "finish" when the goal is already accomplished, "wait" when the screen is mid-transition.',
     strict
       ? "Return raw JSON. No fences, no commentary, no extra fields."
       : "Output JSON only (a single object). Markdown fences are optional but will be stripped.",
@@ -651,13 +649,6 @@ export function parseBrainOutput(raw: string): BrainOutput {
     },
   };
   return validated;
-}
-
-function enforceCaps(out: BrainOutput): BrainOutput {
-  if (out.roi.length > BRAIN_MAX_ROIS) {
-    out.roi = out.roi.slice(0, BRAIN_MAX_ROIS);
-  }
-  return out;
 }
 
 function extractText(value: string | ImageDescriptionResult): string {

--- a/plugins/plugin-computeruse/src/actor/cascade.ts
+++ b/plugins/plugin-computeruse/src/actor/cascade.ts
@@ -2,9 +2,9 @@
  * WS7 — ScreenSeekeR cascade.
  *
  * Step 1: Brain looks at the full-screen scene for `target_display_id`.
- * Step 2: For each ROI (up to BRAIN_MAX_ROIS), crop the *native resolution*
- *         region from the captured PNG and hand it to the Actor for
- *         fine grounding. The Actor returns display-local coords.
+ * Step 2: Preserve every Brain ROI and use the first region, when needed, for
+ *         fine grounding at native resolution. The Actor returns display-local
+ *         coordinates without rewriting the Brain output.
  * Step 3: Combine the Brain's proposed action with the Actor's coordinates
  *         (or fall back to the OCR/AX deterministic actor on `ref`) and
  *         produce a single `ProposedAction` for the dispatcher.
@@ -23,7 +23,7 @@ import type { DisplayCapture } from "../platform/capture.js";
 import type { Scene } from "../scene/scene-types.js";
 import type { Actor, ActorGroundArgs } from "./actor.js";
 import { resolveReference } from "./actor.js";
-import { BRAIN_MAX_ROIS, type Brain } from "./brain.js";
+import type { Brain } from "./brain.js";
 import type { BrainOutput, BrainRoi, CascadeResult } from "./types.js";
 
 export interface CascadeDeps {
@@ -127,7 +127,7 @@ export class Cascade {
     if (action.kind === "wait" || action.kind === "finish") {
       return {
         scene_summary: brainOut.scene_summary,
-        rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+        rois: brainOut.roi,
         proposed: {
           kind: action.kind,
           displayId: targetDisplay,
@@ -145,7 +145,7 @@ export class Cascade {
       }
       return {
         scene_summary: brainOut.scene_summary,
-        rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+        rois: brainOut.roi,
         proposed: {
           kind: "type",
           displayId: targetDisplay,
@@ -163,7 +163,7 @@ export class Cascade {
       }
       return {
         scene_summary: brainOut.scene_summary,
-        rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+        rois: brainOut.roi,
         proposed: {
           kind: "hotkey",
           displayId: targetDisplay,
@@ -181,7 +181,7 @@ export class Cascade {
       }
       return {
         scene_summary: brainOut.scene_summary,
-        rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+        rois: brainOut.roi,
         proposed: {
           kind: "key",
           displayId: targetDisplay,
@@ -204,7 +204,7 @@ export class Cascade {
       const cy = anchor?.y ?? Math.round((display?.bounds[3] ?? 0) / 2);
       return {
         scene_summary: brainOut.scene_summary,
-        rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+        rois: brainOut.roi,
         proposed: {
           kind: "scroll",
           displayId: targetDisplay,
@@ -235,7 +235,7 @@ export class Cascade {
       }
       return {
         scene_summary: brainOut.scene_summary,
-        rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+        rois: brainOut.roi,
         proposed: {
           kind: "drag",
           displayId: targetDisplay,
@@ -256,7 +256,7 @@ export class Cascade {
     }
     return {
       scene_summary: brainOut.scene_summary,
-      rois: brainOut.roi.slice(0, BRAIN_MAX_ROIS),
+      rois: brainOut.roi,
       proposed: {
         kind: action.kind,
         displayId: coords.displayId,
@@ -322,7 +322,7 @@ export class Cascade {
     }
     // Strategy 2: fine grounding on the first ROI via the registered actor.
     if (this.deps.actor && brainOut.roi.length > 0) {
-      const roi = brainOut.roi.slice(0, BRAIN_MAX_ROIS)[0];
+      const roi = brainOut.roi[0];
       if (!roi) return null;
       const grounded = await this.groundRoi(input, brainOut, roi);
       if (grounded) return grounded;

--- a/plugins/plugin-computeruse/src/actor/index.ts
+++ b/plugins/plugin-computeruse/src/actor/index.ts
@@ -46,7 +46,6 @@ export {
 } from "./agent-loop.js";
 export {
   BRAIN_MAX_PIXELS,
-  BRAIN_MAX_ROIS,
   Brain,
   type BrainDeps,
   type BrainInput,


### PR DESCRIPTION
Closes #24817

## What changed
- remove the prompt instruction limiting Brain output to two ROIs
- remove the post-parse first-two rewrite
- preserve every valid ROI in every cascade result
- explicitly use `roi[0]` only at the single-region coordinate-grounding decision without changing the underlying output
- remove the cap export and add prompt-integrity source guards

## Verification
- plugin-computeruse focused Brain/cascade tests: 31 passed
- core prompt-integrity policy tests: 4 passed
- Biome check on all six touched files
- package typecheck was attempted but this sparse isolated worktree lacks existing optional Drizzle, Puppeteer, and nut-js dependency artifacts; the errors are module-resolution-only and outside the touched surfaces

The model output and returned action result now agree exactly; no later first-N slice can hide a grounding candidate.