### PR TITLE
test(agent): cover tool-call cache key derivation

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache/__tests__/tool-cache-key.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/__tests__/tool-cache-key.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildCacheKey, canonicalizeJson } from "./key.ts";
+
+describe("canonicalizeJson", () => {
+  it("sorts object keys recursively", () => {
+    expect(canonicalizeJson({ b: 1, a: 2 })).toBe(
+      canonicalizeJson({ a: 2, b: 1 }),
+    );
+  });
+
+  it("normalizes arrays element-wise", () => {
+    expect(canonicalizeJson([{ b: 1, a: 2 }, [3, 2]])).toBe(
+      canonicalizeJson([{ a: 2, b: 1 }, [3, 2]]),
+    );
+  });
+
+  it("handles primitives", () => {
+    expect(canonicalizeJson(null)).toBe("null");
+    expect(canonicalizeJson(42)).toBe("42");
+    expect(canonicalizeJson("s")).toBe('"s"');
+  });
+
+  it("produces identical output for semantically-equal inputs", () => {
+    const a = canonicalizeJson({ x: { y: 1, z: [2, { w: 3 }] } });
+    const b = canonicalizeJson({ x: { z: [2, { w: 3 }], y: 1 } });
+    expect(a).toBe(b);
+  });
+});
+
+describe("buildCacheKey", () => {
+  it("produces a stable 64-char sha256 hex", () => {
+    const key = buildCacheKey("toolA", { a: 1, b: 2 });
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("collides for arg shapes that are semantically equal", () => {
+    expect(buildCacheKey("t", { a: 1, b: 2 })).toBe(
+      buildCacheKey("t", { b: 2, a: 1 }),
+    );
+  });
+
+  it("differs across tool names", () => {
+    expect(buildCacheKey("t1", { a: 1 })).not.toBe(
+      buildCacheKey("t2", { a: 1 }),
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
