### PR TITLE
perf(cloud): avoid duplicate Steward session exchange

### DIFF
--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
@@ -10,6 +10,11 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  consumeStewardServerCookieSynced,
+  invalidateStewardServerCookieSyncMarker,
+  markStewardServerCookieSynced,
+} from "../../../cloud/lib/steward-session-cookie-sync-marker";
 
 const enabledProviders = vi.hoisted(() => ({
   passkey: true,
@@ -27,7 +32,7 @@ const authRef = vi.hoisted(() => ({
   current: {
     isLoading: false,
     isAuthenticated: true,
-    getToken: vi.fn(() => "token-1"),
+    getToken: vi.fn<() => string | null>(() => "token-1"),
     signOut: vi.fn(),
     providers: enabledProviders,
     isProvidersLoading: false,
@@ -105,6 +110,7 @@ describe("AuthorizeContent", () => {
   let locationAssignMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    invalidateStewardServerCookieSyncMarker();
     locationAssignMock = vi.fn();
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -113,7 +119,7 @@ describe("AuthorizeContent", () => {
     authRef.current = {
       isLoading: false,
       isAuthenticated: true,
-      getToken: vi.fn(() => "token-1"),
+      getToken: vi.fn<() => string | null>(() => "token-1"),
       signOut: vi.fn(),
       providers: enabledProviders,
       isProvidersLoading: false,
@@ -129,6 +135,7 @@ describe("AuthorizeContent", () => {
   });
 
   afterEach(() => {
+    invalidateStewardServerCookieSyncMarker();
     cleanup();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -157,6 +164,34 @@ describe("AuthorizeContent", () => {
     });
     expect(authorizeButton.className).toContain("hover:bg-accent-hover");
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("retires explicit-sync proof before raw SDK sign-out when the token is unreadable", async () => {
+    const user = userEvent.setup();
+    const endpoint = "/api/auth/steward-session";
+    let proofAtSignOut: boolean | undefined;
+    const signOut = vi.fn(() => {
+      proofAtSignOut = consumeStewardServerCookieSynced("token-1", endpoint);
+    });
+    authRef.current = {
+      ...authRef.current,
+      getToken: vi.fn<() => string | null>(() => null),
+      signOut,
+    };
+    markStewardServerCookieSynced("token-1", endpoint);
+
+    render(<AuthorizeContent />);
+
+    await waitFor(() => expect(screen.getByText("Demo App")).toBeTruthy());
+    await user.click(
+      screen.getByRole("button", { name: "Authorize Demo App" }),
+    );
+
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(proofAtSignOut).toBe(false);
+    expect(
+      screen.getByText("Your session expired. Please sign in again."),
+    ).toBeTruthy();
   });
 
   it("uses the local Playwright test-auth adapter without calling the Steward hook", async () => {

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -8,6 +8,7 @@ import { DiscordIcon, GoogleIcon, StewardLogin, useAuth } from "@stwd/react";
 import type { StewardProviders } from "@stwd/sdk";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { invalidateStewardServerCookieSyncMarker } from "../../../cloud/lib/steward-session-cookie-sync-marker";
 import {
   buildStewardOAuthRedirectUri,
   resolveStewardOAuthTenantId,
@@ -281,7 +282,10 @@ function AuthorizeFlow({
     const token = getToken();
     if (!token) {
       // Edge case: useAuth says authenticated but token isn't readable.
-      // Force re-sign-in rather than silently failing.
+      // Force re-sign-in rather than silently failing. This component consumes
+      // the raw SDK context (not LocalStewardAuthContext), so retire any
+      // explicit-sync proof here before the SDK begins fallible sign-out work.
+      invalidateStewardServerCookieSyncMarker();
       signOut();
       setError("Your session expired. Please sign in again.");
       setStatus("ready");

--- a/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.test.ts
+++ b/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   consumeStewardServerCookieSynced,
@@ -7,20 +9,51 @@ import {
 describe("Steward server-cookie sync marker", () => {
   beforeEach(() => {
     // Consumption clears both matching and mismatched pending authority.
-    consumeStewardServerCookieSynced("");
+    consumeStewardServerCookieSynced("", "");
   });
 
-  it("is one-shot for the exact token", () => {
-    markStewardServerCookieSynced("token-a");
+  it("is one-shot for the exact token and endpoint URL", () => {
+    markStewardServerCookieSynced("token-a", "/api/auth/steward-session");
 
-    expect(consumeStewardServerCookieSynced("token-a")).toBe(true);
-    expect(consumeStewardServerCookieSynced("token-a")).toBe(false);
+    expect(
+      consumeStewardServerCookieSynced(
+        "token-a",
+        `${window.location.origin}/api/auth/steward-session`,
+      ),
+    ).toBe(true);
+    expect(
+      consumeStewardServerCookieSynced("token-a", "/api/auth/steward-session"),
+    ).toBe(false);
   });
 
   it("fails closed and invalidates authority on a token mismatch", () => {
-    markStewardServerCookieSynced("token-a");
+    markStewardServerCookieSynced("token-a", "/api/auth/steward-session");
 
-    expect(consumeStewardServerCookieSynced("token-b")).toBe(false);
-    expect(consumeStewardServerCookieSynced("token-a")).toBe(false);
+    expect(
+      consumeStewardServerCookieSynced("token-b", "/api/auth/steward-session"),
+    ).toBe(false);
+    expect(
+      consumeStewardServerCookieSynced("token-a", "/api/auth/steward-session"),
+    ).toBe(false);
+  });
+
+  it("fails closed and invalidates authority on an endpoint mismatch", () => {
+    markStewardServerCookieSynced(
+      "token-a",
+      "https://preview.example/api/auth/steward-session",
+    );
+
+    expect(
+      consumeStewardServerCookieSynced(
+        "token-a",
+        "https://api.example/api/auth/steward-session",
+      ),
+    ).toBe(false);
+    expect(
+      consumeStewardServerCookieSynced(
+        "token-a",
+        "https://preview.example/api/auth/steward-session",
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.test.ts
+++ b/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.test.ts
@@ -1,15 +1,21 @@
 // @vitest-environment jsdom
 
+/**
+ * Steward server-cookie sync marker responsibility: proofs are one-shot,
+ * token/endpoint scoped, canonical across equivalent URLs, and explicitly
+ * retired before any cookie/session clear can invalidate server authority.
+ */
+
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   consumeStewardServerCookieSynced,
+  invalidateStewardServerCookieSyncMarker,
   markStewardServerCookieSynced,
 } from "./steward-session-cookie-sync-marker";
 
 describe("Steward server-cookie sync marker", () => {
   beforeEach(() => {
-    // Consumption clears both matching and mismatched pending authority.
-    consumeStewardServerCookieSynced("", "");
+    invalidateStewardServerCookieSyncMarker();
   });
 
   it("is one-shot for the exact token and endpoint URL", () => {
@@ -54,6 +60,16 @@ describe("Steward server-cookie sync marker", () => {
         "token-a",
         "https://preview.example/api/auth/steward-session",
       ),
+    ).toBe(false);
+  });
+
+  it("retires an unconsumed proof when session authority is cleared", () => {
+    markStewardServerCookieSynced("token-a", "/api/auth/steward-session");
+
+    invalidateStewardServerCookieSyncMarker();
+
+    expect(
+      consumeStewardServerCookieSynced("token-a", "/api/auth/steward-session"),
     ).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.test.ts
+++ b/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  consumeStewardServerCookieSynced,
+  markStewardServerCookieSynced,
+} from "./steward-session-cookie-sync-marker";
+
+describe("Steward server-cookie sync marker", () => {
+  beforeEach(() => {
+    // Consumption clears both matching and mismatched pending authority.
+    consumeStewardServerCookieSynced("");
+  });
+
+  it("is one-shot for the exact token", () => {
+    markStewardServerCookieSynced("token-a");
+
+    expect(consumeStewardServerCookieSynced("token-a")).toBe(true);
+    expect(consumeStewardServerCookieSynced("token-a")).toBe(false);
+  });
+
+  it("fails closed and invalidates authority on a token mismatch", () => {
+    markStewardServerCookieSynced("token-a");
+
+    expect(consumeStewardServerCookieSynced("token-b")).toBe(false);
+    expect(consumeStewardServerCookieSynced("token-a")).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
+++ b/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
@@ -38,6 +38,16 @@ export function markStewardServerCookieSynced(
   };
 }
 
+/**
+ * Retire any unconsumed proof before local code starts clearing server-cookie
+ * or sign-out authority. This must run before fallible storage/network work:
+ * even a partial or rejected clear can change which server session the next
+ * token publication must establish.
+ */
+export function invalidateStewardServerCookieSyncMarker(): void {
+  pendingServerCookieSync = null;
+}
+
 export function consumeStewardServerCookieSynced(
   token: string,
   endpoint: string,

--- a/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
+++ b/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
@@ -1,22 +1,50 @@
 /**
- * One-shot, same-bundle proof that the server cookie already accepted a token.
+ * One-shot, same-bundle proof that a server endpoint already accepted a token.
  *
  * Browser CustomEvent detail is intentionally not authority: arbitrary
  * same-origin JavaScript can forge it. The successful explicit session-sync
- * path records the exact token here only after its POST succeeds, and
- * AuthTokenSync consumes the marker before deciding whether it needs to mirror
- * that token again. A mismatch invalidates the marker so it can never become
- * stale authority after a subsequent token change.
+ * path records the exact token and resolved endpoint here only after its POST
+ * succeeds, and AuthTokenSync consumes the marker before deciding whether it
+ * needs to mirror that token to its own resolved endpoint. Any mismatch
+ * invalidates the marker so it can never become stale authority after a token
+ * or endpoint change.
  */
 
-let pendingServerCookieToken: string | null = null;
+type PendingServerCookieSync = {
+  endpointUrl: string;
+  token: string;
+};
 
-export function markStewardServerCookieSynced(token: string): void {
-  pendingServerCookieToken = token;
+let pendingServerCookieSync: PendingServerCookieSync | null = null;
+
+function canonicalEndpointUrl(endpoint: string): string {
+  if (typeof window === "undefined") return endpoint;
+  try {
+    return new URL(endpoint, window.location.href).href;
+  } catch {
+    // An invalid endpoint cannot accidentally match a different valid target;
+    // retaining the exact string keeps the marker fail-closed.
+    return endpoint;
+  }
 }
 
-export function consumeStewardServerCookieSynced(token: string): boolean {
-  const matches = pendingServerCookieToken === token;
-  pendingServerCookieToken = null;
+export function markStewardServerCookieSynced(
+  token: string,
+  endpoint: string,
+): void {
+  pendingServerCookieSync = {
+    token,
+    endpointUrl: canonicalEndpointUrl(endpoint),
+  };
+}
+
+export function consumeStewardServerCookieSynced(
+  token: string,
+  endpoint: string,
+): boolean {
+  const matches =
+    pendingServerCookieSync?.token === token &&
+    pendingServerCookieSync.endpointUrl === canonicalEndpointUrl(endpoint);
+  pendingServerCookieSync = null;
   return matches;
 }

--- a/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
+++ b/packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
@@ -1,0 +1,22 @@
+/**
+ * One-shot, same-bundle proof that the server cookie already accepted a token.
+ *
+ * Browser CustomEvent detail is intentionally not authority: arbitrary
+ * same-origin JavaScript can forge it. The successful explicit session-sync
+ * path records the exact token here only after its POST succeeds, and
+ * AuthTokenSync consumes the marker before deciding whether it needs to mirror
+ * that token again. A mismatch invalidates the marker so it can never become
+ * stale authority after a subsequent token change.
+ */
+
+let pendingServerCookieToken: string | null = null;
+
+export function markStewardServerCookieSynced(token: string): void {
+  pendingServerCookieToken = token;
+}
+
+export function consumeStewardServerCookieSynced(token: string): boolean {
+  const matches = pendingServerCookieToken === token;
+  pendingServerCookieToken = null;
+  return matches;
+}

--- a/packages/ui/src/cloud/lib/steward-session.test.ts
+++ b/packages/ui/src/cloud/lib/steward-session.test.ts
@@ -9,7 +9,15 @@
 
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { afterEach, describe, expect, it } from "vitest";
-import { hasHydratableStewardToken } from "./steward-session";
+import {
+  clearStewardSession,
+  hasHydratableStewardToken,
+} from "./steward-session";
+import {
+  consumeStewardServerCookieSynced,
+  invalidateStewardServerCookieSyncMarker,
+  markStewardServerCookieSynced,
+} from "./steward-session-cookie-sync-marker";
 
 function makeJwt(payload: Record<string, unknown>): string {
   const b64url = (value: object) =>
@@ -49,5 +57,28 @@ describe("hasHydratableStewardToken", () => {
       makeJwt({ exp: Math.floor(Date.now() / 1000) + 600 }),
     );
     expect(hasHydratableStewardToken()).toBe(false);
+  });
+});
+
+describe("clearStewardSession", () => {
+  afterEach(() => {
+    invalidateStewardServerCookieSyncMarker();
+  });
+
+  it("retires proof before a failing cookie DELETE is issued", () => {
+    const endpoint = "/api/auth/steward-session";
+    markStewardServerCookieSynced("token-a", endpoint);
+    let proofAtDeleteIssue: boolean | undefined;
+    const fetchImpl = (() => {
+      proofAtDeleteIssue = consumeStewardServerCookieSynced(
+        "token-a",
+        endpoint,
+      );
+      return Promise.reject(new Error("offline"));
+    }) as typeof fetch;
+
+    clearStewardSession({ endpoints: [endpoint], fetchImpl });
+
+    expect(proofAtDeleteIssue).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/lib/steward-session.ts
+++ b/packages/ui/src/cloud/lib/steward-session.ts
@@ -19,7 +19,7 @@ import type {
   StewardSessionErrorCode,
 } from "@elizaos/shared/steward-session-client";
 import {
-  clearStewardSession,
+  clearStewardSession as clearCanonicalStewardSession,
   clearStoredStewardToken,
   hasStewardAuthedCookie,
   readStoredStewardToken,
@@ -35,10 +35,10 @@ import {
   tokenIsExpired,
 } from "../shell/StewardProviderShared";
 import { decodeJwtPayload } from "./jwt";
+import { invalidateStewardServerCookieSyncMarker } from "./steward-session-cookie-sync-marker";
 
 export type { ClearOpts, StewardSessionErrorCode };
 export {
-  clearStewardSession,
   clearStoredStewardToken,
   hasStewardAuthedCookie,
   readStoredStewardToken,
@@ -49,6 +49,12 @@ export {
   StewardSessionError,
   writeStoredStewardToken,
 };
+
+/** Clear configured server cookies after retiring any explicit-sync proof. */
+export function clearStewardSession(opts: ClearOpts = {}): void {
+  invalidateStewardServerCookieSyncMarker();
+  clearCanonicalStewardSession(opts);
+}
 
 /**
  * Read the current Steward access token (JWT) from localStorage, or `null`

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -43,8 +43,9 @@ async function postAuthJson(
   body?: object,
   method: "POST" | "DELETE" = "POST",
   signal?: AbortSignal,
+  resolvedEndpoint = resolveStewardAuthEndpoint(path),
 ): Promise<Response> {
-  return fetch(resolveStewardAuthEndpoint(path), {
+  return fetch(resolvedEndpoint, {
     method,
     credentials: "include",
     headers: { "Content-Type": "application/json" },
@@ -86,7 +87,14 @@ export async function syncStewardSessionCookie(
     ...(refreshToken ? { refreshToken } : {}),
     ...(options?.verifiedPhone ? { verifiedPhone: options.verifiedPhone } : {}),
   };
-  const response = await postAuthJson(STEWARD_SESSION_ENDPOINT, request);
+  const sessionEndpoint = resolveStewardAuthEndpoint(STEWARD_SESSION_ENDPOINT);
+  const response = await postAuthJson(
+    STEWARD_SESSION_ENDPOINT,
+    request,
+    "POST",
+    undefined,
+    sessionEndpoint,
+  );
 
   if (!response.ok) {
     const body = await readSessionError(response);
@@ -96,12 +104,12 @@ export async function syncStewardSessionCookie(
   }
 
   if (typeof window !== "undefined") {
-    // The server cookie is authoritative now. Record this exact token before
-    // publishing it to canonical storage: that write can rerender the mounted
-    // Steward runtime, whose passive mirror must not repeat the successful POST.
-    // The marker is module-private and one-shot; browser event detail cannot
-    // forge it.
-    markStewardServerCookieSynced(token);
+    // The server cookie is authoritative at this endpoint now. Record this
+    // exact token/endpoint pair before publishing canonical storage: that write
+    // can rerender the mounted Steward runtime, whose passive mirror may skip
+    // only an identical POST target. The module-private, one-shot marker cannot
+    // be forged through browser event detail.
+    markStewardServerCookieSynced(token, sessionEndpoint);
     // The cookie boundary may be entered directly by an SDK callback or after
     // the login page already persisted the same token. Canonical storage is
     // idempotent, so both paths publish one authority transition in total.

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -25,6 +25,7 @@ import {
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../../join/lib/onboarding-continuation";
 import { decodeJwtPayload } from "../../lib/jwt";
+import { markStewardServerCookieSynced } from "../../lib/steward-session-cookie-sync-marker";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "../../shell/steward-url";
 
 export function resolveStewardAuthEndpoint(
@@ -95,6 +96,12 @@ export async function syncStewardSessionCookie(
   }
 
   if (typeof window !== "undefined") {
+    // The server cookie is authoritative now. Record this exact token before
+    // publishing it to canonical storage: that write can rerender the mounted
+    // Steward runtime, whose passive mirror must not repeat the successful POST.
+    // The marker is module-private and one-shot; browser event detail cannot
+    // forge it.
+    markStewardServerCookieSynced(token);
     // The cookie boundary may be entered directly by an SDK callback or after
     // the login page already persisted the same token. Canonical storage is
     // idempotent, so both paths publish one authority transition in total.

--- a/packages/ui/src/cloud/public-pages/lib/steward-session.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-session.ts
@@ -25,7 +25,10 @@ import {
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../../join/lib/onboarding-continuation";
 import { decodeJwtPayload } from "../../lib/jwt";
-import { markStewardServerCookieSynced } from "../../lib/steward-session-cookie-sync-marker";
+import {
+  invalidateStewardServerCookieSyncMarker,
+  markStewardServerCookieSynced,
+} from "../../lib/steward-session-cookie-sync-marker";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "../../shell/steward-url";
 
 export function resolveStewardAuthEndpoint(
@@ -484,6 +487,9 @@ function isRejectedCookieSession(error: unknown): boolean {
 }
 
 async function clearRejectedCookieSession(): Promise<void> {
+  // The DELETE and subsequent token removal can each fail. Retire proof before
+  // either boundary so recovery can never reuse pre-clear cookie authority.
+  invalidateStewardServerCookieSyncMarker();
   const response = await postAuthJson(
     STEWARD_SESSION_ENDPOINT,
     undefined,

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -22,6 +22,7 @@ import {
   storePendingOnboardingSession,
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../join/lib/onboarding-continuation";
+import { consumeStewardServerCookieSynced } from "../lib/steward-session-cookie-sync-marker";
 import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
 
 // AuthTokenSync's 401 handling is the load-bearing fix for the re-login loop:
@@ -31,12 +32,17 @@ import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
 // 401 could ever clear it. These tests exercise the real AuthTokenSync against
 // a stubbed fetch; only the @stwd SDK boundary is mocked.
 
+const stewardAuthState = vi.hoisted(() => ({
+  isAuthenticated: false,
+  user: null as { id: string } | null,
+}));
+
 vi.mock("@stwd/react", () => ({
   StewardProvider: ({ children }: { children: ReactNode }) => children,
   useAuth: () => ({
-    isAuthenticated: false,
+    isAuthenticated: stewardAuthState.isAuthenticated,
     isLoading: false,
-    user: null,
+    user: stewardAuthState.user,
     session: null,
     signOut: () => {},
     getToken: () => "",
@@ -112,8 +118,31 @@ function mount() {
   );
 }
 
+function setLocation(hostname: string): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      hostname,
+      origin: `https://${hostname}`,
+      href: `https://${hostname}/login`,
+    },
+  });
+}
+
+function rerenderAuthenticated(view: ReturnType<typeof mount>): void {
+  stewardAuthState.isAuthenticated = true;
+  stewardAuthState.user = { id: "u1" };
+  view.rerender(
+    <StewardAuthRuntimeProvider apiUrl="https://steward.test">
+      <div />
+    </StewardAuthRuntimeProvider>,
+  );
+}
+
 beforeEach(() => {
   calls = [];
+  stewardAuthState.isAuthenticated = false;
+  stewardAuthState.user = null;
   storage = createMemoryStorage();
   vi.stubGlobal("localStorage", storage);
   Object.defineProperty(window, "localStorage", {
@@ -124,8 +153,10 @@ beforeEach(() => {
   // paths (unknown jsdom host) — the handlers under test are endpoint-agnostic.
   vi.stubEnv("VITE_API_URL", "");
   vi.stubEnv("NEXT_PUBLIC_API_URL", "");
+  setLocation("localhost");
   stubFetchWith401s();
   clearPendingOnboardingSession();
+  consumeStewardServerCookieSynced("", "");
 });
 
 afterEach(() => {
@@ -136,11 +167,12 @@ afterEach(() => {
 });
 
 describe("AuthTokenSync", () => {
-  it("does not repeat a successful explicit session-cookie sync", async () => {
+  it("dedupes a direct-map explicit sync only at the identical endpoint", async () => {
     const token = makeJwt({
       sub: "u1",
       exp: Math.floor(Date.now() / 1000) + 3600,
     });
+    setLocation("staging.eliza.app");
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -152,17 +184,48 @@ describe("AuthTokenSync", () => {
       }),
     );
 
-    mount();
+    const view = mount();
     await act(() => syncStewardSessionCookie(token));
 
-    // Exercise the same mounted-runtime trigger again after the one-shot hint
-    // has been consumed. lastSyncedToken must now carry durable authority.
-    act(() => {
-      window.dispatchEvent(new CustomEvent("steward-token-sync"));
-    });
+    // Canonical token publication changes the auth provider state in the real
+    // app. Re-render that transition explicitly here so AuthTokenSync consumes
+    // the same-bundle one-shot marker.
+    act(() => rerenderAuthenticated(view));
 
     await waitFor(() => expect(postsTo("steward-session")).toHaveLength(1));
+    expect(postsTo("steward-session")[0]?.url).toBe(
+      "https://staging.eliza.app/api/auth/steward-session",
+    );
     expect(storage.getItem(STEWARD_TOKEN_KEY)).toBe(token);
+  });
+
+  it("uses the configured API fallback when the explicit endpoint differs", async () => {
+    const token = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    setLocation("preview.example");
+    vi.stubEnv("VITE_API_URL", "https://api-preview.example");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          method: init?.method ?? "GET",
+        });
+        return Response.json({ ok: true });
+      }),
+    );
+
+    const view = mount();
+    await act(() => syncStewardSessionCookie(token));
+    act(() => rerenderAuthenticated(view));
+
+    await waitFor(() => expect(postsTo("steward-session")).toHaveLength(2));
+    expect(postsTo("steward-session").map(({ url }) => url)).toEqual([
+      "/api/auth/steward-session",
+      "https://api-preview.example/api/auth/steward-session",
+    ]);
   });
 
   it("does not suppress passive sync after an explicit cookie sync fails", async () => {
@@ -195,54 +258,89 @@ describe("AuthTokenSync", () => {
 
     storage.setItem(STEWARD_TOKEN_KEY, token);
     act(() => {
-      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STEWARD_TOKEN_KEY,
+          newValue: token,
+        }),
+      );
     });
 
     await waitFor(() => expect(postsTo("steward-session")).toHaveLength(2));
   });
 
-  it.each(["storage", "steward-token-sync"])(
-    "still mirrors a token announced by an ordinary %s event",
-    async (eventName) => {
-      const token = makeJwt({
-        sub: "u1",
-        exp: Math.floor(Date.now() / 1000) + 3600,
-      });
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-          calls.push({
-            url: String(input),
-            method: init?.method ?? "GET",
-          });
-          return Response.json({ ok: true });
+  it("ignores a forged same-tab token event and still mirrors on a real storage trigger", async () => {
+    const token = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          method: init?.method ?? "GET",
+        });
+        return Response.json({ ok: true });
+      }),
+    );
+
+    mount();
+    storage.setItem(STEWARD_TOKEN_KEY, token);
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("steward-token-sync", {
+          detail: { token, serverCookieSynced: true },
         }),
       );
+    });
+    expect(postsTo("steward-session")).toHaveLength(0);
 
-      mount();
-      storage.setItem(STEWARD_TOKEN_KEY, token);
-      act(() => {
-        if (eventName === "storage") {
-          window.dispatchEvent(
-            new StorageEvent("storage", {
-              key: STEWARD_TOKEN_KEY,
-              newValue: token,
-            }),
-          );
-          return;
-        }
-        // Even a tempting boolean/detail payload is untrusted. Only the
-        // module-private one-shot marker may suppress the mirror POST.
-        window.dispatchEvent(
-          new CustomEvent("steward-token-sync", {
-            detail: { token, serverCookieSynced: true },
-          }),
-        );
-      });
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STEWARD_TOKEN_KEY,
+          newValue: token,
+        }),
+      );
+    });
 
-      await waitFor(() => expect(postsTo("steward-session")).toHaveLength(1));
-    },
-  );
+    await waitFor(() => expect(postsTo("steward-session")).toHaveLength(1));
+  });
+
+  it("does not loop after a successful passive session sync", async () => {
+    const token = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    storage.setItem(STEWARD_TOKEN_KEY, token);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          method: init?.method ?? "GET",
+        });
+        return Response.json({ ok: true });
+      }),
+    );
+
+    mount();
+    await waitFor(() => expect(postsTo("steward-session")).toHaveLength(1));
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STEWARD_TOKEN_KEY,
+          newValue: token,
+        }),
+      );
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(postsTo("steward-session")).toHaveLength(1);
+  });
 
   it("never carries a pending Telegram account claim through the passive token sync", async () => {
     // The passive JWT → cookie mirror runs on any authenticated page load with

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -13,7 +13,7 @@ import {
   STEWARD_TOKEN_KEY,
   type StewardSessionChangeDetail,
 } from "@elizaos/shared/steward-session-client";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -22,6 +22,7 @@ import {
   storePendingOnboardingSession,
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../join/lib/onboarding-continuation";
+import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
 
 // AuthTokenSync's 401 handling is the load-bearing fix for the re-login loop:
 // a 401 from session-sync or refresh must NOT wipe a still-valid token (a
@@ -134,7 +135,115 @@ afterEach(() => {
   window.sessionStorage.clear();
 });
 
-describe("AuthTokenSync 401 handling", () => {
+describe("AuthTokenSync", () => {
+  it("does not repeat a successful explicit session-cookie sync", async () => {
+    const token = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          method: init?.method ?? "GET",
+        });
+        return Response.json({ ok: true });
+      }),
+    );
+
+    mount();
+    await act(() => syncStewardSessionCookie(token));
+
+    // Exercise the same mounted-runtime trigger again after the one-shot hint
+    // has been consumed. lastSyncedToken must now carry durable authority.
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    });
+
+    await waitFor(() => expect(postsTo("steward-session")).toHaveLength(1));
+    expect(storage.getItem(STEWARD_TOKEN_KEY)).toBe(token);
+  });
+
+  it("does not suppress passive sync after an explicit cookie sync fails", async () => {
+    const token = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    let sessionPostCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          method: init?.method ?? "GET",
+        });
+        if (String(input).includes("steward-session")) {
+          sessionPostCount += 1;
+          if (sessionPostCount === 1) {
+            return Response.json({ error: "sync rejected" }, { status: 500 });
+          }
+        }
+        return Response.json({ ok: true });
+      }),
+    );
+
+    mount();
+    await expect(syncStewardSessionCookie(token)).rejects.toThrow(
+      "sync rejected",
+    );
+
+    storage.setItem(STEWARD_TOKEN_KEY, token);
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    });
+
+    await waitFor(() => expect(postsTo("steward-session")).toHaveLength(2));
+  });
+
+  it.each(["storage", "steward-token-sync"])(
+    "still mirrors a token announced by an ordinary %s event",
+    async (eventName) => {
+      const token = makeJwt({
+        sub: "u1",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          calls.push({
+            url: String(input),
+            method: init?.method ?? "GET",
+          });
+          return Response.json({ ok: true });
+        }),
+      );
+
+      mount();
+      storage.setItem(STEWARD_TOKEN_KEY, token);
+      act(() => {
+        if (eventName === "storage") {
+          window.dispatchEvent(
+            new StorageEvent("storage", {
+              key: STEWARD_TOKEN_KEY,
+              newValue: token,
+            }),
+          );
+          return;
+        }
+        // Even a tempting boolean/detail payload is untrusted. Only the
+        // module-private one-shot marker may suppress the mirror POST.
+        window.dispatchEvent(
+          new CustomEvent("steward-token-sync", {
+            detail: { token, serverCookieSynced: true },
+          }),
+        );
+      });
+
+      await waitFor(() => expect(postsTo("steward-session")).toHaveLength(1));
+    },
+  );
+
   it("never carries a pending Telegram account claim through the passive token sync", async () => {
     // The passive JWT → cookie mirror runs on any authenticated page load with
     // no user gesture, so it must not execute the account-claim merge. Login

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -24,6 +24,7 @@ import {
 } from "../join/lib/onboarding-continuation";
 import { consumeStewardServerCookieSynced } from "../lib/steward-session-cookie-sync-marker";
 import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
+import { clearStaleStewardSession } from "./StewardProviderShared";
 
 // AuthTokenSync's 401 handling is the load-bearing fix for the re-login loop:
 // a 401 from session-sync or refresh must NOT wipe a still-valid token (a
@@ -267,6 +268,52 @@ describe("AuthTokenSync", () => {
     });
 
     await waitFor(() => expect(postsTo("steward-session")).toHaveLength(2));
+  });
+
+  it("re-establishes the same token once after a failing logout cookie clear", async () => {
+    const token = makeJwt({
+      sub: "u1",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    let deleteAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({
+          url: String(input),
+          method: init?.method ?? "GET",
+        });
+        if (init?.method === "DELETE") {
+          deleteAttempts += 1;
+          throw new Error("cookie clear unavailable");
+        }
+        return Response.json({ ok: true });
+      }),
+    );
+
+    mount();
+    await act(() => syncStewardSessionCookie(token));
+    expect(postsTo("steward-session")).toHaveLength(1);
+
+    // The clear is best-effort and its DELETE fails, but it must retire the
+    // unconsumed explicit-sync proof before any fallible teardown boundary.
+    await act(() => clearStaleStewardSession());
+    expect(deleteAttempts).toBeGreaterThan(0);
+    expect(storage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+
+    storage.setItem(STEWARD_TOKEN_KEY, token);
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STEWARD_TOKEN_KEY,
+          newValue: token,
+        }),
+      );
+    });
+
+    await waitFor(() => expect(postsTo("steward-session")).toHaveLength(2));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(postsTo("steward-session")).toHaveLength(2);
   });
 
   it("ignores a forged same-tab token event and still mirrors on a real storage trigger", async () => {

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -114,11 +114,13 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
       }
 
       if (tokenIsExpired(token)) return;
-      if (consumeStewardServerCookieSynced(token)) {
-        // An explicit sync already established this exact token's server
-        // cookie. Seed the passive mirror's local authority without issuing a
-        // duplicate POST. The one-shot marker cannot be forged through DOM
-        // event detail and is invalidated by any token mismatch.
+      const sessionEndpoint = configuredSessionEndpoint();
+      if (consumeStewardServerCookieSynced(token, sessionEndpoint)) {
+        // An explicit sync already established this exact token at the exact
+        // endpoint this passive mirror would use. Seed local authority without
+        // repeating that POST. The module-private marker cannot be forged
+        // through DOM event detail and any token/endpoint mismatch invalidates
+        // it before the passive request proceeds.
         lastSyncedToken.current = token;
         wasAuthenticated.current = true;
         return;
@@ -133,7 +135,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
       // fire only when /get-started attaches the continuation after rendering
       // its identity preview and receiving explicit confirmation. Login,
       // nonce exchange, and SSO establish authentication only.
-      fetch(configuredSessionEndpoint(), {
+      fetch(sessionEndpoint, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -314,7 +316,6 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
 
     const handler = () => syncToken();
     window.addEventListener("storage", handler);
-    window.addEventListener("steward-token-sync", handler);
 
     const visibilityHandler = () => {
       if (document.visibilityState === "visible") {
@@ -340,7 +341,6 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
     return () => {
       clearInterval(refreshInterval);
       window.removeEventListener("storage", handler);
-      window.removeEventListener("steward-token-sync", handler);
       document.removeEventListener("visibilitychange", visibilityHandler);
       window.removeEventListener("online", onlineHandler);
       window.removeEventListener("steward-unauthorized", unauthorizedHandler);

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -35,7 +35,10 @@ import { dispatchStewardSessionChange } from "../../events/steward-session-event
 import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
-import { consumeStewardServerCookieSynced } from "../lib/steward-session-cookie-sync-marker";
+import {
+  consumeStewardServerCookieSynced,
+  invalidateStewardServerCookieSyncMarker,
+} from "../lib/steward-session-cookie-sync-marker";
 import {
   clearServerStewardSessionCookies,
   clearStaleStewardSession,
@@ -363,6 +366,10 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
         : null,
       session: auth.session,
       signOut: () => {
+        // Retire explicit-sync proof before the SDK begins its own fallible
+        // sign-out work. A same-token login after any partial teardown must
+        // establish the local server cookie again.
+        invalidateStewardServerCookieSyncMarker();
         // Drop the at-rest JWT from the persisted active server before the SDK
         // sign-out — leaving it in localStorage is an at-rest token leak. Keeps
         // the backend selection (kind/apiBase) so re-auth lands on the same one.

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -35,6 +35,7 @@ import { dispatchStewardSessionChange } from "../../events/steward-session-event
 import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
+import { consumeStewardServerCookieSynced } from "../lib/steward-session-cookie-sync-marker";
 import {
   clearServerStewardSessionCookies,
   clearStaleStewardSession,
@@ -113,6 +114,15 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
       }
 
       if (tokenIsExpired(token)) return;
+      if (consumeStewardServerCookieSynced(token)) {
+        // An explicit sync already established this exact token's server
+        // cookie. Seed the passive mirror's local authority without issuing a
+        // duplicate POST. The one-shot marker cannot be forged through DOM
+        // event detail and is invalidated by any token mismatch.
+        lastSyncedToken.current = token;
+        wasAuthenticated.current = true;
+        return;
+      }
       if (token === lastSyncedToken.current) return;
 
       lastSyncedToken.current = token;
@@ -304,6 +314,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
 
     const handler = () => syncToken();
     window.addEventListener("storage", handler);
+    window.addEventListener("steward-token-sync", handler);
 
     const visibilityHandler = () => {
       if (document.visibilityState === "visible") {
@@ -329,6 +340,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
     return () => {
       clearInterval(refreshInterval);
       window.removeEventListener("storage", handler);
+      window.removeEventListener("steward-token-sync", handler);
       document.removeEventListener("visibilitychange", visibilityHandler);
       window.removeEventListener("online", onlineHandler);
       window.removeEventListener("steward-unauthorized", unauthorizedHandler);

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -22,6 +22,11 @@ import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
 } from "../../state/persistence";
+import {
+  consumeStewardServerCookieSynced,
+  invalidateStewardServerCookieSyncMarker,
+  markStewardServerCookieSynced,
+} from "../lib/steward-session-cookie-sync-marker";
 
 import {
   clearStaleStewardSession,
@@ -132,6 +137,7 @@ function makeJwt(payload: Record<string, unknown>): string {
 describe("clearStaleStewardSession", () => {
   beforeEach(() => {
     localStorage.clear();
+    invalidateStewardServerCookieSyncMarker();
   });
 
   it("drops a shared Cloud agent selection so the next account resolves its own agent", async () => {
@@ -236,6 +242,10 @@ describe("clearStaleStewardSession", () => {
       accessToken: "still-durable-token",
     });
     const deletionFailure = new Error("native secure deletion denied");
+    markStewardServerCookieSynced(
+      "still-durable-token",
+      "/api/auth/steward-session",
+    );
     const unregister = registerStewardTokenRemoval(async () => {
       throw deletionFailure;
     });
@@ -254,6 +264,12 @@ describe("clearStaleStewardSession", () => {
     expect(loadPersistedActiveServer()?.accessToken).toBe(
       "still-durable-token",
     );
+    expect(
+      consumeStewardServerCookieSynced(
+        "still-durable-token",
+        "/api/auth/steward-session",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -17,6 +17,7 @@ import {
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { clearSharedCloudAccountBinding } from "../../state/shared-cloud-account-binding";
 import { decodeJwtPayload } from "../lib/jwt";
+import { invalidateStewardServerCookieSyncMarker } from "../lib/steward-session-cookie-sync-marker";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "./steward-url";
 
 export function isPlaceholderValue(value: string | undefined): boolean {
@@ -121,6 +122,9 @@ function stewardSessionClearUrls(): string[] {
 }
 
 export function clearServerStewardSessionCookies(): void {
+  // Invalidate before issuing any best-effort DELETE: a rejected request must
+  // never leave a proof that can suppress a later session-establishing POST.
+  invalidateStewardServerCookieSyncMarker();
   for (const url of stewardSessionClearUrls()) {
     // error-policy:J6 best-effort sign-out cookie clear across session hosts;
     // the local token is already cleared and an expired cookie self-heals.
@@ -161,6 +165,10 @@ export function tokenSecsRemaining(token: string): number | null {
 
 export async function clearStaleStewardSession(): Promise<void> {
   if (typeof window === "undefined") return;
+  // This is deliberately before protected-storage removal. That operation can
+  // reject and abort the rest of teardown, but an attempted session clear must
+  // still retire any unconsumed proof from the previous authority epoch.
+  invalidateStewardServerCookieSyncMarker();
   let storedTokenClearError: unknown;
   try {
     await clearStoredStewardToken();

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.test.ts
@@ -9,6 +9,11 @@ import {
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "../join/lib/onboarding-continuation";
 import {
+  consumeStewardServerCookieSynced,
+  invalidateStewardServerCookieSyncMarker,
+  markStewardServerCookieSynced,
+} from "../lib/steward-session-cookie-sync-marker";
+import {
   buildBridgeExchangeUrl,
   buildBridgeMintUrl,
   burnSsoBridgeCode,
@@ -76,6 +81,7 @@ function clearCookies(): void {
 }
 
 beforeEach(() => {
+  invalidateStewardServerCookieSyncMarker();
   localStorage.clear();
   sessionStorage.clear();
   clearCookies();
@@ -525,7 +531,12 @@ describe("burnSsoBridgeCode", () => {
 
 describe("signOutFromSsoBridgedHost", () => {
   it("marks logged-out synchronously, ends the server session, scrubs locally", async () => {
-    localStorage.setItem(STEWARD_TOKEN_KEY, liveToken());
+    const token = liveToken();
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
+    markStewardServerCookieSynced(
+      token,
+      "https://cloud.eliza.app/api/auth/steward-session",
+    );
     // clearStaleStewardSession fires best-effort cookie DELETEs via the
     // global fetch; capture them so jsdom does not attempt real requests.
     const globalCalls: string[] = [];
@@ -535,10 +546,18 @@ describe("signOutFromSsoBridgedHost", () => {
       return Promise.resolve(json(200, { ok: true }));
     }) as typeof fetch;
     try {
-      const { fn, calls } = fetchStub(() => json(200, { success: true }));
+      let proofAtServerLogoutIssue: boolean | undefined;
+      const { fn, calls } = fetchStub(() => {
+        proofAtServerLogoutIssue = consumeStewardServerCookieSynced(
+          token,
+          "https://cloud.eliza.app/api/auth/steward-session",
+        );
+        return json(200, { success: true });
+      });
       await signOutFromSsoBridgedHost("cloud.eliza.app", fn);
       expect(isSsoLoggedOut()).toBe(true);
       expect(calls[0].url).toBe("https://cloud.eliza.app/api/auth/logout");
+      expect(proofAtServerLogoutIssue).toBe(false);
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
     } finally {
       globalThis.fetch = realFetch;

--- a/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
+++ b/packages/ui/src/cloud/sso-bridge/sso-bridge.ts
@@ -53,6 +53,7 @@ import {
 import { shellLocalStorage } from "../../surface-realm-channel";
 import { appModeNavigation } from "../app-mode/app-mode";
 import { decodeJwtPayload } from "../lib/jwt";
+import { invalidateStewardServerCookieSyncMarker } from "../lib/steward-session-cookie-sync-marker";
 import {
   clearStaleStewardSession,
   configuredSessionEndpoint,
@@ -616,6 +617,10 @@ export async function signOutFromSsoBridgedHost(
   hostname: string = window.location.hostname,
   fetchFn: typeof fetch = fetch,
 ): Promise<void> {
+  // Invalidate before even issuing the server logout request: fetch adapters
+  // may have synchronous hooks, and no re-entrant token publication may reuse
+  // proof from the authority epoch being ended.
+  invalidateStewardServerCookieSyncMarker();
   markSsoLoggedOut();
   const base = apiBaseForHostname(hostname);
   const serverLogout = base


### PR DESCRIPTION
# Relates to

Relates to #20848.

Definition of Done: full standard in CONTRIBUTING.md.

- [x] This PR targets develop and was rebased onto origin/develop at 9e3e165cb15b4a4d7d47f6be66f345af137eb4ba with zero conflicts.
- [x] bun install completed with Bun 1.3.14. A full bun run verify passed before the final no-conflict rebase; exact-head focused tests, UI typecheck, Biome, and diff checks passed after it.
- [ ] A reviewer can confirm the change works without reading the code from the exact-head browser/network evidence still being captured for this draft.

# Sync with develop

- [x] Rebasing onto origin/develop completed with zero conflicts at PR creation.
- [ ] Re-run the full verify command on the final merge head after any additional develop drift. The current exact head has affected-path verification; details are below.

# Risks

Medium. This changes auth-session synchronization timing, not token validation or cookie authority. The explicit session POST still has to succeed before any suppression marker exists. A token or endpoint mismatch invalidates the marker, every audited cookie/session-clear and sign-out boundary retires it before fallible teardown, failed explicit synchronization falls back to the passive POST, and browser event detail is never trusted as authority.

# Background

## What does this PR do?

- records a module-private, one-shot acknowledgement only after the explicit Steward JWT to HttpOnly-cookie POST succeeds
- binds that proof to the exact token and canonical session endpoint, then consumes it when the mounted runtime observes canonical storage, avoiding the deterministic second POST
- explicitly invalidates an unconsumed proof before every audited cookie/session-clear and sign-out authority, including failure paths
- keeps ordinary storage, refresh, visibility, and forged DOM-event paths on the existing passive synchronization behavior
- retains the conservative Telegram claim boundary

The successful passkey trace showed the first session exchange taking about 19.7 seconds and a deterministic duplicate exchange taking another 4.3 seconds. This removes the duplicate request without weakening retry or logout behavior.

## What kind of change is this?

Improvement and non-breaking auth performance fix.

# Documentation changes needed?

No product documentation change is required. The behavior is internal session synchronization and is covered by source comments and tests.

# Testing

## Where should a reviewer start?

- packages/ui/src/cloud/lib/steward-session-cookie-sync-marker.ts
- packages/ui/src/cloud/public-pages/lib/steward-session.ts
- packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
- packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx

## Detailed testing steps

1. Complete a successful Steward login that calls syncStewardSessionCookie.
2. Inspect the network log and verify exactly one POST to /api/auth/steward-session for that token.
3. Clear/logout before the passive consumer runs, republish the same token, and verify exactly one new passive POST establishes the new server session.
4. Dispatch an ordinary storage event with a different token or endpoint and verify the passive POST still occurs.
5. Force the explicit POST to fail, publish the token through storage, and verify the passive path retries.

Automated exact-head checks:

- focused Vitest: 7 files, 78 tests passed (including direct-map dedupe, configured-API endpoint mismatch, forged-event rejection, failed-sync retry, passive no-loop coverage, mark-clear-same-token recovery, and clear failure/order coverage)
- node_modules/.bin/tsc --noEmit -p packages/ui/tsconfig.json passed
- Biome check on all 13 changed files passed (one pre-existing noDocumentCookie warning remains in sso-bridge.test.ts)
- git diff HEAD^ --check passed
- bun install --frozen-lockfile passed with Bun 1.3.14
- bun run verify passed all 374 Turbo build/typecheck/lint tasks plus repository audits after the missing local DoorDash artifact was built; that run preceded a conflict-free develop-only rebase, so the final full rerun remains a draft exit item
- full UI suite was run once on the earlier equivalent commit: 1108 files and 11732 tests passed; 24 files and 29 tests failed outside this diff on the current develop baseline

# Evidence Gate

<!-- evidence-head:b927e7983163264de212e02b2b70822073f4ffb7 -->

Any change testable on the frontend is not mergeable without inline evidence. This draft remains intentionally blocked until the exact-head capture is attached.

<!-- evidence-row:before-screenshots -->
- [ ] Before desktop and mobile screenshots: pending exact-head capture of the unchanged login/chat UI with the duplicate request visible in the network trace.
<!-- evidence-row:after-screenshots -->
- [ ] After desktop and mobile screenshots: pending exact-head capture of the unchanged UI with one session POST.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: pending a short exact-head login recording with the network panel.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: pending staging proof that one session request reaches the route and post-commit work continues separately.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs: pending exact-head HAR or sanitized request-count transcript.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, wallet, file, scheduled-task, or on-chain mutation is introduced.
<!-- evidence-row:ocr-review -->
- [ ] OCR review: pending alongside the required before and after capture; no rendered copy is expected to change.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Pending exact-head staging capture before merge.

## Screenshots (before / after) + video walkthrough

Pending exact-head evidence before merge. The rendered UI is intentionally unchanged; evidence will show the same surface and the network request-count difference.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- Exact-head staging network, screenshot, OCR, and video evidence is still pending; this is why the PR is a draft.
- The full UI suite has unrelated existing failures outside this diff, while all affected suites pass.
- An initial full verify attempt failed only because the standalone Bun binary directory lacked a bunx executable. A temporary bunx shim allowed the canonical command to run.
- The next verify attempt found a missing local plugin-doordash build artifact. Building that workspace package resolved the environment issue, after which the full verify passed.
- Production is not touched by this PR.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: N/A - no exception requested
- Validated origin/develop SHA: N/A - no exception requested
- Live ruleset readback and named bypass eligibility: N/A - no exception requested
- Queued or failing checks and run URLs: N/A - no exception requested
- Infrastructure-only or unrelated-failure proof: N/A - no exception requested
- Exact-head commands, exit status, and artifacts: N/A - no exception requested
- Exact-head security, secret-scan, and provenance results: N/A - no exception requested
- Conflict-free and affected-path failure attestation: N/A - no exception requested
- Independent approving reviewer: N/A - no exception requested
- Bypass authorizer: N/A - no exception requested
- Merge method: N/A - no exception requested
- Rollback owner: N/A - no exception requested
- Post-merge develop validation: N/A - no exception requested
