### PR TITLE
fix(cloud): validate MCP registry queries before optional auth

### DIFF
--- a/packages/cloud/api/__tests__/mcp-registry-query-validation-order.test.ts
+++ b/packages/cloud/api/__tests__/mcp-registry-query-validation-order.test.ts
@@ -1,0 +1,159 @@
+/**
+ * GET /api/mcp/registry — invalid query parameters must cost zero lookups.
+ *
+ * The public registry runs an optional getCurrentUser() lookup and a community
+ * userMcpsService.listPublic() lookup. An invalid request such as ?limit=0 has
+ * an already-determined 400, so neither lookup should be started: the auth
+ * catch only degrades a failed lookup to anonymous, it cannot un-spend the
+ * work (#24791). Drives the real Hono handler with both boundaries counted.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as userMcpsActual from "@/lib/services/user-mcps";
+import * as loggerActual from "@/lib/utils/logger";
+
+let authLookups = 0;
+let communityLookups = 0;
+
+const listPublic = mock(async () => {
+  communityLookups += 1;
+  return [] as unknown[];
+});
+
+// Object.create keeps the real instance as prototype so every other method
+// still resolves — only listPublic is shadowed.
+const mockUserMcpsService = Object.create(userMcpsActual.userMcpsService);
+mockUserMcpsService.listPublic = listPublic;
+
+mock.module("@/lib/services/user-mcps", () => ({
+  ...userMcpsActual,
+  userMcpsService: mockUserMcpsService,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  getCurrentUser: mock(async () => {
+    authLookups += 1;
+    return null;
+  }),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const registryRoute = (await import("../mcp/registry/route")) as {
+  default: { fetch: (req: Request, env?: unknown) => Promise<Response> };
+};
+
+const ENV = { NODE_ENV: "test", NEXT_PUBLIC_APP_URL: "https://test.local" };
+
+function get(query = ""): Promise<Response> {
+  return registryRoute.default.fetch(
+    new Request(`http://test.local/${query}`, { method: "GET" }),
+    ENV,
+  );
+}
+
+function reset(): void {
+  authLookups = 0;
+  communityLookups = 0;
+}
+
+describe("GET /api/mcp/registry query validation ordering", () => {
+  test("rejects ?limit=0 with a 400 and zero lookup effects", async () => {
+    reset();
+    const response = await get("?limit=0");
+
+    expect(response.status).toBe(400);
+    // The rejection is fully determined by the query string, so neither
+    // optional auth nor the community registry may have been consulted.
+    expect(authLookups).toBe(0);
+    expect(communityLookups).toBe(0);
+
+    const body = (await response.json()) as {
+      error: string;
+      details: Array<{ field: string }>;
+    };
+    expect(body.error).toBe("Invalid query parameters");
+    expect(body.details.some((issue) => issue.field === "limit")).toBe(true);
+  });
+
+  test.each([
+    ["?limit=0", "limit"],
+    ["?limit=101", "limit"],
+    ["?limit=abc", "limit"],
+    ["?category=not-a-category", "category"],
+    ["?status=not-a-status", "status"],
+    [`?search=${"x".repeat(101)}`, "search"],
+  ])("rejects %s before any lookup", async (query, field) => {
+    reset();
+    const response = await get(query);
+
+    expect(response.status).toBe(400);
+    expect(authLookups).toBe(0);
+    expect(communityLookups).toBe(0);
+
+    const body = (await response.json()) as {
+      details: Array<{ field: string }>;
+    };
+    expect(body.details.some((issue) => issue.field === field)).toBe(true);
+  });
+
+  test("preserves the valid-query response, auth flag, and lookup count", async () => {
+    reset();
+    const response = await get("?limit=5&category=data&status=live");
+
+    expect(response.status).toBe(200);
+    // A valid query must still spend exactly one optional auth lookup and one
+    // community lookup — this guards against over-rejection.
+    expect(authLookups).toBe(1);
+    expect(communityLookups).toBe(1);
+
+    const body = (await response.json()) as {
+      isAuthenticated: boolean;
+      appliedFilters: {
+        category: string | null;
+        status: string | null;
+        limit: number;
+      };
+    };
+    expect(body.isAuthenticated).toBe(false);
+    expect(body.appliedFilters).toMatchObject({
+      category: "data",
+      status: "live",
+      limit: 5,
+    });
+  });
+
+  test("an omitted query still resolves defaults and performs both lookups", async () => {
+    reset();
+    const response = await get();
+
+    expect(response.status).toBe(200);
+    expect(authLookups).toBe(1);
+    expect(communityLookups).toBe(1);
+
+    const body = (await response.json()) as {
+      appliedFilters: {
+        category: string | null;
+        status: string | null;
+        limit: number;
+      };
+    };
+    // "all" is reported as null by the existing contract.
+    expect(body.appliedFilters).toMatchObject({
+      category: null,
+      status: null,
+      limit: 100,
+    });
+  });
+});

--- a/packages/cloud/api/mcp/registry/route.ts
+++ b/packages/cloud/api/mcp/registry/route.ts
@@ -446,25 +446,11 @@ function withRegistryTimeout<T>(
 
 app.get("/", async (c) => {
   try {
-    const user = await withRegistryTimeout(
-      getCurrentUser(c),
-      "optional auth lookup",
-      // error-policy:J4 optional auth on a public catalog — a lookup failure
-      // degrades to the anonymous view, surfaced via isAuthenticated:false below.
-    ).catch((error) => {
-      logger.warn("[MCP Registry] Optional auth lookup failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    });
-    const isAuthenticated = user !== null;
-
-    const baseUrl =
-      c.env.NEXT_PUBLIC_APP_URL ||
-      (c.req.header("host")
-        ? `${c.req.header("x-forwarded-proto") || "https"}://${c.req.header("host")}`
-        : "http://localhost:3000");
-
+    // Validate the public query surface before spending any lookup effort.
+    // An invalid request such as ?limit=0 has an already-determined 400, so
+    // starting the optional auth lookup first only makes that response wait on
+    // the optional-auth timeout; the auth catch degrades a failed lookup to
+    // anonymous but cannot un-spend the work (#24791).
     const limitRaw = c.req.query("limit");
     const parsedLimit =
       limitRaw === undefined || limitRaw === ""
@@ -496,6 +482,25 @@ app.get("/", async (c) => {
     }
 
     const { category, status, limit, search } = validationResult.data;
+
+    const user = await withRegistryTimeout(
+      getCurrentUser(c),
+      "optional auth lookup",
+      // error-policy:J4 optional auth on a public catalog — a lookup failure
+      // degrades to the anonymous view, surfaced via isAuthenticated:false below.
+    ).catch((error) => {
+      logger.warn("[MCP Registry] Optional auth lookup failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    });
+    const isAuthenticated = user !== null;
+
+    const baseUrl =
+      c.env.NEXT_PUBLIC_APP_URL ||
+      (c.req.header("host")
+        ? `${c.req.header("x-forwarded-proto") || "https"}://${c.req.header("host")}`
+        : "http://localhost:3000");
 
     // Process built-in registry entries. Availability gates advertising:
     // unconfigured integrations (their transport would answer 501) are never


### PR DESCRIPTION
Closes #24791

## Summary

`GET /api/mcp/registry` awaited its optional `getCurrentUser(c)` lookup **before**
parsing and validating query parameters. An invalid request such as `?limit=0`
therefore spent the auth lookup — and could wait on the optional-auth timeout —
before returning a `400` that was already fully determined by the query string.

As the issue notes, the auth `.catch()` only degrades a failed lookup to the
anonymous view; it cannot un-spend the work.

## Change

`packages/cloud/api/mcp/registry/route.ts` only — pure statement reordering
inside the handler. The limit pre-parse, `queryParamsSchema.safeParse`, and the
`400` return now run **above** the optional auth lookup and the community
registry read. `baseUrl` moves with the auth block because only the post-
validation path uses it.

No schema, response shape, status code, or filter semantics changed.

## Verification

Confirmed on `develop` that `await withRegistryTimeout(getCurrentUser(c), …)`
precedes `safeParse`, and that `userMcpsService.listPublic(…)` is called
unconditionally on the success path (so counting it is meaningful).

Because `zod` is not installed on this host, I reimplemented the route's schema
semantics faithfully (same enums, `int().min(1).max(100).default(100)`, `search`
max 100) together with the handler's **verbatim** limit pre-parse, and checked
every assertion the new tests make:

| query | expected | schema result |
| --- | --- | --- |
| `?limit=0` | 400 `limit` | invalid → `["limit"]` |
| `?limit=101` | 400 `limit` | invalid → `["limit"]` |
| `?limit=abc` | 400 `limit` | invalid → `["limit"]` (pre-parse → `NaN`) |
| `?category=not-a-category` | 400 `category` | invalid → `["category"]` |
| `?status=not-a-status` | 400 `status` | invalid → `["status"]` |
| `?search=<101 chars>` | 400 `search` | invalid → `["search"]` |
| `?limit=5&category=data&status=live` | 200 | valid → `data/live/5` |
| *(no query)* | 200 | valid → `all/all/100` |

I also verified the `appliedFilters` contract reports `"all"` as `null`, and
asserted that rather than the value I first assumed — the response field is
`appliedFilters`, not `filters`.

- `git diff --check` — clean.
- Both changed files parse cleanly under Node 24 type-stripping.

## Tests

New `packages/cloud/api/__tests__/mcp-registry-query-validation-order.test.ts`,
built on the harness already used by `mcp-registry-community-degrade.test.ts`
(real Hono handler via `route.default.fetch`, `Object.create` prototype shadowing
so sibling suites are unaffected):

- **`rejects ?limit=0 with a 400 and zero lookup effects`** — the exact
  reproduction from the issue: status `400`, `authLookups=0`,
  `communityLookups=0`. On `develop` this observes `authLookups=1`, so the test
  fails without the reorder.
- **`rejects %s before any lookup`** — the same zero-lookup property across all
  four supported fields (six shapes).
- **`preserves the valid-query response, auth flag, and lookup count`** and
  **`an omitted query still resolves defaults and performs both lookups`** —
  guard against over-rejection: a valid query must still spend exactly one auth
  and one community lookup and return the same `isAuthenticated` /
  `appliedFilters` values.

Both counters are incremented inside the mocked boundaries, so the assertions
measure real call effects rather than a proxy for them.

## Risks

Low. Reordering only; no behavioral change for valid queries, and the invalid
path returns the same typed `400` body it did before. The one intended
difference is that the two lookups are no longer started for a request that was
always going to be rejected.

Ordering note: validation now runs before optional auth, so an invalid query
from an authenticated caller is rejected without consulting identity. That is
the intent of the issue and is safe here because the route is public and the
auth result only sets the `isAuthenticated` flag — it does not gate access or
change which entries are validated.

## Known gaps / failures

I could not run the package's `bun test` lane locally: `bun` is not installed on
this host and installing it was blocked, so `node_modules` is absent and
`bun run --cwd packages/cloud/api test` could not execute. The new suite follows
the established harness in this directory, and every status/field it asserts was
verified against the schema semantics above, but hosted CI is authoritative for
execution. Stating that explicitly rather than implying a green local run.

AI provider/model: meituan / longcat-2.0
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-longcat]
<!-- eliza-computer-attribution:v1 {"provider":"meituan","model":"longcat-2.0","client":"Hermes Agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
