### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on whatsapp token validation errors

### DIFF
--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
@@ -9,6 +9,7 @@
  * with credentials stored in the secrets service.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import crypto from "crypto";
 import { timingSafeEqualSecret } from "../../auth/cron";
 import { cache } from "../../cache/client";
@@ -107,7 +108,7 @@ class WhatsAppAutomationService {
         }
         logger.warn("[WhatsAppAutomation] Token validation failed", {
           status: response.status,
-          error: errorText.slice(0, 200),
+          error: truncateWellFormed(toWellFormedUnicode(errorText), 200),
         });
         return {
           valid: false,


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts:110` on failed Meta Graph API token validation responses with `truncateWellFormed(toWellFormedUnicode(errorText), 200)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts:110`, safely truncate token validation error bodies without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`2b1d23080f`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/utils/whatsapp-api.test.ts` | 5 pass (5 tests) | 5 pass (5 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts:13`
- `packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts:110`

## Risks

Low. Prevents surrogate corruption in WhatsApp token validation warning logs.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared WhatsApp automation service; no UI layout touched)
- [x] `audit:browser` — N/A (Token validation routine)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `whatsapp-api.test.ts`
- [x] `lint` — Biome clean
