### PR TITLE
fix(cloud-shared): safe NaN handling in agent warm pool drain sort comparator

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts
@@ -142,7 +142,11 @@ export function decideDrain(
 
   const eligible = state.unclaimedRows
     .filter((r) => r.pool_ready_at && nowMs - r.pool_ready_at.getTime() > policy.idleScaleDownMs)
-    .sort((a, b) => (a.pool_ready_at?.getTime() ?? 0) - (b.pool_ready_at?.getTime() ?? 0))
+    .sort((a, b) => {
+      const aTime = Number.isFinite(a.pool_ready_at?.getTime()) ? (a.pool_ready_at?.getTime() ?? 0) : 0;
+      const bTime = Number.isFinite(b.pool_ready_at?.getTime()) ? (b.pool_ready_at?.getTime() ?? 0) : 0;
+      return aTime - bTime;
+    })
     .slice(0, surplus);
 
   if (eligible.length === 0) {


### PR DESCRIPTION
## Summary

Validates timestamps with `Number.isFinite(...)` in `decideDrain` sort comparators to prevent `NaN` return values when sorting idle container warm pool rows.

## Changes

- In `packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts:145`, guard `pool_ready_at` timestamps with `Number.isFinite(...)` to ensure strict total ordering during surplus container drain candidate selection.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2d823d2790`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/containers/agent-warm-pool.test.ts` | 30 pass (30 tests) | 30 pass (30 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/containers/agent-warm-pool.ts:143-149`

## Risks

Low. Prevents non-deterministic drain decisions when container rows have invalid timestamps.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared warm pool service; no UI layout touched)
- [x] `audit:browser` — N/A (Container lifecycle manager)
- [x] `build` — Clean build across workspace
- [x] `test` — 30/30 pass in `agent-warm-pool.test.ts`
- [x] `lint` — Biome clean
