### PR TITLE
registry: add plugin-signalpulse (SignalPulse — trade signals, sports/racing/prediction markets, x402)

### DIFF
--- a/packages/registry/entries/third-party/plugin-signalpulse.json
+++ b/packages/registry/entries/third-party/plugin-signalpulse.json
@@ -1,0 +1,18 @@
+{
+  "package": "plugin-signalpulse",
+  "repository": "github:GTCC777/plugin-signalpulse",
+  "kind": "plugin",
+  "description": "SignalPulse market intelligence for agents: trade-signal scanners and natural-language market analysis across FX, metals, indices, equities, futures, crypto, 35+ sports, horse & greyhound racing, golf, F1, fantasy, and prediction markets (Polymarket weather/politics/macro/attention ladders) — pay-per-call x402 USDC on Base, or a prepaid credit key. Free machine catalog with exact per-call prices drift-locked to what each endpoint actually charges. Quote-first: every paid call previews its exact price, asset, recipient — and for analysis, the exact question, which is hashed into the authorization — and executes only when the user's entire reply is \"pay <CODE>\" (whole-message match; mentions, negations and questions never authorize), under a per-call cap and a per-process daily budget. Execute-once is enforced on-chain: the EIP-3009 nonce of each signed transfer is the authorization hash, so a confirmed quote can settle at most once even across hosts sharing a wallet. Every paid response carries the server's own agent_action verdict (allow/warn/skip/block); skip bodies are refund-honest and never settled.",
+  "homepage": "https://signalpulse.theaslangroupllc.com",
+  "version": "0.1.1",
+  "tags": [
+    "x402",
+    "micropayments",
+    "usdc",
+    "base",
+    "trading-signals",
+    "sports-betting",
+    "prediction-markets",
+    "market-analysis"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -2037,6 +2037,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "plugin-signalpulse": {
+      "git": {
+        "repo": "GTCC777/plugin-signalpulse",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-signalpulse",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "SignalPulse market intelligence for agents: trade-signal scanners and natural-language market analysis across FX, metals, indices, equities, futures, crypto, 35+ sports, horse & greyhound racing, golf, F1, fantasy, and prediction markets (Polymarket weather/politics/macro/attention ladders) — pay-per-call x402 USDC on Base, or a prepaid credit key. Free machine catalog with exact per-call prices drift-locked to what each endpoint actually charges. Quote-first: every paid call previews its exact price, asset, recipient — and for analysis, the exact question, which is hashed into the authorization — and executes only when the user's entire reply is \"pay <CODE>\" (whole-message match; mentions, negations and questions never authorize), under a per-call cap and a per-process daily budget. Execute-once is enforced on-chain: the EIP-3009 nonce of each signed transfer is the authorization hash, so a confirmed quote can settle at most once even across hosts sharing a wallet. Every paid response carries the server's own agent_action verdict (allow/warn/skip/block); skip bodies are refund-honest and never settled.",
+      "homepage": "https://signalpulse.theaslangroupllc.com",
+      "topics": [
+        "x402",
+        "micropayments",
+        "usdc",
+        "base",
+        "trading-signals",
+        "sports-betting",
+        "prediction-markets",
+        "market-analysis"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-syndicate": {
       "git": {
         "repo": "sailorpepe/plugin-syndicate",


### PR DESCRIPTION
## What

Adds a third-party registry entry for **plugin-signalpulse** — SignalPulse market intelligence for agents: trade-signal scanners and natural-language market analysis across FX, metals, indices, equities, futures, crypto, **35+ sports, horse & greyhound racing, golf, F1, fantasy, and prediction markets** (Polymarket weather/politics/macro/attention ladders). To our knowledge the first sports/racing/prediction-market data seller in the registry.

- Repo: https://github.com/GTCC777/plugin-signalpulse (MIT; 71 tests; live quote evidence in EVIDENCE.md)
- Payments: pay-per-call **x402 USDC on Base** via `@x402/*` 2.x (or a prepaid `sp_` credit key — no wallet needed)
- Free machine catalog (`/api/preflight`) with per-call prices **drift-locked server-side** to what each endpoint actually charges

## Spend-safety (the bar set in the plugin-pulsenetwork 0.2.0 review, #18493 — same maintained scaffold, same author)

- Quote-first with a **content-bound confirmation**: the `pay <CODE>` code hashes the exact operation bytes (URL, method, **request-body hash** — an analysis authorization pays for exactly the question the user saw — amount, asset, network, recipient, nonce); agent-authored text can never trigger a payment; quotes expire in 10 minutes
- **Pinned payment policy** in code before any signature: exact-scheme USDC on Base to SignalPulse's published wallet only, ≤ the per-call cap (default $2.60) — the server's Solana/BSC lanes are deliberately refused
- Daily budget (default $5.00, UTC, debit-before-pay with proof-gated refunds), execute-once charge ledger, single-host allowlist, payment mutex
- Server-side `agent_action: allow|warn|skip|block` verdict on every paid 200 (skip bodies are refund-honest — x402 buyers are never settled for a no-play), surfaced as the first line of every paid reply

npm publish of `plugin-signalpulse@0.1.0` is queued (same account as `plugin-pulsenetwork`).