### PR TITLE
fix(recall): owner-private cross-room history digest for enumeration/time-slice queries

### DIFF
--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -19,6 +19,8 @@ import {
   getRelatedEntityIds,
   logger,
   ModelType,
+  OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS,
+  revalidateOwnerExclusiveDisclosure,
   toWellFormedUnicode,
   validateUuid,
 } from "@elizaos/core";
@@ -335,8 +337,161 @@ function describeScanWindow(scan: CandidateScan): string {
   return `${base} ${scan.saturatedTables.join(", ")} filled that window, so older rows were NOT scanned and this is a windowed match count, not a total — widen with type, entityId, roomId, or a higher limit (the window is max(limit*2, 200) rows per table).`;
 }
 
+/**
+ * Enumeration-style history questions ("what have we talked about lately",
+ * "look at the recent logs") are NOT keyword lookups: BM25/keyword scoring
+ * against phrases like "recent logs" matches rows that literally contain
+ * "recent" or "logs" and misses everything the user actually means (live
+ * sol-dev 2026-08-22: days of covenant history about the dmarz
+ * entropy/simulation roof talks and the Alexis supplements sat in the
+ * messages table while op:search returned only literal matches, so the reply
+ * enumerated a fraction of the week). These patterns request a TIME SLICE,
+ * so serve them a chronological cross-room digest of the last few days.
+ */
+const RECENT_HISTORY_PATTERNS = [
+  /\b(?:recent|latest)\b.*\b(?:logs?|journals?|chats?|conversations?|messages?|days?|history)\b/i,
+  /\b(?:last|past)\s+(?:few|couple(?:\s+of)?|\d+)?\s*(?:days?|nights?|weeks?)\b/i,
+  /\bwhat\s+(?:have|did)\s+we\s+(?:talk|chat|discuss|cover)\b/i,
+  /\b(?:catch|fill)\s+me\s+up\b/i,
+  /\b(?:this|the)\s+week'?s?\b.*\b(?:conversations?|chats?|topics?|logs?)\b/i,
+  /\blately\b/i,
+];
+
+function isRecentHistoryQuery(query: string): boolean {
+  return RECENT_HISTORY_PATTERNS.some((p) => p.test(query));
+}
+
+const HISTORY_DIGEST_DAYS = 7;
+const HISTORY_DIGEST_MAX_ROOMS = 15;
+const HISTORY_DIGEST_FETCH_LIMIT = 800;
+const HISTORY_DIGEST_MAX_LINES = 80;
+const HISTORY_DIGEST_LINE_CHARS = 220;
+/** Ingestion wrapper: '[Discord #chan | guild] @user (date): text' */
+const CONNECTOR_PREFIX_PATTERN =
+  /^\[[^\]\n]{1,120}\]\s+@\S+\s+\([^)]{1,60}\):\s*/;
+
+/**
+ * Chronological digest of the sender's rooms over the last week. Owner-private
+ * gated: this is deliberately cross-room recall, so it renders ONLY when the
+ * live delivery audience is a verified owner-only destination (owner DM, or a
+ * guild whose entire census is {owner, agent}) — the same rule
+ * relevant-conversations enforces. In a mixed room the digest silently
+ * degrades to null and the caller keeps the room-scoped keyword scan, so
+ * other participants never see private-room content.
+ */
+async function buildRecentHistoryDigest(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<string | null> {
+  const disclosure = await revalidateOwnerExclusiveDisclosure(runtime, message);
+  if (
+    !disclosure.allowed ||
+    disclosure.basis !== OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS
+  ) {
+    return null;
+  }
+
+  const cutoff = Date.now() - HISTORY_DIGEST_DAYS * 24 * 60 * 60 * 1000;
+  const clusterIds = await getRelatedEntityIds(runtime, message.entityId);
+  const roomIdSets = await Promise.all(
+    clusterIds.map((id) => runtime.getRoomsForParticipant(id)),
+  );
+  const roomIds = [...new Set(roomIdSets.flat())].slice(
+    0,
+    HISTORY_DIGEST_MAX_ROOMS,
+  );
+  if (roomIds.length === 0) return null;
+
+  const memories = await runtime.getMemoriesByRoomIds({
+    tableName: "messages",
+    roomIds,
+    limit: HISTORY_DIGEST_FETCH_LIMIT,
+  });
+
+  const agentName = runtime.character.name ?? "Agent";
+  const seenTexts = new Set<string>();
+  const rows = memories
+    .filter((m) => {
+      const text = (m.content as { text?: string } | undefined)?.text;
+      if (typeof text !== "string" || !text.trim()) return false;
+      if ((m.createdAt ?? 0) < cutoff) return false;
+      // Synced-corpus rows are book knowledge, not conversation.
+      if (text.startsWith("[SOLIZA_SYNC_V1]")) return false;
+      return true;
+    })
+    .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
+
+  const lines: string[] = [];
+  for (const m of rows) {
+    const raw = ((m.content as { text?: string }).text ?? "").trim();
+    const text = raw.replace(CONNECTOR_PREFIX_PATTERN, "");
+    const normalized = text.replace(/\s+/g, " ").slice(0, 120);
+    // Double-persisted rows (bare + platformMessageId twin) render once.
+    const dedupeKey = `${m.entityId}:${normalized}`;
+    if (seenTexts.has(dedupeKey)) continue;
+    seenTexts.add(dedupeKey);
+    const when = new Date(m.createdAt ?? 0);
+    const stamp = `${String(when.getUTCMonth() + 1).padStart(2, "0")}/${String(
+      when.getUTCDate(),
+    ).padStart(2, "0")} ${String(when.getUTCHours()).padStart(2, "0")}:${String(
+      when.getUTCMinutes(),
+    ).padStart(2, "0")}Z`;
+    const speaker = m.entityId === runtime.agentId ? agentName : "user";
+    lines.push(
+      `[${stamp}] ${speaker}: ${text.replace(/\s+/g, " ").slice(0, HISTORY_DIGEST_LINE_CHARS)}`,
+    );
+  }
+  if (lines.length === 0) return null;
+
+  // Budget per DAY, not head/tail. A head/tail split renders the oldest and
+  // newest edges and silently drops the middle days — observed on the first
+  // live probe: a 7-day window rendered 8/17-8/18 + today while 8/19-8/21
+  // (the days the user was asking about) fell in the omitted middle. Group
+  // lines by UTC day and give each day an equal share of the budget so every
+  // day in the window is represented; within a day, spread evenly across the
+  // day's messages instead of taking a contiguous run.
+  let rendered = lines;
+  if (lines.length > HISTORY_DIGEST_MAX_LINES) {
+    const byDay = new Map<string, string[]>();
+    for (const line of lines) {
+      const day = line.slice(1, 6); // "MM/DD" from "[MM/DD HH:MMZ] ..."
+      const bucket = byDay.get(day);
+      if (bucket) bucket.push(line);
+      else byDay.set(day, [line]);
+    }
+    const days = [...byDay.keys()];
+    const perDay = Math.max(
+      3,
+      Math.floor(HISTORY_DIGEST_MAX_LINES / days.length),
+    );
+    rendered = [];
+    for (const day of days) {
+      const dayLines = byDay.get(day) ?? [];
+      if (dayLines.length <= perDay) {
+        rendered.push(...dayLines);
+        continue;
+      }
+      const step = dayLines.length / perDay;
+      const picked: string[] = [];
+      for (let i = 0; i < perDay; i += 1) {
+        picked.push(dayLines[Math.floor(i * step)] as string);
+      }
+      rendered.push(...picked);
+      rendered.push(
+        `  ... (${dayLines.length - perDay} more messages on ${day}; ask about this day for detail) ...`,
+      );
+    }
+  }
+
+  return [
+    `Chronological conversation digest, last ${HISTORY_DIGEST_DAYS} days across ${roomIds.length} room(s) (owner-private destination verified):`,
+    ...rendered,
+  ].join("\n");
+}
+
 async function doSearch(
   runtime: IAgentRuntime,
+  message: Memory,
   params: MemoryParams,
 ): Promise<ActionResult> {
   const type =
@@ -371,6 +526,22 @@ async function doSearch(
   };
   const scan = await collectCandidates(runtime, { ...scope, limit });
 
+  // Enumeration lane: "what have we talked about lately" is a time-slice
+  // request, not a keyword lookup. Build the chronological digest in
+  // parallel-with-nothing (it's one rooms read + one windowed message read)
+  // and prepend it when the pattern matches AND the destination is verified
+  // owner-private. Never replaces the keyword results — the model gets both.
+  let historyDigest: string | null = null;
+  if (query && isRecentHistoryQuery(query)) {
+    try {
+      historyDigest = await buildRecentHistoryDigest(runtime, message);
+    } catch (err) {
+      // Recall must degrade to the keyword scan, never fail the search.
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`[memory:search] history digest failed: ${msg}`);
+    }
+  }
+
   const matchedInWindow = scan.matches.length;
   const items = scan.matches
     .slice(0, limit)
@@ -400,6 +571,9 @@ async function doSearch(
   return {
     success: true,
     text: [
+      // The digest leads: for an enumeration question it IS the answer, and
+      // the keyword matches below it are supporting detail.
+      ...(historyDigest ? [historyDigest, ""] : []),
       `${renderNote} (filters: ${describeSearchScope(scope)}).`,
       ...(ignoredIdNotes.length > 0
         ? [`Note: ${ignoredIdNotes.join("; ")}.`]
@@ -420,6 +594,7 @@ async function doSearch(
       matchedInWindow,
       scanWindowPerTable: scan.perTable,
       scanWindowSaturated: scan.saturatedTables.length > 0,
+      historyDigestIncluded: historyDigest !== null,
     },
     data: {
       actionName: "MEMORY",
@@ -691,7 +866,7 @@ export const memoryAction: Action = {
         case "create":
           return await doCreate(runtime, message, params);
         case "search":
-          return await doSearch(runtime, params);
+          return await doSearch(runtime, message, params);
         case "update":
           return await doUpdate(runtime, params);
         case "delete":

--- a/packages/agent/src/actions/recall-history-digest.test.ts
+++ b/packages/agent/src/actions/recall-history-digest.test.ts
@@ -1,0 +1,326 @@
+/**
+ * MEMORY op:search enumeration lane: "what have we talked about lately" is a
+ * time-slice request, not a keyword lookup, so doSearch prepends a
+ * chronological cross-room digest — but ONLY when the live delivery audience
+ * is a verified owner-private destination. Both gate directions are covered
+ * here (owner DM renders the digest; a mixed room degrades to the room-scoped
+ * keyword scan with zero cross-room content), plus the query classifier and
+ * the double-persisted-twin dedupe. Deterministic: @elizaos/core is partially
+ * mocked to drive revalidateOwnerExclusiveDisclosure, and the runtime is an
+ * in-memory fake.
+ */
+import type { ActionResult, IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+// The action closes over revalidateOwnerExclusiveDisclosure from @elizaos/core
+// at import time. Partially mock the module (same pattern as
+// providers/relevant-conversations.test.ts) so each test drives the disclosure
+// verdict while every other real export stays intact.
+const revalidateOwnerExclusiveDisclosure = vi.fn();
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    revalidateOwnerExclusiveDisclosure: (
+      ...args: Parameters<typeof actual.revalidateOwnerExclusiveDisclosure>
+    ) => revalidateOwnerExclusiveDisclosure(...args),
+  };
+});
+
+// Imported after the mock so the action binds the mocked disclosure check.
+const { memoryAction } = await import("./memories");
+const { OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS } = await import(
+  "@elizaos/core"
+);
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const OWNER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const DM_ROOM = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const OTHER_ROOM = "00000000-0000-0000-0000-0000000000c2" as UUID;
+
+const HOUR = 60 * 60 * 1000;
+
+type SeedMessage = {
+  id?: UUID;
+  roomId: UUID;
+  entityId: UUID;
+  text: string;
+  createdAt: number;
+};
+
+function makeRuntime(seed: SeedMessage[]): IAgentRuntime {
+  const messages: Memory[] = seed.map((row) => ({
+    id: (row.id ?? (crypto.randomUUID() as UUID)) as UUID,
+    entityId: row.entityId,
+    agentId: AGENT_ID,
+    roomId: row.roomId,
+    content: { text: row.text },
+    createdAt: row.createdAt,
+  })) as Memory[];
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    getSetting: () => undefined,
+    // No relationships service: getRelatedEntityIds degrades to [entityId].
+    getService: () => null,
+    getRoomsForParticipant: async (_entityId: UUID) => [
+      ...new Set(messages.map((m) => m.roomId)),
+    ],
+    getMemoriesByRoomIds: async (params: {
+      tableName: string;
+      roomIds: UUID[];
+      limit?: number;
+    }) => {
+      const inScope = messages.filter((m) => params.roomIds.includes(m.roomId));
+      return params.limit == null ? inScope : inScope.slice(0, params.limit);
+    },
+    // The keyword scan's windowed per-table read. Only the messages table has
+    // rows here; other tables are empty.
+    getMemories: async (params: {
+      tableName: string;
+      roomId?: UUID;
+      limit?: number;
+    }) => {
+      if (params.tableName !== "messages") return [];
+      const inScope = messages.filter(
+        (m) => !params.roomId || m.roomId === params.roomId,
+      );
+      const limited =
+        params.limit == null ? inScope : inScope.slice(-params.limit);
+      return [...limited].reverse();
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeMessage(text: string): Memory {
+  return {
+    id: crypto.randomUUID() as UUID,
+    entityId: OWNER_ID,
+    agentId: AGENT_ID,
+    roomId: DM_ROOM,
+    content: { text },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+async function runSearch(
+  runtime: IAgentRuntime,
+  message: Memory,
+  query: string,
+): Promise<ActionResult> {
+  const result = await memoryAction.handler(runtime, message, undefined, {
+    parameters: { action: "search", query },
+  });
+  if (!result) throw new Error("handler returned no result");
+  return result;
+}
+
+function allowOwnerPrivate(): void {
+  revalidateOwnerExclusiveDisclosure.mockResolvedValue({
+    allowed: true,
+    basis: OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS,
+    audience: {},
+  });
+}
+
+function denyMixedRoom(): void {
+  revalidateOwnerExclusiveDisclosure.mockResolvedValue({
+    allowed: false,
+    reason: "destination_not_private",
+    audience: {},
+  });
+}
+
+function recentSeed(): SeedMessage[] {
+  const now = Date.now();
+  return [
+    {
+      roomId: DM_ROOM,
+      entityId: OWNER_ID,
+      text: "the dmarz entropy talk on the roof went late",
+      createdAt: now - 30 * HOUR,
+    },
+    {
+      roomId: OTHER_ROOM,
+      entityId: OWNER_ID,
+      text: "ordered the alexis supplements finally",
+      createdAt: now - 20 * HOUR,
+    },
+    {
+      roomId: DM_ROOM,
+      entityId: AGENT_ID,
+      text: "logged the covenant follow-ups for tomorrow",
+      createdAt: now - 10 * HOUR,
+    },
+  ];
+}
+
+describe("owner-private destination (gate open)", () => {
+  it("prepends a chronological cross-room digest for a time-slice query", async () => {
+    allowOwnerPrivate();
+    const runtime = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.values?.historyDigestIncluded).toBe(true);
+    const text = result.text ?? "";
+    expect(text).toContain("owner-private destination verified");
+    // Cross-room: rows from BOTH rooms render.
+    expect(text).toContain("dmarz entropy talk");
+    expect(text).toContain("alexis supplements");
+    expect(text).toContain("covenant follow-ups");
+    // Chronological: oldest first, across rooms.
+    const first = text.indexOf("dmarz entropy talk");
+    const second = text.indexOf("alexis supplements");
+    const third = text.indexOf("covenant follow-ups");
+    expect(first).toBeGreaterThanOrEqual(0);
+    expect(first).toBeLessThan(second);
+    expect(second).toBeLessThan(third);
+    // Speaker labels: the agent's own rows carry the character name.
+    expect(text).toContain("Eliza: logged the covenant follow-ups");
+  });
+
+  it("renders double-persisted twin rows (same entityId+text) once", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const runtime = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "twin persisted line about the roof",
+        createdAt: now - 6 * HOUR,
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "twin persisted line about the roof",
+        createdAt: now - 6 * HOUR + 250,
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.values?.historyDigestIncluded).toBe(true);
+    const text = result.text ?? "";
+    const occurrences =
+      text.split("twin persisted line about the roof").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("drops rows older than the digest window", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const runtime = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "ancient message from three weeks ago",
+        createdAt: now - 21 * 24 * HOUR,
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "fresh message from yesterday",
+        createdAt: now - 20 * HOUR,
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("what did we discuss the last few days"),
+      "what did we discuss the last few days",
+    );
+
+    // The keyword lane below the digest may still match the old row (it
+    // legitimately matches the query terms); the WINDOW claim is about the
+    // digest section only, so scope the assertion to it.
+    const text = result.text ?? "";
+    const digestSection = text.slice(0, text.indexOf("Showing"));
+    expect(digestSection).toContain("fresh message from yesterday");
+    expect(digestSection).not.toContain("ancient message");
+  });
+});
+
+describe("mixed room (gate closed)", () => {
+  it("returns no digest and leaks no cross-room content when disclosure is denied", async () => {
+    denyMixedRoom();
+    const runtime = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.success).toBe(true);
+    expect(revalidateOwnerExclusiveDisclosure).toHaveBeenCalled();
+    expect(result.values?.historyDigestIncluded).toBe(false);
+    const text = result.text ?? "";
+    expect(text).not.toContain("owner-private destination verified");
+    expect(text).not.toContain("Chronological conversation digest");
+  });
+
+  it("returns no digest when allowed but on a non-owner-private basis", async () => {
+    // internal_agent_turn is an allowed basis for internal work, but it is
+    // NOT a verified owner-only delivery audience, so the cross-room digest
+    // must stay closed.
+    revalidateOwnerExclusiveDisclosure.mockResolvedValue({
+      allowed: true,
+      basis: "internal_agent_turn",
+      audience: {},
+    });
+    const runtime = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.values?.historyDigestIncluded).toBe(false);
+    expect(result.text ?? "").not.toContain(
+      "Chronological conversation digest",
+    );
+  });
+});
+
+describe("query classification", () => {
+  const enumerationQueries = [
+    "what have we talked about lately",
+    "recent logs",
+    "what did we discuss the last few days",
+    "lately",
+    "catch me up",
+  ];
+
+  for (const query of enumerationQueries) {
+    it(`treats "${query}" as a time-slice query`, async () => {
+      allowOwnerPrivate();
+      revalidateOwnerExclusiveDisclosure.mockClear();
+      const runtime = makeRuntime(recentSeed());
+      const result = await runSearch(runtime, makeMessage(query), query);
+      // The enumeration lane ran: the owner-private gate was consulted and,
+      // being open, the digest rendered.
+      expect(revalidateOwnerExclusiveDisclosure).toHaveBeenCalled();
+      expect(result.values?.historyDigestIncluded).toBe(true);
+    });
+  }
+
+  it("does NOT treat a plain keyword lookup as a time-slice query", async () => {
+    allowOwnerPrivate();
+    revalidateOwnerExclusiveDisclosure.mockClear();
+    const runtime = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("find the postgres migration"),
+      "find the postgres migration",
+    );
+    // The enumeration lane never ran: no disclosure check, no digest.
+    expect(revalidateOwnerExclusiveDisclosure).not.toHaveBeenCalled();
+    expect(result.values?.historyDigestIncluded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause

MEMORY op:search treats every query as a keyword lookup. Enumeration-style history questions ("what have we talked about lately", "recent logs", "catch me up", "last few days") are TIME-SLICE requests, not keyword lookups: BM25/keyword scoring against phrases like "recent logs" matches rows that literally contain "recent" or "logs" and misses everything the user actually means.

**Live symptom (sol-dev, 2026-08-22):** days of covenant history (the dmarz entropy/simulation roof talks, the Alexis supplements) sat in the messages table while op:search returned only literal matches, so the reply enumerated a fraction of the week.

## Fix

- `RECENT_HISTORY_PATTERNS` / `isRecentHistoryQuery()` classify enumeration/time-slice queries.
- `buildRecentHistoryDigest()` renders a chronological cross-room digest of the sender's rooms over the last 7 days and prepends it to the search result. It never replaces the keyword results; the model gets both.
- **Owner-exclusive gating:** cross-room recall is deliberately privileged. The digest renders ONLY when `revalidateOwnerExclusiveDisclosure` allows the live delivery audience on the `OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS` (owner DM, or a room whose entire census is {owner, agent}) — the same rule `relevant-conversations` enforces. In a mixed room, or on an `internal_agent_turn` basis, it degrades to `null` and the caller keeps the room-scoped keyword scan, so other participants never see private-room content. Digest failures degrade the same way; recall never fails the search.
- Rendering: connector ingestion prefixes stripped, double-persisted twin rows (same entityId+text) dedupe to one line, synced-corpus rows excluded, and a per-DAY line budget so no middle day silently drops out of a busy window.

## Test coverage

`packages/agent/src/actions/recall-history-digest.test.ts` (11 tests):
- **Gate open:** owner-private destination renders the cross-room chronological digest (both rooms present, oldest-first ordering, agent speaker labels).
- **Gate closed:** denied disclosure returns no digest and leaks nothing; `allowed:true` on a non-owner-private basis (`internal_agent_turn`) also stays closed.
- **Classifier:** five enumeration phrasings match; a plain keyword lookup ("find the postgres migration") does not (and never consults the disclosure gate).
- **Dedupe:** double-persisted twin rows render once.
- **Window:** rows older than 7 days stay out of the digest.

Existing `memories.test.ts` (29 tests) passes unchanged. 40/40 total.

Attribution: Sol