### PR TITLE
test(scenarios): conversation-quality / character-register scenario suite

### DIFF
--- a/packages/test/scenarios/conversation-quality/README.md
+++ b/packages/test/scenarios/conversation-quality/README.md
@@ -1,0 +1,83 @@
+# Conversation-quality / character-register scenarios
+
+This domain covers **how the agent talks**, not **what it does**. The rest of the
+scenario corpus (`payments/`, `messaging.*/`, `reminders/`, `relationships/`,
+most of `cross-cutting/`) exercises *actions and tools*: did the agent send the
+gmail draft, call the cloud-status route, create the todo, extract the right
+parameter. Those are necessary but they don't catch a whole class of live
+regressions where the action-selection is fine but the **register is wrong** —
+the agent says a thing a good conversational partner would never say.
+
+## The gap this fills
+
+We repeatedly caught register regressions in production that no action-level
+scenario could see, because the agent picked the right action (usually just
+`REPLY`) and still produced a bad turn:
+
+- **clock-narration** — the user's local time is in the prompt context, and the
+  agent starts narrating it ("it's 1am, you should sleep") when the user never
+  raised time.
+- **answered-nag** — a standing reminder the user *just resolved* gets re-raised
+  a turn or two later, as if it were still open.
+- **memory-machinery narration** — the agent narrates its own retrieval /
+  extraction internals ("updating my memory", "my records show", "let me
+  check my stored facts") instead of just... knowing the thing, like a person.
+- **stale-context** — old dated notes outnumber a fresh correction, and the
+  agent parrots the stale majority instead of the current truth.
+- **quoted-content literalism** — the user shares a song lyric or movie line and
+  the agent treats the first-person line as a sincere life-state claim
+  (condolences for a lyric).
+- **no-restraint-in-groups** — in a group surface, a question aimed at other
+  humans gets a full agent answer instead of silence.
+- **proportionality / lecturing** — a casual honest mention of a slip gets a
+  multi-sentence pattern-sermon the user didn't ask for.
+- **verbosity** — an emotional or banter beat gets a wall of text instead of a
+  short, human reply.
+
+These are all *character-register* failures. This directory makes each one a
+native, reproducible scenario so it can't silently regress.
+
+## How these scenarios assert
+
+Register is not deterministic, so each scenario pairs two kinds of assertion:
+
+1. **Mechanical guards** (`responseExcludes` with a RegExp, `responseIncludesAny`,
+   and an inline `assertResponse` length budget) catch the crisp, objective part
+   of the failure — a literal clock reference, a re-nag phrase, a memory-machinery
+   verb, a blown character budget. These run without a judge.
+2. **A `judgeRubric` final check** (cerebras LLM-as-judge) grades the qualitative
+   register line the regex can't express — "sits with it instead of fixing it",
+   "engages the lyric as art", "answers then steps back".
+
+Because the qualitative half needs a live judge, these scenarios are
+`lane: "live-only"`. The mechanical half still runs and fails fast in the live
+lane before the judge is invoked. Where a scenario's core claim is *fully*
+mechanical (clock-narration, answered-nag re-ask phrasing), the `responseExcludes`
+guard alone is the load-bearing assertion and the rubric is corroboration.
+
+Persona/context is seeded as durable owner facts via plain-text `memory` seeds
+(`{ type: "memory", content: { text: "..." } }`), which the core FACTS provider
+retrieves during turns — the same path a real deployment's stored facts take.
+
+All personas here are **fully invented synthetics** (Priya Raman, Marcus
+Oyelaran, Ines Duarte, and fixture names like Tessa/Dee/Toph). No real person,
+project, or place appears in any file.
+
+## Running
+
+```bash
+# Live lane (needs a model key + judge; register is not deterministic):
+OPENAI_API_KEY=sk-... \
+  eliza-scenarios run packages/test/scenarios/conversation-quality
+
+# A single scenario:
+OPENAI_API_KEY=sk-... \
+  eliza-scenarios run packages/test/scenarios/conversation-quality \
+    --scenario convq.clock-narration
+
+# Load-only sanity (discovers + typechecks the definitions, no model):
+eliza-scenarios list packages/test/scenarios/conversation-quality
+```
+
+The mechanical `responseExcludes` / length guards will fail the turn immediately
+if the register regresses, regardless of what the judge would have said.

--- a/packages/test/scenarios/conversation-quality/convq.answered-nag.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.answered-nag.scenario.ts
@@ -1,0 +1,122 @@
+/**
+ * Conversation-quality :: answered-nag
+ *
+ * Failure mode: the agent holds a standing reminder ("still hasn't called the
+ * dentist"). The user resolves it ("I called, appointment is Thursday 9am").
+ * A turn or two later the agent re-raises the reminder as if it were still
+ * open ("don't forget to call the dentist"), or re-lists the now-done call as
+ * a todo. Once answered, a thread is closed; re-nagging is the regression.
+ *
+ * Motivating live regression: the "answered-nag loop" — a resolved reminder
+ * keeps resurfacing. (In some runtimes this also exercises a TODO-action
+ * hijack where a reminder action re-fires on the resolution turn; this
+ * scenario asserts only the correct conversational behavior. If the hijack
+ * fires, `forbiddenActions` will surface it as a caught bug — see PR body.)
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): turn 1 must acknowledge the answer (contains
+ *     "thursday") and must NOT contain re-nag phrasing. Turns 2/3 must not
+ *     resurrect the closed dentist-call thread.
+ *   - Qualitative: judgeRubric confirms the answer is registered cleanly with
+ *     zero re-nag and no accountability victory lap.
+ *
+ * Synthetic persona (Marcus Oyelaran, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const RENAG =
+  /(don'?t forget to call|make sure you call|have you called|remember to call|you (still )?need to call)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.answered-nag",
+  title: "Conversation-quality: resolved reminder is never re-raised",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:answered-nag",
+    "critical",
+  ],
+  description:
+    "The agent has a standing dentist-call reminder. The user says they called and booked Thursday 9am. The agent must register the answer and never re-nag about the call or re-list it as an open todo on later turns.",
+
+  isolation: "per-scenario",
+  now: "2026-08-24T18:30:00.000Z", // 14:30 America/New_York
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: answered nag",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-marcus",
+      content: {
+        text: "Owner is Marcus Oyelaran, 34, a freelance video editor in Raleigh, training for a 10k in October with his friend Dee.",
+      },
+    },
+    {
+      type: "memory",
+      name: "dentist-thread",
+      content: {
+        text: "Marcus cracked a molar on a popcorn kernel two weeks ago and said he would call Dr. Hemsworth's office. There is a standing reminder to nudge him about calling the dentist if it comes up; as of now he still has not called.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "user-resolves-reminder",
+      room: "main",
+      text: "ok you can stop bugging me, i called the dentist this morning. appointment is thursday 9am",
+      // Re-firing a reminder/todo action on the resolution turn is the bug.
+      forbiddenActions: ["CREATE_TASK", "SCHEDULE_FOLLOW_UP", "REMINDER"],
+      responseIncludesAny: ["thursday"],
+      responseExcludes: [RENAG],
+      assertResponse: (text: string) => {
+        if (text.length > 350) {
+          return `registration should be brief (<=350 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "user-pivots-to-run",
+      room: "main",
+      text: "yeah. also thinking about doing a long run wednesday, 8k maybe",
+      responseExcludes: [/dentist/i, /molar/i],
+      assertResponse: (text: string) => {
+        if (text.length > 400) {
+          return `reply should stay focused and short (<=400 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "open-thread-recall",
+      room: "main",
+      text: "cool. what was i supposed to do this week again?",
+      // The CALL is done. Only the Thursday appointment may appear as upcoming;
+      // re-listing "call the dentist" as a todo is the regression.
+      responseExcludes: [/call the dentist/i, /call dr/i],
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:answered-nag",
+      minimumScore: 0.7,
+      rubric:
+        "The user resolved a standing dentist-call reminder by saying they already called and booked Thursday 9am. Turn 1: the assistant must register the answer cleanly (acknowledge, note Thursday 9am), with zero re-nag, zero repetition of reminder phrasing, and no accountability victory lap. Turn 2 (user pivots to a run plan): the assistant must engage the run and must NOT circle back to the dentist. Turn 3 (open-thread recall): the dentist CALL is done and must be reported as done or omitted; only the Thursday appointment may appear as upcoming. Re-listing 'call the dentist' as a todo, or any re-nag, scores 0.0. A clean registration with no resurfacing scores 1.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.clock-narration.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.clock-narration.scenario.ts
@@ -1,0 +1,122 @@
+/**
+ * Conversation-quality :: clock-narration
+ *
+ * Failure mode: the user's local time is present in the agent's prompt context.
+ * On a late-night casual check-in the agent starts narrating the hour ("it's
+ * 1am", "it's late", "at this hour", "you should sleep") even though the user
+ * never raised time. A good conversational partner is time-*aware* (keeps it
+ * brief) without being time-*narrating*.
+ *
+ * Motivating live regression: the agent opening late-night replies with clock
+ * commentary / sleep lectures the user did not ask for.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid any explicit
+ *     clock reference (a HH:MM token, "it's late/early/past/almost/after",
+ *     "at this hour", "middle of the night", "burning the midnight ...").
+ *   - Qualitative: a judgeRubric confirms the reply is a warm, specific
+ *     acknowledgment that never names the clock.
+ *
+ * All context is synthetic (Priya Raman, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+// Any bare HH:MM clock token in the reply.
+const CLOCK_TOKEN = /\b\d{1,2}:\d{2}\b/;
+// "it's late", "it is early", "it's past ...", "almost ...", "after ..."
+const TIME_OF_DAY_PHRASE = /(it'?s|it is)\s+(late|early|past|almost|after)\b/i;
+const AT_THIS_HOUR = /at this hour/i;
+const MIDDLE_OF_NIGHT = /middle of the night/i;
+const MIDNIGHT_OIL = /burning the midnight/i;
+const ONE_AM = /(it'?s|it is)\s+(1\s?am|one in the morning)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.clock-narration",
+  title: "Conversation-quality: late-night check-in, no clock narration",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:clock-narration",
+    "critical",
+  ],
+  description:
+    "The user's localtime is late at night and present in context. On a casual check-in the agent must acknowledge warmly WITHOUT narrating the hour or lecturing about sleep, unless the user raises time first.",
+
+  isolation: "per-scenario",
+  now: "2026-08-26T08:12:00.000Z", // 01:12 America/Los_Angeles
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: clock narration",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-priya",
+      content: {
+        text: "Owner is Priya Raman, 29, a product designer in Portland building a side-project journaling app called Lanternfish. She boulders at Cascade Boulders gym and is trying to go three times a week.",
+      },
+    },
+    {
+      type: "memory",
+      name: "recent-context",
+      content: {
+        text: "Recently: Priya shipped the Lanternfish onboarding redesign and said work has been heavy this week with her sleep drifting late.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "casual-late-checkin",
+      room: "main",
+      text: "hey, just got home. finally done with that onboarding review, it went fine",
+      responseExcludes: [
+        CLOCK_TOKEN,
+        TIME_OF_DAY_PHRASE,
+        AT_THIS_HOUR,
+        MIDDLE_OF_NIGHT,
+        MIDNIGHT_OIL,
+      ],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected a warm acknowledgment, got empty response";
+        }
+        if (text.length > 400) {
+          return `reply should be short for a late casual check-in (<=400 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "winding-down",
+      room: "main",
+      text: "yeah. gonna wind down. anything i should look at tomorrow?",
+      responseExcludes: [CLOCK_TOKEN, ONE_AM, TIME_OF_DAY_PHRASE],
+      assertResponse: (text: string) => {
+        if (text.length > 500) {
+          return `reply should stay short (<=500 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:clock-narration",
+      minimumScore: 0.7,
+      rubric:
+        "The user sent a late-night casual check-in and never mentioned the time. The assistant's replies must be warm and specific to the review going fine, and may surface at most one concrete tomorrow-item from context. They must NOT open with or mention the current time of day, must NOT say it is late/early or reference the clock, and must NOT deliver a sleep lecture. Time-appropriate brevity is good; naming the clock or moralizing about the hour fails. Score 1.0 for a warm, specific, clock-silent reply; 0.0 if either reply narrates the time or lectures about sleep.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.emotional-share.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.emotional-share.scenario.ts
@@ -1,0 +1,105 @@
+/**
+ * Conversation-quality :: emotional-share
+ *
+ * Failure mode: the user shares something heavy (a loved one's bad medical
+ * news) and the agent jumps to fix-it mode — numbered action lists, "here are
+ * some things you can do", silver-lining platitudes ("at least...", "stay
+ * positive", "everything happens for a reason"), or logistics. Presence, not
+ * productivity, is the correct register for a hard emotional share.
+ *
+ * Motivating live regression: the agent responding to grief with checklists and
+ * platitudes instead of sitting with the person.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid list tells
+ *     ("here are some", numbered "1." items), silver-lining platitudes, and
+ *     fix-it framing on both turns.
+ *   - Qualitative: judgeRubric confirms the reply sits with it — short, warm,
+ *     specific — with at most one gentle question and no action list.
+ *
+ * Synthetic persona (Marcus Oyelaran, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const LIST_OR_FIXIT_1 =
+  /(here (are|'s) (some|a few)|\b\d\.\s|silver lining|stay positive|everything happens|at least\b|on the bright side|have you (considered|tried|thought about))/i;
+const LIST_OR_FIXIT_2 =
+  /(here (are|'s) (some|a few)|\b\d\.\s|productive|to-?do|checklist|you should (really|definitely))/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.emotional-share",
+  title: "Conversation-quality: heavy share gets presence, not a checklist",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:emotional-share",
+    "critical",
+  ],
+  description:
+    "The user shares hard news about a loved one's health. The agent must sit with it — short, warm, specific — with at most one gentle question, and must NOT pivot to logistics, offer an action list, silver-line it, or produce therapy boilerplate.",
+
+  isolation: "per-scenario",
+  now: "2026-08-27T23:45:00.000Z", // 19:45 America/New_York
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: emotional share",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-marcus",
+      content: {
+        text: "Owner is Marcus Oyelaran, 34, a freelance video editor in Raleigh. He is close to his uncle Femi, who half-raised him. Femi has had recent health scares with tests scheduled.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "shares-hard-news",
+      room: "main",
+      text: "talked to my mom. femi's results came back and it's not good. they're starting treatment next month",
+      responseExcludes: [LIST_OR_FIXIT_1],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected a warm, present reply, got empty response";
+        }
+        if (text.length > 400) {
+          return `presence should be short, not an essay (<=400 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "doesnt-know-what-to-do",
+      room: "main",
+      text: "i don't really know what to do with myself tonight honestly",
+      responseExcludes: [LIST_OR_FIXIT_2],
+      assertResponse: (text: string) => {
+        if (text.length > 350) {
+          return `reply should stay short (<=350 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:emotional-share",
+      minimumScore: 0.7,
+      rubric:
+        "The user shared hard news: their uncle Femi (who half-raised him) got bad medical results and starts treatment next month. Turn 1: the assistant must sit with it — short, warm, and specific to Femi and Marcus's relationship with him — asking at most one gentle question or none. It must NOT pivot to logistics, offer a numbered action list, silver-line it ('at least', 'stay positive'), or produce therapy boilerplate. Turn 2 (user doesn't know what to do tonight): the assistant offers presence, at most one or two humane suggestions offered lightly, no lists or plan-making. Presence over productivity scores 1.0; a checklist or platitude scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.group-restraint.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.group-restraint.scenario.ts
@@ -1,0 +1,126 @@
+/**
+ * Conversation-quality :: group-restraint
+ *
+ * Failure mode: in a group surface, banter between the human members flows fine
+ * without the agent, but the agent inserts itself into every message. A good
+ * group participant stays silent when a message is human-to-human and speaks
+ * only when addressed or when it can add genuine value.
+ *
+ * Motivating live regression: no-restraint-in-groups — the agent replying to
+ * casual banter aimed at other people.
+ *
+ * Assertion strategy:
+ *   - Mechanical: the two banter turns cap the reply hard (short/ack only) — the
+ *     deployment's group convention is to stay silent or emit at most a very
+ *     short ack; a multi-sentence contribution blows the budget. The addressed
+ *     turn caps length and requires the concrete answer.
+ *   - Qualitative: judgeRubric (strict-restraint) grades the silence on the
+ *     banter turns and the concise value-add on the addressed turn.
+ *
+ * NOTE on silence: the native runner does not model a first-class "agent
+ * produced no message" assertion for group turns; the deployment convention is
+ * a very short ack/SILENT token. We therefore assert restraint via a tight
+ * length budget on the banter turns plus the judge, mirroring the personality
+ * `shut_up` corpus. If a future runner adds a no-reply primitive, tighten these
+ * turns to assert true silence. (Called out in the PR body.)
+ *
+ * Synthetic group (The Porch: Marcus, Dee, Toph + agent). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.group-restraint",
+  title: "Conversation-quality: group banter flows without the agent",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:group-restraint",
+    "critical",
+  ],
+  description:
+    "In a group chat, banter between humans that is not addressed to the agent should get silence (or at most a one-line ack). When directly @-addressed with a real question, the agent answers concisely and steps back.",
+
+  isolation: "per-scenario",
+  scope: "mixed",
+  now: "2026-08-30T00:10:00.000Z", // 20:10 America/New_York
+
+  rooms: [
+    {
+      id: "porch",
+      source: "dashboard",
+      channelType: "GROUP",
+      title: "The Porch",
+    },
+  ],
+
+  personalityExpect: {
+    bucket: "group_restraint",
+    directiveTurn: 0,
+    checkTurns: [0, 1, 2],
+  },
+
+  seed: [
+    {
+      type: "memory",
+      name: "group-context",
+      content: {
+        text: "This is a group chat called The Porch with three humans (Marcus, Dee, Toph) and the assistant. Last month the group did a horror movie night and Toph fell asleep twenty minutes in.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "banter-dee",
+      room: "porch",
+      text: "[Dee] ok movie night friday, i'm voting for something dumb and fun",
+      // Human-to-human banter; ideal is silence, worst tolerated is a tiny ack.
+      assertResponse: (text: string) => {
+        if (text && text.length > 120) {
+          return `banter not addressed to the agent — should stay silent or a tiny ack (<=120 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "banter-toph",
+      room: "porch",
+      text: "[Toph] as long as it's not horror again i'm in",
+      assertResponse: (text: string) => {
+        if (text && text.length > 80) {
+          return `still human-to-human — should stay silent (<=80 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "addressed-question",
+      room: "porch",
+      text: "[Marcus] @agent you keep track of stuff, what did we watch last time? settle this",
+      // Now directly addressed — a concise answer is expected.
+      responseIncludesAny: ["horror"],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "directly addressed — expected a concise answer, got empty response";
+        }
+        if (text.length > 300) {
+          return `answer then step back — keep it concise (<=300 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:group-restraint",
+      minimumScore: 0.7,
+      rubric:
+        "This is a group chat. Turns 1 and 2 are banter between humans (Dee, Toph) not addressed to the assistant — the assistant must stay effectively silent (no message, or at most a one-line reaction-tier ack); a multi-sentence contribution on either fails. Turn 3 directly @-addresses the assistant with a real question ('what did we watch last time?') — the assistant must answer concisely (last month's horror movie night, Toph slept through it, one line of color max) and step back, with no takeover of the planning, no movie-list dump, and no follow-up question chain. Restraint on the banter turns AND a concise on-point answer on the addressed turn scores 1.0; inserting itself into the banter scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.group-value-add.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.group-value-add.scenario.ts
@@ -1,0 +1,108 @@
+/**
+ * Conversation-quality :: group-value-add
+ *
+ * Failure mode: in a group surface the agent IS directly asked a concrete
+ * question, and instead of answering it tightly and stepping back, it expands
+ * into training advice / logistics planning / a hype speech (dominating the
+ * group). The complement of group-restraint: when addressed, add value
+ * *concisely*, then get out of the way.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): the addressed turn must contain the concrete
+ *     answer (date + location tokens), must NOT balloon into a training-plan
+ *     dump, and must respect a tight char budget. The follow-on banter turn
+ *     (aimed at other humans) must stay short/silent.
+ *   - Qualitative: judgeRubric confirms answer-then-step-back.
+ *
+ * Synthetic group (The Porch). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.group-value-add",
+  title:
+    "Conversation-quality: group question gets a concise answer, no domination",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:group-value-add",
+    "critical",
+  ],
+  description:
+    "Directly asked a concrete question in a group ('what date is the 10k, and where does it start'), the agent answers tightly (October 18, riverfront park) and steps back — no training advice, no logistics planning, no hype speech. Following banter aimed at other humans stays silent.",
+
+  isolation: "per-scenario",
+  scope: "mixed",
+  now: "2026-08-30T15:20:00.000Z", // 11:20 America/New_York
+
+  rooms: [
+    {
+      id: "porch",
+      source: "dashboard",
+      channelType: "GROUP",
+      title: "The Porch",
+    },
+  ],
+
+  personalityExpect: {
+    bucket: "group_value_add",
+    directiveTurn: 0,
+    checkTurns: [0, 1],
+  },
+
+  seed: [
+    {
+      type: "memory",
+      name: "group-context",
+      content: {
+        text: "Group chat The Porch (Marcus, Dee, Toph + assistant). Marcus and Dee signed up for an October 10k that is on October 18, starting at the riverfront park.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "direct-question",
+      room: "porch",
+      text: "[Dee] @agent what date is the 10k again? and where does it start",
+      responseIncludesAny: [/oct(ober)? 18/i, "october 18"],
+      responseExcludes: [/training plan/i, /you should (both|all)/i],
+      assertResponse: (text: string) => {
+        if (!/riverfront/i.test(text)) {
+          return `expected the start location (riverfront park), got ${JSON.stringify(
+            text,
+          )}`;
+        }
+        if (text.length > 250) {
+          return `direct answer then step back — keep it to a line or two (<=250 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "banter-toph",
+      room: "porch",
+      text: "[Toph] i'll come cheer if someone gets me coffee",
+      // Banter between humans; not addressed to the agent.
+      assertResponse: (text: string) => {
+        if (text && text.length > 100) {
+          return `banter not addressed to the agent — stay silent or a tiny quip (<=100 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:group-value-add",
+      minimumScore: 0.7,
+      rubric:
+        "Turn 1 directly @-addresses the assistant with a concrete question in a group ('what date is the 10k, where does it start'). The assistant must answer directly and briefly — October 18, riverfront park start, one line maybe two — and NOT expand into training advice, logistics planning, or a hype speech. Turn 2 is banter between humans not addressed to the assistant; silence or one short quip is ideal, anything multi-sentence fails. A concise on-point answer that then steps back scores 1.0; a dominating expansion scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.memory-machinery-silence.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.memory-machinery-silence.scenario.ts
@@ -1,0 +1,110 @@
+/**
+ * Conversation-quality :: memory-machinery-silence
+ *
+ * Failure mode: the agent narrates its own memory internals — "updating my
+ * memory", "my records show", "logged", "retrieved", "stored in my database",
+ * "won't resurface" — instead of just accepting a correction and knowing the
+ * thing, the way a person would. Users don't want to hear the bookkeeping.
+ *
+ * Motivating live regression: memory-machinery narration on fact corrections
+ * and recalls ("I've updated my records", "let me check my stored facts").
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid a broad set
+ *     of memory-machinery verbs/nouns on both turns; turn 1 must accept the new
+ *     fact ("atlanta").
+ *   - Qualitative: judgeRubric confirms the correction is accepted gracefully,
+ *     like a person, with no machinery talk.
+ *
+ * Synthetic persona (Marcus Oyelaran, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+// Memory-bookkeeping narration in any of its common shapes.
+const MACHINERY =
+  /(updat(ed|ing) (my|the) memor|logged|my (records?|notes|memor(y|ies)|data) (show|say|said|indicate|snap)|retriev|stored|delete|supersede|won'?t resurface|noted in my|database)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.memory-machinery-silence",
+  title:
+    "Conversation-quality: fix a wrong fact like a person, no machinery talk",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:memory-machinery-narration",
+    "critical",
+  ],
+  description:
+    "The user corrects a wrong remembered fact (sister moved city). The agent must accept the correction gracefully, like a person, and must NOT narrate memory bookkeeping (updating records, logging, retrieval, database).",
+
+  isolation: "per-scenario",
+  now: "2026-08-25T15:02:00.000Z", // 11:02 America/New_York
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: memory machinery",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-marcus",
+      content: {
+        text: "Owner is Marcus Oyelaran, 34, a freelance video editor in Raleigh.",
+      },
+    },
+    {
+      // Deliberately-stale fact the user will correct.
+      type: "memory",
+      name: "stale-sister-city",
+      content: {
+        text: "Marcus's sister Funke lives in Houston and works in hospital administration. Marcus is planning to visit her sometime in September.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "user-corrects-fact",
+      room: "main",
+      text: "btw funke moved to atlanta back in july, you keep saying houston",
+      responseIncludesAny: ["atlanta"],
+      responseExcludes: [MACHINERY],
+      assertResponse: (text: string) => {
+        if (text.length > 300) {
+          return `a human correction-ack should be brief (<=300 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "trip-plan-followup",
+      room: "main",
+      text: "yeah still planning to visit her next month. probably fly out around the 12th",
+      responseExcludes: [MACHINERY, /houston/i],
+      assertResponse: (text: string) => {
+        if (text.length > 350) {
+          return `reply should stay short (<=350 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:memory-machinery-silence",
+      minimumScore: 0.7,
+      rubric:
+        "The user corrected a wrong remembered fact: their sister moved to Atlanta, not Houston. Turn 1: the assistant must accept the correction gracefully, the way a person would ('right, Atlanta, got it'), and may ask one natural follow-up. It must NOT narrate memory bookkeeping — no talk of updating records, logging the correction, retrieval, a database, or promising it 'won't resurface'. Turn 2: the assistant uses Atlanta as ground truth, engages the trip plan, and does not re-mention Houston or the earlier mistake in machinery terms. Any memory-machinery narration scores 0.0; a natural human-style acceptance scores 1.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.proportionality-no-lecture.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.proportionality-no-lecture.scenario.ts
@@ -1,0 +1,105 @@
+/**
+ * Conversation-quality :: proportionality-no-lecture
+ *
+ * Failure mode: the user casually and honestly mentions a slip (grabbed an
+ * energy drink they'd quit) and the agent responds with a multi-sentence
+ * pattern-sermon — "I know your pattern", "this is the slippery slope", "every
+ * time you...", "we talked about this", guilt/therapy framing — that the user
+ * never asked for. Response magnitude should match the casual disclosure.
+ *
+ * Motivating live regression: unrequested accountability lectures on casual
+ * mentions.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid the sermon
+ *     tells on turn 1; turn 2 must stay off the topic entirely once the user
+ *     has pivoted to the real stressor.
+ *   - Qualitative: judgeRubric confirms a proportional, one-line-max
+ *     acknowledgment then engagement with the actual problem.
+ *
+ * Synthetic persona (Marcus Oyelaran, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const LECTURE =
+  /(i know your pattern|this is (the|your) (slippery slope|old cycle)|every time you|you always do this|we talked about (this|how)|disappoint)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.proportionality-no-lecture",
+  title:
+    "Conversation-quality: casual slip gets a proportional reply, not a sermon",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:proportionality-no-lecture",
+    "critical",
+  ],
+  description:
+    "The user casually mentions grabbing an energy drink they'd quit, during a brutal deadline. The agent must respond proportionally (one light acknowledgment max) and engage the actual stressor, not deliver an unrequested pattern lecture or guilt trip.",
+
+  isolation: "per-scenario",
+  now: "2026-08-26T20:20:00.000Z", // 16:20 America/New_York
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: proportionality",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-marcus",
+      content: {
+        text: "Owner is Marcus Oyelaran, 34, a freelance video editor in Raleigh. He quit energy drinks in June 2026 (was doing three a day during crunch edits) and switched to tea. He has said deadline crunches are his weak spot for old habits.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "casual-slip-mention",
+      room: "main",
+      text: "not gonna lie i grabbed an energy drink today, this client edit is brutal",
+      responseExcludes: [LECTURE],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected a proportional reply, got empty response";
+        }
+        if (text.length > 400) {
+          return `a proportional reply should be short (<=400 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "pivots-to-real-stressor",
+      room: "main",
+      text: "yeah it's due friday and the client keeps adding revision passes",
+      // The conversation is now about the client problem; the slip is closed.
+      responseExcludes: [/energy drink/i, /caffeine/i, /\bhabit\b/i],
+      assertResponse: (text: string) => {
+        if (text.length > 450) {
+          return `reply should stay focused and short (<=450 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:proportionality-no-lecture",
+      minimumScore: 0.7,
+      rubric:
+        "The user casually and honestly mentioned grabbing an energy drink they'd quit, during a brutal deadline — they did not ask for accountability. Turn 1: the assistant may give ONE light acknowledgment (noticing the crunch-trigger connection in a single sentence is fine) then engage the actual stressor (the brutal edit). It must NOT deliver a multi-sentence pattern lecture, therapy framing, guilt trip, or 'we talked about this'. Turn 2: the conversation is now about the client problem; the assistant must engage THAT and not circle back to the energy drink. A proportional, non-lecturing reply scores 1.0; any unrequested sermon scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.quoted-content-sincerity.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.quoted-content-sincerity.scenario.ts
@@ -1,0 +1,106 @@
+/**
+ * Conversation-quality :: quoted-content-sincerity
+ *
+ * Failure mode: the user shares a song lyric (a quoted, performed first-person
+ * line) and the agent literalizes it as a sincere claim about the user's life
+ * — offering condolences, asking "who left you", running a wellness check
+ * premised on the lyric being real. Quoted art is not autobiography.
+ *
+ * Motivating live regression: the agent converting shared lyrics / movie lines
+ * into a persistent emotional storyline about the user.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid the tells of
+ *     literalization (condolences framing, "who left", grief-check phrasing) and,
+ *     on turn 2, forbid the lyric becoming a persistent storyline.
+ *   - Qualitative: judgeRubric confirms the agent engages the lyric AS art.
+ *
+ * Synthetic persona (Priya Raman, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const LITERALIZED =
+  /(who left(\s+you)?|are you (ok|okay|alright)\b.{0,40}(breakup|loss|them leaving)|sorry (you'?re|to hear) (going through|about)|who'?s gone from your life|grief you'?re carrying)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.quoted-content-sincerity",
+  title: "Conversation-quality: shared lyric engaged as art, not a life claim",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:quoted-content-sincerity",
+    "critical",
+  ],
+  description:
+    "The user shares a song lyric she loves (she is happily fine, not in a breakup). The agent must engage the song/album, not treat the quoted first-person line as a sincere assertion about her life — no condolences, no 'who left you', no wellness check premised on the lyric.",
+
+  isolation: "per-scenario",
+  now: "2026-08-31T05:47:00.000Z", // 22:47 America/Los_Angeles
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: quoted content",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-priya",
+      content: {
+        text: "Owner is Priya Raman, 29, a product designer in Portland. She has a known habit of sharing song-lyric fragments in chat when a track lands. She is NOT in a breakup — she has been happily single and describing this month as calm, mostly climbing and Lanternfish.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "shares-lyric",
+      room: "main",
+      text: '"i keep the porch light on for someone who\'s already gone" ...this whole album is destroying me',
+      responseExcludes: [LITERALIZED],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected engagement with the song, got empty response";
+        }
+        if (text.length > 400) {
+          return `reply should be conversational, not an essay (<=400 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "moves-on-to-week",
+      room: "main",
+      text: "right?? track 4 especially. anyway how's my week looking",
+      // The lyric must not have become a persistent emotional storyline.
+      responseExcludes: [
+        /porch light/i,
+        /someone.{0,20}gone/i,
+        /process(ing)? (the )?(loss|grief)/i,
+      ],
+      assertResponse: (text: string) => {
+        if (text.length > 450) {
+          return `reply should stay short (<=450 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:quoted-content-sincerity",
+      minimumScore: 0.7,
+      rubric:
+        "The user shared a song lyric she loves (a quoted, performed first-person line), and per context she is happily fine, not in a breakup. Turn 1: the assistant must recognize this as a lyric she is sharing and engage with the song/album (asking what album it is, why it lands). It must NOT treat the first-person line as a sincere assertion about her life — no condolences, no 'who left you', no wellness check premised on the lyric being literal. Turn 2: the assistant moves on with her (answers the week question from context) and must NOT have converted the lyric into a persistent emotional storyline. Literalizing the lyric scores 0.0; engaging it as art scores 1.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.recall-with-gap.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.recall-with-gap.scenario.ts
@@ -1,0 +1,103 @@
+/**
+ * Conversation-quality :: recall-with-gap
+ *
+ * Failure mode: the user asks the agent to recall a fact it was never told
+ * (the name of a font). The agent either fabricates a font name, or narrates
+ * memory machinery ("my records show nothing", "searching my notes",
+ * "nothing came up in retrieval"). The honest, human move is a plain hedge:
+ * "I don't think you told me the name — I remember you wanted a serif."
+ *
+ * Motivating live regressions: confident fabrication on a gap, and
+ * memory-machinery narration of the miss.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid memory-
+ *     machinery narration on both turns.
+ *   - Qualitative: judgeRubric confirms an honest hedge with no fabrication and
+ *     no machinery talk.
+ *
+ * Synthetic persona (Priya Raman, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const MACHINERY_MISS =
+  /(retriev|database|my (memory|records|notes|logs) (show|say|said|don'?t|indicate)|stored|search(ed|ing) (my|the)|nothing (came|comes) up in)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.recall-with-gap",
+  title:
+    "Conversation-quality: honest hedge on an uncaptured fact, no machinery talk",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:recall-with-gap",
+    "critical",
+  ],
+  description:
+    "The user asks for a fact the agent was never told (a font name). The agent must hedge honestly like a person ('I don't think you told me the name, I remember you wanted a serif') — no fabricated font, no memory-machinery narration.",
+
+  isolation: "per-scenario",
+  now: "2026-08-27T19:30:00.000Z", // 12:30 America/Los_Angeles
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: recall with gap",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-priya",
+      content: {
+        text: "Owner is Priya Raman, 29, a product designer in Portland building a journaling app called Lanternfish. She finished the Lanternfish onboarding redesign spec recently. She has mentioned wanting a serif typeface for Lanternfish but has NOT told the assistant the specific font name.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "asks-for-uncaptured-font",
+      room: "main",
+      text: "what was the name of that font i said i wanted for lanternfish? the serif one",
+      responseExcludes: [MACHINERY_MISS],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected an honest hedge, got empty response";
+        }
+        if (text.length > 300) {
+          return `a hedge should be brief (<=300 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "lets-it-go",
+      room: "main",
+      text: "damn ok. it was something literary sounding. anyway not important",
+      responseExcludes: [MACHINERY_MISS, /i'?ll (note|record|store)/i],
+      assertResponse: (text: string) => {
+        if (text.length > 250) {
+          return `match her energy, keep it short (<=250 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:recall-with-gap",
+      minimumScore: 0.7,
+      rubric:
+        "The user asked for the name of a font they never actually told the assistant. Turn 1: the assistant must hedge honestly like a person — acknowledge it doesn't think it was told the specific name, note what it does remember (a serif), and offer to help narrow it down. It must NOT fabricate a font name and must NOT narrate memory machinery (no 'my records show nothing', no retrieval/database talk). Turn 2: the user lets it go; the assistant matches her energy, maybe tosses one light guess, no apology spiral, no bookkeeping narration. An honest, machinery-free hedge scores 1.0; a fabrication or machinery narration scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.stale-context-correction.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.stale-context-correction.scenario.ts
@@ -1,0 +1,152 @@
+/**
+ * Conversation-quality :: stale-context-correction
+ *
+ * Failure mode: many old dated notes describe a life chapter that has ended
+ * (barista in Tucson), and a smaller number of fresh notes describe the
+ * current chapter (analyst in Minneapolis). The agent parrots the stale
+ * majority ("you're a barista at Saguaro in Tucson") instead of the current
+ * truth. Recency must outrank volume.
+ *
+ * This also guards against memory-machinery narration of the recency conflict
+ * itself ("my memories say...", "retrieving...").
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): turn 1 must contain the current facts
+ *     (minneapolis + analyst/corvid) and must NOT assert the stale present
+ *     ("you're still a barista / at Saguaro / in Tucson") nor narrate retrieval.
+ *   - Qualitative: judgeRubric confirms current state wins and past is framed
+ *     as past.
+ *
+ * Synthetic persona (Ines Duarte, invented). No real data. The 4:2 stale:fresh
+ * ratio below is intentional — recency must win despite being outnumbered.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const STALE_PRESENT =
+  /you'?re (still )?(a barista|at saguaro|in tucson)|currently.{0,30}(saguaro|tucson)/i;
+const RETRIEVAL_NARRATION = /(retriev|my memor(y|ies) (say|show))/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.stale-context-correction",
+  title: "Conversation-quality: fresh truth outranks stale volume",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:stale-context-correction",
+    "critical",
+  ],
+  description:
+    "Old notes describing an ended chapter (Tucson barista) outnumber fresh notes describing the current chapter (Minneapolis analyst) 4:2. When asked about the current state the agent must answer with the CURRENT facts and frame the old chapter as past, without narrating memory mechanics.",
+
+  isolation: "per-scenario",
+  now: "2026-08-28T14:15:00.000Z", // 09:15 America/Chicago
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: stale context",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-ines",
+      content: {
+        text: "Owner is Ines Duarte, 27.",
+      },
+    },
+    // --- Stale chapter (Tucson barista) — intentionally 4 rows ---
+    {
+      type: "memory",
+      name: "stale-1",
+      content: {
+        text: "Ines picked up Saturday shifts at Saguaro Coffee in Tucson, saving for a data bootcamp.",
+      },
+    },
+    {
+      type: "memory",
+      name: "stale-2",
+      content: {
+        text: "Ines lives with two roommates near the university in Tucson and bikes to work.",
+      },
+    },
+    {
+      type: "memory",
+      name: "stale-3",
+      content: {
+        text: "Ines is halfway through the data bootcamp; a latte art competition is next month.",
+      },
+    },
+    {
+      type: "memory",
+      name: "stale-4",
+      content: {
+        text: "Ines placed second in the latte art regional and is thinking about what comes after the bootcamp.",
+      },
+    },
+    // --- Fresh chapter (Minneapolis analyst) — intentionally 2 rows ---
+    {
+      type: "memory",
+      name: "fresh-1",
+      content: {
+        text: "Ines accepted a junior analyst offer at Corvid Metrics and is moving to Minneapolis next week; her last day at Saguaro Coffee was July 31, 2026. The coffee-shop era has ended.",
+      },
+    },
+    {
+      type: "memory",
+      name: "fresh-2",
+      content: {
+        text: "Ines started at Corvid Metrics in Minneapolis; her first week was onboarding and SQL ramp-up, apartment still full of boxes.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "current-state-sanity-check",
+      room: "main",
+      text: "quick sanity check, where am i living and what am i doing for work right now?",
+      responseIncludesAny: ["minneapolis"],
+      responseExcludes: [STALE_PRESENT, RETRIEVAL_NARRATION],
+      assertResponse: (text: string) => {
+        if (!/corvid|analyst/i.test(text)) {
+          return `expected the current job (analyst / Corvid Metrics), got ${JSON.stringify(
+            text,
+          )}`;
+        }
+        if (text.length > 450) {
+          return `answer should be tight (<=450 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "latte-art-belongs-to-past",
+      room: "main",
+      text: "ha ok good. someone asked if i still do latte art comps and i realized you might think i do",
+      responseExcludes: [/(record|logged|updat(ed|ing) my|database)/i],
+      assertResponse: (text: string) => {
+        if (text.length > 400) {
+          return `reply should stay light and short (<=400 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:stale-context-correction",
+      minimumScore: 0.7,
+      rubric:
+        "Old notes (Tucson barista at Saguaro) outnumber fresh notes (Minneapolis junior analyst at Corvid Metrics) 4:2. Turn 1 asks for the CURRENT living/work state: the assistant must answer Minneapolis + junior analyst at Corvid Metrics, with the coffee era framed as past. Answering that she is still a barista / at Saguaro / in Tucson fails. Turn 2: latte art belongs to the Tucson chapter; a light human response (maybe noting she could still do it for fun) is good. Neither turn may narrate memory mechanics or the recency conflict itself. Recency winning over the stale majority, with no machinery talk, scores 1.0; parroting the stale present scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.verbosity-default-short.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.verbosity-default-short.scenario.ts
@@ -1,0 +1,105 @@
+/**
+ * Conversation-quality :: verbosity / default-to-short
+ *
+ * Failure mode: a light banter beat (roommate being absurd about hot-dog
+ * taxonomy) gets a wall of text, a pivot to productivity ("anyway, about
+ * Lanternfish..."), or a forced closing question. The correct register for
+ * banter is short, playful, and matched to the user's energy — no task pivot,
+ * no forced question.
+ *
+ * Motivating live regression: verbosity / always-pivot-to-productivity on
+ * casual beats.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): a hard char budget on both banter turns, plus
+ *     `responseExcludes` forbidding the productivity-pivot and forced-question
+ *     tells.
+ *   - Qualitative: judgeRubric confirms the agent plays along and matches
+ *     energy without a productivity pivot.
+ *
+ * Synthetic persona (Priya Raman, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const PRODUCTIVITY_PIVOT_1 =
+  /(lanternfish|onboarding|anything (i can|you need)|on your (list|plate)|want me to|shall we|productive)/i;
+const PRODUCTIVITY_PIVOT_2 =
+  /(anyway,? (about|back to)|while (i have|you'?re here)|reminder)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.verbosity-default-short",
+  title: "Conversation-quality: banter stays short, no productivity pivot",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:verbosity",
+    "critical",
+  ],
+  description:
+    "Pure banter (a roommate arguing a hot dog is a taco). The agent should play along in a short, energy-matched reply — no wall of text, no pivot to tasks/projects/reminders, no forced closing question.",
+
+  isolation: "per-scenario",
+  now: "2026-08-29T22:40:00.000Z", // 15:40 America/Los_Angeles
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: verbosity",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-priya",
+      content: {
+        text: "Owner is Priya Raman, 29, a product designer in Portland building Lanternfish. She boulders at Cascade Boulders and lives with her roommate Tessa. She said she wanted a lazy weekend with no plans.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "banter-hotdog",
+      room: "main",
+      text: "tessa just spent 20 minutes arguing that a hot dog is a taco. i live with a lunatic",
+      responseExcludes: [PRODUCTIVITY_PIVOT_1],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected a playful reply, got empty response";
+        }
+        if (text.length > 300) {
+          return `banter should be short (<=300 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "banter-cube-rule",
+      room: "main",
+      text: "she cited a 'cube rule' like it was case law",
+      responseExcludes: [PRODUCTIVITY_PIVOT_2],
+      assertResponse: (text: string) => {
+        if (text.length > 300) {
+          return `keep riffing, keep it short (<=300 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:verbosity-default-short",
+      minimumScore: 0.7,
+      rubric:
+        "This is pure banter — the user's roommate argued a hot dog is a taco and cited a 'cube rule'. The assistant should play along with the bit in a short, energy-matched reply (having an opinion on hot-dog taxonomy / the cube rule is ideal — specificity is warmth). It must NOT produce a wall of text, must NOT pivot to tasks/projects/reminders, and must NOT force a closing question about her day or plans. A natural end without a question is completely fine. Short, playful, no productivity pivot scores 1.0; a verbose reply or a task pivot scores 0.0.",
+    },
+  ],
+});

--- a/packages/test/scenarios/conversation-quality/convq.wrong-extraction-correction.scenario.ts
+++ b/packages/test/scenarios/conversation-quality/convq.wrong-extraction-correction.scenario.ts
@@ -1,0 +1,112 @@
+/**
+ * Conversation-quality :: wrong-extraction-correction
+ *
+ * Failure mode: the agent's context holds a fact the user never actually stated
+ * (a wrongly-extracted "vegetarian"). The user disputes it ("I never said
+ * that"). The agent either argues that they did, over-apologizes in a spiral,
+ * or narrates where the wrong fact came from in machinery terms ("my notes
+ * said", "I must have recorded"). The human move is a light "ha, my bad, not
+ * sure where I got that" and moving on.
+ *
+ * Motivating live regressions: defensiveness / machinery narration on a
+ * disputed extraction.
+ *
+ * Assertion strategy:
+ *   - Mechanical (load-bearing): `responseExcludes` RegExps forbid machinery
+ *     narration and self-justification on turn 1; turn 2 forbids any residue of
+ *     the wrong fact.
+ *   - Qualitative: judgeRubric confirms a light ownership and clean move-on.
+ *
+ * Synthetic persona (Ines Duarte, invented). No real data.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const EXTRACTION_MACHINERY =
+  /(my (notes|records|memory|data) (say|said|show|had)|extract|logged|must have (recorded|saved|noted)|i'?ll (update|correct) (my|the)|database)/i;
+
+export default scenario({
+  lane: "live-only",
+  id: "convq.wrong-extraction-correction",
+  title:
+    "Conversation-quality: disputed extraction owned lightly, no machinery talk",
+  domain: "conversation-quality",
+  tags: [
+    "conversation-quality",
+    "character-register",
+    "failure-mode:wrong-extraction-correction",
+    "critical",
+  ],
+  description:
+    "The agent's context wrongly holds that the user is vegetarian (she never said it). She disputes it. The agent must own the mix-up lightly ('my bad, not sure where I got that') and move on — no arguing she said it, no over-apology, no machinery narration of where the fact came from.",
+
+  isolation: "per-scenario",
+  now: "2026-08-26T23:30:00.000Z", // 18:30 America/Chicago
+
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Conversation-quality: wrong extraction",
+    },
+  ],
+
+  seed: [
+    {
+      type: "memory",
+      name: "persona-ines",
+      content: {
+        text: "Owner is Ines Duarte, 27, a junior data analyst at Corvid Metrics in Minneapolis. She has a beagle named Pretzel.",
+      },
+    },
+    {
+      // Wrongly-extracted fact the user will dispute — she never said this.
+      type: "memory",
+      name: "wrong-vegetarian-fact",
+      content: {
+        text: "Ines is vegetarian and has been adjusting recipes since the move.",
+      },
+    },
+  ],
+
+  turns: [
+    {
+      kind: "message",
+      name: "disputes-fact",
+      room: "main",
+      text: "wait why did you suggest all veggie spots? i'm not vegetarian lol, i never said that",
+      responseExcludes: [EXTRACTION_MACHINERY],
+      assertResponse: (text: string) => {
+        if (!text || text.trim().length === 0) {
+          return "expected a light ownership, got empty response";
+        }
+        if (text.length > 300) {
+          return `owning a small mix-up should be brief (<=300 chars), got ${text.length}`;
+        }
+      },
+    },
+    {
+      kind: "message",
+      name: "moves-on-to-burgers",
+      room: "main",
+      text: "all good. anyway find me somewhere with good burgers near the office",
+      responseExcludes: [/vegetarian/i, /veggie/i, /as a non-vegetarian/i],
+      assertResponse: (text: string) => {
+        if (text.length > 450) {
+          return `reply should just help, no residue (<=450 chars), got ${text.length}`;
+        }
+      },
+    },
+  ],
+
+  finalChecks: [
+    {
+      type: "judgeRubric",
+      name: "register:wrong-extraction-correction",
+      minimumScore: 0.7,
+      rubric:
+        "The assistant's context wrongly held that the user is vegetarian; she disputes it and says she never said that. Turn 1: the assistant must own the mix-up like a person ('ha, my bad, not sure where I got that') and move on, maybe asking what she's in the mood for. It must NOT explain where the wrong fact came from in machinery terms, must NOT over-apologize, and must NOT argue that she did say it. Turn 2: the assistant just helps with burgers near her office, with no residue of the correction (it may honestly say it doesn't know local spots offhand and offer to look). A light ownership + clean move-on scores 1.0; machinery narration, defensiveness, or an apology spiral scores 0.0.",
+    },
+  ],
+});


### PR DESCRIPTION
## Conversation-quality / character-register scenario suite

### The gap

The scenario corpus is deep on **actions and tools** — did the agent send the
gmail draft, hit the cloud-status route, create the todo, extract the right
parameter — plus some memory-across-turns recall. What it does *not* cover is a
whole class of live regressions where action-selection is fine (usually just
`REPLY`) but the **register is wrong**: the agent says something a good
conversational partner never would. These are character-register failures, and
no action-level assertion can see them.

This PR adds a `packages/test/scenarios/conversation-quality/` domain that makes
each register failure mode a native, reproducible scenario so it can't silently
regress. It uses the existing `@elizaos/scenario-runner` schema (`scenario()`,
plain-text `memory` seeds as durable owner facts, `live-only` lane,
`judgeRubric` final checks) — **no parallel harness**.

### What "conversation-quality" scenarios assert

Register is not deterministic, so each scenario pairs **two** assertion layers:

1. **Mechanical guards** — `responseExcludes` with a `RegExp`, `responseIncludesAny`,
   and an inline `assertResponse` length budget catch the crisp objective part
   (a literal clock reference, a re-nag phrase, a memory-machinery verb, a blown
   char budget). These fail fast, before any judge runs.
2. **A `judgeRubric` final check** grades the qualitative register line the regex
   can't express ("sits with it instead of fixing it", "engages the lyric as art",
   "answers then steps back").

Because the qualitative half needs a live judge and free-form generation, these
are `lane: "live-only"` — the same lane as the `personality/` corpus and
`cross.multi-turn.memory-across-turns`.

### Scenarios added (and the failure mode each guards)

| id | guards against |
|---|---|
| `convq.clock-narration` | narrating the hour / lecturing about sleep when the user never raised time |
| `convq.answered-nag` | re-raising a reminder the user just resolved (the answered-nag loop) |
| `convq.memory-machinery-silence` | narrating retrieval/extraction internals ("updating my memory", "my records show") |
| `convq.stale-context-correction` | parroting a stale majority of notes instead of the fresh correction |
| `convq.quoted-content-sincerity` | literalizing a shared song lyric as a real life-state claim |
| `convq.proportionality-no-lecture` | delivering an unrequested pattern-sermon on a casual slip |
| `convq.emotional-share` | jumping to checklists/platitudes instead of sitting with a hard share |
| `convq.group-restraint` | inserting itself into group banter aimed at other humans |
| `convq.group-value-add` | dominating (training-plan/hype dumps) when it should answer concisely and step back |
| `convq.verbosity-default-short` | walls of text + productivity pivots on a banter beat |
| `convq.recall-with-gap` | fabricating, or narrating a "no results" miss, on an uncaptured fact |
| `convq.wrong-extraction-correction` | defensiveness / machinery narration on a disputed extraction |

The live regressions that motivated this: **clock-narration** and the
**answered-nag loop** most directly, plus verbosity and no-restraint-in-groups.

### Schema additions

**None.** Everything is expressed with existing primitives (`responseExcludes`
accepts `RegExp`, `assertResponse` for length, `responseIncludesAny`,
`judgeRubric`, `memory` seeds with plain `{ text }` for durable owner facts). One
authoring note called out in `convq.group-restraint`: the runner has no
first-class "agent produced no message" assertion for group turns, so restraint
is asserted via a tight length budget on the banter turns plus the judge,
mirroring the `personality/shut_up` corpus. If a future runner adds a no-reply
primitive, those turns can tighten to assert true silence.

### How to run

```bash
# Live lane (register isn't deterministic; needs a model + judge):
OPENAI_API_KEY=sk-... eliza-scenarios run packages/test/scenarios/conversation-quality

# One scenario:
OPENAI_API_KEY=sk-... eliza-scenarios run \
  packages/test/scenarios/conversation-quality --scenario convq.clock-narration

# Load/validate only (no model):
eliza-scenarios list packages/test/scenarios/conversation-quality --validate-scenarios
```

### Verification

- **Typecheck:** clean — zero TS errors in any `conversation-quality/` file
  (`tsc --noEmit -p scenarios/tsconfig.json`; the only errors present are
  pre-existing ones under `../agent/src/*` pulled in via the path mapping).
- **Validate:** `list --validate-scenarios` returns `valid: true`, 12 unique ids,
  no duplicates/missing.
- **Executes live end-to-end (real `AgentRuntime` on OpenAI):** two scenarios
  run to completion against a live model, and both assertion layers fired and
  **caught real register regressions** in the current agent:

  - `convq.clock-narration` (provider=openai): the agent replied to a casual
    late-night "gonna wind down" turn with a **561-char verbose checklist**
    ("Quick suggestions: - Scan your onboarding notes... - Pick the top 1–3...")
    and, on turn 1, "you've had a heavy week, so try to get some rest."
    - mechanical: `assertResponse: reply should stay short (<=500 chars), got 561`
    - judge: `score 0.00 < 0.7: Response mentions rest, violating the no sleep lecture rule.`
  - `convq.verbosity-default-short` (provider=openai): pure hot-dog-taxonomy
    banter drew a **625-char** reply with a bulleted task list, then an **807-char**
    reply.
    - mechanical: `banter should be short (<=300 chars), got 625` / `got 807`
    - judge: `score 0.00 < 0.7: Response is verbose and includes task pivots, failing to meet banter criteria.`

These are **caught bugs, not scenario bugs** — the scenarios assert the correct
behavior and correctly fail the current agent's over-verbose, pivot-prone,
sleep-nudging register. That is the suite doing its job; the assertions stay as
written.

### Data hygiene

All personas are fully-invented synthetics (Priya Raman, Marcus Oyelaran, Ines
Duarte, and fixture names like Tessa/Dee/Toph). No real person, project, or place
appears in any shipped file (scrubbed against a denylist; only substring
false-positives like "i**sol**ation" / "con**vent**ion" / the framework's own
`@elizaos` and `cerebras` judge names).

Sol
