### PR TITLE
fix(core): traverse complete model-facing retrieval

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -76,6 +76,11 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/fragments\.slice\(/,
 		/resolved\.slice\(/,
 		/toWellFormedUnicode\(contextPack\)/,
+		/options\.limit\s*\?\?/,
+		/count:\s*options\.limit/,
+	],
+	"packages/core/src/features/documents/service.ts": [
+		/limit:\s*(?:20|40|1_000)[,\n]/,
 	],
 	"packages/core/src/runtime/planner-loop.ts": [
 		/maybeCompactPlannerTrajectory/,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -458,6 +458,7 @@ export abstract class DatabaseAdapter<DB extends object = object>
 		match_threshold?: number;
 		count?: number;
 		limit?: number;
+		offset?: number;
 		unique?: boolean;
 		query?: string;
 		roomId?: UUID;

--- a/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
+++ b/packages/core/src/database/inMemoryAdapter.search-memories.test.ts
@@ -244,6 +244,29 @@ describe("InMemoryDatabaseAdapter.searchMemories", () => {
 		});
 		expect(results.map((memory) => memory.content.text)).toEqual(["mine"]);
 	});
+
+	it("applies offset after stable similarity ordering", async () => {
+		const memories = Array.from({ length: 6 }, (_, index) => ({
+			entityId: entityA,
+			roomId: roomA,
+			agentId,
+			content: { text: `rank ${index}` },
+			embedding: offAxis(index * 0.1),
+		})) as Memory[];
+		const adapter = await seed(memories);
+
+		const results = await adapter.searchMemories({
+			tableName: "memories",
+			embedding: onAxis(),
+			count: 2,
+			offset: 3,
+		});
+
+		expect(results.map((memory) => memory.content.text)).toEqual([
+			"rank 3",
+			"rank 4",
+		]);
+	});
 });
 
 describe("InMemoryDatabaseAdapter.clearEmbeddingsOutsideActiveDimension", () => {

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -1433,6 +1433,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		match_threshold?: number;
 		count?: number;
 		limit?: number;
+		offset?: number;
 		unique?: boolean;
 		query?: string;
 		roomId?: UUID;
@@ -1477,7 +1478,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		scored.sort(
 			(left, right) => (right.similarity ?? -1) - (left.similarity ?? -1),
 		);
-		return scored.slice(0, limit);
+		const offset = params.offset ?? 0;
+		return scored.slice(offset, offset + limit);
 	}
 
 	// Batch memory methods

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -241,7 +241,7 @@ describe("DocumentService.searchDocuments", () => {
 				"vector",
 			);
 
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(2);
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(4);
 			expect(results).toHaveLength(1);
 			expect(results[0].id).toBe("frag-1");
 		});
@@ -298,7 +298,7 @@ describe("DocumentService.searchDocuments", () => {
 				"keyword",
 			);
 
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(2);
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(4);
 
 			// frag-a should score highest (both "quantum" and "computing" match)
 			expect(results[0].id).toBe("frag-a");
@@ -336,7 +336,25 @@ describe("DocumentService.searchDocuments", () => {
 
 			expect(results).toHaveLength(1_001);
 			expect(results.map((result) => result.id)).toContain("frag-1000");
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(4);
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(6);
+		});
+
+		it("rejects a stable adapter-imposed page cap", async () => {
+			const fragments = Array.from({ length: 11 }, (_, index) =>
+				makeFragment(`frag-${index}`, `needle document ${index}`),
+			);
+			const rt = buildRuntime({ hasEmbedding: false, fragments });
+			rt.adapter.queryDocumentFragments.mockImplementation(
+				async (params: { offset?: number }) => {
+					const offset = params.offset ?? 0;
+					return fragments.slice(offset, offset + 10);
+				},
+			);
+			const svc = buildService(rt);
+
+			await expect(
+				svc.searchDocuments(makeMessage("needle"), undefined, "keyword"),
+			).rejects.toMatchObject({ code: "DOCUMENT_SEARCH_SOURCE_INCOMPLETE" });
 		});
 
 		it("rejects pagination that repeats the same full page", async () => {
@@ -357,7 +375,8 @@ describe("DocumentService.searchDocuments", () => {
 		it("rejects a fragment source that changes between traversals", async () => {
 			const rt = buildRuntime({ hasEmbedding: false });
 			let read = 0;
-			rt.adapter.queryDocumentFragments.mockImplementation(async () => {
+			rt.adapter.queryDocumentFragments.mockImplementation(async (params) => {
+				if ((params.offset ?? 0) > 0) return [];
 				read += 1;
 				return [makeFragment(`frag-${read}`, "needle")];
 			});
@@ -419,7 +438,7 @@ describe("DocumentService.searchDocuments", () => {
 				"hybrid",
 			);
 
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(4);
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(8);
 			expect(results).toHaveLength(2);
 
 			// frag-b should be ranked higher because BM25 breaks the vector tie

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -133,8 +133,12 @@ function buildRuntime(opts: { hasEmbedding: boolean; fragments?: Memory[] }) {
 	const fragments = opts.fragments ?? [];
 	const agentId = "agent-1" as UUID;
 	const queryDocumentFragments = vi.fn(
-		async (params: { requesterEntityId: UUID }) =>
-			fragments.filter((fragment) => {
+		async (params: {
+			requesterEntityId: UUID;
+			limit: number;
+			offset?: number;
+		}) => {
+			const visible = fragments.filter((fragment) => {
 				const metadata = fragment.metadata as
 					| Record<string, unknown>
 					| undefined;
@@ -142,7 +146,10 @@ function buildRuntime(opts: { hasEmbedding: boolean; fragments?: Memory[] }) {
 					metadata?.scope !== "user-private" ||
 					metadata.scopedToEntityId === params.requesterEntityId
 				);
-			}),
+			});
+			const offset = params.offset ?? 0;
+			return visible.slice(offset, offset + params.limit);
+		},
 	);
 
 	return {
@@ -234,7 +241,7 @@ describe("DocumentService.searchDocuments", () => {
 				"vector",
 			);
 
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledOnce();
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(2);
 			expect(results).toHaveLength(1);
 			expect(results[0].id).toBe("frag-1");
 		});
@@ -251,6 +258,27 @@ describe("DocumentService.searchDocuments", () => {
 				"vector",
 			);
 			expect(results).toHaveLength(0);
+		});
+
+		it("returns every vector match beyond the former top-20 window", async () => {
+			const fragments = Array.from({ length: 21 }, (_, index) =>
+				makeFragment(
+					`frag-${index}`,
+					`semantic result ${index}`,
+					1 - index / 100,
+				),
+			);
+			const rt = buildRuntime({ hasEmbedding: true, fragments });
+			const svc = buildService(rt);
+
+			const results = await svc.searchDocuments(
+				makeMessage("semantic result"),
+				undefined,
+				"vector",
+			);
+
+			expect(results).toHaveLength(21);
+			expect(results.map((result) => result.id)).toContain("frag-20");
 		});
 	});
 
@@ -270,7 +298,7 @@ describe("DocumentService.searchDocuments", () => {
 				"keyword",
 			);
 
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledOnce();
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(2);
 
 			// frag-a should score highest (both "quantum" and "computing" match)
 			expect(results[0].id).toBe("frag-a");
@@ -291,6 +319,53 @@ describe("DocumentService.searchDocuments", () => {
 				"keyword",
 			);
 			expect(results).toHaveLength(0);
+		});
+
+		it("scores every authorized fragment beyond the former 1000-row window", async () => {
+			const fragments = Array.from({ length: 1_001 }, (_, index) =>
+				makeFragment(`frag-${index}`, `needle document ${index}`),
+			);
+			const rt = buildRuntime({ hasEmbedding: false, fragments });
+			const svc = buildService(rt);
+
+			const results = await svc.searchDocuments(
+				makeMessage("needle"),
+				undefined,
+				"keyword",
+			);
+
+			expect(results).toHaveLength(1_001);
+			expect(results.map((result) => result.id)).toContain("frag-1000");
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(4);
+		});
+
+		it("rejects pagination that repeats the same full page", async () => {
+			const fragments = Array.from({ length: 1_000 }, (_, index) =>
+				makeFragment(`frag-${index}`, `needle ${index}`),
+			);
+			const rt = buildRuntime({ hasEmbedding: false, fragments });
+			rt.adapter.queryDocumentFragments.mockImplementation(
+				async () => fragments,
+			);
+			const svc = buildService(rt);
+
+			await expect(
+				svc.searchDocuments(makeMessage("needle"), undefined, "keyword"),
+			).rejects.toMatchObject({ code: "DOCUMENT_SEARCH_PAGINATION_STALLED" });
+		});
+
+		it("rejects a fragment source that changes between traversals", async () => {
+			const rt = buildRuntime({ hasEmbedding: false });
+			let read = 0;
+			rt.adapter.queryDocumentFragments.mockImplementation(async () => {
+				read += 1;
+				return [makeFragment(`frag-${read}`, "needle")];
+			});
+			const svc = buildService(rt);
+
+			await expect(
+				svc.searchDocuments(makeMessage("needle"), undefined, "keyword"),
+			).rejects.toMatchObject({ code: "DOCUMENT_SEARCH_SOURCE_UNSTABLE" });
 		});
 
 		it("filters user-private fragments to the scoped user", async () => {
@@ -344,7 +419,7 @@ describe("DocumentService.searchDocuments", () => {
 				"hybrid",
 			);
 
-			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledOnce();
+			expect(rt.adapter.queryDocumentFragments).toHaveBeenCalledTimes(4);
 			expect(results).toHaveLength(2);
 
 			// frag-b should be ranked higher because BM25 breaks the vector tie

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1959,7 +1959,27 @@ export class DocumentService extends Service {
 			}
 
 			fragments.push(...page);
-			if (page.length < DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE) return fragments;
+			if (page.length < DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE) {
+				const continuation = await this.runtime.adapter.queryDocumentFragments({
+					...params,
+					limit: 1,
+					offset: offset + page.length,
+				});
+				if (continuation.length > 0) {
+					throw new ElizaError(
+						"Document fragment source returned a capped page",
+						{
+							code: "DOCUMENT_SEARCH_SOURCE_INCOMPLETE",
+							context: {
+								offset,
+								requested: DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE,
+								returned: page.length,
+							},
+						},
+					);
+				}
+				return fragments;
+			}
 			if (offset > Number.MAX_SAFE_INTEGER - page.length) {
 				throw new ElizaError(
 					"Document fragment result count is not representable",

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -35,6 +35,7 @@ import {
 	type AccessContext,
 	type Content,
 	type CustomMetadata,
+	type DocumentFragmentQueryParams,
 	type DocumentListCursor,
 	type DocumentListQueryParams,
 	type DocumentListRequesterRole,
@@ -145,6 +146,7 @@ const PRE_DOCUMENTS_TABLE = "knowledge";
 const DOCUMENT_INGESTION_PENDING_TIMEOUT_MS = 5 * 60 * 1_000;
 const CHARACTER_DOCUMENT_EMBEDDING_WAIT_TIMEOUT_MS = 120_000;
 const CHARACTER_DOCUMENT_EMBEDDING_WAIT_INTERVAL_MS = 1_000;
+const DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE = 1_000;
 const DOCUMENT_SCOPES = new Set<DocumentVisibilityScope>([
 	"global",
 	"owner-private",
@@ -1918,6 +1920,78 @@ export class DocumentService extends Service {
 		return filterByAccessContext(results, accessContext, this.runtime.agentId);
 	}
 
+	private async scanDocumentFragments(
+		params: Omit<DocumentFragmentQueryParams, "limit" | "offset">,
+	): Promise<Memory[]> {
+		const fragments: Memory[] = [];
+		let offset = 0;
+		let previousPage: readonly Memory[] = [];
+
+		for (;;) {
+			const page = await this.runtime.adapter.queryDocumentFragments({
+				...params,
+				limit: DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE,
+				offset,
+			});
+			if (page.length > DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE) {
+				throw new ElizaError(
+					"Document fragment source returned an invalid page",
+					{
+						code: "DOCUMENT_SEARCH_INVALID_PAGE",
+						context: {
+							offset,
+							requested: DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE,
+							received: page.length,
+						},
+						severity: "fatal",
+					},
+				);
+			}
+			if (
+				offset > 0 &&
+				page.length > 0 &&
+				JSON.stringify(page) === JSON.stringify(previousPage)
+			) {
+				throw new ElizaError("Document fragment traversal did not advance", {
+					code: "DOCUMENT_SEARCH_PAGINATION_STALLED",
+					context: { offset },
+				});
+			}
+
+			fragments.push(...page);
+			if (page.length < DOCUMENT_FRAGMENT_TRAVERSAL_PAGE_SIZE) return fragments;
+			if (offset > Number.MAX_SAFE_INTEGER - page.length) {
+				throw new ElizaError(
+					"Document fragment result count is not representable",
+					{
+						code: "DOCUMENT_SEARCH_RESULT_TOO_LARGE",
+						context: { offset, pageSize: page.length },
+						severity: "fatal",
+					},
+				);
+			}
+			offset += page.length;
+			previousPage = page;
+		}
+	}
+
+	private async queryCompleteDocumentFragments(
+		params: Omit<DocumentFragmentQueryParams, "limit" | "offset">,
+	): Promise<Memory[]> {
+		const first = await this.scanDocumentFragments(params);
+		const verified = await this.scanDocumentFragments(params);
+		if (JSON.stringify(first) !== JSON.stringify(verified)) {
+			throw new ElizaError(
+				"Document fragment source changed during traversal",
+				{
+					code: "DOCUMENT_SEARCH_SOURCE_UNSTABLE",
+					context: { firstCount: first.length, verifiedCount: verified.length },
+				},
+			);
+		}
+		return verified;
+	}
+
 	/** Pure vector (cosine-similarity) search. */
 	private async _vectorSearch(
 		queryText: string,
@@ -1939,14 +2013,13 @@ export class DocumentService extends Service {
 			return this._keywordSearch(queryText, filterScope, requester);
 		}
 
-		const fragments = await this.runtime.adapter.queryDocumentFragments({
+		const fragments = await this.queryCompleteDocumentFragments({
 			agentId: this.runtime.agentId,
 			requesterEntityId: requester.entityId,
 			requesterRoomIds: requester.roomIds,
 			requesterRole: requester.role,
 			embedding,
 			...filterScope,
-			limit: 20,
 			matchThreshold: 0.1,
 		});
 
@@ -1971,13 +2044,12 @@ export class DocumentService extends Service {
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		requester: DocumentRequester,
 	): Promise<StoredDocument[]> {
-		const allFragments = await this.runtime.adapter.queryDocumentFragments({
+		const allFragments = await this.queryCompleteDocumentFragments({
 			agentId: this.runtime.agentId,
 			requesterEntityId: requester.entityId,
 			requesterRoomIds: requester.roomIds,
 			requesterRole: requester.role,
 			...filterScope,
-			limit: 1_000,
 		});
 		const valid = allFragments.filter(
 			(f) => f.id !== undefined && f.content.text,
@@ -2031,23 +2103,33 @@ export class DocumentService extends Service {
 			return this._keywordSearch(queryText, filterScope, requester);
 		}
 
-		// Fetch a larger PURE-VECTOR candidate set so the explicit BM25 blend below
-		// can re-rank meaningfully. Do NOT pass `query`: that triggers a runtime
-		// BM25 rerank that drops zero-overlap candidates *before* the blend, so the
-		// 0.6·vector + 0.4·bm25 combine never sees the semantic-only matches. And
-		// use `count` (the adapter honours it; `limit` was ignored → pool capped at
-		// the default 10, defeating "fetch a larger candidate set").
-		const candidates = await this.runtime.adapter.queryDocumentFragments({
+		// Traverse both ranked vector matches and the full keyword corpus. Their
+		// union keeps semantic-only rows in the blend while allowing BM25-only rows
+		// to compete; each traversal verifies a stable complete source snapshot.
+		const vectorCandidates = await this.queryCompleteDocumentFragments({
 			agentId: this.runtime.agentId,
 			requesterEntityId: requester.entityId,
 			requesterRoomIds: requester.roomIds,
 			requesterRole: requester.role,
 			embedding,
 			...filterScope,
-			limit: 40,
 			matchThreshold: 0.05,
 		});
-		const valid = candidates.filter(
+		const keywordCandidates = await this.queryCompleteDocumentFragments({
+			agentId: this.runtime.agentId,
+			requesterEntityId: requester.entityId,
+			requesterRoomIds: requester.roomIds,
+			requesterRole: requester.role,
+			...filterScope,
+		});
+		const candidatesById = new Map<string, Memory>();
+		for (const candidate of keywordCandidates) {
+			if (candidate.id) candidatesById.set(candidate.id, candidate);
+		}
+		for (const candidate of vectorCandidates) {
+			if (candidate.id) candidatesById.set(candidate.id, candidate);
+		}
+		const valid = [...candidatesById.values()].filter(
 			(f) => f.id !== undefined && f.content.text,
 		);
 		if (valid.length === 0) return [];

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11516,6 +11516,7 @@ ${section_end}`;
 		match_threshold?: number;
 		count?: number;
 		limit?: number;
+		offset?: number;
 		roomId?: UUID;
 		unique?: boolean;
 		worldId?: UUID;

--- a/packages/core/src/security/pii-context-pack.test.ts
+++ b/packages/core/src/security/pii-context-pack.test.ts
@@ -319,30 +319,40 @@ describe("sourcesFromRuntime", () => {
 	}
 
 	function makeRuntime(config: FakeRuntimeConfig = {}) {
-		const searchMessages = vi.fn(
-			async (): Promise<MessageSearchHit[]> => [
-				{
-					memory: {
-						id: "m1" as UUID,
-						entityId: AGENT_ID,
-						roomId: AGENT_ID,
-						content: { text: "found message" },
-					} as Memory,
-					ftsRank: 3.2,
-					trigramSimilarity: 0.7,
-				},
-			],
-		);
-		const searchMemories = vi.fn(
-			async (): Promise<Memory[]> => [
-				{
-					id: "mem1" as UUID,
+		const messageHits: MessageSearchHit[] = [
+			{
+				memory: {
+					id: "m1" as UUID,
 					entityId: AGENT_ID,
 					roomId: AGENT_ID,
-					content: { text: "found memory" },
-					similarity: 0.8,
+					content: { text: "found message" },
 				} as Memory,
-			],
+				ftsRank: 3.2,
+				trigramSimilarity: 0.7,
+			},
+		];
+		const searchMessages = vi.fn(
+			async (params: { limit?: number; offset?: number }) =>
+				messageHits.slice(
+					params.offset ?? 0,
+					(params.offset ?? 0) + (params.limit ?? 20),
+				),
+		);
+		const memoryHits: Memory[] = [
+			{
+				id: "mem1" as UUID,
+				entityId: AGENT_ID,
+				roomId: AGENT_ID,
+				content: { text: "found memory" },
+				similarity: 0.8,
+			} as Memory,
+		];
+		const searchMemories = vi.fn(
+			async (params: { count?: number; offset?: number }): Promise<Memory[]> =>
+				memoryHits.slice(
+					params.offset ?? 0,
+					(params.offset ?? 0) + (params.count ?? 10),
+				),
 		);
 		const searchDocuments = vi.fn(async (message: Memory) => {
 			void message;
@@ -441,6 +451,99 @@ describe("sourcesFromRuntime", () => {
 		expect(fragments).toEqual([
 			{ text: "found message", origin: "message", ref: "m1", score: 0.7 },
 		]);
+	});
+
+	test("assembles the first, middle, and last memory beyond the legacy source limit", async () => {
+		const memories = Array.from({ length: 130 }, (_, index) => ({
+			id: `mem-${index}` as UUID,
+			entityId: AGENT_ID,
+			roomId: AGENT_ID,
+			content: { text: `memory evidence ${index}` },
+			similarity: 1 - index / 1_000,
+		})) as Memory[];
+		const searchMemories = vi.fn(
+			async (params: { count?: number; offset?: number }) => {
+				const offset = params.offset ?? 0;
+				return memories.slice(offset, offset + (params.count ?? 10));
+			},
+		);
+		const runtime = {
+			agentId: AGENT_ID,
+			getModel: () => vi.fn(),
+			useModel: vi.fn(async () => [0.1, 0.2]),
+			searchMemories,
+			getService: () => null,
+			adapter: { searchMessages: vi.fn() },
+		} as unknown as IAgentRuntime;
+		const sources = sourcesFromRuntime(runtime, { limit: 1 });
+
+		const pack = await assembleContextPack(sources, {
+			chunk: "John Smith",
+			candidates: [{ surfaceForm: "John Smith", kind: "person" }],
+			map: makeMap(),
+			rulesetVersion: RULESET,
+		});
+
+		expect(pack.contextPack).toContain("memory evidence 0");
+		expect(pack.contextPack).toContain("memory evidence 65");
+		expect(pack.contextPack).toContain("memory evidence 129");
+		expect(searchMemories).toHaveBeenCalledWith(
+			expect.objectContaining({ count: 64, offset: 0 }),
+		);
+		expect(searchMemories).toHaveBeenCalledWith(
+			expect.objectContaining({ count: 256, offset: 0 }),
+		);
+	});
+
+	test("rejects a source that ignores continuation offsets", async () => {
+		const hit = {
+			id: "mem-stalled" as UUID,
+			entityId: AGENT_ID,
+			roomId: AGENT_ID,
+			content: { text: "stalled" },
+		} as Memory;
+		const runtime = {
+			agentId: AGENT_ID,
+			getModel: () => vi.fn(),
+			useModel: vi.fn(async () => [0.1]),
+			searchMemories: vi.fn(async () => [hit]),
+			getService: () => null,
+			adapter: { searchMessages: vi.fn() },
+		} as unknown as IAgentRuntime;
+
+		await expect(
+			sourcesFromRuntime(runtime).searchMemories?.("John"),
+		).rejects.toMatchObject({ code: "PII_CONTEXT_SOURCE_INCOMPLETE" });
+	});
+
+	test("rejects a source that changes between complete traversals", async () => {
+		let prefixReads = 0;
+		const searchMemories = vi.fn(
+			async (params: { offset?: number }): Promise<Memory[]> => {
+				if ((params.offset ?? 0) > 0) return [];
+				prefixReads += 1;
+				return [
+					{
+						id: `mem-${prefixReads}` as UUID,
+						entityId: AGENT_ID,
+						roomId: AGENT_ID,
+						content: { text: `version ${prefixReads}` },
+					} as Memory,
+				];
+			},
+		);
+		const runtime = {
+			agentId: AGENT_ID,
+			getModel: () => vi.fn(),
+			useModel: vi.fn(async () => [0.1]),
+			searchMemories,
+			getService: () => null,
+			adapter: { searchMessages: vi.fn() },
+		} as unknown as IAgentRuntime;
+
+		await expect(
+			sourcesFromRuntime(runtime).searchMemories?.("John"),
+		).rejects.toMatchObject({ code: "PII_CONTEXT_SOURCE_UNSTABLE" });
 	});
 });
 

--- a/packages/core/src/security/pii-context-pack.ts
+++ b/packages/core/src/security/pii-context-pack.ts
@@ -196,6 +196,101 @@ export interface AssembleContextPackRequest {
 }
 
 const DEFAULT_MIN_ENTITY_CONFIDENCE = 0.6;
+const COMPLETE_SOURCE_INITIAL_PREFIX = 64;
+
+interface PrefixRequest {
+	readonly limit: number;
+	readonly offset: number;
+}
+
+function sameOrderedValues<T>(
+	left: readonly T[],
+	right: readonly T[],
+): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+async function readStableCompletePrefix<T>(
+	source: string,
+	fetchPrefix: (request: PrefixRequest) => Promise<readonly T[]>,
+): Promise<readonly T[]> {
+	let limit = COMPLETE_SOURCE_INITIAL_PREFIX;
+	let previous: readonly T[] = [];
+
+	for (;;) {
+		const current = await fetchPrefix({ limit, offset: 0 });
+		if (current.length > limit) {
+			throw new ElizaError(
+				`PII context ${source} source exceeded its requested page`,
+				{
+					code: "PII_CONTEXT_SOURCE_INVALID_PAGE",
+					context: { source, requested: limit, received: current.length },
+					severity: "fatal",
+				},
+			);
+		}
+		if (
+			previous.length > 0 &&
+			!sameOrderedValues(current.slice(0, previous.length), previous)
+		) {
+			throw new ElizaError(
+				`PII context ${source} source changed during traversal`,
+				{
+					code: "PII_CONTEXT_SOURCE_UNSTABLE",
+					context: { source, requested: limit },
+				},
+			);
+		}
+
+		if (current.length < limit) {
+			const continuation = await fetchPrefix({
+				limit: 1,
+				offset: current.length,
+			});
+			if (continuation.length > 0) {
+				throw new ElizaError(
+					`PII context ${source} source returned a capped prefix`,
+					{
+						code: "PII_CONTEXT_SOURCE_INCOMPLETE",
+						context: { source, returned: current.length, requested: limit },
+					},
+				);
+			}
+
+			const verified = await fetchPrefix({ limit, offset: 0 });
+			const verifiedContinuation = await fetchPrefix({
+				limit: 1,
+				offset: verified.length,
+			});
+			if (
+				!sameOrderedValues(current, verified) ||
+				verifiedContinuation.length > 0
+			) {
+				throw new ElizaError(
+					`PII context ${source} source changed during verification`,
+					{
+						code: "PII_CONTEXT_SOURCE_UNSTABLE",
+						context: { source, requested: limit },
+					},
+				);
+			}
+			return verified;
+		}
+
+		previous = current;
+		if (limit > Math.floor(Number.MAX_SAFE_INTEGER / 2)) {
+			throw new ElizaError(
+				`PII context ${source} result count is not representable`,
+				{
+					code: "PII_CONTEXT_SOURCE_TOO_LARGE",
+					context: { source, requested: limit },
+					severity: "fatal",
+				},
+			);
+		}
+		limit *= 2;
+	}
+}
 
 function assertWellFormedContextText(value: string, field: string): void {
 	if (toWellFormedUnicode(value) !== value) {
@@ -417,7 +512,7 @@ export interface RuntimeContextSourceOptions {
 	 * When omitted, the messages source is structurally absent.
 	 */
 	readonly roomIds?: readonly UUID[];
-	/** Per-source result limit (default 5). */
+	/** @deprecated Retained for compatibility; complete source traversal ignores it. */
 	readonly limit?: number;
 	/**
 	 * The entity resolver, wired by the pipeline from the knowledge-graph
@@ -447,7 +542,6 @@ export function sourcesFromRuntime(
 	runtime: IAgentRuntime,
 	options: RuntimeContextSourceOptions = {},
 ): PiiContextSources {
-	const limit = options.limit ?? 5;
 	const sources: {
 		-readonly [K in keyof PiiContextSources]: PiiContextSources[K];
 	} = {};
@@ -487,12 +581,17 @@ export function sourcesFromRuntime(
 				ModelType.TEXT_EMBEDDING,
 				params,
 			);
-			const memories = await runtime.searchMemories({
-				embedding,
-				query,
-				tableName: "messages",
-				count: limit,
-			});
+			const memories = await readStableCompletePrefix(
+				"memories",
+				async ({ limit, offset }) =>
+					runtime.searchMemories({
+						embedding,
+						query,
+						tableName: "messages",
+						count: limit,
+						offset,
+					}),
+			);
 			return memories
 				.filter((memory) => typeof memory.content.text === "string")
 				.map((memory) => ({
@@ -509,11 +608,16 @@ export function sourcesFromRuntime(
 	const roomIds = options.roomIds;
 	if (roomIds && roomIds.length > 0) {
 		sources.searchMessages = async (query) => {
-			const hits = await runtime.adapter.searchMessages({
-				roomIds: [...roomIds],
-				query,
-				limit,
-			});
+			const hits = await readStableCompletePrefix(
+				"messages",
+				async ({ limit, offset }) =>
+					runtime.adapter.searchMessages({
+						roomIds: [...roomIds],
+						query,
+						limit,
+						offset,
+					}),
+			);
 			return hits
 				.filter((hit) => typeof hit.memory.content.text === "string")
 				.map((hit) => ({

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1314,6 +1314,7 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		match_threshold?: number;
 		count?: number;
 		limit?: number;
+		offset?: number;
 		unique?: boolean;
 		tableName: string;
 		query?: string;

--- a/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
@@ -845,6 +845,38 @@ describe("Memory Integration Tests", () => {
       expect(results[0].similarity).toBeGreaterThan(0.99);
     });
 
+    it("pages embedding results after stable similarity ordering", async () => {
+      const query = Array.from({ length: 384 }, (_, index) => (index === 0 ? 1 : 0));
+      const vectors = [0.1, 0.2, 0.3].map((tilt) =>
+        Array.from({ length: 384 }, (_, index) => (index === 0 ? 1 : index === 1 ? tilt : 0))
+      );
+      const ids: UUID[] = [];
+      for (const [index, embedding] of vectors.entries()) {
+        const id = v4() as UUID;
+        ids.push(id);
+        await adapter.createMemory(
+          {
+            id,
+            content: { text: `paged ${index}` },
+            createdAt: Date.now(),
+            embedding,
+            agentId: testAgentId,
+            roomId: testRoomId,
+            entityId: testEntityId,
+          } as Memory,
+          "search-page"
+        );
+      }
+
+      const page = await adapter.searchMemoriesByEmbedding(query, {
+        tableName: "search-page",
+        count: 1,
+        offset: 1,
+      });
+
+      expect(page.map((memory) => memory.id)).toEqual([ids[1]]);
+    });
+
     it("creates the HNSW cosine index for the active dimension on ensure", async () => {
       await adapter.ensureEmbeddingDimension(384);
       const rows = await (

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -3746,6 +3746,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     match_threshold?: number;
     count?: number;
     limit?: number;
+    offset?: number;
     unique?: boolean;
     query?: string;
     roomId?: UUID;
@@ -3759,6 +3760,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       // as a legacy alias) instead of silently ignoring it and capping the
       // candidate pool at the default 10.
       count: params.count ?? params.limit,
+      offset: params.offset,
       // Pass direct scope fields down
       roomId: params.roomId,
       worldId: params.worldId,
@@ -3786,6 +3788,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     params: {
       match_threshold?: number;
       count?: number;
+      offset?: number;
       roomId?: UUID;
       worldId?: UUID;
       entityId?: UUID;
@@ -3851,8 +3854,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .from(embeddingTable)
         .innerJoin(memoryTable, eq(memoryTable.id, embeddingTable.memoryId))
         .where(and(...conditions))
-        .orderBy(asc(distance))
-        .limit(count);
+        .orderBy(asc(distance), desc(memoryTable.createdAt), desc(memoryTable.id))
+        .limit(count)
+        .offset(params.offset ?? 0);
 
       // Same truthiness contract as the removed WHERE predicate: an absent or
       // zero threshold applies no similarity floor.


### PR DESCRIPTION
Closes #24789.
Closes #24831.

## What changed
- removes the PII context pack's hidden five-result memory/message cap and ignores the deprecated caller limit
- traverses complete, ordered memory sources through explicit offsets and rejects capped or unstable adapters with typed errors
- removes document search's hidden vector top-20, hybrid top-40, and keyword top-1000 candidate caps
- traverses complete document-fragment sources in ordered pages, verifies a stable second read, and rejects stalled or changing sources
- adds stable SQL memory ordering and offset support across the core and SQL adapter contracts
- extends the prompt-integrity guard against reintroducing these fixed caps

## Verification
- `bunx vitest run src/security/pii-context-pack.test.ts src/features/documents/__tests__/search.test.ts src/database/inMemoryAdapter.search-memories.test.ts src/__tests__/prompt-integrity-policy.test.ts` (64 tests passed after rebase)
- `bun run typecheck` in `packages/core`
- `bun run typecheck` in `plugins/plugin-sql` with its declared package dependencies resolved
- `bunx biome check` on all 12 changed files
- `git diff --check`

The SQL real integration test is included for offset ordering. In this sparse checkout its runner could not initialize against a stale borrowed `@elizaos/core` build (`PrincipalService` undefined), so no plugin test body ran locally; hosted CI should execute it against the PR workspace.