### PR TITLE
test(app-core): cover skip-plugins env helpers

### DIFF
--- a/packages/app-core/src/runtime/__tests__/skip-plugins-env.test.ts
+++ b/packages/app-core/src/runtime/__tests__/skip-plugins-env.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mergedRecoverySkipPlugins,
+  restoreOperatorSkipPlugins,
+} from "./skip-plugins-env.ts";
+
+const ORIGINAL = process.env.ELIZA_SKIP_PLUGINS;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) {
+    delete process.env.ELIZA_SKIP_PLUGINS;
+  } else {
+    process.env.ELIZA_SKIP_PLUGINS = ORIGINAL;
+  }
+});
+
+describe("restoreOperatorSkipPlugins", () => {
+  it("restores the operator value", () => {
+    restoreOperatorSkipPlugins("plugin-a,plugin-b");
+    expect(process.env.ELIZA_SKIP_PLUGINS).toBe("plugin-a,plugin-b");
+  });
+
+  it("deletes the env var when the operator value is undefined", () => {
+    process.env.ELIZA_SKIP_PLUGINS = "stale";
+    restoreOperatorSkipPlugins(undefined);
+    expect(process.env.ELIZA_SKIP_PLUGINS).toBeUndefined();
+  });
+});
+
+describe("mergedRecoverySkipPlugins", () => {
+  it("unions operator and recovery lists with dedupe", () => {
+    expect(mergedRecoverySkipPlugins("a, b", ["b", "c"])).toBe("a,b,c");
+  });
+
+  it("handles missing operator list", () => {
+    expect(mergedRecoverySkipPlugins(undefined, ["x"])).toBe("x");
+  });
+
+  it("handles empty inputs", () => {
+    expect(mergedRecoverySkipPlugins("", [])).toBe("");
+    expect(mergedRecoverySkipPlugins(undefined, [])).toBe("");
+  });
+
+  it("trims and drops blank entries", () => {
+    expect(mergedRecoverySkipPlugins(" a , ,b", [])).toBe("a,b");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
