### PR TITLE
fix(coding-tools): gracefully fall back to raw text on malformed JSON responses in WEB_FETCH

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -513,4 +513,38 @@ describe("coding-tools WEB_FETCH extract bounds", () => {
     expect(result.success).toBe(true);
     expect(result.text).toContain('"a":1');
   });
+
+  it("gracefully falls back to raw text on malformed JSON responses without throwing", async () => {
+    usePinnedRoutes({
+      "https://public.example.test/malformed-json": new Response(
+        '{"error": unclosed json string',
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    });
+    const result = await runFetch({
+      url: "https://public.example.test/malformed-json",
+    });
+    expect(result.success).toBe(true);
+    expect(result.text).toBe('{"error": unclosed json string');
+  });
+
+  it("gracefully falls back to raw text on non-JSON text starting with brace", async () => {
+    usePinnedRoutes({
+      "https://public.example.test/brace-text": new Response(
+        "{ plain text starting with curly brace",
+        {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        },
+      ),
+    });
+    const result = await runFetch({
+      url: "https://public.example.test/brace-text",
+    });
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("{ plain text starting with curly brace");
+  });
 });

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -142,13 +142,18 @@ function extractBody(
     type.includes("json") ||
     (!type && (trimmed.startsWith("{") || trimmed.startsWith("[")))
   ) {
-    const parsed = JSON.parse(body) as unknown;
-    const selected = extract ? resolveJsonPath(parsed, extract) : parsed;
-    // A fuzzy or unresolved extract path must not hard-fail the fetch: fall back
-    // to the full JSON so the model can still read it and pick out what it needs,
-    // rather than surfacing an io_error for a best-effort path hint.
-    const jsonValue = extract && selected === undefined ? parsed : selected;
-    return { value: JSON.stringify(jsonValue), kind: "json" };
+    try {
+      const parsed = JSON.parse(body) as unknown;
+      const selected = extract ? resolveJsonPath(parsed, extract) : parsed;
+      // A fuzzy or unresolved extract path must not hard-fail the fetch: fall back
+      // to the full JSON so the model can still read it and pick out what it needs,
+      // rather than surfacing an io_error for a best-effort path hint.
+      const jsonValue = extract && selected === undefined ? parsed : selected;
+      return { value: JSON.stringify(jsonValue), kind: "json" };
+    } catch {
+      // error-policy:J4 Malformed JSON falls back to raw text extraction rather than failing
+      return { value: body.trim(), kind: "text" };
+    }
   }
   return { value: body.trim(), kind: "text" };
 }


### PR DESCRIPTION
## Summary

Wraps `JSON.parse` in `extractBody` (`plugins/plugin-coding-tools/src/actions/web-fetch.ts:145`) in `try/catch` to gracefully fall back to raw text extraction (`kind: "text"`) instead of crashing the `WEB_FETCH` action with an unhandled `SyntaxError` when servers respond with malformed JSON under `Content-Type: application/json` or plain text starting with `{` / `[`.

## Changes

- In `plugins/plugin-coding-tools/src/actions/web-fetch.ts:141-153`, catch parse errors during JSON body extraction and return `{ value: body.trim(), kind: "text" }`.
- In `plugins/plugin-coding-tools/src/actions/web-fetch.test.ts`, add unit tests covering malformed JSON responses and non-JSON text starting with curly braces.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`f70f7a84bb`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-coding-tools/src/actions/web-fetch.test.ts` | 25 pass (25 tests) | 27 pass (27 tests) |
| `bunx @biomejs/biome check plugins/plugin-coding-tools/src/actions/web-fetch.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-coding-tools/src/actions/web-fetch.ts:135-154`
- `plugins/plugin-coding-tools/src/actions/web-fetch.test.ts:510-545`

## Risks

Low. Preserves model visibility into unparseable JSON or truncated text instead of failing the entire action.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Coding tools WEB_FETCH action; no UI layout touched)
- [x] `audit:browser` — N/A (HTTP action extraction)
- [x] `build` — Clean build across workspace
- [x] `test` — 27/27 pass in `web-fetch.test.ts`
- [x] `lint` — Biome clean
