### PR TITLE
fix(ui): keep callback recovery gated through cleanup

### DIFF
--- a/packages/app/test/ui-smoke/phone-login-session-recovery.spec.ts
+++ b/packages/app/test/ui-smoke/phone-login-session-recovery.spec.ts
@@ -5,6 +5,7 @@
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import { expect, type Page, type TestInfo, test } from "@playwright/test";
+import { seedStewardSession } from "./helpers/test-auth";
 import { saveBrowserVideoArtifact } from "./helpers/video-artifacts";
 
 test.use({ video: "on" });
@@ -43,12 +44,7 @@ for (const viewport of VIEWPORTS) {
     page,
   }, testInfo) => {
     await page.setViewportSize(viewport);
-    await page.addInitScript(() => {
-      window.localStorage.setItem(
-        "steward_session_token",
-        "older-session-token",
-      );
-    });
+    await seedStewardSession(page, { token: "older-session-token" });
 
     const frontendEvents: string[] = [];
     page.on("console", (message) =>
@@ -114,13 +110,15 @@ for (const viewport of VIEWPORTS) {
       });
     });
 
-    await page.goto("/login");
+    await page.goto("/login?error=oauth_failed&reason=server_error");
+    await expect(page).toHaveURL(/\/login$/, { timeout: 45_000 });
     await expect(
       page.getByRole("status", { name: "Loading sign-in options" }),
     ).toBeVisible();
     await expect(
       page.getByRole("textbox", { name: "Phone number" }),
     ).toHaveCount(0);
+    await page.waitForTimeout(250);
     await screenshot(page, testInfo, `${viewport.name}-1-recovery-pending`);
 
     releaseRecovery?.();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.phone-login.test.tsx
@@ -354,6 +354,22 @@ describe("StewardLoginSection phone login", () => {
     expect(returnToSpies.resolve).not.toHaveBeenCalled();
   });
 
+  it("keeps login hidden when callback-error cleanup starts session recovery", async () => {
+    sessionSpies.storedToken = "older-session-token";
+    sessionSpies.sync.mockReturnValueOnce(new Promise<void>(() => undefined));
+
+    renderSection("/login?error=oauth_failed&reason=server_error");
+
+    await waitFor(() =>
+      expect(sessionSpies.sync).toHaveBeenCalledWith(
+        "older-session-token",
+        null,
+      ),
+    );
+    expect(screen.queryByLabelText("Phone number")).toBeNull();
+    expect(screen.getByLabelText("Loading sign-in options")).toBeTruthy();
+  });
+
   it("verifies six digits through the existing session completion authority", async () => {
     renderSection("/login?returnTo=%2Fdashboard%2Fagents");
     await sendPhoneCode();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -838,6 +838,7 @@ export default function StewardLoginSection() {
       return;
     }
 
+    setSessionRecoveryComplete(false);
     let cancelled = false;
 
     const tryRecoverSession = async () => {


### PR DESCRIPTION
## Summary

- reset the session-recovery gate before every non-callback stored-session recovery
- keep phone/email login authority hidden while callback-error URL cleanup starts the stale-session request
- cover the exact callback-error race in unit and real Chromium desktop/mobile flows using the canonical session seeder

Fixes #24852.

## Verification

Exact head: `c0d72810bbecabc32d54ee0d643cdc574bbf01f5`

- `vitest` phone-login recovery: 12 passed
- `packages/ui` typecheck: passed
- scoped Biome and `git diff --check`: passed
- Chromium desktop/mobile callback-recovery walkthrough: 2 passed
- full app audit: 225/227; the two failures are pre-existing unrelated `builtin-relationships` startup timeout and `builtin-settings` density verdicts, with no changed view implicated

## Evidence

<!-- evidence-head:c0d72810bbecabc32d54ee0d643cdc574bbf01f5 -->
<!-- evidence-row:before-screenshots -->
[Desktop regression capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24876-desktop-before-phone-exposed.jpg) — callback error cleanup exposes fresh-login controls while stale-session recovery is still pending.
<!-- evidence-row:after-screenshots -->
[Desktop corrected capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24876-desktop-after-recovery-pending.jpg) — the exact-head UI remains in the recovery loading state with fresh-login controls absent.
<!-- evidence-row:walkthrough-video -->
[Exact-head desktop walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24876-desktop-walkthrough.mp4)
<!-- evidence-row:backend-logs -->
N/A - The real browser test fixes only HTTP responses at the Playwright network boundary; no backend process behavior changes.
<!-- evidence-row:frontend-logs -->
[Exact-head console/network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24876-desktop-frontend.log)
<!-- evidence-row:llm-trajectory -->
N/A - Authentication session recovery does not invoke a model.
<!-- evidence-row:domain-artifacts -->
[Exact-head mobile recovery artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24876-mobile-after-recovery-pending.jpg)
<!-- evidence-row:ocr-review -->
[OCR and visual inspection](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24876-ocr-review.md)

## Attribution

Implementation and evidence prepared by OpenAI Codex under maintainer direction. The original session-recovery implementation remains attributed to its original contributors.
