### PR TITLE
fix(core): report truthful code-unit context on early connector JSON rejection

### DIFF
--- a/packages/core/src/database/connector-json.test.ts
+++ b/packages/core/src/database/connector-json.test.ts
@@ -279,6 +279,58 @@ describe("connector JSON projection", () => {
 		// short-circuited: the precise byte check decides, so a value sitting
 		// exactly on the byte boundary stays accepted while one byte past it is
 		// rejected.
+	it("reports truthful code-unit context on early rejection (#24888)", () => {
+		// The early path reports code-unit counts, NOT byte counts, with the
+		// minimum-bytes invariant and exactUtf8BytesAvailable:false. This is the
+		// case the previous implementation mislabeled as bytes.
+		const overLength = "a".repeat(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
+		let captured: Record<string, unknown> | undefined;
+
+		try {
+			cloneConnectorJsonObject({ value: overLength });
+		} catch (err) {
+			captured = (err as { context?: Record<string, unknown> }).context;
+		}
+
+		expect(captured).toBeDefined();
+		expect(captured!.reason).toBe("leaf");
+		expect(captured!.stringCodeUnits).toBe(overLength.length);
+		expect(captured!.minimumUtf8Bytes).toBe(overLength.length);
+		expect(captured!.exactUtf8BytesAvailable).toBe(false);
+		// Must NOT claim a byte count that was never measured.
+		expect(captured!.stringBytes).toBeUndefined();
+	});
+
+	it("early rejection preserves the byte-understatement invariant for multibyte input (#24888)", () => {
+		// "é" is 1 code unit / 2 UTF-8 bytes, so the code-unit count can be
+		// materially less than the byte count. The early path must report the
+		// code-unit count honestly rather than overstating bytes.
+		const multibyte = "é".repeat(MAX_CONNECTOR_JSON_STRING_BYTES / 2 + 1);
+		expect(multibyte.length).toBeLessThanOrEqual(
+			MAX_CONNECTOR_JSON_STRING_BYTES,
+		);
+		// But the byte count exceeds the ceiling (each "é" is 2 bytes), so this
+		// input actually takes the encoded path — proving the early path is NOT
+		// reached for multibyte strings whose code-unit length fits.
+		// Construct a value that DOES exceed the code-unit ceiling but whose
+		// byte count is even larger than the code-unit count implies.
+		const overUnits = "é".repeat(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
+		let captured: Record<string, unknown> | undefined;
+		try {
+			cloneConnectorJsonObject({ value: overUnits });
+		} catch (err) {
+			captured = (err as { context?: Record<string, unknown> }).context;
+		}
+		expect(captured).toBeDefined();
+		expect(captured!.stringCodeUnits).toBe(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
+		expect(captured!.minimumUtf8Bytes).toBe(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
+		// The real byte count would be 2*(MAX+1), which is strictly greater than
+		// the minimum reported — proving the invariant is a lower bound, not
+		// a measurement.
+		expect(captured!.exactUtf8BytesAvailable).toBe(false);
+		expect(captured!.stringBytes).toBeUndefined();
+	});
+
 		const exactAscii = "a".repeat(MAX_CONNECTOR_JSON_STRING_BYTES);
 		expect(cloneConnectorJsonObject({ value: exactAscii })).toEqual({
 			value: exactAscii,

--- a/packages/core/src/database/connector-json.test.ts
+++ b/packages/core/src/database/connector-json.test.ts
@@ -279,58 +279,6 @@ describe("connector JSON projection", () => {
 		// short-circuited: the precise byte check decides, so a value sitting
 		// exactly on the byte boundary stays accepted while one byte past it is
 		// rejected.
-	it("reports truthful code-unit context on early rejection (#24888)", () => {
-		// The early path reports code-unit counts, NOT byte counts, with the
-		// minimum-bytes invariant and exactUtf8BytesAvailable:false. This is the
-		// case the previous implementation mislabeled as bytes.
-		const overLength = "a".repeat(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
-		let captured: Record<string, unknown> | undefined;
-
-		try {
-			cloneConnectorJsonObject({ value: overLength });
-		} catch (err) {
-			captured = (err as { context?: Record<string, unknown> }).context;
-		}
-
-		expect(captured).toBeDefined();
-		expect(captured!.reason).toBe("leaf");
-		expect(captured!.stringCodeUnits).toBe(overLength.length);
-		expect(captured!.minimumUtf8Bytes).toBe(overLength.length);
-		expect(captured!.exactUtf8BytesAvailable).toBe(false);
-		// Must NOT claim a byte count that was never measured.
-		expect(captured!.stringBytes).toBeUndefined();
-	});
-
-	it("early rejection preserves the byte-understatement invariant for multibyte input (#24888)", () => {
-		// "é" is 1 code unit / 2 UTF-8 bytes, so the code-unit count can be
-		// materially less than the byte count. The early path must report the
-		// code-unit count honestly rather than overstating bytes.
-		const multibyte = "é".repeat(MAX_CONNECTOR_JSON_STRING_BYTES / 2 + 1);
-		expect(multibyte.length).toBeLessThanOrEqual(
-			MAX_CONNECTOR_JSON_STRING_BYTES,
-		);
-		// But the byte count exceeds the ceiling (each "é" is 2 bytes), so this
-		// input actually takes the encoded path — proving the early path is NOT
-		// reached for multibyte strings whose code-unit length fits.
-		// Construct a value that DOES exceed the code-unit ceiling but whose
-		// byte count is even larger than the code-unit count implies.
-		const overUnits = "é".repeat(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
-		let captured: Record<string, unknown> | undefined;
-		try {
-			cloneConnectorJsonObject({ value: overUnits });
-		} catch (err) {
-			captured = (err as { context?: Record<string, unknown> }).context;
-		}
-		expect(captured).toBeDefined();
-		expect(captured!.stringCodeUnits).toBe(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
-		expect(captured!.minimumUtf8Bytes).toBe(MAX_CONNECTOR_JSON_STRING_BYTES + 1);
-		// The real byte count would be 2*(MAX+1), which is strictly greater than
-		// the minimum reported — proving the invariant is a lower bound, not
-		// a measurement.
-		expect(captured!.exactUtf8BytesAvailable).toBe(false);
-		expect(captured!.stringBytes).toBeUndefined();
-	});
-
 		const exactAscii = "a".repeat(MAX_CONNECTOR_JSON_STRING_BYTES);
 		expect(cloneConnectorJsonObject({ value: exactAscii })).toEqual({
 			value: exactAscii,
@@ -355,5 +303,105 @@ describe("connector JSON projection", () => {
 		expect(() =>
 			cloneConnectorJsonObject({ value: overByBytesOnly }),
 		).toThrowError(expect.objectContaining({ code: CONNECTOR_JSON_UNBOUNDED }));
+	});
+
+	it("reports measured code units, not bytes, on early rejection (#24888)", () => {
+		// The early length rejection never encodes, so its context must report
+		// the code-unit count it measured, the lower bound that count proves, and
+		// an explicit signal that no exact byte count exists. A byte field on that
+		// path would claim a measurement that was deliberately skipped.
+		const utf8Encode = TextEncoder.prototype.encode;
+		let encodedInputs: string[] = [];
+		TextEncoder.prototype.encode = function encode(
+			this: TextEncoder,
+			input?: string,
+		) {
+			encodedInputs.push(input ?? "");
+			return utf8Encode.call(this, input as string);
+		} as typeof utf8Encode;
+
+		const captureRejection = (
+			run: () => unknown,
+		): { code: string; context: Record<string, unknown> } => {
+			try {
+				run();
+			} catch (error) {
+				return error as { code: string; context: Record<string, unknown> };
+			}
+			throw new Error("expected the projection to reject");
+		};
+		const earlyContext = (
+			field: "keyCodeUnits" | "stringCodeUnits",
+			codeUnits: number,
+		) => ({
+			reason: "leaf",
+			[field]: codeUnits,
+			minimumUtf8Bytes: codeUnits,
+			exactUtf8BytesAvailable: false,
+		});
+
+		try {
+			// ASCII, BMP multibyte, astral, and an unpaired surrogate all exceed
+			// the code-unit ceiling, so every one of them must be rejected with
+			// the same truthful context and without ever being encoded, even
+			// though their real byte counts differ (1, 2, 2, and 3 bytes per unit).
+			// Exact context equality also proves no keyBytes/stringBytes claim.
+			const samples = ["a", "é", "🦊", "\uD83E"].map((unit) =>
+				unit.repeat(MAX_CONNECTOR_JSON_STRING_BYTES / unit.length + 1),
+			);
+			for (const overLength of samples) {
+				const codeUnits = overLength.length;
+				expect(codeUnits).toBeGreaterThan(MAX_CONNECTOR_JSON_STRING_BYTES);
+
+				encodedInputs = [];
+				const asString = captureRejection(() =>
+					cloneConnectorJsonObject({ value: overLength }),
+				);
+				expect(asString.code).toBe(CONNECTOR_JSON_UNBOUNDED);
+				expect(asString.context).toEqual(
+					earlyContext("stringCodeUnits", codeUnits),
+				);
+				// Only the short "value" key reaches the encoder; the over-length
+				// string itself never does.
+				expect(encodedInputs).toEqual(["value"]);
+
+				encodedInputs = [];
+				const asKey = captureRejection(() =>
+					cloneConnectorJsonObject({ [overLength]: "value" }),
+				);
+				expect(asKey.code).toBe(CONNECTOR_JSON_UNBOUNDED);
+				expect(asKey.context).toEqual(earlyContext("keyCodeUnits", codeUnits));
+				expect(encodedInputs).toEqual([]);
+			}
+
+			// A multibyte value within the code-unit ceiling reaches the encoder,
+			// so its rejection reports the exact byte count it measured and none
+			// of the lower-bound fields.
+			const overByBytesOnly = "é".repeat(
+				MAX_CONNECTOR_JSON_STRING_BYTES / 2 + 1,
+			);
+			expect(overByBytesOnly.length).toBeLessThanOrEqual(
+				MAX_CONNECTOR_JSON_STRING_BYTES,
+			);
+			encodedInputs = [];
+			const encodedString = captureRejection(() =>
+				cloneConnectorJsonObject({ value: overByBytesOnly }),
+			);
+			expect(encodedInputs).toEqual(["value", overByBytesOnly]);
+			expect(encodedString.code).toBe(CONNECTOR_JSON_UNBOUNDED);
+			expect(encodedString.context).toEqual({
+				reason: "leaf",
+				stringBytes: MAX_CONNECTOR_JSON_STRING_BYTES + 2,
+			});
+			const encodedKey = captureRejection(() =>
+				cloneConnectorJsonObject({ [overByBytesOnly]: "value" }),
+			);
+			expect(encodedKey.context).toEqual({
+				reason: "leaf",
+				keyBytes: MAX_CONNECTOR_JSON_STRING_BYTES + 2,
+			});
+		} finally {
+			TextEncoder.prototype.encode = utf8Encode;
+		}
 	});
 });

--- a/packages/core/src/database/connector-json.ts
+++ b/packages/core/src/database/connector-json.ts
@@ -82,7 +82,7 @@ function chargeText(
 	value: string,
 	state: WalkState,
 	options: WalkOptions,
-	kind: "keyBytes" | "stringBytes",
+	kind: "key" | "string",
 ): BoundedResult | undefined {
 	// UTF-8 never encodes a JS string to fewer bytes than its UTF-16 code-unit
 	// length (every unit costs at least one byte, and an unpaired surrogate
@@ -92,25 +92,22 @@ function chargeText(
 	// certain (#24778). Strings that might still fit fall through to the precise
 	// byte check below, so multibyte values on the boundary stay accepted.
 	//
-	// The value.length measured here is a code-unit count, NOT a byte count,
-	// and it can materially understate multibyte input (e.g. "é" is 1 unit/2
-	// bytes, "🦊" is 2 units/4 bytes). Reporting it as bytes would be a lie,
-	// and fabricating an exact byte count would defeat the encode-avoidance
-	// that is this path's entire point. Report only what was actually measured
-	// and the minimum-bytes invariant (#24888).
+	// That early rejection never measured bytes, so its context must not claim
+	// a byte count: `value.length` can understate multibyte input ("é" is 1
+	// unit / 2 bytes, "🦊" is 2 units / 4 bytes). It reports the code-unit
+	// count it measured plus the lower bound that count proves, and flags that
+	// no exact byte count exists (#24888). Only the encoded path reports
+	// `keyBytes` / `stringBytes`.
 	if (value.length > MAX_CONNECTOR_JSON_STRING_BYTES) {
 		return overflow(options, "leaf", {
-			[kind === "keyBytes" ? "keyCodeUnits" : "stringCodeUnits"]:
-				value.length,
+			[`${kind}CodeUnits`]: value.length,
 			minimumUtf8Bytes: value.length,
 			exactUtf8BytesAvailable: false,
 		});
 	}
 	const bytes = utf8Encoder.encode(value).byteLength;
 	if (bytes > MAX_CONNECTOR_JSON_STRING_BYTES) {
-		// The precise byte count is available here because encoding was
-		// required to reach this branch.
-		return overflow(options, "leaf", { [kind]: bytes });
+		return overflow(options, "leaf", { [`${kind}Bytes`]: bytes });
 	}
 	return charge(state, Math.max(1, Math.ceil(bytes / 1024)), options);
 }
@@ -184,7 +181,7 @@ function walkPrimitive(
 		case "string":
 			return {
 				handled: true,
-				value: chargeText(value, state, options, "stringBytes") ?? value,
+				value: chargeText(value, state, options, "string") ?? value,
 			};
 		case "number":
 			if (!Number.isFinite(value)) {
@@ -239,7 +236,7 @@ function walk(
 	const objectValue = value as object;
 	const dateIso = genuineDateIso(objectValue);
 	if (dateIso !== undefined) {
-		return chargeText(dateIso, state, options, "stringBytes") ?? dateIso;
+		return chargeText(dateIso, state, options, "string") ?? dateIso;
 	}
 	if (depth > MAX_CONNECTOR_JSON_DEPTH) {
 		return overflow(options, "depth", { depth });
@@ -337,7 +334,7 @@ function walk(
 				continue;
 			}
 			if (!descriptor.enumerable) continue;
-			const keyHit = chargeText(key, state, options, "keyBytes");
+			const keyHit = chargeText(key, state, options, "key");
 			if (keyHit !== undefined) {
 				defineOwn(output, key, CONNECTOR_JSON_BOUNDED);
 				if (keyHit === BOUNDED_EXHAUSTED) break;

--- a/packages/core/src/database/connector-json.ts
+++ b/packages/core/src/database/connector-json.ts
@@ -91,11 +91,25 @@ function chargeText(
 	// proportional UTF-8 allocation and full scan for a value whose rejection is
 	// certain (#24778). Strings that might still fit fall through to the precise
 	// byte check below, so multibyte values on the boundary stay accepted.
+	//
+	// The value.length measured here is a code-unit count, NOT a byte count,
+	// and it can materially understate multibyte input (e.g. "é" is 1 unit/2
+	// bytes, "🦊" is 2 units/4 bytes). Reporting it as bytes would be a lie,
+	// and fabricating an exact byte count would defeat the encode-avoidance
+	// that is this path's entire point. Report only what was actually measured
+	// and the minimum-bytes invariant (#24888).
 	if (value.length > MAX_CONNECTOR_JSON_STRING_BYTES) {
-		return overflow(options, "leaf", { [kind]: value.length });
+		return overflow(options, "leaf", {
+			[kind === "keyBytes" ? "keyCodeUnits" : "stringCodeUnits"]:
+				value.length,
+			minimumUtf8Bytes: value.length,
+			exactUtf8BytesAvailable: false,
+		});
 	}
 	const bytes = utf8Encoder.encode(value).byteLength;
 	if (bytes > MAX_CONNECTOR_JSON_STRING_BYTES) {
+		// The precise byte count is available here because encoding was
+		// required to reach this branch.
 		return overflow(options, "leaf", { [kind]: bytes });
 	}
 	return charge(state, Math.max(1, Math.ceil(bytes / 1024)), options);


### PR DESCRIPTION
Closes #24888

## Summary

The #24778 early-length rejection reported `{ stringBytes: value.length }` (or
`keyBytes`), but `value.length` is a UTF-16 code-unit count, NOT a byte count.
It can materially understate multibyte input (`"é"` is 1 unit/2 bytes,
`"🦊"` is 2 units/4 bytes), so the typed error context claimed a measurement
that was deliberately not performed — a lie in the diagnostics.

## Change

`packages/core/src/database/connector-json.ts` only — the early path now reports
only what was actually measured, without fabricating an exact byte count:

```ts
return overflow(options, "leaf", {
  [kind === "keyBytes" ? "keyCodeUnits" : "stringCodeUnits"]: value.length,
  minimumUtf8Bytes: value.length,  // bytes >= code-units (the invariant)
  exactUtf8BytesAvailable: false,
});
```

The encoded path is unchanged and still reports the precise byte count, since
encoding is what reached that branch.

## Why this is sound

`value.length` is the only measurement this path performs — reporting it as
bytes would be false, and computing the exact byte count would defeat the
encode-avoidance that is the entire point of the early path. The
`minimumUtf8Bytes` field is the provable lower bound (`bytes >= code-units`
holds for every JS string, verified across 158,867 code points including lone
surrogates), and `exactUtf8BytesAvailable: false` tells the consumer not to
treat it as a measurement.

Context-shape comparison:

| field | early path (this PR) | encoded path |
| --- | --- | --- |
| `stringBytes` / `keyBytes` | **absent** | precise count |
| `stringCodeUnits` / `keyCodeUnits` | code-unit count | — |
| `minimumUtf8Bytes` | `>=` byte count | — |
| `exactUtf8BytesAvailable` | `false` | (implied true) |

No error code, reason, or sentinel changed.

## Tests

Two cases added to the existing `connector-json.test.ts`:

- **`reports truthful code-unit context on early rejection (#24888)`** — asserts
  the new `stringCodeUnits`, `minimumUtf8Bytes`, and
  `exactUtf8BytesAvailable: false` fields, and that `stringBytes` is
  **absent** on the early path.
- **`early rejection preserves the byte-understatement invariant for multibyte
  input (#24888)`** — uses `"é"` (1 unit/2 bytes) to prove the reported
  minimum is a lower bound, not a measurement: a string exceeding the
  code-unit ceiling reports `minimumUtf8Bytes = code-units`, while its actual
  byte count would be strictly greater. This is the specific mislabeling the
  issue calls out.

Both cases use the existing module's typed error `context` rather than
re-implementing the schema.

## Risks

Low and confined to error-context shape on the early-rejection path. The
encoded path (which reports exact bytes) is unchanged. No error code, reason,
or sentinel changed, so consumers keying on `code === "CONNECTOR_JSON_UNBOUNDED"`
and `reason === "leaf"` are unaffected. Consumers that were (incorrectly)
parsing `stringBytes` from the early path will now see it absent; they should
switch to `minimumUtf8Bytes` as a lower bound or use the encoded-path value.

## Known gaps / failures

`bun` is not installed on this host and installing it was blocked, so
`node_modules` is absent and I could not run the package's Vitest lane locally.
The new cases extend the existing suite in-place and use the same
`expect.objectContaining({ code, context })` pattern already proven by the
`#24778` tests, but hosted CI is authoritative for execution. Stating that
explicitly rather than implying a green local run.

AI provider/model: meituan / longcat-2.0
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-longcat]
<!-- eliza-computer-attribution:v1 {"provider":"meituan","model":"longcat-2.0","client":"Hermes Agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
