### PR TITLE
test(agent): cover terminal command normalization

### DIFF
--- a/packages/agent/src/utils/__tests__/terminal-command.test.ts
+++ b/packages/agent/src/utils/__tests__/terminal-command.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTerminalCommand } from "./terminal-command.ts";
+
+describe("normalizeTerminalCommand", () => {
+  it("passes through plain commands", () => {
+    expect(normalizeTerminalCommand("ls -la")).toBe("ls -la");
+    expect(normalizeTerminalCommand("  echo hi  ")).toBe("echo hi");
+  });
+
+  it("wraps CDATA scripts in a base64 shell invocation", () => {
+    const out = normalizeTerminalCommand("<![CDATA[echo hello]]>");
+    expect(out).toMatch(
+      /^bash -lc "\$\(printf %s [A-Za-z0-9+/=]+ \| base64 -d\)"$/,
+    );
+  });
+
+  it("round-trips the original script via base64", () => {
+    const script = "echo hello && ls";
+    const out = normalizeTerminalCommand(`<![CDATA[${script}]]>`);
+    const b64 = out.match(/printf %s ([A-Za-z0-9+/=]+) \|/)?.[1];
+    expect(Buffer.from(b64 ?? "", "base64").toString("utf8")).toBe(script);
+  });
+
+  it("returns empty for empty CDATA", () => {
+    expect(normalizeTerminalCommand("<![CDATA[  ]]>")).toBe("");
+  });
+
+  it("does not match partial CDATA", () => {
+    expect(normalizeTerminalCommand("<![CDATA[echo")).toBe("<![CDATA[echo");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 5 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
