### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on discord auth errors

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts
@@ -5,6 +5,7 @@
  * See: https://discord.com/developers/docs/topics/oauth2
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { discordFetch } from "../../utils/discord-api";
 import { logger } from "../../utils/logger";
 import { elizaAppConfig } from "./config";
@@ -93,13 +94,13 @@ class DiscordAuthService {
       if (tokenResponse.status === 400) {
         logger.warn("[DiscordAuth] Authorization code rejected by Discord", {
           status: tokenResponse.status,
-          error: errorText.slice(0, 200),
+          error: truncateWellFormed(toWellFormedUnicode(errorText), 200),
         });
         return null;
       }
       logger.error("[DiscordAuth] Token exchange failed", {
         status: tokenResponse.status,
-        error: errorText.slice(0, 200),
+        error: truncateWellFormed(toWellFormedUnicode(errorText), 200),
       });
       throw new Error(
         `[DiscordAuth] Discord token endpoint returned status ${tokenResponse.status}`,
@@ -125,7 +126,7 @@ class DiscordAuthService {
       const errorText = await userResponse.text();
       logger.error("[DiscordAuth] User profile fetch failed", {
         status: userResponse.status,
-        error: errorText.slice(0, 200),
+        error: truncateWellFormed(toWellFormedUnicode(errorText), 200),
       });
       throw new Error(`[DiscordAuth] Discord user endpoint returned status ${userResponse.status}`);
     }


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts:96, 102, 128` across Discord OAuth code rejection, token exchange, and user profile fetch error handlers with `truncateWellFormed(toWellFormedUnicode(errorText), 200)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts:96, 102, 128`, safely truncate error strings without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`07783bc316`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/eliza-app/discord-auth.error-policy.test.ts` | 10 pass (10 tests) | 10 pass (10 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts:8`
- `packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts:96-128`

## Risks

Low. Prevents surrogate corruption in Discord OAuth error logging.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared Discord auth service; no UI layout touched)
- [x] `audit:browser` — N/A (OAuth authentication routine)
- [x] `build` — Clean build across workspace
- [x] `test` — 10/10 pass in `discord-auth.error-policy.test.ts`
- [x] `lint` — Biome clean
