### PR TITLE
fix(agent): persist terminal failures on durable replies

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -900,6 +900,59 @@ describe("conversation-route chat idempotency wiring", () => {
     },
   );
 
+  it("reconciles typed terminal metadata onto an already-persisted message-service row", async () => {
+    const { state, handleMessage, storedMemories, updateMemory } =
+      createHarness();
+    const persistedId = stringToUuid("typed-terminal-existing-assistant");
+    handleMessage.mockImplementationOnce(
+      async (runtime: AgentRuntime, message: Memory) => {
+        const persisted: Memory = {
+          id: persistedId,
+          entityId: runtime.agentId,
+          agentId: runtime.agentId,
+          roomId: message.roomId,
+          content: {
+            text: "Shell execution failed.",
+            failureKind: "coding_tool_failure",
+            transient: true,
+            inReplyTo: message.id,
+          },
+        };
+        await runtime.createMemory(persisted, "messages");
+        return {
+          didRespond: true,
+          responseContent: persisted.content,
+          responseMessages: [persisted],
+          persistedResponseMessageIds: [persistedId],
+          terminalFailure: {
+            kind: "coding_tool_failure",
+            message: "Shell execution failed.",
+            transient: true,
+            code: "SHELL_UNAVAILABLE",
+          },
+        };
+      },
+    );
+
+    await runRoute("POST", SEND_PATH, state, {
+      text: "fix the code",
+      clientMessageId: "typed-terminal-existing-row-1",
+    });
+
+    expect(updateMemory).toHaveBeenCalled();
+    expect(
+      storedMemories.find((memory) => memory.id === persistedId)?.content,
+    ).toMatchObject({
+      failureKind: "coding_tool_failure",
+      terminalFailure: {
+        kind: "coding_tool_failure",
+        message: "Shell execution failed.",
+        transient: true,
+        code: "SHELL_UNAVAILABLE",
+      },
+    });
+  });
+
   it("SSE: a retry joins the active turn and replays its durable outcome", async () => {
     const { state, handleMessage } = createHarness();
     let releaseTurn: (() => void) | undefined;

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1041,10 +1041,21 @@ async function resolvePersistedAssistantTurn(
       result,
       userMessageId,
     );
+    const generatedTerminalFailure = parseChatTerminalFailure(
+      generatedTurn.content.terminalFailure,
+    );
+    const terminalFailureNeedsReconciliation =
+      result.terminalFailure !== undefined &&
+      (generatedTerminalFailure?.kind !== result.terminalFailure.kind ||
+        generatedTerminalFailure?.message !== result.terminalFailure.message ||
+        generatedTerminalFailure?.transient !==
+          result.terminalFailure.transient ||
+        generatedTerminalFailure?.code !== result.terminalFailure.code);
     if (
       generatedText !== text ||
       (userMessageId !== undefined &&
-        generatedTurn.content.inReplyTo !== userMessageId)
+        generatedTurn.content.inReplyTo !== userMessageId) ||
+      terminalFailureNeedsReconciliation
     ) {
       try {
         await runtime.roomHandlerQueue.runInLease(


### PR DESCRIPTION
## Summary

- reconcile an already-persisted assistant reply when its durable terminal-failure metadata differs from the completed runtime result
- preserve the existing text/reply-id idempotency while making reloads retain failure kind, message, code, and transience
- add a real persisted-row regression for the matching-text/matching-reply-id case missed by #24825

Relates to #24753. This is a narrow post-merge correction and does not close the broader scenario/trigger/orchestrator terminal-failure acceptance.

## Verification

Exact head: `1e9ff7e6aed8b39630e679420bf320331483981b`

- conversation idempotency: 41/41 passed on the final rebased head
- broader prior synthesis: agent focused 152/152; shared contract 6/6; UI focused 352/352
- agent build, UI build/typecheck, shared build/typecheck/lint, agent lint, changed-file Biome, and diff check passed
- agent typecheck remains blocked only by known optional workspace export materialization gaps outside this two-file diff

## Evidence

<!-- evidence-head:1e9ff7e6aed8b39630e679420bf320331483981b -->
<!-- evidence-row:before-screenshots -->
N/A - This server persistence correction has no rendered UI change.
<!-- evidence-row:after-screenshots -->
N/A - This server persistence correction has no rendered UI change.
<!-- evidence-row:walkthrough-video -->
N/A - The deterministic durable-row contract is exercised in Vitest without a visual flow.
<!-- evidence-row:backend-logs -->
<details><summary>Exact-head backend verification</summary>

```text
Test Files  1 passed (1)
Tests       41 passed (41)
Biome       Checked 2 files; no fixes applied; git diff --check passed
```
</details>
<!-- evidence-row:frontend-logs -->
N/A - No frontend code or network contract changes.
<!-- evidence-row:llm-trajectory -->
N/A - The correction reconciles an already-completed assistant result and does not invoke or alter a model call.
<!-- evidence-row:domain-artifacts -->
<details><summary>Durable-row artifact contract</summary>

```text
Seed: persisted core-style assistant row with matching text and inReplyTo but absent terminalFailure metadata.
Action: resolvePersistedAssistantTurn reconciles the row against result.terminalFailure.
Readback: kind, message, code, and transient survive the durable responseContent reload path.
```
</details>
<!-- evidence-row:ocr-review -->
N/A - No screenshots or generated visual text apply.

## Attribution

Post-merge audit and corrective implementation prepared by OpenAI Codex under maintainer direction. The original #24825 work remains attributed to its contributors.

