### PR TITLE
fix(cloud): type the malformed-utf8 refund test json bodies

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -539,7 +539,7 @@ test("malformed UTF-8 request body returns 400, refunds exact receipt, and skips
     body: malformed as unknown as string,
   });
   expect(res.status).toBe(400);
-  expect(await res.json()).toEqual({
+  expect((await res.json()) as { error: string }).toEqual({
     error: "MCP request body is not valid UTF-8",
   });
   expect(refundCredits).toHaveBeenCalledWith(
@@ -572,7 +572,7 @@ test("malformed UTF-8 upstream response returns 502, refunds exact receipt, and 
   );
   const res = await post();
   expect(res.status).toBe(502);
-  expect(await res.json()).toEqual({
+  expect((await res.json()) as { error: string }).toEqual({
     error: "MCP response is not valid UTF-8",
   });
   expect(refundCredits).toHaveBeenCalledWith(


### PR DESCRIPTION
@lalalune — typecheck unblock on #24959's two new tests (dead-PR-CI leak class, same as #24412/#24762).

Run 32621821849 `Deploy API Worker`:
```
__tests__/mcp-proxy-refund.test.ts(542,36): error TS2769: No overload matches this call.
__tests__/mcp-proxy-refund.test.ts(575,36): error TS2769: No overload matches this call.
```

`expect(await res.json()).toEqual({...})` — the response's `json()` infers `undefined` under bun-types' `toEqual<X = T>(NoInfer<X>)`, so the object literal is rejected. Cast to the expected shape, matching the file-local and package-wide house pattern (`(await res.json()) as {...}`).

Receipts (PR CI dead): package typecheck exit 0; `bun test mcp-proxy-refund.test.ts` 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)