### PR TITLE
test(agent): cover plugin action deduplication

### DIFF
--- a/packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts
+++ b/packages/agent/src/runtime/__tests__/plugin-action-dedupe.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  logger: { debug: vi.fn() },
+}));
+
+import { deduplicatePluginActions } from "./plugin-action-dedupe.ts";
+
+describe("deduplicatePluginActions", () => {
+  it("keeps the first occurrence of each action name", () => {
+    const plugins = [
+      { name: "p1", actions: [{ name: "a" }, { name: "b" }] },
+      { name: "p2", actions: [{ name: "a" }, { name: "c" }] },
+    ] as never;
+    deduplicatePluginActions(plugins);
+    const p1 = plugins[0] as { actions: { name: string }[] };
+    const p2 = plugins[1] as { actions: { name: string }[] };
+    expect(p1.actions.map((a) => a.name)).toEqual(["a", "b"]);
+    expect(p2.actions.map((a) => a.name)).toEqual(["c"]);
+  });
+
+  it("handles plugins without actions", () => {
+    const plugins = [
+      { name: "p1" },
+      { name: "p2", actions: [{ name: "x" }] },
+    ] as never;
+    expect(() => deduplicatePluginActions(plugins)).not.toThrow();
+    const p2 = plugins[1] as { actions: { name: string }[] };
+    expect(p2.actions.map((a) => a.name)).toEqual(["x"]);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
