### PR TITLE
perf(cloud): cut fresh auth session latency

### DIFF
--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -44,6 +44,7 @@ import {
   syncUserFromSteward,
 } from "@/lib/steward-sync";
 import { logger } from "@/lib/utils/logger";
+import { settleOffResponsePath } from "@/lib/utils/settle-off-response-path";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 function stewardSecretConfigured(env: StewardVerifyEnv): boolean {
@@ -352,6 +353,7 @@ app.post("/", async (c) => {
       }
     }
 
+    const executionCtx = getWorkerExecutionContext(c);
     let cloudUser: Awaited<ReturnType<typeof syncUserFromSteward>>;
     if (claims.stagingSessionBinding) {
       if (telegramContinuation) {
@@ -385,7 +387,27 @@ app.post("/", async (c) => {
           telegramContinuation: telegramContinuation ?? undefined,
           sharedRuntimeConversationNamespace:
             c.env.SHARED_RUNTIME_CONVERSATIONS,
-          executionCtx: getWorkerExecutionContext(c),
+          executionCtx,
+          afterRequiredSignupProvisioning: async (user) => {
+            try {
+              // The first authenticated browser request follows immediately.
+              // Prime its authorization projection after strict API-key
+              // readiness but before optional onboarding work starts, so that
+              // request does not race into the slower durable cache-miss path.
+              await primeVerifiedUserSessionCache(token, user);
+            } catch (error) {
+              // error-policy:J4 Cache priming is a latency optimization. Identity is
+              // already durable and the ordinary authenticated cache-miss path can
+              // recover, so a cache write failure must not strand the new account.
+              logger.warn(
+                "[steward-auth] New-user session cache prime failed",
+                {
+                  userId: user.id,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
+            }
+          },
         });
       } catch (error) {
         if (error instanceof StewardPhoneAccountConflictError) {
@@ -419,20 +441,6 @@ app.post("/", async (c) => {
           errorBody("Could not sync Steward user", "steward_user_sync_failed"),
           500,
         );
-      }
-    }
-
-    if (cloudUser.postCommitProvisioningDeferred) {
-      try {
-        await primeVerifiedUserSessionCache(token, cloudUser);
-      } catch (error) {
-        // error-policy:J4 Cache priming is a latency optimization. Identity is
-        // already durable and the ordinary authenticated cache-miss path can
-        // recover, so a Redis write failure must not strand the new account.
-        logger.warn("[steward-auth] New-user session cache prime failed", {
-          userId: cloudUser.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
       }
     }
 
@@ -486,28 +494,32 @@ app.post("/", async (c) => {
     });
 
     logStewardAuth("ok", ttl);
-    await getAuditDispatcher()
-      .emit({
-        actor: { type: "user", id: cloudUser.id },
-        action: "auth.login",
-        result: "success",
-        resource: null,
-        org_id: cloudUser.organization_id ?? undefined,
-        ip: getRequestIp(c),
-        user_agent: c.req.header("user-agent") ?? undefined,
-        request_id: c.get("requestId"),
-        metadata: { provider: "steward", method: "session_exchange" },
-      })
-      // error-policy:J7 audit write must not block the login response; a dropped auth audit is logged.
-      .catch((err) =>
-        logger.error(
-          "[StewardSession] audit emit for successful login failed",
-          {
-            userId: cloudUser.id,
-            error: err instanceof Error ? err.message : String(err),
-          },
-        ),
-      );
+    // The required sink remains owned by the Worker lifetime, but its database
+    // RTT is not account readiness and must not delay the successful response.
+    await settleOffResponsePath(executionCtx, async () => {
+      await getAuditDispatcher()
+        .emit({
+          actor: { type: "user", id: cloudUser.id },
+          action: "auth.login",
+          result: "success",
+          resource: null,
+          org_id: cloudUser.organization_id ?? undefined,
+          ip: getRequestIp(c),
+          user_agent: c.req.header("user-agent") ?? undefined,
+          request_id: c.get("requestId"),
+          metadata: { provider: "steward", method: "session_exchange" },
+        })
+        // error-policy:J7 audit write must not block the login response; a dropped auth audit is logged.
+        .catch((err) =>
+          logger.error(
+            "[StewardSession] audit emit for successful login failed",
+            {
+              userId: cloudUser.id,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          ),
+        );
+    });
     const response: StewardSessionResponse = {
       ok: true,
       userId: cloudUser.id,

--- a/packages/cloud/api/auth/steward-session/steward-session-postcommit-latency.test.ts
+++ b/packages/cloud/api/auth/steward-session/steward-session-postcommit-latency.test.ts
@@ -2,9 +2,10 @@
  * Route contract for direct-signup post-commit provisioning.
  *
  * The session exchange must pass the Worker lifetime into the shared identity
- * authority and may mint cookies/cache only after identity and the required
- * default API key are ready. Its waitUntil-owned, independently self-healing
- * onboarding tail must not delay the response or Personal conversations.
+ * authority and must prime the first-request cache after identity and the
+ * required default API key are ready, before independently self-healing
+ * onboarding starts. The waitUntil-owned onboarding and audit tails must not
+ * delay the response or the first authenticated Personal request.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -18,8 +19,10 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-const emitAudit = mock(async () => undefined);
-const primeVerifiedUserSessionCache = mock(async () => undefined);
+const emitAudit = mock(async (): Promise<void> => undefined);
+const primeVerifiedUserSessionCache = mock(
+  async (): Promise<void> => undefined,
+);
 const verifyStewardTokenCached = mock(async () => ({
   userId: "steward-user-1",
   email: "person@example.test",
@@ -37,15 +40,18 @@ type MockSyncedUser = {
 const syncUserFromSteward = mock(
   async (params: {
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+    afterRequiredSignupProvisioning?: (user: MockSyncedUser) => Promise<void>;
   }): Promise<MockSyncedUser> => {
-    params.executionCtx?.waitUntil(postCommitTail.promise);
-    return {
+    const user = {
       id: "cloud-user-1",
       organization_id: "org-1",
       initialCreditsGranted: false,
       initialFreeCreditsUsd: 0,
       postCommitProvisioningDeferred: true as const,
     };
+    await params.afterRequiredSignupProvisioning?.(user);
+    params.executionCtx?.waitUntil(postCommitTail.promise);
+    return user;
   },
 );
 const committedUser = {
@@ -151,26 +157,37 @@ function sessionRequest(): Request {
 
 beforeEach(() => {
   postCommitTail = deferred<void>();
-  emitAudit.mockClear();
+  emitAudit.mockReset();
+  emitAudit.mockResolvedValue(undefined);
   primeVerifiedUserSessionCache.mockReset();
   primeVerifiedUserSessionCache.mockResolvedValue(undefined);
   syncUserFromSteward.mockClear();
   syncUserFromSteward.mockImplementation(async (params) => {
-    params.executionCtx?.waitUntil(postCommitTail.promise);
-    return {
+    const user = {
       id: "cloud-user-1",
       organization_id: "org-1",
       initialCreditsGranted: false,
       initialFreeCreditsUsd: 0,
       postCommitProvisioningDeferred: true as const,
     };
+    await params.afterRequiredSignupProvisioning?.(user);
+    params.executionCtx?.waitUntil(postCommitTail.promise);
+    return user;
   });
   getByStewardId.mockClear();
   findActivePersonalDedicatedTarget.mockClear();
 });
 
 describe("POST /api/auth/steward-session post-commit tail", () => {
-  test("serves the committed user's Personal conversation before waitUntil settles", async () => {
+  test("primes cache before onboarding starts, then responds while audit and onboarding are pending", async () => {
+    const cachePrimeStarted = deferred<void>();
+    const cachePrimeTail = deferred<void>();
+    const auditTail = deferred<void>();
+    primeVerifiedUserSessionCache.mockImplementationOnce(async () => {
+      cachePrimeStarted.resolve();
+      await cachePrimeTail.promise;
+    });
+    emitAudit.mockImplementationOnce(async () => await auditTail.promise);
     const background: Promise<unknown>[] = [];
     const executionCtx = {
       waitUntil: (promise: Promise<unknown>) => background.push(promise),
@@ -184,20 +201,37 @@ describe("POST /api/auth/steward-session post-commit tail", () => {
       personalConversationsRoute,
     );
 
-    const response = await app.fetch(
-      sessionRequest(),
-      ENV,
-      executionCtx as never,
-    );
+    let responseSettled = false;
+    const responsePromise = Promise.resolve(
+      app.fetch(sessionRequest(), ENV, executionCtx as never),
+    ).then((response) => {
+      responseSettled = true;
+      return response;
+    });
+
+    await cachePrimeStarted.promise;
+    expect(responseSettled).toBe(false);
+    expect(background).toHaveLength(0);
+    cachePrimeTail.resolve();
+
+    const response = await responsePromise;
 
     expect(response.status).toBe(200);
     const setCookie = response.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("steward-token-staging=valid-steward-token");
     expect(setCookie).toContain("steward-authed-staging=1");
-    expect(background).toEqual([postCommitTail.promise]);
+    expect(background[0]).toBe(postCommitTail.promise);
+    expect(background).toHaveLength(2);
     expect(primeVerifiedUserSessionCache).toHaveBeenCalledWith(
       "valid-steward-token",
       expect.objectContaining({ id: "cloud-user-1", organization_id: "org-1" }),
+    );
+    expect(emitAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { type: "user", id: "cloud-user-1" },
+        action: "auth.login",
+        result: "success",
+      }),
     );
 
     const personalResponse = await app.fetch(
@@ -237,10 +271,14 @@ describe("POST /api/auth/steward-session post-commit tail", () => {
     });
     expect(getByStewardId).toHaveBeenCalledTimes(2);
     expect(findActivePersonalDedicatedTarget).toHaveBeenCalledTimes(1);
-    expect(background).toEqual([postCommitTail.promise]);
+    expect(background).toHaveLength(2);
 
     postCommitTail.resolve();
-    await expect(background[0]).resolves.toBeUndefined();
+    auditTail.resolve();
+    await expect(Promise.all(background)).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 
   test("required default API-key failure remains fail-closed and plants no cookie or cache", async () => {
@@ -282,10 +320,76 @@ describe("POST /api/auth/steward-session post-commit tail", () => {
     expect(response.headers.get("set-cookie")).toContain(
       "steward-token-staging=valid-steward-token",
     );
-    expect(background).toEqual([postCommitTail.promise]);
+    expect(background).toHaveLength(2);
 
     postCommitTail.resolve();
-    await expect(background[0]).resolves.toBeUndefined();
+    await expect(Promise.all(background)).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
+  test("audit failure stays fail-open after cookie mint", async () => {
+    emitAudit.mockRejectedValueOnce(new Error("audit unavailable"));
+    const background: Promise<unknown>[] = [];
+    const app = new Hono();
+    app.route("/api/auth/steward-session", stewardSessionRoute);
+
+    const response = await app.fetch(sessionRequest(), ENV, {
+      waitUntil: (promise: Promise<unknown>) => background.push(promise),
+      passThroughOnException: () => undefined,
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain(
+      "steward-token-staging=valid-steward-token",
+    );
+    expect(background).toHaveLength(2);
+
+    postCommitTail.resolve();
+    await expect(Promise.all(background)).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
+  test("non-Worker callers retain inline cache and audit completion", async () => {
+    const cachePrimeStarted = deferred<void>();
+    const cachePrimeTail = deferred<void>();
+    const auditStarted = deferred<void>();
+    const auditTail = deferred<void>();
+    primeVerifiedUserSessionCache.mockImplementationOnce(async () => {
+      cachePrimeStarted.resolve();
+      await cachePrimeTail.promise;
+    });
+    emitAudit.mockImplementationOnce(async () => {
+      auditStarted.resolve();
+      await auditTail.promise;
+    });
+    const app = new Hono();
+    app.route("/api/auth/steward-session", stewardSessionRoute);
+
+    let responseSettled = false;
+    const responsePromise = Promise.resolve(
+      app.fetch(sessionRequest(), ENV),
+    ).then((response) => {
+      responseSettled = true;
+      return response;
+    });
+
+    await cachePrimeStarted.promise;
+    expect(responseSettled).toBe(false);
+    cachePrimeTail.resolve();
+
+    await auditStarted.promise;
+    expect(responseSettled).toBe(false);
+    auditTail.resolve();
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain(
+      "steward-token-staging=valid-steward-token",
+    );
   });
 
   test("returning-user exchanges do not suppress cache-miss self-heal", async () => {
@@ -304,6 +408,7 @@ describe("POST /api/auth/steward-session post-commit tail", () => {
 
     expect(response.status).toBe(200);
     expect(primeVerifiedUserSessionCache).not.toHaveBeenCalled();
-    expect(background).toHaveLength(0);
+    expect(background).toHaveLength(1);
+    await expect(background[0]).resolves.toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
@@ -72,6 +72,31 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
     expectedTelegramOrganizationId: pair.telegram.organization.id,
   });
 
+  const createCanonicalStewardSubject = async () => {
+    sequence += 1;
+    const stewardUserId = `steward-canonical-${sequence}`;
+    const [organization] = await dbWrite
+      .insert(organizations)
+      .values({
+        name: `Canonical ${sequence}`,
+        slug: `canonical-${sequence}`,
+      })
+      .returning();
+    const [user] = await dbWrite
+      .insert(users)
+      .values({
+        steward_user_id: stewardUserId,
+        organization_id: organization.id,
+        role: "owner",
+      })
+      .returning();
+    await dbWrite.insert(userIdentities).values({
+      user_id: user.id,
+      steward_user_id: stewardUserId,
+    });
+    return { stewardUserId, user, organization };
+  };
+
   beforeAll(async () => {
     if (!CAN_USE_ISOLATED_PGLITE) {
       pgliteReady = false;
@@ -186,6 +211,36 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
     await closeDatabaseConnectionsForTests();
   });
 
+  test("returns not_found when the canonical Steward subject does not exist", async () => {
+    await expect(
+      usersRepository.findPendingPhoneTelegramPersonalAccountConvergence({
+        stewardUserId: "missing-steward-subject",
+      }),
+    ).resolves.toEqual({ status: "not_found" });
+  });
+
+  test("returns the canonical user and organization when no pending alias exists", async () => {
+    const canonical = await createCanonicalStewardSubject();
+
+    await expect(
+      usersRepository.findPendingPhoneTelegramPersonalAccountConvergence({
+        stewardUserId: canonical.stewardUserId,
+      }),
+    ).resolves.toMatchObject({
+      status: "canonical_user",
+      user: {
+        id: canonical.user.id,
+        steward_user_id: canonical.stewardUserId,
+        organization_id: canonical.organization.id,
+        organization: {
+          id: canonical.organization.id,
+          slug: canonical.organization.slug,
+          credit_balance: "0.000000",
+        },
+      },
+    });
+  });
+
   test("converges exactly two $0 provisional accounts and retains an idempotent alias receipt", async () => {
     const pair = await createPair();
     const proof = proofFor(pair);
@@ -267,7 +322,14 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
       await usersRepository.findPendingPhoneTelegramPersonalAccountConvergence({
         stewardUserId: proof.stewardUserId,
       }),
-    ).toEqual({ status: "not_found" });
+    ).toMatchObject({
+      status: "canonical_user",
+      user: {
+        id: pair.telegram.user.id,
+        organization_id: pair.telegram.organization.id,
+        organization: { id: pair.telegram.organization.id },
+      },
+    });
     expect(
       await usersRepository.hasPendingPhoneTelegramPersonalAccountConvergenceTarget({
         targetUserId: pair.telegram.user.id,

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
@@ -241,6 +241,25 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
     });
   });
 
+  test("fails closed when the canonical Steward row and identity authority resolve different users", async () => {
+    const canonical = await createCanonicalStewardSubject();
+    const projected = await createCanonicalStewardSubject();
+    await dbWrite
+      .update(userIdentities)
+      .set({ steward_user_id: `drifted-projection-${sequence}` })
+      .where(eq(userIdentities.user_id, canonical.user.id));
+    await dbWrite
+      .update(userIdentities)
+      .set({ steward_user_id: canonical.stewardUserId })
+      .where(eq(userIdentities.user_id, projected.user.id));
+
+    await expect(
+      usersRepository.findPendingPhoneTelegramPersonalAccountConvergence({
+        stewardUserId: canonical.stewardUserId,
+      }),
+    ).resolves.toEqual({ status: "identity_projection_conflict" });
+  });
+
   test("converges exactly two $0 provisional accounts and retains an idempotent alias receipt", async () => {
     const pair = await createPair();
     const proof = proofFor(pair);

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -3,6 +3,7 @@
 import { ElizaError } from "@elizaos/core";
 import { convergeTodoScopesInTransaction } from "@elizaos/plugin-todos/edge";
 import { and, desc, eq, isNull, ne, or, type SQL, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import {
   sharedRuntimeConversationRoomId,
   sharedRuntimeWorldId,
@@ -18,6 +19,9 @@ import {
 } from "../schemas/personal-account-convergences";
 import { type UserIdentity, userIdentities } from "../schemas/user-identities";
 import { type NewUser, type User, users } from "../schemas/users";
+
+const stewardAuthorityIdentity = alias(userIdentities, "steward_authority_identity");
+const canonicalStewardIdentity = alias(userIdentities, "canonical_steward_identity");
 
 export type { NewUser, User, UserIdentity };
 
@@ -1529,30 +1533,59 @@ export class UsersRepository {
     phoneNumber?: string;
     stewardUserId: string;
   }): Promise<FindPendingPhoneTelegramConvergenceResult> {
+    const stewardSubject = dbWrite.$with("steward_subject").as((qb) =>
+      qb
+        .select({
+          stewardUserId: sql<string>`${input.stewardUserId}`.as("requested_steward_subject_id"),
+        })
+        .from(sql`(select 1)`),
+    );
     const [inspection] = await dbWrite
+      .with(stewardSubject)
       .select({
-        user: users,
+        canonicalUser: users,
         organization: organizations,
+        authorityUserId: stewardAuthorityIdentity.user_id,
+        canonicalIdentityStewardUserId: canonicalStewardIdentity.steward_user_id,
         pendingReceiptToken: personalAccountConvergences.token,
       })
-      .from(users)
+      .from(stewardSubject)
+      .leftJoin(users, eq(users.steward_user_id, stewardSubject.stewardUserId))
+      .leftJoin(
+        stewardAuthorityIdentity,
+        eq(stewardAuthorityIdentity.steward_user_id, stewardSubject.stewardUserId),
+      )
+      .leftJoin(canonicalStewardIdentity, eq(canonicalStewardIdentity.user_id, users.id))
       .leftJoin(organizations, eq(organizations.id, users.organization_id))
       .leftJoin(
         personalAccountConvergences,
         and(
           eq(personalAccountConvergences.target_user_id, users.id),
-          eq(personalAccountConvergences.steward_user_id, input.stewardUserId),
+          eq(personalAccountConvergences.steward_user_id, stewardSubject.stewardUserId),
           eq(personalAccountConvergences.status, "pending_alias"),
         ),
       )
-      .where(eq(users.steward_user_id, input.stewardUserId))
       .limit(1);
 
-    if (!inspection) return { status: "not_found" };
+    // The projection remains session authority while legacy canonical-only rows
+    // converge. Accept the repairable canonical-only case, but never choose one
+    // owner while the same Steward subject projects to another.
+    if (!inspection?.canonicalUser) {
+      return inspection?.authorityUserId
+        ? { status: "identity_projection_conflict" }
+        : { status: "not_found" };
+    }
+    if (
+      (inspection.authorityUserId && inspection.authorityUserId !== inspection.canonicalUser.id) ||
+      (inspection.canonicalIdentityStewardUserId &&
+        inspection.canonicalIdentityStewardUserId !== input.stewardUserId)
+    ) {
+      return { status: "identity_projection_conflict" };
+    }
     if (!inspection.pendingReceiptToken) {
       return {
         status: "canonical_user",
-        user: { ...inspection.user, organization: inspection.organization },
+        user: { ...inspection.canonicalUser, organization: inspection.organization },
       };
     }
 

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -227,6 +227,7 @@ export type FindPendingPhoneTelegramConvergenceResult =
       user: User;
       organization: Organization;
     }
+  | { status: "canonical_user"; user: UserWithOrganization }
   | { status: "not_found" }
   | { status: "identity_projection_conflict" };
 
@@ -1525,6 +1526,44 @@ export class UsersRepository {
    * constraint rather than required retry authority.
    */
   async findPendingPhoneTelegramPersonalAccountConvergence(input: {
+    phoneNumber?: string;
+    stewardUserId: string;
+  }): Promise<FindPendingPhoneTelegramConvergenceResult> {
+    const [inspection] = await dbWrite
+      .select({
+        user: users,
+        organization: organizations,
+        pendingReceiptToken: personalAccountConvergences.token,
+      })
+      .from(users)
+      .leftJoin(organizations, eq(organizations.id, users.organization_id))
+      .leftJoin(
+        personalAccountConvergences,
+        and(
+          eq(personalAccountConvergences.target_user_id, users.id),
+          eq(personalAccountConvergences.steward_user_id, input.stewardUserId),
+          eq(personalAccountConvergences.status, "pending_alias"),
+        ),
+      )
+      .where(eq(users.steward_user_id, input.stewardUserId))
+      .limit(1);
+
+    if (!inspection) return { status: "not_found" };
+    if (!inspection.pendingReceiptToken) {
+      return {
+        status: "canonical_user",
+        user: { ...inspection.user, organization: inspection.organization },
+      };
+    }
+
+    return await this.validatePendingPhoneTelegramPersonalAccountConvergence(input);
+  }
+
+  /**
+   * Revalidates a detected pending receipt within the original primary
+   * transaction so rare alias recovery retains its existing snapshot checks.
+   */
+  private async validatePendingPhoneTelegramPersonalAccountConvergence(input: {
     phoneNumber?: string;
     stewardUserId: string;
   }): Promise<FindPendingPhoneTelegramConvergenceResult> {

--- a/packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts
@@ -21,6 +21,7 @@
 
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import crypto from "node:crypto";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
 
 // This proof owns its DB: force an isolated in-memory PGlite regardless of the
 // ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports.
@@ -172,6 +173,56 @@ async function readActiveKeys(
        AND is_active = true AND deleted_at IS NULL;`,
   );
   return rows.rows as Array<{ name: string; key_prefix: string }>;
+}
+
+interface DefaultKeyRow {
+  id: string;
+  key_prefix: string;
+}
+
+async function seedProvisioningTarget(): Promise<{
+  organizationId: string;
+  userId: string;
+}> {
+  const organizationId = uid();
+  const userId = uid();
+  await dbWrite.insert(schemas.organizations).values({
+    id: organizationId,
+    name: "Provisioning Target",
+    slug: `provisioning-${organizationId}`,
+  });
+  await dbWrite.insert(schemas.users).values({
+    id: userId,
+    steward_user_id: `steward-${userId}`,
+    email: `provisioning-${userId}@example.com`,
+    organization_id: organizationId,
+    role: "member",
+  });
+  return { organizationId, userId };
+}
+
+async function readDefaultKeyRows(
+  userId: string,
+  organizationId: string,
+  usableOnly = false,
+): Promise<DefaultKeyRow[]> {
+  const filters = [
+    eq(schemas.apiKeys.user_id, userId),
+    eq(schemas.apiKeys.organization_id, organizationId),
+    eq(schemas.apiKeys.name, "Default API Key"),
+    eq(schemas.apiKeys.is_active, true),
+    isNull(schemas.apiKeys.deleted_at),
+  ];
+  if (usableOnly) {
+    filters.push(
+      or(isNull(schemas.apiKeys.expires_at), gt(schemas.apiKeys.expires_at, new Date()))!,
+    );
+  }
+  return await dbWrite
+    .select({ id: schemas.apiKeys.id, key_prefix: schemas.apiKeys.key_prefix })
+    .from(schemas.apiKeys)
+    .where(and(...filters))
+    .orderBy(schemas.apiKeys.created_at, schemas.apiKeys.id);
 }
 
 beforeAll(async () => {
@@ -371,30 +422,86 @@ describe("invite accept provisions the personal default API key", () => {
     "concurrent default-key provisioning mints one active default key",
     async () => {
       expect(pgliteReady).toBe(true);
-      const organizationId = uid();
-      const userId = uid();
-
-      await dbWrite.insert(schemas.organizations).values({
-        id: organizationId,
-        name: "Team Org",
-        slug: `team-${organizationId}`,
-      });
-      await dbWrite.insert(schemas.users).values({
-        id: userId,
-        steward_user_id: `steward-${userId}`,
-        email: `user-${userId}@example.com`,
-        organization_id: organizationId,
-        role: "member",
-      });
+      const { organizationId, userId } = await seedProvisioningTarget();
 
       await Promise.all([
         apiKeysService.provisionDefaultApiKey(userId, organizationId),
         apiKeysService.provisionDefaultApiKey(userId, organizationId),
+        apiKeysService.provisionDefaultApiKey(userId, organizationId),
       ]);
 
-      const keys = await readActiveKeys(userId, organizationId);
+      const keys = await readDefaultKeyRows(userId, organizationId);
       expect(keys.length).toBe(1);
-      expect(keys[0].name).toBe("Default API Key");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "existing unexpired default key is retained without another insert",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { organizationId, userId } = await seedProvisioningTarget();
+      const existingId = uid();
+      await dbWrite.insert(schemas.apiKeys).values({
+        id: existingId,
+        name: "Default API Key",
+        key_hash: `hash-existing-${existingId}`,
+        key_prefix: "eliza_existing",
+        organization_id: organizationId,
+        user_id: userId,
+        expires_at: new Date(Date.now() + 60_000),
+      });
+
+      await apiKeysService.provisionDefaultApiKey(userId, organizationId);
+
+      const keys = await readDefaultKeyRows(userId, organizationId);
+      expect(keys).toEqual([{ id: existingId, key_prefix: "eliza_existing" }]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "expired default key gets exactly one usable replacement",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const { organizationId, userId } = await seedProvisioningTarget();
+      const expiredId = uid();
+      await dbWrite.insert(schemas.apiKeys).values({
+        id: expiredId,
+        name: "Default API Key",
+        key_hash: `hash-expired-${expiredId}`,
+        key_prefix: "eliza_expired",
+        organization_id: organizationId,
+        user_id: userId,
+        expires_at: new Date(Date.now() - 60_000),
+      });
+
+      await apiKeysService.provisionDefaultApiKey(userId, organizationId);
+
+      const allKeys = await readDefaultKeyRows(userId, organizationId);
+      expect(allKeys).toHaveLength(2);
+      expect(allKeys.some((key) => key.id === expiredId)).toBe(true);
+      const usableKeys = await readDefaultKeyRows(userId, organizationId, true);
+      expect(usableKeys).toHaveLength(1);
+      expect(usableKeys[0].id).not.toBe(expiredId);
+      expect(usableKeys[0].key_prefix).not.toBe("eliza_expired");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "conditional insert failure rejects instead of reporting readiness",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const missingOrganizationId = uid();
+      const missingUserId = uid();
+
+      await expect(
+        apiKeysService.provisionDefaultApiKey(missingUserId, missingOrganizationId),
+      ).rejects.toThrow();
+
+      const keys = await readDefaultKeyRows(missingUserId, missingOrganizationId);
+      expect(keys).toHaveLength(0);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts
@@ -237,6 +237,9 @@ beforeAll(async () => {
     const { users } = await import("../../../db/schemas/users");
     const { userIdentities } = await import("../../../db/schemas/user-identities");
     const { organizationInvites } = await import("../../../db/schemas/organization-invites");
+    const { personalAccountConvergences } = await import(
+      "../../../db/schemas/personal-account-convergences"
+    );
     const { apiKeys } = await import("../../../db/schemas/api-keys");
     const { creditTransactions } = await import("../../../db/schemas/credit-transactions");
     const { userCharacters } = await import("../../../db/schemas/user-characters");
@@ -264,6 +267,7 @@ beforeAll(async () => {
         organizations,
         users,
         userIdentities,
+        personalAccountConvergences,
         organizationInvites,
         apiKeys,
         creditTransactions,

--- a/packages/cloud/shared/src/lib/services/api-keys.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.ts
@@ -6,7 +6,7 @@
 
 import { ElizaError } from "@elizaos/core";
 import crypto from "crypto";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, notExists, or, sql } from "drizzle-orm";
 import { type DbTransaction, dbWrite } from "../../db/client";
 import { encryptApiKey } from "../../db/crypto/api-keys";
 import { type ApiKey, apiKeysRepository, type NewApiKey } from "../../db/repositories";
@@ -433,14 +433,28 @@ export class ApiKeysService {
       throw new Error("Invalid userId or organizationId for default API key provisioning");
     }
 
+    // Build and encrypt outside the transaction so KMS work does not extend
+    // the advisory-lock hold. Existing-key calls may discard this candidate;
+    // direct signup is the latency-sensitive path and always needs it.
+    const { apiKey } = await this.buildApiKeyInsert({
+      user_id: userId,
+      organization_id: organizationId,
+      name: "Default API Key",
+      is_active: true,
+    });
+
     await dbWrite.transaction(async (tx) => {
+      // Keep lock acquisition in its own statement. Under READ COMMITTED, a
+      // waiter gets a fresh snapshot for the conditional INSERT after the lock
+      // holder commits. Folding lock + existence check into one statement
+      // would preserve the pre-wait snapshot and could mint a duplicate.
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(hashtext(${`default_api_key:${userId}:${organizationId}`}))`,
       );
 
       const now = new Date();
-      const existingKeys = await tx
-        .select()
+      const usableDefaultKey = tx
+        .select({ id: apiKeys.id })
         .from(apiKeys)
         .where(
           and(
@@ -449,19 +463,54 @@ export class ApiKeysService {
             eq(apiKeys.name, "Default API Key"),
             eq(apiKeys.is_active, true),
             isNull(apiKeys.deleted_at),
+            or(isNull(apiKeys.expires_at), gt(apiKeys.expires_at, now)),
           ),
         );
-      if (existingKeys.some((key) => !key.expires_at || key.expires_at > now)) {
-        return;
-      }
 
-      const { apiKey } = await this.buildApiKeyInsert({
-        user_id: userId,
-        organization_id: organizationId,
-        name: "Default API Key",
-        is_active: true,
-      });
-      await tx.insert(apiKeys).values(apiKey);
+      // Drizzle's INSERT ... SELECT requires every insertable column in schema
+      // order. Supplying the table's defaults explicitly keeps this one
+      // statement equivalent to values(apiKey), while NOT EXISTS performs the
+      // post-lock readiness check and conditional insert in the same snapshot.
+      await tx.insert(apiKeys).select(
+        tx
+          .select({
+            id: sql<string>`${apiKey.id}::uuid`.as("id"),
+            name: sql<string>`${apiKey.name}::text`.as("name"),
+            description: sql<string | null>`${apiKey.description ?? null}::text`.as("description"),
+            key_hash: sql<string>`${apiKey.key_hash}::text`.as("key_hash"),
+            key_prefix: sql<string>`${apiKey.key_prefix}::text`.as("key_prefix"),
+            key_ciphertext: sql<string | null>`${apiKey.key_ciphertext ?? null}::text`.as(
+              "key_ciphertext",
+            ),
+            key_nonce: sql<string | null>`${apiKey.key_nonce ?? null}::text`.as("key_nonce"),
+            key_auth_tag: sql<string | null>`${apiKey.key_auth_tag ?? null}::text`.as(
+              "key_auth_tag",
+            ),
+            key_kms_key_id: sql<string | null>`${apiKey.key_kms_key_id ?? null}::text`.as(
+              "key_kms_key_id",
+            ),
+            key_kms_key_version: sql<
+              number | null
+            >`${apiKey.key_kms_key_version ?? null}::integer`.as("key_kms_key_version"),
+            organization_id: sql<string>`${apiKey.organization_id}::uuid`.as("organization_id"),
+            user_id: sql<string>`${apiKey.user_id}::uuid`.as("user_id"),
+            source_app_id: sql<string | null>`${apiKey.source_app_id ?? null}::uuid`.as(
+              "source_app_id",
+            ),
+            rate_limit: sql<number>`${apiKey.rate_limit ?? 1000}::integer`.as("rate_limit"),
+            is_active: sql<boolean>`${apiKey.is_active ?? true}::boolean`.as("is_active"),
+            usage_count: sql<number>`${apiKey.usage_count ?? 0}::integer`.as("usage_count"),
+            expires_at: sql<Date | null>`${apiKey.expires_at ?? null}::timestamp`.as("expires_at"),
+            last_used_at: sql<Date | null>`${apiKey.last_used_at ?? null}::timestamp`.as(
+              "last_used_at",
+            ),
+            created_at: sql<Date>`NOW()`.as("created_at"),
+            updated_at: sql<Date>`NOW()`.as("updated_at"),
+            deleted_at: sql<Date | null>`${apiKey.deleted_at ?? null}::timestamp`.as("deleted_at"),
+          })
+          .from(sql`(SELECT 1) AS singleton`)
+          .where(notExists(usableDefaultKey)),
+      );
     });
   }
 

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -22,6 +22,8 @@ const invalidatedSessionBatches: string[][] = [];
 const userDeleteCalls: string[] = [];
 const orgDeleteCalls: string[] = [];
 const lifecycleEvents: string[] = [];
+const repositoryReads: string[] = [];
+const deletedCacheKeys: string[] = [];
 
 let userApiKeys: Array<{ key_hash: string }> = [];
 let orgApiKeys: Array<{ key_hash: string }> = [];
@@ -123,16 +125,32 @@ mock.module("../../db/repositories", () => ({
   usersRepository: {
     findById: async (_id: string) =>
       useReadUserRecordOverride ? readUserRecordOverride : userRecord,
-    findByIdForWrite: async (_id: string) => userRecord,
-    findIdentityByUserIdForWrite: async () =>
-      userRecord?.steward_user_id
+    findByIdForWrite: async (_id: string) => {
+      repositoryReads.push("user-for-write");
+      return userRecord;
+    },
+    findIdentityByUserIdForWrite: async () => {
+      repositoryReads.push("identity-for-write");
+      return userRecord?.steward_user_id
         ? {
             steward_user_id: userRecord.steward_user_id,
             telegram_id: userRecord.telegram_id ?? null,
             discord_id: userRecord.discord_id ?? null,
             phone_number: userRecord.phone_number ?? null,
           }
-        : undefined,
+        : undefined;
+    },
+    create: async (data: Record<string, unknown>) => {
+      userRecord = {
+        id: "u-fresh",
+        email: null,
+        wallet_address: null,
+        is_active: true,
+        ...data,
+      };
+      lifecycleEvents.push("user-create:u-fresh");
+      return userRecord;
+    },
     upsertStewardIdentity: async (id: string, stewardUserId: string) => {
       lifecycleEvents.push(`identity-upsert:${id}:${stewardUserId}`);
       if (userRecord) userRecord.steward_user_id = stewardUserId;
@@ -175,7 +193,9 @@ mock.module("../cache/client", () => ({
   cache: {
     get: async () => null,
     set: async () => {},
-    del: async () => {},
+    del: async (key: string) => {
+      deletedCacheKeys.push(key);
+    },
   },
 }));
 
@@ -198,6 +218,8 @@ beforeEach(() => {
   listByOrganizationUsers = [];
   listByUserError = null;
   lifecycleEvents.length = 0;
+  repositoryReads.length = 0;
+  deletedCacheKeys.length = 0;
 });
 
 describe("UsersService — IAC invalidation on lifecycle", () => {
@@ -318,6 +340,115 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
 
     expect(userRecord.is_active).toBe(true);
     expect(lifecycleEvents).toEqual(["projection-fence-failed:phone:+15551234567"]);
+  });
+
+  test("fresh Steward signup initializes only its projection and active binding", async () => {
+    const { usersService } = await import("./users");
+    const user = await usersService.createFreshStewardSignupUser({
+      email: "fresh@example.com",
+      organization_id: "o1",
+      steward_user_id: "steward-new",
+    });
+
+    await usersService.initializeFreshStewardIdentity({
+      user,
+      stewardUserId: "steward-new",
+    });
+
+    expect(lifecycleEvents).toEqual([
+      "user-create:u-fresh",
+      "identity-upsert:u-fresh:steward-new",
+      "session-binding:o1:u-fresh:steward-new:true",
+    ]);
+    expect(repositoryReads).toEqual([]);
+    expect(deletedCacheKeys).toEqual([]);
+    expect(invalidatedSessionBatches).toEqual([]);
+  });
+
+  test("fresh Steward identity initialization rejects active-binding failure", async () => {
+    const { usersService } = await import("./users");
+    const user = await usersService.createFreshStewardSignupUser({
+      email: "fresh@example.com",
+      organization_id: "o1",
+      steward_user_id: "steward-new",
+    });
+    failNextBindingActivation = true;
+
+    await expect(
+      usersService.initializeFreshStewardIdentity({
+        user,
+        stewardUserId: "steward-new",
+      }),
+    ).rejects.toThrow("binding activation unavailable");
+
+    expect(lifecycleEvents).toEqual([
+      "user-create:u-fresh",
+      "identity-upsert:u-fresh:steward-new",
+      "session-binding:o1:u-fresh:steward-new:true",
+    ]);
+    expect(repositoryReads).toEqual([]);
+    expect(deletedCacheKeys).toEqual([]);
+    expect(invalidatedSessionBatches).toEqual([]);
+  });
+
+  test("fresh Steward identity initialization rejects a missing organization", async () => {
+    const { usersService } = await import("./users");
+
+    await expect(
+      usersService.initializeFreshStewardIdentity({
+        user: {
+          id: "u-fresh",
+          organization_id: null,
+          steward_user_id: "steward-new",
+        },
+        stewardUserId: "steward-new",
+      }),
+    ).rejects.toMatchObject({ code: "FRESH_STEWARD_IDENTITY_INPUT_INVALID" });
+
+    expect(lifecycleEvents).toEqual([]);
+    expect(repositoryReads).toEqual([]);
+    expect(deletedCacheKeys).toEqual([]);
+    expect(invalidatedSessionBatches).toEqual([]);
+  });
+
+  test("fresh Steward identity initialization rejects an empty canonical subject", async () => {
+    const { usersService } = await import("./users");
+
+    await expect(
+      usersService.initializeFreshStewardIdentity({
+        user: {
+          id: "u-fresh",
+          organization_id: "o1",
+          steward_user_id: "",
+        },
+        stewardUserId: "",
+      }),
+    ).rejects.toMatchObject({ code: "FRESH_STEWARD_IDENTITY_INPUT_INVALID" });
+
+    expect(lifecycleEvents).toEqual([]);
+    expect(repositoryReads).toEqual([]);
+    expect(deletedCacheKeys).toEqual([]);
+    expect(invalidatedSessionBatches).toEqual([]);
+  });
+
+  test("fresh Steward identity initialization rejects a canonical subject mismatch", async () => {
+    const { usersService } = await import("./users");
+
+    await expect(
+      usersService.initializeFreshStewardIdentity({
+        user: {
+          id: "u-fresh",
+          organization_id: "o1",
+          steward_user_id: "steward-canonical",
+        },
+        stewardUserId: "steward-other",
+      }),
+    ).rejects.toMatchObject({ code: "FRESH_STEWARD_IDENTITY_INPUT_INVALID" });
+
+    expect(lifecycleEvents).toEqual([]);
+    expect(repositoryReads).toEqual([]);
+    expect(deletedCacheKeys).toEqual([]);
+    expect(invalidatedSessionBatches).toEqual([]);
   });
 
   test("Steward identity upsert fences the prior session generation before relinking", async () => {

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -2,6 +2,7 @@
  * Users service for managing user accounts and organization relationships.
  */
 
+import { ElizaError } from "@elizaos/core";
 import {
   apiKeysRepository,
   type NewUser,
@@ -41,6 +42,16 @@ const PERSONAL_DELIVERY_ROUTING_FIELDS = [
   "discord_id",
   "phone_number",
 ] as const;
+
+type FreshStewardSignupUserData = NewUser & {
+  organization_id: string;
+  steward_user_id: string;
+};
+
+type FreshStewardIdentityInput = {
+  user: Pick<User, "id" | "organization_id" | "steward_user_id">;
+  stewardUserId: string;
+};
 
 function personalDeliveryRoutingIdentities(
   ...sources: Array<PersonalDeliveryIdentitySource | undefined>
@@ -312,6 +323,16 @@ export class UsersService {
   }
 
   /**
+   * Inserts a direct-signup user after the caller has proved the Steward
+   * subject and account lookup keys are absent. User readers cache only
+   * positive rows, so this fresh insert has no negative cache entry to clear.
+   * Linking, restoration, and other existing-account flows must use `create`.
+   */
+  async createFreshStewardSignupUser(data: FreshStewardSignupUserData): Promise<User> {
+    return await usersRepository.create(data);
+  }
+
+  /**
    * Inference hot path (#9981 review gap): drop every cached IAC identity for a
    * user's API keys so a deactivated/deleted user stops fast-pathing inference
    * immediately rather than authorizing until the authContext TTL expires. The
@@ -482,6 +503,40 @@ export class UsersService {
     }
 
     await Promise.all(cacheDeletes);
+  }
+
+  /**
+   * Initializes the Steward projection for a user and organization returned by
+   * the direct-signup inserts. A fresh user ID has no prior binding, session
+   * generation, or positive cache projection to revoke; the new binding still
+   * becomes active only after the identity projection commits.
+   */
+  async initializeFreshStewardIdentity(input: FreshStewardIdentityInput): Promise<void> {
+    const { user, stewardUserId } = input;
+    const organizationId = user.organization_id;
+    const canonicalStewardUserId = user.steward_user_id;
+    if (
+      user.id.trim().length === 0 ||
+      !organizationId?.trim() ||
+      canonicalStewardUserId.trim().length === 0 ||
+      stewardUserId.trim().length === 0 ||
+      canonicalStewardUserId !== stewardUserId
+    ) {
+      throw new ElizaError("Fresh Steward identity input does not match the created user", {
+        code: "FRESH_STEWARD_IDENTITY_INPUT_INVALID",
+        context: {
+          hasUserId: user.id.trim().length > 0,
+          hasOrganizationId: Boolean(organizationId?.trim()),
+          hasCanonicalStewardUserId: canonicalStewardUserId.trim().length > 0,
+          hasRequestedStewardUserId: stewardUserId.trim().length > 0,
+          stewardUserIdMatches: canonicalStewardUserId === stewardUserId,
+        },
+        severity: "fatal",
+      });
+    }
+
+    await usersRepository.upsertStewardIdentity(user.id, stewardUserId);
+    await setInferenceSessionBindingActive(organizationId, user.id, stewardUserId, true);
   }
 
   async linkStewardId(userId: string, stewardUserId: string): Promise<void> {

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -2,9 +2,9 @@
  * Deterministic coverage for direct-signup post-commit provisioning.
  *
  * Worker callers return only after the canonical user, organization, identity,
- * and required default API key are ready. waitUntil owns only the independently
- * self-healing default-character and Steward-tenant tail; non-Worker callers
- * retain the strict inline ordering for every provisioning resource.
+ * required default API key, and an optional caller barrier are ready. waitUntil
+ * owns only the independently self-healing default-character and Steward-tenant
+ * tail; non-Worker callers retain strict inline provisioning without a barrier.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -33,6 +33,8 @@ let tenantProvision = deferred<{ tenantId: string }>();
 let apiKeyProvisionStarted = false;
 let characterProvisionStarted = false;
 let tenantProvisionStarted = false;
+let welcomeEmailStarted = false;
+let discordLogStarted = false;
 let finalIdentityReadCompleted = false;
 const loggerErrors: Array<{ message: string; context?: unknown }> = [];
 const loggerInfos: Array<{ message: string; context?: unknown }> = [];
@@ -134,10 +136,18 @@ mock.module("./services/steward-tenant-config", () => ({
   DEFAULT_STEWARD_TENANT_ID: "elizacloud",
 }));
 mock.module("./services/discord", () => ({
-  discordService: { logUserSignup: async () => undefined },
+  discordService: {
+    logUserSignup: async () => {
+      discordLogStarted = true;
+    },
+  },
 }));
 mock.module("./services/email", () => ({
-  emailService: { sendWelcomeEmail: async () => undefined },
+  emailService: {
+    sendWelcomeEmail: async () => {
+      welcomeEmailStarted = true;
+    },
+  },
 }));
 mock.module("./utils/logger", () => ({
   logger: {
@@ -177,19 +187,28 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
     apiKeyProvisionStarted = false;
     characterProvisionStarted = false;
     tenantProvisionStarted = false;
+    welcomeEmailStarted = false;
+    discordLogStarted = false;
     finalIdentityReadCompleted = false;
     loggerErrors.length = 0;
     loggerInfos.length = 0;
     loggerWarnings.length = 0;
   });
 
-  test("Worker waits for the required API key, then hands one concurrent safe tail to waitUntil", async () => {
+  test("Worker orders key, caller barrier, safe tail, then best-effort notifications", async () => {
     const background: Promise<unknown>[] = [];
+    const callerBarrier = deferred<void>();
+    let callerBarrierStarted = false;
 
     const syncPromise = syncUserFromSteward({
       ...baseParams,
       executionCtx: {
         waitUntil: (promise) => background.push(promise),
+      },
+      afterRequiredSignupProvisioning: async (user) => {
+        expect(user.id).toBe("user-new-1");
+        callerBarrierStarted = true;
+        await callerBarrier.promise;
       },
     });
     await waitFor(() => apiKeyProvisionStarted);
@@ -198,14 +217,27 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
     expect(background).toHaveLength(0);
     expect(characterProvisionStarted).toBe(false);
     expect(tenantProvisionStarted).toBe(false);
+    expect(callerBarrierStarted).toBe(false);
+    expect(welcomeEmailStarted).toBe(false);
+    expect(discordLogStarted).toBe(false);
 
     apiKeyProvision.resolve();
+    await waitFor(() => callerBarrierStarted);
+    expect(background).toHaveLength(0);
+    expect(characterProvisionStarted).toBe(false);
+    expect(tenantProvisionStarted).toBe(false);
+    expect(welcomeEmailStarted).toBe(false);
+    expect(discordLogStarted).toBe(false);
+
+    callerBarrier.resolve();
     const user = await syncPromise;
 
     expect(user.id).toBe("user-new-1");
     expect(user.postCommitProvisioningDeferred).toBe(true);
     expect(background).toHaveLength(1);
     await waitFor(() => characterProvisionStarted && tenantProvisionStarted);
+    expect(welcomeEmailStarted).toBe(true);
+    expect(discordLogStarted).toBe(true);
 
     characterProvision.resolve({ id: "char-1" });
     tenantProvision.resolve({ tenantId: "elizacloud-org-new-1" });

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -35,7 +35,14 @@ let characterProvisionStarted = false;
 let tenantProvisionStarted = false;
 let welcomeEmailStarted = false;
 let discordLogStarted = false;
-let finalIdentityReadCompleted = false;
+let freshUserCreateCompleted = false;
+let freshIdentityInitializeCompleted = false;
+let genericCreateAttempted = false;
+let genericIdentityUpsertAttempted = false;
+let finalIdentityReadAttempted = false;
+let organizationCreateAttempts = 0;
+let organizationSlugPreflightAttempts = 0;
+const organizationCreateErrors: unknown[] = [];
 const loggerErrors: Array<{ message: string; context?: unknown }> = [];
 const loggerInfos: Array<{ message: string; context?: unknown }> = [];
 const loggerWarnings: Array<{ message: string; context?: unknown }> = [];
@@ -45,8 +52,7 @@ const createdOrg = {
   slug: "alice-abc123",
   credit_balance: "0.00",
 };
-const createdUser = { id: "user-new-1", organization_id: "org-new-1" };
-const finalUserWithOrg = {
+const createdUser = {
   id: "user-new-1",
   organization_id: "org-new-1",
   steward_user_id: "steward-123",
@@ -56,7 +62,6 @@ const finalUserWithOrg = {
   role: "owner",
   email_verified: true,
   wallet_verified: false,
-  organization: { id: "org-new-1", name: "alice's Organization" },
 };
 
 mock.module("./services/credits", () => ({
@@ -70,8 +75,16 @@ mock.module("./services/credits", () => ({
 }));
 mock.module("./services/organizations", () => ({
   organizationsService: {
-    getBySlug: async () => undefined,
-    create: async () => createdOrg,
+    getBySlug: async () => {
+      organizationSlugPreflightAttempts += 1;
+      return undefined;
+    },
+    create: async () => {
+      organizationCreateAttempts += 1;
+      const error = organizationCreateErrors.shift();
+      if (error) throw error;
+      return createdOrg;
+    },
     update: async () => createdOrg,
     delete: async () => undefined,
   },
@@ -84,13 +97,28 @@ mock.module("./services/users", () => ({
     getByWalletAddressWithOrganization: async () => undefined,
     getStewardIdentityForWrite: async () => undefined,
     getByStewardIdForWrite: async () => {
-      finalIdentityReadCompleted = true;
-      return finalUserWithOrg;
+      finalIdentityReadAttempted = true;
+      return undefined;
     },
-    create: async () => createdUser,
+    createFreshStewardSignupUser: async () => {
+      freshUserCreateCompleted = true;
+      return createdUser;
+    },
+    initializeFreshStewardIdentity: async ({ user, stewardUserId }) => {
+      expect(freshUserCreateCompleted).toBe(true);
+      expect(user).toBe(createdUser);
+      expect(stewardUserId).toBe("steward-123");
+      freshIdentityInitializeCompleted = true;
+    },
+    create: async () => {
+      genericCreateAttempted = true;
+      return createdUser;
+    },
+    upsertStewardIdentity: async () => {
+      genericIdentityUpsertAttempted = true;
+    },
     update: async () => undefined,
     linkStewardId: async () => undefined,
-    upsertStewardIdentity: async () => undefined,
   },
 }));
 mock.module("../db/repositories/users", () => ({
@@ -109,7 +137,8 @@ mock.module("./services/api-keys", () => ({
     listByOrganization: async () => [],
     create: async () => ({ id: "key-1" }),
     provisionDefaultApiKey: async () => {
-      expect(finalIdentityReadCompleted).toBe(true);
+      expect(freshIdentityInitializeCompleted).toBe(true);
+      expect(finalIdentityReadAttempted).toBe(false);
       apiKeyProvisionStarted = true;
       await apiKeyProvision.promise;
     },
@@ -119,7 +148,8 @@ mock.module("./services/characters/characters", () => ({
   charactersService: {
     hasHealthyCloudCharacterMirror: async () => false,
     create: async () => {
-      expect(finalIdentityReadCompleted).toBe(true);
+      expect(freshIdentityInitializeCompleted).toBe(true);
+      expect(finalIdentityReadAttempted).toBe(false);
       characterProvisionStarted = true;
       return characterProvision.promise;
     },
@@ -127,7 +157,8 @@ mock.module("./services/characters/characters", () => ({
 }));
 mock.module("./services/steward-tenant-config", () => ({
   ensureStewardTenant: async () => {
-    expect(finalIdentityReadCompleted).toBe(true);
+    expect(freshIdentityInitializeCompleted).toBe(true);
+    expect(finalIdentityReadAttempted).toBe(false);
     tenantProvisionStarted = true;
     return tenantProvision.promise;
   },
@@ -189,7 +220,14 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
     tenantProvisionStarted = false;
     welcomeEmailStarted = false;
     discordLogStarted = false;
-    finalIdentityReadCompleted = false;
+    freshUserCreateCompleted = false;
+    freshIdentityInitializeCompleted = false;
+    genericCreateAttempted = false;
+    genericIdentityUpsertAttempted = false;
+    finalIdentityReadAttempted = false;
+    organizationCreateAttempts = 0;
+    organizationSlugPreflightAttempts = 0;
+    organizationCreateErrors.length = 0;
     loggerErrors.length = 0;
     loggerInfos.length = 0;
     loggerWarnings.length = 0;
@@ -213,7 +251,13 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
     });
     await waitFor(() => apiKeyProvisionStarted);
 
-    expect(finalIdentityReadCompleted).toBe(true);
+    expect(freshUserCreateCompleted).toBe(true);
+    expect(freshIdentityInitializeCompleted).toBe(true);
+    expect(genericCreateAttempted).toBe(false);
+    expect(genericIdentityUpsertAttempted).toBe(false);
+    expect(finalIdentityReadAttempted).toBe(false);
+    expect(organizationCreateAttempts).toBe(1);
+    expect(organizationSlugPreflightAttempts).toBe(0);
     expect(background).toHaveLength(0);
     expect(characterProvisionStarted).toBe(false);
     expect(tenantProvisionStarted).toBe(false);
@@ -319,5 +363,42 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
     await expect(syncPromise).rejects.toThrow("strict default-key failure");
     expect(characterProvisionStarted).toBe(false);
     expect(tenantProvisionStarted).toBe(false);
+  });
+
+  test("retries the exact organization slug constraint without a preflight read", async () => {
+    organizationCreateErrors.push(
+      Object.assign(new Error("generated slug collision"), {
+        code: "23505",
+        constraint: "organizations_slug_unique",
+      }),
+    );
+    apiKeyProvision.resolve();
+    characterProvision.resolve({ id: "char-1" });
+    tenantProvision.resolve({ tenantId: "elizacloud-org-new-1" });
+
+    await expect(syncUserFromSteward(baseParams)).resolves.toMatchObject({
+      id: "user-new-1",
+      organization: { id: "org-new-1" },
+    });
+
+    expect(organizationCreateAttempts).toBe(2);
+    expect(organizationSlugPreflightAttempts).toBe(0);
+    expect(freshIdentityInitializeCompleted).toBe(true);
+  });
+
+  test("does not retry an unrelated organization unique violation", async () => {
+    organizationCreateErrors.push(
+      Object.assign(new Error("unrelated organization authority collision"), {
+        code: "23505",
+        constraint: "organizations_steward_tenant_id_unique",
+      }),
+    );
+
+    await expect(syncUserFromSteward(baseParams)).rejects.toThrow(
+      "unrelated organization authority collision",
+    );
+    expect(organizationCreateAttempts).toBe(1);
+    expect(organizationSlugPreflightAttempts).toBe(0);
+    expect(freshUserCreateCompleted).toBe(false);
   });
 });

--- a/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
@@ -159,9 +159,10 @@ mock.module("./db/repositories/organization-invites", () => ({
 mock.module("../db/repositories/users", () => ({
   usersRepository: {
     delete: async () => undefined,
-    findPendingPhoneTelegramPersonalAccountConvergence: async () => ({
-      status: "not_found" as const,
-    }),
+    findPendingPhoneTelegramPersonalAccountConvergence: async () => {
+      const user = await getByStewardIdImpl();
+      return user ? { status: "canonical_user" as const, user } : { status: "not_found" as const };
+    },
   },
 }));
 

--- a/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
@@ -56,8 +56,23 @@ const existingUser = {
 // Default = new-user path (no existing user); existing-user tests override.
 let getByStewardIdImpl: () => Promise<unknown> = async () => undefined;
 
-const createdOrg = { id: "org-new-1", slug: "alice-abc123", credit_balance: "0.00" };
-const createdUser = { id: "user-new-1", organization_id: "org-new-1" };
+const createdOrg = {
+  id: "org-new-1",
+  name: "alice's Organization",
+  slug: "alice-abc123",
+  credit_balance: "0.00",
+};
+const createdUser = {
+  id: "user-new-1",
+  organization_id: "org-new-1",
+  steward_user_id: "steward-123",
+  email: "alice@example.com",
+  name: "alice",
+  wallet_address: null,
+  role: "owner",
+  email_verified: true,
+  wallet_verified: false,
+};
 const finalUserWithOrg = {
   id: "user-new-1",
   steward_user_id: "steward-123",
@@ -109,6 +124,8 @@ mock.module("./services/users", () => ({
     getByWalletAddressWithOrganization: async () => undefined,
     getStewardIdentityForWrite: async () => undefined,
     getByStewardIdForWrite: async () => finalUserWithOrg,
+    createFreshStewardSignupUser: async () => createdUser,
+    initializeFreshStewardIdentity: async () => undefined,
     create: async () => createdUser,
     update: async () => undefined,
     linkStewardId: async () => undefined,

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -12,8 +12,23 @@ let addCreditsImpl: (params: unknown) => Promise<unknown> = async (params) => {
   return { success: true };
 };
 
-const createdOrg = { id: "org-new-1", slug: "alice-abc123", credit_balance: "0.00" };
-const createdUser = { id: "user-new-1", organization_id: "org-new-1" };
+const createdOrg = {
+  id: "org-new-1",
+  name: "alice's Organization",
+  slug: "alice-abc123",
+  credit_balance: "0.00",
+};
+const createdUser = {
+  id: "user-new-1",
+  organization_id: "org-new-1",
+  steward_user_id: "steward-123",
+  email: "alice@example.com",
+  name: "alice",
+  wallet_address: null,
+  role: "owner",
+  email_verified: true,
+  wallet_verified: false,
+};
 const finalUserWithOrg = {
   id: "user-new-1",
   steward_user_id: "steward-123",
@@ -61,6 +76,8 @@ mock.module("./services/users", () => ({
     getByWalletAddressWithOrganization: async () => undefined,
     getStewardIdentityForWrite: async () => undefined,
     getByStewardIdForWrite: async () => finalUserWithOrg,
+    createFreshStewardSignupUser: async () => createdUser,
+    initializeFreshStewardIdentity: async () => undefined,
     create: async () => createdUser,
     update: async () => undefined,
     linkStewardId: async () => undefined,

--- a/packages/cloud/shared/src/lib/steward-sync-profile-refresh.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-profile-refresh.test.ts
@@ -33,10 +33,15 @@ const storedUser = {
   organization: { id: "org-1", name: "org" },
 };
 const refreshedUser = { ...storedUser, email: "alice@example.com", name: "alice" };
+const getByStewardId = mock(async () => storedUser);
+const findPendingPhoneTelegramPersonalAccountConvergence = mock(async () => ({
+  status: "canonical_user" as const,
+  user: storedUser,
+}));
 
 mock.module("./services/users", () => ({
   usersService: {
-    getByStewardId: async () => storedUser,
+    getByStewardId,
     getByStewardIdForWrite: async () => refreshedUser,
     getByEmailWithOrganization: async () => undefined,
     getByWalletAddress: async () => undefined,
@@ -53,9 +58,7 @@ mock.module("./services/users", () => ({
 
 mock.module("../db/repositories/users", () => ({
   usersRepository: {
-    findPendingPhoneTelegramPersonalAccountConvergence: async () => ({
-      status: "not_found" as const,
-    }),
+    findPendingPhoneTelegramPersonalAccountConvergence,
   },
 }));
 
@@ -93,17 +96,21 @@ describe("syncUserFromSteward — existing-user profile refresh (branch 1)", () 
   beforeEach(() => {
     updateCalls.length = 0;
     loggerErrorCalls.length = 0;
+    getByStewardId.mockClear();
+    findPendingPhoneTelegramPersonalAccountConvergence.mockClear();
     updateImpl = async (id, data) => {
       updateCalls.push({ id, data });
       return undefined;
     };
   });
 
-  test("happy path: refresh succeeds and the re-read row is returned", async () => {
+  test("uses the joined canonical inspection without repeating the Steward lookup", async () => {
     const { syncUserFromSteward } = await import("./steward-sync");
 
     const result = await syncUserFromSteward(baseParams);
 
+    expect(findPendingPhoneTelegramPersonalAccountConvergence).toHaveBeenCalledTimes(1);
+    expect(getByStewardId).not.toHaveBeenCalled();
     expect(updateCalls).toHaveLength(1);
     expect(result).toBe(refreshedUser as never);
     expect(loggerErrorCalls).toHaveLength(0);

--- a/packages/cloud/shared/src/lib/steward-sync-verified-phone-link.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-verified-phone-link.test.ts
@@ -46,9 +46,12 @@ function linkedStewardUser(stewardUserId: string): TestUser | undefined {
 }
 
 const promotePhonePersonalAccountToSteward = mock(async () => ({ status: "not_found" as const }));
-const findPendingPhoneTelegramPersonalAccountConvergence = mock(async () => ({
-  status: "not_found" as const,
-}));
+const findPendingPhoneTelegramPersonalAccountConvergence = mock(
+  async ({ stewardUserId }: { stewardUserId: string }) => {
+    const user = linkedStewardUser(stewardUserId);
+    return user ? { status: "canonical_user" as const, user } : { status: "not_found" as const };
+  },
+);
 const linkVerifiedPhone = mock(async (userId: string, phoneNumber: string) => {
   record("linkVerifiedPhone", userId, phoneNumber);
   if (phoneLinkConflict) {
@@ -168,7 +171,12 @@ beforeEach(() => {
   createConflict = false;
   phoneLinkConflict = false;
   findPendingPhoneTelegramPersonalAccountConvergence.mockReset();
-  findPendingPhoneTelegramPersonalAccountConvergence.mockResolvedValue({ status: "not_found" });
+  findPendingPhoneTelegramPersonalAccountConvergence.mockImplementation(
+    async ({ stewardUserId }) => {
+      const user = linkedStewardUser(stewardUserId);
+      return user ? { status: "canonical_user", user } : { status: "not_found" };
+    },
+  );
   promotePhonePersonalAccountToSteward.mockReset();
   promotePhonePersonalAccountToSteward.mockResolvedValue({ status: "not_found" });
   linkVerifiedPhone.mockClear();

--- a/packages/cloud/shared/src/lib/steward-sync-verified-phone-link.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-verified-phone-link.test.ts
@@ -79,6 +79,14 @@ mock.module("../db/repositories/users", () => ({
 
 mock.module("./services/users", () => ({
   usersService: {
+    createFreshStewardSignupUser: async () => {
+      record("create");
+      if (createConflict) {
+        throw Object.assign(new Error("duplicate account"), { code: "23505" });
+      }
+      throw new Error("unexpected new account creation");
+    },
+    initializeFreshStewardIdentity: async () => undefined,
     create: async () => {
       record("create");
       if (createConflict) {

--- a/packages/cloud/shared/src/lib/steward-sync-wallet-canonicalization.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-wallet-canonicalization.test.ts
@@ -83,9 +83,10 @@ mock.module("./services/users", () => ({
 
 mock.module("../db/repositories/users", () => ({
   usersRepository: {
-    findPendingPhoneTelegramPersonalAccountConvergence: async () => ({
-      status: "not_found" as const,
-    }),
+    findPendingPhoneTelegramPersonalAccountConvergence: async () =>
+      userByStewardId
+        ? { status: "canonical_user" as const, user: userByStewardId }
+        : { status: "not_found" as const },
     findBySolanaWalletAddressWithOrganization: async (address: string) => {
       record("findBySolanaWalletAddressWithOrganization", address);
       return userBySolanaWallet;

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -260,6 +260,12 @@ export interface StewardSyncParams {
   sharedRuntimeConversationNamespace?: RuntimeDurableObjectNamespace;
   /** Worker lifetime for direct-new-user post-commit provisioning. */
   executionCtx?: StewardSyncExecutionContext;
+  /**
+   * Optional direct-signup barrier invoked after required API-key readiness
+   * and before independently recoverable onboarding work starts. The caller
+   * owns its error policy; returning-user and account-link paths never run it.
+   */
+  afterRequiredSignupProvisioning?: (user: UserWithOrganization) => Promise<void>;
 }
 
 type DirectSignupProvisioningOperation = {
@@ -290,14 +296,20 @@ async function provisionDirectSignupResources(input: {
   userId: string;
   organizationId: string;
   executionCtx?: StewardSyncExecutionContext;
+  afterRequiredSignupProvisioning?: () => Promise<void>;
 }): Promise<void> {
-  const { userId, organizationId, executionCtx } = input;
+  const { userId, organizationId, executionCtx, afterRequiredSignupProvisioning } = input;
 
   // A default API key is required account readiness, and no durable outbox or
   // restart-safe reconciler owns it. Keep this strict and on the response path
   // for Worker and non-Worker callers alike. The route can therefore prime its
   // verified session cache only after required key readiness has succeeded.
   await apiKeysService.provisionDefaultApiKey(userId, organizationId);
+
+  // The Cloud auth boundary uses this barrier to prime the verified session
+  // projection before optional character/tenant subrequests begin. Keeping the
+  // hook here makes that ordering explicit without weakening API-key readiness.
+  await afterRequiredSignupProvisioning?.();
 
   if (!executionCtx) {
     // Preserve the non-Worker contract: character and tenant provisioning keep
@@ -1213,7 +1225,29 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     throw new Error(`Failed to fetch newly created Steward user ${stewardUserId}`);
   }
 
-  // Send welcome email (fire-and-forget)
+  // Identity is committed above, but the default API key remains required
+  // readiness and is awaited strictly before this function can return. Only
+  // the default character and Steward tenant have proven deterministic repair
+  // paths, so Workers may keep those two concurrent operations alive through
+  // waitUntil. Tests and non-Worker callers retain the prior inline ordering.
+  const newOrganizationId = userWithOrg.organization?.id;
+  if (!newOrganizationId) {
+    throw new Error(`New Steward user ${userWithOrg.id} is missing its organization`);
+  }
+  const afterRequiredSignupProvisioning = params.afterRequiredSignupProvisioning;
+  await provisionDirectSignupResources({
+    userId: userWithOrg.id,
+    organizationId: newOrganizationId,
+    executionCtx: params.executionCtx,
+    afterRequiredSignupProvisioning: afterRequiredSignupProvisioning
+      ? () => afterRequiredSignupProvisioning(userWithOrg)
+      : undefined,
+  });
+
+  // Start best-effort notifications only after required key readiness, the
+  // caller's session-cache barrier, and waitUntil registration have completed.
+  // This keeps external notification subrequests from contending with the
+  // first authorization projection write.
   const recipientEmail = email || userWithOrg.organization?.billing_email;
   if (recipientEmail) {
     queueWelcomeEmail({
@@ -1231,7 +1265,6 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     });
   }
 
-  // Log to Discord (fire-and-forget)
   discordService
     .logUserSignup({
       userId: userWithOrg.id,
@@ -1247,21 +1280,6 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     .catch((error) => {
       logger.error("[StewardSync] Discord signup log failed:", { error });
     });
-
-  // Identity is committed above, but the default API key remains required
-  // readiness and is awaited strictly before this function can return. Only
-  // the default character and Steward tenant have proven deterministic repair
-  // paths, so Workers may keep those two concurrent operations alive through
-  // waitUntil. Tests and non-Worker callers retain the prior inline ordering.
-  const newOrganizationId = userWithOrg.organization?.id;
-  if (!newOrganizationId) {
-    throw new Error(`New Steward user ${userWithOrg.id} is missing its organization`);
-  }
-  await provisionDirectSignupResources({
-    userId: userWithOrg.id,
-    organizationId: newOrganizationId,
-    executionCtx: params.executionCtx,
-  });
 
   return {
     ...userWithOrg,

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -628,6 +628,7 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     stewardUserId,
     ...(verifiedPhone ? { phoneNumber: verifiedPhone } : {}),
   });
+  const inspectedCanonicalUser = pending.status === "canonical_user" ? pending.user : undefined;
   if (pending.status === "identity_projection_conflict") {
     throw new StewardTelegramAccountClaimError(pending.status);
   }
@@ -778,7 +779,7 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
   // misread the subject's own account as `steward_subject_owned_by_other_user`
   // and 409 the first verified-phone session (#19365). An existing user links
   // the unowned verified phone through the existing-user path below instead.
-  let user = claimedTelegramUser ?? (await usersService.getByStewardId(stewardUserId));
+  let user = claimedTelegramUser ?? inspectedCanonicalUser;
 
   // A signed inbound text creates a phone-only personal account before any
   // browser session exists. SMS login may claim only that exact synthetic

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -72,6 +72,7 @@ export interface StewardSyncExecutionContext {
 }
 
 const STEWARD_IDENTITY_UNIQUE_CONSTRAINT = "user_identities_steward_user_id_unique";
+const ORGANIZATION_SLUG_UNIQUE_CONSTRAINT = "organizations_slug_unique";
 
 function extractErrorMetadata(candidate: unknown): {
   code?: string;
@@ -146,6 +147,21 @@ function isRecoverableStewardProjectionConflict(error: unknown): boolean {
     causeMetadata.constraint === STEWARD_IDENTITY_UNIQUE_CONSTRAINT;
 
   return isUniqueViolation && hasExactStewardConstraint;
+}
+
+function isOrganizationSlugConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const errorMetadata = extractErrorMetadata(error);
+  const causeMetadata = "cause" in error ? extractErrorMetadata(error.cause) : { message: "" };
+  const isUniqueViolation = errorMetadata.code === "23505" || causeMetadata.code === "23505";
+  const hasExactSlugConstraint =
+    errorMetadata.constraint === ORGANIZATION_SLUG_UNIQUE_CONSTRAINT ||
+    causeMetadata.constraint === ORGANIZATION_SLUG_UNIQUE_CONSTRAINT;
+
+  return isUniqueViolation && hasExactSlugConstraint;
 }
 
 async function recoverCanonicalStewardUser(
@@ -1054,40 +1070,37 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
 
   // ── 5. Create new user + organization ────────────────────────────────
 
-  // Generate organization slug
-  let orgSlug: string;
-  if (email) {
-    orgSlug = generateSlugFromEmail(email);
-  } else if (walletAddress) {
-    orgSlug = generateSlugFromWallet(walletAddress);
-  } else if (name) {
-    orgSlug = generateSlugFromName(name);
-  } else {
+  const generateOrganizationSlug = (): string => {
+    if (email) return generateSlugFromEmail(email);
+    if (walletAddress) return generateSlugFromWallet(walletAddress);
+    if (name) return generateSlugFromName(name);
     throw new Error(`Cannot generate organization slug for Steward user ${stewardUserId}`);
-  }
+  };
 
-  // Ensure slug uniqueness
-  let attempts = 0;
-  while (await organizationsService.getBySlug(orgSlug)) {
-    attempts++;
-    if (attempts > 10) {
-      throw new Error(
-        `Failed to generate unique organization slug for Steward user ${stewardUserId}`,
-      );
+  // The database's unique constraint is the authority. Avoid a redundant
+  // preflight read (and its TOCTOU window); retry only the exact slug
+  // constraint, never unrelated organization insert failures.
+  let orgSlug = generateOrganizationSlug();
+  let organization: Awaited<ReturnType<typeof organizationsService.create>> | undefined;
+  for (let attempt = 0; attempt <= 10; attempt += 1) {
+    try {
+      organization = await organizationsService.create({
+        name: `${name}'s Organization`,
+        slug: orgSlug,
+        credit_balance: SIGNUP_CREDIT_POLICY.openingBalanceUsd,
+      });
+      break;
+    } catch (error) {
+      if (!isOrganizationSlugConflict(error) || attempt === 10) {
+        throw error;
+      }
+      orgSlug = generateOrganizationSlug();
     }
-    orgSlug = email
-      ? generateSlugFromEmail(email)
-      : walletAddress
-        ? generateSlugFromWallet(walletAddress)
-        : generateSlugFromName(name);
   }
 
-  // Create organization with zero balance initially
-  const organization = await organizationsService.create({
-    name: `${name}'s Organization`,
-    slug: orgSlug,
-    credit_balance: SIGNUP_CREDIT_POLICY.openingBalanceUsd,
-  });
+  if (!organization) {
+    throw new Error(`Failed to create organization for Steward user ${stewardUserId}`);
+  }
 
   // Cloud identity is created at $0. Shared service access is not a credit
   // grant, and purchased credits remain exclusive to explicit funding paths.
@@ -1095,10 +1108,12 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
   const initialFreeCreditsUsd = SIGNUP_CREDIT_POLICY.automaticGrantUsd;
 
   // Create user, handle race conditions
-  let createdUser: Awaited<ReturnType<typeof usersService.create>> | undefined;
+  let createdUser:
+    | Awaited<ReturnType<typeof usersService.createFreshStewardSignupUser>>
+    | undefined;
 
   try {
-    createdUser = await usersService.create({
+    createdUser = await usersService.createFreshStewardSignupUser({
       steward_user_id: stewardUserId,
       email: email || null,
       email_verified: !!email,
@@ -1197,9 +1212,15 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     throw new Error(`Failed to create user for Steward user ${stewardUserId}`);
   }
 
-  // Upsert identity projection
+  // Initialize the identity projection from the exact row returned by the
+  // fresh insert. The direct-signup lookups above proved this subject absent,
+  // so the generic link path's prior-state reads and cache invalidations would
+  // only add database/cache round trips to the first session handoff.
   try {
-    await usersService.upsertStewardIdentity(createdUser.id, stewardUserId);
+    await usersService.initializeFreshStewardIdentity({
+      user: createdUser,
+      stewardUserId,
+    });
   } catch (error) {
     const recovered = await recoverCanonicalStewardUser(
       createdUser.id,
@@ -1218,12 +1239,13 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     }
   }
 
-  // Fetch final user with organization
-  const userWithOrg = await usersService.getByStewardIdForWrite(stewardUserId);
-
-  if (!userWithOrg) {
-    throw new Error(`Failed to fetch newly created Steward user ${stewardUserId}`);
-  }
+  // Both inserts and the identity projection have committed successfully. Use
+  // their primary RETURNING rows instead of immediately reading the same user
+  // and organization back through the database and cache.
+  const userWithOrg: UserWithOrganization = {
+    ...createdUser,
+    organization,
+  };
 
   // Identity is committed above, but the default API key remains required
   // readiness and is awaited strictly before this function can return. Only


### PR DESCRIPTION
# Relates to

Closes #25118.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` completed with no dependency changes and `bun run verify` passes.
- [x] A reviewer can confirm the database and response-ordering contracts from
      the focused unit and real-PGlite evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` `72781181e`; zero conflicts.
- [x] Full `bun run verify`, focused checks, package typecheck, Biome, and Worker production-config dry-run pass post-sync.

# Risks

Medium. This changes the new-account Cloud identity/provisioning path and default API-key insert shape. Returning-user link/update paths stay on their existing generic service methods. Required API-key readiness remains strict and fail-closed. Steward projection drift now fails closed instead of selecting either owner.

# Background

## What does this PR do?

The successful staging passkey ceremony was fast, but the first Cloud session exchange still took about 15 seconds (about 21 seconds through the full Worker lifetime). This PR removes serial work that is not required for the response while preserving identity, key, and cache readiness:

- primes the verified session cache after strict key readiness and before optional onboarding;
- moves successful-login audit work under Worker lifetime ownership instead of response latency;
- reuses one authoritative Steward subject inspection and fails closed on canonical/projection drift;
- uses fresh insert `RETURNING` rows instead of immediate user/organization rereads;
- skips invalidating caches that cannot exist for a proven-new subject;
- replaces the organization-slug preflight read with exact-constraint insert/retry;
- reduces default-key fresh mint database statements from three to two while retaining a separate advisory-lock statement and a fresh READ COMMITTED snapshot.

The default character and tenant remain the only deferred, self-healing signup resources. No chat hot-path, embedding, frontend, schema, or migration behavior changes.

## What kind of change is this?

Bug fix and performance improvement.

# Documentation changes needed?

No project documentation change is required; the operational evidence and follow-up staging timings are tracked in #25118.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/auth/steward-session/steward-session-postcommit-latency.test.ts`
2. `packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts`
3. `packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts`
4. `packages/cloud/shared/src/lib/services/__tests__/invite-accept-default-key.test.ts`

## Detailed testing steps

- 14 affected suites run in isolated Bun processes: **137 pass, 0 fail**.
- Real PGlite Steward authority/convergence suite: **12/12**, including two-user projection drift fail-closed.
- Real PGlite default-key suite: **9/9**, including three concurrent provisioners producing exactly one key, expired replacement, existing usable key, and FK failure.
- API-key invalidation suite: **30/30**.
- Inference authorization lifecycle suite: **26/26**.
- `bun run typecheck` in `packages/cloud/shared`: pass.
- `bunx @biomejs/biome check <all 15 changed files>`: pass.
- `bun run check:worker-bundle` in `packages/cloud/api`: pass (production configuration, dry-run only; no deployment).
- `git diff --check`: pass.

# Evidence Gate

<!-- evidence-head:a07bac28c0e5cf9ed362a75f87f13465f7b7aa34 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Worker/shared-service change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Worker/shared-service change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI interaction or rendered-state change in this diff.
<!-- evidence-row:backend-logs -->
- [x] N/A - exact-head staging logs require a merge because canonical staging deploys reject feature refs; a sanitized pre-fix trace is inline below and exact-head post-merge timings will be added to #25118.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed; the affected request is covered at the Worker route boundary.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; real PGlite database state is asserted in the 12/12 authority suite and 9/9 concurrent default-key suite above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual or text surface changed.

# Evidence Details

## Backend + frontend logs

Sanitized staging trace before this patch:

| Milestone | Time |
|---|---:|
| passkey register options | 318 ms |
| passkey register verify | 771 ms |
| Cloud session response | 14,931 ms |
| total Worker lifetime | 21,425 ms |

Within the session response, canonical org/user/identity work reached about 7.6 s, required default-key readiness about 10.9 s, and cache/audit completion about 13.4 s. No duplicate exchange occurred.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

## Known gaps / failures

- Exact-head staging after timings require this commit to merge to `develop`; the canonical deployment workflow rejects feature refs. They will be attached to #25118 immediately after the staging-only deployment.
- No production mutation or deployment was performed.

## Maintainer CI exception record

N/A - no exception requested.

# Deploy Notes

Standard automatic `develop` -> staging Cloudflare release. Verify the exact health commit, then measure a fresh passkey signup and `/api/auth/steward-session`. Production remains untouched.
