### PR TITLE
test(agent): cover context-signal

### DIFF
--- a/packages/agent/src/actions/context-signal.test.ts
+++ b/packages/agent/src/actions/context-signal.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Covers context-signal helpers against the real keyword matcher and routing
+ * merge: messageText extraction, empty vs single-text queues, strong/weak
+ * hits, ASCII word-boundary misses, lexicon keys (including locale), selected
+ * action-context overlap (general/page filtered), and the async DB backfill
+ * vs state-capacity gate. Runtime doubles only stand in for IAgentRuntime
+ * getMemories — the module under test is not mocked.
+ */
+import type { AgentContext, IAgentRuntime, Memory, State } from "@elizaos/core";
+import {
+	CONTEXT_ROUTING_METADATA_KEY,
+	CONTEXT_ROUTING_STATE_KEY,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	collectKeywordTermMatches,
+	hasContextSignal,
+	hasContextSignalSync,
+	hasContextSignalSyncForKey,
+	hasSelectedActionContext,
+	hasSelectedContextOrSignalSync,
+	messageText,
+	textIncludesKeywordTerm,
+} from "./context-signal.ts";
+
+function messageWith(text: string, extras: Partial<Memory> = {}): Memory {
+	return { content: { text }, ...extras } as Memory;
+}
+
+function stateWithRecent(recentMessages: string): State {
+	return { values: { recentMessages }, data: {}, text: "" } as State;
+}
+
+function stateWithRouting(
+	primaryContext: string,
+	secondaryContexts: string[] = [],
+): State {
+	return {
+		values: {
+			[CONTEXT_ROUTING_STATE_KEY]: {
+				primaryContext,
+				secondaryContexts,
+			},
+		},
+		data: {},
+		text: "",
+	} as State;
+}
+
+function runtimeWithMemories(
+	memories: Array<{ content?: { text?: string } | undefined }>,
+	onGetMemories?: () => void,
+): IAgentRuntime {
+	return {
+		getMemories: async () => {
+			onGetMemories?.();
+			return memories;
+		},
+	} as unknown as IAgentRuntime;
+}
+
+describe("messageText", () => {
+	it("returns empty string when content is missing", () => {
+		expect(messageText({} as Memory)).toBe("");
+		expect(messageText({ content: undefined } as unknown as Memory)).toBe("");
+	});
+
+	it("returns string content as-is", () => {
+		expect(messageText({ content: "plain body" } as unknown as Memory)).toBe(
+			"plain body",
+		);
+	});
+
+	it("returns content.text when it is a string", () => {
+		expect(messageText(messageWith("hello there"))).toBe("hello there");
+	});
+
+	it("returns empty string when content.text is not a string", () => {
+		expect(messageText({ content: { text: 42 } } as unknown as Memory)).toBe(
+			"",
+		);
+		expect(messageText({ content: { text: undefined } } as Memory)).toBe("");
+	});
+});
+
+describe("re-exported keyword matcher", () => {
+	it("matches whole ASCII words, not substrings", () => {
+		expect(textIncludesKeywordTerm("please mail this", "mail")).toBe(true);
+		expect(textIncludesKeywordTerm("gmail inbox", "mail")).toBe(false);
+		expect(
+			[...collectKeywordTermMatches(["browse the category"], ["cat"])].length,
+		).toBe(0);
+		expect([...collectKeywordTermMatches(["I have a cat"], ["cat"])]).toEqual([
+			"cat",
+		]);
+	});
+});
+
+describe("hasContextSignalSync", () => {
+	it("returns false for an empty text queue", () => {
+		expect(hasContextSignalSync(messageWith(""), undefined, ["calendar"])).toBe(
+			false,
+		);
+		expect(
+			hasContextSignalSync(messageWith("   "), {} as State, ["calendar"]),
+		).toBe(false);
+	});
+
+	it("returns false when texts exist but both term lists are empty", () => {
+		expect(
+			hasContextSignalSync(messageWith("calendar tomorrow"), undefined, [], []),
+		).toBe(false);
+	});
+
+	it("activates on a single strong term in the current message", () => {
+		expect(
+			hasContextSignalSync(messageWith("open the calendar"), undefined, [
+				"calendar",
+			]),
+		).toBe(true);
+	});
+
+	it("activates on a weak term when strong terms miss", () => {
+		expect(
+			hasContextSignalSync(
+				messageWith("please forward this later"),
+				undefined,
+				["calendar"],
+				["forward"],
+			),
+		).toBe(true);
+	});
+
+	it("activates when the only match lives in recent conversation state", () => {
+		expect(
+			hasContextSignalSync(
+				messageWith("ok"),
+				stateWithRecent("Alice: check the calendar tomorrow"),
+				["calendar"],
+			),
+		).toBe(true);
+	});
+
+	it("does not activate on an ASCII substring / word-boundary miss", () => {
+		expect(
+			hasContextSignalSync(messageWith("browse the category"), undefined, [
+				"cat",
+			]),
+		).toBe(false);
+		expect(
+			hasContextSignalSync(messageWith("gmail inbox"), undefined, ["mail"]),
+		).toBe(false);
+	});
+
+	it("inspects the full state even when the deprecated contextLimit is 0", () => {
+		expect(
+			hasContextSignalSync(
+				messageWith(""),
+				stateWithRecent("calendar reminder"),
+				["calendar"],
+				[],
+				0,
+			),
+		).toBe(true);
+	});
+
+	it("returns false when no term is present", () => {
+		expect(
+			hasContextSignalSync(messageWith("what is the weather"), undefined, [
+				"calendar",
+			]),
+		).toBe(false);
+	});
+});
+
+describe("hasContextSignalSyncForKey", () => {
+	it("activates on a gmail lexicon strong term", () => {
+		expect(
+			hasContextSignalSyncForKey(
+				messageWith("check my gmail inbox"),
+				undefined,
+				"gmail",
+			),
+		).toBe(true);
+	});
+
+	it("does not activate a gmail key on unrelated text", () => {
+		expect(
+			hasContextSignalSyncForKey(
+				messageWith("what is the weather in tokyo"),
+				undefined,
+				"gmail",
+			),
+		).toBe(false);
+	});
+
+	it("includes localized terms by default and can restrict to a locale", () => {
+		const chineseMail = messageWith("请查看邮件");
+		expect(hasContextSignalSyncForKey(chineseMail, undefined, "gmail")).toBe(
+			true,
+		);
+		expect(
+			hasContextSignalSyncForKey(chineseMail, undefined, "gmail", {
+				includeAllLocales: false,
+				locale: "en",
+			}),
+		).toBe(false);
+		expect(
+			hasContextSignalSyncForKey(chineseMail, undefined, "gmail", {
+				includeAllLocales: false,
+				locale: "zh-CN",
+			}),
+		).toBe(true);
+	});
+
+	it("prefers options.locale over state preferredLanguage", () => {
+		const state = {
+			values: { preferredLanguage: "en" },
+			data: {},
+			text: "",
+		} as State;
+		const chineseMail = messageWith("邮件");
+		expect(
+			hasContextSignalSyncForKey(chineseMail, state, "gmail", {
+				includeAllLocales: false,
+				locale: "zh-CN",
+			}),
+		).toBe(true);
+		expect(
+			hasContextSignalSyncForKey(chineseMail, state, "gmail", {
+				includeAllLocales: false,
+			}),
+		).toBe(false);
+	});
+});
+
+describe("hasSelectedActionContext", () => {
+	it("returns false for an empty action-context list", () => {
+		expect(
+			hasSelectedActionContext(
+				messageWith("hello"),
+				stateWithRouting("code"),
+				[],
+			),
+		).toBe(false);
+	});
+
+	it("returns false when every declared context is general or page-scoped", () => {
+		expect(
+			hasSelectedActionContext(messageWith("hello"), stateWithRouting("code"), [
+				"general" as AgentContext,
+				"page-settings" as AgentContext,
+			]),
+		).toBe(false);
+	});
+
+	it("returns false when there is no active routing overlap", () => {
+		expect(
+			hasSelectedActionContext(
+				messageWith("hello"),
+				stateWithRouting("social"),
+				["code" as AgentContext],
+			),
+		).toBe(false);
+		expect(
+			hasSelectedActionContext(messageWith("hello"), undefined, [
+				"code" as AgentContext,
+			]),
+		).toBe(false);
+	});
+
+	it("returns true when state routing overlaps a declared context", () => {
+		expect(
+			hasSelectedActionContext(messageWith("hello"), stateWithRouting("code"), [
+				"code" as AgentContext,
+			]),
+		).toBe(true);
+	});
+
+	it("matches secondary contexts and ignores case", () => {
+		expect(
+			hasSelectedActionContext(
+				messageWith("hello"),
+				stateWithRouting("social", ["wallet"]),
+				["WALLET" as AgentContext],
+			),
+		).toBe(true);
+	});
+
+	it("returns true when message metadata routing overlaps", () => {
+		const message = {
+			content: {
+				text: "hello",
+				metadata: {
+					[CONTEXT_ROUTING_METADATA_KEY]: {
+						primaryContext: "crypto",
+						secondaryContexts: ["trading"],
+					},
+				},
+			},
+		} as unknown as Memory;
+		expect(
+			hasSelectedActionContext(message, undefined, ["trading" as AgentContext]),
+		).toBe(true);
+	});
+});
+
+describe("hasSelectedContextOrSignalSync", () => {
+	it("returns true from selected action context even without keyword hits", () => {
+		expect(
+			hasSelectedContextOrSignalSync(
+				messageWith("hello"),
+				stateWithRouting("code"),
+				["code" as AgentContext],
+				["calendar"],
+			),
+		).toBe(true);
+	});
+
+	it("falls back to the keyword signal when no context is selected", () => {
+		expect(
+			hasSelectedContextOrSignalSync(
+				messageWith("open the calendar"),
+				undefined,
+				["code" as AgentContext],
+				["calendar"],
+			),
+		).toBe(true);
+		expect(
+			hasSelectedContextOrSignalSync(
+				messageWith("hello"),
+				undefined,
+				["code" as AgentContext],
+				["calendar"],
+			),
+		).toBe(false);
+	});
+});
+
+describe("hasContextSignal", () => {
+	it("returns false for an empty text queue", async () => {
+		await expect(
+			hasContextSignal({} as IAgentRuntime, messageWith(""), undefined, [
+				"calendar",
+			]),
+		).resolves.toBe(false);
+	});
+
+	it("activates from the current message without a DB round-trip", async () => {
+		await expect(
+			hasContextSignal(
+				runtimeWithMemories([{ content: { text: "unrelated" } }]),
+				messageWith("open the calendar"),
+				undefined,
+				["calendar"],
+			),
+		).resolves.toBe(true);
+	});
+
+	it("backfills from room memories when state is thin", async () => {
+		await expect(
+			hasContextSignal(
+				runtimeWithMemories([
+					{ content: { text: "Alice: open the calendar" } },
+				]),
+				messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+				stateWithRecent(""),
+				["calendar"],
+			),
+		).resolves.toBe(true);
+	});
+
+	it("skips getMemories when state already meets contextLimit (capacity gate)", async () => {
+		let called = false;
+		const runtime = runtimeWithMemories(
+			[{ content: { text: "the only calendar mention" } }],
+			() => {
+				called = true;
+			},
+		);
+		const state = stateWithRecent("hello\nworld");
+		const matched = await hasContextSignal(
+			runtime,
+			messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+			state,
+			["calendar"],
+			[],
+			2,
+		);
+		expect(called).toBe(false);
+		expect(matched).toBe(false);
+	});
+
+	it("still inspects the current message after the capacity gate skips the DB", async () => {
+		let called = false;
+		const matched = await hasContextSignal(
+			runtimeWithMemories([{ content: { text: "ignored" } }], () => {
+				called = true;
+			}),
+			messageWith("open the calendar", { roomId: "room-1" } as Partial<Memory>),
+			stateWithRecent("hello\nworld"),
+			["calendar"],
+			[],
+			2,
+		);
+		expect(called).toBe(false);
+		expect(matched).toBe(true);
+	});
+
+	it("treats contextLimit 0 with empty state as already-full and skips the DB", async () => {
+		let called = false;
+		const matched = await hasContextSignal(
+			runtimeWithMemories(
+				[{ content: { text: "the only calendar mention" } }],
+				() => {
+					called = true;
+				},
+			),
+			messageWith("", { roomId: "room-1" } as Partial<Memory>),
+			undefined,
+			["calendar"],
+			[],
+			0,
+		);
+		expect(called).toBe(false);
+		expect(matched).toBe(false);
+	});
+
+	it("falls back to state texts when getMemories throws", async () => {
+		const runtime = {
+			getMemories: async () => {
+				throw new Error("db unavailable");
+			},
+		} as unknown as IAgentRuntime;
+		await expect(
+			hasContextSignal(
+				runtime,
+				messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+				stateWithRecent("calendar reminder"),
+				["calendar"],
+			),
+		).resolves.toBe(true);
+	});
+
+	it("activates on a weak term from backfilled memories", async () => {
+		await expect(
+			hasContextSignal(
+				runtimeWithMemories([{ content: { text: "please forward this" } }]),
+				messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+				undefined,
+				["calendar"],
+				["forward"],
+			),
+		).resolves.toBe(true);
+	});
+});


### PR DESCRIPTION

<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

No linked issue. This is test-only coverage for the existing context-signal helpers in `packages/agent/src/actions/context-signal.ts`, which had no same-named test file on `origin/develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] Focused verification passed in isolation (`bunx vitest run`). `bun run verify` was not run repo-wide; see **Known gaps / failures**. Hosted GitHub Actions CI does not run on this fork PR.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Branched from current `origin/develop` (`6451f6ec02672699333937948dc7d9bfcfdec1c7`); zero conflicts.
- [x] Focused vitest + biome + package `tsc --noEmit` passed post-sync. `bun run verify` was not run repo-wide (test-only addition; fork PRs do not receive hosted CI).

# Risks

Low. Test-only addition. No production code is modified. The suite drives the real helpers (real `collectKeywordTermMatches` / `textIncludesKeywordTerm`, real `resolveContextSignalSpec` lexicon, real `getActiveRoutingContextsForTurn`) and asserts empty vs single-text queues, strong/weak hits, ASCII word-boundary misses, locale-restricted lexicon keys, selected-action-context overlap (including `general` / `page-` filtering), and the async DB backfill vs state-capacity gate. Runtime doubles stand in only for `IAgentRuntime.getMemories`; the module under test is not mocked.

# Background

## What does this PR do?

Adds `packages/agent/src/actions/context-signal.test.ts` covering the exported context-signal helpers:

- `messageText`: missing content, string content, `content.text`, non-string text
- re-exported keyword matcher: ASCII word-boundary hits and substring misses (`mail` vs `gmail`, `cat` vs `category`)
- `hasContextSignalSync`: empty queue, empty term lists, single strong hit, weak-only hit, match in recent conversation state, word-boundary miss, deprecated `contextLimit` ignored, no-match
- `hasContextSignalSyncForKey`: gmail lexicon strong term, unrelated text, all-locales vs locale-restricted Chinese terms, `options.locale` over `state.values.preferredLanguage`
- `hasSelectedActionContext`: empty list, `general`/`page-` filtered, no overlap, state primary overlap, secondary + case-insensitive match, message metadata routing
- `hasSelectedContextOrSignalSync`: context short-circuit without keywords, keyword fallback when no context is selected
- `hasContextSignal` (async): empty queue, message-only hit, room-memory backfill, capacity gate skipping `getMemories`, message still inspected after the gate, `contextLimit` 0 with empty state skips DB, `getMemories` throw falls back to state, weak term from backfilled memories

## What kind of change is this?

Improvements (misc. changes to existing features) — test coverage only.

## Why are we doing this? Any context or related work?

`context-signal.ts` is the shared validate() keyword gate for actions. It had no colocated test file. Sibling action helpers already have colocated vitest files (`recent-conversation-texts.test.ts`, `connect-account.test.ts`). This PR matches that convention.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/actions/context-signal.test.ts`

## Detailed testing steps

Isolated (recorded at head `d5e13f236a7b8067529d5622f1b81678356a905f`):

```
bunx vitest run src/actions/context-signal.test.ts
```

(from `packages/agent`; equivalent path from repo root: `packages/agent/src/actions/context-signal.test.ts`)

Observed:

```
 Test Files  1 passed (1)
      Tests  33 passed (33)
   Start at  11:13:19
   Duration  10.13s (transform 7.71s, setup 120ms, import 9.78s, tests 17ms, environment 0ms)
```

Also:

- `bunx biome check --write packages/agent/src/actions/context-signal.test.ts` — Checked 1 file. Fixed formatting once; subsequent check after type-cast fixes was clean of new issues.
- `packages/agent` `tsc --noEmit -p tsconfig.json` — 0 new errors versus an untouched control (same 33 pre-existing package errors with or without this test file; none in `context-signal.test.ts`).

Hosted GitHub Actions CI does **not** run on PRs from this fork. Do not treat missing Actions checks as a pass.

# Known gaps / failures

- Hosted GitHub Actions CI does not run on this fork PR.
- `bun run verify` was not run repo-wide (test-only addition; isolated vitest + biome + package tsc control are the proof).
- Signed Slop run-receipt / private trace was not finalized: this client has no usage adapter, and finishing a trace requires an interactive identity.slop.cash OAuth click that cannot be completed unattended.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:d5e13f236a7b8067529d5622f1b81678356a905f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI; unit tests for action context-signal helpers, no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI; unit tests for action context-signal helpers, no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI; unit tests for action context-signal helpers, no user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/service path; in-process vitest against context-signal helpers.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit tests, no model call.
<!-- evidence-row:domain-artifacts -->
- [x] Concrete: the new test file in this PR (`packages/agent/src/actions/context-signal.test.ts`) plus the isolated vitest counts above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; deterministic unit tests.

## Backend + frontend logs

N/A - no service or UI path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
