### PR TITLE
fix(discord): chunk DM replies at the 2000-char transport limit

### DIFF
--- a/plugins/plugin-discord/__tests__/dm-send-chunking.test.ts
+++ b/plugins/plugin-discord/__tests__/dm-send-chunking.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Discord DM replies must honor the platform's 2000-char message cap by
+ * chunking, exactly like guild sends do via `sendMessageInChunks`. Before
+ * this seam existed the DM path handed the full text to a single
+ * `user.send(...)`, so a long reply (e.g. a multi-day recall digest) was
+ * rejected by Discord and never delivered.
+ *
+ * Covers `sendDmInChunks`: budget enforcement, ordering, code-fence
+ * integrity across chunk boundaries, single-send passthrough for short
+ * messages, and last-chunk placement of files/components.
+ */
+import type { Message as DiscordMessage } from "discord.js";
+import { describe, expect, it } from "vitest";
+import type { DmSendOptions, DmSendTarget } from "../messages";
+import { sendDmInChunks } from "../messages";
+import { MAX_MESSAGE_LENGTH } from "../utils";
+
+const DISCORD_HARD_LIMIT = 2000;
+
+function makeRecordingUser(): {
+	user: DmSendTarget;
+	sends: DmSendOptions[];
+} {
+	const sends: DmSendOptions[] = [];
+	const user: DmSendTarget = {
+		send: async (options: DmSendOptions) => {
+			sends.push(options);
+			return {
+				id: `msg-${sends.length}`,
+				content: options.content,
+			} as unknown as DiscordMessage;
+		},
+	};
+	return { user, sends };
+}
+
+describe("sendDmInChunks transport budget", () => {
+	it("splits a >2000-char plain message into ordered chunks each within budget", async () => {
+		const paragraphs: string[] = [];
+		for (let i = 0; i < 60; i++) {
+			paragraphs.push(
+				`Paragraph ${i}: ${"lorem ipsum dolor sit amet ".repeat(4)}`,
+			);
+		}
+		const content = paragraphs.join("\n");
+		expect(content.length).toBeGreaterThan(DISCORD_HARD_LIMIT);
+
+		const { user, sends } = makeRecordingUser();
+		const messages = await sendDmInChunks(user, content, [], undefined);
+
+		expect(sends.length).toBeGreaterThan(1);
+		expect(messages.length).toBe(sends.length);
+		for (const options of sends) {
+			expect(options.content.length).toBeLessThanOrEqual(MAX_MESSAGE_LENGTH);
+			expect(options.content.length).toBeLessThanOrEqual(DISCORD_HARD_LIMIT);
+		}
+
+		// Ordering: chunk order matches source order (compare a normalized
+		// reassembly, since the chunker trims boundary whitespace).
+		const rejoined = sends.map((s) => s.content).join("\n");
+		const normalize = (text: string) => text.replace(/\s+/g, " ").trim();
+		expect(normalize(rejoined)).toBe(normalize(content));
+	});
+
+	it("keeps code fences valid in every chunk when a fence spans the boundary", async () => {
+		const fenceBody = Array.from(
+			{ length: 200 },
+			(_, i) => `const line${i} = ${i}; // some code inside the fence`,
+		).join("\n");
+		const content = `Here is the diff:\n\`\`\`ts\n${fenceBody}\n\`\`\`\ndone.`;
+		expect(content.length).toBeGreaterThan(DISCORD_HARD_LIMIT);
+
+		const { user, sends } = makeRecordingUser();
+		await sendDmInChunks(user, content, [], undefined);
+
+		expect(sends.length).toBeGreaterThan(1);
+		for (const options of sends) {
+			// Every chunk must contain an even number of fence markers so its
+			// fenced blocks are balanced (opened fences get closed at the chunk
+			// end and reopened at the start of the next chunk).
+			const fenceMarkers =
+				options.content.match(/^ {0,3}(`{3,}|~{3,})/gm) ?? [];
+			expect(fenceMarkers.length % 2).toBe(0);
+			expect(options.content.length).toBeLessThanOrEqual(MAX_MESSAGE_LENGTH);
+		}
+	});
+
+	it("passes an under-budget message through as exactly ONE send (no regression)", async () => {
+		const content = "short reply that fits in one Discord message";
+		const { user, sends } = makeRecordingUser();
+		const messages = await sendDmInChunks(user, content, [], undefined);
+
+		expect(sends.length).toBe(1);
+		expect(messages.length).toBe(1);
+		expect(sends[0].content).toBe(content);
+		expect(sends[0].files).toBeUndefined();
+		expect(sends[0].components).toBeUndefined();
+	});
+
+	it("preserves chunk ordering across sequential sends", async () => {
+		const content = Array.from(
+			{ length: 400 },
+			(_, i) => `line-${String(i).padStart(3, "0")}`,
+		).join("\n");
+		expect(content.length).toBeGreaterThan(DISCORD_HARD_LIMIT);
+
+		const { user, sends } = makeRecordingUser();
+		await sendDmInChunks(user, content, [], undefined);
+
+		expect(sends.length).toBeGreaterThan(1);
+		const seen: number[] = [];
+		for (const options of sends) {
+			for (const match of options.content.matchAll(/line-(\d{3})/g)) {
+				seen.push(Number(match[1]));
+			}
+		}
+		expect(seen.length).toBe(400);
+		const sorted = [...seen].sort((a, b) => a - b);
+		expect(seen).toEqual(sorted);
+	});
+
+	it("rides files on the LAST chunk only, mirroring sendMessageInChunks", async () => {
+		const content = Array.from(
+			{ length: 300 },
+			(_, i) => `attachment ordering line ${i}`,
+		).join("\n");
+		expect(content.length).toBeGreaterThan(DISCORD_HARD_LIMIT);
+
+		const fakeFile = { name: "report.txt" } as never;
+		const { user, sends } = makeRecordingUser();
+		await sendDmInChunks(user, content, [fakeFile], undefined);
+
+		expect(sends.length).toBeGreaterThan(1);
+		for (let i = 0; i < sends.length; i++) {
+			if (i === sends.length - 1) {
+				expect(sends[i].files).toEqual([fakeFile]);
+			} else {
+				expect(sends[i].files).toBeUndefined();
+			}
+		}
+	});
+
+	it("still delivers a components/files-only reply with empty prose as one send", async () => {
+		const fakeRow = { components: [] } as never;
+		const { user, sends } = makeRecordingUser();
+		const messages = await sendDmInChunks(user, "", [], [fakeRow]);
+
+		expect(sends.length).toBe(1);
+		expect(messages.length).toBe(1);
+		expect(sends[0].components).toEqual([fakeRow]);
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -81,6 +81,7 @@ import {
 	appendCoalescedDiscordMetadata,
 	type DiscordMessageWithCoalescedMetadata,
 } from "./message-coalesce";
+import { chunkDiscordText } from "./messaging";
 import { waitForDiscordIngressReadiness } from "./readiness";
 import {
 	applyDiscordStalenessGuard,
@@ -118,6 +119,7 @@ import {
 	extractUrls,
 	getMessageService,
 	getMessagingAPI,
+	MAX_MESSAGE_LENGTH,
 	normalizeDiscordMessageText,
 	sendMessageInChunks,
 } from "./utils";
@@ -845,6 +847,57 @@ export function buildDmSendOptions(
 		...(files.length > 0 ? { files } : {}),
 		...(components && components.length > 0 ? { components } : {}),
 	};
+}
+
+/** Minimal `User.send` surface needed to deliver a chunked DM reply. */
+export interface DmSendTarget {
+	send(options: DmSendOptions): Promise<DiscordMessage>;
+}
+
+/**
+ * Deliver a DM reply through the same transport chunking as guild sends.
+ *
+ * Discord hard-caps message content at 2000 characters; a single
+ * `user.send(...)` with a longer body (e.g. a multi-day recall digest) is
+ * rejected outright, so the reply never arrives. This routes DM text through
+ * `chunkDiscordText` — the fence-aware chunker every other outbound Discord
+ * path already uses — with the shared `MAX_MESSAGE_LENGTH` (1900) headroom
+ * budget, and sends the chunks sequentially so ordering is preserved.
+ *
+ * Attachments and interactive components ride the LAST chunk, mirroring
+ * `sendMessageInChunks`, so widgets sit directly under the end of the answer.
+ *
+ * A components/files-only reply (no prose after trimming) still produces a
+ * single send so those payloads are never dropped.
+ */
+export async function sendDmInChunks(
+	user: DmSendTarget,
+	textContent: string,
+	files: AttachmentBuilder[],
+	components: ActionRowBuilder<MessageActionRowComponentBuilder>[] | undefined,
+): Promise<DiscordMessage[]> {
+	const chunks =
+		textContent.trim().length > 0
+			? chunkDiscordText(textContent, { maxChars: MAX_MESSAGE_LENGTH })
+			: [];
+	if (chunks.length <= 1) {
+		const content = chunks[0] ?? textContent;
+		return [await user.send(buildDmSendOptions(content, files, components))];
+	}
+	const sent: DiscordMessage[] = [];
+	for (let i = 0; i < chunks.length; i++) {
+		const isLast = i === chunks.length - 1;
+		sent.push(
+			await user.send(
+				buildDmSendOptions(
+					chunks[i],
+					isLast ? files : [],
+					isLast ? components : undefined,
+				),
+			),
+		);
+	}
+	return sent;
 }
 
 /**
@@ -2607,10 +2660,9 @@ export class MessageManager {
 						const dmComponents = hasComponents
 							? buildDiscordComponents(rendered.components)
 							: undefined;
-						const dmMessage = await runResponseDispatch(() =>
-							user.send(buildDmSendOptions(textContent, files, dmComponents)),
+						messages = await runResponseDispatch(() =>
+							sendDmInChunks(user, textContent, files, dmComponents),
 						);
-						messages = [dmMessage];
 					} else {
 						if (!message.id) {
 							this.runtime.logger.warn(


### PR DESCRIPTION
## Problem

Discord hard-caps message content at 2000 characters. The guild send path already chunks long replies via `sendMessageInChunks`, and thread posts / slash-command replies chunk via `chunkDiscordText`, but the **DM branch** in `MessageManager`'s response callback handed the full reply text to a single `user.send(...)`:

```ts
const dmMessage = await runResponseDispatch(() =>
  user.send(buildDmSendOptions(textContent, files, dmComponents)),
);
```

Any DM reply over 2000 chars (e.g. a multi-day recall digest) is rejected by Discord's API outright, so the reply never arrives.

## Fix

Add `sendDmInChunks` and route the DM branch through it. It reuses `chunkDiscordText`, the fence-aware chunker every other outbound Discord path already uses, with the shared `MAX_MESSAGE_LENGTH` (1900) headroom budget:

- splits on line boundaries first, hard-splitting only over-long lines (whitespace-preferring within the window)
- keeps fenced code blocks balanced across chunks: an open fence is closed at the chunk end and reopened at the start of the next chunk
- sends chunks **sequentially with await** so ordering is preserved
- attachments and interactive components ride the **last** chunk, mirroring `sendMessageInChunks` semantics (widgets sit directly under the end of the answer)
- an under-budget reply still produces exactly one send (no regression)
- a components/files-only reply with empty prose still delivers as one send

No new chunker was introduced; this is the same production splitter used by `postToConnectorThread` and the slash-command reply path, now applied at the last uncovered outbound seam.

## Tests

New `__tests__/dm-send-chunking.test.ts` (6 tests, all passing):
- `>2000`-char plain message splits into N ordered chunks each ≤ 1900
- message with a code fence spanning the boundary keeps balanced fences in every chunk
- under-budget message passes through as exactly ONE send
- ordering preserved across 400 numbered lines
- files attach to the last chunk only
- components-only reply (empty prose) still delivers

Also ran the surrounding suites (`dm-widget-components`, `messages-component-delivery`, `messaging-chunking`, `smart-split-lossless`): 26/26 passing. Biome + tsc clean on the touched files.