### PR TITLE
fix(app-core): use surrogate-safe truncateWellFormed on ios runtime bridge error responses

### DIFF
--- a/packages/app-core/src/platform/ios-runtime-bridge.ts
+++ b/packages/app-core/src/platform/ios-runtime-bridge.ts
@@ -9,6 +9,7 @@
  * is in cloud / cloud-hybrid mode.
  */
 import { Preferences } from "@capacitor/preferences";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { formatError } from "@elizaos/shared";
 import { primeIosFullBunRuntime } from "../api/ios-local-agent-transport";
 import { IOS_FULL_BUN_SMOKE_FAILURE_RE } from "./chat-failure-strings.generated";
@@ -171,7 +172,9 @@ async function fetchIosFullBunSmokeJson<T>(
     throw new Error(`${label} did not return a complete response`);
   }
   if (status < 200 || status >= 300) {
-    throw new Error(`${label} returned HTTP ${status}: ${text.slice(0, 500)}`);
+    throw new Error(
+      `${label} returned HTTP ${status}: ${truncateWellFormed(toWellFormedUnicode(text), 500)}`,
+    );
   }
   try {
     return JSON.parse(text) as T;
@@ -205,7 +208,9 @@ async function fetchIosFullBunSmokeText(
     throw new Error(`${label} did not return a complete response`);
   }
   if (status < 200 || status >= 300) {
-    throw new Error(`${label} returned HTTP ${status}: ${text.slice(0, 500)}`);
+    throw new Error(
+      `${label} returned HTTP ${status}: ${truncateWellFormed(toWellFormedUnicode(text), 500)}`,
+    );
   }
   return text;
 }
@@ -226,7 +231,7 @@ function assertIosFullBunSmokeModelReply(label: string, value: unknown): void {
     IOS_FULL_BUN_SMOKE_FAILURE_RE.test(text)
   ) {
     throw new Error(
-      `full Bun ${label} did not return the expected local model reply: ${text.slice(0, 500)}`,
+      `full Bun ${label} did not return the expected local model reply: ${truncateWellFormed(toWellFormedUnicode(text), 500)}`,
     );
   }
 }
@@ -239,7 +244,9 @@ function parseIosFullBunSmokeHttpJson<T>(label: string, value: unknown): T {
   const status = typeof response.status === "number" ? response.status : 0;
   const body = typeof response.body === "string" ? response.body : "";
   if (status < 200 || status >= 300) {
-    throw new Error(`${label} returned HTTP ${status}: ${body.slice(0, 500)}`);
+    throw new Error(
+      `${label} returned HTTP ${status}: ${truncateWellFormed(toWellFormedUnicode(body), 500)}`,
+    );
   }
   try {
     return JSON.parse(body) as T;


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 500)` string slicing in `packages/app-core/src/platform/ios-runtime-bridge.ts` HTTP error handlers and smoke model assertion checks with `truncateWellFormed(toWellFormedUnicode(...), 500)` from `@elizaos/core`.

## Changes

- In `packages/app-core/src/platform/ios-runtime-bridge.ts:174, 208, 229, 242`, safely truncate error bodies and model replies without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`c472211829`) |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/platform/ios-runtime-bridge.test.ts` | 4 pass (4 tests) | 4 pass (4 tests) |
| `bunx @biomejs/biome check packages/app-core/src/platform/ios-runtime-bridge.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/app-core/src/platform/ios-runtime-bridge.ts:12`
- `packages/app-core/src/platform/ios-runtime-bridge.ts:174`
- `packages/app-core/src/platform/ios-runtime-bridge.ts:208`
- `packages/app-core/src/platform/ios-runtime-bridge.ts:229`
- `packages/app-core/src/platform/ios-runtime-bridge.ts:242`

## Risks

Low. Prevents surrogate corruption in iOS bridge smoke test diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (iOS bridge smoke runner; no UI layout touched)
- [x] `audit:browser` — N/A (iOS local runtime bridge)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 pass in `ios-runtime-bridge.test.ts`
- [x] `lint` — Biome clean
