### PR TITLE
test(app-core): cover electrobun global stub

### DIFF
--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-stub.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureElectrobunGlobal } from "./electrobun-stub.ts";
+
+afterEach(() => {
+  // @ts-expect-error cleanup
+  delete globalThis.window;
+});
+
+function makeWindow() {
+  const w = {} as Window & {
+    __electrobun?: {
+      receiveMessageFromBun: (m: unknown) => void;
+      receiveInternalMessageFromBun: (m: unknown) => void;
+    };
+  };
+  (globalThis as { window?: typeof w }).window = w;
+  return w;
+}
+
+describe("ensureElectrobunGlobal", () => {
+  it("creates the global when missing", () => {
+    const w = makeWindow();
+    ensureElectrobunGlobal();
+    expect(typeof w.__electrobun?.receiveMessageFromBun).toBe("function");
+    expect(typeof w.__electrobun?.receiveInternalMessageFromBun).toBe(
+      "function",
+    );
+  });
+
+  it("leaves an existing global untouched", () => {
+    const w = makeWindow();
+    const existing = {
+      receiveMessageFromBun: () => "keep",
+      receiveInternalMessageFromBun: () => "keep",
+    };
+    w.__electrobun = existing;
+    ensureElectrobunGlobal();
+    expect(w.__electrobun).toBe(existing);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
