### PR TITLE
test(agent): cover server autonomy helpers

### DIFF
--- a/packages/agent/src/api/__tests__/server-autonomy-helpers.test.ts
+++ b/packages/agent/src/api/__tests__/server-autonomy-helpers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  MESSAGE_SOURCE_CLIENT_CHAT: "client-chat",
+}));
+
+const routeAutonomyTextToUser = vi.fn(async () => undefined);
+vi.mock("./server-helpers-swarm.ts", () => ({
+  routeAutonomyTextToUser: (...args: unknown[]) =>
+    routeAutonomyTextToUser(...args),
+}));
+
+import {
+  isLifeOpsCloudPluginRoute,
+  maybeRouteAutonomyEventToConversation,
+} from "./server-autonomy-helpers.ts";
+
+describe("isLifeOpsCloudPluginRoute", () => {
+  it("matches cloud plugin routes", () => {
+    expect(isLifeOpsCloudPluginRoute("/api/cloud/features")).toBe(true);
+    expect(isLifeOpsCloudPluginRoute("/api/cloud/features/sync")).toBe(true);
+    expect(isLifeOpsCloudPluginRoute("/api/cloud/travel-providers/abc")).toBe(
+      true,
+    );
+  });
+
+  it("rejects unrelated paths", () => {
+    expect(isLifeOpsCloudPluginRoute("/api/agents")).toBe(false);
+    expect(isLifeOpsCloudPluginRoute("/")).toBe(false);
+  });
+});
+
+describe("maybeRouteAutonomyEventToConversation", () => {
+  const state = { conversations: new Map() } as never;
+
+  it("ignores non-assistant streams", async () => {
+    await maybeRouteAutonomyEventToConversation(state, {
+      stream: "user",
+    } as never);
+    expect(routeAutonomyTextToUser).not.toHaveBeenCalled();
+  });
+
+  it("ignores empty or missing text", async () => {
+    await maybeRouteAutonomyEventToConversation(state, {
+      stream: "assistant",
+      data: {},
+    } as never);
+    expect(routeAutonomyTextToUser).not.toHaveBeenCalled();
+  });
+
+  it("drops client-chat echoes", async () => {
+    await maybeRouteAutonomyEventToConversation(state, {
+      stream: "assistant",
+      data: { text: "hi", source: "client-chat" },
+    } as never);
+    expect(routeAutonomyTextToUser).not.toHaveBeenCalled();
+  });
+
+  it("routes autonomy text without explicit source when roomId exists", async () => {
+    routeAutonomyTextToUser.mockClear();
+    await maybeRouteAutonomyEventToConversation(state, {
+      stream: "assistant",
+      roomId: "r1",
+      data: { text: "hi" },
+    } as never);
+    expect(routeAutonomyTextToUser).toHaveBeenCalledWith(
+      state,
+      "hi",
+      "autonomy",
+    );
+  });
+
+  it("drops events whose room already has an open conversation", async () => {
+    routeAutonomyTextToUser.mockClear();
+    const busyState = {
+      conversations: new Map([["c1", { roomId: "r1" }]]),
+    } as never;
+    await maybeRouteAutonomyEventToConversation(busyState, {
+      stream: "assistant",
+      roomId: "r1",
+      data: { text: "hi" },
+    } as never);
+    expect(routeAutonomyTextToUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for existing exported helpers. -->

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] Focused verification passed in isolation (vitest).
- [x] A reviewer can confirm the change works from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low. Test-only addition exercising existing exported pure functions. No production code modified.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: isolated `npx vitest run` -> all passed |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
