### PR TITLE
fix(elizacloud): use surrogate-safe truncateWellFormed on schedule sync detail

### DIFF
--- a/plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts
+++ b/plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts
@@ -1,3 +1,4 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   normalizeCloudSiteUrl,
   resolveCloudApiBaseUrl,
@@ -124,7 +125,7 @@ async function readJsonResponse<T>(response: Response): Promise<T> {
         };
         detail = parsed.message ?? parsed.error ?? trimmed;
       } catch {
-        detail = trimmed.slice(0, 200);
+        detail = truncateWellFormed(toWellFormedUnicode(trimmed), 200);
       }
     }
     throw new LifeOpsScheduleSyncClientError(response.status, detail);


### PR DESCRIPTION
## Summary
Preserve astral pairs in LifeOps schedule sync client detail (200) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged cloud surrogate batch (97% accept, leaf).

## Changes
- `plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts:127` — `trimmed.slice(0, 200)` → `truncateWellFormed(toWellFormedUnicode(trimmed), 200)`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@57f5abe803` | `fix/elizacloud-lifeops-sync-surrogate-safe@62490797` |

Rebased.

## Reviewer start
Leaf `fix(elizacloud)` 1 file.

## Evidence Gate
- De-dup fresh, biome formatted, affected lint 1 package.
