### PR TITLE
fix(orchestrator): enforce human-only view capabilities

### DIFF
--- a/packages/agent/src/api/views-routes.interact-coverage.test.ts
+++ b/packages/agent/src/api/views-routes.interact-coverage.test.ts
@@ -13,12 +13,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentHttpRequestAuthorization } from "../runtime/host-bridge.ts";
 import { viewActionAffinityMap } from "../runtime/view-action-affinity.ts";
 import {
+  getView,
   registerBuiltinViews,
   registerPluginViews,
   unregisterPluginViews,
 } from "./views-registry.ts";
 import {
   clearCurrentViewState,
+  dispatchViewInteract,
   handleViewsRoutes,
   type ViewsRouteContext,
 } from "./views-routes.ts";
@@ -46,6 +48,11 @@ const SURFACE_PLUGIN = "@test/views-surface-grants";
 const PRIVATE_PLUGIN = "@test/views-owner-private";
 const privateServerInteract = vi.fn(async (capability: string) => ({
   success: true,
+  capability,
+}));
+const declaredServerInteract = vi.fn(async (capability: string) => ({
+  success: true,
+  text: `ran ${capability}`,
   capability,
 }));
 
@@ -195,12 +202,13 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
             path: "/declared-caps",
             capabilities: [
               { id: "do-thing", description: "The one declared capability." },
+              {
+                id: "human-only-thing",
+                description: "A direct human control.",
+                authority: "human",
+              },
             ],
-            serverInteract: async (capability) => ({
-              success: true,
-              text: `ran ${capability}`,
-              capability,
-            }),
+            serverInteract: declaredServerInteract,
           },
         ],
       },
@@ -244,6 +252,7 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
     unregisterPluginViews(SURFACE_PLUGIN);
     unregisterPluginViews(PRIVATE_PLUGIN);
     privateServerInteract.mockClear();
+    declaredServerInteract.mockClear();
     vi.restoreAllMocks();
   });
 
@@ -370,6 +379,42 @@ describe("per-view interact e2e — serverInteract reaches view capabilities hea
       text: "ran do-thing",
       capability: "do-thing",
     });
+  });
+
+  it("rejects a human-only capability at the real route before effects", async () => {
+    const { ctx, json, error } = makeCtx(
+      "POST",
+      "/api/views/declared-caps/interact",
+      {
+        capability: "human-only-thing",
+        params: { humanOverride: true },
+      },
+    );
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+    expect(json).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      'Capability "human-only-thing" on view "declared-caps" requires direct human interaction',
+      403,
+    );
+    expect(declaredServerInteract).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct dispatch of a human-only capability before effects", async () => {
+    const entry = getView("declared-caps");
+    if (!entry) throw new Error("declared-caps fixture was not registered");
+    const result = await dispatchViewInteract(
+      entry,
+      "declared-caps",
+      "human-only-thing",
+      { humanOverride: true },
+      {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/requires direct human interaction/);
+    expect(declaredServerInteract).not.toHaveBeenCalled();
   });
 
   it.each(["read-private", "write-private"])(

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -258,6 +258,23 @@ function viewManifestAllowsCapability(
   return entry.surface?.capabilities?.includes("agent-surface") === true;
 }
 
+function viewManifestAllowsAgentAuthority(
+  entry: ViewRegistryEntry,
+  capability: string,
+): boolean {
+  return (
+    entry.capabilities?.find((declared) => declared.id === capability)
+      ?.authority !== "human"
+  );
+}
+
+function capabilityAuthorityDeniedMessage(
+  viewId: string,
+  capability: string,
+): string {
+  return `Capability "${capability}" on view "${viewId}" requires direct human interaction`;
+}
+
 function capabilityDeniedMessage(viewId: string, capability: string): string {
   return (
     `View "${viewId}" is not granted capability "${capability}" ` +
@@ -1568,6 +1585,10 @@ export async function handleViewsRoutes(
       error(res, capabilityDeniedMessage(id, capability), 403);
       return true;
     }
+    if (!viewManifestAllowsAgentAuthority(entry, capability)) {
+      error(res, capabilityAuthorityDeniedMessage(id, capability), 403);
+      return true;
+    }
 
     const targetClientId = resolveTargetViewClientId(id, req, body);
     const dispatch = await dispatchViewInteract(
@@ -1656,6 +1677,14 @@ export async function dispatchViewInteract(
       requestId,
       success: false,
       error: capabilityDeniedMessage(viewId, capability),
+    };
+  }
+
+  if (!viewManifestAllowsAgentAuthority(entry, capability)) {
+    return {
+      requestId,
+      success: false,
+      error: capabilityAuthorityDeniedMessage(viewId, capability),
     };
   }
 

--- a/packages/app/test/core-view-action-surface-coverage.test.ts
+++ b/packages/app/test/core-view-action-surface-coverage.test.ts
@@ -77,7 +77,12 @@ const CORE_SURFACE_OWNERS: Readonly<Record<string, CoreSurfaceOwner>> = {
   orchestrator: {
     viewId: "orchestrator",
     provider: "dynamic",
-    files: ["plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx"],
+    files: [
+      "plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx",
+      "plugins/plugin-task-coordinator/src/orchestrator-task-inspector.tsx",
+      "plugins/plugin-task-coordinator/src/orchestrator-operator-detail.tsx",
+      "plugins/plugin-task-coordinator/src/orchestrator-workbench-list.tsx",
+    ],
     minAgentElements: 12,
   },
   transcripts: {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -797,6 +797,12 @@ export interface ViewCapability {
 	id: string;
 	/** Human-readable description surfaced to the planner. */
 	description: string;
+	/**
+	 * Who may invoke this typed capability through the agent-view interaction
+	 * path. Human-only controls remain available through their direct UI event
+	 * handlers but are never dispatched from a planner or agent bridge.
+	 */
+	authority?: "agent" | "human";
 	/** JSON Schema for any parameters this capability accepts. */
 	params?: Record<string, ViewCapabilityParameter>;
 }

--- a/plugins/plugin-app-control/src/actions/views-client.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-client.test.ts
@@ -157,6 +157,58 @@ describe("views client", () => {
 		]);
 	});
 
+	it("preserves declared capability authority and drops undeclared values", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				jsonResponse({
+					views: [
+						{
+							id: "orchestrator",
+							label: "Orchestrator",
+							pluginName: "@elizaos/plugin-task-coordinator",
+							available: true,
+							capabilities: [
+								{ id: "orchestrator-status", description: "Read status." },
+								{
+									id: "orchestrator-validate-task",
+									description: "Approve task validation.",
+									authority: "human",
+								},
+								{
+									id: "orchestrator-create-task",
+									description: "Create a task.",
+									authority: "agent",
+								},
+								{
+									id: "orchestrator-open-task",
+									description: "Open a task.",
+									authority: "root",
+								},
+							],
+						},
+					],
+				}),
+			),
+		);
+
+		const [view] = await createViewsClient().listViews();
+		expect(view?.capabilities).toEqual([
+			{ id: "orchestrator-status", description: "Read status." },
+			{
+				id: "orchestrator-validate-task",
+				description: "Approve task validation.",
+				authority: "human",
+			},
+			{
+				id: "orchestrator-create-task",
+				description: "Create a task.",
+				authority: "agent",
+			},
+			{ id: "orchestrator-open-task", description: "Open a task." },
+		]);
+	});
+
 	it("parses current-view state", async () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			expect(String(input)).toBe("http://127.0.0.1:3456/api/views/current");

--- a/plugins/plugin-app-control/src/actions/views-client.ts
+++ b/plugins/plugin-app-control/src/actions/views-client.ts
@@ -310,9 +310,17 @@ function parseViewCapability(entry: unknown): ViewCapability | null {
 	const params =
 		parseCapabilityParams(entry.params) ??
 		parseJsonSchemaParams(entry.inputSchema);
+	// `authority` travels on the wire from the view registry; only the two
+	// declared values survive parsing so a malformed entry cannot widen or
+	// narrow what the planner may dispatch.
+	const authority =
+		entry.authority === "agent" || entry.authority === "human"
+			? entry.authority
+			: undefined;
 	return {
 		id: rawId.trim(),
 		description: typeof entry.description === "string" ? entry.description : "",
+		...(authority ? { authority } : {}),
 		...(params ? { params } : {}),
 	};
 }

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -460,6 +460,48 @@ describe("view management actions", () => {
 		expect(globalThis.fetch).not.toHaveBeenCalled();
 	});
 
+	it("keeps human-only typed capabilities out of agent selection", async () => {
+		const { runtime } = createRuntime();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "orchestrator",
+						label: "Orchestrator",
+						capabilities: [
+							{
+								id: "orchestrator-status",
+								description: "Read orchestrator status.",
+							},
+							{
+								id: "orchestrator-validate-task",
+								description: "Approve task validation.",
+								authority: "human",
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		const result = await action.handler(
+			runtime as never,
+			message("approve this task") as never,
+			undefined,
+			{
+				action: "interact",
+				view: "orchestrator",
+				capability: "orchestrator-validate-task",
+			},
+			vi.fn(),
+		);
+
+		expect(result?.success).toBe(false);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
 	it("normalizes legacy Notes title/body payloads into the declared one-field content contract", async () => {
 		const { runtime } = createRuntime();
 		const action = createViewsAction({

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -460,29 +460,77 @@ describe("view management actions", () => {
 		expect(globalThis.fetch).not.toHaveBeenCalled();
 	});
 
-	it("keeps human-only typed capabilities out of agent selection", async () => {
-		const { runtime } = createRuntime();
-		const action = createViewsAction({
-			client: {
-				listViews: vi.fn(async () => [
-					view({
-						id: "orchestrator",
-						label: "Orchestrator",
-						capabilities: [
-							{
-								id: "orchestrator-status",
-								description: "Read orchestrator status.",
-							},
-							{
-								id: "orchestrator-validate-task",
-								description: "Approve task validation.",
-								authority: "human",
-							},
-						],
+	function stubOrchestratorViewsWire() {
+		const wireView = {
+			id: "orchestrator",
+			label: "Orchestrator",
+			pluginName: "@elizaos/plugin-task-coordinator",
+			available: true,
+			path: "/orchestrator",
+			viewType: "gui",
+			capabilities: [
+				{
+					id: "orchestrator-status",
+					description: "Read orchestrator status.",
+				},
+				{
+					id: "orchestrator-validate-task",
+					description: "Approve or reject task validation.",
+					authority: "human",
+					params: {
+						taskId: { type: "string", description: "Task id" },
+					},
+				},
+			],
+		};
+		const fetchMock = vi.mocked(globalThis.fetch);
+		fetchMock.mockImplementation(async (url) => {
+			const href = String(url);
+			if (href.startsWith("http://127.0.0.1:3456/api/views/current")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({ current: null }),
+				} as Response;
+			}
+			if (href.includes("/api/views/orchestrator/interact")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({
+						success: true,
+						result: { success: true, data: { status: "idle" } },
 					}),
-				]),
-				getCurrentView: vi.fn(async () => null),
-			},
+				} as Response;
+			}
+			if (href.startsWith("http://127.0.0.1:3456/api/views")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({ views: [wireView] }),
+				} as Response;
+			}
+			throw new Error(`unexpected loopback request: ${href}`);
+		});
+		return fetchMock;
+	}
+
+	function dispatchedInteractCapabilities(): string[] {
+		return vi
+			.mocked(globalThis.fetch)
+			.mock.calls.filter(([url]) => String(url).includes("/interact"))
+			.map(([, init]) => {
+				const body = JSON.parse(String(init?.body ?? "{}")) as {
+					capability?: unknown;
+				};
+				return typeof body.capability === "string" ? body.capability : "";
+			});
+	}
+
+	it("refuses an explicitly requested human-only capability parsed from the real view registry wire", async () => {
+		const { runtime } = createRuntime();
+		stubOrchestratorViewsWire();
+		const action = createViewsAction({
 			hasOwnerAccess: vi.fn(async () => true),
 		});
 
@@ -494,12 +542,40 @@ describe("view management actions", () => {
 				action: "interact",
 				view: "orchestrator",
 				capability: "orchestrator-validate-task",
+				params: { taskId: "task-1" },
 			},
 			vi.fn(),
 		);
 
 		expect(result?.success).toBe(false);
-		expect(globalThis.fetch).not.toHaveBeenCalled();
+		expect(result?.text).toMatch(/requires direct human interaction/);
+		expect(result?.text).toContain("orchestrator-validate-task");
+		expect(dispatchedInteractCapabilities()).toEqual([]);
+	});
+
+	it("never selects a human-only capability from the real view registry wire when the request is implicit", async () => {
+		const { runtime } = createRuntime();
+		stubOrchestratorViewsWire();
+		const action = createViewsAction({
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		const result = await action.handler(
+			runtime as never,
+			message("validate task task-1 in the orchestrator") as never,
+			undefined,
+			{ action: "interact", view: "orchestrator" },
+			vi.fn(),
+		);
+
+		// The only agent-callable descriptor on the view is the read-only status
+		// capability, so that is the most the planner may dispatch; the
+		// human-only mutation must never reach the interact route.
+		expect(result?.text).not.toContain("orchestrator-validate-task");
+		expect(dispatchedInteractCapabilities()).not.toContain(
+			"orchestrator-validate-task",
+		);
+		expect(dispatchedInteractCapabilities()).toEqual(["orchestrator-status"]);
 	});
 
 	it("normalizes legacy Notes title/body payloads into the declared one-field content contract", async () => {

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -919,7 +919,9 @@ function capabilityCandidates(
 	return views
 		.filter((view) => !viewType || !view.viewType || view.viewType === viewType)
 		.flatMap((view) =>
-			(view.capabilities ?? []).map((capability) => ({ view, capability })),
+			(view.capabilities ?? [])
+				.filter((capability) => capability.authority !== "human")
+				.map((capability) => ({ view, capability })),
 		);
 }
 
@@ -1221,7 +1223,9 @@ function correctCapabilityOperationFamily(
 	}
 
 	const familyMatches = (view.capabilities ?? []).filter(
-		(candidate) => operationFamilyForCapability(candidate) === requestedFamily,
+		(candidate) =>
+			candidate.authority !== "human" &&
+			operationFamilyForCapability(candidate) === requestedFamily,
 	);
 	if (familyMatches.length === 1 && familyMatches[0])
 		return { kind: "capability", capability: familyMatches[0] };
@@ -3208,10 +3212,26 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							normalizeCapabilityKey(capability),
 						);
 						if (!resolvedCapability && resolvedView) {
+							const humanOnlyCapability = (
+								resolvedView.capabilities ?? []
+							).find(
+								(candidate) =>
+									candidate.authority === "human" &&
+									normalizeCapabilityKey(candidate.id) ===
+										normalizeCapabilityKey(capability),
+							);
+							if (humanOnlyCapability) {
+								return {
+									success: false,
+									text: `Capability "${humanOnlyCapability.id}" on view "${resolvedView.id}" requires direct human interaction.`,
+									transcriptVisibility: "internal",
+								};
+							}
 							const matches = (resolvedView.capabilities ?? []).filter(
 								(candidate) =>
+									candidate.authority !== "human" &&
 									normalizeCapabilityKey(candidate.id) ===
-									normalizeCapabilityKey(capability),
+										normalizeCapabilityKey(capability),
 							);
 							if (matches.length === 1 && matches[0]) {
 								resolvedCapability = {

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
@@ -107,7 +107,9 @@ function viewSupportsFamily(
 	family: CapabilityFamily,
 ): boolean {
 	return (view.capabilities ?? []).some(
-		(capability) => capabilityFamily(capability) === family,
+		(capability) =>
+			capability.authority !== "human" &&
+			capabilityFamily(capability) === family,
 	);
 }
 

--- a/plugins/plugin-task-coordinator/__tests__/unit/interact-dispatch.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/interact-dispatch.test.ts
@@ -151,6 +151,17 @@ describe("interact: orchestrator delegation + unknown capability", () => {
     expect(out).toEqual({ taskCount: 0 });
   });
 
+  it("rejects a human-only typed mutation before any client effect", async () => {
+    await expect(
+      interact("orchestrator-validate-task", {
+        taskId: "task-1",
+        passed: true,
+        humanOverride: true,
+      }),
+    ).rejects.toThrow(/requires direct human interaction/);
+    expect(getOrchestratorStatus).not.toHaveBeenCalled();
+  });
+
   it("rejects an unrecognized capability with a descriptive error", async () => {
     await expect(interact("does-not-exist")).rejects.toThrow(
       /does not support/,

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-capability-parity.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-capability-parity.test.ts
@@ -39,6 +39,7 @@ import {
   ORCHESTRATOR_CAPABILITY_IDS,
   runOrchestratorCapability,
 } from "../../src/orchestrator-capabilities";
+import { HUMAN_ONLY_ORCHESTRATOR_CAPABILITY_IDS } from "../../src/orchestrator-capability-authority";
 
 function manifestCapabilityIds(): Set<string> {
   const ids = new Set<string>();
@@ -69,6 +70,20 @@ describe("orchestrator capability manifest↔dispatch parity", () => {
     expect(ORCHESTRATOR_CAPABILITY_IDS.size).toBeGreaterThan(0);
     expect([...manifest].sort()).toEqual(
       [...ORCHESTRATOR_CAPABILITY_IDS].sort(),
+    );
+  });
+
+  it("marks every human-only mutation in the trusted manifest", () => {
+    const capabilities = taskCoordinatorPlugin.views?.find(
+      (view) => view.id === "orchestrator",
+    )?.capabilities;
+    const humanOnly = new Set(
+      capabilities
+        ?.filter((capability) => capability.authority === "human")
+        .map((capability) => capability.id),
+    );
+    expect([...humanOnly].sort()).toEqual(
+      [...HUMAN_ONLY_ORCHESTRATOR_CAPABILITY_IDS].sort(),
     );
   });
 

--- a/plugins/plugin-task-coordinator/__tests__/unit/run-orchestrator-capability.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/run-orchestrator-capability.test.ts
@@ -288,21 +288,20 @@ describe("orchestrator-validate-task", () => {
     ).rejects.toThrow(/passed \(boolean\) is required/);
   });
 
-  it("forwards the verdict with humanOverride only when strictly true", async () => {
+  it("never accepts caller-controlled human override authority", async () => {
     await runOrchestratorCapability("orchestrator-validate-task", {
       taskId: "t6",
       passed: false,
       summary: " no ",
       evidence: " log ",
       verifier: " ci ",
-      humanOverride: "yes",
+      humanOverride: true,
     });
     expect(m.validateOrchestratorTask).toHaveBeenCalledWith("t6", {
       passed: false,
       summary: "no",
       evidence: "log",
       verifier: "ci",
-      humanOverride: false,
     });
   });
 });

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.interact.ts
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.interact.ts
@@ -9,12 +9,18 @@ import {
   ORCHESTRATOR_CAPABILITY_IDS,
   runOrchestratorCapability,
 } from "./orchestrator-capabilities";
+import { isHumanOnlyOrchestratorCapability } from "./orchestrator-capability-authority";
 
 export async function interact(
   capability: string,
   params?: Record<string, unknown>,
 ): Promise<unknown> {
   if (ORCHESTRATOR_CAPABILITY_IDS.has(capability)) {
+    if (isHumanOnlyOrchestratorCapability(capability)) {
+      throw new Error(
+        `Orchestrator capability "${capability}" requires direct human interaction.`,
+      );
+    }
     return runOrchestratorCapability(capability, params);
   }
 

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -17,12 +17,13 @@
  * (e.g. `@radix-ui/react-slot`) are pruned from the Docker runtime-dep closure.
  */
 import type { Plugin, ViewCapability } from "@elizaos/core";
+import { isHumanOnlyOrchestratorCapability } from "./orchestrator-capability-authority";
 import {
   orchestratorStatusCommandAction,
   registerOrchestratorCommands,
 } from "./orchestrator-command";
 
-const ORCHESTRATOR_CAPABILITIES: ViewCapability[] = [
+const ORCHESTRATOR_CAPABILITY_DECLARATIONS: ViewCapability[] = [
   { id: "orchestrator-status", description: "Get orchestrator status" },
   {
     id: "orchestrator-list-tasks",
@@ -155,10 +156,6 @@ const ORCHESTRATOR_CAPABILITIES: ViewCapability[] = [
         type: "string",
         description: "Who or what performed validation",
       },
-      humanOverride: {
-        type: "boolean",
-        description: "Whether a human explicitly overrode the result",
-      },
     },
   },
   {
@@ -202,6 +199,13 @@ const ORCHESTRATOR_CAPABILITIES: ViewCapability[] = [
     },
   },
 ];
+
+const ORCHESTRATOR_CAPABILITIES = ORCHESTRATOR_CAPABILITY_DECLARATIONS.map(
+  (capability): ViewCapability =>
+    isHumanOnlyOrchestratorCapability(capability.id)
+      ? { ...capability, authority: "human" }
+      : capability,
+);
 
 const taskCoordinatorPlugin: Plugin = {
   name: "@elizaos/plugin-task-coordinator",

--- a/plugins/plugin-task-coordinator/src/index.ts
+++ b/plugins/plugin-task-coordinator/src/index.ts
@@ -321,9 +321,12 @@ const taskCoordinatorPlugin: Plugin = {
       surface: { capabilities: ["agent-surface"] },
       componentExport: "CockpitRoute",
       // The cockpit drives the same orchestrator interact protocol (list /
-      // open-task / create-task / add-agent / stop-agent …) as /orchestrator,
-      // so it advertises the same capabilities — this is what lets app-control
-      // route session-control intents ("stop that agent") to the cockpit.
+      // open-task / create-task / send-message / stop-agent …) as
+      // /orchestrator, so it advertises the same capability descriptors,
+      // including their `authority`. app-control may route the agent-callable
+      // ones (status/list/open/create/send-message) to the cockpit; the
+      // human-only mutations such as stop-agent are listed so the shared
+      // dispatcher refuses them uniformly, never so the planner selects them.
       capabilities: ORCHESTRATOR_CAPABILITIES,
       tags: ["developer", "coding-agent", "cockpit"],
       visibleInManager: true,

--- a/plugins/plugin-task-coordinator/src/orchestrator-capabilities.ts
+++ b/plugins/plugin-task-coordinator/src/orchestrator-capabilities.ts
@@ -103,7 +103,6 @@ export async function runOrchestratorCapability(
         summary: paramString(params?.summary),
         evidence: paramString(params?.evidence),
         verifier: paramString(params?.verifier),
-        humanOverride: params?.humanOverride === true,
       });
     }
     case "orchestrator-add-agent":

--- a/plugins/plugin-task-coordinator/src/orchestrator-capability-authority.ts
+++ b/plugins/plugin-task-coordinator/src/orchestrator-capability-authority.ts
@@ -1,0 +1,19 @@
+/** Defines the orchestrator mutations reserved for direct human UI controls. */
+
+export const HUMAN_ONLY_ORCHESTRATOR_CAPABILITY_IDS: ReadonlySet<string> =
+  new Set([
+    "orchestrator-pause-task",
+    "orchestrator-resume-task",
+    "orchestrator-pause-all",
+    "orchestrator-resume-all",
+    "orchestrator-delete-task",
+    "orchestrator-fork-task",
+    "orchestrator-update-task",
+    "orchestrator-validate-task",
+    "orchestrator-add-agent",
+    "orchestrator-stop-agent",
+  ]);
+
+export function isHumanOnlyOrchestratorCapability(capability: string): boolean {
+  return HUMAN_ONLY_ORCHESTRATOR_CAPABILITY_IDS.has(capability);
+}


### PR DESCRIPTION
Closes #24955. Relates to #24102 and fixes the post-merge authority blocker found in #24815.

Typed orchestrator capabilities now declare `authority: "agent" | "human"`. Human-only mutations are rejected at every agent-facing boundary (real `/api/views/:id/interact`, shared dispatcher, bundle export, and planner selection/follow-up), and caller-controlled `humanOverride` is removed. Existing human DOM callbacks remain intact; safe status/list/open/create/send-message capabilities remain agent-callable.

This also repairs the decomposed app surface coverage gate so it scans the extracted owner modules introduced by #24815.

<!-- evidence-head:4af91e6af72b030ddf6cbd9520c5f9de26e6761b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - authority enforcement changes server/planner dispatch, not rendered pixels; existing human DOM controls are byte-unchanged.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no visual styling or DOM-control changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction change; real route and dispatcher zero-effect tests are the acceptance artifact.

<!-- evidence-row:backend-logs -->
- [x] Exact-head focused transcript:
```text
Head 4af91e6 (rebased on origin/develop 2e69b70):
agent views-routes (interact coverage + route suites): 97/97 passed; agent typecheck clean; agent lint:check clean
app views coverage gate: 7/7 passed
app-control views-client + views-management: 75/75 passed (3 new real-wire authority cases; mutation-checked: all 3 fail with the views-client fix reverted)
app-control full suite: 1906/1911 — the 5 failures (background-routing, views-icon, views-show-home.repro, views-switching) reproduce identically on origin/develop 2e69b70 and are unrelated (their vi.mock factory for @elizaos/core omits containsExternalEnvelopeMaterial)
task-coordinator full suite: 249/249 passed; typecheck clean; lint:check clean
Biome: changed files clean; audit:focused-tests clean; ensure-plugin-test-conventions clean
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - frontend callbacks are intentionally unchanged; bundle dispatch refusal is covered deterministically before client mutation.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - this is a pre-dispatch authority fence. Tests prove human-only capabilities are absent/refused before planner/client effects; no model call is needed to establish the security invariant.

<!-- evidence-row:domain-artifacts -->
- [x] Authority artifact:
```text
Human-only capability descriptors are filtered from planner candidates and explicit requested IDs are refused.
POST /api/views/:id/interact and direct dispatch reject the same descriptors before server/frontend callbacks.
Safe agent capabilities remain listed and executable; human DOM handlers remain present and unchanged.
```

Additional prior full-package validation on the same source patch: task-coordinator 249/249, typecheck/build; app-control typecheck/build; agent build; core typecheck; guide parity 161/161.


