### PR TITLE
test(shared): cover cloud-status classification

### DIFF
--- a/packages/shared/src/utils/__tests__/cloud-status.test.ts
+++ b/packages/shared/src/utils/__tests__/cloud-status.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCloudStatusAuthenticated,
+  isCloudStatusReasonApiKeyOnly,
+} from "./cloud-status.ts";
+
+describe("isCloudStatusReasonApiKeyOnly", () => {
+  it("classifies api-key-only reasons", () => {
+    expect(isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated")).toBe(true);
+    expect(isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started")).toBe(true);
+  });
+
+  it("rejects other reasons and nullish", () => {
+    expect(isCloudStatusReasonApiKeyOnly("connected")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly("")).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(null)).toBe(false);
+    expect(isCloudStatusReasonApiKeyOnly(undefined)).toBe(false);
+  });
+});
+
+describe("isCloudStatusAuthenticated", () => {
+  it("requires connected and non-api-key-only", () => {
+    expect(isCloudStatusAuthenticated(true, "ok")).toBe(true);
+    expect(isCloudStatusAuthenticated(false, "ok")).toBe(false);
+    expect(isCloudStatusAuthenticated(true, "api_key_present_not_authenticated")).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/__tests__/cloud-status.test.ts
+++ b/packages/shared/src/utils/__tests__/cloud-status.test.ts
@@ -6,8 +6,12 @@ import {
 
 describe("isCloudStatusReasonApiKeyOnly", () => {
   it("classifies api-key-only reasons", () => {
-    expect(isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated")).toBe(true);
-    expect(isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started")).toBe(true);
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_not_authenticated"),
+    ).toBe(true);
+    expect(
+      isCloudStatusReasonApiKeyOnly("api_key_present_runtime_not_started"),
+    ).toBe(true);
   });
 
   it("rejects other reasons and nullish", () => {
@@ -22,6 +26,8 @@ describe("isCloudStatusAuthenticated", () => {
   it("requires connected and non-api-key-only", () => {
     expect(isCloudStatusAuthenticated(true, "ok")).toBe(true);
     expect(isCloudStatusAuthenticated(false, "ok")).toBe(false);
-    expect(isCloudStatusAuthenticated(true, "api_key_present_not_authenticated")).toBe(false);
+    expect(
+      isCloudStatusAuthenticated(true, "api_key_present_not_authenticated"),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Unit coverage for cloud-status.ts: api-key-only reason classification and authenticated gating.

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash