### PR TITLE
fix(core): fence in-flight follow-up teardown

### DIFF
--- a/packages/core/src/services/follow-up.test.ts
+++ b/packages/core/src/services/follow-up.test.ts
@@ -19,6 +19,7 @@ function makeRuntime() {
 	const tasks = new Map<string, Task>();
 	const workers = new Map<string, TaskWorker>();
 	const memories: unknown[] = [];
+	const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
 	const noop = () => undefined;
 	const contact = {
 		entityId: ENTITY_ID,
@@ -53,7 +54,9 @@ function makeRuntime() {
 		createMemory: async (memory: unknown) => {
 			memories.push(memory);
 		},
-		emitEvent: async () => undefined,
+		emitEvent: async (event: string, payload: Record<string, unknown>) => {
+			events.push({ event, payload });
+		},
 		// Honors the requested-tags contract of the real adapters: only tasks
 		// carrying EVERY requested tag are returned, so the tests below prove
 		// that a completed row actually leaves the scheduler's polling set.
@@ -90,7 +93,15 @@ function makeRuntime() {
 			tasks.delete(id);
 		},
 	} as unknown as IAgentRuntime;
-	return { runtime, tasks, workers, memories, relationshipsService, contact };
+	return {
+		runtime,
+		tasks,
+		workers,
+		memories,
+		events,
+		relationshipsService,
+		contact,
+	};
 }
 
 describe("FollowUpService completion lifecycle", () => {
@@ -304,6 +315,65 @@ describe("FollowUpService completion lifecycle", () => {
 
 		await vi.advanceTimersByTimeAsync(10_000);
 		expect(memories).toHaveLength(1);
+		await restarted.stop();
+	});
+
+	it("fences a captured worker before effects and delivers its row once after restart", async () => {
+		const { runtime, tasks, memories, events } = makeRuntime();
+		const first = (await FollowUpService.start(runtime)) as FollowUpService;
+		service = (await TaskService.start(runtime)) as TaskService;
+		const task = await first.scheduleFollowUp(
+			ENTITY_ID,
+			new Date(T0 + 5_000),
+			"survive an in-flight stop",
+		);
+		const originalRow = structuredClone(task);
+		const originalGetEntity = runtime.getEntityById.bind(runtime);
+		let entityReads = 0;
+		let releaseExecution: (() => void) | null = null;
+		const executionBlocked = new Promise<void>((resolve) => {
+			releaseExecution = resolve;
+		});
+		let executionPaused: (() => void) | null = null;
+		const paused = new Promise<void>((resolve) => {
+			executionPaused = resolve;
+		});
+		(
+			runtime as { getEntityById: IAgentRuntime["getEntityById"] }
+		).getEntityById = async (id) => {
+			entityReads += 1;
+			if (entityReads === 2) {
+				executionPaused?.();
+				await executionBlocked;
+			}
+			return originalGetEntity(id);
+		};
+
+		const ticking = vi.advanceTimersByTimeAsync(10_000);
+		await paused;
+		let stopSettled = false;
+		const stopping = first.stop().then(() => {
+			stopSettled = true;
+		});
+		await Promise.resolve();
+		expect(stopSettled).toBe(false);
+
+		releaseExecution?.();
+		await stopping;
+		await ticking;
+		expect(memories).toHaveLength(0);
+		expect(events).toHaveLength(0);
+		expect(tasks.get(task.id as string)).toEqual(originalRow);
+
+		const restarted = (await FollowUpService.start(runtime)) as FollowUpService;
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(memories).toHaveLength(1);
+		expect(events).toHaveLength(1);
+		expect(tasks.has(task.id as string)).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(memories).toHaveLength(1);
+		expect(events).toHaveLength(1);
 		await restarted.stop();
 	});
 

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -56,6 +56,9 @@ export class FollowUpService extends Service {
 
 	private relationshipsService!: RelationshipsService;
 	private followUpWorker: TaskWorker | null = null;
+	private stopping = false;
+	private stopPromise: Promise<void> | null = null;
+	private readonly activeWorkerExecutions = new Set<Promise<unknown>>();
 
 	constructor(runtime?: IAgentRuntime) {
 		super();
@@ -84,6 +87,10 @@ export class FollowUpService extends Service {
 	}
 
 	async stop(): Promise<void> {
+		if (this.stopPromise) {
+			return this.stopPromise;
+		}
+		this.stopping = true;
 		const worker = this.followUpWorker;
 		if (
 			worker &&
@@ -98,6 +105,19 @@ export class FollowUpService extends Service {
 			this.runtime.registerTaskWorker(PARKED_FOLLOW_UP_WORKER);
 		}
 		this.followUpWorker = null;
+
+		this.stopPromise = this.finishStop();
+		return this.stopPromise;
+	}
+
+	private async finishStop(): Promise<void> {
+		// A TaskService tick may already hold this instance's worker closure. Wait
+		// until every such execution reaches its no-further-effects boundary before
+		// allowing plugin teardown to complete. Captured closures invoked after the
+		// fence return preserveTask without touching their row.
+		while (this.activeWorkerExecutions.size > 0) {
+			await Promise.allSettled([...this.activeWorkerExecutions]);
+		}
 
 		// relationshipsService will be cleaned up by the runtime
 		logger.info("[FollowUpService] Stopped successfully");
@@ -428,6 +448,7 @@ export class FollowUpService extends Service {
 				runtime: IAgentRuntime,
 				task: Task,
 			): Promise<boolean> => {
+				if (this.stopping) return false;
 				// Execution gate for rows stored before completion stopped
 				// unqueueing them: an explicitly completed follow-up must never
 				// fire. Rows without a status field stay runnable (backward
@@ -440,87 +461,104 @@ export class FollowUpService extends Service {
 				const entity = await runtime.getEntityById(targetEntityId);
 				return entity != null;
 			},
-			execute: async (
+			execute: (
 				runtime: IAgentRuntime,
 				_options: { [key: string]: JsonValue | object },
 				task: Task,
 			) => {
-				try {
-					if (!task.id) return { preserveTask: true };
-					const claimed = await runtime.updatePendingTask(task.id, {
-						tags: (task.tags ?? []).filter((tag) => tag !== "queue"),
-						metadata: { ...task.metadata, status: "executing" },
-					});
-					if (!claimed) return { preserveTask: true };
-
-					const targetEntityId = task.metadata?.targetEntityId as UUID;
-					const message =
-						(task.metadata?.message as string) || "Time for a follow-up!";
-
-					// Get entity
-					const entity = await runtime.getEntityById(targetEntityId);
-					if (!entity) {
-						logger.warn(
-							`[FollowUpService] Entity ${targetEntityId} not found for follow-up`,
-						);
-						return undefined;
-					}
-
-					// Create a follow-up memory/reminder
-					const memory: Memory = {
-						id: createUniqueUuid(runtime, `followup-memory-${Date.now()}`),
-						entityId: runtime.agentId,
-						agentId: runtime.agentId,
-						roomId: stringToUuid(`relationships-${runtime.agentId}`),
-						content: {
-							text: `Follow-up reminder: ${entity.names[0]} - ${task.metadata?.reason || "Check in"}. ${message}`,
-							type: "follow_up_reminder",
-						},
-						metadata: {
-							type: MemoryType.CUSTOM,
-							source: "relationships",
-							targetEntityId: targetEntityId,
-							taskId: task.id ?? "",
-							priority: (task.metadata?.priority as string) ?? "medium",
-						},
-						createdAt: Date.now(),
-					};
-
-					// Save the reminder
-					await runtime.createMemory(memory, "reminders");
-
-					// Emit follow-up event - cast to avoid event type checking
-					await (
-						runtime as {
-							emitEvent: (
-								event: string,
-								payload: Record<string, JsonValue | object>,
-							) => Promise<void>;
-						}
-					).emitEvent("follow_up:due", {
-						taskId: task.id ?? "",
-						taskName: task.name,
-						entityId: entity.id ?? "",
-						message: message,
-					});
-
-					logger.info(
-						`[FollowUpService] Executed follow-up for ${entity.names[0]}`,
-					);
-				} catch (error) {
-					// error-policy:J2 Log follow-up identity and preserve the execution failure.
-					logger.error(
-						"[FollowUpService] Error executing follow-up:",
-						error instanceof Error ? error.message : String(error),
-					);
-					throw error;
-				}
-				return undefined;
+				const execution = this.executeFollowUpWorker(runtime, task);
+				this.activeWorkerExecutions.add(execution);
+				void execution.then(
+					() => this.activeWorkerExecutions.delete(execution),
+					() => this.activeWorkerExecutions.delete(execution),
+				);
+				return execution;
 			},
 		};
 
 		this.runtime.registerTaskWorker(worker);
 		this.followUpWorker = worker;
+	}
+
+	private async executeFollowUpWorker(
+		runtime: IAgentRuntime,
+		task: Task,
+	): Promise<{ preserveTask: true } | undefined> {
+		try {
+			if (this.stopping || !task.id) return { preserveTask: true };
+
+			const targetEntityId = task.metadata?.targetEntityId as UUID;
+			const message =
+				(task.metadata?.message as string) || "Time for a follow-up!";
+
+			// Resolve every fallible prerequisite before the durable claim. If stop
+			// wins this await, the original pending row remains byte-for-byte intact.
+			const entity = await runtime.getEntityById(targetEntityId);
+			if (this.stopping) return { preserveTask: true };
+			if (!entity) {
+				logger.warn(
+					`[FollowUpService] Entity ${targetEntityId} not found for follow-up`,
+				);
+				return undefined;
+			}
+
+			const claimed = await runtime.updatePendingTask(task.id, {
+				tags: (task.tags ?? []).filter((tag) => tag !== "queue"),
+				metadata: { ...task.metadata, status: "executing" },
+			});
+			if (!claimed) return { preserveTask: true };
+
+			// The claim is the delivery linearization point. stop() drains this
+			// tracked execution, so its effects complete before teardown returns.
+
+			const memory: Memory = {
+				id: createUniqueUuid(runtime, `followup-memory-${Date.now()}`),
+				entityId: runtime.agentId,
+				agentId: runtime.agentId,
+				roomId: stringToUuid(`relationships-${runtime.agentId}`),
+				content: {
+					text: `Follow-up reminder: ${entity.names[0]} - ${task.metadata?.reason || "Check in"}. ${message}`,
+					type: "follow_up_reminder",
+				},
+				metadata: {
+					type: MemoryType.CUSTOM,
+					source: "relationships",
+					targetEntityId: targetEntityId,
+					taskId: task.id ?? "",
+					priority: (task.metadata?.priority as string) ?? "medium",
+				},
+				createdAt: Date.now(),
+			};
+
+			await runtime.createMemory(memory, "reminders");
+
+			// Emit follow-up event - cast to avoid event type checking
+			await (
+				runtime as {
+					emitEvent: (
+						event: string,
+						payload: Record<string, JsonValue | object>,
+					) => Promise<void>;
+				}
+			).emitEvent("follow_up:due", {
+				taskId: task.id ?? "",
+				taskName: task.name,
+				entityId: entity.id ?? "",
+				message: message,
+			});
+
+			logger.info(
+				`[FollowUpService] Executed follow-up for ${entity.names[0]}`,
+			);
+		} catch (error) {
+			// error-policy:J2 Log follow-up identity and preserve the execution failure.
+			logger.error(
+				"[FollowUpService] Error executing follow-up:",
+				error instanceof Error ? error.message : String(error),
+			);
+			throw error;
+		}
+		return undefined;
 	}
 
 	// Helper Methods


### PR DESCRIPTION
Closes #24948. Fix-forward for the captured-worker teardown race merged in #24887.

## Why the merged behavior is unsafe

Replacing the registered `follow_up` worker does not invalidate a closure that `TaskService` already captured. That stale closure could resume after `FollowUpService.stop()` returned, write a reminder, emit `follow_up:due`, and let the scheduler consume the one-shot row.

## Fix

- fence new/captured executions with the owning service instance's stopped state;
- track every owned worker execution and make `stop()` await the no-further-effects barrier;
- resolve entity prerequisites before the durable delivery claim, so teardown that wins during that await leaves the queued row byte-for-byte intact;
- retain the atomic pending-row claim as the delivery linearization point; if the claim wins first, stop drains that committed execution before returning;
- keep the stateless parking worker so orphan cleanup cannot delete pending rows while the service is disabled.

## Exact-head verification

Head: `7f6f5dadea84439b597a6f79084f4ada206b2e72` on develop `cbb400ddbcc21117505275557dd4f8505b2ccd1a`.

- `bun run --cwd packages/core test -- src/services/follow-up.test.ts` — 9/9 pass
- `bun run --cwd packages/core typecheck` — pass
- focused Biome for both changed files — pass
- `git diff --check origin/develop...HEAD` — pass

The deterministic regression pauses the already-captured worker during entity resolution, starts teardown and proves the stop barrier remains pending, releases the old closure, then proves zero reminder memories/events and an unchanged durable task row. Restart installs one live worker, delivers exactly once, and removes the one-shot row.

## Evidence

- UI screenshots/video/OCR: N/A — runtime-only service lifecycle.
- Frontend logs: N/A — no frontend or transport path.
- Live-model trajectory: N/A — no model/prompt/action path.
- Domain artifact: deterministic in-memory TaskService row, reminder memory, and event readback described above.

No prompt content, output, or pending row is truncated or silently dropped.
