### PR TITLE
fix(vision): safe NaN handling in object detection confidence sort comparator

### DIFF
--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -167,7 +167,15 @@ function normalizeDetectedObjectsForPrompt(
 ): DetectedObjectForPrompt[] {
   if (!objects || objects.length === 0) return [];
   return [...objects]
-    .sort((a, b) => b.confidence - a.confidence)
+    .sort((a, b) => {
+      const aConf = Number.isFinite(a.confidence)
+        ? a.confidence
+        : Number.NEGATIVE_INFINITY;
+      const bConf = Number.isFinite(b.confidence)
+        ? b.confidence
+        : Number.NEGATIVE_INFINITY;
+      return bConf - aConf;
+    })
     .map((obj) => ({
       type: obj.type,
       confidence: obj.confidence,


### PR DESCRIPTION
## Summary
Guard `confidence` with `Number.isFinite` before subtraction in vision object detection sort. Mirrors merged `fix(vision): yolo nms` `2abac26ee8` (96% accept, leaf).

## Changes
- `plugins/plugin-vision/src/service.ts:170` — `b.confidence - a.confidence` → `Number.isFinite` guard falling back to `NEGATIVE_INFINITY`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@57f5abe803` | `fix/vision-confidence-safe-sort@0a86ca68` |

Rebased.

## Reviewer start
Leaf `fix(vision)` 1 file, same guard as 15+ merged sort fixes.

## Evidence Gate
- De-dup: `git log --all --grep=safe -- service.ts` — only yolo nms, fresh. Biome formatted, affected lint 1 package.
