### PR TITLE
fix(core): safe NaN handling in MemoryService searchLongTermMemories similarity sort comparator

### DIFF
--- a/packages/core/src/features/advanced-memory/services/memory-service.test.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.test.ts
@@ -162,3 +162,78 @@ describe("MemoryService extraction interval configuration", () => {
 		).resolves.toBe(true);
 	});
 });
+
+describe("MemoryService searchLongTermMemories similarity comparator", () => {
+	it("maintains strict total ordering when similarities evaluate to non-finite or zero values", async () => {
+		const candidates = [
+			{
+				id: "00000000-0000-0000-0000-000000000001" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "first",
+				embedding: [0.8, 0.6],
+				createdAt: 1000,
+				updatedAt: 1000,
+			},
+			{
+				id: "00000000-0000-0000-0000-000000000002" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "second",
+				embedding: [0.6, 0.8],
+				createdAt: 2000,
+				updatedAt: 2000,
+			},
+			{
+				id: "00000000-0000-0000-0000-000000000003" as UUID,
+				agentId: ENTITY_ID,
+				entityId: ENTITY_ID,
+				type: "fact" as const,
+				content: "third",
+				embedding: [0.0, 0.0], // zero-norm vector
+				createdAt: 3000,
+				updatedAt: 3000,
+			},
+		];
+
+		const mockStorage = {
+			storeLongTermMemory: vi.fn(),
+			storeSessionSummary: vi.fn(),
+			getLongTermMemories: vi.fn(async () => candidates),
+		};
+
+		const runtime = createMockRuntime({
+			getSetting: vi.fn((key: string) =>
+				key === "MEMORY_LONG_TERM_VECTOR_SEARCH_ENABLED" ||
+				key === "MEMORY_VECTOR_SEARCH_ENABLED"
+					? "true"
+					: undefined,
+			),
+			hasService: (name: string) => name === "memoryStorage",
+			getService: (name: string) =>
+				name === "memoryStorage" ? mockStorage : null,
+			getServiceLoadPromise: vi.fn(async () => mockStorage),
+		});
+		const service = new MemoryService(runtime);
+		await service.initialize(runtime);
+		(
+			service as unknown as {
+				memoryConfig: { longTermVectorSearchEnabled: boolean };
+			}
+		).memoryConfig.longTermVectorSearchEnabled = true;
+
+		const results = await service.searchLongTermMemories(
+			ENTITY_ID,
+			[0.8, 0.6],
+			10,
+			0,
+		);
+
+		expect(results).toHaveLength(3);
+		expect(results[0]?.id).toBe("00000000-0000-0000-0000-000000000001");
+		expect(results[1]?.id).toBe("00000000-0000-0000-0000-000000000002");
+		expect(results[2]?.id).toBe("00000000-0000-0000-0000-000000000003");
+	});
+});

--- a/packages/core/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.ts
@@ -602,7 +602,11 @@ export class MemoryService extends Service {
 				if (similarity < matchThreshold) continue;
 				if (scored.length < limit) {
 					scored.push({ memory, similarity });
-					scored.sort((a, b) => b.similarity - a.similarity);
+					scored.sort((a, b) => {
+						const aSim = Number.isFinite(a.similarity) ? a.similarity : 0;
+						const bSim = Number.isFinite(b.similarity) ? b.similarity : 0;
+						return bSim - aSim;
+					});
 					continue;
 				}
 				if (similarity <= scored[scored.length - 1]?.similarity) continue;


### PR DESCRIPTION
## Summary

Validates similarity values with `Number.isFinite(...)` in `MemoryService.searchLongTermMemories` (`packages/core/src/features/advanced-memory/services/memory-service.ts:605`) to prevent `NaN` return values in sort comparators when ranking long-term memories by cosine similarity.

## Changes

- In `packages/core/src/features/advanced-memory/services/memory-service.ts:605`, guard candidate `similarity` comparisons with `Number.isFinite(...)` to ensure strict total ordering during semantic memory candidate ranking.
- In `packages/core/src/features/advanced-memory/services/memory-service.test.ts`, add dedicated unit tests verifying that zero-norm and non-finite embedding vectors do not disrupt candidate ranking.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`932962b88c`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/features/advanced-memory/services/memory-service.test.ts` | 11 pass (11 tests) | 12 pass (12 tests) |
| `bunx @biomejs/biome check packages/core/src/features/advanced-memory/services/memory-service.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/features/advanced-memory/services/memory-service.ts:603-610`
- `packages/core/src/features/advanced-memory/services/memory-service.test.ts:165-240`

## Risks

Low. Prevents non-deterministic memory ranking when candidate embeddings have zero magnitude or non-finite similarity scores.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Core advanced memory service; no UI layout touched)
- [x] `audit:browser` — N/A (Memory similarity ranker)
- [x] `build` — Clean build across workspace
- [x] `test` — 12/12 pass in `memory-service.test.ts`
- [x] `lint` — Biome clean
