### PR TITLE
fix(logger): render diamond-shaped payloads instead of misreporting them as [Circular]

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1077,6 +1077,111 @@ describe("binary payload redaction", () => {
 });
 
 /**
+ * Shared-substructure fidelity (diamond walk): the deep-walk redactor must
+ * treat a second reference to the same subobject as ordinary shared content,
+ * not as a cycle. A permanent seen-set misreports any diamond
+ * (`{ config: shared, retryConfig: shared }`) as `[Circular]`, corrupting the
+ * diagnostic text every sink (ring buffer, WS stream, file) serves verbatim.
+ * True cycles — self, mutual, through arrays and Map entries — must still
+ * collapse to `[Circular]`, and the depth cap must still bound recursion.
+ */
+describe("shared-substructure redaction fidelity", () => {
+  const fidelityLogger = () => createLogger({ level: "trace" });
+
+  afterEach(() => {
+    fidelityLogger().clear();
+    vi.restoreAllMocks();
+  });
+
+  it("renders both references of a diamond in full instead of [Circular]", () => {
+    const logger = fidelityLogger();
+    const shared = { region: "us-east-fidelity", retries: 3 };
+    logger.info({ config: shared, retryConfig: shared }, "diamond-entry");
+
+    const logs = recentLogs();
+    // Both siblings carry the full shared content.
+    expect(logs.match(/"region":"us-east-fidelity"/g)).toHaveLength(2);
+    expect(logs).not.toContain("[Circular]");
+  });
+
+  it("renders a shared subtree referenced at sibling depths in full", () => {
+    const logger = fidelityLogger();
+    const shared = { zone: "shared-leaf-value" };
+    logger.info(
+      { outer: { inner: shared }, direct: shared },
+      "nested-diamond-entry",
+    );
+
+    const logs = recentLogs();
+    expect(logs.match(/"zone":"shared-leaf-value"/g)).toHaveLength(2);
+    expect(logs).not.toContain("[Circular]");
+  });
+
+  it("still collapses a self-referencing object to [Circular]", () => {
+    const logger = fidelityLogger();
+    const cyclic: Record<string, unknown> = { name: "loop-fidelity" };
+    cyclic.self = cyclic;
+    logger.info({ cyclic, plain: { ok: 1 } }, "self-cycle-entry");
+
+    const logs = recentLogs();
+    expect(logs.match(/\[Circular\]/g)).toHaveLength(1);
+    // The non-cyclic sibling is untouched by the cycle break.
+    expect(logs).toContain('"ok":1');
+  });
+
+  it("still collapses mutual cycles to exactly one [Circular]", () => {
+    const logger = fidelityLogger();
+    const a: Record<string, unknown> = { name: "node-a" };
+    const b: Record<string, unknown> = { name: "node-b", peer: a };
+    a.peer = b;
+    logger.info({ a, b }, "mutual-cycle-entry");
+
+    const logs = recentLogs();
+    // Each sibling reference re-walks the cycle and collapses its own
+    // back-edge, so both full copies carry exactly one marker.
+    expect(logs.match(/\[Circular\]/g)).toHaveLength(2);
+    expect(logs).toContain('"name":"node-a"');
+    expect(logs).toContain('"name":"node-b"');
+  });
+
+  it("still collapses an array self-cycle to [Circular]", () => {
+    const logger = fidelityLogger();
+    const list: unknown[] = ["leaf-value"];
+    list.push(list);
+    logger.info({ list }, "array-cycle-entry");
+
+    const logs = recentLogs();
+    expect(logs).toContain('"leaf-value"');
+    expect(logs.match(/\[Circular\]/g)).toHaveLength(1);
+  });
+
+  it("still collapses a Map that contains itself", () => {
+    const logger = fidelityLogger();
+    const map = new Map<string, unknown>();
+    map.set("label", "map-fidelity");
+    map.set("self", map);
+    logger.info({ map }, "map-cycle-entry");
+
+    const logs = recentLogs();
+    expect(logs).toContain('"map-fidelity"');
+    expect(logs.match(/\[Circular\]/g)).toHaveLength(1);
+  });
+
+  it("keeps the depth cap bounding pathological nesting", () => {
+    const logger = fidelityLogger();
+    let deep: unknown = { leaf: "depth-cap-leaf" };
+    for (let i = 0; i < 12; i += 1) {
+      deep = { nested: deep };
+    }
+    expect(() => logger.info({ deep }, "depth-cap-entry")).not.toThrow();
+
+    const logs = recentLogs();
+    expect(logs).toContain("[REDACTED]");
+    expect(logs).not.toContain("depth-cap-leaf");
+  });
+});
+
+/**
  * File-sink permission contract (W1-059): output.log/prompts.log/chat.log
  * must be created 0600, and files left world-readable by older builds must be
  * healed on first open. Needs a fresh module instance per case because the

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -625,88 +625,98 @@ function redactLogValue(
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value)) return "[Circular]";
   if (depth >= MAX_REDACT_DEPTH) return REDACTED_VALUE;
+  // Track only the active ancestor path: the entry is undone on exit, so a
+  // reference counts as circular iff it re-enters a container currently being
+  // walked. A permanent set would misreport every diamond — an ordinary
+  // shared subobject referenced from two siblings (`{ config: shared,
+  // retryConfig: shared }`) — as "[Circular]", corrupting the diagnostic text
+  // every sink serves. Re-walking a shared subtree matches JSON.stringify's
+  // own DAG semantics; recursion stays bounded by MAX_REDACT_DEPTH.
   seen.add(value);
-
-  if (value instanceof Error) {
-    const clone = new Error(redactSensitiveLogText(value.message));
-    clone.name = redactSensitiveLogText(value.name);
-    if (value.stack) clone.stack = redactSensitiveLogText(value.stack);
-    if (value.cause !== undefined) {
-      clone.cause = redactLogValue(value.cause, seen, depth + 1);
+  try {
+    if (value instanceof Error) {
+      const clone = new Error(redactSensitiveLogText(value.message));
+      clone.name = redactSensitiveLogText(value.name);
+      if (value.stack) clone.stack = redactSensitiveLogText(value.stack);
+      if (value.cause !== undefined) {
+        clone.cause = redactLogValue(value.cause, seen, depth + 1);
+      }
+      const target = clone as unknown as Record<string, unknown>;
+      redactOwnPropertiesInto(value, target, seen, depth + 1);
+      return clone;
     }
-    const target = clone as unknown as Record<string, unknown>;
-    redactOwnPropertiesInto(value, target, seen, depth + 1);
-    return clone;
-  }
 
-  if (Array.isArray(value)) {
-    // Avoid the caller's potentially overridden `map` and species constructor.
-    const result = new Array<unknown>(value.length);
-    for (let index = 0; index < value.length; index += 1) {
-      result[index] = redactLogValue(value[index], seen, depth + 1);
+    if (Array.isArray(value)) {
+      // Avoid the caller's potentially overridden `map` and species constructor.
+      const result = new Array<unknown>(value.length);
+      for (let index = 0; index < value.length; index += 1) {
+        result[index] = redactLogValue(value[index], seen, depth + 1);
+      }
+      return result;
     }
-    return result;
-  }
 
-  // Binary payloads carry raw bytes that JSON serializes verbatim
-  // ({"type":"Buffer","data":[...]}); under a neutral key that silently leaks
-  // secret material into every sink, so mask with a size-only marker. Both
-  // the node and browser log paths funnel through this walker.
-  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
-    return `[BUFFER REDACTED ${value.byteLength} bytes]`;
-  }
-
-  // Built-ins must also be detached from the caller. JSON.stringify invokes a
-  // caller-owned Date/toJSON before its replacer, and pretty sinks may inspect
-  // Map/Set contents directly.
-  if (value instanceof Date) {
-    try {
-      return Date.prototype.toISOString.call(value);
-    } catch {
-      return "[Invalid Date]";
+    // Binary payloads carry raw bytes that JSON serializes verbatim
+    // ({"type":"Buffer","data":[...]}); under a neutral key that silently leaks
+    // secret material into every sink, so mask with a size-only marker. Both
+    // the node and browser log paths funnel through this walker.
+    if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+      return `[BUFFER REDACTED ${value.byteLength} bytes]`;
     }
-  }
-  if (value instanceof RegExp) {
-    return `[RegExp ${redactSensitiveLogText(RegExp.prototype.toString.call(value))}]`;
-  }
-  if (value instanceof Map) {
-    const entries: unknown[] = [];
-    Map.prototype.forEach.call(
-      value,
-      (entryValue: unknown, entryKey: unknown) => {
-        const safeKey = redactLogValue(entryKey, seen, depth + 1);
-        const safeValue =
-          typeof entryKey === "string" && isSensitiveLogKey(entryKey)
-            ? REDACTED_VALUE
-            : redactLogValue(entryValue, seen, depth + 1);
-        entries.push([safeKey, safeValue]);
-      },
-    );
+
+    // Built-ins must also be detached from the caller. JSON.stringify invokes a
+    // caller-owned Date/toJSON before its replacer, and pretty sinks may inspect
+    // Map/Set contents directly.
+    if (value instanceof Date) {
+      try {
+        return Date.prototype.toISOString.call(value);
+      } catch {
+        return "[Invalid Date]";
+      }
+    }
+    if (value instanceof RegExp) {
+      return `[RegExp ${redactSensitiveLogText(RegExp.prototype.toString.call(value))}]`;
+    }
+    if (value instanceof Map) {
+      const entries: unknown[] = [];
+      Map.prototype.forEach.call(
+        value,
+        (entryValue: unknown, entryKey: unknown) => {
+          const safeKey = redactLogValue(entryKey, seen, depth + 1);
+          const safeValue =
+            typeof entryKey === "string" && isSensitiveLogKey(entryKey)
+              ? REDACTED_VALUE
+              : redactLogValue(entryValue, seen, depth + 1);
+          entries.push([safeKey, safeValue]);
+        },
+      );
+      const result = Object.create(null) as Record<string, unknown>;
+      defineSafeProperty(result, "type", "Map");
+      defineSafeProperty(result, "entries", entries);
+      return result;
+    }
+    if (value instanceof Set) {
+      const values: unknown[] = [];
+      Set.prototype.forEach.call(value, (entryValue: unknown) => {
+        values.push(redactLogValue(entryValue, seen, depth + 1));
+      });
+      const result = Object.create(null) as Record<string, unknown>;
+      defineSafeProperty(result, "type", "Set");
+      defineSafeProperty(result, "values", values);
+      return result;
+    }
+    if (value instanceof WeakMap) return "[WeakMap]";
+    if (value instanceof WeakSet) return "[WeakSet]";
+    if (value instanceof Promise) return "[Promise]";
+
+    // Class instances are cloned into plain objects: JSON serialization only
+    // ever emits own enumerable properties anyway, and walking them here masks
+    // credentials stashed on config/response wrappers (axios-style).
     const result = Object.create(null) as Record<string, unknown>;
-    defineSafeProperty(result, "type", "Map");
-    defineSafeProperty(result, "entries", entries);
+    redactOwnPropertiesInto(value, result, seen, depth + 1);
     return result;
+  } finally {
+    seen.delete(value);
   }
-  if (value instanceof Set) {
-    const values: unknown[] = [];
-    Set.prototype.forEach.call(value, (entryValue: unknown) => {
-      values.push(redactLogValue(entryValue, seen, depth + 1));
-    });
-    const result = Object.create(null) as Record<string, unknown>;
-    defineSafeProperty(result, "type", "Set");
-    defineSafeProperty(result, "values", values);
-    return result;
-  }
-  if (value instanceof WeakMap) return "[WeakMap]";
-  if (value instanceof WeakSet) return "[WeakSet]";
-  if (value instanceof Promise) return "[Promise]";
-
-  // Class instances are cloned into plain objects: JSON serialization only
-  // ever emits own enumerable properties anyway, and walking them here masks
-  // credentials stashed on config/response wrappers (axios-style).
-  const result = Object.create(null) as Record<string, unknown>;
-  redactOwnPropertiesInto(value, result, seen, depth + 1);
-  return result;
 }
 
 /** Define a clone key without invoking Object.prototype's `__proto__` setter. */


### PR DESCRIPTION
Closes #25125.

## Summary

`redactLogValue` — the deep-walk redactor every `@elizaos/logger` payload passes through — kept a **permanent** `seen` set: entries were added before recursion and never removed. Any second reference to the same subobject therefore rendered as `[Circular]`, even though nothing is cyclic:

```ts
const shared = { region: "us-east", retries: 3 };
logger.info({ config: shared, retryConfig: shared }, "starting");
// origin/develop renders: config={"region":"us-east","retries":3}, retryConfig=[Circular]
```

Diamonds are ordinary in real payloads (shared config/request objects logged twice, a context object referenced from two siblings). The marker is a false claim about the caller's data and flows verbatim into every sink this package feeds: the ring buffer (`recentLogs()`, `/api/logs`, the WS stream), the optional file line, and the console render.

**Containment, stated explicitly:** nothing throws on this path, so none of the logger's error policies (`error-policy:J6/J7` catches, the per-key getter guard, the Adze invoke try/catch) apply or help; the corrupted text simply ships. The defect is of the "wrong value passes through unchanged" class, not an exception class.

## Fix

Track only the **active ancestor path**: `seen.add(value)` before recursing into children, `seen.delete(value)` after, via `try/finally`. A reference now counts as circular iff it re-enters a container currently being walked. Redaction decisions are untouched — credential-key masking, `MAX_REDACT_DEPTH`, Buffer/Error/Map/Set handling all behave exactly as before. Shared subtrees render in full at each reference, matching `JSON.stringify`'s own DAG semantics; recursion stays bounded by `MAX_REDACT_DEPTH`.

## Evidence

- **Origin reproduction, unmodified code:** reproduced against pristine `origin/develop` (`2e69b70eb`) through the real module seam (`createLogger({level:"trace"}).info(...)` observed via `recentLogs()`). `git show origin/develop:<path> | diff - <path>` reports both `logger.ts` and `logger.test.ts` byte-identical before work started.
- **Load-bearing revert (copy-aside, no stash):** with the new tests present and the original `logger.ts` restored, the suite fails exactly on the diamond cases —

  ```
  Tests  3 failed | 64 passed (67)
    × renders both references of a diamond in full instead of [Circular]
      expected [ '"region":"us-east-fidelity"' ] to have a length of 2 but got 1
      Info diamond-entry (config={...}, retryConfig=[Circular])
    × renders a shared subtree referenced at sibling depths in full
      Info nested-diamond-entry (outer={"inner":{"zone":"shared-leaf-value"}}, direct=[Circular])
    × still collapses mutual cycles to exactly one [Circular]  (assertion tightened post-fix; origin showed b=[Circular])
  ```

  Restoring the fix: **67/67 pass** (`bun run test` in `packages/logger`, exit 0).
- **No over-rejection (origin vs branch, quoted counts):** a 26-entry corpus — credential-key masking at depth, Error wrappers with cause chains and enumerable config, Buffers/TypedArrays/DataView/ArrayBuffer, valid+invalid Dates, RegExp, Map/Set/WeakMap/WeakSet/Promise, true self-cycle, 12-deep nesting hitting the depth cap, throwing getters (per-key fail-closed), unwalkable Proxy, hostile `toJSON` hooks, trailing-arg mixes, prompt/chat instrumentation helpers — was run through the real module on both sides and the captured ring/listener output diffed: **26/26 entries byte-identical** after normalizing wall-clock timestamps (the only differing bytes).
- **Cycle semantics preserved:** self-cycles collapse to exactly one `[Circular]`; mutual cycles collapse once per traversal (both full copies render, each breaks its own back-edge); array self-cycles and self-referencing Maps still collapse; >8-deep chains still hit `[REDACTED]`.
- **Checks:** `tsc --noEmit` clean; `bunx biome check src/logger.ts src/logger.test.ts` clean. Hosted CI does not run on fork PRs, so CI status here is by-construction absent — the local suite, typecheck, lint, and revert/corpus evidence above are the verification.
- **Trajectory:** signed run receipt below carries the finalized private trace for this session.

## Known gaps

- The same permanent-`seen` pattern exists in sibling copies outside this package's scope: `@elizaos/core`'s `security/redact.ts` walker (`packages/core/src/security/redact.ts`, marks with `REDACTED_MASK`) and standalone `safeStringify` copies (`packages/core/src/runtime/trajectory-recorder.ts`, `json-output.ts`, `packages/ui/src/utils/tts-debug.ts`). Within `packages/logger/src`, `safeStringify`'s own cycle replacer is unaffected because every object it serializes is already an acyclic redaction product; its fallback catch contains the pathological case regardless.
- Per-reference re-walking of heavily-shared subtrees costs more than one-time memoization; this matches native `JSON.stringify` DAG behavior and stays bounded by the existing depth cap. No timing claims are made beyond the suite passing unchanged.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: opencode / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [oxalpha-logger-diamond]
<!-- slop-contribution-attribution:v1 {"provider":"opencode","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0PEFCSE1RRED1B70X5GK83K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-23T04:36:17.327Z","completed_at":"2026-08-23T04:38:28.451Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-23T04:36:19.223Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cb9c5c814e9c1ee201e8c3c5eed16e337326277098351d0b000aa3fcb101ef57","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9531ff0a-ec15-4cf4-9f16-1bd42c00c0e9","object_id":"sha256:cb9c5c814e9c1ee201e8c3c5eed16e337326277098351d0b000aa3fcb101ef57","sha256":"cb9c5c814e9c1ee201e8c3c5eed16e337326277098351d0b000aa3fcb101ef57"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA3qp2qlPvWwwKfIl5iPln7EUrHBcgqCX-87Cz0b_VVk0","device_key_id":"7fe9e8ddf85097400d555bf61a271e57f5b547ced7e28fe091fbbd54452478cb","device_signature":"6kFSnTOZPgV39RK0sseEZXUhAM-wjDzxu9POIDKufWkrtyGQMs1-_tCqW3pCvknIAZLVR8M7ZB3vjnPkqSNJDw"}} -->
