### PR TITLE
fix(agent-orchestrator): anchor relative ELIZA_CODEX_ACP_COMMAND

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -149,6 +149,7 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
 
 import {
   AcpService,
+  defaultCodexAcpCommand,
   normalizeClaudeAcpModelId,
 } from "../../src/services/acp-service.js";
 import { InMemorySessionStore } from "../../src/services/session-store.js";
@@ -530,6 +531,53 @@ describe("AcpService", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("anchors a relative ELIZA_CODEX_ACP_COMMAND before the session changes cwd (#24683)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "relative-codex-command-"));
+    const executable = join(dir, "codex-acp");
+    try {
+      await fs.writeFile(executable, "#!/bin/sh\nexit 0\n");
+      await fs.chmod(executable, 0o755);
+      const relative = path.relative(process.cwd(), executable);
+      const service = new AcpService(
+        runtime({
+          ELIZA_ACP_TRANSPORT: "native",
+          ELIZA_CODEX_ACP_COMMAND: `${relative} --stdio`,
+        }),
+      );
+      const inspect = service as unknown as {
+        nativeAgentCommand(agentType: string): string;
+        agentCommandAvailability(agentType: string): { available: boolean };
+      };
+
+      // The managed-codex branch previously returned the configured value
+      // unanchored, so availability resolved it against the service cwd while
+      // the native client spawns with cwd: session.workdir.
+      expect(inspect.nativeAgentCommand("codex")).toBe(`${executable} --stdio`);
+      expect(inspect.agentCommandAvailability("codex")).toEqual({
+        available: true,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the managed default Codex command unanchored (#24683)", async () => {
+    const service = new AcpService(
+      runtime({ ELIZA_ACP_TRANSPORT: "native" }),
+    );
+    const inspect = service as unknown as {
+      nativeAgentCommand(agentType: string): string;
+    };
+
+    // Anchoring must be identity on the managed default: its executable is the
+    // bare `npx`, and the DEFAULT_CODEX_ACP_COMMAND identity comparisons that
+    // drive managed-mode validation, landlock retry, and INITIAL_AGENT_MODE
+    // all depend on this value being returned unchanged.
+    const command = inspect.nativeAgentCommand("codex");
+    expect(command).toBe(defaultCodexAcpCommand());
+    expect(command.startsWith("npx ")).toBe(true);
   });
 
   it("fails with a clear diagnostic when acpx is missing on Android", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -3093,7 +3093,16 @@ export class AcpService extends Service {
     // Operator commands are opaque adapter boundaries. Mutating them with
     // flags from a different codex-acp generation can silently change their
     // argv contract, so only the declared legacy default is upgraded above.
-    return command;
+    //
+    // Anchoring is not such a mutation and must still apply here: a native
+    // session spawns with `cwd: session.workdir`, while availability resolves
+    // against the service cwd, so an unanchored relative command makes the two
+    // disagree about which file they mean (#24683). The managed default's
+    // executable is the bare `npx`, which `anchorRelativeCommandLine` leaves
+    // untouched, so the identity comparisons against
+    // DEFAULT_CODEX_ACP_COMMAND above and in the landlock-retry and
+    // INITIAL_AGENT_MODE gates keep matching.
+    return anchorRelativeCommandLine(command);
   }
 
   private shouldRetryManagedCodexLandlock(


### PR DESCRIPTION
Closes #24683

## Summary

`nativeAgentCommand()` anchors relative command paths through
`anchorRelativeCommandLine()`, but the managed-codex branch returns
`this.codexAgentCommand()` **before** reaching that call. A configured relative
Codex ACP command was therefore never anchored, while the two consumers resolve
it against different directories:

- `agentCommandAvailability()` resolves relative to the **service cwd** → reports `available: true`
- the native client spawns with `cwd: session.workdir` → resolves to a nonexistent path

So availability says ready and spawn fails for any session whose workdir differs
from the service cwd. This is the same argv/path-parity class as #24684.

## Change

`plugins/plugin-agent-orchestrator/src/services/acp-service.ts` only — anchor
the resolved command inside `codexAgentCommand()`, **after** the
managed-default sentinel check:

```ts
return anchorRelativeCommandLine(command);
```

## Why this is safe for managed mode

Three separate gates compare against `DEFAULT_CODEX_ACP_COMMAND` by identity
(managed-mode validation at ~3090, landlock retry at ~3117, `INITIAL_AGENT_MODE`
at ~4818). Anchoring must not disturb them, and it does not: the managed
default is

```
npx -y --prefix "<tmp>" --package=@zed-industries/codex-acp@latest -- codex-acp
```

whose executable token is the bare `npx`. `anchorRelativeCommandLine()` returns
its input unchanged unless the command token contains `/` or `\`, so the managed
default is passed through byte-identical. I verified this rather than assuming
it, and pinned it with a test.

The existing comment about not mutating operator commands is preserved and
extended: anchoring is path resolution, not an argv-contract change, and it is
exactly what the non-managed branch already does for `pi-agent`/`elizaos`.

## Verification

Executed the real `splitCommandLine` / `quoteCommandPart` / `anchorRelativeCommandLine`
implementations against the managed default and operator command shapes:

| input | anchored result |
| --- | --- |
| managed default (`npx …`) | **unchanged** (identity — sentinels safe) |
| `./bin/codex-acp --stdio` | `<abs>/bin/codex-acp --stdio` |
| `.\bin\codex-acp --stdio` | anchored (Windows separator) |
| `/opt/codex-acp --stdio` | unchanged (already absolute) |
| `codex-acp --stdio` | unchanged (bare → PATH resolution preserved) |

Sabotage check: with the pre-image (`return command`), the relative case stays
`./bin/codex-acp --stdio`, which is the reported defect.

- `git diff --check` — clean.
- Test file parses cleanly under Node 24 type-stripping.

## Tests

Two cases in `__tests__/unit/acp-service.test.ts`, mirroring the existing
`anchors a relative native executable before the session changes cwd` test that
covers `ELIZA_PI_AGENT_ACP_COMMAND`:

- **`anchors a relative ELIZA_CODEX_ACP_COMMAND before the session changes cwd (#24683)`**
  — creates a real executable in a temp dir, configures it by a path relative to
  `process.cwd()`, and asserts both `nativeAgentCommand("codex")` and
  `agentCommandAvailability("codex")` agree on the absolute executable. Reverting
  the one-line change makes this observe the unanchored relative string.
- **`leaves the managed default Codex command unanchored (#24683)`** — guards the
  identity property the sentinel comparisons depend on, so a future change to
  the anchoring helper cannot silently break managed-mode detection.

## Risks

Low, confined to how the managed-codex branch returns its command. Bare and
absolute commands are unaffected; the managed default is provably unchanged. The
one behavior change is the intended one: a relative operator command now
resolves to the same absolute path for availability and spawn.

## Known gaps / failures

Adjacent pre-existing defect found while verifying, **deliberately not fixed
here**: `quoteCommandPart()` uses `JSON.stringify` (which escapes backslashes)
while `splitCommandLine()` only strips the quote pair without unescaping. A
relative path **containing a space** therefore re-parses with doubled separators
on Windows:

```
"./my bin/codex-acp" --stdio
  -> "C:\\Users\\…\\my bin\\codex-acp" --stdio
  -> reparsed exe: C:\\Users\\…\\my bin\\codex-acp   (doubled)
```

This is identical on `develop` and affects the already-anchored
`pi-agent`/`elizaos` paths the same way, so it is orthogonal to #24683. I did
not expand this PR to cover it — over-broad scope is how a targeted fix turns
into a regression. Happy to file it separately.

I could not run the package's hosted Vitest lane locally: `bun` is not installed
on this host and installing it was blocked, so `node_modules` is absent and
`bunx vitest run --root plugins/plugin-agent-orchestrator` could not execute.
The new tests follow the patterns already proven in this file (the sibling
pi-agent anchoring test uses the identical harness and inspection shape), and
the behavioral claims are backed by the direct execution above, but hosted CI is
authoritative for the suite itself. Stating this explicitly rather than implying
a green local run.

AI provider/model: meituan / longcat-2.0
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-longcat]
<!-- eliza-computer-attribution:v1 {"provider":"meituan","model":"longcat-2.0","client":"Hermes Agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
