### PR TITLE
fix(zerollama): use surrogate-safe truncateWellFormed on availability error response details

### DIFF
--- a/plugins/plugin-zerollama/models/availability.ts
+++ b/plugins/plugin-zerollama/models/availability.ts
@@ -2,12 +2,14 @@
  * Ensures a requested Ollama model exists before inference, pulling it once
  * when the daemon reports it missing and surfacing every transport failure.
  */
-import { ElizaError, logger } from "@elizaos/core";
+import { ElizaError, logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 async function responseDetail(response: Response): Promise<string> {
   try {
     const body = (await response.text()).trim();
-    return body.length > 0 ? body.slice(0, 500) : response.statusText;
+    return body.length > 0
+      ? truncateWellFormed(toWellFormedUnicode(body), 500)
+      : response.statusText;
   } catch (error) {
     // error-policy:J4 the HTTP status remains authoritative; preserve an
     // explicit unavailable marker instead of disguising the missing body.


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 500)` string slicing in `availability.ts:10` on daemon HTTP error bodies with `truncateWellFormed(toWellFormedUnicode(body), 500)` from `@elizaos/core`.

## Changes

- In `plugins/plugin-zerollama/models/availability.ts:10`, format daemon error response text without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`7a1bdf1684`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-zerollama/__tests__/availability.shape.test.ts` | 5 pass (5 tests) | 5 pass (5 tests) |
| `bunx @biomejs/biome check plugins/plugin-zerollama/models/availability.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-zerollama/models/availability.ts:2-10`

## Risks

Low. Prevents surrogate corruption in Ollama model availability diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (ZeroLLama plugin provider; no UI bundle touched)
- [x] `audit:browser` — N/A (Ollama client)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `availability.shape.test.ts`
- [x] `lint` — Biome clean
