### PR TITLE
fix(plugin-x): use surrogate-safe truncateWellFormed on broker HTTP error bodies

### DIFF
--- a/plugins/plugin-x/src/client/auth-providers/broker.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.ts
@@ -9,7 +9,11 @@
  * Broker HTTP uses AbortSignal.timeout so a hung cloud token hop cannot stall
  * every X action that needs credentials.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import { getSetting } from "../../utils/settings";
 import type { BrokerAuthCredentials, TwitterBrokerProvider } from "./types";
 
@@ -160,7 +164,7 @@ export class BrokerAuthProvider implements TwitterBrokerProvider {
     if (!response.ok) {
       const body = await response.text().catch(() => "");
       throw new Error(
-        `X broker request failed (${response.status}): ${body.slice(0, 200)}`,
+        `X broker request failed (${response.status}): ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
       );
     }
     const token: unknown = await response.json();


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `plugins/plugin-x/src/client/auth-providers/broker.ts:163` on failed X OAuth/broker responses with `truncateWellFormed(toWellFormedUnicode(body), 200)` from `@elizaos/core`.

## Changes

- In `plugins/plugin-x/src/client/auth-providers/broker.ts:163`, safely truncate response bodies without splitting UTF-16 surrogate pairs when throwing broker errors.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`ac35a1fc36`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-x/src/client/auth-providers/broker.test.ts` | 5 pass (5 tests) | 5 pass (5 tests) |
| `bunx @biomejs/biome check plugins/plugin-x/src/client/auth-providers/broker.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-x/src/client/auth-providers/broker.ts:12`
- `plugins/plugin-x/src/client/auth-providers/broker.ts:163`

## Risks

Low. Prevents surrogate corruption when X broker error responses contain non-ASCII characters.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Plugin X auth broker; no UI layout touched)
- [x] `audit:browser` — N/A (Auth provider)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `broker.test.ts`
- [x] `lint` — Biome clean
