### PR TITLE
fix(core): fence stale task scheduler generations

### DIFF
--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -107,6 +107,122 @@ describe("task-scheduler", () => {
 		expect(getTasks).toHaveBeenCalledTimes(2);
 	});
 
+	it("rejects an old query result after the scheduler is restarted", async () => {
+		let releaseOldQuery: ((tasks: Task[]) => void) | undefined;
+		const oldQuery = new Promise<Task[]>((resolve) => {
+			releaseOldQuery = resolve;
+		});
+		const oldGetTasks = vi.fn(() => oldQuery);
+		const oldRunTick = vi.fn(async () => undefined);
+
+		startTaskScheduler({
+			getTasks: oldGetTasks,
+		} as unknown as IDatabaseAdapter);
+		registerTaskSchedulerRuntime(makeRuntime(), { runTick: oldRunTick });
+		await runOneTick();
+		expect(oldGetTasks).toHaveBeenCalledTimes(1);
+
+		stopTaskScheduler();
+
+		const newGetTasks = vi.fn(async () => [] as Task[]);
+		const newRunTick = vi.fn(async () => undefined);
+		startTaskScheduler({
+			getTasks: newGetTasks,
+		} as unknown as IDatabaseAdapter);
+		registerTaskSchedulerRuntime(makeRuntime(), { runTick: newRunTick });
+
+		// The unresolved old query must not block the restarted generation.
+		await runOneTick();
+		expect(newGetTasks).toHaveBeenCalledTimes(1);
+
+		releaseOldQuery?.([{ id: "old", agentId: AGENT_ID } as Task]);
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(oldRunTick).not.toHaveBeenCalled();
+		expect(newRunTick).not.toHaveBeenCalled();
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				err: expect.objectContaining({
+					code: "TASK_SCHEDULER_STALE_GENERATION",
+				}),
+			}),
+			"[TaskScheduler] tick failed",
+		);
+	});
+
+	it("re-queries registered agents when a live adapter is replaced", async () => {
+		let releaseOldQuery: ((tasks: Task[]) => void) | undefined;
+		const oldQuery = new Promise<Task[]>((resolve) => {
+			releaseOldQuery = resolve;
+		});
+		const oldGetTasks = vi.fn(() => oldQuery);
+		const runTick = vi.fn(async () => undefined);
+
+		startTaskScheduler({
+			getTasks: oldGetTasks,
+		} as unknown as IDatabaseAdapter);
+		registerTaskSchedulerRuntime(makeRuntime(), { runTick });
+		await runOneTick();
+
+		const newGetTasks = vi.fn(async () => [] as Task[]);
+		startTaskScheduler({
+			getTasks: newGetTasks,
+		} as unknown as IDatabaseAdapter);
+		await runOneTick();
+		expect(newGetTasks).toHaveBeenCalledTimes(1);
+
+		releaseOldQuery?.([{ id: "old", agentId: AGENT_ID } as Task]);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(runTick).not.toHaveBeenCalled();
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				err: expect.objectContaining({
+					code: "TASK_SCHEDULER_STALE_GENERATION",
+				}),
+			}),
+			"[TaskScheduler] tick failed",
+		);
+	});
+
+	it("rejects query rows for a replaced registration with the same agent id", async () => {
+		let releaseQuery: ((tasks: Task[]) => void) | undefined;
+		const pendingQuery = new Promise<Task[]>((resolve) => {
+			releaseQuery = resolve;
+		});
+		const getTasks = vi
+			.fn<() => Promise<Task[]>>()
+			.mockReturnValueOnce(pendingQuery)
+			.mockResolvedValue([]);
+
+		startTaskScheduler({ getTasks } as unknown as IDatabaseAdapter);
+		const oldRunTick = vi.fn(async () => undefined);
+		registerTaskSchedulerRuntime(makeRuntime(), { runTick: oldRunTick });
+		await runOneTick();
+
+		unregisterTaskSchedulerRuntime(AGENT_ID);
+		const replacementRunTick = vi.fn(async () => undefined);
+		registerTaskSchedulerRuntime(makeRuntime(), {
+			runTick: replacementRunTick,
+		});
+		releaseQuery?.([{ id: "old", agentId: AGENT_ID } as Task]);
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(oldRunTick).not.toHaveBeenCalled();
+		expect(replacementRunTick).not.toHaveBeenCalled();
+		expect(errorSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				err: expect.objectContaining({
+					code: "TASK_SCHEDULER_REGISTRATION_CHANGED",
+				}),
+			}),
+			"[TaskScheduler] rejected tasks for a stale registration",
+		);
+
+		// The replacement registration remains dirty and is queried normally.
+		await runOneTick();
+		expect(getTasks).toHaveBeenCalledTimes(2);
+	});
+
 	it("re-arms a still-registered agent after a transient getTasks rejection (no re-register)", async () => {
 		let getTasksCalls = 0;
 		const adapter = {

--- a/packages/core/src/services/task-scheduler.ts
+++ b/packages/core/src/services/task-scheduler.ts
@@ -18,16 +18,21 @@ interface TaskServiceLike {
 	runTick(tasks: Task[]): Promise<void>;
 }
 
+interface SchedulerRegistration {
+	runtime: IAgentRuntime;
+	taskService: TaskServiceLike;
+	registrationId: number;
+}
+
 // Module state (not exported). WHY: single shared timer and registry for the process.
-const registry = new Map<
-	string,
-	{ runtime: IAgentRuntime; taskService: TaskServiceLike }
->();
+const registry = new Map<string, SchedulerRegistration>();
 /** Agent IDs that need a tick (registered or markTaskSchedulerDirty). Cleared each tick. WHY: only query for agents that care. */
 const dirtyAgents = new Set<string>();
 let timer: ReturnType<typeof setInterval> | null = null;
 let adapter: IDatabaseAdapter | null = null;
 let activeTick: Promise<void> | null = null;
+let schedulerGeneration = 0;
+let nextRegistrationId = 0;
 
 const TICK_INTERVAL_MS = 1000;
 
@@ -35,15 +40,49 @@ const TICK_INTERVAL_MS = 1000;
  * One tick: fetch queue tasks for all dirty agents in one call, group by agentId, runTick per runtime.
  * WHY single getTasks(agentIds): one DB round-trip for many agents instead of N round-trips.
  */
-async function tick(): Promise<void> {
+function staleGenerationError(
+	expectedGeneration: number,
+	cause?: unknown,
+): ElizaError {
+	return new ElizaError("Task scheduler generation changed during a tick", {
+		code: "TASK_SCHEDULER_STALE_GENERATION",
+		context: {
+			expectedGeneration,
+			currentGeneration: schedulerGeneration,
+		},
+		cause,
+		severity: "ephemeral",
+	});
+}
+
+function currentRegistration(
+	agentId: string,
+	registrationId: number,
+	generation: number,
+): SchedulerRegistration | undefined {
+	if (generation !== schedulerGeneration) return undefined;
+	const entry = registry.get(agentId);
+	return entry?.registrationId === registrationId ? entry : undefined;
+}
+
+async function tick(generation: number): Promise<void> {
+	if (generation !== schedulerGeneration) {
+		throw staleGenerationError(generation);
+	}
+
 	const snapshot = Array.from(dirtyAgents);
+	const registrations = new Map<string, number>();
+	for (const agentId of snapshot) {
+		const entry = registry.get(agentId);
+		if (entry) registrations.set(agentId, entry.registrationId);
+	}
 	dirtyAgents.clear();
-	if (snapshot.length === 0) return;
+	if (registrations.size === 0) return;
 
 	const adp = adapter;
 	if (!adp) return;
 
-	const agentIds = snapshot as UUID[];
+	const agentIds = Array.from(registrations.keys()) as UUID[];
 	let allTasks: Task[];
 	try {
 		allTasks = await adp.getTasks({
@@ -51,28 +90,36 @@ async function tick(): Promise<void> {
 			agentIds,
 		});
 	} catch (cause) {
+		if (generation !== schedulerGeneration) {
+			throw staleGenerationError(generation, cause);
+		}
 		// error-policy:J1 The shared query boundary reports a typed failure to
 		// every affected runtime and re-arms them.
 		const error = new ElizaError("Shared task queue query failed", {
 			code: "TASK_SCHEDULER_QUERY_FAILED",
-			context: { agentIds: snapshot },
+			context: { agentIds },
 			cause,
 			severity: "ephemeral",
 		});
-		for (const aid of snapshot) {
-			const entry = registry.get(aid);
+		for (const [aid, registrationId] of registrations) {
+			const entry = currentRegistration(aid, registrationId, generation);
 			if (!entry) continue;
 			dirtyAgents.add(aid);
 			entry.runtime.reportError("TaskScheduler.query", error, { agentId: aid });
 		}
 		throw error;
 	}
+	if (generation !== schedulerGeneration) {
+		throw staleGenerationError(generation);
+	}
 
 	// Group by task.agentId so each runtime only receives its own tasks. WHY: runTick expects one agent's tasks.
 	const byAgent = new Map<string, Task[]>();
+	const staleRegistrations = new Set<string>();
 	for (const task of allTasks) {
 		const aid = task.agentId != null ? String(task.agentId) : "";
-		if (!aid || !snapshot.includes(aid) || !registry.has(aid)) {
+		const registrationId = aid ? registrations.get(aid) : undefined;
+		if (!aid || registrationId === undefined) {
 			const error = new ElizaError(
 				"Task scheduler adapter returned an out-of-scope task",
 				{
@@ -80,17 +127,38 @@ async function tick(): Promise<void> {
 					context: {
 						taskId: task.id,
 						returnedAgentId: aid || null,
-						queriedAgentIds: snapshot,
+						queriedAgentIds: agentIds,
 					},
 					severity: "fatal",
 				},
 			);
-			for (const queriedAgentId of snapshot) {
-				registry
-					.get(queriedAgentId)
-					?.runtime.reportError("TaskScheduler.scope", error, {
-						agentId: queriedAgentId,
-					});
+			for (const [queriedAgentId, queriedRegistrationId] of registrations) {
+				currentRegistration(
+					queriedAgentId,
+					queriedRegistrationId,
+					generation,
+				)?.runtime.reportError("TaskScheduler.scope", error, {
+					agentId: queriedAgentId,
+				});
+			}
+			continue;
+		}
+		if (!currentRegistration(aid, registrationId, generation)) {
+			if (!staleRegistrations.has(aid)) {
+				staleRegistrations.add(aid);
+				logger.error(
+					{
+						err: new ElizaError(
+							"Task scheduler registration changed during a tick",
+							{
+								code: "TASK_SCHEDULER_REGISTRATION_CHANGED",
+								context: { agentId: aid, registrationId },
+								severity: "ephemeral",
+							},
+						),
+					},
+					"[TaskScheduler] rejected tasks for a stale registration",
+				);
 			}
 			continue;
 		}
@@ -100,8 +168,25 @@ async function tick(): Promise<void> {
 	}
 
 	for (const [agentIdKey, tasks] of byAgent) {
-		const entry = registry.get(agentIdKey);
-		if (!entry) continue;
+		const registrationId = registrations.get(agentIdKey);
+		if (registrationId === undefined) continue;
+		const entry = currentRegistration(agentIdKey, registrationId, generation);
+		if (!entry) {
+			logger.error(
+				{
+					err: new ElizaError(
+						"Task scheduler registration changed before dispatch",
+						{
+							code: "TASK_SCHEDULER_REGISTRATION_CHANGED",
+							context: { agentId: agentIdKey, registrationId },
+							severity: "ephemeral",
+						},
+					),
+				},
+				"[TaskScheduler] rejected tasks for a stale registration",
+			);
+			continue;
+		}
 		try {
 			await entry.taskService.runTick(tasks);
 		} catch (error) {
@@ -114,7 +199,7 @@ async function tick(): Promise<void> {
 		// Non-empty queue: keep the agent dirty so the next tick re-queries. WHY: repeat tasks and
 		// not-yet-due one-shots become due purely by time passing, with no markTaskSchedulerDirty
 		// call; only agents whose queue came back empty go quiet until marked dirty again.
-		if (registry.has(agentIdKey)) {
+		if (currentRegistration(agentIdKey, registrationId, generation)) {
 			dirtyAgents.add(agentIdKey);
 		}
 	}
@@ -122,13 +207,23 @@ async function tick(): Promise<void> {
 
 /** WHY: host provides the adapter so the scheduler can call getTasks without going through a specific runtime. */
 export function startTaskScheduler(adapterInstance: IDatabaseAdapter): void {
+	if (timer && adapter === adapterInstance) return;
+
+	// Replacing a live adapter starts a new scheduler generation. The old query
+	// may still settle, but its result cannot cross into this adapter/runtime set.
+	schedulerGeneration += 1;
 	adapter = adapterInstance;
-	if (timer) return;
+	activeTick = null;
+	if (timer) {
+		for (const agentId of registry.keys()) dirtyAgents.add(agentId);
+		return;
+	}
 	timer = setInterval(() => {
 		if (activeTick) return;
 		// error-policy:J1 The process timer is the outer scheduler boundary; per-agent
 		// failures are reported inside tick, while adapter-level failure is logged here.
-		const tickPromise = tick()
+		const generation = schedulerGeneration;
+		const tickPromise = tick(generation)
 			.catch((err) => logger.error({ err }, "[TaskScheduler] tick failed"))
 			.finally(() => {
 				if (activeTick === tickPromise) activeTick = null;
@@ -138,6 +233,7 @@ export function startTaskScheduler(adapterInstance: IDatabaseAdapter): void {
 }
 
 export function stopTaskScheduler(): void {
+	schedulerGeneration += 1;
 	if (timer) {
 		clearInterval(timer);
 		timer = null;
@@ -145,6 +241,9 @@ export function stopTaskScheduler(): void {
 	registry.clear();
 	dirtyAgents.clear();
 	adapter = null;
+	// An in-flight adapter call cannot be cancelled. Detach it so a restarted
+	// generation is not blocked; its generation fence rejects its eventual result.
+	activeTick = null;
 }
 
 /** Called by TaskService.startTimer() when getTaskSchedulerAdapter() != null. WHY: runtime opts into shared tick instead of local timer. */
@@ -153,13 +252,20 @@ export function registerTaskSchedulerRuntime(
 	taskService: TaskServiceLike,
 ): void {
 	const agentIdKey = String(runtime.agentId);
-	registry.set(agentIdKey, { runtime, taskService });
+	nextRegistrationId += 1;
+	registry.set(agentIdKey, {
+		runtime,
+		taskService,
+		registrationId: nextRegistrationId,
+	});
 	dirtyAgents.add(agentIdKey);
 }
 
 /** Called by TaskService.stop(). WHY: daemon must not call runTick after runtime has stopped. */
 export function unregisterTaskSchedulerRuntime(agentId: UUID): void {
-	registry.delete(String(agentId));
+	const agentIdKey = String(agentId);
+	registry.delete(agentIdKey);
+	dirtyAgents.delete(agentIdKey);
 }
 
 /** Called by TaskService.markDirty() when daemon is present. WHY: next tick will include this agent in the batched getTasks. */


### PR DESCRIPTION
# Relates to

Fixes #24900.

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `edcf5056ea88` with zero conflicts.
- [x] `bun install` completed on the publishing worktree. `bun run verify` was run; its unrelated upstream blocker is recorded below.
- [x] The lifecycle behavior is reproducible from the inline test evidence below.

# Sync with develop

- [x] Rebased onto the latest measured `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It is blocked by an exact-`origin/develop` import-order error in `packages/app/src/shims/__tests__/vercel-oidc.test.ts`, recorded under **Known gaps / failures**.

# Risks

Low to moderate. The change is isolated to the process-wide shared task scheduler. Each timer tick is bound to a scheduler generation and each queried agent to the registration identity captured before the adapter call. Restart and live adapter replacement detach the old in-flight promise; its eventual result cannot cross either fence. Persistent task rows are not deleted, rewritten, truncated, or reassigned.

# Background

## What does this PR do?

`stopTaskScheduler()` previously cleared the interval and registry but not the module's unresolved `activeTick`. Restarting while an old adapter query was pending made the new timer skip every tick until the old promise settled. A live adapter replacement had the same behavior. Worse, a successful old query for an agent ID could settle after that ID was unregistered and re-registered, then be dispatched to the replacement runtime because the registry lookup used only the string agent ID.

This PR adds two adjacent lifecycle invariants:

1. A monotonically increasing scheduler generation fences stop/restart and live adapter replacement. The old tick is detached so the new adapter queries immediately; the old promise rejects with typed `TASK_SCHEDULER_STALE_GENERATION` if it later settles.
2. A per-registration identity fences unregister/re-register with the same agent ID. Rows from the stale query are rejected with typed `TASK_SCHEDULER_REGISTRATION_CHANGED`, are never delivered to either runtime, and the replacement remains dirty so its current adapter is queried normally.

The start path remains idempotent when called again with the same adapter and live timer. Existing query retry, non-empty queue re-arming, tenant-scope rejection, unregister-during-dispatch, and runtime error reporting behavior remains unchanged.

The timer already has a `.catch(...)` boundary, but it cannot correct the original defect: no rejection occurs while the new tick is silently skipped, and a stale query can resolve successfully with a currently registered agent ID. The wrong value crosses that catch unchanged.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public documentation change. The focused regression tests document the module lifecycle contract.

# Testing

## Where should a reviewer start?

`packages/core/src/services/task-scheduler.test.ts`, tests:

- `rejects an old query result after the scheduler is restarted`
- `re-queries registered agents when a live adapter is replaced`
- `rejects query rows for a replaced registration with the same agent id`

## Detailed testing steps

1. Run `bun run --cwd packages/core test -- src/services/task-scheduler.test.ts`.
2. Observe `1 passed` test file and `11 passed` tests.
3. For the load-bearing revert, restore only `packages/core/src/services/task-scheduler.ts` from `origin/develop` while retaining the committed regression test.
4. Run each new case independently with `-t`; each fails on origin. Restart and live replacement report the new adapter was called 0 times; same-ID replacement reports the stale row was dispatched once to the replacement runtime.
5. Restore the PR source and rerun the complete file: `11 passed`.
6. Run `bun run --cwd packages/core typecheck` and changed-file Biome.

Origin source identity was checked with:

```text
git show origin/develop:packages/core/src/services/task-scheduler.ts | diff - packages/core/src/services/task-scheduler.ts
exit 0
```

Independent load-bearing origin runs:

```text
restart:
Test Files  1 failed (1)
Tests       1 failed | 10 skipped (11)
AssertionError: expected newGetTasks to be called 1 times, but got 0 times

live adapter replacement:
Test Files  1 failed (1)
Tests       1 failed | 10 skipped (11)
AssertionError: expected newGetTasks to be called 1 times, but got 0 times

same-agent replacement:
Test Files  1 failed (1)
Tests       1 failed | 10 skipped (11)
AssertionError: expected replacementRunTick to not be called, but got 1 call
```

Fixed exact-head output:

```text
Test Files  1 passed (1)
Tests       11 passed (11)
proof-run: recorded PROOF for 6b264ead9
```

No-over-rejection corpus: the untouched origin source plus untouched origin tests passes all 8 pre-existing tests; the fixed branch passes those same 8 assertions unchanged plus 3 lifecycle regressions, for 11/11. Those pre-existing cases assert the exact task arrays dispatched for valid single-tenant rows, retry after a transient query error, repeat/non-empty re-querying, quiet empty queues, unregister-during-tick, scope rejection, and runtime error reporting. Core typecheck exits 0 on both exact-origin and fixed controls: zero added errors.

# Evidence Gate

Evidence head: `6b264ead96194bcf6adeb41d9b1373fcc63c99a5`.
<!-- evidence-head:6b264ead96194bcf6adeb41d9b1373fcc63c99a5 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - runtime-only scheduler lifecycle; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - runtime-only scheduler lifecycle; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - deterministic service lifecycle with no interactive UI.
<!-- evidence-row:backend-logs -->
- [x] Backend/test logs are attached inline above: three independent origin cases fail; fixed exact head passes 11/11.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend or transport path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no model, prompt, provider, action, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: real `Task` rows returned by the delayed adapter are asserted never to reach an old or replacement `runTick`; the new registration remains dirty and re-queries through the current adapter.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a scheduler/service lifecycle repair and invokes no LLM seam.

## Backend + frontend logs

Backend: focused Vitest, origin copy-aside controls, typecheck, Biome, and proof-run outputs are inline above. Frontend: N/A - no frontend path.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path.

## Known gaps / failures

- `bun run verify` was executed after sync. It reached workspace lint and failed outside this PR because `packages/app/src/shims/__tests__/vercel-oidc.test.ts` has an import-order delta. That file is byte-identical to `origin/develop` (`git show origin/develop:<path> | diff - <path>` exits 0), and a direct Biome run on that untouched file reproduces the same error. It does not appear in this PR diff.
- This is a fork contribution. Upstream hosted CI does not run tests for our PRs; no hosted-CI pass is claimed.
- No live external database was invoked; the scheduler regressions use the real module/timer seams with controlled `IDatabaseAdapter` promises and concrete `Task` rows.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: codex
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cr-24161-task-scheduler]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0P0810GNQJV0MESW97HKPCT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T00:27:35.825Z","completed_at":"2026-08-23T00:34:33.808Z","skill_sha256":"97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T00:27:36.517Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8fb7fba3ad24b1365c435bed3cae8c6cecb7741ada849b6dc5c8e95be8f327ff","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4a80fb8a-cd5b-4a0c-923b-0124a92fc1c4","object_id":"sha256:8fb7fba3ad24b1365c435bed3cae8c6cecb7741ada849b6dc5c8e95be8f327ff","sha256":"8fb7fba3ad24b1365c435bed3cae8c6cecb7741ada849b6dc5c8e95be8f327ff"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"9_zLa1vTK31gDLCf_PJPB4kBAulEu3zt3SM11eTgMok67K5reIUYjGqrmuhIXC9Mt6d9jb5eZsm7ANGtvtkRAg"}} -->
