### PR TITLE
fix(cloud): allow trailing slash for plans CORS

### DIFF
--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -14,6 +14,11 @@ import { secureHeaders } from "hono/secure-headers";
 import { setHttpTelemetryHeaders } from "../observability/http-telemetry";
 import { corsMiddleware, isFirstPartyOrigin, isPublicTokenApiPath } from "./cloud-api-hono-cors";
 
+const SUBSCRIPTION_PLAN_PATHS = [
+  "/api/v1/subscriptions/plans",
+  "/api/v1/subscriptions/plans/",
+] as const;
+
 function appWithCors() {
   const app = new Hono();
   app.use("*", corsMiddleware);
@@ -48,12 +53,18 @@ function appWithOuterTelemetry() {
   return app;
 }
 
-async function req(method: string, origin: string | null, isPreflight = false, path = "/ping") {
+async function req(
+  method: string,
+  origin: string | null,
+  isPreflight = false,
+  path = "/ping",
+  requestedMethod = "POST",
+) {
   const app = appWithCors();
   const headers: Record<string, string> = {};
   if (origin) headers.Origin = origin;
   if (isPreflight) {
-    headers["Access-Control-Request-Method"] = "POST";
+    headers["Access-Control-Request-Method"] = requestedMethod;
     headers["Access-Control-Request-Headers"] = "authorization,x-app-id";
   }
   return app.request(path, { method, headers });
@@ -158,7 +169,10 @@ describe("isPublicTokenApiPath", () => {
   test("recognizes explicit public token API paths", () => {
     expect(isPublicTokenApiPath("/api/v1/chat/completions")).toBe(true);
     expect(isPublicTokenApiPath("/api/auth/pair")).toBe(true);
-    expect(isPublicTokenApiPath("/api/v1/subscriptions/plans")).toBe(true);
+    for (const path of SUBSCRIPTION_PLAN_PATHS) {
+      expect(isPublicTokenApiPath(path)).toBe(true);
+    }
+    expect(isPublicTokenApiPath("/api/v1/subscriptions/plans/private")).toBe(false);
     // Native pairing carries a user/org Cloud bearer and must remain limited
     // to first-party app origins rather than the wildcard token-API policy.
     expect(isPublicTokenApiPath("/api/auth/pair/native")).toBe(false);
@@ -245,27 +259,59 @@ describe("corsMiddleware — Eliza app WebView origin (credentialed SSE)", () =>
 });
 
 describe("corsMiddleware — third-party app origins (open, NO credentials)", () => {
-  test("allows third-party browser reads of the public subscription catalog", async () => {
+  test("allows third-party browser GET/HEAD reads of both public subscription catalog paths", async () => {
+    for (const path of SUBSCRIPTION_PLAN_PATHS) {
+      for (const method of ["GET", "HEAD"]) {
+        const res = await req(method, "https://thirdparty.example.com", false, path);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+      }
+    }
+  });
+
+  test("allows only GET/HEAD preflight for both public subscription catalog paths", async () => {
+    for (const path of SUBSCRIPTION_PLAN_PATHS) {
+      for (const requestedMethod of ["GET", "HEAD"]) {
+        const res = await req(
+          "OPTIONS",
+          "https://thirdparty.example.com",
+          true,
+          path,
+          requestedMethod,
+        );
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+        expect(res.headers.get("access-control-allow-methods")).toBe("GET,HEAD,OPTIONS");
+      }
+    }
+  });
+
+  test("keeps mutable methods off the wildcard policy for both catalog paths", async () => {
+    for (const path of SUBSCRIPTION_PLAN_PATHS) {
+      for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+        const res = await req(method, "https://thirdparty.example.com", false, path);
+        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+
+        const preflight = await req(
+          "OPTIONS",
+          "https://thirdparty.example.com",
+          true,
+          path,
+          method,
+        );
+        expect(preflight.headers.get("access-control-allow-origin")).toBeNull();
+      }
+    }
+  });
+
+  test("keeps private subscription descendants off the wildcard policy", async () => {
     const res = await req(
       "GET",
       "https://thirdparty.example.com",
       false,
-      "/api/v1/subscriptions/plans",
+      "/api/v1/subscriptions/plans/private",
     );
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
-    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
-  });
-
-  test("allows GET preflight for the public subscription catalog", async () => {
-    const res = await req(
-      "OPTIONS",
-      "https://thirdparty.example.com",
-      true,
-      "/api/v1/subscriptions/plans",
-    );
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
-    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
-    expect(res.headers.get("access-control-allow-methods")).toContain("GET");
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
   });
 
   test("allows the origin (wildcard) WITHOUT credentials so the browser permits it", async () => {

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -54,6 +54,10 @@ const PUBLIC_TOKEN_API_PATH_PREFIXES = [
   "/api/v1/voice/",
   "/api/v1/models/",
 ];
+const READ_ONLY_PUBLIC_TOKEN_API_PATHS = new Set<string>([
+  "/api/v1/subscriptions/plans",
+  "/api/v1/subscriptions/plans/",
+]);
 const PUBLIC_TOKEN_API_PATHS = new Set<string>([
   "/api/auth/pair",
   "/api/v1/app-credits",
@@ -64,7 +68,7 @@ const PUBLIC_TOKEN_API_PATHS = new Set<string>([
   "/api/v1/generate-video",
   "/api/v1/models",
   "/api/v1/responses",
-  "/api/v1/subscriptions/plans",
+  ...READ_ONLY_PUBLIC_TOKEN_API_PATHS,
   "/api/v1/voice",
   "/api/v1/voice-models",
   "/api/v1/voice-models/catalog",
@@ -75,6 +79,21 @@ export function isPublicTokenApiPath(pathname: string): boolean {
     PUBLIC_TOKEN_API_PATHS.has(pathname) ||
     PUBLIC_TOKEN_API_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix))
   );
+}
+
+function isReadOnlyPublicTokenCorsRequest(
+  pathname: string,
+  method: string,
+  requestedMethod: string | undefined,
+): boolean {
+  if (!READ_ONLY_PUBLIC_TOKEN_API_PATHS.has(pathname)) return false;
+
+  const normalizedMethod = method.toUpperCase();
+  if (normalizedMethod === "GET" || normalizedMethod === "HEAD") return true;
+  if (normalizedMethod !== "OPTIONS") return false;
+
+  const normalizedRequestedMethod = requestedMethod?.trim().toUpperCase();
+  return normalizedRequestedMethod === "GET" || normalizedRequestedMethod === "HEAD";
 }
 
 // First-party: reflect the specific origin + allow credentials (cookie auth).
@@ -107,6 +126,17 @@ const publicCors = cors({
   maxAge: 86400,
 });
 
+// The subscription plan catalog is public but read-only. Keep its wildcard
+// policy narrower than the general token API so a successful catalog
+// preflight cannot advertise or prime mutable methods in the browser cache.
+const readOnlyPublicCors = cors({
+  origin: "*",
+  credentials: false,
+  allowMethods: ["GET", "HEAD", "OPTIONS"],
+  allowHeaders: [...CORS_ALLOW_HEADER_NAMES],
+  maxAge: 86400,
+});
+
 function appendExposedHeaders(headers: Headers): void {
   const exposed = new Map<string, string>();
   for (const name of (headers.get("Access-Control-Expose-Headers") ?? "").split(",")) {
@@ -124,10 +154,23 @@ export const corsMiddleware: MiddlewareHandler = (c, next) => {
   let selectedCors: MiddlewareHandler;
   if (origin && isFirstPartyOrigin(origin)) {
     selectedCors = firstPartyCors;
-  } else if (!origin || isPublicTokenApiPath(new URL(c.req.url).pathname)) {
+  } else if (!origin) {
     selectedCors = publicCors;
   } else {
-    selectedCors = firstPartyCors;
+    const pathname = new URL(c.req.url).pathname;
+    if (
+      isReadOnlyPublicTokenCorsRequest(
+        pathname,
+        c.req.method,
+        c.req.header("access-control-request-method"),
+      )
+    ) {
+      selectedCors = readOnlyPublicCors;
+    } else if (isPublicTokenApiPath(pathname) && !READ_ONLY_PUBLIC_TOKEN_API_PATHS.has(pathname)) {
+      selectedCors = publicCors;
+    } else {
+      selectedCors = firstPartyCors;
+    }
   }
   return selectedCors(c, async () => {
     await next();


### PR DESCRIPTION
# Relates to

Relates to #23090. This intentionally does not close the operator-gated catalog
acceptance issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on
      `origin/develop@cbb400ddbcc21117505275557dd4f8505b2ccd1a`.
- [x] `bun run verify:cloud` completed on the exact head.
- [ ] Root `bun run verify` remains blocked by the unrelated baseline import
      failures recorded below.
- [x] A reviewer can confirm the CORS boundary from the exact-head test log.

# Sync with develop

- [x] Based directly on `origin/develop@cbb400ddbcc21117505275557dd4f8505b2ccd1a`;
      zero conflicts.
- [x] `bun run verify:cloud` completed 84/84 tasks on the exact head.
- [ ] Root `bun run verify` remains blocked by the baseline imports owned by
      #24977; no green root result is claimed.

# Risks

Low. The change adds the trailing-slash alias and isolates both exact catalog
paths behind a read-only wildcard policy. Third-party GET/HEAD requests and
matching preflights are allowed; mutable methods and private descendants fall
back to non-reflecting first-party CORS. Route authentication and provider
behavior are unchanged.

# Background

## What does this PR do?

- Treats `/api/v1/subscriptions/plans/` exactly like the canonical
  `/api/v1/subscriptions/plans` path for third-party browser CORS.
- Allows only GET/HEAD and matching preflights through the catalog wildcard
  policy; its allow-methods response is limited to `GET,HEAD,OPTIONS`.
- Proves POST/PUT/PATCH/DELETE, their preflights, and the `/private` descendant
  remain outside wildcard CORS on both exact aliases.
- Leaves route authentication and all catalog/provider behavior unchanged.

Hono runs with `strict: false`, so both slash forms already reach the same
public GET route. Before this patch, the trailing-slash response omitted
`Access-Control-Allow-Origin` and was unusable from a third-party browser.

## What kind of change is this?

Bug fix for the public subscription catalog transport boundary.

# Documentation changes needed?

No. This restores parity for an already-public route alias.

# Testing

## Where should a reviewer start?

Start with the exact entry added to `PUBLIC_TOKEN_API_PATHS`, then the
`SUBSCRIPTION_PLAN_PATHS` table in the CORS tests.

## Detailed testing steps

```bash
bun test   packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts   packages/cloud/api/v1/subscriptions/plans/route.test.ts
bun run --cwd packages/cloud/shared typecheck
bunx @biomejs/biome check   packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts   packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
bun run verify:cloud
bun run verify
git diff --check origin/develop...HEAD
```

Exact head: 31/31 focused tests, 151 assertions; cloud-shared typecheck,
package Biome, diff check, and 84/84 Cloud verification tasks passed with Bun
1.3.14.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:e3540389799b706da6deed1ed625e0d09242a2dd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend CORS policy only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend CORS policy only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered or interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] [23090-subscription-plans-cors-e3540389.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23090-subscription-plans-cors-e3540389.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, console behavior, or browser UI changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, model, provider, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, payment, provider, migration, or domain-state changes.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: the exact-head log covers both CORS aliases, read-only and mutable
method boundaries, the private descendant, the real plans route/auth contract,
cloud-shared typecheck/lint, and all 84 Cloud verification tasks. Frontend: N/A
- no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - backend CORS policy only.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` exits 1 at `@elizaos/app-core#typecheck` because
  `packages/app-core/src/services/steward-sidecar/__tests__/helpers.test.ts`
  imports `./helpers.ts` although its module is one directory above. That file
  is byte-identical to the validated base, is not touched here, and is already
  claimed by PR #24977.
- This slice does not provision the four protected Stripe catalog bindings,
  ratify resource ceilings, run a real Stripe preflight, deploy, or claim live
  catalog acceptance. Those #23090 gates remain open.
- All focused tests, Cloud typechecks/lints, diff checks, and `verify:cloud`
  pass on this exact head.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`
