### PR TITLE
fix(cloud): require authoritative provider delivery receipts

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-adapter.test.ts
@@ -645,13 +645,18 @@ describe("blooio sendReply", () => {
     ).rejects.toThrow("Missing apiKey");
   });
 
-  test("throws with status and body on a non-ok response", async () => {
+  test("preserves rejection status without exposing provider body", async () => {
     globalThis.fetch = (async () =>
       new Response("rate limited", { status: 429 })) as typeof fetch;
 
-    await expect(
-      blooioAdapter.sendReply(makeConfig(), chatEvent, "hi"),
-    ).rejects.toThrow("Blooio send error (429): rate limited");
+    const failure = blooioAdapter.sendReply(makeConfig(), chatEvent, "hi");
+    await expect(failure).rejects.toMatchObject({
+      deliveryStatus: "failed",
+      code: "DELIVERY_PROVIDER_REJECTED",
+      retryable: true,
+      providerStatus: 429,
+    });
+    await expect(failure).rejects.not.toThrow("rate limited");
   });
 });
 describe("blooio sendTypingIndicator", () => {

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -5,6 +5,7 @@ import type {
   PlatformAdapter,
   WebhookConfig,
 } from "../src/adapters/types";
+import { PlatformDeliveryError } from "../src/adapters/types";
 import { logger } from "../src/logger";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";
@@ -89,6 +90,10 @@ function createAdapter(event: ChatEvent): PlatformAdapter & {
         adapter.replies.push(text);
       },
     ),
+    sendReplyWithReceipt: mock(async (config, replyEvent, text) => {
+      await adapter.sendReply(config, replyEvent, text);
+      return { providerMessageIds: [`reply-${replyEvent.messageId}`] };
+    }),
     sendTypingIndicator: mock(async () => {
       adapter.typingCount += 1;
     }),
@@ -319,6 +324,87 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sharedRequests).toBe(1);
   });
 
+  test("does not record delivery when a provider returns an empty accepted receipt", async () => {
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({ messageId: "SM-empty-receipt" });
+    const adapter = createAdapter(event);
+    const emptyReceipt = mock(async () => ({ providerMessageIds: [] }));
+    adapter.sendReplyWithReceipt = emptyReceipt;
+
+    globalThis.fetch = mock(async () =>
+      Response.json({ success: true, data: { reply: "receipt required" } }),
+    ) as typeof fetch;
+
+    expect(
+      (
+        await handleWebhook(
+          requestFor(event),
+          adapter,
+          {
+            redis,
+            cloudBaseUrl: "https://api.elizacloud.ai",
+            getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+          },
+          "eliza-app",
+        )
+      ).status,
+    ).toBe(200);
+
+    const dedupKey = `webhook:twilio:${event.messageId}`;
+    await waitFor(
+      () => redis.store.get(dedupKey) === "uncertain",
+      "empty receipt uncertainty",
+    );
+    expect(emptyReceipt).toHaveBeenCalledTimes(1);
+    expect(adapter.sendReply).not.toHaveBeenCalled();
+  });
+
+  test("reopens a typed failure known to occur before provider egress", async () => {
+    configureEnv();
+    const redis = new MemoryRedis();
+    const event = createTwilioEvent({ messageId: "SM-pre-egress" });
+    const adapter = createAdapter(event);
+    const preEgressFailure = mock(async () => {
+      throw new PlatformDeliveryError(
+        "credentials unavailable",
+        "failed",
+        "DELIVERY_CREDENTIALS_MISSING",
+        false,
+      );
+    });
+    adapter.sendReplyWithReceipt = preEgressFailure;
+    let sharedRequests = 0;
+    globalThis.fetch = mock(async () => {
+      sharedRequests += 1;
+      return Response.json({
+        success: true,
+        data: { reply: "try after repair" },
+      });
+    }) as typeof fetch;
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    };
+    const dedupKey = `webhook:twilio:${event.messageId}`;
+
+    expect(
+      (await handleWebhook(requestFor(event), adapter, deps, "eliza-app"))
+        .status,
+    ).toBe(200);
+    await waitFor(() => !redis.store.has(dedupKey), "pre-egress claim release");
+    expect(
+      (await handleWebhook(requestFor(event), adapter, deps, "eliza-app"))
+        .status,
+    ).toBe(200);
+    await waitFor(
+      () => preEgressFailure.mock.calls.length === 2,
+      "safe replay",
+    );
+    expect(sharedRequests).toBe(2);
+  });
+
   test("routes an unresolved Blooio iMessage to the same phone Shared path", async () => {
     process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
     const redis = new MemoryRedis();
@@ -341,6 +427,10 @@ describe("gateway webhook handler e2e routing", () => {
       sendTypingIndicator: mock(async () => undefined),
       sendReply: mock(async (_config, _event, reply) => {
         replies.push(reply);
+      }),
+      sendReplyWithReceipt: mock(async (_config, _event, reply) => {
+        replies.push(reply);
+        return { providerMessageIds: ["blooio-reply-1"] };
       }),
     };
     let sharedBody: Record<string, unknown> | null = null;
@@ -931,6 +1021,10 @@ describe("gateway webhook handler e2e routing", () => {
       extractEvent: mock(async () => event),
       sendTypingIndicator: mock(async () => undefined),
       sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-1"] };
+      }),
     };
     class EgressContendedRedis extends MemoryRedis {
       override async set(
@@ -992,6 +1086,10 @@ describe("gateway webhook handler e2e routing", () => {
       verifyWebhook: mock(async () => true),
       extractEvent: mock(async () => event),
       sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-retry-1"] };
+      }),
     };
     const redis = new MemoryRedis();
     redis.store.set(
@@ -1054,6 +1152,10 @@ describe("gateway webhook handler e2e routing", () => {
       extractEvent: mock(async () => event),
       sendTypingIndicator: mock(async () => undefined),
       sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-personal-1"] };
+      }),
     };
     const redis = new MemoryRedis();
     const completionLog = spyOn(logger, "info").mockImplementation(
@@ -1167,13 +1269,18 @@ describe("gateway webhook handler e2e routing", () => {
       providerSentAtMs: Date.now() - 1_000,
       rawPayload: {},
     };
+    const sendReply = mock(async () => undefined);
     const adapter: PlatformAdapter = {
       platform: "telegram",
       getDedupeScope: () => "scope",
       verifyWebhook: mock(async () => true),
       extractEvent: mock(async () => event),
       sendTypingIndicator: mock(async () => undefined),
-      sendReply: mock(async () => undefined),
+      sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-trace-1"] };
+      }),
     };
     const redis = new MemoryRedis();
     const infoLog = spyOn(logger, "info").mockImplementation(() => undefined);
@@ -1295,6 +1402,10 @@ describe("gateway webhook handler e2e routing", () => {
       resolveVoiceNote,
       sendTypingIndicator: mock(async () => undefined),
       sendReply,
+      sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+        await sendReply(config, replyEvent, text, hooks);
+        return { providerMessageIds: ["provider-voice-1"] };
+      }),
     };
     const redis = new MemoryRedis();
     let sharedBody: Record<string, unknown> | null = null;

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -6,7 +6,12 @@ import crypto from "node:crypto";
 import { z } from "zod";
 import { logger } from "../logger";
 import { boundedGatewayFetch } from "./bounded-fetch";
-import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
+import {
+  type ChatEvent,
+  type PlatformAdapter,
+  PlatformDeliveryError,
+  type WebhookConfig,
+} from "./types";
 
 export const BLOOIO_REQUEST_TIMEOUT_MS = 30_000;
 const BLOOIO_RESPONSE_MAX_BYTES = 64 * 1024;
@@ -36,22 +41,32 @@ export function blooioFetch(
   );
 }
 
-export class BlooioApiResponseError extends Error {
+export class BlooioApiResponseError extends PlatformDeliveryError {
   constructor(
     readonly status: number,
     message: string,
   ) {
-    super(message);
+    super(
+      message,
+      status >= 500 ? "uncertain" : "failed",
+      "DELIVERY_PROVIDER_REJECTED",
+      status === 429,
+      status,
+    );
     this.name = "BlooioApiResponseError";
   }
 }
 
-export class BlooioConfigurationError extends Error {
-  readonly code = "BLOOIO_LEGACY_GROUP_FROM_NUMBER_MISSING";
+export class BlooioConfigurationError extends PlatformDeliveryError {
   readonly context: Readonly<{ setting: string; chatId: string }>;
 
   constructor(chatId: string) {
-    super("Missing fromNumber for Blooio legacy group reply");
+    super(
+      "Missing fromNumber for Blooio legacy group reply",
+      "failed",
+      "BLOOIO_LEGACY_GROUP_FROM_NUMBER_MISSING",
+      false,
+    );
     this.name = "BlooioConfigurationError";
     this.context = {
       setting: "fromNumber",
@@ -205,7 +220,14 @@ async function sendBlooioMessage(
   event: ChatEvent,
   text: string,
 ): Promise<string[]> {
-  if (!config.apiKey) throw new Error("Missing apiKey for Blooio reply");
+  if (!config.apiKey) {
+    throw new PlatformDeliveryError(
+      "Missing apiKey for Blooio reply",
+      "failed",
+      "DELIVERY_CREDENTIALS_MISSING",
+      false,
+    );
+  }
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${config.apiKey}`,
@@ -255,11 +277,16 @@ async function sendBlooioMessage(
   if (!response.ok) {
     throw new BlooioApiResponseError(
       response.status,
-      `Blooio send error (${response.status}): ${responseText}`,
+      `Blooio rejected delivery (${response.status})`,
     );
   }
   if (!responseText) {
-    throw new Error("Blooio accepted delivery without a provider receipt");
+    throw new PlatformDeliveryError(
+      "Blooio accepted delivery without a provider receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
   }
   let result: unknown;
   try {
@@ -267,10 +294,20 @@ async function sendBlooioMessage(
   } catch {
     // error-policy:J3 accepted provider responses must still expose a durable
     // message receipt before the scheduler records the occurrence as fired.
-    throw new Error("Blooio accepted delivery without a valid JSON receipt");
+    throw new PlatformDeliveryError(
+      "Blooio accepted delivery without a valid JSON receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
   }
   if (!result || typeof result !== "object") {
-    throw new Error("Blooio accepted delivery without a provider receipt");
+    throw new PlatformDeliveryError(
+      "Blooio accepted delivery without a provider receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
   }
   const record = result as Record<string, unknown>;
   const id =
@@ -280,7 +317,12 @@ async function sendBlooioMessage(
         ? record.message_id
         : undefined;
   if (!id?.trim()) {
-    throw new Error("Blooio accepted delivery without a provider receipt");
+    throw new PlatformDeliveryError(
+      "Blooio accepted delivery without a provider receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
   }
   return [id.trim()];
 }

--- a/packages/cloud/services/gateway-webhook/src/adapters/twilio.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/twilio.test.ts
@@ -69,11 +69,73 @@ describe("Twilio adapter channel addressing", () => {
       rawPayload: {},
     };
 
-    await twilioAdapter.sendReply(config, event, "hello from Eliza");
+    const receipt = await twilioAdapter.sendReplyWithReceipt?.(
+      config,
+      event,
+      "hello from Eliza",
+    );
 
+    expect(receipt).toEqual({ providerMessageIds: ["SM_whatsapp_reply"] });
     expect(requestBody?.get("To")).toBe("whatsapp:+15551234567");
     expect(requestBody?.get("From")).toBe("whatsapp:+14155238886");
     expect(requestBody?.get("Body")).toBe("hello from Eliza");
+  });
+
+  test("keeps an accepted response without a Twilio SID uncertain", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({ status: "queued" }),
+    ) as unknown as typeof fetch;
+    const config: WebhookConfig = {
+      accountSid: "AC_test",
+      authToken: "twilio-secret",
+      phoneNumber: "+15550000000",
+    };
+    const event: ChatEvent = {
+      platform: "twilio",
+      messageId: "SM_inbound",
+      chatId: "+15551234567",
+      senderId: "+15551234567",
+      text: "hello",
+      rawPayload: {},
+    };
+
+    await expect(
+      twilioAdapter.sendReplyWithReceipt?.(config, event, "hello from Eliza"),
+    ).rejects.toMatchObject({
+      deliveryStatus: "uncertain",
+      code: "DELIVERY_RECEIPT_INVALID",
+      retryable: false,
+    });
+  });
+
+  test("does not retry a Twilio 500 that may follow provider acceptance", async () => {
+    const providerFetch = mock(
+      async () => new Response("provider error", { status: 500 }),
+    );
+    globalThis.fetch = providerFetch as unknown as typeof fetch;
+    const config: WebhookConfig = {
+      accountSid: "AC_test",
+      authToken: "twilio-secret",
+      phoneNumber: "+15550000000",
+    };
+    const event: ChatEvent = {
+      platform: "twilio",
+      messageId: "SM_inbound",
+      chatId: "+15551234567",
+      senderId: "+15551234567",
+      text: "hello",
+      rawPayload: {},
+    };
+
+    await expect(
+      twilioAdapter.sendReplyWithReceipt?.(config, event, "hello from Eliza"),
+    ).rejects.toMatchObject({
+      deliveryStatus: "uncertain",
+      code: "DELIVERY_PROVIDER_REJECTED",
+      retryable: false,
+      providerStatus: 500,
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(1);
   });
 
   test("bills malformed SMS cost config at the fallback and warns", async () => {

--- a/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
@@ -8,7 +8,12 @@ import {
 } from "../billing";
 import { logger } from "../logger";
 import { boundedGatewayFetch } from "./bounded-fetch";
-import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
+import {
+  type ChatEvent,
+  type PlatformAdapter,
+  PlatformDeliveryError,
+  type WebhookConfig,
+} from "./types";
 
 const TWILIO_API_BASE = "https://api.twilio.com/2010-04-01";
 
@@ -100,6 +105,87 @@ function extractMediaUrls(event: TwilioEvent): string[] {
     }
   }
   return urls;
+}
+
+async function sendTwilioReply(
+  config: WebhookConfig,
+  event: ChatEvent,
+  text: string,
+): Promise<string[]> {
+  if (!config.accountSid || !config.authToken || !config.phoneNumber) {
+    throw new PlatformDeliveryError(
+      "Missing Twilio credentials for reply",
+      "failed",
+      "DELIVERY_CREDENTIALS_MISSING",
+      false,
+    );
+  }
+  const url = `${TWILIO_API_BASE}/Accounts/${config.accountSid}/Messages.json`;
+  const auth = Buffer.from(`${config.accountSid}:${config.authToken}`).toString(
+    "base64",
+  );
+  const body = new URLSearchParams({
+    To: replyAddress(event.senderId, config.phoneNumber),
+    From: config.phoneNumber,
+    Body: text,
+  });
+  const response = await twilioGatewayFetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+  });
+  if (!response.ok) {
+    throw new PlatformDeliveryError(
+      `Twilio rejected delivery (${response.status})`,
+      response.status >= 500 ? "uncertain" : "failed",
+      "DELIVERY_PROVIDER_REJECTED",
+      response.status === 429,
+      response.status,
+    );
+  }
+  let receipt: unknown;
+  try {
+    receipt = await response.json();
+  } catch (cause) {
+    throw new PlatformDeliveryError(
+      "Twilio accepted delivery without a valid receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+      undefined,
+      { cause },
+    );
+  }
+  const sid =
+    receipt &&
+    typeof receipt === "object" &&
+    typeof (receipt as { sid?: unknown }).sid === "string"
+      ? (receipt as { sid: string }).sid.trim()
+      : "";
+  if (!sid) {
+    throw new PlatformDeliveryError(
+      "Twilio accepted delivery without a message receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
+  }
+
+  const breakdown = calculateTwilioSmsBilling(text, resolveSmsCostPerSegment());
+  logger.info("[TwilioAdapter] Outbound SMS cost recorded", {
+    platform: "twilio",
+    messageId: event.messageId,
+    recipient: event.senderId,
+    segments: breakdown.segments,
+    rawCost: breakdown.rawCost,
+    markup: breakdown.markup,
+    billedCost: breakdown.billedCost,
+    markupRate: breakdown.markupRate,
+  });
+  return [sid];
 }
 
 async function verifySignature(
@@ -236,52 +322,11 @@ export const twilioAdapter: PlatformAdapter = {
     event: ChatEvent,
     text: string,
   ): Promise<void> {
-    if (!config.accountSid || !config.authToken || !config.phoneNumber) {
-      throw new Error("Missing Twilio credentials for reply");
-    }
+    await sendTwilioReply(config, event, text);
+  },
 
-    const url = `${TWILIO_API_BASE}/Accounts/${config.accountSid}/Messages.json`;
-    const auth = Buffer.from(
-      `${config.accountSid}:${config.authToken}`,
-    ).toString("base64");
-
-    const body = new URLSearchParams({
-      To: replyAddress(event.senderId, config.phoneNumber),
-      From: config.phoneNumber,
-      Body: text,
-    });
-
-    const response = await twilioGatewayFetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Basic ${auth}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: body.toString(),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Twilio send error (${response.status}): ${errorText}`);
-    }
-
-    // Record the passthrough cost with the platform markup so downstream
-    // billing persisters can read a single structured line and insert the
-    // usage record. This is the integration point T9d unblocks.
-    const breakdown = calculateTwilioSmsBilling(
-      text,
-      resolveSmsCostPerSegment(),
-    );
-    logger.info("[TwilioAdapter] Outbound SMS cost recorded", {
-      platform: "twilio",
-      messageId: event.messageId,
-      recipient: event.senderId,
-      segments: breakdown.segments,
-      rawCost: breakdown.rawCost,
-      markup: breakdown.markup,
-      billedCost: breakdown.billedCost,
-      markupRate: breakdown.markupRate,
-    });
+  async sendReplyWithReceipt(config, event, text) {
+    return { providerMessageIds: await sendTwilioReply(config, event, text) };
   },
 
   async sendTypingIndicator(): Promise<void> {

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -79,6 +79,21 @@ export interface PlatformDeliveryReceipt {
   providerMessageIds: string[];
 }
 
+/** Carries whether a provider failure is safe to replay across the gateway boundary. */
+export class PlatformDeliveryError extends Error {
+  constructor(
+    message: string,
+    readonly deliveryStatus: "failed" | "uncertain",
+    readonly code: string,
+    readonly retryable: boolean,
+    readonly providerStatus?: number,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "PlatformDeliveryError";
+  }
+}
+
 export interface ResolvedVoiceNote {
   bytesBase64: string;
   mimeType: "audio/ogg";

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
@@ -70,20 +70,50 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
     let seen: AbortSignal | null | undefined;
     globalThis.fetch = vi
       .fn()
-      .mockImplementation(
-        async (_input: RequestInfo | URL, init?: RequestInit) => {
-          seen = init?.signal;
-          return new Response("{}", { status: 200 });
-        },
-      ) as unknown as typeof fetch;
+      .mockImplementation((_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        });
+      }) as unknown as typeof fetch;
 
     const { whatsappFetch } = await import("./whatsapp");
     const controller = new AbortController();
-    await whatsappFetch("https://graph.facebook.com/v21.0/me/messages", {
-      signal: controller.signal,
-    });
+    const request = whatsappFetch(
+      "https://graph.facebook.com/v21.0/me/messages",
+      {
+        signal: controller.signal,
+      },
+    );
     expect(seen?.aborted).toBe(false);
-    controller.abort();
+    controller.abort(new DOMException("caller cancelled", "AbortError"));
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
     expect(seen?.aborted).toBe(true);
+  });
+
+  test("requires provider message IDs before reporting an accepted reply delivered", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({ messages: [] }),
+    ) as unknown as typeof fetch;
+    const { whatsappAdapter } = await import("./whatsapp");
+    const config = { accessToken: "token", phoneNumberId: "phone-id" };
+    const event = {
+      platform: "whatsapp" as const,
+      messageId: "incoming-id",
+      chatId: "15551234567",
+      senderId: "15551234567",
+      text: "hello",
+      rawPayload: {},
+    };
+
+    await expect(
+      whatsappAdapter.sendReplyWithReceipt?.(config, event, "hello from Eliza"),
+    ).rejects.toMatchObject({
+      deliveryStatus: "uncertain",
+      code: "DELIVERY_RECEIPT_INVALID",
+      retryable: false,
+    });
   });
 });

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
@@ -2,9 +2,16 @@
 import crypto from "node:crypto";
 import { z } from "zod";
 import { logger } from "../logger";
-import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
+import { boundedGatewayFetch } from "./bounded-fetch";
+import {
+  type ChatEvent,
+  type PlatformAdapter,
+  PlatformDeliveryError,
+  type WebhookConfig,
+} from "./types";
 
 const WHATSAPP_REQUEST_TIMEOUT_MS = 30_000;
+const WHATSAPP_RESPONSE_MAX_BYTES = 64 * 1024;
 
 /**
  * Bound every WhatsApp Cloud API hop so a hung gateway cannot pin the
@@ -16,13 +23,13 @@ export function whatsappFetch(
   init?: RequestInit,
   timeoutMs: number = WHATSAPP_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  return fetch(input, {
-    ...init,
-    signal: init?.signal
-      ? AbortSignal.any([init.signal, timeoutSignal])
-      : timeoutSignal,
-  });
+  return boundedGatewayFetch(
+    fetch,
+    input,
+    init,
+    timeoutMs,
+    WHATSAPP_RESPONSE_MAX_BYTES,
+  );
 }
 
 const WHATSAPP_API_BASE = "https://graph.facebook.com/v21.0";
@@ -74,6 +81,82 @@ const WhatsAppWebhookPayloadSchema = z.object({
     }),
   ),
 });
+
+async function sendWhatsAppReply(
+  config: WebhookConfig,
+  event: ChatEvent,
+  text: string,
+): Promise<string[]> {
+  if (!config.accessToken || !config.phoneNumberId) {
+    throw new PlatformDeliveryError(
+      "Missing WhatsApp credentials for reply",
+      "failed",
+      "DELIVERY_CREDENTIALS_MISSING",
+      false,
+    );
+  }
+  const url = `${WHATSAPP_API_BASE}/${config.phoneNumberId}/messages`;
+  const response = await whatsappFetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      messaging_product: "whatsapp",
+      recipient_type: "individual",
+      to: event.senderId,
+      type: "text",
+      text: { body: text },
+    }),
+  });
+  if (!response.ok) {
+    throw new PlatformDeliveryError(
+      `WhatsApp rejected delivery (${response.status})`,
+      response.status >= 500 ? "uncertain" : "failed",
+      "DELIVERY_PROVIDER_REJECTED",
+      response.status === 429,
+      response.status,
+    );
+  }
+  let receipt: unknown;
+  try {
+    receipt = await response.json();
+  } catch (cause) {
+    throw new PlatformDeliveryError(
+      "WhatsApp accepted delivery without a valid receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+      undefined,
+      { cause },
+    );
+  }
+  const messages =
+    receipt && typeof receipt === "object"
+      ? (receipt as { messages?: unknown }).messages
+      : undefined;
+  const providerMessageIds = Array.isArray(messages)
+    ? messages
+        .map((message) =>
+          message &&
+          typeof message === "object" &&
+          typeof (message as { id?: unknown }).id === "string"
+            ? (message as { id: string }).id.trim()
+            : "",
+        )
+        .filter(Boolean)
+    : [];
+  if (providerMessageIds.length === 0) {
+    throw new PlatformDeliveryError(
+      "WhatsApp accepted delivery without a message receipt",
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
+  }
+  return providerMessageIds;
+}
 
 export const whatsappAdapter: PlatformAdapter = {
   platform: "whatsapp",
@@ -170,30 +253,11 @@ export const whatsappAdapter: PlatformAdapter = {
     event: ChatEvent,
     text: string,
   ): Promise<void> {
-    if (!config.accessToken || !config.phoneNumberId) {
-      throw new Error("Missing WhatsApp credentials for reply");
-    }
+    await sendWhatsAppReply(config, event, text);
+  },
 
-    const url = `${WHATSAPP_API_BASE}/${config.phoneNumberId}/messages`;
-    const response = await whatsappFetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${config.accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        messaging_product: "whatsapp",
-        recipient_type: "individual",
-        to: event.senderId,
-        type: "text",
-        text: { body: text },
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`WhatsApp send error (${response.status}): ${errorText}`);
-    }
+  async sendReplyWithReceipt(config, event, text) {
+    return { providerMessageIds: await sendWhatsAppReply(config, event, text) };
   },
 
   async sendTypingIndicator(

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -16,6 +16,7 @@ import type {
   PlatformAdapter,
   WebhookConfig,
 } from "./adapters/types";
+import { PlatformDeliveryError } from "./adapters/types";
 import { reacquireAuthHeader } from "./auth";
 import { resolveConnectorAccountId } from "./connector-account";
 import { tryConfirmIdentityLink } from "./identity-link";
@@ -117,6 +118,40 @@ function parseGroupDeliveryDirective(
 interface MessageTraceContext {
   traceId: string;
   gatewayReceivedAtMs: number;
+}
+
+async function sendReplyWithRequiredReceipt(
+  adapter: PlatformAdapter,
+  config: WebhookConfig,
+  event: ChatEvent,
+  text: string,
+  deliveryHooks?: TelegramDeliveryHooks,
+): Promise<void> {
+  if (!adapter.sendReplyWithReceipt) {
+    throw new PlatformDeliveryError(
+      `${adapter.platform} adapter does not expose provider receipts`,
+      "failed",
+      "DELIVERY_RECEIPT_UNSUPPORTED",
+      false,
+    );
+  }
+  const receipt = await adapter.sendReplyWithReceipt(
+    config,
+    event,
+    text,
+    deliveryHooks,
+  );
+  const providerMessageIds = receipt.providerMessageIds
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (providerMessageIds.length === 0) {
+    throw new PlatformDeliveryError(
+      `${adapter.platform} accepted delivery without a message receipt`,
+      "uncertain",
+      "DELIVERY_RECEIPT_INVALID",
+      false,
+    );
+  }
 }
 
 async function reconcileLegacyTelegramDelivery(
@@ -578,7 +613,9 @@ export async function handleWebhook(
       });
       if (
         err instanceof PersonalSharedPreEgressError ||
-        err instanceof PersonalSharedRecoverablePostEgressError
+        err instanceof PersonalSharedRecoverablePostEgressError ||
+        (err instanceof PlatformDeliveryError &&
+          err.deliveryStatus === "failed")
       ) {
         try {
           // The Shared endpoint is idempotent. Blooio also keys provider
@@ -666,7 +703,13 @@ async function processMessage(
     event.text,
   );
   if (linkAttempt.handled && linkAttempt.reply) {
-    await adapter.sendReply(config, event, linkAttempt.reply, deliveryHooks);
+    await sendReplyWithRequiredReceipt(
+      adapter,
+      config,
+      event,
+      linkAttempt.reply,
+      deliveryHooks,
+    );
     return;
   }
 
@@ -858,7 +901,13 @@ async function processMessage(
 
   try {
     stageStartedAt = Date.now();
-    await adapter.sendReply(config, event, responseText, deliveryHooks);
+    await sendReplyWithRequiredReceipt(
+      adapter,
+      config,
+      event,
+      responseText,
+      deliveryHooks,
+    );
     logger.info("Connector message completed", {
       project,
       platform: adapter.platform,
@@ -1453,7 +1502,13 @@ async function sendPersonalSharedReply(
       );
     }
   } else {
-    await adapter.sendReply(config, event, reply, deliveryHooks);
+    await sendReplyWithRequiredReceipt(
+      adapter,
+      config,
+      event,
+      reply,
+      deliveryHooks,
+    );
   }
   return {
     cloudMs,
@@ -1532,7 +1587,13 @@ async function sendOnboardingReply(
   if (typeof reply !== "string" || reply.trim().length === 0) {
     throw new Error("onboarding chat returned no reply");
   }
-  await adapter.sendReply(config, event, reply, deliveryHooks);
+  await sendReplyWithRequiredReceipt(
+    adapter,
+    config,
+    event,
+    reply,
+    deliveryHooks,
+  );
 }
 
 function ackResponse(platform: Platform): Response {

--- a/packages/cloud/shared/src/lib/services/message-router/index.test.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.test.ts
@@ -327,7 +327,7 @@ describe("MessageRouterService contact recording", () => {
     expect(blooioApiRequest).toHaveBeenCalledTimes(1);
   });
 
-  test("preserves explicit provider rejection status and retryability", async () => {
+  test("treats a provider 5xx after dispatch as uncertain without retry", async () => {
     secretsGet.mockResolvedValue("blooio-api-key");
     blooioApiRequest.mockRejectedValue(
       new ElizaError("Blooio rejected the provider request", {
@@ -345,11 +345,37 @@ describe("MessageRouterService contact recording", () => {
     });
 
     expect(delivery).toEqual({
+      status: "uncertain",
+      provider: "blooio",
+      code: "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN",
+      retryable: false,
+    });
+    expect(blooioApiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves an explicit rate-limit rejection as safely retryable", async () => {
+    secretsGet.mockResolvedValue("blooio-api-key");
+    blooioApiRequest.mockRejectedValue(
+      new ElizaError("Blooio rejected the provider request", {
+        code: "PROVIDER_REQUEST_REJECTED",
+        context: { provider: "blooio", status: 429, retryable: true },
+      }),
+    );
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "blooio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "hello friend",
+    });
+
+    expect(delivery).toEqual({
       status: "failed",
       provider: "blooio",
       code: "DELIVERY_PROVIDER_REJECTED",
       retryable: true,
-      providerStatus: 503,
+      providerStatus: 429,
     });
     expect(blooioApiRequest).toHaveBeenCalledTimes(1);
   });

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -133,6 +133,9 @@ function classifyProviderException(
   if (isElizaError(error) && error.code === "PROVIDER_REQUEST_REJECTED") {
     const providerStatus =
       typeof error.context?.status === "number" ? error.context.status : undefined;
+    if (providerStatus !== undefined && providerStatus >= 500) {
+      return deliveryUncertain(provider, "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN");
+    }
     const retryable = error.context?.retryable === true;
     return deliveryFailed(provider, "DELIVERY_PROVIDER_REJECTED", retryable, providerStatus);
   }
@@ -602,6 +605,9 @@ class MessageRouterService {
 
       if (!response.ok) {
         logger.error("[MessageRouter] Twilio API error", { status: response.status });
+        if (response.status >= 500) {
+          return deliveryUncertain("twilio", "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN");
+        }
         return deliveryFailed(
           "twilio",
           "DELIVERY_PROVIDER_REJECTED",


### PR DESCRIPTION
Fixes #24805

Follow-up to #24827, which merged before its exact hosted check and before the independent delivery-authority blockers were repaired.

## What changed
- classify every post-dispatch provider 5xx as `uncertain` and non-retryable unless a provider contract proves zero effect; retain 429 as the explicit safely retryable rejection
- add `PlatformDeliveryError` with stable delivered-boundary status, code, retryability, and provider status
- require nonempty provider message IDs for every gateway reply path, including identity link, ordinary Dedicated, personal Shared, and onboarding replies
- implement validated Twilio and WhatsApp receipt parsing; retain Blooio receipt IDs rather than discarding them
- treat empty/malformed accepted 2xx receipts as uncertain, never delivered
- release the gateway claim for typed failures known safe before provider egress; retain uncertain claims and refuse replay
- use the owned bounded response transport for WhatsApp reply bodies and remove raw Blooio provider bodies from errors

## Verification
Exact head: `201622e10f01fafd90cf928a3f8094be54e889a6`
Base: `4c9b39ef2f`

- focused router/deadline/gateway/Twilio/WhatsApp/Blooio suites: 131 pass, 382 assertions
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — pass
- `bun run --cwd packages/cloud/shared typecheck` — pass
- changed-file Biome and `git diff --check` — pass

Regressions explicitly prove: one-attempt/no-retry after 500; empty accepted receipts become uncertain; every delivered gateway egress has provider IDs; uncertain duplicates cannot resend; typed pre-egress failure reopens safely.

## Evidence
- UI screenshots/video: N/A — server/provider delivery contract only
- live provider send: N/A — would message real users and requires production credentials; deterministic transport/receipt fixtures exercise both accepted and ambiguous boundaries
- generated artifacts: N/A — no artifact-producing surface
