### PR TITLE
fix(whatsapp): preserve personal quoted context

### DIFF
--- a/plugins/plugin-whatsapp/__tests__/inbound-claim-pglite.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/inbound-claim-pglite.test.ts
@@ -35,17 +35,31 @@ afterAll(async () => {
 });
 
 describe("WhatsApp inbound claims on PGLite", () => {
+	it("allows the same provider message id to be claimed independently in two chats", async () => {
+		const externalMessageId = `wamid.cross-chat.${crypto.randomUUID()}`;
+		const firstId = createInboundClaimId(runtime, "default", "chat-a", externalMessageId);
+		const secondId = createInboundClaimId(runtime, "default", "chat-b", externalMessageId);
+
+		expect(firstId).not.toBe(secondId);
+		const [first, second] = await Promise.all([
+			tryClaim(runtime, firstId, "default", "chat-a", externalMessageId),
+			tryClaim(runtime, secondId, "default", "chat-b", externalMessageId),
+		]);
+		expect(first).toMatchObject({ won: true, state: { chatId: "chat-a" } });
+		expect(second).toMatchObject({ won: true, state: { chatId: "chat-b" } });
+	});
+
 	it("elects one winner and preserves a distinct inbound message row", async () => {
 		const externalMessageId = `wamid.race.${crypto.randomUUID()}`;
-		const claimId = createInboundClaimId(runtime, "default", externalMessageId);
+		const claimId = createInboundClaimId(runtime, "default", "chat", externalMessageId);
 		const inboundMessageId = createUniqueUuid(
 			runtime,
 			`whatsapp:chat:${externalMessageId}`,
 		) as UUID;
 
 		const contenders = await Promise.all([
-			tryClaim(runtime, claimId, "default", externalMessageId),
-			tryClaim(runtime, claimId, "default", externalMessageId),
+			tryClaim(runtime, claimId, "default", "chat", externalMessageId),
+			tryClaim(runtime, claimId, "default", "chat", externalMessageId),
 		]);
 		expect(contenders.filter((result) => result.won)).toHaveLength(1);
 
@@ -89,8 +103,8 @@ describe("WhatsApp inbound claims on PGLite", () => {
 
 	it("atomically fences a stale owner and rejects its terminal write", async () => {
 		const externalMessageId = `wamid.stale.${crypto.randomUUID()}`;
-		const claimId = createInboundClaimId(runtime, "default", externalMessageId);
-		const initial = await tryClaim(runtime, claimId, "default", externalMessageId);
+		const claimId = createInboundClaimId(runtime, "default", "chat", externalMessageId);
+		const initial = await tryClaim(runtime, claimId, "default", "chat", externalMessageId);
 		expect(initial.won).toBe(true);
 		if (!initial.state) throw new Error("Initial PGLite claim has no state");
 
@@ -109,8 +123,8 @@ describe("WhatsApp inbound claims on PGLite", () => {
 		});
 
 		const successors = await Promise.all([
-			tryClaim(runtime, claimId, "default", externalMessageId),
-			tryClaim(runtime, claimId, "default", externalMessageId),
+			tryClaim(runtime, claimId, "default", "chat", externalMessageId),
+			tryClaim(runtime, claimId, "default", "chat", externalMessageId),
 		]);
 		expect(successors.filter((result) => result.won)).toHaveLength(1);
 		const successor = successors.find((result) => result.won)?.state;

--- a/plugins/plugin-whatsapp/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/outbound-media.test.ts
@@ -7,7 +7,11 @@
  */
 import type { IAgentRuntime, Media, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { WhatsAppConnectorService } from "../src/runtime-service";
+import { BaileysClient } from "../src/clients/baileys-client";
+import {
+  toInboundWhatsAppMemoryId,
+  WhatsAppConnectorService,
+} from "../src/runtime-service";
 
 type RuntimeSendHandler = Parameters<IAgentRuntime["registerSendHandler"]>[1];
 type ConnectorTargetInfo = Parameters<RuntimeSendHandler>[1];
@@ -87,6 +91,8 @@ describe("WhatsApp connector outbound media — send handler", () => {
       "default",
       "+14155552671",
       expect.objectContaining({ url: "https://cdn.example.com/cat.png" }),
+      undefined,
+      undefined,
     );
   });
 
@@ -110,6 +116,37 @@ describe("WhatsApp connector outbound media — send handler", () => {
     expect(service.sendMessage).not.toHaveBeenCalled();
     expect(service.sendMediaMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("stops at the first failed attachment instead of fabricating partial success", async () => {
+    const registrations: MessageConnectorRegistration[] = [];
+    const runtime = makeRuntime(registrations);
+    const service = mockService();
+    vi.mocked(service.sendMediaMessage).mockRejectedValueOnce(new Error("provider rejected"));
+    WhatsAppConnectorService.registerSendHandlers(runtime, service);
+
+    await expect(
+      registrations[0].sendHandler?.(
+        runtime,
+        TARGET,
+        {
+          text: "",
+          attachments: [
+            { id: "first", url: "https://cdn.example.com/first.png" },
+            { id: "later", url: "https://cdn.example.com/later.png" },
+          ],
+        } as ConnectorContent,
+      ),
+    ).rejects.toThrow("provider rejected");
+
+    expect(service.sendMediaMessage).toHaveBeenCalledTimes(1);
+    expect(service.sendMediaMessage).toHaveBeenCalledWith(
+      "default",
+      "+14155552671",
+      expect.objectContaining({ id: "first" }),
+      undefined,
+      undefined,
+    );
+  });
 });
 
 describe("WhatsApp sendMediaMessage — transport-agnostic media call", () => {
@@ -119,14 +156,25 @@ describe("WhatsApp sendMediaMessage — transport-agnostic media call", () => {
       WhatsAppConnectorService.prototype,
     ) as WhatsAppConnectorService & {
       getClientForAccount: ReturnType<typeof vi.fn>;
+      getConfigForAccount: ReturnType<typeof vi.fn>;
       sendMediaMessage: (
         accountId: string | null | undefined,
         to: string,
         media: Media,
+        replyToMessageId?: string,
+        quote?: {
+          participant?: string;
+          fromMe: boolean;
+          type: "text" | "image" | "audio" | "video" | "document";
+          text: string;
+        },
       ) => Promise<void>;
     };
     (svc as { getClientForAccount: unknown }).getClientForAccount = vi.fn(() => ({
       sendMessage: clientSend,
+    }));
+    (svc as { getConfigForAccount: unknown }).getConfigForAccount = vi.fn(() => ({
+      transport: "cloudapi",
     }));
     return { svc, clientSend };
   }
@@ -164,5 +212,166 @@ describe("WhatsApp sendMediaMessage — transport-agnostic media call", () => {
         filename: "report.pdf",
       },
     });
+  });
+
+  it("does not project personal quote reconstruction fields into Cloud media sends", async () => {
+    const { svc, clientSend } = realServiceWithClient();
+    await svc.sendMediaMessage(
+      "default",
+      "+14155552671",
+      {
+        id: "img",
+        url: "https://cdn.example.com/cat.png",
+        contentType: "image",
+      } as Media,
+      "wamid.parent",
+      {
+        participant: "14155552671@s.whatsapp.net",
+        fromMe: false,
+        type: "image",
+        text: "caption",
+      },
+    );
+
+    expect(clientSend).toHaveBeenCalledWith({
+      type: "image",
+      to: "+14155552671",
+      content: { link: "https://cdn.example.com/cat.png" },
+    });
+  });
+});
+
+describe("WhatsApp personal quoted delivery", () => {
+  it("uses the same account-and-chat scope for default and named inbound reply identities", () => {
+    const runtime = { agentId: "00000000-0000-0000-0000-000000000010" } as IAgentRuntime;
+
+    const defaultParent = toInboundWhatsAppMemoryId(
+      runtime,
+      "default",
+      "120363000000@g.us",
+      "wamid.parent",
+    );
+    expect(
+      toInboundWhatsAppMemoryId(
+        runtime,
+        "DEFAULT",
+        "120363000000@g.us",
+        "wamid.parent",
+      ),
+    ).toBe(defaultParent);
+    expect(
+      toInboundWhatsAppMemoryId(runtime, "work", "120363000000@g.us", "wamid.parent"),
+    ).not.toBe(defaultParent);
+  });
+
+  it.each(["default", "work"])(
+    "preserves %s-account group participant and image payload for text and media",
+    async (accountId) => {
+    const registrations: MessageConnectorRegistration[] = [];
+    const socketSend = vi.fn(async () => ({ key: { id: "wamid.sent" } }));
+    const client = new BaileysClient({ authDir: "/tmp/whatsapp-quote-test" });
+    (
+      client as unknown as { connection: { getSocket: () => unknown } }
+    ).connection.getSocket = () => ({ sendMessage: socketSend });
+    const runtime = makeRuntime(registrations);
+    vi.mocked(runtime.getMemoryById).mockResolvedValueOnce({
+      content: {
+        text: "photo caption",
+        attachments: [
+          { id: "parent", contentType: "image", url: "/api/media/parent.png" },
+        ],
+      },
+      metadata: {
+        messageIdFull: "wamid.group-parent",
+        rawSenderId: "14155552671@s.whatsapp.net",
+        fromBot: false,
+      },
+    } as never);
+    const service = Object.create(
+      WhatsAppConnectorService.prototype,
+    ) as WhatsAppConnectorService;
+    Object.assign(service as object, {
+      runtime,
+      connected: true,
+      defaultAccountId: accountId,
+      configs: new Map([
+        [accountId, { accountId, transport: "baileys", authDir: "/tmp/quote" }],
+      ]),
+      clients: new Map([[accountId, client]]),
+      knownTargets: new Map(),
+    });
+    WhatsAppConnectorService.registerSendHandlers(runtime, service);
+
+    await registrations[0].sendHandler?.(
+      runtime,
+      { source: "whatsapp", channelId: "120363000000@g.us" } as ConnectorTargetInfo,
+      {
+        text: "reply text",
+        inReplyTo: "00000000-0000-0000-0000-000000000001" as UUID,
+        attachments: [
+          {
+            id: "reply",
+            url: "https://cdn.example.com/reply.png",
+            contentType: "image",
+          },
+        ],
+      } as ConnectorContent,
+    );
+
+    expect(socketSend).toHaveBeenCalledTimes(2);
+    for (const call of socketSend.mock.calls) {
+      expect(call[0]).toBe("120363000000@g.us");
+      expect(call[2]).toEqual({
+        quoted: {
+          key: {
+            remoteJid: "120363000000@g.us",
+            id: "wamid.group-parent",
+            fromMe: false,
+            participant: "14155552671@s.whatsapp.net",
+          },
+          message: { imageMessage: { caption: "photo caption" } },
+        },
+      });
+    }
+    },
+  );
+
+  it.each([
+    [null, "WHATSAPP_REPLY_PARENT_NOT_FOUND"],
+    [{ content: { text: "parent" }, metadata: {} }, "WHATSAPP_REPLY_PROVIDER_ID_MISSING"],
+  ])("fails closed before socket I/O for an invalid reply parent", async (parent, code) => {
+    const registrations: MessageConnectorRegistration[] = [];
+    const socketSend = vi.fn(async () => ({ key: { id: "must-not-send" } }));
+    const client = new BaileysClient({ authDir: "/tmp/whatsapp-invalid-reply-test" });
+    (client as unknown as { connection: { getSocket: () => unknown } }).connection.getSocket =
+      () => ({ sendMessage: socketSend });
+    const runtime = makeRuntime(registrations);
+    vi.mocked(runtime.getMemoryById).mockResolvedValueOnce(parent as never);
+    const service = Object.create(
+      WhatsAppConnectorService.prototype,
+    ) as WhatsAppConnectorService;
+    Object.assign(service as object, {
+      runtime,
+      connected: true,
+      defaultAccountId: "default",
+      configs: new Map([
+        ["default", { accountId: "default", transport: "baileys", authDir: "/tmp/quote" }],
+      ]),
+      clients: new Map([["default", client]]),
+      knownTargets: new Map(),
+    });
+    WhatsAppConnectorService.registerSendHandlers(runtime, service);
+
+    await expect(
+      registrations[0].sendHandler?.(
+        runtime,
+        { source: "whatsapp", channelId: "120363000000@g.us" } as ConnectorTargetInfo,
+        {
+          text: "must not send",
+          inReplyTo: "00000000-0000-0000-0000-000000000001" as UUID,
+        } as ConnectorContent,
+      ),
+    ).rejects.toMatchObject({ code });
+    expect(socketSend).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
@@ -465,8 +465,14 @@ describe("WhatsApp inbound delivery idempotency — durable staged claims", () =
 	it("reclaims a stale processing claim after the staleness threshold", async () => {
 		const store = new SharedMemoryStore();
 		const runtime = makeRuntimeWithStore(store);
-		const claimId = createInboundClaimId(runtime, "default", "wamid.stale");
-		const initial = await tryClaim(runtime, claimId, "default", "wamid.stale");
+		const claimId = createInboundClaimId(runtime, "default", "+14155552671", "wamid.stale");
+		const initial = await tryClaim(
+			runtime,
+			claimId,
+			"default",
+			"+14155552671",
+			"wamid.stale",
+		);
 		if (!initial.state) throw new Error("Initial deterministic claim has no state");
 
 		// Simulate a crashed host by aging the actual claim document while

--- a/plugins/plugin-whatsapp/src/clients/baileys-client.test.ts
+++ b/plugins/plugin-whatsapp/src/clients/baileys-client.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Exercises the personal WhatsApp client's real Baileys send boundary with a
+ * deterministic socket seam, including exact native quote reconstruction and
+ * rejection of success-shaped sends that lack an authoritative provider id.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { BaileysClient } from "./baileys-client";
+
+function clientWithSocket(sendMessage: ReturnType<typeof vi.fn>): BaileysClient {
+  const client = new BaileysClient({ authDir: "/tmp/whatsapp-client-quote-test" });
+  (client as unknown as { connection: { getSocket: () => unknown } }).connection.getSocket =
+    () => ({ sendMessage });
+  return client;
+}
+
+describe("BaileysClient quoted delivery", () => {
+  it("sends exact group participant, direction, and document payload context", async () => {
+    const sendMessage = vi.fn(async () => ({ key: { id: "wamid.sent" } }));
+    const client = clientWithSocket(sendMessage);
+
+    await expect(
+      client.sendMessage({
+        type: "text",
+        to: "120363000000@g.us",
+        content: "reply",
+        replyToMessageId: "wamid.document",
+        replyToParticipant: "+1 (415) 555-2671",
+        replyToFromMe: true,
+        replyToType: "document",
+        replyToText: "quarterly report",
+      })
+    ).resolves.toMatchObject({ messages: [{ id: "wamid.sent" }] });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "120363000000@g.us",
+      { text: "reply" },
+      {
+        quoted: {
+          key: {
+            remoteJid: "120363000000@g.us",
+            id: "wamid.document",
+            fromMe: true,
+            participant: "14155552671@s.whatsapp.net",
+          },
+          message: { documentMessage: { caption: "quarterly report" } },
+        },
+      }
+    );
+  });
+
+  it("rejects a send without an authoritative WhatsApp message id", async () => {
+    const client = clientWithSocket(vi.fn(async () => ({ key: {} })));
+
+    await expect(
+      client.sendMessage({ type: "text", to: "+14155552671", content: "hello" })
+    ).rejects.toMatchObject({
+      code: "WHATSAPP_PROVIDER_MESSAGE_ID_MISSING",
+      context: {
+        to: "14155552671@s.whatsapp.net",
+        messageType: "text",
+      },
+    });
+  });
+});

--- a/plugins/plugin-whatsapp/src/clients/baileys-client.ts
+++ b/plugins/plugin-whatsapp/src/clients/baileys-client.ts
@@ -6,10 +6,12 @@
  * WhatsAppClient; selected by ClientFactory based on detected auth method.
  */
 import { EventEmitter } from "node:events";
+import { ElizaError } from "@elizaos/core";
 import { BaileysAuthManager } from "../baileys/auth";
 import { BaileysConnection } from "../baileys/connection";
 import { MessageAdapter } from "../baileys/message-adapter";
 import { QRCodeGenerator } from "../baileys/qr-code";
+import { normalizeBaileysSendTarget } from "../normalize";
 import type {
   BaileysConfig,
   ConnectionStatus,
@@ -90,16 +92,59 @@ export class BaileysClient extends EventEmitter implements IWhatsAppClient {
       throw new Error("Not connected to WhatsApp via Baileys");
     }
 
-    const payload = this.adapter.toBaileys(message);
+    const to = normalizeBaileysSendTarget(message.to);
+    const normalizedMessage = { ...message, to };
+    const payload = this.adapter.toBaileys(normalizedMessage);
+    const quotedMessage = (() => {
+      switch (normalizedMessage.replyToType) {
+        case "image":
+          return { imageMessage: { caption: normalizedMessage.replyToText ?? "" } };
+        case "video":
+          return { videoMessage: { caption: normalizedMessage.replyToText ?? "" } };
+        case "audio":
+          return { audioMessage: {} };
+        case "document":
+          return { documentMessage: { caption: normalizedMessage.replyToText ?? "" } };
+        default:
+          return { conversation: normalizedMessage.replyToText || " " };
+      }
+    })();
     const result = await socket.sendMessage(
-      message.to,
-      payload as Parameters<typeof socket.sendMessage>[1]
+      to,
+      payload as Parameters<typeof socket.sendMessage>[1],
+      normalizedMessage.replyToMessageId
+        ? {
+            quoted: {
+              key: {
+                remoteJid: to,
+                id: normalizedMessage.replyToMessageId,
+                fromMe: normalizedMessage.replyToFromMe ?? false,
+                ...(to.endsWith("@g.us") && normalizedMessage.replyToParticipant
+                  ? {
+                      participant: normalizeBaileysSendTarget(normalizedMessage.replyToParticipant),
+                    }
+                  : {}),
+              },
+              message: quotedMessage,
+            },
+          }
+        : undefined
     );
-    const id = result?.key?.id ?? "";
+    const id = result?.key?.id;
+    if (!id) {
+      throw new ElizaError("Baileys send completed without a WhatsApp message id", {
+        code: "WHATSAPP_PROVIDER_MESSAGE_ID_MISSING",
+        context: {
+          to,
+          messageType: normalizedMessage.type,
+          replyToMessageId: normalizedMessage.replyToMessageId,
+        },
+      });
+    }
 
     return {
       messaging_product: "whatsapp",
-      contacts: [{ input: message.to, wa_id: message.to }],
+      contacts: [{ input: to, wa_id: to }],
       messages: [{ id }],
     };
   }

--- a/plugins/plugin-whatsapp/src/inbound-claim.ts
+++ b/plugins/plugin-whatsapp/src/inbound-claim.ts
@@ -29,6 +29,7 @@ export interface InboundClaimState {
   /** Document CAS revision owned by this generation. */
   revision: number;
   accountId: string;
+  chatId: string;
   externalMessageId: string;
   claimedAt: number;
   updatedAt: number;
@@ -91,11 +92,12 @@ async function ensureClaimNamespace(runtime: IAgentRuntime): Promise<void> {
 export function createInboundClaimId(
   runtime: IAgentRuntime,
   accountId: string,
+  chatId: string,
   externalMessageId: string
 ): UUID {
   return createUniqueUuid(
     runtime,
-    `whatsapp:inbound-claim:${accountId}:${externalMessageId}`
+    `whatsapp:inbound-claim:${accountId}:${chatId}:${externalMessageId}`
   ) as UUID;
 }
 
@@ -109,6 +111,7 @@ function parseClaim(memory: Memory | null): InboundClaimState | null {
     typeof state.generation !== "string" ||
     !Number.isSafeInteger(state.revision) ||
     typeof state.accountId !== "string" ||
+    typeof state.chatId !== "string" ||
     typeof state.externalMessageId !== "string" ||
     typeof state.claimedAt !== "number" ||
     typeof state.updatedAt !== "number"
@@ -191,6 +194,7 @@ export interface ClaimResult {
 
 function freshProcessingState(
   accountId: string,
+  chatId: string,
   externalMessageId: string,
   revision: number,
   now: number
@@ -200,6 +204,7 @@ function freshProcessingState(
     generation: randomUUID() as UUID,
     revision,
     accountId,
+    chatId,
     externalMessageId,
     claimedAt: now,
     updatedAt: now,
@@ -210,6 +215,7 @@ export async function tryClaim(
   runtime: IAgentRuntime,
   claimId: UUID,
   accountId: string,
+  chatId: string,
   externalMessageId: string
 ): Promise<ClaimResult> {
   assertClaimStorage(runtime);
@@ -218,7 +224,7 @@ export async function tryClaim(
   let document = await readClaimDocument(runtime, claimId);
 
   if (!document) {
-    const proposed = freshProcessingState(accountId, externalMessageId, 0, now);
+    const proposed = freshProcessingState(accountId, chatId, externalMessageId, 0, now);
     await runtime.createMemory(
       buildClaimMemory(claimId, proposed, runtime),
       WHATSAPP_INBOUND_CLAIM_TABLE,
@@ -229,7 +235,7 @@ export async function tryClaim(
     if (!persisted) {
       throw new ElizaError("WhatsApp claim insert produced no readable claim", {
         code: "WHATSAPP_INBOUND_CLAIM_INVALID",
-        context: { accountId, externalMessageId, claimId },
+        context: { accountId, chatId, externalMessageId, claimId },
       });
     }
     return {
@@ -242,7 +248,7 @@ export async function tryClaim(
   if (!existing) {
     throw new ElizaError("WhatsApp claim row has invalid metadata", {
       code: "WHATSAPP_INBOUND_CLAIM_INVALID",
-      context: { accountId, externalMessageId, claimId },
+      context: { accountId, chatId, externalMessageId, claimId },
     });
   }
   if (existing.stage === "processed") return { won: false, state: existing };
@@ -252,6 +258,7 @@ export async function tryClaim(
 
   const replacement = freshProcessingState(
     accountId,
+    chatId,
     externalMessageId,
     existing.revision + 1,
     now

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -6,7 +6,7 @@
  * send/read/search messages, reactions, contact resolution, chat/user context).
  *
  * Inbound: webhook events and Baileys socket messages are normalized, deduped
- * into stable memory ids (createUniqueUuid keyed on chat + message id), and
+ * into stable memory ids (createUniqueUuid keyed on account + chat + message), and
  * routed through `runtime.messageService`. Replies are only generated when
  * auto-reply is enabled or the message connector protocol invokes the send
  * handler; otherwise inbound messages are stored to memory only.
@@ -260,6 +260,57 @@ function toTimestampMs(value: number | string | undefined): number {
 
 function toMemoryId(runtime: IAgentRuntime, chatId: string, messageId: string): UUID {
   return createUniqueUuid(runtime, `whatsapp:${chatId}:${messageId}`) as UUID;
+}
+
+function inboundMessageScope(accountId: string, chatId: string): string {
+  return `${normalizeWhatsAppAccountId(accountId)}:${chatId}`;
+}
+
+/** Build the account-and-chat-scoped identity shared by inbound rows and reply links. */
+export function toInboundWhatsAppMemoryId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  chatId: string,
+  messageId: string
+): UUID {
+  return toMemoryId(runtime, inboundMessageScope(accountId, chatId), messageId);
+}
+
+type WhatsAppQuoteContext = {
+  participant?: string;
+  fromMe: boolean;
+  type: "text" | "image" | "audio" | "video" | "document";
+  text: string;
+};
+
+function quoteContextFromMemory(memory: Memory | null): WhatsAppQuoteContext | undefined {
+  if (!memory) return undefined;
+  const metadata = memory.metadata as Record<string, unknown> | undefined;
+  const participant =
+    typeof metadata?.rawSenderId === "string" && metadata.rawSenderId.trim()
+      ? metadata.rawSenderId.trim()
+      : undefined;
+  const attachment = Array.isArray(memory.content?.attachments)
+    ? memory.content.attachments[0]
+    : undefined;
+  const contentType = String(attachment?.contentType ?? "").toLowerCase();
+  const mimeType = String(attachment?.mimeType ?? "").toLowerCase();
+  const type =
+    contentType === "image" || mimeType.startsWith("image/")
+      ? "image"
+      : contentType === "video" || mimeType.startsWith("video/")
+        ? "video"
+        : contentType === "audio" || mimeType.startsWith("audio/")
+          ? "audio"
+          : attachment
+            ? "document"
+            : "text";
+  return {
+    ...(participant ? { participant } : {}),
+    fromMe: metadata?.fromBot === true,
+    type,
+    text: typeof memory.content?.text === "string" ? memory.content.text : "",
+  };
 }
 
 type RuntimeWithOptionalConnectorRegistry = IAgentRuntime & {
@@ -767,14 +818,35 @@ export class WhatsAppConnectorService extends Service {
           }
 
           let replyToMessageId: string | undefined;
+          let quoteContext: WhatsAppQuoteContext | undefined;
           if (typeof content.inReplyTo === "string" && content.inReplyTo.trim()) {
-            const repliedToMemory = await runtime.getMemoryById(content.inReplyTo as UUID);
+            const inReplyTo = content.inReplyTo.trim() as UUID;
+            const repliedToMemory = await runtime.getMemoryById(inReplyTo);
+            if (!repliedToMemory) {
+              throw new ElizaError("WhatsApp reply parent was not found", {
+                code: "WHATSAPP_REPLY_PARENT_NOT_FOUND",
+                context: {
+                  accountId: resolved.accountId,
+                  chatId: resolved.chatId,
+                  inReplyTo,
+                },
+              });
+            }
             const metadata = repliedToMemory?.metadata as Record<string, unknown> | undefined;
             const externalMessageId =
               metadata?.messageIdFull ?? metadata?.externalMessageId ?? metadata?.whatsappMessageId;
-            if (typeof externalMessageId === "string" && externalMessageId.trim()) {
-              replyToMessageId = externalMessageId.trim();
+            if (typeof externalMessageId !== "string" || !externalMessageId.trim()) {
+              throw new ElizaError("WhatsApp reply parent has no authoritative provider id", {
+                code: "WHATSAPP_REPLY_PROVIDER_ID_MISSING",
+                context: {
+                  accountId: resolved.accountId,
+                  chatId: resolved.chatId,
+                  inReplyTo,
+                },
+              });
             }
+            replyToMessageId = externalMessageId.trim();
+            quoteContext = quoteContextFromMemory(repliedToMemory);
           }
 
           if (text) {
@@ -785,28 +857,29 @@ export class WhatsAppConnectorService extends Service {
                 to: resolved.chatId,
                 content: chunk,
                 replyToMessageId,
+                ...(quoteContext
+                  ? {
+                      replyToParticipant: quoteContext.participant,
+                      replyToFromMe: quoteContext.fromMe,
+                      replyToType: quoteContext.type,
+                      replyToText: quoteContext.text,
+                    }
+                  : {}),
               });
             }
           }
 
           // Agent-generated attachments ride as native WhatsApp media messages
-          // (#8876). Both transports (Cloud API by-link + Baileys) build their
-          // payload from the same WhatsAppMessage media type, so one call works
-          // for either. Each is isolated so one failure never drops the rest.
+          // (#8876). Both transports build their payload from the same type;
+          // delivery stops at the first failed effect so partial success is visible.
           for (const media of attachments) {
-            try {
-              await service.sendMediaMessage(resolved.accountId, resolved.chatId, media);
-            } catch (error) {
-              runtime.logger.warn(
-                {
-                  src: "plugin:whatsapp",
-                  agentId: runtime.agentId,
-                  url: media.url,
-                  error: error instanceof Error ? error.message : String(error),
-                },
-                "Failed to send WhatsApp outbound attachment; skipping"
-              );
-            }
+            await service.sendMediaMessage(
+              resolved.accountId,
+              resolved.chatId,
+              media,
+              replyToMessageId,
+              quoteContext
+            );
           }
         },
         resolveTargets: async (query: string) => {
@@ -1145,6 +1218,7 @@ export class WhatsAppConnectorService extends Service {
       text,
       externalMessageId: message.id,
       replyToExternalMessageId: message.replyToId,
+      messageType: message.type,
       createdAt: toTimestampMs(message.timestamp),
       accountId,
     });
@@ -1179,6 +1253,7 @@ export class WhatsAppConnectorService extends Service {
     text: string;
     externalMessageId: string;
     replyToExternalMessageId?: string;
+    messageType?: "text" | "image" | "audio" | "video" | "document";
     createdAt: number;
   }): Promise<void> {
     if (!this.runtime.messageService) {
@@ -1200,9 +1275,7 @@ export class WhatsAppConnectorService extends Service {
     //      convergence;
     //   3. inbound message existence — the deterministic message id catches
     //      a prior successful delivery that pre-dates the claim table.
-    const chatKey =
-      accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`;
-    const dedupeKey = `${accountId}:${params.externalMessageId}`;
+    const dedupeKey = `${accountId}:${params.chatId}:${params.externalMessageId}`;
     if (this.inflightInboundMessageIds.has(dedupeKey)) {
       this.runtime.logger.debug(
         {
@@ -1218,8 +1291,18 @@ export class WhatsAppConnectorService extends Service {
     this.inflightInboundMessageIds.add(dedupeKey);
     let claim: InboundClaimState | null = null;
     let claimHandled = false;
-    const inboundMemoryId = toMemoryId(this.runtime, chatKey, params.externalMessageId);
-    const claimId = createInboundClaimId(this.runtime, accountId, params.externalMessageId);
+    const inboundMemoryId = toInboundWhatsAppMemoryId(
+      this.runtime,
+      accountId,
+      params.chatId,
+      params.externalMessageId
+    );
+    const claimId = createInboundClaimId(
+      this.runtime,
+      accountId,
+      params.chatId,
+      params.externalMessageId
+    );
     try {
       // Durable staged claim: atomically acquire a processing claim in the
       // memory store. Returns won=false if another host or prior delivery
@@ -1228,6 +1311,7 @@ export class WhatsAppConnectorService extends Service {
         this.runtime,
         claimId,
         accountId,
+        params.chatId,
         params.externalMessageId
       );
       if (!claimResult.won) {
@@ -1360,11 +1444,10 @@ export class WhatsAppConnectorService extends Service {
           messageId: params.externalMessageId,
           ...(params.replyToExternalMessageId
             ? {
-                inReplyTo: toMemoryId(
+                inReplyTo: toInboundWhatsAppMemoryId(
                   this.runtime,
-                  accountId === DEFAULT_ACCOUNT_ID
-                    ? params.chatId
-                    : `${accountId}:${params.chatId}`,
+                  accountId,
+                  params.chatId,
                   params.replyToExternalMessageId
                 ),
               }
@@ -1412,7 +1495,13 @@ export class WhatsAppConnectorService extends Service {
             params.chatId,
             chunk,
             params.externalMessageId,
-            accountId
+            accountId,
+            {
+              participant: isGroup ? params.senderId : undefined,
+              fromMe: false,
+              type: params.messageType ?? "text",
+              text: params.text,
+            }
           );
           const externalResponseId =
             response.messages[0]?.id ??
@@ -1421,7 +1510,7 @@ export class WhatsAppConnectorService extends Service {
           responseMemories.push({
             id: toMemoryId(
               this.runtime,
-              accountId === DEFAULT_ACCOUNT_ID ? params.chatId : `${accountId}:${params.chatId}`,
+              inboundMessageScope(accountId, params.chatId),
               externalResponseId
             ),
             entityId: this.runtime.agentId,
@@ -1528,7 +1617,8 @@ export class WhatsAppConnectorService extends Service {
     chatId: string,
     text: string,
     replyToMessageId?: string,
-    accountId?: string
+    accountId?: string,
+    quote?: WhatsAppQuoteContext
   ): Promise<WhatsAppMessageResponse> {
     const normalizedAccountId = this.resolveAccountId(accountId);
     const client = this.getClientForAccount(normalizedAccountId);
@@ -1545,6 +1635,16 @@ export class WhatsAppConnectorService extends Service {
           : normalizeCloudApiSendTarget(chatId),
       content: text,
       replyToMessageId,
+      ...(config.transport === "baileys" && quote?.participant
+        ? { replyToParticipant: quote.participant }
+        : {}),
+      ...(config.transport === "baileys" && quote
+        ? {
+            replyToFromMe: quote.fromMe,
+            replyToType: quote.type,
+            replyToText: quote.text,
+          }
+        : {}),
     });
 
     return "data" in response
@@ -1558,12 +1658,24 @@ export class WhatsAppConnectorService extends Service {
     to: string;
     content: string;
     replyToMessageId?: string;
+    replyToParticipant?: string;
+    replyToFromMe?: boolean;
+    replyToType?: "text" | "image" | "audio" | "video" | "document";
+    replyToText?: string;
   }): Promise<WhatsAppMessageResponse> {
     return this.sendTextMessage(
       message.to,
       message.content,
       message.replyToMessageId,
-      message.accountId
+      message.accountId,
+      message.replyToMessageId
+        ? {
+            participant: message.replyToParticipant,
+            fromMe: message.replyToFromMe ?? false,
+            type: message.replyToType ?? "text",
+            text: message.replyToText ?? "",
+          }
+        : undefined
     );
   }
 
@@ -1586,11 +1698,14 @@ export class WhatsAppConnectorService extends Service {
   async sendMediaMessage(
     accountId: string | null | undefined,
     to: string,
-    media: Media
+    media: Media,
+    replyToMessageId?: string,
+    quote?: WhatsAppQuoteContext
   ): Promise<void> {
     if (!media.url) return;
     const client = this.getClientForAccount(accountId);
-    if (!client) {
+    const config = this.getConfigForAccount(accountId);
+    if (!client || !config) {
       throw new Error("WhatsApp client not initialized");
     }
     const type = this.whatsappMediaType(media);
@@ -1600,7 +1715,22 @@ export class WhatsAppConnectorService extends Service {
       ...(media.description ? { caption: media.description } : {}),
       ...(type === "document" && filename ? { filename } : {}),
     };
-    await client.sendMessage({ type, to, content: mediaContent });
+    await client.sendMessage({
+      type,
+      to,
+      content: mediaContent,
+      ...(config.transport === "baileys" && replyToMessageId ? { replyToMessageId } : {}),
+      ...(config.transport === "baileys" && quote?.participant
+        ? { replyToParticipant: quote.participant }
+        : {}),
+      ...(config.transport === "baileys" && quote
+        ? {
+            replyToFromMe: quote.fromMe,
+            replyToType: quote.type,
+            replyToText: quote.text,
+          }
+        : {}),
+    });
   }
 
   async fetchConnectorMessages(

--- a/plugins/plugin-whatsapp/src/types.ts
+++ b/plugins/plugin-whatsapp/src/types.ts
@@ -51,6 +51,11 @@ export interface WhatsAppMessage {
     | WhatsAppReactionMessage
     | WhatsAppLocationMessage;
   replyToMessageId?: string;
+  /** Baileys-only context needed to reconstruct a native quoted message. */
+  replyToParticipant?: string;
+  replyToFromMe?: boolean;
+  replyToType?: "text" | "image" | "audio" | "video" | "document";
+  replyToText?: string;
 }
 
 export interface WhatsAppTemplate {


### PR DESCRIPTION
Part of #25210.

## Outcome

Preserves complete native reply context for the bundled in-process Baileys personal transport without changing or deleting any official Meta Cloud API client, webhook, setup, auth, media-download, or UI surface.

- one normalized account + chat + provider-message identity owns inbound rows, reply links, in-process dedupe, and durable claims
- same provider id in two chats remains two independent durable effects
- manual/unified text and media replies reconstruct group participant, from-me direction, message type, and text/caption at the actual Baileys socket boundary
- default and named accounts share the same identity rule
- invalid/missing reply parents fail closed before socket I/O
- attachment delivery stops on the first failed effect rather than fabricating partial success
- Baileys success requires an authoritative provider message id and otherwise throws typed `WHATSAPP_PROVIDER_MESSAGE_ID_MISSING`
- personal quote fields are never projected into official Cloud media sends

This PR does not claim the remaining #25210 auth-directory, atomic state, guarded media-byte, group-membership publisher, official Cloud qualification, or real-phone acceptance work.

## Evidence

Exact head: `ba8a3c6cbbb9b405b78d2ddf396e7946e67f0a6f`
Base: `f45a2bd65c1f1d308f9c533f33ffd35dde666633`

- full plugin suite: 17 files / 135 tests passed
- focused blocker matrix: 4 files / 36 tests passed
- plugin typecheck: passed
- package Biome lint: 40 files passed
- format and `git diff --check origin/develop...HEAD`: passed
- real PGlite claim test and exact Baileys socket-argument spies provide structural proof; no LLM judge

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->
