### PR TITLE
fix(meetings): preserve complete session ID in transcription pipeline prefix and segment IDs

### DIFF
--- a/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts
@@ -109,6 +109,7 @@ describe("createMeetingTranscriptionPipeline", () => {
 
     const segments = await pipeline.finalize();
     expect(segments.map((s) => s.text)).toContain("welcome to the standup");
+    expect(segments[0].id).toBe(`${SESSION_ID}:t0:0`);
   });
 
   it("does not call ASR when the billing meter cannot reserve the next window", async () => {
@@ -204,14 +205,14 @@ describe("createMeetingTranscriptionPipeline", () => {
     const pendingUpdate = updates.find((u) => u.pending.length > 0);
     expect(pendingUpdate).toBeDefined();
     expect(pendingUpdate?.pending[0].text).toBe("hello team lets begin");
-    expect(pendingUpdate?.pending[0].id).toBe("12345678:t0:pending");
+    expect(pendingUpdate?.pending[0].id).toBe(`${SESSION_ID}:t0:pending`);
 
     pipeline.pushSpeakerAudio("t0", seconds(2));
     await tick(2000);
     const confirmedUpdate = updates.find((u) => u.confirmed.length > 0);
     expect(confirmedUpdate).toBeDefined();
     expect(confirmedUpdate?.confirmed).toHaveLength(1);
-    expect(confirmedUpdate?.confirmed[0].id).toBe("12345678:t0:0");
+    expect(confirmedUpdate?.confirmed[0].id).toBe(`${SESSION_ID}:t0:0`);
     expect(confirmedUpdate?.confirmed[0].text).toBe("hello team lets begin");
 
     unsubscribe();

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -144,7 +144,7 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
     backend?: AsrBackend,
   ) {
     this.backend = backend ?? new RuntimeModelAsrBackend(options.runtime);
-    this.idPrefix = options.sessionId.slice(0, 8);
+    this.idPrefix = options.sessionId;
     this.manager = new SpeakerStreamManager({
       sampleRate: MEETING_AUDIO_SAMPLE_RATE,
       now: () => Date.now() - this.sessionEpochMs,


### PR DESCRIPTION
## Summary

Preserves the complete `options.sessionId` UUID in `MeetingTranscriptionPipeline` segment identifiers, evidence identifiers, and logs instead of slicing with `.slice(0, 8)`.

## Changes

- In `plugins/plugin-meetings/src/pipeline/pipeline.ts:147`, set `this.idPrefix = options.sessionId` instead of `options.sessionId.slice(0, 8)`.
- In `plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts`, update unit tests to assert that generated segment IDs and pending replacement tails use `${SESSION_ID}:speaker:...`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`ec875358de`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts` | 20 pass (20 tests) | 20 pass (20 tests) |
| `bunx @biomejs/biome check plugins/plugin-meetings/src/pipeline/pipeline.ts plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-meetings/src/pipeline/pipeline.ts:147`
- `plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts:112`
- `plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts:208`
- `plugins/plugin-meetings/src/pipeline/__tests__/pipeline.test.ts:215`

## Risks

Low. Ensures deterministic, unique segment IDs across parallel meeting transcription sessions without ID collisions.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Meetings backend plugin pipeline; no UI bundle touched)
- [x] `audit:browser` — N/A (Audio transcription stream pipeline)
- [x] `build` — Clean build across workspace
- [x] `test` — 20/20 pass in `pipeline.test.ts`
- [x] `lint` — Biome clean
