### PR TITLE
fix(cloud): preserve complete agent ID in billing fallback

### DIFF
--- a/packages/cloud/api/cron/agent-billing/route.ts
+++ b/packages/cloud/api/cron/agent-billing/route.ts
@@ -124,7 +124,7 @@ async function processSandboxBilling(
   runAuthority: { runId: string; leaseToken: string },
 ): Promise<BillingResult> {
   const sandboxId = sandbox.id;
-  const agentName = sandbox.agent_name ?? sandboxId.slice(0, 8);
+  const agentName = sandbox.agent_name ?? sandboxId;
   const organizationId = sandbox.organization_id;
   const hourlyRate = getHourlyRate(sandbox.status);
   const currentBalance = Number(org.credit_balance);

--- a/packages/cloud/shared/src/db/repositories/agent-billing.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing.ts
@@ -371,7 +371,7 @@ export class AgentBillingRepository {
         sandboxId,
         organizationId,
         userId: sandbox.user_id,
-        agentName: sandbox.agent_name ?? sandboxId.slice(0, 8),
+        agentName: sandbox.agent_name ?? sandboxId,
         hourlyRate: 0,
         billingDescription: `Eliza agent lifecycle debt settlement: ${sandbox.agent_name ?? sandboxId}`,
         lowCreditWarningAmount: 0,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1463,7 +1463,7 @@ export class ElizaSandboxService {
     const rawName =
       typeof rawConfig.name === "string" && rawConfig.name.trim()
         ? rawConfig.name.trim()
-        : rec.agent_name?.trim() || `Cloud Agent ${rec.id.slice(0, 8)}`;
+        : rec.agent_name?.trim() || `Cloud Agent ${rec.id}`;
     const plugins =
       Array.isArray(rawConfig.plugins) && rawConfig.plugins.length > 0
         ? rawConfig.plugins


### PR DESCRIPTION
## Summary

Billing fallback names used an 8-char prefix (`sandboxId.slice(0, 8)` / `rec.id.slice(0, 8)`) when `agent_name` was missing. An 8-char UUID prefix collides across agents and breaks invoice reconciliation, ledger `resource.name`, and Cloud Agent display names. Sibling PR #24928 fixes the same class in `active-billing.ts` (4 sites); this PR fixes the remaining 3 sites.

## Change

- `packages/cloud/api/cron/agent-billing/route.ts:127` — `sandbox.agent_name ?? sandboxId.slice(0,8)` → `?? sandboxId`
- `packages/cloud/shared/src/db/repositories/agent-billing.ts:374` — `sandbox.agent_name ?? sandboxId.slice(0,8)` → `?? sandboxId` (and `billingDescription` line)
- `packages/cloud/shared/src/lib/services/eliza-sandbox.ts:1466` — `` `Cloud Agent ${rec.id.slice(0,8)}` `` → `` `Cloud Agent ${rec.id}` ``

Preserves the existing `agent_name` preference; only the fallback is widened to the full UUID.

## Verification

| Check | Result |
| --- | --- |
| `bunx biome check` on 3 files | clean |
| `git diff --check` | clean |
| `grep -rn "slice(0, 8)" packages/cloud --include="*.ts" \| grep agent` | only unrelated hash slice remains at `eliza-sandbox.ts:1660` |
| `bun run --cwd packages/cloud/api typecheck` | pre-existing errors only |

Head: `2d87a3e3f0` on `origin/develop@eccbc80110`

## Risks

Low. No behavioral change when `agent_name` is present; fallback becomes unambiguous. No schema or pricing change.

## Known gaps

Hosted CI is authoritative.

