### PR TITLE
fix(cloud): preserve typed message delivery outcomes

### DIFF
--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.logging.test.ts
@@ -38,7 +38,12 @@ mock.module("@/lib/services/blooio-automation", () => ({
 
 mock.module("@/lib/services/message-router", () => ({
   messageRouterService: {
-    sendMessage: mock(async () => false),
+    sendMessage: mock(async () => ({
+      status: "failed" as const,
+      provider: "blooio" as const,
+      code: "DELIVERY_PROVIDER_REJECTED",
+      retryable: false,
+    })),
   },
 }));
 

--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
@@ -310,11 +310,15 @@ async function handleIncomingMessage(
       agentUserId: routed.userId,
     });
 
-    if (sent) {
+    if (sent.status === "delivered") {
       logger.info("[BlooioWebhook] Agent response sent", { orgId });
     } else {
-      logger.error("[BlooioWebhook] Failed to send agent response", {
+      logger.error("[BlooioWebhook] Agent response delivery did not complete", {
         orgId,
+        deliveryStatus: sent.status,
+        deliveryCode: sent.code,
+        retryable: sent.retryable,
+        providerStatus: sent.providerStatus,
       });
     }
   }

--- a/packages/cloud/api/webhooks/twilio/[orgId]/route.logging.test.ts
+++ b/packages/cloud/api/webhooks/twilio/[orgId]/route.logging.test.ts
@@ -14,7 +14,11 @@ const loggerInfo = mock();
 const loggerWarn = mock();
 const loggerError = mock();
 const loggerDebug = mock();
-const sendMessage = mock(async () => true);
+const sendMessage = mock(async () => ({
+  status: "delivered" as const,
+  provider: "twilio" as const,
+  providerMessageIds: ["SM_reply"],
+}));
 const markAsProcessed = mock(async () => undefined);
 const usageCreate = mock(async (_record: unknown) => {
   throw new Error(sentinelProviderBody);
@@ -100,7 +104,11 @@ const app = new Hono().route("/:orgId", route);
 describe("Twilio webhook privacy", () => {
   beforeEach(() => {
     sendMessage.mockReset();
-    sendMessage.mockResolvedValue(true);
+    sendMessage.mockResolvedValue({
+      status: "delivered",
+      provider: "twilio",
+      providerMessageIds: ["SM_reply"],
+    });
     markAsProcessed.mockClear();
     usageCreate.mockClear();
     loggerInfo.mockClear();

--- a/packages/cloud/api/webhooks/twilio/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/twilio/[orgId]/route.ts
@@ -272,7 +272,7 @@ async function handleIncomingMessage(
 
     const responseTime = Date.now() - startTime;
 
-    if (sent) {
+    if (sent.status === "delivered") {
       const billing = calculateTwilioSmsBilling(
         routed.replyText.trim(),
         resolveSmsCostPerSegment(c.env),
@@ -312,8 +312,12 @@ async function handleIncomingMessage(
         responseTime,
       });
     } else {
-      logger.error("[TwilioWebhook] Failed to send agent response", {
+      logger.error("[TwilioWebhook] Agent response delivery did not complete", {
         orgId,
+        deliveryStatus: sent.status,
+        deliveryCode: sent.code,
+        retryable: sent.retryable,
+        providerStatus: sent.providerStatus,
       });
     }
   }

--- a/packages/cloud/api/webhooks/whatsapp/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/whatsapp/[orgId]/route.ts
@@ -327,14 +327,21 @@ async function handleIncomingMessage(
           agentOrganizationId: phoneRouteResult.organizationId,
         });
 
-        if (sent) {
+        if (sent.status === "delivered") {
           logger.info("[WhatsAppWebhook] Agent response sent", {
             orgId,
           });
         } else {
-          logger.error("[WhatsAppWebhook] Failed to send agent response", {
-            orgId,
-          });
+          logger.error(
+            "[WhatsAppWebhook] Agent response delivery did not complete",
+            {
+              orgId,
+              deliveryStatus: sent.status,
+              deliveryCode: sent.code,
+              retryable: sent.retryable,
+              providerStatus: sent.providerStatus,
+            },
+          );
         }
       }
       return;
@@ -365,14 +372,21 @@ async function handleIncomingMessage(
       agentUserId: routeResult.userId,
     });
 
-    if (sent) {
+    if (sent.status === "delivered") {
       logger.info("[WhatsAppWebhook] Agent response sent", {
         orgId,
       });
     } else {
-      logger.error("[WhatsAppWebhook] Failed to send agent response", {
-        orgId,
-      });
+      logger.error(
+        "[WhatsAppWebhook] Agent response delivery did not complete",
+        {
+          orgId,
+          deliveryStatus: sent.status,
+          deliveryCode: sent.code,
+          retryable: sent.retryable,
+          providerStatus: sent.providerStatus,
+        },
+      );
     }
   } finally {
     stopTyping();

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -256,6 +256,67 @@ describe("gateway webhook handler e2e routing", () => {
     );
     await waitFor(() => adapter.replies.length === 1, "personal Shared reply");
     expect(adapter.replies).toEqual(["same personal Eliza"]);
+    await waitFor(
+      () => [...redis.store.values()].includes("delivered"),
+      "durable delivered state",
+    );
+  });
+
+  test("persists an ambiguous provider failure and refuses an unsafe replay", async () => {
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({ messageId: "SM-uncertain-egress" });
+    const adapter = createAdapter(event);
+    adapter.sendReply = mock(async () => {
+      throw new DOMException("provider receipt timed out", "TimeoutError");
+    });
+    let sharedRequests = 0;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        sharedRequests += 1;
+        return Response.json({ success: true, data: { reply: "send once" } });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const first = await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+    expect(first.status).toBe(200);
+
+    const dedupKey = `webhook:twilio:${event.messageId}`;
+    await waitFor(
+      () => redis.store.get(dedupKey) === "uncertain",
+      "durable uncertain state",
+    );
+
+    const replay = await handleWebhook(
+      requestFor(event),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+    expect(replay.status).toBe(503);
+    expect(await replay.json()).toEqual({
+      error: "delivery outcome uncertain",
+    });
+    expect(adapter.sendReply).toHaveBeenCalledTimes(1);
+    expect(sharedRequests).toBe(1);
   });
 
   test("routes an unresolved Blooio iMessage to the same phone Shared path", async () => {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -29,7 +29,6 @@ import {
 } from "./server-router";
 import { resolveWebhookConfig } from "./webhook-config";
 
-const DEDUP_TTL_SECONDS = 300;
 const PERSONAL_SHARED_DELIVERY_LEASE_MS = 90_000;
 // Must outlive the 75s non-idempotent message-forward budget plus Telegram
 // egress. Otherwise a provider retry can reclaim the update while the first
@@ -38,6 +37,9 @@ const PERSONAL_SHARED_ATTEMPTS = 3;
 const PERSONAL_SHARED_RETRY_DELAY_CAP_MS = 5_000;
 const PROCESSING_TTL_SECONDS = 120;
 const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
+const CONNECTOR_PROCESSING = "processing";
+const CONNECTOR_DELIVERED = "delivered";
+const CONNECTOR_UNCERTAIN = "uncertain";
 const TELEGRAM_EGRESS_STARTED = "egress_started";
 const TELEGRAM_DELIVERED = "delivered";
 const TELEGRAM_TYPING_REFRESH_MS = 4_000;
@@ -510,6 +512,29 @@ export async function handleWebhook(
 
   const priorDeliveryState = await redis.get<string>(dedupKey);
   if (priorDeliveryState) {
+    if (
+      priorDeliveryState === CONNECTOR_UNCERTAIN ||
+      priorDeliveryState === "1"
+    ) {
+      logger.error("Webhook delivery outcome is uncertain; refusing replay", {
+        platform: adapter.platform,
+        messageId: event.messageId,
+        dedupKey,
+      });
+      return new Response(
+        JSON.stringify({ error: "delivery outcome uncertain" }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    if (priorDeliveryState === CONNECTOR_PROCESSING) {
+      return new Response(JSON.stringify({ error: "delivery in progress" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
     logger.debug("Duplicate webhook skipped", {
       platform: adapter.platform,
       messageId: event.messageId,
@@ -518,9 +543,13 @@ export async function handleWebhook(
     return ackResponse(adapter.platform);
   }
 
-  const isNew = await redis.set(dedupKey, "1", {
+  const isNew = await redis.set(dedupKey, CONNECTOR_PROCESSING, {
     nx: true,
-    ex: DEDUP_TTL_SECONDS,
+    // A worker can disappear after provider acceptance but before recording a
+    // receipt. Keep that orphaned claim for the terminal ledger lifetime; a
+    // short lease would eventually replay an outcome that is necessarily
+    // uncertain. Explicit idempotent pre-egress failures delete the claim.
+    ex: TELEGRAM_DELIVERY_TTL_SECONDS,
   });
   if (!isNew) {
     logger.debug("Duplicate webhook skipped", {
@@ -533,8 +562,13 @@ export async function handleWebhook(
 
   // ── Async phase: identity → forward → reply (runs in background) ──
 
-  processMessage(adapter, config, event, deps, project, trace, agentId).catch(
-    async (err) => {
+  processMessage(adapter, config, event, deps, project, trace, agentId)
+    .then(async () => {
+      await redis.set(dedupKey, CONNECTOR_DELIVERED, {
+        ex: TELEGRAM_DELIVERY_TTL_SECONDS,
+      });
+    })
+    .catch(async (err) => {
       logger.error("Background message processing failed", {
         error: err instanceof Error ? err.message : String(err),
         project,
@@ -564,9 +598,29 @@ export async function handleWebhook(
             messageId: event.messageId,
           });
         }
+        return;
       }
-    },
-  );
+      try {
+        // A generic failure can occur after the provider accepted the reply.
+        // Persist ambiguity and refuse replay rather than converting a lost
+        // receipt into a duplicate user-visible message.
+        await redis.set(dedupKey, CONNECTOR_UNCERTAIN, {
+          ex: TELEGRAM_DELIVERY_TTL_SECONDS,
+        });
+      } catch (ledgerError) {
+        // error-policy:J7 The provider result is already ambiguous; retain the
+        // original processing claim and surface the ledger failure separately.
+        logger.error("Failed to persist uncertain webhook delivery", {
+          error:
+            ledgerError instanceof Error
+              ? ledgerError.message
+              : String(ledgerError),
+          project,
+          platform: adapter.platform,
+          messageId: event.messageId,
+        });
+      }
+    });
 
   return ackResponse(adapter.platform);
 }

--- a/packages/cloud/shared/src/lib/services/message-router/index.test.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.test.ts
@@ -1,5 +1,6 @@
 /** Exercises index behavior with deterministic cloud-shared lib fixtures. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 
 // Load SQL metadata projections before this suite installs process-global
 // schema doubles, so later batched PGlite suites retain the real columns.
@@ -166,7 +167,11 @@ describe("MessageRouterService contact recording", () => {
       contactDisplayName: "Friend",
     });
 
-    expect(delivery).toBe(true);
+    expect(delivery).toEqual({
+      status: "delivered",
+      provider: "blooio",
+      providerMessageIds: ["sent-message"],
+    });
     expect(blooioApiRequest).toHaveBeenCalledWith(
       "blooio-api-key",
       "POST",
@@ -223,7 +228,7 @@ describe("MessageRouterService contact recording", () => {
       body: "hello friend",
     });
 
-    expect(delivery).toBe(true);
+    expect(delivery.status).toBe("delivered");
     expect(dbWrite.insert).not.toHaveBeenCalled();
   });
 
@@ -242,8 +247,111 @@ describe("MessageRouterService contact recording", () => {
       agentUserId: "agent-user",
     });
 
-    expect(delivery).toBe(false);
+    expect(delivery).toEqual({
+      status: "uncertain",
+      provider: "blooio",
+      code: "DELIVERY_TRANSPORT_UNCERTAIN",
+      retryable: false,
+    });
     expect(dbWrite.insert).not.toHaveBeenCalled();
+  });
+
+  test("marks a successful provider response without a receipt uncertain", async () => {
+    secretsGet.mockResolvedValue("blooio-api-key");
+    blooioApiRequest.mockResolvedValue({});
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "blooio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "hello friend",
+    });
+
+    expect(delivery).toEqual({
+      status: "uncertain",
+      provider: "blooio",
+      code: "DELIVERY_RECEIPT_INVALID",
+      retryable: false,
+    });
+    expect(blooioApiRequest).toHaveBeenCalledTimes(1);
+    expect(dbWrite.insert).not.toHaveBeenCalled();
+  });
+
+  test("never retries after a provider deadline with ambiguous acceptance", async () => {
+    secretsGet.mockResolvedValue("blooio-api-key");
+    blooioApiRequest.mockRejectedValue(
+      new DOMException("Provider request deadline expired", "TimeoutError"),
+    );
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "blooio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "hello friend",
+    });
+
+    expect(delivery).toEqual({
+      status: "uncertain",
+      provider: "blooio",
+      code: "DELIVERY_TIMEOUT",
+      retryable: false,
+    });
+    expect(blooioApiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves an oversized accepted response as uncertain without retry", async () => {
+    secretsGet.mockResolvedValue("blooio-api-key");
+    blooioApiRequest.mockRejectedValue(
+      new ElizaError("REST response exceeds its bounded-body contract", {
+        code: "CLOUD_REST_RESPONSE_TOO_LARGE",
+        context: { maxResponseBytes: 4 * 1024 * 1024 },
+      }),
+    );
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "blooio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "hello friend",
+    });
+
+    expect(delivery).toEqual({
+      status: "uncertain",
+      provider: "blooio",
+      code: "DELIVERY_RESPONSE_TOO_LARGE",
+      retryable: false,
+    });
+    expect(blooioApiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves explicit provider rejection status and retryability", async () => {
+    secretsGet.mockResolvedValue("blooio-api-key");
+    blooioApiRequest.mockRejectedValue(
+      new ElizaError("Blooio rejected the provider request", {
+        code: "PROVIDER_REQUEST_REJECTED",
+        context: { provider: "blooio", status: 503, retryable: true },
+      }),
+    );
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "blooio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "hello friend",
+    });
+
+    expect(delivery).toEqual({
+      status: "failed",
+      provider: "blooio",
+      code: "DELIVERY_PROVIDER_REJECTED",
+      retryable: true,
+      providerStatus: 503,
+    });
+    expect(blooioApiRequest).toHaveBeenCalledTimes(1);
   });
 
   test("fails closed for an unsupported runtime provider", async () => {
@@ -256,7 +364,12 @@ describe("MessageRouterService contact recording", () => {
       body: "hello friend",
     });
 
-    expect(delivery).toBe(false);
+    expect(delivery).toEqual({
+      status: "failed",
+      provider: "unknown",
+      code: "DELIVERY_PROVIDER_UNSUPPORTED",
+      retryable: false,
+    });
     expect(blooioApiRequest).not.toHaveBeenCalled();
     expect(JSON.stringify(loggerError.mock.calls)).not.toContain(sentinelProvider);
   });
@@ -281,7 +394,7 @@ describe("MessageRouterService contact recording", () => {
       agentUserId: "agent-user",
     });
 
-    expect(delivery).toBe(true);
+    expect(delivery.status).toBe("delivered");
     expect(blooioApiRequest).toHaveBeenCalledTimes(1);
     expect(dbWrite.insert).toHaveBeenCalledTimes(1);
     expect(loggerError).toHaveBeenCalledWith(
@@ -306,7 +419,7 @@ describe("MessageRouterService contact recording", () => {
       agentUserId: "agent-user",
     });
 
-    expect(delivery).toBe(true);
+    expect(delivery.status).toBe("delivered");
     expect(blooioApiRequest).toHaveBeenCalledTimes(1);
     expect(dbWrite.insert).toHaveBeenCalledTimes(1);
   });

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -5,7 +5,7 @@
  * and handles sending responses back through the correct channel.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, isElizaError } from "@elizaos/core";
 import { createHash } from "crypto";
 import { and, eq } from "drizzle-orm";
 import { dbWrite } from "../../../db/client";
@@ -88,6 +88,70 @@ export interface SendMessageParams {
   agentOrganizationId?: string;
   agentUserId?: string;
   contactDisplayName?: string;
+}
+
+export type MessageDeliveryOutcome =
+  | {
+      status: "delivered";
+      provider: SendMessageParams["provider"];
+      providerMessageIds: string[];
+    }
+  | {
+      status: "failed" | "uncertain";
+      provider: SendMessageParams["provider"] | "unknown";
+      code: string;
+      retryable: boolean;
+      providerStatus?: number;
+    };
+
+function deliveryFailed(
+  provider: MessageDeliveryOutcome["provider"],
+  code: string,
+  retryable: boolean,
+  providerStatus?: number,
+): MessageDeliveryOutcome {
+  return {
+    status: "failed",
+    provider,
+    code,
+    retryable,
+    ...(providerStatus === undefined ? {} : { providerStatus }),
+  };
+}
+
+function deliveryUncertain(
+  provider: SendMessageParams["provider"],
+  code: string,
+): MessageDeliveryOutcome {
+  return { status: "uncertain", provider, code, retryable: false };
+}
+
+function classifyProviderException(
+  provider: SendMessageParams["provider"],
+  error: unknown,
+): MessageDeliveryOutcome {
+  if (isElizaError(error) && error.code === "PROVIDER_REQUEST_REJECTED") {
+    const providerStatus =
+      typeof error.context?.status === "number" ? error.context.status : undefined;
+    const retryable = error.context?.retryable === true;
+    return deliveryFailed(provider, "DELIVERY_PROVIDER_REJECTED", retryable, providerStatus);
+  }
+  if (isElizaError(error) && error.code === "PROVIDER_RECEIPT_INVALID") {
+    return deliveryUncertain(provider, "DELIVERY_RECEIPT_INVALID");
+  }
+  if (
+    isElizaError(error) &&
+    (error.code === "PROVIDER_RESPONSE_TOO_LARGE" || error.code === "CLOUD_REST_RESPONSE_TOO_LARGE")
+  ) {
+    return deliveryUncertain(provider, "DELIVERY_RESPONSE_TOO_LARGE");
+  }
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return deliveryUncertain(provider, "DELIVERY_TIMEOUT");
+  }
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return deliveryUncertain(provider, "DELIVERY_CANCELLED_AFTER_DISPATCH");
+  }
+  return deliveryUncertain(provider, "DELIVERY_TRANSPORT_UNCERTAIN");
 }
 
 function providerDiagnostic(value: unknown): string {
@@ -382,12 +446,12 @@ class MessageRouterService {
   /**
    * Send a message through the appropriate provider
    */
-  async sendMessage(params: SendMessageParams): Promise<boolean> {
+  async sendMessage(params: SendMessageParams): Promise<MessageDeliveryOutcome> {
     if (!(["twilio", "blooio", "whatsapp"] as const).includes(params.provider)) {
       logger.error("[MessageRouter] Unsupported message provider", {
         organizationId: params.organizationId,
       });
-      return false;
+      return deliveryFailed("unknown", "DELIVERY_PROVIDER_UNSUPPORTED", false);
     }
     logger.info("[MessageRouter] Sending message", {
       provider: providerDiagnostic(params.provider),
@@ -396,14 +460,14 @@ class MessageRouterService {
 
     const contactRequired = this.contactWriteRequired(params);
 
-    const delivered =
+    const delivery =
       params.provider === "twilio"
         ? await this.sendViaTwilio(params)
         : params.provider === "blooio"
           ? await this.sendViaBlooio(params)
           : await this.sendViaWhatsApp(params);
-    if (!delivered) return false;
-    if (!contactRequired) return true;
+    if (delivery.status !== "delivered") return delivery;
+    if (!contactRequired) return delivery;
 
     try {
       await this.recordAgentPhoneContact(params);
@@ -416,7 +480,7 @@ class MessageRouterService {
         ...phoneErrorDiagnostic(error),
       });
     }
-    return true;
+    return delivery;
   }
 
   private normalizeContactIdentifier(value: string): string {
@@ -501,21 +565,24 @@ class MessageRouterService {
   /**
    * Send message via Twilio
    */
-  private async sendViaTwilio(params: SendMessageParams): Promise<boolean> {
+  private async sendViaTwilio(params: SendMessageParams): Promise<MessageDeliveryOutcome> {
+    const { secretsService } = await import("../secrets");
+    const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = await import("../../constants/secrets");
+    let accountSid: string | null | undefined;
+    let authToken: string | null | undefined;
     try {
-      const { secretsService } = await import("../secrets");
+      accountSid = await secretsService.get(params.organizationId, TWILIO_ACCOUNT_SID);
+      authToken = await secretsService.get(params.organizationId, TWILIO_AUTH_TOKEN);
+    } catch (error) {
+      logger.error("[MessageRouter] Twilio credential lookup failed", phoneErrorDiagnostic(error));
+      return deliveryFailed("twilio", "DELIVERY_CREDENTIAL_LOOKUP_FAILED", true);
+    }
+    if (!accountSid || !authToken) {
+      logger.error("[MessageRouter] Missing Twilio credentials");
+      return deliveryFailed("twilio", "DELIVERY_CREDENTIALS_MISSING", false);
+    }
 
-      // Use secretsService.get() which looks up by (organizationId, secretName)
-      // Note: getDecryptedValue() takes (secretId, organizationId) - different signature
-      const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = await import("../../constants/secrets");
-      const accountSid = await secretsService.get(params.organizationId, TWILIO_ACCOUNT_SID);
-      const authToken = await secretsService.get(params.organizationId, TWILIO_AUTH_TOKEN);
-
-      if (!accountSid || !authToken) {
-        logger.error("[MessageRouter] Missing Twilio credentials");
-        return false;
-      }
-
+    try {
       // Twilio REST API
       const response = await messageRouterTwilioFetch(
         `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
@@ -535,37 +602,63 @@ class MessageRouterService {
 
       if (!response.ok) {
         logger.error("[MessageRouter] Twilio API error", { status: response.status });
-        return false;
+        return deliveryFailed(
+          "twilio",
+          "DELIVERY_PROVIDER_REJECTED",
+          response.status === 429 || response.status >= 500,
+          response.status,
+        );
       }
 
+      let receipt: unknown;
+      try {
+        receipt = await response.json();
+      } catch {
+        return deliveryUncertain("twilio", "DELIVERY_RECEIPT_INVALID");
+      }
+      const sid =
+        receipt &&
+        typeof receipt === "object" &&
+        typeof (receipt as { sid?: unknown }).sid === "string"
+          ? (receipt as { sid: string }).sid.trim()
+          : "";
+      if (!sid) return deliveryUncertain("twilio", "DELIVERY_RECEIPT_INVALID");
+
       logger.info("[MessageRouter] Twilio message sent successfully");
-      return true;
+      return { status: "delivered", provider: "twilio", providerMessageIds: [sid] };
     } catch (error) {
-      // error-policy:J4 provider errors become a typed delivery outcome at the caller.
+      // error-policy:J4 the caller receives a typed outcome that preserves ambiguity.
       logger.error("[MessageRouter] Twilio send error", phoneErrorDiagnostic(error));
-      return false;
+      return classifyProviderException("twilio", error);
     }
   }
 
   /**
    * Send message via Blooio (iMessage)
    */
-  private async sendViaBlooio(params: SendMessageParams): Promise<boolean> {
+  private async sendViaBlooio(params: SendMessageParams): Promise<MessageDeliveryOutcome> {
+    const { secretsService } = await import("../secrets");
+    const { BLOOIO_API_KEY } = await import("../../constants/secrets");
+    let apiKey: string | null | undefined;
     try {
-      const { secretsService } = await import("../secrets");
+      apiKey = await secretsService.get(params.organizationId, BLOOIO_API_KEY);
+    } catch (error) {
+      logger.error("[MessageRouter] Blooio credential lookup failed", phoneErrorDiagnostic(error));
+      return deliveryFailed("blooio", "DELIVERY_CREDENTIAL_LOOKUP_FAILED", true);
+    }
+    if (!apiKey) {
+      logger.error("[MessageRouter] Missing Blooio API key");
+      return deliveryFailed("blooio", "DELIVERY_CREDENTIALS_MISSING", false);
+    }
+
+    try {
       const { blooioApiRequest } = await import("../../utils/blooio-api");
-
-      // Use secretsService.get() which looks up by (organizationId, secretName)
-      const { BLOOIO_API_KEY } = await import("../../constants/secrets");
-      const apiKey = await secretsService.get(params.organizationId, BLOOIO_API_KEY);
-
-      if (!apiKey) {
-        logger.error("[MessageRouter] Missing Blooio API key");
-        return false;
-      }
-
       // Use the blooioApiRequest helper which uses the correct API base URL
-      await blooioApiRequest(
+      const receipt = await blooioApiRequest<{
+        id?: string;
+        message_id?: string;
+        message_ids?: string[];
+      }>(
         apiKey,
         "POST",
         `/chats/${encodeURIComponent(params.to)}/messages`,
@@ -578,12 +671,26 @@ class MessageRouterService {
         },
       );
 
+      const providerMessageIds = [
+        ...(Array.isArray(receipt.message_ids) ? receipt.message_ids : []),
+        receipt.message_id,
+        receipt.id,
+      ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+      const uniqueProviderMessageIds = [...new Set(providerMessageIds.map((id) => id.trim()))];
+      if (uniqueProviderMessageIds.length === 0) {
+        return deliveryUncertain("blooio", "DELIVERY_RECEIPT_INVALID");
+      }
+
       logger.info("[MessageRouter] Blooio message sent successfully");
-      return true;
+      return {
+        status: "delivered",
+        provider: "blooio",
+        providerMessageIds: uniqueProviderMessageIds,
+      };
     } catch (error) {
-      // error-policy:J4 provider errors become a typed delivery outcome at the caller.
+      // error-policy:J4 the caller receives a typed outcome that preserves ambiguity.
       logger.error("[MessageRouter] Blooio send error", phoneErrorDiagnostic(error));
-      return false;
+      return classifyProviderException("blooio", error);
     }
   }
 
@@ -592,17 +699,18 @@ class MessageRouterService {
    * Tries org-specific credentials from secrets service first,
    * falls back to global elizaAppConfig for the public bot.
    */
-  private async sendViaWhatsApp(params: SendMessageParams): Promise<boolean> {
+  private async sendViaWhatsApp(params: SendMessageParams): Promise<MessageDeliveryOutcome> {
+    const { sendWhatsAppMessage } = await import("../../utils/whatsapp-api");
+    const { secretsService } = await import("../secrets");
+    const { WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID } = await import(
+      "../../constants/secrets"
+    );
+    let accessToken: string | null | undefined;
+    let phoneNumberId: string | null | undefined;
     try {
-      const { sendWhatsAppMessage } = await import("../../utils/whatsapp-api");
-      const { secretsService } = await import("../secrets");
-      const { WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID } = await import(
-        "../../constants/secrets"
-      );
-
       // Try org-specific credentials first (from secrets service)
-      let accessToken = await secretsService.get(params.organizationId, WHATSAPP_ACCESS_TOKEN);
-      let phoneNumberId = await secretsService.get(params.organizationId, WHATSAPP_PHONE_NUMBER_ID);
+      accessToken = await secretsService.get(params.organizationId, WHATSAPP_ACCESS_TOKEN);
+      phoneNumberId = await secretsService.get(params.organizationId, WHATSAPP_PHONE_NUMBER_ID);
 
       // Fall back to global config (for eliza-app public bot)
       if (!accessToken || !phoneNumberId) {
@@ -610,27 +718,41 @@ class MessageRouterService {
         accessToken = accessToken || elizaAppConfig.whatsapp.accessToken;
         phoneNumberId = phoneNumberId || elizaAppConfig.whatsapp.phoneNumberId;
       }
+    } catch (error) {
+      logger.error("[MessageRouter] WhatsApp credential lookup failed", {
+        organizationId: params.organizationId,
+        ...phoneErrorDiagnostic(error),
+      });
+      return deliveryFailed("whatsapp", "DELIVERY_CREDENTIAL_LOOKUP_FAILED", true);
+    }
 
-      if (!accessToken || !phoneNumberId) {
-        logger.error("[MessageRouter] Missing WhatsApp credentials", {
-          organizationId: params.organizationId,
-        });
-        return false;
+    if (!accessToken || !phoneNumberId) {
+      logger.error("[MessageRouter] Missing WhatsApp credentials", {
+        organizationId: params.organizationId,
+      });
+      return deliveryFailed("whatsapp", "DELIVERY_CREDENTIALS_MISSING", false);
+    }
+
+    try {
+      const receipt = await sendWhatsAppMessage(accessToken, phoneNumberId, params.to, params.body);
+      const providerMessageIds = receipt.messages
+        .map((message) => message.id.trim())
+        .filter(Boolean);
+      if (providerMessageIds.length === 0) {
+        return deliveryUncertain("whatsapp", "DELIVERY_RECEIPT_INVALID");
       }
-
-      await sendWhatsAppMessage(accessToken, phoneNumberId, params.to, params.body);
 
       logger.info("[MessageRouter] WhatsApp message sent successfully", {
         organizationId: params.organizationId,
       });
-      return true;
+      return { status: "delivered", provider: "whatsapp", providerMessageIds };
     } catch (error) {
       // error-policy:J4 provider errors become a typed delivery outcome at the caller.
       logger.error("[MessageRouter] WhatsApp send error", {
         organizationId: params.organizationId,
         ...phoneErrorDiagnostic(error),
       });
-      return false;
+      return classifyProviderException("whatsapp", error);
     }
   }
 

--- a/packages/cloud/shared/src/lib/utils/blooio-api.ts
+++ b/packages/cloud/shared/src/lib/utils/blooio-api.ts
@@ -4,6 +4,7 @@
  * Shared constants and helpers for Blooio iMessage/SMS API interactions.
  */
 
+import { ElizaError } from "@elizaos/core";
 import crypto from "crypto";
 import { z } from "zod";
 import { ownedBoundedFetch } from "./owned-bounded-fetch";
@@ -173,7 +174,14 @@ export async function blooioApiRequest<T>(
   const responseText = await response.text();
 
   if (!response.ok) {
-    throw new Error(`Blooio API error (${response.status}): ${responseText}`);
+    throw new ElizaError("Blooio rejected the provider request", {
+      code: "PROVIDER_REQUEST_REJECTED",
+      context: {
+        provider: "blooio",
+        status: response.status,
+        retryable: response.status === 429 || response.status >= 500,
+      },
+    });
   }
 
   if (!responseText) {
@@ -182,8 +190,12 @@ export async function blooioApiRequest<T>(
 
   try {
     return JSON.parse(responseText) as T;
-  } catch {
-    throw new Error(`Invalid JSON response from Blooio: ${responseText}`);
+  } catch (cause) {
+    throw new ElizaError("Blooio accepted the request without a valid receipt", {
+      code: "PROVIDER_RECEIPT_INVALID",
+      context: { provider: "blooio" },
+      cause,
+    });
   }
 }
 

--- a/packages/cloud/shared/src/lib/utils/whatsapp-api.ts
+++ b/packages/cloud/shared/src/lib/utils/whatsapp-api.ts
@@ -5,9 +5,11 @@
  * Handles webhook signature verification, message sending, and payload parsing.
  */
 
+import { ElizaError } from "@elizaos/core";
 import crypto from "crypto";
 import { z } from "zod";
 import { logger } from "./logger";
+import { ownedBoundedFetch } from "./owned-bounded-fetch";
 
 export const WHATSAPP_API_BASE = "https://graph.facebook.com/v21.0";
 const WHATSAPP_REQUEST_TIMEOUT_MS = 10_000;
@@ -231,20 +233,30 @@ export async function sendWhatsAppMessage(
     text: { body: text },
   };
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
+  const response = await ownedBoundedFetch(
+    url,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(WHATSAPP_REQUEST_TIMEOUT_MS),
-  });
+    { timeoutMs: WHATSAPP_REQUEST_TIMEOUT_MS },
+  );
 
   const responseText = await response.text();
 
   if (!response.ok) {
-    throw new Error(`WhatsApp API error (${response.status}): ${responseText}`);
+    throw new ElizaError("WhatsApp rejected the provider request", {
+      code: "PROVIDER_REQUEST_REJECTED",
+      context: {
+        provider: "whatsapp",
+        status: response.status,
+        retryable: response.status === 429 || response.status >= 500,
+      },
+    });
   }
 
   try {
@@ -252,11 +264,17 @@ export async function sendWhatsAppMessage(
     return WhatsAppSendMessageResponseSchema.parse(parsed);
   } catch (parseError) {
     if (parseError instanceof z.ZodError) {
-      throw new Error(
-        `Unexpected WhatsApp API response shape: ${parseError.message} (raw: ${responseText.slice(0, 200)})`,
-      );
+      throw new ElizaError("WhatsApp accepted the request without a valid receipt", {
+        code: "PROVIDER_RECEIPT_INVALID",
+        context: { provider: "whatsapp" },
+        cause: parseError,
+      });
     }
-    throw new Error(`Invalid JSON response from WhatsApp: ${responseText}`);
+    throw new ElizaError("WhatsApp accepted the request without a valid receipt", {
+      code: "PROVIDER_RECEIPT_INVALID",
+      context: { provider: "whatsapp" },
+      cause: parseError,
+    });
   }
 }
 


### PR DESCRIPTION
Fixes #24805

## What changed
- replace the MessageRouter boolean contract with `delivered | failed | uncertain` outcomes carrying provider IDs, stable codes, retryability, and provider status
- classify pre-dispatch credential failures separately from post-dispatch timeout, cancellation, oversized response, malformed receipt, and transport ambiguity
- require successful Twilio, Blooio, and WhatsApp receipts before reporting delivery and bound WhatsApp reply buffering through the owned REST deadline/body ceiling
- make org webhook callers log the exact typed outcome and bill Twilio only after a confirmed provider receipt
- persist non-Telegram gateway processing as `delivered` or `uncertain`; duplicates of uncertain/legacy-ambiguous state receive an explicit 503 and never replay provider egress
- retain orphaned processing claims for the terminal ledger lifetime so a worker crash after provider acceptance cannot become a delayed duplicate

## Verification
Exact head: `6284414be980e6465a3a1d7087f6d593fc7445b4`
Base: `9c9eadd946`

- `bun test packages/cloud/shared/src/lib/services/message-router/index.test.ts packages/cloud/shared/src/lib/services/message-router/message-router-deadline.test.ts packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts` — 60 pass, 230 assertions
- exact updated gateway handler suite — 35 pass, 156 assertions
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — pass
- Biome exact changed-file check — pass
- Twilio route logging tests — 2 pass
- WhatsApp API tests — 5 pass
- Blooio API tests — 3 pass
- Blooio route logging test — 1 pass
- cloud-shared typecheck reaches one pre-existing workspace-resolution failure: missing `@elizaos/plugin-doordash` in `src/lib/eliza/runtime/initializer.ts`; no changed-file diagnostic

## Evidence
- UI screenshots/video: N/A — server/provider contract only
- live provider send: N/A — would message real users and requires production credentials; deterministic regressions prove accepted-without-receipt, timeout, oversized body, explicit 503 rejection, and one-attempt/no-replay semantics
- generated artifacts: N/A — no artifact-producing surface
