### PR TITLE
fix(plugin-discord): bound local IPC frame payload length

### DIFF
--- a/plugins/plugin-discord/discord-local-service.ts
+++ b/plugins/plugin-discord/discord-local-service.ts
@@ -52,6 +52,12 @@ const IPC_OP_CLOSE = 2;
 const IPC_OP_PING = 3;
 const IPC_OP_PONG = 4;
 
+// Discord's local RPC frames carry a JSON payload; real ones are a few KB at
+// most. The reader below buffers until a declared frame is complete, so an
+// unbounded length lets a peer on the IPC socket hold the buffer open and grow
+// it without limit. Cap it far above any legitimate payload.
+const IPC_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;
+
 type DiscordLocalConfig = {
 	enabled: boolean;
 	clientId: string;
@@ -1002,6 +1008,13 @@ export class DiscordLocalService extends Service {
 			if (length < 0) {
 				logger.warn(
 					"[discord-local] Discarding malformed IPC frame with negative payload length",
+				);
+				this.readBuffer = Buffer.alloc(0);
+				return;
+			}
+			if (length > IPC_MAX_PAYLOAD_BYTES) {
+				logger.warn(
+					`[discord-local] Discarding IPC frame declaring ${length} bytes, above the ${IPC_MAX_PAYLOAD_BYTES}-byte payload cap`,
 				);
 				this.readBuffer = Buffer.alloc(0);
 				return;


### PR DESCRIPTION
Closes #25121.

### Problem

`handleSocketData` in `plugins/plugin-discord/discord-local-service.ts` reads a local RPC frame header as `op` + `length` (two `int32LE`), then waits until the declared payload has arrived. `length` is checked for being **negative** but never for being **too large**:

```ts
const length = this.readBuffer.readInt32LE(4);
if (length < 0) { /* discard */ }
if (this.readBuffer.length < 8 + length) {
  return;   // waits for the rest — forever, if length is huge
}
```

A peer that declares `2147483647` and keeps writing never satisfies that condition, so `readBuffer` grows without limit.

`readBuffer` is accumulated with `Buffer.concat([this.readBuffer, chunk])` on every socket chunk, which reallocates the whole buffer each time. That makes the wasted work grow quadratically with the traffic rather than linearly.

### Evidence

Replaying the framing loop exactly as written — one header declaring `INT32_MAX`, then 8 MB in 16 KB chunks:

```
WITHOUT cap  buffer held: 8.0 MB  bytes copied by Buffer.concat: 2052 MB  elapsed: 2188 ms  frame discarded: false
WITH cap     buffer held: 0.0 MB  bytes copied by Buffer.concat:    0 MB  elapsed:    0 ms  frame discarded: true
```

8 MB of input costs ~2 GB of copying and 2.2 s of CPU with the buffer still growing. At 64 MB the reproduction did not finish inside a two-minute timeout.

### Fix

One constant and one guard, mirroring the existing negative-length branch:

- `IPC_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024` — orders of magnitude above a real frame, which is a few KB of JSON, so no legitimate payload is affected.
- On violation: warn, reset `readBuffer`, return — identical handling to a negative length.

This is the same shape as #21768, which bounded the Discord local OAuth token fetches in this plugin.

### Scope and severity

Deliberately not overstated: this is the **local** RPC socket (named pipe on Windows, Unix socket otherwise), and the peer is normally the Discord desktop client, so it is not remotely reachable. It matters as robustness against a malformed or truncated frame from a Discord build that disagrees about framing, and against a local process squatting the socket path. Low severity, cheap to close.

I did not restructure the `Buffer.concat` accumulation itself. The framing loop relies on a contiguous buffer for `readInt32LE` and `subarray`, so converting it to a chunk list would be a much larger change than this fix warrants; bounding the length caps the quadratic cost to a single 8 MB worst case, which is not worth further churn.

### Verification

`tsc --noEmit` on the changed file reports no new syntax or type errors (only the pre-existing `@types/node` resolution errors that appear when the file is checked in isolation).

**I was not able to run `bun run verify` locally** — fetching the monorepo timed out on my connection, so this was prepared against the current `develop` blob through the GitHub API. The change is 13 added lines in one file with no import or signature changes, but please let CI be the authority here, and I am happy to adjust if the repo has a preferred constant location or logging convention for this plugin.