### PR TITLE
fix(app-control): safely handle malformed package.json in readPackageJson

### DIFF
--- a/plugins/plugin-app-control/src/actions/app-load-from-directory.test.ts
+++ b/plugins/plugin-app-control/src/actions/app-load-from-directory.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for app-load-from-directory action and package.json discovery.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runLoadFromDirectory } from "./app-load-from-directory.js";
+
+describe("app-load-from-directory discovery", () => {
+	it("skips subdirectories with malformed package.json without throwing SyntaxError", async () => {
+		const tempDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "eliza-app-load-test-"),
+		);
+		try {
+			const malformedAppDir = path.join(tempDir, "invalid-app");
+			await fs.mkdir(malformedAppDir, { recursive: true });
+			await fs.writeFile(
+				path.join(malformedAppDir, "package.json"),
+				"{ invalid json with trailing comma, }",
+				"utf8",
+			);
+
+			const validAppDir = path.join(tempDir, "valid-app");
+			await fs.mkdir(validAppDir, { recursive: true });
+			await fs.writeFile(
+				path.join(validAppDir, "package.json"),
+				JSON.stringify({
+					name: "valid-test-app",
+					elizaos: {
+						app: {
+							permissions: {
+								promptInjection: "sandbox",
+							},
+						},
+					},
+				}),
+				"utf8",
+			);
+
+			const mockRegistry = {
+				register: () => {},
+			};
+
+			const mockRuntime = {
+				getService: () => mockRegistry,
+			};
+
+			const result = await runLoadFromDirectory({
+				runtime: mockRuntime as never,
+				message: {} as never,
+				state: {} as never,
+				options: { directory: tempDir },
+				repoRoot: tempDir,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.values?.registeredCount).toBe(1);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/plugins/plugin-app-control/src/actions/app-load-from-directory.ts
+++ b/plugins/plugin-app-control/src/actions/app-load-from-directory.ts
@@ -54,9 +54,14 @@ async function readPackageJson(
 	const pkgPath = path.join(dir, "package.json");
 	const raw = await fs.readFile(pkgPath, "utf8").catch(() => null);
 	if (raw === null) return null;
-	const parsed = JSON.parse(raw) as unknown;
-	if (!parsed || typeof parsed !== "object") return null;
-	return parsed as Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (!parsed || typeof parsed !== "object") return null;
+		return parsed as Record<string, unknown>;
+	} catch {
+		// error-policy:J4 Malformed package.json yields null rather than throwing SyntaxError
+		return null;
+	}
 }
 
 function readString(value: unknown): string | null {


### PR DESCRIPTION
## Summary

Wraps `JSON.parse` in `readPackageJson` (`plugins/plugin-app-control/src/actions/app-load-from-directory.ts:57`) with `try/catch` to return `null` instead of throwing an unhandled `SyntaxError` when directories contain invalid or malformed `package.json` files during app discovery.

## Changes

- In `plugins/plugin-app-control/src/actions/app-load-from-directory.ts:51-60`, safely guard `JSON.parse(raw)` and return `null` if JSON parsing fails.
- In `plugins/plugin-app-control/src/actions/app-load-from-directory.test.ts`, add dedicated unit tests verifying that subdirectories with malformed `package.json` files are skipped gracefully.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`e99d873533`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-app-control/src/actions/app-load-from-directory.test.ts` | N/A (new test) | 1 pass (1 test) |
| `bunx @biomejs/biome check plugins/plugin-app-control/src/actions/app-load-from-directory.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-app-control/src/actions/app-load-from-directory.ts:51-62`
- `plugins/plugin-app-control/src/actions/app-load-from-directory.test.ts:1-60`

## Risks

Low. Conforms to the return type contract `Promise<Record<string, unknown> | null>`.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (App-control directory loader; no UI layout touched)
- [x] `audit:browser` — N/A (Directory package parser)
- [x] `build` — Clean build across workspace
- [x] `test` — 1/1 pass in `app-load-from-directory.test.ts`
- [x] `lint` — Biome clean
