### PR TITLE
fix(orchestrator): safe NaN handling in curated coding memory note ranking sort comparator

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts
@@ -498,4 +498,33 @@ describe("curated coding memory", () => {
       await rm(workdir, { recursive: true, force: true });
     }
   });
+
+  it("ranks relevant notes deterministically by match score", async () => {
+    const workdir = await tempWorkspace();
+    try {
+      const service = new CuratedCodingMemoryService(memoryRuntime(workdir));
+      await service.harvestVerifiedTask(
+        doc({
+          taskId: "task-1",
+          workdir,
+          text: "Lesson: Always run verification gates before PR creation.",
+        }),
+      );
+      await service.harvestVerifiedTask(
+        doc({
+          taskId: "task-2",
+          workdir,
+          text: "Lesson: Run verification gates and check audit logs carefully.",
+        }),
+      );
+      const notes = await service.retrieveRelevant({
+        text: "verification gates PR creation",
+        repoKey: "elizaOS/eliza",
+      });
+      expect(notes.length).toBeGreaterThan(0);
+      expect(notes[0]?.text).toContain("verification gates before PR creation");
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts
@@ -704,12 +704,21 @@ export class CuratedCodingMemoryService {
         score: jaccard(tokens(note.text), queryTokens),
       }))
       .filter((entry) => entry.score > 0)
-      .sort(
-        (a, b) =>
-          b.score - a.score ||
-          b.note.confidence - a.note.confidence ||
-          b.note.timestamp.localeCompare(a.note.timestamp),
-      );
+      .sort((a, b) => {
+        const aScore = Number.isFinite(a.score) ? a.score : 0;
+        const bScore = Number.isFinite(b.score) ? b.score : 0;
+        const scoreDiff = bScore - aScore;
+        if (scoreDiff !== 0) return scoreDiff;
+        const aConf = Number.isFinite(a.note.confidence)
+          ? a.note.confidence
+          : 0;
+        const bConf = Number.isFinite(b.note.confidence)
+          ? b.note.confidence
+          : 0;
+        const confDiff = bConf - aConf;
+        if (confDiff !== 0) return confDiff;
+        return b.note.timestamp.localeCompare(a.note.timestamp);
+      });
     void policy;
     return ranked.map(({ note }) => note);
   }


### PR DESCRIPTION
## Summary

Validates relevance `score` and note `confidence` with `Number.isFinite(...)` in `CuratedCodingMemoryService.retrieveRelevant` (`plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts:707`) to prevent `NaN` return values in sort comparators during curated memory retrieval.

## Changes

- In `plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts:707`, guard score and confidence comparisons with `Number.isFinite(...)` to preserve strict total ordering and clean fallback to timestamp comparison.
- In `plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts`, add unit tests verifying deterministic note retrieval ranking.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`97e4bc6bd2`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts` | 14 pass (14 tests) | 15 pass (15 tests) |
| `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts:704-725`
- `plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts:495-535`

## Risks

Low. Prevents non-deterministic note ordering when calculating jaccard similarity scores.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent orchestrator memory service; no UI layout touched)
- [x] `audit:browser` — N/A (Memory note ranker)
- [x] `build` — Clean build across workspace
- [x] `test` — 15/15 pass in `curated-coding-memory.test.ts`
- [x] `lint` — Biome clean
