### PR TITLE
fix(core): safe NaN handling in advanced-memory createdAt sorts

### DIFF
--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -248,7 +248,11 @@ async function prepareSummary(
 	});
 	const allDialogueMessages = allMessages
 		.filter(isDialogueMessage)
-		.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+		.sort((a, b) => {
+			const aTime = Number.isFinite(a.createdAt as unknown as number) ? (a.createdAt as unknown as number) : 0;
+			const bTime = Number.isFinite(b.createdAt as unknown as number) ? (b.createdAt as unknown as number) : 0;
+			return aTime - bTime;
+		});
 	const existingSummary = await memoryService.getCurrentSessionSummary(
 		message.roomId,
 	);
@@ -302,7 +306,11 @@ async function prepareLongTermMemory(
 		memoryService,
 		recentMessages: recentRaw
 			.filter((memory) => !isSyntheticConversationArtifactMemory(memory))
-			.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0)),
+			.sort((a, b) => {
+			const aTime = Number.isFinite(a.createdAt as unknown as number) ? (a.createdAt as unknown as number) : 0;
+			const bTime = Number.isFinite(b.createdAt as unknown as number) ? (b.createdAt as unknown as number) : 0;
+			return aTime - bTime;
+		}),
 		existingMemories,
 		currentMessageCount,
 	};


### PR DESCRIPTION
## Summary
Guard `createdAt` with `Number.isFinite` (`||0` does not guard `NaN`).

## Changes
- `packages/core/src/features/advanced-memory/evaluators/memory-items.ts:251,305`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c770eb4aad` | `fix/core-memory-items-sort-safe-sort@03774be1` |
