### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on voice sse bridge error messages

### DIFF
--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -20,6 +20,7 @@
  * decoding path, no live model.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { ELIZA_TRACE_ID_HEADER } from "../observability/http-telemetry";
 import { logger } from "../utils/logger";
@@ -531,9 +532,12 @@ function extractErrorMessage(payload: string): string {
     if (typeof parsed.message === "string" && parsed.message.trim()) return parsed.message;
   } catch (error) {
     // Preserve a bounded raw payload when the canonical route returns malformed JSON.
-    return payload.slice(0, 256) || `unknown agent stream error: ${String(error)}`;
+    return (
+      truncateWellFormed(toWellFormedUnicode(payload), 256) ||
+      `unknown agent stream error: ${String(error)}`
+    );
   }
-  return payload.slice(0, 256) || "unknown agent stream error";
+  return truncateWellFormed(toWellFormedUnicode(payload), 256) || "unknown agent stream error";
 }
 
 function extractPayloadType(payload: string): string | null {


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 256)` string slicing in `packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts:534, 536` on malformed/unparseable SSE payload error strings with `truncateWellFormed(toWellFormedUnicode(payload), 256)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts:534, 536`, safely truncate error payloads without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`a4a04dbc05`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/voice-session/__tests__/eliza-sse-bridge.test.ts` | 31 pass (31 tests) | 31 pass (31 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts:23`
- `packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts:534-536`

## Risks

Low. Prevents Unicode surrogate pair splitting on unparseable SSE error payloads.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared voice bridge; no UI bundle touched)
- [x] `audit:browser` — N/A (Server-side SSE bridge)
- [x] `build` — Clean build across workspace
- [x] `test` — 31/31 pass in `eliza-sse-bridge.test.ts`
- [x] `lint` — Biome clean
