### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on onboarding memory copy error responses

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.surrogate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Focused regression for #24971: memory-copy error body surfaced via the real
+ * exported onboarding path must be bounded, well-formed, and preserve HTTP status.
+ * Covers astral emoji straddling 200 code units and lone-surrogate handling.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realCloudBindings from "../../runtime/cloud-bindings";
+
+const sessionCache = new Map<string, unknown>();
+const getElizaAppProvisioningStatus = mock();
+const readManagedElizaAgentConnection = mock();
+const loggerWarn = mock();
+let cloudEnv: Record<string, string | undefined> = {};
+const REAL_CLOUD_BINDINGS = { ...realCloudBindings };
+
+mock.module("../../cache/client", () => ({
+  CacheClient: class CacheClient {
+    private values = new Map<string, unknown>();
+    isAvailable() { return true; }
+    async get(key: string) { return this.values.get(key) ?? null; }
+    async set(key: string, value: unknown) { this.values.set(key, value); }
+    async expire() {}
+    async del(key: string) { this.values.delete(key); }
+  },
+  cache: {
+    get: mock(async (key: string) => sessionCache.get(key) ?? null),
+    set: mock(async (key: string, value: unknown) => { sessionCache.set(key, value); }),
+  },
+}));
+
+mock.module("../../runtime/cloud-bindings", () => ({
+  ...REAL_CLOUD_BINDINGS,
+  getCloudAwareEnv: mock(() => cloudEnv),
+}));
+
+mock.module("../../utils/logger", () => ({
+  logger: { warn: loggerWarn, debug: mock(), info: mock(), error: mock() },
+}));
+
+mock.module("../eliza-managed-launch", () => ({
+  readManagedElizaAgentConnection,
+}));
+
+mock.module("./provisioning", () => ({
+  getElizaAppProvisioningStatus,
+}));
+
+mock.module("./user-service", () => ({
+  elizaAppUserService: {
+    findOrCreateByPhone: mock(async () => ({ user: { id: "user-1" }, organization: { id: "org-1" }, isNew: false })),
+    linkPhoneToUser: mock(async () => ({ success: true })),
+    linkDiscordToUser: mock(async () => ({ success: true })),
+    linkTelegramToUser: mock(async () => ({ success: true })),
+  },
+}));
+
+const { runOnboardingChat } = await import(`./onboarding-chat.ts?test=onboarding-surrogate-${Date.now()}`);
+
+describe("onboarding-chat memory-copy surrogate-safe preview (#24971)", () => {
+  beforeEach(() => {
+    sessionCache.clear();
+    getElizaAppProvisioningStatus.mockReset();
+    readManagedElizaAgentConnection.mockReset();
+    loggerWarn.mockReset();
+    cloudEnv = {};
+    getElizaAppProvisioningStatus.mockResolvedValue({
+      status: "running",
+      agentId: "agent-1",
+      bridgeUrl: "https://agent-1.example",
+      sandbox: { id: "agent-1", status: "running", bridge_url: "https://agent-1.example" },
+    });
+    readManagedElizaAgentConnection.mockResolvedValue({
+      apiBase: "https://agent-1.example",
+      token: "agent-token",
+    });
+  });
+
+  afterEach(() => {
+    loggerWarn.mockReset();
+  });
+
+  test("surfaces bounded well-formed preview without splitting astral at 200 and preserves 500", async () => {
+    const astral = "🦊";
+    const body = "a".repeat(199) + astral + "b".repeat(50);
+    expect(body.length).toBe(199 + 2 + 50);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      new Response(body, { status: 500, statusText: "Internal Server Error" }),
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await runOnboardingChat({
+        message: "My name is Sam",
+        platform: "blooio",
+        platformUserId: "+14155550123",
+        sessionId: "platform:blooio:+14155550123",
+        trustedPlatformIdentity: true,
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      expect(result.handoffComplete).toBe(false);
+      expect(result.session.handoffCopiedAt).toBeUndefined();
+      const handoffWarn = loggerWarn.mock.calls.find((args: unknown[]) =>
+        String(args[0]).includes("handoff memory copy failed"),
+      ) as unknown[] | undefined;
+      expect(handoffWarn).toBeTruthy();
+      const errorField = (handoffWarn?.[1] as Record<string, unknown>)?.error as string;
+      expect(errorField).toContain("memory copy failed (500)");
+      const preview = errorField.split("memory copy failed (500) ")[1] ?? "";
+      expect(preview.length).toBeLessThanOrEqual(200);
+      expect(preview.includes("\uD800")).toBe(false);
+      expect(preview.includes("\uDC00")).toBe(false);
+      expect(errorField).toMatch(/\(500\)/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("replaces lone surrogate via toWellFormedUnicode before truncation", async () => {
+    const lone = "\uD800";
+    const body = lone + "x".repeat(250);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      ({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        headers: new Headers(),
+        text: async () => body,
+      }) as unknown as Response,
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await runOnboardingChat({
+        message: "My name is Sam",
+        platform: "blooio",
+        platformUserId: "+14155550123",
+        sessionId: "platform:blooio:+14155550123-lone",
+        trustedPlatformIdentity: true,
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      expect(result.handoffComplete).toBe(false);
+      const handoffWarn = loggerWarn.mock.calls.find((args: unknown[]) =>
+        String(args[0]).includes("handoff memory copy failed"),
+      ) as unknown[] | undefined;
+      const errorField = String((handoffWarn?.[1] as Record<string, unknown>)?.error ?? "");
+      expect(errorField.includes("\uD800")).toBe(false);
+      expect(errorField).toContain("�");
+      const preview = errorField.split("memory copy failed (503) ")[1] ?? "";
+      expect(preview.length).toBeLessThanOrEqual(200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("translates body-read failure to [unreadable] without fabricating empty preview", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () =>
+      ({
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: new Headers(),
+        text: async () => { throw new Error("body stream broke"); },
+      }) as unknown as Response,
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await runOnboardingChat({
+        message: "My name is Sam",
+        platform: "blooio",
+        platformUserId: "+14155550123",
+        sessionId: "platform:blooio:+14155550123-readfail",
+        trustedPlatformIdentity: true,
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      expect(result.handoffComplete).toBe(false);
+      const calls = loggerWarn.mock.calls as unknown[][];
+      const readWarn = calls.find((c) => String(c[0]).includes("failed to read remember error body"));
+      expect(readWarn).toBeTruthy();
+      const handoffWarn = calls.find((c) => String(c[0]).includes("handoff memory copy failed"));
+      const errorField = String((handoffWarn?.[1] as Record<string, unknown>)?.error ?? "");
+      expect(errorField).toContain("memory copy failed (502) [unreadable]");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -4,7 +4,7 @@
  * an in-process keyed queue over the cache-backed store.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   RuntimeDurableObjectNamespace,
   RuntimeDurableObjectStub,
@@ -1537,17 +1537,20 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
     );
 
     if (!rememberResponse.ok) {
-      // error-policy:J6 best-effort read of the error body to enrich the error
-      // we throw next; a failed body read must not mask the non-ok status.
-      const body = await rememberResponse.text().catch((error) => {
+      let errorBodyPreview: string;
+      try {
+        const body = await rememberResponse.text();
+        errorBodyPreview = truncateWellFormed(toWellFormedUnicode(body), 200);
+      } catch (error) {
+        // error-policy:J1 translate body-read failure explicitly without fabricating an empty body.
         logger.warn("[eliza-app onboarding] failed to read remember error body", {
           agentId: session.agentId,
           status: rememberResponse.status,
           error: error instanceof Error ? error.message : String(error),
         });
-        return "";
-      });
-      throw new Error(`memory copy failed (${rememberResponse.status}) ${body.slice(0, 200)}`);
+        errorBodyPreview = "[unreadable]";
+      }
+      throw new Error(`memory copy failed (${rememberResponse.status}) ${errorBodyPreview}`);
     }
 
     return {


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts:1550` on rejected memory copy HTTP response bodies with `truncateWellFormed(toWellFormedUnicode(body), 200)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts:1550`, safely format HTTP error bodies to protect UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`dc06cb4456`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts` | 18 pass (18 tests) | 18 pass (18 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts:7`
- `packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts:1550`

## Risks

Low. Prevents surrogate corruption in onboarding memory copy error diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared onboarding service; no UI layout touched)
- [x] `audit:browser` — N/A (Server-side onboarding coordinator)
- [x] `build` — Clean build across workspace
- [x] `test` — 18/18 pass in `onboarding-chat.error-policy.test.ts`
- [x] `lint` — Biome clean
