### PR TITLE
fix(app-core): repair nested test imports

### DIFF
--- a/packages/app-core/src/api/__tests__/automation-action-classifier.test.ts
+++ b/packages/app-core/src/api/__tests__/automation-action-classifier.test.ts
@@ -5,7 +5,7 @@ vi.mock("@elizaos/core", () => ({
   hasActionTags: (...args: unknown[]) => hasActionTags(...args),
 }));
 
-import { classifyRuntimeActionNode } from "./automation-action-classifier.ts";
+import { classifyRuntimeActionNode } from "../automation-action-classifier.ts";
 
 describe("classifyRuntimeActionNode", () => {
   it("classifies agent-orchestration + delegate actions as agent", () => {

--- a/packages/app-core/src/api/__tests__/perf-instrument.test.ts
+++ b/packages/app-core/src/api/__tests__/perf-instrument.test.ts
@@ -3,7 +3,7 @@ import {
   getPerfSnapshot,
   isPerfInstrumentEnabled,
   normalizeRouteKey,
-} from "./perf-instrument.ts";
+} from "../perf-instrument.ts";
 
 describe("normalizeRouteKey", () => {
   it("combines method and collapsed pathname", () => {

--- a/packages/app-core/src/api/__tests__/server-security.test.ts
+++ b/packages/app-core/src/api/__tests__/server-security.test.ts
@@ -14,14 +14,14 @@ const compat = vi.hoisted(() => ({
 }));
 
 vi.mock("@elizaos/agent", () => upstreamFns);
-vi.mock("./server-wallet-trade", () => compat);
+vi.mock("../server-wallet-trade", () => compat);
 
 import {
   resolveMcpTerminalAuthorizationRejection,
   resolveTerminalRunClientId,
   resolveTerminalRunRejection,
   resolveWebSocketUpgradeRejection,
-} from "./server-security.ts";
+} from "../server-security.ts";
 
 describe("server-security wrappers", () => {
   it("forwards MCP terminal authorization rejection through compat context", () => {

--- a/packages/app-core/src/cli/program/__tests__/build-program.test.ts
+++ b/packages/app-core/src/cli/program/__tests__/build-program.test.ts
@@ -19,21 +19,21 @@ vi.mock("commander", () => {
   }
   return { Command };
 });
-vi.mock("../version", () => ({ CLI_VERSION: "9.9.9" }));
-vi.mock("./command-registry", () => ({
+vi.mock("../../version", () => ({ CLI_VERSION: "9.9.9" }));
+vi.mock("../command-registry", () => ({
   registerProgramCommands: (...a: unknown[]) =>
     mocks.registerProgramCommands(...a),
 }));
-vi.mock("./help", () => ({
+vi.mock("../help", () => ({
   configureProgramHelp: (...a: unknown[]) => mocks.configureProgramHelp(...a),
 }));
-vi.mock("./preaction", () => ({
+vi.mock("../preaction", () => ({
   registerPreActionHooks: (...a: unknown[]) =>
     mocks.registerPreActionHooks(...a),
 }));
 
 import { Command } from "commander";
-import { buildProgram } from "./build-program.ts";
+import { buildProgram } from "../build-program.ts";
 
 describe("buildProgram", () => {
   it("assembles the program with help, hooks, and commands", () => {

--- a/packages/app-core/src/utils/__tests__/globals.test.ts
+++ b/packages/app-core/src/utils/__tests__/globals.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   isVerbose,
   isYes,
@@ -6,7 +6,7 @@ import {
   setVerbose,
   setYes,
   shouldLogVerbose,
-} from "./globals.ts";
+} from "../globals.ts";
 
 describe("globals verbose/yes state", () => {
   beforeEach(() => {


### PR DESCRIPTION
Closes #25212.

## Outcome

Repairs five app-core tests that were moved under `__tests__/` without updating their implementation and mock module paths. The affected typecheck previously failed with TS2307 before these suites could execute; the corrected paths load the real parent modules and mock the same dependencies those modules import.

No production files or behavior changed.

## Evidence

Exact head: `9bd5b5b116e`
Base: `57f5abe8034`

- focused Vitest: 5 files / 17 tests passed
- focused Biome: clean after removing newly exposed unused imports
- `git diff --check`: passed
- full app-core typecheck is delegated to hosted affected-closure CI because this worktree intentionally uses the repository's sparse checkout and cannot resolve workspaces absent from disk; the original five TS2307 sites are all corrected

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->
