### PR TITLE
fix(computeruse): reject malformed trajectory text

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -40,6 +40,18 @@ const removedPromptCapCloneTests = [
 	"packages/core/src/services/trajectory-json.surrogate.test.ts",
 ];
 
+const computerUseTrajectoryBoundaryCalls: Record<string, readonly RegExp[]> = {
+	"plugins/plugin-computeruse/src/mobile/android-trajectory.ts": [
+		/assertComputerUseTrajectoryText\("errorMessage",\s*payload\.errorMessage\)/,
+		/buildComputerUseAgentStepTrajectoryPayload\(event\)/,
+	],
+	"plugins/plugin-computeruse/src/actions/use-computer-agent.ts": [
+		/assertComputerUseTrajectoryText\("goal",\s*goal\)/,
+		/assertComputerUseTrajectoryText\([\s\S]{0,80}"rationale"/,
+		/buildComputerUseAgentStepTrajectoryPayload\(\{/,
+	],
+};
+
 const guardedSources: Record<string, readonly RegExp[]> = {
 	"packages/core/src/entities.ts": [/getMemories\([\s\S]{0,240}limit:\s*20/],
 	"packages/core/src/utils/json-llm.ts": [/text\.slice\(0,\s*100_000\)/],
@@ -142,6 +154,13 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"plugins/plugin-computeruse/src/mobile/android-trajectory.ts": [
 		/MAX_ERROR_MSG/,
 		/errorMessage\s*=\s*[^;]*\.slice\(/,
+	],
+	"plugins/plugin-computeruse/src/trajectory-text.ts": [
+		/\.slice\(/,
+		/\.substring\(/,
+		/toWellFormedUnicode/,
+		/truncateWellFormed/,
+		/max(?:Chars|Tokens|Items)/i,
 	],
 	"plugins/plugin-cli-inference/src/prompt-flatten.ts": [
 		/MAX_TOOL_PAYLOAD_(?:DEPTH|NODES|CHARS)/,
@@ -508,6 +527,22 @@ describe("prompt integrity policy", () => {
 			);
 			for (const pattern of forbiddenPatterns) {
 				expect(source, `${relativePath} must not match ${pattern}`).not.toMatch(
+					pattern,
+				);
+			}
+		}
+	});
+
+	it("keeps both computer-use emitters behind the shared rejection boundary", () => {
+		for (const [relativePath, requiredPatterns] of Object.entries(
+			computerUseTrajectoryBoundaryCalls,
+		)) {
+			const source = readFileSync(
+				resolve(repositoryRoot, relativePath),
+				"utf8",
+			);
+			for (const pattern of requiredPatterns) {
+				expect(source, `${relativePath} must match ${pattern}`).toMatch(
 					pattern,
 				);
 			}

--- a/plugins/plugin-computeruse/AGENTS.md
+++ b/plugins/plugin-computeruse/AGENTS.md
@@ -10,7 +10,7 @@ Adds real desktop control to an Eliza agent: taking screenshots, clicking/typing
 
 File operations belong to the FILE action; shell/terminal access belongs to the SHELL action — this plugin does not expose them.
 
-Android action and agent-step trajectory fields are complete audit records. Do not clip error text, goals, rationales, references, or other emitted fields; logging transport failures must reject explicitly rather than produce a shortened trajectory.
+Android and desktop action/agent-step trajectory fields are complete audit records. Route free-form text through the shared trajectory-text boundary: preserve every well-formed value exactly, reject malformed Unicode with `COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE` before logging, and never clip, repair, or partially emit errors, goals, rationales, references, or codes. The shared agent-step `error` field is the complete message and `errorCode` is its stable classifier on every platform.
 
 ## Plugin surface
 

--- a/plugins/plugin-computeruse/CLAUDE.md
+++ b/plugins/plugin-computeruse/CLAUDE.md
@@ -10,7 +10,7 @@ Adds real desktop control to an Eliza agent: taking screenshots, clicking/typing
 
 File operations belong to the FILE action; shell/terminal access belongs to the SHELL action — this plugin does not expose them.
 
-Android action and agent-step trajectory fields are complete audit records. Do not clip error text, goals, rationales, references, or other emitted fields; logging transport failures must reject explicitly rather than produce a shortened trajectory.
+Android and desktop action/agent-step trajectory fields are complete audit records. Route free-form text through the shared trajectory-text boundary: preserve every well-formed value exactly, reject malformed Unicode with `COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE` before logging, and never clip, repair, or partially emit errors, goals, rationales, references, or codes. The shared agent-step `error` field is the complete message and `errorCode` is its stable classifier on every platform.
 
 ## Plugin surface
 

--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
@@ -7,7 +7,7 @@
  * stays in lock-step with the desktop emitter in `use-computer-agent.ts`.
  */
 
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   emitAndroidAction,
@@ -63,6 +63,56 @@ describe("emitAndroidAction", () => {
       spy.mockRestore();
     }
   });
+
+  it("preserves every well-formed action text field and leaves the input unchanged", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      const complete = `${"context ".repeat(400)}🧠 tail`;
+      const event = Object.freeze({
+        kind: "tap" as const,
+        success: false,
+        errorCode: complete,
+        errorMessage: complete,
+        ref: complete,
+        rationale: complete,
+      });
+      const payload = emitAndroidAction(event);
+      expect(payload).not.toBe(event);
+      expect(payload).toEqual(event);
+      expect(spy.mock.calls[0]?.[0]).toMatchObject(event);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it.each(["errorCode", "errorMessage", "ref", "rationale"] as const)(
+    "rejects malformed Unicode in action %s without logging",
+    (field) => {
+      for (const malformed of ["before\ud800after", "before\udc00after"]) {
+        const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+        try {
+          let thrown: unknown;
+          try {
+            emitAndroidAction({
+              kind: "tap",
+              success: false,
+              [field]: malformed,
+            });
+          } catch (error) {
+            thrown = error;
+          }
+          expect(thrown).toBeInstanceOf(ElizaError);
+          expect(thrown).toMatchObject({
+            code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+            context: { field },
+          });
+          expect(spy).not.toHaveBeenCalled();
+        } finally {
+          spy.mockRestore();
+        }
+      }
+    },
+  );
 
   it("does not emit fields that were not supplied", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
@@ -123,6 +173,33 @@ describe("emitAndroidAgentStep", () => {
     }
   });
 
+  it.each(["goal", "actionKind", "error", "errorCode", "rationale"] as const)(
+    "rejects malformed Unicode in agent-step %s without logging",
+    (field) => {
+      for (const malformed of ["before\ud800after", "before\udc00after"]) {
+        const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+        try {
+          const event = {
+            step: 1,
+            goal: "save",
+            actionKind: "click",
+            displayId: 0,
+            rois: 1,
+            success: false,
+            error: "bridge failed",
+            errorCode: "bridge_error",
+            rationale: "tap save",
+            [field]: malformed,
+          };
+          expect(() => emitAndroidAgentStep(event)).toThrowError(ElizaError);
+          expect(spy).not.toHaveBeenCalled();
+        } finally {
+          spy.mockRestore();
+        }
+      }
+    },
+  );
+
   it("shape matches the desktop emitter in use-computer-agent.ts (same evt key)", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
     try {
@@ -132,12 +209,14 @@ describe("emitAndroidAgentStep", () => {
         actionKind: "finish",
         displayId: 0,
         rois: 0,
-        success: true,
+        success: false,
+        error: "bridge failed",
+        errorCode: "bridge_error",
         rationale: "done",
       });
       const obj = spy.mock.calls[0]?.[0] as Record<string, unknown>;
       // The desktop emitter publishes: evt, step, goal, actionKind,
-      // displayId, rois, success, error?, rationale. We add platform.
+      // displayId, rois, success, error?, errorCode?, rationale. We add platform.
       const expectedKeys = [
         "evt",
         "platform",
@@ -148,6 +227,7 @@ describe("emitAndroidAgentStep", () => {
         "rois",
         "success",
         "error",
+        "errorCode",
         "rationale",
       ];
       for (const k of expectedKeys) {

--- a/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
@@ -17,8 +17,8 @@
  * default).
  */
 
-import type { Content } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { type Content, type ElizaError, logger } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
 import {
   type ComputerUseAgentReport,
   type ComputerUseAgentStepProgress,
@@ -132,6 +132,106 @@ describe("runComputerUseAgentLoop — fake Brain", () => {
       actionKind: "finish",
       success: true,
     });
+  });
+
+  it("emits complete desktop step text through the shared structured contract", async () => {
+    const complete = `${"desktop trajectory ".repeat(300)}🧠 tail`;
+    const brain = new Brain(null, {
+      invokeModel: async () =>
+        JSON.stringify({
+          scene_summary: "done",
+          target_display_id: 0,
+          roi: [],
+          proposed_action: { kind: "finish", rationale: complete },
+        }),
+    });
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      await runComputerUseAgentLoop(null, { goal: complete }, fakeService(), {
+        brain,
+        captureAll,
+      });
+      const stepLog = spy.mock.calls
+        .map(([entry]) => entry as Record<string, unknown>)
+        .find((entry) => entry.evt === "computeruse.agent.step");
+      expect(stepLog).toMatchObject({
+        goal: complete,
+        rationale: complete,
+        success: true,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects malformed desktop goals before work or structured logging", async () => {
+    let brainCalls = 0;
+    const brain = new Brain(null, {
+      invokeModel: async () => {
+        brainCalls += 1;
+        return "{}";
+      },
+    });
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      await expect(
+        runComputerUseAgentLoop(
+          null,
+          { goal: "save\ud800document" },
+          fakeService(),
+          { brain, captureAll },
+        ),
+      ).rejects.toMatchObject({
+        name: "ElizaError",
+        code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+        context: { field: "goal" },
+      } satisfies Partial<ElizaError>);
+      expect(brainCalls).toBe(0);
+      expect(
+        spy.mock.calls.some(
+          ([entry]) =>
+            (entry as Record<string, unknown>).evt === "computeruse.agent.step",
+        ),
+      ).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects malformed desktop rationales before dispatch or structured logging", async () => {
+    const brain = new Brain(null, {
+      invokeModel: async () =>
+        JSON.stringify({
+          scene_summary: "done",
+          target_display_id: 0,
+          roi: [],
+          proposed_action: {
+            kind: "finish",
+            rationale: "finish\udc00now",
+          },
+        }),
+    });
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      await expect(
+        runComputerUseAgentLoop(null, { goal: "save" }, fakeService(), {
+          brain,
+          captureAll,
+        }),
+      ).rejects.toMatchObject({
+        name: "ElizaError",
+        code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+        context: { field: "rationale" },
+      } satisfies Partial<ElizaError>);
+      expect(
+        spy.mock.calls.some(
+          ([entry]) =>
+            (entry as Record<string, unknown>).evt === "computeruse.agent.step",
+        ),
+      ).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("aborts on the wall-clock budget before any step (#9170 M11)", async () => {
@@ -362,16 +462,30 @@ describe("runComputerUseAgentLoop — fake Brain", () => {
           proposed_action: { kind: "click", rationale: "click out-of-bounds" },
         }),
     });
-    const report = await runComputerUseAgentLoop(
-      null,
-      { goal: "g" },
-      fakeService(),
-      { brain, captureAll },
-    );
-    expect(report.reason).toBe("error");
-    expect(report.steps.length).toBe(1);
-    expect(report.steps[0]?.result.success).toBe(false);
-    expect(report.error).toMatch(/outside display/);
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      const report = await runComputerUseAgentLoop(
+        null,
+        { goal: "g" },
+        fakeService(),
+        { brain, captureAll },
+      );
+      expect(report.reason).toBe("error");
+      expect(report.steps.length).toBe(1);
+      expect(report.steps[0]?.result.success).toBe(false);
+      expect(report.error).toMatch(/outside display/);
+
+      const stepLog = spy.mock.calls
+        .map(([entry]) => entry as Record<string, unknown>)
+        .find((entry) => entry.evt === "computeruse.agent.step");
+      expect(stepLog).toMatchObject({
+        success: false,
+        error: report.error,
+        errorCode: "out_of_bounds",
+      });
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("aborts on scene refresh error", async () => {

--- a/plugins/plugin-computeruse/src/__tests__/trajectory-text.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/trajectory-text.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Exercises the shared deterministic Android/desktop trajectory-text boundary
+ * without mocking the validator that production emitters call.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  assertComputerUseTrajectoryText,
+  buildComputerUseAgentStepTrajectoryPayload,
+} from "../trajectory-text.js";
+
+describe("computer-use trajectory text boundary", () => {
+  it("preserves complete long and astral step fields exactly", () => {
+    const complete = `${"trajectory ".repeat(1_000)}🧠 tail`;
+    const input = Object.freeze({
+      step: 7,
+      goal: complete,
+      actionKind: complete,
+      displayId: 0,
+      rois: 2,
+      success: false,
+      error: complete,
+      errorCode: complete,
+      rationale: complete,
+    });
+    const payload = buildComputerUseAgentStepTrajectoryPayload(input);
+    expect(payload).not.toBe(input);
+    expect(payload).toEqual(input);
+  });
+
+  it.each(["\ud800", "\udc00"])(
+    "rejects malformed %s without returning repaired evidence",
+    (malformed) => {
+      let rejected: unknown;
+      try {
+        assertComputerUseTrajectoryText("error", `before${malformed}after`);
+      } catch (error) {
+        rejected = error;
+      }
+      expect(rejected).toBeInstanceOf(ElizaError);
+      expect(rejected).toMatchObject({
+        code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+        context: { field: "error" },
+      });
+      expect((rejected as Error).message).not.toContain("before");
+    },
+  );
+});

--- a/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
+++ b/plugins/plugin-computeruse/src/actions/use-computer-agent.ts
@@ -68,6 +68,10 @@ import {
 import { listDisplays } from "../platform/displays.js";
 import type { Scene } from "../scene/scene-types.js";
 import type { ComputerUseService } from "../services/computer-use-service.js";
+import {
+  assertComputerUseTrajectoryText,
+  buildComputerUseAgentStepTrajectoryPayload,
+} from "../trajectory-text.js";
 import { resolveActionParams } from "./helpers.js";
 import {
   buildStepProgressContent,
@@ -192,6 +196,7 @@ export async function runComputerUseAgentLoop(
     Math.min(params.maxSteps ?? DEFAULT_MAX_STEPS, 20),
   );
   const goal = params.goal;
+  assertComputerUseTrajectoryText("goal", goal);
   // Agent-loop registry (#9170 M10): a model string selects the loop. Defaults
   // to the local OCR/AX grounder (Brain → Cascade); provider plugins can
   // register Anthropic / OpenAI computer-use loops keyed by model family.
@@ -312,12 +317,24 @@ export async function runComputerUseAgentLoop(
     // Operator-normalizer + any other transform middleware clean the planned
     // action before it is dispatched.
     proposed = await runTransformProposed(middlewares, proposed, stepCtx);
+    assertComputerUseTrajectoryText("rationale", proposed.proposed.rationale);
     // Persist the Brain's understanding onto the scene (#9105 M3) so the next
     // turn's `scene` provider carries `vlm_scene` instead of re-describing.
     service.setSceneVlmAnnotations(proposed.scene_summary, null);
     const dispatchResult = await dispatch(proposed.proposed, {
       interface: computer,
       listDisplays: () => service.getDisplays(),
+    });
+    const trajectoryPayload = buildComputerUseAgentStepTrajectoryPayload({
+      step,
+      goal,
+      actionKind: proposed.proposed.kind,
+      displayId: proposed.proposed.displayId,
+      rois: proposed.rois.length,
+      success: dispatchResult.success,
+      error: dispatchResult.error?.message,
+      errorCode: dispatchResult.error?.code,
+      rationale: proposed.proposed.rationale,
     });
     await runAfterStep(middlewares, {
       step,
@@ -329,14 +346,7 @@ export async function runComputerUseAgentLoop(
     logger.info(
       {
         evt: "computeruse.agent.step",
-        step,
-        goal,
-        actionKind: proposed.proposed.kind,
-        displayId: proposed.proposed.displayId,
-        rois: proposed.rois.length,
-        success: dispatchResult.success,
-        error: dispatchResult.error?.code,
-        rationale: proposed.proposed.rationale,
+        ...trajectoryPayload,
       },
       `[computeruse/agent] step ${step}: ${proposed.proposed.kind}`,
     );

--- a/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
+++ b/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
@@ -20,11 +20,16 @@
  *                                    lower-level action explicitly).
  *
  * We do not depend on `@elizaos/plugin-trajectory-logger` here — like the
- * desktop side, we publish via `logger.info({ evt, ... })` and rely on the
- * log-capture pipeline.
+ * desktop side, we validate complete free-form text at the shared boundary,
+ * publish via `logger.info({ evt, ... })`, and rely on the log-capture pipeline.
  */
 
 import { logger } from "@elizaos/core";
+import {
+  assertComputerUseTrajectoryText,
+  buildComputerUseAgentStepTrajectoryPayload,
+  type ComputerUseAgentStepTrajectoryPayload,
+} from "../trajectory-text.js";
 
 export type AndroidActionKind =
   | "tap"
@@ -55,16 +60,7 @@ export interface AndroidTrajectoryActionEvent {
   rationale?: string;
 }
 
-export interface AndroidTrajectoryStepEvent {
-  step: number;
-  goal: string;
-  actionKind: string;
-  displayId: number;
-  rois: number;
-  success: boolean;
-  error?: string;
-  rationale: string;
-}
+export type AndroidTrajectoryStepEvent = ComputerUseAgentStepTrajectoryPayload;
 
 /**
  * Emit a `computeruse.android.action` log entry. Returns the payload so
@@ -74,6 +70,10 @@ export function emitAndroidAction(
   event: AndroidTrajectoryActionEvent,
 ): AndroidTrajectoryActionEvent {
   const payload: AndroidTrajectoryActionEvent = { ...event };
+  assertComputerUseTrajectoryText("errorCode", payload.errorCode);
+  assertComputerUseTrajectoryText("errorMessage", payload.errorMessage);
+  assertComputerUseTrajectoryText("ref", payload.ref);
+  assertComputerUseTrajectoryText("rationale", payload.rationale);
   logger.info(
     {
       evt: "computeruse.android.action",
@@ -93,20 +93,14 @@ export function emitAndroidAction(
 export function emitAndroidAgentStep(
   event: AndroidTrajectoryStepEvent,
 ): AndroidTrajectoryStepEvent {
+  const payload = buildComputerUseAgentStepTrajectoryPayload(event);
   logger.info(
     {
       evt: "computeruse.agent.step",
       platform: "android" as const,
-      step: event.step,
-      goal: event.goal,
-      actionKind: event.actionKind,
-      displayId: event.displayId,
-      rois: event.rois,
-      success: event.success,
-      error: event.error,
-      rationale: event.rationale,
+      ...payload,
     },
-    `[computeruse/agent/android] step ${event.step}: ${event.actionKind}`,
+    `[computeruse/agent/android] step ${payload.step}: ${payload.actionKind}`,
   );
-  return event;
+  return payload;
 }

--- a/plugins/plugin-computeruse/src/trajectory-text.ts
+++ b/plugins/plugin-computeruse/src/trajectory-text.ts
@@ -1,0 +1,72 @@
+/**
+ * Validates complete computer-use trajectory text before it reaches an audit
+ * record. The boundary rejects malformed UTF-16 instead of repairing or
+ * shortening caller-owned evidence, and it never includes the rejected text in
+ * its diagnostic context.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export type ComputerUseTrajectoryTextField =
+  | "actionKind"
+  | "error"
+  | "errorCode"
+  | "errorMessage"
+  | "goal"
+  | "rationale"
+  | "ref";
+
+export interface ComputerUseAgentStepTrajectoryPayload {
+  step: number;
+  goal: string;
+  actionKind: string;
+  displayId: number;
+  rois: number;
+  success: boolean;
+  error?: string;
+  errorCode?: string;
+  rationale: string;
+}
+
+function isWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return false;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Reject malformed Unicode while preserving every valid code unit exactly. */
+export function assertComputerUseTrajectoryText(
+  field: ComputerUseTrajectoryTextField,
+  value: string | undefined,
+): void {
+  if (value === undefined || isWellFormedUnicode(value)) return;
+  throw new ElizaError(
+    `Computer-use trajectory field "${field}" contains malformed Unicode`,
+    {
+      code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+      context: { field },
+      severity: "fatal",
+    },
+  );
+}
+
+/** Build the shared Android/desktop agent-step payload after text validation. */
+export function buildComputerUseAgentStepTrajectoryPayload(
+  event: ComputerUseAgentStepTrajectoryPayload,
+): ComputerUseAgentStepTrajectoryPayload {
+  assertComputerUseTrajectoryText("goal", event.goal);
+  assertComputerUseTrajectoryText("actionKind", event.actionKind);
+  assertComputerUseTrajectoryText("error", event.error);
+  assertComputerUseTrajectoryText("errorCode", event.errorCode);
+  assertComputerUseTrajectoryText("rationale", event.rationale);
+  return { ...event };
+}


### PR DESCRIPTION
Fixes #23969
Fixes #24452

## Summary

- validate Android and desktop trajectory strings through one typed boundary
- preserve every well-formed goal, rationale, and error value exactly, including long and astral text
- reject lone high/low surrogates before any structured log call with `COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE`
- make the shared agent-step contract explicit: complete `error` message plus separate stable `errorCode`
- add mutation-sensitive parity, malformed-input, immutability, zero-log, and prompt-integrity regressions

This is the post-merge completion for #24798. That change removed a 256-unit slice, but its accepted tests did not reject malformed Unicode and its Android/desktop `error` values had different semantics.

## Verification

- focused Android/desktop/trajectory/prompt-policy suites: 48 passed, 900 assertions
- full `plugin-computeruse` suite: 969 passed, 14 declared skips
- `bun run --cwd plugins/plugin-computeruse typecheck` — passed
- `bun run --cwd plugins/plugin-computeruse lint:check` — 237 files passed
- `bun run --cwd plugins/plugin-computeruse build` — passed
- `bun run check:agents-claude` — 161 pairs passed
- `git diff --check origin/develop...HEAD` — passed

<!-- evidence-head:a7d48f605097a2e0748498f4f01be50ed6ebefb3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - structured trajectory boundary only; no rendered UI surface changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - structured trajectory boundary only; no rendered UI surface changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive visual flow changes

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic real-emitter suites inspect returned and logged payloads before and after rejection

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser console or network surface changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - trajectory serialization changes after computer-use execution; no model request or response behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact structured payloads, typed errors, zero-log rejection, and cross-emitter parity are asserted in the focused suites above

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes
