### PR TITLE
fix(ci): queue adjacent develop validation runs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,9 +14,11 @@ building plus linting and typechecking the affected workspace closure. It does
 not run tests, scenarios, live providers, devices, deployments, or destructive
 effects. New commits cancel stale work for the same pull request or merge group.
 
-`develop-full.yml` is the sole develop-push workflow. Its stable concurrency
-group cancels the complete read-only graph for a superseded tip, delegates each
-invalidated validation family to its reusable workflow, and publishes `Complete
+`develop-full.yml` is the sole develop-push workflow. Its stable bounded
+concurrency group runs one complete read-only graph at a time and retains up to
+100 waiting merge tips instead of cancelling an adjacent head. Arrivals beyond
+that platform limit are cancelled. Each admitted run delegates its invalidated
+validation families to their reusable workflows and publishes `Complete
 manifest` only when every registered family has current green evidence.
 `.github/develop-surface-graph.json` owns the reviewed surface DAG, workspace
 roots, non-workspace inputs, environment identity, and evidence lifetime.
@@ -30,7 +32,8 @@ duplicate, unexpected, stale, or ambiguous evidence fails closed or reruns the
 surface; unknown changed-path ownership forces the full graph. The expected and
 observed manifests are retained as the run's reviewable domain artifact.
 The hosted runner image is mutable and is not yet measured by this graph, so
-the reviewed `current-run-only` policy disables cross-run verdict reuse. The
+the reviewed `current-run-only` policy disables cross-run verdict reuse. Every
+admitted queue entry therefore executes its own invalidated families. The
 environment digest identifies declared toolchain and runner policy only; it is
 not represented as an exact hosted-image match. Cross-run cache reuse may be
 enabled only after every delegated runner's immutable image identity is bound

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -33,9 +33,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Develop Full owns latest-tip cancellation; standalone dispatches retain their
-# own stable ref group.
-# work instead of accumulating behind the runner fleet.
+# Develop Full serializes complete graphs before they reach this child. Retain
+# the child-local push guard; standalone dispatches keep their stable ref group.
 concurrency:
   group: chat-shell-gestures-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# A newer develop tip invalidates read-only verification of an older tip. Manual
-# diagnostics retain a run-scoped group and never collide with branch health.
+# Develop Full serializes complete graphs before they reach this child. The
+# child-local push guard remains defensive; manual diagnostics stay run-scoped.
 concurrency:
   group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'push' }}

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -7,7 +7,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Develop Full owns latest-tip cancellation for called runs.
+# Develop Full serializes complete graphs before they reach this child. Retain
+# this child-local push guard for any reusable caller carrying a push event.
 concurrency:
   group: cloud-tests-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'push' }}

--- a/.github/workflows/develop-full.yml
+++ b/.github/workflows/develop-full.yml
@@ -1,6 +1,7 @@
-# This workflow is the sole develop-push validation authority. It cancels the
-# complete read-only graph for a superseded tip and reuses a surface verdict
-# only when immutable cached evidence matches that surface's exact input digest.
+# This workflow is the sole develop-push validation authority. It serializes
+# complete read-only graphs so adjacent merge tips can reach terminal results,
+# and reuses a surface verdict only when immutable cached evidence matches that
+# surface's exact input digest.
 name: Develop Full
 
 on:
@@ -9,7 +10,10 @@ on:
 
 concurrency:
   group: develop-full
-  cancel-in-progress: true
+  # Keep one graph active and retain up to GitHub's bounded limit of 100 waiting
+  # merge tips. Arrivals beyond that platform limit are cancelled.
+  cancel-in-progress: false
+  queue: max
 
 permissions:
   contents: read

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,8 +6,8 @@ name: gitleaks
 on:
   workflow_call:
 
-# Develop Full owns cancellation of superseded tips. This stable child group
-# prevents duplicate standalone invocations for the same ref.
+# Develop Full serializes complete graphs before they reach this child. This
+# stable child group remains a defensive duplicate guard for overlapping calls.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,8 +9,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Develop Full owns cancellation of superseded tips. Manual runs stay isolated
-# so an on-demand health read is not parked behind the develop queue.
+# Develop Full serializes complete graphs before they reach this child. The
+# child-local push guard remains defensive, while manual runs stay isolated.
 concurrency:
   group: quality-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'push' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ on:
         default: false
         type: boolean
 
-# Develop Full owns cancellation of superseded tips. Manual runs use a per-run
-# group so an on-demand diagnostic remains independent.
+# Develop Full serializes complete graphs before they reach this child. The
+# child-local push guard remains defensive; manual runs use a per-run group.
 concurrency:
   group: test-${{ github.event_name == 'push' && github.ref || format('{0}-{1}', github.event_name, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'push' }}

--- a/packages/scripts/__tests__/ci-workflow-concurrency.test.ts
+++ b/packages/scripts/__tests__/ci-workflow-concurrency.test.ts
@@ -1,6 +1,6 @@
 /**
- * Pins latest-tip cancellation for the current develop CI graph while manual
- * diagnostics keep independent run-scoped identities.
+ * Pins the CI child's defensive push guard while Develop Full serializes its
+ * complete graphs and manual diagnostics keep independent run identities.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -28,12 +28,12 @@ describe("ci.yml concurrency contract", () => {
     );
   });
 
-  test("uses one stable develop ref group", () => {
+  test("uses one stable push-context backstop group", () => {
     expect(group).toContain("|| github.ref || github.run_id");
     expect(concurrency?.queue).toBeUndefined();
   });
 
-  test("cancels superseded develop pushes", () => {
+  test("cancels only overlapping push-context child runs", () => {
     expect(concurrency?.["cancel-in-progress"]).toBe(
       `\${{ github.event_name == 'push' }}`,
     );

--- a/packages/scripts/__tests__/develop-full-workflow.test.ts
+++ b/packages/scripts/__tests__/develop-full-workflow.test.ts
@@ -9,7 +9,11 @@ const workflowPath = fileURLToPath(
 );
 const workflow = Bun.YAML.parse(readFileSync(workflowPath, "utf8")) as {
   on?: Record<string, { branches?: string[] }>;
-  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  concurrency?: {
+    group?: string;
+    "cancel-in-progress"?: boolean;
+    queue?: string;
+  };
   permissions?: Record<string, string>;
   jobs?: Record<
     string,
@@ -65,11 +69,12 @@ const delegatedJobs = [
 ];
 
 describe("Develop Full workflow authority", () => {
-  test("is the latest-tip develop-push authority", () => {
+  test("preserves adjacent develop heads in a bounded serial queue", () => {
     expect(workflow.on).toEqual({ push: { branches: ["develop"] } });
     expect(workflow.concurrency).toEqual({
       group: "develop-full",
-      "cancel-in-progress": true,
+      "cancel-in-progress": false,
+      queue: "max",
     });
   });
 

--- a/packages/scripts/__tests__/quality-workflow-concurrency.test.ts
+++ b/packages/scripts/__tests__/quality-workflow-concurrency.test.ts
@@ -1,6 +1,6 @@
 /**
- * Pins quality.yml to the Develop Full latest-tip cancellation contract while
- * preserving independent manual diagnostics.
+ * Pins quality.yml's defensive child-local push guard while Develop Full
+ * serializes complete graphs and manual diagnostics remain independent.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -16,7 +16,7 @@ describe("quality.yml concurrency contract", () => {
     concurrency?: { group?: string; "cancel-in-progress"?: string | boolean };
   };
 
-  test("shares one concurrency group per ref so pushes supersede, not queue", () => {
+  test("keeps a stable push-context backstop group", () => {
     const group = workflow.concurrency?.group;
     expect(group).toStartWith("quality-");
     expect(group).toContain("|| github.ref");
@@ -24,14 +24,14 @@ describe("quality.yml concurrency contract", () => {
     // An unconditional run_id fallback would give every push a unique group
     // and re-open the unbounded queue from #14069. run_id may appear only
     // behind an explicit workflow_dispatch guard, so a manual health read is
-    // not parked behind — and then superseded by — the develop push queue.
+    // not parked behind the child group used by called push-context runs.
     const dispatchGuard =
       "github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id)";
     const withoutDispatchGuard = String(group).replace(dispatchGuard, "");
     expect(withoutDispatchGuard).not.toContain("run_id");
   });
 
-  test("cancels a superseded develop tip", () => {
+  test("cancels only overlapping push-context child runs", () => {
     expect(workflow.concurrency?.["cancel-in-progress"]).toBe(
       `\${{ github.event_name == 'push' }}`,
     );

--- a/packages/scripts/__tests__/workflow-trigger-policy.test.ts
+++ b/packages/scripts/__tests__/workflow-trigger-policy.test.ts
@@ -1,4 +1,4 @@
-/** Exercises the single PR Static Smoke and latest-tip Develop Full trigger authorities. */
+/** Exercises the single PR Static Smoke and serial Develop Full trigger authorities. */
 
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -44,6 +44,10 @@ const developPush = `name: Develop Full
 on:
   push:
     branches: [develop]
+concurrency:
+  group: develop-full
+  cancel-in-progress: false
+  queue: max
 jobs: {}
 `;
 
@@ -55,6 +59,10 @@ on:
   push:
     branches: [develop]
   workflow_dispatch:
+concurrency:
+  group: develop-full
+  cancel-in-progress: false
+  queue: max
 jobs: {}
 `),
     ).toEqual({ developPushWorkflows: 1, files: 1 });
@@ -77,7 +85,7 @@ jobs: {}
 
   test("accepts tag-only release pushes", () => {
     const root = buildRepo({
-      "develop-full.yml": `on:\n  push:\n    branches: [develop]\njobs: {}\n`,
+      "develop-full.yml": developPush,
       "release.yml": `on:\n  push:\n    tags: ["v*"]\njobs: {}\n`,
     });
     try {
@@ -124,6 +132,32 @@ jobs: {}
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  test.each([
+    [
+      "active-run cancellation",
+      developPush.replace(
+        "cancel-in-progress: false",
+        "cancel-in-progress: true",
+      ),
+    ],
+    ["single pending run", developPush.replace("queue: max", "queue: 1")],
+    [
+      "a different group",
+      developPush.replace("group: develop-full", "group: other"),
+    ],
+    [
+      "missing configuration",
+      developPush.replace(
+        "concurrency:\n  group: develop-full\n  cancel-in-progress: false\n  queue: max\n",
+        "",
+      ),
+    ],
+  ])("rejects Develop Full concurrency with %s", (_name, workflow) => {
+    expect(() => validateFixture(workflow)).toThrow(
+      /serialize develop-full with cancel-in-progress:false and queue:max/,
+    );
   });
 
   test("fails closed when PR Static Smoke loses either admission trigger", () => {

--- a/packages/scripts/workflow-trigger-policy.mjs
+++ b/packages/scripts/workflow-trigger-policy.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Enforces one lightweight pull-request authority and one latest-tip develop
+ * Enforces one lightweight pull-request authority and one serial develop
  * authority. Periodic and completion-chained triggers remain forbidden so a
  * merged develop tip is the repository's only automatic full-validation event.
  */
@@ -18,6 +18,7 @@ const FORBIDDEN_EVENTS = new Set([
 ]);
 const CANONICAL_ADMISSION_WORKFLOW = "pr-static-smoke.yml";
 const DEVELOP_AUTHORITY_WORKFLOW = "develop-full.yml";
+const DEVELOP_CONCURRENCY_GROUP = "develop-full";
 const FORBIDDEN_AUTOMATION_EVENTS = new Set(["schedule", "workflow_run"]);
 const REQUIRED_PR_BRANCHES = ["develop", "main"];
 const REQUIRED_PR_TYPES = [
@@ -70,6 +71,18 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
     const workflow = document.toJS();
     const entries = triggerEntries(workflow?.on);
     if (name === CANONICAL_ADMISSION_WORKFLOW) sawCanonicalWorkflow = true;
+    if (name === DEVELOP_AUTHORITY_WORKFLOW) {
+      const concurrency = workflow?.concurrency;
+      if (
+        concurrency?.group !== DEVELOP_CONCURRENCY_GROUP ||
+        concurrency?.["cancel-in-progress"] !== false ||
+        concurrency?.queue !== "max"
+      ) {
+        failures.push(
+          `${name}: concurrency must serialize ${DEVELOP_CONCURRENCY_GROUP} with cancel-in-progress:false and queue:max`,
+        );
+      }
+    }
 
     for (const [eventName, config] of entries) {
       if (FORBIDDEN_AUTOMATION_EVENTS.has(eventName)) {


### PR DESCRIPTION
# Relates to

Relates to #19181.

This PR is a conditional implementation of invariant **A** from the unresolved maintainer decision in #19181: every admitted adjacent `develop` tip should reach a terminal validation result. It intentionally does **not** close #19181 because the A/B policy decision and post-merge live proof are still outstanding.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts. Validated base: `2e69b70eb32f0faee4a71f3c59361305eaaeb58a`.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the checked-in scheduling contract from the linked pre-change run evidence and deterministic tests below; the issue-level two-push live acceptance remains post-merge.

# Sync with develop

- [x] Rebased onto `origin/develop` at `2e69b70eb32f0faee4a71f3c59361305eaaeb58a`; zero conflicts.
- [x] `bun run verify` passes post-sync on exact head `57583ae418220bad82f6fbe6e95663ac30a6fc0b`.

# Risks

**Medium — develop-push CI scheduling only; no product runtime is changed.**

- `Develop Full` now runs one complete graph at a time. A slow graph can increase feedback latency and runner spend for later merge tips.
- `queue: max` retains at most GitHub's bounded limit of 100 waiting runs. An arrival beyond that platform limit is still cancelled and is not an admitted run under invariant A.
- The reviewed `current-run-only` evidence policy means every admitted queue entry executes its own validation families; this trades latest-tip cost savings for terminal evidence per admitted tip.
- Child workflow concurrency behavior is unchanged. Their existing push-context guards remain defensive while the parent graph prevents adjacent Develop Full invocations from overlapping in those children.
- Durable reconciliation remains exact-SHA fenced, so a completed older graph cannot promote or reconcile over a newer `develop` tip.

# Background

On 2026-08-23, [Develop Full run 32613080493](https://github.com/elizaOS/eliza/actions/runs/32613080493) started for merge SHA `c98b2131b8c4064458f0c4c31354350c1d45528a` at 02:31:41Z. A later merge created [run 32614279403](https://github.com/elizaOS/eliza/actions/runs/32614279403) at 03:01:03Z. Both used the stable `develop-full` concurrency group, whose `cancel-in-progress: true` setting cancelled the older run. It completed with conclusion `cancelled` at 03:02:43Z; the successor began its first job at 03:02:45Z.

That is a concurrency-group eviction, not a runner failure. It also occurred after the repository verification repaired by #24977 had passed, so #24977 did not correct this scheduling mechanism.

## What does this PR do?

- Changes the sole `develop`-push authority to the stable group `develop-full` with `cancel-in-progress: false` and `queue: max`.
- Serializes complete read-only graphs while retaining up to 100 waiting merge tips, so adjacent admitted tips are not evicted by a newer merge.
- Extends the workflow-trigger policy and contract tests to reject a missing or different group, active-run cancellation, or any queue other than `max`.
- Documents the bounded queue, `current-run-only` cost, and corrected ownership language in the parent and six called workflows.
- Does not change concurrency behavior in `ci.yml`, `cloud-tests.yml`, `gitleaks.yml`, `chat-shell-gestures.yml`, `quality.yml`, or `test.yml`.

## What kind of change is this?

Bug fix (non-breaking CI scheduling correction).

# Documentation changes needed?

Documentation changes are required and included. `.github/workflows/README.md` and the parent/child workflow comments now describe the serial parent queue and child-local guards accurately.

# Testing

## Where should a reviewer start?

1. `.github/workflows/develop-full.yml` — bounded serial concurrency contract.
2. `packages/scripts/__tests__/develop-full-workflow.test.ts` — checked-in workflow assertion.
3. `packages/scripts/workflow-trigger-policy.mjs` and its test — fail-closed policy enforcement.
4. `.github/workflows/README.md` — queue capacity, overflow, and evidence-policy tradeoff.

## Detailed testing steps

All commands passed on exact head `57583ae418220bad82f6fbe6e95663ac30a6fc0b`, rebased onto `2e69b70eb32f0faee4a71f3c59361305eaaeb58a`:

```bash
bun install --frozen-lockfile --ignore-scripts

bun test \
  packages/scripts/__tests__/develop-full-workflow.test.ts \
  packages/scripts/__tests__/workflow-trigger-policy.test.ts \
  packages/scripts/__tests__/actionlint-config.test.ts \
  packages/scripts/__tests__/ci-workflow-concurrency.test.ts \
  packages/scripts/__tests__/quality-workflow-concurrency.test.ts \
  packages/scripts/__tests__/develop-effect-ledger.test.ts \
  packages/scripts/__tests__/develop-impact-evidence.test.ts

node packages/scripts/workflow-trigger-policy.mjs
actionlint -config-file .github/actionlint.yaml .github/workflows/develop-full.yml .github/workflows/cloud-tests.yml .github/workflows/gitleaks.yml .github/workflows/chat-shell-gestures.yml .github/workflows/quality.yml .github/workflows/test.yml .github/workflows/ci.yml
node_modules/.bin/biome check packages/scripts/__tests__/develop-full-workflow.test.ts packages/scripts/__tests__/workflow-trigger-policy.test.ts packages/scripts/__tests__/ci-workflow-concurrency.test.ts packages/scripts/__tests__/quality-workflow-concurrency.test.ts packages/scripts/workflow-trigger-policy.mjs
node scripts/check-markdown-links.mjs
bun run check:agents-claude
git diff --check origin/develop...HEAD
bun run verify
```

Results:

- Frozen install: 3,724 installs across 4,000 packages, no changes.
- Targeted tests: **81 passed, 0 failed, 359 assertions**.
- Trigger audit: 60 workflows, exactly one `develop` push authority.
- Root verify: exit 0; **375/375** Turbo tasks passed, followed by every root audit.
- Actionlint, Biome, Markdown links, AGENTS/CLAUDE parity, and diff checks passed.

Post-merge live verification still required for invariant A:

1. Observe two `develop` pushes close enough that run B is admitted while run A is still active.
2. Record both Develop Full run URLs, SHAs, queue/start/completion timestamps, and conclusions.
3. Confirm both reach terminal conclusions and neither has conclusion `cancelled` because of concurrency eviction. A job failure is distinct from cancellation and should be diagnosed separately.

# Evidence Gate

Evidence matches the exact commit reviewed.
<!-- evidence-head:57583ae418220bad82f6fbe6e95663ac30a6fc0b -->

This is a GitHub Actions workflow, policy, test, and documentation-only diff. It has no frontend-rendered or user-interactive surface.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI or rendered visual surface is changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI or rendered visual surface is changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - there is no user flow; behavior is CI orchestration.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no application backend code path is changed; the linked GitHub Actions runs provide the relevant orchestration evidence.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, tasks, wallet output, media, or generated product artifact is changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - the diff has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

N/A - no application backend or frontend path changes. The live pre-change GitHub Actions evidence is linked in **Background**. Post-change live workflow evidence cannot exist until this configuration lands on `develop`.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface.

### After

N/A - no UI surface.

### Walkthrough video

N/A - no user-interactive flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio change.

## Known gaps / failures

- No local validation command failed.
- Hosted exact-head PR checks are required in addition to local results; do not merge until they are terminal.
- The decisive live acceptance proof—two overlapping `develop` pushes both reaching non-cancelled terminal conclusions—requires the workflow change to land first. Static tests and policy enforcement prove the checked-in contract but do not substitute for this post-merge observation.
- `queue: max` is bounded to 100 waiting runs by GitHub. Overflow cancellation remains a documented platform limitation and is outside the admitted-run guarantee.
- Evidence rows are N/A because this diff changes only CI orchestration and its contracts.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

No manual deployment or database migration. The concurrency contract takes effect on the first `Develop Full` push after merge.
