### PR TITLE
fix(core): deny unresolved private artifact fallback

### DIFF
--- a/packages/core/src/access-control/artifact-disclosure.test.ts
+++ b/packages/core/src/access-control/artifact-disclosure.test.ts
@@ -3,9 +3,10 @@
  * the OWNER/ADMIN-full / USER-grant-driven / fail-closed matrix and the
  * untrusted grant parser. Pure functions, no harness.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AccessContext, Memory, UUID } from "../types";
 import {
+	type ArtifactVariantReferences,
 	artifactDisclosureRecordFromMemory,
 	canAccessArtifact,
 	parseArtifactShareGrants,
@@ -55,13 +56,18 @@ describe("resolveArtifactDisclosure", () => {
 	});
 
 	it("OWNER and ADMIN rank → full regardless of scope or grants", () => {
-		for (const c of [
-			ctx({ role: "OWNER", isOwner: true }),
-			ctx({ role: "ADMIN" }),
-		]) {
-			expect(
-				resolveArtifactDisclosure({ scope: "owner-private" }, c, AGENT),
-			).toBe("full");
+		for (const scope of [
+			"owner-private",
+			"agent-private",
+			"user-private",
+			"private",
+		] as const) {
+			for (const c of [
+				ctx({ role: "OWNER", isOwner: true }),
+				ctx({ role: "ADMIN" }),
+			]) {
+				expect(resolveArtifactDisclosure({ scope }, c, AGENT)).toBe("full");
+			}
 		}
 	});
 
@@ -187,6 +193,28 @@ describe("resolveArtifactDisclosure", () => {
 			),
 		).toBe("none");
 	});
+
+	it.each(["owner-private", "agent-private", "user-private", "private"] as const)(
+		"GUEST and unresolved authority are denied %s artifacts, including self-scoped records",
+		(scope) => {
+			for (const accessContext of [ctx({ role: "GUEST" }), ctx()]) {
+				expect(
+					resolveArtifactDisclosure(
+						{ scope, scopedEntityId: VIEWER },
+						accessContext,
+						AGENT,
+					),
+				).toBe("none");
+			}
+		},
+	);
+
+	it.each(["global", "shared", "room"] as const)(
+		"unresolved authority preserves explicitly open %s disclosure",
+		(scope) => {
+			expect(resolveArtifactDisclosure({ scope }, ctx(), AGENT)).toBe("full");
+		},
+	);
 });
 
 describe("canAccessArtifact", () => {
@@ -252,6 +280,22 @@ describe("selectArtifactVariant", () => {
 				redacted: "/api/media/redacted.txt",
 			}),
 		).toBeNull();
+	});
+
+	it("does not read full or redacted references after a denied decision", () => {
+		const readFullFromProvider = vi.fn(() => "/api/media/full.wav");
+		const readRedactedFromStorage = vi.fn(
+			() => "/api/media/redacted.txt",
+		);
+		const references = {} as ArtifactVariantReferences<string>;
+		Object.defineProperties(references, {
+			full: { enumerable: true, get: readFullFromProvider },
+			redacted: { enumerable: true, get: readRedactedFromStorage },
+		});
+
+		expect(selectArtifactVariant("none", references)).toBeNull();
+		expect(readFullFromProvider).not.toHaveBeenCalled();
+		expect(readRedactedFromStorage).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -232,12 +232,19 @@ export function resolveArtifactDisclosure(
 	const grants = record.grants ?? record.share?.grants;
 	const grant = grants?.find((g) => g.entityId === ctx.requesterEntityId);
 	if (grant) return grant.mode === "full" ? "full" : "redacted";
-	// Tier 4: an UNRESOLVED authority degrades to the least-privileged USER
-	// tier for the ladder step (open scopes stay readable; entity-private
-	// scopes deny), which is exactly how the attested-audience resolver's
-	// bare participants and the attachment fallback context are documented to
-	// behave. A raw UNRESOLVED actor passed straight to `canReadScope` still
-	// denies everywhere — the remap is local to this tier.
+	// Tier 4: absent role authority may preserve open room/global disclosure,
+	// but it must never inherit USER's entity-self exception for private data.
+	// Mapping UNRESOLVED to USER without this private-scope fence lets a bare
+	// requester context read its own `user-private` artifact despite having no
+	// resolved authorization state.
+	if (
+		actor.role === "UNRESOLVED" &&
+		record.scope !== "global" &&
+		record.scope !== "shared" &&
+		record.scope !== "room"
+	) {
+		return "none";
+	}
 	const ladderActor =
 		actor.role === "UNRESOLVED" ? { ...actor, role: "USER" as const } : actor;
 	return canReadScope(record.scope, record.scopedEntityId, ladderActor)


### PR DESCRIPTION
Closes #25124.

## Outcome

Fails closed before the deterministic USER/self fallback whenever the actor is `UNRESOLVED` and the artifact is private. `GUEST` remains denied without an explicit grant; explicit grants still work; legitimate OWNER/ADMIN access remains unchanged; explicitly open global/shared/room disclosure remains readable pending the canonical membership-entitlement cutover.

The denied variant-selection test uses getter spies as the downstream provider/storage boundary and proves neither full nor redacted references are accessed after a `none` decision.

This is the narrow canonical disclosure repair, not the future AuthorizationService or MembershipService.

## Evidence

Exact head: `1cf7c2b793b1b37d74eb1b7afb52a88b2cfd9175`
Base: `b4889cecddf3fb1ee4a28d255e9f1615ff2c0586`

- focused authorization matrix: 8 files / 124 tests passed
- core typecheck: passed
- touched-file Biome: passed
- package Biome: no new findings (existing unrelated warnings remain)
- `git diff --check`: passed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->
