### PR TITLE
test(billing): prove Stripe replay settlement

### DIFF
--- a/packages/cloud/e2e/src/fixtures/stack.ts
+++ b/packages/cloud/e2e/src/fixtures/stack.ts
@@ -31,6 +31,10 @@ import {
   startStewardMock,
 } from "@elizaos/cloud-test-mocks/steward";
 import {
+  type RunningFakeStripe,
+  startFakeStripe,
+} from "@elizaos/cloud-test-mocks/stripe";
+import {
   type RunningBackendFaultProxy,
   startBackendFaultProxy,
 } from "./backend-fault-proxy";
@@ -75,6 +79,8 @@ export interface StackHandle {
     pglite: string;
     /** Mock LLM `/v1` base URL — present only when started with `mockLlm`. */
     mockLlm?: string;
+    /** Stripe-compatible loopback origin, present only with `fakeStripe`. */
+    stripe?: string;
   };
   /**
    * True when the frontend Vite dev was NOT booted (API-only stacks started
@@ -90,6 +96,8 @@ export interface StackHandle {
     controlPlane: RunningControlPlaneMock;
     steward: RunningStewardMock;
     mockLlm?: RunningMockLlm;
+    /** Present only when started with `fakeStripe: true`. */
+    stripe?: RunningFakeStripe;
     /** Present only when started with `backendFaults: true`. */
     backendFaults?: RunningBackendFaultProxy;
   };
@@ -246,6 +254,18 @@ async function closeCloudSharedDatabaseConnections(): Promise<void> {
   await closeDatabaseConnectionsForTests();
 }
 
+async function withFakeStripeBootstrapRollback<T>(
+  fakeStripe: RunningFakeStripe | undefined,
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    await fakeStripe?.stop().catch(() => undefined);
+    throw error;
+  }
+}
+
 export interface StartCloudStackOptions {
   /** Skip running cloud-shared migrations. Defaults to false. */
   skipMigrate?: boolean;
@@ -273,6 +293,11 @@ export interface StartCloudStackOptions {
    * the reply itself reflects retained history. Defaults to false (fixed reply).
    */
   mockLlmEchoContext?: boolean;
+  /**
+   * Boot a stateful Stripe-compatible loopback provider. The Worker receives
+   * the synthetic key and endpoint only under its explicit Cloud E2E gates.
+   */
+  fakeStripe?: boolean;
   /**
    * Put a test-only programmable fault proxy between the Vite frontend and the
    * real local cloud-api. Defaults to false, leaving frontend routing unchanged.
@@ -325,7 +350,6 @@ export async function startCloudStack(
         OPENAI_BASE_URL: mockLlm.url,
       }
     : {};
-
   const sharedEnv = buildSharedEnv(
     {
       hetzner: hetzner.url,
@@ -374,7 +398,7 @@ export async function startCloudStack(
   });
 
   const databaseUrl = `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`;
-  const stackEnv = {
+  const stackEnv: NodeJS.ProcessEnv = {
     ...sharedEnv,
     DATABASE_URL: databaseUrl,
     TEST_DATABASE_URL: databaseUrl,
@@ -401,6 +425,14 @@ export async function startCloudStack(
     );
   }
 
+  // Start Stripe only after database bootstrap. Its origin is needed by the
+  // dev wrapper, while the synthetic credentials stay out of sharedEnv so
+  // sync-api-dev-vars cannot persist them into the developer's .dev.vars.
+  const fakeStripe = opts.fakeStripe ? await startFakeStripe() : undefined;
+  if (fakeStripe) {
+    stackEnv.STRIPE_CLOUD_E2E_API_ORIGIN = fakeStripe.url;
+  }
+
   // Boot cloud-api through its wrangler dev launcher — the same entrypoint the
   // cloud:mock stack uses (`bun run --cwd packages/cloud/api dev`). The earlier
   // no-wrangler "e2e-server" adapter imported cloud-api straight from TypeScript
@@ -410,26 +442,32 @@ export async function startCloudStack(
   // `stripBunAncestryEnv` in env.ts exists precisely so wrangler starts from a
   // bun-spawned context. wrangler pre-bundles, so requests are fast.
   procs.push(
-    spawnLogged(
-      "cloud-api",
-      BUN,
-      ["run", "--cwd", "packages/cloud/api", "dev"],
-      {
-        env: stackEnv,
-        cwd: REPO_ROOT,
-        logFile: join(LOG_DIR, "cloud-api.log"),
-      },
+    await withFakeStripeBootstrapRollback(fakeStripe, () =>
+      spawnLogged(
+        "cloud-api",
+        BUN,
+        ["run", "--cwd", "packages/cloud/api", "dev"],
+        {
+          env: stackEnv,
+          cwd: REPO_ROOT,
+          logFile: join(LOG_DIR, "cloud-api.log"),
+        },
+      ),
     ),
   );
 
   const apiUrl = `http://127.0.0.1:${apiPort}`;
-  await waitForHttpOk(`${apiUrl}/api/health`, {
-    timeoutMs: 180_000,
-    label: "cloud-api",
-  });
+  await withFakeStripeBootstrapRollback(fakeStripe, () =>
+    waitForHttpOk(`${apiUrl}/api/health`, {
+      timeoutMs: 180_000,
+      label: "cloud-api",
+    }),
+  );
 
   const backendFaults = opts.backendFaults
-    ? await startBackendFaultProxy({ targetUrl: apiUrl })
+    ? await withFakeStripeBootstrapRollback(fakeStripe, () =>
+        startBackendFaultProxy({ targetUrl: apiUrl }),
+      )
     : undefined;
   const frontendApiUrl = backendFaults?.url ?? apiUrl;
   const frontendApiPort = backendFaults?.port ?? apiPort;
@@ -445,11 +483,13 @@ export async function startCloudStack(
   const frontendDir = join(REPO_ROOT, "packages", "app");
   if (opts.frontend !== false) {
     if (!existsSync(frontendDir)) {
-      throw new Error(
-        `[stack] frontend boot requested but ${frontendDir} is missing — ` +
-          "the cloud-e2e harness expects packages/app (the apex web dev). " +
-          "Pass { frontend: false } for API-only stacks.",
-      );
+      await withFakeStripeBootstrapRollback(fakeStripe, () => {
+        throw new Error(
+          `[stack] frontend boot requested but ${frontendDir} is missing — ` +
+            "the cloud-e2e harness expects packages/app (the apex web dev). " +
+            "Pass { frontend: false } for API-only stacks.",
+        );
+      });
     }
     const frontendEnv = {
       ...stackEnv,
@@ -461,23 +501,27 @@ export async function startCloudStack(
       NEXT_PUBLIC_API_BASE_URL: frontendApiUrl,
     };
     procs.push(
-      spawnLogged(
-        "frontend",
-        BUN,
-        ["run", "dev", "--", "--host", "127.0.0.1"],
-        {
-          env: frontendEnv,
-          cwd: frontendDir,
-          logFile: join(LOG_DIR, "frontend.log"),
-        },
+      await withFakeStripeBootstrapRollback(fakeStripe, () =>
+        spawnLogged(
+          "frontend",
+          BUN,
+          ["run", "dev", "--", "--host", "127.0.0.1"],
+          {
+            env: frontendEnv,
+            cwd: frontendDir,
+            logFile: join(LOG_DIR, "frontend.log"),
+          },
+        ),
       ),
     );
 
     frontendUrl = `http://127.0.0.1:${frontendPort}`;
-    await waitForHttpOk(frontendUrl, {
-      timeoutMs: 120_000,
-      label: "frontend",
-    });
+    await withFakeStripeBootstrapRollback(fakeStripe, () =>
+      waitForHttpOk(frontendUrl, {
+        timeoutMs: 120_000,
+        label: "frontend",
+      }),
+    );
   } else {
     // API-only stack: no frontend booted. Record why so the handle's
     // frontendSkipped/frontendSkipReason stay coherent and frontend-dependent
@@ -515,6 +559,7 @@ export async function startCloudStack(
     await hetzner.stop().catch(() => undefined);
     await steward.stop().catch(() => undefined);
     await mockLlm?.stop().catch(() => undefined);
+    await fakeStripe?.stop().catch(() => undefined);
     await backendFaults?.stop().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
     if (dbCloseError) {
@@ -538,6 +583,7 @@ export async function startCloudStack(
       controlPlane: controlPlane.url,
       pglite: `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`,
       ...(mockLlm ? { mockLlm: mockLlm.url } : {}),
+      ...(fakeStripe ? { stripe: fakeStripe.url } : {}),
     },
     frontendSkipped: frontendSkipReason !== undefined,
     frontendSkipReason,
@@ -546,6 +592,7 @@ export async function startCloudStack(
       controlPlane,
       steward,
       ...(mockLlm ? { mockLlm } : {}),
+      ...(fakeStripe ? { stripe: fakeStripe } : {}),
       ...(backendFaults ? { backendFaults } : {}),
     },
     dataDir,

--- a/packages/cloud/e2e/src/helpers/test-fixtures.ts
+++ b/packages/cloud/e2e/src/helpers/test-fixtures.ts
@@ -20,7 +20,7 @@ import {
 } from "../fixtures/stack";
 import { loginAsSeededUser } from "./wallet-login";
 
-function buildPlaywrightSessionToken(
+export function buildPlaywrightSessionToken(
   userId: string,
   organizationId: string,
 ): string {

--- a/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
+++ b/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * Adversarial card-payment replay through the real local Worker and PGlite.
+ *
+ * The only simulated boundary is a loopback Stripe-compatible provider. The
+ * first Checkout creation commits at that provider and loses its response. The
+ * Worker must leave durable ambiguity, recover the same Session on an
+ * application retry, and settle one credit/ledger/invoice receipt from
+ * duplicate signed webhooks.
+ */
+
+import { createHmac } from "node:crypto";
+import { webhookEventsRepository } from "@elizaos/cloud-shared/db/repositories/webhook-events";
+import { creditsService } from "@elizaos/cloud-shared/lib/services/credits";
+import { invoicesService } from "@elizaos/cloud-shared/lib/services/invoices";
+import { stripeCheckoutOrdersService } from "@elizaos/cloud-shared/lib/services/stripe-checkout-orders";
+import {
+  buildPlaywrightSessionToken,
+  expect,
+  test,
+} from "../src/helpers/test-fixtures";
+
+const CHECKOUT_PATH = "/api/stripe/create-checkout-session";
+const WEBHOOK_PATH = "/api/stripe/webhook";
+const WEBHOOK_SECRET = "whsec_cloud_e2e";
+
+test.use({
+  stackOptions: {
+    frontend: false,
+    fakeStripe: true,
+  },
+});
+
+test("lost provider response and duplicate webhook settle exactly once", async ({
+  stack,
+  seededUser,
+}) => {
+  test.setTimeout(240_000);
+  const fakeStripe = stack.mocks.stripe;
+  expect(fakeStripe, "fake Stripe must be booted for this lane").toBeDefined();
+  if (!fakeStripe) throw new Error("fake Stripe was not booted");
+
+  const startingBalance = await creditsService.getOrganizationBalanceUsd(
+    seededUser.organizationId,
+  );
+  expect(startingBalance).toBe(1_000);
+  const sessionToken = buildPlaywrightSessionToken(
+    seededUser.userId,
+    seededUser.organizationId,
+  );
+
+  const requestKey = "billing-replay-lost-response-0001";
+  const createCheckout = () =>
+    fetch(`${stack.urls.api}${CHECKOUT_PATH}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `eliza-test-session=${sessionToken}`,
+        Origin: stack.urls.api,
+        "X-Eliza-CSRF": "1",
+        "Idempotency-Key": requestKey,
+      },
+      body: JSON.stringify({ amount: 5, returnUrl: "billing" }),
+    });
+
+  fakeStripe.loseNextCheckoutSessionCreateResponseAfterCommit();
+  const lostResponse = await createCheckout();
+  expect(lostResponse.status).toBe(500);
+
+  expect(fakeStripe.state.customers.size).toBe(1);
+  expect(fakeStripe.state.sessions.size).toBe(1);
+  expect(fakeStripe.state.effects).toHaveLength(1);
+  expect(fakeStripe.state.counters.checkoutSessionsCreated).toBe(1);
+  const lostProviderResponses =
+    fakeStripe.state.counters.checkoutSessionCreateResponsesLost;
+  expect([1, 2]).toContain(lostProviderResponses);
+
+  const session = [...fakeStripe.state.sessions.values()][0];
+  expect(
+    session,
+    "provider effect must retain the committed Session",
+  ).toBeDefined();
+  if (!session) throw new Error("fake Stripe committed no Checkout Session");
+  const checkoutOrderId = session.metadata.checkout_order_id;
+  expect(checkoutOrderId).toBeTruthy();
+
+  const ambiguousOrder = await stripeCheckoutOrdersService.get(checkoutOrderId);
+  expect(ambiguousOrder).toMatchObject({
+    id: checkoutOrderId,
+    organization_id: seededUser.organizationId,
+    initiated_by_user_id: seededUser.userId,
+    status: "provider_ambiguous",
+    stripe_customer_id: session.customer,
+    stripe_checkout_session_id: null,
+    stripe_payment_intent_id: null,
+    credit_transaction_id: null,
+  });
+  expect(ambiguousOrder?.credits_to_grant).toBe("5.000000");
+  expect(ambiguousOrder?.charge_amount_cents).toBe(500n);
+
+  const providerCreatesAfterLoss = fakeStripe.state.requests.filter(
+    (request) =>
+      request.method === "POST" && request.path === "/v1/checkout/sessions",
+  );
+  expect(providerCreatesAfterLoss).toHaveLength(lostProviderResponses);
+  expect(
+    providerCreatesAfterLoss.every(
+      (request) =>
+        request.headers["idempotency-key"] ===
+        `checkout-order:${checkoutOrderId}`,
+    ),
+  ).toBe(true);
+  expect(
+    providerCreatesAfterLoss.every(
+      (request) => request.headers["stripe-version"] === "2024-11-20.acacia",
+    ),
+  ).toBe(true);
+
+  const recoveredResponse = await createCheckout();
+  expect(recoveredResponse.status).toBe(200);
+  const recovered = (await recoveredResponse.json()) as {
+    sessionId?: string;
+    url?: string;
+  };
+  expect(recovered).toEqual({ sessionId: session.id, url: session.url });
+
+  const deliveredOrder = await stripeCheckoutOrdersService.get(checkoutOrderId);
+  expect(deliveredOrder).toMatchObject({
+    status: "delivered",
+    stripe_customer_id: session.customer,
+    stripe_checkout_session_id: session.id,
+    stripe_payment_intent_id: null,
+    credit_transaction_id: null,
+  });
+  expect(fakeStripe.state.effects).toHaveLength(1);
+  expect(fakeStripe.state.sessions.size).toBe(1);
+  expect(fakeStripe.state.counters.checkoutSessionCreateAttempts).toBe(
+    lostProviderResponses,
+  );
+  expect(
+    fakeStripe.state.requests.filter(
+      (request) =>
+        request.method === "GET" && request.path === "/v1/checkout/sessions",
+    ),
+  ).toHaveLength(1);
+  expect(
+    await creditsService.getOrganizationBalanceUsd(seededUser.organizationId),
+  ).toBe(startingBalance);
+
+  const completedSession = fakeStripe.completeCheckoutSession(session.id);
+  expect(completedSession).toMatchObject({
+    payment_status: "paid",
+    status: "complete",
+  });
+  expect(completedSession.payment_intent).toBeTruthy();
+  const timestamp = Math.floor(Date.now() / 1_000);
+  const eventId = "evt_cloud_e2e_checkout_completed_0001";
+  const rawEvent = JSON.stringify({
+    id: eventId,
+    object: "event",
+    api_version: "2024-11-20.acacia",
+    created: timestamp,
+    data: { object: completedSession },
+    livemode: false,
+    pending_webhooks: 1,
+    request: { id: null, idempotency_key: null },
+    type: "checkout.session.completed",
+  });
+  const signature = createHmac("sha256", WEBHOOK_SECRET)
+    .update(`${timestamp}.${rawEvent}`)
+    .digest("hex");
+  const deliverWebhook = () =>
+    fetch(`${stack.urls.api}${WEBHOOK_PATH}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Stripe-Signature": `t=${timestamp},v1=${signature}`,
+      },
+      body: rawEvent,
+    });
+
+  const firstWebhook = await deliverWebhook();
+  expect(firstWebhook.status).toBe(200);
+  expect(await firstWebhook.json()).toEqual({ received: true, queued: true });
+
+  const duplicateWebhook = await deliverWebhook();
+  expect(duplicateWebhook.status).toBe(200);
+  expect(await duplicateWebhook.json()).toEqual({
+    received: true,
+    duplicate: true,
+  });
+  expect(await webhookEventsRepository.findByEventId(eventId)).toMatchObject({
+    event_id: eventId,
+    provider: "stripe",
+    event_type: "checkout.session.completed",
+  });
+
+  const drainResponse = await fetch(
+    `${stack.urls.api}/api/cron/process-stripe-queue`,
+    {
+      method: "POST",
+      headers: { Authorization: "Bearer test-cron-secret" },
+    },
+  );
+  expect(drainResponse.status).toBe(200);
+  const drain = (await drainResponse.json()) as Record<string, unknown>;
+  expect(drain).toMatchObject({
+    success: true,
+    queue: "stripe-events",
+    before: 1,
+    after: 0,
+    attempted: 1,
+    acked: 1,
+    retried: 0,
+    dlqed: 0,
+    failed: 0,
+  });
+
+  const settledOrder = await stripeCheckoutOrdersService.get(checkoutOrderId);
+  expect(settledOrder).toMatchObject({
+    status: "settled",
+    stripe_customer_id: session.customer,
+    stripe_checkout_session_id: session.id,
+    stripe_payment_intent_id: completedSession.payment_intent,
+  });
+  expect(settledOrder?.credit_transaction_id).toBeTruthy();
+  expect(settledOrder?.settled_at).toBeInstanceOf(Date);
+
+  const matchingTransactions = (
+    await creditsService.listTransactionsByOrganization(
+      seededUser.organizationId,
+      100,
+    )
+  ).filter(
+    (transaction) =>
+      transaction.stripe_payment_intent_id === completedSession.payment_intent,
+  );
+  expect(matchingTransactions).toHaveLength(1);
+  expect(matchingTransactions[0]).toMatchObject({
+    id: settledOrder?.credit_transaction_id,
+    organization_id: seededUser.organizationId,
+    amount: "5.000000",
+    type: "credit",
+  });
+
+  const matchingInvoices = (
+    await invoicesService.listByOrganization(seededUser.organizationId)
+  ).filter((invoice) => invoice.stripe_invoice_id === `cs_${session.id}`);
+  expect(matchingInvoices).toHaveLength(1);
+  expect(matchingInvoices[0]).toMatchObject({
+    organization_id: seededUser.organizationId,
+    stripe_customer_id: session.customer,
+    stripe_payment_intent_id: completedSession.payment_intent,
+    amount_paid: "5.00",
+    status: "paid",
+    invoice_type: "custom_amount",
+  });
+  expect(
+    await creditsService.getOrganizationBalanceUsd(seededUser.organizationId),
+  ).toBe(startingBalance + 5);
+});

--- a/packages/cloud/scripts/admin/dev/cloud-api-dev.mjs
+++ b/packages/cloud/scripts/admin/dev/cloud-api-dev.mjs
@@ -256,6 +256,29 @@ async function main() {
         `ELIZA_CLOUD_AGENT_BASE_DOMAIN:${agentBaseDomainOverride}`,
       ]
     : [];
+  // A fake Stripe endpoint is intentionally narrower than ordinary local dev:
+  // pass the synthetic credentials/origin into workerd only for the exact
+  // cloud E2E runtime. `shared/lib/stripe.ts` independently revalidates the
+  // same gates and requires a canonical loopback origin before constructing a
+  // client, so these variables cannot become a generic provider redirect.
+  const isCloudE2ETestMode =
+    process.env.CLOUD_E2E === "1" && process.env.NODE_ENV === "test";
+  const stripeCloudE2EOrigin = process.env.STRIPE_CLOUD_E2E_API_ORIGIN;
+  const stripeE2EDevVars =
+    isCloudE2ETestMode && stripeCloudE2EOrigin
+      ? [
+          "--var",
+          "CLOUD_E2E:1",
+          "--var",
+          "ENVIRONMENT:local",
+          "--var",
+          `STRIPE_CLOUD_E2E_API_ORIGIN:${stripeCloudE2EOrigin}`,
+          "--var",
+          "STRIPE_SECRET_KEY:sk_test_cloud_e2e",
+          "--var",
+          "STRIPE_WEBHOOK_SECRET:whsec_cloud_e2e",
+        ]
+      : [];
   // Redis/cache selection must reach the Worker's `c.env`, not just this launcher's
   // process.env: routes build their client via `buildRedisClient(c.env)`, and
   // wrangler `--local` only exposes vars passed through wrangler.toml/.dev.vars/
@@ -289,6 +312,7 @@ async function main() {
           apiPort,
           "--local",
           ...testModeVars,
+          ...stripeE2EDevVars,
           ...redisDevVars,
           ...appDeployDevVars,
         ];

--- a/packages/cloud/shared/src/lib/stripe.guard.test.ts
+++ b/packages/cloud/shared/src/lib/stripe.guard.test.ts
@@ -24,6 +24,7 @@ const LIVE_KEY = ["sk", "live", "FakeKeyForGuardTests000000"].join("_");
 const TEST_KEY = ["sk", "test", "FakeKeyForGuardTests000000"].join("_");
 const RESTRICTED_LIVE_KEY = ["rk", "live", "FakeKeyForGuardTests000000"].join("_");
 const RESTRICTED_TEST_KEY = ["rk", "test", "FakeKeyForGuardTests000000"].join("_");
+const CLOUD_E2E_TEST_KEY = ["sk", "test", "cloud", "e2e"].join("_");
 
 afterEach(() => {
   __resetStripeForTests();
@@ -207,5 +208,181 @@ describe("stripe client init guard (via Worker bindings)", () => {
       expect(isStripeConfigured()).toBe(false);
       expect(() => getStripe()).toThrow(/LIVE-mode key .* not production/);
     });
+  });
+
+  it("routes the exact Cloud E2E sentinel client to a canonical loopback origin", () => {
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+        STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43123",
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => {
+        expect(isStripeConfigured()).toBe(true);
+        const stripe = getStripe();
+        expect(stripe.getApiField("host")).toBe("127.0.0.1");
+        expect(stripe.getApiField("port")).toBe("43123");
+        expect(stripe.getApiField("protocol")).toBe("http");
+        expect(stripe.getApiField("maxNetworkRetries")).toBe(0);
+      },
+    );
+  });
+
+  for (const [name, bindings] of [
+    [
+      "CLOUD_E2E is absent",
+      {
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+    ],
+    [
+      "NODE_ENV is not test",
+      {
+        CLOUD_E2E: "1",
+        NODE_ENV: "development",
+        ENVIRONMENT: "local",
+      },
+    ],
+    [
+      "ENVIRONMENT is not local",
+      {
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "staging",
+      },
+    ],
+  ] as const) {
+    it(`rejects a Cloud E2E Stripe origin when ${name}`, () => {
+      runWithCloudBindings(
+        {
+          STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+          STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43123",
+          ...bindings,
+        },
+        () => {
+          expect(isStripeConfigured()).toBe(false);
+          expect(() => getStripe()).toThrow(/allowed only .* CLOUD_E2E test runtime/);
+        },
+      );
+    });
+  }
+
+  for (const origin of [
+    "https://127.0.0.1:43123",
+    "http://localhost:43123",
+    "http://127.0.0.1:43123/v1",
+    "http://127.0.0.1:43123?redirect=1",
+    "http://127.0.0.1:43123#fragment",
+    "http://user:pass@127.0.0.1:43123",
+    "http://127.0.0.1",
+    "not-a-url",
+  ]) {
+    it(`rejects the non-canonical Cloud E2E Stripe origin ${origin}`, () => {
+      runWithCloudBindings(
+        {
+          STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+          STRIPE_CLOUD_E2E_API_ORIGIN: origin,
+          CLOUD_E2E: "1",
+          NODE_ENV: "test",
+          ENVIRONMENT: "local",
+        },
+        () => {
+          expect(isStripeConfigured()).toBe(false);
+          expect(() => getStripe()).toThrow(/loopback origin|127\.0\.0\.1/);
+        },
+      );
+    });
+  }
+
+  it("rejects a real-looking test key with the Cloud E2E origin override", () => {
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: TEST_KEY,
+        STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43123",
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => {
+        expect(isStripeConfigured()).toBe(false);
+        expect(() => getStripe()).toThrow(/synthetic test key/);
+      },
+    );
+  });
+
+  it("rejects the synthetic Cloud E2E key when its loopback origin is absent", () => {
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => {
+        expect(isStripeConfigured()).toBe(false);
+        expect(() => getStripe()).toThrow(/requires its canonical loopback endpoint/);
+      },
+    );
+  });
+
+  it("does not reuse a cached Cloud E2E client after its gate is removed", () => {
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+        STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43123",
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => expect(() => getStripe()).not.toThrow(),
+    );
+
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+        STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43123",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => {
+        expect(isStripeConfigured()).toBe(false);
+        expect(() => getStripe()).toThrow(/allowed only .* CLOUD_E2E test runtime/);
+      },
+    );
+  });
+
+  it("rebuilds the cached Cloud E2E client when the loopback origin changes", () => {
+    let first: ReturnType<typeof getStripe> | undefined;
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+        STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43123",
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => {
+        first = getStripe();
+        expect(first.getApiField("port")).toBe("43123");
+      },
+    );
+
+    runWithCloudBindings(
+      {
+        STRIPE_SECRET_KEY: CLOUD_E2E_TEST_KEY,
+        STRIPE_CLOUD_E2E_API_ORIGIN: "http://127.0.0.1:43124",
+        CLOUD_E2E: "1",
+        NODE_ENV: "test",
+        ENVIRONMENT: "local",
+      },
+      () => {
+        const second = getStripe();
+        expect(second).not.toBe(first);
+        expect(second.getApiField("port")).toBe("43124");
+      },
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/stripe.ts
+++ b/packages/cloud/shared/src/lib/stripe.ts
@@ -35,6 +35,13 @@ type PinnedStripeApiVersion = Stripe.WebhookEndpointCreateParams.ApiVersion;
 type StripeConstructorConfig = NonNullable<ConstructorParameters<typeof Stripe>[1]>;
 
 const STRIPE_API_VERSION: PinnedStripeApiVersion = "2024-11-20.acacia";
+const CLOUD_E2E_STRIPE_SECRET_KEY = "sk_test_cloud_e2e";
+
+interface CloudE2EStripeEndpoint {
+  host: string;
+  port: string;
+  protocol: "http";
+}
 
 let stripeInstance: Stripe | null = null;
 let stripeInitError: Error | null = null;
@@ -48,7 +55,72 @@ function buildStripeCacheKey(
   env: Record<string, string | undefined>,
   secretKey: string | undefined,
 ): string {
-  return [env.ENVIRONMENT ?? "", env.NODE_ENV ?? "", secretKey ?? "missing"].join("\0");
+  return [
+    env.ENVIRONMENT ?? "",
+    env.NODE_ENV ?? "",
+    env.CLOUD_E2E ?? "",
+    env.STRIPE_CLOUD_E2E_API_ORIGIN ?? "",
+    secretKey ?? "missing",
+  ].join("\0");
+}
+
+/**
+ * Resolve the Stripe-compatible loopback endpoint used by the full cloud E2E
+ * harness. This is deliberately not a generic Stripe base-URL override: an
+ * override is accepted only for the exact synthetic test key and only inside
+ * the explicit local E2E runtime.
+ */
+function resolveCloudE2EStripeEndpoint(
+  env: Record<string, string | undefined>,
+  secretKey: string,
+): CloudE2EStripeEndpoint | null {
+  const rawOrigin = env.STRIPE_CLOUD_E2E_API_ORIGIN?.trim();
+  if (!rawOrigin) {
+    if (secretKey === CLOUD_E2E_STRIPE_SECRET_KEY) {
+      throw new Error(
+        "SECURITY: the synthetic Stripe Cloud E2E key requires its canonical loopback endpoint",
+      );
+    }
+    return null;
+  }
+
+  if (
+    env.CLOUD_E2E !== "1" ||
+    env.NODE_ENV !== "test" ||
+    env.ENVIRONMENT !== "local" ||
+    secretKey !== CLOUD_E2E_STRIPE_SECRET_KEY
+  ) {
+    throw new Error(
+      "SECURITY: the Stripe Cloud E2E endpoint is allowed only in the explicit local CLOUD_E2E test runtime with its synthetic test key",
+    );
+  }
+
+  let origin: URL;
+  try {
+    origin = new URL(rawOrigin);
+  } catch {
+    throw new Error("SECURITY: the Stripe Cloud E2E endpoint must be a valid loopback origin");
+  }
+  if (
+    origin.protocol !== "http:" ||
+    origin.hostname !== "127.0.0.1" ||
+    !origin.port ||
+    origin.pathname !== "/" ||
+    origin.search ||
+    origin.hash ||
+    origin.username ||
+    origin.password
+  ) {
+    throw new Error(
+      "SECURITY: the Stripe Cloud E2E endpoint must be an http://127.0.0.1:<port> origin without credentials, path, query, or fragment",
+    );
+  }
+  const port = Number(origin.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("SECURITY: the Stripe Cloud E2E endpoint must use an explicit valid port");
+  }
+
+  return { host: origin.hostname, port: origin.port, protocol: "http" };
 }
 
 /**
@@ -101,9 +173,28 @@ function initStripe(): Stripe | null {
     );
   }
 
+  let cloudE2EEndpoint: CloudE2EStripeEndpoint | null;
+  try {
+    cloudE2EEndpoint = resolveCloudE2EStripeEndpoint(env, secretKey);
+  } catch (error) {
+    stripeInitError = error instanceof Error ? error : new Error(String(error));
+    stripeInstance = null;
+    stripeCacheKey = cacheKey;
+    logger.error(`[Stripe] ${stripeInitError.message}`);
+    return null;
+  }
+
   stripeInstance = new Stripe(secretKey, {
     typescript: true,
     apiVersion: STRIPE_API_VERSION as StripeConstructorConfig["apiVersion"],
+    ...(cloudE2EEndpoint
+      ? {
+          ...cloudE2EEndpoint,
+          // A deliberately lost provider response must surface to the Worker;
+          // the durable checkout-order reconciliation owns the retry policy.
+          maxNetworkRetries: 0,
+        }
+      : {}),
   });
   stripeInitError = null;
   stripeCacheKey = cacheKey;
@@ -153,7 +244,13 @@ export function isStripeConfigured(): boolean {
   // A live key outside production is treated as NOT configured (#13752):
   // callers that gate on this helper degrade gracefully instead of creating
   // real-money checkout sessions against a non-prod database.
-  return !shouldBlockLiveStripeKeyOutsideProduction(env);
+  if (shouldBlockLiveStripeKeyOutsideProduction(env)) return false;
+  try {
+    resolveCloudE2EStripeEndpoint(env, key);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -420,6 +420,11 @@ export interface Bindings {
   STRIPE_SECRET_KEY?: string;
   STRIPE_WEBHOOK_SECRET?: string;
   /**
+   * Test-only Stripe-compatible loopback origin. The Stripe client accepts it
+   * only under the explicit CLOUD_E2E + NODE_ENV=test gates and never in prod.
+   */
+  STRIPE_CLOUD_E2E_API_ORIGIN?: string;
+  /**
    * Signing secret for the Stripe **Connect** webhook endpoint
    * (`/api/v1/earnings/payout/stripe-connect/webhook`). Connect endpoints have
    * their own secret, distinct from `STRIPE_WEBHOOK_SECRET` (the main billing
@@ -511,6 +516,8 @@ export interface Bindings {
   CONTAINERS_BOOTSTRAP_SECRET?: string;
   CONTAINERS_HCLOUD_LOCATION?: string;
   NODE_ENV?: string;
+  /** Exact local full-stack test gate; never set on deployed Workers. */
+  CLOUD_E2E?: string;
   /**
    * Git commit stamped at deploy time so `/api/health` can prove which Worker
    * revision is currently served before CI allows another deploy to overwrite it.

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -10,6 +10,7 @@
     "./control-plane": "./src/control-plane/index.ts",
     "./steward": "./src/steward/index.ts",
     "./provider-contract": "./src/provider-contract/index.ts",
+    "./stripe": "./src/stripe/index.ts",
     "./synthetic-environment": "./src/synthetic-environment/index.ts"
   },
   "bin": {

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -3,4 +3,5 @@ export * as controlPlane from "./control-plane";
 export * from "./hetzner";
 export * as providerContract from "./provider-contract";
 export * from "./steward";
+export * from "./stripe";
 export * as syntheticEnvironment from "./synthetic-environment";

--- a/packages/cloud/test-mocks/src/stripe/index.ts
+++ b/packages/cloud/test-mocks/src/stripe/index.ts
@@ -1,0 +1,723 @@
+/** Stateful, loopback-only fake for deterministic Stripe Checkout boundary tests. */
+
+import {
+  createServer,
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { Socket } from "node:net";
+
+const LOOPBACK_HOST = "127.0.0.1";
+
+export interface FakeStripeCustomer {
+  id: string;
+  object: "customer";
+  created: number;
+  livemode: false;
+  email: string | null;
+  name: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface FakeStripeCheckoutSession {
+  id: string;
+  object: "checkout.session";
+  url: string;
+  customer: string;
+  client_reference_id: string | null;
+  metadata: Record<string, string>;
+  amount_total: number;
+  currency: string;
+  payment_status: "unpaid" | "paid";
+  status: "open" | "complete";
+  payment_intent: string | null;
+  created: number;
+  livemode: false;
+}
+
+export interface FakeStripeRequest {
+  method: string;
+  path: string;
+  query: Record<string, string[]>;
+  headers: Record<string, string>;
+  body: string;
+  form: Record<string, string[]>;
+}
+
+export interface FakeStripeEffect {
+  kind: "checkout.session.create";
+  id: string;
+  idempotencyKey: string | null;
+  committedAt: number;
+}
+
+export interface FakeStripeState {
+  requests: FakeStripeRequest[];
+  customers: Map<string, FakeStripeCustomer>;
+  sessions: Map<string, FakeStripeCheckoutSession>;
+  effects: FakeStripeEffect[];
+  counters: {
+    customerCreateAttempts: number;
+    customersCreated: number;
+    checkoutSessionCreateAttempts: number;
+    checkoutSessionsCreated: number;
+    checkoutSessionCreateResponsesLost: number;
+  };
+}
+
+export interface RunningFakeStripe {
+  /** Provider origin. The Stripe client should add its normal `/v1` paths. */
+  url: string;
+  port: number;
+  state: FakeStripeState;
+  /** Commit the next new Checkout Session, then close its socket before any response byte. */
+  loseNextCheckoutSessionCreateResponseAfterCommit(): void;
+  /** Applies the provider-side payment transition used to build a signed completion webhook. */
+  completeCheckoutSession(sessionId: string): FakeStripeCheckoutSession;
+  stop(): Promise<void>;
+}
+
+export interface StartFakeStripeOptions {
+  /** Listen port. Zero (the default) asks the OS for a free port. */
+  port?: number;
+}
+
+interface IdempotentResult<T> {
+  fingerprint: string;
+  value: T;
+}
+
+interface MutableFakeStripeState extends FakeStripeState {
+  customerIdempotency: Map<string, IdempotentResult<FakeStripeCustomer>>;
+  sessionIdempotency: Map<string, IdempotentResult<FakeStripeCheckoutSession>>;
+  nextCustomerId: number;
+  nextSessionId: number;
+  checkoutResponseLossesRemaining: number;
+  checkoutResponseLossTargetKey: string | null;
+}
+
+/**
+ * Starts a deliberately small Stripe-compatible HTTP surface. It always binds
+ * to IPv4 loopback and never accepts a hostname override, so synthetic provider
+ * traffic cannot accidentally leave the local machine.
+ */
+export async function startFakeStripe(
+  options: StartFakeStripeOptions = {},
+): Promise<RunningFakeStripe> {
+  const state: MutableFakeStripeState = {
+    requests: [],
+    customers: new Map(),
+    sessions: new Map(),
+    effects: [],
+    counters: {
+      customerCreateAttempts: 0,
+      customersCreated: 0,
+      checkoutSessionCreateAttempts: 0,
+      checkoutSessionsCreated: 0,
+      checkoutSessionCreateResponsesLost: 0,
+    },
+    customerIdempotency: new Map(),
+    sessionIdempotency: new Map(),
+    nextCustomerId: 1,
+    nextSessionId: 1,
+    checkoutResponseLossesRemaining: 0,
+    checkoutResponseLossTargetKey: null,
+  };
+  const sockets = new Set<Socket>();
+  const server = createServer((incoming, outgoing) => {
+    void handleRequest(incoming, outgoing, state);
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(options.port ?? 0, LOOPBACK_HOST);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server, sockets);
+    throw new Error("Fake Stripe did not bind to a numeric loopback port");
+  }
+
+  return {
+    url: `http://${LOOPBACK_HOST}:${address.port}`,
+    port: address.port,
+    state,
+    loseNextCheckoutSessionCreateResponseAfterCommit() {
+      // stripe-node replays an idempotent POST once even with its configured
+      // network retry count at zero. Lose both the commit response and that
+      // SDK replay so the application must reconcile with a list operation.
+      state.checkoutResponseLossesRemaining = 2;
+      state.checkoutResponseLossTargetKey = null;
+    },
+    completeCheckoutSession(sessionId) {
+      const session = state.sessions.get(sessionId);
+      if (!session) {
+        throw new Error(
+          `Cannot complete missing fake Stripe Session ${sessionId}`,
+        );
+      }
+      session.payment_status = "paid";
+      session.status = "complete";
+      session.payment_intent =
+        session.payment_intent ?? paymentIntentId(session.id);
+      return session;
+    },
+    stop: () => closeServer(server, sockets),
+  };
+}
+
+async function handleRequest(
+  incoming: IncomingMessage,
+  outgoing: ServerResponse,
+  state: MutableFakeStripeState,
+): Promise<void> {
+  try {
+    if (!isLoopback(incoming.socket.remoteAddress)) {
+      writeStripeError(outgoing, 403, "api_error", "Loopback requests only");
+      return;
+    }
+
+    const method = incoming.method ?? "GET";
+    const requestUrl = new URL(incoming.url ?? "/", `http://${LOOPBACK_HOST}`);
+    const body =
+      method === "GET" || method === "HEAD" ? "" : await readBody(incoming);
+    const form = new URLSearchParams(body);
+    state.requests.push({
+      method,
+      path: requestUrl.pathname,
+      query: collectParams(requestUrl.searchParams),
+      headers: inspectableHeaders(incoming.headers),
+      body,
+      form: collectParams(form),
+    });
+
+    if (!hasBearerAuthorization(incoming.headers.authorization)) {
+      writeStripeError(
+        outgoing,
+        401,
+        "invalid_request_error",
+        "Invalid API Key provided",
+      );
+      return;
+    }
+
+    if (method === "GET" && requestUrl.pathname === "/v1/customers/search") {
+      searchCustomers(outgoing, requestUrl.searchParams, state);
+      return;
+    }
+    if (method === "POST" && requestUrl.pathname === "/v1/customers") {
+      createCustomer(outgoing, form, body, incoming.headers, state);
+      return;
+    }
+    const customerMatch = /^\/v1\/customers\/([^/]+)$/.exec(
+      requestUrl.pathname,
+    );
+    if (method === "GET" && customerMatch?.[1]) {
+      retrieveCustomer(outgoing, decodeURIComponent(customerMatch[1]), state);
+      return;
+    }
+    if (method === "POST" && requestUrl.pathname === "/v1/checkout/sessions") {
+      createCheckoutSession(outgoing, form, body, incoming.headers, state);
+      return;
+    }
+    if (method === "GET" && requestUrl.pathname === "/v1/checkout/sessions") {
+      listCheckoutSessions(outgoing, requestUrl.searchParams, state);
+      return;
+    }
+    const sessionMatch = /^\/v1\/checkout\/sessions\/([^/]+)$/.exec(
+      requestUrl.pathname,
+    );
+    if (method === "GET" && sessionMatch?.[1]) {
+      retrieveCheckoutSession(
+        outgoing,
+        decodeURIComponent(sessionMatch[1]),
+        state,
+      );
+      return;
+    }
+
+    writeStripeError(
+      outgoing,
+      404,
+      "invalid_request_error",
+      `Unrecognized request URL (${method}: ${requestUrl.pathname})`,
+      "resource_missing",
+    );
+  } catch (error) {
+    if (outgoing.destroyed) return;
+    writeStripeError(
+      outgoing,
+      500,
+      "api_error",
+      error instanceof Error ? error.message : "Fake Stripe request failed",
+    );
+  }
+}
+
+function searchCustomers(
+  outgoing: ServerResponse,
+  query: URLSearchParams,
+  state: MutableFakeStripeState,
+): void {
+  const search = query.get("query") ?? "";
+  const metadataMatch = /metadata\[['"]([^'"]+)['"]\]\s*:\s*'([^']*)'/.exec(
+    search,
+  );
+  const data = [...state.customers.values()]
+    .filter(
+      (customer) =>
+        !metadataMatch ||
+        customer.metadata[metadataMatch[1] ?? ""] === metadataMatch[2],
+    )
+    .sort(
+      (left, right) =>
+        right.created - left.created || right.id.localeCompare(left.id),
+    );
+  const limit = boundedLimit(query.get("limit"));
+  writeJson(outgoing, 200, {
+    object: "search_result",
+    data: data.slice(0, limit),
+    has_more: data.length > limit,
+    next_page: data.length > limit ? "fake-next-page" : null,
+    url: "/v1/customers/search",
+  });
+}
+
+function createCustomer(
+  outgoing: ServerResponse,
+  form: URLSearchParams,
+  fingerprint: string,
+  headers: IncomingHttpHeaders,
+  state: MutableFakeStripeState,
+): void {
+  state.counters.customerCreateAttempts += 1;
+  const idempotencyKey = headerValue(headers["idempotency-key"]);
+  const existing = idempotencyKey
+    ? state.customerIdempotency.get(idempotencyKey)
+    : undefined;
+  if (existing) {
+    if (existing.fingerprint !== fingerprint) {
+      writeIdempotencyMismatch(outgoing);
+      return;
+    }
+    writeJson(outgoing, 200, existing.value);
+    return;
+  }
+
+  const customer: FakeStripeCustomer = {
+    id: `cus_fake_${padId(state.nextCustomerId)}`,
+    object: "customer",
+    created: nowSeconds(),
+    livemode: false,
+    email: form.get("email"),
+    name: form.get("name"),
+    metadata: parseMetadata(form, "metadata"),
+  };
+  state.nextCustomerId += 1;
+  state.customers.set(customer.id, customer);
+  state.counters.customersCreated += 1;
+  if (idempotencyKey) {
+    state.customerIdempotency.set(idempotencyKey, {
+      fingerprint,
+      value: customer,
+    });
+  }
+  writeJson(outgoing, 200, customer);
+}
+
+function retrieveCustomer(
+  outgoing: ServerResponse,
+  customerId: string,
+  state: MutableFakeStripeState,
+): void {
+  const customer = state.customers.get(customerId);
+  if (!customer) {
+    writeStripeError(
+      outgoing,
+      404,
+      "invalid_request_error",
+      `No such customer: '${customerId}'`,
+      "resource_missing",
+      "id",
+    );
+    return;
+  }
+  writeJson(outgoing, 200, customer);
+}
+
+function createCheckoutSession(
+  outgoing: ServerResponse,
+  form: URLSearchParams,
+  fingerprint: string,
+  headers: IncomingHttpHeaders,
+  state: MutableFakeStripeState,
+): void {
+  state.counters.checkoutSessionCreateAttempts += 1;
+  const idempotencyKey = headerValue(headers["idempotency-key"]);
+  const existing = idempotencyKey
+    ? state.sessionIdempotency.get(idempotencyKey)
+    : undefined;
+  if (existing) {
+    if (existing.fingerprint !== fingerprint) {
+      writeIdempotencyMismatch(outgoing);
+      return;
+    }
+    if (loseCheckoutResponseIfArmed(outgoing, idempotencyKey, state)) return;
+    writeJson(outgoing, 200, existing.value);
+    return;
+  }
+
+  const customer = form.get("customer");
+  if (!customer || !state.customers.has(customer)) {
+    writeStripeError(
+      outgoing,
+      400,
+      "invalid_request_error",
+      "No such customer",
+      "resource_missing",
+      "customer",
+    );
+    return;
+  }
+  const lineItems = parseLineItems(form);
+  if (lineItems.length === 0) {
+    writeStripeError(
+      outgoing,
+      400,
+      "invalid_request_error",
+      "At least one line item is required",
+      undefined,
+      "line_items",
+    );
+    return;
+  }
+  const currency = lineItems[0]?.currency;
+  if (!currency || lineItems.some((item) => item.currency !== currency)) {
+    writeStripeError(
+      outgoing,
+      400,
+      "invalid_request_error",
+      "Line item currencies must match",
+      undefined,
+      "line_items",
+    );
+    return;
+  }
+
+  const numericId = state.nextSessionId;
+  const session: FakeStripeCheckoutSession = {
+    id: `cs_test_fake_${padId(numericId)}`,
+    object: "checkout.session",
+    url: `https://checkout.stripe.test/c/pay/cs_test_fake_${padId(numericId)}`,
+    customer,
+    client_reference_id: form.get("client_reference_id"),
+    metadata: parseMetadata(form, "metadata"),
+    amount_total: lineItems.reduce(
+      (total, item) => total + item.unitAmount * item.quantity,
+      0,
+    ),
+    currency,
+    payment_status: "unpaid",
+    status: "open",
+    payment_intent: null,
+    created: nowSeconds(),
+    livemode: false,
+  };
+  state.nextSessionId += 1;
+  state.sessions.set(session.id, session);
+  state.counters.checkoutSessionsCreated += 1;
+  state.effects.push({
+    kind: "checkout.session.create",
+    id: session.id,
+    idempotencyKey: idempotencyKey ?? null,
+    committedAt: session.created,
+  });
+  if (idempotencyKey) {
+    state.sessionIdempotency.set(idempotencyKey, {
+      fingerprint,
+      value: session,
+    });
+  }
+
+  if (loseCheckoutResponseIfArmed(outgoing, idempotencyKey, state)) return;
+  writeJson(outgoing, 200, session);
+}
+
+function loseCheckoutResponseIfArmed(
+  outgoing: ServerResponse,
+  idempotencyKey: string | undefined,
+  state: MutableFakeStripeState,
+): boolean {
+  if (state.checkoutResponseLossesRemaining <= 0) return false;
+  const targetKey = idempotencyKey ?? "<missing-idempotency-key>";
+  state.checkoutResponseLossTargetKey ??= targetKey;
+  if (state.checkoutResponseLossTargetKey !== targetKey) return false;
+
+  state.checkoutResponseLossesRemaining -= 1;
+  state.counters.checkoutSessionCreateResponsesLost += 1;
+  if (state.checkoutResponseLossesRemaining === 0) {
+    state.checkoutResponseLossTargetKey = null;
+  }
+  const socket = outgoing.socket;
+  outgoing.destroy();
+  socket?.destroy();
+  return true;
+}
+
+function listCheckoutSessions(
+  outgoing: ServerResponse,
+  query: URLSearchParams,
+  state: MutableFakeStripeState,
+): void {
+  const customer = query.get("customer");
+  const createdGte = parseOptionalInteger(query.get("created[gte]"));
+  const createdLte = parseOptionalInteger(query.get("created[lte]"));
+  const startingAfter = query.get("starting_after");
+  const ordered = [...state.sessions.values()]
+    .filter((session) => !customer || session.customer === customer)
+    .filter((session) => createdGte === null || session.created >= createdGte)
+    .filter((session) => createdLte === null || session.created <= createdLte)
+    .sort(
+      (left, right) =>
+        right.created - left.created || right.id.localeCompare(left.id),
+    );
+  const startIndex = startingAfter
+    ? Math.max(
+        ordered.findIndex((session) => session.id === startingAfter) + 1,
+        0,
+      )
+    : 0;
+  const limit = boundedLimit(query.get("limit"));
+  const data = ordered.slice(startIndex, startIndex + limit);
+  writeJson(outgoing, 200, {
+    object: "list",
+    data,
+    has_more: startIndex + data.length < ordered.length,
+    url: "/v1/checkout/sessions",
+  });
+}
+
+function retrieveCheckoutSession(
+  outgoing: ServerResponse,
+  sessionId: string,
+  state: MutableFakeStripeState,
+): void {
+  const session = state.sessions.get(sessionId);
+  if (!session) {
+    writeStripeError(
+      outgoing,
+      404,
+      "invalid_request_error",
+      `No such checkout.session: '${sessionId}'`,
+      "resource_missing",
+    );
+    return;
+  }
+  writeJson(outgoing, 200, session);
+}
+
+function parseMetadata(
+  form: URLSearchParams,
+  prefix: string,
+): Record<string, string> {
+  const metadata: Record<string, string> = {};
+  const pattern = new RegExp(`^${escapeRegExp(prefix)}\\[([^\\]]+)\\]$`);
+  for (const [key, value] of form) {
+    const match = pattern.exec(key);
+    if (match?.[1]) metadata[match[1]] = value;
+  }
+  return metadata;
+}
+
+function parseLineItems(form: URLSearchParams): Array<{
+  index: number;
+  unitAmount: number;
+  quantity: number;
+  currency: string;
+}> {
+  const byIndex = new Map<
+    number,
+    { unitAmount?: number; quantity?: number; currency?: string }
+  >();
+  for (const [key, value] of form) {
+    const match =
+      /^line_items\[(\d+)\]\[(?:price_data\]\[(unit_amount|currency)|(quantity))\]$/.exec(
+        key,
+      );
+    if (!match?.[1]) continue;
+    const index = Number(match[1]);
+    const item = byIndex.get(index) ?? {};
+    const field = match[2] ?? match[3];
+    if (field === "unit_amount") item.unitAmount = Number(value);
+    else if (field === "quantity") item.quantity = Number(value);
+    else if (field === "currency") item.currency = value.toLowerCase();
+    byIndex.set(index, item);
+  }
+  return [...byIndex.entries()]
+    .sort(([left], [right]) => left - right)
+    .flatMap(([index, item]) => {
+      const unitAmount = item.unitAmount;
+      const currency = item.currency;
+      if (
+        unitAmount === undefined ||
+        !Number.isSafeInteger(unitAmount) ||
+        unitAmount < 0 ||
+        !Number.isSafeInteger(item.quantity ?? 1) ||
+        (item.quantity ?? 1) <= 0 ||
+        !currency
+      ) {
+        return [];
+      }
+      return [
+        {
+          index,
+          unitAmount,
+          quantity: item.quantity ?? 1,
+          currency,
+        },
+      ];
+    });
+}
+
+function collectParams(params: URLSearchParams): Record<string, string[]> {
+  const collected: Record<string, string[]> = {};
+  for (const [key, value] of params) {
+    const values = collected[key] ?? [];
+    values.push(value);
+    collected[key] = values;
+  }
+  return collected;
+}
+
+function inspectableHeaders(
+  headers: IncomingHttpHeaders,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const name of ["content-type", "idempotency-key", "stripe-version"]) {
+    const value = headerValue(headers[name]);
+    if (value) result[name] = value;
+  }
+  return result;
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function hasBearerAuthorization(value: string | undefined): boolean {
+  return /^Bearer\s+\S+$/.test(value ?? "");
+}
+
+function boundedLimit(raw: string | null): number {
+  const parsed = Number(raw ?? 10);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? Math.min(parsed, 100)
+    : 10;
+}
+
+function parseOptionalInteger(raw: string | null): number | null {
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function padId(id: number): string {
+  return String(id).padStart(6, "0");
+}
+
+function paymentIntentId(sessionId: string): string {
+  return sessionId.replace(/^cs_test_/, "pi_");
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function writeIdempotencyMismatch(outgoing: ServerResponse): void {
+  writeStripeError(
+    outgoing,
+    400,
+    "idempotency_error",
+    "Keys for idempotent requests can only be used with the same parameters",
+  );
+}
+
+function writeStripeError(
+  outgoing: ServerResponse,
+  status: number,
+  type: string,
+  message: string,
+  code?: string,
+  param?: string,
+): void {
+  writeJson(outgoing, status, {
+    error: {
+      type,
+      message,
+      ...(code ? { code } : {}),
+      ...(param ? { param } : {}),
+    },
+  });
+}
+
+function writeJson(
+  outgoing: ServerResponse,
+  status: number,
+  value: unknown,
+): void {
+  const body = JSON.stringify(value);
+  outgoing.statusCode = status;
+  outgoing.setHeader("content-type", "application/json");
+  outgoing.setHeader("content-length", Buffer.byteLength(body));
+  outgoing.setHeader("request-id", `req_fake_${Date.now()}`);
+  outgoing.end(body);
+}
+
+async function readBody(incoming: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of incoming) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function isLoopback(address: string | undefined): boolean {
+  return (
+    address === "127.0.0.1" ||
+    address === "::1" ||
+    address === "::ffff:127.0.0.1"
+  );
+}
+
+async function closeServer(
+  server: ReturnType<typeof createServer>,
+  sockets: Set<Socket>,
+): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+    for (const socket of sockets) socket.destroy();
+  });
+}

--- a/packages/cloud/test-mocks/test/stripe.test.ts
+++ b/packages/cloud/test-mocks/test/stripe.test.ts
@@ -1,0 +1,274 @@
+/** Exercises Stripe-compatible idempotency and the committed-then-lost response fault. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { request } from "node:http";
+import { type RunningFakeStripe, startFakeStripe } from "../src/stripe";
+
+const AUTH_HEADERS = {
+  Authorization: "Bearer sk_test_local_only",
+  "Content-Type": "application/x-www-form-urlencoded",
+};
+
+let running: RunningFakeStripe | undefined;
+
+afterEach(async () => {
+  await running?.stop();
+  running = undefined;
+});
+
+describe("fake Stripe", () => {
+  test("loses two same-key transport responses, then recovers through list", async () => {
+    running = await startFakeStripe();
+    const customer = await createCustomer(running, "customer-key");
+    const body = checkoutBody(customer.id, "order-123");
+    running.loseNextCheckoutSessionCreateResponseAfterCommit();
+
+    let lostResponseError: unknown;
+    try {
+      await nodeRequestText(
+        `${running.url}/v1/checkout/sessions`,
+        body.toString(),
+        {
+          ...AUTH_HEADERS,
+          "Idempotency-Key": "checkout-order:order-123",
+        },
+      );
+    } catch (error) {
+      lostResponseError = error;
+    }
+    expect(lostResponseError).toBeInstanceOf(Error);
+
+    let replayResponseError: unknown;
+    try {
+      await nodeRequestText(
+        `${running.url}/v1/checkout/sessions`,
+        body.toString(),
+        {
+          ...AUTH_HEADERS,
+          "Idempotency-Key": "checkout-order:order-123",
+        },
+      );
+    } catch (error) {
+      replayResponseError = error;
+    }
+    expect(replayResponseError).toBeInstanceOf(Error);
+
+    expect(running.state.sessions.size).toBe(1);
+    expect(running.state.effects).toHaveLength(1);
+    expect(running.state.counters.checkoutSessionsCreated).toBe(1);
+    expect(running.state.counters.checkoutSessionCreateResponsesLost).toBe(2);
+
+    const session = [...running.state.sessions.values()][0];
+    expect(session).toBeDefined();
+    if (!session)
+      throw new Error("Fake Stripe did not retain the committed session");
+    const recoveryResponse = await fetch(
+      `${running.url}/v1/checkout/sessions?customer=${customer.id}&created[gte]=${session.created - 1}&created[lte]=${session.created + 1}&limit=100`,
+      { headers: { Authorization: AUTH_HEADERS.Authorization } },
+    );
+    expect(recoveryResponse.status).toBe(200);
+    const recovery = (await recoveryResponse.json()) as {
+      data: Array<{ id: string }>;
+    };
+
+    expect(recovery.data).toEqual([{ ...session }]);
+    expect(running.state.sessions.size).toBe(1);
+    expect(running.state.effects).toHaveLength(1);
+    expect(running.state.counters.checkoutSessionCreateAttempts).toBe(2);
+    expect(running.state.counters.checkoutSessionsCreated).toBe(1);
+    expect(
+      running.state.requests
+        .filter(
+          (request) =>
+            request.method === "POST" &&
+            request.path === "/v1/checkout/sessions",
+        )
+        .map((request) => request.headers["idempotency-key"]),
+    ).toEqual(["checkout-order:order-123", "checkout-order:order-123"]);
+  });
+
+  test("idempotently replays customer and Checkout Session creation", async () => {
+    running = await startFakeStripe();
+    const firstCustomer = await createCustomer(running, "same-customer-key");
+    const secondCustomer = await createCustomer(running, "same-customer-key");
+    expect(secondCustomer.id).toBe(firstCustomer.id);
+    expect(running.state.customers.size).toBe(1);
+    expect(running.state.counters.customerCreateAttempts).toBe(2);
+    expect(running.state.counters.customersCreated).toBe(1);
+
+    const body = checkoutBody(firstCustomer.id, "order-456");
+    const first = await createSession(
+      running,
+      body,
+      "checkout-order:order-456",
+    );
+    const replay = await createSession(
+      running,
+      body,
+      "checkout-order:order-456",
+    );
+    expect(replay.id).toBe(first.id);
+    expect(running.state.sessions.size).toBe(1);
+    expect(running.state.effects).toEqual([
+      expect.objectContaining({
+        kind: "checkout.session.create",
+        id: first.id,
+        idempotencyKey: "checkout-order:order-456",
+      }),
+    ]);
+  });
+
+  test("moves an open unpaid Session to one stable paid completion", async () => {
+    running = await startFakeStripe();
+    const customer = await createCustomer(running, "completion-customer-key");
+    const session = await createSession(
+      running,
+      checkoutBody(customer.id, "order-completion"),
+      "checkout-order:order-completion",
+    );
+    const before = running.state.sessions.get(session.id);
+    expect(before).toMatchObject({
+      payment_status: "unpaid",
+      status: "open",
+      payment_intent: null,
+    });
+
+    const completed = running.completeCheckoutSession(session.id);
+    expect(completed).toMatchObject({
+      payment_status: "paid",
+      status: "complete",
+      payment_intent: "pi_fake_000001",
+    });
+    expect(running.completeCheckoutSession(session.id)).toEqual(completed);
+    expect(running.state.sessions.size).toBe(1);
+    expect(running.state.effects).toHaveLength(1);
+  });
+
+  test("retrieves the exact customer and reports Stripe resource_missing", async () => {
+    running = await startFakeStripe();
+    const created = await createCustomer(running, "retrieve-customer-key");
+
+    const foundResponse = await fetch(
+      `${running.url}/v1/customers/${created.id}`,
+      {
+        headers: { Authorization: AUTH_HEADERS.Authorization },
+      },
+    );
+    expect(foundResponse.status).toBe(200);
+    expect(await foundResponse.json()).toEqual(
+      running.state.customers.get(created.id),
+    );
+
+    const missingResponse = await fetch(
+      `${running.url}/v1/customers/cus_missing`,
+      {
+        headers: { Authorization: AUTH_HEADERS.Authorization },
+      },
+    );
+    expect(missingResponse.status).toBe(404);
+    expect(await missingResponse.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "No such customer: 'cus_missing'",
+        code: "resource_missing",
+        param: "id",
+      },
+    });
+  });
+
+  test("lists a committed session by pinned customer and created range", async () => {
+    running = await startFakeStripe();
+    const customer = await createCustomer(running, "search-customer-key");
+    const session = await createSession(
+      running,
+      checkoutBody(customer.id, "order-789"),
+      "checkout-order:order-789",
+    );
+
+    const response = await fetch(
+      `${running.url}/v1/checkout/sessions?customer=${customer.id}&created[gte]=${session.created - 1}&created[lte]=${session.created + 1}&limit=100`,
+      { headers: { Authorization: AUTH_HEADERS.Authorization } },
+    );
+    expect(response.status).toBe(200);
+    const page = (await response.json()) as {
+      data: Array<{
+        id: string;
+        client_reference_id: string;
+        metadata: Record<string, string>;
+      }>;
+      has_more: boolean;
+    };
+    expect(page.has_more).toBe(false);
+    expect(page.data).toEqual([
+      expect.objectContaining({
+        id: session.id,
+        client_reference_id: "order-789",
+        metadata: { checkout_order_id: "order-789", type: "custom_amount" },
+      }),
+    ]);
+  });
+});
+
+async function createCustomer(
+  fake: RunningFakeStripe,
+  idempotencyKey: string,
+): Promise<{ id: string }> {
+  const response = await fetch(`${fake.url}/v1/customers`, {
+    method: "POST",
+    headers: { ...AUTH_HEADERS, "Idempotency-Key": idempotencyKey },
+    body: new URLSearchParams({
+      email: "billing@example.test",
+      "metadata[eliza_customer_attempt_id]": "attempt-123",
+      "metadata[organization_id]": "org-123",
+    }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as { id: string };
+}
+
+async function createSession(
+  fake: RunningFakeStripe,
+  body: URLSearchParams,
+  idempotencyKey: string,
+): Promise<{ id: string; created: number }> {
+  const response = await fetch(`${fake.url}/v1/checkout/sessions`, {
+    method: "POST",
+    headers: { ...AUTH_HEADERS, "Idempotency-Key": idempotencyKey },
+    body,
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as { id: string; created: number };
+}
+
+function checkoutBody(customerId: string, orderId: string): URLSearchParams {
+  return new URLSearchParams({
+    customer: customerId,
+    client_reference_id: orderId,
+    "metadata[checkout_order_id]": orderId,
+    "metadata[type]": "custom_amount",
+    "line_items[0][price_data][currency]": "usd",
+    "line_items[0][price_data][unit_amount]": "2500",
+    "line_items[0][price_data][product_data][name]": "Account Balance Top-up",
+    "line_items[0][quantity]": "1",
+    mode: "payment",
+  });
+}
+
+function nodeRequestText(
+  url: string,
+  body: string,
+  headers: Record<string, string>,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const outgoing = request(url, { method: "POST", headers }, (incoming) => {
+      const chunks: Buffer[] = [];
+      incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+      incoming.once("end", () =>
+        resolve(Buffer.concat(chunks).toString("utf8")),
+      );
+      incoming.once("error", reject);
+    });
+    outgoing.once("error", reject);
+    outgoing.end(body);
+  });
+}


### PR DESCRIPTION
# Relates to

Relates to #22965.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      audit blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      exact-head backend and Playwright evidence attached below.

# Sync with develop

- [x] Rebased onto `origin/develop@515987a8cd5`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated `plugin-calendar`
      formatting blocker is documented in **Known gaps / failures** below.

# Risks

Low. The production billing flow is unchanged except for a narrowly gated
Stripe client seam used by local Cloud E2E. The principal risks are an accidental
provider redirect or synthetic credentials leaking into normal development.
Mitigations are exact `local + test + CLOUD_E2E` gates, an exact sentinel key,
canonical `http://127.0.0.1:<port>` validation, cache partitioning, no ambient
Stripe-secret forwarding, and teardown/residue checks. Independent E2E and
security reviews reported no findings.

# Background

## What does this PR do?

- Adds a stateful loopback Stripe-compatible test provider with idempotent
  customer and Checkout Session behavior.
- Simulates a provider commit followed by two lost transport responses, then
  proves that an application retry recovers the same provider effect.
- Delivers the same signed paid webhook twice and proves one queued outbox item,
  one settlement, one credit transaction, one invoice, and a `1000 -> 1005`
  credit balance transition.
- Wires the provider only into the API-only Cloud E2E stack and adds strict
  fail-closed guards around the local origin override.

## What kind of change is this?

Improvement: adversarial Billing V3 integration coverage and deterministic local
test infrastructure. No production deployment or database migration is included.

# Documentation changes needed?

No project documentation change is required. The behavior is test-only and is
documented by focused guard tests, fake-provider tests, fixture types, and the E2E
scenario itself.

# Testing

Exact head: `d9b89814080d64bb38820dadbd6f1a7e4c3ba54a`

## Where should a reviewer start?

Start with `packages/cloud/e2e/tests/billing-payment-replay.spec.ts`, then review
`packages/cloud/test-mocks/src/stripe/index.ts` and the fail-closed override in
`packages/cloud/shared/src/lib/stripe.ts`.

## Detailed testing steps

- `bun install --frozen-lockfile --ignore-scripts` — success; 3724 installs
  checked across 4000 packages, no changes.
- `bun test src/lib/stripe.guard.test.ts` in `packages/cloud/shared` — 32 passed,
  0 failed, 81 assertions.
- `bun test test/stripe.test.ts` in `packages/cloud/test-mocks` — 5 passed,
  0 failed, 43 assertions.
- `bun run typecheck` in `packages/cloud/shared`, `packages/cloud/test-mocks`,
  and `packages/cloud/e2e` — all passed.
- `bun run test tests/billing-payment-replay.spec.ts` in `packages/cloud/e2e` —
  1 passed, 0 failed.
- `git diff origin/develop...HEAD --check` — passed.
- Biome check over all 11 changed files — passed, no fixes applied.
- `bun run verify` — reaches the repository-wide lint/typecheck phase and stops
  on the unrelated `plugin-calendar` base formatting failure described below.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d9b89814080d64bb38820dadbd6f1a7e4c3ba54a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only billing replay E2E and Stripe test-harness change; no rendered UI surface changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only billing replay E2E and Stripe test-harness change; no rendered UI surface changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered user flow changed; the exercised flow is Worker, loopback provider, and PGlite
<!-- evidence-row:backend-logs -->
- [x] [25149-backend-worker-d9b8981.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25149-backend-worker-d9b8981.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, browser UI, console, or network surface changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no Eliza agent/action/provider, prompt, model, or LLM behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [25149-playwright-d9b8981.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/25149-playwright-d9b8981.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Real LLM-call trajectory

N/A - no Eliza agent/action/provider, prompt, model, or LLM behavior changed.

## Backend + frontend logs

The attached sanitized Worker transcript captures the deliberate first checkout
`500`, the same-key recovery `200`, and the signed webhook `200`. The attached
Playwright transcript records the exact-head pass and the exact-once state
assertions. Frontend logs are N/A because this is an API-only test lane.

State proof from the exact-head run:

| Stage | Observed invariant |
| --- | --- |
| Lost response | `provider_ambiguous`; 1 provider effect; 1 Checkout Session |
| Same-key retry | same Session recovered; 0 credits before payment |
| Duplicate delivery | first webhook `queued`; second `duplicate` |
| Cron drain | attempted 1; acknowledged 1; failed/retried/DLQ 0 |
| Settlement | order `settled`; 1 credit transaction; 1 invoice; balance 1005 |

## Screenshots (before / after) + video walkthrough

N/A - no UI or rendered user flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun run verify` exits 1 in repository-wide lint because Biome would reformat
  `plugins/plugin-calendar/src/internal/time.ts`. That file is byte-identical to
  `origin/develop@515987a8cd5`; the formatting regression was introduced by
  `0dd4f971df2` / #24990. This Billing branch touches none of `plugin-calendar`,
  while an exact Biome check over all 11 changed files passes.
- The first PR Static Smoke run used an earlier moving `develop` snapshot and
  failed in `app-core` because newly added tests could not resolve
  `globals.ts`/`perf-instrument.ts`. Both modules exist on the current base; this
  branch is resynced and the replacement check is expected to exercise that
  corrected source state.
- Screenshots, video, frontend logs, OCR, audio, and LLM trajectory are N/A because
  the diff has no rendered, frontend, voice, Eliza agent/provider, prompt, model, or live-provider
  surface.
- Stripe is a deterministic loopback provider. The first checkout `500` is an
  intentional response loss after provider commit; no real Stripe call or payment
  occurs.
- PGlite state is intentionally ephemeral and destroyed during teardown; the
  exact state assertions are preserved in the attached Playwright transcript.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

N/A - test-only change; no deployment, secret, provider, or database-migration
steps are required.

