### PR TITLE
test(app-core): cover json response helpers

### DIFF
--- a/packages/app-core/src/api/__tests__/api-response.test.ts
+++ b/packages/app-core/src/api/__tests__/api-response.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendJson, sendJsonError } from "./response.ts";
+
+function mockRes() {
+  return {
+    headersSent: false,
+    statusCode: 0,
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as never;
+}
+
+describe("sendJson", () => {
+  it("writes status, content-type, and serialized body", () => {
+    const res = mockRes();
+    sendJson(res, 201, { ok: true });
+    expect(res.statusCode).toBe(201);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "content-type",
+      "application/json; charset=utf-8",
+    );
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+  });
+
+  it("is a no-op once headers are sent", () => {
+    const res = mockRes();
+    res.headersSent = true;
+    sendJson(res, 200, {});
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  it("strips stack traces from payloads", () => {
+    const res = mockRes();
+    const err = new Error("boom");
+    err.stack = "at somewhere";
+    sendJson(res, 500, { err, stack: "leaked" });
+    const body = JSON.parse(res.end.mock.calls[0][0]);
+    expect(body.err).toEqual({ error: "boom" });
+    expect(body.stack).toBeUndefined();
+  });
+});
+
+describe("sendJsonError", () => {
+  it("wraps the message as an error object", () => {
+    const res = mockRes();
+    sendJsonError(res, 400, "bad input");
+    expect(res.statusCode).toBe(400);
+    expect(res.end).toHaveBeenCalledWith(
+      JSON.stringify({ error: "bad input" }),
+    );
+  });
+});

--- a/packages/app-core/src/api/__tests__/api-response.test.ts
+++ b/packages/app-core/src/api/__tests__/api-response.test.ts
@@ -1,52 +1,136 @@
-import { describe, expect, it, vi } from "vitest";
-import { sendJson, sendJsonError } from "./response.ts";
+/**
+ * Pins the app-core JSON response helpers (`sendJson` / `sendJsonError`) from
+ * `../response.ts`: status + `application/json` header + serialized body, the
+ * no-op once headers are already sent, and the stack-scrubbing replacer
+ * (`stack`/`stackTrace` keys dropped at any depth, Error values rendered as
+ * `{ error: message }` with an `Internal error` fallback, `toJSON` values such
+ * as Date passed through). Drives the real helpers through a real Node
+ * `http.Server` on an ephemeral loopback port and reads the wire response with
+ * `fetch` — no mocks.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sendJson, sendJsonError } from "../response.js";
 
-function mockRes() {
+type Handler = (res: http.ServerResponse) => void;
+
+let server: http.Server;
+let baseUrl: string;
+let handler: Handler = (res) => res.end();
+let handlerError: unknown;
+
+async function roundTrip(
+  h: Handler,
+): Promise<{ status: number; contentType: string | null; text: string }> {
+  handler = h;
+  handlerError = undefined;
+  const response = await fetch(baseUrl);
+  const text = await response.text();
+  // An assertion thrown inside the handler must fail the test instead of
+  // hanging the client, so the server ends the response and we rethrow here.
+  if (handlerError !== undefined) throw handlerError;
   return {
-    headersSent: false,
-    statusCode: 0,
-    setHeader: vi.fn(),
-    end: vi.fn(),
-  } as never;
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    text,
+  };
 }
 
+beforeAll(async () => {
+  server = http.createServer((_req, res) => {
+    try {
+      handler(res);
+    } catch (error) {
+      // error-policy:J1 test transport boundary: surface the handler failure
+      // through roundTrip so the in-flight fetch does not hang.
+      handlerError = error;
+      if (!res.writableEnded) res.end();
+    }
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}/`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
 describe("sendJson", () => {
-  it("writes status, content-type, and serialized body", () => {
-    const res = mockRes();
-    sendJson(res, 201, { ok: true });
-    expect(res.statusCode).toBe(201);
-    expect(res.setHeader).toHaveBeenCalledWith(
-      "content-type",
-      "application/json; charset=utf-8",
+  it("writes the status, JSON content-type, and serialized body", async () => {
+    const out = await roundTrip((res) => sendJson(res, 201, { ok: true }));
+    expect(out.status).toBe(201);
+    expect(out.contentType).toBe("application/json; charset=utf-8");
+    expect(out.text).toBe(JSON.stringify({ ok: true }));
+  });
+
+  it("leaves status, headers, and body untouched once headers are sent", async () => {
+    const out = await roundTrip((res) => {
+      res.statusCode = 418;
+      res.setHeader("content-type", "text/plain");
+      res.write("already-started");
+      expect(res.headersSent).toBe(true);
+      sendJson(res, 200, { ok: true });
+      expect(res.statusCode).toBe(418);
+      expect(res.writableEnded).toBe(false);
+      res.end();
+    });
+    expect(out.status).toBe(418);
+    expect(out.contentType).toBe("text/plain");
+    expect(out.text).toBe("already-started");
+  });
+
+  it("drops stack and stackTrace keys at any depth", async () => {
+    const out = await roundTrip((res) =>
+      sendJson(res, 200, {
+        stack: "top-level",
+        stackTrace: ["frame"],
+        nested: { deep: { stack: "inner", keep: 1 } },
+        list: [{ stackTrace: "x", id: 2 }],
+      }),
     );
-    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(JSON.parse(out.text)).toEqual({
+      nested: { deep: { keep: 1 } },
+      list: [{ id: 2 }],
+    });
   });
 
-  it("is a no-op once headers are sent", () => {
-    const res = mockRes();
-    res.headersSent = true;
-    sendJson(res, 200, {});
-    expect(res.end).not.toHaveBeenCalled();
-  });
-
-  it("strips stack traces from payloads", () => {
-    const res = mockRes();
+  it("renders Error values as { error: message } in objects and arrays", async () => {
     const err = new Error("boom");
-    err.stack = "at somewhere";
-    sendJson(res, 500, { err, stack: "leaked" });
-    const body = JSON.parse(res.end.mock.calls[0][0]);
-    expect(body.err).toEqual({ error: "boom" });
-    expect(body.stack).toBeUndefined();
+    err.stack = "Error: boom\n    at secret (/srv/app.ts:1:1)";
+    const out = await roundTrip((res) =>
+      sendJson(res, 500, { err, items: [new TypeError("bad type")] }),
+    );
+    expect(out.status).toBe(500);
+    expect(JSON.parse(out.text)).toEqual({
+      err: { error: "boom" },
+      items: [{ error: "bad type" }],
+    });
+    expect(out.text).not.toContain("secret");
+  });
+
+  it("falls back to 'Internal error' for an Error with an empty message", async () => {
+    const out = await roundTrip((res) => sendJson(res, 500, new Error("")));
+    expect(JSON.parse(out.text)).toEqual({ error: "Internal error" });
+  });
+
+  it("serializes values with toJSON (Date) through toJSON", async () => {
+    const when = new Date("2026-01-02T03:04:05.000Z");
+    const out = await roundTrip((res) => sendJson(res, 200, { when }));
+    expect(JSON.parse(out.text)).toEqual({ when: "2026-01-02T03:04:05.000Z" });
   });
 });
 
 describe("sendJsonError", () => {
-  it("wraps the message as an error object", () => {
-    const res = mockRes();
-    sendJsonError(res, 400, "bad input");
-    expect(res.statusCode).toBe(400);
-    expect(res.end).toHaveBeenCalledWith(
-      JSON.stringify({ error: "bad input" }),
-    );
+  it("wraps the message as { error } with the given status", async () => {
+    const out = await roundTrip((res) => sendJsonError(res, 400, "bad input"));
+    expect(out.status).toBe(400);
+    expect(out.contentType).toBe("application/json; charset=utf-8");
+    expect(out.text).toBe(JSON.stringify({ error: "bad input" }));
   });
 });


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
