### PR TITLE
test(examples): cover env loading from cwd and repo root

### DIFF
--- a/packages/examples/code/src/lib/__tests__/load-env.test.ts
+++ b/packages/examples/code/src/lib/__tests__/load-env.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  config: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({ existsSync: mocks.existsSync }));
+vi.mock("dotenv", () => ({ config: mocks.config }));
+
+import { loadEnv } from "./load-env.ts";
+
+describe("loadEnv", () => {
+  beforeEach(() => {
+    mocks.config.mockClear();
+    mocks.existsSync.mockClear();
+  });
+
+  it("loads cwd .env always, and root .env only when present", () => {
+    mocks.existsSync.mockReturnValue(true);
+    loadEnv();
+    expect(mocks.config).toHaveBeenCalledTimes(2);
+    // First call: default cwd behavior
+    expect(mocks.config.mock.calls[0][0]).toMatchObject({ quiet: true });
+    // Second call: root .env with no override
+    expect(mocks.config.mock.calls[1][0]).toMatchObject({
+      override: false,
+      quiet: true,
+    });
+    expect(mocks.config.mock.calls[1][0].path).toContain(".env");
+  });
+
+  it("skips the root .env when it does not exist", () => {
+    mocks.existsSync.mockReturnValue(false);
+    loadEnv();
+    expect(mocks.config).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
