### PR TITLE
fix(health): safe NaN handling in time disambiguation sort comparators

### DIFF
--- a/plugins/plugin-health/src/util/time.ts
+++ b/plugins/plugin-health/src/util/time.ts
@@ -141,7 +141,11 @@ export function buildUtcDateFromLocalParts(
     .filter((candidate) =>
       sameZonedParts(getZonedDateParts(candidate, timeZone), parts),
     )
-    .sort((left, right) => left.getTime() - right.getTime());
+    .sort((left, right) => {
+      const leftTime = Number.isFinite(left.getTime()) ? left.getTime() : 0;
+      const rightTime = Number.isFinite(right.getTime()) ? right.getTime() : 0;
+      return leftTime - rightTime;
+    });
   if (exact[0]) {
     // Compatible disambiguation selects the earlier instant during a repeat.
     return exact[0];
@@ -154,11 +158,19 @@ export function buildUtcDateFromLocalParts(
         localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) - baseUtcMs,
     }))
     .filter(({ wallDeltaMs }) => wallDeltaMs > 0)
-    .sort(
-      (left, right) =>
-        left.wallDeltaMs - right.wallDeltaMs ||
-        left.candidate.getTime() - right.candidate.getTime(),
-    );
+    .sort((left, right) => {
+      const leftWall = Number.isFinite(left.wallDeltaMs) ? left.wallDeltaMs : 0;
+      const rightWall = Number.isFinite(right.wallDeltaMs)
+        ? right.wallDeltaMs
+        : 0;
+      const leftTime = Number.isFinite(left.candidate.getTime())
+        ? left.candidate.getTime()
+        : 0;
+      const rightTime = Number.isFinite(right.candidate.getTime())
+        ? right.candidate.getTime()
+        : 0;
+      return leftWall - rightWall || leftTime - rightTime;
+    });
   if (shiftedForward[0]) {
     // Compatible disambiguation advances a nonexistent wall time by the gap,
     // including jurisdictions that skip an entire local calendar date.


### PR DESCRIPTION
## Summary

Validates timestamps and wall-clock deltas with `Number.isFinite(...)` in `buildUtcDateFromLocalParts` sort comparators to prevent `NaN` return values from violating strict weak ordering during health activity time zone offset disambiguation.

## Changes

- In `plugins/plugin-health/src/util/time.ts:144, 158`, guard timestamp and wall delta comparisons with `Number.isFinite(...)` during candidate sorting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`506ff42bc6`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-health/src/util/time.localdate.test.ts` | 13 pass (13 tests) | 13 pass (13 tests) |
| `bunx @biomejs/biome check plugins/plugin-health/src/util/time.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-health/src/util/time.ts:140-166`

## Risks

Low. Prevents non-deterministic instant selection during daylight saving time and repeated hour transitions in health scheduling.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Health plugin time utility; no UI layout touched)
- [x] `audit:browser` — N/A (Health time calculation module)
- [x] `build` — Clean build across workspace
- [x] `test` — 13/13 pass in `time.localdate.test.ts`
- [x] `lint` — Biome clean
