### PR TITLE
fix(agent): plumb accessContext into inbox cross-room aggregator

### DIFF
--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -41,6 +41,7 @@
 
 import type http from "node:http";
 import type {
+  AccessContext,
   AgentRuntime,
   ConnectorAccount,
   ConnectorAccountManager,
@@ -52,6 +53,7 @@ import type {
   World,
 } from "@elizaos/core";
 import {
+  buildAccessContext,
   createUniqueUuid,
   getConnectorAccountManager,
   requireConfirmedSendHandlerDelivery,
@@ -59,8 +61,10 @@ import {
   roleRank,
   setRoomMuteUntil,
   setWorldMuteState,
+  stringToUuid,
   toWellFormedUnicode,
   truncateWellFormed,
+  validateUuid,
 } from "@elizaos/core";
 import type { DiscordService as IDiscordService } from "@elizaos/plugin-discord/service";
 import {
@@ -180,6 +184,68 @@ export interface InboxRouteCallerAuthorization {
   role: RoleGateRole;
   identityId?: string;
   principal?: string;
+}
+
+/**
+ * Build a tenant-scoped AccessContext for inbox cross-room reads.
+ *
+ * The inbox aggregator fans out across every agent room (up to
+ * MAX_ROOMS_SCANNED) and merges via getMemoriesByRoomIds. Without a
+ * scoped context that fan-out would leak another tenant's rooms when
+ * a hosted deployment serves multiple principals through one runtime.
+ * See database.ts no-filter invariant + held #24863 and the
+ * relevant-conversations.ts precedent (buildAccessContext -> accessContext
+ * -> getMemories/searchMemories).
+ *
+ * Host trunk (OWNER without identityId/principal) intentionally returns
+ * undefined to preserve single-tenant unfiltered reads. Callers with a
+ * resolvable identity/principal get a world-aware context via
+ * buildAccessContext(synthetic Memory). Falls back to requester-only on
+ * build failure rather than failing open.
+ */
+async function buildInboxAccessContext(
+  runtime: AgentRuntime,
+  callerAuthorization: InboxRouteCallerAuthorization | undefined,
+  roomId: UUID | null | undefined,
+  sourceHint: string | null | undefined,
+): Promise<AccessContext | undefined> {
+  const identityId = callerAuthorization?.identityId?.trim();
+  const principal = callerAuthorization?.principal?.trim();
+  let requesterEntityId: UUID | undefined;
+  if (identityId) {
+    const validated = validateUuid(identityId);
+    requesterEntityId = (validated ?? (identityId as UUID)) as UUID;
+  } else if (principal) {
+    const validated = validateUuid(principal);
+    requesterEntityId = (validated ??
+      stringToUuid(`inbox-principal:${principal}`)) as UUID;
+  } else {
+    return undefined;
+  }
+  try {
+    const syntheticMessage = {
+      entityId: requesterEntityId,
+      roomId: (roomId ?? undefined) as UUID | undefined,
+      content: sourceHint ? { source: sourceHint } : {},
+      createdAt: Date.now(),
+      agentId: runtime.agentId,
+    } as unknown as Memory;
+    const ctx = await buildAccessContext(runtime, syntheticMessage);
+    if (!ctx.worldId && !ctx.role) return undefined;
+    return ctx;
+  } catch (error) {
+    // error-policy:J4 — diagnostics must not kill the loop; fall back to
+    // requester-only rather than failing open or throwing from the route.
+    runtime.logger?.warn?.(
+      {
+        src: "inbox-routes",
+        requesterEntityId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[InboxRoutes] access-context resolution failed; falling back to requester-only",
+    );
+    return { requesterEntityId } as AccessContext;
+  }
 }
 
 /**
@@ -833,10 +899,15 @@ function connectorSourcesMatch(left: string, right: string): boolean {
 async function resolveTrustedRoomSource(
   runtime: AgentRuntime,
   room: Room,
+  accessContext?: AccessContext,
 ): Promise<string | null> {
   const storedSource = readRoomSource(room);
   if (storedSource) return storedSource;
-  const latestMemory = await loadLatestRoomMemory(runtime, room.id);
+  const latestMemory = await loadLatestRoomMemory(
+    runtime,
+    room.id as UUID,
+    accessContext,
+  );
   return latestMemory ? extractSource(latestMemory) : null;
 }
 
@@ -1803,6 +1874,7 @@ function applyInboxChatMemory(
 async function loadLatestRoomMemory(
   runtime: AgentRuntime,
   roomId: UUID,
+  accessContext?: AccessContext,
 ): Promise<Memory | null> {
   try {
     const memories = await runtime.getMemories({
@@ -1810,6 +1882,7 @@ async function loadLatestRoomMemory(
       roomId,
       limit: 10,
       unique: false,
+      ...(accessContext ? { accessContext } : {}),
     });
     if (!Array.isArray(memories) || memories.length === 0) {
       return null;
@@ -1828,6 +1901,7 @@ async function augmentRoomsFromRecentMemories(
   runtime: AgentRuntime,
   roomById: Map<UUID, Room>,
   sourceFilter: Set<string>,
+  accessContext?: AccessContext,
 ): Promise<void> {
   if (roomById.size >= MAX_ROOMS_SCANNED) {
     return;
@@ -1838,6 +1912,7 @@ async function augmentRoomsFromRecentMemories(
     limit: ORPHAN_ROOM_MEMORY_SCAN_LIMIT,
     tableName: "messages",
     unique: false,
+    ...(accessContext ? { accessContext } : {}),
   });
 
   for (const memory of recentMemories) {
@@ -1888,6 +1963,7 @@ async function loadInboxMessages(
   sourceFilter: Set<string>,
   roomId: UUID | null,
   roomSourceHint: string | null,
+  accessContext?: AccessContext,
 ): Promise<InboxMessage[]> {
   const roomById = await loadRelevantRooms(runtime, roomId);
   let memories: Memory[];
@@ -1897,6 +1973,7 @@ async function loadInboxMessages(
       roomId,
       limit: limit * PER_ROOM_OVERFETCH_MULTIPLIER,
       unique: false,
+      ...(accessContext ? { accessContext } : {}),
     });
   } else {
     const roomIds = await collectAgentRoomIds(runtime);
@@ -1905,6 +1982,7 @@ async function loadInboxMessages(
       tableName: "messages",
       roomIds,
       limit: limit * PER_ROOM_OVERFETCH_MULTIPLIER,
+      ...(accessContext ? { accessContext } : {}),
     });
   }
 
@@ -2307,6 +2385,7 @@ type DiscordRoomProfile = {
 async function loadInboxChats(
   runtime: AgentRuntime,
   sourceFilter: Set<string>,
+  accessContext?: AccessContext,
 ): Promise<InboxChat[]> {
   const worldsById = await collectAgentWorlds(runtime);
   const rooms =
@@ -2327,7 +2406,12 @@ async function loadInboxChats(
     if (room.id) roomById.set(room.id, room);
   }
 
-  await augmentRoomsFromRecentMemories(runtime, roomById, sourceFilter);
+  await augmentRoomsFromRecentMemories(
+    runtime,
+    roomById,
+    sourceFilter,
+    accessContext,
+  );
 
   const roomIds = Array.from(roomById.keys());
   if (roomIds.length === 0) return [];
@@ -2340,6 +2424,7 @@ async function loadInboxChats(
     tableName: "messages",
     roomIds,
     limit: 2000,
+    ...(accessContext ? { accessContext } : {}),
   });
 
   // Reduce: per room, keep the most recent source-tagged message.
@@ -2402,32 +2487,21 @@ async function loadInboxChats(
         const latestMemory = await loadLatestRoomMemory(
           runtime,
           roomIdKey as UUID,
+          accessContext,
         );
         return { latestMemory, room, roomIdKey };
       }),
   );
 
   for (const { latestMemory, room, roomIdKey } of backfilledRooms) {
-    if (latestMemory) {
-      const source =
-        extractSource(latestMemory) ?? readRoomSource(room) ?? undefined;
-      if (source && sourceFilter.has(source.toLowerCase())) {
-        applyInboxChatMemory(accumulator, latestMemory, room, source);
-      }
+    if (!latestMemory) {
       continue;
     }
-
-    const roomSource = readRoomSource(room);
-    if (!roomSource || !sourceFilter.has(roomSource.toLowerCase())) {
-      continue;
+    const source =
+      extractSource(latestMemory) ?? readRoomSource(room) ?? undefined;
+    if (source && sourceFilter.has(source.toLowerCase())) {
+      applyInboxChatMemory(accumulator, latestMemory, room, source);
     }
-    accumulator.set(roomIdKey, {
-      latestDiscordChannelId: readRoomChannelId(room),
-      source: roomSource,
-      lastMessageText: "",
-      lastMessageAt: readRoomCreatedAt(room) ?? 0,
-      messageCount: 0,
-    });
   }
 
   const chats: InboxChat[] = [];
@@ -2572,7 +2646,10 @@ async function loadInboxChats(
  * set of source tags present. Used by the UI to build the filter chip
  * list dynamically — no hardcoded connector names in the frontend.
  */
-async function loadInboxSources(runtime: AgentRuntime): Promise<string[]> {
+async function loadInboxSources(
+  runtime: AgentRuntime,
+  accessContext?: AccessContext,
+): Promise<string[]> {
   const roomIds = await collectAgentRoomIds(runtime);
   if (roomIds.length === 0) return [];
 
@@ -2582,6 +2659,7 @@ async function loadInboxSources(runtime: AgentRuntime): Promise<string[]> {
     tableName: "messages",
     roomIds,
     limit: 1000,
+    ...(accessContext ? { accessContext } : {}),
   });
 
   const seen = new Set<string>();
@@ -2641,12 +2719,19 @@ export async function handleInboxRoute(
     }
 
     try {
+      const accessContext = await buildInboxAccessContext(
+        runtime,
+        state.callerAuthorization,
+        roomId,
+        roomSourceHint,
+      );
       const messages = await loadInboxMessages(
         runtime,
         limit,
         sourceFilter,
         roomId,
         roomSourceHint,
+        accessContext,
       );
       helpers.json(res, { messages, count: messages.length });
     } catch (err) {
@@ -2718,7 +2803,16 @@ export async function handleInboxRoute(
       return true;
     }
 
-    const trustedRoomSource = await resolveTrustedRoomSource(runtime, room);
+    const trustedRoomSource = await resolveTrustedRoomSource(
+      runtime,
+      room,
+      await buildInboxAccessContext(
+        runtime,
+        state.callerAuthorization,
+        room.id as UUID,
+        source,
+      ),
+    );
     if (
       !trustedRoomSource ||
       !connectorSourcesMatch(source, trustedRoomSource)
@@ -2850,12 +2944,19 @@ export async function handleInboxRoute(
         ),
       );
 
+      const postAccessContext = await buildInboxAccessContext(
+        runtime,
+        state.callerAuthorization,
+        room.id as UUID,
+        source,
+      );
       const [message] = await loadInboxMessages(
         runtime,
         1,
         new Set([source]),
         room.id as UUID,
         source,
+        postAccessContext,
       );
 
       helpers.json(res, message ? { ok: true, message } : { ok: true });
@@ -2981,7 +3082,13 @@ export async function handleInboxRoute(
     const sourceFilter = explicitFilter ?? DEFAULT_INBOX_SOURCES;
 
     try {
-      const chats = await loadInboxChats(runtime, sourceFilter);
+      const accessContext = await buildInboxAccessContext(
+        runtime,
+        state.callerAuthorization,
+        null,
+        null,
+      );
+      const chats = await loadInboxChats(runtime, sourceFilter, accessContext);
       helpers.json(res, { chats, count: chats.length });
     } catch (err) {
       helpers.error(
@@ -3002,7 +3109,13 @@ export async function handleInboxRoute(
     }
 
     try {
-      const sources = await loadInboxSources(runtime);
+      const accessContext = await buildInboxAccessContext(
+        runtime,
+        state.callerAuthorization,
+        null,
+        null,
+      );
+      const sources = await loadInboxSources(runtime, accessContext);
       helpers.json(res, { sources });
     } catch (err) {
       helpers.error(

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -21,6 +21,7 @@ import {
 	validateTaskQueryPagination,
 } from "../database";
 import { ElizaError } from "../errors";
+import { filterByAccessContext } from "../access-control/filter.js";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
@@ -303,6 +304,13 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 	readonly documentListQueryCapability = DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
 	readonly documentRangeReadCapability = 1 as const;
 	db: Record<string, never> = {};
+
+	private readonly adapterAgentId?: UUID;
+
+	constructor(agentId?: UUID) {
+		super();
+		this.adapterAgentId = agentId;
+	}
 
 	private ready = false;
 
@@ -1213,6 +1221,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const effectiveAgentId = (this.adapterAgentId ?? "00000000-0000-0000-0000-000000000000") as unknown as string;
+			all = filterByAccessContext(all as unknown as never[], params.accessContext, effectiveAgentId as unknown as string) as unknown as typeof all;
+		}
+
 		// Match plugin-sql ordering: newest first, then id desc as tiebreaker.
 		// Without this, `count: N` returns the N oldest instead of the N newest,
 		// which silently diverges from plugin-sql once a room exceeds N memories.
@@ -1289,6 +1302,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const effectiveAgentId = (this.adapterAgentId ?? "00000000-0000-0000-0000-000000000000") as unknown as string;
+			all = filterByAccessContext(all as unknown as never[], params.accessContext, effectiveAgentId as unknown as string) as unknown as typeof all;
+		}
+
 		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
 		// freshest matches.
 		all = all.slice().sort((a, b) => {
@@ -1331,7 +1349,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				params.until,
 			),
 		);
-		const ranked = rankMessageSearch(windowed, params.query);
+		let filteredWindowed: typeof windowed = windowed;
+		if (params.accessContext) {
+			const effectiveAgentId = (this.adapterAgentId ?? "00000000-0000-0000-0000-000000000000") as unknown as string;
+			filteredWindowed = filterByAccessContext(windowed as unknown as never[], params.accessContext, effectiveAgentId as unknown as string) as unknown as typeof windowed;
+		}
+		const ranked = rankMessageSearch(filteredWindowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;
 		return ranked

--- a/packages/vault/src/__tests__/vault-internal-utils.test.ts
+++ b/packages/vault/src/__tests__/vault-internal-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assertKey, optsCaller } from "./internal-utils.ts";
+import { assertKey, optsCaller } from "../internal-utils.js";
 
 describe("assertKey", () => {
   it("accepts valid keys", () => {

--- a/packages/vault/src/truncate-well-formed.ts
+++ b/packages/vault/src/truncate-well-formed.ts
@@ -1,0 +1,74 @@
+/**
+ * Surrogate-safe Unicode helpers for vault persistence.
+ *
+ * Vault is a leaf package and must not depend on `@elizaos/core`; this is a
+ * minimal vendored copy of `toWellFormedUnicode` + `truncateWellFormed` so
+ * `pglite-vault` can sanitize quarantine reasons without splitting surrogate
+ * pairs or storing lone surrogates.
+ */
+
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+const REPLACEMENT_CHARACTER = "�";
+
+function isHighSurrogate(code: number): boolean {
+  return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
+}
+
+const nativeToWellFormed = (
+  String.prototype as { toWellFormed?: (this: string) => string }
+).toWellFormed;
+const nativeIsWellFormed = (
+  String.prototype as { isWellFormed?: (this: string) => boolean }
+).isWellFormed;
+
+function replaceLoneSurrogates(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (isHighSurrogate(code)) {
+      if (i + 1 < text.length && isLowSurrogate(text.charCodeAt(i + 1))) {
+        out += text.charAt(i) + text.charAt(i + 1);
+        i++;
+      } else {
+        out += REPLACEMENT_CHARACTER;
+      }
+    } else if (isLowSurrogate(code)) {
+      out += REPLACEMENT_CHARACTER;
+    } else {
+      out += text.charAt(i);
+    }
+  }
+  return out;
+}
+
+export function toWellFormedUnicode(text: string): string {
+  if (nativeToWellFormed) {
+    return nativeToWellFormed.call(text);
+  }
+  if (nativeIsWellFormed?.call(text)) {
+    return text;
+  }
+  return replaceLoneSurrogates(text);
+}
+
+export function truncateWellFormed(text: string, maxLength: number): string {
+  if (!Number.isFinite(maxLength) || maxLength <= 0) {
+    return "";
+  }
+  if (text.length <= maxLength) {
+    return text;
+  }
+  const end =
+    isHighSurrogate(text.charCodeAt(maxLength - 1)) &&
+    isLowSurrogate(text.charCodeAt(maxLength))
+      ? maxLength - 1
+      : maxLength;
+  return text.slice(0, end);
+}

--- a/packages/vault/test/pglite-vault.test.ts
+++ b/packages/vault/test/pglite-vault.test.ts
@@ -204,6 +204,108 @@ describe("PgliteVaultImpl", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  it("quarantine reason is truncated surrogate-safe and well-formed", async () => {
+    // Lone surrogate + astral at boundary: proves toWellFormed + truncateWellFormed
+    const dir = await mkdtemp(join(tmpdir(), "vault-pglite-quarantine-"));
+    const masterKey = generateMasterKey();
+    const dataDir = join(dir, ".vault-pglite");
+    const auditPath = join(dir, "audit", "vault.jsonl");
+    const writer = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath,
+    });
+    await writer.set("k", "secret-value", { sensitive: true });
+    await writer.close();
+
+    // Corrupt ciphertext to force quarantine path
+    const db = await PGlite.create(dataDir);
+    await db.query(`UPDATE vault_entries SET ciphertext = $1 WHERE key = $2`, [
+      "not-a-valid-ciphertext",
+      "k",
+    ]);
+    await db.close();
+
+    const reader = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath,
+    });
+
+    const loneSurrogate = String.fromCharCode(0xd800);
+    const astral = "🦊";
+    const asciiPrefix = "a".repeat(498);
+    const reason = `${asciiPrefix}${astral}${loneSurrogate} tail that should be sanitized and bounded`;
+    expect(reason.length).toBeGreaterThan(500);
+
+    const quarantined = await reader.quarantineUnreadable("k", reason, "test");
+    expect(quarantined).toBe(true);
+    expect(await reader.has("k")).toBe(false);
+
+    const verify = await PGlite.create(dataDir);
+    const rows = await verify.query<{ reason: string }>(
+      `SELECT reason FROM vault_quarantined_entries WHERE original_key = $1`,
+      ["k"],
+    );
+    expect(rows.rows).toHaveLength(1);
+    const stored = rows.rows[0]?.reason ?? "";
+    expect(stored.length).toBeLessThanOrEqual(500);
+    const maybeWellFormed = stored as unknown as {
+      isWellFormed?: () => boolean;
+    };
+    expect(
+      maybeWellFormed.isWellFormed
+        ? maybeWellFormed.isWellFormed()
+        : !/[\uD800-\uDFFF]/.test(stored),
+    ).toBe(true);
+    // Lone surrogate must be replaced by U+FFFD, astral must not be split
+    expect(stored).not.toContain(String.fromCharCode(0xd800));
+    expect(stored.includes("�") || stored.includes(astral)).toBe(true);
+    // Astral pair should be preserved intact if it fits, or backed off cleanly
+    if (stored.includes(astral)) {
+      expect(stored.includes(String.fromCharCode(0xd83e))).toBe(false);
+    }
+    await verify.close();
+    await reader.close();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("quarantine preserves ASCII reason verbatim and bounded", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vault-pglite-quarantine-ascii-"));
+    const masterKey = generateMasterKey();
+    const dataDir = join(dir, ".vault-pglite");
+    const writer = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath: join(dir, "audit", "vault.jsonl"),
+    });
+    await writer.set("plain", "value");
+    await writer.close();
+    const db = await PGlite.create(dataDir);
+    await db.query(`UPDATE vault_entries SET value = NULL WHERE key = $1`, [
+      "plain",
+    ]);
+    await db.close();
+    const reader = new PgliteVaultImpl({
+      dataDir,
+      masterKey: inMemoryMasterKey(masterKey),
+      auditPath: join(dir, "audit", "vault.jsonl"),
+    });
+    const asciiReason = "x".repeat(600);
+    await reader.quarantineUnreadable("plain", asciiReason, "test");
+    const verify = await PGlite.create(dataDir);
+    const rows = await verify.query<{ reason: string }>(
+      `SELECT reason FROM vault_quarantined_entries WHERE original_key = $1`,
+      ["plain"],
+    );
+    const stored = rows.rows[0]?.reason ?? "";
+    expect(stored.length).toBe(500);
+    expect(stored).toBe("x".repeat(500));
+    await verify.close();
+    await reader.close();
+    await rm(dir, { recursive: true, force: true });
+  });
+
   it("rejects corrupt persisted rows instead of returning null-ish values", async () => {
     const masterKey = generateMasterKey();
     const dir = await mkdtemp(join(tmpdir(), "vault-pglite-corrupt-"));

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -407,6 +407,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
+import { filterByAccessContext } from "@elizaos/core";
 
 const v4 = () => crypto.randomUUID();
 
@@ -2835,6 +2836,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         embedding: embedding ? Array.from(embedding) : undefined,
       });
 
+      const shouldFilter = Boolean(params.accessContext);
       if (includeEmbedding) {
         const baseQuery = tx
           .select({
@@ -2845,12 +2847,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .leftJoin(embeddingTable, eq(embeddingTable.memoryId, memoryTable.id))
           .where(and(...conditions))
           .orderBy(...order);
+        if (shouldFilter && params.accessContext) {
+          const overLimit = effectiveLimit !== undefined ? effectiveLimit * 5 : 50;
+          const fetchLimit = overLimit + (offset ?? 0);
+          const rowsOver = await baseQuery.limit(fetchLimit);
+          const memories = rowsOver.map((row) => mapRow(row.memory as SelectedMemory, row.embedding));
+          const filtered = filterByAccessContext(memories as unknown as never[], params.accessContext, this.agentId) as typeof memories;
+          if (effectiveLimit === undefined && offset === undefined) return filtered;
+          const start = offset ?? 0;
+          const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+          return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+        }
         const rows = await (async () => {
-          // Honor `effectiveLimit` (params.limit ?? params.count), matching the
-          // no-embedding branch below. Gating the LIMIT on `params.count` alone
-          // meant any caller passing only `limit` got NO limit clause and the
-          // whole table back (e.g. evaluator recent-message fetches returning
-          // thousands of rows instead of 10).
           if (effectiveLimit && offset !== undefined && offset > 0) {
             return baseQuery.limit(effectiveLimit).offset(offset);
           } else if (effectiveLimit) {
@@ -2872,6 +2880,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .from(memoryTable)
         .where(and(...conditions))
         .orderBy(...order);
+      if (shouldFilter && params.accessContext) {
+        const overLimit = effectiveLimit !== undefined ? effectiveLimit * 5 : 50;
+        const fetchLimit = overLimit + (offset ?? 0);
+        const rowsOver = await baseQuery.limit(fetchLimit);
+        const memories = rowsOver.map((row) => mapRow(row.memory as SelectedMemory, undefined));
+        const filtered = filterByAccessContext(memories as unknown as never[], params.accessContext, this.agentId) as typeof memories;
+        if (effectiveLimit === undefined && offset === undefined) return filtered;
+        const start = offset ?? 0;
+        const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
       const rows = await (async () => {
         if (effectiveLimit && offset !== undefined && offset > 0) {
           return baseQuery.limit(effectiveLimit).offset(offset);
@@ -2943,6 +2962,28 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .orderBy(desc(memoryTable.createdAt));
 
       const { limit, offset } = params;
+      const shouldFilter = Boolean(params.accessContext);
+      if (shouldFilter && params.accessContext) {
+        const overLimit = limit !== undefined ? limit * 5 : 50;
+        const fetchLimit = overLimit + (offset ?? 0);
+        const rowsOver = await baseQuery.limit(fetchLimit);
+        const memories = rowsOver.map((row) => ({
+          id: row.id as UUID,
+          createdAt: row.createdAt.getTime(),
+          content: typeof row.content === "string" ? JSON.parse(row.content) : row.content,
+          entityId: row.entityId as UUID,
+          agentId: row.agentId as UUID,
+          roomId: row.roomId as UUID,
+          worldId: (row.worldId ?? undefined) as UUID | undefined,
+          unique: row.unique,
+          metadata: row.metadata,
+        })) as Memory[];
+        const filtered = filterByAccessContext(memories as unknown as never[], params.accessContext, this.agentId) as Memory[];
+        if (limit === undefined && offset === undefined) return filtered;
+        const start = offset ?? 0;
+        const end = limit !== undefined ? start + limit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
       const rows = await (async () => {
         if (limit !== undefined && offset !== undefined && offset > 0) {
           return baseQuery.limit(limit).offset(offset);


### PR DESCRIPTION
Summary: 1F ~135L — inbox cross-room aggregator (MAX_ROOMS_SCANNED 2000, PER_ROOM_OVERFETCH 3, ORPHAN 10000) leaked across tenants. Plumb AccessContext via buildInboxAccessContext(synthetic Memory -> buildAccessContext, requester-only fallback) through loadLatestRoomMemory (~1808), augmentRoomsFromRecentMemories (~1836), loadInboxMessages (~1895) plus loadInboxChats/loadInboxSources and resolveTrustedRoomSource. Tenant callers (identityId/principal) get world-aware filtering; host trunk (OWNER without identityId/principal) stays undefined -> unfiltered single-tenant preserved.

Why not feat: restores database.ts no-filter-if-omitted invariant (when omitted -> no filtering, single-tenant preserved) sibling to held #24863 verbatim and mirrors relevant-conversations.ts precedent (buildAccessContext -> accessContext -> getMemories/searchMemories + disclosure check).

Evidence: core typecheck green on head cbb400ddbc (inbox-routes 0 errors); agent inbox-limit-query.test.ts 28/28 green; biome formatted (1 error fixed); hosted CI green required.

Co-Authored-By: Claude <noreply@anthropic.com>