### PR TITLE
fix(evidence): use surrogate-safe truncateWellFormed on ffmpeg install error reasons

### DIFF
--- a/packages/evidence/src/ffmpeg-binaries.ts
+++ b/packages/evidence/src/ffmpeg-binaries.ts
@@ -197,6 +197,12 @@ export async function withInstallLock<T>(
   }
 }
 
+function truncateWellFormed(text: string, maxChars: number): string {
+  const wellFormed =
+    typeof text.toWellFormed === "function" ? text.toWellFormed() : text;
+  return Array.from(wellFormed).slice(0, maxChars).join("");
+}
+
 function installFfmpegStaticOnce(
   candidate: string,
 ): Promise<{ installed: true } | { installed: false; reason: string }> {
@@ -237,7 +243,7 @@ function installFfmpegStaticOnce(
       const message = error instanceof Error ? error.message : String(error);
       return {
         installed: false,
-        reason: `ffmpeg-static install failed: ${message.slice(0, 160)}`,
+        reason: `ffmpeg-static install failed: ${truncateWellFormed(message, 160)}`,
       };
     }
   })();


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 160)` string slicing in `packages/evidence/src/ffmpeg-binaries.ts:240` on `ffmpeg-static` installation errors with a surrogate-safe `truncateWellFormed` helper.

## Changes

- In `packages/evidence/src/ffmpeg-binaries.ts:240`, safely truncate install error messages without splitting UTF-16 surrogate pairs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`302289605c`) |
| --- | --- | --- |
| `bunx vitest run packages/evidence/src/ffmpeg-binaries.test.ts` | 10 pass (10 tests) | 10 pass (10 tests) |
| `bunx @biomejs/biome check packages/evidence/src/ffmpeg-binaries.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/evidence/src/ffmpeg-binaries.ts:200-245`

## Risks

Low. Prevents surrogate corruption in ffmpeg binary install failure diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Evidence package binary resolver; no UI layout touched)
- [x] `audit:browser` — N/A (Binary resolver)
- [x] `build` — Clean build across workspace
- [x] `test` — 10/10 pass in `ffmpeg-binaries.test.ts`
- [x] `lint` — Biome clean
