### PR TITLE
test(app-core): cover local-agent dispatcher registry

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/local-agent-dispatcher-registry.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/local-agent-dispatcher-registry.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getActiveLocalAgentDispatcher,
+	requireActiveLocalAgentDispatcher,
+	setActiveLocalAgentDispatcher,
+} from "./local-agent-dispatcher-registry.ts";
+
+describe("local-agent-dispatcher-registry", () => {
+	beforeEach(() => setActiveLocalAgentDispatcher(null));
+	afterEach(() => setActiveLocalAgentDispatcher(null));
+
+	it("starts with no dispatcher", () => {
+		expect(getActiveLocalAgentDispatcher()).toBeNull();
+	});
+
+	it("returns the registered dispatcher", () => {
+		const dispatcher = { name: "ipc" } as never;
+		setActiveLocalAgentDispatcher(dispatcher);
+		expect(getActiveLocalAgentDispatcher()).toBe(dispatcher);
+	});
+
+	it("requireActiveLocalAgentDispatcher returns the dispatcher when set", () => {
+		const dispatcher = {} as never;
+		setActiveLocalAgentDispatcher(dispatcher);
+		expect(requireActiveLocalAgentDispatcher()).toBe(dispatcher);
+	});
+
+	it("requireActiveLocalAgentDispatcher throws when unset", () => {
+		expect(() => requireActiveLocalAgentDispatcher()).toThrow(
+			"no local-agent IPC dispatcher",
+		);
+	});
+
+	it("clearing with null resets the registry", () => {
+		setActiveLocalAgentDispatcher({} as never);
+		setActiveLocalAgentDispatcher(null);
+		expect(getActiveLocalAgentDispatcher()).toBeNull();
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
