### PR TITLE
fix(elizacloud): safely handle non-JSON and plaintext 402 responses in parseX402Response

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/x402-payment-handler.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/x402-payment-handler.test.ts
@@ -73,4 +73,33 @@ describe("parseX402Response", () => {
     const requirements = await parseX402Response(response);
     expect(requirements).toBeNull();
   });
+
+  it("returns null on plaintext 402 error bodies without throwing SyntaxError", async () => {
+    const response = new Response("Payment Required", {
+      status: 402,
+      headers: { "Content-Type": "text/plain" },
+    });
+    const requirements = await parseX402Response(response);
+    expect(requirements).toBeNull();
+  });
+
+  it("returns null on HTML 402 gateway error pages without throwing SyntaxError", async () => {
+    const response = new Response("<html><body>402 Payment Required</body></html>", {
+      status: 402,
+      headers: { "Content-Type": "text/html" },
+    });
+    const requirements = await parseX402Response(response);
+    expect(requirements).toBeNull();
+  });
+
+  it("returns null on malformed www-authenticate x402 headers without throwing", async () => {
+    const response = new Response("Payment Required", {
+      status: 402,
+      headers: {
+        "WWW-Authenticate": "x402 { invalid json",
+      },
+    });
+    const requirements = await parseX402Response(response);
+    expect(requirements).toBeNull();
+  });
 });

--- a/plugins/plugin-elizacloud/src/cloud/x402-payment-handler.ts
+++ b/plugins/plugin-elizacloud/src/cloud/x402-payment-handler.ts
@@ -134,22 +134,31 @@ export async function parseX402Response(
   if (headerValue?.toLowerCase().startsWith("x402")) {
     const jsonPart = headerValue.slice(4).trim();
     if (jsonPart.length > 0) {
-      const parsed = JSON.parse(jsonPart) as RawX402Body | RawRequirement[];
-      const requirements = Array.isArray(parsed)
-        ? parseRequirementsArray(parsed)
-        : parseRequirementsArray(parsed.paymentRequirements ?? parsed.accepts);
-      if (requirements.length > 0) return requirements;
+      try {
+        const parsed = JSON.parse(jsonPart) as RawX402Body | RawRequirement[];
+        const requirements = Array.isArray(parsed)
+          ? parseRequirementsArray(parsed)
+          : parseRequirementsArray(parsed.paymentRequirements ?? parsed.accepts);
+        if (requirements.length > 0) return requirements;
+      } catch {
+        // error-policy:J4 Non-JSON www-authenticate falls through to body parse
+      }
     }
   }
   // Fall back to body parse. Clone so the caller can still read it.
   const cloned = response.clone();
   const text = await cloned.text();
   if (text.length === 0) return null;
-  const body = JSON.parse(text) as RawX402Body;
-  const requirements = parseRequirementsArray(
-    body.paymentRequirements ?? body.accepts,
-  );
-  return requirements.length > 0 ? requirements : null;
+  try {
+    const body = JSON.parse(text) as RawX402Body;
+    const requirements = parseRequirementsArray(
+      body.paymentRequirements ?? body.accepts,
+    );
+    return requirements.length > 0 ? requirements : null;
+  } catch {
+    // error-policy:J4 Plaintext or HTML 402 responses yield null rather than throwing SyntaxError
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Guards `JSON.parse` calls in `parseX402Response` (`plugins/plugin-elizacloud/src/cloud/x402-payment-handler.ts:137, 148`) with `try/catch` to return `null` rather than throwing an uncaught `SyntaxError` when upstream endpoints return plaintext (e.g. `"Payment Required"`), HTML error pages, or malformed `www-authenticate` headers.

## Changes

- In `plugins/plugin-elizacloud/src/cloud/x402-payment-handler.ts`, wrap `JSON.parse(jsonPart)` and `JSON.parse(text)` in `try/catch`, honoring the contract to return `null` on unparseable responses.
- In `plugins/plugin-elizacloud/__tests__/unit/x402-payment-handler.test.ts`, add dedicated regression unit tests covering plaintext, HTML gateway pages, and malformed header inputs.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`e3049639af`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-elizacloud/__tests__/unit/x402-payment-handler.test.ts` | 3 pass (3 tests) | 6 pass (6 tests) |
| `bunx @biomejs/biome check plugins/plugin-elizacloud/src/cloud/x402-payment-handler.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-elizacloud/src/cloud/x402-payment-handler.ts:130-155`
- `plugins/plugin-elizacloud/__tests__/unit/x402-payment-handler.test.ts:75-105`

## Risks

Low. Adheres to existing JSDoc contract returning `null` on unparseable responses instead of crashing callers.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Cloud payment response parser; no UI layout touched)
- [x] `audit:browser` — N/A (Payment handler)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 pass in `x402-payment-handler.test.ts`
- [x] `lint` — Biome clean
