### PR TITLE
fix(core): safe NaN handling in channel-topics score sort

### DIFF
--- a/packages/core/src/services/channel-topics.ts
+++ b/packages/core/src/services/channel-topics.ts
@@ -336,7 +336,11 @@ export function matchTopicRooms(
 			});
 		}
 	}
-	scored.sort((a, b) => b.score - a.score || a.roomId.localeCompare(b.roomId));
+	scored.sort((a, b) => {
+		const aScore = Number.isFinite(a.score) ? a.score : 0;
+		const bScore = Number.isFinite(b.score) ? b.score : 0;
+		return bScore - aScore || a.roomId.localeCompare(b.roomId);
+	});
 	const selected =
 		limit === undefined ? scored : scored.slice(0, Math.max(0, limit));
 	return selected.map(({ score, ...hit }) => hit);


### PR DESCRIPTION
## Summary
Guard score with `Number.isFinite`.

## Changes
- `packages/core/src/services/channel-topics.ts:339`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@c770eb4aad` | `fix/core-channel-topics-score-safe-sort@8e3a14c8` |
