### PR TITLE
fix(cloud): reject malformed UTF-8 and preserve billing IDs (bundle)

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
@@ -91,6 +91,46 @@ describe("readBodyTextWithinBudget", () => {
     });
   });
 
+  test("rejects malformed UTF-8 with a typed malformed-utf8 budget result (#24768)", async () => {
+    // 0xc3 0x28 is an invalid 2-byte sequence (lead without continuation) — the
+    // stream is valid bytes but not valid UTF-8, and must be rejected before
+    // JSON.parse rather than silently replacing with U+FFFD.
+    const malformed = new Uint8Array([
+      0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
+    ]);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(malformed);
+        controller.close();
+      },
+    });
+
+    expect(await readBodyTextWithinBudget(source(body), 1024)).toEqual({
+      ok: false,
+      bytes: malformed.byteLength,
+      reason: "malformed-utf8",
+    });
+  });
+
+  test("rejects malformed UTF-8 split across chunks (#24768)", async () => {
+    const malformed = new Uint8Array([
+      0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d,
+    ]);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(malformed.subarray(0, 7));
+        controller.enqueue(malformed.subarray(7));
+        controller.close();
+      },
+    });
+
+    expect(await readBodyTextWithinBudget(source(body), 1024)).toEqual({
+      ok: false,
+      bytes: malformed.byteLength,
+      reason: "malformed-utf8",
+    });
+  });
+
   test("rejects malicious tiny-chunk fragmentation without retaining chunk objects", async () => {
     let pulls = 0;
     const body = new ReadableStream<Uint8Array>({

--- a/packages/cloud/api/cron/agent-billing/route.ts
+++ b/packages/cloud/api/cron/agent-billing/route.ts
@@ -124,7 +124,7 @@ async function processSandboxBilling(
   runAuthority: { runId: string; leaseToken: string },
 ): Promise<BillingResult> {
   const sandboxId = sandbox.id;
-  const agentName = sandbox.agent_name ?? sandboxId.slice(0, 8);
+  const agentName = sandbox.agent_name ?? sandboxId;
   const organizationId = sandbox.organization_id;
   const hourlyRate = getHourlyRate(sandbox.status);
   const currentBalance = Number(org.credit_balance);

--- a/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
@@ -34,7 +34,11 @@ export type BudgetedText =
   | {
       readonly ok: false;
       readonly bytes: number;
-      readonly reason: "byte-budget" | "fragmentation-budget" | "deadline";
+      readonly reason:
+        | "byte-budget"
+        | "fragmentation-budget"
+        | "deadline"
+        | "malformed-utf8";
     };
 
 export interface ReadBodyBudgetOptions {
@@ -311,7 +315,7 @@ export async function readBodyTextWithinBudget(
   }
 
   const reader = source.body.getReader();
-  const decoder = new TextDecoder("utf-8");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   const retained = new Uint8Array(maxBytes);
   let received = 0;
   let chunkCount = 0;
@@ -362,5 +366,11 @@ export async function readBodyTextWithinBudget(
     }
   }
 
-  return { ok: true, text: decoder.decode(retained.subarray(0, received)) };
+  try {
+    return { ok: true, text: decoder.decode(retained.subarray(0, received)) };
+  } catch {
+    // error-policy:J1 malformed UTF-8 is payload-integrity rejection, not replacement.
+    cancelBestEffort(source.body, "malformed-utf8", onCancelFailure);
+    return { ok: false, bytes: received, reason: "malformed-utf8" };
+  }
 }

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -162,6 +162,15 @@ export class McpProxyBodyTooLargeError extends Error {
   }
 }
 
+export class McpProxyMalformedUtf8Error extends Error {
+  readonly bytes: number;
+  constructor(bytes: number) {
+    super(`MCP proxy body is not valid UTF-8 (${bytes} bytes)`);
+    this.name = "McpProxyMalformedUtf8Error";
+    this.bytes = bytes;
+  }
+}
+
 export async function parseJsonBody(
   request: Request,
   maxBytes: number = MAX_PROXY_REQUEST_BODY_BYTES,
@@ -182,6 +191,9 @@ export async function parseJsonBody(
       throw signal.reason instanceof Error
         ? signal.reason
         : new McpProxyHopDeadlineError(MCP_PROXY_HOP_TIMEOUT_MS);
+    }
+    if (budgeted.reason === "malformed-utf8") {
+      throw new McpProxyMalformedUtf8Error(budgeted.bytes);
     }
     throw new McpProxyBodyTooLargeError(budgeted.bytes, maxBytes);
   }
@@ -500,6 +512,16 @@ app.post("/", async (c) => {
         });
         return c.json({ error: "MCP request body is too large" }, 413);
       }
+      if (error instanceof McpProxyMalformedUtf8Error) {
+        logger.warn("[MCP Proxy] Request body is not valid UTF-8", {
+          mcpId,
+          bytes: error.bytes,
+        });
+        await refundPrecharge("request_body_malformed_utf8", {
+          bytes: error.bytes,
+        });
+        return c.json({ error: "MCP request body is not valid UTF-8" }, 400);
+      }
       logger.warn("[MCP Proxy] Invalid JSON request body", {
         mcpId,
         error: error instanceof Error ? error.message : String(error),
@@ -588,6 +610,17 @@ app.post("/", async (c) => {
       if (!budgeted.ok) {
         if (budgeted.reason === "deadline") {
           return await refundDeadline();
+        }
+        if (budgeted.reason === "malformed-utf8") {
+          logger.warn("[MCP Proxy] MCP response is not valid UTF-8", {
+            mcpId,
+            status: mcpResponse.status,
+            receivedBytes: budgeted.bytes,
+          });
+          await refundPrecharge("mcp_response_malformed_utf8", {
+            status: mcpResponse.status,
+          });
+          return c.json({ error: "MCP response is not valid UTF-8" }, 502);
         }
         logger.warn("[MCP Proxy] MCP response exceeded the proxy byte budget", {
           mcpId,

--- a/packages/cloud/shared/src/db/repositories/agent-billing.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing.ts
@@ -371,7 +371,7 @@ export class AgentBillingRepository {
         sandboxId,
         organizationId,
         userId: sandbox.user_id,
-        agentName: sandbox.agent_name ?? sandboxId.slice(0, 8),
+        agentName: sandbox.agent_name ?? sandboxId,
         hourlyRate: 0,
         billingDescription: `Eliza agent lifecycle debt settlement: ${sandbox.agent_name ?? sandboxId}`,
         lowCreditWarningAmount: 0,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1463,7 +1463,7 @@ export class ElizaSandboxService {
     const rawName =
       typeof rawConfig.name === "string" && rawConfig.name.trim()
         ? rawConfig.name.trim()
-        : rec.agent_name?.trim() || `Cloud Agent ${rec.id.slice(0, 8)}`;
+        : rec.agent_name?.trim() || `Cloud Agent ${rec.id}`;
     const plugins =
       Array.isArray(rawConfig.plugins) && rawConfig.plugins.length > 0
         ? rawConfig.plugins


### PR DESCRIPTION
Closes #24768

Bundles two high-acceptance `fix(cloud)` changes that are also available as separate narrow PRs #24959 and #24960 for easier review.

## Change

- **Malformed UTF-8** (`proxy-body-budget.ts`, `route.ts`, test) — fatal decode, typed `malformed-utf8` budget, 400/502 refunds (Closes #24768)
- **Billing preserve** (`cron/agent-billing`, `agent-billing.ts`, `eliza-sandbox.ts`) — full ID fallback instead of `slice(0,8)` (sibling to #24928)

## Verification

See #24959 and #24960 for per-commit verification tables.

- `bun test mcp-proxy-body-budget.test.ts` — 19 pass
- `biome check` — clean
- `git diff --check` — clean

Head: `78a8a4a1e6` (2 commits) on `origin/develop@eccbc80110`

## Risks

Low. See individual PRs.

