### PR TITLE
chore(evidence): format error boundaries

### DIFF
--- a/packages/evidence/src/analyzers/ocr/engines.ts
+++ b/packages/evidence/src/analyzers/ocr/engines.ts
@@ -28,8 +28,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { EvidenceError } from "../../errors.ts";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { EvidenceError } from "../../errors.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -693,5 +693,8 @@ function isEnoent(error: unknown): boolean {
 }
 
 function errMessage(error: unknown): string {
-  return truncateWellFormed(toWellFormedUnicode(String(error instanceof Error ? error.message : error)), 160);
+  return truncateWellFormed(
+    toWellFormedUnicode(String(error instanceof Error ? error.message : error)),
+    160,
+  );
 }

--- a/packages/evidence/src/vision-qa/ask.ts
+++ b/packages/evidence/src/vision-qa/ask.ts
@@ -13,8 +13,8 @@
  * (CLI / certify) turns those into an explicit skipped/failed record.
  */
 
-import { EvidenceError } from "../errors.ts";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { EvidenceError } from "../errors.ts";
 import {
   type BackendResponse,
   parseAnswers,
@@ -103,7 +103,10 @@ async function postJson(
       `vision-qa backend returned ${response.status} ${response.statusText}`,
       {
         code: "VISION_BACKEND_HTTP",
-        context: { status: response.status, detail: truncateWellFormed(toWellFormedUnicode(detail), 500) },
+        context: {
+          status: response.status,
+          detail: truncateWellFormed(toWellFormedUnicode(detail), 500),
+        },
       },
     );
   }


### PR DESCRIPTION
Closes #25237.

Formatting-only repair for two already-merged evidence error-boundary files that block the affected-workspace lint closure. No tokens, values, branches, or behavior change; pinned repository Biome only reordered imports and wrapped long expressions.

Evidence:
- pinned `biome check --write` then `biome check`: clean, 2 files
- `git diff --check`: passed
- diff inspected as import order / line wrapping only

This failure was reproduced in unrelated PR #25222 run 32622630437.
