### PR TITLE
fix(elizacloud): remove provider output defaults

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -275,6 +275,15 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"plugins/plugin-elizacloud/src/cloud/bridge-client.ts": [
 		/(?:text|errorText)\.slice\(/,
 	],
+	"plugins/plugin-elizacloud/src/models/text.ts": [
+		/max_tokens\s*=\s*params\.maxTokens\s*\?\?/,
+		/max_output_tokens\s*=\s*params\.maxTokens\s*\?\?/,
+		/(?:max_tokens|max_output_tokens)\s*[:=]\s*8192/,
+	],
+	"plugins/plugin-elizacloud/src/models/image.ts": [
+		/IMAGE_DESCRIPTION_MAX_TOKENS[^\n]*["']8192["']/,
+		/max_tokens\s*:\s*maxTokens/,
+	],
 	"packages/core/src/runtime/limits.ts": [
 		/compactionEnabled/,
 		/compactionKeepSteps/,

--- a/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
@@ -31,8 +31,11 @@ vi.mock("../src/utils/config", async (orig) => {
 
 const { handleImageDescription, handleImageGeneration } = await import("../src/models/image");
 
-function runtime(): IAgentRuntime {
-  return { getSetting: () => "", emitEvent: () => {} } as unknown as IAgentRuntime;
+function runtime(settings: Record<string, string> = {}): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key] ?? "",
+    emitEvent: () => {},
+  } as unknown as IAgentRuntime;
 }
 
 function warming503(): Response {
@@ -67,6 +70,30 @@ describe("handleImageDescription warming-503 retry", () => {
     });
     expect(postRaw).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(result)).toContain("red square");
+  });
+
+  it("omits the output cap unless an operator explicitly configures it", async () => {
+    postRaw.mockResolvedValue(ok("Complete description."));
+    await handleImageDescription(runtime(), "https://example.com/full.png");
+    expect(postRaw.mock.calls[0]?.[0]?.json).not.toHaveProperty("max_tokens");
+
+    postRaw.mockClear();
+    postRaw.mockResolvedValue(ok("Complete description."));
+    await handleImageDescription(
+      runtime({ ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS: "16384" }),
+      "https://example.com/full.png"
+    );
+    expect(postRaw.mock.calls[0]?.[0]?.json?.max_tokens).toBe(16384);
+  });
+
+  it("rejects an invalid explicit image output budget before dispatch", async () => {
+    await expect(
+      handleImageDescription(
+        runtime({ ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS: "8192oops" }),
+        "https://example.com/full.png"
+      )
+    ).rejects.toMatchObject({ code: "ELIZAOS_CLOUD_IMAGE_OUTPUT_BUDGET_INVALID" });
+    expect(postRaw).not.toHaveBeenCalled();
   });
 
   it("throws (fails closed) on a hard 500 instead of fabricating a description", async () => {

--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -1225,7 +1225,7 @@ describe("cloud streaming gate decision (wantsStream)", () => {
     expect(lastJson().stream).not.toBe(true);
   });
 
-  it("omits native max_tokens only when omitMaxTokens is set", async () => {
+  it("omits native max_tokens unless the caller explicitly sets it", async () => {
     nextResponse = bufferedChatResponse("buffered reply");
     await handleResponseHandler(fakeRuntime(), {
       prompt: "hi",
@@ -1239,10 +1239,18 @@ describe("cloud streaming gate decision (wantsStream)", () => {
       prompt: "hi",
       providerOptions: { eliza: {} },
     } as never);
-    expect(lastJson().max_tokens).toBe(8192);
+    expect(lastJson()).not.toHaveProperty("max_tokens");
+
+    nextResponse = bufferedChatResponse("buffered reply");
+    await handleResponseHandler(fakeRuntime(), {
+      prompt: "hi",
+      providerOptions: { eliza: {} },
+      maxTokens: 16384,
+    } as never);
+    expect(lastJson().max_tokens).toBe(16384);
   });
 
-  it("omits responses max_output_tokens only when omitMaxTokens is set", async () => {
+  it("omits responses max_output_tokens unless the caller explicitly sets it", async () => {
     nextResponse = bufferedChatResponse("buffered reply");
     await handleResponseHandler(fakeRuntime(), {
       prompt: "hi",
@@ -1254,7 +1262,14 @@ describe("cloud streaming gate decision (wantsStream)", () => {
     await handleResponseHandler(fakeRuntime(), {
       prompt: "hi",
     } as never);
-    expect(lastJson().max_output_tokens).toBe(8192);
+    expect(lastJson()).not.toHaveProperty("max_output_tokens");
+
+    nextResponse = bufferedChatResponse("buffered reply");
+    await handleResponseHandler(fakeRuntime(), {
+      prompt: "hi",
+      maxTokens: 16384,
+    } as never);
+    expect(lastJson().max_output_tokens).toBe(16384);
   });
 
   it("never logs rendered prompt content while preserving the provider request", async () => {

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -1,5 +1,5 @@
 import type { IAgentRuntime, ImageDescriptionParams, ImageGenerationParams } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { ElizaError, logger, ModelType } from "@elizaos/core";
 import {
   getImageDescriptionModel,
   getImageGenerationModel,
@@ -118,10 +118,22 @@ export async function handleImageDescription(
   let promptText: string | undefined;
   const modelName = getImageDescriptionModel(runtime);
   logger.log(`[ELIZAOS_CLOUD] Using IMAGE_DESCRIPTION model: ${modelName}`);
-  const maxTokens = Number.parseInt(
-    getSetting(runtime, "ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS", "8192") || "8192",
-    10
-  );
+  const configuredMaxTokens = (
+    getSetting(runtime, "ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS", "") ?? ""
+  ).trim();
+  const maxTokens = configuredMaxTokens === "" ? undefined : Number(configuredMaxTokens);
+  if (
+    maxTokens !== undefined &&
+    (!Number.isSafeInteger(maxTokens) || maxTokens <= 0)
+  ) {
+    throw new ElizaError(
+      "ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS must be a positive safe integer",
+      {
+        code: "ELIZAOS_CLOUD_IMAGE_OUTPUT_BUDGET_INVALID",
+        context: { received: configuredMaxTokens },
+      }
+    );
+  }
 
   if (typeof params === "string") {
     imageUrl = params;
@@ -148,8 +160,8 @@ export async function handleImageDescription(
     const requestBody: Record<string, unknown> = {
       model: modelName,
       messages: messages,
-      max_tokens: maxTokens,
     };
+    if (maxTokens !== undefined) requestBody.max_tokens = maxTokens;
 
     // On 429, honour the upstream's `retryAfter` instead of retrying on a
     // hardcoded backoff. Hardcoded retries inside the rate-limit window add

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -975,11 +975,11 @@ function buildNativeRequestBody(
     model: modelName,
     messages: buildNativeMessages(params, promptText, systemPrompt),
   };
-  // Omit the cap entirely when the caller opted out (direct-channel Stage-1):
-  // a hardcoded max_tokens 400s on a model whose real limit differs. Every other
-  // caller keeps the 8192 default so it stays bounded.
-  if (!params.omitMaxTokens) {
-    requestBody.max_tokens = params.maxTokens ?? 8192;
+  // An omitted output budget remains omitted. The selected provider owns its
+  // real model boundary; core defaults would silently turn a complete request
+  // into a partial completion. Explicit values are forwarded unchanged.
+  if (!params.omitMaxTokens && params.maxTokens !== undefined) {
+    requestBody.max_tokens = params.maxTokens;
   }
 
   if (!isReasoningModel(modelName) && typeof params.temperature === "number") {
@@ -1290,8 +1290,8 @@ async function generateTextWithModel(
     model: modelName,
     input,
   };
-  if (!params.omitMaxTokens) {
-    requestBody.max_output_tokens = params.maxTokens ?? 8192;
+  if (!params.omitMaxTokens && params.maxTokens !== undefined) {
+    requestBody.max_output_tokens = params.maxTokens;
   }
   if (!reasoning && typeof params.temperature === "number") {
     requestBody.temperature = params.temperature;


### PR DESCRIPTION
Closes #24833

## What changed
- chat-completions omits `max_tokens` when the caller did not explicitly set one
- Responses API omits `max_output_tokens` under the same contract
- image description no longer defaults to 8192; an explicit environment value is validated as a positive safe integer before dispatch
- explicit caller/operator values continue to be forwarded unchanged
- prompt-integrity source guards prevent restoration of the 8192 defaults

## Verification
- text streaming/provider wire tests: 66 passed
- image-description tests: 7 passed
- core prompt-integrity tests: 4 passed
- changed-file Biome and `git diff --check` passed
- package typecheck reached the touched files cleanly; the sparse isolated worktree still reports pre-existing missing optional UI/Capacitor/Cloud dependency artifacts outside these files

This prevents the Eliza Cloud provider from silently undoing the uncapped core planner/evaluator behavior merged in #24811.