### PR TITLE
fix(plugin-local-inference): close the residual assignment races from #25147

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.concurrency.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.concurrency.test.ts
@@ -18,10 +18,15 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
+import http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applyLocalInferenceManagementMutation } from "./local-inference-routes.js";
+import {
+	applyLocalInferenceManagementMutation,
+	handleLocalInferenceRoutes,
+} from "./local-inference-routes.js";
+import { writeAssignments as servicesWriteAssignments } from "./services/assignments.js";
 
 const originalStateDir = process.env.ELIZA_STATE_DIR;
 let tempStateDir: string;
@@ -171,5 +176,67 @@ describe("local-inference concurrent config mutations (#25123)", () => {
 		for (const slot of slots) {
 			expect(file.assignments[slot]).toBe("eliza-1-2b");
 		}
+	});
+
+	it("persists both slots when two POST /api/local-inference/assignments requests race", async () => {
+		// The HTTP route did its read-modify-write outside the per-file lock, so
+		// two concurrent POSTs both returned 200 while the second write clobbered
+		// the first on the stale pre-write snapshot (#25123's race on the route
+		// that motivated it).
+		const server = http.createServer((req, res) => {
+			void handleLocalInferenceRoutes(req, res).then((handled) => {
+				if (!handled && !res.writableEnded) {
+					res.statusCode = 404;
+					res.end();
+				}
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(0, resolve));
+		const address = server.address() as { port: number };
+		const post = async (slot: string, modelId: string) => {
+			const response = await fetch(
+				`http://127.0.0.1:${address.port}/api/local-inference/assignments`,
+				{
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ slot, modelId }),
+				},
+			);
+			return response.status;
+		};
+		try {
+			const statuses = await Promise.all([
+				post("TEXT_SMALL", "eliza-1-2b"),
+				post("TEXT_LARGE", "eliza-1-4b"),
+			]);
+			expect(statuses).toEqual([200, 200]);
+			const file = readAssignmentsFile();
+			expect(file.assignments).toEqual({
+				TEXT_SMALL: "eliza-1-2b",
+				TEXT_LARGE: "eliza-1-4b",
+			});
+		} finally {
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve())),
+			);
+		}
+	});
+
+	it("does not race the services module's staging file under concurrent writes", async () => {
+		// services/assignments.ts staged every write to one fixed
+		// `${path}.tmp`, so concurrent writers raced on fs.rename and rejected
+		// with ENOENT after the first rename consumed the shared temp file.
+		const writes = await Promise.allSettled(
+			Array.from({ length: 5 }, (_, index) =>
+				servicesWriteAssignments({
+					TEXT_SMALL: `eliza-1-2b`,
+					TEXT_LARGE: index % 2 === 0 ? "eliza-1-4b" : "eliza-1-9b",
+				}),
+			),
+		);
+		expect(writes.filter((entry) => entry.status === "rejected")).toEqual([]);
+		const file = readAssignmentsFile();
+		expect(file.version).toBe(1);
+		expect(file.assignments.TEXT_SMALL).toBe("eliza-1-2b");
 	});
 });

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -1779,22 +1779,30 @@ export async function handleLocalInferenceRoutes(
 			sendJsonError(res, "slot is required");
 			return true;
 		}
-		const assignments = await readAssignments();
-		if (typeof body.modelId === "string" && body.modelId.trim()) {
-			const modelId = body.modelId.trim();
-			if (!isCuratedCatalogModelId(modelId)) {
-				sendJsonError(
-					res,
-					"Local inference assignments are limited to curated Eliza-1 tiers.",
-					400,
-				);
-				return true;
-			}
-			assignments[slot as keyof Assignments] = modelId;
-		} else {
-			delete assignments[slot as keyof Assignments];
+		const modelId =
+			typeof body.modelId === "string" && body.modelId.trim()
+				? body.modelId.trim()
+				: null;
+		if (modelId && !isCuratedCatalogModelId(modelId)) {
+			sendJsonError(
+				res,
+				"Local inference assignments are limited to curated Eliza-1 tiers.",
+				400,
+			);
+			return true;
 		}
-		sendJson(res, { assignments: await writeAssignments(assignments) });
+		// Read-modify-write must run inside the per-file lock: a bare
+		// readAssignments/writeAssignments pair here loses one of two
+		// concurrent POSTs to the stale pre-write snapshot (issue #25123's
+		// race, on the route that motivated it).
+		const assignments = await updateAssignments((current) => {
+			if (modelId) {
+				current[slot as keyof Assignments] = modelId;
+			} else {
+				delete current[slot as keyof Assignments];
+			}
+		});
+		sendJson(res, { assignments });
 		return true;
 	}
 	if (method === "GET" && pathname === "/api/local-inference/routing") {

--- a/plugins/plugin-local-inference/src/services/assignments.ts
+++ b/plugins/plugin-local-inference/src/services/assignments.ts
@@ -11,6 +11,7 @@
  * enough to rewrite on every change — we never mutate in place.
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { findCatalogModel, isDefaultEligibleId } from "./catalog";
@@ -147,9 +148,20 @@ export async function writeAssignments(
 ): Promise<void> {
 	await ensureRoot();
 	const payload: AssignmentsFile = { version: 1, assignments };
-	const tmp = `${assignmentsPath()}.tmp`;
-	await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
-	await fs.rename(tmp, assignmentsPath());
+	// Unique staging name per write: a fixed `${path}.tmp` shared by concurrent
+	// writers lets one rename consume the other's temp file and throw ENOENT
+	// out of a mutation that reported success (issue #25123's staging race,
+	// mirrored from local-inference-routes.ts writeJsonFile).
+	const tmp = `${assignmentsPath()}.${crypto.randomBytes(6).toString("hex")}.tmp`;
+	try {
+		await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
+		await fs.rename(tmp, assignmentsPath());
+	} catch (error) {
+		// error-policy:J6 temp cleanup is best-effort; unique names keep an
+		// orphan harmless to concurrent writers, and the write error is preserved.
+		await fs.rm(tmp, { force: true }).catch(() => undefined);
+		throw error;
+	}
 }
 
 export async function setAssignment(

--- a/plugins/plugin-local-inference/src/services/registry.ts
+++ b/plugins/plugin-local-inference/src/services/registry.ts
@@ -8,6 +8,7 @@
  * first-run, setup, or normal Settings surfaces.
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { logger } from "@elizaos/core";
@@ -159,13 +160,24 @@ function storedRowIsCanonical(
 
 async function writeElizaOwned(models: InstalledModel[]): Promise<void> {
 	await ensureRootDir();
-	const tmp = `${registryPath()}.tmp`;
+	// Unique staging name per write: a fixed `${path}.tmp` shared by concurrent
+	// writers lets one rename consume the other's temp file and throw ENOENT
+	// out of a mutation that reported success (issue #25123's staging race,
+	// mirrored from local-inference-routes.ts writeJsonFile).
+	const tmp = `${registryPath()}.${crypto.randomBytes(6).toString("hex")}.tmp`;
 	const payload: RegistryFile = {
 		version: 1,
 		models: models.map(serializeElizaOwnedModel),
 	};
-	await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
-	await fs.rename(tmp, registryPath());
+	try {
+		await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
+		await fs.rename(tmp, registryPath());
+	} catch (error) {
+		// error-policy:J6 temp cleanup is best-effort; unique names keep an
+		// orphan harmless to concurrent writers, and the write error is preserved.
+		await fs.rm(tmp, { force: true }).catch(() => undefined);
+		throw error;
+	}
 }
 
 function hydrateStoredElizaModel(


### PR DESCRIPTION
# Relates to

Closes #25181. Completes #25147 (issue #25123), where I measured these two residual races during independent review.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on current `origin/develop` at `8bba1a0e11`; zero conflicts. Exact head `c341a9b523bf34804904458a9da2c648d6aa30a5`.

# Risks

Low. The route change reuses the `updateAssignments` helper #25147 introduced (validation stays outside the lock, mutation inside), so single-request behavior is unchanged. The services change only alters temp-file naming plus best-effort cleanup, byte-identical output on the happy path.

# Background

## What does this PR do?

Two surfaces kept the #25123 races after #25147:

- **`POST /api/local-inference/assignments`** read-modified-wrote outside `withConfigFileLock`. Measured on the real exported handler via a real `http.Server`: two concurrent POSTs both return 200, one assignment silently lost, 10/10 runs. The route now goes through `updateAssignments`.
- **`services/{assignments,registry}.ts`** staged to a fixed `${path}.tmp`; concurrent writers raced on `fs.rename` (measured 4/5 rejections with the shared-tmp ENOENT). Both writers now stage to a unique random-suffix temp with `error-policy:J6` cleanup, mirroring the routes module's `writeJsonFile`.

The deeper unification (two modules, two mutex maps, in-process-only locking beside `withRoutingLock`'s cross-process pattern) is deliberately left to #25181's follow-up note — this PR removes the two measured defects with minimal surface.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

The two new cases at the end of `src/local-inference-routes.concurrency.test.ts` — a real-server racing-POST regression and a five-writer services staging regression.

## Detailed testing steps

1. Check out exact head `c341a9b523bf34804904458a9da2c648d6aa30a5`.
2. From `plugins/plugin-local-inference`: `bun x vitest run src/local-inference-routes.concurrency.test.ts` → **5/5** (the three #25147 regressions plus the two new ones).
3. Counterfactual: stash only the three source files (keep the test) and re-run → **2 failed / 3 passed** — exactly the two new cases: the POST race loses a slot, and the services writer rejects with the shared-tmp ENOENT. Restore.
4. Focused lane: routes, encoding, concurrency, services registry/assignments/downloader → **71/71 across 6 files**.
5. Biome on all four changed files: clean. `git diff --check`: clean.

<!-- evidence-head:c341a9b523bf34804904458a9da2c648d6aa30a5 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — backend persistence behavior with no UI surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — backend persistence behavior with no UI surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the deterministic counterfactual below is the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Head vs counterfactual (vitest)</summary>

```
# head c341a9b523 — plugins/plugin-local-inference
$ bun x vitest run src/local-inference-routes.concurrency.test.ts
 Tests  5 passed (5)

# three source files stashed (test kept)
$ bun x vitest run src/local-inference-routes.concurrency.test.ts
 × persists both slots when two POST /api/local-inference/assignments requests race
 × does not race the services module's staging file under concurrent writes
 Tests  2 failed | 3 passed (5)

# focused lane at head
$ bun x vitest run <routes, encoding, concurrency, services registry/assignments/downloader>
 Test Files  6 passed (6)
 Tests  71 passed (71)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic filesystem/HTTP behavior, no agent path.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Static gates at exact head</summary>

```
$ /Users/lostboy/Desktop/eliza/node_modules/.bin/biome check \
    plugins/plugin-local-inference/src/local-inference-routes.ts \
    plugins/plugin-local-inference/src/services/assignments.ts \
    plugins/plugin-local-inference/src/services/registry.ts \
    plugins/plugin-local-inference/src/local-inference-routes.concurrency.test.ts
Checked 4 files in 29ms. No fixes applied.

$ git diff --check
(clean, exit 0)

$ git diff --stat origin/develop..HEAD
 .../src/local-inference-routes.concurrency.test.ts | 74 +++++++++++++++++++++-
 .../src/local-inference-routes.ts                  | 33 ++++++----
 .../src/services/assignments.ts                    | 16 ++++-
 .../src/services/registry.ts                       | 17 ++++-
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` (repo-wide) was not run: hand-wired review worktree (packages linked from the main checkout) cannot support the full gate honestly; the focused package gates above stand in.
- The cross-module unification (single lock and single persistence module over these files) is scoped out to #25181's follow-up note by design.
