### PR TITLE
fix(plugin-google-workspace): all-day event reschedule emits mixed date/dateTime rejected by Google Calendar

### DIFF
--- a/plugins/plugin-google-workspace/src/calendar.allday-patch.test.ts
+++ b/plugins/plugin-google-workspace/src/calendar.allday-patch.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression coverage for all-day event rescheduling. Exercises the real
+ * GoogleCalendarClient.updateEvent over a mock client factory whose events.get
+ * returns an all-day (date-only) event and whose events.patch echoes the
+ * request body. When only one bound of an all-day event is patched, the derived
+ * counterpart must stay a date-only {date} value so the patch body does not mix
+ * an all-day date with a timed dateTime — the exact shape Google Calendar's
+ * events.patch rejects with HTTP 400 ("Cannot combine date and dateTime").
+ */
+import type { calendar_v3 } from "googleapis";
+import { describe, expect, it, vi } from "vitest";
+import { GoogleCalendarClient } from "./calendar";
+import type { GoogleApiClientFactory } from "./client-factory";
+
+type PatchMock = ReturnType<typeof vi.fn>;
+
+function updateEventCapture(existing: calendar_v3.Schema$Event): {
+  client: GoogleCalendarClient;
+  patch: PatchMock;
+} {
+  const patch = vi.fn(async (params: calendar_v3.Params$Resource$Events$Patch) => ({
+    data: { id: params.eventId, ...params.requestBody },
+  }));
+  const events = {
+    get: vi.fn(async () => ({ data: existing })),
+    patch,
+  };
+  const factory = {
+    calendar: vi.fn(async () => ({ events })),
+  } as unknown as GoogleApiClientFactory;
+  return { client: new GoogleCalendarClient(factory), patch };
+}
+
+function patchedBody(patch: PatchMock): calendar_v3.Schema$Event {
+  const call = patch.mock.calls[0]?.[0] as calendar_v3.Params$Resource$Events$Patch;
+  return call.requestBody as calendar_v3.Schema$Event;
+}
+
+describe("GoogleCalendarClient all-day reschedule patch", () => {
+  it("keeps the derived end date-only when only the start of an all-day event is patched", async () => {
+    const { client, patch } = updateEventCapture({
+      id: "allday-1",
+      start: { date: "2026-06-01" },
+      end: { date: "2026-06-03" },
+    });
+
+    await client.updateEvent({ accountId: "acct-1", eventId: "allday-1", start: "2026-06-05" });
+
+    const body = patchedBody(patch);
+    // Existing span is 2 whole days (Jun 1 -> Jun 3), preserved from the new start.
+    expect(body.start?.date).toBe("2026-06-05");
+    expect(body.end?.date).toBe("2026-06-07");
+    expect(body.start?.dateTime).toBeUndefined();
+    expect(body.end?.dateTime).toBeUndefined();
+  });
+
+  it("keeps the derived start date-only when only the end of an all-day event is patched", async () => {
+    const { client, patch } = updateEventCapture({
+      id: "allday-2",
+      start: { date: "2026-06-01" },
+      end: { date: "2026-06-03" },
+    });
+
+    await client.updateEvent({ accountId: "acct-1", eventId: "allday-2", end: "2026-06-10" });
+
+    const body = patchedBody(patch);
+    expect(body.end?.date).toBe("2026-06-10");
+    expect(body.start?.date).toBe("2026-06-08");
+    expect(body.start?.dateTime).toBeUndefined();
+    expect(body.end?.dateTime).toBeUndefined();
+  });
+
+  it("defaults to a one-day span when the existing all-day duration is unknown", async () => {
+    const { client, patch } = updateEventCapture({
+      id: "allday-3",
+      start: { date: "2026-06-01" },
+      // No end bound -> span cannot be inferred and must default to one day.
+    });
+
+    await client.updateEvent({ accountId: "acct-1", eventId: "allday-3", start: "2026-06-05" });
+
+    const body = patchedBody(patch);
+    expect(body.start?.date).toBe("2026-06-05");
+    expect(body.end?.date).toBe("2026-06-06");
+    expect(body.end?.dateTime).toBeUndefined();
+  });
+
+  it("still derives a timed dateTime end for timed events (unchanged behavior)", async () => {
+    const { client, patch } = updateEventCapture({
+      id: "timed-1",
+      start: { dateTime: "2026-06-01T09:00:00.000Z" },
+      end: { dateTime: "2026-06-01T10:00:00.000Z" },
+    });
+
+    await client.updateEvent({
+      accountId: "acct-1",
+      eventId: "timed-1",
+      start: "2026-06-05T09:00:00.000Z",
+    });
+
+    const body = patchedBody(patch);
+    expect(body.start?.dateTime).toBe("2026-06-05T09:00:00.000Z");
+    expect(body.end?.dateTime).toBe("2026-06-05T10:00:00.000Z");
+    expect(body.start?.date).toBeUndefined();
+    expect(body.end?.date).toBeUndefined();
+  });
+});

--- a/plugins/plugin-google-workspace/src/calendar.ts
+++ b/plugins/plugin-google-workspace/src/calendar.ts
@@ -987,6 +987,8 @@ function readEventInstant(
   return null;
 }
 
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
 function normalizePatchBounds(params: {
   start?: string;
   end?: string;
@@ -1002,6 +1004,28 @@ function normalizePatchBounds(params: {
   const existingEnd = eventDateValue(params.existing.end);
   const existingDurationMs =
     existingStart && existingEnd ? Date.parse(existingEnd) - Date.parse(existingStart) : Number.NaN;
+
+  // The single supplied bound decides how toEventDateTime will serialize it: a
+  // date-only "YYYY-MM-DD" value emits {date}, anything else emits {dateTime}.
+  // The derived counterpart must match that shape, otherwise the patch body
+  // mixes an all-day date with a timed dateTime and Google Calendar's
+  // events.patch rejects it with HTTP 400 ("Cannot combine date and dateTime").
+  const anchor = start ?? end;
+  if (isDateOnly(anchor)) {
+    // All-day reschedule: preserve the existing span as whole calendar days and
+    // derive the missing bound as a date-only string so both bounds stay {date}.
+    const spanDays =
+      Number.isFinite(existingDurationMs) && existingDurationMs > 0
+        ? Math.max(1, Math.round(existingDurationMs / MILLISECONDS_PER_DAY))
+        : 1;
+    if (start && !end) {
+      end = addCalendarDays(start, spanDays);
+    } else if (end && !start) {
+      start = addCalendarDays(end, -spanDays);
+    }
+    return { start, end };
+  }
+
   const fallbackDurationMs =
     Number.isFinite(existingDurationMs) && existingDurationMs > 0
       ? existingDurationMs
@@ -1016,11 +1040,21 @@ function normalizePatchBounds(params: {
   return { start, end };
 }
 
+function isDateOnly(value: string | undefined): value is string {
+  return value !== undefined && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function addCalendarDays(dateOnly: string, days: number): string {
+  const base = new Date(`${dateOnly}T00:00:00.000Z`);
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString().slice(0, 10);
+}
+
 function toEventDateTime(
   value: string,
   timeZone: string | undefined
 ): calendar_v3.Schema$EventDateTime {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+  if (isDateOnly(value)) {
     return { date: value, timeZone };
   }
   return { dateTime: value, timeZone };


### PR DESCRIPTION
# Relates to

Closes #25104

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates were run (see **Known gaps / failures** for the `bun run verify` note).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to one internal helper (`normalizePatchBounds`) in `plugins/plugin-google-workspace/src/calendar.ts`. The timed (dateTime) reschedule path is byte-for-byte unchanged and is covered by a regression test. Only the previously-broken all-day single-bound patch path changes behavior.

# Background

## What does this PR do?

`GoogleCalendarClient.updateEvent()` reschedules an all-day event incorrectly when only one bound is supplied. `normalizePatchBounds` derived the missing bound by adding **milliseconds** and formatting an ISO `dateTime`, ignoring that the anchoring value is a date-only (all-day) value. The resulting patch body mixed an all-day `date` with a timed `dateTime`, e.g.:

```
PATCH BODY {"start":{"date":"2026-06-05"},"end":{"dateTime":"2026-06-07T00:00:00.000Z"}}
```

Google Calendar's `events.patch` rejects a body whose `start` and `end` mix `date` and `dateTime` with **HTTP 400** ("Cannot combine date and dateTime"). So a very common operation — moving an all-day event by patching only its `start` (or only its `end`) — fails and the reschedule is silently lost (surfaced as a definitive `GoogleCalendarMutationError` `not_accepted`).

**Fix:** when the single supplied bound is a date-only `YYYY-MM-DD` value, derive the missing bound as a whole-day date string. The existing span is preserved in **whole calendar days** (defaulting to one day when the span is unknown/zero) so `toEventDateTime` emits `{date}` for **both** bounds:

```
PATCH BODY {"start":{"date":"2026-06-05"},"end":{"date":"2026-06-07"}}
```

Timed (`dateTime`) events keep the millisecond-based derivation unchanged. Callers that already pass both bounds are unaffected — which is why existing tests missed this.

## Scope boundary

One function (`normalizePatchBounds`) plus two small pure helpers (`isDateOnly`, `addCalendarDays`). `toEventDateTime` is unchanged except for reusing the extracted `isDateOnly` predicate. No public API, DTO, or type surface changes.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. The behavior is an internal correctness fix of the Calendar client's patch-body construction; no documented contract changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/calendar.allday-patch.test.ts` — it drives the **real** `GoogleCalendarClient.updateEvent` through a mock client factory whose `events.get` returns an all-day event and whose `events.patch` echoes the request body, then asserts the exact `requestBody.start`/`requestBody.end` shapes.

## Detailed testing steps

```bash
bun install
node packages/shared/scripts/generate-keywords.mjs   # generate core i18n data
bun run --cwd packages/core build                     # build @elizaos/core for typecheck
bun run --cwd plugins/plugin-google-workspace test
bun run --cwd plugins/plugin-google-workspace typecheck
bun run --cwd plugins/plugin-google-workspace lint:check
```

Covered cases in the new test:
1. All-day **start-only** patch → both bounds `{date}`, end = start + existing whole-day span (2 days).
2. All-day **end-only** patch → both bounds `{date}`, start = end − span.
3. All-day with **unknown/zero** existing span → defaults to a 1-day span.
4. Regression: **timed** `dateTime` start-only patch still yields a `dateTime` end (unchanged behavior).

Failing-before / passing-after: with the fix reverted, cases 1–3 fail (derived `end.date`/`start.date` is `undefined` because a `dateTime` was emitted) while case 4 passes; with the fix, all four pass.

# Evidence Gate

<!-- evidence-head:6b1d476828b202bb142467bb5dad3b2f2781bc02 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this changes a server/runtime Google Calendar API client helper.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this changes a server/runtime Google Calendar API client helper.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; the changed path is an API-client library helper exercised by unit tests.`
<!-- evidence-row:backend-logs -->
- [x] Focused vitest run showing the real `GoogleCalendarClient.updateEvent` path (failing-before, passing-after) attached below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; deterministic API-client helper only.`
<!-- evidence-row:domain-artifacts -->
- [x] The actual Google Calendar `events.patch` request body produced by the code, before vs after the fix, attached below.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Frontend: N/A - no frontend involved.

Backend: focused package test output. Cases 1–3 fail before the fix (derived bound is a `dateTime`, so `end.date`/`start.date` is `undefined`); case 4 (timed) passes throughout. All four pass after the fix.

<details>
<summary>BEFORE FIX — focused vitest (3 failed, 1 passed)</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-25104/plugins/plugin-google-workspace

 ❯ src/calendar.allday-patch.test.ts (4 tests | 3 failed) 18ms
     × keeps the derived end date-only when only the start of an all-day event is patched 11ms
     × keeps the derived start date-only when only the end of an all-day event is patched 2ms
     × defaults to a one-day span when the existing all-day duration is unknown 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/calendar.allday-patch.test.ts > GoogleCalendarClient all-day reschedule patch > keeps the derived end date-only when only the start of an all-day event is patched
AssertionError: expected undefined to be '2026-06-07' // Object.is equality

- Expected:
"2026-06-07"

+ Received:
undefined

 ❯ src/calendar.allday-patch.test.ts:52:28
     50|     // Existing span is 2 whole days (Jun 1 -> Jun 3), preserved from …
     51|     expect(body.start?.date).toBe("2026-06-05");
     52|     expect(body.end?.date).toBe("2026-06-07");
       |                            ^
     53|     expect(body.start?.dateTime).toBeUndefined();
     54|     expect(body.end?.dateTime).toBeUndefined();

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  src/calendar.allday-patch.test.ts > GoogleCalendarClient all-day reschedule patch > keeps the derived start date-only when only the end of an all-day event is patched
AssertionError: expected undefined to be '2026-06-08' // Object.is equality

- Expected:
"2026-06-08"

+ Received:
undefined

 ❯ src/calendar.allday-patch.test.ts:68:30
     66|     const body = patchedBody(patch);
     67|     expect(body.end?.date).toBe("2026-06-10");
     68|     expect(body.start?.date).toBe("2026-06-08");
       |                              ^
     69|     expect(body.start?.dateTime).toBeUndefined();
     70|     expect(body.end?.dateTime).toBeUndefined();

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/calendar.allday-patch.test.ts > GoogleCalendarClient all-day reschedule patch > defaults to a one-day span when the existing all-day duration is unknown
AssertionError: expected undefined to be '2026-06-06' // Object.is equality

- Expected:
"2026-06-06"

+ Received:
undefined

 ❯ src/calendar.allday-patch.test.ts:84:28
     82|     const body = patchedBody(patch);
     83|     expect(body.start?.date).toBe("2026-06-05");
     84|     expect(body.end?.date).toBe("2026-06-06");
       |                            ^
     85|     expect(body.end?.dateTime).toBeUndefined();
     86|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
   Start at  04:46:53
   Duration  13.11s (transform 10.64s, setup 0ms, import 12.90s, tests 18ms, environment 0ms)
```

</details>

<details>
<summary>AFTER FIX — focused vitest (4 passed)</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/issue-25104/plugins/plugin-google-workspace


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  04:47:07
   Duration  13.46s (transform 10.79s, setup 0ms, import 13.17s, tests 10ms, environment 0ms)
```

</details>

## Domain artifacts — the actual `events.patch` request body

Existing all-day event `start {date:2026-06-01}, end {date:2026-06-03}`; patch `start=2026-06-05`, `end` omitted. This is the exact request body the client hands to Google's `events.patch`:

```
## BEFORE FIX (mixed date/dateTime -> Google Calendar events.patch returns HTTP 400):
PATCH BODY {"start":{"date":"2026-06-05"},"end":{"dateTime":"2026-06-07T00:00:00.000Z"}}

## AFTER FIX (both bounds date-only, internally consistent):
PATCH BODY {"start":{"date":"2026-06-05"},"end":{"date":"2026-06-07"}}
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no audio/voice path.

## Known gaps / failures

- `bun run verify` (the full repo gate) was not run to completion on this constrained build host: `bun install` requires overriding a global `minimumReleaseAge` guard to resolve already-lockfile-pinned transitive versions, and `@elizaos/core` must be built before dependent typecheck can resolve `@elizaos/core` declarations. I ran the owning package's gates directly and they pass on the synced head: `test` (28 files, 324 tests passed), `typecheck` (clean, after `bun run --cwd packages/core build`), and `lint:check` (no findings). No source outside `plugins/plugin-google-workspace` was modified.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c770eb4aad53eca4b28be01ae09623f3f389f9e9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c770eb4aad53eca4b28be01ae09623f3f389f9e9:packages/skills/skills/contribute-to-eliza"} -->
