### PR TITLE
fix(app-core): correct dev mac test paths

### DIFF
--- a/packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts
+++ b/packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../electrobun.config", () => ({
+vi.mock("../../electrobun.config", () => ({
 	default: { app: { identifier: "x" } },
 }));
-vi.mock("./local-adhoc-sign-macos", () => ({ signLocalAppBundle: vi.fn() }));
-vi.mock("./postwrap-diagnostics", () => ({
+vi.mock("../local-adhoc-sign-macos", () => ({ signLocalAppBundle: vi.fn() }));
+vi.mock("../postwrap-diagnostics", () => ({
 	resolveWrapperBundlePath: () => "/tmp/bundle.app",
 }));
 
-import { shouldSignDevMacApp } from "./sign-dev-macos-app.ts";
+import { shouldSignDevMacApp } from "../sign-dev-macos-app.ts";
 
 const DEV_ENV = {
 	ELECTROBUN_BUILD_ENV: "dev",


### PR DESCRIPTION
# Relates to

Fixes #25158

Definition of Done: full standard in [`CONTRIBUTING.md`](../blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (base `48416269b4063b56210d48e66815b5816f432b57`).
- [ ] `bun install` and `bun run verify` were not run locally because this
      host has no OS sandbox; hosted CI is required, as recorded below.
- [x] A reviewer can confirm the path correction from the static resolution
      evidence below and the required hosted CI results.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` was not executed locally; hosted CI is required and the
      exact local execution constraint is documented under **Known gaps / failures**.

# Risks

Low. This changes only four relative module specifiers in one existing test.
Runtime code and the test matrix are unchanged. The residual risk is a
platform/toolchain resolution difference, which the hosted app-core test and
typecheck lanes must catch.

# Background

## What does this PR do?

Corrects the test's import and mock paths from its nested `__tests__`
directory so they resolve to the same config and helper modules imported by
`sign-dev-macos-app.ts`.

## What kind of change is this?

Bug fix (non-breaking test correction).

# Documentation changes needed?

No. This corrects test module resolution only; no public or runtime contract
changes.

# Testing

## Where should a reviewer start?

`packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts`

## Detailed testing steps

Hosted CI must run the focused Vitest file and the relevant
`@elizaos/app-core` typecheck at exact PR head
`c3e7d132c2dac45fc33ea5c788057a94514534ab`. No repository or PR code was
executed locally because an OS sandbox is unavailable.

Static validation performed after the final sync:

- `git diff --check origin/develop..HEAD` — exit 0.
- `git diff --name-status origin/develop..HEAD` — exactly one modified file.
- Diff size — 4 insertions, 4 deletions.
- The four corrected paths resolve to tracked regular files:
  - `scripts/sign-dev-macos-app.ts`
  - `scripts/local-adhoc-sign-macos.ts`
  - `scripts/postwrap-diagnostics.ts`
  - `electrobun.config.ts`

# Evidence Gate

Evidence matches exact commit `c3e7d132c2dac45fc33ea5c788057a94514534ab`.
<!-- evidence-head:c3e7d132c2dac45fc33ea5c788057a94514534ab -->

This is a test-only module-path correction with no rendered or runtime surface.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI or rendered surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI or rendered surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or runtime behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changes; local execution is prohibited without an OS sandbox.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, response, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or artifacts are produced by this test-only path correction.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model changes.

## Backend + frontend logs

N/A - no backend or frontend runtime path changes; no local code execution was
performed without an OS sandbox.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI or user flow changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio changes.

## Known gaps / failures

- Not run locally: focused Vitest, app-core typecheck, `bun install`, and
  `bun run verify`.
- Reason: this host has no disposable OS sandbox, and repository/PR code was
  therefore not executed.
- CI required: the focused
  `packages/app-core/platforms/electrobun/scripts/__tests__/sign-dev-macos-app.test.ts`
  Vitest file and relevant app-core typecheck must pass on this exact head.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@515987a8cd51a094b552714dc50e0518f376e9a7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@515987a8cd51a094b552714dc50e0518f376e9a7:packages/skills/skills/contribute-to-eliza"} -->
