### PR TITLE
fix(cloud-shared): safe NaN handling in account limits snapshot rate segment sort comparator

### DIFF
--- a/packages/cloud/shared/src/lib/services/account-limits-snapshot.ts
+++ b/packages/cloud/shared/src/lib/services/account-limits-snapshot.ts
@@ -838,7 +838,13 @@ function observeActiveComputeRate(
   if (eligible.length === 0) {
     return unavailableActiveComputeRate(observedAt, "active_compute_rate_segment_future_only");
   }
-  eligible.sort((left, right) => right.effectiveAt.getTime() - left.effectiveAt.getTime());
+  eligible.sort((left, right) => {
+    const leftTime = Number.isFinite(left.effectiveAt.getTime()) ? left.effectiveAt.getTime() : 0;
+    const rightTime = Number.isFinite(right.effectiveAt.getTime())
+      ? right.effectiveAt.getTime()
+      : 0;
+    return rightTime - leftTime;
+  });
   const { segment, effectiveAt } = eligible[0]!;
   if (segment.billingState !== expected.billingState) {
     return unavailableActiveComputeRate(observedAt, "active_compute_rate_segment_state_mismatch");


### PR DESCRIPTION
## Summary

Validates segment timestamps with `Number.isFinite(...)` in `resolveActiveComputeRate` (`packages/cloud/shared/src/lib/services/account-limits-snapshot.ts:841`) to prevent `NaN` return values in sort comparators when identifying the active compute billing rate segment.

## Changes

- In `packages/cloud/shared/src/lib/services/account-limits-snapshot.ts:841`, guard `effectiveAt` timestamp comparisons with `Number.isFinite(...)` during eligible rate segment sorting.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`681e690a3b`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/account-limits-snapshot.test.ts` | 12 pass (12 tests) | 12 pass (12 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/account-limits-snapshot.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/account-limits-snapshot.ts:838-846`

## Risks

Low. Prevents non-deterministic rate segment selection during compute rate resolution.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared account limits snapshot; no UI layout touched)
- [x] `audit:browser` — N/A (Compute rate resolver)
- [x] `build` — Clean build across workspace
- [x] `test` — 12/12 pass in `account-limits-snapshot.test.ts`
- [x] `lint` — Biome clean
