### PR TITLE
test(cloud): adversarial coverage for Personal Shared group chats

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
@@ -1,0 +1,658 @@
+/**
+ * Adversarial coverage for Personal Shared group routing: forged Blooio reply
+ * invocations must not bypass mention_only, non-owners must not change room
+ * policy, upgraded (Dedicated) accounts must keep their group conversation
+ * authority, and stale claim or binding states must map to their exact
+ * recovery replies without ever entering owner-billed inference. The harness
+ * mirrors route.test.ts: bun-mocked collaborators around the real Hono route.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let activeTarget: {
+  id: string;
+  status: "running" | "sleeping" | "stopped";
+  bridge_url?: string;
+} | null = null;
+const resolvePersonalDelivery = mock(async () => ({
+  userId: "00000000-0000-4000-8000-000000000002",
+  organizationId: "00000000-0000-4000-8000-000000000001",
+  dedicatedTarget: activeTarget,
+  isNew: false,
+  resolution: "single-query-repeat" as const,
+}));
+const sharedRestMessageSend = mock(async () => ({ text: "hello from Eliza" }));
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
+const runOnboardingChat = mock(async () => ({
+  loginUrl:
+    "https://cloud-staging.eliza.app/get-started?onboardingSession=claim-token",
+}));
+const findActivePersonalDedicatedTarget = mock(async () => activeTarget);
+let creditGateResult: { allowed: boolean; balance: number; error?: string } = {
+  allowed: true,
+  balance: 10,
+};
+let workerHealthResult:
+  | { ok: true; required: false }
+  | {
+      ok: false;
+      required: true;
+      status: 503;
+      code: "PROVISIONING_WORKER_UNHEALTHY";
+      error: string;
+    } = { ok: true, required: false };
+const enqueueAgentResumeOnce = mock(async () => ({
+  created: true,
+  job: { id: "resume-job-1" },
+}));
+const enqueueAgentWakeOnce = mock(async () => ({
+  created: true,
+  job: { id: "wake-job-1" },
+  appliedRestoreBackupId: null,
+  appliedForceFreshBoot: false,
+}));
+const triggerImmediate = mock(async () => undefined);
+type BridgeResponse =
+  | {
+      jsonrpc: "2.0";
+      id: string;
+      result: { text: string };
+    }
+  | {
+      jsonrpc: "2.0";
+      id: string;
+      error: { code: number; message: string };
+    };
+const bridge = mock(
+  async (): Promise<BridgeResponse> => ({
+    jsonrpc: "2.0" as const,
+    id: "telegram:eliza:group-42",
+    result: { text: "hello from Dedicated" },
+  }),
+);
+type ImportReceipt = {
+  complete: true;
+  sourceMessageCount: number;
+  inserted: number;
+  skipped: number;
+};
+const importCanonicalConversation = mock(
+  async (
+    _agentId: string,
+    _orgId: string,
+    _conversationId: string,
+    _messages: Array<{
+      sourceId: string;
+      role: "user" | "assistant";
+      text: string;
+      timestamp?: number;
+    }>,
+  ): Promise<ImportReceipt | null> => ({
+    complete: true,
+    sourceMessageCount: 2,
+    inserted: 2,
+    skipped: 0,
+  }),
+);
+const coordinateSharedHistory = mock(async () => [
+  { id: "source-1", role: "user" as const, content: "before", createdAt: 100 },
+  {
+    id: "source-2",
+    role: "assistant" as const,
+    content: "after",
+    createdAt: 101,
+  },
+]);
+const issueGroupClaim = mock(async () => undefined);
+const consumeGroupClaimAndBind = mock(
+  async (): Promise<
+    | { status: "invalid" }
+    | { status: "expired" }
+    | { status: "already_used" }
+    | { status: "already_bound" }
+    | { status: "bound"; binding: Record<string, unknown> }
+  > => ({ status: "invalid" }),
+);
+const resolveGroupBinding = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const setGroupResponsePolicy = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const revokeGroupBinding = mock(async () => false);
+const applyGroupMembershipChange = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const recordGroupDeliveryReceipts = mock(async () => 0);
+const hasGroupDeliveryReceipt = mock(async () => false);
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const runtimeWaitUntil = mock((_promise: Promise<unknown>) => undefined);
+const runtimeExecutionCtx = { waitUntil: runtimeWaitUntil };
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: {
+    resolvePersonalDelivery,
+  },
+}));
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
+mock.module("@/lib/services/eliza-app/onboarding-chat", () => ({
+  runOnboardingChat,
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: async () => creditGateResult,
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: async () => workerHealthResult,
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentResumeOnce,
+    enqueueAgentWakeOnce,
+    triggerImmediate,
+  },
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { bridge, importCanonicalConversation },
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedHistory,
+}));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    issueClaim: issueGroupClaim,
+    consumeClaimAndBind: consumeGroupClaimAndBind,
+    resolveBinding: resolveGroupBinding,
+    setResponsePolicy: setGroupResponsePolicy,
+    revokeBinding: revokeGroupBinding,
+    applyMembershipChange: applyGroupMembershipChange,
+    recordDeliveryReceipts: recordGroupDeliveryReceipts,
+    hasDeliveryReceipt: hasGroupDeliveryReceipt,
+  },
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: runtimeExecutionCtx,
+  }),
+}));
+
+const { default: app } = await import("./route");
+const executionCtx = { waitUntil() {}, passThroughOnException() {}, props: {} };
+
+function request(
+  body: unknown,
+  authorization = "Bearer test-secret",
+  traceId = "11111111-1111-4111-8111-111111111111",
+) {
+  return app.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization,
+        "content-type": "application/json",
+        "x-eliza-trace-id": traceId,
+      },
+      body: JSON.stringify(body),
+    },
+    {
+      INTERNAL_SECRET: "test-secret",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+      WHISPER_STT_URL: "https://whisper.test",
+    } as never,
+    executionCtx as never,
+  );
+}
+
+// Same canonical owner as route.test.ts: personalSharedAgent for this
+// userId/organizationId derives exactly this personal_agent_id, which the
+// route cross-checks against the binding before any group turn.
+const canonicalGroupBinding = {
+  id: "00000000-0000-4000-8000-000000000030",
+  organization_id: "00000000-0000-4000-8000-000000000001",
+  owner_user_id: "00000000-0000-4000-8000-000000000002",
+  personal_agent_id: "personal:3e91680e-2611-5ff5-b759-c16b990967bd",
+  platform: "telegram",
+  project: "eliza-app",
+  connector_account_id: "telegram:test-bot",
+  provider_chat_id: "-100123456789",
+  conversation_id: "group:00000000-0000-5000-8000-000000000030",
+  state: "active",
+  response_policy: "mention_only",
+  created_by_platform_user_id: "123456789",
+};
+
+const blooioGroupBinding = {
+  ...canonicalGroupBinding,
+  id: "00000000-0000-4000-8000-000000000031",
+  platform: "blooio",
+  connector_account_id: "blooio:test-number",
+  provider_chat_id: "chat_group_123",
+  conversation_id: "group:00000000-0000-5000-8000-000000000031",
+  created_by_platform_user_id: "+15551234567",
+};
+
+const validGroup = {
+  platform: "telegram",
+  chatType: "supergroup",
+  project: "eliza-app",
+  connectorAccountId: "telegram:test-bot",
+  chatId: "-100123456789",
+  actor: {
+    platformUserId: "123456789",
+    displayName: "Nubs",
+    role: "administrator",
+  },
+  messageId: "telegram:eliza:group-42",
+  message: "@ElizaIsNotABot hello",
+  invocation: "mention",
+};
+
+const validBlooioGroup = {
+  platform: "blooio",
+  chatType: "group",
+  project: "eliza-app",
+  connectorAccountId: "blooio:test-number",
+  chatId: "chat_group_123",
+  actor: {
+    platformUserId: "+15551234567",
+    displayName: "Ada",
+    role: "possessor",
+  },
+  messageId: "blooio:eliza:group-42",
+  message: "following up on that",
+  invocation: "reply",
+  replyToMessageId: "provider-eliza-reply-0",
+};
+
+describe("adversarial Personal Shared group routing", () => {
+  beforeEach(() => {
+    activeTarget = null;
+    resolvePersonalDelivery.mockClear();
+    findActivePersonalDedicatedTarget.mockClear();
+    sharedRestMessageSend.mockClear();
+    prewarmPersonalSharedAgentTurnCaches.mockClear();
+    runtimeWaitUntil.mockClear();
+    runOnboardingChat.mockClear();
+    bridge.mockClear();
+    importCanonicalConversation.mockClear();
+    coordinateSharedHistory.mockClear();
+    issueGroupClaim.mockClear();
+    consumeGroupClaimAndBind.mockClear();
+    resolveGroupBinding.mockClear();
+    setGroupResponsePolicy.mockClear();
+    revokeGroupBinding.mockClear();
+    applyGroupMembershipChange.mockClear();
+    recordGroupDeliveryReceipts.mockClear();
+    hasGroupDeliveryReceipt.mockClear();
+    resolveGroupBinding.mockImplementation(async () => null);
+    hasGroupDeliveryReceipt.mockImplementation(async () => false);
+    setGroupResponsePolicy.mockImplementation(
+      async () => canonicalGroupBinding,
+    );
+    revokeGroupBinding.mockImplementation(async () => true);
+    enqueueAgentResumeOnce.mockClear();
+    enqueueAgentWakeOnce.mockClear();
+    triggerImmediate.mockClear();
+    creditGateResult = { allowed: true, balance: 10 };
+    workerHealthResult = { ok: true, required: false };
+  });
+
+  test("downgrades a forged Blooio reply without a delivery receipt to silent ambient", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => blooioGroupBinding);
+
+    const response = await request({
+      ...validBlooioGroup,
+      replyToMessageId: "forged-provider-id",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_silent", reply: "" },
+    });
+    expect(hasGroupDeliveryReceipt).toHaveBeenCalledWith({
+      bindingId: blooioGroupBinding.id,
+      providerMessageId: "forged-provider-id",
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("answers a Blooio reply only after its receipt verifies the reply target", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => blooioGroupBinding);
+    hasGroupDeliveryReceipt.mockImplementationOnce(async () => true);
+
+    const response = await request(validBlooioGroup);
+
+    expect(response.status).toBe(200);
+    expect(hasGroupDeliveryReceipt).toHaveBeenCalledWith({
+      bindingId: blooioGroupBinding.id,
+      providerMessageId: "provider-eliza-reply-0",
+    });
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: blooioGroupBinding.personal_agent_id }),
+      blooioGroupBinding.conversation_id,
+      expect.stringMatching(/^Ada \[participant [0-9a-f]{8}\]: /),
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      validBlooioGroup.messageId,
+      "platform",
+      undefined,
+      undefined,
+      { type: "GROUP", source: "blooio" },
+    );
+  });
+
+  test("treats a Blooio reply lacking a reply target as ambient without probing receipts", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => blooioGroupBinding);
+
+    const response = await request({
+      ...validBlooioGroup,
+      replyToMessageId: undefined,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_silent", reply: "" },
+    });
+    expect(hasGroupDeliveryReceipt).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("keeps Telegram reply invocations connector-trusted without receipt probes", async () => {
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+
+    const response = await request({
+      ...validGroup,
+      message: "sounds good",
+      invocation: "reply",
+      replyToMessageId: "unverified-telegram-reply",
+    });
+
+    expect(response.status).toBe(200);
+    expect(hasGroupDeliveryReceipt).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { reply: "hello from Eliza" },
+    });
+  });
+
+  test("rejects a non-owner policy change with group_owner_required", async () => {
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+
+    const response = await request({
+      ...validGroup,
+      actor: {
+        platformUserId: "987654321",
+        displayName: "Mallory",
+        role: "administrator",
+      },
+      message: "Eliza ambient on",
+      invocation: "command",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_owner_required",
+        reply: expect.stringContaining("Only the owner"),
+      },
+    });
+    expect(setGroupResponsePolicy).not.toHaveBeenCalled();
+    expect(revokeGroupBinding).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-owner leave command with group_owner_required", async () => {
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+
+    const response = await request({
+      ...validGroup,
+      actor: {
+        platformUserId: "987654321",
+        displayName: "Mallory",
+        role: "administrator",
+      },
+      message: "Eliza leave",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_owner_required" },
+    });
+    expect(revokeGroupBinding).not.toHaveBeenCalled();
+    expect(setGroupResponsePolicy).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("routes a bound group mention through Dedicated after cutover", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+
+    const response = await request(validGroup);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      data: {
+        identity: {
+          id: canonicalGroupBinding.personal_agent_id,
+          runtime: "dedicated",
+          activeAgentId: "00000000-0000-4000-8000-000000000020",
+        },
+        account: {
+          userId: canonicalGroupBinding.owner_user_id,
+          organizationId: canonicalGroupBinding.organization_id,
+        },
+        reply: "hello from Dedicated",
+      },
+    });
+    expect(findActivePersonalDedicatedTarget).toHaveBeenCalledWith(
+      canonicalGroupBinding.organization_id,
+      canonicalGroupBinding.personal_agent_id,
+    );
+    expect(bridge).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000020",
+      canonicalGroupBinding.organization_id,
+      expect.objectContaining({
+        id: validGroup.messageId,
+        method: "message.send",
+        params: expect.objectContaining({
+          text: expect.stringMatching(
+            /^Nubs \[participant [0-9a-f]{8}\]: @ElizaIsNotABot hello$/,
+          ),
+          roomId: canonicalGroupBinding.conversation_id,
+          conversationId: canonicalGroupBinding.conversation_id,
+          senderName: expect.stringMatching(
+            /^Nubs \[participant [0-9a-f]{8}\]$/,
+          ),
+          clientMessageId: validGroup.messageId,
+          platformName: "telegram",
+          source: "telegram",
+        }),
+      }),
+    );
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("repairs a missing Dedicated group conversation from group Shared history", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+    resolveGroupBinding.mockImplementationOnce(
+      async () => canonicalGroupBinding,
+    );
+    bridge
+      .mockImplementationOnce(async () => ({
+        jsonrpc: "2.0" as const,
+        id: validGroup.messageId,
+        error: { code: -32_000, message: "Bridge returned HTTP 404" },
+      }))
+      .mockImplementationOnce(async () => ({
+        jsonrpc: "2.0" as const,
+        id: validGroup.messageId,
+        result: { text: "repaired Dedicated group reply" },
+      }));
+
+    const response = await request(validGroup);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { reply: "repaired Dedicated group reply" },
+    });
+    expect(coordinateSharedHistory).toHaveBeenCalledWith(
+      canonicalGroupBinding.personal_agent_id,
+      canonicalGroupBinding.conversation_id,
+      { namespace },
+    );
+    expect(importCanonicalConversation).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000020",
+      canonicalGroupBinding.organization_id,
+      canonicalGroupBinding.conversation_id,
+      [
+        { sourceId: "source-1", role: "user", text: "before", timestamp: 100 },
+        {
+          sourceId: "source-2",
+          role: "assistant",
+          text: "after",
+          timestamp: 101,
+        },
+      ],
+    );
+    expect(bridge).toHaveBeenCalledTimes(2);
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("maps an expired group claim to its expired recovery reply", async () => {
+    consumeGroupClaimAndBind.mockImplementationOnce(async () => ({
+      status: "expired" as const,
+    }));
+
+    const response = await request({
+      ...validGroup,
+      message: "/eliza_link 23456789",
+      invocation: "command",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_claim_expired",
+        reply: expect.stringContaining("expired"),
+      },
+    });
+    expect(resolveGroupBinding).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("maps a consumed group claim to its already-used recovery reply", async () => {
+    consumeGroupClaimAndBind.mockImplementationOnce(async () => ({
+      status: "already_used" as const,
+    }));
+
+    const response = await request({
+      ...validGroup,
+      message: "/eliza_link 23456789",
+      invocation: "command",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_claim_already_used",
+        reply: expect.stringContaining("already used"),
+      },
+    });
+    expect(resolveGroupBinding).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("tells a mention in a suspended group how to reconnect without inference", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...canonicalGroupBinding,
+      state: "suspended",
+    }));
+
+    const response = await request(validGroup);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_binding_suspended",
+        reply: expect.stringContaining("inactive"),
+      },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("keeps ambient traffic in a suspended group fully silent", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...canonicalGroupBinding,
+      state: "suspended",
+    }));
+
+    const response = await request({ ...validGroup, invocation: "ambient" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_binding_suspended", reply: "" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("tells a mention in an unlinked group how to link without inference", async () => {
+    const response = await request(validGroup);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_not_bound",
+        reply: expect.stringContaining("not linked yet"),
+      },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
+  test("keeps ambient traffic in an unlinked group fully silent", async () => {
+    const response = await request({ ...validGroup, invocation: "ambient" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_not_bound", reply: "" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Adversarial group egress coverage for the gateway webhook handler with
+ * deterministic in-memory Redis and fixture adapters: a failed group receipt
+ * persistence must keep the dedupe closed (no double provider egress on
+ * provider retry), the receipt POST must survive a stale-auth 401, and a
+ * Telegram supergroup turn must run the full group classification and
+ * receipt path without being rerouted onto the personal edge-forward.
+ */
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type {
+  ChatEvent,
+  PlatformAdapter,
+  WebhookConfig,
+} from "../src/adapters/types";
+import { logger } from "../src/logger";
+import type { GatewayRedis } from "../src/redis";
+import { handleWebhook } from "../src/webhook-handler";
+
+type RedisSetOptions = { ex?: number; nx?: boolean };
+
+class MemoryRedis implements GatewayRedis {
+  readonly store = new Map<string, string>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const value = this.store.get(key);
+    if (value === undefined) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return value as T;
+    }
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: RedisSetOptions = {},
+  ): Promise<unknown> {
+    if (options.nx && this.store.has(key)) return null;
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+const originalFetch = globalThis.fetch;
+const envKeys = [
+  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+] as const;
+const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+
+async function waitFor(assertion: () => boolean, label: string): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < 2_000) {
+    if (assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function blooioGroupEvent(messageId: string): ChatEvent {
+  return {
+    platform: "blooio",
+    messageId,
+    chatId: "chat_group_123",
+    chatType: "group",
+    senderId: "+15551234567",
+    senderName: "Ada",
+    text: "@eliza status?",
+    rawPayload: {},
+  };
+}
+
+function blooioGroupAdapter(event: ChatEvent): PlatformAdapter & {
+  sendReplyWithReceipt: ReturnType<typeof mock>;
+  sendReply: ReturnType<typeof mock>;
+} {
+  return {
+    platform: "blooio",
+    verifyWebhook: mock(async () => true),
+    extractEvent: mock(async () => event),
+    sendTypingIndicator: mock(async () => undefined),
+    stopTypingIndicator: mock(async () => undefined),
+    sendReply: mock(async () => undefined),
+    sendReplyWithReceipt: mock(async () => ({
+      providerMessageIds: ["provider-eliza-reply-1"],
+    })),
+  };
+}
+
+function blooioRequest(): Request {
+  return new Request("https://gateway.example/webhook/eliza-app/blooio", {
+    method: "POST",
+    body: "{}",
+  });
+}
+
+describe("gateway webhook group egress adversarial paths", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const key of envKeys) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mock.restore();
+  });
+
+  test("keeps the dedupe closed after group egress when receipt persistence fails", async () => {
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
+    const redis = new MemoryRedis();
+    const event = blooioGroupEvent("blooio-group-receipt-500");
+    const adapter = blooioGroupAdapter(event);
+    const errorLog = spyOn(logger, "error").mockImplementation(() => undefined);
+    let turnCalls = 0;
+    let receiptCalls = 0;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_receipt") {
+          receiptCalls += 1;
+          return new Response("receipt store unavailable", { status: 500 });
+        }
+        turnCalls += 1;
+        return Response.json({ success: true, data: { reply: "group reply" } });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    };
+
+    const response = await handleWebhook(
+      blooioRequest(),
+      adapter,
+      deps,
+      "eliza-app",
+    );
+    expect(response.status).toBe(200);
+    await waitFor(
+      () =>
+        errorLog.mock.calls.some(
+          ([message]) => message === "Background message processing failed",
+        ),
+      "background receipt persistence failure",
+    );
+
+    // The provider message already went out: the failure is post-egress, so
+    // the dedupe key must survive (a PersonalSharedPreEgressError would have
+    // reopened it) and the receipt-tail error must name the real cause.
+    expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+    expect(receiptCalls).toBe(1);
+    expect(
+      redis.store.has("webhook:blooio:blooio-group-receipt-500"),
+    ).toBe(true);
+    expect(errorLog).toHaveBeenCalledWith(
+      "Background message processing failed",
+      expect.objectContaining({
+        error: expect.stringContaining(
+          "group delivery receipt persistence failed (500)",
+        ),
+      }),
+    );
+
+    // A Blooio retry of the identical webhook is acked as a duplicate: no
+    // second turn, no second provider egress into the group.
+    const replay = await handleWebhook(
+      blooioRequest(),
+      adapter,
+      deps,
+      "eliza-app",
+    );
+    expect(replay.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(turnCalls).toBe(1);
+    expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+    expect(receiptCalls).toBe(1);
+  });
+
+  test("retries the group receipt once with fresh auth after a stale 401", async () => {
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
+    const redis = new MemoryRedis();
+    const event = blooioGroupEvent("blooio-group-receipt-401");
+    const adapter = blooioGroupAdapter(event);
+    const errorLog = spyOn(logger, "error").mockImplementation(() => undefined);
+    const infoLog = spyOn(logger, "info").mockImplementation(() => undefined);
+    const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+    const receiptAttempts: Array<string | null> = [];
+    let receiptBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_receipt") {
+          receiptAttempts.push(request.headers.get("authorization"));
+          if (receiptAttempts.length === 1) {
+            return new Response("unauthorized", { status: 401 });
+          }
+          receiptBody = body;
+          return Response.json({ success: true, data: { inserted: 1 } });
+        }
+        return Response.json({ success: true, data: { reply: "group reply" } });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      blooioRequest(),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer stale" }),
+        reacquireAuthHeader: reauth,
+      },
+      "eliza-app",
+    );
+    expect(response.status).toBe(200);
+    await waitFor(
+      () => receiptBody !== null,
+      "reauthenticated receipt persistence",
+    );
+
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(receiptAttempts).toEqual(["Bearer stale", "Bearer fresh"]);
+    expect(receiptBody).toEqual({
+      eventType: "delivery_receipt",
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550000001",
+      chatId: "chat_group_123",
+      sourceMessageId: "blooio:eliza-app:blooio-group-receipt-401",
+      providerMessageIds: ["provider-eliza-reply-1"],
+    });
+    expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+    await waitFor(
+      () =>
+        infoLog.mock.calls.some(
+          ([message]) => message === "Personal Eliza connector message completed",
+        ),
+      "group turn completion log",
+    );
+    expect(
+      errorLog.mock.calls.some(
+        ([message]) => message === "Background message processing failed",
+      ),
+    ).toBe(false);
+  });
+
+  test("runs a Telegram supergroup turn through the delivery ledger, not the edge forward", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const redis = new MemoryRedis();
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "tg-group-update-1",
+      platformRecordId: "tg-group-message-1",
+      chatId: "-100123456789",
+      chatType: "supergroup",
+      senderId: "123456789",
+      senderName: "Nubs",
+      text: "@ElizaIsNotABot hello",
+      groupActorRole: "administrator",
+      groupInvocation: "mention",
+      rawPayload: {},
+    };
+    const sendReply = mock(async () => undefined);
+    const sendReplyWithReceipt = mock(async () => ({
+      providerMessageIds: ["tg-provider-7"],
+    }));
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      getDedupeScope: () => "scope",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply,
+      sendReplyWithReceipt,
+    };
+    let turnBody: Record<string, unknown> | null = null;
+    let receiptBody: Record<string, unknown> | null = null;
+    let turnCalls = 0;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (request.url.endsWith("/api/eliza-app/webhook/telegram/edge")) {
+        throw new Error(
+          "group turn was rerouted onto the personal edge forward",
+        );
+      }
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_receipt") {
+          receiptBody = body;
+          return Response.json({ success: true, data: { inserted: 1 } });
+        }
+        turnCalls += 1;
+        turnBody = body;
+        return Response.json({
+          success: true,
+          data: { reply: "group turn reply" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      // The edge cutover secret is configured; DMs would take the edge
+      // forward, but groups must stay on the gateway-owned ledger path.
+      deliveryAuthoritySecret: "edge-secret",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    };
+    const request = () =>
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      });
+
+    const response = await handleWebhook(
+      request(),
+      adapter,
+      deps,
+      "eliza-app",
+    );
+    expect(response.status).toBe(200);
+
+    expect(turnBody).toEqual({
+      platform: "telegram",
+      chatType: "supergroup",
+      project: "eliza-app",
+      connectorAccountId:
+        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      chatId: "-100123456789",
+      actor: {
+        platformUserId: "123456789",
+        displayName: "Nubs",
+        role: "administrator",
+      },
+      messageId: "telegram:eliza-app:tg-group-update-1",
+      message: "@ElizaIsNotABot hello",
+      invocation: "mention",
+    });
+    expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+    expect(sendReply).not.toHaveBeenCalled();
+    expect(receiptBody).toEqual({
+      eventType: "delivery_receipt",
+      platform: "telegram",
+      project: "eliza-app",
+      connectorAccountId:
+        "bot:a7df583dbeed5b233d355143673e458bf882856d938ab4bd0fc7adfa4be6bf3c",
+      chatId: "-100123456789",
+      sourceMessageId: "telegram:eliza-app:tg-group-update-1",
+      providerMessageIds: ["tg-provider-7"],
+    });
+    expect(
+      redis.store.get("webhook:telegram:scope:message:tg-group-update-1"),
+    ).toBe("delivered");
+
+    // Telegram redelivers the same update: the delivery ledger refuses the
+    // replay outright — no second turn, no second group egress.
+    const replay = await handleWebhook(request(), adapter, deps, "eliza-app");
+    expect(replay.status).toBe(200);
+    expect(turnCalls).toBe(1);
+    expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
@@ -1,10 +1,12 @@
 /**
  * Adversarial group egress coverage for the gateway webhook handler with
- * deterministic in-memory Redis and fixture adapters: a failed group receipt
- * persistence must keep the dedupe closed (no double provider egress on
- * provider retry), the receipt POST must survive a stale-auth 401, and a
- * Telegram supergroup turn must run the full group classification and
- * receipt path without being rerouted onto the personal edge-forward.
+ * deterministic in-memory Redis and fixture adapters. Every group turn runs
+ * the real authorization → commit → provider egress → receipt ledger: a
+ * receipt that the Shared endpoint rejects as stale authority must reopen the
+ * webhook without a second provider send on replay, the receipt POST must
+ * survive a stale-auth 401 while keeping the same lease token, and a Telegram
+ * supergroup turn must run the full ledger path instead of the personal
+ * edge-forward.
  */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type {
@@ -27,6 +29,8 @@ class MemoryRedis implements GatewayRedis {
     try {
       return JSON.parse(value) as T;
     } catch {
+      // error-policy:J3 the handler stores both JSON documents and bare ledger
+      // markers under the same client; a non-JSON value is the marker itself.
       return value as T;
     }
   }
@@ -64,6 +68,14 @@ const envKeys = [
   "ELIZA_APP_BLOOIO_PHONE_NUMBER",
 ] as const;
 const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+
+const SHARED_MESSAGES_PATH = "/api/internal/eliza-app/personal-shared/messages";
+const AUTHORITY = {
+  bindingId: "00000000-0000-4000-8000-000000000030",
+  ownerUserId: "00000000-0000-4000-8000-000000000002",
+  personalAgentId: "personal:3e91680e-2611-5ff5-b759-c16b990967bd",
+  version: 7,
+};
 
 async function waitFor(assertion: () => boolean, label: string): Promise<void> {
   const started = Date.now();
@@ -111,6 +123,63 @@ function blooioRequest(): Request {
   });
 }
 
+/**
+ * Minimal Shared-endpoint ledger: one lease per source message. Authorization
+ * is granted until a commit lands for that source message, which mirrors the
+ * durable fence the cloud route applies on replay.
+ */
+class SharedLedgerMock {
+  readonly committed = new Set<string>();
+  readonly leaseTokens: string[] = [];
+  authorizationCalls = 0;
+  commitCalls = 0;
+
+  authorize(body: Record<string, unknown>): Response {
+    this.authorizationCalls += 1;
+    const sourceMessageId = body.sourceMessageId as string;
+    if (this.committed.has(sourceMessageId)) {
+      return Response.json({
+        success: true,
+        data: {
+          code: "group_delivery_authorization",
+          authorized: false,
+          leaseToken: null,
+          expiresAt: null,
+        },
+      });
+    }
+    this.leaseTokens.push(body.leaseToken as string);
+    return Response.json({
+      success: true,
+      data: {
+        code: "group_delivery_authorization",
+        authorized: true,
+        leaseToken: body.leaseToken,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    });
+  }
+
+  commit(body: Record<string, unknown>): Response {
+    this.commitCalls += 1;
+    this.committed.add(body.sourceMessageId as string);
+    return Response.json({
+      success: true,
+      data: { code: "group_delivery_committed", committed: true },
+    });
+  }
+}
+
+function turnResponse(reply: string): Response {
+  return Response.json({
+    success: true,
+    data: {
+      reply,
+      groupDelivery: { kind: "binding", authority: AUTHORITY },
+    },
+  });
+}
+
 describe("gateway webhook group egress adversarial paths", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
@@ -125,27 +194,41 @@ describe("gateway webhook group egress adversarial paths", () => {
     mock.restore();
   });
 
-  test("keeps the dedupe closed after group egress when receipt persistence fails", async () => {
+  test("reopens the webhook after a stale-authority receipt rejection without resending into the group", async () => {
     process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
     const redis = new MemoryRedis();
-    const event = blooioGroupEvent("blooio-group-receipt-500");
+    const event = blooioGroupEvent("blooio-group-receipt-stale");
     const adapter = blooioGroupAdapter(event);
     const errorLog = spyOn(logger, "error").mockImplementation(() => undefined);
+    const ledger = new SharedLedgerMock();
     let turnCalls = 0;
     let receiptCalls = 0;
 
     globalThis.fetch = mock(async (input, init) => {
       const request = new Request(input, init);
-      if (
-        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
-      ) {
+      if (request.url.endsWith(SHARED_MESSAGES_PATH)) {
         const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_authorization") {
+          return ledger.authorize(body);
+        }
+        if (body.eventType === "delivery_commit") {
+          return ledger.commit(body);
+        }
         if (body.eventType === "delivery_receipt") {
           receiptCalls += 1;
-          return new Response("receipt store unavailable", { status: 500 });
+          // The binding's authority moved between commit and receipt: the
+          // route persists nothing and reports the rejection explicitly.
+          return Response.json({
+            success: true,
+            data: {
+              code: "group_delivery_receipt_recorded",
+              recorded: false,
+              inserted: 0,
+            },
+          });
         }
         turnCalls += 1;
-        return Response.json({ success: true, data: { reply: "group reply" } });
+        return turnResponse("group reply");
       }
       throw new Error(`Unexpected fetch: ${request.url}`);
     }) as typeof fetch;
@@ -155,6 +238,7 @@ describe("gateway webhook group egress adversarial paths", () => {
       cloudBaseUrl: "https://api.elizacloud.ai",
       getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
     };
+    const dedupKey = "webhook:blooio:blooio-group-receipt-stale";
 
     const response = await handleWebhook(
       blooioRequest(),
@@ -171,25 +255,24 @@ describe("gateway webhook group egress adversarial paths", () => {
       "background receipt persistence failure",
     );
 
-    // The provider message already went out: the failure is post-egress, so
-    // the dedupe key must survive (a PersonalSharedPreEgressError would have
-    // reopened it) and the receipt-tail error must name the real cause.
+    // The provider message already went out once. The rejected receipt is a
+    // recoverable post-egress failure: the error names the real cause and the
+    // webhook is reopened so the gateway can retry the exact same message.
     expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
     expect(receiptCalls).toBe(1);
-    expect(
-      redis.store.has("webhook:blooio:blooio-group-receipt-500"),
-    ).toBe(true);
     expect(errorLog).toHaveBeenCalledWith(
       "Background message processing failed",
       expect.objectContaining({
-        error: expect.stringContaining(
-          "group delivery receipt persistence failed (500)",
-        ),
+        error: "group delivery receipt persistence rejected stale authority",
+        platform: "blooio",
+        messageId: "blooio-group-receipt-stale",
       }),
     );
+    await waitFor(() => !redis.store.has(dedupKey), "dedupe reopening");
 
-    // A Blooio retry of the identical webhook is acked as a duplicate: no
-    // second turn, no second provider egress into the group.
+    // A Blooio retry of the identical webhook re-runs the idempotent turn but
+    // the committed lease refuses a second authorization: no second provider
+    // egress into the group, and the replay settles as delivered.
     const replay = await handleWebhook(
       blooioRequest(),
       adapter,
@@ -197,13 +280,21 @@ describe("gateway webhook group egress adversarial paths", () => {
       "eliza-app",
     );
     expect(replay.status).toBe(200);
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(turnCalls).toBe(1);
+    await waitFor(
+      () => ledger.authorizationCalls === 2,
+      "replay authorization",
+    );
+    await waitFor(
+      () => redis.store.get(dedupKey) === "delivered",
+      "replay settling as delivered",
+    );
+    expect(turnCalls).toBe(2);
+    expect(ledger.commitCalls).toBe(1);
     expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
     expect(receiptCalls).toBe(1);
   });
 
-  test("retries the group receipt once with fresh auth after a stale 401", async () => {
+  test("retries the group receipt once with fresh auth after a stale 401 under the same lease", async () => {
     process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550000001";
     const redis = new MemoryRedis();
     const event = blooioGroupEvent("blooio-group-receipt-401");
@@ -211,24 +302,38 @@ describe("gateway webhook group egress adversarial paths", () => {
     const errorLog = spyOn(logger, "error").mockImplementation(() => undefined);
     const infoLog = spyOn(logger, "info").mockImplementation(() => undefined);
     const reauth = mock(async () => ({ Authorization: "Bearer fresh" }));
+    const ledger = new SharedLedgerMock();
     const receiptAttempts: Array<string | null> = [];
     let receiptBody: Record<string, unknown> | null = null;
 
     globalThis.fetch = mock(async (input, init) => {
       const request = new Request(input, init);
-      if (
-        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
-      ) {
+      if (request.url.endsWith(SHARED_MESSAGES_PATH)) {
         const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_authorization") {
+          return ledger.authorize(body);
+        }
+        if (body.eventType === "delivery_commit") {
+          return ledger.commit(body);
+        }
         if (body.eventType === "delivery_receipt") {
+          // The internal token expires between the durable commit and the
+          // receipt POST: only the receipt sees the stale credential.
           receiptAttempts.push(request.headers.get("authorization"));
           if (receiptAttempts.length === 1) {
             return new Response("unauthorized", { status: 401 });
           }
           receiptBody = body;
-          return Response.json({ success: true, data: { inserted: 1 } });
+          return Response.json({
+            success: true,
+            data: {
+              code: "group_delivery_receipt_recorded",
+              recorded: true,
+              inserted: 1,
+            },
+          });
         }
-        return Response.json({ success: true, data: { reply: "group reply" } });
+        return turnResponse("group reply");
       }
       throw new Error(`Unexpected fetch: ${request.url}`);
     }) as typeof fetch;
@@ -252,6 +357,7 @@ describe("gateway webhook group egress adversarial paths", () => {
 
     expect(reauth).toHaveBeenCalledTimes(1);
     expect(receiptAttempts).toEqual(["Bearer stale", "Bearer fresh"]);
+    expect(ledger.leaseTokens).toHaveLength(1);
     expect(receiptBody).toEqual({
       eventType: "delivery_receipt",
       platform: "blooio",
@@ -260,12 +366,17 @@ describe("gateway webhook group egress adversarial paths", () => {
       chatId: "chat_group_123",
       sourceMessageId: "blooio:eliza-app:blooio-group-receipt-401",
       providerMessageIds: ["provider-eliza-reply-1"],
+      authority: AUTHORITY,
+      // The retried receipt must still name the lease that was authorized and
+      // committed; a fresh token would orphan the committed delivery.
+      leaseToken: ledger.leaseTokens[0],
     });
     expect(adapter.sendReplyWithReceipt).toHaveBeenCalledTimes(1);
     await waitFor(
       () =>
         infoLog.mock.calls.some(
-          ([message]) => message === "Personal Eliza connector message completed",
+          ([message]) =>
+            message === "Personal Eliza connector message completed",
         ),
       "group turn completion log",
     );
@@ -274,6 +385,12 @@ describe("gateway webhook group egress adversarial paths", () => {
         ([message]) => message === "Background message processing failed",
       ),
     ).toBe(false);
+    await waitFor(
+      () =>
+        redis.store.get("webhook:blooio:blooio-group-receipt-401") ===
+        "delivered",
+      "group turn settling as delivered",
+    );
   });
 
   test("runs a Telegram supergroup turn through the delivery ledger, not the edge forward", async () => {
@@ -305,6 +422,7 @@ describe("gateway webhook group egress adversarial paths", () => {
       sendReply,
       sendReplyWithReceipt,
     };
+    const ledger = new SharedLedgerMock();
     let turnBody: Record<string, unknown> | null = null;
     let receiptBody: Record<string, unknown> | null = null;
     let turnCalls = 0;
@@ -316,20 +434,28 @@ describe("gateway webhook group egress adversarial paths", () => {
           "group turn was rerouted onto the personal edge forward",
         );
       }
-      if (
-        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
-      ) {
+      if (request.url.endsWith(SHARED_MESSAGES_PATH)) {
         const body = (await request.json()) as Record<string, unknown>;
+        if (body.eventType === "delivery_authorization") {
+          return ledger.authorize(body);
+        }
+        if (body.eventType === "delivery_commit") {
+          return ledger.commit(body);
+        }
         if (body.eventType === "delivery_receipt") {
           receiptBody = body;
-          return Response.json({ success: true, data: { inserted: 1 } });
+          return Response.json({
+            success: true,
+            data: {
+              code: "group_delivery_receipt_recorded",
+              recorded: true,
+              inserted: 1,
+            },
+          });
         }
         turnCalls += 1;
         turnBody = body;
-        return Response.json({
-          success: true,
-          data: { reply: "group turn reply" },
-        });
+        return turnResponse("group turn reply");
       }
       throw new Error(`Unexpected fetch: ${request.url}`);
     }) as typeof fetch;
@@ -348,12 +474,7 @@ describe("gateway webhook group egress adversarial paths", () => {
         body: "{}",
       });
 
-    const response = await handleWebhook(
-      request(),
-      adapter,
-      deps,
-      "eliza-app",
-    );
+    const response = await handleWebhook(request(), adapter, deps, "eliza-app");
     expect(response.status).toBe(200);
 
     expect(turnBody).toEqual({
@@ -372,6 +493,8 @@ describe("gateway webhook group egress adversarial paths", () => {
       message: "@ElizaIsNotABot hello",
       invocation: "mention",
     });
+    expect(ledger.authorizationCalls).toBe(1);
+    expect(ledger.commitCalls).toBe(1);
     expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
     expect(sendReply).not.toHaveBeenCalled();
     expect(receiptBody).toEqual({
@@ -383,6 +506,8 @@ describe("gateway webhook group egress adversarial paths", () => {
       chatId: "-100123456789",
       sourceMessageId: "telegram:eliza-app:tg-group-update-1",
       providerMessageIds: ["tg-provider-7"],
+      authority: AUTHORITY,
+      leaseToken: ledger.leaseTokens[0],
     });
     expect(
       redis.store.get("webhook:telegram:scope:message:tg-group-update-1"),
@@ -393,6 +518,7 @@ describe("gateway webhook group egress adversarial paths", () => {
     const replay = await handleWebhook(request(), adapter, deps, "eliza-app");
     expect(replay.status).toBe(200);
     expect(turnCalls).toBe(1);
+    expect(ledger.authorizationCalls).toBe(1);
     expect(sendReplyWithReceipt).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.groups-adversarial.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.groups-adversarial.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Adversarial Personal Shared group claim lifecycle against isolated PGlite:
+ * exact TTL-boundary expiry, reissue invalidation, cross-platform and
+ * cross-connector reuse that must neither bind nor burn a live code, and the
+ * silent policy reset when the same owner relinks a suspended binding.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_A = "72000000-0000-4000-8000-000000000001";
+const USER_A = "72000000-0000-4000-8000-000000000011";
+const CHAT_ID = "chat_group_adversarial";
+const BLOOIO_CONNECTOR = "blooio:+15550000002";
+const TELEGRAM_CONNECTOR = "telegram:test-bot";
+const NOW = new Date("2026-08-22T00:00:00.000Z");
+const EXPIRES_AT = new Date(NOW.getTime() + 60_000);
+
+let closeDatabaseConnectionsForTests:
+  | typeof import("../client").closeDatabaseConnectionsForTests
+  | undefined;
+let getPgliteClientForTests: typeof import("../client").getPgliteClientForTests;
+let repository: typeof import("./personal-shared-groups").personalSharedGroupsRepository;
+
+async function issue(input: {
+  codeHash: string;
+  platform?: "telegram" | "blooio";
+  connectorAccountId?: string;
+  platformUserId: string;
+  expiresAt?: Date;
+}): Promise<void> {
+  await repository.issueClaim({
+    codeHash: input.codeHash,
+    organizationId: ORG_A,
+    ownerUserId: USER_A,
+    personalAgentId: "personal:owner-a",
+    platform: input.platform ?? "blooio",
+    project: "eliza-app",
+    connectorAccountId: input.connectorAccountId ?? BLOOIO_CONNECTOR,
+    issuedToPlatformUserId: input.platformUserId,
+    expiresAt: input.expiresAt ?? EXPIRES_AT,
+  });
+}
+
+async function consume(input: {
+  codeHash: string;
+  platform?: "telegram" | "blooio";
+  connectorAccountId?: string;
+  platformUserId: string;
+  verifiedAt?: Date;
+}) {
+  return repository.consumeClaimAndBind({
+    codeHash: input.codeHash,
+    platform: input.platform ?? "blooio",
+    project: "eliza-app",
+    connectorAccountId: input.connectorAccountId ?? BLOOIO_CONNECTOR,
+    providerChatId: CHAT_ID,
+    actorPlatformUserId: input.platformUserId,
+    verifiedAt: input.verifiedAt ?? NOW,
+  });
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests, getPgliteClientForTests } = await import("../client"));
+  ({ personalSharedGroupsRepository: repository } = await import("./personal-shared-groups"));
+  const database = getPgliteClientForTests();
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+  `);
+  const migration = await Bun.file(
+    new URL("../migrations/0297_personal_shared_group_bindings.sql", import.meta.url),
+  ).text();
+  await database.exec(migration);
+});
+
+beforeEach(async () => {
+  await getPgliteClientForTests().exec(`
+    TRUNCATE personal_shared_group_delivery_receipts,
+      personal_shared_group_bindings,
+      personal_shared_group_claims,
+      users,
+      organizations CASCADE;
+    INSERT INTO organizations (id) VALUES ('${ORG_A}');
+    INSERT INTO users (id) VALUES ('${USER_A}');
+  `);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+});
+
+describe("personalSharedGroupsRepository adversarial claim lifecycle", () => {
+  test("expires a claim at the exact boundary but honors the final live millisecond", async () => {
+    await issue({ codeHash: "claim-boundary", platformUserId: "+15551110001" });
+
+    // `gt(expires_at, now)` is strict: verification AT the expiry instant is
+    // already expired, and the expired attempt must not consume the code.
+    expect(
+      await consume({
+        codeHash: "claim-boundary",
+        platformUserId: "+15551110001",
+        verifiedAt: EXPIRES_AT,
+      }),
+    ).toEqual({ status: "expired" });
+    expect(
+      (
+        await consume({
+          codeHash: "claim-boundary",
+          platformUserId: "+15551110001",
+          verifiedAt: new Date(EXPIRES_AT.getTime() - 1),
+        })
+      ).status,
+    ).toBe("bound");
+  });
+
+  test("reports a claim past its boundary as expired, not invalid", async () => {
+    await issue({ codeHash: "claim-stale", platformUserId: "+15551110001" });
+
+    expect(
+      await consume({
+        codeHash: "claim-stale",
+        platformUserId: "+15551110001",
+        verifiedAt: new Date(EXPIRES_AT.getTime() + 60_000),
+      }),
+    ).toEqual({ status: "expired" });
+  });
+
+  test("issuing a fresh code kills the previous unconsumed code as already_used", async () => {
+    await issue({ codeHash: "claim-first", platformUserId: "+15551110001" });
+    await issue({ codeHash: "claim-second", platformUserId: "+15551110001" });
+
+    expect(
+      await consume({ codeHash: "claim-first", platformUserId: "+15551110001" }),
+    ).toEqual({ status: "already_used" });
+    expect(
+      (
+        await consume({
+          codeHash: "claim-second",
+          platformUserId: "+15551110001",
+        })
+      ).status,
+    ).toBe("bound");
+  });
+
+  test("a Telegram code pasted into a Blooio group neither binds nor burns the code", async () => {
+    await issue({
+      codeHash: "claim-telegram",
+      platform: "telegram",
+      connectorAccountId: TELEGRAM_CONNECTOR,
+      platformUserId: "123456789",
+    });
+
+    expect(
+      await consume({
+        codeHash: "claim-telegram",
+        platform: "blooio",
+        connectorAccountId: BLOOIO_CONNECTOR,
+        platformUserId: "123456789",
+      }),
+    ).toEqual({ status: "invalid" });
+    expect(
+      await repository.resolveBinding({
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: BLOOIO_CONNECTOR,
+        providerChatId: CHAT_ID,
+      }),
+    ).toBeNull();
+
+    // The failed UPDATE left the claim live for its real platform.
+    const rebound = await consume({
+      codeHash: "claim-telegram",
+      platform: "telegram",
+      connectorAccountId: TELEGRAM_CONNECTOR,
+      platformUserId: "123456789",
+    });
+    expect(rebound.status).toBe("bound");
+    if (rebound.status !== "bound") throw new Error("expected telegram binding");
+    expect(rebound.binding).toMatchObject({
+      platform: "telegram",
+      connector_account_id: TELEGRAM_CONNECTOR,
+      owner_user_id: USER_A,
+    });
+  });
+
+  test("a code presented through the wrong connector account stays live for the right one", async () => {
+    await issue({ codeHash: "claim-connector", platformUserId: "+15551110001" });
+
+    expect(
+      await consume({
+        codeHash: "claim-connector",
+        connectorAccountId: "blooio:+15559999999",
+        platformUserId: "+15551110001",
+      }),
+    ).toEqual({ status: "invalid" });
+    expect(
+      (
+        await consume({
+          codeHash: "claim-connector",
+          platformUserId: "+15551110001",
+        })
+      ).status,
+    ).toBe("bound");
+  });
+
+  test("same-owner relink over a suspended binding keeps history but resets policy", async () => {
+    await issue({ codeHash: "claim-relink-1", platformUserId: "+15551110001" });
+    const first = await consume({
+      codeHash: "claim-relink-1",
+      platformUserId: "+15551110001",
+    });
+    if (first.status !== "bound") throw new Error("expected initial binding");
+
+    expect(
+      await repository.setResponsePolicy({
+        bindingId: first.binding.id,
+        ownerUserId: USER_A,
+        policy: "ambient",
+      }),
+    ).toMatchObject({ response_policy: "ambient" });
+    expect(
+      await repository.applyMembershipChange({
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: BLOOIO_CONNECTOR,
+        providerChatId: CHAT_ID,
+        membershipChange: "removed",
+        verifiedAt: NOW,
+      }),
+    ).toMatchObject({ state: "suspended" });
+
+    await issue({ codeHash: "claim-relink-2", platformUserId: "+15551110001" });
+    const relinked = await consume({
+      codeHash: "claim-relink-2",
+      platformUserId: "+15551110001",
+    });
+    expect(relinked.status).toBe("bound");
+    if (relinked.status !== "bound") throw new Error("expected relinked binding");
+    // Same row and deterministic conversation: group history continuity.
+    expect(relinked.binding.id).toBe(first.binding.id);
+    expect(relinked.binding.conversation_id).toBe(first.binding.conversation_id);
+    // The ambient opt-in does NOT survive the relink: policy silently returns
+    // to mention_only, which the owner must re-enable deliberately.
+    expect(relinked.binding).toMatchObject({
+      state: "active",
+      response_policy: "mention_only",
+      owner_user_id: USER_A,
+    });
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.groups-adversarial.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.groups-adversarial.test.ts
@@ -70,10 +70,17 @@ beforeAll(async () => {
     CREATE TABLE organizations (id uuid PRIMARY KEY);
     CREATE TABLE users (id uuid PRIMARY KEY);
   `);
-  const migration = await Bun.file(
-    new URL("../migrations/0297_personal_shared_group_bindings.sql", import.meta.url),
-  ).text();
-  await database.exec(migration);
+  // The repository reads authority_version and delivery_lease_* columns, so
+  // the schema must include the authority (0303) and lease (0304) migrations
+  // that extend the base group tables from 0297.
+  for (const file of [
+    "0297_personal_shared_group_bindings.sql",
+    "0303_personal_shared_group_authority_version.sql",
+    "0304_personal_shared_group_delivery_lease.sql",
+  ]) {
+    const migration = await Bun.file(new URL(`../migrations/${file}`, import.meta.url)).text();
+    await database.exec(migration);
+  }
 });
 
 beforeEach(async () => {
@@ -132,9 +139,9 @@ describe("personalSharedGroupsRepository adversarial claim lifecycle", () => {
     await issue({ codeHash: "claim-first", platformUserId: "+15551110001" });
     await issue({ codeHash: "claim-second", platformUserId: "+15551110001" });
 
-    expect(
-      await consume({ codeHash: "claim-first", platformUserId: "+15551110001" }),
-    ).toEqual({ status: "already_used" });
+    expect(await consume({ codeHash: "claim-first", platformUserId: "+15551110001" })).toEqual({
+      status: "already_used",
+    });
     expect(
       (
         await consume({


### PR DESCRIPTION
> **Draft status:** rebased onto `origin/develop` (`c770eb4`) and re-pinned to the authority-version + delivery-lease contracts. Part of `nubs/demo-night`. Test-only change.

# Relates to
Group-chat hardening for #24322 (Personal Shared provider groups). Companion PRs: lifeops owner-entity fix, Blooio image understanding, group reminders.

# Risks
None to runtime — adds 3 new test files, modifies no source and no existing tests.

# Background
## What does this PR do?
Adds 23 adversarial tests closing the top coverage gaps a truth-doc-driven gap analysis found in the group-chat feature (all 4 existing suites pass; these pin what they did not):
- Spoofed Blooio `replyToMessageId` under `mention_only` stays silent without a verified delivery receipt (policy-bypass + owner-billed-inference risk).
- Non-owner `Eliza ambient on` / `Eliza leave` → `group_owner_required`, zero side effects.
- Dedicated-cutover group turns: bridge keyed on the group conversation id, speaker labels preserved, 404-repair history import uses the group conversation.
- Claim TTL strict boundary; expired vs invalid vs already_used recovery replies; reissue consumes the prior code.
- Cross-platform code reuse (Telegram code in a Blooio group) rejected without burning the code.
- Suspended/unbound group replies; same-owner relink resets policy to mention_only.
- Stale-authority receipt rejection is a recoverable post-egress failure: the webhook reopens, and the replay is fenced by the committed lease (no second provider send); receipt POST survives a stale-auth 401 under the same lease token; Telegram supergroup turns run the full authorization → commit → egress → receipt ledger instead of the edge forward.

Files: `route.groups-adversarial.test.ts` (14), `personal-shared-groups.groups-adversarial.test.ts` (6), `webhook-handler.groups-adversarial.test.ts` (3). All green on the rebased head; the repository file applies migrations 0297 + 0303 + 0304 to match the current repository schema.

Note: if this lands together with the group-reminders PR, one pin needs the follow-up adjustment already staged on `nubs/demo-night` (`448d2d5`) — the reply-verification test's delivery-slot expectation changes from `undefined` to the group trusted-delivery payload.

# Testing
`bun test` / the package runners on the three files: 23/23 pass (44+36+20+8 existing group tests also green alongside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

