### PR TITLE
test(app): cover deferred app-module import cache

### DIFF
--- a/packages/app/src/__tests__/app-module-cache.test.ts
+++ b/packages/app/src/__tests__/app-module-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { cachedDynamicImport } from "./app-module-cache.ts";
+
+describe("cachedDynamicImport", () => {
+  it("invokes the loader once per key", async () => {
+    const loader = vi.fn(async () => "ns");
+    const p1 = cachedDynamicImport("pkg", loader);
+    const p2 = cachedDynamicImport("pkg", loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(await p1).toBe("ns");
+    expect(await p2).toBe("ns");
+  });
+
+  it("keys by full key including suffixes", async () => {
+    const loaderA = vi.fn(async () => "a");
+    const loaderB = vi.fn(async () => "b");
+    const p1 = cachedDynamicImport("pkg-2", loaderA);
+    const p2 = cachedDynamicImport("pkg-2/register", loaderB);
+    expect(loaderA).toHaveBeenCalledTimes(1);
+    expect(loaderB).toHaveBeenCalledTimes(1);
+    expect(await p1).toBe("a");
+    expect(await p2).toBe("b");
+  });
+
+  it("returns the same promise for concurrent requests", () => {
+    const loader = vi.fn(async () => "x");
+    const p1 = cachedDynamicImport("k", loader);
+    const p2 = cachedDynamicImport("k", loader);
+    expect(p1).toBe(p2);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
