### PR TITLE
fix(calendar): safe NaN handling in time disambiguation sort comparators

### DIFF
--- a/plugins/plugin-calendar/src/internal/time.ts
+++ b/plugins/plugin-calendar/src/internal/time.ts
@@ -130,7 +130,11 @@ export function buildUtcDateFromLocalParts(
     .filter((candidate) =>
       sameZonedParts(getZonedDateParts(candidate, timeZone), parts),
     )
-    .sort((left, right) => left.getTime() - right.getTime());
+    .sort((left, right) => {
+      const leftTime = Number.isFinite(left.getTime()) ? left.getTime() : 0;
+      const rightTime = Number.isFinite(right.getTime()) ? right.getTime() : 0;
+      return leftTime - rightTime;
+    });
   if (exact[0]) {
     // "Compatible" selects the earlier instant when a fall-back repeats time.
     return exact[0];
@@ -143,11 +147,19 @@ export function buildUtcDateFromLocalParts(
         localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) - baseUtcMs,
     }))
     .filter(({ wallDeltaMs }) => wallDeltaMs > 0)
-    .sort(
-      (left, right) =>
-        left.wallDeltaMs - right.wallDeltaMs ||
-        left.candidate.getTime() - right.candidate.getTime(),
-    );
+    .sort((left, right) => {
+      const leftWall = Number.isFinite(left.wallDeltaMs) ? left.wallDeltaMs : 0;
+      const rightWall = Number.isFinite(right.wallDeltaMs)
+        ? right.wallDeltaMs
+        : 0;
+      const leftTime = Number.isFinite(left.candidate.getTime())
+        ? left.candidate.getTime()
+        : 0;
+      const rightTime = Number.isFinite(right.candidate.getTime())
+        ? right.candidate.getTime()
+        : 0;
+      return leftWall - rightWall || leftTime - rightTime;
+    });
   if (shiftedForward[0]) {
     // A nonexistent time advances by the timezone gap. This also handles a
     // jurisdiction that skips an entire local date at the international date


### PR DESCRIPTION
## Summary

Validates timestamps and wall-clock deltas with `Number.isFinite(...)` in `buildUtcDateFromLocalParts` sort comparators to prevent `NaN` return values from violating strict weak ordering during time zone offset disambiguation.

## Changes

- In `plugins/plugin-calendar/src/internal/time.ts:133, 147`, guard timestamp and wall delta comparisons with `Number.isFinite(...)` during candidate sorting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`473c71818b`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-calendar/src/internal/time.test.ts` | 11 pass (11 tests) | 11 pass (11 tests) |
| `bunx @biomejs/biome check plugins/plugin-calendar/src/internal/time.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-calendar/src/internal/time.ts:130-155`

## Risks

Low. Prevents non-deterministic candidate selection during daylight saving time and repeated hour transitions.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Calendar plugin time utility; no UI layout touched)
- [x] `audit:browser` — N/A (Internal time calculation module)
- [x] `build` — Clean build across workspace
- [x] `test` — 11/11 pass in `time.test.ts`
- [x] `lint` — Biome clean
