### PR TITLE
fix(cloud): reconcile uncertain Twilio call submissions

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.test.ts
@@ -10,7 +10,7 @@ const requireUser = mock(async () => ({
 }));
 interface OwnedCall {
   id: string;
-  call_sid: string;
+  call_sid: string | null;
   account_sid: string;
   user_id: string;
   organization_id: string;
@@ -78,9 +78,13 @@ const env = {
   ELIZA_APP_TWILIO_AUTH_TOKEN: "secret",
 };
 
-function request(method: "GET" | "DELETE", idempotencyKey?: string) {
+function request(
+  method: "GET" | "DELETE",
+  idempotencyKey?: string,
+  reference = callSid,
+) {
   return app.request(
-    `/${callSid}`,
+    `/${reference}`,
     {
       method,
       headers: idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {},
@@ -115,6 +119,7 @@ describe("Twilio outbound owned call", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       success: true,
+      callId: baseCall.id,
       callSid,
       status: "in-progress",
       to: "***0100",
@@ -122,6 +127,50 @@ describe("Twilio outbound owned call", () => {
       terminalAt: null,
       hangupRequestedAt: null,
     });
+  });
+
+  test("polls a submission-unknown call by its durable id", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        ...baseCall,
+        call_sid: null,
+        call_status: "submission-unknown",
+        answered_at: null,
+      },
+    ]);
+
+    const response = await request("GET", undefined, baseCall.id);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      callId: baseCall.id,
+      callSid: null,
+      status: "submission-unknown",
+    });
+  });
+
+  test("does not claim it can hang up before a CallSid is known", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        ...baseCall,
+        call_sid: null,
+        call_status: "submission-unknown",
+        answered_at: null,
+      },
+    ]);
+
+    const response = await request(
+      "DELETE",
+      "77777777-7777-4777-8777-777777777777",
+      baseCall.id,
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "call_submission_unknown",
+    });
+    expect(providerRequest).not.toHaveBeenCalled();
   });
 
   test("requests one provider hangup and persists it", async () => {

--- a/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.ts
@@ -18,6 +18,7 @@ import { isTerminalTwilioCallStatus } from "../../lib/twilio-call-status";
 
 const app = new Hono<AppEnv>();
 const CallSid = z.string().regex(/^CA[a-fA-F0-9]{32}$/);
+const CallId = z.string().uuid();
 const IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
 
 interface PublicTwilioEnv {
@@ -35,14 +36,21 @@ app.use("*", rateLimit({ ...RateLimitPresets.CRITICAL, failClosed: true }));
 
 async function ownedCall(c: Parameters<typeof requireUserOrApiKeyWithOrg>[0]) {
   const auth = await requireUserOrApiKeyWithOrg(c);
-  const parsedSid = CallSid.safeParse(c.req.param("callSid"));
-  if (!parsedSid.success) return { auth, call: null };
+  const reference = c.req.param("callSid");
+  const parsedSid = CallSid.safeParse(reference);
+  const parsedId = CallId.safeParse(reference);
+  const referenceCondition = parsedSid.success
+    ? eq(twilioOutboundCalls.call_sid, parsedSid.data)
+    : parsedId.success
+      ? eq(twilioOutboundCalls.id, parsedId.data)
+      : undefined;
+  if (!referenceCondition) return { auth, call: null };
   const [call] = await dbWrite
     .select()
     .from(twilioOutboundCalls)
     .where(
       and(
-        eq(twilioOutboundCalls.call_sid, parsedSid.data),
+        referenceCondition,
         eq(twilioOutboundCalls.user_id, auth.id),
         eq(twilioOutboundCalls.organization_id, auth.organization_id),
       ),
@@ -57,6 +65,7 @@ app.get("/", async (c) => {
     return c.json({ error: "Call not found", code: "call_not_found" }, 404);
   return c.json({
     success: true,
+    callId: call.id,
     callSid: call.call_sid,
     status: call.call_status,
     to: maskPhoneNumber(call.to_number),
@@ -68,12 +77,22 @@ app.get("/", async (c) => {
 
 app.delete("/", async (c) => {
   const { auth, call } = await ownedCall(c);
+  if (call?.call_status === "submission-unknown" && !call.call_sid) {
+    return c.json(
+      {
+        error: "Call acceptance is still being reconciled",
+        code: "call_submission_unknown",
+      },
+      409,
+    );
+  }
   if (!call?.call_sid) {
     return c.json({ error: "Call not found", code: "call_not_found" }, 404);
   }
   if (isTerminalTwilioCallStatus(call.call_status)) {
     return c.json({
       success: true,
+      callId: call.id,
       callSid: call.call_sid,
       status: call.call_status,
       alreadyTerminal: true,
@@ -124,6 +143,7 @@ app.delete("/", async (c) => {
   if (!claim) {
     return c.json({
       success: true,
+      callId: call.id,
       callSid: call.call_sid,
       status: call.call_status,
       replayed: true,
@@ -167,6 +187,7 @@ app.delete("/", async (c) => {
     .where(eq(twilioOutboundCalls.id, call.id));
   return c.json({
     success: true,
+    callId: call.id,
     callSid: call.call_sid,
     status: "hangup-requested",
   });

--- a/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
@@ -243,14 +243,45 @@ describe("POST Twilio outbound voice call", () => {
     expect(queueCall).not.toHaveBeenCalled();
   });
 
-  test("persists a fail-closed terminal provider error", async () => {
+  test("returns a durable poll target while an exact replay is unresolved", async () => {
+    returning.mockResolvedValue([]);
+    selectLimit.mockResolvedValue([
+      {
+        id: "33333333-3333-4333-8333-333333333333",
+        callSid: null,
+        status: "submission-unknown",
+        to: "+14155550100",
+      },
+    ]);
+
+    const response = await callRequest(
+      { to: "+14155550100" },
+      "00000000-0000-4000-8000-000000000004",
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      callId: "33333333-3333-4333-8333-333333333333",
+      callSid: null,
+      status: "submission-unknown",
+      replayed: true,
+    });
+    expect(queueCall).not.toHaveBeenCalled();
+  });
+
+  test("retains an ambiguous provider submission for signed reconciliation", async () => {
     queueCall.mockRejectedValueOnce(new Error("Twilio unavailable"));
 
     const response = await callRequest({ to: "+14155550100" });
 
-    expect(response.status).toBe(502);
+    expect(response.status).toBe(202);
     await expect(response.json()).resolves.toMatchObject({
-      code: "provider_unavailable",
+      success: true,
+      callId: expect.any(String),
+      callSid: null,
+      status: "submission-unknown",
+      auditPending: true,
     });
     expect(outboundInserts).toHaveLength(1);
     expect(updateWhere).toHaveBeenCalledTimes(1);

--- a/packages/cloud/api/v1/twilio/voice/calls/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { and, eq, lt } from "drizzle-orm";
+import { and, eq, lt, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { dbWrite } from "@/db/helpers";
@@ -182,23 +182,17 @@ app.post("/", async (c) => {
         ),
       )
       .limit(1);
-    if (existingCall?.callSid) {
-      return c.json({
-        success: true,
-        callId: existingCall.id,
-        callSid: existingCall.callSid,
-        status: existingCall.status,
-        to: maskPhoneNumber(existingCall.to),
-        replayed: true,
-      });
-    }
     if (existingCall) {
       return c.json(
         {
-          error: "This call request is already being reconciled",
-          code: "duplicate_call_pending",
+          success: true,
+          callId: existingCall.id,
+          callSid: existingCall.callSid,
+          status: existingCall.status,
+          to: maskPhoneNumber(existingCall.to),
+          replayed: true,
         },
-        409,
+        existingCall.callSid ? 200 : 202,
       );
     }
 
@@ -266,9 +260,9 @@ app.post("/", async (c) => {
       form,
     );
   } catch (error) {
-    // error-policy:J1 provider failure becomes a boundary response. Retain the
-    // claim because Twilio may have accepted the call before the response was
-    // lost; replaying the same request could create a duplicate paid call.
+    // error-policy:J4 a missing or unusable provider response cannot prove
+    // rejection. Retain the claim and expose the durable call id so signed
+    // callbacks can reconcile an accepted call without authorizing a retry.
     logger.error("[twilio-voice-outbound] failed to queue call", {
       userId: auth.id,
       organizationId: auth.organization_id,
@@ -277,15 +271,21 @@ app.post("/", async (c) => {
     await dbWrite
       .update(twilioOutboundCalls)
       .set({
-        call_status: "provider-error",
+        call_status: "submission-unknown",
         provider_error_code: "provider_unavailable",
-        terminal_at: new Date(),
         updated_at: new Date(),
       })
       .where(eq(twilioOutboundCalls.id, callId));
     return c.json(
-      { error: "Unable to start the call", code: "provider_unavailable" },
-      502,
+      {
+        success: true,
+        callId,
+        callSid: null,
+        status: "submission-unknown",
+        to: maskPhoneNumber(requestedPhoneNumber),
+        auditPending: true,
+      },
+      202,
     );
   }
 
@@ -295,7 +295,10 @@ app.post("/", async (c) => {
       .update(twilioOutboundCalls)
       .set({
         call_sid: call.sid,
-        call_status: call.status,
+        call_status: sql`CASE
+          WHEN ${twilioOutboundCalls.last_status_sequence} < 0 THEN ${call.status}
+          ELSE ${twilioOutboundCalls.call_status}
+        END`,
         updated_at: new Date(),
       })
       .where(eq(twilioOutboundCalls.id, callId));

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-call-status.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-call-status.ts
@@ -12,6 +12,7 @@ export const TWILIO_CALL_STATUSES = [
   "no-answer",
   "canceled",
   "hangup-requested",
+  "submission-unknown",
   "provider-error",
 ] as const;
 

--- a/packages/ui/src/components/composites/chat/pstn-call-button.test.tsx
+++ b/packages/ui/src/components/composites/chat/pstn-call-button.test.tsx
@@ -46,6 +46,7 @@ describe("PstnCallButton", () => {
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "11111111-1111-4111-8111-111111111111",
         callSid: "CA11111111111111111111111111111111",
         status: "queued",
         to: "***0100",
@@ -116,12 +117,14 @@ describe("PstnCallButton", () => {
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "22222222-2222-4222-8222-222222222222",
         callSid: "CA22222222222222222222222222222222",
         status: "queued",
         to: "***0100",
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "22222222-2222-4222-8222-222222222222",
         callSid: "CA22222222222222222222222222222222",
         status: "hangup-requested",
         to: "***0100",
@@ -168,6 +171,36 @@ describe("PstnCallButton", () => {
     ).toBe(true);
   });
 
+  it("blocks another call while provider acceptance is being reconciled", async () => {
+    mocks.api
+      .mockResolvedValueOnce({
+        phone_number: "+14155550100",
+        phone_verified: true,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        callId: "77777777-7777-4777-8777-777777777777",
+        callSid: null,
+        status: "submission-unknown",
+        to: "***0100",
+        auditPending: true,
+      });
+    const user = userEvent.setup();
+    render(<PstnCallButton />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Have Eliza call me" }),
+    );
+    await screen.findByDisplayValue("+14155550100");
+    await user.click(screen.getByRole("button", { name: "Call me" }));
+
+    expect(
+      await screen.findByText(/call acceptance is being reconciled/i),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Call again" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Hang up" })).toBeNull();
+  });
+
   it("clears a previously loaded number when a profile refresh fails", async () => {
     mocks.api
       .mockResolvedValueOnce({
@@ -206,12 +239,14 @@ describe("PstnCallButton", () => {
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "33333333-3333-4333-8333-333333333333",
         callSid: "CA33333333333333333333333333333333",
         status: "queued",
         to: "***0100",
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "33333333-3333-4333-8333-333333333333",
         callSid: "CA33333333333333333333333333333333",
         status: "completed",
         to: "***0100",
@@ -221,6 +256,7 @@ describe("PstnCallButton", () => {
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "44444444-4444-4444-8444-444444444444",
         callSid: "CA44444444444444444444444444444444",
         status: "queued",
         to: "***0100",
@@ -257,6 +293,7 @@ describe("PstnCallButton", () => {
       })
       .mockResolvedValueOnce({
         success: true,
+        callId: "55555555-5555-4555-8555-555555555555",
         callSid: "CA55555555555555555555555555555555",
         status: "queued",
         to: "***0100",
@@ -264,6 +301,7 @@ describe("PstnCallButton", () => {
       .mockRejectedValueOnce(new Error("Status service unavailable"))
       .mockResolvedValueOnce({
         success: true,
+        callId: "55555555-5555-4555-8555-555555555555",
         callSid: "CA55555555555555555555555555555555",
         status: "hangup-requested",
         to: "***0100",
@@ -305,6 +343,7 @@ describe("PstnCallButton", () => {
       .mockRejectedValueOnce(new Error("Provider temporarily unavailable"))
       .mockResolvedValueOnce({
         success: true,
+        callId: "66666666-6666-4666-8666-666666666666",
         callSid: "CA66666666666666666666666666666666",
         status: "queued",
         to: "***0100",

--- a/packages/ui/src/components/composites/chat/pstn-call-button.tsx
+++ b/packages/ui/src/components/composites/chat/pstn-call-button.tsx
@@ -24,7 +24,8 @@ interface CurrentUserResponse {
 
 interface StartCallResponse {
   success: boolean;
-  callSid: string;
+  callId: string;
+  callSid: string | null;
   status: string;
   to: string;
 }
@@ -36,7 +37,8 @@ interface CallStatusResponse extends StartCallResponse {
 }
 
 interface ActiveCall {
-  callSid: string;
+  callId: string;
+  callSid: string | null;
   status: string;
   to: string;
   hangupIdempotencyKey: string;
@@ -92,13 +94,18 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
     const refresh = async () => {
       try {
         const result = await api<CallStatusResponse>(
-          `/api/v1/twilio/voice/calls/${encodeURIComponent(activeCall.callSid)}`,
+          `/api/v1/twilio/voice/calls/${encodeURIComponent(activeCall.callSid ?? activeCall.callId)}`,
         );
         if (cancelled) return;
         setStatusError("");
         setActiveCall((current) =>
-          current?.callSid === result.callSid
-            ? { ...current, status: result.status, to: result.to }
+          current?.callId === result.callId
+            ? {
+                ...current,
+                callSid: result.callSid,
+                status: result.status,
+                to: result.to,
+              }
             : current,
         );
       } catch (error) {
@@ -154,6 +161,7 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
       );
       toast.success(`Eliza is calling ${result.to}`);
       setActiveCall({
+        callId: result.callId,
         callSid: result.callSid,
         status: result.status,
         to: result.to,
@@ -167,7 +175,7 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
   };
 
   const handleHangup = async () => {
-    if (!activeCall || hangingUp) return;
+    if (!activeCall?.callSid || hangingUp) return;
     setHangingUp(true);
     try {
       const result = await api<CallStatusResponse>(
@@ -236,7 +244,7 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
               <DialogFooter>
                 {TERMINAL_CALL_STATUSES.has(activeCall.status) ? (
                   <Button onClick={handleNewCall}>Call again</Button>
-                ) : (
+                ) : activeCall.callSid ? (
                   <Button
                     variant="destructive"
                     onClick={() => void handleHangup()}
@@ -247,6 +255,11 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
                     ) : null}
                     Hang up
                   </Button>
+                ) : (
+                  <p className="text-sm text-muted">
+                    Call acceptance is being reconciled. Calling again is
+                    disabled until a signed provider update arrives.
+                  </p>
                 )}
                 <Button variant="ghost" onClick={() => setOpen(false)}>
                   Close


### PR DESCRIPTION
## Summary

Follow-up safety repair for merged #24780.

- retain an ambiguous Twilio submission as nonterminal `submission-unknown` instead of claiming a provider rejection
- expose the durable pre-submission call ID for polling until a signed callback binds the CallSid
- fence exact idempotent replays and disable Call again/Hang up while provider acceptance is unknown
- prevent an early signed callback status from being overwritten backwards by the later initial API response
- allow owned status reads by either durable call ID or Twilio CallSid without passing a CallSid through the UUID comparison

## Why

The merged catch path says Twilio may have accepted the call before its response was lost, but it wrote terminal `provider-error`. The UI therefore offered Call again and could create a second paid call from one unresolved first attempt.

## Verification

- outbound start/status/hangup boundary suites: 21 passed
- `pstn-call-button.test.tsx`: 9/9 passed
- Cloud API build/typecheck: passed
- UI typecheck: passed
- changed-file Biome: passed
- `git diff --check`: passed

## Evidence

- Screenshots/video: N/A for layout; this adds a textual fail-closed state using the existing dialog styling. The protected real-call lane still belongs to the parent feature acceptance.
- Backend/provider: deterministic transport-unknown and signed-reconciliation boundary coverage; no paid call was made.
- `audit:app`: the earlier exact-session attempt failed before Playwright config load with host filesystem write error `Unknown system error -122`; prerequisite view/core/shared builds completed.
