### PR TITLE
fix(orchestrator): safe NaN handling in listScratchWorkspaces sort comparator

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts
@@ -291,3 +291,41 @@ describe("config parsing", () => {
     expect(config.minFreeBytes).toBe(6789);
   });
 });
+
+describe("CodingWorkspaceService listScratchWorkspaces sorting", () => {
+  it("maintains strict total ordering when terminalAt timestamps contain non-finite numbers", async () => {
+    const mockRuntime = {
+      getSetting: () => undefined,
+      getService: () => null,
+      reportError: () => undefined,
+      logger: { warn: () => undefined, info: () => undefined },
+    };
+    const service = new CodingWorkspaceService(mockRuntime as never);
+
+    await service.registerScratchWorkspace(
+      "sess-1",
+      "/tmp/sess-1",
+      "Session 1",
+      "done",
+    );
+    await service.registerScratchWorkspace(
+      "sess-2",
+      "/tmp/sess-2",
+      "Session 2",
+      "done",
+    );
+
+    const scratchMap = (
+      service as unknown as {
+        scratchBySession: Map<string, { terminalAt: number }>;
+      }
+    ).scratchBySession;
+    const sess1 = scratchMap.get("sess-1");
+    if (sess1) sess1.terminalAt = Number.NaN;
+
+    const list = service.listScratchWorkspaces();
+    expect(list).toHaveLength(2);
+    expect(list[0]?.sessionId).toBe("sess-2");
+    expect(list[1]?.sessionId).toBe("sess-1");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -1295,9 +1295,11 @@ export class CodingWorkspaceService {
   }
 
   listScratchWorkspaces(): ScratchWorkspaceRecord[] {
-    return Array.from(this.scratchBySession.values()).sort(
-      (a, b) => b.terminalAt - a.terminalAt,
-    );
+    return Array.from(this.scratchBySession.values()).sort((a, b) => {
+      const aTerm = Number.isFinite(a.terminalAt) ? a.terminalAt : 0;
+      const bTerm = Number.isFinite(b.terminalAt) ? b.terminalAt : 0;
+      return bTerm - aTerm;
+    });
   }
 
   async registerScratchWorkspace(


### PR DESCRIPTION
## Summary

Validates scratch workspace `terminalAt` timestamps with `Number.isFinite(...)` in `CodingWorkspaceService.listScratchWorkspaces` (`plugins/plugin-agent-orchestrator/src/services/workspace-service.ts:1298`) to prevent `NaN` return values in sort comparators during scratch workspace cleanup and listing.

## Changes

- In `plugins/plugin-agent-orchestrator/src/services/workspace-service.ts:1298`, guard `terminalAt` timestamp comparisons with `Number.isFinite(...)` to preserve strict total ordering.
- In `plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts`, add unit tests verifying deterministic ordering when timestamps contain non-finite numbers.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`20e506430a`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts` | 15 pass (15 tests) | 16 pass (16 tests) |
| `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/workspace-service.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-agent-orchestrator/src/services/workspace-service.ts:1295-1305`
- `plugins/plugin-agent-orchestrator/src/__tests__/workspace-registry.test.ts:290-320`

## Risks

Low. Ensures deterministic eviction order of scratch workspaces during cleanup.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Workspace service; no UI layout touched)
- [x] `audit:browser` — N/A (Scratch workspace manager)
- [x] `build` — Clean build across workspace
- [x] `test` — 16/16 pass in `workspace-registry.test.ts`
- [x] `lint` — Biome clean
