### PR TITLE
fix(cloud-shared): use surrogate-safe truncateWellFormed on stream error cause in shared runtime chat

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -7,7 +7,13 @@
  */
 
 import crypto from "node:crypto";
-import { ChannelType, ElizaError, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
+import {
+  ChannelType,
+  ElizaError,
+  MESSAGE_SOURCE_CLIENT_CHAT,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core/edge";
 import { parseSharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { UserCharacter } from "../../../db/repositories/characters";
 import { sharedTurnTracesRepository } from "../../../db/repositories/shared-turn-traces";
@@ -1922,7 +1928,7 @@ export class SharedRuntimeChatService {
             error: error instanceof Error ? error.message : String(error),
             cause:
               error instanceof Error && error.cause instanceof Error
-                ? error.cause.message.slice(0, 240)
+                ? truncateWellFormed(toWellFormedUnicode(error.cause.message), 240)
                 : undefined,
           });
           if (!consumerCanceled) {


### PR DESCRIPTION
## Summary

Replaces raw `.slice(0, 240)` string slicing in `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts:1925` on stream error causes with `truncateWellFormed(toWellFormedUnicode(error.cause.message), 240)` from `@elizaos/core/edge`.

## Changes

- In `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts:1925`, safely truncate error cause messages without splitting UTF-16 surrogate pairs during stream failure logging.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`d750add836`) |
| --- | --- | --- |
| `bun test --cwd packages/cloud/shared src/lib/services/shared-runtime/shared-runtime-chat.test.ts` | 38 pass (38 tests) | 38 pass (38 tests) |
| `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts:14`
- `packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts:1925`

## Risks

Low. Prevents surrogate corruption in cloud shared runtime stream error diagnostics.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud shared chat service; no UI layout touched)
- [x] `audit:browser` — N/A (Chat streaming service)
- [x] `build` — Clean build across workspace
- [x] `test` — 38/38 pass in `shared-runtime-chat.test.ts`
- [x] `lint` — Biome clean
