### PR TITLE
fix(sql): safe NaN handling in advanced memory storage sort comparators

### DIFF
--- a/plugins/plugin-sql/src/__tests__/advanced-memory-storage.test.ts
+++ b/plugins/plugin-sql/src/__tests__/advanced-memory-storage.test.ts
@@ -205,4 +205,26 @@ describe("AdvancedMemoryStorageService.updateLongTermMemory", () => {
     const [updated] = await service.getLongTermMemories(agentId, entityId);
     expect(updated?.lastAccessedAt?.toISOString()).toBe(older.toISOString());
   });
+
+  it("maintains strict total ordering when updatedAt or createdAt contain invalid dates", async () => {
+    const service = new AdvancedMemoryStorageService();
+    const sorted = (service as any).sortLongTermMemories([
+      {
+        id: "mem-valid",
+        updatedAt: new Date("2026-08-01T00:00:00.000Z"),
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        confidence: 0.9,
+      },
+      {
+        id: "mem-invalid",
+        updatedAt: new Date("invalid-date"),
+        createdAt: new Date("invalid-date"),
+        confidence: 0.5,
+      },
+    ]);
+
+    expect(sorted).toHaveLength(2);
+    expect(sorted[0]?.id).toBe("mem-valid");
+    expect(sorted[1]?.id).toBe("mem-invalid");
+  });
 });

--- a/plugins/plugin-sql/src/services/advanced-memory-storage.ts
+++ b/plugins/plugin-sql/src/services/advanced-memory-storage.ts
@@ -389,28 +389,52 @@ export class AdvancedMemoryStorageService extends Service implements MemoryStora
 
   private sortLongTermMemories(memories: LongTermMemoryRecord[]): LongTermMemoryRecord[] {
     return [...memories].sort((left, right) => {
-      const leftUpdated = left.updatedAt.getTime();
-      const rightUpdated = right.updatedAt.getTime();
+      const leftUpdated = Number.isFinite(left.updatedAt.getTime())
+        ? left.updatedAt.getTime()
+        : 0;
+      const rightUpdated = Number.isFinite(right.updatedAt.getTime())
+        ? right.updatedAt.getTime()
+        : 0;
       if (rightUpdated !== leftUpdated) {
         return rightUpdated - leftUpdated;
       }
-      const leftConfidence = left.confidence ?? 0;
-      const rightConfidence = right.confidence ?? 0;
+      const leftConfidence = Number.isFinite(left.confidence)
+        ? (left.confidence as number)
+        : 0;
+      const rightConfidence = Number.isFinite(right.confidence)
+        ? (right.confidence as number)
+        : 0;
       if (rightConfidence !== leftConfidence) {
         return rightConfidence - leftConfidence;
       }
-      return right.createdAt.getTime() - left.createdAt.getTime();
+      const leftCreated = Number.isFinite(left.createdAt.getTime())
+        ? left.createdAt.getTime()
+        : 0;
+      const rightCreated = Number.isFinite(right.createdAt.getTime())
+        ? right.createdAt.getTime()
+        : 0;
+      return rightCreated - leftCreated;
     });
   }
 
   private sortSessionSummaries(summaries: SessionSummaryRecord[]): SessionSummaryRecord[] {
     return [...summaries].sort((left, right) => {
-      const leftUpdated = left.updatedAt.getTime();
-      const rightUpdated = right.updatedAt.getTime();
+      const leftUpdated = Number.isFinite(left.updatedAt.getTime())
+        ? left.updatedAt.getTime()
+        : 0;
+      const rightUpdated = Number.isFinite(right.updatedAt.getTime())
+        ? right.updatedAt.getTime()
+        : 0;
       if (rightUpdated !== leftUpdated) {
         return rightUpdated - leftUpdated;
       }
-      return right.createdAt.getTime() - left.createdAt.getTime();
+      const leftCreated = Number.isFinite(left.createdAt.getTime())
+        ? left.createdAt.getTime()
+        : 0;
+      const rightCreated = Number.isFinite(right.createdAt.getTime())
+        ? right.createdAt.getTime()
+        : 0;
+      return rightCreated - leftCreated;
     });
   }
 


### PR DESCRIPTION
## Summary

Validates `updatedAt`, `createdAt`, and `confidence` with `Number.isFinite(...)` across `sortLongTermMemories` and `sortSessionSummaries` (`plugins/plugin-sql/src/services/advanced-memory-storage.ts:391, 407`) to prevent `NaN` return values in sort comparators when memory records contain invalid dates or non-finite confidence values.

## Changes

- In `plugins/plugin-sql/src/services/advanced-memory-storage.ts:391-403`, guard `updatedAt`, `createdAt`, and `confidence` comparisons with `Number.isFinite(...)` in `sortLongTermMemories`.
- In `plugins/plugin-sql/src/services/advanced-memory-storage.ts:407-415`, guard `updatedAt` and `createdAt` comparisons with `Number.isFinite(...)` in `sortSessionSummaries`.
- In `plugins/plugin-sql/src/__tests__/advanced-memory-storage.test.ts`, add dedicated unit tests verifying that invalid date timestamps maintain strict total ordering.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`82b95c4493`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-sql/src/__tests__/advanced-memory-storage.test.ts` | 6 pass (6 tests) | 7 pass (7 tests) |
| `bunx @biomejs/biome check plugins/plugin-sql/src/services/advanced-memory-storage.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-sql/src/services/advanced-memory-storage.ts:390-418`
- `plugins/plugin-sql/src/__tests__/advanced-memory-storage.test.ts:205-230`

## Risks

Low. Fallback to 0 ensures invalid date entries are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (SQL plugin memory storage; no UI layout touched)
- [x] `audit:browser` — N/A (Memory storage sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 7/7 pass in `advanced-memory-storage.test.ts`
- [x] `lint` — Biome clean
