### PR TITLE
fix(codex-cli): use surrogate-safe truncateWellFormed on HTTP error responses

### DIFF
--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -12,7 +12,16 @@
  * Function-call `arguments` JSON is type-checked by the bounded walker in
  * `codex-json-value.ts`.
  */
-import { ElizaError, logger, type ChatMessage, type JsonValue, type ToolCall, type ToolDefinition } from "@elizaos/core";
+import {
+  ElizaError,
+  logger,
+  toWellFormedUnicode,
+  truncateWellFormed,
+  type ChatMessage,
+  type JsonValue,
+  type ToolCall,
+  type ToolDefinition,
+} from "@elizaos/core";
 import { CODEX_JSON_UNBOUNDED, isJsonRecord } from "./codex-json-value";
 import { parseSSE } from "./sse-parser";
 import { toOpenAITool, type OpenAITool } from "./tool-format-openai";
@@ -180,7 +189,7 @@ export class CodexBackend {
     }
     if (!res.ok) {
       const errText = await safeReadText(res);
-      throw new Error(`codex /responses returned ${res.status} ${res.statusText} :: ${errText.slice(0, 512)}`);
+      throw new Error(`codex /responses returned ${res.status} ${res.statusText} :: ${truncateWellFormed(toWellFormedUnicode(errText), 512)}`);
     }
     if (!res.body) throw new Error("codex /responses returned no body");
     return consumeResponseStream(res.body, params.abortSignal, params.onTextDelta);


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 512)` string slicing on `CodexBackend` HTTP error responses with `truncateWellFormed(toWellFormedUnicode(errText), 512)` from `@elizaos/core`.

## Changes

- In `plugins/plugin-codex-cli/src/codex-backend.ts:183`, format rejected HTTP response bodies safely to protect UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`ac6545e926`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-codex-cli/__tests__/codex-backend.test.ts` | 11 pass (11 tests) | 11 pass (11 tests) |

## Reviewer start

- `plugins/plugin-codex-cli/src/codex-backend.ts:15-24`
- `plugins/plugin-codex-cli/src/codex-backend.ts:183`

## Risks

Low. Prevents malformed Unicode in error messages without altering stream decoding.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Codex CLI plugin backend; no UI bundle touched)
- [x] `audit:browser` — N/A (Headless LLM client)
- [x] `build` — Clean build across workspace
- [x] `test` — 11/11 pass in `codex-backend.test.ts`
