### PR TITLE
test(agent): cover context-signal-lexicon

### DIFF
--- a/packages/agent/src/actions/context-signal-lexicon.test.ts
+++ b/packages/agent/src/actions/context-signal-lexicon.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Covers context-signal-lexicon: per-key context-window limits (including the
+ * default when a spec omits `contextLimit`), locale normalization, strong/weak
+ * term resolution against the real shared keyword registry, includeAllLocales
+ * union, and the empty-weak fallback for signals that have no weak terms.
+ */
+import { getValidationKeywordTerms } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import {
+  type ContextSignalKey,
+  getContextSignalTerms,
+  resolveContextSignalSpec,
+} from "./context-signal-lexicon.ts";
+
+const DEFAULT_CONTEXT_LIMIT = 8;
+
+/** Explicit per-key windows from CONTEXT_SIGNAL_SPECS; omitted keys use 8. */
+const CONTEXT_LIMITS = {
+  affirmative: 4,
+  calendar: 12,
+  draft_edit: 4,
+  gmail: 12,
+  link_entity: 8,
+  lifeops: 12,
+  lifeops_cadence: 12,
+  lifeops_complete: 12,
+  lifeops_delete: 12,
+  lifeops_escalation: 12,
+  lifeops_goal: 12,
+  lifeops_overview: 12,
+  lifeops_phone: 12,
+  lifeops_reminder_pref: 12,
+  lifeops_review: 12,
+  lifeops_skip: 12,
+  lifeops_snooze: 12,
+  lifeops_update: 12,
+  negative: 4,
+  read_channel: DEFAULT_CONTEXT_LIMIT,
+  read_messages: DEFAULT_CONTEXT_LIMIT,
+  search_conversations: DEFAULT_CONTEXT_LIMIT,
+  search_entity: DEFAULT_CONTEXT_LIMIT,
+  send_message: DEFAULT_CONTEXT_LIMIT,
+  stream_control: DEFAULT_CONTEXT_LIMIT,
+  temporal_followup: 6,
+  temporal_next: 6,
+  web_search: 6,
+} as const satisfies Record<ContextSignalKey, number>;
+
+const ALL_KEYS = Object.keys(CONTEXT_LIMITS) as ContextSignalKey[];
+
+const KEYS_WITH_WEAK_TERMS = new Set<ContextSignalKey>([
+  "calendar",
+  "gmail",
+  "lifeops",
+  "read_channel",
+  "read_messages",
+  "search_conversations",
+  "search_entity",
+  "send_message",
+  "stream_control",
+  "web_search",
+]);
+
+describe("resolveContextSignalSpec", () => {
+  it("returns the documented contextLimit for every signal key", () => {
+    for (const key of ALL_KEYS) {
+      expect(resolveContextSignalSpec(key).contextLimit).toBe(
+        CONTEXT_LIMITS[key],
+      );
+    }
+  });
+
+  it("defaults contextLimit to 8 when the spec omits it", () => {
+    expect(resolveContextSignalSpec("send_message").contextLimit).toBe(8);
+    expect(resolveContextSignalSpec("search_conversations").contextLimit).toBe(
+      8,
+    );
+    expect(resolveContextSignalSpec("read_channel").contextLimit).toBe(8);
+    expect(resolveContextSignalSpec("read_messages").contextLimit).toBe(8);
+    expect(resolveContextSignalSpec("stream_control").contextLimit).toBe(8);
+    expect(resolveContextSignalSpec("search_entity").contextLimit).toBe(8);
+  });
+
+  it("keeps an explicit contextLimit of 8 for link_entity", () => {
+    expect(resolveContextSignalSpec("link_entity").contextLimit).toBe(8);
+  });
+
+  it("normalizes missing, blank, and unknown locales to en", () => {
+    expect(resolveContextSignalSpec("gmail").locale).toBe("en");
+    expect(resolveContextSignalSpec("gmail", undefined).locale).toBe("en");
+    expect(resolveContextSignalSpec("gmail", "").locale).toBe("en");
+    expect(resolveContextSignalSpec("gmail", "   ").locale).toBe("en");
+    expect(resolveContextSignalSpec("gmail", 12).locale).toBe("en");
+    expect(resolveContextSignalSpec("gmail", null).locale).toBe("en");
+    expect(resolveContextSignalSpec("gmail", "fr").locale).toBe("en");
+  });
+
+  it("maps locale aliases onto CharacterLanguage values", () => {
+    expect(resolveContextSignalSpec("gmail", "zh").locale).toBe("zh-CN");
+    expect(resolveContextSignalSpec("gmail", "zh-cn").locale).toBe("zh-CN");
+    expect(resolveContextSignalSpec("gmail", "zh-Hans").locale).toBe("zh-CN");
+    expect(resolveContextSignalSpec("gmail", "ko-KR").locale).toBe("ko");
+    expect(resolveContextSignalSpec("gmail", "es-MX").locale).toBe("es");
+    expect(resolveContextSignalSpec("gmail", "pt-BR").locale).toBe("pt");
+    expect(resolveContextSignalSpec("gmail", "vi-VN").locale).toBe("vi");
+    expect(resolveContextSignalSpec("gmail", "fil").locale).toBe("tl");
+    expect(resolveContextSignalSpec("gmail", "tl").locale).toBe("tl");
+  });
+
+  it("loads English gmail terms from the real keyword registry", () => {
+    const spec = resolveContextSignalSpec("gmail");
+    expect(spec.strongTerms).toEqual(
+      expect.arrayContaining(["gmail", "inbox", "email", "mailbox"]),
+    );
+    expect(spec.weakTerms).toEqual(
+      expect.arrayContaining(["send", "reply", "attachment"]),
+    );
+    expect(spec.strongTerms).not.toContain("邮件");
+    expect(spec.weakTerms).not.toContain("发送");
+  });
+
+  it("loads locale-specific terms for zh-CN without dropping the English base", () => {
+    const spec = resolveContextSignalSpec("gmail", "zh-CN");
+    expect(spec.locale).toBe("zh-CN");
+    expect(spec.strongTerms).toEqual(
+      expect.arrayContaining(["gmail", "邮件", "收件箱"]),
+    );
+    expect(spec.weakTerms).toEqual(expect.arrayContaining(["send", "发送"]));
+  });
+
+  it("returns an empty weak list for signals that only declare strong terms", () => {
+    for (const key of ALL_KEYS) {
+      if (KEYS_WITH_WEAK_TERMS.has(key)) {
+        continue;
+      }
+      const spec = resolveContextSignalSpec(key);
+      expect(spec.weakTerms).toEqual([]);
+      expect(spec.strongTerms.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns a non-empty weak list for every signal that declares weak terms", () => {
+    for (const key of KEYS_WITH_WEAK_TERMS) {
+      expect(resolveContextSignalSpec(key).weakTerms.length).toBeGreaterThan(0);
+      expect(resolveContextSignalSpec(key).strongTerms.length).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
+  it("unions every locale when includeAllLocales is true", () => {
+    const english = resolveContextSignalSpec("gmail");
+    const all = resolveContextSignalSpec("gmail", "en", {
+      includeAllLocales: true,
+    });
+    expect(all.locale).toBe("en");
+    expect(all.strongTerms).toEqual(
+      expect.arrayContaining(["gmail", "邮件", "이메일", "correo"]),
+    );
+    expect(all.weakTerms).toEqual(
+      expect.arrayContaining(["send", "发送", "보내기"]),
+    );
+    expect(all.strongTerms.length).toBeGreaterThan(english.strongTerms.length);
+    expect(all.weakTerms.length).toBeGreaterThan(english.weakTerms.length);
+  });
+
+  it("defaults includeAllLocales to false", () => {
+    expect(resolveContextSignalSpec("gmail").strongTerms).toEqual(
+      resolveContextSignalSpec("gmail", undefined, {
+        includeAllLocales: false,
+      }).strongTerms,
+    );
+  });
+
+  it("wires each key's strong terms to the matching validation-keyword path", () => {
+    for (const key of ALL_KEYS) {
+      expect(resolveContextSignalSpec(key).strongTerms).toEqual(
+        getValidationKeywordTerms(`contextSignal.${key}.strong`),
+      );
+    }
+  });
+
+  it("throws when the signal key is not in the lexicon", () => {
+    expect(() =>
+      resolveContextSignalSpec("not_a_signal" as ContextSignalKey),
+    ).toThrow();
+  });
+});
+
+describe("getContextSignalTerms", () => {
+  it("returns the same strong terms as resolveContextSignalSpec", () => {
+    for (const key of ALL_KEYS) {
+      expect(getContextSignalTerms(key, "strong")).toEqual(
+        resolveContextSignalSpec(key).strongTerms,
+      );
+    }
+  });
+
+  it("returns the same weak terms as resolveContextSignalSpec", () => {
+    for (const key of ALL_KEYS) {
+      expect(getContextSignalTerms(key, "weak")).toEqual(
+        resolveContextSignalSpec(key).weakTerms,
+      );
+    }
+  });
+
+  it("returns [] for weak strength when the spec has no weak keyword key", () => {
+    expect(getContextSignalTerms("affirmative", "weak")).toEqual([]);
+    expect(getContextSignalTerms("negative", "weak")).toEqual([]);
+    expect(getContextSignalTerms("draft_edit", "weak")).toEqual([]);
+    expect(getContextSignalTerms("temporal_next", "weak")).toEqual([]);
+    expect(getContextSignalTerms("lifeops_complete", "weak")).toEqual([]);
+  });
+
+  it("honors locale and includeAllLocales on the real registry", () => {
+    const zh = getContextSignalTerms("send_message", "strong", {
+      locale: "zh",
+    });
+    expect(zh).toEqual(
+      expect.arrayContaining(["send message", "dm", "发消息"]),
+    );
+
+    const all = getContextSignalTerms("send_message", "strong", {
+      includeAllLocales: true,
+    });
+    expect(all).toEqual(
+      expect.arrayContaining([
+        "send message",
+        "发消息",
+        "메시지 보내",
+        "enviar mensaje",
+      ]),
+    );
+    expect(all.length).toBeGreaterThan(zh.length);
+  });
+
+  it("defaults includeAllLocales to false when options are omitted", () => {
+    expect(getContextSignalTerms("gmail", "strong")).toEqual(
+      getContextSignalTerms("gmail", "strong", { includeAllLocales: false }),
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

No linked issue. `packages/agent/src/actions/context-signal-lexicon.ts` had no colocated test file; this PR adds one.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification passed in isolation (vitest). Hosted GitHub Actions
      CI does **not** run on this fork PR; do not treat Checks as green.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Head is `3190a6fd9d7786fba892c14b88e68f418aa41a62` on top of
      `515987a8cd51` (`origin/develop` at push time).
- [x] `bun run verify` was **not** run (full-repo; hosted CI does not run on
      fork PRs). Focused proof:

      `bunx vitest run packages/agent/src/actions/context-signal-lexicon.test.ts --config packages/agent/vitest.config.ts`

      Observed: `Test Files  1 passed (1)` / `Tests  18 passed (18)`.

      `bunx tsc --noEmit -p packages/agent/tsconfig.json` vs an untouched control
      (test file moved aside): **1856 vs 1856** `error TS` lines — zero new errors.

# Risks

Low. Test-only addition. No production source, exports, or runtime behavior
changed. The suite drives the real lexicon and the real `@elizaos/shared`
keyword registry; it does not mock term lists.

# Background

## What does this PR do?

Adds `packages/agent/src/actions/context-signal-lexicon.test.ts` covering the
exported helpers `resolveContextSignalSpec` and `getContextSignalTerms`:

- per-key `contextLimit` for every `ContextSignalKey`, including the default `8`
  when a spec omits `contextLimit`
- locale normalization (`undefined` / blank / unknown → `en`; `zh` / `fil` aliases)
- English and `zh-CN` term loading from the real validation-keyword registry
- empty weak-term lists for signals that only declare strong keywords
- `includeAllLocales` union vs the default single-locale path
- wiring of each key's strong terms to `contextSignal.<key>.strong`
- unknown-key throw

## What kind of change is this?

Improvements (test coverage for existing exported helpers). No production code
change.

## Why are we doing this? Any context or related work?

The lexicon is the map from context-signal keys to localized keyword terms and
context-window limits used by action validators. It had no same-named test
file. A wrong `contextLimit` or missing weak-term fallback changes which
actions enter the prompt.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/actions/context-signal-lexicon.test.ts` next to
`context-signal-lexicon.ts`. Import path is `./context-signal-lexicon.ts`,
matching sibling colocated unit tests.

## Detailed testing steps

None: automated tests are the proof.

```bash
bunx vitest run packages/agent/src/actions/context-signal-lexicon.test.ts --config packages/agent/vitest.config.ts
```

Observed on head `3190a6fd9d7786fba892c14b88e68f418aa41a62`:

```
Test Files  1 passed (1)
     Tests  18 passed (18)
```

Hosted CI does not run on PRs from this fork. The counts above are from a local
`bunx vitest run` at this exact head, recorded through the factory proof ledger.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:3190a6fd9d7786fba892c14b88e68f418aa41a62 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only change; no user flow to record.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/service path; focused vitest of a pure helper.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit tests; no product-path model call.
<!-- evidence-row:domain-artifacts -->
- [x] Concrete: colocated test file in this PR; vitest 18/18 at this head.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic unit tests; no model call on the product path.

## Known gaps / failures

- Hosted GitHub Actions CI does not run on this fork PR.
- `bun run verify` was not run; focused vitest + package `tsc` delta only.

# Agent disclosure

- AI assistance: yes
- AI provider/model: xai / grok-4.6
- Client / agent tooling: grok
- Fork contributor: hosted CI does not run on this PR.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xai / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
