### PR TITLE
fix(core): preserve duplicate conversation turns in recent-context

### DIFF
--- a/packages/core/src/actions/recent-context.test.ts
+++ b/packages/core/src/actions/recent-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { recentConversationTextsFromState } from "./recent-context";
+
+describe("recentConversationTextsFromState", () => {
+	it("preserves every occurrence including identical wording (#24858)", () => {
+		// Two distinct turns with identical wording must remain two entries.
+		const state = {
+			values: { recentMessages: "User: repeat this\nUser: repeat this" },
+		} as never;
+
+		const result = recentConversationTextsFromState(state);
+		expect(result).toEqual(["repeat this", "repeat this"]);
+	});
+
+	it("preserves identical wording across mixed sources (#24858)", () => {
+		// Identical text arriving via state.values.recentMessages and via a
+		// memory row must both be preserved, not collapsed.
+		const state = {
+			values: { recentMessages: "repeat this" },
+			recentMessages: [
+				{
+					id: "m1",
+					content: { text: "repeat this" },
+				},
+			],
+		} as never;
+
+		const result = recentConversationTextsFromState(state);
+		expect(result).toEqual(["repeat this", "repeat this"]);
+	});
+
+	it("returns an empty array when state is undefined", () => {
+		expect(recentConversationTextsFromState(undefined)).toEqual([]);
+	});
+
+	it("strips speaker prefixes and drops empty lines", () => {
+		const state = {
+			values: { recentMessages: "Alice: Hello\n\nBob: World" },
+		} as never;
+		expect(recentConversationTextsFromState(state)).toEqual([
+			"Hello",
+			"World",
+		]);
+	});
+});

--- a/packages/core/src/actions/recent-context.ts
+++ b/packages/core/src/actions/recent-context.ts
@@ -27,19 +27,6 @@ function splitConversationText(value: string): string[] {
 		.filter((line) => line.length > 0);
 }
 
-function dedupePreservingOrder(values: string[]): string[] {
-	const seen = new Set<string>();
-	const deduped: string[] = [];
-	for (const value of values) {
-		if (seen.has(value)) {
-			continue;
-		}
-		seen.add(value);
-		deduped.push(value);
-	}
-	return deduped;
-}
-
 export function recentConversationTextsFromState(
 	state: State | undefined,
 	_limit?: number,
@@ -61,7 +48,10 @@ export function recentConversationTextsFromState(
 		}
 	}
 
-	return dedupePreservingOrder(collected);
+	// Do NOT dedupe. Two distinct conversation turns with identical wording are
+	// still two turns — collapsing them drops an occurrence before model
+	// extractors build prompt context (#24858).
+	return collected;
 }
 
 export async function recentConversationTexts(args: {
@@ -92,7 +82,9 @@ export async function recentConversationTexts(args: {
 					)
 					.filter((text) => text.length > 0)
 			: [];
-		return dedupePreservingOrder([...memoryTexts, ...stateTexts]);
+		// Preserve every occurrence, including identical wording from distinct
+		// turns — deduping drops occurrences before prompt assembly (#24858).
+		return [...memoryTexts, ...stateTexts];
 	} catch (error) {
 		// error-policy:J2 A failed history read is not equivalent to an empty room;
 		// report the room context and preserve the storage error.


### PR DESCRIPTION
Closes #24858

## Summary

`recentConversationTextsFromState` passed collected turns through
`dedupePreservingOrder`, which collapsed two distinct turns with identical
wording into one entry before model extractors assembled prompt context. An
outer catch could not recover the missing occurrence because nothing threw.

## Change

`packages/core/src/actions/recent-context.ts` only — replace the dedup pass
with identity and remove the now-dead `dedupePreservingOrder`. Both
`recentConversationTextsFromState` and its async sibling
`recentConversationTexts` are updated; nothing else called the deduper.

Behavior change: identical wording from distinct turns is preserved. Empty
state, speaker-prefix stripping, and the memory fallback are unchanged.

## Verification

Verified the defect reproduces byte-for-byte as described in the issue (the
state line `"User: repeat this\nUser: repeat this"` yields `["repeat this"]`
before the fix). Then confirmed every assertion the new tests make against the
real module shape — particularly that two identical lines yield two entries,
and that identical text arriving via both `state.values.recentMessages` and a
memory row is preserved.

- `git diff --check` — clean.
- Both changed files parse cleanly under Node 24 type-stripping.

## Tests

New `packages/core/src/actions/recent-context.test.ts` with four cases:

- **`preserves every occurrence including identical wording (#24858)`** —
  the exact issue reproduction: `"User: repeat this\nUser: repeat this"`
  yields `["repeat this", "repeat this"]`. This fails before the fix.
- **`preserves identical wording across mixed sources (#24858)`** — identical
  text via `recentMessages` and a memory row both preserved.
- **`returns an empty array when state is undefined`** — guards the nil-state
  path.
- **`strips speaker prefixes and drops empty lines`** — confirms the
  existing normalization is untouched.

## Risks

Low. The dedup was a convenience that dropped data, and the fix is an
identity pass-through. All existing consumers (action extractors) receive a
longer array only when there were genuine repeated turns — which is the
correct behavior. The only regression risk is if a consumer relied on the
array being deduped, but that would mean it was silently losing turns, which
is the defect.

## Known gaps / failures

`bun` is not installed on this host and installing it was blocked, so
`node_modules` is absent and I could not run the package's Vitest lane
locally. The new suite follows the established pattern from
`packages/agent/src/actions/recent-conversation-texts.test.ts` and the
assertions were verified against the real module shape, but hosted CI is
authoritative for execution. Stating that explicitly rather than implying a
green local run.

AI provider/model: meituan / longcat-2.0
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-longcat]
<!-- eliza-computer-attribution:v1 {"provider":"meituan","model":"longcat-2.0","client":"Hermes Agent","skill_revision":"local:slop-eliza/skills/slop-cash-contribute"} -->
