### PR TITLE
fix(core): restrict artifact disclosure tier-2 full to OWNER and ADMIN

### DIFF
--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -223,11 +223,24 @@ export function resolveArtifactDisclosure(
 	if (!ctx) return "full";
 	if (ctx.requesterEntityId === agentId) return "full";
 	const actor = actorFromAccessContext(ctx, agentId);
-	if (actor.role !== "USER") return "full";
+	// Tier 2 is OWNER/ADMIN only. Every other actor — USER, GUEST, RUNTIME, or
+	// an UNRESOLVED authority — must fall through to the grant check and the
+	// scope ladder below: treating "not USER" as elevated here hands
+	// least-privileged viewers tier-2 `full` disclosure and inverts the
+	// fail-closed matrix this module documents.
+	if (actor.role === "OWNER" || actor.role === "ADMIN") return "full";
 	const grants = record.grants ?? record.share?.grants;
 	const grant = grants?.find((g) => g.entityId === ctx.requesterEntityId);
 	if (grant) return grant.mode === "full" ? "full" : "redacted";
-	return canReadScope(record.scope, record.scopedEntityId, actor)
+	// Tier 4: an UNRESOLVED authority degrades to the least-privileged USER
+	// tier for the ladder step (open scopes stay readable; entity-private
+	// scopes deny), which is exactly how the attested-audience resolver's
+	// bare participants and the attachment fallback context are documented to
+	// behave. A raw UNRESOLVED actor passed straight to `canReadScope` still
+	// denies everywhere — the remap is local to this tier.
+	const ladderActor =
+		actor.role === "UNRESOLVED" ? { ...actor, role: "USER" as const } : actor;
+	return canReadScope(record.scope, record.scopedEntityId, ladderActor)
 		? "full"
 		: "none";
 }


### PR DESCRIPTION
Closes #25124.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. Branch point is `origin/develop` @ `2e69b70e` with zero conflicts; no `packages/core/src/access-control` commit has landed between the branch point and `origin/develop` @ `1a7df85a`, so there is nothing to rebase over. Before the change, `packages/core/src/access-control/artifact-disclosure.ts` was verified byte-identical to `origin/develop` (`git show origin/develop:<path> | diff - <path>` → empty).
- [x] `bun install` was run. Repo-wide `bun run verify` was not run; focused suites are recorded below. We are a fork contributor: hosted CI does not run on this PR. Pre-existing unrelated red on `develop`: `packages/agent/src/providers/relevant-conversations.test.ts` fails 7 tests identically with and without this change (root cause lives in that package, outside this diff).
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openrouter/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from `origin/develop` @ `2e69b70e`; zero conflicts; zero upstream commits touch `packages/core/src/access-control` between `2e69b70e` and `1a7df85a`.
- [ ] `bun run verify` was not run repo-wide. Focused package tests are recorded under **Testing**; known unrelated failures are recorded under **Known gaps / failures**.

# Risks

Low-to-medium, deliberately narrowed by construction:

- OWNER and ADMIN tier-2 behavior is unchanged (same `full`).
- USER is unchanged: `USER === USER` never took the old early return.
- Agent self-read is unchanged (earlier explicit branch).
- RUNTIME (documents read path) keeps landing on `full` for every scope via the ladder (`canReadScope` admits `RUNTIME` on all scopes); the only behavioral delta is that a stored `redacted` grant targeting a runtime entity would now narrow it — the documented "grant wins in BOTH directions" doctrine, and a fail-closed direction.
- GUEST loses `full` on entity-private scopes (the point of the fix); GUEST keeps `full` on `global`/`shared`/`room` via the ladder, matching `canReadScope`.
- UNRESOLVED degrades to the least-privileged USER tier for the ladder step only (open scopes readable, entity-private denied). A raw UNRESOLVED actor passed directly to `canReadScope` still denies everywhere; the remap is local to this function's tier 4, exactly as the attested-audience resolver contract ("every other participant resolves as the least-privileged `USER` tier") and the attachment fallback's J3 comment ("never unrestricted") already document.

# Background

## What does this PR do?

Restricts the tier-2 "full disclosure" early return in `resolveArtifactDisclosure` to OWNER and ADMIN, so GUEST, UNRESOLVED, and RUNTIME actors fall through to the per-entity grant check and the scope ladder as tiers 3–4 of the documented matrix.

## What kind of change is this?

Bug fix (non-breaking). Restores the module's own documented and tested fail-closed contract.

## Why are we doing this? Any context or related work?

`if (actor.role !== "USER") return "full"` elevated every non-USER actor — including GUEST and authority-unresolved contexts — to tier-2 `full`, skipping grants and the scope ladder. The matrix docstrings in `artifact-disclosure.ts`, `filter.ts`, `audience-disclosure.ts`, and `audience-egress.ts` all specify the opposite, and 18 committed contract tests across two packages have been red on `develop` since the line was introduced in 9e265557 (#15259). Full containment analysis and reproduction: #25124.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/access-control/artifact-disclosure.test.ts`, then the audience suites that consume the resolver.

## Detailed testing steps

None: automated tests are acceptable. All commands run at the exact head SHA of this PR.

Before (unmodified `develop` source, deps built):

```
cd packages/core && bunx vitest run src/access-control src/services/message.egress-audience-admission.test.ts
Test Files  4 failed | 4 passed (8)
     Tests  17 failed | 99 passed (116)

cd packages/agent && bunx vitest run src/api/attachment-disclosure.test.ts
Test Files  1 failed (1)
     Tests  1 failed | 7 passed (8)
```

Load-bearing revert (copy-aside of the origin file, not git stash): restoring origin `artifact-disclosure.ts` under the fixed tree turns `artifact-disclosure.test.ts` red again —

```
Test Files  1 failed (1)
     Tests  2 failed | 26 passed (28)
```

— and re-applying the one-line tier-2 gate turns everything green:

```
cd packages/core && bunx vitest run src/access-control src/services/message.egress-audience-admission.test.ts
Test Files  8 passed (8)
     Tests  116 passed (116)

cd packages/agent && bunx vitest run src/api/attachment-disclosure.test.ts
Test Files  1 passed (1)
     Tests  8 passed (8)
```

No-over-rejection corpus: all 18 previously-failing tests pass, and all 98 previously-passing tests in the same files still pass (116 core + 8 agent, zero regressions). Neighbor consumer suites are unchanged and green with the fix: `attachmentContext.test.ts` + `action-gate.test.ts` + `attachments.test.ts` = 38/38; `document-access.test.ts` + `relevant-conversations.fastfail.test.ts` green.

Typecheck against an untouched control: `tsc --noEmit` exit 0 on BOTH the control (stashed) tree and this branch; error sets diffed byte-identical (both empty — zero added errors).

Lint: `bunx biome check packages/core/src/access-control/artifact-disclosure.ts` → "Checked 1 file in 20ms. No fixes applied."

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:5d567b1384cc35411d92f7ffdc80c3a7e7600398 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure access-control decision logic; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - same reason; behavior is asserted by unit/integration suites quoted above.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; test output above is the walkthrough.
<!-- evidence-row:backend-logs -->
- [x] Backend path shown via committed test output above, including the egress wiring failure on develop (`SCOPED_LEAK_…` present in response content that must be withheld) flipping to withheld with the fix.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic access-control logic; no model call participates.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, or generated artifacts; state is in-test fixtures.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior in this diff.

## Backend + frontend logs

See **Detailed testing steps** for the full command outputs (before / revert / after).

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered surface.

### After

N/A - no rendered surface.

### Walkthrough video

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface.

## Known gaps / failures

- Hosted CI does not run on fork PRs; the suites above were executed locally at this exact head.
- `packages/agent/src/providers/relevant-conversations.test.ts` fails 7 tests on unmodified `develop`, identically before and after this change; its root cause lives outside `packages/core/src/access-control` (the suite mocks the core functions this PR touches), so it is neither fixed nor masked here.
- `canonical-memory-pglite.integration.test.ts` requires the workspace build (`generate-keywords.mjs` output plus a built `@elizaos/core` dist) to collect; without those steps it fails at import time with `Cannot find module './generated/validation-keyword-data.ts'` / package-entry resolution errors. With them, it passes (included in the 116/116).
- Repo-wide `bun run verify` was not executed locally (time/cost); risk bounded by the focused consumer suites listed above.

## Maintainer CI exception record

N/A - no exception requested.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-ac-tier2]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0PEBZK3A4V3ZEV4WQS7B9V9","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T04:34:25.507Z","completed_at":"2026-08-23T04:39:09.976Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T04:34:27.641Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cfeed3bc88ecf4ad87fc4f997813ed32fcc9a2239279bf214d8a9a509567f5ce","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3067caff-fe05-4450-8a99-4fa2b563d205","object_id":"sha256:cfeed3bc88ecf4ad87fc4f997813ed32fcc9a2239279bf214d8a9a509567f5ce","sha256":"cfeed3bc88ecf4ad87fc4f997813ed32fcc9a2239279bf214d8a9a509567f5ce"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"BNr-x5V8YeFz2wffrMMz5aYJpd3fOj3GejdqSVm-06cO_68HCnIxpaOD83HpD9_SQ6bv10el8NR9LrmmRqnnDA"}} -->
