### PR TITLE
fix(agent-orchestrator): make ACP command anchoring lossless

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -152,6 +152,7 @@ import {
   defaultCodexAcpCommand,
   normalizeClaudeAcpModelId,
 } from "../../src/services/acp-service.js";
+import { splitCommandLine } from "../../src/services/acp-native-transport.js";
 import { InMemorySessionStore } from "../../src/services/session-store.js";
 
 vi.mock("node:child_process", () => ({
@@ -555,6 +556,49 @@ describe("AcpService", () => {
       // unanchored, so availability resolved it against the service cwd while
       // the native client spawns with cwd: session.workdir.
       expect(inspect.nativeAgentCommand("codex")).toBe(`${executable} --stdio`);
+      expect(inspect.agentCommandAvailability("codex")).toEqual({
+        available: true,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("anchors a relative executable path containing spaces losslessly (#24683)", async () => {
+    // anchor -> split must round-trip byte-for-byte. quoteCommandPart()
+    // previously used JSON.stringify, which escapes backslashes, while
+    // splitCommandLine() only strips the surrounding quote pair — so a Windows
+    // path containing spaces re-parsed with doubled separators and the native
+    // transport spawned an executable that does not exist.
+    const dir = mkdtempSync(join(tmpdir(), "relative codex spaces-"));
+    const nested = join(dir, "my bin");
+    const executable = join(nested, "codex-acp");
+    try {
+      await fs.mkdir(nested, { recursive: true });
+      await fs.writeFile(executable, "#!/bin/sh\nexit 0\n");
+      await fs.chmod(executable, 0o755);
+      const relative = path.relative(process.cwd(), executable);
+      // Guard the fixture actually exercises the reported shape.
+      expect(relative).toContain(" ");
+
+      const service = new AcpService(
+        runtime({
+          ELIZA_ACP_TRANSPORT: "native",
+          ELIZA_CODEX_ACP_COMMAND: `"${relative}" --stdio`,
+        }),
+      );
+      const inspect = service as unknown as {
+        nativeAgentCommand(agentType: string): string;
+        agentCommandAvailability(agentType: string): { available: boolean };
+      };
+
+      // Re-parsing the anchored command must recover the exact absolute path
+      // and the original argv tail — no doubled separators, no lost args.
+      const anchored = inspect.nativeAgentCommand("codex");
+      expect(splitCommandLine(anchored)).toEqual({
+        command: executable,
+        args: ["--stdio"],
+      });
       expect(inspect.agentCommandAvailability("codex")).toEqual({
         available: true,
       });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -608,9 +608,7 @@ describe("AcpService", () => {
   });
 
   it("leaves the managed default Codex command unanchored (#24683)", async () => {
-    const service = new AcpService(
-      runtime({ ELIZA_ACP_TRANSPORT: "native" }),
-    );
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
     const inspect = service as unknown as {
       nativeAgentCommand(agentType: string): string;
     };

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -147,12 +147,12 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
   };
 });
 
+import { splitCommandLine } from "../../src/services/acp-native-transport.js";
 import {
   AcpService,
   defaultCodexAcpCommand,
   normalizeClaudeAcpModelId,
 } from "../../src/services/acp-service.js";
-import { splitCommandLine } from "../../src/services/acp-native-transport.js";
 import { InMemorySessionStore } from "../../src/services/session-store.js";
 
 vi.mock("node:child_process", () => ({

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -411,7 +411,7 @@ function quoteCommandPart(value: string): string {
     "Command part contains both quote characters and cannot be represented",
     {
       code: "ACP_COMMAND_UNQUOTABLE",
-      context: { value },
+      context: { valueLength: value.length },
     },
   );
 }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -391,8 +391,29 @@ function findExecutableOnPath(name: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Serialize one command part so `splitCommandLine` recovers it byte-for-byte.
+ *
+ * That parser strips a surrounding quote pair WITHOUT unescaping the contents,
+ * so its exact inverse is "wrap in a quote pair" — not `JSON.stringify`, which
+ * escapes backslashes and made a Windows path containing spaces re-parse with
+ * doubled separators (an executable the native transport cannot spawn).
+ */
 function quoteCommandPart(value: string): string {
-  return /\s/u.test(value) ? JSON.stringify(value) : value;
+  if (!/[\s"']/u.test(value)) return value;
+  if (!value.includes('"')) return `"${value}"`;
+  // A value containing a double quote cannot live inside a double-quoted span
+  // under this grammar; single quotes round-trip identically.
+  if (!value.includes("'")) return `'${value}'`;
+  // Containing both quote kinds is unrepresentable here. Fail loudly rather
+  // than emit an argv the child would silently mis-parse.
+  throw new ElizaError(
+    "Command part contains both quote characters and cannot be represented",
+    {
+      code: "ACP_COMMAND_UNQUOTABLE",
+      context: { value },
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #24874.

Follow-up to merged #24840. The original anchoring fix was correct for ordinary relative paths, but its known Windows/space quoting gap landed with it.

This change:
- makes quoteCommandPart the exact inverse of splitCommandLine instead of JSON-escaping backslashes
- fails with typed ACP_COMMAND_UNQUOTABLE when both quote kinds cannot be represented by the grammar
- reports only valueLength, never the raw potentially credential-bearing command part
- formats the test that caused #24840 hosted lint to fail

Validation at the rebased exact head:
- orchestrator acp-service unit suite: 88 passed
- Biome clean on both changed files
- git diff --check clean