### PR TITLE
fix(personal-assistant): safe NaN handling in scheduled task log sort comparator

### DIFF
--- a/plugins/plugin-personal-assistant/src/providers/recent-task-states.ts
+++ b/plugins/plugin-personal-assistant/src/providers/recent-task-states.ts
@@ -85,8 +85,15 @@ export async function readScheduledTaskLog(
         typeof entry.taskId === "string" &&
         typeof entry.recordedAt === "string",
     )
-    .slice()
-    .sort((a, b) => Date.parse(a.recordedAt) - Date.parse(b.recordedAt));
+    .sort((a, b) => {
+      const aTime = Number.isFinite(Date.parse(a.recordedAt))
+        ? Date.parse(a.recordedAt)
+        : 0;
+      const bTime = Number.isFinite(Date.parse(b.recordedAt))
+        ? Date.parse(b.recordedAt)
+        : 0;
+      return aTime - bTime;
+    });
 }
 
 /**

--- a/plugins/plugin-personal-assistant/test/recent-task-states.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/recent-task-states.integration.test.ts
@@ -58,4 +58,28 @@ describe("recent task states integration", () => {
     expect(summary.summary).toMatch(/checkin: 1 done/);
     expect(summary.summary).not.toMatch(/reminder/);
   });
+
+  it("maintains strict total ordering when recordedAt contains invalid date strings", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const { readScheduledTaskLog } = await import(
+      "../src/providers/recent-task-states.ts"
+    );
+    await appendScheduledTaskLogEntry(runtime, {
+      taskId: "task-invalid",
+      kind: "reminder",
+      outcome: "completed",
+      recordedAt: "invalid-date-string",
+    });
+    await appendScheduledTaskLogEntry(runtime, {
+      taskId: "task-valid",
+      kind: "reminder",
+      outcome: "completed",
+      recordedAt: "2026-08-01T00:00:00.000Z",
+    });
+
+    const log = await readScheduledTaskLog(runtime);
+    expect(log).toHaveLength(2);
+    expect(log[0]?.taskId).toBe("task-invalid"); // fallback 0 is earliest
+    expect(log[1]?.taskId).toBe("task-valid");
+  });
 });


### PR DESCRIPTION
## Summary

Validates `recordedAt` date parsing with `Number.isFinite(...)` in `readScheduledTaskLog` (`plugins/plugin-personal-assistant/src/providers/recent-task-states.ts:89`) to prevent `NaN` return values in sort comparators when persisted task history entries contain invalid or unparseable date strings.

## Changes

- In `plugins/plugin-personal-assistant/src/providers/recent-task-states.ts:89`, guard `recordedAt` timestamp comparisons with `Number.isFinite(...)` in `readScheduledTaskLog`.
- In `plugins/plugin-personal-assistant/test/recent-task-states.integration.test.ts`, add dedicated unit tests verifying that task log entries maintain strict total ordering with invalid date strings.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`150655f5e8`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-personal-assistant/test/recent-task-states.integration.test.ts` | 2 pass (2 tests) | 3 pass (3 tests) |
| `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/providers/recent-task-states.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-personal-assistant/src/providers/recent-task-states.ts:80-95`
- `plugins/plugin-personal-assistant/test/recent-task-states.integration.test.ts:55-80`

## Risks

Low. Fallback to 0 ensures invalid date entries are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Personal assistant task state provider; no UI layout touched)
- [x] `audit:browser` — N/A (Task state log sort comparator)
- [x] `build` — Clean build across workspace
- [x] `test` — 3/3 pass in `recent-task-states.integration.test.ts`
- [x] `lint` — Biome clean
