### PR TITLE
feat(cloud): owner-scheduled group reminders for Personal Shared group bindings

### DIFF
--- a/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts
+++ b/packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Exercises the Dedicated cutover relay with the REAL Shared reminder
+ * dispatcher for group destinations: after cutover the deliver route still
+ * leases the group send through the binding delivery authority (authorize,
+ * commit before egress, receipt after) and prefixes the group send, and a
+ * refused lease on a revoked binding fails the relay closed. Mocked auth,
+ * source row, and repository; intercepted gateway fetch.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: { organization_id: "org-owner" },
+}));
+const getAgent = mock(async () => ({ id: "dedicated-agent" }));
+const BINDING_ID = "8b8f2c69-6a3e-4a0f-9be1-1f8f6a3e4a0f";
+const AUTHORITY = {
+  bindingId: BINDING_ID,
+  ownerUserId: "00000000-0000-4000-8000-000000000002",
+  personalAgentId: "personal:00000000-0000-5000-8000-000000000000",
+  version: 7,
+};
+const committedGroupTask = {
+  taskId: "shared-reminder-1",
+  kind: "reminder" as const,
+  promptInstructions: "pay the rent",
+  ownerVisible: true,
+  contextRequest: undefined,
+  output: { fallback: { body: "pay the rent" } },
+  metadata: {
+    dispatchIdempotencyKey: "shared-reminder-1:2026-08-15T17:00:00.000Z",
+    delivery: {
+      platform: "telegram",
+      kind: "group",
+      project: "eliza-app",
+      connectorAccountId: "telegram:test-bot",
+      chatId: "-100123456789",
+      ownerLabel: "Nubs",
+      authority: AUTHORITY,
+    },
+  },
+};
+const readCommittedSharedReminderForTarget = mock(
+  async () => committedGroupTask,
+);
+const activeBinding = {
+  id: BINDING_ID,
+  organization_id: "00000000-0000-4000-8000-000000000001",
+  owner_user_id: "00000000-0000-4000-8000-000000000002",
+  personal_agent_id: "personal:00000000-0000-5000-8000-000000000000",
+  authority_version: 7,
+  platform: "telegram",
+  project: "eliza-app",
+  connector_account_id: "telegram:test-bot",
+  provider_chat_id: "-100123456789",
+  conversation_id: "group:00000000-0000-5000-8000-000000000030",
+  state: "active",
+  response_policy: "mention_only",
+  created_by_platform_user_id: "123456789",
+};
+const findBindingById = mock(
+  async (): Promise<Record<string, unknown> | null> => activeBinding,
+);
+type DeliveryLease = {
+  authorized: boolean;
+  leaseToken: string | null;
+  expiresAt: string | null;
+};
+const authorizeDelivery = mock(
+  async (input: { leaseToken: string }): Promise<DeliveryLease> => ({
+    authorized: true,
+    leaseToken: input.leaseToken,
+    expiresAt: "2026-08-15T17:01:30.000Z",
+  }),
+);
+const commitDelivery = mock(async () => true);
+const recordDeliveryReceipts = mock(async () => ({
+  recorded: true,
+  inserted: 1,
+}));
+
+mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { getAgent },
+}));
+mock.module("@/lib/services/shared-runtime/shared-scheduling", () => ({
+  readCommittedSharedReminderForTarget,
+  createSharedScheduledTaskRunner: mock(() => {
+    throw new Error("the relay must not open a Shared runner");
+  }),
+  executeSharedSchedulingSql: mock(async () => []),
+}));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    findBindingById,
+    authorizeDelivery,
+    commitDelivery,
+    recordDeliveryReceipts,
+  },
+}));
+
+const route = (
+  await import(
+    "../v1/eliza/agents/[agentId]/shared-reminders/[taskId]/deliver/route"
+  )
+).default;
+const app = new Hono<AppEnv>();
+app.route(
+  "/api/v1/eliza/agents/:agentId/shared-reminders/:taskId/deliver",
+  route,
+);
+const originalFetch = globalThis.fetch;
+
+function request() {
+  return app.request(
+    "/api/v1/eliza/agents/dedicated-agent/shared-reminders/shared-reminder-1/deliver",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": "agent-key" },
+      body: JSON.stringify({ firedAtIso: "2026-08-15T17:00:00.000Z" }),
+    },
+    {
+      ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example/",
+      GATEWAY_INTERNAL_SECRET: "internal-secret",
+    } as AppEnv["Bindings"],
+  );
+}
+
+beforeEach(() => {
+  findBindingById.mockClear();
+  findBindingById.mockImplementation(async () => activeBinding);
+  authorizeDelivery.mockClear();
+  authorizeDelivery.mockImplementation(
+    async (input: { leaseToken: string }): Promise<DeliveryLease> => ({
+      authorized: true,
+      leaseToken: input.leaseToken,
+      expiresAt: "2026-08-15T17:01:30.000Z",
+    }),
+  );
+  commitDelivery.mockClear();
+  recordDeliveryReceipts.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Dedicated cutover group reminder relay", () => {
+  test("leases the binding and delivers the prefixed group send", async () => {
+    const requests: Request[] = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const outgoing = new Request(input, init);
+        requests.push(outgoing);
+        const body = (await outgoing.clone().json()) as Record<string, unknown>;
+        return Response.json({
+          success: true,
+          idempotencyKey: body.idempotencyKey,
+          acceptedAt: "2026-08-15T17:00:00.100Z",
+          providerMessageIds: ["provider-group-1"],
+        });
+      },
+    ) as unknown as typeof fetch;
+
+    const response = await request();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      metadata: { providerMessageIds: ["provider-group-1"] },
+    });
+    expect(authorizeDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authority: AUTHORITY,
+        connectorAccountId: "telegram:test-bot",
+        providerChatId: "-100123456789",
+        sourceMessageId: "shared-reminder-1:2026-08-15T17:00:00.000Z",
+        invocation: "command",
+      }),
+    );
+    expect(commitDelivery).toHaveBeenCalledTimes(1);
+    expect(findBindingById).not.toHaveBeenCalled();
+    expect(requests[0]?.url).toBe("https://gateway.example/internal/deliver");
+    await expect(requests[0]?.json()).resolves.toEqual({
+      platform: "telegram",
+      project: "eliza-app",
+      chatId: "-100123456789",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: "shared-reminder-1:2026-08-15T17:00:00.000Z",
+    });
+    expect(recordDeliveryReceipts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authority: AUTHORITY,
+        sourceMessageId: "shared-reminder-1:2026-08-15T17:00:00.000Z",
+        providerMessageIds: ["provider-group-1"],
+      }),
+    );
+  });
+
+  test("fails the relay closed when the binding was revoked after cutover", async () => {
+    authorizeDelivery.mockImplementationOnce(async () => ({
+      authorized: false,
+      leaseToken: null,
+      expiresAt: null,
+    }));
+    findBindingById.mockImplementationOnce(async () => ({
+      ...activeBinding,
+      state: "revoked",
+      authority_version: 8,
+    }));
+    globalThis.fetch = mock(async () => {
+      throw new Error("connector egress must not run");
+    }) as unknown as typeof fetch;
+
+    const response = await request();
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      reason: "unknown_recipient",
+      acceptance: "not_accepted",
+    });
+    expect(findBindingById).toHaveBeenCalledWith(BINDING_ID);
+    expect(commitDelivery).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(recordDeliveryReceipts).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Verifies owner-gated group reminder destinations on the trusted messaging
+ * route: the owner's group turn receives a destination pinned to the binding's
+ * live delivery authority, and every other participant or binding state gets
+ * none. Mocked account, runtime, and repository boundaries.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const resolvePersonalDelivery = mock(async () => ({
+  userId: "00000000-0000-4000-8000-000000000002",
+  organizationId: "00000000-0000-4000-8000-000000000001",
+  dedicatedTarget: null,
+  isNew: false,
+  resolution: "single-query-repeat" as const,
+}));
+const sharedRestMessageSend = mock(async (..._args: unknown[]) => ({
+  text: "hello from Eliza",
+}));
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
+const runOnboardingChat = mock(async () => ({
+  loginUrl:
+    "https://cloud-staging.eliza.app/get-started?onboardingSession=claim-token",
+}));
+const findActivePersonalDedicatedTarget = mock(async () => null);
+const bridge = mock(async () => ({
+  jsonrpc: "2.0" as const,
+  id: "unused",
+  result: { text: "hello from Dedicated" },
+}));
+const importCanonicalConversation = mock(async () => null);
+const coordinateSharedHistory = mock(async () => []);
+const issueGroupClaim = mock(async () => undefined);
+const consumeGroupClaimAndBind = mock(
+  async (): Promise<{ status: "invalid" }> => ({ status: "invalid" }),
+);
+const resolveGroupBinding = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const setGroupResponsePolicy = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const revokeGroupBinding = mock(async () => false);
+const applyGroupMembershipChange = mock(
+  async (): Promise<Record<string, unknown> | null> => null,
+);
+const authorizeGroupDelivery = mock(async () => ({
+  authorized: false,
+  leaseToken: null,
+  expiresAt: null,
+}));
+const commitGroupDelivery = mock(async () => false);
+const recordGroupDeliveryReceipts = mock(async () => ({
+  recorded: false,
+  inserted: 0,
+}));
+const hasGroupDeliveryReceipt = mock(async () => true);
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const runtimeExecutionCtx = { waitUntil: mock(() => undefined) };
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: { resolvePersonalDelivery },
+}));
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
+mock.module("@/lib/services/eliza-app/onboarding-chat", () => ({
+  runOnboardingChat,
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: async () => ({ allowed: true, balance: 10 }),
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: async () => ({ ok: true, required: false }),
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentResumeOnce: mock(async () => ({
+      created: true,
+      job: { id: "resume-job-1" },
+    })),
+    enqueueAgentWakeOnce: mock(async () => ({
+      created: true,
+      job: { id: "wake-job-1" },
+    })),
+    triggerImmediate: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { bridge, importCanonicalConversation },
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedHistory,
+}));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    issueClaim: issueGroupClaim,
+    consumeClaimAndBind: consumeGroupClaimAndBind,
+    resolveBinding: resolveGroupBinding,
+    setResponsePolicy: setGroupResponsePolicy,
+    revokeBinding: revokeGroupBinding,
+    applyMembershipChange: applyGroupMembershipChange,
+    authorizeDelivery: authorizeGroupDelivery,
+    commitDelivery: commitGroupDelivery,
+    recordDeliveryReceipts: recordGroupDeliveryReceipts,
+    hasDeliveryReceipt: hasGroupDeliveryReceipt,
+  },
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: runtimeExecutionCtx,
+  }),
+}));
+
+const { default: app } = await import("./route");
+const executionCtx = { waitUntil() {}, passThroughOnException() {}, props: {} };
+
+function request(body: unknown) {
+  return app.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-secret",
+        "content-type": "application/json",
+        "x-eliza-trace-id": "11111111-1111-4111-8111-111111111111",
+      },
+      body: JSON.stringify(body),
+    },
+    {
+      INTERNAL_SECRET: "test-secret",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+    } as never,
+    executionCtx as never,
+  );
+}
+
+const blooioGroupBinding = {
+  id: "00000000-0000-4000-8000-000000000031",
+  organization_id: "00000000-0000-4000-8000-000000000001",
+  owner_user_id: "00000000-0000-4000-8000-000000000002",
+  personal_agent_id: "personal:3e91680e-2611-5ff5-b759-c16b990967bd",
+  platform: "blooio",
+  project: "eliza-app",
+  connector_account_id: "blooio:test-number",
+  provider_chat_id: "chat_group_123",
+  conversation_id: "group:00000000-0000-5000-8000-000000000031",
+  state: "active",
+  response_policy: "mention_only",
+  created_by_platform_user_id: "+15551234567",
+  authority_version: 3,
+};
+const blooioGroupAuthority = {
+  bindingId: blooioGroupBinding.id,
+  ownerUserId: blooioGroupBinding.owner_user_id,
+  personalAgentId: blooioGroupBinding.personal_agent_id,
+  version: blooioGroupBinding.authority_version,
+};
+
+const ownerBlooioGroupTurn = {
+  platform: "blooio",
+  chatType: "group",
+  project: "eliza-app",
+  connectorAccountId: "blooio:test-number",
+  chatId: "chat_group_123",
+  actor: {
+    platformUserId: "+15551234567",
+    displayName: "Nubs",
+    role: "possessor",
+  },
+  messageId: "blooio:eliza:group-42",
+  message: "Eliza remind us to pay rent in an hour",
+  invocation: "mention",
+};
+
+describe("personal Shared group reminder destinations", () => {
+  beforeEach(() => {
+    sharedRestMessageSend.mockClear();
+    resolveGroupBinding.mockClear();
+    resolveGroupBinding.mockImplementation(async () => blooioGroupBinding);
+    hasGroupDeliveryReceipt.mockClear();
+    hasGroupDeliveryReceipt.mockImplementation(async () => true);
+  });
+
+  test("grants the owner's group turn a trusted group reminder destination", async () => {
+    const response = await request(ownerBlooioGroupTurn);
+
+    expect(response.status).toBe(200);
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: blooioGroupBinding.personal_agent_id }),
+      blooioGroupBinding.conversation_id,
+      expect.stringMatching(/^Nubs \[participant [0-9a-f]{8}\]: /),
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      ownerBlooioGroupTurn.messageId,
+      "platform",
+      {
+        platform: "blooio",
+        kind: "group",
+        project: "eliza-app",
+        connectorAccountId: "blooio:test-number",
+        chatId: "chat_group_123",
+        ownerLabel: "Nubs",
+        authority: blooioGroupAuthority,
+      },
+      undefined,
+      { type: "GROUP", source: "blooio" },
+    );
+    // The response's delivery authority and the stored reminder destination
+    // must describe the same binding generation.
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        groupDelivery: { kind: "binding", authority: blooioGroupAuthority },
+      },
+    });
+  });
+
+  test("pins the reminder destination to the binding generation of the current turn", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...blooioGroupBinding,
+      authority_version: 4,
+    }));
+    const response = await request(ownerBlooioGroupTurn);
+
+    expect(response.status).toBe(200);
+    expect(sharedRestMessageSend.mock.calls[0]?.[8]).toMatchObject({
+      kind: "group",
+      authority: { ...blooioGroupAuthority, version: 4 },
+    });
+  });
+
+  test("labels an owner without a display name as the group owner", async () => {
+    const response = await request({
+      ...ownerBlooioGroupTurn,
+      actor: { platformUserId: "+15551234567", role: "possessor" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sharedRestMessageSend.mock.calls[0]?.[8]).toMatchObject({
+      kind: "group",
+      ownerLabel: "the group owner",
+    });
+  });
+
+  test("withholds the reminder destination from a non-owner participant", async () => {
+    const response = await request({
+      ...ownerBlooioGroupTurn,
+      actor: {
+        platformUserId: "+15559990000",
+        displayName: "Guest",
+        role: "member",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+    expect(sharedRestMessageSend.mock.calls[0]?.[8]).toBeUndefined();
+  });
+
+  test("keeps owner-only control copy for a non-owner policy command", async () => {
+    const response = await request({
+      ...ownerBlooioGroupTurn,
+      actor: {
+        platformUserId: "+15559990000",
+        displayName: "Guest",
+        role: "member",
+      },
+      message: "Eliza ambient on",
+      invocation: "command",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        code: "group_owner_required",
+        reply:
+          "Only the owner who linked Eliza can change this group's response policy.",
+      },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("suspended bindings never reach inference or a reminder destination", async () => {
+    resolveGroupBinding.mockImplementationOnce(async () => ({
+      ...blooioGroupBinding,
+      state: "suspended",
+    }));
+    const response = await request(ownerBlooioGroupTurn);
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_binding_suspended" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+
+  test("mention-only groups still drop ambient turns before any capability", async () => {
+    hasGroupDeliveryReceipt.mockImplementationOnce(async () => false);
+    const response = await request({
+      ...ownerBlooioGroupTurn,
+      message: "unrelated ambient chatter",
+      invocation: "ambient",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { code: "group_silent", reply: "" },
+    });
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -1104,7 +1104,20 @@ describe("personal Shared messaging deliveries", () => {
       namespace,
       validGroup.messageId,
       "platform",
-      undefined,
+      {
+        platform: "telegram",
+        kind: "group",
+        project: "eliza-app",
+        connectorAccountId: "telegram:test-bot",
+        chatId: "-100123456789",
+        ownerLabel: "Nubs",
+        authority: {
+          bindingId: canonicalGroupBinding.id,
+          ownerUserId: canonicalGroupBinding.owner_user_id,
+          personalAgentId: canonicalGroupBinding.personal_agent_id,
+          version: canonicalGroupBinding.authority_version,
+        },
+      },
       undefined,
       { type: "GROUP", source: "telegram" },
     );

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1,6 +1,7 @@
 /** Runs a trusted messaging delivery through one rowless personal Shared turn. */
 
 import { ChannelType } from "@elizaos/core/edge";
+import type { SharedGroupReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
@@ -524,14 +525,8 @@ app.post("/", async (c) => {
     let groupConversationId: string | undefined;
     let groupActorLabel: string | undefined;
     let groupPersonalAgentId: string | undefined;
-    let groupDeliveryAuthority:
-      | {
-          bindingId: string;
-          ownerUserId: string;
-          personalAgentId: string;
-          version: number;
-        }
-      | undefined;
+    let groupDeliveryAuthority: GroupDeliveryAuthority | undefined;
+    let groupTrustedDelivery: SharedGroupReminderDelivery | undefined;
     let dedicated:
       | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
       | null
@@ -722,6 +717,23 @@ app.post("/", async (c) => {
       groupConversationId = binding.conversation_id;
       groupPersonalAgentId = binding.personal_agent_id;
       groupDeliveryAuthority = groupBindingDelivery(binding).authority;
+      // Only the owner who linked Eliza may schedule proactive sends into the
+      // group; other participants have no account or billing authority here.
+      // The stored destination pins the binding generation of this turn so a
+      // later rebind, revocation, or chat cutover fails the fire closed.
+      if (
+        parsed.data.actor.platformUserId === binding.created_by_platform_user_id
+      ) {
+        groupTrustedDelivery = {
+          platform: parsed.data.platform,
+          kind: "group",
+          project: parsed.data.project,
+          connectorAccountId: parsed.data.connectorAccountId,
+          chatId: parsed.data.chatId,
+          ownerLabel: parsed.data.actor.displayName ?? "the group owner",
+          authority: groupDeliveryAuthority,
+        };
+      }
       const actorDigest = (
         await sha256Hex(
           `${parsed.data.platform}\n${parsed.data.actor.platformUserId}`,
@@ -1168,7 +1180,7 @@ app.post("/", async (c) => {
           worker.namespace,
           parsed.data.messageId,
           "platform",
-          undefined,
+          groupTrustedDelivery,
           undefined,
           { type: ChannelType.GROUP, source: parsed.data.platform },
         )

--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Verifies proactive group delivery at the gateway boundary: a Blooio
+ * `chat_*` recipient reaches the provider's chat-thread endpoint with no
+ * to/from pair, a Telegram group chat id reaches sendMessage unchanged, and
+ * malformed group recipients are rejected before egress. In-memory Redis and
+ * an intercepted provider fetch.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { deliverInternalMessage } from "../src/internal-delivery";
+import type { GatewayRedis } from "../src/redis";
+
+type RedisSetOptions = { ex?: number; nx?: boolean };
+
+class MemoryRedis implements GatewayRedis {
+  readonly store = new Map<string, string>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    return (this.store.get(key) as T | undefined) ?? null;
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: RedisSetOptions = {},
+  ): Promise<unknown> {
+    if (options.nx && this.store.has(key)) return null;
+    this.store.set(key, value);
+    return "OK";
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.store.delete(key) ? 1 : 0;
+  }
+
+  async lpush(): Promise<unknown> {
+    return 1;
+  }
+
+  async ltrim(): Promise<unknown> {
+    return "OK";
+  }
+
+  async expire(): Promise<unknown> {
+    return 1;
+  }
+}
+
+const originalFetch = globalThis.fetch;
+const originalToken = process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+const originalBlooioKey = process.env.ELIZA_APP_BLOOIO_API_KEY;
+const originalBlooioNumber = process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalToken === undefined)
+    delete process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN;
+  else process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = originalToken;
+  if (originalBlooioKey === undefined)
+    delete process.env.ELIZA_APP_BLOOIO_API_KEY;
+  else process.env.ELIZA_APP_BLOOIO_API_KEY = originalBlooioKey;
+  if (originalBlooioNumber === undefined)
+    delete process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER;
+  else process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = originalBlooioNumber;
+  mock.restore();
+});
+
+function request(overrides: Record<string, unknown> = {}) {
+  return new Request("https://gateway.example/internal/deliver", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      platform: "blooio",
+      project: "eliza-app",
+      chatId: "chat_group_123",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: "group-task-1:2026-08-20T19:30:00.000Z",
+      ...overrides,
+    }),
+  });
+}
+
+describe("internal proactive group delivery", () => {
+  test("sends a Blooio group reminder through the provider chat thread once", async () => {
+    process.env.ELIZA_APP_BLOOIO_API_KEY = "blooio-test-key";
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550001111";
+    const redis = new MemoryRedis();
+    const requests: Request[] = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push(new Request(input, init));
+        return Response.json({ id: "blooio-group-message-1" });
+      },
+    ) as typeof fetch;
+
+    const first = await deliverInternalMessage(request(), { redis });
+    const replay = await deliverInternalMessage(request(), { redis });
+
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({
+      success: true,
+      replayed: false,
+      providerMessageIds: ["blooio-group-message-1"],
+    });
+    await expect(replay.json()).resolves.toMatchObject({
+      success: true,
+      replayed: true,
+      providerMessageIds: ["blooio-group-message-1"],
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(
+      "https://api.blooio.com/v4/chats/chat_group_123/messages",
+    );
+    expect(requests[0]?.headers.get("Idempotency-Key")).toBe(
+      "gw-reply-group-task-1:2026-08-20T19:30:00.000Z",
+    );
+    // The chat thread owns its participants; v4 forbids to/from here.
+    await expect(requests[0]?.json()).resolves.toEqual({
+      text: "Reminder for this group from Nubs: pay the rent",
+    });
+  });
+
+  test("sends a Telegram group reminder to its negative chat id unchanged", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const redis = new MemoryRedis();
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const outgoing = new Request(input, init);
+        expect(outgoing.url).toBe(
+          "https://api.telegram.org/bottelegram-test-token/sendMessage",
+        );
+        bodies.push((await outgoing.json()) as Record<string, unknown>);
+        return Response.json({ ok: true, result: { message_id: 71 } });
+      },
+    ) as typeof fetch;
+
+    const response = await deliverInternalMessage(
+      request({ platform: "telegram", chatId: "-100123456789" }),
+      { redis },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      providerMessageIds: ["71"],
+    });
+    expect(bodies).toEqual([
+      {
+        chat_id: "-100123456789",
+        text: "Reminder for this group from Nubs: pay the rent",
+        parse_mode: "Markdown",
+      },
+    ]);
+  });
+
+  test("rejects malformed group recipients before egress", async () => {
+    const redis = new MemoryRedis();
+    globalThis.fetch = mock(async () => {
+      throw new Error("egress must not run");
+    }) as typeof fetch;
+
+    for (const overrides of [
+      { chatId: "group_123" },
+      { chatId: "chat_" },
+      { chatId: "chat_../escape" },
+      { chatId: "+15551234567" },
+    ]) {
+      const response = await deliverInternalMessage(request(overrides), {
+        redis,
+      });
+      expect(response.status).toBe(400);
+    }
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("keeps the private phone-number recipient contract unchanged", async () => {
+    process.env.ELIZA_APP_BLOOIO_API_KEY = "blooio-test-key";
+    process.env.ELIZA_APP_BLOOIO_PHONE_NUMBER = "+15550001111";
+    const redis = new MemoryRedis();
+    const requests: Request[] = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push(new Request(input, init));
+        return Response.json({ id: "blooio-dm-message-1" });
+      },
+    ) as typeof fetch;
+
+    const response = await deliverInternalMessage(
+      request({ chatId: undefined, phoneNumber: "+15551234567" }),
+      { redis },
+    );
+
+    expect(response.status).toBe(200);
+    expect(requests[0]?.url).toBe("https://api.blooio.com/v4/messages");
+    await expect(requests[0]?.json()).resolves.toEqual({
+      to: "+15551234567",
+      from: "+15550001111",
+      text: "Reminder for this group from Nubs: pay the rent",
+    });
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -25,6 +25,13 @@ type InternalWebhookDelivery =
       phoneNumber: string;
       text: string;
       idempotencyKey: string;
+    }
+  | {
+      platform: "blooio";
+      project: string;
+      chatId: string;
+      text: string;
+      idempotencyKey: string;
     };
 
 const DELIVERY_RECEIPT_TTL_SECONDS = 14 * 24 * 60 * 60;
@@ -106,6 +113,21 @@ function parseDelivery(value: unknown): InternalWebhookDelivery | undefined {
       platform: "blooio",
       project: input.project,
       phoneNumber: input.phoneNumber,
+      text: input.text.trim(),
+      idempotencyKey: input.idempotencyKey,
+    };
+  }
+  // A `chat_*` id addresses a provider-owned Blooio group thread; the adapter
+  // sends it through `/v4/chats/{id}/messages` with no `to`/`from` pair.
+  if (
+    input.platform === "blooio" &&
+    typeof input.chatId === "string" &&
+    /^chat_[A-Za-z0-9_-]{1,120}$/i.test(input.chatId)
+  ) {
+    return {
+      platform: "blooio",
+      project: input.project,
+      chatId: input.chatId,
       text: input.text.trim(),
       idempotencyKey: input.idempotencyKey,
     };
@@ -213,18 +235,17 @@ export async function deliverInternalMessage(
       delivery.platform,
       delivery.project,
     );
+    const recipientId =
+      "chatId" in delivery ? delivery.chatId : delivery.phoneNumber;
     const event: ChatEvent = {
       platform: delivery.platform,
       messageId: delivery.idempotencyKey,
-      chatId:
-        delivery.platform === "telegram"
-          ? delivery.chatId
-          : delivery.phoneNumber,
-      chatType: "private",
-      senderId:
-        delivery.platform === "telegram"
-          ? delivery.chatId
-          : delivery.phoneNumber,
+      chatId: recipientId,
+      chatType:
+        delivery.platform === "blooio" && "chatId" in delivery
+          ? "group"
+          : "private",
+      senderId: recipientId,
       text: delivery.text,
       rawPayload: { source: "shared-reminder" },
     };

--- a/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-groups.ts
@@ -312,6 +312,21 @@ export const personalSharedGroupsRepository = {
     });
   },
 
+  /**
+   * Diagnostic read of one binding by id. Outbound sends must not gate on this
+   * alone; the delivery lease methods below are the authority fence, and this
+   * read only explains why a lease was refused. Reads the primary like the
+   * rest of this repository so it never lags the lease it diagnoses.
+   */
+  async findBindingById(bindingId: string): Promise<PersonalSharedGroupBinding | null> {
+    const [binding] = await dbWrite
+      .select()
+      .from(personalSharedGroupBindings)
+      .where(eq(personalSharedGroupBindings.id, bindingId))
+      .limit(1);
+    return binding ?? null;
+  },
+
   async resolveBinding(input: {
     platform: PersonalSharedGroupPlatform;
     project: string;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Verifies group reminder dispatch against the binding delivery lease: a fire
+ * authorizes under the stored authority generation, commits the lease before
+ * any connector egress, records provider receipts through the same lease
+ * afterwards, and never sends the owner a DM-styled push. A refused lease is
+ * terminal when the binding is gone, inactive, or on another authority
+ * generation / provider chat, and retryable while the live binding is only
+ * held by a concurrent group send. Covers both the gateway path and the
+ * Personal Shared Telegram edge dispatch path. Mocked scheduler and repository
+ * harness with an intercepted gateway fetch.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const listDueScheduledTaskRefs = mock(async () => []);
+const listRecoverableScheduledTaskRefs = mock(async () => []);
+const coordinateSharedPushDispatch = mock(async () => {});
+const createSharedScheduledTaskRunner = mock(() => ({
+  async fireWithResult() {
+    return { kind: "fired" as const };
+  },
+}));
+
+const BINDING_ID = "8b8f2c69-6a3e-4a0f-9be1-1f8f6a3e4a0f";
+const OWNER_USER_ID = "00000000-0000-4000-8000-000000000002";
+const PERSONAL_AGENT_ID = "personal:00000000-0000-5000-8000-000000000000";
+const AUTHORITY = {
+  bindingId: BINDING_ID,
+  ownerUserId: OWNER_USER_ID,
+  personalAgentId: PERSONAL_AGENT_ID,
+  version: 7,
+};
+const activeTelegramBinding = {
+  id: BINDING_ID,
+  organization_id: "00000000-0000-4000-8000-000000000001",
+  owner_user_id: OWNER_USER_ID,
+  personal_agent_id: PERSONAL_AGENT_ID,
+  authority_version: 7,
+  platform: "telegram",
+  project: "eliza-app",
+  connector_account_id: "telegram:test-bot",
+  provider_chat_id: "-100123456789",
+  conversation_id: "group:00000000-0000-5000-8000-000000000030",
+  state: "active",
+  response_policy: "mention_only",
+  created_by_platform_user_id: "123456789",
+};
+const IDEMPOTENCY_KEY = "group-reminder-1:2026-08-20T19:30:00.000Z";
+const telegramLease = {
+  authority: AUTHORITY,
+  platform: "telegram",
+  project: "eliza-app",
+  connectorAccountId: "telegram:test-bot",
+  providerChatId: "-100123456789",
+  sourceMessageId: IDEMPOTENCY_KEY,
+  leaseToken: expect.stringMatching(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  ),
+};
+
+const findBindingById = mock(
+  async (): Promise<Record<string, unknown> | null> => activeTelegramBinding,
+);
+type DeliveryLease = {
+  authorized: boolean;
+  leaseToken: string | null;
+  expiresAt: string | null;
+};
+const authorizeDelivery = mock(
+  async (input: { leaseToken: string }): Promise<DeliveryLease> => ({
+    authorized: true,
+    leaseToken: input.leaseToken,
+    expiresAt: "2026-08-20T19:31:30.000Z",
+  }),
+);
+const commitDelivery = mock(async () => true);
+const recordDeliveryReceipts = mock(async () => ({ recorded: true, inserted: 1 }));
+
+// The real prefix builder keeps the asserted fire-time text and the plugin's
+// creation-time budget on the same source of truth.
+const { sharedGroupReminderMessageText } = await import("@elizaos/plugin-scheduling/edge");
+
+mock.module("@elizaos/plugin-scheduling/edge", () => ({
+  listDueScheduledTaskRefs,
+  listRecoverableScheduledTaskRefs,
+  SHARED_REMINDER_MAX_TEXT_LENGTH: 2000,
+  sharedGroupReminderMessageText,
+  parseSharedReminderDelivery(value: unknown) {
+    if (!value || typeof value !== "object") return undefined;
+    const delivery = value as Record<string, unknown>;
+    if (delivery.platform === "telegram") return delivery;
+    if (delivery.platform === "blooio") return delivery;
+    if (delivery.platform === "discord") return delivery;
+    return undefined;
+  },
+  isSharedGroupReminderDelivery(delivery: Record<string, unknown>) {
+    return delivery.kind === "group";
+  },
+}));
+mock.module("./shared-scheduling", () => ({
+  createSharedScheduledTaskRunner,
+  executeSharedSchedulingSql: mock(async () => []),
+}));
+mock.module("./conversation-coordinator", () => ({
+  coordinateSharedPushDispatch,
+}));
+mock.module("../../../db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    findBindingById,
+    authorizeDelivery,
+    commitDelivery,
+    recordDeliveryReceipts,
+  },
+}));
+
+const { sharedReminderDispatcher } = await import("./shared-reminder-cron");
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  coordinateSharedPushDispatch.mockClear();
+  findBindingById.mockClear();
+  findBindingById.mockImplementation(async () => activeTelegramBinding);
+  authorizeDelivery.mockClear();
+  authorizeDelivery.mockImplementation(
+    async (input: { leaseToken: string }): Promise<DeliveryLease> => ({
+      authorized: true,
+      leaseToken: input.leaseToken,
+      expiresAt: "2026-08-20T19:31:30.000Z",
+    }),
+  );
+  commitDelivery.mockClear();
+  commitDelivery.mockImplementation(async () => true);
+  recordDeliveryReceipts.mockClear();
+  recordDeliveryReceipts.mockImplementation(async () => ({ recorded: true, inserted: 1 }));
+  mock.restore();
+});
+
+const env = {
+  ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example/",
+  ELIZA_APP_DISCORD_WEBHOOK_HANDLER_URL: "https://gateway-discord.example/",
+  GATEWAY_INTERNAL_SECRET: "internal-secret",
+  SHARED_RUNTIME_CONVERSATIONS: { getByName: mock() },
+} as never;
+
+function groupRecord(overrides: { delivery?: Record<string, unknown>; body?: string } = {}) {
+  return {
+    taskId: "group-reminder-1",
+    promptInstructions: "pay the rent",
+    firedAtIso: "2026-08-20T19:30:00.000Z",
+    metadata: {
+      dispatchIdempotencyKey: IDEMPOTENCY_KEY,
+      delivery: {
+        platform: "telegram",
+        kind: "group",
+        project: "eliza-app",
+        connectorAccountId: "telegram:test-bot",
+        chatId: "-100123456789",
+        ownerLabel: "Nubs",
+        authority: AUTHORITY,
+        ...overrides.delivery,
+      },
+    },
+    output: { fallback: { body: overrides.body ?? "pay the rent" } },
+  };
+}
+
+function acceptingFetch(requests: Request[]) {
+  return mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    requests.push(request);
+    const body = (await request.clone().json()) as Record<string, unknown>;
+    return Response.json({
+      success: true,
+      idempotencyKey: body.idempotencyKey,
+      acceptedAt: "2026-08-20T19:30:00.100Z",
+      providerMessageIds: ["provider-group-1"],
+    });
+  }) as typeof fetch;
+}
+
+function refusingFetch() {
+  return mock(async () => {
+    throw new Error("connector egress must not run");
+  }) as typeof fetch;
+}
+
+function callOrder(): string[] {
+  const calls: Array<[string, number]> = [];
+  const order = (name: string, fn: { mock: { invocationCallOrder: number[] } }) => {
+    for (const sequence of fn.mock.invocationCallOrder) calls.push([name, sequence]);
+  };
+  order("authorize", authorizeDelivery);
+  order("commit", commitDelivery);
+  order("fetch", globalThis.fetch as unknown as { mock: { invocationCallOrder: number[] } });
+  order("receipt", recordDeliveryReceipts);
+  return calls.sort((a, b) => a[1] - b[1]).map(([name]) => name);
+}
+
+describe("Shared group reminder dispatch", () => {
+  test("leases, commits before egress, delivers the owner-attributed prefix, and reconciles the receipt", async () => {
+    const requests: Request[] = [];
+    globalThis.fetch = acceptingFetch(requests);
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+    const result = await dispatcher.dispatch(groupRecord());
+
+    expect(authorizeDelivery).toHaveBeenCalledWith({
+      ...telegramLease,
+      invocation: "command",
+    });
+    expect(commitDelivery).toHaveBeenCalledWith(telegramLease);
+    expect(callOrder()).toEqual(["authorize", "commit", "fetch", "receipt"]);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://gateway.example/internal/deliver");
+    await expect(requests[0]?.json()).resolves.toEqual({
+      platform: "telegram",
+      project: "eliza-app",
+      chatId: "-100123456789",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      target: "-100123456789",
+      metadata: { providerMessageIds: ["provider-group-1"] },
+    });
+    expect(recordDeliveryReceipts).toHaveBeenCalledWith({
+      ...telegramLease,
+      providerMessageIds: ["provider-group-1"],
+    });
+    // The same fire always derives the same lease token so a recovered
+    // dispatch can re-authorize its own committed slot.
+    const [authorizeInput] = authorizeDelivery.mock.calls[0] ?? [];
+    const [commitInput] = commitDelivery.mock.calls[0] ?? [];
+    const [receiptInput] = recordDeliveryReceipts.mock.calls[0] ?? [];
+    expect(authorizeInput?.leaseToken).toBe(commitInput?.leaseToken);
+    expect(authorizeInput?.leaseToken).toBe(receiptInput?.leaseToken);
+    expect(findBindingById).not.toHaveBeenCalled();
+    expect(coordinateSharedPushDispatch).not.toHaveBeenCalled();
+  });
+
+  test("derives a stable lease token per fire and a different one for another fire", async () => {
+    globalThis.fetch = acceptingFetch([]);
+    const dispatcher = sharedReminderDispatcher(env);
+
+    await dispatcher.dispatch(groupRecord());
+    await dispatcher.dispatch(groupRecord());
+    await dispatcher.dispatch({
+      ...groupRecord(),
+      metadata: {
+        ...groupRecord().metadata,
+        dispatchIdempotencyKey: "group-reminder-1:2026-08-21T19:30:00.000Z",
+      },
+    });
+
+    const tokens = authorizeDelivery.mock.calls.map(([input]) => input?.leaseToken);
+    expect(tokens[0]).toBe(tokens[1]);
+    expect(tokens[2]).not.toBe(tokens[0]);
+  });
+
+  test("delivers a Telegram group reminder through the edge dispatch with the prefixed text and records receipts", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("gateway egress must not run when edge dispatch is configured");
+    }) as typeof fetch;
+    const telegramDispatch = mock(async () => ({
+      ok: true as const,
+      acceptedAt: "2026-08-20T19:30:00.100Z",
+      providerMessageIds: ["provider-group-edge-1"],
+    }));
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID, { telegramDispatch });
+
+    const result = await dispatcher.dispatch(groupRecord());
+
+    expect(authorizeDelivery).toHaveBeenCalledTimes(1);
+    expect(commitDelivery).toHaveBeenCalledTimes(1);
+    expect(commitDelivery.mock.invocationCallOrder[0]).toBeLessThan(
+      telegramDispatch.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(telegramDispatch).toHaveBeenCalledWith({
+      project: "eliza-app",
+      chatId: "-100123456789",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: true,
+      target: "-100123456789",
+      metadata: { providerMessageIds: ["provider-group-edge-1"] },
+    });
+    expect(recordDeliveryReceipts).toHaveBeenCalledWith({
+      ...telegramLease,
+      providerMessageIds: ["provider-group-edge-1"],
+    });
+    expect(coordinateSharedPushDispatch).not.toHaveBeenCalled();
+  });
+
+  test("routes a Blooio group thread through the gateway by provider chat id", async () => {
+    const requests: Request[] = [];
+    globalThis.fetch = acceptingFetch(requests);
+    const dispatcher = sharedReminderDispatcher(env);
+
+    const result = await dispatcher.dispatch(
+      groupRecord({
+        delivery: {
+          platform: "blooio",
+          connectorAccountId: "blooio:test-number",
+          chatId: "chat_group_123",
+        },
+      }),
+    );
+
+    expect(authorizeDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "blooio",
+        connectorAccountId: "blooio:test-number",
+        providerChatId: "chat_group_123",
+        authority: AUTHORITY,
+      }),
+    );
+    expect(requests[0]?.url).toBe("https://gateway.example/internal/deliver");
+    await expect(requests[0]?.json()).resolves.toEqual({
+      platform: "blooio",
+      project: "eliza-app",
+      chatId: "chat_group_123",
+      text: "Reminder for this group from Nubs: pay the rent",
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    expect(result).toMatchObject({ ok: true, target: "chat_group_123" });
+  });
+
+  for (const [label, binding] of [
+    ["missing", null],
+    ["suspended", { ...activeTelegramBinding, state: "suspended" }],
+    ["revoked", { ...activeTelegramBinding, state: "revoked" }],
+    [
+      "rebound to another owner generation",
+      {
+        ...activeTelegramBinding,
+        owner_user_id: "00000000-0000-4000-8000-000000000099",
+        authority_version: 8,
+      },
+    ],
+    ["on a newer authority version", { ...activeTelegramBinding, authority_version: 8 }],
+    [
+      "serving another personal agent",
+      { ...activeTelegramBinding, personal_agent_id: "personal:other" },
+    ],
+    [
+      "rebound to a different chat",
+      { ...activeTelegramBinding, provider_chat_id: "-100987654321" },
+    ],
+    [
+      "moved to another connector account",
+      { ...activeTelegramBinding, connector_account_id: "telegram:other-bot" },
+    ],
+  ] as const) {
+    test(`fails closed before egress when the lease is refused and the binding is ${label}`, async () => {
+      authorizeDelivery.mockImplementationOnce(async () => ({
+        authorized: false,
+        leaseToken: null,
+        expiresAt: null,
+      }));
+      findBindingById.mockImplementationOnce(async () => binding);
+      globalThis.fetch = refusingFetch();
+      const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+      await expect(dispatcher.dispatch(groupRecord())).resolves.toMatchObject({
+        ok: false,
+        reason: "unknown_recipient",
+        userActionable: true,
+        acceptance: "not_accepted",
+      });
+      expect(findBindingById).toHaveBeenCalledWith(BINDING_ID);
+      expect(commitDelivery).not.toHaveBeenCalled();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(recordDeliveryReceipts).not.toHaveBeenCalled();
+      expect(coordinateSharedPushDispatch).not.toHaveBeenCalled();
+    });
+  }
+
+  test("retries shortly when the live binding's slot is held by a concurrent group send", async () => {
+    authorizeDelivery.mockImplementationOnce(async () => ({
+      authorized: false,
+      leaseToken: null,
+      expiresAt: null,
+    }));
+    globalThis.fetch = refusingFetch();
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+    await expect(dispatcher.dispatch(groupRecord())).resolves.toMatchObject({
+      ok: false,
+      reason: "rate_limited",
+      retryAfterMinutes: 1,
+      userActionable: false,
+      acceptance: "not_accepted",
+    });
+    expect(findBindingById).toHaveBeenCalledWith(BINDING_ID);
+    expect(commitDelivery).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(recordDeliveryReceipts).not.toHaveBeenCalled();
+  });
+
+  test("never reaches the connector when the commit loses the lease after authorization", async () => {
+    commitDelivery.mockImplementationOnce(async () => false);
+    findBindingById.mockImplementationOnce(async () => ({
+      ...activeTelegramBinding,
+      state: "revoked",
+      authority_version: 8,
+    }));
+    globalThis.fetch = refusingFetch();
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+    await expect(dispatcher.dispatch(groupRecord())).resolves.toMatchObject({
+      ok: false,
+      reason: "unknown_recipient",
+      acceptance: "not_accepted",
+    });
+    expect(authorizeDelivery).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(recordDeliveryReceipts).not.toHaveBeenCalled();
+  });
+
+  test("rejects text that exceeds the connector limit after the group prefix before taking a lease", async () => {
+    globalThis.fetch = refusingFetch();
+    const dispatcher = sharedReminderDispatcher(env);
+
+    await expect(
+      dispatcher.dispatch(groupRecord({ body: "x".repeat(1990) })),
+    ).resolves.toMatchObject({
+      ok: false,
+      userActionable: true,
+      acceptance: "not_accepted",
+    });
+    expect(authorizeDelivery).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("keeps the verified acceptance when the receipt is not recorded or the store fails", async () => {
+    recordDeliveryReceipts.mockImplementationOnce(async () => ({ recorded: false, inserted: 0 }));
+    const requests: Request[] = [];
+    globalThis.fetch = acceptingFetch(requests);
+    const dispatcher = sharedReminderDispatcher(env);
+
+    await expect(dispatcher.dispatch(groupRecord())).resolves.toMatchObject({
+      ok: true,
+      metadata: { providerMessageIds: ["provider-group-1"] },
+    });
+
+    recordDeliveryReceipts.mockImplementationOnce(async () => {
+      throw new Error("receipt store unavailable");
+    });
+    await expect(dispatcher.dispatch(groupRecord())).resolves.toMatchObject({
+      ok: true,
+      metadata: { providerMessageIds: ["provider-group-1"] },
+    });
+    expect(requests).toHaveLength(2);
+  });
+
+  test("does not lease, gate, or receipt a private reminder through the group authority", async () => {
+    const requests: Request[] = [];
+    globalThis.fetch = acceptingFetch(requests);
+    const dispatcher = sharedReminderDispatcher(env, PERSONAL_AGENT_ID);
+
+    const result = await dispatcher.dispatch({
+      taskId: "dm-reminder-1",
+      promptInstructions: "stretch",
+      firedAtIso: "2026-08-20T19:30:00.000Z",
+      metadata: {
+        dispatchIdempotencyKey: "dm-reminder-1:2026-08-20T19:30:00.000Z",
+        delivery: {
+          platform: "telegram",
+          project: "eliza-app",
+          chatId: "123456789",
+        },
+      },
+      output: { fallback: { body: "stretch" } },
+    });
+
+    expect(result).toMatchObject({ ok: true, target: "123456789" });
+    await expect(requests[0]?.json()).resolves.toMatchObject({
+      text: "stretch",
+    });
+    expect(authorizeDelivery).not.toHaveBeenCalled();
+    expect(commitDelivery).not.toHaveBeenCalled();
+    expect(findBindingById).not.toHaveBeenCalled();
+    expect(recordDeliveryReceipts).not.toHaveBeenCalled();
+    expect(coordinateSharedPushDispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.test.ts
@@ -47,10 +47,13 @@ const createSharedScheduledTaskRunner = mock(
   }),
 );
 
+const { sharedGroupReminderMessageText } = await import("@elizaos/plugin-scheduling/edge");
+
 mock.module("@elizaos/plugin-scheduling/edge", () => ({
   listDueScheduledTaskRefs,
   listRecoverableScheduledTaskRefs,
   SHARED_REMINDER_MAX_TEXT_LENGTH: 2000,
+  sharedGroupReminderMessageText,
   parseSharedReminderDelivery(value: unknown) {
     if (!value || typeof value !== "object") return undefined;
     const delivery = value as Record<string, unknown>;
@@ -58,6 +61,9 @@ mock.module("@elizaos/plugin-scheduling/edge", () => ({
     if (delivery.platform === "blooio") return delivery;
     if (delivery.platform === "discord") return delivery;
     return undefined;
+  },
+  isSharedGroupReminderDelivery(delivery: Record<string, unknown>) {
+    return delivery.kind === "group";
   },
 }));
 mock.module("./shared-scheduling", () => ({

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts
@@ -1,14 +1,27 @@
-/** Finds due Shared reminders, atomically claims them, and dispatches through the connector gateway. */
+/**
+ * Finds due Shared reminders, atomically claims them, and dispatches through
+ * the connector gateway. The Dedicated cutover deliver route reuses the same
+ * dispatcher, so every group delivery passes through the binding delivery
+ * lease here (authorize, commit before egress, receipt after) regardless of
+ * which runtime requested the fire; the lease is the single outbound-send
+ * authority for a group binding and is shared with inbound group turns.
+ */
 
 import {
+  type DispatchResult,
+  isSharedGroupReminderDelivery,
   listDueScheduledTaskRefs,
   listRecoverableScheduledTaskRefs,
   parseSharedReminderDelivery,
   type ScheduledTaskDispatcher,
   type ScheduledTaskDispatchRecord,
   SHARED_REMINDER_MAX_TEXT_LENGTH,
+  type SharedGroupReminderDelivery,
   type SharedReminderDelivery,
+  sharedGroupReminderMessageText,
 } from "@elizaos/plugin-scheduling/edge";
+import { v5 as uuidv5 } from "uuid";
+import { personalSharedGroupsRepository } from "../../../db/repositories/personal-shared-groups";
 import type { Bindings } from "../../../types/cloud-worker-env";
 import { logger } from "../../utils/logger";
 import { coordinateSharedPushDispatch } from "./conversation-coordinator";
@@ -76,6 +89,77 @@ interface SharedReminderDispatcherOptions {
   telegramDispatch?: SharedTelegramReminderDispatch;
 }
 
+/**
+ * Namespace for the deterministic delivery lease token of a group reminder
+ * fire. Deriving the token from the dispatch idempotency key lets a recovered
+ * fire (worker crash between commit and receipt) re-authorize the exact
+ * committed source/token pair instead of waiting out the lease recovery
+ * horizon, while two distinct fires can never share a token.
+ */
+const GROUP_REMINDER_LEASE_NAMESPACE = "4f0d4d6e-0c4a-5a8f-9c3e-2a8c1c5d7e11";
+
+function groupReminderLeaseToken(idempotencyKey: string): string {
+  return uuidv5(idempotencyKey, GROUP_REMINDER_LEASE_NAMESPACE);
+}
+
+type GroupDispatchFailure = Extract<DispatchResult, { ok: false }>;
+
+/**
+ * Classifies a refused group delivery lease without any connector egress.
+ * The binding is read once more: if it is gone, inactive, or no longer the
+ * authority generation / provider chat the reminder was scheduled under, the
+ * send is terminally not deliverable. Otherwise the binding is still live and
+ * the slot is only held by a concurrent group delivery (an inbound turn's
+ * lease lasts at most 90s), so the fire is retried on the same step shortly.
+ */
+async function refusedGroupDelivery(
+  delivery: SharedGroupReminderDelivery,
+  stage: "authorize" | "commit",
+): Promise<GroupDispatchFailure> {
+  const binding = await personalSharedGroupsRepository.findBindingById(
+    delivery.authority.bindingId,
+  );
+  const stillAuthoritative =
+    binding !== null &&
+    binding.state === "active" &&
+    binding.owner_user_id === delivery.authority.ownerUserId &&
+    binding.personal_agent_id === delivery.authority.personalAgentId &&
+    binding.authority_version === delivery.authority.version &&
+    binding.platform === delivery.platform &&
+    binding.project === delivery.project &&
+    binding.connector_account_id === delivery.connectorAccountId &&
+    binding.provider_chat_id === delivery.chatId;
+  if (!stillAuthoritative) {
+    return {
+      ok: false,
+      reason: "unknown_recipient",
+      userActionable: true,
+      acceptance: "not_accepted",
+      message:
+        "This group is no longer linked to Eliza under the authority that scheduled the reminder, so the group reminder was not delivered.",
+    };
+  }
+  return {
+    ok: false,
+    reason: "rate_limited",
+    retryAfterMinutes: 1,
+    userActionable: false,
+    acceptance: "not_accepted",
+    message: `Group delivery slot is held by a concurrent group send (${stage}); the reminder will be retried.`,
+  };
+}
+
+/** The connector gateway only accepts the provider-addressable delivery fields. */
+function gatewayWireDelivery(delivery: SharedReminderDelivery) {
+  return isSharedGroupReminderDelivery(delivery)
+    ? {
+        platform: delivery.platform,
+        project: delivery.project,
+        chatId: delivery.chatId,
+      }
+    : delivery;
+}
+
 async function readGatewayDeliveryResponse(
   response: Response,
 ): Promise<GatewayDeliveryResponse | undefined> {
@@ -100,7 +184,11 @@ export function sharedReminderDispatcher(
       if (typeof idempotencyKey !== "string" || !idempotencyKey) {
         throw new Error("Shared reminder dispatch idempotency key is missing");
       }
-      const text = record.output?.fallback?.body ?? record.promptInstructions;
+      const groupDelivery = isSharedGroupReminderDelivery(delivery) ? delivery : undefined;
+      const body = record.output?.fallback?.body ?? record.promptInstructions;
+      // Creation reserved this prefix inside the connector limit, so the
+      // guard below only trips for rows written before that budget existed.
+      const text = groupDelivery ? sharedGroupReminderMessageText(groupDelivery, body) : body;
       if (text.length > SHARED_REMINDER_MAX_TEXT_LENGTH) {
         return {
           ok: false,
@@ -109,6 +197,36 @@ export function sharedReminderDispatcher(
           acceptance: "not_accepted",
           message: `Reminder text exceeds the ${SHARED_REMINDER_MAX_TEXT_LENGTH}-character connector limit.`,
         };
+      }
+      // A group fire is one more outbound group delivery and takes the same
+      // per-binding lease as an inbound turn: authorize fences on the stored
+      // authority generation and the live binding; commit pins the slot
+      // immediately before egress; the receipt reconciles it afterwards.
+      const groupLease = groupDelivery
+        ? {
+            authority: groupDelivery.authority,
+            platform: groupDelivery.platform,
+            project: groupDelivery.project,
+            connectorAccountId: groupDelivery.connectorAccountId,
+            providerChatId: groupDelivery.chatId,
+            sourceMessageId: idempotencyKey,
+            leaseToken: groupReminderLeaseToken(idempotencyKey),
+          }
+        : undefined;
+      if (groupDelivery && groupLease) {
+        const lease = await personalSharedGroupsRepository.authorizeDelivery({
+          ...groupLease,
+          // An owner-scheduled reminder is an explicit request, never ambient
+          // chatter, so a mention_only policy does not suppress it.
+          invocation: "command",
+        });
+        if (!lease.authorized) {
+          return await refusedGroupDelivery(groupDelivery, "authorize");
+        }
+        const committed = await personalSharedGroupsRepository.commitDelivery(groupLease);
+        if (!committed) {
+          return await refusedGroupDelivery(groupDelivery, "commit");
+        }
       }
       let acceptedAt: string | undefined;
       let providerMessageIds: string[] = [];
@@ -147,7 +265,7 @@ export function sharedReminderDispatcher(
               "X-Internal-Secret": secret,
             },
             body: JSON.stringify({
-              ...delivery,
+              ...gatewayWireDelivery(delivery),
               text,
               idempotencyKey,
             }),
@@ -253,7 +371,35 @@ export function sharedReminderDispatcher(
           message: "Reminder delivery returned no verifiable provider receipt.",
         };
       }
-      if (agentId && isPersonalSharedAgentId(agentId)) {
+      if (groupLease) {
+        try {
+          const receipt = await personalSharedGroupsRepository.recordDeliveryReceipts({
+            ...groupLease,
+            providerMessageIds,
+          });
+          if (!receipt.recorded) {
+            // The committed slot stays pinned to this fire until the lease
+            // recovery horizon releases it; surface that rather than hide it.
+            logger.warn("[SharedReminders] group delivery receipt was not recorded", {
+              taskId: record.taskId,
+              bindingId: groupLease.authority.bindingId,
+              sourceMessageId: idempotencyKey,
+              providerMessageIds,
+            });
+          }
+        } catch (error) {
+          // error-policy:J7 the provider already accepted the send; a receipt
+          // store failure is diagnosed and reported, never turned into a refire.
+          logger.warn("[SharedReminders] group delivery receipt recording failed", {
+            taskId: record.taskId,
+            bindingId: groupLease.authority.bindingId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+      // A group reminder already landed in the group thread; a DM-styled push
+      // notification to the owner's phone would misattribute the destination.
+      if (!groupDelivery && agentId && isPersonalSharedAgentId(agentId)) {
         const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
         if (!namespace) {
           logger.warn("[SharedReminders] mobile push coordinator is unavailable", {
@@ -292,8 +438,9 @@ export function sharedReminderDispatcher(
       return {
         ok: true,
         channelKey: "current_dm",
-        target:
-          delivery.platform === "telegram"
+        target: isSharedGroupReminderDelivery(delivery)
+          ? delivery.chatId
+          : delivery.platform === "telegram"
             ? delivery.chatId
             : delivery.platform === "blooio"
               ? delivery.phoneNumber

--- a/plugins/plugin-scheduling/src/edge.ts
+++ b/plugins/plugin-scheduling/src/edge.ts
@@ -152,10 +152,15 @@ export {
 export {
   createSharedRemindersEdgeAction,
   createSharedRemindersEdgePlugin,
+  isSharedGroupReminderDelivery,
   parseSharedReminderDelivery,
   SHARED_CUTOVER_GATEWAY_CHANNEL,
   SHARED_REMINDER_MAX_TEXT_LENGTH,
   SHARED_REMINDERS_EDGE_COMPATIBILITY,
+  type SharedGroupReminderDelivery,
+  type SharedGroupReminderDeliveryAuthority,
   type SharedReminderDelivery,
   type SharedRemindersEdgePluginOptions,
+  sharedGroupReminderMessageText,
+  sharedReminderMaxBodyLength,
 } from "./shared-reminders.js";

--- a/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.group.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Verifies the Shared reminder group-destination contract: parse round-trips
+ * for trusted group deliveries, rejection of malformed or redirected group
+ * targets, the group-facing action copy, and the dispatch-policy outcome for a
+ * binding that is no longer active. Deterministic, mocked runner harness.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core/edge";
+import { describe, expect, it, vi } from "vitest";
+import { decideDispatchPolicy } from "./dispatch-policy.js";
+import type {
+  ScheduledTask,
+  ScheduledTaskInput,
+  ScheduledTaskRunner,
+} from "./scheduled-task/types.js";
+import {
+  createSharedRemindersEdgePlugin,
+  isSharedGroupReminderDelivery,
+  parseSharedReminderDelivery,
+  SHARED_REMINDER_MAX_TEXT_LENGTH,
+  type SharedReminderDelivery,
+  type SharedRemindersEdgePluginOptions,
+  sharedGroupReminderMessageText,
+  sharedReminderMaxBodyLength,
+} from "./shared-reminders.js";
+
+const NOW = "2026-08-14T20:00:00.000Z";
+const BINDING_ID = "8b8f2c69-6a3e-4a0f-9be1-1f8f6a3e4a0f";
+const OWNER_USER_ID = "00000000-0000-4000-8000-000000000002";
+const AUTHORITY = {
+  bindingId: BINDING_ID,
+  ownerUserId: OWNER_USER_ID,
+  personalAgentId: "personal:00000000-0000-5000-8000-000000000000",
+  version: 7,
+} as const;
+
+const telegramGroupDelivery = {
+  platform: "telegram",
+  kind: "group",
+  project: "eliza-app",
+  connectorAccountId: "telegram:test-bot",
+  chatId: "-100123456789",
+  ownerLabel: "Nubs",
+  authority: AUTHORITY,
+} as const;
+
+const blooioGroupDelivery = {
+  platform: "blooio",
+  kind: "group",
+  project: "eliza-app",
+  connectorAccountId: "blooio:test-number",
+  chatId: "chat_group_123",
+  ownerLabel: "Nubs",
+  authority: AUTHORITY,
+} as const;
+
+function scheduledTask(input: ScheduledTaskInput): ScheduledTask {
+  return {
+    taskId: "reminder-1",
+    ...input,
+    state: { status: "scheduled", followupCount: 0 },
+  };
+}
+
+function harness(delivery: SharedReminderDelivery): {
+  options: SharedRemindersEdgePluginOptions;
+  scheduleWithResult: ReturnType<typeof vi.fn>;
+} {
+  const scheduleWithResult = vi.fn(async (input: ScheduledTaskInput) => ({
+    task: scheduledTask(input),
+    commit: { logId: "scheduled-log-1", occurredAtIso: NOW },
+    replayed: false,
+  }));
+  const runner = {
+    scheduleWithResult,
+    list: vi.fn(async () => []),
+    applyWithResult: vi.fn(),
+    pipeline: vi.fn(async () => []),
+  } as unknown as ScheduledTaskRunner;
+  return {
+    scheduleWithResult,
+    options: {
+      runner,
+      agentId: "personal:user-1",
+      delivery,
+      now: () => new Date(NOW),
+    },
+  };
+}
+
+describe("Shared group reminder delivery parsing", () => {
+  it("round-trips trusted Telegram and Blooio group destinations", () => {
+    expect(parseSharedReminderDelivery(telegramGroupDelivery)).toEqual(
+      telegramGroupDelivery,
+    );
+    expect(parseSharedReminderDelivery(blooioGroupDelivery)).toEqual(
+      blooioGroupDelivery,
+    );
+    expect(isSharedGroupReminderDelivery(telegramGroupDelivery)).toBe(true);
+    expect(
+      isSharedGroupReminderDelivery({
+        platform: "telegram",
+        project: "eliza-app",
+        chatId: "123456",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects malformed or platform-mismatched group destinations", () => {
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        chatId: "@channelname",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...blooioGroupDelivery,
+        chatId: "+15551234567",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        chatId: "chat_group_123",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        connectorAccountId: "tg",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        ownerLabel: "   ",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        ownerLabel: "x".repeat(129),
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        platform: "discord",
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        project: "bad project!",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rejects a group destination whose delivery authority is missing or malformed", () => {
+    const { authority: _authority, ...withoutAuthority } =
+      telegramGroupDelivery;
+    expect(parseSharedReminderDelivery(withoutAuthority)).toBeUndefined();
+    for (const authority of [
+      { ...AUTHORITY, bindingId: "not-a-uuid" },
+      { ...AUTHORITY, ownerUserId: "owner-1" },
+      { ...AUTHORITY, personalAgentId: "" },
+      { ...AUTHORITY, version: 0 },
+      { ...AUTHORITY, version: 1.5 },
+      { ...AUTHORITY, version: "7" },
+      null,
+    ]) {
+      expect(
+        parseSharedReminderDelivery({ ...telegramGroupDelivery, authority }),
+      ).toBeUndefined();
+    }
+    // Extra keys on the stored authority never widen what the parser returns.
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        authority: { ...AUTHORITY, extra: "ignored" },
+      }),
+    ).toEqual(telegramGroupDelivery);
+  });
+
+  it("strips Markdown formatting and link syntax from the owner label", () => {
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        ownerLabel: "[Nubs](https://evil.example)",
+      }),
+    ).toMatchObject({ ownerLabel: "Nubshttps://evil.example" });
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        ownerLabel: "*bold*  _sneaky_ `code`",
+      }),
+    ).toMatchObject({ ownerLabel: "bold sneaky code" });
+    expect(
+      parseSharedReminderDelivery({
+        ...telegramGroupDelivery,
+        ownerLabel: "*_`[]()",
+      }),
+    ).toMatchObject({ ownerLabel: "the group owner" });
+  });
+
+  it("still parses the existing private-chat destinations unchanged", () => {
+    expect(
+      parseSharedReminderDelivery({
+        platform: "telegram",
+        project: "eliza-app",
+        chatId: "123456",
+      }),
+    ).toEqual({ platform: "telegram", project: "eliza-app", chatId: "123456" });
+    expect(
+      parseSharedReminderDelivery({
+        platform: "blooio",
+        project: "eliza-app",
+        phoneNumber: "+15551234567",
+      }),
+    ).toEqual({
+      platform: "blooio",
+      project: "eliza-app",
+      phoneNumber: "+15551234567",
+    });
+    expect(
+      parseSharedReminderDelivery({
+        platform: "discord",
+        discordUserId: "123456789012345678", // gitleaks:allow synthetic snowflake
+      }),
+    ).toEqual({ platform: "discord", discordUserId: "123456789012345678" }); // gitleaks:allow synthetic snowflake
+  });
+});
+
+describe("Shared group reminder action", () => {
+  it("pins a group-created reminder to its trusted group destination", async () => {
+    const { options, scheduleWithResult } = harness(telegramGroupDelivery);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-1" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stand-up starts",
+          inMinutes: 5,
+          chatId: "attacker-chat",
+          platform: "discord",
+        },
+      },
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toBe(
+      "Got it — I'll remind this group in 5 minutes: Stand-up starts",
+    );
+    expect(action?.description).toContain("this linked group chat");
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
+    expect(scheduleWithResult.mock.calls[0]?.[0]?.metadata).toEqual({
+      delivery: telegramGroupDelivery,
+    });
+  });
+
+  it("reserves the fire-time owner prefix inside the connector text budget", async () => {
+    const budget = sharedReminderMaxBodyLength(telegramGroupDelivery);
+    expect(budget).toBe(
+      SHARED_REMINDER_MAX_TEXT_LENGTH -
+        "Reminder for this group from Nubs: ".length,
+    );
+    expect(
+      sharedGroupReminderMessageText(telegramGroupDelivery, "x".repeat(budget))
+        .length,
+    ).toBe(SHARED_REMINDER_MAX_TEXT_LENGTH);
+    expect(
+      sharedReminderMaxBodyLength({
+        platform: "telegram",
+        project: "eliza-app",
+        chatId: "123456",
+      }),
+    ).toBe(SHARED_REMINDER_MAX_TEXT_LENGTH);
+
+    const { options, scheduleWithResult } = harness(telegramGroupDelivery);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const rejected = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-2" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "x".repeat(budget + 1),
+          inMinutes: 5,
+        },
+      },
+    );
+    expect(rejected?.success).toBe(false);
+    expect(rejected?.text).toBe(
+      `Reminder text must be ${budget} characters or fewer.`,
+    );
+    expect(scheduleWithResult).not.toHaveBeenCalled();
+
+    const accepted = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-3" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "x".repeat(budget),
+          inMinutes: 5,
+        },
+      },
+    );
+    expect(accepted?.success).toBe(true);
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to build the action from an unparseable group destination", () => {
+    const { options } = harness({
+      ...telegramGroupDelivery,
+      authority: { ...AUTHORITY, bindingId: "not-a-uuid" },
+    } as unknown as SharedReminderDelivery);
+    expect(() => createSharedRemindersEdgePlugin(options)).toThrow(
+      "Shared reminders require a trusted server-owned destination",
+    );
+  });
+});
+
+describe("group dispatch failure policy", () => {
+  it("keeps an inactive-binding failure visible and terminal for a reminder ladder", () => {
+    const failure = {
+      ok: false as const,
+      reason: "unknown_recipient" as const,
+      userActionable: true,
+      acceptance: "not_accepted" as const,
+      message: "This group is no longer linked to Eliza.",
+    };
+    // Step 0 surfaces the degradation to the owner; the final ladder step has
+    // nowhere left to advance, so the runner settles the task as failed
+    // rather than recording a silent fire.
+    expect(
+      decideDispatchPolicy(failure, { currentStepIndex: 0, totalSteps: 2 }),
+    ).toMatchObject({ kind: "surface_degraded", reason: "unknown_recipient" });
+    expect(
+      decideDispatchPolicy(failure, { currentStepIndex: 1, totalSteps: 2 }),
+    ).toMatchObject({ kind: "surface_degraded", reason: "unknown_recipient" });
+  });
+});

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -1,7 +1,12 @@
 /**
  * Minimal reminder action for Shared edge runtimes. The host supplies the
- * canonical runner and a trusted current-DM destination; model parameters can
- * choose reminder content and timing but can never redirect delivery.
+ * canonical runner and a trusted destination — the current verified private
+ * chat, or a linked group chat when the sender is the binding owner; model
+ * parameters can choose reminder content and timing but can never redirect
+ * delivery. Group destinations carry the binding's delivery authority
+ * (binding id, owner, personal agent, authority version) and connector account
+ * so the fire-time dispatcher can lease the send through the same fence that
+ * guards inbound group turns.
  */
 
 import type {
@@ -47,20 +52,160 @@ export type SharedReminderDelivery =
   | {
       platform: "discord";
       discordUserId: string;
+    }
+  | {
+      platform: "telegram" | "blooio";
+      kind: "group";
+      project: string;
+      connectorAccountId: string;
+      chatId: string;
+      ownerLabel: string;
+      authority: SharedGroupReminderDeliveryAuthority;
     };
 
-/** Validates the server-owned private destination stored with a Shared reminder. */
+/**
+ * The binding generation a group reminder was scheduled under. Fire-time
+ * delivery is authorized only while the live binding still matches every
+ * field, so an owner rebind, revocation, or chat cutover fails the send closed.
+ */
+export interface SharedGroupReminderDeliveryAuthority {
+  bindingId: string;
+  ownerUserId: string;
+  personalAgentId: string;
+  version: number;
+}
+
+export type SharedGroupReminderDelivery = Extract<
+  SharedReminderDelivery,
+  { kind: "group" }
+>;
+
+export function isSharedGroupReminderDelivery(
+  delivery: SharedReminderDelivery,
+): delivery is SharedGroupReminderDelivery {
+  return "kind" in delivery && delivery.kind === "group";
+}
+
+/**
+ * Telegram legacy-Markdown metacharacters. The owner label is interpolated
+ * into connector text sent with parse_mode Markdown, so formatting and link
+ * syntax are stripped rather than rendered. Stripping (instead of escaping)
+ * never lengthens the label, which keeps the creation-time prefix budget
+ * exact at fire time.
+ */
+const OWNER_LABEL_MARKDOWN_METACHARACTERS = /[[\]()*_`]/g;
+const FALLBACK_OWNER_LABEL = "the group owner";
+
+function sanitizedOwnerLabel(label: string): string {
+  const sanitized = label
+    .replace(OWNER_LABEL_MARKDOWN_METACHARACTERS, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return sanitized.length > 0 ? sanitized : FALLBACK_OWNER_LABEL;
+}
+
+/**
+ * The owner-attributed text a group reminder delivers at fire time.
+ * Participants who never scheduled anything must see why Eliza spoke.
+ */
+export function sharedGroupReminderMessageText(
+  delivery: SharedGroupReminderDelivery,
+  body: string,
+): string {
+  return `Reminder for this group from ${delivery.ownerLabel}: ${body}`;
+}
+
+/**
+ * Group deliveries reserve the fire-time prefix inside the connector text
+ * limit so a reminder accepted at creation can never become undeliverable.
+ */
+export function sharedReminderMaxBodyLength(
+  delivery: SharedReminderDelivery,
+): number {
+  return isSharedGroupReminderDelivery(delivery)
+    ? SHARED_REMINDER_MAX_TEXT_LENGTH -
+        sharedGroupReminderMessageText(delivery, "").length
+    : SHARED_REMINDER_MAX_TEXT_LENGTH;
+}
+
+const PROJECT_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+const TELEGRAM_CHAT_ID_PATTERN = /^-?\d{1,20}$/;
+const BLOOIO_GROUP_CHAT_ID_PATTERN = /^chat_[A-Za-z0-9_-]{1,120}$/i;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CONNECTOR_ACCOUNT_ID_MAX_LENGTH = 160;
+const PERSONAL_AGENT_ID_MAX_LENGTH = 160;
+
+function parseGroupDeliveryAuthority(
+  value: unknown,
+): SharedGroupReminderDeliveryAuthority | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const authority = value as Record<string, unknown>;
+  if (
+    typeof authority.bindingId === "string" &&
+    UUID_PATTERN.test(authority.bindingId) &&
+    typeof authority.ownerUserId === "string" &&
+    UUID_PATTERN.test(authority.ownerUserId) &&
+    typeof authority.personalAgentId === "string" &&
+    authority.personalAgentId.trim().length > 0 &&
+    authority.personalAgentId.length <= PERSONAL_AGENT_ID_MAX_LENGTH &&
+    typeof authority.version === "number" &&
+    Number.isInteger(authority.version) &&
+    authority.version > 0
+  ) {
+    return {
+      bindingId: authority.bindingId,
+      ownerUserId: authority.ownerUserId,
+      personalAgentId: authority.personalAgentId,
+      version: authority.version,
+    };
+  }
+  return undefined;
+}
+
+/** Validates the server-owned destination stored with a Shared reminder. */
 export function parseSharedReminderDelivery(
   value: unknown,
 ): SharedReminderDelivery | undefined {
   if (!value || typeof value !== "object") return undefined;
   const delivery = value as Record<string, unknown>;
+  if (delivery.kind === "group") {
+    const authority = parseGroupDeliveryAuthority(delivery.authority);
+    if (
+      authority &&
+      (delivery.platform === "telegram" || delivery.platform === "blooio") &&
+      typeof delivery.project === "string" &&
+      PROJECT_PATTERN.test(delivery.project) &&
+      typeof delivery.connectorAccountId === "string" &&
+      delivery.connectorAccountId.trim().length >= 3 &&
+      delivery.connectorAccountId.length <= CONNECTOR_ACCOUNT_ID_MAX_LENGTH &&
+      typeof delivery.chatId === "string" &&
+      (delivery.platform === "telegram"
+        ? TELEGRAM_CHAT_ID_PATTERN
+        : BLOOIO_GROUP_CHAT_ID_PATTERN
+      ).test(delivery.chatId) &&
+      typeof delivery.ownerLabel === "string" &&
+      delivery.ownerLabel.trim().length > 0 &&
+      delivery.ownerLabel.length <= 128
+    ) {
+      return {
+        platform: delivery.platform,
+        kind: "group",
+        project: delivery.project,
+        connectorAccountId: delivery.connectorAccountId,
+        chatId: delivery.chatId,
+        ownerLabel: sanitizedOwnerLabel(delivery.ownerLabel),
+        authority,
+      };
+    }
+    return undefined;
+  }
   if (
     delivery.platform === "telegram" &&
     typeof delivery.project === "string" &&
-    /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(delivery.project) &&
+    PROJECT_PATTERN.test(delivery.project) &&
     typeof delivery.chatId === "string" &&
-    /^-?\d{1,20}$/.test(delivery.chatId)
+    TELEGRAM_CHAT_ID_PATTERN.test(delivery.chatId)
   ) {
     return {
       platform: "telegram",
@@ -71,7 +216,7 @@ export function parseSharedReminderDelivery(
   if (
     delivery.platform === "blooio" &&
     typeof delivery.project === "string" &&
-    /^[a-z0-9][a-z0-9_-]{0,63}$/i.test(delivery.project) &&
+    PROJECT_PATTERN.test(delivery.project) &&
     typeof delivery.phoneNumber === "string" &&
     /^\+[1-9]\d{6,14}$/.test(delivery.phoneNumber)
   ) {
@@ -445,9 +590,10 @@ export function createSharedRemindersEdgeAction(
   const delivery = parseSharedReminderDelivery(options.delivery);
   if (!delivery) {
     throw new Error(
-      "Shared reminders require a trusted current-DM destination",
+      "Shared reminders require a trusted server-owned destination",
     );
   }
+  const groupDelivery = isSharedGroupReminderDelivery(delivery);
 
   return {
     name: "REMINDERS",
@@ -461,8 +607,9 @@ export function createSharedRemindersEdgeAction(
     tags: ["resource:scheduled-item", "capability:read", "capability:write"],
     contexts: ["reminders", "general"],
     roleGate: { minRole: "GUEST" },
-    description:
-      "Create, list, snooze, complete, or dismiss free reminders delivered only to this current verified private chat. For create, supply reminderText and one schedule: inMinutes, atIso, everyMinutes, or cronExpression plus timezone.",
+    description: groupDelivery
+      ? "Create, list, snooze, complete, or dismiss free reminders delivered only to this linked group chat. For create, supply reminderText and one schedule: inMinutes, atIso, everyMinutes, or cronExpression plus timezone."
+      : "Create, list, snooze, complete, or dismiss free reminders delivered only to this current verified private chat. For create, supply reminderText and one schedule: inMinutes, atIso, everyMinutes, or cronExpression plus timezone.",
     parameters: [
       {
         name: "operation",
@@ -553,9 +700,11 @@ export function createSharedRemindersEdgeAction(
         const body = textParameter(input, "reminderText", "text", "body");
         if (!body)
           return await actionFailure("Reminder text is required.", callback);
-        if (body.length > SHARED_REMINDER_MAX_TEXT_LENGTH) {
+        // Group sends reserve the fire-time owner prefix inside the limit.
+        const maxBodyLength = sharedReminderMaxBodyLength(delivery);
+        if (body.length > maxBodyLength) {
           return await actionFailure(
-            `Reminder text must be ${SHARED_REMINDER_MAX_TEXT_LENGTH} characters or fewer.`,
+            `Reminder text must be ${maxBodyLength} characters or fewer.`,
             callback,
           );
         }
@@ -627,7 +776,7 @@ export function createSharedRemindersEdgeAction(
         const persistedBody = reminderText(scheduled.task);
         const text = scheduled.replayed
           ? `That reminder is already set ${schedule}: ${persistedBody}`
-          : `Got it — I'll remind you ${schedule}: ${persistedBody}`;
+          : `Got it — I'll remind ${groupDelivery ? "this group" : "you"} ${schedule}: ${persistedBody}`;
         const receipt = creationReceipt(scheduled);
         await callback?.({ text });
         return {
@@ -740,7 +889,7 @@ export function createSharedRemindersEdgePlugin(
   return {
     name: "shared-reminders-edge",
     description:
-      "Free reminders persisted by the canonical scheduler and locked to the current verified private chat.",
+      "Free reminders persisted by the canonical scheduler and locked to the trusted chat that created them.",
     actions: [createSharedRemindersEdgeAction(options)],
   };
 }


### PR DESCRIPTION
> **Draft status:** based on `ed4d4a3`; will rebase before ready. Part of `nubs/demo-night`. Interaction note: when landing with the adversarial-tests PR, cherry-pick `448d2d5` from `nubs/demo-night` (updates one test pin to the new group trusted-delivery payload).


## What

Personal Shared reminders can now be created from a linked group chat and fire
back into that group. The capability is owner-only and binding-scoped:

- **Creation (route):** on a group turn, the trusted messaging route builds a
  `kind: "group"` reminder destination only when the sender is the binding's
  `created_by_platform_user_id`. Non-owner participants get no reminder
  capability at all (the `trustedDelivery` slot stays `undefined`, so the
  REMINDERS action is never mounted for their turns).
- **Storage (plugin-scheduling):** `SharedReminderDelivery` gains a
  `{ platform: "telegram" | "blooio", kind: "group", project, chatId,
  groupBindingId, ownerLabel }` member. `parseSharedReminderDelivery`
  validates it (telegram `-?\d{1,20}` / blooio `chat_*` chat ids, uuid binding
  id, non-empty ownerLabel <= 128 chars) and strips Telegram legacy-Markdown
  metacharacters (`[]()*_` and backtick) from the owner label, falling back to
  "the group owner" when nothing survives, so a display name can never inject
  formatting or link syntax into the connector send. Existing DM shapes are
  unchanged. Group creation validates the body against
  `sharedReminderMaxBodyLength(delivery)` — the connector limit minus the
  fire-time prefix — so an accepted reminder can never become undeliverable.
- **Fire (cron dispatcher):** before any connector egress, a group delivery
  re-loads its binding by id and requires `state === "active"` plus an
  unchanged platform/project/provider chat id. Suspended (Eliza removed),
  revoked (`/eliza_leave`), or re-bound chats fail closed with a typed
  `unknown_recipient` / `not_accepted` dispatch failure that the dispatch
  policy surfaces as a connector degradation and settles terminally; the task
  is never silently marked fired. Delivered sends are prefixed
  `"Reminder for this group from <owner>: ..."` via the shared
  `sharedGroupReminderMessageText` helper (single source of truth with the
  creation-time budget) so participants know why Eliza spoke, provider message
  ids are recorded as group delivery receipts (so
  Blooio replies to a fired reminder pass reply verification), and the
  DM-styled mobile push fan-out is skipped for group sends.
- **Gateway:** `/internal/deliver` accepts a Blooio `chat_*` recipient and
  routes it through the provider's `/v4/chats/{id}/messages` thread endpoint
  (no `to`/`from`); Telegram group chat ids already fit the existing shape.

## Why

Group bindings already carry the owner's identity, billing authority, and a
durable provider chat id, but reminders were DM-only: the route explicitly
passed `undefined` as the trusted delivery for group turns. This closes that
gap without widening authority: only the binding owner can schedule, and the
binding stays the single revocation authority at fire time.

## How it holds the policy line

- **Owner-only:** enforced at the route with the same identity the existing
  policy/leave commands use (`created_by_platform_user_id`).
- **mention_only unaffected:** `group_silent` still short-circuits ambient
  turns before any capability; reminder *delivery* is an owner-requested
  proactive send and correctly ignores the inbound response policy.
- **Fail closed on suspension/revocation/cutover:** the binding check lives in
  `sharedReminderDispatcher.dispatch`, the single choke point shared by the
  Cloudflare cron and the Dedicated-cutover deliver route
  (`/v1/eliza/agents/:agentId/shared-reminders/:taskId/deliver`), so both
  runtimes get the same gate.

## Rollout

No flag: the feature is data-driven. Existing reminders have DM metadata and
behave exactly as before; group metadata only starts existing once the new
route code runs. Deploy order is tolerant: an old cron reading a new group
task fails parse (`Shared reminder delivery metadata is invalid`) rather than
misdelivering, and a new cron reading old DM tasks is unchanged. The
gateway-webhook service should deploy before or with the Worker so Blooio
`chat_*` deliveries are accepted (until then they fail as
not-accepted/retryable at the gateway parse boundary, never misrouted). No DB
migration: only a new read (`findBindingById`) on an existing table.

## Files changed

- `plugins/plugin-scheduling/src/shared-reminders.ts` — group delivery union
  member, validation with owner-label Markdown sanitization, group-aware
  action copy, prefix/budget helpers (`sharedGroupReminderMessageText`,
  `sharedReminderMaxBodyLength`) used at creation
- `plugins/plugin-scheduling/src/edge.ts` — export the new type/guard/helpers
- `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts` —
  owner-gated group `trustedDelivery` on group turns
- `packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.ts`
  — binding re-verification, group prefix, receipt recording, push skip,
  gateway wire payload
- `packages/cloud/shared/src/db/repositories/personal-shared-groups.ts` —
  `findBindingById`
- `packages/cloud/services/gateway-webhook/src/internal-delivery.ts` — Blooio
  `chat_*` recipient shape and group ChatEvent
- Tests: `plugins/plugin-scheduling/src/shared-reminders.group.test.ts`,
  `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.group-reminders.test.ts`,
  `packages/cloud/api/__tests__/shared-reminder-dedicated-delivery.group.test.ts`,
  `packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-cron.group.test.ts`,
  `packages/cloud/services/gateway-webhook/__tests__/internal-delivery.group.test.ts`,
  plus updated assertions in the existing route and cron suites

## Test evidence

- `plugins/plugin-scheduling` full vitest suite: **579 passed (36 files)**,
  including 8 new group tests (parse round-trip/rejections, owner-label
  Markdown sanitization, group action copy, destination pinning, the reserved
  prefix budget at creation, dispatch-policy outcome).
- `packages/cloud/shared` `bun test --isolate src/lib/services/shared-runtime/`:
  **459 pass**; the new cron group suite is 10 tests (active delivery + receipt
  + no push via the gateway path, the same contract through the Personal
  Shared Telegram edge dispatch, Blooio thread routing,
  missing/suspended/revoked/rebound bindings fail closed pre-egress,
  over-limit after prefix, receipt-failure tolerance, DM regression).
  2 failures in this sweep are pre-existing on the base
  commit and unrelated (`shared-capability-wall.test.ts` continuation-bounds
  assertion; `shared-facts.test.ts` missing `SHARED_FACTS_MAX_FACT_CHARS`
  export), verified by stashing this change.
- `packages/cloud/services/gateway-webhook` full `bun test`: **192 pass
  (25 files)**, including 4 new group tests (chat-thread egress + idempotent
  replay, Telegram group id, malformed recipients 400 pre-egress, DM
  regression).
- `packages/cloud/api` full isolated unit lane
  (`node test/run-unit-isolated.mjs`): **exit 0, all files pass**, including
  the touched `personal-shared` route suites (44 existing + 6 new route
  tests) and both Dedicated-delivery suites (3 existing + 2 new). The new
  route tests cover the owner grant (incl. Blooio), the owner-label fallback,
  the non-owner withholding, the owner-only control copy, the suspended
  binding, and the `group_silent` regression; the 2 new Dedicated-cutover
  tests run the REAL dispatcher through the deliver route (an active binding
  delivers the prefixed group send; a revoked binding returns 409
  `unknown_recipient` with no egress).
- Typecheck: clean for every touched file in `plugin-scheduling`,
  `cloud/shared`, `cloud/api`, and `gateway-webhook` (remaining typecheck
  output in the first three packages is pre-existing transitive noise from
  unbuilt sibling workspaces, unchanged by this PR).
- Biome: clean on all touched files.

## Limitations (honest)

- **No live end-to-end run.** Coverage is unit/contract level with mocked
  provider HTTP and repository boundaries; a real Telegram/Blooio group fire
  from a deployed stack has not been exercised.
- **Owner label is frozen at creation.** The prefix uses the display name the
  owner had when the reminder was created; a later rename is not reflected,
  and an owner without a platform display name (or whose name is entirely
  Markdown metacharacters) is labeled "the group owner". Sanitization strips
  `[]()*_` and backtick from the rendered label rather than escaping them.
- **Telegram edge cases:** a group migrating to a supergroup changes its chat
  id; the binding check then fails the reminder closed as
  `unknown_recipient` (safe, but the owner must relink and reschedule).
- **Dedicated runtimes** deliver group reminders only through the Shared
  cutover relay for tasks created while on Shared; reminders newly created
  inside a Dedicated container's own scheduler are out of scope here.
- **Terminal failure surfacing:** an inactive-binding failure records
  `connectorDegradation` and settles the task as failed via the existing
  dispatch policy; there is no additional owner DM notifying that a group
  reminder was dropped.
- **Repository-wide gates:** package-scoped tests, typecheck, and lint were
  run; the full root `bun run verify` sweep has not been run on this branch
  yet and should run in CI before merge.

## Review

Code review verdict: **ship**, with three minor findings, all addressed:

1. **Undeliverable long group reminders (fixed).** The fire-time prefix
   `"Reminder for this group from <owner>: "` was prepended after creation
   had already validated the raw body against the 2000-character connector
   limit, so a body in roughly the 1842–2000 range was accepted at creation
   but failed every fire as `transport_error`. Fix: creation now validates
   against `sharedReminderMaxBodyLength(delivery)`, which reserves the exact
   prefix budget; the prefix itself moved into the shared
   `sharedGroupReminderMessageText` helper used by both creation and the cron
   dispatcher, so the two sides cannot drift. The cron over-limit guard
   remains as defense in depth for pre-budget rows. Covered by a new plugin
   test that rejects at budget+1 and accepts at exactly the budget (fire-time
   text length == 2000).
2. **Markdown injection via the owner display name (fixed).** `ownerLabel`
   came from the actor's display name (length-validated only) and was
   interpolated verbatim into text sent to Telegram with
   `parse_mode: "Markdown"`, letting a display name render formatting or
   links in the group message. Fix: `parseSharedReminderDelivery` now strips
   Telegram legacy-Markdown metacharacters (`[]()*_` and backtick) from the
   label, collapses whitespace, and falls back to "the group owner" when
   nothing survives. Stripping (not escaping) never lengthens the label, so
   the creation-time prefix budget stays exact, and the sanitizer runs at the
   parse boundary used by both creation and fire. The reminder *body* keeps
   its existing behavior (pre-dates this PR for DM reminders; Telegram
   auto-retries without Markdown on a parse rejection). Covered by new parse
   tests including link-syntax and all-metacharacter labels.
3. **No group coverage of the Telegram edge dispatch path (fixed).** When
   `isPersonalSharedTelegramEdgeEnabled` is set, cron group Telegram sends go
   through `dispatchPersonalTelegramReminder` rather than the gateway; that
   branch had no group test. Added a cron group test driving the
   `telegramDispatch` option and asserting the prefixed text and group chat
   id reach the edge dispatch, no gateway fetch happens, and receipts are
   still recorded. Also verified the synthesized event's
   `chatType: "private"` / `senderId = chatId` have no adverse downstream
   effect for groups: `sendTelegramReply` addresses the send by
   `event.chatId`, and the exact-once ledger keys its Durable Object by
   `senderId` directly via `namespace.getByName` (unique per group chat id;
   the positive-only `DELIVERY_SENDER_RE` guards only the separate inbound
   HTTP ledger route, which this path never traverses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
