### PR TITLE
fix(local-inference): use surrogate-safe truncateWellFormed on elevenlabs error response bodies

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -13,6 +13,7 @@
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { NlmsEchoCanceller } from "@elizaos/shared/voice/aec";
 import {
 	type OwnerObservation,
@@ -510,7 +511,7 @@ async function elevenLabsPcm(args: {
 	if (!response.ok) {
 		const body = await response.text().catch(() => "");
 		throw new Error(
-			`[voice:workbench --real] ElevenLabs ${response.status} for ${args.voiceId}: ${body.slice(0, 240)}`,
+			`[voice:workbench --real] ElevenLabs ${response.status} for ${args.voiceId}: ${truncateWellFormed(toWellFormedUnicode(body), 240)}`,
 		);
 	}
 	const pcm = pcm16ToFloat32(new Uint8Array(await response.arrayBuffer()));


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 240)` string slicing in `workbench-real-services.ts` on ElevenLabs API error response bodies with `truncateWellFormed(toWellFormedUnicode(body), 240)` from `@elizaos/core`.

## Changes

- In `plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts:513`, safely truncate ElevenLabs HTTP error messages without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`f149725d48`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-local-inference/src/services/voice/workbench-real-services.test.ts` | 11 pass (11 tests) | 11 pass (11 tests) |
| `bunx @biomejs/biome check plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts:16`
- `plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts:513`

## Risks

Low. Prevents surrogate corruption in voice workbench error diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Local inference voice workbench; no UI bundle touched)
- [x] `audit:browser` — N/A (Voice workbench services)
- [x] `build` — Clean build across workspace
- [x] `test` — 11/11 pass in `workbench-real-services.test.ts`
- [x] `lint` — Biome clean
