### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on sandbox state restore errors

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5,7 +5,7 @@
 
 import crypto from "node:crypto";
 import { isIP } from "node:net";
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { ChannelType } from "@elizaos/core/edge";
 import {
   MAX_RESTORABLE_AGENT_BACKUP_BYTES,
@@ -12101,7 +12101,9 @@ export class ElizaSandboxService {
         });
         return "";
       });
-      throw new Error(`State restore failed: HTTP ${res.status} ${text.slice(0, 200)}`);
+      throw new Error(
+        `State restore failed: HTTP ${res.status} ${truncateWellFormed(toWellFormedUnicode(text), 200)}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/cloud/shared/src/lib/services/eliza-sandbox.ts:12104` on rejected state restore HTTP response bodies with `truncateWellFormed(toWellFormedUnicode(text), 200)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/services/eliza-sandbox.ts:12104`, safely truncate error bodies without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`0b9e759bc2`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/eliza-sandbox-create-idempotency.test.ts` | 17 pass (17 tests) | 17 pass (17 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-sandbox.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/eliza-sandbox.ts:8`
- `packages/cloud/shared/src/lib/services/eliza-sandbox.ts:12104`

## Risks

Low. Prevents surrogate corruption in cloud sandbox state restore diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared sandbox service; no UI layout touched)
- [x] `audit:browser` — N/A (Sandbox manager service)
- [x] `build` — Clean build across workspace
- [x] `test` — 17/17 pass in `eliza-sandbox-create-idempotency.test.ts`
- [x] `lint` — Biome clean
