### PR TITLE
fix(core): safe NaN handling in message dialogue sort comparators

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2477,7 +2477,11 @@ function appendPriorDialogueEvents(
 			if (looksLikePriorDialogueArtifact(text)) return false;
 			return text.length > 0;
 		})
-		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
+		.sort((a, b) => {
+			const aTime = Number.isFinite(a.createdAt as unknown as number) ? (a.createdAt as unknown as number) : 0;
+			const bTime = Number.isFinite(b.createdAt as unknown as number) ? (b.createdAt as unknown as number) : 0;
+			return aTime - bTime;
+		});
 	// Bound how many of the agent's own turns render (newest win): the planner
 	// needs the immediate question/preview a continuation refers to, not the
 	// agent's whole side of a long conversation.
@@ -2806,7 +2810,11 @@ function getRecentConversationSearchText(
 			if (isSubAgentCompletionArtifact(memory)) return false;
 			return typeof memory.content?.text === "string";
 		})
-		.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+		.sort((a, b) => {
+			const aTime = Number.isFinite(a.createdAt as unknown as number) ? (a.createdAt as unknown as number) : 0;
+			const bTime = Number.isFinite(b.createdAt as unknown as number) ? (b.createdAt as unknown as number) : 0;
+			return bTime - aTime;
+		})
 		.map((memory) => memory.content.text.trim())
 		.filter(Boolean);
 }


### PR DESCRIPTION
## Summary
Guard `createdAt` with `Number.isFinite` before subtraction in message dialogue ordering (`??0` does not guard `NaN`). Mirrors merged `fix(core): fence stale task scheduler` and container-billing sort fixes.

## Changes
- `packages/core/src/services/message.ts:2477` — `(a.createdAt??0)-(b.createdAt??0)` → finite guard
- `packages/core/src/services/message.ts:2810` — `(b.createdAt??0)-(a.createdAt??0)` → finite guard (desc)

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c98b2131b8` | `fix/core-message-sort-safe-sort@d6731d38` |

Rebased.

## Reviewer start
Same pattern as 10 merged sort total-order fixes.

## Evidence Gate
- De-dup: no `fix/*` for `packages/core/src/services/message.ts` (verified); fresh. `NaN` `createdAt` now sorts as 0, no `NaN` comparator return.
