### PR TITLE
fix(plugin-local-inference): concurrency-safe registry/assignments config writes (#25123)

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.concurrency.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.concurrency.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression coverage for concurrent persisted-config mutations against the
+ * real exported `applyLocalInferenceManagementMutation` handler with a temp
+ * `ELIZA_STATE_DIR` (issue #25123). Before the fix, `writeJsonFile` staged every
+ * write to one shared `${filePath}.tmp` and the read-modify-write helpers ran
+ * unserialized, so two mutations touching the same file either raced on
+ * `fs.rename` (ENOENT thrown out of a handler that reported success) or both
+ * read the pre-write snapshot and the second write clobbered the first (a
+ * silently dropped update). These tests drive the assignments.json and
+ * registry.json paths concurrently and assert every update lands with no
+ * rejection and intact JSON on disk. No mocks: these ops touch only the
+ * filesystem.
+ */
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyLocalInferenceManagementMutation } from "./local-inference-routes.js";
+
+const originalStateDir = process.env.ELIZA_STATE_DIR;
+let tempStateDir: string;
+
+function localInferenceRoot(): string {
+	return path.join(tempStateDir, "local-inference");
+}
+
+function readAssignmentsFile(): {
+	version?: number;
+	assignments: Record<string, string>;
+} {
+	return JSON.parse(
+		readFileSync(path.join(localInferenceRoot(), "assignments.json"), "utf8"),
+	);
+}
+
+function readRegistryFile(): {
+	version?: number;
+	models: Array<{ id: string; path: string }>;
+} {
+	return JSON.parse(
+		readFileSync(path.join(localInferenceRoot(), "registry.json"), "utf8"),
+	);
+}
+
+function seedRegistry(ids: string[]): void {
+	const modelsDir = path.join(localInferenceRoot(), "models");
+	mkdirSync(modelsDir, { recursive: true });
+	const models = ids.map((id) => {
+		const rel = `models/${id}.gguf`;
+		const abs = path.join(localInferenceRoot(), rel);
+		// readRegistry() stats the artifact and drops rows whose file is missing,
+		// so every seeded id must have a real file under the root.
+		writeFileSync(abs, "GGUFxxxx");
+		return {
+			id,
+			displayName: id,
+			path: rel,
+			sizeBytes: 8,
+			installedAt: "2026-05-17T06:17:00.000Z",
+			lastUsedAt: null,
+			source: "eliza-download" as const,
+		};
+	});
+	writeFileSync(
+		path.join(localInferenceRoot(), "registry.json"),
+		JSON.stringify({ version: 1, models }),
+	);
+}
+
+describe("local-inference concurrent config mutations (#25123)", () => {
+	beforeEach(() => {
+		tempStateDir = mkdtempSync(path.join(tmpdir(), "eliza-li-concurrency-"));
+		process.env.ELIZA_STATE_DIR = tempStateDir;
+		mkdirSync(localInferenceRoot(), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempStateDir, { recursive: true, force: true });
+		if (originalStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+		else process.env.ELIZA_STATE_DIR = originalStateDir;
+	});
+
+	it("persists both slots when two set_assignment mutations run concurrently", async () => {
+		const results = await Promise.all([
+			applyLocalInferenceManagementMutation({
+				op: "set_assignment",
+				slot: "TEXT_SMALL",
+				modelId: "eliza-1-2b",
+			}),
+			applyLocalInferenceManagementMutation({
+				op: "set_assignment",
+				slot: "TEXT_LARGE",
+				modelId: "eliza-1-4b",
+			}),
+		]);
+
+		// Neither call rejected, and each reported the write it performed.
+		expect(results).toHaveLength(2);
+		for (const result of results) {
+			expect(result.op).toBe("set_assignment");
+		}
+
+		// The on-disk file — not just the return value — carries both writes.
+		const file = readAssignmentsFile();
+		expect(file.version).toBe(1);
+		expect(file.assignments).toEqual({
+			TEXT_SMALL: "eliza-1-2b",
+			TEXT_LARGE: "eliza-1-4b",
+		});
+	});
+
+	it("keeps every registry row when concurrent uninstalls hit registry.json", async () => {
+		seedRegistry(["eliza-1-2b", "eliza-1-4b", "eliza-1-9b"]);
+
+		const [removedA, removedB] = await Promise.all([
+			applyLocalInferenceManagementMutation({
+				op: "uninstall_model",
+				modelId: "eliza-1-2b",
+			}),
+			applyLocalInferenceManagementMutation({
+				op: "uninstall_model",
+				modelId: "eliza-1-4b",
+			}),
+		]);
+
+		// Both uninstalls actually removed their target; a lost update would have
+		// resurrected one of the removed ids by writing the stale snapshot.
+		expect(removedA).toMatchObject({ op: "uninstall_model", removed: true });
+		expect(removedB).toMatchObject({ op: "uninstall_model", removed: true });
+
+		const registry = readRegistryFile();
+		expect(registry.version).toBe(1);
+		const remainingIds = registry.models.map((model) => model.id).sort();
+		expect(remainingIds).toEqual(["eliza-1-9b"]);
+	});
+
+	it("survives N concurrent set_assignment writes with intact JSON and no ENOENT", async () => {
+		const slots = [
+			"TEXT_SMALL",
+			"TEXT_LARGE",
+			"TEXT_EMBEDDING",
+			"TEXT_TO_SPEECH",
+			"TRANSCRIPTION",
+		] as const;
+
+		const results = await Promise.allSettled(
+			slots.map((slot) =>
+				applyLocalInferenceManagementMutation({
+					op: "set_assignment",
+					slot,
+					modelId: "eliza-1-2b",
+				}),
+			),
+		);
+
+		// The shared-tmp rename race previously surfaced as a rejected mutation.
+		for (const result of results) {
+			expect(result.status).toBe("fulfilled");
+		}
+
+		// Final file is valid JSON and every distinct slot survived.
+		const file = readAssignmentsFile();
+		expect(file.version).toBe(1);
+		expect(Object.keys(file.assignments).sort()).toEqual([...slots].sort());
+		for (const slot of slots) {
+			expect(file.assignments[slot]).toBe("eliza-1-2b");
+		}
+	});
+});

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -520,9 +520,47 @@ async function writeJsonFile(
 	payload: unknown,
 ): Promise<void> {
 	await fsp.mkdir(path.dirname(filePath), { recursive: true });
-	const tmp = `${filePath}.tmp`;
-	await fsp.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
-	await fsp.rename(tmp, filePath);
+	// Unique staging name per write: concurrent writers to the same target must
+	// not share one fixed `${filePath}.tmp`, or one writer's rename races the
+	// other's and throws ENOENT once the first rename consumes the shared temp
+	// file — an unhandled error out of a mutation that reported success
+	// (issue #25123). Mirrors plugin-matrix's saveCryptoStore atomic-write.
+	const tmp = `${filePath}.${crypto.randomBytes(6).toString("hex")}.tmp`;
+	try {
+		await fsp.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
+		await fsp.rename(tmp, filePath);
+	} catch (error) {
+		// error-policy:J6 temp cleanup is best-effort; unique names keep an orphan
+		// harmless to concurrent writers, and the primary write error is preserved.
+		await fsp.rm(tmp, { force: true }).catch(() => undefined);
+		throw error;
+	}
+}
+
+// Serializes read-modify-write transactions per persisted config file. The
+// management mutations (set_assignment, upsertInstalledModel,
+// removeInstalledModel) each read the current JSON, mutate it, and write it
+// back; two concurrent mutations against one file would otherwise both read the
+// pre-write state and the second write would clobber the first, silently
+// dropping an update while both callers return success (issue #25123). Keyed by
+// absolute file path so unrelated files never serialize against each other. The
+// stored promise is settle-tracking, so one rejected transaction never breaks
+// the chain for the next waiter.
+const configFileMutex = new Map<string, Promise<unknown>>();
+async function withConfigFileLock<T>(
+	filePath: string,
+	task: () => Promise<T>,
+): Promise<T> {
+	const prior = configFileMutex.get(filePath) ?? Promise.resolve();
+	const next = prior.then(task, task);
+	configFileMutex.set(
+		filePath,
+		next.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+	return next;
 }
 
 async function hashFile(filePath: string): Promise<string> {
@@ -591,20 +629,24 @@ async function writeRegistry(models: InstalledModel[]): Promise<void> {
 }
 
 async function upsertInstalledModel(model: InstalledModel): Promise<void> {
-	const current = await readRegistry();
-	await writeRegistry([
-		...current.filter((entry) => entry.id !== model.id),
-		model,
-	]);
+	await withConfigFileLock(registryPath(), async () => {
+		const current = await readRegistry();
+		await writeRegistry([
+			...current.filter((entry) => entry.id !== model.id),
+			model,
+		]);
+	});
 }
 
 async function removeInstalledModel(id: string): Promise<boolean> {
-	const current = await readRegistry();
-	const target = current.find((model) => model.id === id);
-	if (!target) return false;
-	await fsp.rm(target.path, { force: true });
-	await writeRegistry(current.filter((model) => model.id !== id));
-	return true;
+	return withConfigFileLock(registryPath(), async () => {
+		const current = await readRegistry();
+		const target = current.find((model) => model.id === id);
+		if (!target) return false;
+		await fsp.rm(target.path, { force: true });
+		await writeRegistry(current.filter((model) => model.id !== id));
+		return true;
+	});
 }
 
 async function readAssignments(): Promise<Assignments> {
@@ -624,29 +666,45 @@ async function writeAssignments(
 	return assignments;
 }
 
+// Serialized read-modify-write for assignments.json. The mutator runs inside
+// the per-file lock between a fresh read and the write-back, so concurrent
+// assignment updates observe each other's writes instead of racing on the
+// stale pre-write snapshot (issue #25123).
+async function updateAssignments(
+	mutate: (assignments: Assignments) => void,
+): Promise<Assignments> {
+	return withConfigFileLock(assignmentsPath(), async () => {
+		const assignments = await readAssignments();
+		mutate(assignments);
+		return writeAssignments(assignments);
+	});
+}
+
 async function assignModel(
 	model: CatalogModel,
 	overwrite: boolean,
 ): Promise<void> {
-	const assignments = await readAssignments();
-	if (model.role === "embedding") {
-		if (overwrite || !assignments.TEXT_EMBEDDING) {
-			assignments.TEXT_EMBEDDING = model.id;
+	await updateAssignments((assignments) => {
+		if (model.role === "embedding") {
+			if (overwrite || !assignments.TEXT_EMBEDDING) {
+				assignments.TEXT_EMBEDDING = model.id;
+			}
+		} else if (model.role === "chat") {
+			if (overwrite || !assignments.TEXT_SMALL)
+				assignments.TEXT_SMALL = model.id;
+			if (overwrite || !assignments.TEXT_LARGE)
+				assignments.TEXT_LARGE = model.id;
+			if (overwrite || !assignments.TEXT_EMBEDDING) {
+				assignments.TEXT_EMBEDDING = model.id;
+			}
+			if (overwrite || !assignments.TEXT_TO_SPEECH) {
+				assignments.TEXT_TO_SPEECH = model.id;
+			}
+			if (overwrite || !assignments.TRANSCRIPTION) {
+				assignments.TRANSCRIPTION = model.id;
+			}
 		}
-	} else if (model.role === "chat") {
-		if (overwrite || !assignments.TEXT_SMALL) assignments.TEXT_SMALL = model.id;
-		if (overwrite || !assignments.TEXT_LARGE) assignments.TEXT_LARGE = model.id;
-		if (overwrite || !assignments.TEXT_EMBEDDING) {
-			assignments.TEXT_EMBEDDING = model.id;
-		}
-		if (overwrite || !assignments.TEXT_TO_SPEECH) {
-			assignments.TEXT_TO_SPEECH = model.id;
-		}
-		if (overwrite || !assignments.TRANSCRIPTION) {
-			assignments.TRANSCRIPTION = model.id;
-		}
-	}
-	await writeAssignments(assignments);
+	});
 }
 
 async function ensureDefaultAssignment(model: CatalogModel): Promise<void> {
@@ -1487,23 +1545,24 @@ export async function applyLocalInferenceManagementMutation(
 			if (!ASSIGNMENT_SLOTS.has(slot as keyof Assignments)) {
 				throw new Error(`Unknown local-inference assignment slot: ${slot}`);
 			}
-			const assignments = await readAssignments();
 			const modelId = input.modelId?.trim() || null;
-			if (modelId) {
-				if (!isCuratedCatalogModelId(modelId)) {
-					throw new Error(
-						"Local inference assignments are limited to curated Eliza-1 tiers.",
-					);
-				}
-				assignments[slot as keyof Assignments] = modelId;
-			} else {
-				delete assignments[slot as keyof Assignments];
+			if (modelId && !isCuratedCatalogModelId(modelId)) {
+				throw new Error(
+					"Local inference assignments are limited to curated Eliza-1 tiers.",
+				);
 			}
+			const assignments = await updateAssignments((current) => {
+				if (modelId) {
+					current[slot as keyof Assignments] = modelId;
+				} else {
+					delete current[slot as keyof Assignments];
+				}
+			});
 			return {
 				op: input.op,
 				slot: slot as keyof Assignments,
 				modelId,
-				assignments: await writeAssignments(assignments),
+				assignments,
 			};
 		}
 		default: {


### PR DESCRIPTION
# Relates to

Closes #25123

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates run (see below). `bun run verify` full-repo run not completed on this machine — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below (red-on-develop / green-after-fix on the real exported handler).

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** (full-repo verify not run here; focused package typecheck + lint + focused tests pass).

# Risks

Low. The change is confined to two persistence helpers in one file (`plugins/plugin-local-inference/src/local-inference-routes.ts`). It makes concurrent writes safer without changing the single-writer behavior or the on-disk file shape. `routing.json` is untouched (it already routes through `@elizaos/shared`'s locked atomic writer).

# Background

## What does this PR do?

Fixes a data-integrity defect: the persisted-config helpers in `local-inference-routes.ts` were not concurrency-safe.

- `writeJsonFile` always staged to one **fixed** `${filePath}.tmp` name and then renamed it into place. Two concurrent writes to the same target share that one temp path, so one writer's `fs.rename` races the other's and throws `ENOENT: rename '<file>.tmp' -> '<file>'` — an **unhandled error out of a mutation that reported success**.
- The management read-modify-write handlers (`set_assignment` → `writeAssignments`, and `upsertInstalledModel` / `removeInstalledModel` → `writeRegistry`) ran **unserialized**: two concurrent mutations both read the pre-write snapshot and the second write clobbered the first, so **one update was silently dropped while both callers returned success** (e.g. a fully-downloaded model dropped from `registry.json`, or a completed download marked failed).

The same fixed-tmp + unserialized-RMW pattern affected `registry.json` and `assignments.json`.

### Fix (scoped to the two still-vulnerable files)

1. `writeJsonFile` now stages to a **unique** `${filePath}.<crypto.randomBytes(6).hex>.tmp` name and cleans up the temp on failure (`error-policy:J6`), mirroring plugin-matrix's `saveCryptoStore` atomic-write. Concurrent renames never collide.
2. `registry.json` and `assignments.json` read-modify-write transactions run behind a **per-file promise-chain mutex** (`withConfigFileLock`, keyed by absolute path). `set_assignment` / `upsertInstalledModel` / `removeInstalledModel` can no longer interleave and lose updates.

### Scope boundary

`routing.json` (`set_policy` / `set_preferred_provider`) is **deliberately untouched**: on current `develop` that path already routes through `@elizaos/shared`'s `withRoutingLock` + unique-tmp atomic writer, so it is already serialized and safe. The scout's original repro included `routing.json`; I re-ran it and confirmed that path no longer races, so this PR re-scopes to the two paths that are still broken. (Verified: 5/5 concurrent `set_policy` runs persist both slots with no ENOENT.)

## What kind of change is this?

Bug fix (non-breaking change which fixes a data-integrity issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is unchanged for a single writer; only concurrent-writer safety improves. The on-disk file shape is identical.

# Testing

## Where should a reviewer start?

`plugins/plugin-local-inference/src/local-inference-routes.concurrency.test.ts` — it drives the **real exported** `applyLocalInferenceManagementMutation` handler against a temp `ELIZA_STATE_DIR`. No production surface was widened for the test.

## Detailed testing steps

```bash
# Generate i18n data once (dev prerequisite), then:
bunx vitest run src/local-inference-routes.concurrency.test.ts --dir plugins/plugin-local-inference
bun run --cwd plugins/plugin-local-inference typecheck
bun run --cwd plugins/plugin-local-inference lint
```

The three regression tests:
- concurrent `set_assignment` for `TEXT_SMALL` + `TEXT_LARGE` → both slots persist on disk, neither call rejects;
- concurrent `uninstall_model` of two seeded registry rows → no resurrected row (proves the registry RMW serializes);
- N-way concurrent `set_assignment` across 5 distinct slots → no ENOENT rejection, intact JSON, every slot survives.

All three **fail on develop** (ENOENT on `assignments.json.tmp` **and** `registry.json.tmp`, plus a rejected mutation) and **pass after the fix**.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:78910fe0c5d96f74b3f03a5a50bf054de6a65dd8 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a server-side persistence/concurrency fix in an HTTP route handler.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; server-side persistence fix.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the defect is a backend race reproduced via a Node/vitest harness, shown below.`
<!-- evidence-row:backend-logs -->
- [x] Red-on-develop / green-after-fix output from the real exported handler is attached inline below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; only file-persistence helpers.`
<!-- evidence-row:domain-artifacts -->
- [x] On-disk `assignments.json` / `registry.json` state before and after are shown inline (the domain artifacts here).
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Reproduction is a backend race in `applyLocalInferenceManagementMutation`. Below is the real focused test output on the exported handler.

<details>
<summary><b>RED — on develop (fix reverted): 3/3 fail, ENOENT on both assignments.json.tmp AND registry.json.tmp</b></summary>

```
 ❯ src/local-inference-routes.concurrency.test.ts (3 tests | 3 failed)
     × persists both slots when two set_assignment mutations run concurrently
     × keeps every registry row when concurrent uninstalls hit registry.json
     × survives N concurrent set_assignment writes with intact JSON and no ENOENT

Error: ENOENT: no such file or directory, rename '/tmp/eliza-li-concurrency-XESI8Y/local-inference/assignments.json.tmp' -> '/tmp/eliza-li-concurrency-XESI8Y/local-inference/assignments.json'
 ❯ writeJsonFile plugins/plugin-local-inference/src/local-inference-routes.ts:525:2
    523|  const tmp = `${filePath}.tmp`;
    524|  await fsp.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
    525|  await fsp.rename(tmp, filePath);
 ❯ writeAssignments .../local-inference-routes.ts:623:2
 ❯ applyLocalInferenceManagementMutation .../local-inference-routes.ts:1506:18

Error: ENOENT: no such file or directory, rename '/tmp/eliza-li-concurrency-qEEXQ1/local-inference/registry.json.tmp' -> '/tmp/eliza-li-concurrency-qEEXQ1/local-inference/registry.json'
 ❯ writeJsonFile .../local-inference-routes.ts:525:2
 ❯ writeRegistry .../local-inference-routes.ts:579:2
 ❯ removeInstalledModel .../local-inference-routes.ts:606:2

AssertionError: expected 'rejected' to be 'fulfilled' // Object.is equality
 Test Files  1 failed (1)
      Tests  3 failed (3)
```
</details>

<details>
<summary><b>GREEN — after fix: 3/3 pass</b></summary>

```
 RUN  v4.1.10

 ✓ src/local-inference-routes.concurrency.test.ts (3 tests) 22ms
   ✓ persists both slots when two set_assignment mutations run concurrently
   ✓ keeps every registry row when concurrent uninstalls hit registry.json
   ✓ survives N concurrent set_assignment writes with intact JSON and no ENOENT

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  15.21s
```
</details>

<details>
<summary><b>Standalone repro against the raw handler (before/after on disk) — 5 runs</b></summary>

Before the fix (develop), concurrent `set_assignment` for two slots:
```
ASSIGN err: ENOENT: no such file or directory, rename '<dir>/local-inference/assignments.json.tmp' -> '<dir>/local-inference/assignments.json'
```
After the fix, same input, 5/5 runs:
```
MULTI err: null
MULTI file: {
    "TEXT_SMALL": "eliza-1-2b",
    "TEXT_LARGE": "eliza-1-4b",
    "TEXT_EMBEDDING": "eliza-1-2b"
}
```
</details>

<details>
<summary><b>Typecheck + lint (focused package)</b></summary>

```
$ tsc --noEmit -p tsconfig.json          # (typecheck) — exit 0, no errors
$ bunx @biomejs/biome check --write --unsafe .
Checked 511 files in 3s. No fixes applied.   # (lint) — exit 0
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - server-side persistence/concurrency fix with no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Full-repo `bun run verify` was not run on this machine (Raspberry Pi; the full workspace build/verify is prohibitively heavy). Instead the owning package's **typecheck (exit 0)**, **lint (exit 0)**, and **focused tests** were run.
- The full `plugin-local-inference` test suite has 7 pre-existing failures in unrelated domains (`transcript-store`, `voice-profiles-management`, `bionic-host-loader`, `transcripts-routes`) that reproduce identically on pristine `origin/develop` without this change (verified by stashing the fix and re-running the same 4 files). They are environment/timeout issues on this ARM machine (one test's real UDS/DB path timed out at 360s) and are unrelated to this fix, which touches only `assignments.json` / `registry.json` persistence.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

Closes #25123

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@9244158813470792e2532fd0564a013d357b069d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@9244158813470792e2532fd0564a013d357b069d:packages/skills/skills/contribute-to-eliza"} -->
