### PR TITLE
test(app-core): cover dev-mac signing gate

### DIFF
--- a/packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts
+++ b/packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../electrobun.config", () => ({
+	default: { app: { identifier: "x" } },
+}));
+vi.mock("./local-adhoc-sign-macos", () => ({ signLocalAppBundle: vi.fn() }));
+vi.mock("./postwrap-diagnostics", () => ({
+	resolveWrapperBundlePath: () => "/tmp/bundle.app",
+}));
+
+import { shouldSignDevMacApp } from "./sign-dev-macos-app.ts";
+
+const DEV_ENV = {
+	ELECTROBUN_BUILD_ENV: "dev",
+	ELECTROBUN_OS: "macos",
+	ELECTROBUN_SKIP_CODESIGN: "1",
+};
+
+describe("shouldSignDevMacApp", () => {
+	it("signs only on darwin with dev/macos/skip-codesign env", () => {
+		expect(shouldSignDevMacApp(DEV_ENV, "darwin")).toBe(true);
+	});
+
+	it("refuses on non-darwin hosts", () => {
+		expect(shouldSignDevMacApp(DEV_ENV, "linux")).toBe(false);
+		expect(shouldSignDevMacApp(DEV_ENV, "win32")).toBe(false);
+	});
+
+	it("refuses when env flags are missing", () => {
+		expect(shouldSignDevMacApp({}, "darwin")).toBe(false);
+		expect(
+			shouldSignDevMacApp(
+				{ ...DEV_ENV, ELECTROBUN_BUILD_ENV: "prod" },
+				"darwin",
+			),
+		).toBe(false);
+		expect(
+			shouldSignDevMacApp({ ...DEV_ENV, ELECTROBUN_OS: "ios" }, "darwin"),
+		).toBe(false);
+		expect(
+			shouldSignDevMacApp(
+				{ ...DEV_ENV, ELECTROBUN_SKIP_CODESIGN: "0" },
+				"darwin",
+			),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
