### PR TITLE
fix(agent): safe NaN handling in swarm conversation selection sort comparators

### DIFF
--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -973,4 +973,41 @@ describe("routeAutonomyTextToUser", () => {
     expect(createMemory).toHaveBeenCalledTimes(1);
     expect(broadcastWs).toHaveBeenCalledTimes(2);
   });
+
+  it("selects the newest conversation even when a conversation has an invalid updatedAt date string", async () => {
+    const createMemory = vi.fn();
+    const broadcastWs = vi.fn();
+    const state = {
+      runtime: {
+        agentId: "00000000-0000-0000-0000-000000000001",
+        createMemory,
+      },
+      conversations: new Map([
+        [
+          "conv-invalid",
+          {
+            id: "conv-invalid",
+            roomId: "00000000-0000-0000-0000-000000000002",
+            updatedAt: "not-a-valid-date",
+          },
+        ],
+        [
+          "conv-valid",
+          {
+            id: "conv-valid",
+            roomId: "00000000-0000-0000-0000-000000000003",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+          },
+        ],
+      ]),
+      broadcastWs,
+    } as never;
+
+    await routeAutonomyTextToUser(state, "autonomy update", "autonomy");
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: "conv-valid",
+      }),
+    );
+  });
 });

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -108,10 +108,15 @@ export async function routeAutonomyTextToUser(
   }
   if (!conv) {
     // Fall back to most recently updated conversation
-    const sorted = Array.from(state.conversations.values()).sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
+    const sorted = Array.from(state.conversations.values()).sort((a, b) => {
+      const aTime = Number.isFinite(new Date(a.updatedAt).getTime())
+        ? new Date(a.updatedAt).getTime()
+        : 0;
+      const bTime = Number.isFinite(new Date(b.updatedAt).getTime())
+        ? new Date(b.updatedAt).getTime()
+        : 0;
+      return bTime - aTime;
+    });
     conv = sorted[0];
   }
   if (!conv) return; // No conversations exist yet
@@ -895,11 +900,19 @@ export function wireCoordinatorEventRouting(st: ServerState): boolean {
             if (displayText && displayText.length > 2) {
               const conv = st.activeConversationId
                 ? st.conversations.get(st.activeConversationId)
-                : Array.from(st.conversations.values()).sort(
-                    (a, b) =>
-                      new Date(b.updatedAt).getTime() -
+                : Array.from(st.conversations.values()).sort((a, b) => {
+                    const aTime = Number.isFinite(
                       new Date(a.updatedAt).getTime(),
-                  )[0];
+                    )
+                      ? new Date(a.updatedAt).getTime()
+                      : 0;
+                    const bTime = Number.isFinite(
+                      new Date(b.updatedAt).getTime(),
+                    )
+                      ? new Date(b.updatedAt).getTime()
+                      : 0;
+                    return bTime - aTime;
+                  })[0];
               if (conv) {
                 st.broadcastWs?.({
                   type: "proactive-message",


### PR DESCRIPTION
## Summary

Validates conversation `updatedAt` date parsing with `Number.isFinite(...)` in `packages/agent/src/api/server-helpers-swarm.ts:111, 898` to prevent `NaN` return values in sort comparators when selecting active conversations during swarm message routing and WebSocket broadcasts.

## Changes

- In `packages/agent/src/api/server-helpers-swarm.ts:111-115`, guard `updatedAt` date comparison in `routeAutonomyTextToUser` fallback conversation lookup with `Number.isFinite(...)`.
- In `packages/agent/src/api/server-helpers-swarm.ts:898-902`, guard `updatedAt` date comparison in coordinator WebSocket proactive broadcast conversation lookup with `Number.isFinite(...)`.
- In `packages/agent/src/api/server-helpers-swarm.test.ts`, add dedicated unit tests verifying that invalid date strings do not disrupt active conversation selection.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`adb68810d6`) |
| --- | --- | --- |
| `bunx vitest run packages/agent/src/api/server-helpers-swarm.test.ts` | 21 pass (21 tests) | 22 pass (22 tests) |
| `bunx @biomejs/biome check packages/agent/src/api/server-helpers-swarm.ts` | 0 errors | 0 errors |

## Reviewer start

- `packages/agent/src/api/server-helpers-swarm.ts:108-118`
- `packages/agent/src/api/server-helpers-swarm.ts:898-906`
- `packages/agent/src/api/server-helpers-swarm.test.ts:970-1015`

## Risks

Low. Fallback to 0 ensures older/invalid date records do not supersede valid active conversations.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent swarm router; no UI layout touched)
- [x] `audit:browser` — N/A (Swarm conversation selector)
- [x] `build` — Clean build across workspace
- [x] `test` — 22/22 pass in `server-helpers-swarm.test.ts`
- [x] `lint` — Biome clean
