### PR TITLE
test(shared): cover error classification helpers

### DIFF
--- a/packages/shared/src/utils/__tests__/errors.test.ts
+++ b/packages/shared/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  formatError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+
+import { errorMessage, isRedirectResponse, isTimeoutError } from "./errors.ts";
+
+describe("isTimeoutError", () => {
+  it("detects TimeoutError/AbortError names", () => {
+    const err = new Error("x");
+    err.name = "TimeoutError";
+    expect(isTimeoutError(err)).toBe(true);
+    const abort = new Error("x");
+    abort.name = "AbortError";
+    expect(isTimeoutError(abort)).toBe(true);
+  });
+
+  it("detects timeout text in messages", () => {
+    expect(isTimeoutError(new Error("request timed out"))).toBe(true);
+    expect(isTimeoutError(new Error("fetch timeout after 30s"))).toBe(true);
+  });
+
+  it("detects timeout shapes on plain objects", () => {
+    expect(isTimeoutError({ name: "TimeoutError" })).toBe(true);
+    expect(isTimeoutError({ message: "timed out" })).toBe(true);
+  });
+
+  it("detects timeout strings", () => {
+    expect(isTimeoutError("operation timed out")).toBe(true);
+    expect(isTimeoutError("no")).toBe(false);
+  });
+
+  it("rejects falsy and unrelated values", () => {
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError(42)).toBe(false);
+    expect(isTimeoutError(new Error("other"))).toBe(false);
+  });
+});
+
+describe("isRedirectResponse", () => {
+  it("accepts 3xx statuses", () => {
+    expect(isRedirectResponse({ status: 301 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 302 } as Response)).toBe(true);
+    expect(isRedirectResponse({ status: 399 } as Response)).toBe(true);
+  });
+
+  it("rejects non-3xx and malformed", () => {
+    expect(isRedirectResponse({ status: 200 } as Response)).toBe(false);
+    expect(isRedirectResponse({ status: 404 } as Response)).toBe(false);
+    expect(isRedirectResponse(null as never)).toBe(false);
+    expect(isRedirectResponse({} as never)).toBe(false);
+  });
+});
+
+describe("errorMessage", () => {
+  it("formats errors and values", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+    expect(errorMessage("raw")).toBe("raw");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
