### PR TITLE
fix(computeruse): safe NaN handling in OCR provider priority sort comparator

### DIFF
--- a/plugins/plugin-computeruse/src/mobile/ocr-provider.ts
+++ b/plugins/plugin-computeruse/src/mobile/ocr-provider.ts
@@ -77,7 +77,11 @@ export function unregisterOcrProvider(name: string): void {
 }
 
 export function listOcrProviders(): readonly OcrProvider[] {
-  return [...REGISTRY.values()].sort((a, b) => b.priority - a.priority);
+  return [...REGISTRY.values()].sort((a, b) => {
+    const aPriority = Number.isFinite(a.priority) ? a.priority : 0;
+    const bPriority = Number.isFinite(b.priority) ? b.priority : 0;
+    return bPriority - aPriority;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Validates provider priorities with `Number.isFinite(...)` in `listOcrProviders` (`plugins/plugin-computeruse/src/mobile/ocr-provider.ts:80`) to prevent `NaN` return values in sort comparators when ranking OCR providers for mobile computer use.

## Changes

- In `plugins/plugin-computeruse/src/mobile/ocr-provider.ts:80`, guard `priority` comparisons with `Number.isFinite(...)` to ensure strict total ordering during provider selection.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`5a1e0554c8`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-computeruse/src/mobile/ocr-provider.test.ts` | 7 pass (7 tests) | 7 pass (7 tests) |
| `bunx @biomejs/biome check plugins/plugin-computeruse/src/mobile/ocr-provider.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-computeruse/src/mobile/ocr-provider.ts:79-84`

## Risks

Low. Prevents non-deterministic OCR provider selection when custom providers are registered.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Computer use OCR provider registry; no UI layout touched)
- [x] `audit:browser` — N/A (OCR registry)
- [x] `build` — Clean build across workspace
- [x] `test` — 7/7 pass in `ocr-provider.test.ts`
- [x] `lint` — Biome clean
