### PR TITLE
test(agent): cover session store path resolution

### DIFF
--- a/packages/agent/src/providers/__tests__/session-utils.test.ts
+++ b/packages/agent/src/providers/__tests__/session-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSessionProviders: vi.fn(() => []),
+  resolveStateDir: vi.fn(() => "/state"),
+}));
+
+vi.mock("@elizaos/core", () => ({
+  getSessionProviders: (...a: unknown[]) => mocks.getSessionProviders(...a),
+  resolveStateDir: (...a: unknown[]) => mocks.resolveStateDir(...a),
+}));
+
+import {
+  getSessionProviders,
+  resolveDefaultSessionStorePath,
+} from "./session-utils.ts";
+
+describe("resolveDefaultSessionStorePath", () => {
+  it("resolves the sessions.json path under the state dir", () => {
+    expect(resolveDefaultSessionStorePath("agent-1")).toBe(
+      "/state/agents/agent-1/sessions/sessions.json",
+    );
+  });
+
+  it("defaults to the main agent", () => {
+    expect(resolveDefaultSessionStorePath()).toBe(
+      "/state/agents/main/sessions/sessions.json",
+    );
+  });
+});
+
+describe("getSessionProviders", () => {
+  it("re-exports the canonical providers", () => {
+    expect(getSessionProviders()).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
