### PR TITLE
fix(plugin-x): preserve complete discovery drafts

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -263,6 +263,10 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"plugins/plugin-x/src/lifeops-message-adapter.ts": [
 		/draft\.body\.(?:slice|substring)\(/,
 	],
+	"plugins/plugin-x/src/discovery.ts": [
+		/maxTokens:\s*100/,
+		/(?:replyText|quoteText|response)\.(?:slice|substring)\(/,
+	],
 	"plugins/plugin-anthropic/models/image.ts": [/firstLine\.slice\(/],
 	"plugins/plugin-local-inference/src/services/voice/voice-emotion-classifier.ts":
 		[/WAV2SMALL_MAX_SAMPLES/, /truncated to the trailing window/],

--- a/plugins/plugin-x/src/discovery.test.ts
+++ b/plugins/plugin-x/src/discovery.test.ts
@@ -22,6 +22,8 @@ type DiscoveryHarness = {
     tweets: unknown[],
     session: TwitterAccountSession,
   ): Promise<number>;
+  generateReply(tweet: unknown): Promise<string>;
+  generateQuote(tweet: unknown): Promise<string>;
   delay(ms: number): Promise<void>;
 };
 
@@ -321,6 +323,7 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
 
   it("replies to a discovered tweet once across cycles", async () => {
     const { runtime } = makeEngagementRuntime("welcome to the timeline");
+    const useModel = runtime.useModel as ReturnType<typeof vi.fn>;
     const { client, session, sendTweet, likeTweet } = makeEngagementClient();
     const discovery = new TwitterDiscoveryClient(
       client,
@@ -340,6 +343,50 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
       "welcome to the timeline",
       "1750000000000000001",
     );
+    expect(useModel.mock.calls[0]?.[1]).not.toHaveProperty("maxTokens");
     expect(likeTweet).not.toHaveBeenCalled();
+  });
+
+  it("does not impose hidden model-output caps on reply or quote drafts", async () => {
+    const { runtime } = makeEngagementRuntime("complete draft");
+    const useModel = runtime.useModel as ReturnType<typeof vi.fn>;
+    const { client } = makeEngagementClient();
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    const tweet = scoredTweet("reply").tweet;
+
+    await expect(discovery.generateReply(tweet)).resolves.toBe(
+      "complete draft",
+    );
+    await expect(discovery.generateQuote(tweet)).resolves.toBe(
+      "complete draft",
+    );
+
+    for (const [, request] of useModel.mock.calls) {
+      expect(request).not.toHaveProperty("maxTokens");
+    }
+  });
+
+  it("rejects a complete overlength draft instead of clipping it", async () => {
+    const completeDraft = "\u4f60".repeat(141);
+    const { runtime } = makeEngagementRuntime(completeDraft);
+    const useModel = runtime.useModel as ReturnType<typeof vi.fn>;
+    const { client } = makeEngagementClient();
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+
+    await expect(
+      discovery.generateReply(scoredTweet("reply").tweet),
+    ).rejects.toMatchObject({
+      code: "X_DISCOVERY_DRAFT_LENGTH_EXCEEDED",
+      context: { weightedLength: 282, maxWeightedLength: 280 },
+    });
+    expect(useModel).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-x/src/discovery.ts
+++ b/plugins/plugin-x/src/discovery.ts
@@ -16,7 +16,9 @@ import {
 import type { ClientBase, TwitterAccountSession } from "./base";
 import type { Client, Tweet } from "./client/index";
 import { SearchMode } from "./client/index";
+import { TWEET_MAX_LENGTH } from "./constants";
 import { getRandomInterval } from "./environment";
+import { countTwitterWeightedLength } from "./tweet-length";
 import type { TwitterClientState } from "./types";
 import { createMemorySafe, ensureTwitterContext } from "./utils/memory";
 import { getSetting } from "./utils/settings";
@@ -34,6 +36,20 @@ interface DiscoveryConfig {
   likeThreshold: number;
   replyThreshold: number;
   quoteThreshold: number;
+}
+
+function validateCompleteDraft(text: string): string {
+  const weightedLength = countTwitterWeightedLength(text);
+  if (weightedLength > TWEET_MAX_LENGTH) {
+    throw new ElizaError(
+      `Generated X draft exceeds ${TWEET_MAX_LENGTH} weighted characters; received ${weightedLength}`,
+      {
+        code: "X_DISCOVERY_DRAFT_LENGTH_EXCEEDED",
+        context: { weightedLength, maxWeightedLength: TWEET_MAX_LENGTH },
+      },
+    );
+  }
+  return text;
 }
 
 interface ScoredTweet {
@@ -960,11 +976,10 @@ Reply:`;
 
     const response = await this.runtime.useModel(ModelType.TEXT_SMALL, {
       prompt,
-      maxTokens: 100,
       temperature: 0.8,
     });
 
-    return response.trim();
+    return validateCompleteDraft(response.trim());
   }
 
   private async generateQuote(tweet: DiscoveryTweet): Promise<string> {
@@ -998,11 +1013,10 @@ Quote tweet:`;
 
     const response = await this.runtime.useModel(ModelType.TEXT_SMALL, {
       prompt,
-      maxTokens: 100,
       temperature: 0.8,
     });
 
-    return response.trim();
+    return validateCompleteDraft(response.trim());
   }
 
   private async saveEngagementMemory(


### PR DESCRIPTION
Closes #24834

## What changed
- remove the fixed 100-token output caps from autonomous reply and quote generation
- preserve the complete model draft, then validate the real X weighted-character boundary
- reject overlength drafts with `X_DISCOVERY_DRAFT_LENGTH_EXCEEDED` instead of clipping or sending partial content
- guard the source against fixed cap or slice regressions

## Verification
- `bunx vitest run src/discovery.test.ts` (8 passed)
- `bun run typecheck` in `plugins/plugin-x`
- `bun test packages/core/src/__tests__/prompt-integrity-policy.test.ts` (4 passed)
- Biome check and `git diff --check`