### PR TITLE
test(app-core): cover brand-env reads

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/brand-env-reads.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/brand-env-reads.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/shared", () => ({
+  readAliasedEnv: (key: string) => {
+    const value = process.env[key] ?? "";
+    return value ? value : undefined;
+  },
+}));
+
+import {
+  resolveNamespaceFromEnv,
+  resolveRendererUrlFromEnv,
+} from "./brand-env-reads.ts";
+
+describe("resolveRendererUrlFromEnv", () => {
+  it("prefers ELIZA_RENDERER_URL", () => {
+    process.env.ELIZA_RENDERER_URL = "http://renderer";
+    expect(resolveRendererUrlFromEnv()).toBe("http://renderer");
+    delete process.env.ELIZA_RENDERER_URL;
+  });
+
+  it("falls back to VITE_DEV_SERVER_URL then empty", () => {
+    delete process.env.ELIZA_RENDERER_URL;
+    process.env.VITE_DEV_SERVER_URL = "http://vite";
+    expect(resolveRendererUrlFromEnv()).toBe("http://vite");
+    delete process.env.VITE_DEV_SERVER_URL;
+    expect(resolveRendererUrlFromEnv()).toBe("");
+  });
+});
+
+describe("resolveNamespaceFromEnv", () => {
+  it("uses the env value when set", () => {
+    process.env.ELIZA_NAMESPACE = "brand-ns";
+    expect(resolveNamespaceFromEnv("default-ns")).toBe("brand-ns");
+    delete process.env.ELIZA_NAMESPACE;
+  });
+
+  it("falls back to the compiled-in namespace", () => {
+    delete process.env.ELIZA_NAMESPACE;
+    expect(resolveNamespaceFromEnv("fallback-ns")).toBe("fallback-ns");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
