### PR TITLE
fix(discord): use surrogate-safe truncateWellFormed on voice status normalization

### DIFF
--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -42,6 +42,8 @@ import {
 	stringToUuid,
 	type TargetInfo,
 	type ThreadHandle,
+	toWellFormedUnicode,
+	truncateWellFormed,
 	type UUID,
 	type World,
 } from "@elizaos/core";
@@ -1156,7 +1158,10 @@ export class DiscordService extends Service implements IDiscordService {
 		}
 
 		const voiceChannel = channel as BaseGuildVoiceChannel;
-		const normalizedStatus = status.trim().slice(0, 500);
+		const normalizedStatus = truncateWellFormed(
+			toWellFormedUnicode(status.trim()),
+			500,
+		);
 		await client.rest.put(`/channels/${voiceChannel.id}/voice-status`, {
 			body: {
 				status: normalizedStatus || null,


### PR DESCRIPTION
## Summary
Preserve astral pairs in Discord voice status normalization (500) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged `fix(cloud): ingress plaid` `00883b4df2` (98.5% accept, leaf scope).

## Changes
- `plugins/plugin-discord/service.ts:1159` — `status.trim().slice(0, 500)` → `truncateWellFormed(toWellFormedUnicode(status.trim()), 500)`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@57f5abe803` | `fix/discord-service-status-surrogate-safe@88689f05` |

Rebased on current `origin/develop`.

## Reviewer start
Narrow `fix(discord)` leaf scope, 1 file.

## Evidence Gate
- De-dup: `git log --all --grep=surrogate -- service.ts` — fresh. Biome formatted. Affected lint is 1 package (plugin-discord) — no wide blast radius, no pre-existing shared errors.
