### PR TITLE
fix(cloud-api): drop contract-named keys from nested Steward provider envelopes

### DIFF
--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -375,6 +375,40 @@ function isValidCaptcha(value: unknown): boolean {
   return true;
 }
 
+/**
+ * Every key the provider contract validates. In a legacy-nested envelope only
+ * `data` is validated, so a copy of one of these at the envelope's top level is
+ * unvalidated input wearing a contract name.
+ */
+const PROVIDER_CONTRACT_KEYS: ReadonlySet<string> = new Set<string>([
+  ...REQUIRED_PROVIDER_BOOLEAN_FIELDS,
+  ...OPTIONAL_PROVIDER_BOOLEAN_FIELDS,
+  ...OPTIONAL_PROVIDER_STRING_ARRAY_FIELDS,
+  "oauth",
+  "captcha",
+]);
+
+/**
+ * Drops contract-named keys from a legacy-nested envelope's top level.
+ *
+ * The nested branch validates `data` alone, so echoing the envelope verbatim
+ * would republish a sibling `passkey: "yes"` — a wrong-typed known field that
+ * `isProvidersData` never inspected — as part of a healthy, cacheable 200.
+ * Unknown envelope fields are deliberately preserved: forward-compatibility for
+ * fields Steward may add is contract, and only contract-named keys can be
+ * mistaken for validated provider state by a consumer reading the envelope.
+ */
+function withoutProviderContractKeys(
+  envelope: Record<string, unknown>,
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(envelope)) {
+    if (key !== "data" && PROVIDER_CONTRACT_KEYS.has(key)) continue;
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
 function isProvidersData(value: unknown): value is ProvidersData {
   if (!isRecord(value)) return false;
   if (
@@ -643,7 +677,7 @@ async function patchProvidersResponse(
   patched.oauth = [...oauth];
 
   const body = hasNestedData
-    ? { ...parsed, data: patched }
+    ? { ...withoutProviderContractKeys(parsed), data: patched }
     : { ...parsed, ...patched };
   return Response.json(body, {
     status: upstream.status,

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -384,6 +384,70 @@ describe("createStewardThinApp", () => {
   });
 
   test.each([
+    ["a wrong-typed boolean field", "passkey", "yes-actually-truthy"],
+    ["a wrong-typed array field", "oauth", "google,apple"],
+    ["a malformed captcha", "captcha", { enabled: "sure" }],
+  ])(
+    "drops %s smuggled beside a valid nested data object",
+    async (_case, key, value) => {
+      stubFetch(async () =>
+        Response.json({
+          ok: true,
+          requestVersion: 7,
+          [key]: value,
+          data: providersData(),
+        }),
+      );
+
+      const app = createStewardThinApp();
+      const response = await app.request(
+        "https://api.elizacloud.ai/steward/auth/providers",
+        { method: "GET" },
+        stewardEnv,
+      );
+      const body = (await response.json()) as Record<string, unknown> & {
+        data?: Record<string, unknown>;
+      };
+
+      // The nested branch validates `data` alone, so an unvalidated
+      // contract-named sibling must never be republished as healthy state.
+      expect(response.status).toBe(200);
+      expect(Object.hasOwn(body, key)).toBe(false);
+      expect(body.ok).toBe(true);
+      expect(body.requestVersion).toBe(7);
+      expect(body.data?.passkey).toBe(true);
+      expect(Array.isArray(body.data?.oauth)).toBe(true);
+    },
+  );
+
+  test("keeps unknown envelope fields while dropping contract-named siblings", async () => {
+    stubFetch(async () =>
+      Response.json({
+        ok: true,
+        requestVersion: 7,
+        futureEnvelopeField: { state: "preview" },
+        passkey: "yes-actually-truthy",
+        data: providersData({ sms: true }),
+      }),
+    );
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/providers",
+      { method: "GET" },
+      stewardEnv,
+    );
+    const body = (await response.json()) as Record<string, unknown> & {
+      data?: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.futureEnvelopeField).toEqual({ state: "preview" });
+    expect(Object.hasOwn(body, "passkey")).toBe(false);
+    expect(body.data?.sms).toBe(true);
+  });
+
+  test.each([
     ["object", { requestVersion: 7 }],
     ["null", null],
   ])(


### PR DESCRIPTION
# Relates to

Closes #25153. Completes the fail-closed contract from #24380 (merged as #24499), where I reported this bypass during independent review.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `origin/develop` at `3548df8296`; zero conflicts. Exact head `cf7ebe26cb03c547f7e8dfb400de1175beba3f88`.

# Risks

Low. The change narrows what the proxy republishes and never widens it. The flat branch is untouched (there the validated object *is* the whole body). In the nested branch, unknown envelope fields are still preserved — only contract-named keys are dropped, and in a well-formed upstream response those keys do not appear at the envelope top level at all, so a conforming Steward response is byte-identical before and after.

# Background

## What does this PR do?

`patchProvidersResponse` classifies with `hasNestedData = !isProvidersData(parsed)`. A body carrying a valid nested `data` **plus** a malformed sibling copy of a known provider field fails the flat check, is treated as legacy-nested, validates through `data` alone, and is then re-emitted as `{ ...parsed, data: patched }` — spreading the unvalidated top level into a healthy, cacheable 200. The proxy ends up vouching for a field `isProvidersData` never inspected.

This adds `withoutProviderContractKeys`, which drops contract-named keys (the required/optional boolean fields, the string-array fields, `oauth`, and `captcha`) from the envelope before it is spread. Unknown envelope fields are deliberately kept: forward-compatibility for fields Steward may add is contract and is pinned by the existing suite; only contract-named keys can be mistaken for validated provider state.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No. The behavior now matches what the module's fail-closed contract already documents.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/steward/thin-app.test.ts` — the four new cases are the regression line; then `withoutProviderContractKeys` in `embedded.ts`.

## Detailed testing steps

1. Check out exact head `cf7ebe26cb03c547f7e8dfb400de1175beba3f88`.
2. From `packages/cloud/api`: `bun test src/steward/thin-app.test.ts` → **90 pass / 0 fail** (418 expects), including three parametrized smuggling cases (wrong-typed boolean `passkey`, wrong-typed array `oauth`, malformed `captcha`) and one case asserting unknown envelope fields survive while a contract-named sibling is dropped.
3. Counterfactual: `git stash push packages/cloud/api/src/steward/embedded.ts` (keep the tests) and re-run → **86 pass / 4 fail** — exactly the four new cases, each failing because the smuggled key is present in the served body. `git stash pop` to restore.
4. Adjacent: `bun test src/index.test.ts` → 52 pass / 2 fail, and those same 2 failures reproduce **identically with all my changes stashed** (pre-existing on `develop`, not introduced here).
5. Biome on both changed files: clean. `git diff --check`: clean.

<!-- evidence-head:cf7ebe26cb03c547f7e8dfb400de1175beba3f88 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — server-side response-assembly behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — server-side response-assembly behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the deterministic counterfactual below is the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Head vs counterfactual (bun test)</summary>

```
# head cf7ebe26cb — packages/cloud/api
$ bun test src/steward/thin-app.test.ts
 90 pass
 0 fail
 418 expect() calls

# embedded.ts stashed (tests kept)
$ bun test src/steward/thin-app.test.ts
 86 pass
 4 fail
(fail) drops a wrong-typed boolean field smuggled beside a valid nested data object
(fail) drops a wrong-typed array field smuggled beside a valid nested data object
(fail) drops a malformed captcha smuggled beside a valid nested data object
(fail) keeps unknown envelope fields while dropping contract-named siblings

# adjacent, head
$ bun test src/index.test.ts
 52 pass / 2 fail   <-- identical 2 failures with ALL changes stashed (pre-existing)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic proxy validation, no agent behavior.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates at exact head</summary>

```
$ biome check packages/cloud/api/src/steward/embedded.ts \
    packages/cloud/api/src/steward/thin-app.test.ts
Checked 2 files in 48ms. No fixes applied.

$ git diff --check
(clean)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: this is a hand-wired review worktree (packages linked from the main checkout), which cannot support the full repository gate honestly. Focused package gates are reported above instead.
- `packages/cloud/api` typecheck is blocked in this worktree by the pre-existing `@elizaos/plugin-doordash` / `@cloudflare/playwright` workspace gaps documented on recent cloud PRs; those errors are confined to files this PR does not touch.
- Impact is stated precisely in #25153: the envelope unwrapping happens inside the external Steward SDK, so I could not demonstrate an in-repo consumer that reads the smuggled top-level field. This fixes a validation-contract violation (the proxy vouching for, and caching, a field it never validated), not an observed UI failure.
