### PR TITLE
fix(zerollama): use surrogate-safe truncateWellFormed on audio and embedding error details

### DIFF
--- a/plugins/plugin-zerollama/models/audio.ts
+++ b/plugins/plugin-zerollama/models/audio.ts
@@ -12,7 +12,7 @@ import type {
   IAgentRuntime,
   RecordLlmCallDetails,
 } from "@elizaos/core";
-import { logger, recordLlmCall } from "@elizaos/core";
+import { logger, recordLlmCall, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   getApiBase,
   getTranscriptionModel,
@@ -144,7 +144,7 @@ async function fetchAudioFromUrl(url: string, signal?: AbortSignal): Promise<Blo
 async function readHttpErrorDetail(response: Response): Promise<string> {
   try {
     const detail = (await response.text()).trim();
-    return detail.length > 0 ? detail.slice(0, 500) : "empty response body";
+    return detail.length > 0 ? truncateWellFormed(toWellFormedUnicode(detail), 500) : "empty response body";
   } catch (error) {
     // error-policy:J4 the status remains authoritative and the unavailable
     // diagnostic body is represented explicitly.

--- a/plugins/plugin-zerollama/models/embedding.ts
+++ b/plugins/plugin-zerollama/models/embedding.ts
@@ -10,7 +10,7 @@
  * no prefix is silently substituted for the requested embedding.
  */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { logger, ModelType, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { type EmbeddingModel, embed } from "ai";
 import { createOllama } from "ollama-ai-provider-v2";
 
@@ -157,7 +157,7 @@ export async function handleTextEmbedding(
       typeof (error as { responseBody?: unknown }).responseBody === "string"
         ? {
             message: error.message,
-            responseBody: (error as { responseBody: string }).responseBody.slice(0, 400),
+            responseBody: truncateWellFormed(toWellFormedUnicode((error as { responseBody: string }).responseBody), 400),
           }
         : error;
     logger.error({ error: detail }, "Error in TEXT_EMBEDDING model");


### PR DESCRIPTION
## Summary
Preserve astral pairs in zerollama audio transcription and embedding error details (500/400) via `toWellFormedUnicode` + `truncateWellFormed`. Missed siblings of merged `fix(zerollama): availability` `7a1bdf16`.

## Changes
- `plugins/plugin-zerollama/models/audio.ts:147` — `readHttpErrorDetail` 500
- `plugins/plugin-zerollama/models/embedding.ts:160` — `TEXT_EMBEDDING responseBody` 400
- Imports from `@elizaos/core`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c98b2131b8` | `fix/zerollama-audio-embedding-surrogate-safe-errors@42afe78c` |

2 files, same defect class, narrow `fix(zerollama)` scope (as in \#24906).

## Reviewer start
Grouped as in merged plugins surrogate batch.

## Evidence Gate
- De-dup: `audio.ts` + `embedding.ts` not in `git log --all --grep=surrogate` file list; fresh.
