### PR TITLE
fix(personal-assistant): safe NaN handling in lifeops time disambiguation sort comparators

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -149,7 +149,11 @@ export function buildUtcDateFromLocalParts(
     .filter((candidate) =>
       sameZonedParts(getZonedDateParts(candidate, timeZone), parts),
     )
-    .sort((left, right) => left.getTime() - right.getTime());
+    .sort((left, right) => {
+      const leftTime = Number.isFinite(left.getTime()) ? left.getTime() : 0;
+      const rightTime = Number.isFinite(right.getTime()) ? right.getTime() : 0;
+      return leftTime - rightTime;
+    });
   if (exact[0]) {
     // Compatible disambiguation selects the earlier instant during a repeat.
     return exact[0];
@@ -162,11 +166,19 @@ export function buildUtcDateFromLocalParts(
         localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) - baseUtcMs,
     }))
     .filter(({ wallDeltaMs }) => wallDeltaMs > 0)
-    .sort(
-      (left, right) =>
-        left.wallDeltaMs - right.wallDeltaMs ||
-        left.candidate.getTime() - right.candidate.getTime(),
-    );
+    .sort((left, right) => {
+      const leftWall = Number.isFinite(left.wallDeltaMs) ? left.wallDeltaMs : 0;
+      const rightWall = Number.isFinite(right.wallDeltaMs)
+        ? right.wallDeltaMs
+        : 0;
+      const leftTime = Number.isFinite(left.candidate.getTime())
+        ? left.candidate.getTime()
+        : 0;
+      const rightTime = Number.isFinite(right.candidate.getTime())
+        ? right.candidate.getTime()
+        : 0;
+      return leftWall - rightWall || leftTime - rightTime;
+    });
   if (shiftedForward[0]) {
     // Compatible disambiguation advances a nonexistent wall time by the gap,
     // including jurisdictions that skip an entire local calendar date.


### PR DESCRIPTION
## Summary

Validates timestamps and wall-clock deltas with `Number.isFinite(...)` in `buildUtcDateFromLocalParts` sort comparators to prevent `NaN` return values from violating strict weak ordering during LifeOps time zone offset disambiguation.

## Changes

- In `plugins/plugin-personal-assistant/src/lifeops/time.ts:152, 168`, guard timestamp and wall delta comparisons with `Number.isFinite(...)` during candidate sorting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`fe96854851`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/time.localdate.test.ts` | 5 pass (5 tests) | 5 pass (5 tests) |
| `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/time.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-personal-assistant/src/lifeops/time.ts:148-173`

## Risks

Low. Prevents non-deterministic candidate selection during daylight saving time and repeat-hour LifeOps actions.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Personal assistant plugin time utility; no UI layout touched)
- [x] `audit:browser` — N/A (LifeOps time calculation module)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `time.localdate.test.ts`
- [x] `lint` — Biome clean
