### PR TITLE
fix(cloud): enforce CloudBootstrap deadline even when RUN_TIMEOUT stalls

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/deadline-enforcement.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/deadline-enforcement.test.ts
@@ -1,0 +1,87 @@
+// Regression coverage for the CloudBootstrapMessageService deadline (#25109):
+// the configured timeout must settle handleMessage even when the RUN_TIMEOUT
+// lifecycle emission never settles or rejects. The service runs real; only the
+// runtime surface is stubbed and the DEFLLMOFF branch keeps the turn LLM-free.
+import { describe, expect, it } from "bun:test";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { EventType } from "@elizaos/core";
+import { CloudBootstrapMessageService } from "./service";
+
+function message(): Memory {
+  return {
+    id: "00000000-0000-4000-8000-00000000a001",
+    entityId: "00000000-0000-4000-8000-00000000a002",
+    roomId: "00000000-0000-4000-8000-00000000a003",
+    agentId: "00000000-0000-4000-8000-00000000a004",
+    content: { text: "hello" },
+  } as unknown as Memory;
+}
+
+type EmitLog = Array<{ event: string; settle: "pending" | "reject" | "resolve" }>;
+
+function stubRuntime(emitLog: EmitLog, mode: "pending" | "reject"): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-00000000a004",
+    character: { name: "Agent" },
+    getSetting: () => null,
+    getMemoryById: async () => null,
+    createMemory: async () => "00000000-0000-4000-8000-00000000a010",
+    queueEmbeddingGeneration: async () => undefined,
+    getParticipantUserState: async () => null,
+    // A DM room keeps shouldRespond on the synchronous fast path; the turn
+    // then stalls inside composeState, exactly the in-flight shape #25109
+    // describes when the deadline must fire.
+    getRoom: async () => ({
+      id: "00000000-0000-4000-8000-00000000a003",
+      type: "DM",
+      source: "client_chat",
+    }),
+    composeState: async () =>
+      new Promise(() => {
+        // The stalled processing continuation — never settles.
+      }),
+    startRun: () => "00000000-0000-4000-8000-00000000a0f0",
+    emitEvent: async (event: string) => {
+      emitLog.push({ event, settle: mode });
+      if (event === EventType.RUN_TIMEOUT) {
+        if (mode === "reject") {
+          throw new Error("emission listener exploded");
+        }
+        // Pending forever: exactly the stalled-listener shape from #25109.
+        return new Promise<void>(() => {});
+      }
+      // All other lifecycle emissions behave like a healthy runtime.
+    },
+    reportError: () => {},
+  } as unknown as IAgentRuntime;
+}
+
+async function expectTimeoutSettles(mode: "pending" | "reject"): Promise<EmitLog> {
+  const emitLog: EmitLog = [];
+  const service = new CloudBootstrapMessageService();
+  const runtime = stubRuntime(emitLog, mode);
+
+  let settled: "timeout" | "other" | "none" = "none";
+  const run = service.handleMessage(runtime, message(), undefined, { timeoutDuration: 30 }).then(
+    (result) => ((settled = "other"), result),
+    (error) => ((settled = "timeout"), error),
+  );
+  await run;
+  expect(settled).toBe("timeout");
+  return emitLog;
+}
+
+describe("CloudBootstrapMessageService deadline enforcement", () => {
+  it("enforces the deadline when RUN_TIMEOUT emission stays pending", async () => {
+    const emitLog = await expectTimeoutSettles("pending");
+    expect(emitLog.some(({ event }) => event === EventType.RUN_TIMEOUT)).toBe(true);
+    // The DEFLLMOFF branch must have been the turn terminator; otherwise
+    // this test would not be exercising a LLM-free path.
+    expect(emitLog.some(({ event }) => event === EventType.RUN_ENDED)).toBe(true);
+  }, 10_000);
+
+  it("enforces the deadline when RUN_TIMEOUT emission rejects", async () => {
+    const emitLog = await expectTimeoutSettles("reject");
+    expect(emitLog.some(({ event }) => event === EventType.RUN_TIMEOUT)).toBe(true);
+  }, 10_000);
+});

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
@@ -163,8 +163,13 @@ export class CloudBootstrapMessageService implements IMessageService {
 
       // Set up timeout
       const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(async () => {
-          await runtime.emitEvent(EventType.RUN_TIMEOUT, {
+        timeoutId = setTimeout(() => {
+          // The configured deadline must be enforced regardless of whether the
+          // diagnostic RUN_TIMEOUT emission settles (#25109): awaiting it here
+          // let a stalled or rejecting listener keep the entire run pending
+          // forever. Reject first, then emit the lifecycle event in the
+          // background with failures reported and never blocking the deadline.
+          const timeoutEmission = runtime.emitEvent(EventType.RUN_TIMEOUT, {
             runtime,
             runId,
             messageId: message.id!,
@@ -176,7 +181,23 @@ export class CloudBootstrapMessageService implements IMessageService {
             duration: Date.now() - startTime,
             error: "Run exceeded timeout",
             source: "CloudBootstrapMessageService",
-          } as never);
+          } as never) as unknown;
+          if (typeof (timeoutEmission as { then?: unknown })?.then === "function") {
+            (timeoutEmission as Promise<void>).catch((error: unknown) => {
+              logger.warn(
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                },
+                "[CloudBootstrap] RUN_TIMEOUT emission failed after deadline enforcement",
+              );
+              try {
+                runtime.reportError("CloudBootstrapMessageService.runTimeoutEmission", error);
+              } catch {
+                // error-policy:J7 reporting is best-effort diagnostics; the
+                // deadline was already enforced above.
+              }
+            });
+          }
           reject(new Error("Run exceeded timeout"));
         }, timeoutDuration);
       });


### PR DESCRIPTION
## Summary

Fixes #25109.

`CloudBootstrapMessageService.handleMessage` awaited the `RUN_TIMEOUT` lifecycle emission inside the timeout callback **before** rejecting the timeout promise:

```ts
timeoutId = setTimeout(async () => {
  await runtime.emitEvent(EventType.RUN_TIMEOUT, { ... }); // stalls here
  reject(new Error("Run exceeded timeout"));               // unreachable
}, timeoutDuration);
```

When that emission never settled (a stalled event listener) or rejected, the reject was unreachable: the configured deadline passed silently, `handleMessage` stayed pending, and the run leaked its timeout slot indefinitely.

### What changed

- The timeout callback now rejects the deadline promise **first**, then emits `RUN_TIMEOUT` as a background diagnostic.
- Emission failures are logged (`logger.warn`) and reported through `runtime.reportError`, but can never block or undo deadline enforcement.
- Non-promise emission return values are handled safely.

### Verification

<!-- evidence-head:48674415158d9cdb621a17e83702d5339165bd4f -->

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is run-deadline enforcement.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; the changed surface is run-deadline enforcement.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow change beyond correct timeout behavior; verified by deterministic tests.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation run at `48674415158d9cdb621a17e83702d5339165bd4f`:

```
## bun test: deadline-enforcement.test.ts
  2 pass
  0 fail
  5 expect() calls
Ran 2 tests across 1 file. [1049.00ms]

## typecheck: packages/cloud/shared
PASS (exit 0)

## Biome changed files
Checked 2 files in 45ms. No fixes applied.

## git diff --check
OK
```

The new regression tests reproduce both failure shapes from the issue: a runtime whose `RUN_TIMEOUT` emission stays pending forever, and one whose emission throws. In both cases the deadline still settles `handleMessage` with "Run exceeded timeout".
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic lifecycle enforcement; no LLM execution involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; unit coverage proves the behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or scanned artifacts in this change.

## Attribution

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2

<!-- attribution-row:models -->
z.ai/glm-5.2

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
self-reported
