### PR TITLE
fix(browser): safe NaN handling in browser target resolution sort comparator

### DIFF
--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -373,7 +373,13 @@ export class BrowserService extends Service {
     }
 
     return available
-      .sort((a, b) => b.score - a.score || a.order - b.order)
+      .sort((a, b) => {
+        const aScore = Number.isFinite(a.score) ? a.score : 0;
+        const bScore = Number.isFinite(b.score) ? b.score : 0;
+        const aOrder = Number.isFinite(a.order) ? a.order : 0;
+        const bOrder = Number.isFinite(b.order) ? b.order : 0;
+        return bScore - aScore || aOrder - bOrder;
+      })
       .map(({ target }) => target);
   }
 


### PR DESCRIPTION
## Summary

Validates candidate score and order values with `Number.isFinite(...)` in `resolveTargets` (`plugins/plugin-browser/src/browser-service.ts:376`) to prevent `NaN` return values in sort comparators when prioritizing available browser targets.

## Changes

- In `plugins/plugin-browser/src/browser-service.ts:376`, guard `score` and `order` comparisons with `Number.isFinite(...)` to ensure strict total ordering during browser target selection.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`a14a0b4877`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-browser/src/__tests__/browser-service.test.ts` | 22 pass (22 tests) | 22 pass (22 tests) |
| `bunx @biomejs/biome check plugins/plugin-browser/src/browser-service.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-browser/src/browser-service.ts:374-380`

## Risks

Low. Prevents non-deterministic target candidate sorting when target scores or ordering are non-finite.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Browser plugin service; no UI layout touched)
- [x] `audit:browser` — N/A (Target selector)
- [x] `build` — Clean build across workspace
- [x] `test` — 22/22 pass in `browser-service.test.ts`
- [x] `lint` — Biome clean
