### PR TITLE
fix(core): scope role activity scorer to accessContext

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -21,6 +21,7 @@ import {
 	validateTaskQueryPagination,
 } from "../database";
 import { ElizaError } from "../errors";
+import { filterByAccessContext } from "../access-control/filter";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
@@ -1213,6 +1214,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const agentIdForFilter = (all[0]?.agentId as any) ?? params.accessContext.requesterEntityId;
+			all = filterByAccessContext(all as any, params.accessContext, agentIdForFilter as any) as any;
+		}
+
 		// Match plugin-sql ordering: newest first, then id desc as tiebreaker.
 		// Without this, `count: N` returns the N oldest instead of the N newest,
 		// which silently diverges from plugin-sql once a room exceeds N memories.
@@ -1289,6 +1295,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const agentIdForFilter = (all[0]?.agentId as any) ?? params.accessContext.requesterEntityId;
+			all = filterByAccessContext(all as any, params.accessContext, agentIdForFilter as any) as any;
+		}
+
 		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
 		// freshest matches.
 		all = all.slice().sort((a, b) => {
@@ -1331,7 +1342,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				params.until,
 			),
 		);
-		const ranked = rankMessageSearch(windowed, params.query);
+		let filteredWindowed: typeof windowed = windowed;
+		if (params.accessContext) {
+			const agentIdForFilter = (windowed[0]?.agentId as any) ?? params.accessContext.requesterEntityId;
+			filteredWindowed = filterByAccessContext(windowed as any, params.accessContext, agentIdForFilter as any) as any;
+		}
+		const ranked = rankMessageSearch(filteredWindowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;
 		return ranked

--- a/packages/core/src/features/advanced-capabilities/actions/role.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.ts
@@ -8,6 +8,7 @@
  *   - list:   returns current role assignments for the world.
  */
 
+import { buildAccessContext } from "../../../access-context.ts";
 import {
 	findKeywordTermMatch,
 	getValidationKeywordTerms,
@@ -24,6 +25,7 @@ import {
 	setEntityRole,
 } from "../../../roles.ts";
 import type {
+	AccessContext,
 	Action,
 	ActionResult,
 	HandlerCallback,
@@ -267,12 +269,14 @@ function scoreNameMatch(target: string, candidate: CandidateRecord): number {
 async function getRecentRoomActivity(
 	runtime: IAgentRuntime,
 	roomId: UUID,
+	accessContext?: AccessContext,
 ): Promise<Map<UUID, number>> {
 	const activity = new Map<UUID, number>();
 	if (typeof runtime.getMemoriesByRoomIds !== "function") return activity;
 	const memories = await runtime.getMemoriesByRoomIds({
 		tableName: "messages",
 		roomIds: [roomId],
+		accessContext,
 	});
 	for (const memory of memories) {
 		if (!memory.entityId || typeof memory.createdAt !== "number") continue;
@@ -287,10 +291,15 @@ async function resolveTargetEntityIdByName(args: {
 	runtime: IAgentRuntime;
 	roomId: UUID;
 	targetName: string;
+	accessContext?: AccessContext;
 }): Promise<{ entityId: UUID | null; error?: string }> {
-	const { runtime, roomId, targetName } = args;
+	const { runtime, roomId, targetName, accessContext } = args;
 	const candidates = new Map<UUID, CandidateRecord>();
-	const recentActivity = await getRecentRoomActivity(runtime, roomId);
+	const recentActivity = await getRecentRoomActivity(
+		runtime,
+		roomId,
+		accessContext,
+	);
 
 	const roomEntities = await runtime.getEntitiesForRoom(roomId);
 	for (const entity of roomEntities) {
@@ -403,10 +412,12 @@ async function buildAssignmentsFromParams(args: {
 			errors.push("Could not determine target role.");
 			return { assignments, errors };
 		}
+		const accessContext = await buildAccessContext(runtime, message);
 		const resolution = await resolveTargetEntityIdByName({
 			runtime,
 			roomId: message.roomId,
 			targetName,
+			accessContext,
 		});
 		if (!resolution.entityId) {
 			errors.push(resolution.error ?? `User "${targetName}" not found.`);

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -406,6 +406,7 @@ import {
   type SQLWrapper,
   sql,
 } from "drizzle-orm";
+import { filterByAccessContext } from "@elizaos/core";
 import { alias } from "drizzle-orm/pg-core";
 
 const v4 = () => crypto.randomUUID();
@@ -2845,7 +2846,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .leftJoin(embeddingTable, eq(embeddingTable.memoryId, memoryTable.id))
           .where(and(...conditions))
           .orderBy(...order);
+        const shouldFilter = Boolean(params.accessContext);
         const rows = await (async () => {
+          if (shouldFilter) {
+            return baseQuery;
+          }
           // Honor `effectiveLimit` (params.limit ?? params.count), matching the
           // no-embedding branch below. Gating the LIMIT on `params.count` alone
           // meant any caller passing only `limit` got NO limit clause and the
@@ -2861,7 +2866,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             return baseQuery;
           }
         })();
-        return rows.map((row) => mapRow(row.memory as SelectedMemory, row.embedding));
+        const memories = rows.map((row) => mapRow(row.memory as SelectedMemory, row.embedding));
+        if (shouldFilter && params.accessContext) {
+          const filtered = filterByAccessContext(memories as any, params.accessContext, this.agentId) as Memory[];
+          if (effectiveLimit === undefined && offset === undefined) return filtered;
+          const start = offset ?? 0;
+          const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+          return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+        }
+        return memories;
       }
 
       // includeEmbedding === false: skip the embeddingTable join + column. The
@@ -2872,7 +2885,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .from(memoryTable)
         .where(and(...conditions))
         .orderBy(...order);
-      const rows = await (async () => {
+      const rows2 = await (async () => {
+        if (shouldFilter) {
+          return baseQuery;
+        }
         if (effectiveLimit && offset !== undefined && offset > 0) {
           return baseQuery.limit(effectiveLimit).offset(offset);
         } else if (effectiveLimit) {
@@ -2883,7 +2899,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           return baseQuery;
         }
       })();
-      return rows.map((row) => mapRow(row.memory as SelectedMemory, undefined));
+      const memories2 = rows2.map((row) => mapRow(row.memory as SelectedMemory, undefined));
+      if (shouldFilter && params.accessContext) {
+        const filtered = filterByAccessContext(memories2 as any, params.accessContext, this.agentId) as Memory[];
+        if (effectiveLimit === undefined && offset === undefined) return filtered;
+        const start = offset ?? 0;
+        const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
+      return memories2;
     });
   }
 
@@ -2943,7 +2967,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .orderBy(desc(memoryTable.createdAt));
 
       const { limit, offset } = params;
+      const shouldFilter = Boolean(params.accessContext);
       const rows = await (async () => {
+        if (shouldFilter) {
+          return baseQuery;
+        }
         if (limit !== undefined && offset !== undefined && offset > 0) {
           return baseQuery.limit(limit).offset(offset);
         } else if (limit !== undefined) {
@@ -2954,7 +2982,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         return baseQuery;
       })();
 
-      return rows.map((row) => ({
+      const memories = rows.map((row) => ({
         id: row.id as UUID,
         createdAt: row.createdAt.getTime(),
         content: typeof row.content === "string" ? JSON.parse(row.content) : row.content,
@@ -2965,6 +2993,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         unique: row.unique,
         metadata: row.metadata,
       })) as Memory[];
+      if (shouldFilter && params.accessContext) {
+        const filtered = filterByAccessContext(memories as any, params.accessContext, this.agentId) as Memory[];
+        const start = offset ?? 0;
+        const end = limit !== undefined ? start + limit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
+      return memories;
     });
   }
 


### PR DESCRIPTION
Role activity scorer queried by room without accessContext filtering. Thread buildAccessContext into getMemoriesByRoomIds for tenant isolation completeness, matching relevant-conversations precedent.