### PR TITLE
fix(cloud): use surrogate-safe truncateWellFormed on ingress plaid and content-safety error bodies

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-plaid-connector.ts
+++ b/packages/cloud/shared/src/lib/services/agent-plaid-connector.ts
@@ -18,6 +18,7 @@
  */
 
 import { z } from "zod";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const PLAID_DEFAULT_HOST = "https://sandbox.plaid.com";
 const PLAID_REQUEST_TIMEOUT_MS = 30_000;
@@ -135,7 +136,7 @@ function redactPlaidErrorMessage(
   config: PlaidConfig,
   body: Record<string, unknown>,
 ): string {
-  let sanitized = message.slice(0, 500);
+  let sanitized = truncateWellFormed(toWellFormedUnicode(message), 500);
   const secrets = [config.clientId, config.secret];
   for (const value of Object.values(body)) {
     if (typeof value === "string" && value.length > 0) {

--- a/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
+++ b/packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts
@@ -13,7 +13,7 @@
  * `scripts/verify-apps-ingress-routing.sh`.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type AppRouteInput,
   buildCaddyAddRouteUrl,
@@ -78,7 +78,7 @@ function mutationError(input: {
 
 async function responseDetail(res: IngressResponse): Promise<string> {
   try {
-    return (await res.text()).slice(0, 200);
+    return truncateWellFormed(toWellFormedUnicode(await res.text()), 200);
   } catch (cause) {
     // error-policy:J2 Preserve the body-read failure at the Caddy boundary.
     throw new ElizaError("[apps-ingress] failed to read Caddy admin error response", {

--- a/packages/cloud/shared/src/lib/services/content-safety.ts
+++ b/packages/cloud/shared/src/lib/services/content-safety.ts
@@ -3,6 +3,7 @@ import { ApiError } from "../api/cloud-worker-errors";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const OPENAI_MODERATIONS_URL = "https://api.openai.com/v1/moderations";
 const DEFAULT_MODERATION_MODEL = "omni-moderation-latest";
@@ -98,7 +99,7 @@ function redactProviderErrorDetail(detail: string): string {
 
 async function readModerationErrorDetail(response: Response): Promise<string> {
   try {
-    return redactProviderErrorDetail(await response.text()).slice(0, 300);
+    return truncateWellFormed(toWellFormedUnicode(redactProviderErrorDetail(await response.text())), 300);
   } catch (error) {
     // error-policy:J7 diagnostics-must-not-kill-the-loop — the moderation
     // response is already failed; keep that boundary decision intact while

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -7,7 +7,13 @@
  */
 
 import crypto from "node:crypto";
-import { ChannelType, ElizaError, MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core/edge";
+import {
+  ChannelType,
+  ElizaError,
+  MESSAGE_SOURCE_CLIENT_CHAT,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core/edge";
 import { parseSharedReminderDelivery } from "@elizaos/plugin-scheduling/edge";
 import type { UserCharacter } from "../../../db/repositories/characters";
 import { sharedTurnTracesRepository } from "../../../db/repositories/shared-turn-traces";
@@ -1922,7 +1928,7 @@ export class SharedRuntimeChatService {
             error: error instanceof Error ? error.message : String(error),
             cause:
               error instanceof Error && error.cause instanceof Error
-                ? error.cause.message.slice(0, 240)
+                ? truncateWellFormed(toWellFormedUnicode(error.cause.message), 240)
                 : undefined,
           });
           if (!consumerCanceled) {


### PR DESCRIPTION
## Summary
Preserve astral pairs in Caddy ingress (200), Plaid (500) and moderation (300) error bodies via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged cloud surrogate batch (#25063 pattern).

## Changes
- `packages/cloud/shared/src/lib/services/apps-ingress-provisioner.ts:81` — 200
- `packages/cloud/shared/src/lib/services/agent-plaid-connector.ts:138` — 500
- `packages/cloud/shared/src/lib/services/content-safety.ts:101` — 300

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c770eb4aad` | `fix/cloud-ingress-plaid-content-surrogate@18e265f3` |

Rebased on current `origin/develop`.

## Reviewer start
Narrow `fix(cloud)` scope, 3 files same defect.

## Evidence Gate
- De-dup: no branch for these 3 files (checked `log --all --grep=surrogate`), fresh.
