### PR TITLE
fix(orchestrator): preserve complete session ID in sub-agent label fallback and acp service logs

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -2046,7 +2046,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         const label =
           typeof meta.label === "string" && meta.label.trim().length > 0
             ? meta.label
-            : `sub-agent ${sessionId.slice(0, 8)}`;
+            : `sub-agent ${sessionId}`;
         const isTerminalEvent =
           evName === "stopped" ||
           evName === "error" ||

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2785,7 +2785,7 @@ export class AcpService extends Service {
         }
       }
       this.log("info", "resuming orphaned sub-agent after restart", {
-        sessionId: session.id.slice(0, 8),
+        sessionId: session.id,
         status: session.status,
         transportMode,
         label:
@@ -2798,7 +2798,7 @@ export class AcpService extends Service {
       void this.sendPrompt(session.id, ORPHAN_RESUME_PROMPT).catch(
         (err: unknown) =>
           this.log("warn", "orphan resume sendPrompt failed", {
-            sessionId: session.id.slice(0, 8),
+            sessionId: session.id,
             err: err instanceof Error ? err.message : String(err),
           }),
       );


### PR DESCRIPTION
## Summary

Preserves the complete `sessionId` UUID in the sub-agent label fallback (`sub-agent ${sessionId}`) and ACP service orphan resume logging rather than truncating with `.slice(0, 8)`.

## Changes

- In `plugins/plugin-agent-orchestrator/src/index.ts:2049`, fallback to `sub-agent ${sessionId}` instead of `sub-agent ${sessionId.slice(0, 8)}`.
- In `plugins/plugin-agent-orchestrator/src/services/acp-service.ts:2788, 2801`, pass full `session.id` in structured logs instead of `session.id.slice(0, 8)`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`76ae33c9fa`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-label.surrogate.test.ts` | 3 pass (3 tests) | 3 pass (3 tests) |
| `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/index.ts plugins/plugin-agent-orchestrator/src/services/acp-service.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-agent-orchestrator/src/index.ts:2046-2050`
- `plugins/plugin-agent-orchestrator/src/services/acp-service.ts:2788`
- `plugins/plugin-agent-orchestrator/src/services/acp-service.ts:2801`

## Risks

Low. Preserves complete session identity in string and structured log fields.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent Orchestrator backend plugin; no UI bundle touched)
- [x] `audit:browser` — N/A (Headless ACP service / sub-agent orchestration)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 pass in `orchestrator-label.surrogate.test.ts`
- [x] `lint` — Biome clean
