### PR TITLE
fix(cloud): reconcile uncertain Twilio call submissions

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.test.ts
@@ -60,7 +60,7 @@ const dbWrite = {
 };
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  requireUserOrApiKeyWithOrg: requireUser,
+  requireSessionUserWithOrg: requireUser,
 }));
 mock.module("@/db/helpers", () => ({ dbWrite }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
@@ -69,6 +69,10 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 }));
 mock.module("@/lib/utils/twilio-api", () => ({
   twilioApiRequest: providerRequest,
+  verifyTwilioSignature: mock(async () => true),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock() },
 }));
 
 const { default: route } = await import("./route");

--- a/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.test.ts
@@ -72,7 +72,7 @@ mock.module("@/lib/utils/twilio-api", () => ({
   verifyTwilioSignature: mock(async () => true),
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { error: mock(), info: mock() },
+  logger: { debug: mock(), error: mock(), info: mock(), warn: mock() },
 }));
 
 const { default: route } = await import("./route");

--- a/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/[callSid]/route.ts
@@ -6,7 +6,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { dbWrite } from "@/db/helpers";
 import { idempotencyKeys, twilioOutboundCalls } from "@/db/schemas";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { requireSessionUserWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -34,8 +34,8 @@ function maskPhoneNumber(phoneNumber: string): string {
 
 app.use("*", rateLimit({ ...RateLimitPresets.CRITICAL, failClosed: true }));
 
-async function ownedCall(c: Parameters<typeof requireUserOrApiKeyWithOrg>[0]) {
-  const auth = await requireUserOrApiKeyWithOrg(c);
+async function ownedCall(c: Parameters<typeof requireSessionUserWithOrg>[0]) {
+  const auth = await requireSessionUserWithOrg(c);
   const reference = c.req.param("callSid");
   const parsedSid = CallSid.safeParse(reference);
   const parsedId = CallId.safeParse(reference);

--- a/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
@@ -1,6 +1,7 @@
 /** Tests the outbound Twilio call boundary with provider and storage doubles. */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 
 const requireUser = mock(async () => ({
   id: "11111111-1111-4111-8111-111111111111",
@@ -46,20 +47,28 @@ const dbWrite = {
   })),
   update: mock(() => ({ set: () => ({ where: updateWhere }) })),
 };
+const writeTransaction = mock(
+  async (callback: (transaction: typeof dbWrite) => unknown) =>
+    callback(dbWrite),
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  requireUserOrApiKeyWithOrg: requireUser,
+  requireSessionUserWithOrg: requireUser,
 }));
 mock.module("@/db/repositories/users", () => ({
   usersRepository: { findById: findUser },
 }));
-mock.module("@/db/helpers", () => ({ dbWrite }));
+mock.module("@/db/helpers", () => ({ dbWrite, writeTransaction }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { CRITICAL: { windowMs: 300_000, maxRequests: 5 } },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }));
 mock.module("@/lib/utils/twilio-api", () => ({
   twilioApiRequest: queueCall,
+  verifyTwilioSignature: mock(async () => true),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock() },
 }));
 mock.module("../lib/resolve-voice-target", () => ({
   resolveTwilioVoiceTarget: resolveTarget,
@@ -85,6 +94,8 @@ function callRequest(
       headers: {
         "Content-Type": "application/json",
         "Idempotency-Key": idempotencyKey,
+        "X-Forwarded-Host": "attacker.example",
+        "X-Forwarded-Proto": "http",
       },
       body: JSON.stringify(body),
     },
@@ -108,6 +119,7 @@ describe("POST Twilio outbound voice call", () => {
     selectLimit.mockClear();
     selectLimit.mockImplementation(async () => []);
     updateWhere.mockClear();
+    writeTransaction.mockClear();
     outboundInserts.length = 0;
   });
 
@@ -182,20 +194,29 @@ describe("POST Twilio outbound voice call", () => {
     expect(queueCall).not.toHaveBeenCalled();
   });
 
-  test("reclaims an expired idempotency key and queues the current call", async () => {
-    returning
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ key: "reclaimed" }]);
+  test("returns the same unresolved call for a fresh client key", async () => {
+    returning.mockResolvedValueOnce([]);
+    selectLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: "33333333-3333-4333-8333-333333333333",
+        callSid: null,
+        status: "submission-unknown",
+        to: "+14155550100",
+      },
+    ]);
 
     const response = await callRequest(
       { to: "+14155550100" },
       "00000000-0000-4000-8000-000000000001",
     );
 
-    expect(response.status).toBe(200);
-    expect(deleteWhere).toHaveBeenCalledTimes(1);
-    expect(returning).toHaveBeenCalledTimes(2);
-    expect(queueCall).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      callId: "33333333-3333-4333-8333-333333333333",
+      status: "submission-unknown",
+      replayed: true,
+    });
+    expect(queueCall).not.toHaveBeenCalled();
   });
 
   test("keeps a live duplicate claim fail-closed", async () => {
@@ -208,7 +229,7 @@ describe("POST Twilio outbound voice call", () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toMatchObject({
-      code: "duplicate_call",
+      code: "duplicate_call_pending",
     });
     expect(deleteWhere).toHaveBeenCalledTimes(1);
     expect(returning).toHaveBeenCalledTimes(2);
@@ -286,4 +307,77 @@ describe("POST Twilio outbound voice call", () => {
     expect(outboundInserts).toHaveLength(1);
     expect(updateWhere).toHaveBeenCalledTimes(1);
   });
+
+  test("terminalizes an explicit provider rejection and releases the fence", async () => {
+    queueCall.mockRejectedValueOnce(
+      new ElizaError("Twilio rejected the request", {
+        code: "TWILIO_PROVIDER_REJECTED",
+        context: { providerStatus: 400, retryable: false },
+      }),
+    );
+
+    const response = await callRequest({ to: "+14155550100" });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "provider_rejected",
+      providerStatus: 400,
+    });
+    expect(queueCall).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ["missing CallSid", { status: "queued" }],
+    [
+      "invalid status",
+      { sid: "CA11111111111111111111111111111111", status: "invented" },
+    ],
+  ])(
+    "keeps an accepted malformed receipt uncertain: %s",
+    async (_case, receipt) => {
+      queueCall.mockResolvedValueOnce(receipt as never);
+
+      const response = await callRequest({ to: "+14155550100" });
+
+      expect(response.status).toBe(202);
+      await expect(response.json()).resolves.toMatchObject({
+        status: "submission-unknown",
+        auditPending: true,
+      });
+      expect(deleteWhere).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    ["missing", undefined],
+    ["non-HTTPS", "http://api.eliza.app"],
+    ["credentials", "https://user:secret@api.eliza.app"],
+    ["path", "https://api.eliza.app/callback"],
+  ])(
+    "rejects %s canonical public URL before storage or provider side effects",
+    async (_case, publicUrl) => {
+      const response = await app.request(
+        "https://worker.internal/",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": crypto.randomUUID(),
+            "X-Forwarded-Host": "attacker.example",
+            "X-Forwarded-Proto": "https",
+          },
+          body: JSON.stringify({ to: "+14155550100" }),
+        },
+        { ...env, TWILIO_PUBLIC_URL: publicUrl } as never,
+      );
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toMatchObject({
+        code: "voice_not_configured",
+      });
+      expect(writeTransaction).not.toHaveBeenCalled();
+      expect(queueCall).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
@@ -11,7 +11,6 @@ const findUser = mock(async () => ({
   phone_number: "+14155550100",
   phone_verified: true,
 }));
-const resolveTarget = mock(async () => ({ agentId: "agent-1" }));
 const queueCall = mock(
   async (
     _accountSid: string,
@@ -68,10 +67,7 @@ mock.module("@/lib/utils/twilio-api", () => ({
   verifyTwilioSignature: mock(async () => true),
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { error: mock(), info: mock() },
-}));
-mock.module("../lib/resolve-voice-target", () => ({
-  resolveTwilioVoiceTarget: resolveTarget,
+  logger: { debug: mock(), error: mock(), info: mock(), warn: mock() },
 }));
 
 const { default: app } = await import("./route");
@@ -111,7 +107,6 @@ describe("POST Twilio outbound voice call", () => {
       phone_number: "+14155550100",
       phone_verified: true,
     }));
-    resolveTarget.mockClear();
     queueCall.mockClear();
     returning.mockClear();
     returning.mockImplementation(async () => [{ key: "claimed" }]);

--- a/packages/cloud/api/v1/twilio/voice/calls/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.ts
@@ -4,13 +4,14 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { and, eq, lt, sql } from "drizzle-orm";
+import { ElizaError, isElizaError } from "@elizaos/core";
+import { and, eq, inArray, lt, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbWrite } from "@/db/helpers";
+import { dbWrite, writeTransaction } from "@/db/helpers";
 import { usersRepository } from "@/db/repositories/users";
 import { idempotencyKeys, twilioOutboundCalls } from "@/db/schemas";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { requireSessionUserWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
@@ -23,10 +24,14 @@ import {
 } from "@/lib/utils/phone-normalization";
 import { twilioApiRequest } from "@/lib/utils/twilio-api";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import {
+  TWILIO_CALL_FENCE_EXPIRY,
+  twilioCallFenceKey,
+} from "../lib/twilio-call-fence";
+import { normalizeTwilioProviderCallStatus } from "../lib/twilio-call-status";
 import { resolveTwilioPublicUrl } from "../lib/twilio-public-url";
 
 const app = new Hono<AppEnv>();
-const IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
 
 const StartCallBody = z.object({
   to: z.string().min(1).max(32).optional(),
@@ -41,9 +46,21 @@ interface PublicTwilioEnv {
   ELIZA_APP_TWILIO_PHONE_NUMBER?: string;
 }
 
-interface TwilioCallResponse {
-  sid: string;
+const TwilioCallResponse = z.object({
+  sid: z.string().regex(/^CA[a-fA-F0-9]{32}$/),
+  status: z.string().transform((status, context) => {
+    const normalized = normalizeTwilioProviderCallStatus(status);
+    if (normalized) return normalized;
+    context.addIssue({ code: "custom", message: "Invalid Twilio call status" });
+    return z.NEVER;
+  }),
+});
+
+interface ExistingCall {
+  id: string;
+  callSid: string | null;
   status: string;
+  to: string;
 }
 
 function resolveCallbackUrl(c: AppContext): string {
@@ -73,7 +90,7 @@ app.use(
 );
 
 app.post("/", async (c) => {
-  const auth = await requireUserOrApiKeyWithOrg(c);
+  const auth = await requireSessionUserWithOrg(c);
   const idempotencyHeader = c.req.header("Idempotency-Key")?.trim();
   if (!idempotencyHeader || idempotencyHeader.length > 128) {
     return c.json(
@@ -151,22 +168,37 @@ app.post("/", async (c) => {
     );
   }
 
+  const callId = randomUUID();
+  let callbackUrl: string;
+  let statusCallbackUrl: string;
+  try {
+    callbackUrl = resolveCallbackUrl(c);
+    statusCallbackUrl = resolveStatusCallbackUrl(c, callId);
+  } catch (error) {
+    // error-policy:J1 invalid server-owned callback configuration is known
+    // before provider dispatch and becomes an explicit unavailable response.
+    logger.error("[twilio-voice-outbound] public callback origin is invalid", {
+      errorCode: isElizaError(error) ? error.code : "TWILIO_PUBLIC_URL_INVALID",
+    });
+    return c.json(
+      {
+        error: "Eliza calling callback origin is not configured",
+        code: "voice_not_configured",
+      },
+      503,
+    );
+  }
+
   const idempotencyDigest = createHash("sha256")
     .update(`${auth.id}:${idempotencyHeader}`)
     .digest("hex");
-  const idempotencyKey = `twilio-call:${idempotencyDigest}`;
-  let [claim] = await dbWrite
-    .insert(idempotencyKeys)
-    .values({
-      key: idempotencyKey,
-      source: "twilio-voice-outbound",
-      expires_at: new Date(Date.now() + IDEMPOTENCY_TTL_MS),
-    })
-    .onConflictDoNothing({ target: idempotencyKeys.key })
-    .returning({ key: idempotencyKeys.key });
-
-  if (!claim) {
-    const [existingCall] = await dbWrite
+  const fenceKey = twilioCallFenceKey(
+    auth.organization_id,
+    auth.id,
+    requestedPhoneNumber,
+  );
+  const admission = await writeTransaction(async (tx) => {
+    const [exactCall] = await tx
       .select({
         id: twilioOutboundCalls.id,
         callSid: twilioOutboundCalls.call_sid,
@@ -182,100 +214,190 @@ app.post("/", async (c) => {
         ),
       )
       .limit(1);
-    if (existingCall) {
-      return c.json(
-        {
-          success: true,
-          callId: existingCall.id,
-          callSid: existingCall.callSid,
-          status: existingCall.status,
-          to: maskPhoneNumber(existingCall.to),
-          replayed: true,
-        },
-        existingCall.callSid ? 200 : 202,
-      );
-    }
+    if (exactCall) return { existingCall: exactCall };
 
-    const now = new Date();
-    await dbWrite
-      .delete(idempotencyKeys)
-      .where(
-        and(
-          eq(idempotencyKeys.key, idempotencyKey),
-          lt(idempotencyKeys.expires_at, now),
-        ),
-      );
-
-    [claim] = await dbWrite
+    let [fenceClaim] = await tx
       .insert(idempotencyKeys)
       .values({
-        key: idempotencyKey,
-        source: "twilio-voice-outbound",
-        expires_at: new Date(now.getTime() + IDEMPOTENCY_TTL_MS),
+        key: fenceKey,
+        source: "twilio-voice-outbound-fence",
+        expires_at: TWILIO_CALL_FENCE_EXPIRY,
       })
       .onConflictDoNothing({ target: idempotencyKeys.key })
       .returning({ key: idempotencyKeys.key });
 
-    if (!claim) {
+    if (!fenceClaim) {
+      const [unresolvedCall] = await tx
+        .select({
+          id: twilioOutboundCalls.id,
+          callSid: twilioOutboundCalls.call_sid,
+          status: twilioOutboundCalls.call_status,
+          to: twilioOutboundCalls.to_number,
+        })
+        .from(twilioOutboundCalls)
+        .where(
+          and(
+            eq(twilioOutboundCalls.organization_id, auth.organization_id),
+            eq(twilioOutboundCalls.user_id, auth.id),
+            eq(twilioOutboundCalls.to_number, requestedPhoneNumber),
+            inArray(twilioOutboundCalls.call_status, [
+              "requesting",
+              "submission-unknown",
+            ]),
+          ),
+        )
+        .limit(1);
+      if (unresolvedCall) return { existingCall: unresolvedCall };
+
+      // A validated provider receipt or signed callback normally clears the
+      // fence. Recover a stale fence only after proving no unresolved call owns it.
+      await tx.delete(idempotencyKeys).where(eq(idempotencyKeys.key, fenceKey));
+      [fenceClaim] = await tx
+        .insert(idempotencyKeys)
+        .values({
+          key: fenceKey,
+          source: "twilio-voice-outbound-fence",
+          expires_at: TWILIO_CALL_FENCE_EXPIRY,
+        })
+        .onConflictDoNothing({ target: idempotencyKeys.key })
+        .returning({ key: idempotencyKeys.key });
+      if (!fenceClaim) return { existingCall: null };
+    }
+
+    await tx.insert(twilioOutboundCalls).values({
+      id: callId,
+      request_digest: idempotencyDigest,
+      account_sid: accountSid,
+      organization_id: auth.organization_id,
+      user_id: auth.id,
+      from_number: fromNumber,
+      to_number: requestedPhoneNumber,
+      call_status: "requesting",
+    });
+    return { callId };
+  });
+
+  if ("existingCall" in admission) {
+    const existingCall: ExistingCall | null = admission.existingCall ?? null;
+    if (!existingCall) {
       return c.json(
         {
-          error: "This call request was already submitted",
-          code: "duplicate_call",
+          error: "Another call request is being admitted",
+          code: "duplicate_call_pending",
         },
         409,
       );
     }
+    return c.json(
+      {
+        success: true,
+        callId: existingCall.id,
+        callSid: existingCall.callSid,
+        status: existingCall.status,
+        to: maskPhoneNumber(existingCall.to),
+        replayed: true,
+      },
+      existingCall.callSid ? 200 : 202,
+    );
   }
 
-  const callId = randomUUID();
-  await dbWrite.insert(twilioOutboundCalls).values({
-    id: callId,
-    request_digest: idempotencyDigest,
-    account_sid: accountSid,
-    organization_id: auth.organization_id,
-    user_id: auth.id,
-    from_number: fromNumber,
-    to_number: requestedPhoneNumber,
-    call_status: "requesting",
-  });
-
-  let call: TwilioCallResponse;
+  let call: z.infer<typeof TwilioCallResponse>;
   try {
     const form = new URLSearchParams();
     form.set("To", requestedPhoneNumber);
     form.set("From", fromNumber);
-    form.set("Url", resolveCallbackUrl(c));
+    form.set("Url", callbackUrl);
     form.set("Method", "POST");
-    form.set("StatusCallback", resolveStatusCallbackUrl(c, callId));
+    form.set("StatusCallback", statusCallbackUrl);
     form.set("StatusCallbackMethod", "POST");
     for (const event of ["initiated", "ringing", "answered", "completed"]) {
       form.append("StatusCallbackEvent", event);
     }
 
-    call = await twilioApiRequest<TwilioCallResponse>(
+    const rawCall = await twilioApiRequest<unknown>(
       accountSid,
       authToken,
       "POST",
       "/Calls.json",
       form,
     );
+    const parsedCall = TwilioCallResponse.safeParse(rawCall);
+    if (!parsedCall.success) {
+      throw new ElizaError("Twilio accepted the call without a valid receipt", {
+        code: "TWILIO_RECEIPT_INVALID",
+        context: { callId, provider: "twilio" },
+        cause: parsedCall.error,
+        severity: "fatal",
+      });
+    }
+    call = parsedCall.data;
   } catch (error) {
-    // error-policy:J4 a missing or unusable provider response cannot prove
-    // rejection. Retain the claim and expose the durable call id so signed
-    // callbacks can reconcile an accepted call without authorizing a retry.
+    const providerRejected =
+      isElizaError(error) && error.code === "TWILIO_PROVIDER_REJECTED";
     logger.error("[twilio-voice-outbound] failed to queue call", {
       userId: auth.id,
       organizationId: auth.organization_id,
+      errorCode: isElizaError(error)
+        ? error.code
+        : "TWILIO_SUBMISSION_UNCERTAIN",
       error: error instanceof Error ? error.message : String(error),
     });
+    if (providerRejected) {
+      // error-policy:J1 an explicit provider 4xx proves the paid call was not
+      // accepted, so the boundary may terminalize and release the global fence.
+      await writeTransaction(async (tx) => {
+        await tx
+          .update(twilioOutboundCalls)
+          .set({
+            call_status: "provider-error",
+            provider_error_code: error.code,
+            terminal_at: new Date(),
+            updated_at: new Date(),
+          })
+          .where(
+            and(
+              eq(twilioOutboundCalls.id, callId),
+              lt(twilioOutboundCalls.last_status_sequence, 0),
+              eq(twilioOutboundCalls.call_status, "requesting"),
+            ),
+          );
+        await tx
+          .delete(idempotencyKeys)
+          .where(eq(idempotencyKeys.key, fenceKey));
+      });
+      const providerStatus =
+        typeof error.context?.providerStatus === "number"
+          ? error.context.providerStatus
+          : undefined;
+      return c.json(
+        {
+          error: "Twilio rejected the call request",
+          code: "provider_rejected",
+          ...(providerStatus === undefined ? {} : { providerStatus }),
+        },
+        providerStatus === 429 ? 429 : 502,
+      );
+    }
+
+    // error-policy:J4 a missing or unusable provider response cannot prove
+    // rejection. Retain the fence and expose the durable call id so signed
+    // callbacks can reconcile an accepted call without authorizing a retry.
     await dbWrite
       .update(twilioOutboundCalls)
       .set({
         call_status: "submission-unknown",
-        provider_error_code: "provider_unavailable",
+        provider_error_code: isElizaError(error)
+          ? error.code
+          : "TWILIO_SUBMISSION_UNCERTAIN",
         updated_at: new Date(),
       })
-      .where(eq(twilioOutboundCalls.id, callId));
+      .where(
+        and(
+          eq(twilioOutboundCalls.id, callId),
+          lt(twilioOutboundCalls.last_status_sequence, 0),
+          eq(twilioOutboundCalls.call_status, "requesting"),
+        ),
+      );
     return c.json(
       {
         success: true,
@@ -291,17 +413,20 @@ app.post("/", async (c) => {
 
   let auditPending = false;
   try {
-    await dbWrite
-      .update(twilioOutboundCalls)
-      .set({
-        call_sid: call.sid,
-        call_status: sql`CASE
-          WHEN ${twilioOutboundCalls.last_status_sequence} < 0 THEN ${call.status}
-          ELSE ${twilioOutboundCalls.call_status}
-        END`,
-        updated_at: new Date(),
-      })
-      .where(eq(twilioOutboundCalls.id, callId));
+    await writeTransaction(async (tx) => {
+      await tx
+        .update(twilioOutboundCalls)
+        .set({
+          call_sid: call.sid,
+          call_status: sql`CASE
+            WHEN ${twilioOutboundCalls.last_status_sequence} < 0 THEN ${call.status}
+            ELSE ${twilioOutboundCalls.call_status}
+          END`,
+          updated_at: new Date(),
+        })
+        .where(eq(twilioOutboundCalls.id, callId));
+      await tx.delete(idempotencyKeys).where(eq(idempotencyKeys.key, fenceKey));
+    });
   } catch (error) {
     // error-policy:J4 Twilio accepted the call; the signed callback keyed by
     // callId remains the authoritative reconciliation path for this row.

--- a/packages/cloud/api/v1/twilio/voice/calls/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.ts
@@ -27,6 +27,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 import {
   TWILIO_CALL_FENCE_EXPIRY,
   twilioCallFenceKey,
+  twilioCallFenceSource,
 } from "../lib/twilio-call-fence";
 import { normalizeTwilioProviderCallStatus } from "../lib/twilio-call-status";
 import { resolveTwilioPublicUrl } from "../lib/twilio-public-url";
@@ -220,7 +221,7 @@ app.post("/", async (c) => {
       .insert(idempotencyKeys)
       .values({
         key: fenceKey,
-        source: "twilio-voice-outbound-fence",
+        source: twilioCallFenceSource(callId),
         expires_at: TWILIO_CALL_FENCE_EXPIRY,
       })
       .onConflictDoNothing({ target: idempotencyKeys.key })
@@ -256,7 +257,7 @@ app.post("/", async (c) => {
         .insert(idempotencyKeys)
         .values({
           key: fenceKey,
-          source: "twilio-voice-outbound-fence",
+          source: twilioCallFenceSource(callId),
           expires_at: TWILIO_CALL_FENCE_EXPIRY,
         })
         .onConflictDoNothing({ target: idempotencyKeys.key })
@@ -363,7 +364,12 @@ app.post("/", async (c) => {
           );
         await tx
           .delete(idempotencyKeys)
-          .where(eq(idempotencyKeys.key, fenceKey));
+          .where(
+            and(
+              eq(idempotencyKeys.key, fenceKey),
+              eq(idempotencyKeys.source, twilioCallFenceSource(callId)),
+            ),
+          );
       });
       const providerStatus =
         typeof error.context?.providerStatus === "number"
@@ -425,7 +431,14 @@ app.post("/", async (c) => {
           updated_at: new Date(),
         })
         .where(eq(twilioOutboundCalls.id, callId));
-      await tx.delete(idempotencyKeys).where(eq(idempotencyKeys.key, fenceKey));
+      await tx
+        .delete(idempotencyKeys)
+        .where(
+          and(
+            eq(idempotencyKeys.key, fenceKey),
+            eq(idempotencyKeys.source, twilioCallFenceSource(callId)),
+          ),
+        );
     });
   } catch (error) {
     // error-policy:J4 Twilio accepted the call; the signed callback keyed by

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-call-fence.pglite.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-call-fence.pglite.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Proves against real PostgreSQL semantics that delayed receipts cannot release
+ * a destination fence after ownership has moved to a newer outbound call.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { twilioCallFenceKey, twilioCallFenceSource } from "./twilio-call-fence";
+
+const ORGANIZATION_ID = "10000000-0000-4000-8000-000000000001";
+const USER_ID = "10000000-0000-4000-8000-000000000002";
+const DESTINATION = "+15551234567";
+const CALL_A = "10000000-0000-4000-8000-00000000000a";
+const CALL_B = "10000000-0000-4000-8000-00000000000b";
+const CALL_C = "10000000-0000-4000-8000-00000000000c";
+
+async function claimFence(
+  database: PGlite,
+  fenceKey: string,
+  callId: string,
+): Promise<boolean> {
+  const result = await database.query<{ key: string }>(
+    `INSERT INTO idempotency_keys (key, source, expires_at)
+     VALUES ($1, $2, '9999-12-31T23:59:59.999Z')
+     ON CONFLICT (key) DO NOTHING
+     RETURNING key`,
+    [fenceKey, twilioCallFenceSource(callId)],
+  );
+  return result.rows.length === 1;
+}
+
+async function releaseFence(
+  database: PGlite,
+  fenceKey: string,
+  callId: string,
+): Promise<void> {
+  await database.query(
+    `DELETE FROM idempotency_keys WHERE key = $1 AND source = $2`,
+    [fenceKey, twilioCallFenceSource(callId)],
+  );
+}
+
+describe("Twilio outbound call fence ownership", () => {
+  const databases: PGlite[] = [];
+
+  afterEach(async () => {
+    await Promise.all(databases.splice(0).map((database) => database.close()));
+  });
+
+  test("keeps B fenced across delayed REST and callback releases for A", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await database.exec(`
+      CREATE TABLE idempotency_keys (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        key text NOT NULL UNIQUE,
+        source text NOT NULL,
+        created_at timestamp NOT NULL DEFAULT now(),
+        expires_at timestamp NOT NULL
+      )
+    `);
+    const fenceKey = twilioCallFenceKey(ORGANIZATION_ID, USER_ID, DESTINATION);
+
+    expect(await claimFence(database, fenceKey, CALL_A)).toBe(true);
+    await releaseFence(database, fenceKey, CALL_A);
+    expect(await claimFence(database, fenceKey, CALL_B)).toBe(true);
+
+    // A's delayed REST completion and replayed signed callback both use the
+    // same compare-and-delete authority and cannot release B's newer claim.
+    await releaseFence(database, fenceKey, CALL_A);
+    await releaseFence(database, fenceKey, CALL_A);
+
+    const owner = await database.query<{ source: string }>(
+      `SELECT source FROM idempotency_keys WHERE key = $1`,
+      [fenceKey],
+    );
+    expect(owner.rows).toEqual([{ source: twilioCallFenceSource(CALL_B) }]);
+    expect(await claimFence(database, fenceKey, CALL_C)).toBe(false);
+
+    await releaseFence(database, fenceKey, CALL_B);
+    expect(await claimFence(database, fenceKey, CALL_C)).toBe(true);
+  });
+});

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-call-fence.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-call-fence.ts
@@ -1,0 +1,16 @@
+/** Builds the durable authority key that fences ambiguous paid call submissions. */
+
+import { createHash } from "node:crypto";
+
+export const TWILIO_CALL_FENCE_EXPIRY = new Date("9999-12-31T23:59:59.999Z");
+
+export function twilioCallFenceKey(
+  organizationId: string,
+  userId: string,
+  destination: string,
+): string {
+  const digest = createHash("sha256")
+    .update(`${organizationId}:${userId}:${destination}`)
+    .digest("hex");
+  return `twilio-call-fence:${digest}`;
+}

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-call-fence.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-call-fence.ts
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 
 export const TWILIO_CALL_FENCE_EXPIRY = new Date("9999-12-31T23:59:59.999Z");
+const TWILIO_CALL_FENCE_SOURCE_PREFIX = "twilio-voice-outbound-fence:";
 
 export function twilioCallFenceKey(
   organizationId: string,
@@ -13,4 +14,9 @@ export function twilioCallFenceKey(
     .update(`${organizationId}:${userId}:${destination}`)
     .digest("hex");
   return `twilio-call-fence:${digest}`;
+}
+
+/** Binds a shared destination fence to the exact durable outbound call row. */
+export function twilioCallFenceSource(callId: string): string {
+  return `${TWILIO_CALL_FENCE_SOURCE_PREFIX}${callId}`;
 }

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-public-url.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-public-url.ts
@@ -1,19 +1,56 @@
-/** Resolves the externally signed Twilio webhook URL behind trusted proxies. */
+/** Resolves signed Twilio webhook URLs from the canonical configured origin. */
 
+import { ElizaError } from "@elizaos/core";
 import type { AppContext } from "@/types/cloud-worker-env";
 
 export function resolveTwilioPublicUrl(c: AppContext, pathname: string): URL {
-  const url = new URL(c.req.url);
-  const forwardedProto = c.req.header("x-forwarded-proto");
-  const forwardedHost = c.req.header("x-forwarded-host");
-  if (forwardedProto) url.protocol = `${forwardedProto}:`;
-  if (forwardedHost) url.host = forwardedHost;
   const configured = (c.env.TWILIO_PUBLIC_URL as string | undefined)?.trim();
-  if (configured) {
-    const publicBase = new URL(configured);
-    url.protocol = publicBase.protocol;
-    url.host = publicBase.host;
+  if (!configured) {
+    throw new ElizaError(
+      "TWILIO_PUBLIC_URL must configure the public HTTPS origin",
+      {
+        code: "TWILIO_PUBLIC_URL_REQUIRED",
+        context: { pathname },
+        severity: "fatal",
+      },
+    );
   }
+
+  let publicBase: URL;
+  try {
+    publicBase = new URL(configured);
+  } catch (cause) {
+    // error-policy:J2 retain the invalid configured value's parse failure while
+    // exposing only its stable setting name at the route boundary.
+    throw new ElizaError("TWILIO_PUBLIC_URL must be a valid HTTPS origin", {
+      code: "TWILIO_PUBLIC_URL_INVALID",
+      context: { setting: "TWILIO_PUBLIC_URL", pathname },
+      cause,
+      severity: "fatal",
+    });
+  }
+  if (
+    publicBase.protocol !== "https:" ||
+    publicBase.username !== "" ||
+    publicBase.password !== "" ||
+    publicBase.pathname !== "/" ||
+    publicBase.search !== "" ||
+    publicBase.hash !== ""
+  ) {
+    throw new ElizaError(
+      "TWILIO_PUBLIC_URL must be a credential-free HTTPS origin",
+      {
+        code: "TWILIO_PUBLIC_URL_INVALID",
+        context: { setting: "TWILIO_PUBLIC_URL", pathname },
+        severity: "fatal",
+      },
+    );
+  }
+
+  const url = new URL(publicBase.origin);
   url.pathname = pathname;
+  // The request query is part of Twilio's signed callback URL. Preserve it,
+  // while deriving authority exclusively from the configured origin.
+  url.search = new URL(c.req.url).search;
   return url;
 }

--- a/packages/cloud/api/v1/twilio/voice/status/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/status/route.test.ts
@@ -9,6 +9,8 @@ const selectLimit = mock(async () => [
     id: requestId,
     callSid,
     accountSid: "AC123",
+    organizationId: "22222222-2222-4222-8222-222222222222",
+    userId: "11111111-1111-4111-8111-111111111111",
     from: "+14484080429",
     to: "+14155550100",
   },
@@ -23,6 +25,7 @@ const verifySignature = mock(
 );
 const insertConflict = mock(async () => undefined);
 const updateWhere = mock(async () => undefined);
+const deleteWhere = mock(async () => undefined);
 const updateSets: Record<string, unknown>[] = [];
 const tx = {
   insert: mock(() => ({
@@ -34,6 +37,7 @@ const tx = {
       return { where: updateWhere };
     },
   })),
+  delete: mock(() => ({ where: deleteWhere })),
 };
 const writeTransaction = mock(async (callback: (value: typeof tx) => unknown) =>
   callback(tx),
@@ -46,7 +50,11 @@ const dbWrite = {
 
 mock.module("@/db/helpers", () => ({ dbWrite, writeTransaction }));
 mock.module("@/lib/utils/twilio-api", () => ({
+  twilioApiRequest: mock(),
   verifyTwilioSignature: verifySignature,
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock() },
 }));
 
 const { default: app } = await import("./route");
@@ -92,6 +100,8 @@ describe("POST Twilio outbound status callback", () => {
         id: requestId,
         callSid,
         accountSid: "AC123",
+        organizationId: "22222222-2222-4222-8222-222222222222",
+        userId: "11111111-1111-4111-8111-111111111111",
         from: "+14484080429",
         to: "+14155550100",
       },
@@ -107,6 +117,7 @@ describe("POST Twilio outbound status callback", () => {
     );
     insertConflict.mockClear();
     updateWhere.mockClear();
+    deleteWhere.mockClear();
     updateSets.length = 0;
     writeTransaction.mockClear();
   });
@@ -122,6 +133,7 @@ describe("POST Twilio outbound status callback", () => {
     expect(writeTransaction).toHaveBeenCalledTimes(1);
     expect(insertConflict).toHaveBeenCalledTimes(1);
     expect(updateWhere).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
     expect(updateSets[0]).toMatchObject({
       call_sid: callSid,
       call_status: "completed",

--- a/packages/cloud/api/v1/twilio/voice/status/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/status/route.test.ts
@@ -54,7 +54,7 @@ mock.module("@/lib/utils/twilio-api", () => ({
   verifyTwilioSignature: verifySignature,
 }));
 mock.module("@/lib/utils/logger", () => ({
-  logger: { error: mock(), info: mock() },
+  logger: { debug: mock(), error: mock(), info: mock(), warn: mock() },
 }));
 
 const { default: app } = await import("./route");

--- a/packages/cloud/api/v1/twilio/voice/status/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/status/route.ts
@@ -5,11 +5,16 @@ import { and, eq, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { dbWrite, writeTransaction } from "@/db/helpers";
-import { twilioCallStatusEvents, twilioOutboundCalls } from "@/db/schemas";
+import {
+  idempotencyKeys,
+  twilioCallStatusEvents,
+  twilioOutboundCalls,
+} from "@/db/schemas";
 import { logger } from "@/lib/utils/logger";
 import { normalizePhoneNumber } from "@/lib/utils/phone-normalization";
 import { verifyTwilioSignature } from "@/lib/utils/twilio-api";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { twilioCallFenceKey } from "../lib/twilio-call-fence";
 import {
   isTerminalTwilioCallStatus,
   normalizeTwilioProviderCallStatus,
@@ -78,6 +83,8 @@ app.post("/", async (c) => {
       id: twilioOutboundCalls.id,
       callSid: twilioOutboundCalls.call_sid,
       accountSid: twilioOutboundCalls.account_sid,
+      organizationId: twilioOutboundCalls.organization_id,
+      userId: twilioOutboundCalls.user_id,
       from: twilioOutboundCalls.from_number,
       to: twilioOutboundCalls.to_number,
     })
@@ -153,6 +160,15 @@ app.post("/", async (c) => {
         and(
           eq(twilioOutboundCalls.id, call.id),
           lt(twilioOutboundCalls.last_status_sequence, sequence),
+        ),
+      );
+
+    await tx
+      .delete(idempotencyKeys)
+      .where(
+        eq(
+          idempotencyKeys.key,
+          twilioCallFenceKey(call.organizationId, call.userId, call.to),
         ),
       );
   });

--- a/packages/cloud/api/v1/twilio/voice/status/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/status/route.ts
@@ -14,7 +14,10 @@ import { logger } from "@/lib/utils/logger";
 import { normalizePhoneNumber } from "@/lib/utils/phone-normalization";
 import { verifyTwilioSignature } from "@/lib/utils/twilio-api";
 import type { AppEnv } from "@/types/cloud-worker-env";
-import { twilioCallFenceKey } from "../lib/twilio-call-fence";
+import {
+  twilioCallFenceKey,
+  twilioCallFenceSource,
+} from "../lib/twilio-call-fence";
 import {
   isTerminalTwilioCallStatus,
   normalizeTwilioProviderCallStatus,
@@ -166,9 +169,12 @@ app.post("/", async (c) => {
     await tx
       .delete(idempotencyKeys)
       .where(
-        eq(
-          idempotencyKeys.key,
-          twilioCallFenceKey(call.organizationId, call.userId, call.to),
+        and(
+          eq(
+            idempotencyKeys.key,
+            twilioCallFenceKey(call.organizationId, call.userId, call.to),
+          ),
+          eq(idempotencyKeys.source, twilioCallFenceSource(call.id)),
         ),
       );
   });

--- a/packages/cloud/shared/src/lib/utils/twilio-api-request.test.ts
+++ b/packages/cloud/shared/src/lib/utils/twilio-api-request.test.ts
@@ -1,0 +1,64 @@
+/** Exercises typed Twilio REST outcomes with a deterministic fetch boundary. */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import { twilioApiRequest } from "./twilio-api";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("twilioApiRequest typed outcomes", () => {
+  test.each([
+    [400, "TWILIO_PROVIDER_REJECTED"],
+    [429, "TWILIO_PROVIDER_REJECTED"],
+    [500, "TWILIO_SUBMISSION_UNCERTAIN"],
+  ])("classifies provider status %d as %s", async (status, code) => {
+    const fetchMock = mock(async () => new Response("provider body", { status }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const error = await twilioApiRequest(
+      "AC123",
+      "secret",
+      "POST",
+      "/Calls.json",
+      new URLSearchParams({ To: "+14155550100" }),
+    ).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect(error).toMatchObject({
+      code,
+      context: {
+        providerStatus: status,
+        retryable: status === 429,
+      },
+    });
+    expect(String((error as Error).message)).not.toContain("provider body");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ["", "empty"],
+    ["not-json", "invalid JSON"],
+  ])("rejects an accepted %s receipt", async (body) => {
+    globalThis.fetch = mock(async () => new Response(body, { status: 200 })) as never;
+
+    await expect(twilioApiRequest("AC123", "secret", "POST", "/Calls.json")).rejects.toMatchObject({
+      code: "TWILIO_RECEIPT_INVALID",
+    });
+  });
+
+  test("preserves transport ambiguity and cause after dispatch", async () => {
+    const transportError = new Error("connection reset after write");
+    globalThis.fetch = mock(async () => {
+      throw transportError;
+    }) as never;
+
+    await expect(twilioApiRequest("AC123", "secret", "POST", "/Calls.json")).rejects.toMatchObject({
+      code: "TWILIO_SUBMISSION_UNCERTAIN",
+      cause: transportError,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/twilio-api.ts
+++ b/packages/cloud/shared/src/lib/utils/twilio-api.ts
@@ -4,6 +4,7 @@
  * Shared constants and helpers for Twilio SMS/MMS/Voice API interactions.
  */
 
+import { ElizaError, isElizaError } from "@elizaos/core";
 import crypto from "crypto";
 import { z } from "zod";
 import { ownedBoundedFetch } from "./owned-bounded-fetch";
@@ -106,29 +107,67 @@ export async function twilioApiRequest<T>(
 
   const auth = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
 
-  const response = await twilioFetch(url, {
-    method,
-    headers: {
-      Authorization: `Basic ${auth}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: body?.toString(),
-  });
+  let response: Response;
+  try {
+    response = await twilioFetch(url, {
+      method,
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: body?.toString(),
+    });
+  } catch (cause) {
+    if (isElizaError(cause)) throw cause;
+    // error-policy:J2 transport failure after dispatch cannot prove whether
+    // Twilio accepted the paid operation.
+    throw new ElizaError("Twilio request acceptance is uncertain", {
+      code: "TWILIO_SUBMISSION_UNCERTAIN",
+      context: { endpoint, method },
+      cause,
+      severity: "fatal",
+    });
+  }
 
   const responseText = await response.text();
 
   if (!response.ok) {
-    throw new Error(`Twilio API error (${response.status}): ${responseText}`);
+    throw new ElizaError(
+      response.status >= 500
+        ? "Twilio request acceptance is uncertain"
+        : "Twilio rejected the request",
+      {
+        code: response.status >= 500 ? "TWILIO_SUBMISSION_UNCERTAIN" : "TWILIO_PROVIDER_REJECTED",
+        context: {
+          endpoint,
+          method,
+          providerStatus: response.status,
+          retryable: response.status === 429,
+        },
+        severity: response.status >= 500 ? "fatal" : "ephemeral",
+      },
+    );
   }
 
   if (!responseText) {
-    return {} as T;
+    throw new ElizaError("Twilio accepted the request without a receipt", {
+      code: "TWILIO_RECEIPT_INVALID",
+      context: { endpoint, method },
+      severity: "fatal",
+    });
   }
 
   try {
     return JSON.parse(responseText) as T;
-  } catch {
-    throw new Error(`Invalid JSON response from Twilio: ${responseText}`);
+  } catch (cause) {
+    // error-policy:J2 accepted responses must retain their parse failure while
+    // refusing to fabricate a provider receipt.
+    throw new ElizaError("Twilio accepted the request without a valid JSON receipt", {
+      code: "TWILIO_RECEIPT_INVALID",
+      context: { endpoint, method },
+      cause,
+      severity: "fatal",
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #24859.

This is a narrow fix-forward for the paid outbound-call boundary introduced by #24780 and partially reconciled by #24838.

- require a current session user for paid call creation and hangup; API keys can no longer initiate either operation
- derive TwiML and status callback URLs only from configured, credential-free HTTPS TWILIO_PUBLIC_URL; caller forwarding headers cannot steer signed provider callbacks
- atomically fence one unresolved call per organization/user/destination and return the existing durable poll target for fresh client keys
- classify provider 5xx, transport failures, and malformed accepted receipts as submission-unknown without retry; signed callbacks remain authoritative and clear the fence
- validate Twilio CallSid/status receipts and preserve typed provider status/cause context

## Verification

- focused Twilio route, receipt, and session-auth tests: 62 pass
- Cloud shared typecheck: pass
- Cloud API typecheck and production Worker dry-run bundle: pass
- Biome on all 10 touched files: pass
- git diff check: pass

No live Twilio call was placed: this repair prevents duplicate paid side effects and cannot be safely verified by issuing an unsolicited real call.