### PR TITLE
test(app-core): cover desktop deep-link events

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/desktop-deep-link-events.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/desktop-deep-link-events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyDeepLinkRoute,
+  readOpenUrlEventUrl,
+} from "./desktop-deep-link-events.ts";
+
+describe("readOpenUrlEventUrl", () => {
+  it("reads string events", () => {
+    expect(readOpenUrlEventUrl("https://a.com")).toBe("https://a.com");
+    expect(readOpenUrlEventUrl("  https://a.com  ")).toBe("https://a.com");
+    expect(readOpenUrlEventUrl("")).toBeNull();
+    expect(readOpenUrlEventUrl("   ")).toBeNull();
+  });
+
+  it("reads url and data.url object forms", () => {
+    expect(readOpenUrlEventUrl({ url: "https://a.com" })).toBe("https://a.com");
+    expect(readOpenUrlEventUrl({ data: { url: "https://b.com" } })).toBe(
+      "https://b.com",
+    );
+  });
+
+  it("rejects malformed events", () => {
+    expect(readOpenUrlEventUrl(null)).toBeNull();
+    expect(readOpenUrlEventUrl(42)).toBeNull();
+    expect(readOpenUrlEventUrl({})).toBeNull();
+    expect(readOpenUrlEventUrl({ url: 5 })).toBeNull();
+  });
+});
+
+describe("classifyDeepLinkRoute", () => {
+  it("routes apps hosts to app windows", () => {
+    expect(classifyDeepLinkRoute("elizaos://apps/plugin-viewer")).toEqual({
+      kind: "app",
+      slug: "plugin-viewer",
+    });
+  });
+
+  it("normalizes host case (opaque host not lowercased by URL parser)", () => {
+    expect(classifyDeepLinkRoute("ELIZAOS://Apps/plugin-viewer")).toEqual({
+      kind: "app",
+      slug: "plugin-viewer",
+    });
+  });
+
+  it("forwards non-app links", () => {
+    expect(classifyDeepLinkRoute("elizaos://agents/x")).toEqual({
+      kind: "forward",
+    });
+    expect(classifyDeepLinkRoute("https://a.com/x")).toEqual({
+      kind: "forward",
+    });
+  });
+
+  it("forwards unparseable urls", () => {
+    expect(classifyDeepLinkRoute("not a url")).toEqual({ kind: "forward" });
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
