### PR TITLE
fix(workflow): match generated user names exactly

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/context.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/context.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies workflow ownership tags against real, generated-default, and
+ * identifier-bearing custom entity names through the runtime lookup seam.
+ */
 import type { IAgentRuntime, UUID } from '@elizaos/core';
 import { describe, expect, it, vi } from 'vitest';
 import { getUserTagName } from '../../src/utils/context';
@@ -43,5 +47,20 @@ describe('getUserTagName', () => {
 
     const tag = await getUserTagName(runtime, userId);
     expect(tag).toBe('User12345678Special_12345678_agent_87654321222233334444555566667777');
+  });
+
+  it('preserves a custom name that contains the complete user ID', async () => {
+    const runtime = {
+      agentId,
+      getEntityById: vi.fn().mockResolvedValue({
+        id: userId,
+        names: [`Customer ${userId}`],
+      }),
+    } as unknown as IAgentRuntime;
+
+    const tag = await getUserTagName(runtime, userId);
+    expect(tag).toBe(
+      'Customer 12345678-1111-2222-3333-444455556666_12345678_agent_87654321222233334444555566667777'
+    );
   });
 });

--- a/plugins/plugin-workflow/src/utils/context.ts
+++ b/plugins/plugin-workflow/src/utils/context.ts
@@ -45,8 +45,8 @@ export async function getUserTagName(runtime: IAgentRuntime, userId: string): Pr
   const shortId = userId.replace(/-/g, '').slice(0, 8);
   const agentScopeId = runtime.agentId.replace(/-/g, '');
   const name = entity?.names?.[0];
-  // ElizaOS default name is "User " + UUID — not useful for a tag
-  const isRealName = name && !name.includes(userId);
+  const isDefaultName = name === `User ${userId}` || name === `User${userId}`;
+  const isRealName = name && !isDefaultName;
   const userTag = isRealName ? `${name}_${shortId}` : `user_${shortId}`;
   return `${userTag}_agent_${agentScopeId}`;
 }


### PR DESCRIPTION
Closes #24963. Post-merge correction for #24931.

The merged implementation replaced one substring heuristic with another: a legitimate custom name containing the complete user UUID was still classified as generated-default and silently replaced. This checks the two known generated shapes by exact equality and adds the missing full-UUID custom-name regression plus the required test responsibility header.

<!-- evidence-head:e1f51075db77103f8f3ab2568d04d3d8fe117d10 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI rendering change; this is a workflow ownership-tag utility.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI rendering change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic runtime lookup/tag output is the relevant contract.

<!-- evidence-row:backend-logs -->
- [x] Exact-head focused transcript:
```text
bunx vitest run plugins/plugin-workflow/__tests__/unit/context.test.ts
1 file passed; 4 tests passed
Biome checked both changed files; git diff --check passed.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt path changed.

<!-- evidence-row:domain-artifacts -->
- [x] Tag contract artifact:
```text
Generated `User <uuid>` and legacy `User<uuid>` names map to the generic scoped user tag.
Custom names containing either the UUID prefix or the complete UUID remain present in the scoped tag.
Agent scoping and the existing short-ID suffix remain byte-compatible.
```

