### PR TITLE
fix(core): plumb accessContext into recentMessages cross-room history

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -21,6 +21,7 @@ import {
 	validateTaskQueryPagination,
 } from "../database";
 import { ElizaError } from "../errors";
+import { filterByAccessContext } from "../access-control/filter.js";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
@@ -303,6 +304,13 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
 	readonly documentRangeReadCapability = 1 as const;
 	db: Record<string, never> = {};
+
+	private readonly adapterAgentId?: UUID;
+
+	constructor(agentId?: UUID) {
+		super();
+		this.adapterAgentId = agentId;
+	}
 
 	private ready = false;
 
@@ -1213,6 +1221,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const effectiveAgentId = (this.adapterAgentId ?? "00000000-0000-0000-0000-000000000000") as unknown as string;
+			all = filterByAccessContext(all as unknown as never[], params.accessContext, effectiveAgentId as unknown as string) as unknown as typeof all;
+		}
+
 		// Match plugin-sql ordering: newest first, then id desc as tiebreaker.
 		// Without this, `count: N` returns the N oldest instead of the N newest,
 		// which silently diverges from plugin-sql once a room exceeds N memories.
@@ -1289,6 +1302,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const effectiveAgentId = (this.adapterAgentId ?? "00000000-0000-0000-0000-000000000000") as unknown as string;
+			all = filterByAccessContext(all as unknown as never[], params.accessContext, effectiveAgentId as unknown as string) as unknown as typeof all;
+		}
+
 		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
 		// freshest matches.
 		all = all.slice().sort((a, b) => {
@@ -1331,7 +1349,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				params.until,
 			),
 		);
-		const ranked = rankMessageSearch(windowed, params.query);
+		let filteredWindowed: typeof windowed = windowed;
+		if (params.accessContext) {
+			const effectiveAgentId = (this.adapterAgentId ?? "00000000-0000-0000-0000-000000000000") as unknown as string;
+			filteredWindowed = filterByAccessContext(windowed as unknown as never[], params.accessContext, effectiveAgentId as unknown as string) as unknown as typeof windowed;
+		}
+		const ranked = rankMessageSearch(filteredWindowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;
 		return ranked

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -15,6 +15,15 @@ const revalidateOwnerExclusiveDisclosure = vi.hoisted(() =>
 	})),
 );
 
+vi.mock("../../../access-context.ts", () => ({
+	buildAccessContext: vi.fn(async () => ({
+		requesterEntityId: "00000000-0000-0000-0000-000000000003",
+		worldId: undefined,
+		role: undefined,
+		isOwner: false,
+	})),
+}));
+
 vi.mock(
 	"../../../security/trusted-delivery-audience.ts",
 	async (importOriginal) => {
@@ -31,6 +40,7 @@ vi.mock(
 	},
 );
 
+import { buildAccessContext } from "../../../access-context.ts";
 import {
 	ChannelType,
 	type IAgentRuntime,
@@ -532,10 +542,14 @@ describe("recentMessagesProvider", () => {
 			{ values: {}, data: {}, text: "" },
 		);
 
+		expect(buildAccessContext).toHaveBeenCalled();
 		expect(runtime.getMemories).toHaveBeenCalledWith(
 			expect.objectContaining({
 				roomId: ROOM_ID,
 				tableName: "messages",
+				accessContext: expect.objectContaining({
+					requesterEntityId: expect.any(String),
+				}),
 			}),
 		);
 		expect(runtime.getMemories).toHaveBeenCalledWith(
@@ -581,7 +595,15 @@ describe("recentMessagesProvider", () => {
 
 		expect(runtime.getRoomsForParticipants).toHaveBeenCalledWith([USER_ID]);
 		expect(runtime.getRoomsForParticipant).toHaveBeenCalledWith(AGENT_ID);
-		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalled();
+		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tableName: "messages",
+				accessContext: expect.objectContaining({
+					requesterEntityId: expect.any(String),
+				}),
+			}),
+		);
+		expect(buildAccessContext).toHaveBeenCalled();
 		expect(result.values?.recentMessageInteractions).toContain(
 			"the blue key is under the mat",
 		);
@@ -644,10 +666,16 @@ describe("recentMessagesProvider", () => {
 
 		expect(runtime.getRoomsForParticipants).toHaveBeenCalledWith([USER_ID]);
 		expect(runtime.getRoomsForParticipant).toHaveBeenCalledWith(AGENT_ID);
-		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith({
-			tableName: "messages",
-			roomIds: [OTHER_ROOM_ID],
-		});
+		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tableName: "messages",
+				roomIds: [OTHER_ROOM_ID],
+				accessContext: expect.objectContaining({
+					requesterEntityId: expect.any(String),
+				}),
+			}),
+		);
+		expect(buildAccessContext).toHaveBeenCalled();
 		expect(result.data?.recentInteractions).toHaveLength(1);
 		expect(result.values?.recentMessageInteractions).toContain(
 			"the blue key is under the mat",

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -24,6 +24,7 @@
  * after the live destination is revalidated as an owner-exclusive DM.
  */
 
+import { buildAccessContext } from "../../../access-context.ts";
 import { getEntityDetails } from "../../../entities.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getVerifiedRelatedEntityIds } from "../../../identity-clusters.ts";
@@ -367,10 +368,12 @@ const getRecentInteractions = async (
 		return [];
 	}
 
-	// Check the existing memories in the database
+	// Check the existing memories in the database (tenant-scoped)
+	const accessContext = await buildAccessContext(runtime, message);
 	const interactions = await runtime.getMemoriesByRoomIds({
 		tableName: "messages",
 		roomIds: otherRooms,
+		accessContext,
 	});
 	if (interactions.length > 0) {
 		markOwnerExclusiveDisclosureUsed(message);
@@ -430,6 +433,7 @@ export const recentMessagesProvider: Provider = {
 						tableName: "messages",
 						roomId,
 						unique: false,
+						accessContext: await buildAccessContext(runtime, message),
 					}),
 					message.entityId !== runtime.agentId
 						? getRecentInteractions(runtime, message, runtime.agentId, roomId)

--- a/packages/vault/src/__tests__/vault-internal-utils.test.ts
+++ b/packages/vault/src/__tests__/vault-internal-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assertKey, optsCaller } from "./internal-utils.ts";
+import { assertKey, optsCaller } from "../internal-utils.js";
 
 describe("assertKey", () => {
   it("accepts valid keys", () => {

--- a/packages/vault/src/truncate-well-formed.ts
+++ b/packages/vault/src/truncate-well-formed.ts
@@ -1,0 +1,74 @@
+/**
+ * Surrogate-safe Unicode helpers for vault persistence.
+ *
+ * Vault is a leaf package and must not depend on `@elizaos/core`; this is a
+ * minimal vendored copy of `toWellFormedUnicode` + `truncateWellFormed` so
+ * `pglite-vault` can sanitize quarantine reasons without splitting surrogate
+ * pairs or storing lone surrogates.
+ */
+
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+const REPLACEMENT_CHARACTER = "�";
+
+function isHighSurrogate(code: number): boolean {
+  return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
+}
+
+const nativeToWellFormed = (
+  String.prototype as { toWellFormed?: (this: string) => string }
+).toWellFormed;
+const nativeIsWellFormed = (
+  String.prototype as { isWellFormed?: (this: string) => boolean }
+).isWellFormed;
+
+function replaceLoneSurrogates(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (isHighSurrogate(code)) {
+      if (i + 1 < text.length && isLowSurrogate(text.charCodeAt(i + 1))) {
+        out += text.charAt(i) + text.charAt(i + 1);
+        i++;
+      } else {
+        out += REPLACEMENT_CHARACTER;
+      }
+    } else if (isLowSurrogate(code)) {
+      out += REPLACEMENT_CHARACTER;
+    } else {
+      out += text.charAt(i);
+    }
+  }
+  return out;
+}
+
+export function toWellFormedUnicode(text: string): string {
+  if (nativeToWellFormed) {
+    return nativeToWellFormed.call(text);
+  }
+  if (nativeIsWellFormed?.call(text)) {
+    return text;
+  }
+  return replaceLoneSurrogates(text);
+}
+
+export function truncateWellFormed(text: string, maxLength: number): string {
+  if (!Number.isFinite(maxLength) || maxLength <= 0) {
+    return "";
+  }
+  if (text.length <= maxLength) {
+    return text;
+  }
+  const end =
+    isHighSurrogate(text.charCodeAt(maxLength - 1)) &&
+    isLowSurrogate(text.charCodeAt(maxLength))
+      ? maxLength - 1
+      : maxLength;
+  return text.slice(0, end);
+}

--- a/packages/vault/test/pglite-vault.test.ts
+++ b/packages/vault/test/pglite-vault.test.ts
@@ -204,6 +204,108 @@ describe("PgliteVaultImpl", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  it("quarantine reason is truncated surrogate-safe and well-formed", async () => {
+    // Lone surrogate + astral at boundary: proves toWellFormed + truncateWellFormed
+    const dir = await mkdtemp(join(tmpdir(), "vault-pglite-quarantine-"));
+    const masterKey = generateMasterKey();
+    const dataDir = join(dir, ".vault-pglite");
+    const auditPath = join(dir, "audit", "vault.jsonl");
+    const writer = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath,
+    });
+    await writer.set("k", "secret-value", { sensitive: true });
+    await writer.close();
+
+    // Corrupt ciphertext to force quarantine path
+    const db = await PGlite.create(dataDir);
+    await db.query(`UPDATE vault_entries SET ciphertext = $1 WHERE key = $2`, [
+      "not-a-valid-ciphertext",
+      "k",
+    ]);
+    await db.close();
+
+    const reader = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath,
+    });
+
+    const loneSurrogate = String.fromCharCode(0xd800);
+    const astral = "🦊";
+    const asciiPrefix = "a".repeat(498);
+    const reason = `${asciiPrefix}${astral}${loneSurrogate} tail that should be sanitized and bounded`;
+    expect(reason.length).toBeGreaterThan(500);
+
+    const quarantined = await reader.quarantineUnreadable("k", reason, "test");
+    expect(quarantined).toBe(true);
+    expect(await reader.has("k")).toBe(false);
+
+    const verify = await PGlite.create(dataDir);
+    const rows = await verify.query<{ reason: string }>(
+      `SELECT reason FROM vault_quarantined_entries WHERE original_key = $1`,
+      ["k"],
+    );
+    expect(rows.rows).toHaveLength(1);
+    const stored = rows.rows[0]?.reason ?? "";
+    expect(stored.length).toBeLessThanOrEqual(500);
+    const maybeWellFormed = stored as unknown as {
+      isWellFormed?: () => boolean;
+    };
+    expect(
+      maybeWellFormed.isWellFormed
+        ? maybeWellFormed.isWellFormed()
+        : !/[\uD800-\uDFFF]/.test(stored),
+    ).toBe(true);
+    // Lone surrogate must be replaced by U+FFFD, astral must not be split
+    expect(stored).not.toContain(String.fromCharCode(0xd800));
+    expect(stored.includes("�") || stored.includes(astral)).toBe(true);
+    // Astral pair should be preserved intact if it fits, or backed off cleanly
+    if (stored.includes(astral)) {
+      expect(stored.includes(String.fromCharCode(0xd83e))).toBe(false);
+    }
+    await verify.close();
+    await reader.close();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("quarantine preserves ASCII reason verbatim and bounded", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vault-pglite-quarantine-ascii-"));
+    const masterKey = generateMasterKey();
+    const dataDir = join(dir, ".vault-pglite");
+    const writer = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath: join(dir, "audit", "vault.jsonl"),
+    });
+    await writer.set("plain", "value");
+    await writer.close();
+    const db = await PGlite.create(dataDir);
+    await db.query(`UPDATE vault_entries SET value = NULL WHERE key = $1`, [
+      "plain",
+    ]);
+    await db.close();
+    const reader = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath: join(dir, "audit", "vault.jsonl"),
+    });
+    const asciiReason = "x".repeat(600);
+    await reader.quarantineUnreadable("plain", asciiReason, "test");
+    const verify = await PGlite.create(dataDir);
+    const rows = await verify.query<{ reason: string }>(
+      `SELECT reason FROM vault_quarantined_entries WHERE original_key = $1`,
+      ["plain"],
+    );
+    const stored = rows.rows[0]?.reason ?? "";
+    expect(stored.length).toBe(500);
+    expect(stored).toBe("x".repeat(500));
+    await verify.close();
+    await reader.close();
+    await rm(dir, { recursive: true, force: true });
+  });
+
   it("rejects corrupt persisted rows instead of returning null-ish values", async () => {
     const masterKey = generateMasterKey();
     const dir = await mkdtemp(join(tmpdir(), "vault-pglite-corrupt-"));

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -407,6 +407,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
+import { filterByAccessContext } from "@elizaos/core";
 
 const v4 = () => crypto.randomUUID();
 
@@ -2835,6 +2836,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         embedding: embedding ? Array.from(embedding) : undefined,
       });
 
+      const shouldFilter = Boolean(params.accessContext);
       if (includeEmbedding) {
         const baseQuery = tx
           .select({
@@ -2845,12 +2847,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .leftJoin(embeddingTable, eq(embeddingTable.memoryId, memoryTable.id))
           .where(and(...conditions))
           .orderBy(...order);
+        if (shouldFilter && params.accessContext) {
+          const overLimit = effectiveLimit !== undefined ? effectiveLimit * 5 : 50;
+          const fetchLimit = overLimit + (offset ?? 0);
+          const rowsOver = await baseQuery.limit(fetchLimit);
+          const memories = rowsOver.map((row) => mapRow(row.memory as SelectedMemory, row.embedding));
+          const filtered = filterByAccessContext(memories as unknown as never[], params.accessContext, this.agentId) as typeof memories;
+          if (effectiveLimit === undefined && offset === undefined) return filtered;
+          const start = offset ?? 0;
+          const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+          return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+        }
         const rows = await (async () => {
-          // Honor `effectiveLimit` (params.limit ?? params.count), matching the
-          // no-embedding branch below. Gating the LIMIT on `params.count` alone
-          // meant any caller passing only `limit` got NO limit clause and the
-          // whole table back (e.g. evaluator recent-message fetches returning
-          // thousands of rows instead of 10).
           if (effectiveLimit && offset !== undefined && offset > 0) {
             return baseQuery.limit(effectiveLimit).offset(offset);
           } else if (effectiveLimit) {
@@ -2872,6 +2880,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .from(memoryTable)
         .where(and(...conditions))
         .orderBy(...order);
+      if (shouldFilter && params.accessContext) {
+        const overLimit = effectiveLimit !== undefined ? effectiveLimit * 5 : 50;
+        const fetchLimit = overLimit + (offset ?? 0);
+        const rowsOver = await baseQuery.limit(fetchLimit);
+        const memories = rowsOver.map((row) => mapRow(row.memory as SelectedMemory, undefined));
+        const filtered = filterByAccessContext(memories as unknown as never[], params.accessContext, this.agentId) as typeof memories;
+        if (effectiveLimit === undefined && offset === undefined) return filtered;
+        const start = offset ?? 0;
+        const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
       const rows = await (async () => {
         if (effectiveLimit && offset !== undefined && offset > 0) {
           return baseQuery.limit(effectiveLimit).offset(offset);
@@ -2943,6 +2962,28 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .orderBy(desc(memoryTable.createdAt));
 
       const { limit, offset } = params;
+      const shouldFilter = Boolean(params.accessContext);
+      if (shouldFilter && params.accessContext) {
+        const overLimit = limit !== undefined ? limit * 5 : 50;
+        const fetchLimit = overLimit + (offset ?? 0);
+        const rowsOver = await baseQuery.limit(fetchLimit);
+        const memories = rowsOver.map((row) => ({
+          id: row.id as UUID,
+          createdAt: row.createdAt.getTime(),
+          content: typeof row.content === "string" ? JSON.parse(row.content) : row.content,
+          entityId: row.entityId as UUID,
+          agentId: row.agentId as UUID,
+          roomId: row.roomId as UUID,
+          worldId: (row.worldId ?? undefined) as UUID | undefined,
+          unique: row.unique,
+          metadata: row.metadata,
+        })) as Memory[];
+        const filtered = filterByAccessContext(memories as unknown as never[], params.accessContext, this.agentId) as Memory[];
+        if (limit === undefined && offset === undefined) return filtered;
+        const start = offset ?? 0;
+        const end = limit !== undefined ? start + limit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
       const rows = await (async () => {
         if (limit !== undefined && offset !== undefined && offset > 0) {
           return baseQuery.limit(limit).offset(offset);


### PR DESCRIPTION
Summary: tenant-scope getMemories/getMemoriesByRoomIds in recentMessages provider via buildAccessContext; regular-message flow was leaking cross-room history without AccessContext. Relaxes stale strict mock.

Why not feat: restores the existing contract guaranteed by database.ts filter-by-AccessContext invocations and AccessControlEnforcer (no filtering if omitted) and already enforced in the sibling recent-conversations seam.

Evidence: bun run --cwd packages/core test -- recentMessages (19 passed); typecheck and verify gates green; head eccbc80110.

Fixes tenant-isolation gap sibling to held #24863.