### PR TITLE
fix(shared): correct test module imports

### DIFF
--- a/packages/shared/src/__tests__/restart.test.ts
+++ b/packages/shared/src/__tests__/restart.test.ts
@@ -3,7 +3,7 @@ import {
   RESTART_EXIT_CODE,
   requestRestart,
   setRestartHandler,
-} from "./restart.ts";
+} from "../restart.ts";
 
 describe("restart", () => {
   it("exposes a numeric restart exit code", () => {

--- a/packages/shared/src/utils/__tests__/cloud-status.test.ts
+++ b/packages/shared/src/utils/__tests__/cloud-status.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isCloudStatusAuthenticated,
   isCloudStatusReasonApiKeyOnly,
-} from "./cloud-status.ts";
+} from "../cloud-status.ts";
 
 describe("isCloudStatusReasonApiKeyOnly", () => {
   it("classifies api-key-only reasons", () => {


### PR DESCRIPTION
# Relates to

Closes #24978.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto
      `origin/develop@cbb400ddbcc21117505275557dd4f8505b2ccd1a` with zero
      conflicts.
- [x] `bun install` was already current and `bun run verify` was run after
      sync; its exact unrelated next blocker is recorded below.
- [x] A reviewer can confirm the change from the exact-head test/typecheck log.

# Sync with develop

- [x] Based directly on `origin/develop@cbb400ddbcc21117505275557dd4f8505b2ccd1a`;
      zero conflicts.
- [x] `bun run verify` passes the repaired `@elizaos/shared#typecheck` and
      then stops at the unrelated, already-claimed app-core baseline blocker
      documented below.

# Risks

Low. This changes only two test-module specifiers from the test directories to
their real parent modules. Runtime code, assertions, package configuration, and
production behavior are unchanged.

# Background

## What does this PR do?

- Changes `packages/shared/src/__tests__/restart.test.ts` from
  `./restart.ts` to `../restart.ts`.
- Changes `packages/shared/src/utils/__tests__/cloud-status.test.ts` from
  `./cloud-status.ts` to `../cloud-status.ts`.
- Restores the shared package typecheck broken by merged PRs #24925 and #24930.

## What kind of change is this?

Bug fix for the test/typecheck baseline. No product behavior changes.

# Documentation changes needed?

No. This corrects test-only relative imports.

# Testing

## Where should a reviewer start?

The entire diff is the two import statements.

## Detailed testing steps

```bash
bun run --cwd packages/shared typecheck
bun test   packages/shared/src/__tests__/restart.test.ts   packages/shared/src/utils/__tests__/cloud-status.test.ts
bunx @biomejs/biome check   packages/shared/src/__tests__/restart.test.ts   packages/shared/src/utils/__tests__/cloud-status.test.ts
git diff --check origin/develop...HEAD
bun run verify
```

Exact head: shared typecheck passed; 6/6 focused tests passed; Biome and diff
check passed.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:ad4c1f283e46e48bcac07f36de5d1915e8d7869b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only import correction with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only import correction with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or rendered flow changes.
<!-- evidence-row:backend-logs -->
- [x] [24978-shared-import-baseline-ad4c1f28.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24978-shared-import-baseline-ad4c1f28.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser request changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, model, provider, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, migration, provider, payment, or domain-state changes.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: the exact-head log contains the real shared typecheck and both focused
test suites. Frontend: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - test-only import correction.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` now passes `@elizaos/shared#typecheck`, then exits 1
  at `@elizaos/app-core#typecheck`: the test
  `packages/app-core/src/services/steward-sidecar/__tests__/helpers.test.ts`
  imports `./helpers.ts` although its module is one directory above. That file
  is byte-identical to the validated base, is not touched here, and is already
  claimed by PR #24977.
- The shared typecheck, focused suites, targeted Biome, and diff check all pass
  on this exact head with Bun 1.3.14.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
