### PR TITLE
fix(vault): safe NaN handling in external login sort comparator

### DIFF
--- a/packages/vault/src/manager.ts
+++ b/packages/vault/src/manager.ts
@@ -365,7 +365,11 @@ class ManagerImpl implements SecretsManager {
         title: e.title,
         updatedAt: e.updatedAt,
       }))
-      .sort((a, b) => b.updatedAt - a.updatedAt);
+      .sort((a, b) => {
+        const aTime = Number.isFinite(a.updatedAt) ? a.updatedAt : 0;
+        const bTime = Number.isFinite(b.updatedAt) ? b.updatedAt : 0;
+        return bTime - aTime;
+      });
 
     // In-house first (sort by domain asc, username asc), then externals
     // by updatedAt desc — matches the spec.


### PR DESCRIPTION
## Summary
Guard `updatedAt` with `Number.isFinite` before subtraction in vault external login sort. Mirrors merged `fix(cloud-api): container-billing` `adc1ffbf` and `fix(vault)` patterns.

## Changes
- `packages/vault/src/manager.ts:368` — `b.updatedAt - a.updatedAt` → `Number.isFinite` guard returning 0 for non-finite, strict total order

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c98b2131b8` | `fix/vault-manager-safe-sort@ca566b07` |

Rebased.

## Reviewer start
Same comparator guard as 10+ merged sort fixes (calendar, scheduling, health, lifeops, container-billing).

## Evidence Gate
- De-dup: `git log --all --grep="sort"` — no branch for `packages/vault/src/manager.ts`; fresh. Injects `NaN` `updatedAt` → comparator now returns finite (0) not `NaN`, deterministic order.
