### PR TITLE
fix(ui): render chat as a flat transcript

### DIFF
--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -323,11 +323,7 @@ export interface ConversationMessage {
   attachments?: MessageAttachment[];
   /** Source channel when forwarded from another channel (e.g. "autonomy"). */
   source?: string;
-  /**
-   * Short topic labels extracted for this turn (Stage-1 `topics`). Drives the
-   * transcript topic grouping + chips bar (#8928). Absent when the turn had no
-   * salient topic.
-   */
+  /** Short topic labels retained for search and memory semantics. */
   topics?: string[];
   /** Concrete action name that produced this assistant turn, when applicable. */
   actionName?: string;

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -1459,11 +1459,7 @@ describe("ChatOverlay", () => {
     expect(log?.querySelectorAll('[data-testid="thread-line"]').length).toBe(1);
   });
 
-  it("hides the topic chips bar + dividers on a single-topic thread", () => {
-    // The lock-screen leak: a fresh thread whose only Stage-1 topic is
-    // `greeting` was rendering a grey `greeting` chip top-left and a
-    // "— GREETING —" divider above the only message. One topic group must
-    // open clean — no chips rail, no divider.
+  it("renders a single-topic thread without topic chrome", () => {
     render(
       <ChatOverlay
         controller={makeController({
@@ -1490,12 +1486,11 @@ describe("ChatOverlay", () => {
     expect(screen.queryByTestId("topic-chips-bar")).toBeNull();
     expect(screen.queryByTestId("topic-group-header")).toBeNull();
     expect(screen.queryByTestId("topic-group-pill")).toBeNull();
-    // The message still renders — gating only removes the topic chrome.
     const log = document.getElementById("continuous-thread");
     expect(log?.textContent).toContain("how can I help");
   });
 
-  it("shows the chips bar + dividers once the thread spans two topics", () => {
+  it("renders multiple-topic messages as one flat chronological transcript", () => {
     render(
       <ChatOverlay
         controller={makeController({
@@ -1519,15 +1514,13 @@ describe("ChatOverlay", () => {
       />,
     );
     fireEvent.focus(screen.getByLabelText("message"));
-    expect(screen.getByTestId("topic-chips-bar")).toBeTruthy();
-    // Two distinct topics → two group dividers, labels humanized.
-    expect(screen.getAllByTestId("topic-group-header").length).toBe(2);
-    expect(screen.getByTestId("topic-chips-bar").textContent).toContain(
-      "Deployment",
-    );
-    expect(screen.getByTestId("topic-chips-bar").textContent).toContain(
-      "Billing",
-    );
+    expect(screen.queryByTestId("topic-chips-bar")).toBeNull();
+    expect(screen.queryByTestId("topic-group-header")).toBeNull();
+    expect(screen.queryByTestId("topic-group-pill")).toBeNull();
+    const lines = screen.getAllByTestId("thread-line");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.textContent).toContain("deploy failing");
+    expect(lines[1]?.textContent).toContain("charged twice");
   });
 
   it("aligns the assistant bubble left and the user bubble right", () => {
@@ -4209,7 +4202,7 @@ describe("ChatOverlay single-thread (no chat swipe, #13531)", () => {
     expect(controller.clearConversation).not.toHaveBeenCalled();
   });
 
-  it("renders the infinite-scroll top sentinel above a populated flat thread (#14279)", () => {
+  it("renders the infinite-scroll top sentinel above a populated thread (#14279)", () => {
     const { controller } = makeSwipeController();
     render(<ChatOverlay controller={controller} />);
     openSheet();

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -166,14 +166,6 @@ import {
   filterRenderableShellMessages,
   type ShellMessage,
 } from "./shell-state";
-import { ShellTopicChipsBar } from "./TopicChipsBar";
-import { TopicGroup } from "./TopicGroup";
-import { findTopicElement } from "./topic-element";
-import {
-  deriveChannelTopics,
-  groupMessagesByTopic,
-  hasMultipleTopicGroups,
-} from "./topic-grouping";
 import { type PullGestureBinding, usePullGesture } from "./use-pull-gesture";
 import type { ConversationNav, ShellController } from "./useShellController";
 import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
@@ -2171,26 +2163,6 @@ export function ChatOverlay({
     markLayoutShiftIntent,
   ]);
 
-  // Topic grouping + chips bar (#8928). Derived from the per-message Stage-1
-  // topic tags. The chips rail and dividers ONLY earn their pixels once a
-  // transcript genuinely spans MULTIPLE topics — a fresh/single-subject thread
-  // renders flat so the lock-screen chat opens clean (no machine-topic pill
-  // top-left, no "— GREETING —" divider above the only group). See
-  // `hasMultipleTopicGroups`. Chip labels are humanized from the tagger's
-  // machine slugs (`user_greeting` → "User Greeting").
-  const topicSegments = React.useMemo(
-    () => groupMessagesByTopic(visibleMessages),
-    [visibleMessages],
-  );
-  const hasTopics = React.useMemo(
-    () => hasMultipleTopicGroups(topicSegments),
-    [topicSegments],
-  );
-  const channelTopics = React.useMemo(
-    () => deriveChannelTopics(visibleMessages),
-    [visibleMessages],
-  );
-
   // ── Infinite upward scroll (#13532/#14329), wired into the overlay per #14279
   // The overlay is the primary mobile/PWA chat surface. The shadcn
   // MessageScroller owns bottom-follow and streamed growth on `threadRef`; the
@@ -2202,13 +2174,9 @@ export function ChatOverlay({
     scrollRef: threadRef,
     sentinelRef: topSentinelRef,
     onLoadOlder: renderWindow.onLoadOlder,
-    // Topic grouping wraps rows in collapsible segments, which breaks the
-    // sentinel's flat-prepend anchor math; restrict load-older to the flat
-    // transcript (the common case). A topic-grouped thread still shows its
-    // recent window; scroll-up paging there is a follow-up.
-    hasMore: !hasTopics && renderWindow.canLoadOlder,
+    hasMore: renderWindow.canLoadOlder,
     topItemKey: visibleMessages[0]?.id ?? "",
-    enabled: threadPresented && !hasTopics,
+    enabled: threadPresented,
   });
 
   // ── Message search across previous chats (#9955, wired into the overlay per
@@ -2387,35 +2355,6 @@ export function ChatOverlay({
     ],
   );
 
-  const [collapsedTopics, setCollapsedTopics] = React.useState<
-    ReadonlySet<string>
-  >(() => new Set<string>());
-  const setTopicCollapsed = React.useCallback(
-    (key: string, collapsed: boolean) => {
-      setCollapsedTopics((prev) => {
-        if (collapsed === prev.has(key)) return prev;
-        const next = new Set(prev);
-        if (collapsed) next.add(key);
-        else next.delete(key);
-        return next;
-      });
-    },
-    [],
-  );
-  // Tapping a chip expands its group and scrolls its header into view.
-  const scrollToTopic = React.useCallback((topic: string) => {
-    setCollapsedTopics((prev) => {
-      if (!prev.has(topic)) return prev;
-      const next = new Set(prev);
-      next.delete(topic);
-      return next;
-    });
-    if (typeof requestAnimationFrame === "undefined") return;
-    requestAnimationFrame(() => {
-      const el = findTopicElement(threadRef.current, topic);
-      el?.scrollIntoView({ behavior: "smooth", block: "start" });
-    });
-  }, []);
   // The stable body renderer keeps ChatMessage's memo intact while the sheet
   // moves; only the active assistant row receives volatile turn status.
   const renderRowBody = React.useCallback(
@@ -6262,16 +6201,6 @@ export function ChatOverlay({
                             <Loader2 className="h-6 w-6 animate-spin text-accent" />
                           </div>
                         ) : null}
-                        {/* Topic chips bar (#8928): the channel's current topics,
-                      sticky above the scrolling transcript. Tap a chip to jump
-                      to (and expand) its group. Hidden when nothing is tagged. */}
-                        {hasTopics ? (
-                          <ShellTopicChipsBar
-                            topics={channelTopics}
-                            onSelectTopic={scrollToTopic}
-                            className="sticky top-0 z-[2] -mx-5 mb-1 bg-gradient-to-b from-scrim to-transparent px-5"
-                          />
-                        ) : null}
                         {/* Normal chat consumes only the free space in genuinely
                   short threads to keep their latest line near the composer.
                   Once content fills the viewport there is no free space to
@@ -6292,10 +6221,8 @@ export function ChatOverlay({
                         a zero-height marker just above the oldest turn. When it
                         nears the top of the scroller, useLoadOlderOnScroll
                         prefetches + prepends an older page a viewport early and
-                        preserves the reader's anchor so the thread never jumps.
-                        Only meaningful in the flat (non-topic) transcript. */}
+                        preserves the reader's anchor so the thread never jumps. */}
                           {!firstRunOpen &&
-                          !hasTopics &&
                           renderWindow.canLoadOlder &&
                           visibleMessages.length > 0 ? (
                             <div
@@ -6305,57 +6232,12 @@ export function ChatOverlay({
                               className="pointer-events-none h-px w-full shrink-0"
                             />
                           ) : null}
-                          {hasTopics
-                            ? // Topic-grouped transcript: each cluster collapses via a
-                              // gesture on its header (no visible buttons).
-                              (() => {
-                                let lineIndex = 0;
-                                return topicSegments.map((segment) => {
-                                  const lines = segment.messages.map((m) =>
-                                    renderThreadLine(m, lineIndex++),
-                                  );
-                                  return (
-                                    // The React key is the segment's first message id
-                                    // (stable + unique) because a topic can recur in a
-                                    // non-adjacent run (A → B → A). Collapse state stays
-                                    // keyed by topic (`segment.key`) so a chip tap
-                                    // expands every run of that topic.
-                                    <MessageScrollerItem
-                                      key={
-                                        segment.messages[0]?.id ?? segment.key
-                                      }
-                                      messageId={`topic:${segment.messages[0]?.id ?? segment.key}`}
-                                      className="w-full"
-                                    >
-                                      <TopicGroup
-                                        topic={segment.topic}
-                                        count={segment.messages.length}
-                                        collapsed={collapsedTopics.has(
-                                          segment.key,
-                                        )}
-                                        onCollapsedChange={(collapsed) =>
-                                          setTopicCollapsed(
-                                            segment.key,
-                                            collapsed,
-                                          )
-                                        }
-                                      >
-                                        {lines}
-                                      </TopicGroup>
-                                    </MessageScrollerItem>
-                                  );
-                                });
-                              })()
-                            : // Flat transcript (no topic tags) — unchanged behavior.
-                              // Only the LAST, content-less assistant turn (the
-                              // in-flight one) reads turnStatus — every settled bubble
-                              // gets undefined so its memo identity is unchanged.
-                              null}
-                          {hasTopics
-                            ? null
-                            : visibleMessages.map((m, i) =>
-                                renderThreadLine(m, i),
-                              )}
+                          {/* Topic metadata remains available to search and
+                          memory consumers, but ordinary chat is always one
+                          chronological transcript. */}
+                          {visibleMessages.map((m, i) =>
+                            renderThreadLine(m, i),
+                          )}
                         </MessageScrollerContent>
                       </MessageScrollerViewport>
                     </motion.div>

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -70,10 +70,7 @@ export interface ShellMessage {
   attachments?: MessageAttachment[];
   /** Pending secret / OAuth request (rendered as an actionable block). */
   secretRequest?: ConversationSecretRequest;
-  /**
-   * Short topic labels for this turn (Stage-1 `topics`). Drives the transcript
-   * topic grouping + chips bar (#8928). Absent when the turn had no topic.
-   */
+  /** Short topic labels retained for search and memory semantics. */
   topics?: string[];
 }
 


### PR DESCRIPTION
## Product decision

Implements the explicit Nubs/Shaw normal-chat decision: no automatic topic chips, counts, collapsible group pills, or topic divider headers. Messages render as one chronological transcript with ordinary history loading.

Per-message topic metadata remains in the data contract for search/memory consumers; this changes presentation only.

## Evidence

- ChatOverlay Vitest: 203/203
- UI typecheck: pass
- UI Biome: pass with 5 pre-existing cookie-test warnings

Split from closed composite #24777 for independent review.