### PR TITLE
test(agent): cover send-handler availability

### DIFF
--- a/packages/agent/src/services/__tests__/send-handler-availability.test.ts
+++ b/packages/agent/src/services/__tests__/send-handler-availability.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+	logger: { info: vi.fn() },
+}));
+
+import { logger } from "@elizaos/core";
+import {
+	_resetMissingSendHandlerLogsForTests,
+	hasRuntimeSendHandler,
+	logMissingSendHandlerOnce,
+} from "./send-handler-availability.ts";
+
+beforeEach(() => {
+	_resetMissingSendHandlerLogsForTests();
+	vi.clearAllMocks();
+});
+afterEach(() => _resetMissingSendHandlerLogsForTests());
+
+describe("hasRuntimeSendHandler", () => {
+	it("checks the sendHandlers map", () => {
+		const runtime = { sendHandlers: new Map([["telegram", {}]]) } as never;
+		expect(hasRuntimeSendHandler(runtime, "telegram")).toBe(true);
+		expect(hasRuntimeSendHandler(runtime, "discord")).toBe(false);
+	});
+
+	it("returns false when sendHandlers is absent or not a Map", () => {
+		expect(hasRuntimeSendHandler({} as never, "telegram")).toBe(false);
+		expect(
+			hasRuntimeSendHandler({ sendHandlers: [] } as never, "telegram"),
+		).toBe(false);
+	});
+});
+
+describe("logMissingSendHandlerOnce", () => {
+	it("logs once per context:source pair", () => {
+		logMissingSendHandlerOnce("ctx", "src");
+		logMissingSendHandlerOnce("ctx", "src");
+		logMissingSendHandlerOnce("ctx", "src");
+		expect(logger.info).toHaveBeenCalledTimes(1);
+	});
+
+	it("logs separately for different sources", () => {
+		logMissingSendHandlerOnce("ctx", "a");
+		logMissingSendHandlerOnce("ctx", "b");
+		expect(logger.info).toHaveBeenCalledTimes(2);
+	});
+
+	it("re-logs after reset", () => {
+		logMissingSendHandlerOnce("ctx", "a");
+		_resetMissingSendHandlerLogsForTests();
+		logMissingSendHandlerOnce("ctx", "a");
+		expect(logger.info).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
