### PR TITLE
fix(core): safe NaN handling in follow-up task scheduled date sort comparator

### DIFF
--- a/packages/core/src/services/follow-up.test.ts
+++ b/packages/core/src/services/follow-up.test.ts
@@ -420,12 +420,50 @@ describe("FollowUpService suggestion completeness", () => {
 				relationshipsService: typeof relationshipsService;
 			}
 		).relationshipsService = relationshipsService;
-
 		const suggestions = await followUps.getFollowUpSuggestions();
 
 		expect(suggestions).toHaveLength(12);
 		expect(suggestions.map((item) => item.daysSinceLastContact)).toEqual(
 			Array.from({ length: 12 }, (_, index) => 31 - index),
 		);
+	});
+
+	it("maintains strict total ordering when scheduledAt metadata contains invalid dates", async () => {
+		const { runtime } = makeRuntime();
+		const followUps = (await FollowUpService.start(runtime)) as FollowUpService;
+
+		await runtime.createTask({
+			name: "Follow up 1",
+			tags: ["follow-up"],
+			metadata: {
+				status: "pending",
+				targetEntityId: ENTITY_ID,
+				scheduledAt: "2026-01-02T10:00:00.000Z",
+			},
+		});
+		await runtime.createTask({
+			name: "Follow up NaN",
+			tags: ["follow-up"],
+			metadata: {
+				status: "pending",
+				targetEntityId: ENTITY_ID,
+				scheduledAt: "invalid-date-string",
+			},
+		});
+		await runtime.createTask({
+			name: "Follow up 2",
+			tags: ["follow-up"],
+			metadata: {
+				status: "pending",
+				targetEntityId: ENTITY_ID,
+				scheduledAt: "2026-01-03T10:00:00.000Z",
+			},
+		});
+
+		const upcoming = await followUps.getUpcomingFollowUps();
+		expect(upcoming.length).toBe(3);
+		expect(upcoming[0]?.task.name).toBe("Follow up NaN"); // fallback 0 scheduled time
+		expect(upcoming[1]?.task.name).toBe("Follow up 1");
+		expect(upcoming[2]?.task.name).toBe("Follow up 2");
 	});
 });

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -202,9 +202,10 @@ export class FollowUpService extends Service {
 		for (const task of tasks) {
 			if (task.metadata?.status !== "pending") continue;
 
-			const scheduledAt = task.metadata.scheduledAt
+			const scheduledAtRaw = task.metadata.scheduledAt
 				? new Date(task.metadata.scheduledAt as string).getTime()
 				: 0;
+			const scheduledAt = Number.isFinite(scheduledAtRaw) ? scheduledAtRaw : 0;
 
 			// Check if task is within the time range
 			if (includeOverdue && scheduledAt < now) {
@@ -228,12 +229,14 @@ export class FollowUpService extends Service {
 
 		// Sort by scheduled date
 		upcomingFollowUps.sort((a, b) => {
-			const aScheduled = a.task.metadata?.scheduledAt
+			const aRaw = a.task.metadata?.scheduledAt
 				? new Date(a.task.metadata.scheduledAt as string).getTime()
 				: 0;
-			const bScheduled = b.task.metadata?.scheduledAt
+			const bRaw = b.task.metadata?.scheduledAt
 				? new Date(b.task.metadata.scheduledAt as string).getTime()
 				: 0;
+			const aScheduled = Number.isFinite(aRaw) ? aRaw : 0;
+			const bScheduled = Number.isFinite(bRaw) ? bRaw : 0;
 			return aScheduled - bScheduled;
 		});
 


### PR DESCRIPTION
## Summary

Validates task `scheduledAt` timestamp parsing with `Number.isFinite(...)` in `FollowUpService.getUpcomingFollowUps` (`packages/core/src/services/followUp.ts:205, 230`) to prevent `NaN` return values in filtering logic and sort comparators when follow-up task metadata contains non-finite or invalid date strings.

## Changes

- In `packages/core/src/services/followUp.ts:205-207`, ensure `scheduledAt` timestamp evaluates to finite numbers before timeframe window checks.
- In `packages/core/src/services/followUp.ts:230-238`, guard scheduled date subtraction with `Number.isFinite(...)` to preserve strict total ordering.
- In `packages/core/src/services/follow-up.test.ts`, add dedicated unit tests verifying that invalid date metadata strings maintain deterministic sort ordering.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`fc9e4901b3`) |
| --- | --- | --- |
| `bunx vitest run packages/core/src/services/follow-up.test.ts` | 9 pass (9 tests) | 10 pass (10 tests) |
| `bunx @biomejs/biome check packages/core/src/services/followUp.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/core/src/services/followUp.ts:202-240`
- `packages/core/src/services/follow-up.test.ts:430-465`

## Risks

Low. Fallback to 0 for unparseable dates ensures overdue task grouping and deterministic total ordering.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Core follow-up service; no UI layout touched)
- [x] `audit:browser` — N/A (Follow-up scheduler)
- [x] `build` — Clean build across workspace
- [x] `test` — 10/10 pass in `follow-up.test.ts`
- [x] `lint` — Biome clean
