### PR TITLE
fix(cloud): use surrogate-safe truncateWellFormed on auto-top-up error messages

### DIFF
--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -26,6 +26,7 @@ import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { requireStripe } from "../stripe";
 import { logger } from "../utils/logger";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { emailService } from "./email";
 import { invalidateOrgTierCache } from "./org-rate-limits";
 import {
@@ -259,7 +260,7 @@ function stripeErrorCode(error: unknown): string | null {
 
 function safeErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : "Unknown provider error";
-  return message.replaceAll(/\s+/g, " ").slice(0, 500);
+  return truncateWellFormed(toWellFormedUnicode(message.replaceAll(/\s+/g, " ")), 500);
 }
 
 function curatedProviderResult(paymentIntent: Stripe.PaymentIntent): Record<string, unknown> {


### PR DESCRIPTION
## Summary
Preserve astral pairs in cloud auto-top-up `safeErrorMessage` (500) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged `fix(cloud-shared)` surrogate batch (`team-credential-pool`, `whatsapp-automation`).

## Changes
- `packages/cloud/shared/src/lib/services/auto-top-up.ts:262` — `safeErrorMessage` 500

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c98b2131b8` | `fix/cloud-auto-topup-surrogate-safe-errors@407d0aa4` |

Rebased, single scope `fix(cloud)`.

## Evidence Gate
- De-dup: no existing `fix/*` touches `auto-top-up.ts` (verified via `git diff --name-only develop..fix/*`); fresh at HEAD.
