### PR TITLE
fix(cloud): secure dedicated API handoff

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -1104,6 +1104,24 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       const cutoverTodo = cutoverTodoMutation.result.todo;
       cutoverTodoId = cutoverTodo.id;
 
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ environment_vars: { ELIZAOS_API_KEY: "eliza_cloud_key_only" } })
+        .where(eq(agentSandboxes.id, CUTOVER_TARGET));
+      const noTransport = await cutover(PERSONAL_C, CUTOVER_TARGET);
+      expect(noTransport.status).toBe(503);
+      expect(await noTransport.json()).toMatchObject({
+        code: "dedicated_transport_unavailable",
+      });
+      expect(cutoverCoordinatorOperations).toEqual([]);
+      expect(importFetch).not.toHaveBeenCalled();
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          environment_vars: { ELIZA_API_TOKEN: "agent_cutover_transport" },
+        })
+        .where(eq(agentSandboxes.id, CUTOVER_TARGET));
+
       const refused = await cutover(PERSONAL_C, CUTOVER_TARGET);
       expect(refused.status).toBe(503);
       expect(await refused.json()).toMatchObject({

--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -992,6 +992,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       status: "running",
       database_status: "none",
       bridge_url: "https://dedicated-cutover.test/chat",
+      environment_vars: { ELIZA_API_TOKEN: "agent_cutover_transport" },
     });
 
     const originalFetch = globalThis.fetch;
@@ -1300,7 +1301,8 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({
-            Authorization: "Bearer steward-test",
+            Authorization: "Bearer agent_cutover_transport",
+            "X-API-Key": "agent_cutover_transport",
           }),
         }),
       );

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.auth-status.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.auth-status.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Verifies the Shared catch-all answers the legacy `auth/status` startup probe
+ * with the adapter's authenticated-bearer projection for a resolved Shared
+ * agent, and still 404s an unknown shell path. Real route module mounted on a
+ * real Hono router; the resolver, adapter, and CORS helpers are deterministic
+ * fakes.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const AGENT = "cccccccc-4444-4444-8444-444444444444";
+const authStatusCalls: number[] = [];
+
+mock.module("@/lib/mobile-push/types", () => ({
+  MAX_MOBILE_PUSH_TOKEN_CHARACTERS: 4096,
+}));
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedPushList: async () => [],
+  coordinateSharedPushRegister: async () => ({}),
+  coordinateSharedPushUnregister: async () => ({}),
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedAgent: async () => ({
+    agent: {
+      id: AGENT,
+      organization_id: "org-1",
+      user_id: "user-1",
+      agent_name: "Eliza",
+      execution_tier: "shared",
+    },
+    agentId: AGENT,
+    orgId: "org-1",
+    agentName: "Eliza",
+    agentKind: "sandbox",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  }),
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    error: "unavailable",
+    status: 503,
+  }),
+}));
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestAgentEvents: () => ({}),
+  sharedRestAgentStart: () => ({}),
+  sharedRestAuthMe: () => ({}),
+  sharedRestAuthStatus: () => {
+    authStatusCalls.push(Date.now());
+    return {
+      required: false,
+      authenticated: true,
+      pairingEnabled: false,
+      expiresAt: null,
+      localAccess: false,
+      passwordConfigured: false,
+    };
+  },
+  sharedRestCharacter: () => ({}),
+  sharedRestCommands: () => ({}),
+  sharedRestConfig: () => ({}),
+  sharedRestCustomActions: () => ({}),
+  sharedRestFirstRun: () => ({}),
+  sharedRestFirstRunStatus: () => ({}),
+  sharedRestFirstRunSubmit: () => ({}),
+  sharedRestGreeting: () => ({}),
+  sharedRestOverlayPresence: () => ({}),
+  sharedRestRuntimeMode: () => ({}),
+  sharedRestStatus: () => ({}),
+  sharedRestStreamSettings: () => ({}),
+  sharedRestViewNavigate: () => ({}),
+  sharedRestViews: () => ({}),
+}));
+mock.module("../../workflows/_shared", () => ({
+  workflowRuntimeUnavailableResponse: () =>
+    Response.json({ success: false }, { status: 409 }),
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono<AppEnv>();
+app.route("/api/v1/eliza/agents/:agentId/api/:*{.+}", route);
+const ENV = {
+  ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app",
+} as unknown as AppEnv["Bindings"];
+
+describe("GET .../api/auth/status (Shared shell probe)", () => {
+  test("returns the authenticated-bearer projection", async () => {
+    const response = await app.request(
+      `http://cloud.local/api/v1/eliza/agents/${AGENT}/api/auth/status`,
+      { headers: { "X-API-Key": "eliza_test" } },
+      ENV,
+    );
+    expect(response.status).toBe(200);
+    expect((await response.json()) as Record<string, unknown>).toEqual({
+      required: false,
+      authenticated: true,
+      pairingEnabled: false,
+      expiresAt: null,
+      localAccess: false,
+      passwordConfigured: false,
+    });
+    expect(authStatusCalls).toHaveLength(1);
+  });
+
+  test("keeps unknown shell paths at 404", async () => {
+    const response = await app.request(
+      `http://cloud.local/api/v1/eliza/agents/${AGENT}/api/auth/unknown`,
+      { headers: { "X-API-Key": "eliza_test" } },
+      ENV,
+    );
+    expect(response.status).toBe(404);
+    expect(authStatusCalls).toHaveLength(1);
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.encoding.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.encoding.test.ts
@@ -25,6 +25,7 @@ mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
   sharedRestAgentEvents: () => ({}),
   sharedRestAgentStart: () => ({}),
   sharedRestAuthMe: () => ({}),
+  sharedRestAuthStatus: () => ({}),
   sharedRestCharacter: () => ({}),
   sharedRestCommands: () => ({}),
   sharedRestConfig: () => ({}),

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -11,8 +11,10 @@
  * LifeOps activity-signal requests into the canonical typed
  * capability-unavailable response. Generated routing mounts the specific
  * conversation, health, identity, and wallet siblings first; unknown catch-all
- * paths remain 404. Dedicated agents use their own subdomain and never enter
- * this adapter.
+ * paths remain 404. Production Dedicated agents use their own subdomain and
+ * never enter this adapter; only the local harness's loopback Dedicated
+ * runtime does, through the owner-scoped proxy middleware registered before
+ * every handler here and on each sibling.
  */
 import { type Context, Hono } from "hono";
 import { MAX_MOBILE_PUSH_TOKEN_CHARACTERS } from "@/lib/mobile-push/types";

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -30,6 +30,7 @@ import {
   sharedRestAgentEvents,
   sharedRestAgentStart,
   sharedRestAuthMe,
+  sharedRestAuthStatus,
   sharedRestCharacter,
   sharedRestCommands,
   sharedRestConfig,
@@ -47,11 +48,14 @@ import {
 } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { workflowRuntimeUnavailableResponse } from "../../workflows/_shared";
+import { proxyLocalDedicatedOrNext } from "../_local-dedicated-proxy";
 
 const CORS_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
 const MAX_PUSH_REGISTRATION_BODY_BYTES = 8_192;
 
 const app = new Hono<AppEnv>();
+
+app.use("*", proxyLocalDedicatedOrNext);
 
 function json(
   c: Context<AppEnv>,
@@ -286,6 +290,8 @@ app.get("/", async (c) => {
       // key (resolveSharedAgent validated it), so report the authed machine
       // identity instead of 404'ing into "server_unavailable".
       return json(c, sharedRestAuthMe(r.agentId, r.agentName));
+    case "auth/status":
+      return json(c, sharedRestAuthStatus());
     case "runtime/mode":
       return json(c, sharedRestRuntimeMode());
     case "commands":

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Verifies the loopback Dedicated proxy middleware: sentinel gating, ownership
+ * and tier fall-through, readiness and credential 503s, the Cloud-to-runtime
+ * credential swap, cookie and set-cookie stripping, path/query forwarding, and
+ * preflight. Real Hono routing with the real health sibling mounted; the
+ * repository, Cloud auth, CORS, Shared resolver, and upstream fetch are
+ * deterministic fakes.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const OWNER_ORG = "11111111-1111-4111-8111-111111111111";
+const OTHER_ORG = "22222222-2222-4222-8222-222222222222";
+const AGENT = "cccccccc-4444-4444-8444-444444444444";
+const RUNTIME_ORIGIN = "http://127.0.0.1:8790";
+
+type SandboxRow = {
+  id: string;
+  organization_id: string;
+  execution_tier: string;
+  status: string;
+  headscale_ip: string | null;
+  bridge_url: string | null;
+  health_url: string | null;
+  environment_vars: Record<string, string>;
+};
+
+function runningSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
+  return {
+    id: AGENT,
+    organization_id: OWNER_ORG,
+    execution_tier: "dedicated-always",
+    status: "running",
+    headscale_ip: null,
+    bridge_url: null,
+    health_url: `${RUNTIME_ORIGIN}/api/health`,
+    environment_vars: { ELIZA_API_TOKEN: "agent-token-1" },
+    ...overrides,
+  };
+}
+
+const sandboxes = new Map<string, SandboxRow>();
+const lookups: Array<{ id: string; orgId: string }> = [];
+let authedOrg = OWNER_ORG;
+let resolveSharedAgentCalls = 0;
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    findByIdAndOrg: async (id: string, orgId: string) => {
+      lookups.push({ id, orgId });
+      const row = sandboxes.get(id);
+      return row && row.organization_id === orgId ? row : undefined;
+    },
+  },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: authedOrg,
+  }),
+}));
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response, methods?: string) => {
+    const headers = new Headers(response.headers);
+    headers.set("x-test-cors", methods ?? "");
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  },
+  handleCorsOptions: (methods: string) =>
+    new Response(null, { status: 204, headers: { "x-test-cors": methods } }),
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedAgent: async () => {
+    resolveSharedAgentCalls += 1;
+    return { error: "Not a shared-runtime agent", status: 404 };
+  },
+}));
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestHealth: () => ({ status: "ok", runtime: "shared" }),
+}));
+
+const { proxyLocalDedicatedOrNext } = await import("./_local-dedicated-proxy");
+const { default: healthRoute } = await import("./health/route");
+
+type UpstreamCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+};
+const upstreamCalls: UpstreamCall[] = [];
+let upstreamResponse: () => Response = () =>
+  Response.json({ ok: true }, { status: 200 });
+const realFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const request = new Request(input, init);
+  upstreamCalls.push({
+    url: request.url,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    body:
+      request.method === "GET" || request.method === "HEAD"
+        ? null
+        : await request.text(),
+  });
+  return upstreamResponse();
+}) as typeof fetch;
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+function buildApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  const catchAll = new Hono<AppEnv>();
+  catchAll.use("*", proxyLocalDedicatedOrNext);
+  catchAll.all("/", (c) =>
+    Response.json({
+      handler: "shared-catch-all",
+      agentId: c.req.param("agentId"),
+    }),
+  );
+  app.route("/api/v1/eliza/agents/:agentId/api/health", healthRoute);
+  app.route("/api/v1/eliza/agents/:agentId/api/:*{.+}", catchAll);
+  return app;
+}
+
+async function request(
+  path: string,
+  init: RequestInit = {},
+  baseDomain: string | undefined = "https://",
+): Promise<Response> {
+  return await buildApp().request(`http://cloud.local${path}`, init, {
+    ELIZA_CLOUD_AGENT_BASE_DOMAIN: baseDomain,
+  } as unknown as AppEnv["Bindings"]);
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  sandboxes.clear();
+  lookups.length = 0;
+  upstreamCalls.length = 0;
+  authedOrg = OWNER_ORG;
+  resolveSharedAgentCalls = 0;
+  upstreamResponse = () => Response.json({ ok: true }, { status: 200 });
+});
+
+describe("proxyLocalDedicatedOrNext", () => {
+  test("stays inert outside the local https:// sentinel mode", async () => {
+    sandboxes.set(AGENT, runningSandbox());
+    const response = await request(
+      `/api/v1/eliza/agents/${AGENT}/api/status`,
+      {},
+      "cloud.eliza.app",
+    );
+    expect(await readJson(response)).toEqual({
+      handler: "shared-catch-all",
+      agentId: AGENT,
+    });
+    expect(lookups).toEqual([]);
+    expect(upstreamCalls).toEqual([]);
+  });
+
+  test("falls through for non-UUID, unknown, foreign-org, and Shared agents", async () => {
+    const personal = "personal:00000000-0000-5000-8000-000000000001";
+    expect(
+      await readJson(
+        await request(
+          `/api/v1/eliza/agents/${encodeURIComponent(personal)}/api/status`,
+        ),
+      ),
+    ).toMatchObject({ handler: "shared-catch-all" });
+    expect(lookups).toEqual([]);
+
+    expect(
+      await readJson(await request(`/api/v1/eliza/agents/${AGENT}/api/status`)),
+    ).toMatchObject({ handler: "shared-catch-all" });
+    expect(lookups).toEqual([{ id: AGENT, orgId: OWNER_ORG }]);
+
+    sandboxes.set(AGENT, runningSandbox());
+    authedOrg = OTHER_ORG;
+    expect(
+      await readJson(await request(`/api/v1/eliza/agents/${AGENT}/api/status`)),
+    ).toMatchObject({ handler: "shared-catch-all" });
+    authedOrg = OWNER_ORG;
+
+    sandboxes.set(AGENT, runningSandbox({ execution_tier: "shared" }));
+    expect(
+      await readJson(await request(`/api/v1/eliza/agents/${AGENT}/api/status`)),
+    ).toMatchObject({ handler: "shared-catch-all" });
+    expect(upstreamCalls).toEqual([]);
+  });
+
+  test("reports a non-running owned Dedicated agent as retryable 503", async () => {
+    sandboxes.set(AGENT, runningSandbox({ status: "starting" }));
+    const response = await request(`/api/v1/eliza/agents/${AGENT}/api/status`);
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("5");
+    expect(await readJson(response)).toEqual({
+      success: false,
+      code: "agent_not_running",
+      error: "Dedicated agent is not running yet",
+      data: { status: "starting" },
+    });
+    expect(upstreamCalls).toEqual([]);
+  });
+
+  test("refuses to forward without a loopback base or an agent token", async () => {
+    sandboxes.set(AGENT, runningSandbox({ environment_vars: {} }));
+    const noToken = await request(`/api/v1/eliza/agents/${AGENT}/api/status`);
+    expect(noToken.status).toBe(503);
+    expect(await readJson(noToken)).toMatchObject({
+      code: "agent_unavailable",
+    });
+
+    sandboxes.set(
+      AGENT,
+      runningSandbox({
+        environment_vars: { ELIZAOS_API_KEY: "eliza_cloud_key" },
+      }),
+    );
+    const cloudKeyOnly = await request(
+      `/api/v1/eliza/agents/${AGENT}/api/status`,
+    );
+    expect(cloudKeyOnly.status).toBe(503);
+    expect(await readJson(cloudKeyOnly)).toMatchObject({
+      code: "agent_unavailable",
+    });
+
+    sandboxes.set(
+      AGENT,
+      runningSandbox({ health_url: "https://attacker.example/api/health" }),
+    );
+    const remoteHost = await request(
+      `/api/v1/eliza/agents/${AGENT}/api/status`,
+    );
+    expect(remoteHost.status).toBe(503);
+    expect(await readJson(remoteHost)).toMatchObject({
+      code: "agent_unavailable",
+    });
+    expect(upstreamCalls).toEqual([]);
+  });
+
+  test("swaps the Cloud credential for the runtime token and forwards the exact path", async () => {
+    sandboxes.set(AGENT, runningSandbox());
+    upstreamResponse = () =>
+      new Response(JSON.stringify({ from: "runtime" }), {
+        status: 201,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "runtime=1; HttpOnly",
+          "x-runtime": "yes",
+        },
+      });
+    const response = await request(
+      `/api/v1/eliza/agents/${AGENT}/api/conversations/conv%201/messages?limit=5&after=x`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer eliza_cloud_session",
+          Cookie: "session=browser",
+          "X-API-Key": "eliza_cloud_key",
+          "X-Eliza-Csrf": "token",
+          "Content-Type": "application/json",
+          Origin: "http://localhost:5173",
+        },
+        body: JSON.stringify({ text: "hello" }),
+      },
+    );
+    expect(response.status).toBe(201);
+    expect(await readJson(response)).toEqual({ from: "runtime" });
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("x-runtime")).toBe("yes");
+    expect(response.headers.get("x-test-cors")).toBe(
+      "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+    );
+
+    expect(upstreamCalls).toHaveLength(1);
+    const [call] = upstreamCalls;
+    expect(call.url).toBe(
+      `${RUNTIME_ORIGIN}/api/conversations/conv%201/messages?limit=5&after=x`,
+    );
+    expect(call.method).toBe("POST");
+    expect(call.body).toBe(JSON.stringify({ text: "hello" }));
+    expect(call.headers.authorization).toBe("Bearer agent-token-1");
+    expect(call.headers.cookie).toBeUndefined();
+    expect(call.headers["x-api-key"]).toBeUndefined();
+    expect(call.headers["x-eliza-csrf"]).toBeUndefined();
+    expect(call.headers["content-type"]).toBe("application/json");
+    // The Cloud host must not ride along; fetch derives Host from the target.
+    expect(call.headers.host).toBeUndefined();
+  });
+
+  test("serves the health sibling from the runtime instead of the Shared resolver", async () => {
+    sandboxes.set(AGENT, runningSandbox());
+    upstreamResponse = () =>
+      Response.json({ status: "ok", runtime: "dedicated" }, { status: 200 });
+    const response = await request(`/api/v1/eliza/agents/${AGENT}/api/health`);
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toEqual({
+      status: "ok",
+      runtime: "dedicated",
+    });
+    expect(upstreamCalls.map((call) => call.url)).toEqual([
+      `${RUNTIME_ORIGIN}/api/health`,
+    ]);
+    expect(resolveSharedAgentCalls).toBe(0);
+
+    sandboxes.clear();
+    const shared = await request(`/api/v1/eliza/agents/${AGENT}/api/health`);
+    expect(shared.status).toBe(404);
+    expect(resolveSharedAgentCalls).toBe(1);
+  });
+
+  test("answers preflight locally without touching the runtime", async () => {
+    sandboxes.set(AGENT, runningSandbox());
+    const response = await request(`/api/v1/eliza/agents/${AGENT}/api/status`, {
+      method: "OPTIONS",
+      headers: { Origin: "http://localhost:5173" },
+    });
+    expect(response.status).toBe(204);
+    expect(response.headers.get("x-test-cors")).toBe(
+      "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+    );
+    expect(lookups).toEqual([]);
+    expect(upstreamCalls).toEqual([]);
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.ts
@@ -1,8 +1,22 @@
+/**
+ * Owner-scoped loopback hop that lets the local cloud harness reach a Dedicated
+ * Docker runtime through the Shared REST path family.
+ *
+ * Production routes Dedicated traffic to a per-agent hostname, so this
+ * middleware is inert unless `ELIZA_CLOUD_AGENT_BASE_DOMAIN` is the explicit
+ * `https://` sentinel (no DNS host to synthesize). Every Hono leaf under
+ * `/api/v1/eliza/agents/:agentId/api` registers it first so a client pointed at
+ * `personalDedicatedClientApiBase` never falls into a Shared-only handler for a
+ * running Dedicated agent. The Cloud session stays on the Cloud side: ownership
+ * is re-checked per request, cookies and Cloud credentials are stripped, and
+ * the runtime's own `ELIZA_API_TOKEN` is swapped in as the bearer.
+ */
 import type { Context, Next } from "hono";
-import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
-import { personalDedicatedAgentApiBase } from "@/lib/services/shared-runtime/personal-shared-agent";
+import {
+  dedicatedAgentTransportToken,
+  personalDedicatedAgentApiBase,
+} from "@/lib/services/shared-runtime/personal-shared-agent";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
@@ -22,16 +36,18 @@ function runtimeApiPath(requestUrl: string, agentId: string): string | null {
 }
 
 /**
- * Development-only path proxy for Dedicated Docker agents. Production uses a
- * per-agent hostname; the repository's explicit `https://` sentinel has no
- * DNS host, so this route keeps the Cloud ownership/auth boundary and forwards
- * to the validated loopback runtime after swapping in its agent credential.
+ * Forward an owner's request to the loopback Dedicated runtime, or fall through
+ * to the Shared handler when the agent is not a local Dedicated one.
  */
 export async function proxyLocalDedicatedOrNext(
   c: Context<AppEnv>,
   next: Next,
 ): Promise<Response | undefined> {
-  if (c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN !== "https://") {
+  // Leaves mounted without bindings (unit harnesses) have no env object at
+  // all; that is the same "no sentinel configured" state as production and
+  // must leave the Shared handler untouched rather than throw.
+  const baseDomain = c.env ? c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN : undefined;
+  if (baseDomain !== "https://") {
     return continueToNext(next);
   }
   const agentId = c.req.param("agentId")?.trim() ?? "";
@@ -43,6 +59,13 @@ export async function proxyLocalDedicatedOrNext(
     return handleCorsOptions(CORS_METHODS, c.req.header("origin"));
   }
 
+  // Loaded only once a request is eligible so Shared-only leaves that mount
+  // this middleware do not pull the database client into their module graph.
+  const [{ requireUserOrApiKeyWithOrg }, { agentSandboxesRepository }] =
+    await Promise.all([
+      import("@/lib/auth/workers-hono-auth"),
+      import("@/db/repositories/agent-sandboxes"),
+    ]);
   const user = await requireUserOrApiKeyWithOrg(c);
   const sandbox = await agentSandboxesRepository.findByIdAndOrg(
     agentId,
@@ -67,13 +90,8 @@ export async function proxyLocalDedicatedOrNext(
     );
   }
 
-  const runtimeBase = personalDedicatedAgentApiBase(
-    sandbox,
-    c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
-  );
-  const agentToken = (
-    sandbox.environment_vars as Record<string, string> | null
-  )?.ELIZA_API_TOKEN?.trim();
+  const runtimeBase = personalDedicatedAgentApiBase(sandbox, baseDomain);
+  const agentToken = dedicatedAgentTransportToken(sandbox);
   if (!runtimeBase || !agentToken) {
     return applyCorsHeaders(
       Response.json(
@@ -99,13 +117,16 @@ export async function proxyLocalDedicatedOrNext(
   headers.delete("x-eliza-csrf");
   headers.set("authorization", `Bearer ${agentToken}`);
 
-  const init: RequestInit = {
+  const init: RequestInit & { duplex?: "half" } = {
     method: c.req.method,
     headers,
     redirect: "manual",
   };
   if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    // Streaming a request body requires half-duplex on Node and Bun fetch;
+    // workerd ignores the flag.
     init.body = c.req.raw.body;
+    init.duplex = "half";
   }
   const upstream = await fetch(new Request(target, init));
   const responseHeaders = new Headers(upstream.headers);

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/_local-dedicated-proxy.ts
@@ -1,0 +1,123 @@
+import type { Context, Next } from "hono";
+import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
+import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import { personalDedicatedAgentApiBase } from "@/lib/services/shared-runtime/personal-shared-agent";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const CORS_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
+const DEDICATED_AGENT_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+async function continueToNext(next: Next): Promise<undefined> {
+  await next();
+  return undefined;
+}
+
+function runtimeApiPath(requestUrl: string, agentId: string): string | null {
+  const pathname = new URL(requestUrl).pathname;
+  const marker = `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/api`;
+  if (pathname !== marker && !pathname.startsWith(`${marker}/`)) return null;
+  return pathname.slice(marker.length) || "";
+}
+
+/**
+ * Development-only path proxy for Dedicated Docker agents. Production uses a
+ * per-agent hostname; the repository's explicit `https://` sentinel has no
+ * DNS host, so this route keeps the Cloud ownership/auth boundary and forwards
+ * to the validated loopback runtime after swapping in its agent credential.
+ */
+export async function proxyLocalDedicatedOrNext(
+  c: Context<AppEnv>,
+  next: Next,
+): Promise<Response | undefined> {
+  if (c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN !== "https://") {
+    return continueToNext(next);
+  }
+  const agentId = c.req.param("agentId")?.trim() ?? "";
+  if (!DEDICATED_AGENT_ID.test(agentId)) return continueToNext(next);
+
+  const path = runtimeApiPath(c.req.url, agentId);
+  if (path === null) return continueToNext(next);
+  if (c.req.method === "OPTIONS") {
+    return handleCorsOptions(CORS_METHODS, c.req.header("origin"));
+  }
+
+  const user = await requireUserOrApiKeyWithOrg(c);
+  const sandbox = await agentSandboxesRepository.findByIdAndOrg(
+    agentId,
+    user.organization_id,
+  );
+  if (!sandbox || sandbox.execution_tier === "shared") {
+    return continueToNext(next);
+  }
+  if (sandbox.status !== "running") {
+    return applyCorsHeaders(
+      Response.json(
+        {
+          success: false,
+          code: "agent_not_running",
+          error: "Dedicated agent is not running yet",
+          data: { status: sandbox.status },
+        },
+        { status: 503, headers: { "Retry-After": "5" } },
+      ),
+      CORS_METHODS,
+      c.req.header("origin"),
+    );
+  }
+
+  const runtimeBase = personalDedicatedAgentApiBase(
+    sandbox,
+    c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+  );
+  const agentToken = (
+    sandbox.environment_vars as Record<string, string> | null
+  )?.ELIZA_API_TOKEN?.trim();
+  if (!runtimeBase || !agentToken) {
+    return applyCorsHeaders(
+      Response.json(
+        {
+          success: false,
+          code: "agent_unavailable",
+          error: "Dedicated agent connection is unavailable",
+        },
+        { status: 503 },
+      ),
+      CORS_METHODS,
+      c.req.header("origin"),
+    );
+  }
+
+  const target = new URL(runtimeBase);
+  target.pathname = `/api${path}`;
+  target.search = new URL(c.req.url).search;
+  const headers = new Headers(c.req.raw.headers);
+  headers.delete("cookie");
+  headers.delete("host");
+  headers.delete("x-api-key");
+  headers.delete("x-eliza-csrf");
+  headers.set("authorization", `Bearer ${agentToken}`);
+
+  const init: RequestInit = {
+    method: c.req.method,
+    headers,
+    redirect: "manual",
+  };
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    init.body = c.req.raw.body;
+  }
+  const upstream = await fetch(new Request(target, init));
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("set-cookie");
+  responseHeaders.delete("set-cookie2");
+  return applyCorsHeaders(
+    new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    }),
+    CORS_METHODS,
+    c.req.header("origin"),
+  );
+}

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -18,6 +18,7 @@ import {
 import { sharedTurnClientMessageId } from "@/lib/services/shared-runtime/shared-runtime-chat";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../../_local-dedicated-proxy";
 
 /**
  * /api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages
@@ -30,6 +31,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const CORS_METHODS = "GET, POST, OPTIONS";
 
 const app = new Hono<AppEnv>();
+
+app.use("*", proxyLocalDedicatedOrNext);
 
 app.options("/", (c) =>
   handleCorsOptions(CORS_METHODS, c.req.header("origin")),

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream/route.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/services/shared-runtime/shared-turn-observability";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../../../_local-dedicated-proxy";
 
 /**
  * /api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/stream
@@ -57,6 +58,8 @@ const VOICE_ORGANIZATION_HEADER = "X-Eliza-Organization-Id";
 const VOICE_USER_HEADER = "X-Eliza-User-Id";
 
 const app = new Hono<AppEnv>();
+
+app.use("*", proxyLocalDedicatedOrNext);
 
 function nowMs(): number {
   return performance.now();

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/route.ts
@@ -7,6 +7,7 @@ import {
   sharedRestConversationUpdate,
 } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../_local-dedicated-proxy";
 
 /**
  * /api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]
@@ -20,6 +21,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const CORS_METHODS = "PATCH, DELETE, OPTIONS";
 
 const app = new Hono<AppEnv>();
+
+app.use("*", proxyLocalDedicatedOrNext);
 
 app.options("/", (c) =>
   handleCorsOptions(CORS_METHODS, c.req.header("origin")),

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/route.ts
@@ -7,6 +7,7 @@ import {
   sharedRestConversationsList,
 } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../_local-dedicated-proxy";
 
 /**
  * /api/v1/eliza/agents/[agentId]/api/conversations
@@ -20,6 +21,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const CORS_METHODS = "GET, POST, OPTIONS";
 
 const app = new Hono<AppEnv>();
+
+app.use("*", proxyLocalDedicatedOrNext);
 
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/health/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/health/route.ts
@@ -4,6 +4,7 @@ import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { resolveSharedAgent } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { sharedRestHealth } from "@/lib/services/shared-runtime/shared-rest-adapter";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../_local-dedicated-proxy";
 
 /**
  * GET /api/v1/eliza/agents/[agentId]/api/health
@@ -18,6 +19,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const CORS_METHODS = "GET, OPTIONS";
 
 const app = new Hono<AppEnv>();
+app.use("*", proxyLocalDedicatedOrNext);
 
 app.options("/", () => handleCorsOptions(CORS_METHODS));
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts
@@ -3,6 +3,7 @@ import { type Context, Hono } from "hono";
 import { type Address, isAddress } from "viem";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../_local-dedicated-proxy";
 import {
   defaultRegistry,
   getCurrentIdentity,
@@ -88,6 +89,7 @@ export async function handleGetOnchainIdentity(
 }
 
 const app = new Hono<AppEnv>();
+app.use("*", proxyLocalDedicatedOrNext);
 app.options("/", () => __next_OPTIONS());
 app.get("/", (c) =>
   handleGetOnchainIdentity(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/register/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/register/route.ts
@@ -6,6 +6,7 @@ import { agentIdentities } from "@/db/schemas/agent-identities";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../_local-dedicated-proxy";
 import {
   defaultRegistry,
   getCurrentIdentity,
@@ -159,6 +160,7 @@ export async function handleRegisterIdentity(
 }
 
 const app = new Hono<AppEnv>();
+app.use("*", proxyLocalDedicatedOrNext);
 app.options("/", () => __next_OPTIONS());
 app.post("/", (c) =>
   handleRegisterIdentity(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/route.ts
@@ -2,6 +2,7 @@
 import { type Context, Hono } from "hono";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../_local-dedicated-proxy";
 import {
   getCurrentIdentity,
   json,
@@ -39,6 +40,7 @@ export async function handleGetIdentity(
 }
 
 const app = new Hono<AppEnv>();
+app.use("*", proxyLocalDedicatedOrNext);
 app.options("/", () => __next_OPTIONS());
 app.get("/", (c) =>
   handleGetIdentity(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/uri/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/identity/uri/route.ts
@@ -5,6 +5,7 @@ import { dbWrite } from "@/db/helpers";
 import { agentIdentities } from "@/db/schemas/agent-identities";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../_local-dedicated-proxy";
 import {
   getCurrentIdentity,
   identityClient,
@@ -104,6 +105,7 @@ export async function handlePutIdentityUri(
 }
 
 const app = new Hono<AppEnv>();
+app.use("*", proxyLocalDedicatedOrNext);
 app.options("/", () => __next_OPTIONS());
 app.put("/", (c) =>
   handlePutIdentityUri(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -16,6 +16,7 @@ import { createStewardClient } from "@/lib/services/steward-client";
 import { parseClampedLimit, parseClampedOffset } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { proxyLocalDedicatedOrNext } from "../../_local-dedicated-proxy";
 
 const CORS_METHODS = "GET, POST, PUT, OPTIONS";
 type WalletMethod = "GET" | "POST" | "PUT";
@@ -540,6 +541,7 @@ const ROUTE_PARAM_SPEC = [
   { name: "path", splat: true },
 ] as const;
 const honoRouter = new Hono<AppEnv>();
+honoRouter.use("*", proxyLocalDedicatedOrNext);
 honoRouter.options("/", () => __next_OPTIONS());
 honoRouter.get("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -28,6 +28,7 @@ import {
   coordinateSharedCutoverSeal,
 } from "@/lib/services/shared-runtime/conversation-coordinator";
 import {
+  dedicatedAgentTransportToken,
   personalDedicatedAgentApiBase,
   personalDedicatedClientApiBase,
   personalSharedAgentId,
@@ -155,24 +156,6 @@ async function postDedicatedImport(
         ? (parsed as Record<string, unknown>)
         : null,
   };
-}
-
-function dedicatedTransportToken(target: {
-  environment_vars: unknown;
-}): string | null {
-  const env =
-    target.environment_vars && typeof target.environment_vars === "object"
-      ? (target.environment_vars as Record<string, unknown>)
-      : {};
-  for (const key of [
-    "ELIZA_API_TOKEN",
-    "ELIZAOS_API_KEY",
-    "ELIZAOS_CLOUD_API_KEY",
-  ]) {
-    const value = env[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return null;
 }
 
 async function readTodoCutoverSnapshot(
@@ -346,7 +329,7 @@ app.post("/", async (c) => {
         marker.sharedTodoDigest === activeTodoSnapshot.digest &&
         activeBase
       ) {
-        const activeToken = dedicatedTransportToken(active);
+        const activeToken = dedicatedAgentTransportToken(active);
         if (!activeToken) {
           return json(
             {
@@ -465,7 +448,7 @@ app.post("/", async (c) => {
         409,
       );
     }
-    const targetToken = dedicatedTransportToken(target);
+    const targetToken = dedicatedAgentTransportToken(target);
     if (!targetToken) {
       return json(
         {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/services/shared-runtime/conversation-coordinator";
 import {
   personalDedicatedAgentApiBase,
+  personalDedicatedClientApiBase,
   personalSharedAgentId,
 } from "@/lib/services/shared-runtime/personal-shared-agent";
 import {
@@ -133,16 +134,15 @@ async function readJsonResponse(response: Response): Promise<unknown> {
 async function postDedicatedImport(
   url: string,
   body: Record<string, unknown>,
-  authorization: string | undefined,
-  apiKey: string | undefined,
+  agentToken: string,
 ): Promise<{ response: Response; receipt: Record<string, unknown> | null }> {
   const response = await fetch(url, {
     method: "POST",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
-      ...(authorization ? { Authorization: authorization } : {}),
-      ...(apiKey ? { "X-API-Key": apiKey } : {}),
+      Authorization: `Bearer ${agentToken}`,
+      "X-API-Key": agentToken,
     },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(20_000),
@@ -155,6 +155,24 @@ async function postDedicatedImport(
         ? (parsed as Record<string, unknown>)
         : null,
   };
+}
+
+function dedicatedTransportToken(target: {
+  environment_vars: unknown;
+}): string | null {
+  const env =
+    target.environment_vars && typeof target.environment_vars === "object"
+      ? (target.environment_vars as Record<string, unknown>)
+      : {};
+  for (const key of [
+    "ELIZA_API_TOKEN",
+    "ELIZAOS_API_KEY",
+    "ELIZAOS_CLOUD_API_KEY",
+  ]) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
 }
 
 async function readTodoCutoverSnapshot(
@@ -301,8 +319,6 @@ app.post("/", async (c) => {
     }
     const sealToken = `personal-cutover:${sourceAgentId}:${parsed.data.dedicatedAgentId}`;
     const reminderReservationToken = `${sealToken}:reminders:${crypto.randomUUID()}`;
-    const authorization = c.req.header("authorization");
-    const apiKey = c.req.header("x-api-key");
     const active = await findActivePersonalDedicatedTarget(
       user.organization_id,
       sourceAgentId,
@@ -330,6 +346,18 @@ app.post("/", async (c) => {
         marker.sharedTodoDigest === activeTodoSnapshot.digest &&
         activeBase
       ) {
+        const activeToken = dedicatedTransportToken(active);
+        if (!activeToken) {
+          return json(
+            {
+              success: false,
+              code: "dedicated_transport_unavailable",
+              error:
+                "Dedicated authentication is still being prepared. Shared remains active.",
+            },
+            503,
+          );
+        }
         try {
           await invalidateUserDeliveryProjections(c.env, user);
           await coordinateSharedCutoverCommit(
@@ -354,8 +382,7 @@ app.post("/", async (c) => {
               cutoverToken: sealToken,
               activateScheduledTasks: true,
             },
-            authorization,
-            apiKey,
+            activeToken,
           );
           if (
             !activation.response.ok ||
@@ -384,7 +411,12 @@ app.post("/", async (c) => {
               personalElizaId: sourceAgentId,
               activeAgentId: active.id,
               runtime: "dedicated" as const,
-              apiBase: activeBase,
+              apiBase:
+                personalDedicatedClientApiBase(
+                  active,
+                  c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+                  new URL(c.req.url).origin,
+                ) ?? activeBase,
               importedMessages: marker.sharedMessageCount,
               importedScheduledTasks: marker.sharedScheduledTaskCount,
               importedTodos: marker.sharedTodoCount,
@@ -431,6 +463,18 @@ app.post("/", async (c) => {
             "Dedicated has no reachable endpoint yet. Shared remains active.",
         },
         409,
+      );
+    }
+    const targetToken = dedicatedTransportToken(target);
+    if (!targetToken) {
+      return json(
+        {
+          success: false,
+          code: "dedicated_transport_unavailable",
+          error:
+            "Dedicated authentication is still being prepared. Shared remains active.",
+        },
+        503,
       );
     }
     const history = await coordinateSharedCutoverSeal(
@@ -503,8 +547,7 @@ app.post("/", async (c) => {
             todoSnapshot,
             cutoverToken: sealToken,
           },
-          authorization,
-          apiKey,
+          targetToken,
         );
         if (!imported.response.ok) {
           return json(
@@ -597,8 +640,7 @@ app.post("/", async (c) => {
           cutoverToken: sealToken,
           activateScheduledTasks: true,
         },
-        authorization,
-        apiKey,
+        targetToken,
       );
       if (
         !activation.response.ok ||
@@ -633,7 +675,12 @@ app.post("/", async (c) => {
           personalElizaId: sourceAgentId,
           activeAgentId: activeTarget.id,
           runtime: "dedicated" as const,
-          apiBase: base,
+          apiBase:
+            personalDedicatedClientApiBase(
+              activeTarget,
+              c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
+              new URL(c.req.url).origin,
+            ) ?? base,
           importedMessages: history.length,
           importedScheduledTasks: scheduledTasks.length,
           importedTodos: todoSnapshot.todos.length,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  dedicatedAgentTransportToken,
   isCanonicalPersonalSharedAgent,
   isPersonalSharedAgentId,
   personalDedicatedAgentApiBase,
@@ -103,5 +104,22 @@ describe("personalSharedAgent", () => {
         "https://",
       ),
     ).toBeNull();
+  });
+
+  test("accepts only the runtime's own ELIZA_API_TOKEN as the transport credential", () => {
+    expect(
+      dedicatedAgentTransportToken({ environment_vars: { ELIZA_API_TOKEN: " agent-1 " } }),
+    ).toBe("agent-1");
+    expect(
+      dedicatedAgentTransportToken({ environment_vars: { ELIZA_API_TOKEN: "   " } }),
+    ).toBeNull();
+    expect(
+      dedicatedAgentTransportToken({
+        environment_vars: { ELIZAOS_API_KEY: "eliza_cloud", ELIZAOS_CLOUD_API_KEY: "eliza_cloud" },
+      }),
+    ).toBeNull();
+    expect(dedicatedAgentTransportToken({ environment_vars: { ELIZA_API_TOKEN: 42 } })).toBeNull();
+    expect(dedicatedAgentTransportToken({ environment_vars: null })).toBeNull();
+    expect(dedicatedAgentTransportToken({ environment_vars: ["ELIZA_API_TOKEN"] })).toBeNull();
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.test.ts
@@ -64,12 +64,13 @@ describe("personalSharedAgent", () => {
       id: "00000000-0000-4000-8000-000000000004",
       headscale_ip: null,
       bridge_url: "http://127.0.0.1:8787/api/compat/agents/local",
+      health_url: "http://127.0.0.1:8788/api",
     };
 
     expect(personalDedicatedAgentApiBase(target, "cloud.eliza.app")).toBe(
       `https://${target.id}.cloud.eliza.app`,
     );
-    expect(personalDedicatedAgentApiBase(target, "https://")).toBe(target.bridge_url);
+    expect(personalDedicatedAgentApiBase(target, "https://")).toBe("http://127.0.0.1:8788");
     expect(
       personalDedicatedClientApiBase(target, "https://", "http://127.0.0.1:8787/request"),
     ).toBe(`http://127.0.0.1:8787/api/v1/eliza/agents/${target.id}`);
@@ -78,13 +79,27 @@ describe("personalSharedAgent", () => {
     );
     expect(
       personalDedicatedAgentApiBase(
-        { ...target, bridge_url: "https://attacker.example/agent" },
+        { ...target, health_url: "https://attacker.example/api" },
+        "https://",
+      ),
+    ).toBe(target.bridge_url);
+    expect(
+      personalDedicatedAgentApiBase(
+        {
+          ...target,
+          bridge_url: "https://attacker.example/agent",
+          health_url: "https://attacker.example/api",
+        },
         "https://",
       ),
     ).toBeNull();
     expect(
       personalDedicatedAgentApiBase(
-        { ...target, bridge_url: "http://user:secret@127.0.0.1:8787" },
+        {
+          ...target,
+          bridge_url: "http://user:secret@127.0.0.1:8787",
+          health_url: "http://user:secret@127.0.0.1:8788/api",
+        },
         "https://",
       ),
     ).toBeNull();

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
@@ -96,6 +96,21 @@ export function personalDedicatedAgentApiBase(
     : (localRestApiBase(target.health_url) ?? localBridgeApiBase(target.bridge_url));
 }
 
+/**
+ * The credential a Cloud-side caller presents to a Dedicated runtime. Only the
+ * container's own `ELIZA_API_TOKEN` is accepted: Cloud API keys stored beside
+ * it authenticate the agent *to* Cloud and a runtime rejects them, so falling
+ * back to one would turn a missing token into an opaque upstream 401.
+ */
+export function dedicatedAgentTransportToken(target: { environment_vars: unknown }): string | null {
+  const env = target.environment_vars;
+  if (!env || typeof env !== "object" || Array.isArray(env)) return null;
+  const value = (env as Record<string, unknown>).ELIZA_API_TOKEN;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 /** Resolve the browser-facing base; local Docker stays behind the Cloud proxy. */
 export function personalDedicatedClientApiBase(
   target: Pick<AgentSandbox, "id" | "headscale_ip" | "bridge_url"> & {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
@@ -67,9 +67,18 @@ function localBridgeApiBase(value: string | null): string | null {
   }
 }
 
+function localRestApiBase(value: string | null | undefined): string | null {
+  const healthBase = localBridgeApiBase(value ?? null);
+  if (!healthBase) return null;
+  const url = new URL(healthBase);
+  return url.origin;
+}
+
 /** Resolve the same Dedicated agent base for cutover and future account login. */
 export function personalDedicatedAgentApiBase(
-  target: Pick<AgentSandbox, "id" | "headscale_ip" | "bridge_url">,
+  target: Pick<AgentSandbox, "id" | "headscale_ip" | "bridge_url"> & {
+    health_url?: string | null;
+  },
   baseDomain?: string,
 ): string | null {
   const publicBase = getElizaAgentPublicWebUiUrl(target, {
@@ -82,12 +91,16 @@ export function personalDedicatedAgentApiBase(
   // explicit mode may fall back to the server-owned loopback bridge; accepting
   // arbitrary stored hosts here would turn an account bearer into an SSRF
   // credential leak. Production's configured domain always wins above.
-  return baseDomain === undefined ? null : localBridgeApiBase(target.bridge_url);
+  return baseDomain === undefined
+    ? null
+    : (localRestApiBase(target.health_url) ?? localBridgeApiBase(target.bridge_url));
 }
 
 /** Resolve the browser-facing base; local Docker stays behind the Cloud proxy. */
 export function personalDedicatedClientApiBase(
-  target: Pick<AgentSandbox, "id" | "headscale_ip" | "bridge_url">,
+  target: Pick<AgentSandbox, "id" | "headscale_ip" | "bridge_url"> & {
+    health_url?: string | null;
+  },
   baseDomain: string | undefined,
   cloudApiOrigin: string,
 ): string | null {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -40,6 +40,7 @@ mock.module("./shared-runtime-chat", () => ({
 const {
   sharedRestAgentStart,
   sharedRestAuthMe,
+  sharedRestAuthStatus,
   sharedRestCharacter,
   sharedRestConfig,
   sharedRestConversationCreate,
@@ -203,6 +204,14 @@ describe("shared-rest-adapter — startup shell surface", () => {
 
   test("auth/me falls back to a display name when the agent has none", () => {
     expect(sharedRestAuthMe(AGENT, "").identity.displayName).toBe("Eliza");
+    expect(sharedRestAuthStatus()).toEqual({
+      required: false,
+      authenticated: true,
+      pairingEnabled: false,
+      expiresAt: null,
+      localAccess: false,
+      passwordConfigured: false,
+    });
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -438,6 +438,31 @@ export function sharedRestAuthMe(
 }
 
 /**
+ * GET .../api/auth/status — legacy startup-coordinator probe. The newer
+ * top-level gate uses `/api/auth/me`, but `ElizaClient.getAuthStatus()` still
+ * asks for this compact shape before first-run hydration. The enclosing Cloud
+ * route has already authenticated the API key, so Shared is unambiguously an
+ * authenticated bearer session with no pairing flow of its own.
+ */
+export function sharedRestAuthStatus(): {
+  required: false;
+  authenticated: true;
+  pairingEnabled: false;
+  expiresAt: null;
+  localAccess: false;
+  passwordConfigured: false;
+} {
+  return {
+    required: false,
+    authenticated: true,
+    pairingEnabled: false,
+    expiresAt: null,
+    localAccess: false,
+    passwordConfigured: false,
+  };
+}
+
+/**
  * GET .../api/character — the character the app reads. Reuse the same cache-only
  * character resolver as the shared turn; a linked-character cache miss schedules
  * authoritative hydration under waitUntil and fails retryably instead of reading


### PR DESCRIPTION
## Scope

Fourth Dedicated Cloud slice: owner-scoped API proxying, exact path forwarding, server-side runtime credential exchange, Shared-to-Dedicated cutover transport, and authenticated Shared REST startup behavior.

## Security boundary

The browser keeps its Cloud session. Runtime credentials remain server-side; Cloud cookies, API keys, CSRF headers, and upstream Set-Cookie headers are stripped at the hop. Ownership is checked on every request, arbitrary stored hosts are rejected, and production routing remains the configured per-agent Cloud domain.

## Exact-head proof

At `3b1c1f8bccf3e9f104ebd9d157ee1985973dd8ad`:

- Local Dedicated proxy and auth/status boundary: 15/15
- Upgrade/cutover transport and failure states: 16/16
- Personal base and Shared REST adapter: 37/37
- Total focused API/shared tests: 68/68
- Cloud API TypeScript and Worker bundle dry-run pass
- Biome passes across all 21 changed files

## Full-stack stacked proof

The exact final stacked source `d557f714f24` was run locally against the preserved account, PGlite DB, control plane, and real Dedicated container.

- `POST /api/test/auth/session` 200 through the development-only real session fixture
- owner-scoped Dedicated auth, status, conversations, messages, notifications, character, events, and view calls returned 200 through the Cloud proxy
- pairing-token admission returned 200 and the runtime recorded successful managed exchanges
- no browser-visible runtime credential was logged or retained
- prior and current Cerebras `gemma-4-31b` transcript remained visible through the proxy

Depends on #24892. Local-only evidence; no production mutation, real balance debit, or paid provider resource.