### PR TITLE
test(app-core): repair profile helper coverage

### DIFF
--- a/packages/app-core/src/cli/__tests__/profile-utils.test.ts
+++ b/packages/app-core/src/cli/__tests__/profile-utils.test.ts
@@ -1,8 +1,11 @@
+/**
+ * Direct unit coverage for CLI profile-name validation and normalization.
+ *
+ * The production helpers are deterministic, so this harness imports them
+ * without mocks and exercises both accepted and rejected user input.
+ */
 import { describe, expect, it } from "vitest";
-import {
-  isValidProfileName,
-  normalizeProfileName,
-} from "./profile-utils.ts";
+import { isValidProfileName, normalizeProfileName } from "../profile-utils.ts";
 
 describe("isValidProfileName", () => {
   it("accepts path-safe names", () => {


### PR DESCRIPTION
## What changed

- Point the merged profile helper test at the real parent production module.
- Add the required responsibility and harness header.
- Apply the owning-package Biome format.

## Why

The current develop test imported from its own __tests__ directory, so it could not execute. Its formatting also failed the repository affected-lint closure.

## Verification

- Focused production-module test: 5/5 passed, 100% line/function coverage.
- app-core lint: 369 files clean.
- git diff --check: clean.
- Package typecheck reaches unrelated missing native workspace package declarations in this local install; hosted affected-closure remains authoritative.

No production source or UI behavior changes.