### PR TITLE
fix(cloud): redact payment request responses

### DIFF
--- a/packages/cloud/api/v1/payment-requests/[id]/cancel/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/cancel/route.test.ts
@@ -1,0 +1,86 @@
+/** Exercises the mocked payment-request cancel boundary and its constructive creator response. */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { PaymentRequestRow } from "@/lib/services/payment-requests";
+import {
+  expectedPaymentRequestDto,
+  INTERNAL_PAYMENT_REQUEST_CANARIES,
+  paymentRequestRow,
+} from "../../payment-request-route-test-fixtures";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const cancelMock = mock(
+  async (
+    _id: string,
+    _organizationId: string,
+    _reason?: string,
+  ): Promise<PaymentRequestRow> => paymentRequestRow({ status: "canceled" }),
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/payment-requests-default", () => ({
+  getPaymentRequestsService: () => ({ cancel: cancelMock }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: "standard" },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (
+    c: { json: (body: unknown, status: number) => Response },
+    _error: unknown,
+  ) => c.json({ success: false, error: "internal error" }, 500),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id/cancel", route);
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockClear();
+  cancelMock.mockReset();
+  cancelMock.mockResolvedValue(
+    paymentRequestRow({
+      status: "canceled",
+      updatedAt: new Date("2026-08-20T10:06:00.000Z"),
+    }),
+  );
+});
+
+describe("POST /api/v1/payment-requests/:id/cancel", () => {
+  test("returns only the creator DTO and preserves tenant-scoped cancellation", async () => {
+    const response = await app.request("/pr-1/cancel", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ reason: "No longer needed" }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const row = paymentRequestRow({
+      status: "canceled",
+      updatedAt: new Date("2026-08-20T10:06:00.000Z"),
+    });
+    expect(body).toEqual({
+      success: true,
+      paymentRequest: expectedPaymentRequestDto(row),
+    });
+    const serialized = JSON.stringify(body);
+    for (const canary of INTERNAL_PAYMENT_REQUEST_CANARIES) {
+      expect(serialized).not.toContain(canary);
+    }
+    expect(cancelMock).toHaveBeenCalledWith(
+      "pr-1",
+      "org-1",
+      "No longer needed",
+    );
+  });
+});

--- a/packages/cloud/api/v1/payment-requests/[id]/cancel/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/cancel/route.ts
@@ -12,6 +12,7 @@ import {
   moneyRateLimit,
   RateLimitPresets,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { toPaymentRequestDto } from "@/lib/services/payment-requests";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -55,7 +56,10 @@ app.post("/", async (c) => {
       parsed.data.reason,
     );
 
-    return c.json({ success: true, paymentRequest });
+    return c.json({
+      success: true,
+      paymentRequest: toPaymentRequestDto(paymentRequest),
+    });
   } catch (error) {
     logger.error("[PaymentRequests API] Failed to cancel payment request", {
       error,

--- a/packages/cloud/api/v1/payment-requests/[id]/expire/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/expire/route.test.ts
@@ -1,0 +1,99 @@
+/** Exercises the mocked payment-request expire boundary and its constructive creator response. */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { PaymentRequestRow } from "@/lib/services/payment-requests";
+import {
+  expectedPaymentRequestDto,
+  INTERNAL_PAYMENT_REQUEST_CANARIES,
+  paymentRequestRow,
+} from "../../payment-request-route-test-fixtures";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+const getMock = mock(
+  async (
+    _id: string,
+    _organizationId: string,
+  ): Promise<PaymentRequestRow | null> => paymentRequestRow(),
+);
+const expireMock = mock(async (_id: string, _organizationId: string) => ({
+  paymentRequest: paymentRequestRow({ status: "expired" }),
+  expired: true,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/payment-requests-default", () => ({
+  getPaymentRequestsService: () => ({ get: getMock, expire: expireMock }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: "standard" },
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (
+    c: { json: (body: unknown, status: number) => Response },
+    _error: unknown,
+  ) => c.json({ success: false, error: "internal error" }, 500),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/:id/expire", route);
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockClear();
+  getMock.mockReset();
+  getMock.mockResolvedValue(paymentRequestRow());
+  expireMock.mockReset();
+  expireMock.mockResolvedValue({
+    paymentRequest: paymentRequestRow({
+      status: "expired",
+      updatedAt: new Date("2026-08-20T10:07:00.000Z"),
+    }),
+    expired: true,
+  });
+});
+
+describe("POST /api/v1/payment-requests/:id/expire", () => {
+  test("returns only the creator DTO and preserves the scoped expiration result", async () => {
+    const response = await app.request("/pr-1/expire", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const row = paymentRequestRow({
+      status: "expired",
+      updatedAt: new Date("2026-08-20T10:07:00.000Z"),
+    });
+    expect(body).toEqual({
+      success: true,
+      paymentRequest: expectedPaymentRequestDto(row),
+      expired: true,
+    });
+    const serialized = JSON.stringify(body);
+    for (const canary of INTERNAL_PAYMENT_REQUEST_CANARIES) {
+      expect(serialized).not.toContain(canary);
+    }
+    expect(getMock).toHaveBeenCalledWith("pr-1", "org-1");
+    expect(expireMock).toHaveBeenCalledWith("pr-1", "org-1");
+  });
+
+  test("does not expire a request outside the caller organization", async () => {
+    getMock.mockResolvedValue(null);
+
+    const response = await app.request("/pr-other/expire", { method: "POST" });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Payment request not found",
+    });
+    expect(expireMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
@@ -16,6 +16,7 @@ import {
   moneyRateLimit,
   RateLimitPresets,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { toPaymentRequestDto } from "@/lib/services/payment-requests";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -52,7 +53,7 @@ app.post("/", async (c) => {
 
     return c.json({
       success: true,
-      paymentRequest: after,
+      paymentRequest: toPaymentRequestDto(after),
       expired: wasExpired,
     });
   } catch (error) {

--- a/packages/cloud/api/v1/payment-requests/[id]/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.test.ts
@@ -6,6 +6,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import type { PaymentRequestRow } from "@/lib/services/payment-requests";
+import {
+  expectedPaymentRequestDto,
+  INTERNAL_PAYMENT_REQUEST_CANARIES,
+  paymentRequestRow,
+} from "../payment-request-route-test-fixtures";
 
 const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
@@ -54,32 +59,7 @@ mock.module("@/lib/utils/logger", () => ({
 const { default: route } = await import("./route");
 const app = new Hono().route("/:id", route);
 
-const paymentRequest: PaymentRequestRow = {
-  id: "pr-1",
-  organizationId: "org-1",
-  agentId: "agent-1",
-  appId: "app-1",
-  provider: "stripe" as const,
-  amountCents: 2500,
-  currency: "USD",
-  reason: "Premium plan",
-  paymentContext: { kind: "any_payer" as const },
-  payerIdentityId: "payer-identity-1",
-  payerUserId: "payer-user-1",
-  payerOrganizationId: "payer-org-1",
-  status: "pending" as const,
-  hostedUrl: "https://checkout.example.test/session",
-  callbackUrl: "https://merchant.example.test/callback",
-  callbackSecret: "callback-secret",
-  providerIntent: { secretSessionId: "provider-secret" },
-  settledAt: null,
-  settlementTxRef: "provider-tx-ref",
-  settlementProof: { signature: "proof-secret" },
-  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  metadata: { internal: "do-not-expose" },
-};
+const paymentRequest = paymentRequestRow();
 
 describe("GET /api/v1/payment-requests/:id", () => {
   beforeEach(() => {
@@ -149,15 +129,15 @@ describe("GET /api/v1/payment-requests/:id", () => {
     const response = await app.request("/pr-1");
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    const body = await response.json();
+    expect(body).toEqual({
       success: true,
-      paymentRequest: {
-        ...paymentRequest,
-        createdAt: paymentRequest.createdAt.toISOString(),
-        expiresAt: paymentRequest.expiresAt.toISOString(),
-        updatedAt: paymentRequest.updatedAt.toISOString(),
-      },
+      paymentRequest: expectedPaymentRequestDto(paymentRequest),
     });
+    const serialized = JSON.stringify(body);
+    for (const canary of INTERNAL_PAYMENT_REQUEST_CANARIES) {
+      expect(serialized).not.toContain(canary);
+    }
     expect(getMock).toHaveBeenCalledWith("pr-1", "org-1");
     expect(getPublicMock).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/v1/payment-requests/[id]/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/route.ts
@@ -1,7 +1,7 @@
 /**
  * Payment requests — single resource.
  *
- * GET   /api/v1/payment-requests/:id            Authed creator view (full row).
+ * GET   /api/v1/payment-requests/:id            Authed creator view (allowlisted DTO).
  * GET   /api/v1/payment-requests/:id?public=1   Allowlisted checkout view (no auth required).
  */
 
@@ -12,7 +12,10 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { toPublicPaymentRequest } from "@/lib/services/payment-requests";
+import {
+  toPaymentRequestDto,
+  toPublicPaymentRequest,
+} from "@/lib/services/payment-requests";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -76,7 +79,10 @@ app.get("/", async (c) => {
       );
     }
 
-    return c.json({ success: true, paymentRequest: row });
+    return c.json({
+      success: true,
+      paymentRequest: toPaymentRequestDto(row),
+    });
   } catch (error) {
     // error-policy:J1 route boundary - translate failures into a structured HTTP response.
     logger.error("[PaymentRequests API] Failed to get payment request", {

--- a/packages/cloud/api/v1/payment-requests/payment-request-route-test-fixtures.ts
+++ b/packages/cloud/api/v1/payment-requests/payment-request-route-test-fixtures.ts
@@ -1,0 +1,79 @@
+/** Provides deterministic sensitive rows and independent DTO expectations for payment-request route tests. */
+import type { PaymentRequestRow } from "@/lib/services/payment-requests";
+import type { PaymentRequestDto } from "@/types/cloud-api";
+
+/** Internal-only values that must never appear in an authenticated response. */
+export const INTERNAL_PAYMENT_REQUEST_CANARIES = [
+  "internal-org-canary",
+  "payment-context-canary",
+  "payer-identity-canary",
+  "payer-user-canary",
+  "payer-org-canary",
+  "callback-url-canary",
+  "callback-secret-canary",
+  "provider-intent-canary",
+  "settlement-tx-canary",
+  "settlement-proof-canary",
+  "metadata-canary",
+  "success-url-canary",
+  "cancel-url-canary",
+] as const;
+
+/** Creates a complete internal row with sensitive fields populated. */
+export function paymentRequestRow(
+  overrides: Partial<PaymentRequestRow> = {},
+): PaymentRequestRow {
+  return {
+    id: "pr-1",
+    organizationId: "internal-org-canary",
+    agentId: "agent-1",
+    appId: "app-1",
+    provider: "stripe",
+    amountCents: 2500,
+    currency: "USD",
+    reason: "Premium plan",
+    paymentContext: {
+      kind: "specific_payer",
+      payerIdentityId: "payment-context-canary",
+    },
+    payerIdentityId: "payer-identity-canary",
+    payerUserId: "payer-user-canary",
+    payerOrganizationId: "payer-org-canary",
+    status: "pending",
+    hostedUrl: "https://checkout.example.test/session",
+    callbackUrl: "https://callback-url-canary.example.test/hook",
+    callbackSecret: "callback-secret-canary",
+    providerIntent: { sessionId: "provider-intent-canary" },
+    settledAt: null,
+    settlementTxRef: "settlement-tx-canary",
+    settlementProof: { signature: "settlement-proof-canary" },
+    expiresAt: new Date("2030-01-02T03:04:05.000Z"),
+    createdAt: new Date("2026-08-20T10:00:00.000Z"),
+    updatedAt: new Date("2026-08-20T10:05:00.000Z"),
+    metadata: { internal: "metadata-canary" },
+    successUrl: "https://success-url-canary.example.test/complete",
+    cancelUrl: "https://cancel-url-canary.example.test/cancel",
+    ...overrides,
+  };
+}
+
+/** Builds the independently specified JSON shape expected from route responses. */
+export function expectedPaymentRequestDto(
+  row: PaymentRequestRow,
+): PaymentRequestDto {
+  return {
+    id: row.id,
+    agentId: row.agentId,
+    appId: row.appId,
+    provider: row.provider,
+    amountCents: row.amountCents,
+    currency: row.currency,
+    reason: row.reason,
+    status: row.status,
+    hostedUrl: row.hostedUrl,
+    settledAt: row.settledAt?.toISOString() ?? null,
+    expiresAt: row.expiresAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/packages/cloud/api/v1/payment-requests/route.test.ts
+++ b/packages/cloud/api/v1/payment-requests/route.test.ts
@@ -1,23 +1,30 @@
 /**
- * Exercises the payment-request creation boundary with mocked authentication
- * and payment services, proving public callers cannot attach agent identity.
+ * Exercises the payment-request collection boundary with mocked authentication
+ * and services, proving identity validation and constructive response redaction.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import type { PaymentRequestRow } from "@/lib/services/payment-requests";
+import {
+  expectedPaymentRequestDto,
+  INTERNAL_PAYMENT_REQUEST_CANARIES,
+  paymentRequestRow,
+} from "./payment-request-route-test-fixtures";
 
 const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-a",
   organization_id: "org-a",
 }));
-const createPaymentRequest = mock(async (input: Record<string, unknown>) => ({
-  paymentRequest: {
-    id: "payment-request-a",
-    organizationId: input.organizationId,
-    agentId: null,
-  },
-  hostedUrl: "https://pay.example/request-a",
-}));
-const listPaymentRequests = mock(async () => []);
+const createPaymentRequest = mock(async (input: Record<string, unknown>) => {
+  const row = paymentRequestRow({
+    organizationId: String(input.organizationId),
+  });
+  return {
+    paymentRequest: row,
+    hostedUrl: row.hostedUrl ?? undefined,
+  };
+});
+const listPaymentRequests = mock(async (): Promise<PaymentRequestRow[]> => []);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
@@ -63,29 +70,42 @@ function createRequest(body: Record<string, unknown> = {}): Request {
   });
 }
 
-describe("POST /api/v1/payment-requests agent identity", () => {
-  beforeEach(() => {
-    requireUserOrApiKeyWithOrg.mockReset();
-    requireUserOrApiKeyWithOrg.mockResolvedValue({
-      id: "user-a",
-      organization_id: "org-a",
-    });
-    createPaymentRequest.mockReset();
-    createPaymentRequest.mockResolvedValue({
-      paymentRequest: {
-        id: "payment-request-a",
-        organizationId: "org-a",
-        agentId: null,
-      },
-      hostedUrl: "https://pay.example/request-a",
-    });
-  });
+function expectNoInternalCanaries(body: unknown): void {
+  const serialized = JSON.stringify(body);
+  for (const canary of INTERNAL_PAYMENT_REQUEST_CANARIES) {
+    expect(serialized).not.toContain(canary);
+  }
+}
 
-  test("creates a payment request when agent identity is omitted", async () => {
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    id: "user-a",
+    organization_id: "org-a",
+  });
+  createPaymentRequest.mockReset();
+  const row = paymentRequestRow({ organizationId: "org-a" });
+  createPaymentRequest.mockResolvedValue({
+    paymentRequest: row,
+    hostedUrl: row.hostedUrl ?? undefined,
+  });
+  listPaymentRequests.mockReset();
+  listPaymentRequests.mockResolvedValue([]);
+});
+
+describe("POST /api/v1/payment-requests", () => {
+  test("creates a payment request and returns only its creator DTO", async () => {
     const response = await app.fetch(createRequest());
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({ success: true });
+    const body = await response.json();
+    const row = paymentRequestRow({ organizationId: "org-a" });
+    expect(body).toEqual({
+      success: true,
+      paymentRequest: expectedPaymentRequestDto(row),
+      hostedUrl: row.hostedUrl,
+    });
+    expectNoInternalCanaries(body);
     expect(createPaymentRequest).toHaveBeenCalledWith(
       expect.not.objectContaining({ agentId: expect.anything() }),
     );
@@ -114,5 +134,45 @@ describe("POST /api/v1/payment-requests agent identity", () => {
       expect(response.status).toBe(400);
     }
     expect(createPaymentRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/v1/payment-requests", () => {
+  test("projects every listed row and preserves the scoped filters", async () => {
+    const first = paymentRequestRow({
+      id: "pr-list-1",
+      status: "settled",
+      settledAt: new Date("2026-08-20T10:03:00.000Z"),
+    });
+    const second = paymentRequestRow({
+      id: "pr-list-2",
+      agentId: null,
+      appId: null,
+      status: "settled",
+      settledAt: new Date("2026-08-20T10:04:00.000Z"),
+    });
+    listPaymentRequests.mockResolvedValue([first, second]);
+
+    const response = await app.request(
+      "/api/v1/payment-requests?status=settled&provider=stripe&agentId=agent-1&limit=2&offset=1",
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      paymentRequests: [
+        expectedPaymentRequestDto(first),
+        expectedPaymentRequestDto(second),
+      ],
+    });
+    expectNoInternalCanaries(body);
+    expect(listPaymentRequests).toHaveBeenCalledWith("org-a", {
+      status: "settled",
+      provider: "stripe",
+      agentId: "agent-1",
+      limit: 2,
+      offset: 1,
+    });
   });
 });

--- a/packages/cloud/api/v1/payment-requests/route.ts
+++ b/packages/cloud/api/v1/payment-requests/route.ts
@@ -21,6 +21,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { toPaymentRequestDto } from "@/lib/services/payment-requests";
 import { getPaymentRequestsService } from "@/lib/services/payment-requests-default";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -142,7 +143,7 @@ app.post("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
 
     return c.json({
       success: true,
-      paymentRequest: result.paymentRequest,
+      paymentRequest: toPaymentRequestDto(result.paymentRequest),
       hostedUrl: result.hostedUrl,
     });
   } catch (error) {
@@ -185,7 +186,10 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
       offset: parsed.data.offset,
     });
 
-    return c.json({ success: true, paymentRequests });
+    return c.json({
+      success: true,
+      paymentRequests: paymentRequests.map(toPaymentRequestDto),
+    });
   } catch (error) {
     logger.error("[PaymentRequests API] Failed to list payment requests", {
       error,

--- a/packages/cloud/shared/src/lib/services/payment-requests.test.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.test.ts
@@ -5,7 +5,11 @@ import {
   type PaymentRequestRow,
   PaymentRequestsRepository,
 } from "../../db/repositories/payment-requests";
-import { createPaymentRequestsService, toPublicPaymentRequest } from "./payment-requests";
+import {
+  createPaymentRequestsService,
+  toPaymentRequestDto,
+  toPublicPaymentRequest,
+} from "./payment-requests";
 
 class GuardedPaymentRequestsRepository extends PaymentRequestsRepository {
   createCalls = 0;
@@ -85,6 +89,68 @@ describe("toPublicPaymentRequest", () => {
     };
 
     expect(toPublicPaymentRequest(row, new Date(1)).hostedUrl).toBe(row.hostedUrl);
+  });
+});
+
+describe("toPaymentRequestDto", () => {
+  test("constructs the creator DTO without internal payment state", () => {
+    const row: PaymentRequestRow = {
+      ...fakeRow("pr-creator", "organization-canary"),
+      agentId: "agent-1",
+      appId: "app-1",
+      reason: "Premium plan",
+      status: "settled",
+      hostedUrl: "https://checkout.example.test/session",
+      paymentContext: { kind: "specific_payer", payerIdentityId: "context-canary" },
+      payerIdentityId: "payer-identity-canary",
+      payerUserId: "payer-user-canary",
+      payerOrganizationId: "payer-org-canary",
+      callbackUrl: "https://callback.example.test/canary",
+      callbackSecret: "callback-secret-canary",
+      providerIntent: { sessionSecret: "provider-intent-canary" },
+      settledAt: new Date("2026-08-20T10:03:00.000Z"),
+      settlementTxRef: "settlement-tx-canary",
+      settlementProof: { signature: "settlement-proof-canary" },
+      expiresAt: new Date("2026-08-20T10:30:00.000Z"),
+      createdAt: new Date("2026-08-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-08-20T10:03:00.000Z"),
+      metadata: { internal: "metadata-canary" },
+      successUrl: "https://success.example.test/canary",
+      cancelUrl: "https://cancel.example.test/canary",
+    };
+
+    const dto = toPaymentRequestDto(row);
+
+    expect(dto).toEqual({
+      id: "pr-creator",
+      agentId: "agent-1",
+      appId: "app-1",
+      provider: "stripe",
+      amountCents: 100,
+      currency: "USD",
+      reason: "Premium plan",
+      status: "settled",
+      hostedUrl: "https://checkout.example.test/session",
+      settledAt: "2026-08-20T10:03:00.000Z",
+      expiresAt: "2026-08-20T10:30:00.000Z",
+      createdAt: "2026-08-20T10:00:00.000Z",
+      updatedAt: "2026-08-20T10:03:00.000Z",
+    });
+    const serialized = JSON.stringify(dto);
+    for (const canary of [
+      "organization-canary",
+      "context-canary",
+      "payer-identity-canary",
+      "payer-user-canary",
+      "payer-org-canary",
+      "callback-secret-canary",
+      "provider-intent-canary",
+      "settlement-tx-canary",
+      "settlement-proof-canary",
+      "metadata-canary",
+    ]) {
+      expect(serialized).not.toContain(canary);
+    }
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.ts
@@ -1,9 +1,10 @@
-/** Coordinates payment-request state, provider intents, and public checkout projection. */
+/** Coordinates payment-request state, provider intents, and transport projections. */
 import type {
   PaymentRequestRow,
   PaymentRequestsRepository,
 } from "../../db/repositories/payment-requests";
 import { MAX_PAYMENT_REQUEST_LEDGER_CENTS } from "../../db/schemas/payment-requests";
+import type { PaymentRequestDto } from "../types/cloud-api";
 
 export { IgnoredWebhookEvent } from "./payment-webhook-errors";
 
@@ -465,6 +466,25 @@ export function createPaymentRequestsService(
   deps: PaymentRequestsServiceDeps,
 ): PaymentRequestsService {
   return new PaymentRequestsServiceImpl(deps);
+}
+
+/** Constructs the allowlisted creator-facing representation of an internal row. */
+export function toPaymentRequestDto(row: PaymentRequestRow): PaymentRequestDto {
+  return {
+    id: row.id,
+    agentId: row.agentId,
+    appId: row.appId,
+    provider: row.provider,
+    amountCents: row.amountCents,
+    currency: row.currency,
+    reason: row.reason,
+    status: row.status,
+    hostedUrl: row.hostedUrl,
+    settledAt: row.settledAt?.toISOString() ?? null,
+    expiresAt: row.expiresAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
 }
 
 export function toPublicPaymentRequest(

--- a/packages/cloud/shared/src/lib/types/cloud-api.ts
+++ b/packages/cloud/shared/src/lib/types/cloud-api.ts
@@ -1,4 +1,4 @@
-// Defines cloud shared cloud api behavior for backend service consumers.
+/** Defines cloud transport DTOs shared by backend producers and API consumers. */
 export type IsoDateString = string;
 export type DateLike = Date | IsoDateString;
 
@@ -102,6 +102,39 @@ export interface InvoiceDto {
   updated_at: DateLike;
   due_date: DateLike | null;
   paid_at: DateLike | null;
+}
+
+/** Payment rails represented by the unified payment-request transport. */
+export type PaymentRequestProviderDto = "stripe" | "oxapay" | "x402" | "wallet_native";
+
+/** Persisted payment-request lifecycle states exposed to creators. */
+export type PaymentRequestStatusDto =
+  | "pending"
+  | "delivered"
+  | "settled"
+  | "failed"
+  | "expired"
+  | "canceled";
+
+/**
+ * Creator-facing payment-request projection. Provider payloads, callback
+ * credentials, payer identities, settlement proof, and arbitrary metadata
+ * never cross this transport boundary.
+ */
+export interface PaymentRequestDto {
+  id: string;
+  agentId: string | null;
+  appId: string | null;
+  provider: PaymentRequestProviderDto;
+  amountCents: number;
+  currency: string;
+  reason: string | null;
+  status: PaymentRequestStatusDto;
+  hostedUrl: string | null;
+  settledAt: IsoDateString | null;
+  expiresAt: IsoDateString;
+  createdAt: IsoDateString;
+  updatedAt: IsoDateString;
 }
 
 export type AppDeploymentStatus = "draft" | "building" | "deploying" | "deployed" | "failed";


### PR DESCRIPTION
# Relates to

Closes #24848.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      `verify` blocker is recorded below.
- [x] A reviewer can confirm the change from the attached exact-head test report.

# Sync with develop

- [x] Rebased onto `origin/develop@cbb400ddbcc21117505275557dd4f8505b2ccd1a`; zero conflicts.
- [x] `bun run verify` was run post-sync. Its unrelated baseline lint blocker is
      documented in **Known gaps / failures** below; `bun run verify:cloud`
      completed 84/84 tasks successfully.

# Risks

Medium. This intentionally removes internal database fields from five authenticated
API responses, so an out-of-repository client that depended on undocumented fields
could need adjustment. In-repository consumers were audited and none rely on those
fields. A single constructive mapper, exact-shape tests, secret canaries, tenant-scope
assertions, and unchanged public-checkout tests constrain the risk.

# Background

## What does this PR do?

- Adds the canonical creator-facing `PaymentRequestDto` and constructs it
  field-by-field from an internal `PaymentRequestRow`.
- Applies that DTO to create, list, authenticated detail, cancel, and expire
  responses.
- Excludes organization ownership, payment context, payer identities, callback
  credentials, provider intents, settlement references/proofs, metadata, and
  redirect URLs from those JSON boundaries.
- Keeps tenant-scoped lookups, IDOR-as-404 behavior, and the existing
  unauthenticated `?public=1` checkout DTO unchanged.

## What kind of change is this?

Bug fix / security hardening of an existing API response contract. No endpoint,
schema, migration, provider, payment-state, entitlement, UI, deploy, or production
change.

# Documentation changes needed?

No project-documentation change is needed. The transport contract is documented by
the exported DTO and mapper comments, and the linked issue owns the broader Billing
history context.

# Testing

## Where should a reviewer start?

Start with `toPaymentRequestDto()` in
`packages/cloud/shared/src/lib/services/payment-requests.ts`, then the five route
call sites and `payment-request-route-test-fixtures.ts`.

## Detailed testing steps

Run from the repository root at PR head:

```bash
bun install --frozen-lockfile
bun test --isolate \
  packages/cloud/shared/src/lib/services/payment-requests.test.ts \
  packages/cloud/api/v1/payment-requests/route.test.ts \
  'packages/cloud/api/v1/payment-requests/[id]/route.test.ts' \
  'packages/cloud/api/v1/payment-requests/[id]/cancel/route.test.ts' \
  'packages/cloud/api/v1/payment-requests/[id]/expire/route.test.ts' \
  'packages/cloud/api/v1/payment-requests/[id]/route.public-query.test.ts' \
  packages/cloud/api/__tests__/payment-request-public-auth.integration.test.ts
bun run verify:cloud
bun run verify
```

Exact-head result: 37 focused tests passed with 192 assertions; `verify:cloud`
completed 84/84 tasks. The root `verify` baseline blocker is detailed below.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:74863a320aae3cfa6b51e8ef072333d7978bd8d8 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. This patch has no rendered frontend surface.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only API response projection; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only API response projection; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered or interactive user flow changed.

<!-- evidence-row:backend-logs -->
- [x] [24907-payment-request-response-dto-tests-74863a32.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24907-payment-request-response-dto-tests-74863a32.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, console behavior, or browser network flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, model, or provider behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database row, schema, migration, provider state, wallet, or external side effect changed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: the exact-head JUnit report covers all five authenticated response
boundaries, public auth/shape compatibility, tenant scoping, IDOR behavior, and
constructive canary exclusion. Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - backend-only response projection with no rendered UI.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` exits 1 in `@elizaos/shared#typecheck` because
  `packages/shared/src/__tests__/restart.test.ts` imports `./restart.ts` and
  `packages/shared/src/utils/__tests__/cloud-status.test.ts` imports
  `./cloud-status.ts`, while both modules live one directory above their tests.
  Those two tests are byte-identical to the validated parent
  `origin/develop@cbb400ddbcc21117505275557dd4f8505b2ccd1a`; this PR does not
  touch `packages/shared`.
- The focused tests, Cloud shared/API typechecks and lints, Worker production
  dry-run bundle, and `bun run verify:cloud` all pass on the exact PR head.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`



