### PR TITLE
test(computeruse): prove desktop trajectory error boundary

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
@@ -64,6 +64,28 @@ describe("emitAndroidAction", () => {
     }
   });
 
+  it.each([undefined, "", "short bridge failure"])(
+    "preserves absent, empty, and short action errors exactly: %s",
+    (errorMessage) => {
+      const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+      try {
+        const event = {
+          kind: "tap" as const,
+          success: false,
+          ...(errorMessage === undefined ? {} : { errorMessage }),
+        };
+        const payload = emitAndroidAction(event);
+        const structured = spy.mock.calls[0]?.[0] as Record<string, unknown>;
+        expect(payload).toEqual(event);
+        expect("errorMessage" in payload).toBe(errorMessage !== undefined);
+        expect("errorMessage" in structured).toBe(errorMessage !== undefined);
+        expect(structured.errorMessage).toBe(errorMessage);
+      } finally {
+        spy.mockRestore();
+      }
+    },
+  );
+
   it("preserves every well-formed action text field and leaves the input unchanged", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
     try {

--- a/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/computer-use-agent.test.ts
@@ -26,6 +26,7 @@ import {
   runComputerUseAgentLoop,
 } from "../actions/use-computer-agent.js";
 import { Brain } from "../actor/brain.js";
+import { makeComputerInterface } from "../actor/computer-interface.js";
 import type { DisplayCapture } from "../platform/capture.js";
 import type { Scene } from "../scene/scene-types.js";
 import type { ComputerUseService } from "../services/computer-use-service.js";
@@ -487,6 +488,101 @@ describe("runComputerUseAgentLoop — fake Brain", () => {
       spy.mockRestore();
     }
   });
+
+  it("preserves complete long and astral desktop dispatch errors", async () => {
+    const complete = `${"desktop driver failure ".repeat(300)}🧠 tail`;
+    const brain = new Brain(null, {
+      invokeModel: async () =>
+        JSON.stringify({
+          scene_summary: "S",
+          target_display_id: 0,
+          roi: [],
+          proposed_action: {
+            kind: "click",
+            ref: "t0-1",
+            rationale: "click save",
+          },
+        }),
+    });
+    const computerInterface = makeComputerInterface({
+      listDisplays: () => [display()],
+      driver: {
+        click: async () => {
+          throw new Error(complete);
+        },
+      },
+    });
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      const report = await runComputerUseAgentLoop(
+        null,
+        { goal: "save" },
+        fakeService(),
+        { brain, captureAll, computerInterface },
+      );
+      const stepLog = spy.mock.calls
+        .map(([entry]) => entry as Record<string, unknown>)
+        .find((entry) => entry.evt === "computeruse.agent.step");
+      expect(report.error).toBe(complete);
+      expect(stepLog).toMatchObject({
+        success: false,
+        error: complete,
+        errorCode: "driver_error",
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it.each(["before\ud800after", "before\udc00after"])(
+    "rejects malformed desktop dispatch error %s before trajectory logging",
+    async (malformed) => {
+      const brain = new Brain(null, {
+        invokeModel: async () =>
+          JSON.stringify({
+            scene_summary: "S",
+            target_display_id: 0,
+            roi: [],
+            proposed_action: {
+              kind: "click",
+              ref: "t0-1",
+              rationale: "click save",
+            },
+          }),
+      });
+      const computerInterface = makeComputerInterface({
+        listDisplays: () => [display()],
+        driver: {
+          click: async () => {
+            throw new Error(malformed);
+          },
+        },
+      });
+      const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+      try {
+        await expect(
+          runComputerUseAgentLoop(null, { goal: "save" }, fakeService(), {
+            brain,
+            captureAll,
+            computerInterface,
+          }),
+        ).rejects.toMatchObject({
+          name: "ElizaError",
+          code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+          context: { field: "error" },
+        } satisfies Partial<ElizaError>);
+        expect(
+          spy.mock.calls.some(
+            ([entry]) =>
+              (entry as Record<string, unknown>).evt ===
+              "computeruse.agent.step",
+          ),
+        ).toBe(false);
+      } finally {
+        spy.mockRestore();
+      }
+    },
+  );
 
   it("aborts on scene refresh error", async () => {
     const brain = new Brain(null, {


### PR DESCRIPTION
Fixes #24868
Follow-up to #24844.

## Summary

- drive the desktop agent loop through its real cascade and dispatch boundary with fake driver failures
- prove long and astral driver errors remain complete while `driver_error` stays a separate stable classifier
- prove lone-high and lone-low surrogate driver errors fail with `COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE` before the structured step event
- complete Android direct-action parity for absent, empty, and short error messages

## Verification

- exact-head focused trajectory suites: 49 passed
- full `plugin-computeruse` suite before the final unrelated develop-only rebase: 972 passed, 17 declared skips
- exact-head `bun run --cwd plugins/plugin-computeruse typecheck` — passed
- exact-head `bun run --cwd plugins/plugin-computeruse lint:check` — 237 files passed
- exact-head `bun run --cwd plugins/plugin-computeruse build` — passed
- prompt-integrity policy: 5 passed
- guide parity: 161 pairs passed
- `git diff --check github/develop...HEAD` — passed

<!-- evidence-head:195ff838f572d43ca74f4f9e16576e563b1cae62 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deterministic non-visual trajectory regression coverage only

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive visual flow changes

<!-- evidence-row:backend-logs -->
- [ ] N/A - real emitter tests inspect the exact structured logger payload and prove zero step logs on rejection

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser console or network surface changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - tests only; no model request, response, prompt, or planner behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - returned reports, typed errors, and structured trajectory payloads are the asserted artifacts

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@4da77681bdf0f4213d1ee74e6b6855bbfb54d250:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@4da77681bdf0f4213d1ee74e6b6855bbfb54d250:packages/skills/skills/contribute-to-eliza"} -->