### PR TITLE
fix(plugin-x): enforce complete discovery generations

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -286,7 +286,7 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/draft\.body\.(?:slice|substring)\(/,
 	],
 	"plugins/plugin-x/src/discovery.ts": [
-		/maxTokens:\s*100/,
+		/\bmaxTokens\s*:/,
 		/(?:replyText|quoteText|response)\.(?:slice|substring)\(/,
 	],
 	"plugins/plugin-anthropic/models/image.ts": [/firstLine\.slice\(/],
@@ -574,5 +574,14 @@ describe("prompt integrity policy", () => {
 			const source = readFileSync(sourcePath, "utf8");
 			expect(source, sourcePath).not.toMatch(/truncation\s*=\s*True/);
 		}
+	});
+
+	it("keeps X discovery drafts on the provider-maximum output contract", () => {
+		const source = readFileSync(
+			resolve(repositoryRoot, "plugins/plugin-x/src/discovery.ts"),
+			"utf8",
+		);
+		expect(source.match(/omitMaxTokens:\s*true/g)).toHaveLength(2);
+		expect(source).toMatch(/X_DISCOVERY_DRAFT_PROVIDER_TRUNCATED/);
 	});
 });

--- a/plugins/plugin-x/src/discovery.test.ts
+++ b/plugins/plugin-x/src/discovery.test.ts
@@ -1,6 +1,7 @@
 /** Exercises discovery-cycle session binding, fail-closed read behavior, and the engagement dedup guard (#22710) with deterministic provider fakes. */
 import {
   createUniqueUuid,
+  type GenerateTextResult,
   type IAgentRuntime,
   type Memory,
   type UUID,
@@ -185,7 +186,7 @@ type EngagementRuntimeHandle = {
  * that #22710 broke.
  */
 function makeEngagementRuntime(
-  replyText = "a thoughtful reply",
+  replyText: string | GenerateTextResult = "a thoughtful reply",
 ): EngagementRuntimeHandle {
   const memories = new Map<string, Memory>();
   const runtime = {
@@ -204,7 +205,7 @@ function makeEngagementRuntime(
     updateWorld: vi.fn(async () => {}),
     ensureRoomExists: vi.fn(async () => {}),
     ensureConnection: vi.fn(async () => {}),
-    useModel: vi.fn(async () => replyText),
+    useModel: vi.fn(async () => replyText as never),
   } as unknown as IAgentRuntime;
   return { runtime, memories };
 }
@@ -343,12 +344,18 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
       "welcome to the timeline",
       "1750000000000000001",
     );
+    expect(useModel.mock.calls[0]?.[1]).toMatchObject({
+      omitMaxTokens: true,
+    });
     expect(useModel.mock.calls[0]?.[1]).not.toHaveProperty("maxTokens");
     expect(likeTweet).not.toHaveBeenCalled();
   });
 
   it("does not impose hidden model-output caps on reply or quote drafts", async () => {
-    const { runtime } = makeEngagementRuntime("complete draft");
+    const { runtime } = makeEngagementRuntime({
+      text: "complete draft",
+      finishReason: "stop",
+    });
     const useModel = runtime.useModel as ReturnType<typeof vi.fn>;
     const { client } = makeEngagementClient();
     const discovery = new TwitterDiscoveryClient(
@@ -366,8 +373,67 @@ describe("TwitterDiscoveryClient engagement dedup (#22710)", () => {
     );
 
     for (const [, request] of useModel.mock.calls) {
+      expect(request).toMatchObject({
+        messages: [
+          {
+            role: "user",
+            content: expect.stringMatching(/under 280 characters/i),
+          },
+        ],
+        omitMaxTokens: true,
+      });
+      expect(request).not.toHaveProperty("prompt");
       expect(request).not.toHaveProperty("maxTokens");
     }
+  });
+
+  it.each([
+    ["generateReply", "length"],
+    ["generateQuote", "MAX_TOKENS"],
+    ["generateReply", "output-limit"],
+  ] as const)(
+    "%s rejects provider completion-limit signal %s instead of accepting partial text",
+    async (method, finishReason) => {
+      const { runtime } = makeEngagementRuntime({
+        text: "This sounds complete but the provider says it was cut off",
+        finishReason,
+      });
+      const { client } = makeEngagementClient();
+      const discovery = new TwitterDiscoveryClient(
+        client,
+        runtime,
+        {} as TwitterClientState,
+      ) as unknown as DiscoveryHarness;
+
+      await expect(
+        discovery[method](scoredTweet("reply").tweet),
+      ).rejects.toMatchObject({
+        code: "X_DISCOVERY_DRAFT_PROVIDER_TRUNCATED",
+        context: { finishReason },
+      });
+    },
+  );
+
+  it("does not call X or persist a receipt for a provider-truncated draft", async () => {
+    const { runtime, memories } = makeEngagementRuntime({
+      text: "partial draft",
+      finishReason: "length",
+    });
+    const { client, session, sendTweet } = makeEngagementClient();
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+
+    await expect(
+      discovery.processTweets([scoredTweet("reply")], session),
+    ).rejects.toMatchObject({
+      code: "X_DISCOVERY_EFFECT_FAILED",
+      cause: { code: "X_DISCOVERY_DRAFT_PROVIDER_TRUNCATED" },
+    });
+    expect(sendTweet).not.toHaveBeenCalled();
+    expect(memories).toHaveProperty("size", 0);
   });
 
   it("rejects a complete overlength draft instead of clipping it", async () => {

--- a/plugins/plugin-x/src/discovery.ts
+++ b/plugins/plugin-x/src/discovery.ts
@@ -8,6 +8,7 @@
 import {
   createUniqueUuid,
   ElizaError,
+  type GenerateTextResult,
   type IAgentRuntime,
   logger,
   type Memory,
@@ -38,7 +39,52 @@ interface DiscoveryConfig {
   quoteThreshold: number;
 }
 
-function validateCompleteDraft(text: string): string {
+const COMPLETION_LIMIT_REASON =
+  /\b(?:length|max[-_\s]?tokens?|token[-_\s]?limit|output[-_\s]?limit)\b/iu;
+
+function extractDraftText(result: string | GenerateTextResult): string {
+  if (typeof result === "string") return result;
+
+  const finishReason = result.finishReason?.trim() ?? "";
+  if (COMPLETION_LIMIT_REASON.test(finishReason)) {
+    throw new ElizaError(
+      `X draft generation stopped at the provider completion limit (${finishReason})`,
+      {
+        code: "X_DISCOVERY_DRAFT_PROVIDER_TRUNCATED",
+        context: { finishReason },
+      },
+    );
+  }
+
+  if (typeof result.text === "string" && result.text.trim().length > 0) {
+    return result.text;
+  }
+  if (typeof result.content === "string" && result.content.trim().length > 0) {
+    return result.content;
+  }
+  if (Array.isArray(result.content)) {
+    const contentText = result.content
+      .filter(
+        (part) =>
+          part.type === undefined ||
+          part.type === "text" ||
+          part.type === "output_text",
+      )
+      .map((part) => part.text ?? part.content ?? "")
+      .join("");
+    if (contentText.trim().length > 0) return contentText;
+  }
+  if (typeof result.response === "string") return result.response;
+  return result.text;
+}
+
+function validateCompleteDraft(result: string | GenerateTextResult): string {
+  const text = extractDraftText(result).trim();
+  if (text.length === 0) {
+    throw new ElizaError("X draft generation returned no complete text", {
+      code: "X_DISCOVERY_DRAFT_EMPTY",
+    });
+  }
   const weightedLength = countTwitterWeightedLength(text);
   if (weightedLength > TWEET_MAX_LENGTH) {
     throw new ElizaError(
@@ -974,12 +1020,13 @@ Keep the reply:
 
 Reply:`;
 
-    const response = await this.runtime.useModel(ModelType.TEXT_SMALL, {
-      prompt,
+    const response = (await this.runtime.useModel(ModelType.TEXT_SMALL, {
+      messages: [{ role: "user", content: prompt }],
+      omitMaxTokens: true,
       temperature: 0.8,
-    });
+    })) as string | GenerateTextResult;
 
-    return validateCompleteDraft(response.trim());
+    return validateCompleteDraft(response);
   }
 
   private async generateQuote(tweet: DiscoveryTweet): Promise<string> {
@@ -1011,12 +1058,13 @@ Create a quote tweet that:
 
 Quote tweet:`;
 
-    const response = await this.runtime.useModel(ModelType.TEXT_SMALL, {
-      prompt,
+    const response = (await this.runtime.useModel(ModelType.TEXT_SMALL, {
+      messages: [{ role: "user", content: prompt }],
+      omitMaxTokens: true,
       temperature: 0.8,
-    });
+    })) as string | GenerateTextResult;
 
-    return validateCompleteDraft(response.trim());
+    return validateCompleteDraft(response);
   }
 
   private async saveEngagementMemory(


### PR DESCRIPTION
# Relates to

Closes #24834. Post-merge correction to #24846.

- [x] Targets `develop` and is rebased onto `c1029a4014c4aa70b15e59f901a461a9edb1a3e3` with zero conflicts.
- [ ] `bun install` and root `bun run verify` were not rerun in this sparse audit checkout; exact affected-package gates and the repository policy test are recorded below.
- [x] A reviewer can confirm the failure behavior from the regression tests and exact request assertions below.

# Risks

Medium. Discovery reply/quote generation now requests the provider/model output maximum and asks for the native message result so completion metadata is preserved. The behavior is limited to the opt-in autonomous X discovery loop. Oversized, empty, or provider-truncated drafts fail before any X write or receipt persistence.

# Background

## What does this PR do?

PR #24846 removed `maxTokens: 100`, but omission alone still caused hosted adapters to inject their normal default cap (for example, 8192 tokens). Its prompt-only result also collapsed provider `finishReason`, so a `length`/`MAX_TOKENS` partial completion could still look like a valid draft.

This correction:

- sends `omitMaxTokens: true` for both discovery draft calls;
- uses the native message result path so provider completion metadata survives;
- rejects `length`, `MAX_TOKENS`, and output-limit completion reasons with `X_DISCOVERY_DRAFT_PROVIDER_TRUNCATED`;
- rejects empty and X-weighted overlength drafts before side effects;
- proves a truncated draft neither calls X nor persists an engagement receipt; and
- strengthens the repository source guard against any restored explicit `maxTokens` cap while requiring the provider-maximum/truncation contract.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. The existing plugin documentation already states that oversized posts fail without rewriting; this change makes discovery honor that contract at the model boundary.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/discovery.test.ts`, especially the native-result, provider-limit, Unicode weighted-length, and no-external-effect cases.

## Detailed testing steps

- `bunx vitest run src/discovery.test.ts` in `plugins/plugin-x`: 12 passed.
- `bun run test` in `plugins/plugin-x`: 362 passed, 13 skipped.
- `bun run typecheck` in `plugins/plugin-x`: passed.
- `bun run lint:check` in `plugins/plugin-x`: 100 files clean.
- `bun run build` in `plugins/plugin-x`: ESM and DTS builds passed.
- `bun run typecheck` in `packages/core`: passed.
- `bun test packages/core/src/__tests__/prompt-integrity-policy.test.ts`: 6 passed / 751 assertions on the immediately preceding rebased head; after the final unrelated `develop` sync, the X-specific policy test passed at this exact head.
- `git diff --check origin/develop...HEAD`: passed.

# Evidence Gate

<!-- evidence-head:48d22cd141ad3f40a417fc60477e3f4d25edeaa2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the corrected failure path intentionally stops before an external X request; the regression asserts `sendTweet` is never called and no receipt is persisted.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no live provider/X credentials were exercised in this isolated audit lane; deterministic native-result fixtures cover the provider completion metadata and exact outbound model request contract.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the required domain outcome is absence of an X effect and receipt, asserted directly by the focused test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no live provider/X credentials were exercised. The exact boundary fixtures return metadata-bearing native completions, including three provider limit spellings, and the effect-level test proves fail-closed delivery.

## Backend + frontend logs

N/A - no frontend path. The failure occurs before the backend connector write; automated assertions are the review artifact.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun install` / `bun run verify` were not run because this is a sparse audit checkout that intentionally omits most workspaces. The complete affected `plugin-x` suite, package build/typecheck/lint, core typecheck, repository policy test, and diff check passed.
- No live X/model trajectory was captured because this lane did not have or exercise external posting credentials. The change is fail-closed and the effect boundary is asserted with deterministic provider output.

## Maintainer CI exception record

N/A - no exception requested.

AI provider/model: openai / GPT-5
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop"} -->
