### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on managed launch onboarding errors

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
@@ -2,6 +2,7 @@
  * Coordinates managed agent launch, credential refresh, provisioning, and
  * onboarding behind Cloud route handlers.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type AgentSandbox,
   CONTAINER_BACKED_EXECUTION_TIERS,
@@ -212,7 +213,7 @@ async function ensureManagedOnboarding(
       return "";
     });
     throw new ManagedElizaLaunchError(
-      `Failed to bootstrap managed onboarding (HTTP ${onboardingResponse.status})${text ? `: ${text.slice(0, 200)}` : ""}`,
+      `Failed to bootstrap managed onboarding (HTTP ${onboardingResponse.status})${text ? `: ${truncateWellFormed(toWellFormedUnicode(text), 200)}` : ""}`,
       502,
     );
   }


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/cloud/shared/src/lib/services/eliza-managed-launch.ts:215` on rejected onboarding bootstrap responses with `truncateWellFormed(toWellFormedUnicode(text), 200)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/services/eliza-managed-launch.ts:215`, safely truncate onboarding error text without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`a48f18ce60`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/eliza-managed-launch-warm-claim.test.ts` | 9 pass (9 tests) | 9 pass (9 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-managed-launch.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/eliza-managed-launch.ts:5`
- `packages/cloud/shared/src/lib/services/eliza-managed-launch.ts:215`

## Risks

Low. Prevents surrogate corruption in managed agent onboarding launch diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared launch service; no UI layout touched)
- [x] `audit:browser` — N/A (Managed agent launcher)
- [x] `build` — Clean build across workspace
- [x] `test` — 9/9 pass in `eliza-managed-launch-warm-claim.test.ts`
- [x] `lint` — Biome clean
