### PR TITLE
feat(cloud): flag-gated vision descriptions for inbound Blooio images on personal Shared turns

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Pins Blooio inbound-media enrichment at the trusted messaging route: the
+ * additive mediaUrls schema (allowlist re-validation), the flag-off/disabled
+ * path staying byte-identical to the current media-URL text, the flag-on
+ * described turn, and the degrade contract — a typed enrichment failure keeps
+ * the user's turn instead of failing the delivery. Collaborators are mocked;
+ * the describe helper's real typed errors are used so the route's instanceof
+ * branches are the code under test.
+ */
+
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { logger } from "@/lib/utils/logger";
+
+const resolvePersonalDelivery = mock(async () => ({
+  userId: "00000000-0000-4000-8000-000000000002",
+  organizationId: "00000000-0000-4000-8000-000000000001",
+  dedicatedTarget: null,
+  isNew: false,
+  resolution: "single-query-repeat" as const,
+}));
+const sharedRestMessageSend = mock(async (..._args: unknown[]) => ({
+  text: "hello from Eliza",
+}));
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
+const findActivePersonalDedicatedTarget = mock(async () => null);
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const runtimeExecutionCtx = {
+  waitUntil: mock((_promise: Promise<unknown>) => undefined),
+};
+
+// Real typed errors + constants from the helper module; only the describe
+// entrypoint itself is replaced so its call/throw contract stays authentic.
+const {
+  InboundMediaDescriptionError,
+  InboundMediaVisionDisabledError,
+  MAX_INBOUND_MEDIA_IMAGES,
+} = await import("@/lib/services/eliza-app/describe-inbound-media");
+const { isAllowedBlooioMediaUrl } = await import(
+  "@/lib/services/eliza-app/blooio-media-allowlist"
+);
+const describeInboundImageMedia = mock(
+  async (
+    _env: Record<string, unknown>,
+    _urls: readonly string[],
+  ): Promise<string> => {
+    throw new InboundMediaVisionDisabledError(
+      "Inbound media vision is disabled for this deployment",
+    );
+  },
+);
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: { resolvePersonalDelivery },
+}));
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
+mock.module("@/lib/services/eliza-app/onboarding-chat", () => ({
+  runOnboardingChat: mock(async () => ({
+    loginUrl: "https://cloud-staging.eliza.app/get-started",
+  })),
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: async () => ({ allowed: true, balance: 10 }),
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: async () => ({ ok: true, required: false }),
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentResumeOnce: mock(async () => ({ created: true })),
+    enqueueAgentWakeOnce: mock(async () => ({ created: true })),
+    triggerImmediate: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    bridge: mock(async () => ({ jsonrpc: "2.0", id: "x", result: {} })),
+    importCanonicalConversation: mock(async () => null),
+  },
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedHistory: mock(async () => []),
+}));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    issueClaim: mock(async () => undefined),
+    consumeClaimAndBind: mock(async () => ({ status: "invalid" })),
+    resolveBinding: mock(async () => null),
+    setResponsePolicy: mock(async () => null),
+    revokeBinding: mock(async () => false),
+    applyMembershipChange: mock(async () => null),
+    recordDeliveryReceipts: mock(async () => 0),
+    hasDeliveryReceipt: mock(async () => false),
+  },
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: runtimeExecutionCtx,
+  }),
+}));
+mock.module("@/lib/services/eliza-app/describe-inbound-media", () => ({
+  describeInboundImageMedia,
+  InboundMediaDescriptionError,
+  InboundMediaVisionDisabledError,
+  MAX_INBOUND_MEDIA_IMAGES,
+}));
+
+const { default: app } = await import("./route");
+const executionCtx = { waitUntil() {}, passThroughOnException() {}, props: {} };
+
+const MEDIA_URL = "https://media.blooio.com/files/photo-1.jpeg";
+const RAW_MEDIA_MESSAGE = `[media: ${MEDIA_URL}]`;
+
+function request(body: unknown) {
+  return app.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-secret",
+        "content-type": "application/json",
+        "x-eliza-trace-id": "11111111-1111-4111-8111-111111111111",
+      },
+      body: JSON.stringify(body),
+    },
+    {
+      INTERNAL_SECRET: "test-secret",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+      ELIZA_APP_INBOUND_MEDIA_VISION: "true",
+    } as never,
+    executionCtx as never,
+  );
+}
+
+function blooioDelivery(overrides: Record<string, unknown> = {}) {
+  return {
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: "+15550001111",
+    phoneNumber: "+15551234567",
+    messageId: "blooio:eliza-app:message-42",
+    message: RAW_MEDIA_MESSAGE,
+    mediaUrls: [MEDIA_URL],
+    ...overrides,
+  };
+}
+
+function deliveredMessage(): string {
+  expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+  return sharedRestMessageSend.mock.calls[0]?.[2] as string;
+}
+
+describe("blooio inbound media enrichment at the messaging route", () => {
+  beforeEach(() => {
+    resolvePersonalDelivery.mockClear();
+    sharedRestMessageSend.mockClear();
+    prewarmPersonalSharedAgentTurnCaches.mockClear();
+    findActivePersonalDedicatedTarget.mockClear();
+    describeInboundImageMedia.mockReset();
+    describeInboundImageMedia.mockImplementation(async () => {
+      throw new InboundMediaVisionDisabledError(
+        "Inbound media vision is disabled for this deployment",
+      );
+    });
+  });
+
+  test("schema accepts allowlisted https media URLs on a Blooio delivery", async () => {
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(describeInboundImageMedia).toHaveBeenCalledTimes(1);
+    expect(describeInboundImageMedia.mock.calls[0]?.[1]).toEqual([MEDIA_URL]);
+    const env = describeInboundImageMedia.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(env.ELIZA_APP_INBOUND_MEDIA_VISION).toBe("true");
+  });
+
+  test("schema rejects mediaUrls on a Twilio delivery", async () => {
+    const response = await request(
+      blooioDelivery({
+        platform: "twilio",
+        connectorAccountId: "+15550009999",
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("schema rejects more media URLs than the image ceiling", async () => {
+    const response = await request(
+      blooioDelivery({
+        mediaUrls: Array.from(
+          { length: MAX_INBOUND_MEDIA_IMAGES + 1 },
+          (_, index) => `https://media.blooio.com/files/photo-${index}.jpeg`,
+        ),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+  });
+
+  test("schema rejects media URLs off the Blooio allowlist", async () => {
+    for (const url of [
+      "https://evil.example/photo.jpeg",
+      "https://blooio.com.evil.com/photo.jpeg",
+      "http://media.blooio.com/photo.jpeg",
+    ]) {
+      expect(isAllowedBlooioMediaUrl(url)).toBe(false);
+      const response = await request(blooioDelivery({ mediaUrls: [url] }));
+      expect(response.status).toBe(400);
+    }
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("a Blooio delivery without mediaUrls never consults the vision path", async () => {
+    const response = await request(
+      blooioDelivery({ mediaUrls: undefined, message: "hey eliza" }),
+    );
+    expect(response.status).toBe(200);
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(deliveredMessage()).toBe("hey eliza");
+  });
+
+  test("disabled vision keeps the turn byte-identical to the raw media text", async () => {
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+  });
+
+  test("an enabled description enriches the turn as an attached-image block", async () => {
+    describeInboundImageMedia.mockResolvedValue(
+      "A tabby cat sitting on a mechanical keyboard.",
+    );
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(
+      `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n` +
+        "A tabby cat sitting on a mechanical keyboard.",
+    );
+  });
+
+  test("a typed enrichment failure degrades to the raw text without dropping the turn", async () => {
+    const errorSpy = spyOn(logger, "error");
+    describeInboundImageMedia.mockRejectedValue(
+      new InboundMediaDescriptionError(
+        "Inbound media fetch failed",
+        "media_fetch_failed",
+      ),
+    );
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    const degradeLog = errorSpy.mock.calls.find(
+      ([message]) =>
+        message ===
+        "[personal-shared-messaging] inbound media description failed",
+    );
+    expect(degradeLog?.[1]).toMatchObject({ reason: "media_fetch_failed" });
+    errorSpy.mockRestore();
+  });
+
+  test("an unexpected enrichment failure fails the delivery at the media stage", async () => {
+    describeInboundImageMedia.mockRejectedValue(new Error("bug"));
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(500);
+    expect(response.headers.get("X-Eliza-Failure-Stage")).toBe(
+      "media_description",
+    );
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
@@ -3,18 +3,24 @@
  * additive mediaUrls schema (allowlist re-validation), the flag-off/disabled
  * path staying byte-identical to the current media-URL text, the flag-on
  * described turn, and the degrade contract — a typed enrichment failure keeps
- * the user's turn instead of failing the delivery. Collaborators are mocked;
- * the describe helper's real typed errors are used so the route's instanceof
+ * the user's turn instead of failing the delivery, and a dedicated-runtime
+ * turn bypassing pooled-key vision entirely. Collaborators are mocked; the
+ * describe helper's real typed errors are used so the route's instanceof
  * branches are the code under test.
  */
 
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { logger } from "@/lib/utils/logger";
 
+let activeTarget: {
+  id: string;
+  status: "running";
+  bridge_url: string;
+} | null = null;
 const resolvePersonalDelivery = mock(async () => ({
   userId: "00000000-0000-4000-8000-000000000002",
   organizationId: "00000000-0000-4000-8000-000000000001",
-  dedicatedTarget: null,
+  dedicatedTarget: activeTarget,
   isNew: false,
   resolution: "single-query-repeat" as const,
 }));
@@ -22,7 +28,18 @@ const sharedRestMessageSend = mock(async (..._args: unknown[]) => ({
   text: "hello from Eliza",
 }));
 const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
-const findActivePersonalDedicatedTarget = mock(async () => null);
+const findActivePersonalDedicatedTarget = mock(async () => activeTarget);
+const bridge = mock(
+  async (
+    _agentId: string,
+    _organizationId: string,
+    _request: { params: { text: string } },
+  ) => ({
+    jsonrpc: "2.0" as const,
+    id: "blooio:eliza-app:message-42",
+    result: { text: "hello from Dedicated" },
+  }),
+);
 const namespace = {
   getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
 };
@@ -87,7 +104,7 @@ mock.module("@/lib/services/provisioning-jobs", () => ({
 }));
 mock.module("@/lib/services/eliza-sandbox", () => ({
   elizaSandboxService: {
-    bridge: mock(async () => ({ jsonrpc: "2.0", id: "x", result: {} })),
+    bridge,
     importCanonicalConversation: mock(async () => null),
   },
 }));
@@ -166,10 +183,12 @@ function deliveredMessage(): string {
 
 describe("blooio inbound media enrichment at the messaging route", () => {
   beforeEach(() => {
+    activeTarget = null;
     resolvePersonalDelivery.mockClear();
     sharedRestMessageSend.mockClear();
     prewarmPersonalSharedAgentTurnCaches.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
+    bridge.mockClear();
     describeInboundImageMedia.mockReset();
     describeInboundImageMedia.mockImplementation(async () => {
       throw new InboundMediaVisionDisabledError(
@@ -254,6 +273,30 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n` +
         "A tabby cat sitting on a mechanical keyboard.",
     );
+  });
+
+  test("a dedicated-runtime turn skips pooled-key vision and bridges the raw media text", async () => {
+    activeTarget = {
+      id: "00000000-0000-4000-8000-000000000020",
+      status: "running",
+      bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+    };
+    describeInboundImageMedia.mockResolvedValue(
+      "A tabby cat sitting on a mechanical keyboard.",
+    );
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        identity: { runtime: "dedicated", activeAgentId: activeTarget.id },
+        reply: "hello from Dedicated",
+      },
+    });
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(bridge).toHaveBeenCalledTimes(1);
+    expect(bridge.mock.calls[0]?.[2].params.text).toBe(RAW_MEDIA_MESSAGE);
   });
 
   test("a typed enrichment failure degrades to the raw text without dropping the turn", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -14,6 +14,13 @@ import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
 import { sha256Hex } from "@/lib/oidc/crypto";
 import { findActivePersonalDedicatedTarget } from "@/lib/services/agent-tier-upgrade-target";
 import { elizaAppUserService } from "@/lib/services/eliza-app";
+import { isAllowedBlooioMediaUrl } from "@/lib/services/eliza-app/blooio-media-allowlist";
+import {
+  describeInboundImageMedia,
+  InboundMediaDescriptionError,
+  InboundMediaVisionDisabledError,
+  MAX_INBOUND_MEDIA_IMAGES,
+} from "@/lib/services/eliza-app/describe-inbound-media";
 import { runOnboardingChat } from "@/lib/services/eliza-app/onboarding-chat";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { preparePersonalDedicatedDelivery } from "@/lib/services/personal-dedicated-delivery";
@@ -50,6 +57,7 @@ type DeliveryStage =
   | "worker_context"
   | "account_resolution"
   | "voice_transcription"
+  | "media_description"
   | "account_claim"
   | "dedicated_runtime"
   | "shared_runtime";
@@ -220,17 +228,26 @@ const sharedMessageSchema = z.union([
     messageId: z.string().trim().min(1).max(160),
     message: z.string().trim().min(1).max(4000),
   }),
-  z.object({
-    platform: z.enum(["twilio", "blooio"]),
-    project: projectSchema,
-    connectorAccountId: connectorAccountIdSchema,
-    phoneNumber: z
-      .string()
-      .trim()
-      .regex(/^\+[1-9]\d{6,14}$/),
-    messageId: z.string().trim().min(1).max(160),
-    message: z.string().trim().min(1).max(4000),
-  }),
+  z
+    .object({
+      platform: z.enum(["twilio", "blooio"]),
+      project: projectSchema,
+      connectorAccountId: connectorAccountIdSchema,
+      phoneNumber: z
+        .string()
+        .trim()
+        .regex(/^\+[1-9]\d{6,14}$/),
+      messageId: z.string().trim().min(1).max(160),
+      message: z.string().trim().min(1).max(4000),
+      mediaUrls: z
+        .array(z.string().url().refine(isAllowedBlooioMediaUrl))
+        .min(1)
+        .max(MAX_INBOUND_MEDIA_IMAGES)
+        .optional(),
+    })
+    .refine(
+      (input) => input.platform === "blooio" || input.mediaUrls === undefined,
+    ),
   z.object({
     platform: z.literal("blooio"),
     chatType: z.literal("group"),
@@ -887,6 +904,56 @@ app.post("/", async (c) => {
           userId: account.userId,
         },
       );
+    }
+    if (
+      parsed.data.platform === "blooio" &&
+      !isGroupMessage(parsed.data) &&
+      parsed.data.mediaUrls
+    ) {
+      stage = "media_description";
+      // Unmetered pooled-key spend (same posture as the Whisper voice path
+      // above, but reachable by any inbound sender): production enablement of
+      // ELIZA_APP_INBOUND_MEDIA_VISION requires a per-sender/per-connector
+      // rate limit or billing-meter gate here first — see the PR rollout plan.
+      try {
+        const description = await describeInboundImageMedia(
+          c.env,
+          parsed.data.mediaUrls,
+        );
+        deliveryMessage = `${deliveryMessage}\n\n[Attached image description]\n${description}`;
+        logger.info(
+          "[personal-shared-messaging] Blooio inbound media described",
+          {
+            mediaCount: parsed.data.mediaUrls.length,
+            userId: account.userId,
+          },
+        );
+      } catch (error) {
+        if (error instanceof InboundMediaVisionDisabledError) {
+          // Disabled is the fleet default, not a fault; the turn keeps the
+          // raw media-URL text the adapter synthesized.
+          logger.debug(
+            "[personal-shared-messaging] inbound media vision disabled",
+            { mediaCount: parsed.data.mediaUrls.length },
+          );
+        } else if (error instanceof InboundMediaDescriptionError) {
+          // error-policy:J4 enrichment is additive: an expected fetch/vision
+          // failure degrades to the current media-URL text instead of
+          // dropping the user's turn. Reported here because the turn still
+          // returns success to the connector.
+          logger.error(
+            "[personal-shared-messaging] inbound media description failed",
+            {
+              reason: error.reason,
+              mediaCount: parsed.data.mediaUrls.length,
+              userId: account.userId,
+              error: error.message,
+            },
+          );
+        } else {
+          throw error;
+        }
+      }
     }
     if (deliveryMessage && groupActorLabel) {
       deliveryMessage = `${groupActorLabel}: ${deliveryMessage}`;

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -905,16 +905,20 @@ app.post("/", async (c) => {
         },
       );
     }
+    // A dedicated runtime describes images itself through its own metered
+    // IMAGE_DESCRIPTION model, so pooled-key vision runs only for turns the
+    // shared runtime (text-only) will answer.
     if (
       parsed.data.platform === "blooio" &&
       !isGroupMessage(parsed.data) &&
-      parsed.data.mediaUrls
+      parsed.data.mediaUrls &&
+      !dedicated
     ) {
       stage = "media_description";
       // Unmetered pooled-key spend (same posture as the Whisper voice path
       // above, but reachable by any inbound sender): production enablement of
       // ELIZA_APP_INBOUND_MEDIA_VISION requires a per-sender/per-connector
-      // rate limit or billing-meter gate here first — see the PR rollout plan.
+      // rate limit or billing-meter gate at this stage first.
       try {
         const description = await describeInboundImageMedia(
           c.env,

--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Pins the Blooio inbound-media forward: allowlisted media URLs ride the
+ * personal-Shared POST body only for Blooio one-to-one turns, media turns take
+ * the voice-style long-turn retry posture (no status/transport re-POST that
+ * could overlap a still-running vision route), group media events keep the
+ * plain text-turn posture, and the gateway's runtime-local media allowlist
+ * stays byte-identical to the canonical cloud-shared copy the Worker route
+ * validates against. Deterministic fixtures with a mocked cloud fetch — no
+ * live services.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  ALLOWED_BLOOIO_MEDIA_DOMAINS,
+  isAllowedBlooioMediaUrl,
+} from "@elizaos/cloud-shared/lib/services/eliza-app/blooio-media-allowlist";
+import { ALLOWED_MEDIA_DOMAINS, isValidMediaUrl } from "../src/adapters/blooio";
+import type {
+  ChatEvent,
+  PlatformAdapter,
+  WebhookConfig,
+} from "../src/adapters/types";
+import type { GatewayRedis } from "../src/redis";
+import { handleWebhook } from "../src/webhook-handler";
+
+type RedisSetOptions = { ex?: number; nx?: boolean };
+
+class MemoryRedis implements GatewayRedis {
+  readonly store = new Map<string, string>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const value = this.store.get(key);
+    if (value === undefined) return null;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return value as T;
+    }
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: RedisSetOptions = {},
+  ): Promise<unknown> {
+    if (options.nx && this.store.has(key)) return null;
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+const MEDIA_URL = "https://media.blooio.com/files/photo-1.jpeg";
+
+function createEvent(
+  platform: "blooio" | "twilio",
+  overrides: Partial<ChatEvent> = {},
+): ChatEvent {
+  return {
+    platform,
+    messageId: `msg_${Math.random().toString(16).slice(2)}`,
+    chatId: "+15551234567",
+    senderId: "+15551234567",
+    senderName: "Ada",
+    text: `[media: ${MEDIA_URL}]`,
+    rawPayload: {},
+    ...overrides,
+  };
+}
+
+function createAdapter(
+  event: ChatEvent,
+): PlatformAdapter & { replies: string[] } {
+  const adapter: PlatformAdapter & { replies: string[] } = {
+    platform: event.platform,
+    replies: [],
+    verifyWebhook: mock(async () => true),
+    extractEvent: mock(async () => event),
+    sendReply: mock(
+      async (_config: WebhookConfig, _event: ChatEvent, text: string) => {
+        adapter.replies.push(text);
+      },
+    ),
+    sendTypingIndicator: mock(async () => {}),
+  };
+  return adapter;
+}
+
+const originalFetch = globalThis.fetch;
+const envKeys = [
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_TWILIO_ACCOUNT_SID",
+  "ELIZA_APP_TWILIO_AUTH_TOKEN",
+  "ELIZA_APP_TWILIO_PHONE_NUMBER",
+] as const;
+const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+
+function configureEnv(): void {
+  process.env.ELIZA_APP_BLOOIO_API_KEY = "bl_live_test";
+  process.env.ELIZA_APP_BLOOIO_WEBHOOK_SECRET = "whsec_test";
+  process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550001111";
+  process.env.ELIZA_APP_TWILIO_ACCOUNT_SID = "AC_test";
+  process.env.ELIZA_APP_TWILIO_AUTH_TOKEN = "twilio-secret";
+  process.env.ELIZA_APP_TWILIO_PHONE_NUMBER = "+15550002222";
+}
+
+async function waitFor(assertion: () => boolean, label: string): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < 2_000) {
+    if (assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function requestFor(event: ChatEvent): Request {
+  return new Request(
+    `https://gateway.example/webhook/eliza-app/${event.platform}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event: "message.received" }),
+    },
+  );
+}
+
+async function deliverToPersonalShared(
+  event: ChatEvent,
+): Promise<Record<string, unknown>> {
+  const redis = new MemoryRedis();
+  const adapter = createAdapter(event);
+  let sharedBody: Record<string, unknown> | null = null;
+
+  globalThis.fetch = mock(async (input, init) => {
+    const request = new Request(input, init);
+    if (request.url.endsWith("/api/internal/identity/resolve")) {
+      return new Response(JSON.stringify({ success: false }), { status: 404 });
+    }
+    if (
+      request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+    ) {
+      sharedBody = (await request.json()) as Record<string, unknown>;
+      return Response.json({ data: { reply: "seen" } });
+    }
+    throw new Error(`Unexpected fetch: ${request.url}`);
+  }) as typeof fetch;
+
+  const response = await handleWebhook(
+    requestFor(event),
+    adapter,
+    {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    },
+    "eliza-app",
+  );
+  expect(response.status).toBe(200);
+  await waitFor(() => sharedBody !== null, "personal Shared request");
+  await waitFor(() => adapter.replies.length === 1, "personal Shared reply");
+  if (sharedBody === null) throw new Error("personal Shared body missing");
+  return sharedBody;
+}
+
+describe("blooio inbound media forward", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const key of envKeys) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mock.restore();
+  });
+
+  test("forwards allowlisted Blooio media URLs on the personal Shared body", async () => {
+    configureEnv();
+    const event = createEvent("blooio", { mediaUrls: [MEDIA_URL] });
+
+    const sharedBody = await deliverToPersonalShared(event);
+
+    expect(sharedBody).toEqual({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550001111",
+      phoneNumber: "+15551234567",
+      messageId: `blooio:eliza-app:${event.messageId}`,
+      message: `[media: ${MEDIA_URL}]`,
+      mediaUrls: [MEDIA_URL],
+    });
+  });
+
+  test("a Blooio text turn carries no mediaUrls field", async () => {
+    configureEnv();
+    const event = createEvent("blooio", { text: "hey eliza" });
+
+    const sharedBody = await deliverToPersonalShared(event);
+
+    expect(sharedBody.message).toBe("hey eliza");
+    expect("mediaUrls" in sharedBody).toBe(false);
+  });
+
+  test("a Twilio turn never forwards mediaUrls even when the event has them", async () => {
+    configureEnv();
+    const event = createEvent("twilio", { mediaUrls: [MEDIA_URL] });
+
+    const sharedBody = await deliverToPersonalShared(event);
+
+    expect(sharedBody.platform).toBe("twilio");
+    expect("mediaUrls" in sharedBody).toBe(false);
+  });
+});
+
+async function countFailingPersonalSharedPosts(
+  event: ChatEvent,
+  adapterOverrides: Partial<PlatformAdapter> = {},
+): Promise<{ posts: () => number; bodies: Record<string, unknown>[] }> {
+  const redis = new MemoryRedis();
+  const adapter = { ...createAdapter(event), ...adapterOverrides };
+  const bodies: Record<string, unknown>[] = [];
+
+  globalThis.fetch = mock(async (input, init) => {
+    const request = new Request(input, init);
+    if (request.url.endsWith("/api/internal/identity/resolve")) {
+      return new Response(JSON.stringify({ success: false }), { status: 404 });
+    }
+    if (
+      request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+    ) {
+      bodies.push((await request.json()) as Record<string, unknown>);
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    }
+    throw new Error(`Unexpected fetch: ${request.url}`);
+  }) as typeof fetch;
+
+  const response = await handleWebhook(
+    requestFor(event),
+    adapter,
+    {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    },
+    "eliza-app",
+  );
+  expect(response.status).toBe(200);
+  await waitFor(() => bodies.length >= 1, "first personal Shared attempt");
+  return { posts: () => bodies.length, bodies };
+}
+
+describe("blooio media turn retry posture", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const key of envKeys) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mock.restore();
+  });
+
+  test("a text turn re-POSTs a 5xx up to the shared attempt budget (control)", async () => {
+    configureEnv();
+    const event = createEvent("blooio", { text: "hey eliza" });
+
+    const { posts } = await countFailingPersonalSharedPosts(event);
+
+    // 200ms + 400ms backoff between the three status-retried attempts.
+    await waitFor(() => posts() === 3, "text-turn status retries");
+  });
+
+  test("a media turn is never re-POSTed on a 5xx (no overlapping vision runs)", async () => {
+    configureEnv();
+    const event = createEvent("blooio", { mediaUrls: [MEDIA_URL] });
+
+    const { posts } = await countFailingPersonalSharedPosts(event);
+
+    // Longer than the control test's full retry window: a status retry, if one
+    // were still enabled for media turns, would have landed well within this.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(posts()).toBe(1);
+  });
+
+  test("a group media event keeps the plain-turn posture and drops mediaUrls", async () => {
+    configureEnv();
+    const event = createEvent("blooio", {
+      chatType: "group",
+      mediaUrls: [MEDIA_URL],
+    });
+
+    const { posts, bodies } = await countFailingPersonalSharedPosts(event, {
+      sendReplyWithReceipt: mock(async () => ({ providerMessageIds: ["p1"] })),
+    });
+
+    await waitFor(() => posts() === 3, "group-turn status retries");
+    for (const body of bodies) {
+      expect("mediaUrls" in body).toBe(false);
+    }
+  });
+});
+
+describe("blooio media allowlist parity with cloud-shared", () => {
+  test("the runtime-local domain list matches the canonical copy", () => {
+    expect([...ALLOWED_MEDIA_DOMAINS]).toEqual([
+      ...ALLOWED_BLOOIO_MEDIA_DOMAINS,
+    ]);
+  });
+
+  test("both predicates agree across accept and reject cases", () => {
+    const matrix = [
+      "https://media.blooio.com/files/a.jpg",
+      "https://cdn.backend.blooio.com/a.png",
+      "https://api.blooio.com/v4/files/a.heic",
+      "https://blooio.com/a.gif",
+      "http://media.blooio.com/a.jpg",
+      "https://notblooio.com/a.jpg",
+      "https://blooio.com.evil.com/a.jpg",
+      "not a url",
+      "",
+    ];
+    for (const url of matrix) {
+      expect(isValidMediaUrl(url)).toBe(isAllowedBlooioMediaUrl(url));
+    }
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts
@@ -1,12 +1,14 @@
 /**
- * Pins the Blooio inbound-media forward: allowlisted media URLs ride the
- * personal-Shared POST body only for Blooio one-to-one turns, media turns take
- * the voice-style long-turn retry posture (no status/transport re-POST that
- * could overlap a still-running vision route), group media events keep the
- * plain text-turn posture, and the gateway's runtime-local media allowlist
- * stays byte-identical to the canonical cloud-shared copy the Worker route
- * validates against. Deterministic fixtures with a mocked cloud fetch — no
- * live services.
+ * Pins the Blooio inbound-media forward: with ELIZA_APP_INBOUND_MEDIA_VISION
+ * set to "true", allowlisted media URLs ride the personal-Shared POST body only
+ * for Blooio one-to-one turns and those turns take the voice-style long-turn
+ * retry posture (no status/transport re-POST that could overlap a still-running
+ * vision route); with the flag unset the same image turn is byte-identical to a
+ * plain text turn (no mediaUrls, full retry budget); group media events keep
+ * the plain text-turn posture either way; and the gateway's runtime-local media
+ * allowlist stays byte-identical to the canonical cloud-shared copy the Worker
+ * route validates against. Deterministic fixtures with a mocked cloud fetch —
+ * no live services.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
@@ -95,6 +97,12 @@ function createAdapter(
         adapter.replies.push(text);
       },
     ),
+    sendReplyWithReceipt: mock(
+      async (config: WebhookConfig, replyEvent: ChatEvent, text: string) => {
+        await adapter.sendReply(config, replyEvent, text);
+        return { providerMessageIds: [`reply-${replyEvent.messageId}`] };
+      },
+    ),
     sendTypingIndicator: mock(async () => {}),
   };
   return adapter;
@@ -102,6 +110,7 @@ function createAdapter(
 
 const originalFetch = globalThis.fetch;
 const envKeys = [
+  "ELIZA_APP_INBOUND_MEDIA_VISION",
   "ELIZA_APP_BLOOIO_API_KEY",
   "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
   "ELIZA_APP_BLOOIO_PHONE_NUMBER",
@@ -111,7 +120,12 @@ const envKeys = [
 ] as const;
 const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
 
-function configureEnv(): void {
+function configureEnv(options: { mediaVision?: boolean } = {}): void {
+  if (options.mediaVision === false) {
+    delete process.env.ELIZA_APP_INBOUND_MEDIA_VISION;
+  } else {
+    process.env.ELIZA_APP_INBOUND_MEDIA_VISION = "true";
+  }
   process.env.ELIZA_APP_BLOOIO_API_KEY = "bl_live_test";
   process.env.ELIZA_APP_BLOOIO_WEBHOOK_SECRET = "whsec_test";
   process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550001111";
@@ -219,6 +233,22 @@ describe("blooio inbound media forward", () => {
     expect("mediaUrls" in sharedBody).toBe(false);
   });
 
+  test("with the vision flag unset a Blooio image turn forwards no mediaUrls", async () => {
+    configureEnv({ mediaVision: false });
+    const event = createEvent("blooio", { mediaUrls: [MEDIA_URL] });
+
+    const sharedBody = await deliverToPersonalShared(event);
+
+    expect(sharedBody).toEqual({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550001111",
+      phoneNumber: "+15551234567",
+      messageId: `blooio:eliza-app:${event.messageId}`,
+      message: `[media: ${MEDIA_URL}]`,
+    });
+  });
+
   test("a Twilio turn never forwards mediaUrls even when the event has them", async () => {
     configureEnv();
     const event = createEvent("twilio", { mediaUrls: [MEDIA_URL] });
@@ -303,6 +333,18 @@ describe("blooio media turn retry posture", () => {
     expect(posts()).toBe(1);
   });
 
+  test("with the vision flag unset an image turn keeps the full text-turn retry budget", async () => {
+    configureEnv({ mediaVision: false });
+    const event = createEvent("blooio", { mediaUrls: [MEDIA_URL] });
+
+    const { posts, bodies } = await countFailingPersonalSharedPosts(event);
+
+    await waitFor(() => posts() === 3, "dark image-turn status retries");
+    for (const body of bodies) {
+      expect("mediaUrls" in body).toBe(false);
+    }
+  });
+
   test("a group media event keeps the plain-turn posture and drops mediaUrls", async () => {
     configureEnv();
     const event = createEvent("blooio", {
@@ -310,9 +352,7 @@ describe("blooio media turn retry posture", () => {
       mediaUrls: [MEDIA_URL],
     });
 
-    const { posts, bodies } = await countFailingPersonalSharedPosts(event, {
-      sendReplyWithReceipt: mock(async () => ({ providerMessageIds: ["p1"] })),
-    });
+    const { posts, bodies } = await countFailingPersonalSharedPosts(event);
 
     await waitFor(() => posts() === 3, "group-turn status retries");
     for (const body of bodies) {

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.ts
@@ -187,14 +187,18 @@ function providerSentAtMs(event: BlooioWebhookEvent): number | undefined {
   return Number.isSafeInteger(milliseconds) ? milliseconds : undefined;
 }
 
-const ALLOWED_MEDIA_DOMAINS = [
+// Runtime-local copy of the canonical allowlist in
+// `@elizaos/cloud-shared/lib/services/eliza-app/blooio-media-allowlist` (this
+// service must not depend on cloud-shared at runtime); the adapter parity test
+// pins the two to each other.
+export const ALLOWED_MEDIA_DOMAINS = [
   "blooio.com",
   "backend.blooio.com",
   "api.blooio.com",
   "media.blooio.com",
 ];
 
-function isValidMediaUrl(url: string): boolean {
+export function isValidMediaUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -45,6 +45,10 @@ const TELEGRAM_EGRESS_STARTED = "egress_started";
 const TELEGRAM_DELIVERED = "delivered";
 const TELEGRAM_TYPING_REFRESH_MS = 4_000;
 const PERSONAL_SHARED_VOICE_TIMEOUT_MS = 90_000;
+// Inbound Blooio image turns may spend the cloud stage fetching media and
+// running a vision description before the model turn; the plain 30s ceiling
+// would abort those turns mid-flight and re-run them.
+const PERSONAL_SHARED_MEDIA_TIMEOUT_MS = 90_000;
 const ELIZA_TRACE_ID_HEADER = "X-Eliza-Trace-Id";
 const OPAQUE_TRACE_ID =
   /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
@@ -1072,10 +1076,19 @@ async function sendPersonalSharedReply(
       "connector cannot resolve the supplied voice note",
     );
   }
-  // Voice turns can spend most of the 120-second processing lease in STT + the
-  // model. Only a stale-auth retry is safe inline; provider/transport failures
-  // reopen the webhook for Telegram's durable retry instead of overlapping it.
-  const maxAttempts = voiceNote ? 2 : PERSONAL_SHARED_ATTEMPTS;
+  // Media turns mirror voice: the cloud route may spend fetch + vision + the
+  // model turn, so a re-POST can overlap a still-running route execution and
+  // re-run the unbilled vision call. Group Blooio events carry mediaUrls too
+  // but are never forwarded as media (no vision runs), so they keep the plain
+  // text-turn retry/timeout posture.
+  const isMediaTurn =
+    adapter.platform === "blooio" && !isGroup && !!event.mediaUrls?.length;
+  // Voice and media turns can spend most of the 120-second processing lease in
+  // STT/vision + the model. Only a stale-auth retry is safe inline; provider/
+  // transport failures reopen the webhook for the platform's durable retry
+  // instead of overlapping it.
+  const isLongTurn = Boolean(voiceNote) || isMediaTurn;
+  const maxAttempts = isLongTurn ? 2 : PERSONAL_SHARED_ATTEMPTS;
   const postMessage = (authHeader: Record<string, string>) =>
     fetch(`${cloudBaseUrl}/api/internal/eliza-app/personal-shared/messages`, {
       method: "POST",
@@ -1139,10 +1152,19 @@ async function sendPersonalSharedReply(
                   phoneNumber: event.senderId,
                   messageId: `${adapter.platform}:${project}:${event.messageId}`,
                   message: event.text,
+                  // Only Blooio media URLs are provider-hosted and fetchable
+                  // by the cloud vision path; other platforms keep text-only.
+                  ...(isMediaTurn && event.mediaUrls?.length
+                    ? { mediaUrls: event.mediaUrls }
+                    : {}),
                 },
       ),
       signal: AbortSignal.timeout(
-        voiceNote ? PERSONAL_SHARED_VOICE_TIMEOUT_MS : 30_000,
+        voiceNote
+          ? PERSONAL_SHARED_VOICE_TIMEOUT_MS
+          : isMediaTurn
+            ? PERSONAL_SHARED_MEDIA_TIMEOUT_MS
+            : 30_000,
       ),
     });
 
@@ -1156,8 +1178,8 @@ async function sendPersonalSharedReply(
       refreshAuth: async () => {
         authHeader = await reauth();
       },
-      retryStatuses: !voiceNote,
-      retryTransport: !voiceNote,
+      retryStatuses: !isLongTurn,
+      retryTransport: !isLongTurn,
       retryDelayCapMs: PERSONAL_SHARED_RETRY_DELAY_CAP_MS,
       observe: (observation) => {
         const response = observation.response;

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -49,6 +49,16 @@ const PERSONAL_SHARED_VOICE_TIMEOUT_MS = 90_000;
 // running a vision description before the model turn; the plain 30s ceiling
 // would abort those turns mid-flight and re-run them.
 const PERSONAL_SHARED_MEDIA_TIMEOUT_MS = 90_000;
+// Mirrors the Worker binding of the same name. Both sides must be enabled
+// together: the gateway only forwards Blooio media URLs (and adopts the
+// long-turn timeout/retry posture they require) when this is exactly "true",
+// so a dark Worker never receives media it would not describe and a dark
+// gateway never trades retries for a vision stage that does not run.
+const INBOUND_MEDIA_VISION_ENV = "ELIZA_APP_INBOUND_MEDIA_VISION";
+
+function inboundMediaVisionEnabled(): boolean {
+  return process.env[INBOUND_MEDIA_VISION_ENV]?.trim() === "true";
+}
 const ELIZA_TRACE_ID_HEADER = "X-Eliza-Trace-Id";
 const OPAQUE_TRACE_ID =
   /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
@@ -1079,10 +1089,14 @@ async function sendPersonalSharedReply(
   // Media turns mirror voice: the cloud route may spend fetch + vision + the
   // model turn, so a re-POST can overlap a still-running route execution and
   // re-run the unbilled vision call. Group Blooio events carry mediaUrls too
-  // but are never forwarded as media (no vision runs), so they keep the plain
-  // text-turn retry/timeout posture.
+  // but are never forwarded as media (no vision runs), and with the vision
+  // flag off no media is forwarded at all, so both keep the plain text-turn
+  // retry/timeout posture.
   const isMediaTurn =
-    adapter.platform === "blooio" && !isGroup && !!event.mediaUrls?.length;
+    inboundMediaVisionEnabled() &&
+    adapter.platform === "blooio" &&
+    !isGroup &&
+    !!event.mediaUrls?.length;
   // Voice and media turns can spend most of the 120-second processing lease in
   // STT/vision + the model. Only a stale-auth retry is safe inline; provider/
   // transport failures reopen the webhook for the platform's durable retry

--- a/packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.test.ts
@@ -1,0 +1,32 @@
+// Pins the canonical Blooio media-URL allowlist: https-only, Blooio-owned
+// hosts (including subdomains), and rejection of lookalike/suffix-attack
+// hosts. Pure deterministic predicate — no network or mocks.
+import { describe, expect, test } from "bun:test";
+import { ALLOWED_BLOOIO_MEDIA_DOMAINS, isAllowedBlooioMediaUrl } from "./blooio-media-allowlist";
+
+describe("isAllowedBlooioMediaUrl", () => {
+  test("accepts https URLs on every allowlisted domain and its subdomains", () => {
+    for (const domain of ALLOWED_BLOOIO_MEDIA_DOMAINS) {
+      expect(isAllowedBlooioMediaUrl(`https://${domain}/files/a.jpg`)).toBe(true);
+      expect(isAllowedBlooioMediaUrl(`https://cdn.${domain}/a.png`)).toBe(true);
+    }
+  });
+
+  test("rejects non-https schemes even on allowlisted hosts", () => {
+    expect(isAllowedBlooioMediaUrl("http://media.blooio.com/a.jpg")).toBe(false);
+    expect(isAllowedBlooioMediaUrl("ftp://media.blooio.com/a.jpg")).toBe(false);
+  });
+
+  test("rejects lookalike and suffix-attack hosts", () => {
+    expect(isAllowedBlooioMediaUrl("https://notblooio.com/a.jpg")).toBe(false);
+    expect(isAllowedBlooioMediaUrl("https://blooio.com.evil.com/a.jpg")).toBe(false);
+    expect(isAllowedBlooioMediaUrl("https://evilblooio.com/a.jpg")).toBe(false);
+    expect(isAllowedBlooioMediaUrl("https://example.com/blooio.com")).toBe(false);
+  });
+
+  test("rejects unparsable input instead of defaulting", () => {
+    expect(isAllowedBlooioMediaUrl("")).toBe(false);
+    expect(isAllowedBlooioMediaUrl("not a url")).toBe(false);
+    expect(isAllowedBlooioMediaUrl("//media.blooio.com/a.jpg")).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.test.ts
@@ -1,6 +1,8 @@
-// Pins the canonical Blooio media-URL allowlist: https-only, Blooio-owned
-// hosts (including subdomains), and rejection of lookalike/suffix-attack
-// hosts. Pure deterministic predicate — no network or mocks.
+/**
+ * Pins the canonical Blooio media-URL allowlist: https-only, Blooio-owned
+ * hosts (including subdomains), and rejection of lookalike/suffix-attack
+ * hosts. Pure deterministic predicate — no network or mocks.
+ */
 import { describe, expect, test } from "bun:test";
 import { ALLOWED_BLOOIO_MEDIA_DOMAINS, isAllowedBlooioMediaUrl } from "./blooio-media-allowlist";
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical allowlist for inbound Blooio media URLs. The gateway's Blooio
+ * adapter keeps a runtime-local copy (it must not depend on cloud-shared at
+ * runtime); its parity test pins that copy to this module, so edit the domain
+ * set here first. Dependency-free on purpose so the gateway test can import it
+ * without pulling the provider stack.
+ */
+
+export const ALLOWED_BLOOIO_MEDIA_DOMAINS = [
+  "blooio.com",
+  "backend.blooio.com",
+  "api.blooio.com",
+  "media.blooio.com",
+] as const;
+
+/** True only for an https URL on a Blooio-owned media domain. */
+export function isAllowedBlooioMediaUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // error-policy:J3 an unparsable URL is explicitly disallowed, never a default.
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  return ALLOWED_BLOOIO_MEDIA_DOMAINS.some(
+    (domain) => parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`),
+  );
+}

--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
@@ -1,0 +1,322 @@
+// Pins the fail-closed contract of inbound-media vision enrichment: the flag
+// and provider gates throw the typed disabled error, every fetch/size/type/
+// model failure throws the typed description error (so callers degrade instead
+// of dropping the turn), and a truncated or empty completion is rejected, never
+// returned. Deterministic mocks stand in for safe-fetch, the provider factory,
+// and the AI SDK — no network.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+class FakeProviderConfigurationError extends Error {
+  override readonly name = "ProviderConfigurationError";
+}
+
+const safeFetch = mock<(url: string, init?: RequestInit) => Promise<Response>>(
+  async () => new Response("unset", { status: 500 }),
+);
+const getLanguageModel = mock((_model: string): unknown => "vision-model");
+const generateText = mock(
+  async (_options: unknown): Promise<{ text: string; finishReason: string }> => ({
+    text: "unset",
+    finishReason: "stop",
+  }),
+);
+
+mock.module("../../security/safe-fetch", () => ({ safeFetch }));
+mock.module("../../providers/language-model", () => ({
+  getLanguageModel,
+  ProviderConfigurationError: FakeProviderConfigurationError,
+}));
+mock.module("ai", () => ({ generateText }));
+
+const {
+  describeInboundImageMedia,
+  InboundMediaDescriptionError,
+  InboundMediaVisionDisabledError,
+  MAX_INBOUND_IMAGE_BYTES,
+} = await import(`./describe-inbound-media.ts?test=describe-inbound-media-${Date.now()}`);
+
+const ENABLED = { ELIZA_APP_INBOUND_MEDIA_VISION: "true" };
+const URL_A = "https://media.blooio.com/files/photo-a.jpg";
+const URL_B = "https://backend.blooio.com/files/photo-b.png";
+
+function imageResponse(
+  bytes: Uint8Array,
+  contentType = "image/jpeg",
+  extraHeaders: Record<string, string> = {},
+): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: { "content-type": contentType, ...extraHeaders },
+  });
+}
+
+async function expectDescriptionFailure(
+  promise: Promise<string>,
+  reason: string,
+): Promise<InstanceType<typeof InboundMediaDescriptionError>> {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(InboundMediaDescriptionError);
+  const typed = caught as InstanceType<typeof InboundMediaDescriptionError>;
+  expect(typed.reason).toBe(reason as never);
+  return typed;
+}
+
+describe("describeInboundImageMedia — fail-closed gates", () => {
+  beforeEach(() => {
+    safeFetch.mockReset();
+    getLanguageModel.mockReset();
+    generateText.mockReset();
+    getLanguageModel.mockReturnValue("vision-model");
+    generateText.mockResolvedValue({
+      text: "a described image",
+      finishReason: "stop",
+    });
+    safeFetch.mockResolvedValue(imageResponse(new Uint8Array([1, 2, 3])));
+  });
+
+  test("unset flag throws the disabled error before any fetch", async () => {
+    await expect(describeInboundImageMedia({}, [URL_A])).rejects.toBeInstanceOf(
+      InboundMediaVisionDisabledError,
+    );
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test('any non-"true" flag value stays disabled', async () => {
+    await expect(
+      describeInboundImageMedia({ ELIZA_APP_INBOUND_MEDIA_VISION: "1" }, [URL_A]),
+    ).rejects.toBeInstanceOf(InboundMediaVisionDisabledError);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  test("missing vision provider is retyped as disabled, before any fetch", async () => {
+    getLanguageModel.mockImplementation(() => {
+      throw new FakeProviderConfigurationError("no key");
+    });
+    let caught: unknown;
+    try {
+      await describeInboundImageMedia(ENABLED, [URL_A]);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(InboundMediaVisionDisabledError);
+    expect((caught as Error).cause).toBeInstanceOf(FakeProviderConfigurationError);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  test("a non-configuration provider-factory failure propagates untyped", async () => {
+    const bug = new Error("factory bug");
+    getLanguageModel.mockImplementation(() => {
+      throw bug;
+    });
+    await expect(describeInboundImageMedia(ENABLED, [URL_A])).rejects.toBe(bug);
+  });
+
+  test("a URL off the Blooio allowlist is a contract violation, not a degrade", async () => {
+    let caught: unknown;
+    try {
+      await describeInboundImageMedia(ENABLED, ["https://evil.example/a.jpg"]);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).not.toBeInstanceOf(InboundMediaDescriptionError);
+    expect((caught as { code?: string }).code).toBe("INBOUND_MEDIA_URL_DISALLOWED");
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  test("zero and above-max URL counts are contract violations", async () => {
+    for (const urls of [[], [URL_A, URL_A, URL_A, URL_A, URL_A]]) {
+      let caught: unknown;
+      try {
+        await describeInboundImageMedia(ENABLED, urls);
+      } catch (error) {
+        caught = error;
+      }
+      expect((caught as { code?: string }).code).toBe("INBOUND_MEDIA_URL_COUNT_INVALID");
+    }
+  });
+});
+
+describe("describeInboundImageMedia — enrichment path", () => {
+  beforeEach(() => {
+    safeFetch.mockReset();
+    getLanguageModel.mockReset();
+    generateText.mockReset();
+    getLanguageModel.mockReturnValue("vision-model");
+    generateText.mockResolvedValue({
+      text: "  a cat on a keyboard  ",
+      finishReason: "stop",
+    });
+  });
+
+  test("fetches every URL through the SSRF guard and sends bytes as image parts", async () => {
+    const bytesA = new Uint8Array([1, 2, 3]);
+    const bytesB = new Uint8Array([4, 5]);
+    safeFetch.mockImplementation(async (url) =>
+      url === URL_A ? imageResponse(bytesA, "image/jpeg") : imageResponse(bytesB, "image/png"),
+    );
+
+    const description = await describeInboundImageMedia(ENABLED, [URL_A, URL_B]);
+
+    expect(description).toBe("a cat on a keyboard");
+    expect(safeFetch.mock.calls.map((call) => call[0])).toEqual([URL_A, URL_B]);
+    expect(getLanguageModel).toHaveBeenCalledWith("openai/gpt-5.4-mini");
+    const options = generateText.mock.calls[0]?.[0] as {
+      messages: Array<{
+        role: string;
+        content: Array<
+          { type: "text"; text: string } | { type: "image"; image: Uint8Array; mediaType: string }
+        >;
+      }>;
+      maxOutputTokens: number;
+    };
+    expect(options.messages).toHaveLength(1);
+    const [textPart, imageA, imageB] = options.messages[0].content;
+    expect(textPart.type).toBe("text");
+    expect(imageA).toEqual({
+      type: "image",
+      image: bytesA,
+      mediaType: "image/jpeg",
+    });
+    expect(imageB).toEqual({
+      type: "image",
+      image: bytesB,
+      mediaType: "image/png",
+    });
+    expect(options.maxOutputTokens).toBeGreaterThan(0);
+  });
+
+  test("every media fetch forbids redirects so hops cannot leave the allowlist", async () => {
+    safeFetch.mockImplementation(async () => imageResponse(new Uint8Array([1, 2, 3])));
+
+    await describeInboundImageMedia(ENABLED, [URL_A, URL_B]);
+
+    expect(safeFetch).toHaveBeenCalledTimes(2);
+    for (const call of safeFetch.mock.calls) {
+      expect((call[1] as { redirect?: string } | undefined)?.redirect).toBe("error");
+    }
+  });
+
+  test("a mixed fetch outcome waits for every sibling to settle before failing", async () => {
+    let slowSiblingSettled = false;
+    safeFetch.mockImplementation(async (url) => {
+      if (url === URL_A) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        slowSiblingSettled = true;
+        return imageResponse(new Uint8Array([1, 2, 3]));
+      }
+      throw new Error("connect refused");
+    });
+
+    const error = await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A, URL_B]),
+      "media_fetch_failed",
+    );
+
+    expect(slowSiblingSettled).toBe(true);
+    expect(error.context).toMatchObject({ reason: "media_fetch_failed", url: URL_B });
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("transport failure from the SSRF guard becomes media_fetch_failed", async () => {
+    const transport = new Error("connect refused");
+    safeFetch.mockRejectedValue(transport);
+    const error = await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "media_fetch_failed",
+    );
+    expect(error.cause).toBe(transport);
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("non-2xx media response becomes media_fetch_failed", async () => {
+    safeFetch.mockResolvedValue(new Response("gone", { status: 404 }));
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "media_fetch_failed",
+    );
+  });
+
+  test("non-image content type becomes unsupported_media_type", async () => {
+    safeFetch.mockResolvedValue(imageResponse(new Uint8Array([1]), "application/pdf"));
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "unsupported_media_type",
+    );
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("a declared Content-Length above the ceiling is rejected before reading", async () => {
+    safeFetch.mockResolvedValue(
+      imageResponse(new Uint8Array([1]), "image/jpeg", {
+        "content-length": String(MAX_INBOUND_IMAGE_BYTES + 1),
+      }),
+    );
+    await expectDescriptionFailure(describeInboundImageMedia(ENABLED, [URL_A]), "media_too_large");
+  });
+
+  test("a streamed body above the ceiling is rejected even without Content-Length", async () => {
+    const chunk = new Uint8Array(4 * 1024 * 1024);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+    safeFetch.mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+    await expectDescriptionFailure(describeInboundImageMedia(ENABLED, [URL_A]), "media_too_large");
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("an empty media body is a fetch failure, not an empty image", async () => {
+    safeFetch.mockResolvedValue(imageResponse(new Uint8Array(0)));
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "media_fetch_failed",
+    );
+  });
+
+  test("vision-model rejection becomes vision_model_failed", async () => {
+    safeFetch.mockResolvedValue(imageResponse(new Uint8Array([1])));
+    const upstream = new Error("upstream 500");
+    generateText.mockRejectedValue(upstream);
+    const error = await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "vision_model_failed",
+    );
+    expect(error.cause).toBe(upstream);
+  });
+
+  test("an empty completion is rejected, never returned as a description", async () => {
+    safeFetch.mockResolvedValue(imageResponse(new Uint8Array([1])));
+    generateText.mockResolvedValue({ text: "   ", finishReason: "stop" });
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "empty_description",
+    );
+  });
+
+  test("prompt integrity: a completion clipped at the output ceiling is rejected", async () => {
+    safeFetch.mockResolvedValue(imageResponse(new Uint8Array([1])));
+    generateText.mockResolvedValue({
+      text: "a partial descrip",
+      finishReason: "length",
+    });
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "incomplete_description",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
@@ -1,9 +1,11 @@
-// Pins the fail-closed contract of inbound-media vision enrichment: the flag
-// and provider gates throw the typed disabled error, every fetch/size/type/
-// model failure throws the typed description error (so callers degrade instead
-// of dropping the turn), and a truncated or empty completion is rejected, never
-// returned. Deterministic mocks stand in for safe-fetch, the provider factory,
-// and the AI SDK — no network.
+/**
+ * Pins the fail-closed contract of inbound-media vision enrichment: the flag
+ * and provider gates throw the typed disabled error, every fetch/size/type/
+ * model failure throws the typed description error (so callers degrade instead
+ * of dropping the turn), and a truncated or empty completion is rejected, never
+ * returned. Deterministic mocks stand in for safe-fetch, the provider factory,
+ * and the AI SDK — no network.
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 class FakeProviderConfigurationError extends Error {

--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts
@@ -1,0 +1,288 @@
+/**
+ * Describes inbound platform image media with a vision model so the shared
+ * Personal turn (whose default text model cannot see images) receives real
+ * image content instead of a bare provider URL. Fail-closed by design: the
+ * `ELIZA_APP_INBOUND_MEDIA_VISION` binding must be exactly "true" and a vision
+ * provider must be configured, otherwise the typed disabled error tells the
+ * caller to keep the un-enriched message. Media bytes are fetched through the
+ * SSRF-guarded `safeFetch` after an https/domain allowlist re-check, with
+ * redirects rejected outright (a followed hop is only SSRF-checked, not
+ * allowlist-checked), a content-type gate, and a streamed size cap, so a
+ * compromised or spoofed gateway payload cannot make this Worker read
+ * arbitrary or unbounded bytes.
+ *
+ * Every enrichment failure is a typed `InboundMediaDescriptionError`; callers
+ * degrade to the raw media-URL text on it and must never fabricate a
+ * description. A truncated completion is rejected, not returned: a clipped
+ * description entering conversation history as if complete violates the
+ * repository prompt-integrity rule.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { generateText } from "ai";
+import type { Bindings } from "../../../types/cloud-worker-env";
+import { getLanguageModel, ProviderConfigurationError } from "../../providers/language-model";
+import { safeFetch } from "../../security/safe-fetch";
+import { isAllowedBlooioMediaUrl } from "./blooio-media-allowlist";
+
+export const INBOUND_MEDIA_VISION_MODEL = "openai/gpt-5.4-mini";
+export const MAX_INBOUND_MEDIA_IMAGES = 4;
+// Mirrors the Telegram voice ceiling: keeps the fetched copies bounded in a
+// 128 MiB Worker isolate while covering ordinary conversational photos.
+export const MAX_INBOUND_IMAGE_BYTES = 8 * 1024 * 1024;
+const INBOUND_MEDIA_FETCH_TIMEOUT_MS = 15_000;
+const INBOUND_MEDIA_VISION_TIMEOUT_MS = 45_000;
+// Output-side ceiling only; the completion is rejected (never clipped) when
+// the model reports it ran into this bound.
+const INBOUND_MEDIA_DESCRIPTION_MAX_OUTPUT_TOKENS = 768;
+
+const DESCRIPTION_PROMPT =
+  "Describe the attached image(s) for an assistant that cannot see them. " +
+  "State the subject, any visible text verbatim, and details a reply would " +
+  "need. Describe only what is visible; do not guess at hidden content.";
+
+/** Vision enrichment is off for this deployment; keep the un-enriched turn. */
+export class InboundMediaVisionDisabledError extends ElizaError {
+  override readonly name = "InboundMediaVisionDisabledError";
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, {
+      code: "INBOUND_MEDIA_VISION_DISABLED",
+      severity: "ephemeral",
+      ...options,
+    });
+  }
+}
+
+export type InboundMediaDescriptionFailureReason =
+  | "media_fetch_failed"
+  | "unsupported_media_type"
+  | "media_too_large"
+  | "vision_model_failed"
+  | "empty_description"
+  | "incomplete_description";
+
+/** One enrichment attempt failed; callers degrade to the raw media-URL text. */
+export class InboundMediaDescriptionError extends ElizaError {
+  override readonly name = "InboundMediaDescriptionError";
+  readonly reason: InboundMediaDescriptionFailureReason;
+
+  constructor(
+    message: string,
+    reason: InboundMediaDescriptionFailureReason,
+    options?: { cause?: unknown; context?: Record<string, unknown> },
+  ) {
+    super(message, {
+      code: "INBOUND_MEDIA_DESCRIPTION_FAILED",
+      severity: "ephemeral",
+      cause: options?.cause,
+      context: { reason, ...options?.context },
+    });
+    this.reason = reason;
+  }
+}
+
+interface FetchedInboundImage {
+  bytes: Uint8Array;
+  mediaType: string;
+}
+
+async function readImageBytesWithCap(response: Response, url: string): Promise<Uint8Array> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_INBOUND_IMAGE_BYTES) {
+    await response.body?.cancel();
+    throw new InboundMediaDescriptionError(
+      "Inbound media declares a size above the image ceiling",
+      "media_too_large",
+      { context: { url, declaredLength } },
+    );
+  }
+  if (!response.body) {
+    throw new InboundMediaDescriptionError(
+      "Inbound media response carried no body",
+      "media_fetch_failed",
+      { context: { url } },
+    );
+  }
+  // Content-Length is provider-asserted; enforce the ceiling on the actual
+  // stream so a lying header cannot buffer an unbounded body.
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_INBOUND_IMAGE_BYTES) {
+      await reader.cancel();
+      throw new InboundMediaDescriptionError(
+        "Inbound media exceeds the image ceiling",
+        "media_too_large",
+        { context: { url } },
+      );
+    }
+    chunks.push(value);
+  }
+  if (total === 0) {
+    throw new InboundMediaDescriptionError(
+      "Inbound media response body was empty",
+      "media_fetch_failed",
+      { context: { url } },
+    );
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function fetchInboundImage(url: string): Promise<FetchedInboundImage> {
+  let response: Response;
+  try {
+    // redirect: "error" — safeFetch re-validates redirect hops only against
+    // the SSRF/private-IP guard, not the Blooio allowlist, so following even
+    // one hop would let an open redirect on an allowlisted host fetch bytes
+    // from any public origin. Fail the fetch instead; if Blooio media is ever
+    // served via a CDN redirect, widen this deliberately with a per-hop
+    // allowlist re-check.
+    response = await safeFetch(url, {
+      redirect: "error",
+      signal: AbortSignal.timeout(INBOUND_MEDIA_FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // error-policy:J2 wrap transport/SSRF-guard failures with the media URL context.
+    throw new InboundMediaDescriptionError("Inbound media fetch failed", "media_fetch_failed", {
+      cause: error,
+      context: { url },
+    });
+  }
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new InboundMediaDescriptionError(
+      `Inbound media fetch returned HTTP ${response.status}`,
+      "media_fetch_failed",
+      { context: { url, status: response.status } },
+    );
+  }
+  const mediaType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (!mediaType.startsWith("image/")) {
+    await response.body?.cancel();
+    throw new InboundMediaDescriptionError(
+      "Inbound media is not an image",
+      "unsupported_media_type",
+      { context: { url, mediaType } },
+    );
+  }
+  return { bytes: await readImageBytesWithCap(response, url), mediaType };
+}
+
+/**
+ * Fetches every allowlisted image URL and returns one vision-model description
+ * covering all of them. Throws {@link InboundMediaVisionDisabledError} when the
+ * flag is off or no vision provider is configured, and
+ * {@link InboundMediaDescriptionError} on any per-turn enrichment failure.
+ */
+export async function describeInboundImageMedia(
+  env: Pick<Bindings, "ELIZA_APP_INBOUND_MEDIA_VISION">,
+  urls: readonly string[],
+): Promise<string> {
+  if (env.ELIZA_APP_INBOUND_MEDIA_VISION?.trim() !== "true") {
+    throw new InboundMediaVisionDisabledError(
+      "Inbound media vision is disabled for this deployment",
+    );
+  }
+  if (urls.length === 0 || urls.length > MAX_INBOUND_MEDIA_IMAGES) {
+    throw new ElizaError("Inbound media description got an invalid URL count", {
+      code: "INBOUND_MEDIA_URL_COUNT_INVALID",
+      context: { count: urls.length, max: MAX_INBOUND_MEDIA_IMAGES },
+    });
+  }
+  for (const url of urls) {
+    // Defence-in-depth: the route schema already enforces the allowlist, so a
+    // disallowed URL here is a broken caller contract, not a degradable turn.
+    if (!isAllowedBlooioMediaUrl(url)) {
+      throw new ElizaError("Inbound media URL is not on the Blooio allowlist", {
+        code: "INBOUND_MEDIA_URL_DISALLOWED",
+        context: { url },
+      });
+    }
+  }
+  let model: ReturnType<typeof getLanguageModel>;
+  try {
+    model = getLanguageModel(INBOUND_MEDIA_VISION_MODEL);
+  } catch (error) {
+    if (error instanceof ProviderConfigurationError) {
+      // error-policy:J2 a missing vision provider key means the capability is
+      // off for this deployment; retype so callers keep the un-enriched turn.
+      throw new InboundMediaVisionDisabledError("Inbound media vision has no configured provider", {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+  // allSettled instead of all: on a mixed outcome, `all` would reject while
+  // sibling fetches still hold sockets and buffering bodies in the isolate.
+  // Waiting for every settle keeps the error path leak-free (each fetch either
+  // fully reads its capped body or cancels it itself), then the first failure
+  // is rethrown unchanged.
+  const settledImages = await Promise.allSettled(urls.map(fetchInboundImage));
+  const firstFailure = settledImages.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (firstFailure) {
+    throw firstFailure.reason;
+  }
+  const images = settledImages.map(
+    (result) => (result as PromiseFulfilledResult<FetchedInboundImage>).value,
+  );
+  let completion: Awaited<ReturnType<typeof generateText>>;
+  try {
+    completion = await generateText({
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: DESCRIPTION_PROMPT },
+            ...images.map((image) => ({
+              type: "image" as const,
+              image: image.bytes,
+              mediaType: image.mediaType,
+            })),
+          ],
+        },
+      ],
+      maxOutputTokens: INBOUND_MEDIA_DESCRIPTION_MAX_OUTPUT_TOKENS,
+      abortSignal: AbortSignal.timeout(INBOUND_MEDIA_VISION_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // error-policy:J2 retype provider failures so callers degrade instead of
+    // dropping the user's turn.
+    throw new InboundMediaDescriptionError(
+      "Vision provider failed to describe inbound media",
+      "vision_model_failed",
+      { cause: error, context: { model: INBOUND_MEDIA_VISION_MODEL } },
+    );
+  }
+  const description = completion.text.trim();
+  if (!description) {
+    throw new InboundMediaDescriptionError(
+      "Vision provider returned an empty description",
+      "empty_description",
+      { context: { model: INBOUND_MEDIA_VISION_MODEL } },
+    );
+  }
+  // Prompt integrity: a description clipped at the output ceiling must be
+  // rejected, never delivered as if it were the complete image content.
+  if (completion.finishReason === "length") {
+    throw new InboundMediaDescriptionError(
+      "Vision provider truncated the description at the output ceiling",
+      "incomplete_description",
+      { context: { model: INBOUND_MEDIA_VISION_MODEL } },
+    );
+  }
+  return description;
+}

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -477,6 +477,11 @@ export interface Bindings {
   WEBHOOK_GATEWAY_URL?: string;
   GATEWAY_WEBHOOK_URL?: string;
   ELIZA_APP_WEBHOOK_PROJECT?: string;
+  /**
+   * Exactly `"true"` enables vision descriptions of inbound Blooio image media
+   * on Personal Shared turns; any other value keeps the raw media-URL text.
+   */
+  ELIZA_APP_INBOUND_MEDIA_VISION?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
   /** Collision-free secret used by the protected staging edge cutover. */

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -480,6 +480,8 @@ export interface Bindings {
   /**
    * Exactly `"true"` enables vision descriptions of inbound Blooio image media
    * on Personal Shared turns; any other value keeps the raw media-URL text.
+   * The gateway-webhook service reads the same variable to decide whether to
+   * forward media URLs at all, so enable both deployments together.
    */
   ELIZA_APP_INBOUND_MEDIA_VISION?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */


### PR DESCRIPTION
> **Draft status:** based on `ed4d4a3`; will rebase before ready. Part of `nubs/demo-night`. Heads-up @lalalune: may overlap your openviking attachment-awareness track — happy to fold this into it.


### What

Inbound Blooio (iMessage/SMS) image attachments currently reach the personal
Shared turn as the literal `[media: <url>]` text the gateway adapter
synthesizes, so the model never sees the image. This PR adds an additive,
flag-gated enrichment path: with `ELIZA_APP_INBOUND_MEDIA_VISION="true"` on the
Worker, the route fetches the allowlisted Blooio media, describes it with a
vision model, and delivers the turn as:

```
[media: <url>]

[Attached image description]
<vision description>
```

With the flag off (the default), a missing vision provider key, or any
enrichment failure, the delivered message is byte-identical to today's
`[media: url]` text and the user's turn is never dropped.

### Why

The shared turn's default text model cannot see images (only the Node/dedicated
runtime path has `ModelType.IMAGE_DESCRIPTION` via plugin-elizacloud). This
follows the existing Telegram voice-note precedent exactly: the gateway
resolves media context, posts it as a structured field, and the route enriches
`deliveryMessage` before the turn — no changes to `run-shared-agent-turn`.

### How

- **Gateway** (`packages/cloud/services/gateway-webhook/src/webhook-handler.ts`):
  for Blooio one-to-one turns, forwards the adapter's already-allowlisted
  `event.mediaUrls` on the personal-Shared POST body and raises the request
  timeout to 90s for media turns (mirroring the voice ceiling) so a vision
  enrichment cannot be aborted mid-flight and re-run. Media turns adopt the
  voice-note retry posture: attempts capped at 2 (stale-auth inline retry
  only) with status/transport re-POSTs disabled, because an aborted long turn
  may still be running server-side and a re-POST would overlap it and re-run
  the vision call. Blooio group events (which carry `mediaUrls` but are never
  forwarded as media and run no vision) keep the plain text-turn 30s
  timeout and full retry budget.
- **Allowlist one-source-of-truth**
  (`packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.ts`):
  canonical https + Blooio-domain predicate, dependency-free so the gateway
  test can import it. The adapter keeps its runtime-local copy (the gateway
  must not depend on cloud-shared at runtime); a parity test pins the two
  byte-identical, following the existing `billing.test.ts` precedent.
- **Helper**
  (`packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts`):
  `describeInboundImageMedia(env, urls)` — fail-closed typed
  `InboundMediaVisionDisabledError` when the flag is off or no provider key is
  configured; SSRF-guarded byte fetch via `safeFetch` with `redirect: "error"`
  (redirect hops are only SSRF-checked, not allowlist-checked, so any redirect
  fails the fetch rather than letting an open redirect on an allowlisted host
  reach an arbitrary origin), an `image/*`
  content-type gate and an 8 MiB streamed size cap (Content-Length is treated
  as untrusted); concurrent fetches settle via `Promise.allSettled` so a
  failing sibling cannot leave in-flight bodies buffering in the isolate;
  `generateText` with `openai/gpt-5.4-mini` image parts, bounded
  output tokens, 45s abort. Every per-turn failure (fetch, non-image,
  oversize, provider error, empty completion, length-truncated completion) is
  a typed `InboundMediaDescriptionError` with a machine-readable `reason`.
  Empty/truncated completions are rejected, never delivered, per the
  repository prompt-integrity rule.
- **Route**
  (`packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`):
  additive optional `mediaUrls` (1–4, allowlist-re-validated, Blooio-only) on
  the twilio/blooio schema variant; a `media_description` delivery stage;
  disabled → debug log + raw text, typed description failure → `logger.error`
  (reported, since the turn still succeeds) + raw text, unexpected errors
  propagate to the J1 boundary and fail the delivery with the
  `media_description` failure-stage header.
- **Bindings**: `ELIZA_APP_INBOUND_MEDIA_VISION?: string` documented in
  `packages/cloud/shared/src/types/cloud-worker-env.ts`.

### Flag rollout

1. Ships dark: no Worker/wrangler config change, so the flag is unset and the
   behavior is byte-identical everywhere (only the gateway body gains the
   ignored-by-default `mediaUrls` field).
2. Enable on staging (`ELIZA_APP_INBOUND_MEDIA_VISION=true` as a Worker var)
   and send a real inbound iMessage image to verify the one unproven
   assumption live: that Blooio media URLs are fetchable by the Worker without
   provider auth **and without redirects** (the fetch now rejects any redirect
   hop; if Blooio legitimately serves media via a CDN redirect, widen this
   deliberately with a per-hop allowlist re-check rather than reverting to
   follow-mode). If they need auth, fall back to a gateway-side byte fetch
   (Node `safeFetch` with true socket pinning) posting a size-capped base64
   `imageAttachment` field, exactly like `voiceNote`.
3. Production enablement after staging evidence **and** an abuse-spend gate:
   the `media_description` stage spends unmetered pooled-key vision credit and
   is reachable by any inbound sender to the connected number (unlike the
   voice path, which requires a linked account), so a per-sender or
   per-connector rate limit — or routing the describe call through the org
   billing meter — must land before the flag is set in production. Follow-up
   issue to be filed with this PR. Disabling the flag restores current
   behavior instantly, no deploy of the gateway required.

### Test evidence

All new suites are deterministic (mocked fetch/provider, no live services):

- `packages/cloud/shared` — `describe-inbound-media.test.ts` +
  `blooio-media-allowlist.test.ts`: **22 pass, 0 fail** (flag off, non-"true"
  values, provider-unconfigured retype, disallowed URL/count contract
  violations, happy path with per-image bytes/mediaType parts, every fetch
  pinned to `redirect: "error"`, mixed-outcome fetches settle every sibling
  before failing, transport
  failure, non-2xx, non-image type, declared and streamed oversize, empty
  body, provider rejection, empty completion, length-truncated completion;
  allowlist accept/reject/lookalike matrix).
- `packages/cloud/services/gateway-webhook` —
  `blooio-inbound-media-forward.test.ts`: **8 pass, 0 fail** (media body
  forward, no-media body, Twilio never forwards, text-turn 5xx retry control,
  media-turn 5xx never re-POSTed, group media keeps plain-turn posture with
  no mediaUrls, domain-list parity, predicate
  parity). Full package suite: **196 pass, 0 fail** (25 files). `tsc --noEmit`
  clean.
- `packages/cloud/api` — `route.inbound-media.test.ts`: **9 pass, 0 fail**
  (schema accept; Twilio/mediaUrls reject; >4 reject; off-allowlist and http
  reject; no-media path never consults vision; disabled → byte-identical raw
  text; enabled → enriched block; typed failure → degrade + reported error;
  unexpected failure → 500 with `media_description` stage header). Existing
  `route.test.ts`: **44 pass, 0 fail**. Isolated unit lane for both files
  passes; `check:worker-bundle` (wrangler dry-run) passes.
- `packages/cloud/shared` eliza-app service sweep (`bun test --isolate`):
  210 pass / 2 pre-existing failures in `onboarding-chat.test.ts`
  (reproduced on the clean tree with this change stashed — unrelated).

### Files changed

- `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`
- `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts` (new)
- `packages/cloud/services/gateway-webhook/src/webhook-handler.ts`
- `packages/cloud/services/gateway-webhook/src/adapters/blooio.ts` (exports for parity test + comment)
- `packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts` (new)
- `packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.ts` (new)
- `packages/cloud/shared/src/lib/services/eliza-app/blooio-media-allowlist.test.ts` (new)
- `packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts` (new)
- `packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts` (new)
- `packages/cloud/shared/src/types/cloud-worker-env.ts`

## Review

An internal fix-first review of the initial revision found five issues; all
are addressed in the current revision:

1. **(major, fixed)** `describe-inbound-media.ts`: the media fetch used
   safeFetch's default redirect-follow mode. Redirect hops are re-validated
   only against the SSRF/private-IP guard — not the Blooio allowlist — so an
   open redirect on any allowlisted host (api.blooio.com is a general API
   host) could have fetched attacker-chosen bytes from any public origin and
   fed them to the vision model, contradicting the module's own safety claim.
   Fixed by passing `redirect: "error"`: any redirect now fails the fetch as
   `media_fetch_failed`. A regression test pins the init on every call. If
   staging shows Blooio media legitimately redirecting to a CDN, the widening
   must be a deliberate per-hop allowlist re-check (rollout step 2).
2. **(major, fixed)** `webhook-handler.ts`: media turns got the 90s ceiling
   but kept `maxAttempts=3` with status/transport retries enabled — the exact
   combination the voice path avoids. A >90s or 5xx media turn would be
   re-POSTed while the first route execution (fetch + unbilled vision + model
   turn) may still be running server-side, duplicating spend and risking
   overlapping agent turns. Fixed by treating media turns exactly like voice:
   `maxAttempts=2`, `retryStatuses`/`retryTransport` disabled, stale-auth
   inline retry kept. Regression tests pin both the no-retry media posture
   and a retrying text-turn control.
3. **(minor, fixed)** `webhook-handler.ts`: the 90s media-timeout condition
   did not exclude group events, which carry `mediaUrls` but are never
   forwarded as media (no vision runs) — a group image message would hold the
   background slot up to 90s for a plain text turn. Fixed with a single
   `isMediaTurn` predicate (`blooio && !isGroup && mediaUrls`) used by the
   timeout, the retry posture, and the body forward guard; a regression test
   pins the group posture.
4. **(minor, addressed as a rollout gate)** route `media_description` stage:
   once the flag is on, any inbound sender can trigger unmetered pooled-key
   vision spend with no rate limit or billing gate. A production-blocking
   gate is now recorded in rollout step 3 and as an in-code comment at the
   stage; the rate-limit/billing implementation is a follow-up issue, filed
   with this PR, that must land before production enablement.
5. **(minor, fixed)** `describe-inbound-media.ts`: `Promise.all` over the
   concurrent fetches rejected on the first failure while sibling responses
   kept buffering in the isolate until GC. Fixed with `Promise.allSettled`
   (every fetch fully reads its capped body or cancels it) before rethrowing
   the first failure unchanged; a mixed-outcome regression test pins it.

## Limitations (honest)

- **No live verification yet.** The repo evidence policy requires exercising
  the real boundary; the one unverified assumption is whether Blooio media
  URLs are publicly fetchable (the adapter documents no auth contract). This
  must be proven with one real inbound iMessage image on staging before
  production enablement; the `voiceNote`-style gateway byte-fetch fallback is
  the designed escape hatch if they need auth.
- **Billing bypass.** The describe call uses the pooled provider key and
  bypasses per-org billing — the same posture as the existing Whisper voice
  path in this route, but with a wider blast radius: any stranger who texts
  the connected number can trigger the spend, with no linked-account
  requirement. Acceptable while flag-off/staging-only; a per-sender or
  per-connector rate limit (or billing-meter routing) is a hard gate on
  production enablement (rollout step 3).
- **workerd SSRF residual.** `safeFetch` cannot pin sockets on Cloudflare
  Workers (documented in `safe-fetch.ts`); the allowlist restricts targets to
  Blooio-owned domains, but the platform-level DNS-rebinding TOCTOU noted in
  #12229 M5 applies until the Cloudflare egress policy closes it.
- **One-to-one Blooio only.** Group Blooio media and Telegram/Twilio/WhatsApp
  media are out of scope; those turns keep their current behavior.
- **Non-image media** (video, PDF, audio attachments on Blooio) intentionally
  degrade to the raw `[media: url]` text via the `unsupported_media_type`
  path — no attempt is made to describe them.
- **Latency.** An enriched turn adds up to ~15s fetch + ~45s vision on top of
  the model turn; the gateway timeout for media turns was raised to 90s to
  cover it. Blooio webhook-retry interplay past 90s is unchanged from the
  voice path's posture.
- **Pre-existing worktree failures (not from this change):**
  `packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts` fails
  `tsc --noEmit`, and two `onboarding-chat.test.ts` cases fail; both reproduce
  on the clean base tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
