### PR TITLE
fix(local-inference): use surrogate-safe truncateWellFormed on PII recognizer error preview

### DIFF
--- a/plugins/plugin-local-inference/src/pii/llm-recognizer.ts
+++ b/plugins/plugin-local-inference/src/pii/llm-recognizer.ts
@@ -20,6 +20,8 @@ import {
 	type EntitySpan,
 	logger,
 	type PiiEntityRecognizer,
+	toWellFormedUnicode,
+	truncateWellFormed,
 } from "@elizaos/core";
 
 /** Local-only text generation seam the recognizer runs its prompt through. */
@@ -95,7 +97,7 @@ export function parseReportedEntities(completion: string): ReportedEntity[] {
 	const end = completion.lastIndexOf("]");
 	if (start === -1 || end === -1 || end < start) {
 		throw new Error(
-			`[LocalPii] model output contains no JSON array: ${JSON.stringify(completion.slice(0, 200))}`,
+			`[LocalPii] model output contains no JSON array: ${JSON.stringify(truncateWellFormed(toWellFormedUnicode(completion), 200))}`,
 		);
 	}
 	let parsed: unknown;


### PR DESCRIPTION
## Summary
Preserve astral pairs in PII LLM recognizer model error preview (200) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged surrogate pattern (97% accept, leaf).

## Changes
- `plugins/plugin-local-inference/src/pii/llm-recognizer.ts:98` — `completion.slice(0, 200)` inside `JSON.stringify` → `truncateWellFormed(toWellFormedUnicode(completion), 200)`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@57f5abe803` | `fix/local-inference-pii-recognizer-surrogate-safe@aaf6fe5f` |

Rebased.

## Reviewer start
Leaf `fix(local-inference)` 1 file.

## Evidence Gate
- De-dup fresh, biome formatted, affected lint 1 package.
