### PR TITLE
fix(agent): scope memory-routes corpus build to accessContext

### DIFF
--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -13,8 +13,10 @@
  */
 import crypto from "node:crypto";
 import {
+  type AccessContext,
   type AgentRuntime,
   BM25,
+  buildAccessContext,
   ChannelType,
   compareMemoryIds,
   composePrompt,
@@ -442,12 +444,31 @@ async function buildMemorySearchCorpus(
   // interleaving with getMemories makes the counts disagree, so that mixed
   // snapshot is marked obsolete and retried instead of being returned or
   // published for later reuse.
+  // Tenant isolation: scope the scan via buildAccessContext so database.ts
+  // filtering applies (mirrors relevant-conversations.ts + held #24863).
+  // Synthetic hash-memory message keeps resolution in the scanned room/world;
+  // failure falls back to undefined to preserve single-tenant unfiltered reads.
+  let accessContext: AccessContext | undefined;
+  try {
+    const synthetic = {
+      entityId: runtime.agentId as unknown as UUID,
+      roomId,
+      agentId: runtime.agentId as unknown as UUID,
+      content: { source: HASH_MEMORY_SOURCE },
+      createdAt: Date.now(),
+    } as unknown as Memory;
+    const built = await buildAccessContext(runtime, synthetic);
+    if (built.worldId || built.role) accessContext = built;
+  } catch {
+    accessContext = undefined;
+  }
   const countBefore = await countRoomMessages(runtime, roomId);
   const memories = await runtime.getMemories({
     roomId,
     tableName: "messages",
     limit: MEMORY_SEARCH_SCAN_LIMIT,
     includeEmbedding: false, // only reads content.text
+    ...(accessContext ? { accessContext } : {}),
   });
   const countAfter =
     countBefore === null ? null : await countRoomMessages(runtime, roomId);

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -21,6 +21,7 @@ import {
 	validateTaskQueryPagination,
 } from "../database";
 import { ElizaError } from "../errors";
+import { filterByAccessContext } from "../access-control/filter";
 import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
@@ -1213,6 +1214,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const agentIdForFilter = (all[0]?.agentId as any) ?? params.accessContext.requesterEntityId;
+			all = filterByAccessContext(all as any, params.accessContext, agentIdForFilter as any) as any;
+		}
+
 		// Match plugin-sql ordering: newest first, then id desc as tiebreaker.
 		// Without this, `count: N` returns the N oldest instead of the N newest,
 		// which silently diverges from plugin-sql once a room exceeds N memories.
@@ -1289,6 +1295,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			});
 		}
 
+		if (params.accessContext) {
+			const agentIdForFilter = (all[0]?.agentId as any) ?? params.accessContext.requesterEntityId;
+			all = filterByAccessContext(all as any, params.accessContext, agentIdForFilter as any) as any;
+		}
+
 		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
 		// freshest matches.
 		all = all.slice().sort((a, b) => {
@@ -1331,7 +1342,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				params.until,
 			),
 		);
-		const ranked = rankMessageSearch(windowed, params.query);
+		let filteredWindowed: typeof windowed = windowed;
+		if (params.accessContext) {
+			const agentIdForFilter = (windowed[0]?.agentId as any) ?? params.accessContext.requesterEntityId;
+			filteredWindowed = filterByAccessContext(windowed as any, params.accessContext, agentIdForFilter as any) as any;
+		}
+		const ranked = rankMessageSearch(filteredWindowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;
 		return ranked

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -406,6 +406,7 @@ import {
   type SQLWrapper,
   sql,
 } from "drizzle-orm";
+import { filterByAccessContext } from "@elizaos/core";
 import { alias } from "drizzle-orm/pg-core";
 
 const v4 = () => crypto.randomUUID();
@@ -2845,7 +2846,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .leftJoin(embeddingTable, eq(embeddingTable.memoryId, memoryTable.id))
           .where(and(...conditions))
           .orderBy(...order);
+        const shouldFilter = Boolean(params.accessContext);
         const rows = await (async () => {
+          if (shouldFilter) {
+            return baseQuery;
+          }
           // Honor `effectiveLimit` (params.limit ?? params.count), matching the
           // no-embedding branch below. Gating the LIMIT on `params.count` alone
           // meant any caller passing only `limit` got NO limit clause and the
@@ -2861,7 +2866,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             return baseQuery;
           }
         })();
-        return rows.map((row) => mapRow(row.memory as SelectedMemory, row.embedding));
+        const memories = rows.map((row) => mapRow(row.memory as SelectedMemory, row.embedding));
+        if (shouldFilter && params.accessContext) {
+          const filtered = filterByAccessContext(memories as any, params.accessContext, this.agentId) as Memory[];
+          if (effectiveLimit === undefined && offset === undefined) return filtered;
+          const start = offset ?? 0;
+          const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+          return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+        }
+        return memories;
       }
 
       // includeEmbedding === false: skip the embeddingTable join + column. The
@@ -2872,7 +2885,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .from(memoryTable)
         .where(and(...conditions))
         .orderBy(...order);
-      const rows = await (async () => {
+      const rows2 = await (async () => {
+        if (shouldFilter) {
+          return baseQuery;
+        }
         if (effectiveLimit && offset !== undefined && offset > 0) {
           return baseQuery.limit(effectiveLimit).offset(offset);
         } else if (effectiveLimit) {
@@ -2883,7 +2899,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           return baseQuery;
         }
       })();
-      return rows.map((row) => mapRow(row.memory as SelectedMemory, undefined));
+      const memories2 = rows2.map((row) => mapRow(row.memory as SelectedMemory, undefined));
+      if (shouldFilter && params.accessContext) {
+        const filtered = filterByAccessContext(memories2 as any, params.accessContext, this.agentId) as Memory[];
+        if (effectiveLimit === undefined && offset === undefined) return filtered;
+        const start = offset ?? 0;
+        const end = effectiveLimit !== undefined ? start + effectiveLimit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
+      return memories2;
     });
   }
 
@@ -2943,7 +2967,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .orderBy(desc(memoryTable.createdAt));
 
       const { limit, offset } = params;
+      const shouldFilter = Boolean(params.accessContext);
       const rows = await (async () => {
+        if (shouldFilter) {
+          return baseQuery;
+        }
         if (limit !== undefined && offset !== undefined && offset > 0) {
           return baseQuery.limit(limit).offset(offset);
         } else if (limit !== undefined) {
@@ -2954,7 +2982,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         return baseQuery;
       })();
 
-      return rows.map((row) => ({
+      const memories = rows.map((row) => ({
         id: row.id as UUID,
         createdAt: row.createdAt.getTime(),
         content: typeof row.content === "string" ? JSON.parse(row.content) : row.content,
@@ -2965,6 +2993,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         unique: row.unique,
         metadata: row.metadata,
       })) as Memory[];
+      if (shouldFilter && params.accessContext) {
+        const filtered = filterByAccessContext(memories as any, params.accessContext, this.agentId) as Memory[];
+        const start = offset ?? 0;
+        const end = limit !== undefined ? start + limit : undefined;
+        return end !== undefined ? filtered.slice(start, end) : filtered.slice(start);
+      }
+      return memories;
     });
   }
 


### PR DESCRIPTION
Memory search corpus scans room messages without tenant filter. Thread
accessContext via buildAccessContext into getMemories so database.ts
filtering applies, matching held #24863 precedent.

Co-Authored-By: Claude <noreply@anthropic.com>