### PR TITLE
fix(cloud): remove conversation output default

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0308_remove_conversation_token_default.sql
+++ b/packages/cloud/shared/src/db/migrations/0308_remove_conversation_token_default.sql
@@ -1,0 +1,10 @@
+-- Remove the hidden model-output cap for new conversations while preserving all
+-- other deployed defaults.
+ALTER TABLE "conversations" ALTER COLUMN "settings" SET DEFAULT '{"temperature":0.7,"topP":1,"frequencyPenalty":0,"presencePenalty":0,"systemPrompt":"You are a helpful AI assistant."}'::jsonb;
+--> statement-breakpoint
+-- The exact object below is the sole historical database default. Restricting
+-- the backfill to full-object equality leaves every customized settings object,
+-- including an explicitly selected 2000-token value, unchanged.
+UPDATE "conversations"
+SET "settings" = "settings" - 'maxTokens'
+WHERE "settings" = '{"temperature":0.7,"maxTokens":2000,"topP":1,"frequencyPenalty":0,"presencePenalty":0,"systemPrompt":"You are a helpful AI assistant."}'::jsonb;

--- a/packages/cloud/shared/src/db/migrations/conversation-token-default.test.ts
+++ b/packages/cloud/shared/src/db/migrations/conversation-token-default.test.ts
@@ -1,0 +1,71 @@
+/** Applies migration 0308 to real PGlite and proves implicit caps are removed without rewriting explicit settings. */
+import { afterEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+
+const migration = await Bun.file(
+  new URL("./0308_remove_conversation_token_default.sql", import.meta.url),
+).text();
+const databases: PGlite[] = [];
+
+async function database(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`CREATE TABLE conversations (
+    id text PRIMARY KEY,
+    settings jsonb NOT NULL DEFAULT '{"temperature":0.7,"maxTokens":2000,"topP":1,"frequencyPenalty":0,"presencePenalty":0,"systemPrompt":"You are a helpful AI assistant."}'::jsonb
+  )`);
+  return db;
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0308 conversation output default", () => {
+  test("removes only the exact implicit cap and leaves explicit settings intact", async () => {
+    const db = await database();
+    await db.exec(`
+      INSERT INTO conversations (id) VALUES ('implicit');
+      INSERT INTO conversations (id, settings) VALUES
+        ('explicit-2000', '{"temperature":0.2,"maxTokens":2000}'::jsonb),
+        ('explicit-1000', '{"maxTokens":1000}'::jsonb),
+        ('already-uncapped', '{"temperature":0.7}'::jsonb);
+    `);
+
+    await db.exec(migration);
+    await db.exec(migration);
+    await db.exec("INSERT INTO conversations (id) VALUES ('new-default')");
+
+    const result = await db.query<{ id: string; settings: Record<string, unknown> }>(
+      "SELECT id, settings FROM conversations ORDER BY id",
+    );
+    expect(result.rows).toEqual([
+      { id: "already-uncapped", settings: { temperature: 0.7 } },
+      { id: "explicit-1000", settings: { maxTokens: 1000 } },
+      {
+        id: "explicit-2000",
+        settings: { maxTokens: 2000, temperature: 0.2 },
+      },
+      {
+        id: "implicit",
+        settings: {
+          frequencyPenalty: 0,
+          presencePenalty: 0,
+          systemPrompt: "You are a helpful AI assistant.",
+          temperature: 0.7,
+          topP: 1,
+        },
+      },
+      {
+        id: "new-default",
+        settings: {
+          frequencyPenalty: 0,
+          presencePenalty: 0,
+          systemPrompt: "You are a helpful AI assistant.",
+          temperature: 0.7,
+          topP: 1,
+        },
+      },
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2038,6 +2038,13 @@
       "when": 1794168000003,
       "tag": "0307_twilio_outbound_call_audit",
       "breakpoints": true
+    },
+    {
+      "idx": 291,
+      "version": "7",
+      "when": 1794168000004,
+      "tag": "0308_remove_conversation_token_default",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/conversations.ts
+++ b/packages/cloud/shared/src/db/schemas/conversations.ts
@@ -48,11 +48,10 @@ export const conversations = pgTable(
       .notNull()
       .default({
         temperature: 0.7,
-        maxTokens: 2000,
         topP: 1,
         frequencyPenalty: 0,
         presencePenalty: 0,
-        systemPrompt: "",
+        systemPrompt: "You are a helpful AI assistant.",
       }),
     status: text("status").notNull().default("active"),
     message_count: integer("message_count").notNull().default(0),

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -44,6 +44,9 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"packages/core/src/entities.ts": [/getMemories\([\s\S]{0,240}limit:\s*20/],
 	"packages/core/src/utils/json-llm.ts": [/text\.slice\(0,\s*100_000\)/],
 	"packages/core/src/utils/message-text.ts": [/MAX_MESSAGE_TEXT_LENGTH/],
+	"packages/cloud/shared/src/db/schemas/conversations.ts": [
+		/maxTokens:\s*2000/,
+	],
 	"packages/core/src/runtime/evaluator.ts": [
 		/MAX_EVALUATOR_INPUT_CHARS/,
 		/chars truncated/,


### PR DESCRIPTION
Closes #24836

## What changed
- remove the implicit `maxTokens: 2000` conversation schema default
- add migration 0308 so new rows omit an output cap
- strip `maxTokens` only from rows equal to the exact historical default object; customized settings, including explicit 2,000-token choices, remain unchanged
- add a repository guard against restoring the schema cap

## Verification
- real PGlite migration test: implicit historical row backfilled, explicit 2,000/1,000-token rows preserved, new default uncapped, migration replay-safe
- `bun test packages/core/src/__tests__/prompt-integrity-policy.test.ts` (4 passed)
- Biome and diff checks

Package typecheck was attempted but this sparse worktree lacks `drizzle-orm` and other unrelated optional workspace dependencies; the errors are dependency-resolution failures across untouched files.