### PR TITLE
fix(ui): use surrogate-safe truncateWellFormed on cloud and local asr error bodies

### DIFF
--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -12,6 +12,7 @@
  * hook swallows + cleans up state) stays at the call-site.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { getCloudAuthToken } from "../api/client-cloud";
 import { fetchWithCsrf, requestViaAgentTransport } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
@@ -337,7 +338,7 @@ export async function transcribeCloudWav(
         // not mask the HTTP status the error below already carries.
         const body = await res.text().catch(() => "");
         throw new CloudSttError(
-          `Cloud ASR ${res.status}: ${body.slice(0, 200)}`,
+          `Cloud ASR ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
           {
             status: res.status,
             code: readCloudSttErrorCode(body),
@@ -444,7 +445,9 @@ export async function transcribeLocalInferenceWav(
     // error-policy:J6 the error body is diagnostic-only; a failed read must not
     // mask the real signal (the HTTP status the throw below already carries).
     const body = await res.text().catch(() => "");
-    throw new Error(`Local inference ASR ${res.status}: ${body.slice(0, 200)}`);
+    throw new Error(
+      `Local inference ASR ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+    );
   }
   // error-policy:J3 unparseable body falls through to the explicit
   // empty-transcript throw below


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/ui/src/voice/local-asr-transcribe.ts` on `CloudSttError` and local inference ASR error bodies with `truncateWellFormed(toWellFormedUnicode(body), 200)` from `@elizaos/core`.

## Changes

- In `packages/ui/src/voice/local-asr-transcribe.ts:340, 447`, truncate ASR error bodies safely to protect UTF-16 surrogate pairs in error notifications.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`32268daf07`) |
| --- | --- | --- |
| `bunx vitest run packages/ui/src/voice/local-asr-transcribe.test.ts` | 22 pass (22 tests) | 22 pass (22 tests) |
| `bunx @biomejs/biome check packages/ui/src/voice/local-asr-transcribe.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/ui/src/voice/local-asr-transcribe.ts:15`
- `packages/ui/src/voice/local-asr-transcribe.ts:340`
- `packages/ui/src/voice/local-asr-transcribe.ts:447`

## Risks

Low. Prevents Unicode corruption in speech transcription error reporting.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (UI speech transcription helper; no layout changes)
- [x] `audit:browser` — N/A (Audio transcription fetch helper)
- [x] `build` — Clean build across workspace
- [x] `test` — 22/22 pass in `local-asr-transcribe.test.ts`
- [x] `lint` — Biome clean
