### PR TITLE
fix(core): preserve complete target room ID in autonomy escalation action

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -125,6 +125,10 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/truncateWellFormed/,
 		/text\s*=\s*text\.slice\(/,
 	],
+	"packages/core/src/features/autonomy/action.ts": [
+		/targetRoomId\.slice\(0,\s*8\)/,
+		/targetRoomId\.(?:slice|substring)\(/,
+	],
 	"packages/prompts/specs/actions/core.json": [/"c0a8012e"/],
 	"packages/core/src/generated/action-docs.ts": [/"c0a8012e"/],
 	"packages/core/src/runtime/trajectory-recorder.ts": [

--- a/packages/core/src/features/autonomy/action.test.ts
+++ b/packages/core/src/features/autonomy/action.test.ts
@@ -79,6 +79,7 @@ describe("escalateAction", () => {
 		);
 
 		expect(result.success).toBe(true);
+		expect(result.text).toBe(`Message sent to admin in room ${agentId}...`);
 		expect(result.data).toMatchObject({
 			adminUserId: "admin-user",
 			targetRoomId: agentId,

--- a/packages/core/src/features/autonomy/action.ts
+++ b/packages/core/src/features/autonomy/action.ts
@@ -135,7 +135,7 @@ async function escalateToAdmin(
 
 	await runtime.createMemory(adminMessage, "memories");
 
-	const successMessage = `Message sent to admin in room ${targetRoomId.slice(0, 8)}...`;
+	const successMessage = `Message sent to admin in room ${targetRoomId}...`;
 
 	if (callback) {
 		await callback({


### PR DESCRIPTION
## Summary

Preserves the complete `targetRoomId` UUID in the autonomy `ESCALATE` action result text rather than truncating it with `.slice(0, 8)`.

## Changes

- In `packages/core/src/features/autonomy/action.ts:138`, use `${targetRoomId}` instead of `${targetRoomId.slice(0, 8)}` in `successMessage`.
- In `packages/core/src/features/autonomy/action.test.ts`, assert that `result.text` contains the full `targetRoomId` UUID.
- In `packages/core/src/__tests__/prompt-integrity-policy.test.ts`, extend policy rules to guard `packages/core/src/features/autonomy/action.ts` against short ID slicing.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`c4f5844fcc`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/features/autonomy/action.test.ts packages/core/src/__tests__/prompt-integrity-policy.test.ts` | 9 pass (9 tests) | 9 pass (9 tests) |
| `bunx @biomejs/biome check packages/core/src/features/autonomy/action.ts packages/core/src/features/autonomy/action.test.ts packages/core/src/__tests__/prompt-integrity-policy.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/features/autonomy/action.ts:138`
- `packages/core/src/features/autonomy/action.test.ts:82`
- `packages/core/src/__tests__/prompt-integrity-policy.test.ts:128-131`

## Risks

Low. Removes truncation on action output string while preserving all return properties and metadata.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Core runtime action; no UI bundle touched)
- [x] `audit:browser` — N/A (Headless autonomy action)
- [x] `build` — Clean build across workspace
- [x] `test` — 9/9 pass in `action.test.ts` and `prompt-integrity-policy.test.ts`
- [x] `lint` — Biome clean
