### PR TITLE
fix(anthropic): use surrogate-safe truncateWellFormed on claude-cli stderr and raw json output

### DIFF
--- a/plugins/plugin-anthropic/utils/claude-cli.ts
+++ b/plugins/plugin-anthropic/utils/claude-cli.ts
@@ -7,7 +7,13 @@
  * `tools`, `toolChoice`, or `responseSchema`.
  */
 import type { IAgentRuntime, ModelTypeName, TextStreamResult } from "@elizaos/core";
-import { buildCanonicalSystemPrompt, ElizaError, logger } from "@elizaos/core";
+import {
+  buildCanonicalSystemPrompt,
+  ElizaError,
+  logger,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import { emitModelUsageEvent } from "./events";
 
 interface ClaudeCliModelUsage {
@@ -263,7 +269,9 @@ export async function generateViaCli(
   const { output, stderr, exitCode } = await collectClaudeCliOutput(proc);
 
   if (exitCode !== 0) {
-    throw new Error(`[Anthropic CLI] claude -p failed (exit ${exitCode}): ${stderr.slice(0, 500)}`);
+    throw new Error(
+      `[Anthropic CLI] claude -p failed (exit ${exitCode}): ${truncateWellFormed(toWellFormedUnicode(stderr), 500)}`
+    );
   }
 
   let data: ClaudeCliResult;
@@ -272,9 +280,12 @@ export async function generateViaCli(
   } catch (error) {
     // error-policy:J2 context-adding rethrow — surface the raw CLI output that
     // failed to parse, with the parse error as cause.
-    throw new Error(`[Anthropic CLI] Failed to parse JSON. Raw: ${output.slice(0, 500)}`, {
-      cause: error,
-    });
+    throw new Error(
+      `[Anthropic CLI] Failed to parse JSON. Raw: ${truncateWellFormed(toWellFormedUnicode(output), 500)}`,
+      {
+        cause: error,
+      }
+    );
   }
 
   logger.debug(
@@ -456,7 +467,7 @@ export function streamViaCli(
         const settledStderr = await stderrOutcome;
         const stderrText = settledStderr.ok ? settledStderr.value : "";
         throw new Error(
-          `[Anthropic CLI] claude -p stream failed (exit ${exitCode}): ${stderrText.slice(0, 500)}`
+          `[Anthropic CLI] claude -p stream failed (exit ${exitCode}): ${truncateWellFormed(toWellFormedUnicode(stderrText), 500)}`
         );
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 500)` string slicing on `claude-cli.ts` process stderr and unparsed JSON CLI output with `truncateWellFormed(toWellFormedUnicode(...), 500)` from `@elizaos/core`.

## Changes

- In `plugins/plugin-anthropic/utils/claude-cli.ts:266, 275, 459`, use `truncateWellFormed(toWellFormedUnicode(...), 500)` when reporting CLI failure stderr and JSON parsing errors.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`5e2d996a2f`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-anthropic/__tests__/claude-cli.budget.test.ts` | 7 pass (7 tests) | 7 pass (7 tests) |
| `bunx @biomejs/biome check plugins/plugin-anthropic/utils/claude-cli.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-anthropic/utils/claude-cli.ts:9-16`
- `plugins/plugin-anthropic/utils/claude-cli.ts:266`
- `plugins/plugin-anthropic/utils/claude-cli.ts:275`
- `plugins/plugin-anthropic/utils/claude-cli.ts:459`

## Risks

Low. Prevents splitting multi-byte UTF-16 surrogate pairs on international or emoji-containing CLI error messages.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Anthropic plugin CLI utility; no UI bundle touched)
- [x] `audit:browser` — N/A (CLI process wrapper)
- [x] `build` — Clean build across workspace
- [x] `test` — 7/7 pass in `claude-cli.budget.test.ts`
- [x] `lint` — Biome clean
