### PR TITLE
fix(agent): preserve typed coding terminal failures across adapters

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
@@ -345,6 +345,43 @@ describe("conversation failureKind round-trip", () => {
     expect(assistant?.failureKind).toBe("insufficient_credits");
   });
 
+  it("GET /messages re-emits the complete typed terminal failure", async () => {
+    const state = createState([
+      userMemory(),
+      assistantMemory({
+        text: "Shell execution failed.",
+        failureKind: "coding_tool_failure",
+        terminalFailure: {
+          kind: "coding_tool_failure",
+          message: "Shell execution failed.",
+          transient: true,
+          code: "SHELL_UNAVAILABLE",
+        },
+      }),
+    ]);
+    const { ctx, captured } = createCtx(
+      "GET",
+      "/api/conversations/conv-1/messages",
+      state,
+    );
+
+    await handleConversationRoutes(ctx);
+
+    const payload = captured.payload as {
+      messages: Array<{
+        role: string;
+        terminalFailure?: Record<string, unknown>;
+      }>;
+    };
+    const assistant = payload.messages.find((m) => m.role === "assistant");
+    expect(assistant?.terminalFailure).toEqual({
+      kind: "coding_tool_failure",
+      message: "Shell execution failed.",
+      transient: true,
+      code: "SHELL_UNAVAILABLE",
+    });
+  });
+
   it.each([
     "handler_error",
     "missing_capability",

--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -391,12 +391,14 @@ function parseDataFrames(record: MockResponseRecord): Array<{
   type: string;
   fullText?: string;
   messageId?: string;
+  userMessageId?: string;
   agentName?: string;
   transcriptVisibility?: "internal";
   thought?: string;
   usage?: unknown;
   actionResults?: unknown;
   failureKind?: string;
+  terminalFailure?: unknown;
   accountConnect?: unknown;
   localInference?: unknown;
   noResponseReason?: "ignored";
@@ -412,12 +414,14 @@ function parseDataFrames(record: MockResponseRecord): Array<{
           type: string;
           fullText?: string;
           messageId?: string;
+          userMessageId?: string;
           agentName?: string;
           transcriptVisibility?: "internal";
           thought?: string;
           usage?: unknown;
           actionResults?: unknown;
           failureKind?: string;
+          terminalFailure?: unknown;
           accountConnect?: unknown;
           localInference?: unknown;
           noResponseReason?: "ignored";
@@ -657,7 +661,13 @@ describe("conversation-route chat idempotency wiring", () => {
         llmCalls: 1,
       },
       actionResults: [{ actionName: "VIEWS", success: true }],
-      failureKind: "no_provider",
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
       accountConnect: { providers: ["openai-codex"] },
       localInference: { status: "ready" },
     });
@@ -676,7 +686,13 @@ describe("conversation-route chat idempotency wiring", () => {
         thought: "private reasoning",
         usage: expect.objectContaining({ totalTokens: 10 }),
         actionResults: [{ actionName: "VIEWS", success: true }],
-        failureKind: "no_provider",
+        failureKind: "coding_tool_failure",
+        terminalFailure: {
+          kind: "coding_tool_failure",
+          message: "Shell execution failed.",
+          transient: true,
+          code: "SHELL_UNAVAILABLE",
+        },
         accountConnect: { providers: ["openai-codex"] },
         localInference: { status: "ready" },
       }),
@@ -692,7 +708,13 @@ describe("conversation-route chat idempotency wiring", () => {
       messageId: stringToUuid("terminal-contract-reply"),
       transcriptVisibility: "internal",
       actionResults: [{ actionName: "VIEWS", success: true }],
-      failureKind: "no_provider",
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
       accountConnect: { providers: ["openai-codex"] },
       localInference: { status: "ready" },
     });
@@ -1091,6 +1113,84 @@ describe("conversation-route chat idempotency wiring", () => {
     expect(
       parseDataFrames(retry.record).find((frame) => frame.type === "done"),
     ).toEqual(firstDone);
+    expect(updateMemory.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("SSE: a typed terminal failure survives outcome-marker settlement failure and restart", async () => {
+    const { state, handleMessage, updateMemory, createMemory, storedMemories } =
+      createHarness({ failOutcomeSettlementOnce: true });
+    handleMessage.mockImplementationOnce(
+      async (_runtime: unknown, _message: unknown, callback: unknown) => {
+        await (
+          callback as ((content: { text: string }) => Promise<void>) | undefined
+        )?.({ text: "Done." });
+        return {
+          didRespond: true,
+          responseContent: null,
+          responseMessages: [],
+          terminalFailure: {
+            kind: "coding_tool_failure",
+            message: "Shell execution failed.",
+            transient: true,
+            code: "SHELL_UNAVAILABLE",
+          },
+          mode: "actions" as const,
+        };
+      },
+    );
+    const body = {
+      text: "fix the code",
+      clientMessageId: "typed-failure-settlement-restart-1",
+    };
+
+    const first = await runRoute("POST", STREAM_PATH, state, body);
+    const firstDone = parseDataFrames(first.record).find(
+      (frame) => frame.type === "done",
+    );
+    expect(firstDone).toMatchObject({
+      type: "done",
+      fullText: "Shell execution failed.",
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
+      messageId: expect.any(String),
+    });
+    const receipt = storedMemories.find(
+      (memory) => memory.id === firstDone?.messageId,
+    );
+    expect(receipt?.content).toMatchObject({
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        transient: true,
+      },
+    });
+    const persistsAfterFailure = createMemory.mock.calls.length;
+
+    resetChatDedupe();
+    const retry = await runRoute("POST", STREAM_PATH, state, body);
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(createMemory).toHaveBeenCalledTimes(persistsAfterFailure);
+    expect(
+      parseDataFrames(retry.record).find((frame) => frame.type === "done"),
+    ).toMatchObject({
+      type: "done",
+      fullText: "Shell execution failed.",
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
+      messageId: firstDone?.messageId,
+      userMessageId: firstDone?.userMessageId,
+    });
     expect(updateMemory.mock.calls.length).toBeGreaterThan(1);
   });
 

--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -699,6 +699,35 @@ function createEphemeralReplyMessageService(
   } satisfies NonNullable<AgentRuntime["messageService"]>;
 }
 
+function createCallbackTerminalFailureMessageService(
+  failureKind: "coding_mutation_unverified" | "coding_tool_failure",
+): NonNullable<AgentRuntime["messageService"]> {
+  return {
+    async handleMessage(_runtime, _message, callback) {
+      await callback?.({ text: "Done." });
+      return {
+        didRespond: true,
+        responseContent: null,
+        responseMessages: [],
+        terminalFailure: {
+          kind: failureKind,
+          transient: true,
+          message: "Shell execution failed.",
+          code: "SHELL_UNAVAILABLE",
+        },
+        mode: "actions" as const,
+      };
+    },
+    shouldRespond: () => ({
+      shouldRespond: true,
+      skipEvaluation: true,
+      reason: "typed-coding-failure-stream-contract-test",
+    }),
+    deleteMessage: async () => undefined,
+    clearChannel: async () => undefined,
+  } satisfies NonNullable<AgentRuntime["messageService"]>;
+}
+
 function createState(
   messageServiceOverride?: NonNullable<AgentRuntime["messageService"]>,
 ): {
@@ -2530,6 +2559,52 @@ describe("conversation stream SSE contract (#10712)", () => {
         failureKind,
       });
       expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["coding_mutation_unverified", "coding_tool_failure"] as const)(
+    "makes typed %s authoritative when callback prose disagrees",
+    async (failureKind) => {
+      const { ctx, record, state } = createCtx(
+        createCallbackTerminalFailureMessageService(failureKind),
+      );
+      const emitEvent = vi.mocked(
+        state.runtime?.emitEvent as NonNullable<AgentRuntime["emitEvent"]>,
+      );
+
+      await handleConversationRoutes(ctx);
+
+      const done = parseSsePayloads(record.writes).find(
+        (payload) => payload.type === "done",
+      );
+      expect(done).toMatchObject({
+        type: "done",
+        fullText: "Shell execution failed.",
+        failureKind,
+        terminalFailure: {
+          kind: failureKind,
+          message: "Shell execution failed.",
+          transient: true,
+          code: "SHELL_UNAVAILABLE",
+        },
+      });
+      const messageSentCall = emitEvent.mock.calls.find(
+        ([eventType]) => eventType === "MESSAGE_SENT",
+      );
+      expect(messageSentCall?.[1]).toMatchObject({
+        message: {
+          content: {
+            text: "Shell execution failed.",
+            failureKind,
+            terminalFailure: {
+              kind: failureKind,
+              message: "Shell execution failed.",
+              transient: true,
+              code: "SHELL_UNAVAILABLE",
+            },
+          },
+        },
+      });
     },
   );
 

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -61,6 +61,7 @@ import {
 } from "@elizaos/core";
 import type {
   ChatFailureKind,
+  ChatTerminalFailure,
   ChatToolCallEvent,
   ChatTurnStatus,
   LinkedAccountProviderId,
@@ -74,6 +75,7 @@ import {
   isLinkedAccountProviderId,
   normalizeCharacterLanguage,
   parseChatFailureKind,
+  parseChatTerminalFailure,
   readAliasedEnv,
   resolveStreamingUpdate,
 } from "@elizaos/shared";
@@ -304,6 +306,7 @@ export interface ChatMessageIdOutcome {
   usage?: ChatGenerationResult["usage"];
   actionResults?: ChatActionResultSummary[];
   failureKind?: ChatFailureKind;
+  terminalFailure?: ChatTerminalFailure;
   accountConnect?: AccountConnectRequest;
   localInference?: LocalInferenceChatMetadata;
   noResponseReason?: "ignored";
@@ -929,6 +932,7 @@ export interface ChatGenerationResult {
   thought?: string;
   noResponseReason?: "ignored";
   failureKind?: ChatFailureKind;
+  terminalFailure?: ChatTerminalFailure;
   /** Structured "connect another account" request carried from the CONNECT_ACCOUNT action. */
   accountConnect?: AccountConnectRequest;
   localInference?: LocalInferenceChatMetadata;
@@ -1593,6 +1597,29 @@ export function markSyntheticChatFailureContent<T extends Content>(
       chatFailureKind: failureKind,
     },
   } as T;
+}
+
+/** Keeps append-only delivery truthful when a late typed failure contradicts prose. */
+function terminalFailureVisibleText(
+  deliveredText: string,
+  failure: ChatTerminalFailure,
+): string {
+  const delivered = deliveredText.trimEnd();
+  if (!delivered) return failure.message;
+  if (delivered.includes(failure.message)) return deliveredText;
+  return `${delivered}\n\nTask failed: ${failure.message}`;
+}
+
+/** Converts the public DTO to Content's JSON-compatible indexed object shape. */
+function terminalFailureContentValue(
+  failure: ChatTerminalFailure,
+): Record<string, string | boolean> {
+  return {
+    kind: failure.kind,
+    message: failure.message,
+    transient: failure.transient,
+    ...(failure.code ? { code: failure.code } : {}),
+  };
 }
 
 function normalizeActionName(value: unknown): string {
@@ -3489,6 +3516,7 @@ async function generateChatResponseWithTiming(
           >
         >
       | undefined;
+    let terminalFailure: ChatTerminalFailure | undefined;
     let trajectoryTerminalOwner: "run" | undefined;
     const settledActionResults: ActionResult[] = [];
     let capturedUsage: CapturedModelUsage | null = null;
@@ -3852,6 +3880,19 @@ async function generateChatResponseWithTiming(
           // disconnect. The remaining path finalizes that result and only runs
           // new work while the owner signal is live.
 
+          terminalFailure = parseChatTerminalFailure(result?.terminalFailure);
+          if (terminalFailure) {
+            const failureText =
+              opts?.onChunk && !opts.onSnapshot
+                ? terminalFailureVisibleText(responseText, terminalFailure)
+                : terminalFailure.message;
+            if (opts?.onSnapshot) {
+              emitSnapshot(failureText);
+            } else {
+              responseText = failureText;
+            }
+          }
+
           // Ensure MESSAGE_SENT hooks run for API chat flows.
           try {
             const responseMessages = Array.isArray(result?.responseMessages)
@@ -3860,13 +3901,21 @@ async function generateChatResponseWithTiming(
                   content?: Content;
                 }>)
               : [];
-            const fallbackResponseContent =
+            const baseFallbackResponseContent =
               result?.responseContent &&
               typeof result.responseContent === "object"
                 ? (result.responseContent as Content)
                 : responseText
                   ? ({ text: responseText } as Content)
                   : null;
+            const fallbackResponseContent = terminalFailure
+              ? ({
+                  ...(baseFallbackResponseContent ?? {}),
+                  text: responseText,
+                  failureKind: terminalFailure.kind,
+                  terminalFailure: terminalFailureContentValue(terminalFailure),
+                } satisfies Content)
+              : baseFallbackResponseContent;
             // Safety net ONLY for flows where the message handler produced no
             // responseMessages of its own. When responseMessages exist the
             // handler already emitted MESSAGE_SENT for each (message.ts), so
@@ -4154,7 +4203,9 @@ async function generateChatResponseWithTiming(
       ? null
       : await resolveExactDocumentValueForChat(runtime, message);
     const normalizedResponseText = trimWalletProgressPrefix(
-      exactDocumentValue || responseText || resultText || "",
+      terminalFailure
+        ? responseText
+        : exactDocumentValue || responseText || resultText || "",
     );
     const intentionalNoResponse = isIntentionalNoResponseResult(
       result,
@@ -4214,12 +4265,22 @@ async function generateChatResponseWithTiming(
           (id): id is UUID => typeof id === "string" && id.length > 0,
         )
       : [];
+    const terminalFailureKind = terminalFailure?.kind;
     const responseContent: Content | null =
       result?.responseContent && typeof result.responseContent === "object"
         ? (() => {
             const content = {
               ...result.responseContent,
               text: finalText,
+              ...(terminalFailureKind
+                ? { failureKind: terminalFailureKind }
+                : {}),
+              ...(terminalFailure
+                ? {
+                    terminalFailure:
+                      terminalFailureContentValue(terminalFailure),
+                  }
+                : {}),
             } satisfies Content;
             delete content.transcriptVisibility;
             if (transcriptVisibility) {
@@ -4230,6 +4291,15 @@ async function generateChatResponseWithTiming(
         : finalText
           ? ({
               text: finalText,
+              ...(terminalFailureKind
+                ? { failureKind: terminalFailureKind }
+                : {}),
+              ...(terminalFailure
+                ? {
+                    terminalFailure:
+                      terminalFailureContentValue(terminalFailure),
+                  }
+                : {}),
               ...(transcriptVisibility ? { transcriptVisibility } : {}),
             } satisfies Content)
           : null;
@@ -4249,8 +4319,9 @@ async function generateChatResponseWithTiming(
         ? responseRecord.localInference
         : undefined;
     const responseMetadata = asRecord(responseRecord?.metadata);
-    const rawFailureKind =
-      typeof responseRecord?.failureKind === "string"
+    const rawFailureKind = terminalFailureKind
+      ? terminalFailureKind
+      : typeof responseRecord?.failureKind === "string"
         ? responseRecord.failureKind
         : typeof responseMetadata?.chatFailureKind === "string"
           ? responseMetadata.chatFailureKind
@@ -4310,6 +4381,7 @@ async function generateChatResponseWithTiming(
         ? { noResponseReason: "ignored" as const }
         : {}),
       ...(failureKind ? { failureKind } : {}),
+      ...(terminalFailure ? { terminalFailure } : {}),
       ...(accountConnect ? { accountConnect } : {}),
       ...(localInference ? { localInference } : {}),
       ...(usedActionCallbacks ? { usedActionCallbacks: true } : {}),

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -51,7 +51,7 @@ import {
   isScheduledTask,
   type ScheduledTask,
 } from "@elizaos/plugin-scheduling";
-import type { ChatFailureKind } from "@elizaos/shared";
+import type { ChatFailureKind, ChatTerminalFailure } from "@elizaos/shared";
 import {
   isChatFailureKind,
   LOCAL_VOICE_RUNTIME_AGENT_HEADER,
@@ -62,6 +62,7 @@ import {
   PostConversationTruncateRequestSchema,
   PostSeedMessagesRequestSchema,
   parseChatFailureKind,
+  parseChatTerminalFailure,
   parsePositiveInteger,
 } from "@elizaos/shared";
 import {
@@ -1426,6 +1427,7 @@ const DURABLE_CHAT_OUTCOME_KEYS = new Set([
   "usage",
   "actionResults",
   "failureKind",
+  "terminalFailure",
   "accountConnect",
   "localInference",
   "noResponseReason",
@@ -1536,6 +1538,8 @@ function parseDurableConversationChatOutcome(
         !outcome.actionResults.every(isDurableChatActionResult))) ||
     (outcome.failureKind !== undefined &&
       !isChatFailureKind(outcome.failureKind)) ||
+    (outcome.terminalFailure !== undefined &&
+      parseChatTerminalFailure(outcome.terminalFailure) === undefined) ||
     (outcome.accountConnect !== undefined &&
       normalizeAccountConnectRequest(outcome.accountConnect) === null) ||
     (outcome.localInference !== undefined &&
@@ -1551,6 +1555,7 @@ function parseDurableConversationChatOutcome(
     outcome.accountConnect === undefined
       ? undefined
       : normalizeAccountConnectRequest(outcome.accountConnect);
+  const terminalFailure = parseChatTerminalFailure(outcome.terminalFailure);
   return {
     text: outcome.text,
     agentName: outcome.agentName,
@@ -1585,6 +1590,7 @@ function parseDurableConversationChatOutcome(
     ...(typeof outcome.failureKind === "string"
       ? { failureKind: outcome.failureKind as ChatFailureKind }
       : {}),
+    ...(terminalFailure ? { terminalFailure } : {}),
     ...(accountConnect ? { accountConnect } : {}),
     ...(outcome.localInference !== undefined
       ? {
@@ -1636,6 +1642,7 @@ function buildRecoveredConversationChatOutcome(
 ): ChatMessageIdOutcome {
   const content = memory.content as Content;
   const failureKind = parseChatFailureKind(content.failureKind);
+  const terminalFailure = parseChatTerminalFailure(content.terminalFailure);
   const accountConnect = normalizeAccountConnectRequest(content.accountConnect);
   const localInference =
     content.localInference && typeof content.localInference === "object"
@@ -1653,6 +1660,7 @@ function buildRecoveredConversationChatOutcome(
       ? { thought: content.thought }
       : {}),
     ...(failureKind ? { failureKind } : {}),
+    ...(terminalFailure ? { terminalFailure } : {}),
     ...(accountConnect ? { accountConnect } : {}),
     ...(localInference ? { localInference } : {}),
     ...(normalizeActionCallbackHistory(content.actionCallbackHistory).length > 0
@@ -2095,6 +2103,9 @@ function buildGenerationMessageIdOutcome(
       ? { actionResults: result.actionResults }
       : {}),
     ...(result.failureKind ? { failureKind: result.failureKind } : {}),
+    ...(result.terminalFailure
+      ? { terminalFailure: result.terminalFailure }
+      : {}),
     ...(result.accountConnect ? { accountConnect: result.accountConnect } : {}),
     ...(result.localInference ? { localInference: result.localInference } : {}),
     ...(result.noResponseReason
@@ -2120,6 +2131,9 @@ function buildConversationJsonOutcome(
       ? { actionResults: outcome.actionResults }
       : {}),
     ...(outcome.failureKind ? { failureKind: outcome.failureKind } : {}),
+    ...(outcome.terminalFailure
+      ? { terminalFailure: outcome.terminalFailure }
+      : {}),
     ...(outcome.accountConnect
       ? { accountConnect: outcome.accountConnect }
       : {}),
@@ -2450,6 +2464,8 @@ type ConversationRouteMessageRecord = {
    * here so the renderer's gate + Retry survive a GET /messages full-replace.
    */
   failureKind?: ChatFailureKind;
+  /** Complete typed terminal failure retained across history reloads. */
+  terminalFailure?: ChatTerminalFailure;
   /**
    * Structured "connect another account" request from the CONNECT_ACCOUNT
    * action. Persisted on the assistant memory as `content.accountConnect`
@@ -3145,6 +3161,9 @@ export async function handleConversationRoutes(
                 ? meta.chatFailureKind
                 : undefined;
           const failureKind = parseChatFailureKind(rawFailureKind);
+          const terminalFailure = parseChatTerminalFailure(
+            content.terminalFailure,
+          );
           // The CONNECT_ACCOUNT action stamps `content.accountConnect` on the
           // assistant memory. Validate + round-trip it so the inline
           // AddAccountDialog entry point survives the GET /messages replace.
@@ -3241,6 +3260,7 @@ export async function handleConversationRoutes(
             senderEntityId:
               typeof m.entityId === "string" ? m.entityId : undefined,
             ...(failureKind ? { failureKind } : {}),
+            ...(terminalFailure ? { terminalFailure } : {}),
             ...(accountConnect ? { accountConnect } : {}),
             ...(interrupted ? { interrupted: true } : {}),
           } satisfies ConversationRouteMessageRecord;
@@ -4148,6 +4168,38 @@ export async function handleConversationRoutes(
         }
         settleTurnReservationInMemory(outcome);
       };
+      const settleDurableAssistantOutcome = async (
+        outcome: ChatMessageIdOutcome,
+      ): Promise<void> => {
+        try {
+          await settleTurnReservation(outcome);
+        } catch (settlementError) {
+          assertLocalVoiceTurnFence();
+          // error-policy:J7 the assistant reply is already durable and can be
+          // reconstructed by its in-reply-to link after restart. Preserve the
+          // truthful terminal locally while reporting the failed marker write.
+          settleTurnReservationInMemory(outcome);
+          runtime.reportError(
+            "ConversationStream.durableReplySettlement",
+            settlementError,
+            {
+              conversationId: conv.id,
+              roomId: conv.roomId,
+              clientMessageId,
+              messageId: outcome.messageId,
+            },
+          );
+          logger.warn(
+            {
+              err: getErrorMessage(settlementError),
+              conversationId: conv.id,
+              roomId: conv.roomId,
+              messageId: outcome.messageId,
+            },
+            "[ConversationStream] durable assistant reply persisted but outcome marker settlement failed",
+          );
+        }
+      };
       const idempotencyAdmission = await awaitConversationChatAdmission(
         chatIdempotencyScope,
         clientMessageId ?? null,
@@ -4657,7 +4709,11 @@ export async function handleConversationRoutes(
                   : {}),
               },
             );
-            await settleTurnReservation(outcome);
+            if (persistedAssistant.kind === "durable") {
+              await settleDurableAssistantOutcome(outcome);
+            } else {
+              await settleTurnReservation(outcome);
+            }
             assertConversationConnectionRuntime(
               state.runtime,
               connectionDescriptor,

--- a/packages/agent/src/cli/benchmark.test.ts
+++ b/packages/agent/src/cli/benchmark.test.ts
@@ -204,6 +204,42 @@ describe("runBenchmarkTask", () => {
       error: "reply gate declined",
     });
   });
+
+  it("does not report callback-delivered terminal failure prose as success", async () => {
+    const runtime = createRuntime();
+    installCodingActions(runtime);
+    vi.spyOn(getMessageService(runtime), "handleMessage").mockImplementation(
+      async (_runtime, _message, callback) => {
+        await callback?.({
+          text: "I changed files but could not verify the coding task.",
+        });
+        return {
+          didRespond: true,
+          responseContent: null,
+          responseMessages: [],
+          terminalFailure: {
+            kind: "coding_mutation_unverified",
+            transient: false,
+            message: "Coding changes were not verified.",
+          },
+        };
+      },
+    );
+
+    await expect(
+      runBenchmarkTask(
+        runtime,
+        { id: "typed-failure", type: "coding", prompt: "Fix the parser" },
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({
+      response: "I changed files but could not verify the coding task.",
+      success: false,
+      error: "Coding changes were not verified.",
+      failure_kind: "coding_mutation_unverified",
+      transient: false,
+    });
+  });
 });
 
 describe("parseBenchmarkTask", () => {

--- a/packages/agent/src/cli/benchmark.ts
+++ b/packages/agent/src/cli/benchmark.ts
@@ -35,6 +35,9 @@ export interface BenchmarkResult {
   duration_ms: number;
   success: boolean;
   error?: string;
+  failure_kind?: string;
+  failure_code?: string;
+  transient?: boolean;
 }
 
 const REQUIRED_CODING_ACTIONS = ["READ", "WRITE", "EDIT", "SHELL"] as const;
@@ -162,7 +165,10 @@ export async function runBenchmarkTask(
     // the final answer with duplicated chunks or verbose action output.
     const responseText =
       resultText || messagesText || streamText || callbackText || "";
-    const success = result.didRespond && responseText.trim().length > 0;
+    const success =
+      result.terminalFailure === undefined &&
+      result.didRespond &&
+      responseText.trim().length > 0;
 
     return {
       id: task.id,
@@ -172,7 +178,21 @@ export async function runBenchmarkTask(
       duration_ms: Math.round(performance.now() - start),
       success,
       ...(!success
-        ? { error: result.reason ?? "Agent completed without a response" }
+        ? {
+            error:
+              result.terminalFailure?.message ??
+              result.reason ??
+              "Agent completed without a response",
+            ...(result.terminalFailure
+              ? {
+                  failure_kind: result.terminalFailure.kind,
+                  ...(result.terminalFailure.code
+                    ? { failure_code: result.terminalFailure.code }
+                    : {}),
+                  transient: result.terminalFailure.transient,
+                }
+              : {}),
+          }
         : {}),
     };
   } catch (err) {

--- a/packages/shared/src/contracts/chat.test.ts
+++ b/packages/shared/src/contracts/chat.test.ts
@@ -18,6 +18,7 @@ import {
   isChatFailureKind,
   isRetryableChatFailureKind,
   parseChatFailureKind,
+  parseChatTerminalFailure,
   RETRYABLE_CHAT_FAILURE_KINDS,
 } from "./chat.js";
 
@@ -57,10 +58,10 @@ describe("ChatTurnStatus contract", () => {
 });
 
 describe("ChatFailureKind contract", () => {
-  it("covers exactly the ten turn-failure discriminators", () => {
+  it("covers exactly the twelve turn-failure discriminators", () => {
     const kinds: ChatFailureKind[] = [...CHAT_FAILURE_KINDS];
     expect(new Set(kinds).size).toBe(kinds.length);
-    expect(kinds).toHaveLength(10);
+    expect(kinds).toHaveLength(12);
     expect(kinds).toEqual([
       "insufficient_credits",
       "missing_capability",
@@ -72,6 +73,8 @@ describe("ChatFailureKind contract", () => {
       "handler_error",
       "persistence_error",
       "local_inference",
+      "coding_mutation_unverified",
+      "coding_tool_failure",
     ]);
   });
 
@@ -102,5 +105,39 @@ describe("ChatFailureKind contract", () => {
     expect(isRetryableChatFailureKind("missing_capability")).toBe(false);
     expect(isRetryableChatFailureKind("no_provider")).toBe(false);
     expect(isRetryableChatFailureKind("insufficient_credits")).toBe(false);
+    expect(isRetryableChatFailureKind("coding_mutation_unverified")).toBe(
+      false,
+    );
+    expect(isRetryableChatFailureKind("coding_tool_failure")).toBe(false);
+  });
+
+  it("validates complete terminal failures without inventing missing fields", () => {
+    expect(
+      parseChatTerminalFailure({
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      }),
+    ).toEqual({
+      kind: "coding_tool_failure",
+      message: "Shell execution failed.",
+      transient: true,
+      code: "SHELL_UNAVAILABLE",
+    });
+    expect(
+      parseChatTerminalFailure({
+        kind: "coding_tool_failure",
+        message: "",
+        transient: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      parseChatTerminalFailure({
+        kind: "unknown",
+        message: "Failed.",
+        transient: false,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/shared/src/contracts/chat.ts
+++ b/packages/shared/src/contracts/chat.ts
@@ -84,6 +84,8 @@ export interface ChatToolCallEvent {
  * - `handler_error` — action handler failed; not a generic Retry affordance.
  * - `persistence_error` — save boundary failed; not a generic Retry affordance.
  * - `local_inference` — local model path issue; may recover after load/retry.
+ * - `coding_mutation_unverified` — coding changes lack successful verification.
+ * - `coding_tool_failure` — a coding tool failed without narrower provenance.
  */
 export const CHAT_FAILURE_KINDS = [
   "insufficient_credits",
@@ -96,6 +98,8 @@ export const CHAT_FAILURE_KINDS = [
   "handler_error",
   "persistence_error",
   "local_inference",
+  "coding_mutation_unverified",
+  "coding_tool_failure",
 ] as const;
 
 /**
@@ -105,6 +109,14 @@ export const CHAT_FAILURE_KINDS = [
  * provider"), not a chat reply.
  */
 export type ChatFailureKind = (typeof CHAT_FAILURE_KINDS)[number];
+
+/** Authoritative terminal failure carried independently of assistant prose. */
+export interface ChatTerminalFailure {
+  kind: ChatFailureKind;
+  message: string;
+  transient: boolean;
+  code?: string;
+}
 
 /**
  * Failure kinds for which a one-tap Retry (resend preceding user turn) is a
@@ -135,6 +147,32 @@ export function parseChatFailureKind(
   value: unknown,
 ): ChatFailureKind | undefined {
   return isChatFailureKind(value) ? value : undefined;
+}
+
+/** Strictly validates a terminal failure received across a chat transport. */
+export function parseChatTerminalFailure(
+  value: unknown,
+): ChatTerminalFailure | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const kind = parseChatFailureKind(record.kind);
+  if (
+    !kind ||
+    typeof record.message !== "string" ||
+    record.message.trim().length === 0 ||
+    typeof record.transient !== "boolean" ||
+    (record.code !== undefined && typeof record.code !== "string")
+  ) {
+    return undefined;
+  }
+  return {
+    kind,
+    message: record.message,
+    transient: record.transient,
+    ...(record.code ? { code: record.code } : {}),
+  };
 }
 
 /** Whether UI surfaces should offer Retry for this structured failure. */

--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -125,6 +125,45 @@ describe("ElizaClient agent streaming transport", () => {
     });
   });
 
+  it("preserves a validated typed terminal failure from the done event", async () => {
+    const encoder = new TextEncoder();
+    const read = vi.fn().mockResolvedValueOnce({
+      done: false,
+      value: encoder.encode(
+        'data: {"type":"done","fullText":"Shell execution failed.","agentName":"Eliza","failureKind":"coding_tool_failure","terminalFailure":{"kind":"coding_tool_failure","message":"Shell execution failed.","transient":true,"code":"SHELL_UNAVAILABLE"}}\n\n',
+      ),
+    });
+    const request = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({ read, cancel: vi.fn(async () => {}) }),
+        },
+      } as unknown as Response;
+    });
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/conversation-id/messages/stream",
+      "fix the code",
+      vi.fn(),
+    );
+
+    expect(result).toMatchObject({
+      text: "Shell execution failed.",
+      completed: true,
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
+    });
+  });
+
   it("surfaces internal transcript visibility from the terminal done event", async () => {
     const encoder = new TextEncoder();
     const read = vi.fn().mockResolvedValueOnce({

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -11,6 +11,7 @@ import {
   SHELL_NAVIGATE_VIEW_WS_EVENT,
   stripAssistantStageDirections,
 } from "@elizaos/shared";
+import { parseChatTerminalFailure } from "@elizaos/shared/contracts";
 import {
   isElizaCloudControlPlaneHostname,
   isElizaDedicatedAgentHostname,
@@ -60,6 +61,7 @@ import type {
   AccountConnectRequest,
   ChatActionResultSummary,
   ChatFailureKind,
+  ChatTerminalFailure,
   ChatTokenUsage,
   ChatToolCallEvent,
   ChatTurnStatus,
@@ -126,6 +128,7 @@ type StreamChatEvent = {
   thought?: string;
   noResponseReason?: string;
   failureKind?: ChatFailureKind;
+  terminalFailure?: ChatTerminalFailure;
   accountConnect?: AccountConnectRequest;
   localInference?: LocalInferenceChatMetadata;
   actionResults?: ChatActionResultSummary[];
@@ -256,6 +259,7 @@ type StreamChatState = {
   doneNoResponseReason: "ignored" | null;
   doneUsage: ChatTokenUsage | undefined;
   doneFailureKind: ChatFailureKind | undefined;
+  doneTerminalFailure: ChatTerminalFailure | undefined;
   doneAccountConnect: AccountConnectRequest | undefined;
   doneLocalInference: LocalInferenceChatMetadata | undefined;
   doneActionResults: ChatActionResultSummary[] | undefined;
@@ -436,6 +440,7 @@ function applyStreamChatDoneEvent(
   if (typeof parsed.failureKind === "string") {
     state.doneFailureKind = parsed.failureKind;
   }
+  state.doneTerminalFailure = parseChatTerminalFailure(parsed.terminalFailure);
   if (parsed.accountConnect && typeof parsed.accountConnect === "object") {
     state.doneAccountConnect = parsed.accountConnect;
   }
@@ -2647,6 +2652,7 @@ export class ElizaClient {
     noResponseReason?: "ignored";
     usage?: ChatTokenUsage;
     failureKind?: ChatFailureKind;
+    terminalFailure?: ChatTerminalFailure;
     accountConnect?: AccountConnectRequest;
     localInference?: LocalInferenceChatMetadata;
     actionResults?: ChatActionResultSummary[];
@@ -2721,6 +2727,7 @@ export class ElizaClient {
       doneNoResponseReason: null,
       doneUsage: undefined,
       doneFailureKind: undefined,
+      doneTerminalFailure: undefined,
       doneAccountConnect: undefined,
       doneLocalInference: undefined,
       doneActionResults: undefined,
@@ -2867,6 +2874,9 @@ export class ElizaClient {
       ...(streamState.doneUsage ? { usage: streamState.doneUsage } : {}),
       ...(streamState.doneFailureKind
         ? { failureKind: streamState.doneFailureKind }
+        : {}),
+      ...(streamState.doneTerminalFailure
+        ? { terminalFailure: streamState.doneTerminalFailure }
         : {}),
       ...(streamState.doneAccountConnect
         ? { accountConnect: streamState.doneAccountConnect }

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -14,6 +14,7 @@ import type {
   ApiError,
   ChatActionResultSummary,
   ChatFailureKind,
+  ChatTerminalFailure,
   ChatTokenUsage,
   ChatToolCallEvent,
   ChatTurnStatus,
@@ -313,6 +314,7 @@ declare module "./client-base" {
       agentName: string;
       noResponseReason?: "ignored";
       failureKind?: ChatFailureKind;
+      terminalFailure?: ChatTerminalFailure;
       localInference?: LocalInferenceChatMetadata;
       actionResults?: ChatActionResultSummary[];
     }>;
@@ -329,6 +331,7 @@ declare module "./client-base" {
       noResponseReason?: "ignored";
       usage?: ChatTokenUsage;
       failureKind?: ChatFailureKind;
+      terminalFailure?: ChatTerminalFailure;
       localInference?: LocalInferenceChatMetadata;
       actionResults?: ChatActionResultSummary[];
     }>;
@@ -493,6 +496,8 @@ declare module "./client-base" {
        * as a normal assistant reply.
        */
       failureKind?: ChatFailureKind;
+      /** Typed terminal coding/runtime failure; authoritative over reply prose. */
+      terminalFailure?: ChatTerminalFailure;
       /** Structured "connect another account" request from CONNECT_ACCOUNT. */
       accountConnect?: AccountConnectRequest;
       localInference?: LocalInferenceChatMetadata;
@@ -542,6 +547,8 @@ declare module "./client-base" {
       usage?: ChatTokenUsage;
       /** See sendConversationMessage above. */
       failureKind?: ChatFailureKind;
+      /** See sendConversationMessage above. */
+      terminalFailure?: ChatTerminalFailure;
       /** See sendConversationMessage above. */
       accountConnect?: AccountConnectRequest;
       localInference?: LocalInferenceChatMetadata;
@@ -1301,6 +1308,7 @@ ElizaClient.prototype.sendConversationMessage = async function (
     blocks?: ContentBlock[];
     noResponseReason?: "ignored";
     failureKind?: ChatFailureKind;
+    terminalFailure?: ChatTerminalFailure;
     accountConnect?: AccountConnectRequest;
     localInference?: LocalInferenceChatMetadata;
     actionResults?: ChatActionResultSummary[];

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -7,6 +7,7 @@
 import type { LinkedAccountProviderId } from "@elizaos/shared";
 import type {
   ChatFailureKind,
+  ChatTerminalFailure,
   ChatToolCallEvent,
   ChatTurnStatus,
 } from "@elizaos/shared/contracts";
@@ -20,7 +21,12 @@ import type {
 // here so existing `@elizaos/ui` `api` consumers keep their import path. Imported
 // (not export-from) because `failureKind` fields below reference the type in this
 // module's scope.
-export type { ChatFailureKind, ChatToolCallEvent, ChatTurnStatus };
+export type {
+  ChatFailureKind,
+  ChatTerminalFailure,
+  ChatToolCallEvent,
+  ChatTurnStatus,
+};
 
 // Conversations
 export interface Conversation {
@@ -387,6 +393,8 @@ export interface ConversationMessage {
    * the fallback `text` as a normal reply bubble.
    */
   failureKind?: ChatFailureKind;
+  /** Authoritative terminal failure details retained for retry and diagnostics. */
+  terminalFailure?: ChatTerminalFailure;
   /** Structured local-inference status returned with local model command/error replies. */
   localInference?: LocalInferenceChatMetadata;
   /** Structured sensitive/private information request metadata. */

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1504,7 +1504,12 @@ export function MessageContent({
   // one-tap Retry that resends the preceding user turn. Permanent gates
   // (`no_provider`, `insufficient_credits`, `missing_capability`) stay off the
   // shared retry contract in `@elizaos/shared`.
-  if (message.failureKind && isRetryableChatFailureKind(message.failureKind)) {
+  if (
+    message.failureKind &&
+    (message.terminalFailure
+      ? message.terminalFailure.transient
+      : isRetryableChatFailureKind(message.failureKind))
+  ) {
     return (
       <div className="border border-warn/30 bg-warn/5 rounded-sm p-3 text-sm">
         <div className="text-muted whitespace-pre-wrap mb-2">

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -465,6 +465,7 @@ function arePropsEqual(
     a.reactions === b.reactions &&
     a.voiceSpeaker === b.voiceSpeaker &&
     a.failureKind === b.failureKind &&
+    a.terminalFailure === b.terminalFailure &&
     a.attachments === b.attachments &&
     // Inline tool-call rows: a mode:"tool" stream update replaces `toolEvents`
     // by reference while every other compared field stays identical, so without
@@ -1000,7 +1001,9 @@ export const ChatMessage = memo(function ChatMessage({
       isAssistant &&
       !!onRetry &&
       !!message.failureKind &&
-      isRetryableChatFailureKind(message.failureKind);
+      (message.terminalFailure
+        ? message.terminalFailure.transient
+        : isRetryableChatFailureKind(message.failureKind));
 
     const toggleRevealed = () => {
       if (!hasActions || isEditing) return;

--- a/packages/ui/src/components/composites/chat/chat-transcript.memoization.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.memoization.test.tsx
@@ -140,6 +140,44 @@ describe("ChatTranscript memoization", () => {
     expect(screen.getByTestId("content-msg-2").textContent).toBe("completed");
   });
 
+  it("re-renders when terminal failure policy lands without changing text or kind", () => {
+    const assistant: ChatMessageData = {
+      ...makeMessage("msg-2", "assistant", "The planner cannot continue."),
+      failureKind: "planner_exhaustion",
+    };
+    const renderMessageContent = vi.fn((message: ChatMessageData) => (
+      <span data-testid="terminal-policy">
+        {message.terminalFailure?.transient === false ? "permanent" : "static"}
+      </span>
+    ));
+    const rendered = render(
+      <ChatTranscript
+        messages={[assistant]}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+    expect(screen.getByTestId("terminal-policy").textContent).toBe("static");
+
+    rendered.rerender(
+      <ChatTranscript
+        messages={[
+          {
+            ...assistant,
+            terminalFailure: {
+              kind: "planner_exhaustion",
+              message: "The planner cannot continue.",
+              transient: false,
+            },
+          },
+        ]}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+
+    expect(renderMessageContent).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("terminal-policy").textContent).toBe("permanent");
+  });
+
   it("does NOT re-render a row whose toolEvents reference is unchanged", () => {
     // The transcript rebuilds message OBJECTS every parent render; a row whose
     // toolEvents array is the SAME reference (no tool change) must still be

--- a/packages/ui/src/components/composites/chat/chat-types.ts
+++ b/packages/ui/src/components/composites/chat/chat-types.ts
@@ -7,6 +7,7 @@
 
 import type {
   ChatFailureKind,
+  ChatTerminalFailure,
   ChatTurnStatus,
   ConversationSecretRequest,
   MessageAttachment,
@@ -124,6 +125,8 @@ export interface ChatMessageData {
    * render failure gates in their body renderer instead.
    */
   failureKind?: ChatFailureKind;
+  /** Authoritative typed failure details, including transient retry policy. */
+  terminalFailure?: ChatTerminalFailure;
   /** Media attached to this turn — read by body renderers and the in-flight
    * (empty assistant) detection; the row itself renders no attachment chrome. */
   attachments?: MessageAttachment[];

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -5507,6 +5507,53 @@ describe("ChatOverlay — routed OS-intent composer prefill (#9148, #16441)", ()
     expect(screen.queryByTestId("thread-line-retry")).toBeNull();
   });
 
+  it("shows Retry when a typed terminal failure explicitly marks a normally permanent kind transient", () => {
+    const controller = makeController({
+      messages: [
+        { id: "u1", role: "user", content: "fix it", createdAt: 1 },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "Shell execution failed.",
+          createdAt: 2,
+          failureKind: "coding_tool_failure",
+          terminalFailure: {
+            kind: "coding_tool_failure",
+            message: "Shell execution failed.",
+            transient: true,
+            code: "SHELL_UNAVAILABLE",
+          },
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    render(<ChatOverlay controller={controller} />);
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(screen.getByTestId("thread-line-retry")).toBeTruthy();
+  });
+
+  it("hides Retry when a typed terminal failure marks a normally retryable kind permanent", () => {
+    const controller = makeController({
+      messages: [
+        { id: "u1", role: "user", content: "try it", createdAt: 1 },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "The planner cannot continue.",
+          createdAt: 2,
+          failureKind: "planner_exhaustion",
+          terminalFailure: {
+            kind: "planner_exhaustion",
+            message: "The planner cannot continue.",
+            transient: false,
+          },
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    render(<ChatOverlay controller={controller} />);
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(screen.queryByTestId("thread-line-retry")).toBeNull();
+  });
+
   it("restores the persisted composer draft for the active conversation (shared app composer slot)", () => {
     // The overlay reads the SHARED ChatComposerContext draft; the app-level
     // persistence hook (AppContext runs the same one this harness runs)

--- a/packages/ui/src/components/shell/chat-overlay-transcript.tsx
+++ b/packages/ui/src/components/shell/chat-overlay-transcript.tsx
@@ -207,6 +207,7 @@ export function shellToChatMessageData(m: ShellMessage): ChatMessageData {
     ...(m.source ? { source: m.source } : {}),
     ...(m.interrupted ? { interrupted: true } : {}),
     ...(m.failureKind ? { failureKind: m.failureKind } : {}),
+    ...(m.terminalFailure ? { terminalFailure: m.terminalFailure } : {}),
     ...(m.attachments ? { attachments: m.attachments } : {}),
     ...(m.secretRequest ? { secretRequest: m.secretRequest } : {}),
   };

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -4,6 +4,7 @@
  */
 import type {
   ChatFailureKind,
+  ChatTerminalFailure,
   ConversationSecretRequest,
   MessageAttachment,
   NativeToolCallEvent,
@@ -61,6 +62,8 @@ export interface ShellMessage {
   source?: string;
   /** Set on assistant turns the server flagged as failed (e.g. no provider). */
   failureKind?: ChatFailureKind;
+  /** Complete typed terminal failure used for truthful transient retry state. */
+  terminalFailure?: ChatTerminalFailure;
   /** Agent reasoning/thought for this turn, rendered as a collapsed block. */
   reasoning?: string;
   /** Inline tool-call rows for this turn, streamed live from the chat SSE `tool`

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -1004,6 +1004,7 @@ export function useShellController(): ShellController {
         cached.content === message.text &&
         cached.interrupted === (message.interrupted || undefined) &&
         cached.failureKind === message.failureKind &&
+        cached.terminalFailure === message.terminalFailure &&
         (cached.reasoning || undefined) === (message.reasoning || undefined) &&
         cached.secretRequest === message.secretRequest &&
         // Tool-event merges return a NEW array reference each step, so a
@@ -1024,6 +1025,7 @@ export function useShellController(): ShellController {
         // can omit it. Drives the suggestion affordance (#8792).
         ...(message.source ? { source: message.source } : {}),
         failureKind: message.failureKind,
+        terminalFailure: message.terminalFailure,
         ...(message.reasoning ? { reasoning: message.reasoning } : {}),
         ...(message.toolEvents?.length
           ? { toolEvents: message.toolEvents }

--- a/packages/ui/src/native-transcript/chat-event-adapter.ts
+++ b/packages/ui/src/native-transcript/chat-event-adapter.ts
@@ -5,14 +5,21 @@
  */
 
 import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
-import type { ChatFailureKind, ChatToolCallEvent } from "../api";
+import type {
+  ChatFailureKind,
+  ChatTerminalFailure,
+  ChatToolCallEvent,
+} from "../api";
 import { publishNativeTranscriptEvent } from "./transport";
 
 /** Whether retry can plausibly resolve a structured chat failure as-is. */
 export function isNativeChatFailureRetryable(
   failureKind: ChatFailureKind,
+  terminalFailure?: ChatTerminalFailure,
 ): boolean {
-  return isRetryableChatFailureKind(failureKind);
+  return terminalFailure
+    ? terminalFailure.transient
+    : isRetryableChatFailureKind(failureKind);
 }
 
 function toolDetail(event: ChatToolCallEvent): string | undefined {
@@ -65,7 +72,11 @@ export interface NativeChatTranscriptTurnPublisher {
   publishUserFinal(text: string, at: number): void;
   publishAgentText(text: string, final?: boolean): void;
   publishToolState(event: ChatToolCallEvent): void;
-  publishFailureKind(failureKind: ChatFailureKind, message?: string): void;
+  publishFailureKind(
+    failureKind: ChatFailureKind,
+    message?: string,
+    terminalFailure?: ChatTerminalFailure,
+  ): void;
   publishError(options: {
     code: string;
     retryable: boolean;
@@ -77,6 +88,7 @@ export interface NativeChatTranscriptTurnPublisher {
     streamedText: string;
     completed?: boolean;
     failureKind?: ChatFailureKind;
+    terminalFailure?: ChatTerminalFailure;
     accountConnect?: unknown;
   }): void;
 }
@@ -146,11 +158,16 @@ export function createNativeChatTranscriptTurnPublisher(options: {
   const publishFailureKind = (
     failureKind: ChatFailureKind,
     message?: string,
+    terminalFailure?: ChatTerminalFailure,
   ): void => {
     publishError({
-      code: failureKind,
-      retryable: isNativeChatFailureRetryable(failureKind),
-      ...(message ? { message } : {}),
+      code: terminalFailure?.code ?? failureKind,
+      retryable: isNativeChatFailureRetryable(failureKind, terminalFailure),
+      ...(terminalFailure?.message
+        ? { message: terminalFailure.message }
+        : message
+          ? { message }
+          : {}),
     });
   };
 
@@ -182,7 +199,11 @@ export function createNativeChatTranscriptTurnPublisher(options: {
         result.completed !== false,
       );
       if (result.failureKind) {
-        publishFailureKind(result.failureKind);
+        publishFailureKind(
+          result.failureKind,
+          undefined,
+          result.terminalFailure,
+        );
       } else if (result.accountConnect) {
         publishError({
           code: "account-connect-required",

--- a/packages/ui/src/native-transcript/transport.test.ts
+++ b/packages/ui/src/native-transcript/transport.test.ts
@@ -142,6 +142,23 @@ describe("native transcript producer transport", () => {
     expect(isNativeChatFailureRetryable(failureKind)).toBe(retryable);
   });
 
+  it("lets typed transience override the static failure-kind retry policy", () => {
+    expect(
+      isNativeChatFailureRetryable("coding_tool_failure", {
+        kind: "coding_tool_failure",
+        message: "Shell unavailable.",
+        transient: true,
+      }),
+    ).toBe(true);
+    expect(
+      isNativeChatFailureRetryable("planner_exhaustion", {
+        kind: "planner_exhaustion",
+        message: "The planner cannot continue.",
+        transient: false,
+      }),
+    ).toBe(false);
+  });
+
   it("keeps primary and replay snapshots on one stable logical turn", () => {
     const seen: unknown[] = [];
     const listener = (event: Event) => {

--- a/packages/ui/src/state/__tests__/useStreamingText.test.ts
+++ b/packages/ui/src/state/__tests__/useStreamingText.test.ts
@@ -97,6 +97,30 @@ describe("applyStreamingTextModification", () => {
     expect(harness.current[0].failureKind).toBe("no_provider");
   });
 
+  it("complete retains typed terminal failure details", () => {
+    const initial = [assistantMsg("a1", "Done")];
+    const harness = makeSetter(initial);
+
+    applyStreamingTextModification(harness.setter, {
+      messageId: "a1",
+      mode: "complete",
+      fullText: "Shell execution failed.",
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
+    });
+
+    expect(harness.current[0].terminalFailure).toMatchObject({
+      kind: "coding_tool_failure",
+      transient: true,
+      code: "SHELL_UNAVAILABLE",
+    });
+  });
+
   it("complete clears a stale failureKind when none is provided", () => {
     const initial = [
       assistantMsg("a1", "partial", { failureKind: "no_provider" }),

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -2501,6 +2501,39 @@ describe("useChatSend empty-reply failure surfacing (#10231)", () => {
     expect(assistant[0]?.failureKind).toBe("no_provider");
   });
 
+  it("retains typed terminal failure details on the completed assistant turn", async () => {
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => ({
+      text: "Shell execution failed.",
+      completed: true,
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
+    }));
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("fix it", { conversationId: "conv-1" });
+    });
+
+    const assistant = deps.conversationMessagesRef.current.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.terminalFailure).toMatchObject({
+      kind: "coding_tool_failure",
+      transient: true,
+      code: "SHELL_UNAVAILABLE",
+    });
+  });
+
   it("still drops an empty terminal reply that carries no failureKind", async () => {
     mocks.client.sendConversationMessageStream.mockImplementation(async () => ({
       text: "",

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -676,7 +676,13 @@ export function useChatSend(deps: UseChatSendDeps) {
         applyStreamingModificationForConversation(conversationId, {
           messageId: assistantMessageId,
           ...(data.failureKind
-            ? { mode: "fail", failureKind: data.failureKind }
+            ? {
+                mode: "fail",
+                failureKind: data.failureKind,
+                ...(data.terminalFailure
+                  ? { terminalFailure: data.terminalFailure }
+                  : {}),
+              }
             : { mode: "drop" }),
         });
       } else if (
@@ -689,6 +695,9 @@ export function useChatSend(deps: UseChatSendDeps) {
           mode: "complete",
           fullText: data.text,
           ...(data.failureKind ? { failureKind: data.failureKind } : {}),
+          ...(data.terminalFailure
+            ? { terminalFailure: data.terminalFailure }
+            : {}),
           ...(options.includeAccountConnect && data.accountConnect
             ? { accountConnect: data.accountConnect }
             : {}),
@@ -703,6 +712,9 @@ export function useChatSend(deps: UseChatSendDeps) {
           messageId: assistantMessageId,
           mode: "fail",
           failureKind: data.failureKind,
+          ...(data.terminalFailure
+            ? { terminalFailure: data.terminalFailure }
+            : {}),
         });
       } else if (options.includeAccountConnect && data.accountConnect) {
         applyStreamingModificationForConversation(conversationId, {

--- a/packages/ui/src/state/useStreamingText.ts
+++ b/packages/ui/src/state/useStreamingText.ts
@@ -30,6 +30,7 @@ import type { Dispatch, SetStateAction } from "react";
 import type {
   AccountConnectRequest,
   ChatFailureKind,
+  ChatTerminalFailure,
   ChatToolCallEvent,
   ConversationMessage,
 } from "../api";
@@ -72,6 +73,8 @@ export type StreamingTextModification =
       fullText: string;
       /** Optional server-flagged failure class to stamp alongside the text. */
       failureKind?: ChatFailureKind;
+      /** Authoritative terminal failure details from the runtime. */
+      terminalFailure?: ChatTerminalFailure;
       /**
        * Optional structured "connect another account" request to stamp on the
        * completed turn so the renderer can swap in the AccountConnectBlock.
@@ -102,6 +105,8 @@ export type StreamingTextModification =
       mode: "fail";
       /** Server-flagged failure class. Text is left untouched. */
       failureKind: ChatFailureKind;
+      /** Authoritative terminal failure details from the runtime. */
+      terminalFailure?: ChatTerminalFailure;
     }
   | {
       messageId: string;
@@ -165,6 +170,8 @@ function computeNextMessage(
     case "complete": {
       const sameText = message.text === mod.fullText;
       const sameFailure = message.failureKind === mod.failureKind;
+      const sameTerminalFailure =
+        message.terminalFailure === mod.terminalFailure;
       const sameAccountConnect = message.accountConnect === mod.accountConnect;
       const sameReasoning =
         mod.reasoning === undefined || message.reasoning === mod.reasoning;
@@ -176,6 +183,7 @@ function computeNextMessage(
       if (
         sameText &&
         sameFailure &&
+        sameTerminalFailure &&
         sameAccountConnect &&
         sameReasoning &&
         sameAssistantEphemeral &&
@@ -198,6 +206,11 @@ function computeNextMessage(
         next.failureKind = mod.failureKind;
       } else if (message.failureKind !== undefined) {
         delete next.failureKind;
+      }
+      if (mod.terminalFailure) {
+        next.terminalFailure = mod.terminalFailure;
+      } else if (message.terminalFailure !== undefined) {
+        delete next.terminalFailure;
       }
       if (mod.accountConnect) {
         next.accountConnect = mod.accountConnect;
@@ -227,8 +240,18 @@ function computeNextMessage(
       return { ...message, toolEvents: nextEvents };
     }
     case "fail": {
-      if (message.failureKind === mod.failureKind) return null;
-      return { ...message, failureKind: mod.failureKind };
+      if (
+        message.failureKind === mod.failureKind &&
+        message.terminalFailure === mod.terminalFailure
+      )
+        return null;
+      return {
+        ...message,
+        failureKind: mod.failureKind,
+        ...(mod.terminalFailure
+          ? { terminalFailure: mod.terminalFailure }
+          : {}),
+      };
     }
     case "interrupt": {
       if (message.interrupted === true) return null;


### PR DESCRIPTION
Closes #24753

## Summary
- make `terminalFailure` authoritative over optimistic callback prose in benchmarks and HTTP/SSE chat
- preserve kind, message, code, and transient state through durable idempotency, restart recovery, history reload, UI state, shell projection, and native transcript delivery
- make typed transient policy override static failure-kind retry defaults
- preserve the durable completed outcome when its idempotency marker write fails

## Exact-head validation
Head: `872b08161370ed36f95fd529dc11b764d3c9619f`
Base: `9c9eadd9460b3e0bad2a3fdee97c8905c17165ad`

- `bun install`
- shared chat contract: 6 passed
- agent benchmark/SSE/idempotency/history: 151 passed
- UI client/reducer/native/memoization: 58 passed
- UI terminal hook: 1 passed (88 skipped)
- UI retry-policy shell: 2 passed (203 skipped)
- shared and UI typecheck passed
- agent typecheck has only existing missing optional workspace-export errors (`plugin-capacitor-bridge`, wallet diagnostic, video/vision/notes/todos); no changed-file error
- `bun run verify` reaches the repository gate but currently stops at pre-existing `check:i18n` drift (14 missing English connector-card keys and 1,000+ untranslated locale keys); none are in this PR

## Review
Independent read-only review found no remaining blocker. The full typed failure is retained across live, durable, recovery, history, web, memoized-row, and native surfaces.