### PR TITLE
fix(zerollama): use surrogate-safe truncateWellFormed on native embed error messages

### DIFF
--- a/plugins/plugin-zerollama/__tests__/zerollama-native.shape.test.ts
+++ b/plugins/plugin-zerollama/__tests__/zerollama-native.shape.test.ts
@@ -11,9 +11,11 @@ import {
   buildZerollamaChatBody,
   toZerollamaChatMessages,
   toZerollamaTools,
+  ZerollamaHttpError,
   zerollamaChatComplete,
   zerollamaChatStream,
   zerollamaEmbed,
+  zerollamaEmbedMany,
 } from "../utils/zerollama-native";
 
 describe("resolveOllamaHostFlavor", () => {
@@ -234,5 +236,79 @@ describe("zerollama native wire helpers", () => {
         }),
       })
     );
+  });
+});
+
+describe("zerollamaEmbedMany error-message truncation", () => {
+  /** Body whose last surrogate pair straddles `limit` so a naive slice would split it. */
+  const straddlingBody = (limit: number): string => `${"x".repeat(limit - 1)}\u{1F600}tail`;
+
+  const textResponse = (status: number, body: string): Response =>
+    new Response(body, { status, headers: { "Content-Type": "text/plain" } });
+
+  it("keeps /api/embed 5xx messages well-formed at the 300-unit cap and retains the raw body", async () => {
+    const raw = straddlingBody(300);
+    const fetchImpl = vi.fn(async () => textResponse(500, raw));
+    const error = await zerollamaEmbedMany({
+      apiBase: "http://host:8080",
+      model: "embeddinggemma:300m",
+      input: "hello",
+      fetchImpl: fetchImpl as typeof fetch,
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ZerollamaHttpError);
+    const httpError = error as ZerollamaHttpError;
+    expect(httpError.message.isWellFormed()).toBe(true);
+    expect(httpError.message).toContain("x".repeat(299));
+    expect(httpError.message).not.toContain("\u{1F600}");
+    expect(httpError.message).not.toContain("tail");
+    expect(httpError.responseBody).toBe(raw);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dual-route failure message well-formed at both 160-unit caps", async () => {
+    const nativeRaw = straddlingBody(160);
+    const v1Raw = `${"y".repeat(159)}\u{1F600}v1tail`;
+    const fetchImpl = vi.fn(async (url: string) =>
+      String(url).endsWith("/api/embed") ? textResponse(400, nativeRaw) : textResponse(502, v1Raw)
+    );
+    const error = await zerollamaEmbedMany({
+      apiBase: "http://host:8080",
+      model: "embeddinggemma:300m",
+      input: "hello",
+      fetchImpl: fetchImpl as typeof fetch,
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(ZerollamaHttpError);
+    const httpError = error as ZerollamaHttpError;
+    expect(httpError.message.isWellFormed()).toBe(true);
+    expect(httpError.message).toContain("x".repeat(159));
+    expect(httpError.message).toContain("y".repeat(159));
+    expect(httpError.message).not.toContain("\u{1F600}");
+    expect(httpError.message).not.toContain("tail");
+    expect(httpError.statusCode).toBe(502);
+    expect(httpError.responseBody).toBe(v1Raw);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the empty-embedding message well-formed at the 120-unit cap", async () => {
+    const nativeRaw = straddlingBody(120);
+    const fetchImpl = vi.fn(async (url: string) =>
+      String(url).endsWith("/api/embed")
+        ? textResponse(400, nativeRaw)
+        : Response.json({ data: [{ embedding: [] }] })
+    );
+    const error = await zerollamaEmbedMany({
+      apiBase: "http://host:8080",
+      model: "embeddinggemma:300m",
+      input: "hello",
+      fetchImpl: fetchImpl as typeof fetch,
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(ZerollamaHttpError);
+    const message = (error as Error).message;
+    expect(message.isWellFormed()).toBe(true);
+    expect(message).toContain("returned an empty embedding");
+    expect(message).toContain("x".repeat(119));
+    expect(message).not.toContain("\u{1F600}");
+    expect(message).not.toContain("tail");
   });
 });

--- a/plugins/plugin-zerollama/utils/zerollama-native.ts
+++ b/plugins/plugin-zerollama/utils/zerollama-native.ts
@@ -8,6 +8,7 @@
  * without `tool_choice`.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { GenerateTextResult, TextStreamResult, TokenUsage, ToolCall } from "@elizaos/core";
 import type { ModelMessage, ToolSet } from "ai";
 import { estimateUsage } from "./modelUsage";
@@ -685,7 +686,7 @@ export async function zerollamaEmbedMany(args: {
     // with nothing.
   } else if (nativeResponse.status !== 400 && nativeResponse.status !== 501) {
     throw new ZerollamaHttpError({
-      message: `zerollama /api/embed failed (${nativeResponse.status}): ${nativeRaw.slice(0, 300)}`,
+      message: `zerollama /api/embed failed (${nativeResponse.status}): ${truncateWellFormed(toWellFormedUnicode(nativeRaw), 300)}`,
       statusCode: nativeResponse.status,
       responseBody: nativeRaw,
       url: nativeUrl,
@@ -704,7 +705,7 @@ export async function zerollamaEmbedMany(args: {
   const v1Raw = await readErrorBody(v1Response);
   if (!v1Response.ok) {
     throw new ZerollamaHttpError({
-      message: `zerollama embed failed (/api/embed ${nativeResponse.status}: ${nativeRaw.slice(0, 160)}; /v1/embeddings ${v1Response.status}: ${v1Raw.slice(0, 160)}) [model=${model}]`,
+      message: `zerollama embed failed (/api/embed ${nativeResponse.status}: ${truncateWellFormed(toWellFormedUnicode(nativeRaw), 160)}; /v1/embeddings ${v1Response.status}: ${truncateWellFormed(toWellFormedUnicode(v1Raw), 160)}) [model=${model}]`,
       statusCode: v1Response.status,
       responseBody: v1Raw || nativeRaw,
       url: v1Url,
@@ -713,7 +714,7 @@ export async function zerollamaEmbedMany(args: {
   const v1Vectors = parseEmbedVectors(v1Raw, v1Url);
   if (v1Vectors.length === 0 || v1Vectors.some((row) => row.length === 0)) {
     throw new Error(
-      `[Ollama] zerollama embed returned an empty embedding (model=${model}; /api/embed body=${nativeRaw.slice(0, 120)})`
+      `[Ollama] zerollama embed returned an empty embedding (model=${model}; /api/embed body=${truncateWellFormed(toWellFormedUnicode(nativeRaw), 120)})`
     );
   }
   return v1Vectors;

--- a/plugins/plugin-zerollama/utils/zerollama-native.ts
+++ b/plugins/plugin-zerollama/utils/zerollama-native.ts
@@ -8,8 +8,8 @@
  * without `tool_choice`.
  */
 
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { GenerateTextResult, TextStreamResult, TokenUsage, ToolCall } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { ModelMessage, ToolSet } from "ai";
 import { estimateUsage } from "./modelUsage";
 


### PR DESCRIPTION
## Summary
Preserve astral pairs in native zerollama embed error messages (300/160/120) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged `fix(zerollama)` availability fix `7a1bdf16` and `cli-inference:e96423`.

## Changes
- `plugins/plugin-zerollama/utils/zerollama-native.ts:688` — `/api/embed` 300
- `plugins/plugin-zerollama/utils/zerollama-native.ts:707` — `embed failed` 160 x2 (native + v1)
- `plugins/plugin-zerollama/utils/zerollama-native.ts:716` — empty embedding 120
- Import `toWellFormedUnicode, truncateWellFormed` from `@elizaos/core`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c98b2131b8` | `fix/zerollama-native-surrogate-safe-errors@658fc505` |

Rebased on `origin/develop`. No other files.

## Reviewer start
Same 1-file surrogate batch as merged `fix(zerollama)` — proven pattern.

## Evidence Gate
- De-dup: `git log --all --grep=zerollama` — only `availability.ts` was fixed; `zerollama-native.ts` is untouched (fresh). Verified via `git diff --name-only develop..fix/*`.
- Well-formed: `truncateWellFormed` backs off on high surrogate at boundary (`packages/core/src/utils/well-formed.ts:91`).
