### PR TITLE
fix(elizacloud): reject non-canonical image output budgets

### DIFF
--- a/plugins/plugin-elizacloud/README.md
+++ b/plugins/plugin-elizacloud/README.md
@@ -118,7 +118,7 @@ Get an API key from
 | `ELIZAOS_CLOUD_EMBEDDING_API_KEY` | Optional custom embedding API key | `ELIZAOS_CLOUD_API_KEY` |
 | `ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS` | Embedding vector size | `1536` |
 | `ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MODEL` | Vision model used for image descriptions | `gpt-5.4-mini` |
-| `ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS` | Max image-description response tokens | `8192` |
+| `ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS` | Optional positive-integer image-description output limit; omitted sends no provider cap | unset |
 | `ELIZAOS_CLOUD_IMAGE_GENERATION_MODEL` | Image generation model override | `google/nano-banana-2/text-to-image` |
 | `ELIZAOS_CLOUD_TTS_MODEL` | Text-to-speech model | `gpt-5-mini-tts` |
 | `ELIZAOS_CLOUD_TTS_TIMEOUT_MS` | Cloud TTS request timeout; `0` disables the deadline | `60000` |

--- a/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/image-description-warming.test.ts
@@ -86,15 +86,23 @@ describe("handleImageDescription warming-503 retry", () => {
     expect(postRaw.mock.calls[0]?.[0]?.json?.max_tokens).toBe(16384);
   });
 
-  it("rejects an invalid explicit image output budget before dispatch", async () => {
-    await expect(
-      handleImageDescription(
-        runtime({ ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS: "8192oops" }),
-        "https://example.com/full.png"
-      )
-    ).rejects.toMatchObject({ code: "ELIZAOS_CLOUD_IMAGE_OUTPUT_BUDGET_INVALID" });
-    expect(postRaw).not.toHaveBeenCalled();
-  });
+  it.each(["8192oops", "1e3", "01", "+1", "1.5", "0", "-1"])(
+    "rejects invalid explicit image output budget %s before dispatch",
+    async (configuredMaxTokens) => {
+      await expect(
+        handleImageDescription(
+          runtime({
+            ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS: configuredMaxTokens,
+          }),
+          "https://example.com/full.png"
+        )
+      ).rejects.toMatchObject({
+        code: "ELIZAOS_CLOUD_IMAGE_OUTPUT_BUDGET_INVALID",
+        context: { received: configuredMaxTokens },
+      });
+      expect(postRaw).not.toHaveBeenCalled();
+    }
+  );
 
   it("throws (fails closed) on a hard 500 instead of fabricating a description", async () => {
     postRaw.mockResolvedValue(new Response("upstream boom", { status: 500 }));

--- a/plugins/plugin-elizacloud/src/models/image.ts
+++ b/plugins/plugin-elizacloud/src/models/image.ts
@@ -1,3 +1,9 @@
+/**
+ * Eliza Cloud image generation and description handlers. Requests preserve
+ * caller output-budget intent and reject malformed operator limits before any
+ * provider dispatch.
+ */
+
 import type { IAgentRuntime, ImageDescriptionParams, ImageGenerationParams } from "@elizaos/core";
 import { ElizaError, logger, ModelType } from "@elizaos/core";
 import {
@@ -124,7 +130,9 @@ export async function handleImageDescription(
   const maxTokens = configuredMaxTokens === "" ? undefined : Number(configuredMaxTokens);
   if (
     maxTokens !== undefined &&
-    (!Number.isSafeInteger(maxTokens) || maxTokens <= 0)
+    (!/^[1-9]\d*$/.test(configuredMaxTokens) ||
+      !Number.isSafeInteger(maxTokens) ||
+      maxTokens <= 0)
   ) {
     throw new ElizaError(
       "ELIZAOS_CLOUD_IMAGE_DESCRIPTION_MAX_TOKENS must be a positive safe integer",


### PR DESCRIPTION
Closes #24850

Follow-up to merged #24837.

- requires canonical positive decimal syntax for the optional image-description output budget
- rejects exponent, prefixed, fractional, zero, and negative spellings with the existing typed code/context before dispatch
- keeps absent configuration uncapped
- corrects README default to `unset`
- adds the required production responsibility header

Exact local verification on `fa15df4cc3`:
- image-description + text streaming: 79/79
- core prompt-integrity: 4/4
- changed source Biome and diff-check: green
- full plugin lane: 572 passed; two unrelated current-develop failures remain (research-retirement workspace export resolution and stale opencode expectation)
