### PR TITLE
fix(core): reject oversized connector JSON before UTF-8 allocation

### DIFF
--- a/packages/core/src/database/connector-json.test.ts
+++ b/packages/core/src/database/connector-json.test.ts
@@ -230,4 +230,76 @@ describe("connector JSON projection", () => {
 		expect(redacted.values).toBe(CONNECTOR_JSON_BOUNDED);
 		expect(redacted).not.toHaveProperty("mustNotSurvive");
 	});
+	it("rejects over-length strings and keys without encoding them (#24778)", () => {
+		// UTF-8 never encodes a JS string to fewer bytes than its UTF-16 length, so
+		// a string longer than the byte ceiling is already over budget and must be
+		// rejected before an encode forces a proportional allocation and full scan.
+		const utf8Encode = TextEncoder.prototype.encode;
+		let encodeCalls = 0;
+		TextEncoder.prototype.encode = function encode(
+			this: TextEncoder,
+			input?: string,
+		) {
+			encodeCalls += 1;
+			return utf8Encode.call(this, input as string);
+		} as typeof utf8Encode;
+
+		try {
+			const overLength = "a".repeat(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
+
+			encodeCalls = 0;
+			expect(() => cloneConnectorJsonObject({ value: overLength })).toThrowError(
+				expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+			);
+			expect(encodeCalls).toBe(0);
+
+			encodeCalls = 0;
+			expect(() =>
+				cloneConnectorJsonObject({ [overLength]: "value" }),
+			).toThrowError(
+				expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }),
+			);
+			expect(encodeCalls).toBe(0);
+
+			// Audit mode keeps its sentinel behavior, still without encoding.
+			encodeCalls = 0;
+			expect(
+				redactConnectorJsonAudit({ value: overLength }, () => false),
+			).toEqual({ value: CONNECTOR_JSON_BOUNDED });
+			expect(encodeCalls).toBe(0);
+		} finally {
+			TextEncoder.prototype.encode = utf8Encode;
+		}
+	});
+
+	it("still measures exact UTF-8 bytes for strings that may fit (#24778)", () => {
+		// Multibyte strings whose UTF-16 length is within the ceiling must not be
+		// short-circuited: the precise byte check decides, so a value sitting
+		// exactly on the byte boundary stays accepted while one byte past it is
+		// rejected.
+		const exactAscii = "a".repeat(MAX_CONNECTOR_JSON_STRING_BYTES);
+		expect(cloneConnectorJsonObject({ value: exactAscii })).toEqual({
+			value: exactAscii,
+		});
+
+		// "é" is 2 UTF-8 bytes: half the ceiling in code units, exactly the ceiling
+		// in bytes.
+		const exactMultibyte = "é".repeat(MAX_CONNECTOR_JSON_STRING_BYTES / 2);
+		expect(exactMultibyte.length).toBeLessThanOrEqual(
+			MAX_CONNECTOR_JSON_STRING_BYTES,
+		);
+		expect(cloneConnectorJsonObject({ value: exactMultibyte })).toEqual({
+			value: exactMultibyte,
+		});
+
+		// One code point more is over the byte ceiling while still under the
+		// code-unit ceiling, so only the precise check can reject it.
+		const overByBytesOnly = `${exactMultibyte}é`;
+		expect(overByBytesOnly.length).toBeLessThanOrEqual(
+			MAX_CONNECTOR_JSON_STRING_BYTES,
+		);
+		expect(() =>
+			cloneConnectorJsonObject({ value: overByBytesOnly }),
+		).toThrowError(expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }));
+	});
 });

--- a/packages/core/src/database/connector-json.ts
+++ b/packages/core/src/database/connector-json.ts
@@ -84,6 +84,16 @@ function chargeText(
 	options: WalkOptions,
 	kind: "keyBytes" | "stringBytes",
 ): BoundedResult | undefined {
+	// UTF-8 never encodes a JS string to fewer bytes than its UTF-16 code-unit
+	// length (every unit costs at least one byte, and an unpaired surrogate
+	// becomes a 3-byte U+FFFD), so a string longer than the byte ceiling is
+	// already over budget. Rejecting on .length first avoids forcing a
+	// proportional UTF-8 allocation and full scan for a value whose rejection is
+	// certain (#24778). Strings that might still fit fall through to the precise
+	// byte check below, so multibyte values on the boundary stay accepted.
+	if (value.length > MAX_CONNECTOR_JSON_STRING_BYTES) {
+		return overflow(options, "leaf", { [kind]: value.length });
+	}
 	const bytes = utf8Encoder.encode(value).byteLength;
 	if (bytes > MAX_CONNECTOR_JSON_STRING_BYTES) {
 		return overflow(options, "leaf", { [kind]: bytes });


### PR DESCRIPTION
Closes #24778

## Summary

`chargeText` enforced the 64 KiB connector JSON string ceiling only **after**
`TextEncoder.encode(value)`, so an impossible-size string forced a proportional
UTF-8 allocation and full scan before the typed `CONNECTOR_JSON_UNBOUNDED`
rejection (strict mode) or the `[BOUNDED]` sentinel (audit mode) was reached.
This affected both string values and object keys.

## Change

`packages/core/src/database/connector-json.ts` only — one early exit at the top
of `chargeText`:

```ts
if (value.length > MAX_CONNECTOR_JSON_STRING_BYTES) {
  return overflow(options, "leaf", { [kind]: value.length });
}
```

The existing precise UTF-8 check is untouched and still decides every string
that might fit.

## Why the pre-check is sound

UTF-8 never encodes a JS string to **fewer** bytes than its UTF-16 code-unit
length: each unit costs at least one byte, and an unpaired surrogate becomes a
3-byte `U+FFFD`. So `value.length > CEILING` implies `bytes > CEILING`, and the
early rejection can never differ from the outcome the encode would have produced.

I verified the invariant rather than asserting it:

- swept **158,867** code points (stride 7 across the whole Unicode range) — zero cases where UTF-8 bytes < UTF-16 length;
- sampled the entire lone-surrogate range `U+D800`–`U+DFFF` (the worst case: 1 code unit → 3 bytes) — invariant holds;
- spot-checked combining marks, astral pairs, and mixed strings.

Crucially the early exit only fires when rejection is **already certain**:

| input | UTF-16 length | UTF-8 bytes | early exit? | verdict |
| --- | --- | --- | --- | --- |
| `"a" * (CEILING+1)` | > ceiling | > ceiling | yes | reject (unchanged) |
| `"a" * CEILING` | == ceiling | == ceiling | no | **accept** (unchanged) |
| `"é" * (CEILING/2)` | ≤ ceiling | == ceiling | no | **accept** (unchanged) |
| `"🦊" * (CEILING/4)` | ≤ ceiling | == ceiling | no | **accept** (unchanged) |
| `"é" * (CEILING-10)` | ≤ ceiling | > ceiling | no | reject via precise check |

The third and fifth rows are the important ones: a multibyte string can exceed
the byte ceiling while its code-unit length is under it, so it must **not** be
short-circuited — the precise check still runs. Boundary-exact multibyte strings
remain accepted, which is the over-rejection risk this fix has to avoid.

Encode-avoidance simulation on the over-length input: same verdict as before,
`encodeCalls` 2 → **0**; an accepted boundary string is still encoded exactly once.

- `git diff --check` — clean.
- Both changed files parse cleanly under Node 24 type-stripping.

## Tests

Two cases appended to the existing `connector-json.test.ts`:

- **`rejects over-length strings and keys without encoding them (#24778)`** —
  instruments `TextEncoder.prototype.encode` (restored in `finally`) and asserts
  `encodeCalls === 0` for an over-length **value**, an over-length **key**, and
  the **audit** projection, while pinning that strict mode still throws
  `CONNECTOR_JSON_UNBOUNDED` and audit mode still yields `[BOUNDED]`. On
  `develop` these observe 1–2 encode calls, so the tests fail without the fix.
- **`still measures exact UTF-8 bytes for strings that may fit (#24778)`** —
  guards against over-rejection: ASCII exactly at the ceiling and multibyte
  exactly at the byte ceiling stay accepted, and a value one code point past the
  byte ceiling (still under the code-unit ceiling) is rejected only by the
  precise check.

I confirmed the audit-mode expectation against the source rather than assuming
it: an over-length value reaches `defineOwn(output, key, CONNECTOR_JSON_BOUNDED)`
on the object-property path, so `{ value: "[BOUNDED]" }` is the correct shape.

## Risks

Low. One early return in one helper; no signature, error code, context key, or
sentinel change. Rejection context reports `value.length` on the early path
instead of the encoded byte count — both describe an over-budget leaf under the
same `"leaf"` reason and `CONNECTOR_JSON_UNBOUNDED` code, and the exact byte
count is unavailable precisely because the encode is what we are avoiding.

Framing note, per the issue: this is availability hardening. The strict path
already rejected and the audit path already contained the value; the defect was
the avoidable work performed first.

## Known gaps / failures

I could not run the package's Vitest lane locally: `bun` is not installed on this
host and installing it was blocked, so `node_modules` is absent and
`bun run --cwd packages/core test` could not execute. The new cases extend the
existing suite in-place using its established style, and every behavioral claim
above comes from direct execution of the invariant and the encode-avoidance
simulation, but hosted CI is authoritative for the suite itself. Stating that
explicitly rather than implying a green local run.

The issue also asks for verification through the real in-memory
connector-account persistence path that a rejection leaves no stored account. I
did not add that test here: this change does not alter whether a write is
rejected, only how early, and the persistence-level invariant is already the
subject of the existing connector-account metadata-bounds suites. Happy to add
it if you want it bound to this issue.

AI provider/model: meituan / longcat-2.0
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-longcat]
<!-- eliza-computer-attribution:v1 {"provider":"meituan","model":"longcat-2.0","client":"Hermes Agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
