### PR TITLE
fix(core): drain notification writes before service shutdown completes

### DIFF
--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -2,12 +2,23 @@
  * Integration coverage for NotificationService over a real AgentRuntime,
  * in-memory database adapter, and AgentEventService. External systems are not involved.
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { createCharacter } from "../character.ts";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter.ts";
 import { AgentRuntime } from "../runtime.ts";
 import type { AgentEventPayload } from "../types/agentEvent.ts";
-import type { AgentNotification } from "../types/notification.ts";
+import {
+	type AgentNotification,
+	NOTIFICATION_STREAM,
+} from "../types/notification.ts";
 import type { Plugin } from "../types/plugin.ts";
 import { ServiceType } from "../types/service.ts";
 import { AgentEventService } from "./agentEvent.ts";
@@ -811,5 +822,106 @@ describe("NotificationService", () => {
 		await service.notify({ title: "C", groupKey: "gc" });
 		await service.markReadByGroupKey("ga"); // read the oldest
 		expect(service.list().map((n) => n.title)).toEqual(["C", "B", "A"]);
+	});
+
+	describe("stop() drain and admission close", () => {
+		let stopRuntime: AgentRuntime;
+		let stopCleanup: () => Promise<void>;
+		let stopService: NotificationService;
+		let unsubscribeStopEvents: (() => void) | undefined;
+		const stopEmitted: AgentEventPayload[] = [];
+
+		beforeAll(async () => {
+			const created = await createRuntime([
+				AgentEventService,
+				NotificationService,
+			]);
+			stopRuntime = created.runtime;
+			stopCleanup = created.cleanup;
+			stopService = (await stopRuntime.getServiceLoadPromise(
+				ServiceType.NOTIFICATION,
+			)) as NotificationService;
+			const stopEventService = (await stopRuntime.getServiceLoadPromise(
+				ServiceType.AGENT_EVENT,
+			)) as AgentEventService;
+			unsubscribeStopEvents = stopEventService.subscribe((event) =>
+				stopEmitted.push(event),
+			);
+		}, 180_000);
+
+		afterAll(async () => {
+			unsubscribeStopEvents?.();
+			// The runtime's own teardown path is exercised in the drain test; a
+			// second full stop() is idempotent for the remaining lifecycle.
+			await stopCleanup?.();
+		});
+
+		it("drains the durable write tail before stop() resolves", async () => {
+			await stopService.clear();
+			let releaseSetCache: (() => void) | undefined;
+			const originalSetCache = stopRuntime.setCache.bind(stopRuntime);
+			// Block the durable write of an accepted notify() mid-flight, then
+			// call stop() while that write is still pending.
+			(stopRuntime as { setCache: unknown }).setCache = (
+				key: string,
+				value: unknown,
+			) => {
+				if (key.startsWith("notifications:")) {
+					return new Promise<boolean>((resolve) => {
+						releaseSetCache = () => resolve(originalSetCache(key, value));
+					});
+				}
+				return originalSetCache(key, value as never);
+			};
+
+			const accepted = stopService.notify({ title: "in-flight write" });
+			// Wait until the blocked write actually holds the tail.
+			await vi.waitFor(() => {
+				expect(releaseSetCache).toBeDefined();
+			});
+
+			let stopped = false;
+			const stopping = stopService.stop().then(() => {
+				stopped = true;
+			});
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(stopped).toBe(false);
+
+			releaseSetCache?.();
+			await Promise.all([accepted, stopping]);
+
+			// The accepted write persisted and broadcast BEFORE stop resolved.
+			expect(
+				stopEmitted.some(
+					(event) =>
+						event.stream === NOTIFICATION_STREAM &&
+						(event.data as { notification?: { title?: string } }).notification
+							?.title === "in-flight write",
+				),
+			).toBe(true);
+			// The durable write completed: the accepted record survived in the
+			// durable inbox (it must be served again after restart), while the
+			// in-memory list was cleared once the drained tail settled.
+			const persisted = await stopRuntime.getCache<AgentNotification[]>(
+				`notifications:${stopRuntime.agentId}`,
+			);
+			expect(persisted?.map((n) => n.title)).toEqual(["in-flight write"]);
+			expect(stopService.listIncludingExpired()).toEqual([]);
+			// Restore before the runtime-level cleanup stops services again.
+			(stopRuntime as { setCache: unknown }).setCache = originalSetCache;
+			// No post-stop clear(): write admission is closed by design; the
+			// durable record stays for restart hydration and afterAll teardown
+			// discards the whole test runtime.
+		});
+
+		it("rejects writes admitted after stop() with an explicit error", async () => {
+			await stopService.stop();
+			await expect(stopService.notify({ title: "too late" })).rejects.toThrow(
+				/service is stopped/,
+			);
+			await expect(
+				stopService.markRead("00000000-0000-4000-8000-000000000000"),
+			).rejects.toThrow(/service is stopped/);
+		});
 	});
 });

--- a/packages/core/src/services/notification.ts
+++ b/packages/core/src/services/notification.ts
@@ -159,9 +159,24 @@ export class NotificationService extends Service {
 	/** Newest-last ordered list (mirrors the persisted store). */
 	private notifications: AgentNotification[] = [];
 	private notificationWriteTail: Promise<void> = Promise.resolve();
+	/**
+	 * Set once {@link stop} begins. Write admission closes immediately so a
+	 * caller racing after teardown receives an explicit failure instead of a
+	 * silently accepted mutation that could outlive the service.
+	 */
+	private stopped = false;
 
 	/** Serialize every mutation of the shared inbox and its durable snapshot. */
 	private enqueueWrite<T>(write: () => Promise<T>): Promise<T> {
+		if (this.stopped) {
+			// Teardown has begun; a write admitted now could persist and fan out
+			// after the service reports it is stopped. Fail explicitly instead.
+			return Promise.reject(
+				new Error(
+					"[NotificationService] notification write rejected: service is stopped",
+				),
+			);
+		}
 		const operation = this.notificationWriteTail.then(write, write);
 		// error-policy:J5 the caller observes `operation`; the tail converts either
 		// outcome to completion so a rejected write cannot poison later mutations.
@@ -306,6 +321,16 @@ export class NotificationService extends Service {
 	}
 
 	async stop(): Promise<void> {
+		// Close write admission first: any caller racing this teardown from now
+		// on receives an explicit rejection instead of a silently accepted
+		// mutation that could persist after the service reports it stopped.
+		this.stopped = true;
+		// Drain the serialized durable-write tail so a notification accepted
+		// before shutdown finishes persisting (and broadcasting) BEFORE the
+		// service reports teardown complete. error-policy:J5 — the tail never
+		// rejects, but await defensively so a future tail change cannot leak an
+		// unhandled rejection out of stop().
+		await this.notificationWriteTail.catch(() => undefined);
 		this.notifications = [];
 	}
 


### PR DESCRIPTION
## Summary

Fixes #24776.

`NotificationService.stop()` cleared its in-memory inbox without closing write admission or waiting for the service's serialized durable-write tail. A notification accepted before shutdown could therefore persist and fan out after the service reported that teardown was complete, while a caller racing after `stop()` was still accepted instead of receiving an explicit failure.

### What changed

- `stop()` now sets `this.stopped = true` first (closing write admission), then awaits the write tail (which never rejects per error-policy:J5) before clearing the in-memory list. An accepted notification always finishes persisting and broadcasting before teardown reports completion.
- `enqueueWrite` rejects with a typed `"service is stopped"` error once admission is closed, instead of silently accepting a mutation that could outlive the service.

### Verification

- [Exact-head validation transcript](https://github.com/sharkwon/eliza/releases/download/pr-evidence-24776/validation-24776.log)
- `src/services/notification.test.ts` vitest integration suite: 48/48 pass (2 new tests: drain order + post-stop rejection)
- `bun run --cwd packages/core typecheck`: clean
- Biome on both changed files: clean
- `git diff --check`: clean

<!-- evidence-head:33cf5dd3daa7ac1b40ef9be09027f0da6157496d -->

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is service lifecycle sequencing.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; the changed surface is service lifecycle sequencing.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow change; pure lifecycle repair verified by integration tests.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation run at `33cf5dd3daa7ac1b40ef9be09027f0da6157496d`:

```
## packages/core vitest suite: src/services/notification.test.ts
 Test Files  1 passed (1)
      Tests  48 passed (48)
   Duration  6.13s (transform 4.50s, setup 0ms, import 5.67s, tests 337ms, environment 0ms)

## typecheck packages/core
Done!
## Biome changed files
Checked 2 files in 30ms. No fixes applied.
## git diff --check
OK
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic lifecycle logic; no LLM execution involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; integration coverage proves the behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or scanned artifacts in this change.

## Attribution

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2

<!-- attribution-row:models -->
z.ai/glm-5.2

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
self-reported
