### PR TITLE
fix(agent-skills): safe NaN handling in skills provider relevance sort comparator

### DIFF
--- a/plugins/plugin-agent-skills/src/providers/skills.ts
+++ b/plugins/plugin-agent-skills/src/providers/skills.ts
@@ -159,7 +159,11 @@ export const skillInstructionsProvider: Provider = {
 				score: calculateSkillRelevance(skill, fullContext),
 			}))
 			.filter((s) => s.score > 0)
-			.sort((a, b) => b.score - a.score);
+			.sort((a, b) => {
+				const aScore = Number.isFinite(a.score) ? a.score : 0;
+				const bScore = Number.isFinite(b.score) ? b.score : 0;
+				return bScore - aScore;
+			});
 
 		// Require minimum relevance score
 		if (scoredSkills.length === 0 || scoredSkills[0].score < 3) {


### PR DESCRIPTION
## Summary

Validates skill relevance scores with `Number.isFinite(...)` in `skillsProvider` (`plugins/plugin-agent-skills/src/providers/skills.ts:162`) to prevent `NaN` return values in sort comparators when ranking skills for context injection.

## Changes

- In `plugins/plugin-agent-skills/src/providers/skills.ts:162`, guard `score` comparisons with `Number.isFinite(...)` to ensure strict total ordering during skill candidate ranking.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`7946452595`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-agent-skills/src/providers/skills.test.ts` | 6 pass (6 tests) | 6 pass (6 tests) |
| `bunx @biomejs/biome check plugins/plugin-agent-skills/src/providers/skills.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-agent-skills/src/providers/skills.ts:159-166`

## Risks

Low. Prevents non-deterministic skill ranking and unstable context selection.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent skills provider; no UI layout touched)
- [x] `audit:browser` — N/A (Skills provider)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 pass in `skills.test.ts`
- [x] `lint` — Biome clean
