### PR TITLE
fix(core): detach follow-up worker without deleting pending rows

### DIFF
--- a/packages/core/src/services/follow-up.test.ts
+++ b/packages/core/src/services/follow-up.test.ts
@@ -1,7 +1,8 @@
 /**
- * Tests for FollowUpService lifecycle: a completed follow-up must never fire
- * through the task scheduler and its completion record must survive. Driven
- * by fake timers over the real TaskService tick loop with an in-memory store.
+ * Tests for FollowUpService lifecycle: completed or stopped follow-ups must
+ * never fire through the task scheduler, persisted rows must survive service
+ * teardown, and restart must install exactly one live worker. Driven by fake
+ * timers over the real TaskService tick loop with an in-memory store.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UUID } from "../types/primitives";
@@ -45,6 +46,7 @@ function makeRuntime() {
 			workers.set(worker.name, worker);
 		},
 		getTaskWorker: (name: string) => workers.get(name),
+		unregisterTaskWorker: (name: string) => workers.delete(name),
 		getServiceLoadPromise: async () => relationshipsService,
 		getEntityById: async (id: UUID) =>
 			id === ENTITY_ID ? { id, names: ["Test Contact"] } : null,
@@ -264,6 +266,60 @@ describe("FollowUpService completion lifecycle", () => {
 		expect(memories).toHaveLength(0);
 
 		await followUps.stop();
+	});
+
+	it("parks pending rows on stop and executes them exactly once after restart", async () => {
+		const { runtime, tasks, workers, memories } = makeRuntime();
+		const first = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+		const task = await first.scheduleFollowUp(
+			ENTITY_ID,
+			new Date(T0 + 5_000),
+			"survive relationships reload",
+		);
+		const liveWorker = workers.get("follow_up");
+		expect(liveWorker).toBeDefined();
+
+		await first.stop();
+		const parkedWorker = workers.get("follow_up");
+		expect(parkedWorker).toBeDefined();
+		expect(parkedWorker).not.toBe(liveWorker);
+		expect(await parkedWorker?.shouldRun?.(runtime, task)).toBe(false);
+
+		// TaskService's orphan grace has elapsed, but the exact persisted row is
+		// retained and the stopped service cannot emit a reminder.
+		await vi.advanceTimersByTimeAsync(70_000);
+		expect(memories).toHaveLength(0);
+		expect(tasks.get(task.id as string)).toEqual(task);
+
+		// Repeated stop is a no-op and must not replace the parking worker.
+		await first.stop();
+		expect(workers.get("follow_up")).toBe(parkedWorker);
+
+		const restarted = (await FollowUpService.start(runtime)) as FollowUpService;
+		expect(workers.get("follow_up")).not.toBe(parkedWorker);
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(memories).toHaveLength(1);
+		expect(tasks.has(task.id as string)).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(memories).toHaveLength(1);
+		await restarted.stop();
+	});
+
+	it("does not remove a newer worker that replaced its owned registration", async () => {
+		const { runtime, workers } = makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+		const replacement: TaskWorker = {
+			name: "follow_up",
+			execute: async () => undefined,
+		};
+		runtime.registerTaskWorker(replacement);
+
+		await followUps.stop();
+		await followUps.stop();
+
+		expect(workers.get("follow_up")).toBe(replacement);
 	});
 });
 

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -18,6 +18,19 @@ import type { Task, TaskWorker } from "../types/task";
 import { stringToUuid } from "../utils";
 import type { ContactInfo, RelationshipsService } from "./relationships.ts";
 
+const FOLLOW_UP_WORKER_NAME = "follow_up";
+
+/**
+ * Keeps one-shot follow-up rows out of TaskService's orphan deletion path while
+ * the relationships plugin is disabled. This worker is deliberately stateless:
+ * it captures no service/runtime and a later FollowUpService start replaces it.
+ */
+const PARKED_FOLLOW_UP_WORKER: TaskWorker = {
+	name: FOLLOW_UP_WORKER_NAME,
+	shouldRun: async () => false,
+	execute: async () => ({ preserveTask: true }),
+};
+
 export interface FollowUpTask {
 	entityId: UUID;
 	reason: string;
@@ -42,6 +55,7 @@ export class FollowUpService extends Service {
 		"Task-based follow-up scheduling and management for contacts";
 
 	private relationshipsService!: RelationshipsService;
+	private followUpWorker: TaskWorker | null = null;
 
 	constructor(runtime?: IAgentRuntime) {
 		super();
@@ -70,6 +84,21 @@ export class FollowUpService extends Service {
 	}
 
 	async stop(): Promise<void> {
+		const worker = this.followUpWorker;
+		if (
+			worker &&
+			this.runtime.getTaskWorker(FOLLOW_UP_WORKER_NAME) === worker
+		) {
+			// A missing worker makes TaskService delete queued one-shot follow-ups
+			// after its orphan grace period. Replace only our exact worker with a
+			// module-level parking worker: it retains no stopped service instance,
+			// never executes a reminder, and leaves every persisted task byte-for-byte
+			// intact for the next relationships-plugin start to reclaim.
+			this.runtime.unregisterTaskWorker(FOLLOW_UP_WORKER_NAME);
+			this.runtime.registerTaskWorker(PARKED_FOLLOW_UP_WORKER);
+		}
+		this.followUpWorker = null;
+
 		// relationshipsService will be cleaned up by the runtime
 		logger.info("[FollowUpService] Stopped successfully");
 	}
@@ -386,8 +415,15 @@ export class FollowUpService extends Service {
 
 	// Task Workers
 	private registerFollowUpWorker(): void {
+		if (
+			this.followUpWorker &&
+			this.runtime.getTaskWorker(FOLLOW_UP_WORKER_NAME) === this.followUpWorker
+		) {
+			return;
+		}
+
 		const worker: TaskWorker = {
-			name: "follow_up",
+			name: FOLLOW_UP_WORKER_NAME,
 			shouldRun: async (
 				runtime: IAgentRuntime,
 				task: Task,
@@ -484,6 +520,7 @@ export class FollowUpService extends Service {
 		};
 
 		this.runtime.registerTaskWorker(worker);
+		this.followUpWorker = worker;
 	}
 
 	// Helper Methods


### PR DESCRIPTION
# Relates to

Fixes #24878.

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `c1029a4014c4` with zero conflicts.
- [x] `bun install` completed on the final head. `bun run verify` was run; its unrelated upstream blocker is recorded below.
- [x] The lifecycle behavior is reproducible from the inline test evidence below.

# Sync with develop

- [x] Rebased onto the latest measured `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It is blocked by the clean-upstream `plugin-agent-orchestrator` lint failures recorded under **Known gaps / failures**.

# Risks

Low. The change affects only the native follow-up worker lifecycle. It guards removal by worker identity, so a stopped service cannot remove a newer registration. A module-level stateless parking worker preserves pending one-shot rows without holding a stopped service/runtime closure or allowing delivery.

# Background

## What does this PR do?

`FollowUpService.stop()` previously left its live `follow_up` TaskWorker registered. Disabling the native relationships plugin therefore allowed pending reminders to execute through a service that had already been unloaded.

This PR replaces only the exact worker owned by the stopping instance with a stateless parking worker. That adjacent behavior is load-bearing: simply unregistering the worker makes `TaskService` classify pending one-shot rows as orphans and delete them after its 60-second grace. Restart replaces the parking worker with one live worker and consumes each preserved row exactly once.

The stop path is idempotent and does not remove a newer replacement registration.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change. The existing TaskService orphan semantics remain unchanged; the regression test documents the service-specific lifecycle invariant.

# Testing

## Where should a reviewer start?

`packages/core/src/services/follow-up.test.ts`, test `parks pending rows on stop and executes them exactly once after restart`.

## Detailed testing steps

1. Run `bun run --cwd packages/core test -- src/services/follow-up.test.ts`.
2. Observe `1 passed` test file and `8 passed` tests.
3. For the load-bearing revert, restore only `packages/core/src/services/followUp.ts` from `origin/develop` while keeping the committed regression test. The suite reports `1 failed | 7 passed`, because the worker after stop is still the identical live worker.
4. Restore the PR source and rerun: `8 passed`.
5. Run `bun run --cwd packages/core typecheck` and changed-file Biome.

Origin source identity was checked with:

```text
git show origin/develop:packages/core/src/services/followUp.ts | diff - packages/core/src/services/followUp.ts
exit 0
```

Load-bearing revert output:

```text
Test Files  1 failed (1)
Tests       1 failed | 7 passed (8)
AssertionError: expected ... not to be ... // Object.is equality
src/services/follow-up.test.ts:286
```

Fixed exact-head output:

```text
Test Files  1 passed (1)
Tests       8 passed (8)
proof-run: recorded PROOF for b7e2e7819
```

No-over-rejection corpus: all six pre-existing follow-up tests pass unchanged on both origin and the branch. The two new lifecycle cases add stopped/restarted and replacement-owner coverage without changing existing schedule, complete, concurrency, or suggestion behavior. Core typecheck exits 0 on both the fixed and copy-aside origin controls: zero added errors.

# Evidence Gate

Evidence head: `b7e2e7819bd10f3b19be04476c3d1593cdbfd7e1`.
<!-- evidence-head:b7e2e7819bd10f3b19be04476c3d1593cdbfd7e1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - runtime-only service lifecycle; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - runtime-only service lifecycle; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - deterministic TaskService lifecycle with no interactive UI.
<!-- evidence-row:backend-logs -->
- [x] Backend/test logs are attached inline above: origin fails `1/8`, fixed exact head passes `8/8`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend or transport path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no model, prompt, provider, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: the real in-memory task row is asserted byte-for-byte equal after 70 seconds stopped, then removed after exactly one post-restart delivery; reminder memory count remains 0 while stopped and 1 after restart.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a scheduler/service lifecycle repair and invokes no LLM seam.

## Backend + frontend logs

Backend: focused Vitest and proof-run outputs are inline above. Frontend: N/A - no frontend path.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path.

## Known gaps / failures

- `bun run verify` was executed after sync. It reaches workspace lint and fails in clean upstream files outside this PR: `plugins/plugin-agent-orchestrator/src/services/sub-agent-inbox.ts` has an unused private member and `plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts` has a formatter delta. `bun run --cwd plugins/plugin-agent-orchestrator lint:check` reproduces the same blocker in the clean rebased publishing worktree. Neither file appears in this PR diff.
- This is a fork contribution. Upstream hosted CI does not run tests for our PRs; no hosted-CI pass is claimed.
- No live external service was needed or invoked.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cr-24161-followup]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0NZKA80EWR18QC4RVE7YHG3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T00:16:17.152Z","completed_at":"2026-08-23T00:24:15.257Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T00:16:18.051Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ac7b7d0ceef662e38a8d20d8c5ff7a3564db753d3f75bb8709aa0eb383564dd6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a1bbfe38-b402-48a3-9ccf-9cffa36558d7","object_id":"sha256:ac7b7d0ceef662e38a8d20d8c5ff7a3564db753d3f75bb8709aa0eb383564dd6","sha256":"ac7b7d0ceef662e38a8d20d8c5ff7a3564db753d3f75bb8709aa0eb383564dd6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"JPzXjp6KB3gLUjrBuCl4UzX-ReTkXUzaMsTpq8Pp_9co4eoVaRhZ83ap22kDPDUBJrUmt-UoaBqS3nJZYUDiAg"}} -->
