### PR TITLE
fix(cloud): keep new-email passkey routing private

### DIFF
--- a/packages/app/test/ui-smoke/passkey-explicit-recovery.spec.ts
+++ b/packages/app/test/ui-smoke/passkey-explicit-recovery.spec.ts
@@ -3,13 +3,12 @@
  * route and Steward SDK run against Chromium's virtual platform authenticator;
  * only Steward HTTP responses are fixed at the network boundary.
  *
- * Canonical Steward returns discoverable-credential options with an empty
- * allow-list instead of revealing whether an email has an account or passkey.
- * With no matching virtual credential, the browser-owned ceremony rejects. The
- * UI must offer explicit recovery without sending email until the user chooses
- * Magic Link or Set up passkey. The accent button retains its accessible text
- * token on hover, and a same-mounted retry ending in a hard 500 must clear the
- * recovery actions.
+ * A typed email with no device-local passkey hint goes directly to verified
+ * enrollment without querying Steward or invoking WebAuthn. Returning users on
+ * a new device can deliberately choose the separate existing-passkey action;
+ * canonical constant-shaped options then reach the browser ceremony without an
+ * account-existence signal. The accent button retains its accessible text token
+ * on hover, and a same-mounted retry ending in a hard 500 clears recovery.
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import { expect, type Page, type TestInfo, test } from "@playwright/test";
@@ -94,6 +93,22 @@ for (const viewport of VIEWPORTS) {
     page,
   }, testInfo) => {
     await page.setViewportSize(viewport);
+    await page.addInitScript(() => {
+      const trackedWindow = window as Window & {
+        __passkeyCredentialGetCount?: number;
+      };
+      trackedWindow.__passkeyCredentialGetCount = 0;
+      const credentials = navigator.credentials;
+      const originalGet = credentials.get.bind(credentials);
+      Object.defineProperty(credentials, "get", {
+        configurable: true,
+        value: (...args: Parameters<CredentialContainer["get"]>) => {
+          trackedWindow.__passkeyCredentialGetCount =
+            (trackedWindow.__passkeyCredentialGetCount ?? 0) + 1;
+          return originalGet(...args);
+        },
+      });
+    });
     await enableEmptyVirtualAuthenticator(page);
 
     const frontendEvents: string[] = [];
@@ -143,7 +158,9 @@ for (const viewport of VIEWPORTS) {
     });
 
     let optionsMode: "discoverable" | "server-error" = "discoverable";
+    let optionsRequestCount = 0;
     await page.route("**/auth/passkey/login/options", (route) => {
+      optionsRequestCount += 1;
       if (optionsMode === "server-error") {
         return route.fulfill({
           status: 500,
@@ -214,6 +231,32 @@ for (const viewport of VIEWPORTS) {
 
     await passkeyButton.click();
 
+    await expect(page.getByText("Set up your passkey")).toBeVisible();
+    expect(
+      optionsRequestCount,
+      "an unhinted email must not query passkey options or invoke WebAuthn",
+    ).toBe(0);
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            window as Window & {
+              __passkeyCredentialGetCount?: number;
+            }
+          ).__passkeyCredentialGetCount ?? 0,
+      ),
+      "an unhinted email must make zero navigator.credentials.get calls",
+    ).toBe(0);
+    expect(otpSendCount, "an unhinted Passkey action sends one setup OTP").toBe(
+      1,
+    );
+    expect(magicLinkSendCount).toBe(0);
+    await screenshot(page, testInfo, `${viewport.name}-1-unhinted-setup-otp`);
+
+    await page.reload();
+    await page.getByPlaceholder("you@example.com").fill(EMAIL);
+    await page.getByRole("button", { name: "Use an existing passkey" }).click();
+
     await expect(page.getByText("Passkey not completed")).toBeVisible();
     await expect(
       page.getByText(
@@ -222,16 +265,17 @@ for (const viewport of VIEWPORTS) {
     ).toBeVisible();
     expect(
       otpSendCount,
-      "ambiguous WebAuthn failure must not send setup OTP",
-    ).toBe(0);
+      "deliberate existing-passkey recovery must not send another setup OTP",
+    ).toBe(1);
     expect(
       magicLinkSendCount,
       "ambiguous WebAuthn failure must not send a magic link",
     ).toBe(0);
-    await screenshot(page, testInfo, `${viewport.name}-1-explicit-recovery`);
+    expect(optionsRequestCount).toBe(1);
+    await screenshot(page, testInfo, `${viewport.name}-2-explicit-recovery`);
 
     optionsMode = "server-error";
-    await passkeyButton.click();
+    await page.getByRole("button", { name: "Use an existing passkey" }).click();
     await expect(
       page.getByText("User verification service unavailable"),
     ).toBeVisible();
@@ -242,35 +286,37 @@ for (const viewport of VIEWPORTS) {
     await expect(
       page.getByRole("button", { name: "Use Magic Link" }),
     ).toHaveCount(0);
-    expect(otpSendCount, "same-mount 500 must not send setup OTP").toBe(0);
+    expect(otpSendCount, "same-mount 500 must not send setup OTP").toBe(1);
     expect(magicLinkSendCount, "same-mount 500 must not send magic link").toBe(
       0,
     );
     await screenshot(
       page,
       testInfo,
-      `${viewport.name}-2-same-mount-server-error`,
+      `${viewport.name}-3-same-mount-server-error`,
     );
 
     optionsMode = "discoverable";
     await page.reload();
     await page.getByPlaceholder("you@example.com").fill(EMAIL);
-    await page.getByRole("button", { name: /^Passkey$/ }).click();
+    await page.getByRole("button", { name: "Use an existing passkey" }).click();
     await page.getByRole("button", { name: "Set up passkey" }).click();
     await expect(page.getByText("Set up your passkey")).toBeVisible();
-    expect(otpSendCount, "explicit setup intent sends exactly one OTP").toBe(1);
+    expect(otpSendCount, "explicit setup intent sends one additional OTP").toBe(
+      2,
+    );
     expect(magicLinkSendCount).toBe(0);
-    await screenshot(page, testInfo, `${viewport.name}-3-setup-otp`);
+    await screenshot(page, testInfo, `${viewport.name}-4-recovery-setup-otp`);
 
     optionsMode = "discoverable";
     await page.reload();
     const emailForMagicLink = page.getByPlaceholder("you@example.com");
     await emailForMagicLink.fill(EMAIL);
-    await page.getByRole("button", { name: /^Passkey$/ }).click();
+    await page.getByRole("button", { name: "Use an existing passkey" }).click();
     await page.getByRole("button", { name: "Use Magic Link" }).click();
     await expect(page.getByText("Check your email")).toBeVisible();
     expect(magicLinkSendCount, "explicit Magic Link intent sends once").toBe(1);
-    expect(otpSendCount).toBe(1);
+    expect(otpSendCount).toBe(2);
 
     const logPath = testInfo.outputPath(`${viewport.name}-frontend.log`);
     await writeFile(logPath, `${frontendEvents.join("\n")}\n`, "utf8");

--- a/packages/ui/src/cloud/public-pages/pages/login/passkey-device-hints.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/passkey-device-hints.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Deterministic coverage for privacy-preserving device-local passkey hints.
+ * Web Crypto is real; only browser storage is an in-memory test boundary.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  hasPasskeyDeviceHint,
+  normalizePasskeyHintEmail,
+  PASSKEY_DEVICE_HINT_STORAGE_KEY,
+  type PasskeyDeviceHintEnvironment,
+  rememberPasskeyDeviceHint,
+} from "./passkey-device-hints";
+
+class MemoryStorage implements Pick<Storage, "getItem" | "setItem"> {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function createEnvironment(storage = new MemoryStorage()): {
+  environment: PasskeyDeviceHintEnvironment;
+  storage: MemoryStorage;
+} {
+  return {
+    environment: { storage, crypto: globalThis.crypto },
+    storage,
+  };
+}
+
+describe("passkey device hints", () => {
+  it("normalizes whitespace, case, and compatible Unicode forms", () => {
+    expect(normalizePasskeyHintEmail("  PERSON@EXAMPLE.COM  ")).toBe(
+      "person@example.com",
+    );
+    expect(normalizePasskeyHintEmail("ｐｅｒｓｏｎ@example.com")).toBe(
+      "person@example.com",
+    );
+  });
+
+  it("matches normalized emails without storing plaintext or a stable digest", async () => {
+    const first = createEnvironment();
+    const second = createEnvironment();
+
+    await expect(
+      rememberPasskeyDeviceHint(" Person@Example.com ", first.environment),
+    ).resolves.toBe(true);
+    await expect(
+      hasPasskeyDeviceHint("person@example.com", first.environment),
+    ).resolves.toBe(true);
+
+    const firstRaw = first.storage.getItem(PASSKEY_DEVICE_HINT_STORAGE_KEY);
+    expect(firstRaw).not.toBeNull();
+    expect(firstRaw?.toLowerCase()).not.toContain("person");
+    expect(firstRaw?.toLowerCase()).not.toContain("example.com");
+
+    await rememberPasskeyDeviceHint("person@example.com", second.environment);
+    expect(second.storage.getItem(PASSKEY_DEVICE_HINT_STORAGE_KEY)).not.toBe(
+      firstRaw,
+    );
+  });
+
+  it("keeps only the sixteen most recently marked emails", async () => {
+    const { environment, storage } = createEnvironment();
+    for (let index = 0; index < 20; index += 1) {
+      await rememberPasskeyDeviceHint(
+        `person-${index}@example.com`,
+        environment,
+      );
+    }
+
+    const raw = storage.getItem(PASSKEY_DEVICE_HINT_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw ?? "{}").hints).toHaveLength(16);
+    await expect(
+      hasPasskeyDeviceHint("person-0@example.com", environment),
+    ).resolves.toBe(false);
+    await expect(
+      hasPasskeyDeviceHint("person-19@example.com", environment),
+    ).resolves.toBe(true);
+  });
+
+  it("treats corrupted storage as unhinted and replaces it on a later success", async () => {
+    const { environment, storage } = createEnvironment();
+    storage.setItem(PASSKEY_DEVICE_HINT_STORAGE_KEY, "not-json");
+
+    await expect(
+      hasPasskeyDeviceHint("person@example.com", environment),
+    ).resolves.toBe(false);
+    await expect(
+      rememberPasskeyDeviceHint("person@example.com", environment),
+    ).resolves.toBe(true);
+    await expect(
+      hasPasskeyDeviceHint("person@example.com", environment),
+    ).resolves.toBe(true);
+  });
+
+  it("fails closed when storage is unavailable", async () => {
+    await expect(
+      hasPasskeyDeviceHint("person@example.com", null),
+    ).resolves.toBe(false);
+    await expect(
+      rememberPasskeyDeviceHint("person@example.com", null),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/passkey-device-hints.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/passkey-device-hints.ts
@@ -1,0 +1,214 @@
+/**
+ * Stores a bounded, device-local hint that an email has completed passkey use.
+ *
+ * The hint is advisory: it chooses between scoped passkey authentication and
+ * email-verified enrollment without asking Steward whether an account exists.
+ * Emails are normalized and HMACed with a random device-local key so browser
+ * storage never contains the address in plaintext or a cross-device digest.
+ */
+
+export const PASSKEY_DEVICE_HINT_STORAGE_KEY = "eliza:passkey-device-hints:v1";
+
+const PASSKEY_DEVICE_HINT_VERSION = 1;
+const PASSKEY_DEVICE_HINT_LIMIT = 16;
+const PASSKEY_DEVICE_HINT_KEY_BYTES = 32;
+
+type PasskeyDeviceHintRecord = {
+  version: typeof PASSKEY_DEVICE_HINT_VERSION;
+  key: string;
+  hints: string[];
+};
+
+type PasskeyDeviceHintStorage = Pick<Storage, "getItem" | "setItem">;
+
+export type PasskeyDeviceHintEnvironment = {
+  storage: PasskeyDeviceHintStorage;
+  crypto: Crypto;
+};
+
+type ReadRecordResult =
+  | { kind: "missing" }
+  | { kind: "invalid" }
+  | { kind: "ready"; record: PasskeyDeviceHintRecord };
+
+export function normalizePasskeyHintEmail(email: string): string {
+  return email.trim().normalize("NFKC").toLowerCase();
+}
+
+function resolveDefaultEnvironment(): PasskeyDeviceHintEnvironment | null {
+  if (
+    typeof globalThis === "undefined" ||
+    !globalThis.crypto?.subtle ||
+    typeof globalThis.localStorage === "undefined"
+  ) {
+    return null;
+  }
+
+  try {
+    return { storage: globalThis.localStorage, crypto: globalThis.crypto };
+  } catch {
+    // error-policy:J4 storage-denied browsers safely take the enrollment path;
+    // the server is never queried for account existence as a fallback.
+    return null;
+  }
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new Error("Passkey hint key is not base64url");
+  }
+  const padded = value
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+function isHintDigest(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function readRecord(storage: PasskeyDeviceHintStorage): ReadRecordResult {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(PASSKEY_DEVICE_HINT_STORAGE_KEY);
+  } catch {
+    // error-policy:J4 storage failure degrades to enrollment without revealing
+    // whether Steward has an account or passkey for the entered email.
+    return { kind: "missing" };
+  }
+  if (raw === null) return { kind: "missing" };
+
+  try {
+    const candidate: unknown = JSON.parse(raw);
+    if (
+      typeof candidate !== "object" ||
+      candidate === null ||
+      Array.isArray(candidate)
+    ) {
+      return { kind: "invalid" };
+    }
+    const record = candidate as Record<string, unknown>;
+    if (
+      record.version !== PASSKEY_DEVICE_HINT_VERSION ||
+      typeof record.key !== "string" ||
+      !Array.isArray(record.hints) ||
+      record.hints.length > PASSKEY_DEVICE_HINT_LIMIT ||
+      !record.hints.every(isHintDigest) ||
+      new Set(record.hints).size !== record.hints.length ||
+      base64UrlToBytes(record.key).length !== PASSKEY_DEVICE_HINT_KEY_BYTES
+    ) {
+      return { kind: "invalid" };
+    }
+    return {
+      kind: "ready",
+      record: {
+        version: PASSKEY_DEVICE_HINT_VERSION,
+        key: record.key,
+        hints: record.hints,
+      },
+    };
+  } catch {
+    // error-policy:J3 browser storage is untrusted input; malformed records
+    // become an explicit invalid state and are replaced only by a later mark.
+    return { kind: "invalid" };
+  }
+}
+
+async function hashEmail(
+  normalizedEmail: string,
+  key: Uint8Array,
+  crypto: Crypto,
+): Promise<string> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    copyToArrayBuffer(key),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    cryptoKey,
+    copyToArrayBuffer(new TextEncoder().encode(normalizedEmail)),
+  );
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+export async function hasPasskeyDeviceHint(
+  email: string,
+  environment: PasskeyDeviceHintEnvironment | null = resolveDefaultEnvironment(),
+): Promise<boolean> {
+  const normalizedEmail = normalizePasskeyHintEmail(email);
+  if (!normalizedEmail || !environment) return false;
+
+  const result = readRecord(environment.storage);
+  if (result.kind !== "ready") return false;
+
+  try {
+    const digest = await hashEmail(
+      normalizedEmail,
+      base64UrlToBytes(result.record.key),
+      environment.crypto,
+    );
+    return result.record.hints.includes(digest);
+  } catch {
+    // error-policy:J4 unavailable Web Crypto safely routes through verified
+    // enrollment instead of falling back to a server-side existence check.
+    return false;
+  }
+}
+
+export async function rememberPasskeyDeviceHint(
+  email: string,
+  environment: PasskeyDeviceHintEnvironment | null = resolveDefaultEnvironment(),
+): Promise<boolean> {
+  const normalizedEmail = normalizePasskeyHintEmail(email);
+  if (!normalizedEmail || !environment) return false;
+
+  try {
+    const result = readRecord(environment.storage);
+    const key =
+      result.kind === "ready"
+        ? base64UrlToBytes(result.record.key)
+        : environment.crypto.getRandomValues(
+            new Uint8Array(PASSKEY_DEVICE_HINT_KEY_BYTES),
+          );
+    const digest = await hashEmail(normalizedEmail, key, environment.crypto);
+    const previousHints = result.kind === "ready" ? result.record.hints : [];
+    const hints = [
+      ...previousHints.filter((hint) => hint !== digest),
+      digest,
+    ].slice(-PASSKEY_DEVICE_HINT_LIMIT);
+    const record: PasskeyDeviceHintRecord = {
+      version: PASSKEY_DEVICE_HINT_VERSION,
+      key: bytesToBase64Url(key),
+      hints,
+    };
+    environment.storage.setItem(
+      PASSKEY_DEVICE_HINT_STORAGE_KEY,
+      JSON.stringify(record),
+    );
+    return true;
+  } catch {
+    // error-policy:J4 hint persistence is an optional UX optimization. A
+    // successful authentication remains successful when storage is denied.
+    return false;
+  }
+}

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-auth-passkey-fallback.test.ts
@@ -1,8 +1,8 @@
 /**
- * Verifies the patched Steward SDK's opt-out from implicit passkey enrollment
+ * Verifies explicit Steward passkey authentication and enrollment boundaries
  * using the real client and SimpleWebAuthn implementation. HTTP and browser
- * credential boundaries are deterministic, but registration and MFA execute
- * all SDK/browser-library code through navigator.credentials.
+ * credential boundaries are deterministic, but each ceremony executes all
+ * SDK/browser-library code through navigator.credentials.
  */
 // @vitest-environment jsdom
 
@@ -87,31 +87,26 @@ function authSuccess(token = validSessionToken()) {
   };
 }
 
-describe("StewardAuth passkey registration fallback", () => {
+describe("StewardAuth passkey ceremony boundaries", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("preserves the default smart registration fallback", async () => {
-    const recorder = recordFetch([
-      jsonResponse(404, "No passkey registered"),
-      jsonResponse(401, "Authentication required"),
-    ]);
-    vi.stubGlobal("fetch", recorder.fetch);
-    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
-
-    await expect(
-      auth.signInWithPasskey("person@example.com"),
-    ).rejects.toMatchObject({
-      status: 401,
-      message: "Authentication required",
+  it("runs WebAuthn for constant-shaped options without starting registration", async () => {
+    const get = vi.fn(async () => {
+      throw new DOMException("No matching credential", "NotAllowedError");
     });
-    expect(recorder.callCount()).toBe(2);
-  });
-
-  it("exposes 404 without starting registration when fallback is disabled", async () => {
-    const recorder = recordFetch([jsonResponse(404, "No passkey registered")]);
+    installWebAuthnCredentialContainer({ get });
+    const recorder = recordFetch([
+      successResponse({
+        challenge: "AQIDBA",
+        challengeId: "login-challenge-id",
+        rpId: "example.test",
+        allowCredentials: [],
+        userVerification: "required",
+      }),
+    ]);
     vi.stubGlobal("fetch", recorder.fetch);
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
 
@@ -122,11 +117,15 @@ describe("StewardAuth passkey registration fallback", () => {
       .catch((cause: unknown) => cause);
 
     expect(recorder.callCount()).toBe(1);
+    expect(get).toHaveBeenCalledTimes(1);
     expect(error).toBeInstanceOf(StewardApiError);
     expect(error).toMatchObject({
-      status: 404,
-      message: "No passkey registered",
+      status: 0,
+      message: expect.stringContaining("No matching credential"),
     });
+    expect(String(recorder.requests()[0]?.input)).toBe(
+      "https://api.example.test/auth/passkey/login/options",
+    );
   });
 
   it("does not reinterpret non-404 login failures", async () => {
@@ -174,7 +173,6 @@ describe("StewardAuth passkey registration fallback", () => {
     installWebAuthnCredentialContainer({ create });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const recorder = recordFetch([
-      jsonResponse(404, "No passkey registered"),
       successResponse(registrationOptions),
       successResponse(authSuccess()),
     ]);
@@ -182,7 +180,7 @@ describe("StewardAuth passkey registration fallback", () => {
     const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
 
     await expect(
-      auth.signInWithPasskey("person@example.com"),
+      auth.addPasskey("person@example.com", { emailGrant: "email-grant" }),
     ).resolves.toMatchObject({ token: expect.any(String) });
 
     expect(create).toHaveBeenCalledTimes(1);
@@ -190,8 +188,16 @@ describe("StewardAuth passkey registration fallback", () => {
     expect(createRequest?.publicKey?.challenge).toBeInstanceOf(ArrayBuffer);
     expect(createRequest?.publicKey?.user.id).toBeInstanceOf(ArrayBuffer);
     expect(warn).not.toHaveBeenCalled();
-    expect(recorder.callCount()).toBe(3);
-    const verifyRequest = recorder.requests()[2];
+    expect(recorder.callCount()).toBe(2);
+    const optionsRequest = recorder.requests()[0];
+    expect(String(optionsRequest?.input)).toBe(
+      "https://api.example.test/auth/passkey/register/options",
+    );
+    expect(JSON.parse(String(optionsRequest?.init?.body))).toMatchObject({
+      email: "person@example.com",
+      emailGrant: "email-grant",
+    });
+    const verifyRequest = recorder.requests()[1];
     expect(String(verifyRequest?.input)).toBe(
       "https://api.example.test/auth/passkey/register/verify",
     );

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -25,6 +25,16 @@ vi.mock("./passkey-capability", () => ({
   resolveWebPasskeyCapability: () => Promise.resolve(capabilityRef),
 }));
 
+const passkeyHintSpies = vi.hoisted(() => ({
+  has: vi.fn(),
+  remember: vi.fn(),
+}));
+
+vi.mock("./passkey-device-hints", () => ({
+  hasPasskeyDeviceHint: passkeyHintSpies.has,
+  rememberPasskeyDeviceHint: passkeyHintSpies.remember,
+}));
+
 const stewardAuthSpies = vi.hoisted(() => ({
   getProviders: vi.fn(),
   getSession: vi.fn(),
@@ -157,6 +167,8 @@ describe("StewardLoginSection passkey capability gating", () => {
     stewardAuthSpies.getSession.mockReturnValue(null);
     stewardAuthSpies.refreshSession.mockResolvedValue(null);
     stewardAuthSpies.sendEmailOtp.mockResolvedValue(undefined);
+    passkeyHintSpies.has.mockResolvedValue(false);
+    passkeyHintSpies.remember.mockResolvedValue(true);
     emailLoginSpies.start.mockResolvedValue({
       expiresAt: "2026-07-17T12:10:00.000Z",
       challengeId: "challenge-1",
@@ -220,7 +232,7 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(stewardAuthSpies.signInWithPasskey).not.toHaveBeenCalled();
   });
 
-  it("renders passkey but never arms webauthn autofill after a positive capability probe", async () => {
+  it("routes an unhinted email to OTP without passkey lookup or WebAuthn", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";
 
@@ -231,25 +243,69 @@ describe("StewardLoginSection passkey capability gating", () => {
     // available, the email input must NOT carry the "webauthn" autocomplete
     // token. That token arms browser conditional-mediation autofill, which
     // prompts for an existing account's discoverable credential when a
-    // brand-new email is typed and hijacks signup. Passkey sign-in stays
-    // available only through the explicit Passkey button (email-scoped).
+    // brand-new email is typed and hijacks signup. The primary Passkey action
+    // uses only the device-local hint and routes a new email to verified setup.
     expect(input.getAttribute("autocomplete")).toBe("email");
     expect(input.getAttribute("autocomplete")).not.toContain("webauthn");
-    expect(screen.getByRole("button", { name: /Passkey/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Passkey$/i })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    ).toBeTruthy();
     expect(
       screen.queryByText("New here? Passkey sets up your account in seconds."),
     ).toBeNull();
 
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
+
+    expect(await screen.findByText("Set up your passkey")).toBeTruthy();
+    expect(passkeyHintSpies.has).toHaveBeenCalledWith("person@example.com");
+    expect(stewardAuthSpies.sendEmailOtp).toHaveBeenCalledWith(
+      "person@example.com",
+    );
+    expect(stewardAuthSpies.signInWithPasskey).not.toHaveBeenCalled();
+    expect(emailLoginSpies.start).not.toHaveBeenCalled();
+  });
+
+  it("routes Enter through the same unhinted OTP gate", async () => {
+    capabilityRef.usable = true;
+    capabilityRef.reason = "available";
+
+    renderSection();
+
+    const input = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(input, { target: { value: "person@example.com" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText("Set up your passkey")).toBeTruthy();
+    expect(passkeyHintSpies.has).toHaveBeenCalledWith("person@example.com");
+    expect(stewardAuthSpies.sendEmailOtp).toHaveBeenCalledWith(
+      "person@example.com",
+    );
+    expect(stewardAuthSpies.signInWithPasskey).not.toHaveBeenCalled();
+  });
+
+  it("uses scoped passkey login for a locally hinted email and marks only after success", async () => {
+    capabilityRef.usable = true;
+    capabilityRef.reason = "available";
+    passkeyHintSpies.has.mockResolvedValue(true);
+
+    renderSection();
+
+    const input = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(input, { target: { value: " PERSON@EXAMPLE.COM " } });
+    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
 
     await waitFor(() =>
       expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
-        "person@example.com",
+        "PERSON@EXAMPLE.COM",
         { fallbackToRegistration: false },
       ),
     );
-    expect(emailLoginSpies.start).not.toHaveBeenCalled();
+    expect(passkeyHintSpies.remember).toHaveBeenCalledWith(
+      "PERSON@EXAMPLE.COM",
+    );
+    expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
   });
 
   it("requires an email before invoking passkey sign-in", async () => {
@@ -259,7 +315,7 @@ describe("StewardLoginSection passkey capability gating", () => {
     renderSection();
 
     const passkeyButton = await screen.findByRole("button", {
-      name: /Passkey/i,
+      name: /^Passkey$/i,
     });
     fireEvent.click(passkeyButton);
 
@@ -289,7 +345,9 @@ describe("StewardLoginSection passkey capability gating", () => {
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     expect(await screen.findByText("Passkey not completed")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Use Magic Link" })).toBeTruthy();
@@ -323,30 +381,35 @@ describe("StewardLoginSection passkey capability gating", () => {
         { emailGrant: "grant-1" },
       ),
     );
+    expect(passkeyHintSpies.remember).toHaveBeenCalledWith(
+      "person@example.com",
+    );
   });
 
-  it("routes a no-passkey 404 directly into email-verified enrollment", async () => {
+  it("keeps a deliberate existing-passkey failure distinct from enrollment", async () => {
     capabilityRef.usable = true;
     capabilityRef.reason = "available";
     stewardAuthSpies.signInWithPasskey.mockRejectedValue(
-      new StewardApiError("Passkey sign-in is unavailable for this email", 404),
+      new StewardApiError("Passkey sign-in is unavailable", 500),
     );
-    stewardAuthSpies.sendEmailOtp.mockResolvedValue(undefined);
 
     renderSection();
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
-    expect(await screen.findByText("Set up your passkey")).toBeTruthy();
+    expect(
+      await screen.findByText("Passkey sign-in is unavailable"),
+    ).toBeTruthy();
     expect(stewardAuthSpies.signInWithPasskey).toHaveBeenCalledWith(
       "person@example.com",
       { fallbackToRegistration: false },
     );
-    expect(stewardAuthSpies.sendEmailOtp).toHaveBeenCalledWith(
-      "person@example.com",
-    );
+    expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
+    expect(passkeyHintSpies.remember).not.toHaveBeenCalled();
     expect(screen.queryByText("Passkey not completed")).toBeNull();
     expect(screen.queryByRole("button", { name: "Use Magic Link" })).toBeNull();
     expect(emailLoginSpies.start).not.toHaveBeenCalled();
@@ -369,7 +432,9 @@ describe("StewardLoginSection passkey capability gating", () => {
       "you@example.com",
     )) as HTMLInputElement;
     await user.type(input, "first@example.com");
-    await user.click(screen.getByRole("button", { name: /^Passkey$/i }));
+    await user.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     expect(await screen.findByText("Passkey not completed")).toBeTruthy();
 
@@ -399,7 +464,9 @@ describe("StewardLoginSection passkey capability gating", () => {
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     // Error is surfaced; no OTP email is sent, no signup flow is entered.
     await waitFor(() =>
@@ -434,13 +501,16 @@ describe("StewardLoginSection passkey capability gating", () => {
 
       const input = await screen.findByPlaceholderText("you@example.com");
       fireEvent.change(input, { target: { value: "person@example.com" } });
-      fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Use an existing passkey" }),
+      );
 
       expect(await screen.findByText(passkeyError.message)).toBeTruthy();
       expect(screen.queryByText("Passkey not completed")).toBeNull();
       expect(screen.queryByText("Set up your passkey")).toBeNull();
       expect(stewardAuthSpies.sendEmailOtp).not.toHaveBeenCalled();
       expect(emailLoginSpies.start).not.toHaveBeenCalled();
+      expect(passkeyHintSpies.remember).not.toHaveBeenCalled();
     },
   );
 
@@ -462,13 +532,17 @@ describe("StewardLoginSection passkey capability gating", () => {
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     expect(await screen.findByText("Passkey not completed")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Use Magic Link" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Set up passkey" })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /^Passkey$/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     expect(
       await screen.findByText("User verification service unavailable"),
@@ -499,7 +573,9 @@ describe("StewardLoginSection passkey capability gating", () => {
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     expect(
       await screen.findByText(
@@ -534,7 +610,9 @@ describe("StewardLoginSection passkey capability gating", () => {
 
     const input = await screen.findByPlaceholderText("you@example.com");
     fireEvent.change(input, { target: { value: "person@example.com" } });
-    fireEvent.click(screen.getByRole("button", { name: /Passkey/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Use an existing passkey" }),
+    );
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Set up passkey" }),

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -110,6 +110,10 @@ import {
   type WebPasskeyCapability,
 } from "./passkey-capability";
 import {
+  hasPasskeyDeviceHint,
+  rememberPasskeyDeviceHint,
+} from "./passkey-device-hints";
+import {
   inferPhoneCountry,
   normalizePhoneForCountry,
   PHONE_COUNTRY_OPTIONS,
@@ -1127,21 +1131,25 @@ export default function StewardLoginSection() {
     );
   }
 
-  async function handlePasskey() {
+  function validatePasskeyIntent(): boolean {
     if (!showPasskey) {
       if (providers.email !== false) {
-        await handleEmail();
-        return;
+        void handleEmail();
+        return false;
       }
       setError(
         "Passkeys are not available in this browser. Use Google, Discord, or open this sign-in link on another device.",
       );
-      return;
+      return false;
     }
     if (!email.trim()) {
       setError("Enter your email first");
-      return;
+      return false;
     }
+    return true;
+  }
+
+  async function runScopedPasskeyLogin() {
     setLoading("passkey");
     setError(null);
     setShowPasskeyRecovery(false);
@@ -1151,6 +1159,7 @@ export default function StewardLoginSection() {
           fallbackToRegistration: false,
         }),
       );
+      await rememberPasskeyDeviceHint(email);
       await handleSuccess(result.token, result.refreshToken);
     } catch (e: unknown) {
       // error-policy:J4 authentication failures remain visibly distinct and
@@ -1160,11 +1169,6 @@ export default function StewardLoginSection() {
           "Passkey sign-in requires device verification (PIN or biometric). Your device may not support this — try Magic Link instead.",
         );
         setLoading(null);
-      } else if (e instanceof StewardApiError && e.status === 404) {
-        // A typed email with no matching passkey never reached WebAuthn. Continue
-        // directly into the email-verified enrollment path instead of presenting
-        // browser-cancellation recovery for a prompt that never opened.
-        await startPasskeySignup();
       } else if (isUserCancelled(e)) {
         // A browser-owned cancellation is ambiguous, so keep recovery as an
         // explicit user choice rather than sending signup mail automatically.
@@ -1175,6 +1179,27 @@ export default function StewardLoginSection() {
         setLoading(null);
       }
     }
+  }
+
+  async function handlePasskey() {
+    if (!validatePasskeyIntent()) return;
+    setLoading("passkey");
+    setError(null);
+    setShowPasskeyRecovery(false);
+
+    const hinted = await hasPasskeyDeviceHint(email);
+    if (!hinted) {
+      // A new device-local email goes straight to verified enrollment. This
+      // decision never asks Steward whether an account or passkey exists.
+      await startPasskeySignup();
+      return;
+    }
+    await runScopedPasskeyLogin();
+  }
+
+  async function handleExistingPasskey() {
+    if (!validatePasskeyIntent()) return;
+    await runScopedPasskeyLogin();
   }
 
   async function startPasskeySignup() {
@@ -1205,6 +1230,7 @@ export default function StewardLoginSection() {
       const result = requireCompletedAuth(
         await auth.addPasskey(email.trim(), { emailGrant }),
       );
+      await rememberPasskeyDeviceHint(email);
       await handleSuccess(result.token, result.refreshToken);
     } catch (e: unknown) {
       if (isUserCancelled(e)) {
@@ -2087,6 +2113,20 @@ export default function StewardLoginSection() {
           </Button>
         )}
       </div>
+
+      {showPasskey && (
+        <Button
+          variant="ghost"
+          type="button"
+          onClick={handleExistingPasskey}
+          disabled={isLoading}
+          className="hosted-signin-focus-emphasis flex w-full min-h-touch items-center justify-center rounded-md px-3 py-2 text-sm font-medium text-muted transition-[color,background-color,transform] hover:bg-bg-hover hover:text-txt active:scale-[0.99] disabled:pointer-events-none disabled:text-muted"
+        >
+          {t("cloud.login.button.existingPasskey", {
+            defaultValue: "Use an existing passkey",
+          })}
+        </Button>
+      )}
 
       {!showPasskey &&
       providers.passkey !== false &&

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -1952,6 +1952,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "Magic Link",
+  "cloud.login.button.existingPasskey": "Use an existing passkey",
   "cloud.login.button.passkey": "Passkey",
   "cloud.login.button.sms": "Text me a code",
   "cloud.login.button.telegram": "Telegram",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "Enlace mágico",
+  "cloud.login.button.existingPasskey": "Usar una clave de acceso existente",
   "cloud.login.button.passkey": "Passkey",
   "cloud.login.button.sms": "Envíame un código",
   "cloud.login.callback.cantComplete": "No se pudo completar el inicio de sesión en Eliza Cloud.",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "マジックリンク",
+  "cloud.login.button.existingPasskey": "既存のパスキーを使用",
   "cloud.login.button.passkey": "パスキー",
   "cloud.login.button.sms": "コードをSMSで送信",
   "cloud.login.callback.cantComplete": "Eliza Cloud のサインインを完了できませんでした。",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "매직 링크",
+  "cloud.login.button.existingPasskey": "기존 패스키 사용",
   "cloud.login.button.passkey": "패스키",
   "cloud.login.button.sms": "문자로 코드 받기",
   "cloud.login.callback.cantComplete": "Eliza Cloud 로그인을 완료하지 못했어요.",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "Magic Link",
+  "cloud.login.button.existingPasskey": "Usar uma chave de acesso existente",
   "cloud.login.button.passkey": "Passkey",
   "cloud.login.button.sms": "Envie-me um código",
   "cloud.login.callback.cantComplete": "Não foi possível concluir o login no Eliza Cloud.",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "Magic Link",
+  "cloud.login.button.existingPasskey": "Gumamit ng kasalukuyang passkey",
   "cloud.login.button.passkey": "Passkey",
   "cloud.login.callback.cantComplete": "Hindi natapos ang Eliza Cloud sign-in.",
   "cloud.login.callback.cantRestore": "Hindi nai-restore ang local Steward session",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "Magic Link",
+  "cloud.login.button.existingPasskey": "Dùng passkey hiện có",
   "cloud.login.button.passkey": "Passkey",
   "cloud.login.callback.cantComplete": "Không hoàn tất đăng nhập Eliza Cloud.",
   "cloud.login.callback.cantRestore": "Không khôi phục được phiên Steward cục bộ",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -1690,6 +1690,7 @@
   "cloud.login.button.github": "GitHub",
   "cloud.login.button.google": "Google",
   "cloud.login.button.magicLink": "魔法链接",
+  "cloud.login.button.existingPasskey": "使用现有通行密钥",
   "cloud.login.button.passkey": "通行密钥",
   "cloud.login.button.sms": "发送短信验证码",
   "cloud.login.callback.cantComplete": "无法完成 Eliza Cloud 登录。",


### PR DESCRIPTION
# Relates to

Closes #24841.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was restacked with zero conflicts onto `origin/develop` at `a5e54ea94436e5a99ff2d2d78e2388539f9a5239`.
- [ ] Full `bun run verify` was not rerun. The exact affected unit, UI/app typecheck, i18n, Biome, and diff gates pass below.
- [ ] Inline screenshots, walkthrough video, frontend logs, and OCR evidence are pending; this PR remains draft.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop app`
<!-- attribution-row:skill-revision -->
- Skill revision: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Restacked onto then-current `origin/develop` at publication; zero conflicts.
- [ ] Full repository verify is pending. Exact affected gates are green.

# Risks

Medium: this changes privacy-sensitive passkey routing on the public login surface. The local device hint is advisory only and is never authentication authority. A new browser with a synced passkey defaults to OTP until the user deliberately chooses **Use an existing passkey**. Storage failure/corruption fails to no hint and preserves that explicit recovery path.

# Background

## What does this PR do?

An unhinted typed email now enters the existing six-digit OTP passkey-setup flow before any passkey-options lookup or `navigator.credentials.get`. A passkey ceremony runs automatically only when this origin/device has a bounded local hint written after a prior successful passkey ceremony. Returning users on a new device retain a separate explicit discoverable-credential action.

The bounded hint stores only HMAC-SHA-256 digests under a random device-local key, never plaintext email. This avoids restoring the account/passkey-existence oracle rejected in #24841; the same-origin key and digests are data minimization, not an XSS defense.

## What kind of change is this?

Bug fix and privacy hardening.

# Documentation changes needed?

No product documentation change is required. The user-visible recovery label is localized in all existing locale files.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx`
- `packages/ui/src/cloud/public-pages/pages/login/passkey-device-hints.ts`
- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx`
- `packages/app/test/ui-smoke/passkey-explicit-recovery.spec.ts`

## Detailed testing steps

1. In a clean browser profile, type an email with no device hint and press the primary Passkey action or Enter. Confirm OTP setup appears with zero passkey-options requests and zero `navigator.credentials.get` calls.
2. Confirm a hinted email invokes the scoped passkey ceremony.
3. In a new browser, choose **Use an existing passkey** and confirm a discoverable assertion is attempted without sending OTP or Magic Link automatically.
4. Cancel the chooser and confirm explicit OTP/Magic Link recovery remains visible.
5. Confirm the email input keeps `autocomplete="email"`, not `webauthn`.

Exact publication-head results (`a2fd3cb691748d4140e87a8ce60252087d85bea1`):

- Focused UI Vitest: 28/28 passed across three files.
- `packages/ui` typecheck: passed.
- `packages/app` typecheck: passed.
- Biome on all 14 changed files: passed.
- i18n validation: passed; repository-wide translation-gap warnings remain advisory/baseline.
- `git diff --check origin/develop...HEAD`: passed.
- Playwright: 2/2 passed at 1440x900 and 390x844 on `ddfc0eff85f40a31867a85ffefa5c5a71c262292`. Its stable patch ID (`1ebaf96628226a28b47a574b8c0ec4d7910a4e7b`) exactly matches the publication head. Subsequent restacks changed only the base and had no login-path conflicts; this is not claimed as a publication-base integration run.
- Prior full app audit capture: 226/227. The only failure was the existing, diff-isolated `builtin-settings` `readableChars` state across four viewports; no passkey/login capture failed. OCR was skipped by the aggregate capture gate. No independent untouched-base comparison was run, so this is not claimed as a proven baseline.

# Evidence Gate

<!-- evidence-head:a2fd3cb691748d4140e87a8ce60252087d85bea1 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page desktop and mobile screenshots are pending inline attachment.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page desktop and mobile screenshots were captured by the focused Playwright flow and are pending inline attachment.
<!-- evidence-row:walkthrough-video -->
- [ ] Desktop and mobile walkthrough videos were captured and are pending inline attachment.
<!-- evidence-row:backend-logs -->
- [x] N/A - this PR changes only client routing/local device hints; no backend implementation changes.
<!-- evidence-row:frontend-logs -->
- [ ] Focused browser console/network logs were captured and are pending inline attachment.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, agent, provider, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifacts, database writes, wallet actions, or generated user files.
<!-- evidence-row:ocr-review -->
- [ ] Exact affected screenshots still require inline OCR review; the prior aggregate audit stopped after the unrelated `builtin-settings` capture failure.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Backend: N/A - no backend implementation changes.

Frontend: the focused browser run records response/request-failure events and ceremony counters. Sanitized desktop/mobile logs are pending inline attachment.

## Screenshots (before / after) + video walkthrough

Focused desktop and mobile after-state screenshots and walkthrough videos are captured locally and pending inline PR attachment. Before-state captures and OCR review remain pending, so the PR stays draft.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- Inline before/after screenshots, walkthrough video, frontend logs, and OCR evidence are still pending.
- The 226/227 full audit result is not an independent baseline comparison. The sole failure was outside this diff, but no untouched control run was performed.
- Full `bun run verify` and a publication-head browser run against its newest base are pending; exact affected static/type/unit gates pass, and the browser-tested patch ID is identical.
- No staging deployment or live auth mutation was performed by this PR publication task.
- Production is untouched and remains out of scope without explicit Shadow approval.

## Maintainer CI exception record

N/A - no exception requested.

# Deploy Notes

Staging-only validation after review. No database migration. Production requires separate explicit approval.
