### PR TITLE
fix(cloud): preserve complete agent ID fallback name in active billing ledger and cancellation resources

### DIFF
--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -206,7 +206,7 @@ class ActiveBillingService {
       return {
         resourceType: "agent_sandbox",
         resourceId: agent.id,
-        name: agent.agent_name ?? agent.id.slice(0, 8),
+        name: agent.agent_name ?? agent.id,
         status: agent.status,
         billingStatus: agent.billing_status,
         unitPrice,
@@ -419,7 +419,7 @@ class ActiveBillingService {
             resource: {
               resourceType: "agent_sandbox",
               resourceId: agent.id,
-              name: agent.agent_name ?? agent.id.slice(0, 8),
+              name: agent.agent_name ?? agent.id,
               status: "deleted",
               billingStatus: "suspended",
               unitPrice,
@@ -492,7 +492,7 @@ class ActiveBillingService {
             resource: {
               resourceType: "agent_sandbox",
               resourceId: agent.id,
-              name: agent.agent_name ?? agent.id.slice(0, 8),
+              name: agent.agent_name ?? agent.id,
               status: "deleted",
               billingStatus: "suspended",
               unitPrice,
@@ -523,7 +523,7 @@ class ActiveBillingService {
           resource: {
             resourceType: "agent_sandbox",
             resourceId: updated.id,
-            name: updated.agent_name ?? updated.id.slice(0, 8),
+            name: updated.agent_name ?? updated.id,
             status: updated.status,
             billingStatus: updated.billing_status,
             unitPrice,


### PR DESCRIPTION
## Summary

Preserves the complete `agent.id` UUID as the resource fallback name in `active-billing.ts` instead of truncating it with `.slice(0, 8)`.

## Changes

- In `packages/cloud/shared/src/lib/services/active-billing.ts:209, 422, 495, 526`, use `agent.agent_name ?? agent.id` instead of `agent.agent_name ?? agent.id.slice(0, 8)`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`d9a560870b`) |
| --- | --- | --- |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/active-billing.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/active-billing.ts:209`
- `packages/cloud/shared/src/lib/services/active-billing.ts:422`
- `packages/cloud/shared/src/lib/services/active-billing.ts:495`
- `packages/cloud/shared/src/lib/services/active-billing.ts:526`

## Risks

Low. Preserves complete agent UUID identity in active billing invoice rows and cancellation receipts when custom agent names are not provided.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared billing service; no UI bundle touched)
- [x] `audit:browser` — N/A (Headless billing ledger service)
- [x] `build` — Clean build across workspace
- [x] `lint` — Biome clean
