### PR TITLE
fix(core): reconcile split owner-entity UUIDs at the owner-private disclosure gate

### DIFF
--- a/packages/core/src/roles.owner-for-message.test.ts
+++ b/packages/core/src/roles.owner-for-message.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression coverage for the owner-private disclosure gate's owner resolution
+ * (resolveCanonicalOwnerIdForMessage). A connector may persist the world's
+ * canonical owner under a DIFFERENT entity UUID than the one it stamps on the
+ * owner's own inbound messages — e.g. plugin-discord records
+ * `ownership.ownerId` as the synthetic `stringToUuid("<name>-admin-entity")`
+ * fallback while the owner's message carries `createUniqueUuid(runtime,
+ * <snowflake>)`. Both denote the same human, but the gate compares this id to
+ * the message actor with strict equality, so a naive resolver returns the
+ * synthetic id, the equality fails, and every owner-private surface is denied
+ * with `owner_mismatch` — even in a 2-person owner DM/guild.
+ *
+ * This proves BOTH directions: the genuine owner (matched via connector-stable
+ * identity) resolves to the ACTOR's id so the gate matches, while a non-owner
+ * sender never does and stays denied.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveCanonicalOwnerIdForMessage } from "./roles.ts";
+import type { Entity, IAgentRuntime, Memory, Room, UUID, World } from "./types";
+
+const AGENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const WORLD_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID;
+const ROOM_ID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" as UUID;
+
+// The synthetic owner UUID a connector persisted onto the world.
+const SYNTHETIC_OWNER_ID = "0afe069b-83d3-0ea3-aa07-a47dd72ade03" as UUID;
+// The owner's ACTUAL message-actor entity UUID (createUniqueUuid(snowflake)).
+const OWNER_ACTOR_ID = "1ac7128f-c24b-0773-a5e5-472dfcff09b1" as UUID;
+// A non-owner sender.
+const STRANGER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID;
+
+const OWNER_SNOWFLAKE = "308276393450668032";
+const STRANGER_SNOWFLAKE = "876543210987654321";
+
+type FakeOptions = {
+	entities?: Record<string, Entity>;
+	worldMetadata?: Record<string, unknown>;
+};
+
+function makeRuntime(options: FakeOptions = {}): IAgentRuntime {
+	const entities = options.entities ?? {};
+	const world: World = {
+		id: WORLD_ID,
+		name: "owner guild",
+		agentId: AGENT_ID,
+		metadata: (options.worldMetadata ?? {}) as World["metadata"],
+	};
+	return {
+		agentId: AGENT_ID,
+		// No configured canonical owner — force world-metadata resolution.
+		getSetting: () => undefined,
+		getRoom: async (id: UUID): Promise<Room | null> =>
+			id === ROOM_ID
+				? ({
+						id: ROOM_ID,
+						agentId: AGENT_ID,
+						worldId: WORLD_ID,
+						source: "discord",
+					} as Room)
+				: null,
+		getWorld: async (id: UUID): Promise<World | null> =>
+			id === WORLD_ID ? world : null,
+		getEntityById: async (id: UUID) => entities[id] ?? null,
+		getRelationships: async () => [],
+	} as unknown as IAgentRuntime;
+}
+
+function ownerEntity(): Entity {
+	return {
+		id: OWNER_ACTOR_ID,
+		names: ["Owner"],
+		agentId: AGENT_ID,
+		metadata: {
+			discord: {
+				id: OWNER_SNOWFLAKE,
+				userId: OWNER_SNOWFLAKE,
+				username: "owner",
+			},
+		},
+	};
+}
+
+// The synthetic owner entity the connector linked the world ownership to; it
+// carries the SAME stable platform snowflake as the owner actor entity.
+function syntheticOwnerEntity(): Entity {
+	return {
+		id: SYNTHETIC_OWNER_ID,
+		names: ["Owner"],
+		agentId: AGENT_ID,
+		metadata: {
+			discord: {
+				id: OWNER_SNOWFLAKE,
+				userId: OWNER_SNOWFLAKE,
+				username: "owner",
+			},
+		},
+	};
+}
+
+function strangerEntity(): Entity {
+	return {
+		id: STRANGER_ID,
+		names: ["Stranger"],
+		agentId: AGENT_ID,
+		metadata: {
+			discord: {
+				id: STRANGER_SNOWFLAKE,
+				userId: STRANGER_SNOWFLAKE,
+				username: "stranger",
+			},
+		},
+	};
+}
+
+function message(entityId: UUID): Memory {
+	return {
+		id: "66666666-6666-6666-6666-666666666666" as UUID,
+		entityId,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text: "what have we talked about?", source: "discord" },
+	} as Memory;
+}
+
+describe("resolveCanonicalOwnerIdForMessage — split owner-UUID reconciliation", () => {
+	it("without the fix, the recorded synthetic owner would never equal the actor (the bug)", async () => {
+		// This asserts the raw invariant the gate relies on: the world records a
+		// DIFFERENT id than the owner's own message actor. A resolver that returns
+		// the recorded id verbatim fails the gate's strict equality.
+		expect(SYNTHETIC_OWNER_ID).not.toBe(OWNER_ACTOR_ID);
+	});
+
+	it("resolves the genuine owner (matched by connector identity) to the ACTOR id so the gate matches", async () => {
+		const runtime = makeRuntime({
+			worldMetadata: { ownership: { ownerId: SYNTHETIC_OWNER_ID } },
+			entities: {
+				[SYNTHETIC_OWNER_ID]: syntheticOwnerEntity(),
+				[OWNER_ACTOR_ID]: ownerEntity(),
+			},
+		});
+		const resolved = await resolveCanonicalOwnerIdForMessage(
+			runtime,
+			message(OWNER_ACTOR_ID),
+		);
+		// The genuine owner resolves to their OWN actor id, so the gate's
+		// `actorEntityId === canonicalOwnerEntityId` check passes.
+		expect(resolved).toBe(OWNER_ACTOR_ID);
+	});
+
+	it("keeps a non-owner sender denied (resolver returns the recorded owner, not the stranger)", async () => {
+		const runtime = makeRuntime({
+			worldMetadata: { ownership: { ownerId: SYNTHETIC_OWNER_ID } },
+			entities: {
+				[SYNTHETIC_OWNER_ID]: syntheticOwnerEntity(),
+				[STRANGER_ID]: strangerEntity(),
+			},
+		});
+		const resolved = await resolveCanonicalOwnerIdForMessage(
+			runtime,
+			message(STRANGER_ID),
+		);
+		// A stranger never satisfies resolveOwnershipRole, so the resolver returns
+		// the recorded owner id — which is NOT the stranger, so the gate's strict
+		// equality denies the stranger with owner_mismatch.
+		expect(resolved).toBe(SYNTHETIC_OWNER_ID);
+		expect(resolved).not.toBe(STRANGER_ID);
+	});
+
+	it("returns the recorded owner unchanged when it already equals the actor", async () => {
+		const runtime = makeRuntime({
+			worldMetadata: { ownership: { ownerId: OWNER_ACTOR_ID } },
+			entities: { [OWNER_ACTOR_ID]: ownerEntity() },
+		});
+		const resolved = await resolveCanonicalOwnerIdForMessage(
+			runtime,
+			message(OWNER_ACTOR_ID),
+		);
+		expect(resolved).toBe(OWNER_ACTOR_ID);
+	});
+});

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -1005,7 +1005,46 @@ export async function resolveCanonicalOwnerIdForMessage(
 	}
 
 	const resolved = await resolveWorldForMessage(runtime, message);
-	return resolveCanonicalOwnerId(runtime, resolved?.metadata);
+	const recordedOwnerId = resolveCanonicalOwnerId(runtime, resolved?.metadata);
+
+	// The owner-exclusive disclosure gate compares this id to the message actor
+	// with strict equality. A connector can persist the owner under a DIFFERENT
+	// canonical UUID than the one it stamps on the owner's own messages: e.g.
+	// plugin-discord records `ownership.ownerId` as the synthetic
+	// `stringToUuid("<name>-admin-entity")` fallback while the owner's inbound
+	// message carries `createUniqueUuid(runtime, <snowflake>)`. Both denote the
+	// same human, but a naive equality check reads them as different principals
+	// and denies every owner-private surface with `owner_mismatch`, even in a
+	// 2-person owner DM/guild whose census is exactly {owner, agent}.
+	//
+	// The role system already reconciles these via connector-stable-identity and
+	// confirmed identity links (resolveOwnershipRole). Reuse that verdict: when
+	// the message actor IS the owner but under a different entity UUID than the
+	// world recorded, return the ACTOR's id so the strict-equality gate matches
+	// the genuine owner. Non-owners never satisfy resolveOwnershipRole, so they
+	// stay denied. Idempotent and connector-agnostic — no Discord-only branch.
+	const actorEntityId = message.entityId;
+	if (
+		actorEntityId &&
+		recordedOwnerId &&
+		recordedOwnerId !== actorEntityId &&
+		resolved?.world
+	) {
+		const actorOwnershipRole = await resolveOwnershipRole(
+			runtime,
+			resolved.metadata,
+			actorEntityId,
+			{
+				liveEntityMetadata: getLiveEntityMetadataFromMessage(message),
+				liveEntityId: actorEntityId,
+			},
+		);
+		if (actorOwnershipRole === "OWNER") {
+			return actorEntityId;
+		}
+	}
+
+	return recordedOwnerId;
 }
 
 export async function checkSenderRole(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -329,7 +329,7 @@ import type {
 	StructuredOutputFailure,
 } from "./types/state";
 import type { ToolPolicyConfig, ToolProfileId } from "./types/tools";
-import { parseJSONObjectFromText, stringToUuid } from "./utils";
+import { parseJSONObjectFromText, stringToUuid, validateUuid } from "./utils";
 import { parseBooleanValue } from "./utils/boolean";
 import { BufferUtils } from "./utils/buffer";
 import { resolveProviderContexts } from "./utils/context-catalog";
@@ -3316,11 +3316,99 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 
+		// LOUD GUARD (owner-private disclosure regression class): a world whose
+		// canonical owner is a bare platform id (snowflake) instead of a valid
+		// entity UUID makes resolveCanonicalOwnerId return null (validateUuid
+		// rejects it), which denies every owner-private provider with
+		// `owner_mismatch`. This has recurred whenever a connector persisted a raw
+		// snowflake into `ownership.ownerId`. Assert it loudly at boot so the
+		// regression is caught in CI/health instead of silently degrading recall.
+		try {
+			await this.assertResolvableWorldOwners();
+		} catch (guardError) {
+			// error-policy:J6 the guard is diagnostic; a scan failure must not brick
+			// startup. Report and continue.
+			this.reportError(
+				"AgentRuntime.assertResolvableWorldOwners",
+				guardError,
+			);
+		}
+
 		// Resolve init promise to allow services to start
 		if (this.initResolver) {
 			this.initResolver();
 			this.initResolver = undefined;
 		}
+	}
+
+	/**
+	 * Fail-loud scan for the owner-private disclosure regression class: any world
+	 * whose `ownership.ownerId` (or an OWNER-role grant) is a non-UUID value — the
+	 * bare-snowflake shape that makes resolveCanonicalOwnerId return null and
+	 * denies owner-private recall with `owner_mismatch`. Logs each offender
+	 * loudly and reports one aggregated error; it is diagnostic, not fatal.
+	 */
+	async assertResolvableWorldOwners(): Promise<void> {
+		if (typeof this.adapter?.getAllWorlds !== "function") {
+			return;
+		}
+		const worlds = await this.getAllWorlds();
+		const offenders: Array<{
+			worldId: string;
+			field: string;
+			value: string;
+		}> = [];
+		for (const world of worlds) {
+			const metadata = (world?.metadata ?? {}) as {
+				ownership?: { ownerId?: unknown };
+				roles?: Record<string, unknown>;
+			};
+			const ownerId = metadata.ownership?.ownerId;
+			if (
+				typeof ownerId === "string" &&
+				ownerId.length > 0 &&
+				validateUuid(ownerId) === null
+			) {
+				offenders.push({
+					worldId: String(world?.id ?? "unknown"),
+					field: "ownership.ownerId",
+					value: ownerId,
+				});
+			}
+			const roles = metadata.roles;
+			if (roles && typeof roles === "object") {
+				for (const [entityId, role] of Object.entries(roles)) {
+					if (role === "OWNER" && validateUuid(entityId) === null) {
+						offenders.push({
+							worldId: String(world?.id ?? "unknown"),
+							field: "roles[OWNER]",
+							value: entityId,
+						});
+					}
+				}
+			}
+		}
+		if (offenders.length === 0) {
+			return;
+		}
+		for (const offender of offenders) {
+			this.logger.error(
+				{
+					src: "agent",
+					agentId: this.agentId,
+					worldId: offender.worldId,
+					field: offender.field,
+				},
+				"OWNER-PRIVATE DISCLOSURE GUARD: world owner is a non-resolvable, non-UUID value (bare platform id/snowflake). resolveCanonicalOwnerId will return null and owner-private providers will be denied with owner_mismatch. Fix the connector so it records a canonical entity UUID.",
+			);
+		}
+		this.reportError(
+			"AgentRuntime.assertResolvableWorldOwners",
+			new Error(
+				`${offenders.length} world(s) record a non-resolvable owner (bare snowflake / non-UUID). Owner-private recall is degraded until fixed.`,
+			),
+			{ offenderCount: offenders.length },
+		);
 	}
 
 	private getBasicCapabilitiesSettings(): Record<string, string> {


### PR DESCRIPTION
## Problem

The owner-exclusive disclosure gate (`packages/core/src/security/trusted-delivery-audience.ts`) compares the canonical owner id to the message actor with **strict equality** (`actorEntityId === canonicalOwnerEntityId`). This breaks when a connector persists the world's owner under a **different entity UUID** than the one it stamps on the owner's own inbound messages.

Concretely with `plugin-discord`:
- `buildDiscordWorldMetadata` records `ownership.ownerId` as the synthetic `stringToUuid("<name>-admin-entity")` fallback (from `resolveElizaOwnerEntityId`) when no canonical owner is configured.
- The owner's inbound message can arrive as `createUniqueUuid(runtime, <snowflake>)` (see `resolveDiscordRuntimeEntityId`'s non-owner-alias path, and every other connector that keys entities off the platform id).

Both UUIDs denote the same human, but the naive equality reads them as different principals. Result: every owner-private provider (`relevant-conversations`, `firstRun`, `pendingApprovals`, …) is denied with `reason=owner_mismatch` — even in a 2-person owner DM/guild whose census is exactly `{owner, agent}`. Owner-private recall silently degrades.

The role system already reconciles these two ids for role purposes (`resolveOwnershipRole` via connector-stable-identity matching + confirmed identity links), so `checkSenderRole` correctly reports `OWNER` — but the disclosure gate uses a separate single-id resolver (`resolveCanonicalOwnerIdForMessage`) that did **not** apply that reconciliation.

## Fix

`resolveCanonicalOwnerIdForMessage` now reuses the audited `resolveOwnershipRole` verdict: when the message actor **is** the owner but under a different entity UUID than the world recorded, it returns the **actor's** id so the strict-equality gate matches the genuine owner. Non-owners never satisfy `resolveOwnershipRole`, so they stay denied. Generic across connectors, no Discord-only branch, idempotent.

## Loud guard

Adds `AgentRuntime.assertResolvableWorldOwners()` (runs at end of init): reports loudly (per-world `logger.error` + one aggregated `reportError`) every world whose `ownership.ownerId` or an OWNER-role grant is a **non-UUID** value — the bare-platform-snowflake shape that makes `resolveCanonicalOwnerId` return `null` (via `validateUuid`) and silently denies owner-private recall. Diagnostic, not fatal.

## Tests

`packages/core/src/roles.owner-for-message.test.ts` proves both directions with the exact split-UUID scenario:
- genuine owner (matched by connector identity) → resolver returns the **actor** id → gate matches ✅
- stranger → resolver returns the recorded owner id (not the stranger) → gate denies ✅
- no-op when the recorded owner already equals the actor.

The failing-before / passing-after is captured: without the fix the genuine-owner test asserts `expected '<synthetic-uuid>' to be '<actor-uuid>'` and fails; with the fix it passes. Existing `roles`, `roles.resolution`, `trusted-delivery-audience`, and `connection` suites remain green.

---

Attribution: Sol
