### PR TITLE
fix(scheduling): safe NaN handling in local time disambiguation sort comparator

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
@@ -179,7 +179,13 @@ export function resolveLocalHHMMToIso(
     const exactCandidates = [...offsets]
       .map((offset) => new Date(wallClockAsUtc - offset * MINUTE_MS))
       .filter((candidate) => sameLocalMinute(candidate, target, timeZone))
-      .sort((left, right) => left.getTime() - right.getTime());
+      .sort((left, right) => {
+        const leftTime = Number.isFinite(left.getTime()) ? left.getTime() : 0;
+        const rightTime = Number.isFinite(right.getTime())
+          ? right.getTime()
+          : 0;
+        return leftTime - rightTime;
+      });
     if (exactCandidates.length > 0) {
       return exactCandidates[0].toISOString();
     }


### PR DESCRIPTION
## Summary

Validates candidate timestamps with `Number.isFinite(...)` in `resolveLocalTimeToIsoUtc` sort comparators to prevent `NaN` return values from violating strict weak ordering during scheduled task time zone disambiguation.

## Changes

- In `plugins/plugin-scheduling/src/scheduled-task/local-time.ts:182`, guard candidate timestamp comparisons with `Number.isFinite(...)` during candidate sorting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`94cb2cafe2`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-scheduling/src/scheduled-task/local-time.test.ts` | 4 pass (4 tests) | 4 pass (4 tests) |
| `bunx @biomejs/biome check plugins/plugin-scheduling/src/scheduled-task/local-time.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-scheduling/src/scheduled-task/local-time.ts:179-186`

## Risks

Low. Prevents non-deterministic instant selection during DST and repeat-hour scheduled tasks.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Scheduling plugin local time utility; no UI layout touched)
- [x] `audit:browser` — N/A (Scheduled task time calculator)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 pass in `local-time.test.ts`
- [x] `lint` — Biome clean
