### PR TITLE
fix(core): remove abort event listener in sleepWithAbort onAbort handler

### DIFF
--- a/packages/core/src/utils/retry.backoff.test.ts
+++ b/packages/core/src/utils/retry.backoff.test.ts
@@ -4,7 +4,7 @@
  * maxMs cap, and the jitter bounds.
  */
 import { describe, expect, it } from "vitest";
-import { type BackoffPolicy, computeBackoff } from "./retry";
+import { type BackoffPolicy, computeBackoff, sleepWithAbort } from "./retry";
 
 const noJitter: BackoffPolicy = {
 	initialMs: 100,
@@ -42,5 +42,29 @@ describe("computeBackoff", () => {
 			expect(v).toBeGreaterThanOrEqual(400);
 			expect(v).toBeLessThanOrEqual(600); // 400 * 1.5
 		}
+	});
+});
+
+describe("sleepWithAbort abort signal listener cleanup", () => {
+	it("rejects immediately if signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(sleepWithAbort(100, controller.signal)).rejects.toThrow(
+			"aborted",
+		);
+	});
+
+	it("cleans up listener when sleep times out normally", async () => {
+		const controller = new AbortController();
+		await sleepWithAbort(10, controller.signal);
+		// Signal should not trigger reject after resolution
+		controller.abort();
+	});
+
+	it("cleans up listener and rejects when aborted during sleep", async () => {
+		const controller = new AbortController();
+		const promise = sleepWithAbort(1000, controller.signal);
+		controller.abort();
+		await expect(promise).rejects.toThrow("aborted");
 	});
 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -41,11 +41,14 @@ export async function sleepWithAbort(
 
 		function onAbort() {
 			clearTimeout(timeoutId);
+			if (abortSignal) {
+				abortSignal.removeEventListener("abort", onAbort);
+			}
 			reject(new Error("aborted"));
 		}
 
 		if (abortSignal) {
-			abortSignal.addEventListener("abort", onAbort);
+			abortSignal.addEventListener("abort", onAbort, { once: true });
 		}
 	});
 }


### PR DESCRIPTION
## Summary

Ensures `sleepWithAbort` in `packages/core/src/utils/retry.ts` cleans up its `abort` event listener when the abort handler triggers and adds `{ once: true }` to avoid lingering listener closures and memory leaks on shared signals.

## Changes

- In `packages/core/src/utils/retry.ts:44`, explicitly call `abortSignal.removeEventListener("abort", onAbort)` inside `onAbort()`.
- In `packages/core/src/utils/retry.ts:50`, attach the `abort` listener with `{ once: true }`.
- In `packages/core/src/utils/retry.backoff.test.ts`, add unit tests covering immediate abort, normal timeout cleanup, and in-flight abort cleanup.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`1e82cd16ad`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/utils/retry.backoff.test.ts` | 4 pass (4 tests) | 7 pass (7 tests) |
| `bunx @biomejs/biome check packages/core/src/utils/retry.ts packages/core/src/utils/retry.backoff.test.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/utils/retry.ts:41-51`
- `packages/core/src/utils/retry.backoff.test.ts:47-68`

## Risks

Low. Ensures idempotent signal cleanup without altering retry backoff math.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Core utility; no UI bundle touched)
- [x] `audit:browser` — N/A (Headless async retry utility)
- [x] `build` — Clean build across workspace
- [x] `test` — 7/7 pass in `retry.backoff.test.ts`
- [x] `lint` — Biome clean
