### PR TITLE
fix(trajectory-logger): use surrogate-safe truncateWellFormed on HTTP error response bodies

### DIFF
--- a/plugins/plugin-trajectory-logger/src/api-client.ts
+++ b/plugins/plugin-trajectory-logger/src/api-client.ts
@@ -4,6 +4,8 @@
  * the fields the widget reads and tolerates extra route fields.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 export interface TrajectoryListItem {
   id: string;
   status: "active" | "completed" | "error";
@@ -75,7 +77,7 @@ export class TrajectoryHttpError extends Error {
 
   constructor(status: number, statusText: string, body: string) {
     super(
-      `[trajectory-logger] ${status} ${statusText}${body ? `: ${body.slice(0, 200)}` : ""}`,
+      `[trajectory-logger] ${status} ${statusText}${body ? `: ${truncateWellFormed(toWellFormedUnicode(body), 200)}` : ""}`,
     );
     this.name = "TrajectoryHttpError";
     this.status = status;


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `plugins/plugin-trajectory-logger/src/api-client.ts:78` on trajectory route HTTP error bodies with `truncateWellFormed(toWellFormedUnicode(body), 200)` from `@elizaos/core`.

## Changes

- In `plugins/plugin-trajectory-logger/src/api-client.ts:78`, safely truncate error bodies without splitting UTF-16 surrogate pairs in `TrajectoryHttpError`.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`a27183743b`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-trajectory-logger/src/api-client.contract.test.ts` | 13 pass (13 tests) | 13 pass (13 tests) |
| `bunx @biomejs/biome check plugins/plugin-trajectory-logger/src/api-client.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-trajectory-logger/src/api-client.ts:7`
- `plugins/plugin-trajectory-logger/src/api-client.ts:78`

## Risks

Low. Prevents surrogate corruption in trajectory logger error messages.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Trajectory logger widget client; no UI layout touched)
- [x] `audit:browser` — N/A (Trajectory client)
- [x] `build` — Clean build across workspace
- [x] `test` — 13/13 pass in `api-client.contract.test.ts`
- [x] `lint` — Biome clean
