### PR TITLE
test(plugin-fish-audio): regression coverage for the stream-only unhandled-rejection guard (#25072)

### DIFF
--- a/plugins/plugin-fish-audio/__tests__/streaming.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/streaming.test.ts
@@ -1,6 +1,13 @@
 /**
  * Fish Audio plugin TTS tests with an in-memory WebSocket.
  *
+ * Includes the regression guard for issue #25072: a streaming consumer that
+ * only iterates `audioStream` (the documented `for await` pattern in
+ * packages/core/src/types/model.ts) must never leave the parallel `bytes`
+ * promise as an unhandled rejection when synthesis fails mid-stream. These
+ * tests fail if the passive `void bytes.catch(...)` guard in `src/index.ts` is
+ * removed, while every other assertion in this file stays green without it.
+ *
  * Live Fish Audio coverage runs only with explicitly supplied credentials and
  * can write an inspectable WAV when `FISH_AUDIO_EVIDENCE_PATH` is provided:
  * `ELIZA_TTS_FISH_ENABLED=true FISH_AUDIO_API_KEY=... FISH_AUDIO_REFERENCE_ID=... \
@@ -530,6 +537,118 @@ describe("fishAudioPlugin", () => {
     vi.advanceTimersByTime(25);
 
     expect(socket?.readyState).toBe(3);
+  });
+
+  test("stream-only consumer of an early-closed synthesis leaks no unhandled rejection", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const leaks: unknown[] = [];
+    const onUnhandled = (reason: unknown) => leaks.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const result = await handleFishAudioTextToSpeech(
+        runtime({
+          ELIZA_TTS_FISH_ENABLED: "true",
+          FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+          FISH_AUDIO_API_KEY: "key",
+          FISH_AUDIO_REFERENCE_ID: "voice",
+        }),
+        { text: "stream only", audioStream: true },
+      );
+      if (result instanceof Uint8Array)
+        throw new Error("Expected streaming result");
+      // Consume ONLY the documented `for await (chunk of audioStream)` surface
+      // from packages/core/src/types/model.ts:830 and never touch result.bytes.
+      const iterator = result.audioStream[Symbol.asyncIterator]();
+      await Promise.resolve();
+      const socket = FakeFishSocket.instances.at(-1);
+      socket?.emitAudio(new Uint8Array([5, 6]));
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: new Uint8Array([5, 6]),
+      });
+      socket?.close(1011, "provider failed");
+
+      await expect(iterator.next()).rejects.toMatchObject({
+        code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
+      });
+      // Give Node a full task tick to surface any unhandled bytes rejection.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(leaks).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  test("stream-only consumer of a buffer-ceiling breach leaks no unhandled rejection", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const leaks: unknown[] = [];
+    const onUnhandled = (reason: unknown) => leaks.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const result = await handleFishAudioTextToSpeech(
+        runtime({
+          ELIZA_TTS_FISH_ENABLED: "true",
+          FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+          FISH_AUDIO_API_KEY: "key",
+          FISH_AUDIO_REFERENCE_ID: "voice",
+        }),
+        { text: "stream only overflow", audioStream: true, maxBufferBytes: 3 },
+      );
+      if (result instanceof Uint8Array)
+        throw new Error("Expected streaming result");
+      const iterator = result.audioStream[Symbol.asyncIterator]();
+      await Promise.resolve();
+      const socket = FakeFishSocket.instances.at(-1);
+      socket?.emitAudio(new Uint8Array([1, 2]));
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: new Uint8Array([1, 2]),
+      });
+      socket?.emitAudio(new Uint8Array([3, 4]));
+
+      await expect(iterator.next()).rejects.toMatchObject({
+        code: "FISH_AUDIO_MAX_BUFFER_BYTES_EXCEEDED",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(leaks).toEqual([]);
+      expect(socket?.readyState).toBe(3);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  test("the passive bytes guard does not swallow the failure for explicit awaiters", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const result = await handleFishAudioTextToSpeech(
+      runtime({
+        ELIZA_TTS_FISH_ENABLED: "true",
+        FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+        FISH_AUDIO_API_KEY: "key",
+        FISH_AUDIO_REFERENCE_ID: "voice",
+      }),
+      { text: "stream then bytes", audioStream: true },
+    );
+    if (result instanceof Uint8Array)
+      throw new Error("Expected streaming result");
+    const iterator = result.audioStream[Symbol.asyncIterator]();
+    await Promise.resolve();
+    const socket = FakeFishSocket.instances.at(-1);
+    socket?.emitAudio(new Uint8Array([5, 6]));
+    await iterator.next();
+    socket?.close(1011, "provider failed");
+    await expect(iterator.next()).rejects.toMatchObject({
+      code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
+    });
+
+    // A real consumer that DID reach `const full = await result.bytes` after an
+    // error still observes the same typed rejection; the guard only marks the
+    // source promise handled, it does not resolve or swallow it.
+    await expect(result.bytes).rejects.toMatchObject({
+      code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
+    });
   });
 
   test("wraps live PCM evidence in a valid mono WAV container", () => {


### PR DESCRIPTION
# Relates to

Closes #25072

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package gates (`test`, `typecheck`, `lint`) were run after sync; the repo-wide `bun run verify` blocker is recorded under **Known gaps** below.
- [x] A reviewer can confirm the change works without reading the code: the negative-control run below shows the two new tests fail if the guard is deleted, and pass with it.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` full pass — see **Known gaps** (unrelated install/registry blocker on this machine); focused package `test` + `typecheck` + `lint` all pass.

# Risks

Low. This PR is **test-only** — it adds regression coverage to `plugins/plugin-fish-audio/__tests__/streaming.test.ts` and touches no production code, no public surface, and no other package.

# Background

## What does this PR do?

Adds the missing regression test for issue #25072: a streaming TTS consumer that follows the documented `for await (const chunk of result.audioStream) …; const full = await result.bytes;` pattern (contract example at `packages/core/src/types/model.ts:830-831`) must not leak the parallel `bytes` promise as a Node `unhandledRejection` when synthesis fails mid-stream. Under Node 24's default `--unhandled-rejections=throw` that leak crashes the agent host.

**Important scope note (verified before writing code):** the *runtime* fix — the passive `void bytes.catch(() => undefined)` guard in `src/index.ts` — already landed on `develop` in PR #24745 (merged 2026-08-22 15:30), ~12 hours **before** this issue was filed (2026-08-23 03:00). The issue's proposed 2-line change would therefore be a **no-op**, so per the contribution guardrails I re-scoped honestly to the genuine remaining gap.

That gap is real and provable: **no existing test covers the stream-only path.** With the guard line deleted, all 17 pre-existing tests still pass — the guard could be silently removed by a future refactor and CI would stay green. This PR closes that gap with three tests that drive the in-memory `FakeFishSocket` to fail mid-stream while consuming **only** `audioStream`:

1. **Early close** (`close(1011, "provider failed")` after one chunk): the iterator's `next()` rejects with `FISH_AUDIO_WEBSOCKET_CLOSED_EARLY`, and a `process.on("unhandledRejection")` spy records **zero** leaks.
2. **Buffer-ceiling breach** (`maxBufferBytes: 3`): the iterator's `next()` rejects with `FISH_AUDIO_MAX_BUFFER_BYTES_EXCEEDED`, the socket closes (`readyState === 3`), and the spy records **zero** leaks.
3. **Guard does not swallow**: a consumer that *does* reach `await result.bytes` after an error still observes the same typed `FISH_AUDIO_WEBSOCKET_CLOSED_EARLY` rejection — proving the guard only marks the source promise handled, it does not resolve or swallow the failure.

## What kind of change is this?

Bug fix — regression coverage that locks in the already-landed `#24745` guard (non-breaking, test-only).

# Documentation changes needed?

No. Behavior is unchanged; the test file header documents the invariant.

# Testing

## Where should a reviewer start?

`plugins/plugin-fish-audio/__tests__/streaming.test.ts` — the three new tests in the `fishAudioPlugin` describe block, plus the updated file header.

## Detailed testing steps

```bash
# From plugins/plugin-fish-audio (after building @elizaos/core):
node_modules/.bin/vitest run          # 20 passed | 1 skipped
bun run typecheck                     # clean
bunx @biomejs/biome check __tests__/streaming.test.ts src/index.ts   # clean

# Negative control — proves the tests are true regression guards:
# delete the `void bytes.catch(() => undefined)` line from src/index.ts, then:
node_modules/.bin/vitest run
#   → exactly the 2 stream-only tests FAIL ("expected [ …(1) ] to deeply equal []"),
#     all 18 other tests stay green. Restore the line → all pass.
```

# Evidence Gate

<!-- evidence-head:55a439f6e725f1ea46ec16e2295c0c6fed6dfe71 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change to a .ts test file, no rendered UI surface exists`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change to a .ts test file, no rendered UI surface exists`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - test-only change with no user-facing flow to record`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — focused `vitest run` over the in-memory WebSocket transport (guard present):
  <details><summary>vitest output / test logs — guard present (20 passed | 1 skipped)</summary>

  ```
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > returns AudioStreamResult when audioStream is true and sends MessagePack frames 7ms
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > rejects when Fish closes before a finish frame 2ms
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > stream-only consumer of an early-closed synthesis leaks no unhandled rejection 27ms
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > stream-only consumer of a buffer-ceiling breach leaks no unhandled rejection 26ms
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > the passive bytes guard does not swallow the failure for explicit awaiters 1ms
   ↓ __tests__/streaming.test.ts > fishAudioPlugin > live Fish Audio realtime WebSocket returns PCM bytes
   Test Files  1 passed (1)
        Tests  20 passed | 1 skipped (21)
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend surface is exercised by this change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior is added or altered`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — negative-control run proving the new tests catch the regression (guard line removed):
  <details><summary>vitest output / test logs — guard REMOVED (2 failed | 18 passed)</summary>

  ```
  ### NEGATIVE CONTROL: guard line 'void bytes.catch(() => undefined)' REMOVED from src/index.ts
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > rejects both result surfaces and closes when audio exceeds the buffer ceiling 4ms
   × __tests__/streaming.test.ts > fishAudioPlugin > stream-only consumer of an early-closed synthesis leaks no unhandled rejection 34ms
     → expected [ …(1) ] to deeply equal []
   × __tests__/streaming.test.ts > fishAudioPlugin > stream-only consumer of a buffer-ceiling breach leaks no unhandled rejection 28ms
     → expected [ …(1) ] to deeply equal []
   ✓ __tests__/streaming.test.ts > fishAudioPlugin > the passive bytes guard does not swallow the failure for explicit awaiters 1ms
        Tests  2 failed | 18 passed | 1 skipped (21)
  ```
  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - change has no rendered visual surface to OCR`.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model behavior is added or altered.

## Backend + frontend logs

Backend: the focused vitest run (in-memory WebSocket transport) is the code path firing end to end; passing and negative-control runs are inlined in the evidence rows above. Frontend: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - test-only change with no rendered UI surface.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - no live TTS round-trip is added; the change is a deterministic in-memory-transport regression test. The pre-existing opt-in live Fish Audio test is unchanged.

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this machine: `bun install` requires overriding a global `minimumReleaseAge` policy to resolve unrelated recently-published packages (`viem`, `@cloudflare/playwright`), which are outside this diff. The owning-package gates that this change affects — `vitest run` (20 passed | 1 skipped), `tsc --noEmit` (clean), and Biome `check` (clean) — all pass. This is a test-only diff to a single plugin.
- Evidence is attached inline (`<details>` blocks) rather than as `pr-evidence` release assets: fork contributors lack push access to the upstream `pr-evidence` release (asset upload returns HTTP 404), which is the documented first-party route only for maintainers. CONTRIBUTING.md and the root AGENTS.md both prescribe inline `<details>` logs for exactly this case.

## Maintainer CI exception record

`N/A - no exception requested`

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c98b2131b8c4064458f0c4c31354350c1d45528a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c98b2131b8c4064458f0c4c31354350c1d45528a:packages/skills/skills/contribute-to-eliza"} -->
