### PR TITLE
fix(inbox): safe NaN handling in inbox thread group and search sort comparators

### DIFF
--- a/plugins/plugin-inbox/src/inbox/aggregate.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.ts
@@ -166,7 +166,9 @@ export function toInboxMessage(
     channel === "gmail"
       ? (message.gmailMessageId ?? message.id)
       : (message.entityId ?? message.roomId ?? message.id);
-  const receivedAt = new Date(message.timestamp).toISOString();
+  const receivedAt = Number.isFinite(message.timestamp)
+    ? new Date(message.timestamp).toISOString()
+    : new Date(0).toISOString();
   const subject =
     channel === "gmail"
       ? message.channelName.startsWith("Email from ")
@@ -315,7 +317,15 @@ function buildThreadGroups(
 
   const groups: LifeOpsInboxThreadGroup[] = [];
   for (const [key, members] of buckets) {
-    members.sort((a, b) => Date.parse(b.receivedAt) - Date.parse(a.receivedAt));
+    members.sort((a, b) => {
+      const aTime = Number.isFinite(Date.parse(a.receivedAt))
+        ? Date.parse(a.receivedAt)
+        : 0;
+      const bTime = Number.isFinite(Date.parse(b.receivedAt))
+        ? Date.parse(b.receivedAt)
+        : 0;
+      return bTime - aTime;
+    });
     const latestMessage = members[0];
     if (!latestMessage) continue;
     const totalCount = members.length;
@@ -402,20 +412,29 @@ function buildThreadGroups(
 
   if (sortByPriority) {
     groups.sort((a, b) => {
-      const aScore = a.maxPriorityScore ?? -1;
-      const bScore = b.maxPriorityScore ?? -1;
+      const aRaw = a.maxPriorityScore ?? -1;
+      const bRaw = b.maxPriorityScore ?? -1;
+      const aScore = Number.isFinite(aRaw) ? aRaw : -1;
+      const bScore = Number.isFinite(bRaw) ? bRaw : -1;
       if (aScore !== bScore) return bScore - aScore;
-      return (
-        Date.parse(b.latestMessage.receivedAt) -
-        Date.parse(a.latestMessage.receivedAt)
-      );
+      const aTime = Number.isFinite(Date.parse(a.latestMessage.receivedAt))
+        ? Date.parse(a.latestMessage.receivedAt)
+        : 0;
+      const bTime = Number.isFinite(Date.parse(b.latestMessage.receivedAt))
+        ? Date.parse(b.latestMessage.receivedAt)
+        : 0;
+      return bTime - aTime;
     });
   } else {
-    groups.sort(
-      (a, b) =>
-        Date.parse(b.latestMessage.receivedAt) -
-        Date.parse(a.latestMessage.receivedAt),
-    );
+    groups.sort((a, b) => {
+      const aTime = Number.isFinite(Date.parse(a.latestMessage.receivedAt))
+        ? Date.parse(a.latestMessage.receivedAt)
+        : 0;
+      const bTime = Number.isFinite(Date.parse(b.latestMessage.receivedAt))
+        ? Date.parse(b.latestMessage.receivedAt)
+        : 0;
+      return bTime - aTime;
+    });
   }
   return groups;
 }
@@ -500,7 +519,15 @@ export function buildInboxFromMessages(
     }
   }
 
-  collected.sort((a, b) => Date.parse(b.receivedAt) - Date.parse(a.receivedAt));
+  collected.sort((a, b) => {
+    const aTime = Number.isFinite(Date.parse(a.receivedAt))
+      ? Date.parse(a.receivedAt)
+      : 0;
+    const bTime = Number.isFinite(Date.parse(b.receivedAt))
+      ? Date.parse(b.receivedAt)
+      : 0;
+    return bTime - aTime;
+  });
 
   const trimmed =
     collected.length > options.limit

--- a/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts
@@ -79,4 +79,21 @@ describe("x_dm unread derivation", () => {
     ]);
     expect(inbox.messages[0]?.unread).toBe(true);
   });
+
+  it("maintains strict total ordering in thread groups when timestamp is NaN", () => {
+    const inbox = build([
+      xDm({
+        id: "dm-invalid",
+        threadId: "conv-mixed",
+        timestamp: Number.NaN,
+      }),
+      xDm({
+        id: "dm-valid",
+        threadId: "conv-mixed",
+        timestamp: NOW,
+      }),
+    ]);
+    expect(inbox.threadGroups).toHaveLength(1);
+    expect(inbox.threadGroups?.[0]?.latestMessage.id).toBe("x_dm:dm-valid");
+  });
 });


### PR DESCRIPTION
## Summary

Validates timestamps and `receivedAt` date parsing with `Number.isFinite(...)` across `buildThreadGroups` and `searchInboxMessages` (`plugins/plugin-inbox/src/inbox/aggregate.ts:169, 318, 410, 520`) to prevent `NaN` return values in sort comparators when inbound messages contain missing or invalid timestamp numbers/dates.

## Changes

- In `plugins/plugin-inbox/src/inbox/aggregate.ts:169`, guard `new Date(message.timestamp).toISOString()` against `NaN` timestamp inputs in `toInboxMessage`.
- In `plugins/plugin-inbox/src/inbox/aggregate.ts:318, 410, 520`, guard `receivedAt` timestamp comparisons with `Number.isFinite(...)` in member sorting, group sorting, and search results sorting.
- In `plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts`, add dedicated unit tests verifying that thread group sorting maintains strict total ordering with `NaN` timestamps.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`c5cf37c074`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts` | 4 pass (4 tests) | 5 pass (5 tests) |
| `bunx @biomejs/biome check plugins/plugin-inbox/src/inbox/aggregate.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-inbox/src/inbox/aggregate.ts:165-175`
- `plugins/plugin-inbox/src/inbox/aggregate.ts:315-325`
- `plugins/plugin-inbox/src/inbox/aggregate.ts:405-430`
- `plugins/plugin-inbox/src/inbox/aggregate.ts:515-525`
- `plugins/plugin-inbox/src/inbox/aggregate.xdm-unread.test.ts:80-100`

## Risks

Low. Fallback to 0 ensures invalid date entries are treated as older without disrupting valid message groupings.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Inbox plugin message aggregator; no UI layout touched)
- [x] `audit:browser` — N/A (Inbox thread group sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 5/5 pass in `aggregate.xdm-unread.test.ts`
- [x] `lint` — Biome clean
