### PR TITLE
test(cloud): diagnose anchored history reconstruction

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -525,7 +525,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: app-live-e2e-cloud-staging
-          path: artifacts/app-live-e2e/cloud-staging-receipt.json
+          path: |
+            artifacts/app-live-e2e/cloud-staging-receipt.json
+            packages/app/test-results/**/privacy-safe-*-history-network-diagnostics.json
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -31,6 +31,10 @@ on:
         description: "Also run the production Cloud login+personal-identity+chat lane. Keep false for staging-only evidence."
         type: boolean
         default: false
+      run_only_requested:
+        description: "Skip the default local/walkthrough/desktop lanes and run only explicitly selected opt-in lanes."
+        type: boolean
+        default: false
 
 concurrency:
   group: app-live-e2e-${{ github.ref }}
@@ -74,6 +78,7 @@ jobs:
   # agent from the UI.
   app-live-chat:
     name: app live chat (real local runtime)
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.run_only_requested }}
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
@@ -158,6 +163,7 @@ jobs:
   # writes WALKTHROUGH_VERDICTS.md (the PR mock lane is keyless and can't).
   walkthrough-live:
     name: full walkthrough (real backend + model + vision verdicts)
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.run_only_requested }}
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
@@ -589,6 +595,7 @@ jobs:
   # still validate, so the renderer step is best-effort.
   desktop-packaged:
     name: desktop packaged (build + boot + renderer)
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.run_only_requested }}
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 60
     env:

--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -212,6 +212,10 @@ describe("forbidden Cloud agent mutations", () => {
       failedHistoryGetRequestCount: 0,
       timedOutHistoryGetRequestCount: 0,
       pendingHistoryGetRequestCount: 0,
+      inspectedHistoryResponseCount: 0,
+      uninspectableHistoryResponseCount: 0,
+      historyResponseWithAnchorUserCount: 0,
+      historyResponseWithAnchoredAssistantCount: 0,
     });
     expect(JSON.stringify(snapshot)).not.toMatch(
       /api\.test|private|idempotency|prompt/,
@@ -261,6 +265,10 @@ describe("forbidden Cloud agent mutations", () => {
       failedHistoryGetRequestCount: 2,
       timedOutHistoryGetRequestCount: 1,
       pendingHistoryGetRequestCount: 1,
+      inspectedHistoryResponseCount: 0,
+      uninspectableHistoryResponseCount: 0,
+      historyResponseWithAnchorUserCount: 0,
+      historyResponseWithAnchoredAssistantCount: 0,
     });
     expect(JSON.stringify(diagnostics)).not.toMatch(
       /api\.test|private|token|ERR_|conversation/,
@@ -297,6 +305,89 @@ describe("forbidden Cloud agent mutations", () => {
       historyGetRequestCount: 1,
       successfulHistoryGetResponseCount: 1,
       pendingHistoryGetRequestCount: 1,
+    });
+  });
+
+  it("classifies an anchored history pair without retaining private body content", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const history =
+      "https://api.test/api/conversations/private-conversation/messages";
+    const anchor = "private-anchor-token";
+    audit.setHistoryAnchorToken(anchor);
+    const before = await audit.snapshot();
+    const body = boundedJsonBody({
+      messages: [
+        { role: "assistant", text: "old private answer" },
+        { role: "user", text: `private prompt ${anchor}` },
+        { role: "assistant", text: "new private answer" },
+      ],
+    });
+
+    audit.observeRequest("GET", history);
+    audit.observeResponse("GET", history, 200, body.responseBody);
+    const diagnostics = createCloudLiveHistoryNetworkDiagnostics(
+      "post-reload",
+      before,
+      await audit.snapshot(),
+    );
+
+    expect(diagnostics).toMatchObject({
+      successfulHistoryGetResponseCount: 1,
+      inspectedHistoryResponseCount: 1,
+      uninspectableHistoryResponseCount: 0,
+      historyResponseWithAnchorUserCount: 1,
+      historyResponseWithAnchoredAssistantCount: 1,
+    });
+    expect(body.budgets).toEqual([1024 * 1024]);
+    expect(JSON.stringify(diagnostics)).not.toMatch(
+      /private|anchor|prompt|answer|api\.test|conversation/,
+    );
+  });
+
+  it("does not pair an anchor with an assistant after a newer user turn", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const history = "/api/conversations/private/messages";
+    audit.setHistoryAnchorToken("private-anchor");
+    audit.observeRequest("GET", history);
+    audit.observeResponse(
+      "GET",
+      history,
+      200,
+      boundedJsonBody({
+        messages: [
+          { role: "user", text: "private-anchor" },
+          { role: "user", text: "newer private turn" },
+          { role: "assistant", text: "belongs to newer turn" },
+        ],
+      }).responseBody,
+    );
+
+    expect(await audit.snapshot()).toMatchObject({
+      inspectedHistoryResponseCount: 1,
+      historyResponseWithAnchorUserCount: 1,
+      historyResponseWithAnchoredAssistantCount: 0,
+    });
+  });
+
+  it("reports unreadable or oversized history bodies as uninspectable", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const history = "/api/conversations/private/messages";
+    audit.setHistoryAnchorToken("private-anchor");
+    for (const body of [
+      boundedJsonBody({}, { contentType: "text/plain" }).responseBody,
+      boundedJsonBody({}, { reject: true }).responseBody,
+      boundedJsonBody({}, { raw: "{", ignoreBudget: true }).responseBody,
+    ]) {
+      audit.observeRequest("GET", history);
+      audit.observeResponse("GET", history, 200, body);
+    }
+
+    expect(await audit.snapshot()).toMatchObject({
+      successfulHistoryGetCount: 3,
+      inspectedHistoryResponseCount: 0,
+      uninspectableHistoryResponseCount: 3,
+      historyResponseWithAnchorUserCount: 0,
+      historyResponseWithAnchoredAssistantCount: 0,
     });
   });
 

--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -369,6 +369,27 @@ describe("forbidden Cloud agent mutations", () => {
     });
   });
 
+  it("does not report an anchored assistant when the user anchor is absent", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const history = "/api/conversations/private/messages";
+    audit.setHistoryAnchorToken("missing-private-anchor");
+    audit.observeRequest("GET", history);
+    audit.observeResponse(
+      "GET",
+      history,
+      200,
+      boundedJsonBody({
+        messages: [{ role: "assistant", text: "unrelated older assistant" }],
+      }).responseBody,
+    );
+
+    expect(await audit.snapshot()).toMatchObject({
+      inspectedHistoryResponseCount: 1,
+      historyResponseWithAnchorUserCount: 0,
+      historyResponseWithAnchoredAssistantCount: 0,
+    });
+  });
+
   it("reports unreadable or oversized history bodies as uninspectable", async () => {
     const audit = createCloudLiveNetworkAudit();
     const history = "/api/conversations/private/messages";

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -69,6 +69,10 @@ export interface CloudLiveNetworkAuditSnapshot {
   failedHistoryGetRequestCount: number;
   timedOutHistoryGetRequestCount: number;
   pendingHistoryGetRequestCount: number;
+  inspectedHistoryResponseCount: number;
+  uninspectableHistoryResponseCount: number;
+  historyResponseWithAnchorUserCount: number;
+  historyResponseWithAnchoredAssistantCount: number;
 }
 
 export interface CloudLiveHistoryNetworkDiagnostics {
@@ -83,6 +87,10 @@ export interface CloudLiveHistoryNetworkDiagnostics {
   failedHistoryGetRequestCount: number;
   timedOutHistoryGetRequestCount: number;
   pendingHistoryGetRequestCount: number;
+  inspectedHistoryResponseCount: number;
+  uninspectableHistoryResponseCount: number;
+  historyResponseWithAnchorUserCount: number;
+  historyResponseWithAnchoredAssistantCount: number;
 }
 
 export interface CloudLiveNamedWarmingModeInput {
@@ -266,6 +274,26 @@ export function createCloudLiveHistoryNetworkDiagnostics(
     "pendingHistoryGetRequestCount current value",
     after.pendingHistoryGetRequestCount,
   );
+  const inspectedHistoryResponseCount = monotonicDelta(
+    "inspectedHistoryResponseCount",
+    before.inspectedHistoryResponseCount,
+    after.inspectedHistoryResponseCount,
+  );
+  const uninspectableHistoryResponseCount = monotonicDelta(
+    "uninspectableHistoryResponseCount",
+    before.uninspectableHistoryResponseCount,
+    after.uninspectableHistoryResponseCount,
+  );
+  const historyResponseWithAnchorUserCount = monotonicDelta(
+    "historyResponseWithAnchorUserCount",
+    before.historyResponseWithAnchorUserCount,
+    after.historyResponseWithAnchorUserCount,
+  );
+  const historyResponseWithAnchoredAssistantCount = monotonicDelta(
+    "historyResponseWithAnchoredAssistantCount",
+    before.historyResponseWithAnchoredAssistantCount,
+    after.historyResponseWithAnchoredAssistantCount,
+  );
   return {
     schemaVersion: 1,
     phase,
@@ -278,6 +306,10 @@ export function createCloudLiveHistoryNetworkDiagnostics(
     failedHistoryGetRequestCount,
     timedOutHistoryGetRequestCount,
     pendingHistoryGetRequestCount,
+    inspectedHistoryResponseCount,
+    uninspectableHistoryResponseCount,
+    historyResponseWithAnchorUserCount,
+    historyResponseWithAnchoredAssistantCount,
   };
 }
 
@@ -321,6 +353,7 @@ const NAMED_WARMING_CODES = new Set([
   "shared_runtime_cache_warming",
 ]);
 const MAX_WARMING_RESPONSE_BYTES = 4 * 1024;
+const MAX_HISTORY_RESPONSE_BYTES = 1024 * 1024;
 
 function isJsonContentType(contentType: string | null | undefined): boolean {
   return (
@@ -352,6 +385,85 @@ async function isNamedWarmingResponse(
     // error-policy:J3 malformed or non-UTF-8 diagnostic bodies are simply not
     // named warming proof; the real browser response remains authoritative.
     return false;
+  }
+}
+
+interface HistoryAnchorInspection {
+  inspected: boolean;
+  anchorUserPresent: boolean;
+  anchoredAssistantPresent: boolean;
+}
+
+async function inspectHistoryAnchor(
+  responseBody: CloudLiveBoundedResponseBody,
+  anchorToken: string,
+): Promise<HistoryAnchorInspection> {
+  const unavailable = {
+    inspected: false,
+    anchorUserPresent: false,
+    anchoredAssistantPresent: false,
+  };
+  if (!isJsonContentType(responseBody.contentType)) return unavailable;
+  try {
+    const bytes = await responseBody.read(MAX_HISTORY_RESPONSE_BYTES);
+    if (
+      !bytes ||
+      bytes.byteLength === 0 ||
+      bytes.byteLength > MAX_HISTORY_RESPONSE_BYTES
+    ) {
+      return unavailable;
+    }
+    const parsed = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    ) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return unavailable;
+    }
+    const messages = (parsed as Record<string, unknown>).messages;
+    if (!Array.isArray(messages)) return unavailable;
+    const normalizedAnchor = anchorToken.trim().toLowerCase();
+    let anchorUserIndex = -1;
+    for (let index = 0; index < messages.length; index += 1) {
+      const message = messages[index];
+      if (!message || typeof message !== "object" || Array.isArray(message)) {
+        continue;
+      }
+      const record = message as Record<string, unknown>;
+      if (
+        record.role === "user" &&
+        typeof record.text === "string" &&
+        record.text.toLowerCase().includes(normalizedAnchor)
+      ) {
+        anchorUserIndex = index;
+        break;
+      }
+    }
+    let anchoredAssistantPresent = false;
+    for (let index = anchorUserIndex + 1; index < messages.length; index += 1) {
+      const message = messages[index];
+      if (!message || typeof message !== "object" || Array.isArray(message)) {
+        continue;
+      }
+      const record = message as Record<string, unknown>;
+      if (record.role === "user") break;
+      if (
+        record.role === "assistant" &&
+        typeof record.text === "string" &&
+        record.text.trim().length > 0
+      ) {
+        anchoredAssistantPresent = true;
+        break;
+      }
+    }
+    return {
+      inspected: true,
+      anchorUserPresent: anchorUserIndex >= 0,
+      anchoredAssistantPresent,
+    };
+  } catch {
+    // error-policy:J3 malformed, non-UTF-8, oversized, or unreadable history
+    // bodies provide no anchor proof; the browser response remains authoritative.
+    return unavailable;
   }
 }
 
@@ -544,6 +656,7 @@ export function createCloudLiveNetworkAudit(): {
     rawUrl: string,
     errorText?: string,
   ): void;
+  setHistoryAnchorToken(anchorToken: string): void;
   snapshot(): Promise<CloudLiveNetworkAuditSnapshot>;
 } {
   let forbiddenAgentMutationCount = 0;
@@ -563,6 +676,11 @@ export function createCloudLiveNetworkAudit(): {
   let otherHistoryGetResponseCount = 0;
   let failedHistoryGetRequestCount = 0;
   let timedOutHistoryGetRequestCount = 0;
+  let inspectedHistoryResponseCount = 0;
+  let uninspectableHistoryResponseCount = 0;
+  let historyResponseWithAnchorUserCount = 0;
+  let historyResponseWithAnchoredAssistantCount = 0;
+  let historyAnchorToken = "";
   const pendingResponseHandlers = new Set<Promise<void>>();
 
   const trackResponseHandler = (handler: () => Promise<void>) => {
@@ -627,6 +745,25 @@ export function createCloudLiveNetworkAudit(): {
       if (isHistoryGet(method, rawUrl)) {
         if (status >= 200 && status < 300) {
           successfulHistoryGetCount += 1;
+          if (historyAnchorToken && responseBody) {
+            trackResponseHandler(async () => {
+              const inspection = await inspectHistoryAnchor(
+                responseBody,
+                historyAnchorToken,
+              );
+              if (!inspection.inspected) {
+                uninspectableHistoryResponseCount += 1;
+                return;
+              }
+              inspectedHistoryResponseCount += 1;
+              if (inspection.anchorUserPresent) {
+                historyResponseWithAnchorUserCount += 1;
+              }
+              if (inspection.anchoredAssistantPresent) {
+                historyResponseWithAnchoredAssistantCount += 1;
+              }
+            });
+          }
         } else if (status >= 400 && status < 500) {
           clientErrorHistoryGetResponseCount += 1;
         } else if (status >= 500 && status < 600) {
@@ -649,6 +786,9 @@ export function createCloudLiveNetworkAudit(): {
       if (/tim(?:e|ed)[ _-]?out/i.test(errorText)) {
         timedOutHistoryGetRequestCount += 1;
       }
+    },
+    setHistoryAnchorToken(anchorToken) {
+      historyAnchorToken = anchorToken.trim().toLowerCase();
     },
     snapshot: async () => {
       await drainResponseHandlers();
@@ -680,6 +820,10 @@ export function createCloudLiveNetworkAudit(): {
           0,
           historyGetRequestCount - terminalHistoryGetCount,
         ),
+        inspectedHistoryResponseCount,
+        uninspectableHistoryResponseCount,
+        historyResponseWithAnchorUserCount,
+        historyResponseWithAnchoredAssistantCount,
       };
     },
   };

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -439,7 +439,11 @@ async function inspectHistoryAnchor(
       }
     }
     let anchoredAssistantPresent = false;
-    for (let index = anchorUserIndex + 1; index < messages.length; index += 1) {
+    for (
+      let index = anchorUserIndex >= 0 ? anchorUserIndex + 1 : messages.length;
+      index < messages.length;
+      index += 1
+    ) {
       const message = messages[index];
       if (!message || typeof message !== "object" || Array.isArray(message)) {
         continue;

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -410,9 +410,6 @@ function installNetworkAudit(context: BrowserContext) {
   context.on("response", (response) => {
     const responseHeaders = response.headers();
     const contentType = responseHeaders["content-type"];
-    const contentEncoding = responseHeaders["content-encoding"]
-      ?.trim()
-      .toLowerCase();
     audit.observeResponse(
       response.request().method(),
       response.url(),
@@ -420,12 +417,11 @@ function installNetworkAudit(context: BrowserContext) {
       {
         contentType,
         async read(maxBytes) {
-          if (contentEncoding && contentEncoding !== "identity") return null;
           if (await response.finished()) return null;
           const { responseBodySize } = await response.request().sizes();
           if (
-            !Number.isSafeInteger(responseBodySize) ||
-            responseBodySize <= 0 ||
+            Number.isSafeInteger(responseBodySize) &&
+            responseBodySize > 0 &&
             responseBodySize > maxBytes
           )
             return null;

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -472,12 +472,26 @@ async function proveAnchoredTurnHistory(
   turnAnchorToken: string,
   phase: "post-reload" | "fresh-context",
 ): Promise<CloudLiveHistoryObservation> {
+  let successfulHistoryResponseObserved = false;
   try {
     await expect
       .poll(
         async () =>
           (await audit.snapshot()).successfulHistoryGetCount >
           before.successfulHistoryGetCount,
+        { timeout: 120_000 },
+      )
+      .toBe(true);
+    successfulHistoryResponseObserved = true;
+    await expect
+      .poll(
+        async () => {
+          const anchored = findAnchoredLiveTurn(
+            await readLivenessThreadLines(page),
+            { anchorToken: turnAnchorToken },
+          );
+          return Boolean(anchored && isLiveReply(anchored.reply));
+        },
         { timeout: 120_000 },
       )
       .toBe(true);
@@ -503,22 +517,10 @@ async function proveAnchoredTurnHistory(
       },
     );
     throw new Error(
-      `[cloud-live] ${phase} history proof timed out; privacy-safe counters were retained`,
+      `[cloud-live] ${phase} history proof timed out ${successfulHistoryResponseObserved ? "after a successful history response" : "before a successful history response"}; privacy-safe counters were retained`,
       { cause },
     );
   }
-  await expect
-    .poll(
-      async () => {
-        const anchored = findAnchoredLiveTurn(
-          await readLivenessThreadLines(page),
-          { anchorToken: turnAnchorToken },
-        );
-        return Boolean(anchored && isLiveReply(anchored.reply));
-      },
-      { timeout: 120_000 },
-    )
-    .toBe(true);
   return {
     historyGetSucceeded: true,
     challengeUserLinePresent: true,
@@ -676,6 +678,7 @@ test.describe("real cloud login + personal identity + chat", () => {
     // liveness requirement.
     await openAppPath(page, "/chat");
     const turnAnchorToken = randomBytes(8).toString("hex");
+    primaryAudit.setHistoryAnchorToken(turnAnchorToken);
     const turnPrompt = `In one short sentence, say hello. Unique turn marker: ${turnAnchorToken}`;
     const auditBeforeLiveness = await primaryAudit.snapshot();
     const domBeforeLiveness = await page.evaluate(() => ({
@@ -892,6 +895,7 @@ test.describe("real cloud login + personal identity + chat", () => {
 
         const freshPage = await freshContext.newPage();
         const freshAudit = installNetworkAudit(freshContext);
+        freshAudit.setHistoryAnchorToken(turnAnchorToken);
         const { deployedRenderer: freshDeployedRenderer } =
           await openProtectedCloudBlankStart(
             freshPage,


### PR DESCRIPTION
## What

The deployed Cloud renderer continuity lane has repeatedly reached a successful history GET and then timed out waiting for the exact marked user and assistant pair after reload. The existing failure artifact was written only when the HTTP success poll failed, so the actual repeated DOM timeout uploaded nothing.

This change:
- writes the same closed-schema mode-0600 artifact for both network and DOM reconstruction timeouts;
- inspects only a bounded successful history JSON body in memory;
- emits aggregate counters proving whether that payload contained the marked user and its following non-empty assistant turn;
- never persists message text, marker values, conversation/runtime IDs, URLs, headers, or response bodies;
- leaves the fail-closed continuity assertion unchanged.

## Proof

- `bun test packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts packages/app/test/cloud-live-continuity-contract.test.ts` — 28 pass, 0 fail, 195 expects
- `bun run typecheck` — 232 successful / 232 total
- Biome on all three changed files — pass
- `git diff --check` — pass
- gitleaks over `origin/develop..c59b3c78a5` — no leaks

## Release use

Do not merge as a way to waive the current renderer failure. Once reviewed, include this exact diagnostic in the next serialized non-production Cloud release so a failure identifies server omission versus client reconstruction without exposing private content.

@lalalune please review this separately from grounding PR #24779.