### PR TITLE
fix(plugins): use surrogate-safe truncateWellFormed on remote API error responses

### DIFF
--- a/plugins/plugin-local-inference/src/services/vision/llama-server.ts
+++ b/plugins/plugin-local-inference/src/services/vision/llama-server.ts
@@ -49,6 +49,7 @@
  *   `__tests__/vision-describe.test.ts` notes for the GPU smoke check.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { resolveImageBytes } from "./hash";
 import type {
 	VisionDescribeBackend,
@@ -124,7 +125,7 @@ export function createLlamaServerVisionBackend(
 			if (!res.ok) {
 				const text = await res.text().catch(() => "<unreadable>");
 				throw new Error(
-					`[vision/llama-server] /completion returned ${res.status}: ${text.slice(0, 200)}`,
+					`[vision/llama-server] /completion returned ${res.status}: ${truncateWellFormed(toWellFormedUnicode(text), 200)}`,
 				);
 			}
 			const payload = (await res.json()) as {

--- a/plugins/plugin-local-inference/src/services/voice/embedding-server.ts
+++ b/plugins/plugin-local-inference/src/services/voice/embedding-server.ts
@@ -10,6 +10,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import net from "node:net";
 import os from "node:os";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
 	isValidEmbeddingDim,
 	type LocalEmbeddingRoute,
@@ -68,7 +69,7 @@ export async function embedWithFetch(
 	if (!response.ok) {
 		const body = await response.text().catch(() => "");
 		throw new Error(
-			`[embedding-server] /v1/embeddings returned ${response.status}: ${body.slice(0, 200)}`,
+			`[embedding-server] /v1/embeddings returned ${response.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
 		);
 	}
 	const payload = (await response.json()) as {

--- a/plugins/plugin-sql/src/write-back/index.ts
+++ b/plugins/plugin-sql/src/write-back/index.ts
@@ -20,7 +20,7 @@
  * If neither env var is set, the service is a no-op.
  */
 
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const MAX_BATCH = 100;
 const FLUSH_DEBOUNCE_MS = 200;
@@ -193,7 +193,7 @@ export class WriteBackService {
         const text = await response.text().catch(() => "");
         logger.warn(
           { src: "plugin:sql", status: response.status },
-          `WriteBackService: cloud API returned ${response.status}: ${text.slice(0, 200)}`
+          `WriteBackService: cloud API returned ${response.status}: ${truncateWellFormed(toWellFormedUnicode(text), 200)}`
         );
         this.requeueOrDrop(batch);
       }


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string truncation with `truncateWellFormed(toWellFormedUnicode(...), 200)` from `@elizaos/core` on remote HTTP error bodies in `plugin-local-inference` (`llama-server.ts`, `embedding-server.ts`) and `plugin-sql` (`write-back/index.ts`).

## Changes

- In `plugins/plugin-local-inference/src/services/vision/llama-server.ts:127`, use `truncateWellFormed(toWellFormedUnicode(text), 200)` for `/completion` HTTP error messages.
- In `plugins/plugin-local-inference/src/services/voice/embedding-server.ts:71`, use `truncateWellFormed(toWellFormedUnicode(body), 200)` for `/v1/embeddings` HTTP error messages.
- In `plugins/plugin-sql/src/write-back/index.ts:196`, use `truncateWellFormed(toWellFormedUnicode(text), 200)` for write-back cloud API error logging.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`84cf246f67`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-local-inference/__tests__/vision-describe.test.ts plugins/plugin-local-inference/__tests__/embedding-handler.test.ts` | 24 pass (24 tests) | 24 pass (24 tests) |
| `bunx vitest run plugins/plugin-sql/src/__tests__/unit/write-back.test.ts` | 15 pass (15 tests) | 15 pass (15 tests) |
| `bunx @biomejs/biome check plugins/plugin-local-inference/src/services/vision/llama-server.ts plugins/plugin-local-inference/src/services/voice/embedding-server.ts plugins/plugin-sql/src/write-back/index.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-local-inference/src/services/vision/llama-server.ts:127`
- `plugins/plugin-local-inference/src/services/voice/embedding-server.ts:71`
- `plugins/plugin-sql/src/write-back/index.ts:196`

## Risks

Low. Prevents splitting 4-byte surrogate pairs or unpaired Unicode in diagnostic error reporting strings without altering any success data structures.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Backend plugins; no UI bundle touched)
- [x] `audit:browser` — N/A (Local inference sidecars and SQL write-back)
- [x] `build` — Clean build across workspace
- [x] `test` — 39/39 pass across `vision-describe.test.ts`, `embedding-handler.test.ts`, and `write-back.test.ts`
- [x] `lint` — Biome clean
