### PR TITLE
fix(agent-skills): safely handle corrupted scan report JSON in memory mode getSkillScanReport

### DIFF
--- a/plugins/plugin-agent-skills/src/services/skills.startup.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.startup.test.ts
@@ -154,4 +154,20 @@ describe("Agent Skills startup catalog policy", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(102);
 		expect(service.getCatalogStats().total).toBe(101);
 	});
+
+	it("returns null when memory mode scan results file contains corrupted JSON without throwing", async () => {
+		const memoryStore = new MemorySkillStore();
+		await memoryStore.savePackage({
+			slug: "corrupted-scan-skill",
+			files: [{ name: ".scan-results.json", content: "{ invalid json format, unclosed \"" }],
+		});
+
+		const service = await AgentSkillsService.start(createRuntime(), {
+			autoLoad: false,
+			storage: memoryStore,
+		});
+
+		const report = await service.getSkillScanReport("corrupted-scan-skill");
+		expect(report).toBeNull();
+	});
 });

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -2432,9 +2432,16 @@ export class AgentSkillsService extends Service {
 		const reportFile = pkg?.files.get(".scan-results.json");
 		if (!reportFile?.isText) return null;
 
-		const parsed = JSON.parse(reportFile.content as string) as SkillScanReport;
-		if (!parsed.scannedAt || !Array.isArray(parsed.findings)) return null;
-		return parsed;
+		try {
+			const parsed = JSON.parse(
+				reportFile.content as string,
+			) as SkillScanReport;
+			if (!parsed.scannedAt || !Array.isArray(parsed.findings)) return null;
+			return parsed;
+		} catch {
+			// error-policy:J4 Corrupted scan report yields null rather than throwing SyntaxError
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Wraps `JSON.parse` in `getSkillScanReport` (`plugins/plugin-agent-skills/src/services/skills.ts:2435`) with `try/catch` to return `null` instead of throwing an unhandled `SyntaxError` when in-memory `.scan-results.json` files contain corrupted or malformed JSON.

## Changes

- In `plugins/plugin-agent-skills/src/services/skills.ts:2434-2438`, guard `JSON.parse(reportFile.content)` with `try/catch` and return `null` on parse errors.
- In `plugins/plugin-agent-skills/src/services/skills.startup.test.ts`, add dedicated unit tests verifying that corrupted in-memory scan report files are handled gracefully without throwing.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`deb0c594aa`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-agent-skills/src/services/skills.startup.test.ts` | 5 pass (5 tests) | 6 pass (6 tests) |
| `bunx @biomejs/biome check plugins/plugin-agent-skills/src/services/skills.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-agent-skills/src/services/skills.ts:2430-2440`
- `plugins/plugin-agent-skills/src/services/skills.startup.test.ts:150-185`

## Risks

Low. Returns `null` when the file cannot be parsed, matching the documented return type `Promise<SkillScanReport | null>`.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent skills service; no UI layout touched)
- [x] `audit:browser` — N/A (Skill scan report loader)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 pass in `skills.startup.test.ts`
- [x] `lint` — Biome clean
