### PR TITLE
fix(recall): owner-private cross-room history via complete paged traversal

### DIFF
--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -7,6 +7,7 @@
  * id becomes a clean handled result, never a raw SQL error in model context.
  */
 import type {
+  AccessContext,
   Action,
   ActionResult,
   HandlerOptions,
@@ -15,10 +16,15 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
+  buildAccessContext,
   MemoryType as CoreMemoryType,
   getRelatedEntityIds,
   logger,
   ModelType,
+  markOwnerExclusiveDisclosureUsed,
+  OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS,
+  recordOwnerExclusiveSuppression,
+  revalidateOwnerExclusiveDisclosure,
   toWellFormedUnicode,
   validateUuid,
 } from "@elizaos/core";
@@ -46,6 +52,8 @@ interface MemoryParams {
   limit?: number;
   memoryId?: string;
   confirm?: boolean;
+  /** search: 1-based caller-selected page of the cross-room history digest. */
+  page?: number;
 }
 
 interface MemoryListItem {
@@ -335,8 +343,447 @@ function describeScanWindow(scan: CandidateScan): string {
   return `${base} ${scan.saturatedTables.join(", ")} filled that window, so older rows were NOT scanned and this is a windowed match count, not a total — widen with type, entityId, roomId, or a higher limit (the window is max(limit*2, 200) rows per table).`;
 }
 
+/**
+ * Enumeration-style history questions ("what have we talked about lately",
+ * "look at the recent logs") are NOT keyword lookups: BM25/keyword scoring
+ * against phrases like "recent logs" matches rows that literally contain
+ * "recent" or "logs" and misses everything the user actually means (live
+ * 2026-08-22: days of history sat in the messages table while op:search
+ * returned only literal matches, so the reply enumerated a fraction of the
+ * week). These patterns request a TIME SLICE, so serve them a chronological
+ * cross-room digest of the last few days.
+ *
+ * The classifier requires a history/conversation context word: bare temporal
+ * adverbs ("lately") fire on unrelated sentences ("the tests have been flaky
+ * lately"), so "lately" only classifies when the query also names talking,
+ * chatting, messages, logs, or history.
+ */
+const RECENT_HISTORY_PATTERNS = [
+  /\b(?:recent|latest)\b.*\b(?:logs?|journals?|chats?|conversations?|messages?|days?|history)\b/i,
+  /\b(?:last|past)\s+(?:few|couple(?:\s+of)?|\d+)?\s*(?:days?|nights?|weeks?)\b/i,
+  /\bwhat\s+(?:have|did)\s+we\s+(?:talk|chat|discuss|cover)\b/i,
+  /\b(?:catch|fill)\s+me\s+up\b/i,
+  /\b(?:this|the)\s+week'?s?\b.*\b(?:conversations?|chats?|topics?|logs?)\b/i,
+];
+const HISTORY_CONTEXT_PATTERN =
+  /\b(?:talk(?:ed|ing)?|chat(?:s|ted|ting)?|discuss(?:ed|ion|ions)?|conversations?|messages?|logs?|history|said|covered|catch(?:ing)?\s+up)\b/i;
+
+function isRecentHistoryQuery(query: string): boolean {
+  if (RECENT_HISTORY_PATTERNS.some((p) => p.test(query))) return true;
+  return /\blately\b/i.test(query) && HISTORY_CONTEXT_PATTERN.test(query);
+}
+
+const HISTORY_DIGEST_DAYS = 7;
+/** Store page size for the internal complete traversal. */
+const HISTORY_TRAVERSAL_PAGE_ROWS = 500;
+/** Traversal budget. Hitting it returns typed-incomplete, never a partial. */
+const HISTORY_TRAVERSAL_MAX_ROWS = 20_000;
+/** Caller-visible digest page size (complete lines per op:search call). */
+const HISTORY_DIGEST_PAGE_LINES = 150;
+/**
+ * Double-persist twins are the same platform message written twice ~250ms
+ * apart. Identical text from the same speaker OUTSIDE this window is a real
+ * repeat (someone genuinely said it again) and must render.
+ */
+const HISTORY_TWIN_WINDOW_MS = 2_000;
+/** Ingestion wrapper: '[Discord #chan | guild] @user (date): text' */
+const CONNECTOR_PREFIX_PATTERN =
+  /^\[[^\]\n]{1,120}\]\s+@\S+\s+\([^)]{1,60}\):\s*/;
+
+type HistoryDigestOutcome =
+  | {
+      status: "rendered";
+      text: string;
+      totalLines: number;
+      renderedLines: number;
+      page: number;
+      pageCount: number;
+      traversedRows: number;
+      roomCount: number;
+    }
+  /** The digest lane does not apply (gate denied or wrong disclosure basis). */
+  | { status: "not_applicable" }
+  /**
+   * The digest applies but could not be produced completely. The caller must
+   * surface this as a typed failure — never fall back to a healthy-looking
+   * keyword result, and never emit a partial digest.
+   */
+  | {
+      status: "unavailable";
+      code:
+        | "MEMORY_HISTORY_DIGEST_INCOMPLETE"
+        | "MEMORY_HISTORY_DIGEST_UNAVAILABLE";
+      detail: string;
+    };
+
+interface HistoryTraversalOutcome {
+  rows?: Memory[];
+  traversedRows?: number;
+  failure?: HistoryDigestOutcome & { status: "unavailable" };
+}
+
+/**
+ * Complete traversal of the interval's authorized rows via advancing
+ * limit/offset pages over `getMemoriesByRoomIds` (store contract: createdAt
+ * DESC). Completeness is guaranteed by construction, not by a cap:
+ * - a short or empty page means the scoped set is exhausted;
+ * - a full page whose oldest row predates the cutoff means every remaining
+ *   row is older than the interval (ordering is verified, below), so the
+ *   interval is fully collected;
+ * - otherwise the offset advances and the next page is read.
+ * Instability is detected instead of silently tolerated: a page that repeats
+ * the previous page, contributes zero unseen rows, violates DESC ordering
+ * internally, or is newer than the previous page boundary means the
+ * underlying set shifted mid-traversal — the traversal returns
+ * typed-incomplete rather than emitting rows it cannot prove complete.
+ */
+async function traverseHistoryRows(
+  runtime: IAgentRuntime,
+  roomIds: UUID[],
+  accessContext: AccessContext,
+  cutoff: number,
+  message: Memory,
+): Promise<HistoryTraversalOutcome> {
+  const seenIds = new Set<string>();
+  const collected: Memory[] = [];
+  let offset = 0;
+  let prevBoundaryOldest = Number.POSITIVE_INFINITY;
+  let prevPageSignature = "";
+
+  while (true) {
+    if (offset >= HISTORY_TRAVERSAL_MAX_ROWS) {
+      return {
+        failure: {
+          status: "unavailable",
+          code: "MEMORY_HISTORY_DIGEST_INCOMPLETE",
+          detail: `the interval spans more than ${HISTORY_TRAVERSAL_MAX_ROWS} stored rows; narrow the time window or use a keyword query`,
+        },
+      };
+    }
+
+    let page: Memory[];
+    try {
+      page = await runtime.getMemoriesByRoomIds({
+        tableName: "messages",
+        roomIds,
+        limit: HISTORY_TRAVERSAL_PAGE_ROWS,
+        offset,
+        accessContext,
+      });
+    } catch (error) {
+      // error-policy: a storage failure must surface as a typed unavailable
+      // outcome, not degrade into a healthy keyword result.
+      runtime.reportError("MemoryAction.recentHistoryDigest.read", error, {
+        roomCount: roomIds.length,
+        offset,
+        roomId: message.roomId,
+        entityId: message.entityId,
+      });
+      return {
+        failure: {
+          status: "unavailable",
+          code: "MEMORY_HISTORY_DIGEST_UNAVAILABLE",
+          detail: "the message store read failed",
+        },
+      };
+    }
+
+    if (page.length === 0) break;
+
+    const signature = page
+      .map((m) => m.id ?? `${m.roomId}:${m.entityId}:${m.createdAt}`)
+      .join("|");
+    let orderedDesc = true;
+    for (let i = 1; i < page.length; i += 1) {
+      if ((page[i]?.createdAt ?? 0) > (page[i - 1]?.createdAt ?? 0)) {
+        orderedDesc = false;
+        break;
+      }
+    }
+    const newestInPage = page.reduce(
+      (max, m) => Math.max(max, m.createdAt ?? 0),
+      0,
+    );
+    let newRows = 0;
+    for (const m of page) {
+      const key = m.id ?? `${m.roomId}:${m.entityId}:${m.createdAt}`;
+      if (!seenIds.has(key)) {
+        seenIds.add(key);
+        newRows += 1;
+      }
+    }
+
+    if (
+      signature === prevPageSignature ||
+      newRows === 0 ||
+      !orderedDesc ||
+      newestInPage > prevBoundaryOldest
+    ) {
+      const reason =
+        signature === prevPageSignature || newRows === 0
+          ? "pagination did not advance (stalled page)"
+          : "page ordering changed mid-traversal";
+      runtime.reportError(
+        "MemoryAction.recentHistoryDigest.traversal",
+        new Error(`history traversal instability: ${reason}`),
+        {
+          roomCount: roomIds.length,
+          offset,
+          roomId: message.roomId,
+          entityId: message.entityId,
+        },
+      );
+      return {
+        failure: {
+          status: "unavailable",
+          code: "MEMORY_HISTORY_DIGEST_INCOMPLETE",
+          detail: `the store returned unstable pages (${reason}); the interval could not be traversed completely`,
+        },
+      };
+    }
+
+    prevPageSignature = signature;
+    const oldestInPage = page.reduce(
+      (min, m) => Math.min(min, m.createdAt ?? 0),
+      Number.POSITIVE_INFINITY,
+    );
+    prevBoundaryOldest = oldestInPage;
+
+    for (const m of page) {
+      const text = (m.content as { text?: string } | undefined)?.text;
+      if (typeof text !== "string" || !text.trim()) continue;
+      if ((m.createdAt ?? 0) < cutoff) continue;
+      collected.push(m);
+    }
+
+    // Ordering is DESC and verified: a full page whose oldest row predates
+    // the cutoff proves every unread row is older than the interval.
+    if (oldestInPage < cutoff) break;
+    if (page.length < HISTORY_TRAVERSAL_PAGE_ROWS) break;
+    offset += page.length;
+  }
+
+  return { rows: collected, traversedRows: seenIds.size };
+}
+
+/**
+ * Chronological digest of the sender's rooms over the last week. Owner-private
+ * gated: this is deliberately cross-room recall, so it renders ONLY when the
+ * live delivery audience is a verified owner-only destination — an owner DM,
+ * private voice room, or authenticated owner api_private room whose entire
+ * 2-member census is exactly {owner, agent}. The gate DENIES every
+ * group/channel kind. On deny the search keeps its room-scoped keyword scan
+ * (with the suppression recorded), so other participants never see
+ * private-room content.
+ *
+ * Output contract (no silent partials):
+ * - Complete row text. No per-line truncation; only the ingestion connector
+ *   wrapper (which duplicates the stamp/speaker the line already carries) is
+ *   stripped.
+ * - Complete traversal of the interval before any rendering; if the interval
+ *   cannot be traversed completely and stably, the outcome is a typed
+ *   incomplete/unavailable result and NO digest text is produced.
+ * - When the digest exceeds one page of lines, paging is explicit and
+ *   caller-selected via the `page` parameter: lines are ordered ascending by
+ *   (createdAt, id) so earlier pages stay stable as new messages arrive, and
+ *   the footer names the exact remaining line count and the next page number.
+ * - Dedupe removes only the double-persist twin (same platform message row
+ *   written twice ~250ms apart): rows sharing a platformMessageId render
+ *   once, and text-keyed dedupe uses the FULL normalized text within a 2s
+ *   window — distinct messages that share a long prefix, and genuine repeats
+ *   minutes apart, all render.
+ */
+async function buildRecentHistoryDigest(
+  runtime: IAgentRuntime,
+  message: Memory,
+  requestedPage: number | undefined,
+): Promise<HistoryDigestOutcome> {
+  let disclosure: Awaited<
+    ReturnType<typeof revalidateOwnerExclusiveDisclosure>
+  >;
+  try {
+    disclosure = await revalidateOwnerExclusiveDisclosure(runtime, message);
+  } catch (error) {
+    // error-policy: a gate evaluation failure is not a deny and not a healthy
+    // keyword search — it is a typed unavailable outcome.
+    runtime.reportError("MemoryAction.recentHistoryDigest.gate", error, {
+      roomId: message.roomId,
+      entityId: message.entityId,
+    });
+    return {
+      status: "unavailable",
+      code: "MEMORY_HISTORY_DIGEST_UNAVAILABLE",
+      detail: "the owner-private disclosure gate could not be evaluated",
+    };
+  }
+  if (
+    !disclosure.allowed ||
+    disclosure.basis !== OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS
+  ) {
+    // Suppression is recorded only on a real deny. An allowed-but-wrong-basis
+    // decision (internal_agent_turn) is not a suppressed owner surface — the
+    // lane simply does not apply to that audience.
+    if (!disclosure.allowed) {
+      recordOwnerExclusiveSuppression(message, disclosure.reason);
+    }
+    return { status: "not_applicable" };
+  }
+
+  const cutoff = Date.now() - HISTORY_DIGEST_DAYS * 24 * 60 * 60 * 1000;
+  let accessContext: AccessContext;
+  let roomIds: UUID[];
+  try {
+    // The access context scopes the store read to what the requester may see;
+    // per the database contract, omitting it disables access-context filtering
+    // entirely, which would leak access-restricted rows into the digest.
+    accessContext = await buildAccessContext(runtime, message);
+    const clusterIds = await getRelatedEntityIds(runtime, message.entityId);
+    const roomIdSets = await Promise.all(
+      clusterIds.map((id) => runtime.getRoomsForParticipant(id)),
+    );
+    roomIds = [...new Set(roomIdSets.flat())];
+  } catch (error) {
+    runtime.reportError("MemoryAction.recentHistoryDigest.scope", error, {
+      roomId: message.roomId,
+      entityId: message.entityId,
+    });
+    return {
+      status: "unavailable",
+      code: "MEMORY_HISTORY_DIGEST_UNAVAILABLE",
+      detail: "the sender's room scope could not be resolved",
+    };
+  }
+
+  const header = (roomCount: number, totalLines: number): string =>
+    `Chronological conversation digest, last ${HISTORY_DIGEST_DAYS} days across ${roomCount} room(s), complete traversal of the interval (${totalLines} line(s) after twin dedupe; owner-private destination verified):`;
+
+  if (roomIds.length === 0) {
+    return {
+      status: "rendered",
+      text: [
+        header(0, 0),
+        `No conversation rooms are associated with this sender, so there are no messages in the last ${HISTORY_DIGEST_DAYS} days.`,
+      ].join("\n"),
+      totalLines: 0,
+      renderedLines: 0,
+      page: 1,
+      pageCount: 1,
+      traversedRows: 0,
+      roomCount: 0,
+    };
+  }
+
+  const traversal = await traverseHistoryRows(
+    runtime,
+    roomIds,
+    accessContext,
+    cutoff,
+    message,
+  );
+  if (traversal.failure) return traversal.failure;
+  const rows = traversal.rows ?? [];
+
+  rows.sort((a, b) => {
+    const at = a.createdAt ?? 0;
+    const bt = b.createdAt ?? 0;
+    if (at !== bt) return at - bt;
+    return (a.id ?? "").localeCompare(b.id ?? "");
+  });
+
+  const agentName = runtime.character.name ?? "Agent";
+  const lastSeenAt = new Map<string, number>();
+  const lines: string[] = [];
+  for (const m of rows) {
+    const raw = ((m.content as { text?: string }).text ?? "").trim();
+    const text = raw.replace(CONNECTOR_PREFIX_PATTERN, "").replace(/\s+/g, " ");
+    const createdAt = m.createdAt ?? 0;
+    const platformMessageId = (
+      m.metadata as { platformMessageId?: string } | undefined
+    )?.platformMessageId;
+    // Twin dedupe on a stable identity when one exists; otherwise on the FULL
+    // normalized text inside a tight window. Never on a sliced prefix —
+    // distinct messages sharing a long prefix must both render.
+    const key = platformMessageId
+      ? `pmid:${m.roomId}:${platformMessageId}`
+      : `txt:${m.roomId}:${m.entityId}:${text}`;
+    const prev = lastSeenAt.get(key);
+    if (
+      prev !== undefined &&
+      (platformMessageId || createdAt - prev <= HISTORY_TWIN_WINDOW_MS)
+    ) {
+      lastSeenAt.set(key, createdAt);
+      continue;
+    }
+    lastSeenAt.set(key, createdAt);
+    const when = new Date(createdAt);
+    const stamp = `${String(when.getUTCMonth() + 1).padStart(2, "0")}/${String(
+      when.getUTCDate(),
+    ).padStart(2, "0")} ${String(when.getUTCHours()).padStart(2, "0")}:${String(
+      when.getUTCMinutes(),
+    ).padStart(2, "0")}Z`;
+    const speaker = m.entityId === runtime.agentId ? agentName : "user";
+    lines.push(`[${stamp}] ${speaker}: ${text}`);
+  }
+
+  const totalLines = lines.length;
+  if (totalLines === 0) {
+    return {
+      status: "rendered",
+      text: [
+        header(roomIds.length, 0),
+        `No messages in the last ${HISTORY_DIGEST_DAYS} days.`,
+      ].join("\n"),
+      totalLines: 0,
+      renderedLines: 0,
+      page: 1,
+      pageCount: 1,
+      traversedRows: traversal.traversedRows ?? 0,
+      roomCount: roomIds.length,
+    };
+  }
+
+  const pageCount = Math.max(
+    1,
+    Math.ceil(totalLines / HISTORY_DIGEST_PAGE_LINES),
+  );
+  const requested = Math.max(1, Math.floor(requestedPage ?? 1));
+  const page = Math.min(requested, pageCount);
+  const start = (page - 1) * HISTORY_DIGEST_PAGE_LINES;
+  const shown = lines.slice(start, start + HISTORY_DIGEST_PAGE_LINES);
+  const end = start + shown.length;
+
+  const notes: string[] = [];
+  if (requested !== page) {
+    notes.push(
+      `Requested page ${requested} exceeds the ${pageCount} available page(s); showing page ${pageCount}.`,
+    );
+  }
+  let footer: string;
+  if (pageCount === 1) {
+    footer = `Digest complete: all ${totalLines} line(s) shown.`;
+  } else if (page < pageCount) {
+    footer = `Digest page ${page} of ${pageCount}: lines ${start + 1}-${end} of ${totalLines}. ${totalLines - end} later line(s) are NOT shown on this page; request op:search with the same query and page:${page + 1} to continue.`;
+  } else {
+    footer = `Digest page ${page} of ${pageCount}: lines ${start + 1}-${end} of ${totalLines}. Earlier lines are on pages 1-${pageCount - 1}.`;
+  }
+
+  return {
+    status: "rendered",
+    text: [header(roomIds.length, totalLines), ...notes, ...shown, footer].join(
+      "\n",
+    ),
+    totalLines,
+    renderedLines: shown.length,
+    page,
+    pageCount,
+    traversedRows: traversal.traversedRows ?? 0,
+    roomCount: roomIds.length,
+  };
+}
+
 async function doSearch(
   runtime: IAgentRuntime,
+  message: Memory,
   params: MemoryParams,
 ): Promise<ActionResult> {
   const type =
@@ -371,6 +818,40 @@ async function doSearch(
   };
   const scan = await collectCandidates(runtime, { ...scope, limit });
 
+  // Enumeration lane: "what have we talked about lately" is a time-slice
+  // request, not a keyword lookup. When the pattern matches AND the delivery
+  // audience is verified owner-private, a complete chronological digest leads
+  // the result. A digest FAILURE is a typed unavailable outcome for the whole
+  // search — the keyword scan alone would silently answer a question it
+  // cannot answer, presenting a broken pipeline as a healthy-but-thin result.
+  let digest: (HistoryDigestOutcome & { status: "rendered" }) | null = null;
+  if (query && isRecentHistoryQuery(query)) {
+    const outcome = await buildRecentHistoryDigest(
+      runtime,
+      message,
+      params.page,
+    );
+    if (outcome.status === "unavailable") {
+      return {
+        success: false,
+        text: `The cross-room history digest for this time-slice query is unavailable: ${outcome.detail}. No partial digest was emitted. Retry, or scope the request to a room with a keyword query.`,
+        data: {
+          actionName: "MEMORY",
+          op: "search" as const,
+          error: outcome.code,
+          detail: outcome.detail,
+        },
+      };
+    }
+    if (outcome.status === "rendered") {
+      // The digest discloses cross-room owner-private content: arm the egress
+      // re-validation / stream-suppression seams keyed on
+      // ownerExclusiveDisclosureWasUsed.
+      markOwnerExclusiveDisclosureUsed(message);
+      digest = outcome;
+    }
+  }
+
   const matchedInWindow = scan.matches.length;
   const items = scan.matches
     .slice(0, limit)
@@ -400,6 +881,9 @@ async function doSearch(
   return {
     success: true,
     text: [
+      // The digest leads: for an enumeration question it IS the answer, and
+      // the keyword matches below it are supporting detail.
+      ...(digest ? [digest.text, ""] : []),
       `${renderNote} (filters: ${describeSearchScope(scope)}).`,
       ...(ignoredIdNotes.length > 0
         ? [`Note: ${ignoredIdNotes.join("; ")}.`]
@@ -420,6 +904,17 @@ async function doSearch(
       matchedInWindow,
       scanWindowPerTable: scan.perTable,
       scanWindowSaturated: scan.saturatedTables.length > 0,
+      historyDigestIncluded: digest !== null,
+      ...(digest
+        ? {
+            historyDigestTotalLines: digest.totalLines,
+            historyDigestRenderedLines: digest.renderedLines,
+            historyDigestPage: digest.page,
+            historyDigestPageCount: digest.pageCount,
+            historyDigestTraversedRows: digest.traversedRows,
+            historyDigestRoomCount: digest.roomCount,
+          }
+        : {}),
     },
     data: {
       actionName: "MEMORY",
@@ -691,7 +1186,7 @@ export const memoryAction: Action = {
         case "create":
           return await doCreate(runtime, message, params);
         case "search":
-          return await doSearch(runtime, params);
+          return await doSearch(runtime, message, params);
         case "update":
           return await doUpdate(runtime, params);
         case "delete":
@@ -771,6 +1266,13 @@ export const memoryAction: Action = {
     {
       name: "limit",
       description: "search: maximum results to return (1-200).",
+      required: false,
+      schema: { type: "number" as const },
+    },
+    {
+      name: "page",
+      description:
+        "search: 1-based page of the cross-room history digest for time-slice queries. Each page renders complete lines; when more remain, the digest footer names the next page to request.",
       required: false,
       schema: { type: "number" as const },
     },

--- a/packages/agent/src/actions/recall-history-digest.test.ts
+++ b/packages/agent/src/actions/recall-history-digest.test.ts
@@ -1,0 +1,921 @@
+/**
+ * MEMORY op:search enumeration lane: "what have we talked about lately" is a
+ * time-slice request, not a keyword lookup, so doSearch leads with a
+ * chronological cross-room digest — but ONLY when the live delivery audience
+ * is a verified owner-private destination (owner DM / voice_private /
+ * api_private with a 2-member {owner, agent} census; every group/channel kind
+ * is denied).
+ *
+ * The digest's output contract is completeness-first and these tests are its
+ * adversarial proof:
+ * - complete traversal via advancing store pages: inputs beyond every former
+ *   cap (>15 rooms, >800 rows, lines >220 chars) render with NO data dropped;
+ * - explicit caller-selected paging: pages partition the digest exactly, and
+ *   the footer names the continuation;
+ * - dedupe removes only the double-persist twin: same-prefix DISTINCT rows
+ *   both render;
+ * - unstable stores (stalled or changing pages) and injected read/gate
+ *   failures produce a TYPED unavailable outcome through reportError — never
+ *   a healthy-looking keyword result and never a partial digest;
+ * - the endorsed security gate carries forward: AccessContext reaches the
+ *   store read, cross-room scoping excludes rooms the sender is not in, the
+ *   egress mark is set on render (not on deny), and suppression is recorded
+ *   only on a real deny (not on the wrong-basis internal_agent_turn case).
+ *
+ * Deterministic: @elizaos/core is partially mocked to drive the disclosure
+ * verdict and observe the mark/suppression calls; the runtime is an in-memory
+ * fake whose getMemoriesByRoomIds honors the store's createdAt-DESC
+ * limit/offset contract.
+ */
+import type {
+  AccessContext,
+  ActionResult,
+  IAgentRuntime,
+  Memory,
+  UUID,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidateOwnerExclusiveDisclosure = vi.fn();
+const markOwnerExclusiveDisclosureUsed = vi.fn();
+const recordOwnerExclusiveSuppression = vi.fn();
+const buildAccessContext = vi.fn();
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
+  return {
+    ...actual,
+    revalidateOwnerExclusiveDisclosure: (
+      ...args: Parameters<typeof actual.revalidateOwnerExclusiveDisclosure>
+    ) => revalidateOwnerExclusiveDisclosure(...args),
+    markOwnerExclusiveDisclosureUsed: (
+      ...args: Parameters<typeof actual.markOwnerExclusiveDisclosureUsed>
+    ) => markOwnerExclusiveDisclosureUsed(...args),
+    recordOwnerExclusiveSuppression: (
+      ...args: Parameters<typeof actual.recordOwnerExclusiveSuppression>
+    ) => recordOwnerExclusiveSuppression(...args),
+    buildAccessContext: (
+      ...args: Parameters<typeof actual.buildAccessContext>
+    ) => buildAccessContext(...args),
+  };
+});
+
+// Imported after the mock so the action binds the mocked seams.
+const { memoryAction } = await import("./memories");
+const { OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS } = await import(
+  "@elizaos/core"
+);
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const OWNER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const STRANGER_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+const DM_ROOM = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const OTHER_ROOM = "00000000-0000-0000-0000-0000000000c2" as UUID;
+const FOREIGN_ROOM = "00000000-0000-0000-0000-0000000000c3" as UUID;
+
+const HOUR = 60 * 60 * 1000;
+const ACCESS_CONTEXT_SENTINEL = {
+  requesterEntityId: OWNER_ID,
+  isOwner: true,
+} as AccessContext;
+
+type SeedMessage = {
+  id?: UUID;
+  roomId: UUID;
+  entityId: UUID;
+  text: string;
+  createdAt: number;
+  platformMessageId?: string;
+};
+
+interface FakeRuntimeOptions {
+  /** Rooms per participant entity. Default: every seeded room, for OWNER. */
+  roomsByEntity?: Map<UUID, UUID[]>;
+  /** Replace the paged store read wholesale (failure/instability injection). */
+  getMemoriesByRoomIds?: (params: {
+    tableName: string;
+    roomIds: UUID[];
+    limit?: number;
+    offset?: number;
+    accessContext?: AccessContext;
+  }) => Promise<Memory[]>;
+}
+
+interface FakeRuntime {
+  runtime: IAgentRuntime;
+  reportError: ReturnType<typeof vi.fn>;
+  roomIdsSeenByStore: () => Set<UUID>;
+  accessContextsSeenByStore: () => (AccessContext | undefined)[];
+}
+
+function seedToMemory(row: SeedMessage): Memory {
+  return {
+    id: (row.id ?? (crypto.randomUUID() as UUID)) as UUID,
+    entityId: row.entityId,
+    agentId: AGENT_ID,
+    roomId: row.roomId,
+    content: { text: row.text },
+    metadata: row.platformMessageId
+      ? { platformMessageId: row.platformMessageId }
+      : undefined,
+    createdAt: row.createdAt,
+  } as Memory;
+}
+
+function makeRuntime(
+  seed: SeedMessage[],
+  options: FakeRuntimeOptions = {},
+): FakeRuntime {
+  const messages = seed.map(seedToMemory);
+  const reportError = vi.fn();
+  const storeRoomIds = new Set<UUID>();
+  const storeAccessContexts: (AccessContext | undefined)[] = [];
+
+  const pagedRead = async (params: {
+    tableName: string;
+    roomIds: UUID[];
+    limit?: number;
+    offset?: number;
+    accessContext?: AccessContext;
+  }): Promise<Memory[]> => {
+    // Store contract: createdAt DESC, LIMIT/OFFSET over the scoped set.
+    const inScope = messages
+      .filter((m) => params.roomIds.includes(m.roomId))
+      .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    const offset = params.offset ?? 0;
+    const sliced = inScope.slice(offset);
+    return params.limit == null ? sliced : sliced.slice(0, params.limit);
+  };
+
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    getSetting: () => undefined,
+    // No relationships service: getRelatedEntityIds degrades to [entityId].
+    getService: () => null,
+    reportError,
+    getRoomsForParticipant: async (entityId: UUID) => {
+      if (options.roomsByEntity) {
+        return options.roomsByEntity.get(entityId) ?? [];
+      }
+      return [...new Set(messages.map((m) => m.roomId))];
+    },
+    getMemoriesByRoomIds: async (params: {
+      tableName: string;
+      roomIds: UUID[];
+      limit?: number;
+      offset?: number;
+      accessContext?: AccessContext;
+    }) => {
+      for (const id of params.roomIds) storeRoomIds.add(id);
+      storeAccessContexts.push(params.accessContext);
+      const read = options.getMemoriesByRoomIds ?? pagedRead;
+      return read(params);
+    },
+    // The keyword scan's windowed per-table read. Only the messages table has
+    // rows here; other tables are empty.
+    getMemories: async (params: {
+      tableName: string;
+      roomId?: UUID;
+      limit?: number;
+    }) => {
+      if (params.tableName !== "messages") return [];
+      const inScope = messages.filter(
+        (m) => !params.roomId || m.roomId === params.roomId,
+      );
+      const limited =
+        params.limit == null ? inScope : inScope.slice(-params.limit);
+      return [...limited].reverse();
+    },
+  } as unknown as IAgentRuntime;
+
+  return {
+    runtime,
+    reportError,
+    roomIdsSeenByStore: () => storeRoomIds,
+    accessContextsSeenByStore: () => storeAccessContexts,
+  };
+}
+
+function makeMessage(text: string): Memory {
+  return {
+    id: crypto.randomUUID() as UUID,
+    entityId: OWNER_ID,
+    agentId: AGENT_ID,
+    roomId: DM_ROOM,
+    content: { text },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+async function runSearch(
+  runtime: IAgentRuntime,
+  message: Memory,
+  query: string,
+  page?: number,
+): Promise<ActionResult> {
+  const result = await memoryAction.handler(runtime, message, undefined, {
+    parameters: { action: "search", query, ...(page ? { page } : {}) },
+  });
+  if (!result) throw new Error("handler returned no result");
+  return result;
+}
+
+function allowOwnerPrivate(): void {
+  revalidateOwnerExclusiveDisclosure.mockResolvedValue({
+    allowed: true,
+    basis: OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS,
+    audience: {},
+  });
+}
+
+function denyMixedRoom(): void {
+  revalidateOwnerExclusiveDisclosure.mockResolvedValue({
+    allowed: false,
+    reason: "destination_not_private",
+    audience: {},
+  });
+}
+
+function recentSeed(): SeedMessage[] {
+  const now = Date.now();
+  return [
+    {
+      roomId: DM_ROOM,
+      entityId: OWNER_ID,
+      text: "the dmarz entropy talk on the roof went late",
+      createdAt: now - 30 * HOUR,
+    },
+    {
+      roomId: OTHER_ROOM,
+      entityId: OWNER_ID,
+      text: "ordered the alexis supplements finally",
+      createdAt: now - 20 * HOUR,
+    },
+    {
+      roomId: DM_ROOM,
+      entityId: AGENT_ID,
+      text: "logged the covenant follow-ups for tomorrow",
+      createdAt: now - 10 * HOUR,
+    },
+  ];
+}
+
+beforeEach(() => {
+  revalidateOwnerExclusiveDisclosure.mockReset();
+  markOwnerExclusiveDisclosureUsed.mockReset();
+  recordOwnerExclusiveSuppression.mockReset();
+  buildAccessContext.mockReset();
+  buildAccessContext.mockResolvedValue(ACCESS_CONTEXT_SENTINEL);
+});
+
+describe("owner-private destination (gate open)", () => {
+  it("leads with a chronological cross-room digest for a time-slice query", async () => {
+    allowOwnerPrivate();
+    const { runtime } = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.values?.historyDigestIncluded).toBe(true);
+    const text = result.text ?? "";
+    expect(text).toContain("owner-private destination verified");
+    // Cross-room: rows from BOTH rooms render.
+    expect(text).toContain("dmarz entropy talk");
+    expect(text).toContain("alexis supplements");
+    expect(text).toContain("covenant follow-ups");
+    // Chronological: oldest first, across rooms.
+    const first = text.indexOf("dmarz entropy talk");
+    const second = text.indexOf("alexis supplements");
+    const third = text.indexOf("covenant follow-ups");
+    expect(first).toBeGreaterThanOrEqual(0);
+    expect(first).toBeLessThan(second);
+    expect(second).toBeLessThan(third);
+    // Speaker labels: the agent's own rows carry the character name.
+    expect(text).toContain("Eliza: logged the covenant follow-ups");
+  });
+
+  it("marks owner-exclusive disclosure as used when the digest renders", async () => {
+    allowOwnerPrivate();
+    const { runtime } = makeRuntime(recentSeed());
+    const message = makeMessage("what have we talked about lately");
+    await runSearch(runtime, message, "what have we talked about lately");
+
+    expect(markOwnerExclusiveDisclosureUsed).toHaveBeenCalledWith(message);
+    expect(recordOwnerExclusiveSuppression).not.toHaveBeenCalled();
+  });
+
+  it("passes the built AccessContext to every store read", async () => {
+    allowOwnerPrivate();
+    const fake = makeRuntime(recentSeed());
+    const message = makeMessage("catch me up");
+    await runSearch(fake.runtime, message, "catch me up");
+
+    expect(buildAccessContext).toHaveBeenCalledWith(fake.runtime, message);
+    const contexts = fake.accessContextsSeenByStore();
+    expect(contexts.length).toBeGreaterThan(0);
+    for (const ctx of contexts) {
+      expect(ctx).toBe(ACCESS_CONTEXT_SENTINEL);
+    }
+  });
+
+  it("drops rows older than the digest window", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const { runtime } = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "ancient message from three weeks ago",
+        createdAt: now - 21 * 24 * HOUR,
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "fresh message from yesterday",
+        createdAt: now - 20 * HOUR,
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("what did we discuss the last few days"),
+      "what did we discuss the last few days",
+    );
+
+    // The keyword lane below the digest may still match the old row; the
+    // WINDOW claim is about the digest section only, so scope the assertion.
+    const text = result.text ?? "";
+    const digestSection = text.slice(0, text.indexOf("Showing"));
+    expect(digestSection).toContain("fresh message from yesterday");
+    expect(digestSection).not.toContain("ancient message");
+  });
+});
+
+describe("completeness beyond every former cap", () => {
+  it("renders every row across >15 rooms with no room dropped", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const roomCount = 20; // former cap: 15 rooms
+    const seed: SeedMessage[] = [];
+    for (let i = 0; i < roomCount; i += 1) {
+      seed.push({
+        roomId:
+          `00000000-0000-0000-0000-${String(1000 + i).padStart(12, "0")}` as UUID,
+        entityId: OWNER_ID,
+        text: `unique marker for room number ${i} zqx${i}zqx`,
+        createdAt: now - (roomCount - i) * HOUR,
+      });
+    }
+    const { runtime } = makeRuntime(seed);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.success).toBe(true);
+    const text = result.text ?? "";
+    for (let i = 0; i < roomCount; i += 1) {
+      expect(text).toContain(`zqx${i}zqx`);
+    }
+    expect(result.values?.historyDigestRoomCount).toBe(roomCount);
+  });
+
+  it("traverses >800 rows completely and partitions them exactly across explicit pages", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const rowCount = 1200; // former cap: 800 fetched rows, 80 rendered lines
+    const seed: SeedMessage[] = [];
+    for (let i = 0; i < rowCount; i += 1) {
+      seed.push({
+        roomId: i % 2 === 0 ? DM_ROOM : OTHER_ROOM,
+        entityId: OWNER_ID,
+        text: `row marker qq${i}qq end`,
+        createdAt: now - 6 * 24 * HOUR + i * 60_000,
+      });
+    }
+    const { runtime } = makeRuntime(seed);
+
+    const firstPage = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+    expect(firstPage.success).toBe(true);
+    expect(firstPage.values?.historyDigestTotalLines).toBe(rowCount);
+    const pageCount = firstPage.values?.historyDigestPageCount as number;
+    expect(pageCount).toBeGreaterThan(1);
+    expect(firstPage.text ?? "").toContain(`page:2 to continue`);
+
+    // Union of all caller-selected pages = every row exactly once.
+    const seen = new Map<number, number>();
+    for (let page = 1; page <= pageCount; page += 1) {
+      const result = await runSearch(
+        runtime,
+        makeMessage("catch me up"),
+        "catch me up",
+        page,
+      );
+      expect(result.success).toBe(true);
+      expect(result.values?.historyDigestPage).toBe(page);
+      const digestText = (result.text ?? "").slice(
+        0,
+        (result.text ?? "").indexOf("Showing"),
+      );
+      for (const match of digestText.matchAll(/qq(\d+)qq/g)) {
+        const idx = Number(match[1]);
+        seen.set(idx, (seen.get(idx) ?? 0) + 1);
+      }
+    }
+    expect(seen.size).toBe(rowCount);
+    for (const [, count] of seen) expect(count).toBe(1);
+  });
+
+  it("renders lines longer than 220 chars with COMPLETE text, no truncation", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const longTail = "TAIL_MARKER_AT_THE_VERY_END_OF_THE_LONG_LINE";
+    const longText = `${"the quick brown fox jumps over the lazy dog ".repeat(12)}${longTail}`;
+    expect(longText.length).toBeGreaterThan(400); // well past the former 220 cap
+    const { runtime } = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: longText,
+        createdAt: now - 5 * HOUR,
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.text ?? "").toContain(longTail);
+  });
+
+  it("clamps an out-of-range requested page instead of dropping data", async () => {
+    allowOwnerPrivate();
+    const { runtime } = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+      99,
+    );
+    expect(result.success).toBe(true);
+    expect(result.values?.historyDigestPage).toBe(1);
+    expect(result.text ?? "").toContain("Requested page 99");
+    expect(result.text ?? "").toContain("dmarz entropy talk");
+  });
+});
+
+describe("dedupe: twins collapse, distinct rows never do", () => {
+  it("renders same-prefix DISTINCT rows (shared 120+ char prefix, different tails) BOTH", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const sharedPrefix =
+      "we walked through the deployment plan for the new gateway cluster and agreed the rollout should start with the canary region before ";
+    expect(sharedPrefix.length).toBeGreaterThan(120);
+    const { runtime } = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: `${sharedPrefix}FIRST_DISTINCT_TAIL`,
+        createdAt: now - 6 * HOUR,
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: `${sharedPrefix}SECOND_DISTINCT_TAIL`,
+        createdAt: now - 6 * HOUR + 250, // inside the twin timing window
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    const text = result.text ?? "";
+    expect(text).toContain("FIRST_DISTINCT_TAIL");
+    expect(text).toContain("SECOND_DISTINCT_TAIL");
+  });
+
+  it("renders double-persisted twin rows (identical text ~250ms apart) once", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const { runtime } = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "twin persisted line about the roof",
+        createdAt: now - 6 * HOUR,
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "twin persisted line about the roof",
+        createdAt: now - 6 * HOUR + 250,
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    const digestText = (result.text ?? "").slice(
+      0,
+      (result.text ?? "").indexOf("Showing"),
+    );
+    const occurrences =
+      digestText.split("twin persisted line about the roof").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("renders twin rows sharing a platformMessageId once", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const { runtime } = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "platform twin body",
+        createdAt: now - 6 * HOUR,
+        platformMessageId: "discord-123",
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "platform twin body",
+        createdAt: now - 6 * HOUR + 250,
+        platformMessageId: "discord-123",
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    const digestText = (result.text ?? "").slice(
+      0,
+      (result.text ?? "").indexOf("Showing"),
+    );
+    expect(digestText.split("platform twin body").length - 1).toBe(1);
+  });
+
+  it("renders a GENUINE repeat (identical text minutes apart) twice", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const { runtime } = makeRuntime([
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "are you there",
+        createdAt: now - 6 * HOUR,
+      },
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "are you there",
+        createdAt: now - 6 * HOUR + 10 * 60_000,
+      },
+    ]);
+    const result = await runSearch(
+      runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    const digestText = (result.text ?? "").slice(
+      0,
+      (result.text ?? "").indexOf("Showing"),
+    );
+    expect(digestText.split("are you there").length - 1).toBe(2);
+  });
+});
+
+describe("unstable stores return typed-incomplete, never a partial", () => {
+  it("detects a stalled (non-advancing) page and reports it", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const stuckPage: SeedMessage[] = [];
+    for (let i = 0; i < 500; i += 1) {
+      stuckPage.push({
+        id: `00000000-0000-0000-0000-${String(2000 + i).padStart(12, "0")}` as UUID,
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: `stalled row ${i}`,
+        createdAt: now - i * 1000,
+      });
+    }
+    const stuckMemories = stuckPage.map(seedToMemory);
+    const fake = makeRuntime(recentSeed(), {
+      // Ignores offset: every read returns the identical full page.
+      getMemoriesByRoomIds: async () => stuckMemories,
+    });
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MEMORY_HISTORY_DIGEST_INCOMPLETE");
+    expect(result.text ?? "").toContain("No partial digest was emitted");
+    expect(result.text ?? "").not.toContain("stalled row");
+    expect(fake.reportError).toHaveBeenCalledWith(
+      "MemoryAction.recentHistoryDigest.traversal",
+      expect.any(Error),
+      expect.objectContaining({ offset: expect.any(Number) }),
+    );
+  });
+
+  it("detects pages that change (newer rows appearing mid-traversal) and reports it", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const makePage = (startId: number, newest: number): Memory[] => {
+      const rows: SeedMessage[] = [];
+      for (let i = 0; i < 500; i += 1) {
+        rows.push({
+          id: `00000000-0000-0000-0000-${String(startId + i).padStart(12, "0")}` as UUID,
+          roomId: DM_ROOM,
+          entityId: OWNER_ID,
+          text: `shifting row ${startId + i}`,
+          createdAt: newest - i * 1000,
+        });
+      }
+      return rows.map(seedToMemory);
+    };
+    let call = 0;
+    const fake = makeRuntime(recentSeed(), {
+      getMemoriesByRoomIds: async () => {
+        call += 1;
+        // Page 2 is NEWER than page 1's oldest boundary: the set shifted.
+        return call === 1
+          ? makePage(300000, now - HOUR)
+          : makePage(400000, now);
+      },
+    });
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MEMORY_HISTORY_DIGEST_INCOMPLETE");
+    expect(result.text ?? "").not.toContain("shifting row");
+    expect(fake.reportError).toHaveBeenCalledWith(
+      "MemoryAction.recentHistoryDigest.traversal",
+      expect.any(Error),
+      expect.anything(),
+    );
+  });
+
+  it("stops an interval wider than the traversal budget with typed-incomplete", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    let nextId = 500000;
+    const fake = makeRuntime(recentSeed(), {
+      // Endless well-formed pages: always full, always advancing, always
+      // inside the window. Budget must end this, not a silent partial.
+      getMemoriesByRoomIds: async (params) => {
+        const offset = params.offset ?? 0;
+        const rows: SeedMessage[] = [];
+        for (let i = 0; i < 500; i += 1) {
+          nextId += 1;
+          rows.push({
+            id: `00000000-0000-0000-0000-${String(nextId).padStart(12, "0")}` as UUID,
+            roomId: DM_ROOM,
+            entityId: OWNER_ID,
+            text: `endless row ${offset + i}`,
+            createdAt: now - offset - i, // ms apart, never crosses the cutoff
+          });
+        }
+        return rows.map(seedToMemory);
+      },
+    });
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MEMORY_HISTORY_DIGEST_INCOMPLETE");
+    expect(result.text ?? "").not.toContain("endless row");
+  });
+});
+
+describe("injected failures surface as typed unavailable through reportError", () => {
+  it("READ failure: getMemoriesByRoomIds throws -> reportError + typed unavailable, no keyword disguise", async () => {
+    allowOwnerPrivate();
+    const fake = makeRuntime(recentSeed(), {
+      getMemoriesByRoomIds: async () => {
+        throw new Error("connection reset by peer");
+      },
+    });
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MEMORY_HISTORY_DIGEST_UNAVAILABLE");
+    expect(fake.reportError).toHaveBeenCalledWith(
+      "MemoryAction.recentHistoryDigest.read",
+      expect.any(Error),
+      expect.anything(),
+    );
+    // NOT a healthy keyword result: no match listing, no scan-window prose.
+    expect(result.text ?? "").not.toContain("match(es)");
+    expect(result.text ?? "").not.toContain("Scanned only");
+    expect(markOwnerExclusiveDisclosureUsed).not.toHaveBeenCalled();
+  });
+
+  it("GATE failure: revalidate throws -> reportError + typed unavailable, no keyword disguise", async () => {
+    revalidateOwnerExclusiveDisclosure.mockRejectedValue(
+      new Error("audience lookup timed out"),
+    );
+    const fake = makeRuntime(recentSeed());
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MEMORY_HISTORY_DIGEST_UNAVAILABLE");
+    expect(fake.reportError).toHaveBeenCalledWith(
+      "MemoryAction.recentHistoryDigest.gate",
+      expect.any(Error),
+      expect.anything(),
+    );
+    expect(result.text ?? "").not.toContain("match(es)");
+    expect(markOwnerExclusiveDisclosureUsed).not.toHaveBeenCalled();
+  });
+
+  it("scope failure: getRoomsForParticipant throws -> reportError + typed unavailable", async () => {
+    allowOwnerPrivate();
+    const seed = recentSeed();
+    const fake = makeRuntime(seed);
+    (
+      fake.runtime as unknown as {
+        getRoomsForParticipant: () => Promise<UUID[]>;
+      }
+    ).getRoomsForParticipant = async () => {
+      throw new Error("rooms table locked");
+    };
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MEMORY_HISTORY_DIGEST_UNAVAILABLE");
+    expect(fake.reportError).toHaveBeenCalledWith(
+      "MemoryAction.recentHistoryDigest.scope",
+      expect.any(Error),
+      expect.anything(),
+    );
+  });
+});
+
+describe("mixed room (gate closed)", () => {
+  it("returns no digest, records suppression, and leaks no cross-room content", async () => {
+    denyMixedRoom();
+    const { runtime } = makeRuntime(recentSeed());
+    const message = makeMessage("what have we talked about lately");
+    const result = await runSearch(
+      runtime,
+      message,
+      "what have we talked about lately",
+    );
+
+    expect(result.success).toBe(true);
+    expect(revalidateOwnerExclusiveDisclosure).toHaveBeenCalled();
+    expect(result.values?.historyDigestIncluded).toBe(false);
+    const text = result.text ?? "";
+    expect(text).not.toContain("owner-private destination verified");
+    expect(text).not.toContain("Chronological conversation digest");
+    // Suppression recorded on the real deny; the egress mark stays unset.
+    expect(recordOwnerExclusiveSuppression).toHaveBeenCalledWith(
+      message,
+      "destination_not_private",
+    );
+    expect(markOwnerExclusiveDisclosureUsed).not.toHaveBeenCalled();
+  });
+
+  it("returns no digest and records NO suppression when allowed on a non-owner-private basis", async () => {
+    // internal_agent_turn is an allowed basis for internal work, but it is
+    // NOT a verified owner-only delivery audience, so the cross-room digest
+    // stays closed. It is also not a suppressed owner surface: the lane just
+    // does not apply, so no suppression note is recorded.
+    revalidateOwnerExclusiveDisclosure.mockResolvedValue({
+      allowed: true,
+      basis: "internal_agent_turn",
+      audience: {},
+    });
+    const { runtime } = makeRuntime(recentSeed());
+    const result = await runSearch(
+      runtime,
+      makeMessage("what have we talked about lately"),
+      "what have we talked about lately",
+    );
+
+    expect(result.values?.historyDigestIncluded).toBe(false);
+    expect(result.text ?? "").not.toContain(
+      "Chronological conversation digest",
+    );
+    expect(recordOwnerExclusiveSuppression).not.toHaveBeenCalled();
+    expect(markOwnerExclusiveDisclosureUsed).not.toHaveBeenCalled();
+  });
+});
+
+describe("room scoping follows the sender's cluster", () => {
+  it("never renders content from a room the sender is not a participant of", async () => {
+    allowOwnerPrivate();
+    const now = Date.now();
+    const seed: SeedMessage[] = [
+      {
+        roomId: DM_ROOM,
+        entityId: OWNER_ID,
+        text: "message in the owner's own dm",
+        createdAt: now - 5 * HOUR,
+      },
+      {
+        roomId: FOREIGN_ROOM,
+        entityId: STRANGER_ID,
+        text: "SECRET foreign-room content the sender must never see",
+        createdAt: now - 4 * HOUR,
+      },
+    ];
+    const fake = makeRuntime(seed, {
+      roomsByEntity: new Map([
+        [OWNER_ID, [DM_ROOM]],
+        [STRANGER_ID, [FOREIGN_ROOM]],
+      ]),
+    });
+    const result = await runSearch(
+      fake.runtime,
+      makeMessage("catch me up"),
+      "catch me up",
+    );
+
+    const digestText = (result.text ?? "").slice(
+      0,
+      (result.text ?? "").indexOf("Showing"),
+    );
+    expect(digestText).toContain("message in the owner's own dm");
+    expect(digestText).not.toContain("SECRET foreign-room content");
+    // The store was never even asked for the foreign room.
+    expect(fake.roomIdsSeenByStore().has(FOREIGN_ROOM)).toBe(false);
+  });
+});
+
+describe("query classification", () => {
+  const enumerationQueries = [
+    "what have we talked about lately",
+    "recent logs",
+    "what did we discuss the last few days",
+    "what have we been chatting about lately",
+    "catch me up",
+  ];
+
+  for (const query of enumerationQueries) {
+    it(`treats "${query}" as a time-slice query`, async () => {
+      allowOwnerPrivate();
+      const { runtime } = makeRuntime(recentSeed());
+      const result = await runSearch(runtime, makeMessage(query), query);
+      // The enumeration lane ran: the owner-private gate was consulted and,
+      // being open, the digest rendered.
+      expect(revalidateOwnerExclusiveDisclosure).toHaveBeenCalled();
+      expect(result.values?.historyDigestIncluded).toBe(true);
+    });
+  }
+
+  const offPatternQueries = [
+    "find the postgres migration",
+    // "lately" without a history/conversation context word is NOT a
+    // time-slice request (the old bare-\blately\b pattern fired on this).
+    "the tests have been flaky lately",
+  ];
+
+  for (const query of offPatternQueries) {
+    it(`does NOT treat "${query}" as a time-slice query`, async () => {
+      allowOwnerPrivate();
+      const { runtime } = makeRuntime(recentSeed());
+      const result = await runSearch(runtime, makeMessage(query), query);
+      // The enumeration lane never ran: no disclosure check, no digest.
+      expect(revalidateOwnerExclusiveDisclosure).not.toHaveBeenCalled();
+      expect(result.values?.historyDigestIncluded).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
Supersedes #24863 (closed; do not reopen). The security-gate direction from that PR carries forward unchanged; the cap-and-sample traversal it wrapped is replaced wholesale with a complete, paged traversal that honors the repo's model-context-completeness and error-surfacing contracts.

## Root cause (unchanged premise)

Enumeration-style history questions ("what have we talked about lately", "look at the recent logs") are time-slice requests, not keyword lookups. BM25/keyword scoring against phrases like "recent logs" matches rows literally containing "recent" or "logs" and misses everything the user means, so the reply enumerates a fraction of the interval. MEMORY op:search now serves these queries a chronological cross-room digest.

## What was wrong with the closed implementation

The prior `buildRecentHistoryDigest` silently capped rooms at 15 and fetched rows at 800, rendered at most 80 lines of 220 chars each, sampled each day dropping the remaining rows, and deduped on a 120-char sliced prefix that collapsed distinct same-prefix messages. Those partials went into model context with no continuation contract and no typed incomplete rejection. Its broad catch also warned and returned the ordinary keyword result, presenting storage/disclosure/parser failures as a healthy-but-thin search.

## The rebuilt traversal contract

**Complete, stable, internally paged store traversal.** `traverseHistoryRows` walks `getMemoriesByRoomIds` (store contract: createdAt DESC) in advancing limit/offset pages until the scoped set is exhausted or a full page's oldest row provably predates the interval cutoff. Completeness holds by construction, not by a cap. Every page is checked for stability: a page that repeats the previous page, contributes zero unseen rows, violates DESC ordering internally, or is newer than the previous page's oldest boundary means the underlying set shifted mid-traversal. Instability is reported via `runtime.reportError` and the search returns a typed `MEMORY_HISTORY_DIGEST_INCOMPLETE` failure. No partial digest text is ever produced. An interval wider than the traversal budget (20k rows) also fails typed rather than truncating.

**Complete row text.** No per-line truncation and no prefix-sliced dedupe key. Only the ingestion connector wrapper (which duplicates the stamp/speaker the digest line already carries) is stripped.

**Twin-only dedupe.** The genuine double-persist twin (same platform message written twice ~250ms apart) is collapsed by stable identity: rows sharing a `platformMessageId` render once; otherwise the key is the full normalized text within a tight 2s timestamp window. Distinct messages sharing a 120+ char prefix both render; a genuine repeat minutes apart renders twice.

**Explicit caller-selected paging of the rendered digest.** When the digest exceeds one page (150 lines), paging is a continuation contract the model drives: lines order ascending by (createdAt, id) so earlier pages stay stable as new messages arrive, the `page` parameter selects the page, and the footer names the exact remaining line count and the next page number. Nothing is dropped between pages; the union of pages is the complete interval (asserted by test).

## Error surfacing

The broad catch-into-keyword-result is gone. Store read failures, gate evaluation failures, and scope-resolution failures each classify through `runtime.reportError` (scopes `MemoryAction.recentHistoryDigest.read` / `.gate` / `.scope` / `.traversal`, matching the `context.runtime.reportError(scope, error, context)` pattern used across the repo) and return a typed unavailable `ActionResult` (`MEMORY_HISTORY_DIGEST_UNAVAILABLE` / `MEMORY_HISTORY_DIGEST_INCOMPLETE`) that states no partial digest was emitted. The keyword lane is reserved for off-pattern queries where the digest genuinely does not apply, never for failures.

## Endorsed security gate (carried forward)

- Gate before fetch: `revalidateOwnerExclusiveDisclosure` is the first act of the digest path, with an exact `basis === OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS` check. The gate denies all group/channel kinds; only an owner DM, voice_private, or authenticated-owner api_private room whose entire 2-member census is exactly {owner, agent} passes.
- `recordOwnerExclusiveSuppression` on real deny only; the allowed-but-wrong-basis case (internal_agent_turn) records nothing and simply does not apply.
- `markOwnerExclusiveDisclosureUsed(message)` when the digest renders, arming the egress re-validation and stream-suppression seams keyed on `ownerExclusiveDisclosureWasUsed`.
- `buildAccessContext(runtime, message)` is passed to every `getMemoriesByRoomIds` read: per the database contract, omitting it disables access-context filtering, which would leak access-restricted rows.
- Room scope is the sender's identity cluster (`getRelatedEntityIds` -> `getRoomsForParticipant`), uncapped.
- The classifier is tightened: bare "lately" no longer fires (it matched "the tests have been flaky lately"); it now requires a history/conversation context word. The unreferenced synced-corpus prefix filter from the old patch is dropped entirely.

## Tests (28, all green)

Adversarial, beyond every former cap:
- 20 rooms (former cap 15): every room's marker renders.
- 1,200 rows (former caps: 800 fetched / 80 rendered): full traversal, and the union of all caller-selected pages equals every row exactly once.
- 400+ char line (former cap 220): tail marker renders untruncated.
- Same-prefix distinct rows (shared 120+ char prefix, different tails, twin-window timing): both render.
- Stalled page, shifting pages, and over-budget interval: typed `MEMORY_HISTORY_DIGEST_INCOMPLETE` with `reportError`, zero digest content leaked into the failure text.
- Injected read failure, injected gate failure, injected scope failure: `reportError` called with the right scope and a typed unavailable outcome; no healthy keyword disguise; egress mark not set.

Security and behavior:
- Owner-private destination: cross-room chronological digest renders, mark set, AccessContext observed on every store read.
- Mixed room deny: no digest, no cross-room leak, suppression recorded, mark not set.
- Wrong basis (internal_agent_turn): no digest, no suppression, no mark.
- Cluster scoping with a per-entity room map: a room the sender is not in never renders and is never even requested from the store.
- Classifier: five enumeration phrasings fire; "find the postgres migration" and "the tests have been flaky lately" do not (gate never consulted).
- Window, twin dedupe (text and platformMessageId), genuine-repeat preservation, out-of-range page clamping.

Typecheck: packages/agent tsc clean for the touched files (the 25 remaining errors are pre-existing missing-optional-package stubs, identical on a clean origin/develop checkout, none in memories.ts or the test).

Attribution: Sol
