### PR TITLE
fix(wallet): safely handle invalid JSON in ERC-8004 parseDataURI

### DIFF
--- a/plugins/plugin-wallet/src/sdk/identity/__tests__/erc8004.test.ts
+++ b/plugins/plugin-wallet/src/sdk/identity/__tests__/erc8004.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for ERC-8004 identity data URI builder and parser.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type AgentRegistrationFile,
+  buildDataURI,
+  parseDataURI,
+} from "../erc8004.js";
+
+describe("ERC-8004 parseDataURI", () => {
+  it("round-trips valid registration file through data URI", () => {
+    const original: AgentRegistrationFile = {
+      type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+      name: "TestAgent",
+      description: "A test agent for ERC-8004",
+      image: "https://example.com/agent.png",
+      services: [],
+      active: true,
+      registrant: "0x1234567890123456789012345678901234567890",
+    };
+
+    const uri = buildDataURI(original);
+    const parsed = parseDataURI(uri);
+
+    expect(parsed.name).toBe("TestAgent");
+    expect(parsed.description).toBe("A test agent for ERC-8004");
+  });
+
+  it("parses valid inline JSON payload", () => {
+    const inlineJson = JSON.stringify({
+      name: "InlineAgent",
+      description: "Direct inline JSON",
+      services: [],
+      active: true,
+      registrant: "0x1234567890123456789012345678901234567890",
+    });
+
+    const parsed = parseDataURI(inlineJson);
+    expect(parsed.name).toBe("InlineAgent");
+  });
+
+  it("throws descriptive error on malformed base64 data URI payload", () => {
+    const malformedDataUri =
+      "data:application/json;base64,invalid-base64-payload!!!";
+    expect(() => parseDataURI(malformedDataUri)).toThrowError(
+      /parseDataURI: Invalid base64 JSON payload/,
+    );
+  });
+
+  it("throws descriptive error on malformed inline JSON", () => {
+    const malformedInline = "{ invalid json without closing quote: 123";
+    expect(() => parseDataURI(malformedInline)).toThrowError(
+      /parseDataURI: Invalid inline JSON payload/,
+    );
+  });
+
+  it("throws on unsupported URI scheme", () => {
+    expect(() => parseDataURI("ftp://invalid.uri")).toThrowError(
+      /parseDataURI: Cannot parse URI scheme/,
+    );
+  });
+});

--- a/plugins/plugin-wallet/src/sdk/identity/erc8004.ts
+++ b/plugins/plugin-wallet/src/sdk/identity/erc8004.ts
@@ -606,11 +606,29 @@ export function buildDataURI(registrationFile: AgentRegistrationFile): string {
 
 export function parseDataURI(uri: string): AgentRegistrationFile {
   if (uri.startsWith("data:application/json;base64,")) {
-    const b64 = uri.replace("data:application/json;base64,", "");
-    const json = decodeURIComponent(escape(atob(b64)));
-    return JSON.parse(json);
+    try {
+      const b64 = uri.replace("data:application/json;base64,", "");
+      const json = decodeURIComponent(escape(atob(b64)));
+      return JSON.parse(json) as AgentRegistrationFile;
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow for malformed data URI payload
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`parseDataURI: Invalid base64 JSON payload: ${detail}`, {
+        cause: error,
+      });
+    }
   }
-  if (uri.startsWith("{")) return JSON.parse(uri);
+  if (uri.startsWith("{")) {
+    try {
+      return JSON.parse(uri) as AgentRegistrationFile;
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow for malformed inline JSON
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`parseDataURI: Invalid inline JSON payload: ${detail}`, {
+        cause: error,
+      });
+    }
+  }
   throw new Error(
     `parseDataURI: Cannot parse URI scheme: ${uri.substring(0, 50)}`,
   );


### PR DESCRIPTION
## Summary

Wraps `JSON.parse` in `parseDataURI` (`plugins/plugin-wallet/src/sdk/identity/erc8004.ts:611, 613`) with `try/catch` to rethrow typed, actionable errors when parsing invalid base64 payloads or malformed inline JSON registration files.

## Changes

- In `plugins/plugin-wallet/src/sdk/identity/erc8004.ts:607-625`, guard `JSON.parse` with `try/catch` and attach descriptive error context when decoding data URIs or inline JSON.
- In `plugins/plugin-wallet/src/sdk/identity/__tests__/erc8004.test.ts`, add dedicated unit tests covering valid round-trip data URIs, valid inline JSON, malformed base64 payloads, and malformed inline JSON.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`6b440ce5f8`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-wallet/src/sdk/identity/__tests__/erc8004.test.ts` | N/A (new test) | 5 pass (5 tests) |
| `bunx @biomejs/biome check plugins/plugin-wallet/src/sdk/identity/erc8004.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-wallet/src/sdk/identity/erc8004.ts:606-630`
- `plugins/plugin-wallet/src/sdk/identity/__tests__/erc8004.test.ts:1-60`

## Risks

Low. Preserves existing success path while improving error diagnostics on malformed data URIs.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Wallet ERC-8004 SDK; no UI layout touched)
- [x] `audit:browser` — N/A (Identity registration URI parser)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `erc8004.test.ts`
- [x] `lint` — Biome clean
