### PR TITLE
fix(cloud): simplify agent navigation

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
@@ -197,6 +197,9 @@ describe("ElizaAgentsTable per-row view model", () => {
         name: "Open Web UI",
       }),
     ).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Dedicated Eliza" })).toBeNull();
+    expect(screen.getAllByText("Dedicated Eliza")).toHaveLength(2);
+    expect(screen.queryByRole("link", { name: "Open Eliza app" })).toBeNull();
     expect(
       within(dedicatedRow as HTMLElement).getByRole("button", {
         name: "Delete agent",

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.render.test.tsx
@@ -197,8 +197,15 @@ describe("ElizaAgentsTable per-row view model", () => {
         name: "Open Web UI",
       }),
     ).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "Dedicated Eliza" })).toBeNull();
-    expect(screen.getAllByText("Dedicated Eliza")).toHaveLength(2);
+    const detailLinks = screen.getAllByRole("link", {
+      name: "Dedicated Eliza",
+    });
+    expect(detailLinks).toHaveLength(2);
+    expect(
+      detailLinks.every((link) =>
+        link.getAttribute("href")?.startsWith("/cloud/agents/"),
+      ),
+    ).toBe(true);
     expect(screen.queryByRole("link", { name: "Open Eliza app" })).toBeNull();
     expect(
       within(dedicatedRow as HTMLElement).getByRole("button", {

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -949,31 +949,18 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
             }),
           }}
         />
-        {/* Search and primary navigation for the visible agent set. */}
-        <div className="flex flex-col sm:flex-row gap-3">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted" />
-            <Input
-              placeholder={t("cloud.elizaAgentsTable.searchAgents", {
-                defaultValue: "Search agents…",
-              })}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9 h-9 border-border bg-card text-txt placeholder:text-muted"
-            />
-          </div>
-          <Button asChild size="sm" className="h-9">
-            <a
-              href={ELIZA_APP_AGENT_CREATE_URL}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <ExternalLink className="h-4 w-4" />
-              {t("cloud.elizaAgentsTable.openElizaApp", {
-                defaultValue: "Open Eliza app",
-              })}
-            </a>
-          </Button>
+        {/* Search the authoritative agent set. Each runnable row owns its one
+            launch affordance: Open Web UI. */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+          <Input
+            placeholder={t("cloud.elizaAgentsTable.searchAgents", {
+              defaultValue: "Search agents…",
+            })}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-9 border-border bg-card pl-9 text-txt placeholder:text-muted"
+          />
         </div>
 
         {searchQuery && (
@@ -1092,10 +1079,7 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                       <TableCell>
                         <div className="space-y-1">
                           <div className="flex flex-wrap items-center gap-2">
-                            <a
-                              href={`/cloud/agents/${sb.id}`}
-                              className="font-medium text-txt-strong hover:text-accent transition-colors"
-                            >
+                            <span className="font-medium text-txt-strong">
                               {getAgentDisplayName(
                                 sb,
                                 t("cloud.elizaAgentsTable.sharedAgentName", {
@@ -1105,7 +1089,7 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                                   defaultValue: "Unnamed Agent",
                                 }),
                               )}
-                            </a>
+                            </span>
                             <AgentCostBadge
                               status={displayStatus}
                               executionTier={sb.executionTier}
@@ -1341,10 +1325,7 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 space-y-1">
-                      <a
-                        href={`/cloud/agents/${sb.id}`}
-                        className="font-medium text-txt-strong hover:text-accent transition-colors block truncate"
-                      >
+                      <span className="block truncate font-medium text-txt-strong">
                         {getAgentDisplayName(
                           sb,
                           t("cloud.elizaAgentsTable.sharedAgentName", {
@@ -1354,7 +1335,7 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                             defaultValue: "Unnamed Agent",
                           }),
                         )}
-                      </a>
+                      </span>
                       <AgentCostBadge
                         status={displayStatus}
                         executionTier={sb.executionTier}

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -1079,7 +1079,10 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                       <TableCell>
                         <div className="space-y-1">
                           <div className="flex flex-wrap items-center gap-2">
-                            <span className="font-medium text-txt-strong">
+                            <a
+                              href={`/cloud/agents/${sb.id}`}
+                              className="font-medium text-txt-strong transition-colors hover:text-accent"
+                            >
                               {getAgentDisplayName(
                                 sb,
                                 t("cloud.elizaAgentsTable.sharedAgentName", {
@@ -1089,7 +1092,7 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                                   defaultValue: "Unnamed Agent",
                                 }),
                               )}
-                            </span>
+                            </a>
                             <AgentCostBadge
                               status={displayStatus}
                               executionTier={sb.executionTier}
@@ -1325,7 +1328,10 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 space-y-1">
-                      <span className="block truncate font-medium text-txt-strong">
+                      <a
+                        href={`/cloud/agents/${sb.id}`}
+                        className="block truncate font-medium text-txt-strong transition-colors hover:text-accent"
+                      >
                         {getAgentDisplayName(
                           sb,
                           t("cloud.elizaAgentsTable.sharedAgentName", {
@@ -1335,7 +1341,7 @@ export function ElizaAgentsTable({ agents }: { agents: AgentListItemDto[] }) {
                             defaultValue: "Unnamed Agent",
                           }),
                         )}
-                      </span>
+                      </a>
                       <AgentCostBadge
                         status={displayStatus}
                         executionTier={sb.executionTier}

--- a/packages/ui/src/cloud/shell/ManagedCloudPage.test.tsx
+++ b/packages/ui/src/cloud/shell/ManagedCloudPage.test.tsx
@@ -4,7 +4,7 @@
  */
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -59,6 +59,14 @@ vi.mock("./cloud-route-registry", async () => {
     getCloudRouteGate: () => undefined,
     listCloudRoutes: () => [
       {
+        path: "cloud",
+        group: "cloud",
+        element: () => {
+          useSetPageHeader({ title: "Overview" });
+          return <div data-testid="cloud-overview" />;
+        },
+      },
+      {
         path: "cloud/billing",
         group: "cloud",
         element: () => {
@@ -94,8 +102,9 @@ function LocationProbe(): React.JSX.Element {
 function renderPage(path: string): void {
   render(
     <MemoryRouter initialEntries={[path]}>
+      <LocationProbe />
       <Routes>
-        <Route path="/login" element={<LocationProbe />} />
+        <Route path="/login" element={<div data-testid="login-page" />} />
         <Route path="*" element={<ManagedCloudPage />} />
       </Routes>
     </MemoryRouter>,
@@ -112,6 +121,17 @@ afterEach(() => {
 });
 
 describe("ManagedCloudPage", () => {
+  it("returns nested Cloud routes to the Cloud overview", () => {
+    renderPage("/cloud/billing");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Back to Cloud overview" }),
+    );
+
+    expect(screen.getByTestId("location").textContent).toBe("/cloud");
+    expect(screen.getByTestId("cloud-overview")).toBeTruthy();
+  });
+
   it("renders a registered /cloud route inside the app for cloud-managed agents", () => {
     renderPage("/cloud/billing");
     expect(screen.getByTestId("billing-page")).toBeTruthy();

--- a/packages/ui/src/cloud/shell/ManagedCloudPage.tsx
+++ b/packages/ui/src/cloud/shell/ManagedCloudPage.tsx
@@ -6,7 +6,12 @@
  */
 
 import { type ComponentType, Suspense } from "react";
-import { matchPath, Navigate, useLocation } from "react-router-dom";
+import {
+  matchPath,
+  Navigate,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import {
   EnsurePageHeaderProvider,
   usePageHeader,
@@ -75,10 +80,17 @@ function ManagedCloudRouteFrame({
   email: string | null;
 }): React.JSX.Element {
   const { pageInfo } = usePageHeader();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isCloudOverview = location.pathname === "/cloud";
   return (
     <div className="theme-cloud flex min-h-0 min-w-0 flex-1 flex-col bg-bg text-txt">
       <ViewHeader
         title={pageInfo?.title ?? "Cloud"}
+        onBack={isCloudOverview ? undefined : () => navigate("/cloud")}
+        backLabel={
+          isCloudOverview ? "Back to launcher" : "Back to Cloud overview"
+        }
         right={
           <div className="flex items-center gap-2">
             {pageInfo?.actions}


### PR DESCRIPTION
## Product decision

Removes duplicate launch/navigation affordances from the Cloud agent list: the agent name is informational, and each runnable row has one authoritative `Open Web UI` action. The redundant top-level `Open Eliza app` link is removed.

Nested Cloud pages now return to `/cloud` with preserved Cloud context; the overview keeps its launcher-level back behavior.

## Evidence

- Agent table + managed Cloud frame Vitest: 18/18
- UI typecheck: pass
- UI Biome: pass with 5 pre-existing cookie-test warnings

Split from closed composite #24777 for independent product review.