### PR TITLE
fix(core): safe NaN handling in character backup file retention sort comparator

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts
@@ -259,7 +259,15 @@ export class CharacterFileManager extends Service {
 							};
 						}),
 				)
-			).sort((a, b) => b.stat.mtime.getTime() - a.stat.mtime.getTime());
+			).sort((a, b) => {
+				const aTime = Number.isFinite(a.stat.mtime.getTime())
+					? a.stat.mtime.getTime()
+					: 0;
+				const bTime = Number.isFinite(b.stat.mtime.getTime())
+					? b.stat.mtime.getTime()
+					: 0;
+				return bTime - aTime;
+			});
 
 			// Keep only the most recent backups
 			const filesToDelete = backupFiles.slice(this.maxBackups);


### PR DESCRIPTION
## Summary

Validates filesystem modification timestamps with `Number.isFinite(...)` in `CharacterFileManager` (`cleanupOldBackups`) to prevent `NaN` return values in sort comparators when pruning character backup files.

## Changes

- In `packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts:262`, guard `mtime` timestamp subtraction with `Number.isFinite(...)` to ensure strict total ordering during backup retention pruning.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`c5f4a2aa3a`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts` | 12 pass (12 tests) | 12 pass (12 tests) |
| `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/features/advanced-capabilities/personality/services/character-file-manager.ts:259-266`

## Risks

Low. Prevents non-deterministic file sorting and accidental deletion of newer backups.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Core character file manager; no UI layout touched)
- [x] `audit:browser` — N/A (Filesystem backup manager)
- [x] `build` — Clean build across workspace
- [x] `test` — 12/12 pass in `personality-store.test.ts`
- [x] `lint` — Biome clean
