### PR TITLE
fix(agent-orchestrator): restore lint baseline

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-inbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-inbox.ts
@@ -12,10 +12,7 @@
 
 const DEFAULT_CAP = 16;
 
-/**
- * Called when enqueue drops entries past the cap. `droppedNow` is the count
- * dropped by this enqueue; `droppedTotal` the session's cumulative drops.
- */
+/** Legacy observer shape retained for callers while the inbox is lossless. */
 export type InboxOverflowObserver = (
   sessionId: string,
   droppedNow: number,
@@ -25,19 +22,14 @@ export type InboxOverflowObserver = (
 export class SubAgentInbox {
   private readonly pending = new Map<string, string[]>();
   private readonly droppedTotals = new Map<string, number>();
-  private onOverflow: InboxOverflowObserver | undefined;
 
   constructor(cap: number = DEFAULT_CAP) {
     void cap;
   }
 
-  /**
-   * Register the overflow observer. The inbox is constructed at plugin-factory
-   * scope before any runtime exists, so the runtime-bound warn/reportError
-   * hookup happens later, in plugin init.
-   */
+  /** Compatibility no-op: a lossless queue cannot overflow. */
   setOverflowObserver(observer: InboxOverflowObserver | undefined): void {
-    this.onOverflow = observer;
+    void observer;
   }
 
   /** Queue a message for a session without evicting earlier input. */


### PR DESCRIPTION
# Relates to

Closes #24894

Definition of Done: full standard in CONTRIBUTING.md.

- [x] This PR targets develop and is rebased onto the latest origin/develop with zero conflicts.
- [x] bun install and bun run verify were run after sync; the exact unrelated root failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto origin/develop at edcf5056ea889ec99e5f341a9e1898491199c80d; zero conflicts.
- [x] bun run verify was run post-sync; the exact unrelated blocker is documented below.

# Risks

Low. The runtime queue remains lossless. The overflow-observer setter stays available as a compatibility no-op, and the ACP test change is formatter-only.

# Background

## What does this PR do?

Removes dead private storage for an overflow callback that cannot fire in the deliberately lossless SubAgentInbox, documents the retained compatibility API, and applies Biome formatting to one ACP unit test.

## What kind of change is this?

Bug fix: restores the hosted lint baseline without changing runtime behavior.

# Documentation changes needed?

N/A - comments beside the compatibility API now accurately document its lossless semantics; no user-facing documentation changes.

# Testing

## Where should a reviewer start?

Review src/services/sub-agent-inbox.ts, then confirm the ACP test diff is formatting-only.

## Detailed testing steps

- mise exec bun@1.3.14 node@24.15.0 -- bun install (pass)
- mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd plugins/plugin-agent-orchestrator lint:check (pass; 436 files)
- mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd plugins/plugin-agent-orchestrator format:check (pass; 436 files)
- mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd plugins/plugin-agent-orchestrator typecheck (pass)
- mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/acp-service.test.ts (pass; 87 tests)
- mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/active-session-forward.test.ts (pass; 21 tests)
- git diff --check (pass)

# Evidence Gate

<!-- evidence-head:fc63046ddd79e70239e017d62714fd391ddac66f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or rendered UI changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a lint-only compatibility cleanup; no runtime path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or requests changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or generated artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - no runtime or frontend behavior changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT changes.

## Known gaps / failures

The develop baseline has three stale SubAgentInbox unit assertions that expect capacity-based message dropping, contradicting the lossless implementation and repository prompt-integrity invariant introduced by #24134. This PR does not broaden into changing those pre-existing tests. A dependency build also reached an environment-specific mise npm-wrapper packaging failure after producing the required core artifacts; package typecheck and affected focused tests pass afterward. Root verify reached the workspace lint/typecheck lane and failed in @elizaos/core on pre-existing lint/format diagnostics. This PR has no core diff: both HEAD:packages/core and origin/develop:packages/core resolve to tree 35b36bc359d3f949ee38edb7552a2ebfa8746042, and git diff --quiet origin/develop -- packages/core exits 0. The affected plugin lint and typecheck pass.

## Maintainer CI exception record

N/A - no exception requested. Independent review and hosted green are required before merge.
