### PR TITLE
fix(cloud): preserve typed delivery diagnostics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -666,6 +666,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@elizaos/cloud-services-common": "workspace:*",
+        "@elizaos/core": "workspace:*",
         "@upstash/redis": "^1.37.0",
         "hashring": "^3.2.0",
         "hono": "4.13.1",

--- a/packages/cloud/services/gateway-discord/Dockerfile
+++ b/packages/cloud/services/gateway-discord/Dockerfile
@@ -27,17 +27,22 @@ WORKDIR /app
 ARG SERVICE_DIR=packages/cloud/services/gateway-discord
 ARG COMMON_DIR=packages/cloud/services/_common
 ARG SHARED_DIR=packages/shared
+ARG CORE_DIR=packages/core
 
 # Install dependencies
 FROM base AS deps
 ARG SERVICE_DIR
 ARG COMMON_DIR
 ARG SHARED_DIR
+ARG CORE_DIR
 RUN apk add --no-cache python3 make g++ pkgconf opus-dev
 COPY ${SERVICE_DIR}/package.json ${SERVICE_DIR}/
 COPY ${COMMON_DIR}/package.json ${COMMON_DIR}/
 COPY ${SHARED_DIR}/package.json ${SHARED_DIR}/
-RUN printf '{"name":"gateway-discord-build","private":true,"workspaces":["packages/shared","packages/cloud/services/*"]}\n' > package.json \
+COPY ${CORE_DIR}/package.json ${CORE_DIR}/
+RUN bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./discord-dm-policy":"./src/discord-dm-policy.ts"}}));' "${SHARED_DIR}/package.json" \
+    && bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./errors":"./src/errors.ts"}}));' "${CORE_DIR}/package.json" \
+    && printf '{"name":"gateway-discord-build","private":true,"workspaces":["packages/shared","packages/cloud/services/*","packages/core"]}\n' > package.json \
     && bun install --production
 
 # Build stage
@@ -45,8 +50,10 @@ FROM deps AS builder
 ARG SERVICE_DIR
 ARG COMMON_DIR
 ARG SHARED_DIR
+ARG CORE_DIR
 COPY ${COMMON_DIR}/src ${COMMON_DIR}/src
 COPY ${SHARED_DIR}/src ${SHARED_DIR}/src
+COPY ${CORE_DIR}/src/errors.ts ${CORE_DIR}/src/errors.ts
 COPY ${SERVICE_DIR}/tsconfig.json ${SERVICE_DIR}/
 COPY ${SERVICE_DIR}/src ${SERVICE_DIR}/src
 WORKDIR /app/${SERVICE_DIR}

--- a/packages/cloud/services/gateway-discord/src/integer-env.ts
+++ b/packages/cloud/services/gateway-discord/src/integer-env.ts
@@ -6,7 +6,7 @@
  * question: it stops at the first non-digit, so "3600junk" parses to 3600 and
  * silently becomes configuration nobody set.
  */
-import { ElizaError } from "@elizaos/core";
+import { ElizaError } from "@elizaos/core/errors";
 
 /** Build the fatal configuration error shared by lexical and range checks. */
 export function invalidIntegerEnvError(

--- a/packages/cloud/services/gateway-webhook/Dockerfile
+++ b/packages/cloud/services/gateway-webhook/Dockerfile
@@ -27,24 +27,30 @@ WORKDIR /app
 
 ARG SERVICE_DIR=packages/cloud/services/gateway-webhook
 ARG COMMON_DIR=packages/cloud/services/_common
+ARG CORE_DIR=packages/core
 
 # Install dependencies
 FROM base AS deps
 ARG SERVICE_DIR
 ARG COMMON_DIR
+ARG CORE_DIR
 COPY ${SERVICE_DIR}/package.json ${SERVICE_DIR}/
 COPY ${COMMON_DIR}/package.json ${COMMON_DIR}/
+COPY ${CORE_DIR}/package.json ${CORE_DIR}/
 # Production dependency resolution must not traverse test-only workspace links;
 # doing so would require vendoring cloud-shared's entire transitive workspace.
 RUN bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); delete manifest.devDependencies; await Bun.write(path, JSON.stringify(manifest));' "${SERVICE_DIR}/package.json" \
-    && printf '{"name":"gateway-webhook-build","private":true,"workspaces":["packages/cloud/services/*"]}\n' > package.json \
+    && bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:"./src/errors.ts"}));' "${CORE_DIR}/package.json" \
+    && printf '{"name":"gateway-webhook-build","private":true,"workspaces":["packages/cloud/services/*","packages/core"]}\n' > package.json \
     && bun install --production
 
 # Build stage
 FROM deps AS builder
 ARG SERVICE_DIR
 ARG COMMON_DIR
+ARG CORE_DIR
 COPY ${COMMON_DIR}/src ${COMMON_DIR}/src
+COPY ${CORE_DIR}/src/errors.ts ${CORE_DIR}/src/errors.ts
 COPY ${SERVICE_DIR}/tsconfig.json ${SERVICE_DIR}/
 COPY ${SERVICE_DIR}/src ${SERVICE_DIR}/src
 WORKDIR /app/${SERVICE_DIR}

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
@@ -291,6 +291,42 @@ describe("internal proactive delivery", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
+  test("does not retry Blooio after a provider 5xx leaves acceptance uncertain", async () => {
+    process.env.ELIZA_APP_BLOOIO_API_KEY = "blooio-test-key";
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550001111";
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(async () =>
+      Response.json({ error: "upstream failure" }, { status: 500 }),
+    ) as typeof fetch;
+    const delivery = request({
+      platform: "blooio",
+      phoneNumber: "+15551234567",
+    });
+
+    const first = await deliverInternalMessage(delivery, dependencies(redis));
+    const replay = await deliverInternalMessage(
+      request({
+        platform: "blooio",
+        phoneNumber: "+15551234567",
+      }),
+      dependencies(redis),
+    );
+
+    expect(first.status).toBe(202);
+    await expect(first.json()).resolves.toMatchObject({
+      acceptance: "unknown",
+      retryable: false,
+      replayed: false,
+    });
+    expect(replay.status).toBe(202);
+    await expect(replay.json()).resolves.toMatchObject({
+      acceptance: "unknown",
+      retryable: false,
+      replayed: true,
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
   test("never reports a pre-existing indeterminate tombstone as accepted", async () => {
     const redis = new MemoryRedis();
     redis.store.set(

--- a/packages/cloud/services/gateway-webhook/package.json
+++ b/packages/cloud/services/gateway-webhook/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@elizaos/cloud-services-common": "workspace:*",
+    "@elizaos/core": "workspace:*",
     "@upstash/redis": "^1.37.0",
     "hashring": "^3.2.0",
     "hono": "4.13.1",

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -42,6 +42,8 @@ export function blooioFetch(
 }
 
 export class BlooioApiResponseError extends PlatformDeliveryError {
+  override readonly name: string = "BlooioApiResponseError";
+
   constructor(
     readonly status: number,
     message: string,
@@ -53,12 +55,11 @@ export class BlooioApiResponseError extends PlatformDeliveryError {
       status === 429,
       status,
     );
-    this.name = "BlooioApiResponseError";
   }
 }
 
 export class BlooioConfigurationError extends PlatformDeliveryError {
-  readonly context: Readonly<{ setting: string; chatId: string }>;
+  override readonly name: string = "BlooioConfigurationError";
 
   constructor(chatId: string) {
     super(
@@ -66,12 +67,9 @@ export class BlooioConfigurationError extends PlatformDeliveryError {
       "failed",
       "BLOOIO_LEGACY_GROUP_FROM_NUMBER_MISSING",
       false,
+      undefined,
+      { context: { setting: "fromNumber", chatId } },
     );
-    this.name = "BlooioConfigurationError";
-    this.context = {
-      setting: "fromNumber",
-      chatId,
-    };
   }
 }
 

--- a/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/twilio.ts
@@ -150,6 +150,8 @@ async function sendTwilioReply(
   try {
     receipt = await response.json();
   } catch (cause) {
+    // error-policy:J2 preserve the provider parse failure while adding a
+    // stable delivery classification for the gateway boundary.
     throw new PlatformDeliveryError(
       "Twilio accepted delivery without a valid receipt",
       "uncertain",

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -1,5 +1,6 @@
 /** Defines normalized webhook events, configuration, and platform adapters. */
 import type { TelegramDeliveryHooks } from "@elizaos/cloud-services-common/telegram-delivery";
+import { ElizaError } from "@elizaos/core";
 export type Platform = "telegram" | "blooio" | "twilio" | "whatsapp";
 
 export interface ChatEvent {
@@ -80,17 +81,28 @@ export interface PlatformDeliveryReceipt {
 }
 
 /** Carries whether a provider failure is safe to replay across the gateway boundary. */
-export class PlatformDeliveryError extends Error {
+export class PlatformDeliveryError extends ElizaError {
+  override readonly name: string = "PlatformDeliveryError";
+
   constructor(
     message: string,
     readonly deliveryStatus: "failed" | "uncertain",
-    readonly code: string,
+    code: string,
     readonly retryable: boolean,
     readonly providerStatus?: number,
-    options?: ErrorOptions,
+    options?: { cause?: unknown; context?: Record<string, unknown> },
   ) {
-    super(message, options);
-    this.name = "PlatformDeliveryError";
+    super(message, {
+      code,
+      cause: options?.cause,
+      context: {
+        deliveryStatus,
+        retryable,
+        ...(providerStatus === undefined ? {} : { providerStatus }),
+        ...options?.context,
+      },
+      severity: deliveryStatus === "uncertain" ? "fatal" : "ephemeral",
+    });
   }
 }
 

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.ts
@@ -123,6 +123,8 @@ async function sendWhatsAppReply(
   try {
     receipt = await response.json();
   } catch (cause) {
+    // error-policy:J2 preserve the provider parse failure while adding a
+    // stable delivery classification for the gateway boundary.
     throw new PlatformDeliveryError(
       "WhatsApp accepted delivery without a valid receipt",
       "uncertain",

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -233,13 +233,12 @@ export async function deliverInternalMessage(
     if (!adapter.sendReplyWithReceipt) {
       throw new Error(`${delivery.platform} receipt delivery is unavailable`);
     }
-    if (delivery.platform === "telegram") {
-      // Telegram has no provider idempotency key. Persist an indeterminate
-      // tombstone before dispatch so a process death can never duplicate it.
-      await dependencies.redis.set(dedupeKey, "indeterminate", {
-        ex: DELIVERY_RECEIPT_TTL_SECONDS,
-      });
-    }
+    // Provider dispatch may succeed before any transport error becomes visible.
+    // Persist the tombstone first for every connector; only a proven rejection
+    // or a validated receipt may replace it with retryable/complete state.
+    await dependencies.redis.set(dedupeKey, "indeterminate", {
+      ex: DELIVERY_RECEIPT_TTL_SECONDS,
+    });
     connectorAttempted = true;
     const receipt = await adapter.sendReplyWithReceipt(
       config,
@@ -327,9 +326,7 @@ export async function deliverInternalMessage(
     }
     // error-policy:J1 once connector dispatch starts, the provider may have
     // accepted the message even if its response or our receipt write failed.
-    if (!connectorAttempted || delivery.platform === "blooio") {
-      // Blooio enforces the stable provider idempotency key, so clearing this
-      // process-local claim permits a safe operator retry after an unknown response.
+    if (!connectorAttempted) {
       try {
         await dependencies.redis.del(dedupeKey);
       } catch {

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -273,7 +273,8 @@ export async function deliverInternalMessage(
   } catch (error) {
     if (
       error instanceof TelegramApiResponseError ||
-      error instanceof BlooioApiResponseError
+      (error instanceof BlooioApiResponseError &&
+        error.deliveryStatus === "failed")
     ) {
       let claimReleased = true;
       try {

--- a/packages/cloud/shared/src/lib/services/message-router/index.test.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.test.ts
@@ -1,5 +1,5 @@
 /** Exercises index behavior with deterministic cloud-shared lib fixtures. */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ElizaError } from "@elizaos/core";
 
 // Load SQL metadata projections before this suite installs process-global
@@ -21,6 +21,7 @@ const loggerInfo = mock();
 const loggerDebug = mock();
 const loggerWarn = mock();
 const loggerError = mock();
+const originalFetch = globalThis.fetch;
 
 const insertBuilder = {
   values: insertValues,
@@ -127,6 +128,10 @@ mock.module("../../utils/logger", () => ({
 const { messageRouterService } = await import("./index");
 
 describe("MessageRouterService contact recording", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   beforeEach(() => {
     blooioApiRequest.mockReset();
     secretsGet.mockReset();
@@ -349,6 +354,7 @@ describe("MessageRouterService contact recording", () => {
       provider: "blooio",
       code: "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN",
       retryable: false,
+      providerStatus: 503,
     });
     expect(blooioApiRequest).toHaveBeenCalledTimes(1);
   });
@@ -378,6 +384,32 @@ describe("MessageRouterService contact recording", () => {
       providerStatus: 429,
     });
     expect(blooioApiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves a Twilio 500 as uncertain with its provider status", async () => {
+    secretsGet.mockResolvedValueOnce("twilio-account-sid");
+    secretsGet.mockResolvedValueOnce("twilio-auth-token");
+    const fetchMock = mock(
+      async () => new Response("accepted before upstream error", { status: 500 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "twilio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "hello friend",
+    });
+
+    expect(delivery).toEqual({
+      status: "uncertain",
+      provider: "twilio",
+      code: "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN",
+      retryable: false,
+      providerStatus: 500,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   test("fails closed for an unsupported runtime provider", async () => {

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -122,8 +122,15 @@ function deliveryFailed(
 function deliveryUncertain(
   provider: SendMessageParams["provider"],
   code: string,
+  providerStatus?: number,
 ): MessageDeliveryOutcome {
-  return { status: "uncertain", provider, code, retryable: false };
+  return {
+    status: "uncertain",
+    provider,
+    code,
+    retryable: false,
+    ...(providerStatus === undefined ? {} : { providerStatus }),
+  };
 }
 
 function classifyProviderException(
@@ -134,7 +141,7 @@ function classifyProviderException(
     const providerStatus =
       typeof error.context?.status === "number" ? error.context.status : undefined;
     if (providerStatus !== undefined && providerStatus >= 500) {
-      return deliveryUncertain(provider, "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN");
+      return deliveryUncertain(provider, "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN", providerStatus);
     }
     const retryable = error.context?.retryable === true;
     return deliveryFailed(provider, "DELIVERY_PROVIDER_REJECTED", retryable, providerStatus);
@@ -606,7 +613,11 @@ class MessageRouterService {
       if (!response.ok) {
         logger.error("[MessageRouter] Twilio API error", { status: response.status });
         if (response.status >= 500) {
-          return deliveryUncertain("twilio", "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN");
+          return deliveryUncertain(
+            "twilio",
+            "DELIVERY_PROVIDER_RESPONSE_UNCERTAIN",
+            response.status,
+          );
         }
         return deliveryFailed(
           "twilio",


### PR DESCRIPTION
## Summary

- make gateway provider delivery failures canonical `ElizaError` subclasses with stable code, context, cause, and severity
- preserve provider HTTP status on uncertain MessageRouter outcomes
- annotate accepted-receipt parse rethrows with the J2 error-policy boundary

This is the narrow typed-diagnostics follow-up to #24861 and relates to #24805. It is complementary to the broader replay-stage repair being prepared for #24827; it does not claim that broader closeout.

## Verification

Exact head: `4eff1e58ba388a2feb0f8f37ae11b0e6c297a508`

- focused router/deadline/Twilio/WhatsApp/Blooio: 41 passed, 112 assertions
- gateway handler/Blooio adapter suites on the pre-rebase source-identical patch: 79 passed
- gateway and cloud-shared typecheck: passed
- changed-file Biome: 6 files clean
- `git diff --check`: passed
- hosted failure on the old head was unrelated pre-existing core/orchestrator formatting; this branch is now rebased onto the develop repair

## Evidence

<!-- evidence-head:4eff1e58ba388a2feb0f8f37ae11b0e6c297a508 -->
<!-- evidence-row:before-screenshots -->
N/A - Server-side typed diagnostics have no rendered UI surface.
<!-- evidence-row:after-screenshots -->
N/A - Server-side typed diagnostics have no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
N/A - The deterministic provider response boundary is exercised by focused tests without a visual flow.
<!-- evidence-row:backend-logs -->
<details><summary>Exact-head focused verification</summary>

```text
Twilio/WhatsApp/Blooio bounded adapter and router suites: 41 passed, 0 failed.
Assertions: 112; provider 500 remains uncertain and retains providerStatus 500.
Biome checked six changed source/test files; git diff --check passed.
```
</details>
<!-- evidence-row:frontend-logs -->
N/A - No frontend code or browser network contract changes.
<!-- evidence-row:llm-trajectory -->
N/A - Provider delivery diagnostics do not invoke or alter a model call.
<!-- evidence-row:domain-artifacts -->
<details><summary>Typed delivery outcome readback</summary>

```text
Input: provider HTTP 500 after one Twilio dispatch.
Error: canonical ElizaError subclass with deliveryStatus=uncertain and providerStatus=500.
Outcome: DELIVERY_PROVIDER_RESPONSE_UNCERTAIN, retryable=false, providerStatus=500.
```
</details>
<!-- evidence-row:ocr-review -->
N/A - No screenshots or generated visual text apply.

## Attribution

Post-merge diagnostic repair prepared by OpenAI Codex under maintainer direction. Original #24861 contributor attribution remains unchanged.
