### PR TITLE
fix(core): plumb accessContext into recentMessages cross-room history

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -31,6 +31,18 @@ vi.mock(
 	},
 );
 
+vi.mock("../../../access-context.ts", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../access-context.ts")>();
+	return {
+		...actual,
+		buildAccessContext: vi.fn(async () => ({
+			requesterEntityId: "00000000-0000-0000-0000-000000000003",
+			source: "discord",
+		})),
+	};
+});
+
 import {
 	ChannelType,
 	type IAgentRuntime,
@@ -644,10 +656,13 @@ describe("recentMessagesProvider", () => {
 
 		expect(runtime.getRoomsForParticipants).toHaveBeenCalledWith([USER_ID]);
 		expect(runtime.getRoomsForParticipant).toHaveBeenCalledWith(AGENT_ID);
-		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith({
-			tableName: "messages",
-			roomIds: [OTHER_ROOM_ID],
-		});
+		expect(runtime.getMemoriesByRoomIds).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tableName: "messages",
+				roomIds: [OTHER_ROOM_ID],
+				accessContext: expect.any(Object),
+			}),
+		);
 		expect(result.data?.recentInteractions).toHaveLength(1);
 		expect(result.values?.recentMessageInteractions).toContain(
 			"the blue key is under the mat",

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -24,6 +24,7 @@
  * after the live destination is revalidated as an owner-exclusive DM.
  */
 
+import { buildAccessContext } from "../../../access-context.ts";
 import { getEntityDetails } from "../../../entities.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getVerifiedRelatedEntityIds } from "../../../identity-clusters.ts";
@@ -35,6 +36,7 @@ import {
 	revalidateOwnerExclusiveDisclosure,
 } from "../../../security/trusted-delivery-audience.ts";
 import type {
+	AccessContext,
 	CustomMetadata,
 	Entity,
 	IAgentRuntime,
@@ -320,6 +322,7 @@ const getRecentInteractions = async (
 	message: Memory,
 	targetEntityId: UUID,
 	excludeRoomId: UUID,
+	accessContext: AccessContext,
 ): Promise<Memory[]> => {
 	// The standalone agent installs a richer, always-on provider for this exact
 	// cross-room surface. Let it own those rows so Stage 1 does not render the
@@ -371,6 +374,7 @@ const getRecentInteractions = async (
 	const interactions = await runtime.getMemoriesByRoomIds({
 		tableName: "messages",
 		roomIds: otherRooms,
+		accessContext,
 	});
 	if (interactions.length > 0) {
 		markOwnerExclusiveDisclosureUsed(message);
@@ -421,6 +425,7 @@ export const recentMessagesProvider: Provider = {
 	): Promise<ProviderResult> => {
 		try {
 			const { roomId } = message;
+			const accessContext = await buildAccessContext(runtime, message);
 
 			// Parallelize initial data fetching operations including recentInteractions
 			const [entitiesData, recentMessagesData, recentInteractionsData, room] =
@@ -430,9 +435,16 @@ export const recentMessagesProvider: Provider = {
 						tableName: "messages",
 						roomId,
 						unique: false,
+						accessContext,
 					}),
 					message.entityId !== runtime.agentId
-						? getRecentInteractions(runtime, message, runtime.agentId, roomId)
+						? getRecentInteractions(
+								runtime,
+								message,
+								runtime.agentId,
+								roomId,
+								accessContext,
+							)
 						: Promise.resolve([]),
 					runtime.getRoom(roomId),
 				]);


### PR DESCRIPTION
## Summary
Cross-room `getRecentInteractions` queried `otherRooms` without `accessContext`, so `database.ts` returned unfiltered rows. Per `database.ts` omitting `accessContext` means no filtering — same class as held #24863. Thread `buildAccessContext` from message scope into `getMemoriesByRoomIds`, mirroring `relevant-conversations` provider.

## Scope
- `packages/core/src/features/basic-capabilities/providers/recentMessages.ts` — plumb `AccessContext` into `getRecentInteractions` cross-room history and main `getMemories` call
- `packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts` — mock `buildAccessContext` and update `getMemoriesByRoomIds` expectation to `expect.objectContaining` with `accessContext: expect.any(Object)`

## Verification
- `git rev-parse HEAD`: `a2a920b517582f23bbe9057ca273cb848b3e8417`
- `bun run --cwd packages/core typecheck`: PASS (tsc --noEmit, no errors)
- `bun run --cwd packages/core test -- recentMessages`: PASS (19 tests)
- `bun run --cwd packages/core lint` / `biome check --write`: PASS (no fixes after final format, multi-line call formatted)
- `git diff --check`: PASS (no whitespace errors)

## Why not a feat
Security fix restoring tenant-filtering guarantee — no new surface, single `accessContext` plumbed through existing calls, matching established `relevant-conversations` pattern. No API/shape change.

## Evidence
- `getRecentInteractions` now requires `accessContext: AccessContext` and passes it to `runtime.getMemoriesByRoomIds({ tableName: "messages", roomIds: otherRooms, accessContext })`
- Outer `get` builds `const accessContext = await buildAccessContext(runtime, message)` once and reuses for both `runtime.getMemories({ ..., accessContext })` and cross-room call
- Mirrors `packages/agent/src/providers/relevant-conversations.ts: const accessContext: AccessContext = await buildAccessContext(runtime, message)` → `loadHashMemories(runtime, text, accessContext)` → `runtime.getMemories({ ..., accessContext })`
