### PR TITLE
fix(cloud): reject malformed UTF-8 in metered MCP proxy bodies

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
@@ -91,6 +91,46 @@ describe("readBodyTextWithinBudget", () => {
     });
   });
 
+  test("rejects malformed UTF-8 with a typed malformed-utf8 budget result (#24768)", async () => {
+    // 0xc3 0x28 is an invalid 2-byte sequence (lead without continuation) — the
+    // stream is valid bytes but not valid UTF-8, and must be rejected before
+    // JSON.parse rather than silently replacing with U+FFFD.
+    const malformed = new Uint8Array([
+      0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
+    ]);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(malformed);
+        controller.close();
+      },
+    });
+
+    expect(await readBodyTextWithinBudget(source(body), 1024)).toEqual({
+      ok: false,
+      bytes: malformed.byteLength,
+      reason: "malformed-utf8",
+    });
+  });
+
+  test("rejects malformed UTF-8 split across chunks (#24768)", async () => {
+    const malformed = new Uint8Array([
+      0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
+    ]);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(malformed.subarray(0, 7));
+        controller.enqueue(malformed.subarray(7));
+        controller.close();
+      },
+    });
+
+    expect(await readBodyTextWithinBudget(source(body), 1024)).toEqual({
+      ok: false,
+      bytes: malformed.byteLength,
+      reason: "malformed-utf8",
+    });
+  });
+
   test("rejects malicious tiny-chunk fragmentation without retaining chunk objects", async () => {
     let pulls = 0;
     const body = new ReadableStream<Uint8Array>({

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -528,3 +528,60 @@ test("affiliate surcharge uses one exact debit, persisted receipt, and refund au
   expect(failure.status).toBe(502);
   expect(refundCredits.mock.calls[0]?.[0].amount).toBe(0.065);
 });
+
+test("malformed UTF-8 request body returns 400, refunds exact receipt, and skips upstream (#24768)", async () => {
+  const malformed = new Uint8Array([
+    0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
+  ]);
+  const res = await app.request("/test-mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: malformed as unknown as string,
+  });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({
+    error: "MCP request body is not valid UTF-8",
+  });
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "request_body_malformed_utf8",
+      }),
+    }),
+  );
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("malformed UTF-8 upstream response returns 502, refunds exact receipt, and skips usage (#24768)", async () => {
+  const malformed = new Uint8Array([
+    0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
+  ]);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(malformed);
+      controller.close();
+    },
+  });
+  safeFetch.mockResolvedValue(
+    new Response(stream as unknown as BodyInit, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  const res = await post();
+  expect(res.status).toBe(502);
+  expect(await res.json()).toEqual({
+    error: "MCP response is not valid UTF-8",
+  });
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "mcp_response_malformed_utf8",
+      }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
@@ -34,7 +34,11 @@ export type BudgetedText =
   | {
       readonly ok: false;
       readonly bytes: number;
-      readonly reason: "byte-budget" | "fragmentation-budget" | "deadline";
+      readonly reason:
+        | "byte-budget"
+        | "fragmentation-budget"
+        | "deadline"
+        | "malformed-utf8";
     };
 
 export interface ReadBodyBudgetOptions {
@@ -311,7 +315,7 @@ export async function readBodyTextWithinBudget(
   }
 
   const reader = source.body.getReader();
-  const decoder = new TextDecoder("utf-8");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   const retained = new Uint8Array(maxBytes);
   let received = 0;
   let chunkCount = 0;
@@ -362,5 +366,11 @@ export async function readBodyTextWithinBudget(
     }
   }
 
-  return { ok: true, text: decoder.decode(retained.subarray(0, received)) };
+  try {
+    return { ok: true, text: decoder.decode(retained.subarray(0, received)) };
+  } catch {
+    // error-policy:J1 malformed UTF-8 is payload-integrity rejection, not replacement.
+    cancelBestEffort(source.body, "malformed-utf8", onCancelFailure);
+    return { ok: false, bytes: received, reason: "malformed-utf8" };
+  }
 }

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -162,6 +162,15 @@ export class McpProxyBodyTooLargeError extends Error {
   }
 }
 
+export class McpProxyMalformedUtf8Error extends Error {
+  readonly bytes: number;
+  constructor(bytes: number) {
+    super(`MCP proxy body is not valid UTF-8 (${bytes} bytes)`);
+    this.name = "McpProxyMalformedUtf8Error";
+    this.bytes = bytes;
+  }
+}
+
 export async function parseJsonBody(
   request: Request,
   maxBytes: number = MAX_PROXY_REQUEST_BODY_BYTES,
@@ -182,6 +191,9 @@ export async function parseJsonBody(
       throw signal.reason instanceof Error
         ? signal.reason
         : new McpProxyHopDeadlineError(MCP_PROXY_HOP_TIMEOUT_MS);
+    }
+    if (budgeted.reason === "malformed-utf8") {
+      throw new McpProxyMalformedUtf8Error(budgeted.bytes);
     }
     throw new McpProxyBodyTooLargeError(budgeted.bytes, maxBytes);
   }
@@ -500,6 +512,16 @@ app.post("/", async (c) => {
         });
         return c.json({ error: "MCP request body is too large" }, 413);
       }
+      if (error instanceof McpProxyMalformedUtf8Error) {
+        logger.warn("[MCP Proxy] Request body is not valid UTF-8", {
+          mcpId,
+          bytes: error.bytes,
+        });
+        await refundPrecharge("request_body_malformed_utf8", {
+          bytes: error.bytes,
+        });
+        return c.json({ error: "MCP request body is not valid UTF-8" }, 400);
+      }
       logger.warn("[MCP Proxy] Invalid JSON request body", {
         mcpId,
         error: error instanceof Error ? error.message : String(error),
@@ -588,6 +610,17 @@ app.post("/", async (c) => {
       if (!budgeted.ok) {
         if (budgeted.reason === "deadline") {
           return await refundDeadline();
+        }
+        if (budgeted.reason === "malformed-utf8") {
+          logger.warn("[MCP Proxy] MCP response is not valid UTF-8", {
+            mcpId,
+            status: mcpResponse.status,
+            receivedBytes: budgeted.bytes,
+          });
+          await refundPrecharge("mcp_response_malformed_utf8", {
+            status: mcpResponse.status,
+          });
+          return c.json({ error: "MCP response is not valid UTF-8" }, 502);
         }
         logger.warn("[MCP Proxy] MCP response exceeded the proxy byte budget", {
           mcpId,


### PR DESCRIPTION
Closes #24768

## Summary

The metered MCP proxy reader decoded bodies with a non-fatal `TextDecoder`, so invalid UTF-8 such as `0xc3 0x28` (`{"x":"` + `c3 28` + `"}`) was silently replaced with `U+FFFD` and then passed to `JSON.parse` and downstream billing/tool dispatch. The isolate byte budget was also not enforcing payload integrity.

## Change

- `packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts` — `BudgetedText` gains `| "malformed-utf8"`, `new TextDecoder("utf-8", { fatal: true })`, and a `try/catch` that returns `{ ok: false, bytes: received, reason: "malformed-utf8" }` with `// error-policy:J1`.
- `packages/cloud/api/mcp/proxy/[mcpId]/route.ts` — adds `McpProxyMalformedUtf8Error`, `parseJsonBody` throws it on `malformed-utf8`, POST request path refunds `request_body_malformed_utf8` and returns `400 "MCP request body is not valid UTF-8"`, response path refunds `mcp_response_malformed_utf8` and returns `502`.
- `packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts` — covers the exact `c3 28` corpus from the issue, both single-chunk and split-chunk, and preserves the existing `A🦊B` split-code-point valid test.

Valid UTF-8 split across chunks remains accepted because the slab is decoded once after the full byte budget is validated.

## Verification

| Check | Result |
| --- | --- |
| `bun test packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts` | 19 pass (was 17) — 2 new malformed-utf8 cases pass, valid split still passes |
| `bunx biome check` on 3 changed files | clean |
| `git diff --check` | clean |
| `bun run --cwd packages/cloud/api typecheck` | pre-existing errors in `doordash-browser-run.ts` only — no new errors in proxy files (fatal:true is valid TextDecoder option) |

Head: `2df6e00811` on `origin/develop@eccbc80110`

## Risks

Low. Rejects only previously-corrupted payloads; valid UTF-8 path unchanged. The 400/502 mapping preserves the existing 413/byte-budget and deadline semantics.

## Known gaps

Hosted CI is authoritative; local `bun` run covered the metered reader suite, not the full cloud lane.

