### PR TITLE
fix(inmemorydb): safe NaN handling in getLogs sort comparator

### DIFF
--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -1417,7 +1417,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       if (params.type && l.type !== params.type) return false;
       return true;
     });
-    logs.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    logs.sort((a, b) => {
+      const aTime = Number.isFinite(new Date(a.createdAt).getTime())
+        ? new Date(a.createdAt).getTime()
+        : 0;
+      const bTime = Number.isFinite(new Date(b.createdAt).getTime())
+        ? new Date(b.createdAt).getTime()
+        : 0;
+      return bTime - aTime;
+    });
     const offset = params.offset ?? 0;
     if (offset > 0) logs = logs.slice(offset);
     if (params.limit !== undefined) logs = logs.slice(0, params.limit);


### PR DESCRIPTION
## Summary

Validates timestamps with `Number.isFinite(...)` in `getLogs` (`plugins/plugin-inmemorydb/adapter.ts`) to prevent `NaN` return values in sort comparators when retrieving in-memory database logs.

## Changes

- In `plugins/plugin-inmemorydb/adapter.ts:1420`, guard `createdAt` timestamp conversions with `Number.isFinite(...)` to ensure strict total ordering during log sorting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`9633ce5f6b`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-inmemorydb/access-context.test.ts` | 3 pass (3 tests) | 3 pass (3 tests) |
| `bunx @biomejs/biome check plugins/plugin-inmemorydb/adapter.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-inmemorydb/adapter.ts:1418-1425`

## Risks

Low. Prevents non-deterministic log pagination and order instability.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (In-memory DB adapter; no UI layout touched)
- [x] `audit:browser` — N/A (Storage adapter)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 pass in `access-context.test.ts`
- [x] `lint` — Biome clean
