### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on discord automation error bodies

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { discordChannelsRepository } from "../../../db/repositories/discord-channels";
 import { discordGuildsRepository } from "../../../db/repositories/discord-guilds";
 import { discordFetch } from "../../utils/discord-api";
@@ -182,7 +183,7 @@ class DiscordAutomationService {
         const errorText = await tokenResponse.text();
         logger.warn("[Discord] Token exchange failed", {
           status: tokenResponse.status,
-          error: errorText.slice(0, 200),
+          error: truncateWellFormed(toWellFormedUnicode(errorText), 200),
         });
         return null;
       }
@@ -416,7 +417,7 @@ class DiscordAutomationService {
         logger.warn("[Discord] Failed to set bot nickname", {
           guildId,
           status: response.status,
-          error: errorText.slice(0, 200),
+          error: truncateWellFormed(toWellFormedUnicode(errorText), 200),
         });
         return false;
       }


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 200)` string slicing in `packages/cloud/shared/src/lib/services/discord-automation/index.ts:185, 419` on failed Discord token exchange and bot nickname requests with `truncateWellFormed(toWellFormedUnicode(errorText), 200)` from `@elizaos/core`.

## Changes

- In `packages/cloud/shared/src/lib/services/discord-automation/index.ts:185, 419`, safely truncate error strings without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`ff8af20d69`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/utils/discord-helpers.test.ts` | 4 pass (4 tests) | 4 pass (4 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/discord-automation/index.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/discord-automation/index.ts:9`
- `packages/cloud/shared/src/lib/services/discord-automation/index.ts:185`
- `packages/cloud/shared/src/lib/services/discord-automation/index.ts:419`

## Risks

Low. Prevents surrogate corruption in Discord automation warning logs.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared Discord automation service; no UI layout touched)
- [x] `audit:browser` — N/A (Automation service)
- [x] `build` — Clean build across workspace
- [x] `test` — 4/4 pass in `discord-helpers.test.ts`
- [x] `lint` — Biome clean
