### PR TITLE
fix(plugin-local-inference): use surrogate-safe truncateWellFormed for error body

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -13,6 +13,7 @@
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { NlmsEchoCanceller } from "@elizaos/shared/voice/aec";
 import {
 	type OwnerObservation,
@@ -510,7 +511,7 @@ async function elevenLabsPcm(args: {
 	if (!response.ok) {
 		const body = await response.text().catch(() => "");
 		throw new Error(
-			`[voice:workbench --real] ElevenLabs ${response.status} for ${args.voiceId}: ${body.slice(0, 240)}`,
+			`[voice:workbench --real] ElevenLabs ${response.status} for ${args.voiceId}: ${truncateWellFormed(toWellFormedUnicode(body), 240)}`,
 		);
 	}
 	const pcm = pcm16ToFloat32(new Uint8Array(await response.arrayBuffer()));


### PR DESCRIPTION
Raw `body.slice(0,240)` truncates mid-surrogate, corrupting Unicode. Use `truncateWellFormed(toWellFormedUnicode(body), 240)` matching landed siblings #24935 (cli-inference) and #24938 (x/broker).

HC-09 noted remaining candidate `plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts:513`:
`[voice:workbench --real] ElevenLabs ${response.status} for ${args.voiceId}: ${body.slice(0, 240)}`

Fix replaces with surrogate-safe pattern already used in `@elizaos/core` and plugins (import from `@elizaos/core`).

Precedents:
- #24935 cli-inference `text.slice(0,160)` → `truncateWellFormed(toWellFormedUnicode)`
- #24938 x/broker `body.slice(0,200)` → same

Grep sweep evidence:
- `grep -rn "\.slice(0," plugins --include="*.ts"` found 3 HTTP-body truncations still raw on develop (cli-inference 160, x/broker 200, local-inference 240). This PR closes the trilogy's last sibling.
- `grep -rn "truncateWellFormed" packages --include="*.ts"` confirms `@elizaos/core` export via `utils/well-formed.ts` and re-export from `@elizaos/core`.

Diff: 1 file, <15 lines.
Typecheck: `bun run --cwd plugins/plugin-local-inference typecheck` — pass.
Biome: `biome check --write` — no fixes.

Co-Authored-By: Claude <noreply@anthropic.com>