### PR TITLE
fix(evidence): use surrogate-safe truncateWellFormed on vision-qa and ocr error details

### DIFF
--- a/packages/evidence/src/analyzers/ocr/engines.ts
+++ b/packages/evidence/src/analyzers/ocr/engines.ts
@@ -29,6 +29,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { EvidenceError } from "../../errors.ts";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const execFileAsync = promisify(execFile);
 
@@ -343,7 +344,7 @@ async function runAppleVision(
           // output; the bare SyntaxError says nothing about which helper broke.
           reject(
             new EvidenceError(
-              `apple-vision helper emitted unparseable output: ${line.slice(0, 160)}`,
+              `apple-vision helper emitted unparseable output: ${truncateWellFormed(toWellFormedUnicode(line), 160)}`,
               {
                 code: "APPLE_VISION_OCR_FAILED",
                 cause,
@@ -357,7 +358,7 @@ async function runAppleVision(
         if (!record) {
           reject(
             new EvidenceError(
-              `apple-vision helper record missing ok/text fields: ${line.slice(0, 160)}`,
+              `apple-vision helper record missing ok/text fields: ${truncateWellFormed(toWellFormedUnicode(line), 160)}`,
               { code: "APPLE_VISION_OCR_FAILED", context: { imagePath } },
             ),
           );
@@ -692,5 +693,5 @@ function isEnoent(error: unknown): boolean {
 }
 
 function errMessage(error: unknown): string {
-  return String(error instanceof Error ? error.message : error).slice(0, 160);
+  return truncateWellFormed(toWellFormedUnicode(String(error instanceof Error ? error.message : error)), 160);
 }

--- a/packages/evidence/src/vision-qa/ask.ts
+++ b/packages/evidence/src/vision-qa/ask.ts
@@ -14,6 +14,7 @@
  */
 
 import { EvidenceError } from "../errors.ts";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type BackendResponse,
   parseAnswers,
@@ -102,7 +103,7 @@ async function postJson(
       `vision-qa backend returned ${response.status} ${response.statusText}`,
       {
         code: "VISION_BACKEND_HTTP",
-        context: { status: response.status, detail: detail.slice(0, 500) },
+        context: { status: response.status, detail: truncateWellFormed(toWellFormedUnicode(detail), 500) },
       },
     );
   }


### PR DESCRIPTION
## Summary
Preserve astral pairs in vision-qa detail (500) and apple-vision ocr (160) via `toWellFormedUnicode` + `truncateWellFormed`.

## Changes
- `packages/evidence/src/vision-qa/ask.ts:105`
- `packages/evidence/src/analyzers/ocr/engines.ts:346,360,695`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c770eb4aad` | `fix/evidence-ffmpeg-vision-surrogate@d381b336` |
