### PR TITLE
fix(orchestrator): safe NaN handling in admission queue effective band and sort comparator

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts
@@ -153,5 +153,28 @@ describe("admission-queue ordering (#13772)", () => {
         "t5", // low
       ]);
     });
+
+    it("maintains strict total ordering when enqueuedAt contains invalid date strings", () => {
+      const now = 1_000_000;
+      const ordered = orderQueue(
+        [
+          {
+            taskId: "task-valid",
+            priorityAtEnqueue: "normal",
+            enqueuedAt: new Date(now - 1_000).toISOString(),
+          },
+          {
+            taskId: "task-invalid",
+            priorityAtEnqueue: "normal",
+            enqueuedAt: "invalid-date-string",
+          },
+        ],
+        now,
+        AGING_MS,
+      );
+      expect(ordered).toHaveLength(2);
+      expect(ordered[0]?.taskId).toBe("task-invalid"); // fallback 0 time is earliest
+      expect(ordered[1]?.taskId).toBe("task-valid");
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/admission-queue.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/admission-queue.ts
@@ -65,7 +65,10 @@ export function effectiveBand(
 ): number {
   const base = priorityBand(entry.priorityAtEnqueue);
   if (agingMs <= 0) return base;
-  const waitMs = Math.max(0, now - Date.parse(entry.enqueuedAt));
+  const enqueuedMs = Date.parse(entry.enqueuedAt);
+  const waitMs = Number.isFinite(enqueuedMs)
+    ? Math.max(0, now - enqueuedMs)
+    : 0;
   return base + Math.floor(waitMs / agingMs);
 }
 
@@ -88,10 +91,21 @@ export function orderQueue(
   agingMs: number,
 ): QueueEntry[] {
   return [...entries].sort((a, b) => {
-    const bandDelta =
-      effectiveBand(b, now, agingMs) - effectiveBand(a, now, agingMs);
+    const aBand = Number.isFinite(effectiveBand(a, now, agingMs))
+      ? effectiveBand(a, now, agingMs)
+      : 0;
+    const bBand = Number.isFinite(effectiveBand(b, now, agingMs))
+      ? effectiveBand(b, now, agingMs)
+      : 0;
+    const bandDelta = bBand - aBand;
     if (bandDelta !== 0) return bandDelta;
-    const timeDelta = Date.parse(a.enqueuedAt) - Date.parse(b.enqueuedAt);
+    const aTime = Number.isFinite(Date.parse(a.enqueuedAt))
+      ? Date.parse(a.enqueuedAt)
+      : 0;
+    const bTime = Number.isFinite(Date.parse(b.enqueuedAt))
+      ? Date.parse(b.enqueuedAt)
+      : 0;
+    const timeDelta = aTime - bTime;
     if (timeDelta !== 0) return timeDelta;
     return a.taskId.localeCompare(b.taskId);
   });


### PR DESCRIPTION
## Summary

Validates `enqueuedAt` date parsing with `Number.isFinite(...)` in `effectiveBand` and `orderQueue` (`plugins/plugin-agent-orchestrator/src/services/admission-queue.ts:68, 90`) to prevent `NaN` return values in aging calculations and sort comparators when queue entries contain invalid or unparseable date strings.

## Changes

- In `plugins/plugin-agent-orchestrator/src/services/admission-queue.ts:61-70`, guard wait time calculation with `Number.isFinite(enqueuedMs)` to prevent `NaN` effective band promotions.
- In `plugins/plugin-agent-orchestrator/src/services/admission-queue.ts:90-98`, guard `effectiveBand` and `Date.parse(enqueuedAt)` comparisons with `Number.isFinite(...)` to preserve strict total ordering.
- In `plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts`, add dedicated unit tests verifying that invalid date strings maintain strict total ordering.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`4f93861c04`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts` | 9 pass (9 tests) | 10 pass (10 tests) |
| `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/admission-queue.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-agent-orchestrator/src/services/admission-queue.ts:60-100`
- `plugins/plugin-agent-orchestrator/src/__tests__/admission-queue.test.ts:150-180`

## Risks

Low. Fallback to 0 for unparseable dates ensures deterministic fallback ordering by `taskId`.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Agent orchestrator admission queue; no UI layout touched)
- [x] `audit:browser` — N/A (Admission queue orderer)
- [x] `build` — Clean build across workspace
- [x] `test` — 10/10 pass in `admission-queue.test.ts`
- [x] `lint` — Biome clean
