### PR TITLE
fix(mcp): safely handle invalid config JSON in restartConnection

### DIFF
--- a/plugins/plugin-mcp/__tests__/service-lifecycle.test.ts
+++ b/plugins/plugin-mcp/__tests__/service-lifecycle.test.ts
@@ -43,4 +43,29 @@ describe("McpService lifecycle", () => {
     expect(internals.connections.has("bad-close")).toBe(false);
     expect(internals.connectionStates.has("bad-close")).toBe(false);
   });
+
+  it("handles corrupted config JSON in restartConnection by setting error status without throwing", async () => {
+    const service = new McpService();
+    const internals = service as unknown as {
+      connections: Map<
+        string,
+        {
+          server: { status: string; error?: string; config: string };
+        }
+      >;
+    };
+
+    internals.connections.set("corrupted-server", {
+      server: {
+        status: "idle",
+        config: "{ invalid json payload, unclosed",
+      },
+    });
+
+    await expect(service.restartConnection("corrupted-server")).resolves.toBeUndefined();
+
+    const connection = internals.connections.get("corrupted-server");
+    expect(connection?.server.status).toBe("error");
+    expect(connection?.server.error).toContain("Invalid server configuration JSON");
+  });
 });

--- a/plugins/plugin-mcp/src/service.ts
+++ b/plugins/plugin-mcp/src/service.ts
@@ -663,8 +663,18 @@ export class McpService extends Service {
     if (config) {
       connection.server.status = "connecting";
       connection.server.error = "";
+      let parsedConfig: McpServerConfig;
+      try {
+        parsedConfig = JSON.parse(config) as McpServerConfig;
+      } catch (error) {
+        // error-policy:J1 boundary translation: record error status on malformed config
+        const detail = error instanceof Error ? error.message : String(error);
+        connection.server.status = "error";
+        connection.server.error = `Invalid server configuration JSON: ${detail}`;
+        return;
+      }
       await this.deleteConnection(serverName);
-      await this.initializeConnection(serverName, JSON.parse(config));
+      await this.initializeConnection(serverName, parsedConfig);
     }
   }
 


### PR DESCRIPTION
## Summary

Wraps `JSON.parse` in `McpService.restartConnection` (`plugins/plugin-mcp/src/service.ts:667`) with `try/catch` to record error status rather than throwing an unhandled `SyntaxError` when server configuration JSON is corrupted.

## Changes

- In `plugins/plugin-mcp/src/service.ts:660-675`, wrap `JSON.parse(config)` in `try/catch` and set `connection.server.status = "error"` with descriptive error diagnostics.
- In `plugins/plugin-mcp/__tests__/service-lifecycle.test.ts`, add dedicated unit tests verifying that corrupted configuration strings in `restartConnection` set the error status gracefully without throwing.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`157ed2e29e`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-mcp/__tests__/service-lifecycle.test.ts` | 1 pass (1 test) | 2 pass (2 tests) |
| `bunx @biomejs/biome check plugins/plugin-mcp/src/service.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-mcp/src/service.ts:660-675`
- `plugins/plugin-mcp/__tests__/service-lifecycle.test.ts:40-70`

## Risks

Low. Records error state on the affected connection rather than terminating the restart routine with an unhandled exception.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (MCP service; no UI layout touched)
- [x] `audit:browser` — N/A (MCP connection restarter)
- [x] `build` — Clean build across workspace
- [x] `test` — 2/2 pass in `service-lifecycle.test.ts`
- [x] `lint` — Biome clean
