### PR TITLE
chore(agent): format new test coverage

### DIFF
--- a/packages/agent/src/actions/context-signal.test.ts
+++ b/packages/agent/src/actions/context-signal.test.ts
@@ -8,449 +8,449 @@
  */
 import type { AgentContext, IAgentRuntime, Memory, State } from "@elizaos/core";
 import {
-	CONTEXT_ROUTING_METADATA_KEY,
-	CONTEXT_ROUTING_STATE_KEY,
+  CONTEXT_ROUTING_METADATA_KEY,
+  CONTEXT_ROUTING_STATE_KEY,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
-	collectKeywordTermMatches,
-	hasContextSignal,
-	hasContextSignalSync,
-	hasContextSignalSyncForKey,
-	hasSelectedActionContext,
-	hasSelectedContextOrSignalSync,
-	messageText,
-	textIncludesKeywordTerm,
+  collectKeywordTermMatches,
+  hasContextSignal,
+  hasContextSignalSync,
+  hasContextSignalSyncForKey,
+  hasSelectedActionContext,
+  hasSelectedContextOrSignalSync,
+  messageText,
+  textIncludesKeywordTerm,
 } from "./context-signal.ts";
 
 function messageWith(text: string, extras: Partial<Memory> = {}): Memory {
-	return { content: { text }, ...extras } as Memory;
+  return { content: { text }, ...extras } as Memory;
 }
 
 function stateWithRecent(recentMessages: string): State {
-	return { values: { recentMessages }, data: {}, text: "" } as State;
+  return { values: { recentMessages }, data: {}, text: "" } as State;
 }
 
 function stateWithRouting(
-	primaryContext: string,
-	secondaryContexts: string[] = [],
+  primaryContext: string,
+  secondaryContexts: string[] = [],
 ): State {
-	return {
-		values: {
-			[CONTEXT_ROUTING_STATE_KEY]: {
-				primaryContext,
-				secondaryContexts,
-			},
-		},
-		data: {},
-		text: "",
-	} as State;
+  return {
+    values: {
+      [CONTEXT_ROUTING_STATE_KEY]: {
+        primaryContext,
+        secondaryContexts,
+      },
+    },
+    data: {},
+    text: "",
+  } as State;
 }
 
 function runtimeWithMemories(
-	memories: Array<{ content?: { text?: string } | undefined }>,
-	onGetMemories?: () => void,
+  memories: Array<{ content?: { text?: string } | undefined }>,
+  onGetMemories?: () => void,
 ): IAgentRuntime {
-	return {
-		getMemories: async () => {
-			onGetMemories?.();
-			return memories;
-		},
-	} as unknown as IAgentRuntime;
+  return {
+    getMemories: async () => {
+      onGetMemories?.();
+      return memories;
+    },
+  } as unknown as IAgentRuntime;
 }
 
 describe("messageText", () => {
-	it("returns empty string when content is missing", () => {
-		expect(messageText({} as Memory)).toBe("");
-		expect(messageText({ content: undefined } as unknown as Memory)).toBe("");
-	});
+  it("returns empty string when content is missing", () => {
+    expect(messageText({} as Memory)).toBe("");
+    expect(messageText({ content: undefined } as unknown as Memory)).toBe("");
+  });
 
-	it("returns string content as-is", () => {
-		expect(messageText({ content: "plain body" } as unknown as Memory)).toBe(
-			"plain body",
-		);
-	});
+  it("returns string content as-is", () => {
+    expect(messageText({ content: "plain body" } as unknown as Memory)).toBe(
+      "plain body",
+    );
+  });
 
-	it("returns content.text when it is a string", () => {
-		expect(messageText(messageWith("hello there"))).toBe("hello there");
-	});
+  it("returns content.text when it is a string", () => {
+    expect(messageText(messageWith("hello there"))).toBe("hello there");
+  });
 
-	it("returns empty string when content.text is not a string", () => {
-		expect(messageText({ content: { text: 42 } } as unknown as Memory)).toBe(
-			"",
-		);
-		expect(messageText({ content: { text: undefined } } as Memory)).toBe("");
-	});
+  it("returns empty string when content.text is not a string", () => {
+    expect(messageText({ content: { text: 42 } } as unknown as Memory)).toBe(
+      "",
+    );
+    expect(messageText({ content: { text: undefined } } as Memory)).toBe("");
+  });
 });
 
 describe("re-exported keyword matcher", () => {
-	it("matches whole ASCII words, not substrings", () => {
-		expect(textIncludesKeywordTerm("please mail this", "mail")).toBe(true);
-		expect(textIncludesKeywordTerm("gmail inbox", "mail")).toBe(false);
-		expect(
-			[...collectKeywordTermMatches(["browse the category"], ["cat"])].length,
-		).toBe(0);
-		expect([...collectKeywordTermMatches(["I have a cat"], ["cat"])]).toEqual([
-			"cat",
-		]);
-	});
+  it("matches whole ASCII words, not substrings", () => {
+    expect(textIncludesKeywordTerm("please mail this", "mail")).toBe(true);
+    expect(textIncludesKeywordTerm("gmail inbox", "mail")).toBe(false);
+    expect(
+      [...collectKeywordTermMatches(["browse the category"], ["cat"])].length,
+    ).toBe(0);
+    expect([...collectKeywordTermMatches(["I have a cat"], ["cat"])]).toEqual([
+      "cat",
+    ]);
+  });
 });
 
 describe("hasContextSignalSync", () => {
-	it("returns false for an empty text queue", () => {
-		expect(hasContextSignalSync(messageWith(""), undefined, ["calendar"])).toBe(
-			false,
-		);
-		expect(
-			hasContextSignalSync(messageWith("   "), {} as State, ["calendar"]),
-		).toBe(false);
-	});
+  it("returns false for an empty text queue", () => {
+    expect(hasContextSignalSync(messageWith(""), undefined, ["calendar"])).toBe(
+      false,
+    );
+    expect(
+      hasContextSignalSync(messageWith("   "), {} as State, ["calendar"]),
+    ).toBe(false);
+  });
 
-	it("returns false when texts exist but both term lists are empty", () => {
-		expect(
-			hasContextSignalSync(messageWith("calendar tomorrow"), undefined, [], []),
-		).toBe(false);
-	});
+  it("returns false when texts exist but both term lists are empty", () => {
+    expect(
+      hasContextSignalSync(messageWith("calendar tomorrow"), undefined, [], []),
+    ).toBe(false);
+  });
 
-	it("activates on a single strong term in the current message", () => {
-		expect(
-			hasContextSignalSync(messageWith("open the calendar"), undefined, [
-				"calendar",
-			]),
-		).toBe(true);
-	});
+  it("activates on a single strong term in the current message", () => {
+    expect(
+      hasContextSignalSync(messageWith("open the calendar"), undefined, [
+        "calendar",
+      ]),
+    ).toBe(true);
+  });
 
-	it("activates on a weak term when strong terms miss", () => {
-		expect(
-			hasContextSignalSync(
-				messageWith("please forward this later"),
-				undefined,
-				["calendar"],
-				["forward"],
-			),
-		).toBe(true);
-	});
+  it("activates on a weak term when strong terms miss", () => {
+    expect(
+      hasContextSignalSync(
+        messageWith("please forward this later"),
+        undefined,
+        ["calendar"],
+        ["forward"],
+      ),
+    ).toBe(true);
+  });
 
-	it("activates when the only match lives in recent conversation state", () => {
-		expect(
-			hasContextSignalSync(
-				messageWith("ok"),
-				stateWithRecent("Alice: check the calendar tomorrow"),
-				["calendar"],
-			),
-		).toBe(true);
-	});
+  it("activates when the only match lives in recent conversation state", () => {
+    expect(
+      hasContextSignalSync(
+        messageWith("ok"),
+        stateWithRecent("Alice: check the calendar tomorrow"),
+        ["calendar"],
+      ),
+    ).toBe(true);
+  });
 
-	it("does not activate on an ASCII substring / word-boundary miss", () => {
-		expect(
-			hasContextSignalSync(messageWith("browse the category"), undefined, [
-				"cat",
-			]),
-		).toBe(false);
-		expect(
-			hasContextSignalSync(messageWith("gmail inbox"), undefined, ["mail"]),
-		).toBe(false);
-	});
+  it("does not activate on an ASCII substring / word-boundary miss", () => {
+    expect(
+      hasContextSignalSync(messageWith("browse the category"), undefined, [
+        "cat",
+      ]),
+    ).toBe(false);
+    expect(
+      hasContextSignalSync(messageWith("gmail inbox"), undefined, ["mail"]),
+    ).toBe(false);
+  });
 
-	it("inspects the full state even when the deprecated contextLimit is 0", () => {
-		expect(
-			hasContextSignalSync(
-				messageWith(""),
-				stateWithRecent("calendar reminder"),
-				["calendar"],
-				[],
-				0,
-			),
-		).toBe(true);
-	});
+  it("inspects the full state even when the deprecated contextLimit is 0", () => {
+    expect(
+      hasContextSignalSync(
+        messageWith(""),
+        stateWithRecent("calendar reminder"),
+        ["calendar"],
+        [],
+        0,
+      ),
+    ).toBe(true);
+  });
 
-	it("returns false when no term is present", () => {
-		expect(
-			hasContextSignalSync(messageWith("what is the weather"), undefined, [
-				"calendar",
-			]),
-		).toBe(false);
-	});
+  it("returns false when no term is present", () => {
+    expect(
+      hasContextSignalSync(messageWith("what is the weather"), undefined, [
+        "calendar",
+      ]),
+    ).toBe(false);
+  });
 });
 
 describe("hasContextSignalSyncForKey", () => {
-	it("activates on a gmail lexicon strong term", () => {
-		expect(
-			hasContextSignalSyncForKey(
-				messageWith("check my gmail inbox"),
-				undefined,
-				"gmail",
-			),
-		).toBe(true);
-	});
+  it("activates on a gmail lexicon strong term", () => {
+    expect(
+      hasContextSignalSyncForKey(
+        messageWith("check my gmail inbox"),
+        undefined,
+        "gmail",
+      ),
+    ).toBe(true);
+  });
 
-	it("does not activate a gmail key on unrelated text", () => {
-		expect(
-			hasContextSignalSyncForKey(
-				messageWith("what is the weather in tokyo"),
-				undefined,
-				"gmail",
-			),
-		).toBe(false);
-	});
+  it("does not activate a gmail key on unrelated text", () => {
+    expect(
+      hasContextSignalSyncForKey(
+        messageWith("what is the weather in tokyo"),
+        undefined,
+        "gmail",
+      ),
+    ).toBe(false);
+  });
 
-	it("includes localized terms by default and can restrict to a locale", () => {
-		const chineseMail = messageWith("请查看邮件");
-		expect(hasContextSignalSyncForKey(chineseMail, undefined, "gmail")).toBe(
-			true,
-		);
-		expect(
-			hasContextSignalSyncForKey(chineseMail, undefined, "gmail", {
-				includeAllLocales: false,
-				locale: "en",
-			}),
-		).toBe(false);
-		expect(
-			hasContextSignalSyncForKey(chineseMail, undefined, "gmail", {
-				includeAllLocales: false,
-				locale: "zh-CN",
-			}),
-		).toBe(true);
-	});
+  it("includes localized terms by default and can restrict to a locale", () => {
+    const chineseMail = messageWith("请查看邮件");
+    expect(hasContextSignalSyncForKey(chineseMail, undefined, "gmail")).toBe(
+      true,
+    );
+    expect(
+      hasContextSignalSyncForKey(chineseMail, undefined, "gmail", {
+        includeAllLocales: false,
+        locale: "en",
+      }),
+    ).toBe(false);
+    expect(
+      hasContextSignalSyncForKey(chineseMail, undefined, "gmail", {
+        includeAllLocales: false,
+        locale: "zh-CN",
+      }),
+    ).toBe(true);
+  });
 
-	it("prefers options.locale over state preferredLanguage", () => {
-		const state = {
-			values: { preferredLanguage: "en" },
-			data: {},
-			text: "",
-		} as State;
-		const chineseMail = messageWith("邮件");
-		expect(
-			hasContextSignalSyncForKey(chineseMail, state, "gmail", {
-				includeAllLocales: false,
-				locale: "zh-CN",
-			}),
-		).toBe(true);
-		expect(
-			hasContextSignalSyncForKey(chineseMail, state, "gmail", {
-				includeAllLocales: false,
-			}),
-		).toBe(false);
-	});
+  it("prefers options.locale over state preferredLanguage", () => {
+    const state = {
+      values: { preferredLanguage: "en" },
+      data: {},
+      text: "",
+    } as State;
+    const chineseMail = messageWith("邮件");
+    expect(
+      hasContextSignalSyncForKey(chineseMail, state, "gmail", {
+        includeAllLocales: false,
+        locale: "zh-CN",
+      }),
+    ).toBe(true);
+    expect(
+      hasContextSignalSyncForKey(chineseMail, state, "gmail", {
+        includeAllLocales: false,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("hasSelectedActionContext", () => {
-	it("returns false for an empty action-context list", () => {
-		expect(
-			hasSelectedActionContext(
-				messageWith("hello"),
-				stateWithRouting("code"),
-				[],
-			),
-		).toBe(false);
-	});
+  it("returns false for an empty action-context list", () => {
+    expect(
+      hasSelectedActionContext(
+        messageWith("hello"),
+        stateWithRouting("code"),
+        [],
+      ),
+    ).toBe(false);
+  });
 
-	it("returns false when every declared context is general or page-scoped", () => {
-		expect(
-			hasSelectedActionContext(messageWith("hello"), stateWithRouting("code"), [
-				"general" as AgentContext,
-				"page-settings" as AgentContext,
-			]),
-		).toBe(false);
-	});
+  it("returns false when every declared context is general or page-scoped", () => {
+    expect(
+      hasSelectedActionContext(messageWith("hello"), stateWithRouting("code"), [
+        "general" as AgentContext,
+        "page-settings" as AgentContext,
+      ]),
+    ).toBe(false);
+  });
 
-	it("returns false when there is no active routing overlap", () => {
-		expect(
-			hasSelectedActionContext(
-				messageWith("hello"),
-				stateWithRouting("social"),
-				["code" as AgentContext],
-			),
-		).toBe(false);
-		expect(
-			hasSelectedActionContext(messageWith("hello"), undefined, [
-				"code" as AgentContext,
-			]),
-		).toBe(false);
-	});
+  it("returns false when there is no active routing overlap", () => {
+    expect(
+      hasSelectedActionContext(
+        messageWith("hello"),
+        stateWithRouting("social"),
+        ["code" as AgentContext],
+      ),
+    ).toBe(false);
+    expect(
+      hasSelectedActionContext(messageWith("hello"), undefined, [
+        "code" as AgentContext,
+      ]),
+    ).toBe(false);
+  });
 
-	it("returns true when state routing overlaps a declared context", () => {
-		expect(
-			hasSelectedActionContext(messageWith("hello"), stateWithRouting("code"), [
-				"code" as AgentContext,
-			]),
-		).toBe(true);
-	});
+  it("returns true when state routing overlaps a declared context", () => {
+    expect(
+      hasSelectedActionContext(messageWith("hello"), stateWithRouting("code"), [
+        "code" as AgentContext,
+      ]),
+    ).toBe(true);
+  });
 
-	it("matches secondary contexts and ignores case", () => {
-		expect(
-			hasSelectedActionContext(
-				messageWith("hello"),
-				stateWithRouting("social", ["wallet"]),
-				["WALLET" as AgentContext],
-			),
-		).toBe(true);
-	});
+  it("matches secondary contexts and ignores case", () => {
+    expect(
+      hasSelectedActionContext(
+        messageWith("hello"),
+        stateWithRouting("social", ["wallet"]),
+        ["WALLET" as AgentContext],
+      ),
+    ).toBe(true);
+  });
 
-	it("returns true when message metadata routing overlaps", () => {
-		const message = {
-			content: {
-				text: "hello",
-				metadata: {
-					[CONTEXT_ROUTING_METADATA_KEY]: {
-						primaryContext: "crypto",
-						secondaryContexts: ["trading"],
-					},
-				},
-			},
-		} as unknown as Memory;
-		expect(
-			hasSelectedActionContext(message, undefined, ["trading" as AgentContext]),
-		).toBe(true);
-	});
+  it("returns true when message metadata routing overlaps", () => {
+    const message = {
+      content: {
+        text: "hello",
+        metadata: {
+          [CONTEXT_ROUTING_METADATA_KEY]: {
+            primaryContext: "crypto",
+            secondaryContexts: ["trading"],
+          },
+        },
+      },
+    } as unknown as Memory;
+    expect(
+      hasSelectedActionContext(message, undefined, ["trading" as AgentContext]),
+    ).toBe(true);
+  });
 });
 
 describe("hasSelectedContextOrSignalSync", () => {
-	it("returns true from selected action context even without keyword hits", () => {
-		expect(
-			hasSelectedContextOrSignalSync(
-				messageWith("hello"),
-				stateWithRouting("code"),
-				["code" as AgentContext],
-				["calendar"],
-			),
-		).toBe(true);
-	});
+  it("returns true from selected action context even without keyword hits", () => {
+    expect(
+      hasSelectedContextOrSignalSync(
+        messageWith("hello"),
+        stateWithRouting("code"),
+        ["code" as AgentContext],
+        ["calendar"],
+      ),
+    ).toBe(true);
+  });
 
-	it("falls back to the keyword signal when no context is selected", () => {
-		expect(
-			hasSelectedContextOrSignalSync(
-				messageWith("open the calendar"),
-				undefined,
-				["code" as AgentContext],
-				["calendar"],
-			),
-		).toBe(true);
-		expect(
-			hasSelectedContextOrSignalSync(
-				messageWith("hello"),
-				undefined,
-				["code" as AgentContext],
-				["calendar"],
-			),
-		).toBe(false);
-	});
+  it("falls back to the keyword signal when no context is selected", () => {
+    expect(
+      hasSelectedContextOrSignalSync(
+        messageWith("open the calendar"),
+        undefined,
+        ["code" as AgentContext],
+        ["calendar"],
+      ),
+    ).toBe(true);
+    expect(
+      hasSelectedContextOrSignalSync(
+        messageWith("hello"),
+        undefined,
+        ["code" as AgentContext],
+        ["calendar"],
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("hasContextSignal", () => {
-	it("returns false for an empty text queue", async () => {
-		await expect(
-			hasContextSignal({} as IAgentRuntime, messageWith(""), undefined, [
-				"calendar",
-			]),
-		).resolves.toBe(false);
-	});
+  it("returns false for an empty text queue", async () => {
+    await expect(
+      hasContextSignal({} as IAgentRuntime, messageWith(""), undefined, [
+        "calendar",
+      ]),
+    ).resolves.toBe(false);
+  });
 
-	it("activates from the current message without a DB round-trip", async () => {
-		await expect(
-			hasContextSignal(
-				runtimeWithMemories([{ content: { text: "unrelated" } }]),
-				messageWith("open the calendar"),
-				undefined,
-				["calendar"],
-			),
-		).resolves.toBe(true);
-	});
+  it("activates from the current message without a DB round-trip", async () => {
+    await expect(
+      hasContextSignal(
+        runtimeWithMemories([{ content: { text: "unrelated" } }]),
+        messageWith("open the calendar"),
+        undefined,
+        ["calendar"],
+      ),
+    ).resolves.toBe(true);
+  });
 
-	it("backfills from room memories when state is thin", async () => {
-		await expect(
-			hasContextSignal(
-				runtimeWithMemories([
-					{ content: { text: "Alice: open the calendar" } },
-				]),
-				messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
-				stateWithRecent(""),
-				["calendar"],
-			),
-		).resolves.toBe(true);
-	});
+  it("backfills from room memories when state is thin", async () => {
+    await expect(
+      hasContextSignal(
+        runtimeWithMemories([
+          { content: { text: "Alice: open the calendar" } },
+        ]),
+        messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+        stateWithRecent(""),
+        ["calendar"],
+      ),
+    ).resolves.toBe(true);
+  });
 
-	it("skips getMemories when state already meets contextLimit (capacity gate)", async () => {
-		let called = false;
-		const runtime = runtimeWithMemories(
-			[{ content: { text: "the only calendar mention" } }],
-			() => {
-				called = true;
-			},
-		);
-		const state = stateWithRecent("hello\nworld");
-		const matched = await hasContextSignal(
-			runtime,
-			messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
-			state,
-			["calendar"],
-			[],
-			2,
-		);
-		expect(called).toBe(false);
-		expect(matched).toBe(false);
-	});
+  it("skips getMemories when state already meets contextLimit (capacity gate)", async () => {
+    let called = false;
+    const runtime = runtimeWithMemories(
+      [{ content: { text: "the only calendar mention" } }],
+      () => {
+        called = true;
+      },
+    );
+    const state = stateWithRecent("hello\nworld");
+    const matched = await hasContextSignal(
+      runtime,
+      messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+      state,
+      ["calendar"],
+      [],
+      2,
+    );
+    expect(called).toBe(false);
+    expect(matched).toBe(false);
+  });
 
-	it("still inspects the current message after the capacity gate skips the DB", async () => {
-		let called = false;
-		const matched = await hasContextSignal(
-			runtimeWithMemories([{ content: { text: "ignored" } }], () => {
-				called = true;
-			}),
-			messageWith("open the calendar", { roomId: "room-1" } as Partial<Memory>),
-			stateWithRecent("hello\nworld"),
-			["calendar"],
-			[],
-			2,
-		);
-		expect(called).toBe(false);
-		expect(matched).toBe(true);
-	});
+  it("still inspects the current message after the capacity gate skips the DB", async () => {
+    let called = false;
+    const matched = await hasContextSignal(
+      runtimeWithMemories([{ content: { text: "ignored" } }], () => {
+        called = true;
+      }),
+      messageWith("open the calendar", { roomId: "room-1" } as Partial<Memory>),
+      stateWithRecent("hello\nworld"),
+      ["calendar"],
+      [],
+      2,
+    );
+    expect(called).toBe(false);
+    expect(matched).toBe(true);
+  });
 
-	it("treats contextLimit 0 with empty state as already-full and skips the DB", async () => {
-		let called = false;
-		const matched = await hasContextSignal(
-			runtimeWithMemories(
-				[{ content: { text: "the only calendar mention" } }],
-				() => {
-					called = true;
-				},
-			),
-			messageWith("", { roomId: "room-1" } as Partial<Memory>),
-			undefined,
-			["calendar"],
-			[],
-			0,
-		);
-		expect(called).toBe(false);
-		expect(matched).toBe(false);
-	});
+  it("treats contextLimit 0 with empty state as already-full and skips the DB", async () => {
+    let called = false;
+    const matched = await hasContextSignal(
+      runtimeWithMemories(
+        [{ content: { text: "the only calendar mention" } }],
+        () => {
+          called = true;
+        },
+      ),
+      messageWith("", { roomId: "room-1" } as Partial<Memory>),
+      undefined,
+      ["calendar"],
+      [],
+      0,
+    );
+    expect(called).toBe(false);
+    expect(matched).toBe(false);
+  });
 
-	it("falls back to state texts when getMemories throws", async () => {
-		const runtime = {
-			getMemories: async () => {
-				throw new Error("db unavailable");
-			},
-		} as unknown as IAgentRuntime;
-		await expect(
-			hasContextSignal(
-				runtime,
-				messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
-				stateWithRecent("calendar reminder"),
-				["calendar"],
-			),
-		).resolves.toBe(true);
-	});
+  it("falls back to state texts when getMemories throws", async () => {
+    const runtime = {
+      getMemories: async () => {
+        throw new Error("db unavailable");
+      },
+    } as unknown as IAgentRuntime;
+    await expect(
+      hasContextSignal(
+        runtime,
+        messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+        stateWithRecent("calendar reminder"),
+        ["calendar"],
+      ),
+    ).resolves.toBe(true);
+  });
 
-	it("activates on a weak term from backfilled memories", async () => {
-		await expect(
-			hasContextSignal(
-				runtimeWithMemories([{ content: { text: "please forward this" } }]),
-				messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
-				undefined,
-				["calendar"],
-				["forward"],
-			),
-		).resolves.toBe(true);
-	});
+  it("activates on a weak term from backfilled memories", async () => {
+    await expect(
+      hasContextSignal(
+        runtimeWithMemories([{ content: { text: "please forward this" } }]),
+        messageWith("ok", { roomId: "room-1" } as Partial<Memory>),
+        undefined,
+        ["calendar"],
+        ["forward"],
+      ),
+    ).resolves.toBe(true);
+  });
 });

--- a/packages/agent/src/actions/extract-params.test.ts
+++ b/packages/agent/src/actions/extract-params.test.ts
@@ -9,446 +9,446 @@ import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-	extractActionParamsViaLlm,
-	type ParamSchemaDescriptor,
+  extractActionParamsViaLlm,
+  type ParamSchemaDescriptor,
 } from "./extract-params.ts";
 
 afterEach(() => {
-	vi.restoreAllMocks();
+  vi.restoreAllMocks();
 });
 
 const SCHEMA: readonly ParamSchemaDescriptor[] = [
-	{
-		name: "subaction",
-		description: "Inbox operation to run",
-		required: true,
-		schema: { type: "string", enum: ["search", "digest", "respond"] },
-	},
-	{
-		name: "query",
-		description: "Search query",
-		schema: { type: "string" },
-	},
-	{
-		name: "limit",
-		description: "Max results",
-		schema: { type: "number" },
-	},
+  {
+    name: "subaction",
+    description: "Inbox operation to run",
+    required: true,
+    schema: { type: "string", enum: ["search", "digest", "respond"] },
+  },
+  {
+    name: "query",
+    description: "Search query",
+    schema: { type: "string" },
+  },
+  {
+    name: "limit",
+    description: "Max results",
+    schema: { type: "number" },
+  },
 ];
 
 type Params = {
-	subaction?: string | null;
-	query?: string | null;
-	limit?: number | null;
-	extra?: unknown;
+  subaction?: string | null;
+  query?: string | null;
+  limit?: number | null;
+  extra?: unknown;
 };
 
 function message(text: unknown = "search github"): Memory {
-	return { content: { text } } as unknown as Memory;
+  return { content: { text } } as unknown as Memory;
 }
 
 function conversationState(
-	rows: Array<{
-		text?: unknown;
-		content?: unknown;
-		metadata?: Memory["metadata"];
-	}>,
+  rows: Array<{
+    text?: unknown;
+    content?: unknown;
+    metadata?: Memory["metadata"];
+  }>,
 ): State {
-	const recentMessages = rows.map((row) => ({
-		content: row.content !== undefined ? row.content : { text: row.text },
-		metadata: row.metadata,
-	}));
-	return {
-		data: {
-			providers: {
-				RECENT_MESSAGES: { data: { recentMessages } },
-			},
-		},
-	} as unknown as State;
+  const recentMessages = rows.map((row) => ({
+    content: row.content !== undefined ? row.content : { text: row.text },
+    metadata: row.metadata,
+  }));
+  return {
+    data: {
+      providers: {
+        RECENT_MESSAGES: { data: { recentMessages } },
+      },
+    },
+  } as unknown as State;
 }
 
 function runtime(
-	useModel: IAgentRuntime["useModel"] = vi.fn(
-		async () => '{"subaction":"search"}',
-	),
+  useModel: IAgentRuntime["useModel"] = vi.fn(
+    async () => '{"subaction":"search"}',
+  ),
 ): { runtime: IAgentRuntime; useModel: IAgentRuntime["useModel"] } {
-	return {
-		runtime: { useModel } as unknown as IAgentRuntime,
-		useModel,
-	};
+  return {
+    runtime: { useModel } as unknown as IAgentRuntime,
+    useModel,
+  };
 }
 
 function extract(
-	overrides: {
-		runtime?: IAgentRuntime;
-		message?: Memory;
-		state?: State;
-		existingParams?: Partial<Params>;
-		requiredFields?: ReadonlyArray<keyof Params & string>;
-		paramSchema?: readonly ParamSchemaDescriptor[];
-		modelType?: (typeof ModelType)[keyof typeof ModelType];
-		recentMessagesLimit?: number;
-		actionName?: string;
-		actionDescription?: string;
-	} = {},
+  overrides: {
+    runtime?: IAgentRuntime;
+    message?: Memory;
+    state?: State;
+    existingParams?: Partial<Params>;
+    requiredFields?: ReadonlyArray<keyof Params & string>;
+    paramSchema?: readonly ParamSchemaDescriptor[];
+    modelType?: (typeof ModelType)[keyof typeof ModelType];
+    recentMessagesLimit?: number;
+    actionName?: string;
+    actionDescription?: string;
+  } = {},
 ) {
-	const { runtime: rt, useModel } = overrides.runtime
-		? { runtime: overrides.runtime, useModel: overrides.runtime.useModel }
-		: runtime();
-	return {
-		useModel,
-		promise: extractActionParamsViaLlm<Params>({
-			runtime: rt,
-			message: overrides.message ?? message(),
-			state: overrides.state,
-			actionName: overrides.actionName ?? "MESSAGE",
-			actionDescription:
-				overrides.actionDescription ??
-				"Cross-channel inbox: triage / digest / respond / search",
-			paramSchema: overrides.paramSchema ?? SCHEMA,
-			existingParams: overrides.existingParams ?? {},
-			requiredFields: overrides.requiredFields ?? ["subaction"],
-			modelType: overrides.modelType,
-			recentMessagesLimit: overrides.recentMessagesLimit,
-		}),
-	};
+  const { runtime: rt, useModel } = overrides.runtime
+    ? { runtime: overrides.runtime, useModel: overrides.runtime.useModel }
+    : runtime();
+  return {
+    useModel,
+    promise: extractActionParamsViaLlm<Params>({
+      runtime: rt,
+      message: overrides.message ?? message(),
+      state: overrides.state,
+      actionName: overrides.actionName ?? "MESSAGE",
+      actionDescription:
+        overrides.actionDescription ??
+        "Cross-channel inbox: triage / digest / respond / search",
+      paramSchema: overrides.paramSchema ?? SCHEMA,
+      existingParams: overrides.existingParams ?? {},
+      requiredFields: overrides.requiredFields ?? ["subaction"],
+      modelType: overrides.modelType,
+      recentMessagesLimit: overrides.recentMessagesLimit,
+    }),
+  };
 }
 
 describe("extractActionParamsViaLlm", () => {
-	describe("short-circuit when required fields are already present", () => {
-		it("returns the same object and skips the model when every required field is filled", async () => {
-			const existingParams = { subaction: "digest", query: "github" };
-			const { useModel, promise } = extract({ existingParams });
-			const result = await promise;
-			expect(result).toBe(existingParams);
-			expect(useModel).not.toHaveBeenCalled();
-		});
+  describe("short-circuit when required fields are already present", () => {
+    it("returns the same object and skips the model when every required field is filled", async () => {
+      const existingParams = { subaction: "digest", query: "github" };
+      const { useModel, promise } = extract({ existingParams });
+      const result = await promise;
+      expect(result).toBe(existingParams);
+      expect(useModel).not.toHaveBeenCalled();
+    });
 
-		it('treats 0, false, and empty arrays as present (only null/undefined/"" are missing)', async () => {
-			const existingParams = {
-				subaction: "search",
-				limit: 0,
-				extra: false,
-			};
-			const { useModel, promise } = extract({
-				existingParams,
-				requiredFields: ["subaction", "limit"],
-			});
-			expect(await promise).toBe(existingParams);
-			expect(useModel).not.toHaveBeenCalled();
-		});
+    it('treats 0, false, and empty arrays as present (only null/undefined/"" are missing)', async () => {
+      const existingParams = {
+        subaction: "search",
+        limit: 0,
+        extra: false,
+      };
+      const { useModel, promise } = extract({
+        existingParams,
+        requiredFields: ["subaction", "limit"],
+      });
+      expect(await promise).toBe(existingParams);
+      expect(useModel).not.toHaveBeenCalled();
+    });
 
-		it("skips the model when requiredFields is empty", async () => {
-			const existingParams = {};
-			const { useModel, promise } = extract({
-				existingParams,
-				requiredFields: [],
-			});
-			expect(await promise).toBe(existingParams);
-			expect(useModel).not.toHaveBeenCalled();
-		});
+    it("skips the model when requiredFields is empty", async () => {
+      const existingParams = {};
+      const { useModel, promise } = extract({
+        existingParams,
+        requiredFields: [],
+      });
+      expect(await promise).toBe(existingParams);
+      expect(useModel).not.toHaveBeenCalled();
+    });
 
-		it("does not treat schema.required as the missing-field source", async () => {
-			const existingParams = { query: "github" };
-			const { useModel, promise } = extract({
-				existingParams,
-				requiredFields: ["query"],
-			});
-			// subaction is required:true on the schema, but not in requiredFields.
-			expect(await promise).toBe(existingParams);
-			expect(useModel).not.toHaveBeenCalled();
-		});
-	});
+    it("does not treat schema.required as the missing-field source", async () => {
+      const existingParams = { query: "github" };
+      const { useModel, promise } = extract({
+        existingParams,
+        requiredFields: ["query"],
+      });
+      // subaction is required:true on the schema, but not in requiredFields.
+      expect(await promise).toBe(existingParams);
+      expect(useModel).not.toHaveBeenCalled();
+    });
+  });
 
-	describe("missing-field detection", () => {
-		it.each([
-			{ label: "undefined", existingParams: {} },
-			{ label: "null", existingParams: { subaction: null } },
-			{ label: "empty string", existingParams: { subaction: "" } },
-		])(
-			"calls the model when $label is the required value",
-			async ({ existingParams }) => {
-				const { useModel, promise } = extract({ existingParams });
-				await promise;
-				expect(useModel).toHaveBeenCalledTimes(1);
-			},
-		);
+  describe("missing-field detection", () => {
+    it.each([
+      { label: "undefined", existingParams: {} },
+      { label: "null", existingParams: { subaction: null } },
+      { label: "empty string", existingParams: { subaction: "" } },
+    ])(
+      "calls the model when $label is the required value",
+      async ({ existingParams }) => {
+        const { useModel, promise } = extract({ existingParams });
+        await promise;
+        expect(useModel).toHaveBeenCalledTimes(1);
+      },
+    );
 
-		it("does not treat a whitespace-only string as missing", async () => {
-			const existingParams = { subaction: "  " };
-			const { useModel, promise } = extract({ existingParams });
-			expect(await promise).toBe(existingParams);
-			expect(useModel).not.toHaveBeenCalled();
-		});
-	});
+    it("does not treat a whitespace-only string as missing", async () => {
+      const existingParams = { subaction: "  " };
+      const { useModel, promise } = extract({ existingParams });
+      expect(await promise).toBe(existingParams);
+      expect(useModel).not.toHaveBeenCalled();
+    });
+  });
 
-	describe("model invocation and prompt construction", () => {
-		it("calls TEXT_SMALL with stopSequences: [] by default", async () => {
-			const { useModel, promise } = extract({
-				existingParams: { subaction: null },
-			});
-			await promise;
-			expect(useModel).toHaveBeenCalledWith(ModelType.TEXT_SMALL, {
-				prompt: expect.any(String),
-				stopSequences: [],
-			});
-		});
+  describe("model invocation and prompt construction", () => {
+    it("calls TEXT_SMALL with stopSequences: [] by default", async () => {
+      const { useModel, promise } = extract({
+        existingParams: { subaction: null },
+      });
+      await promise;
+      expect(useModel).toHaveBeenCalledWith(ModelType.TEXT_SMALL, {
+        prompt: expect.any(String),
+        stopSequences: [],
+      });
+    });
 
-		it("forwards an explicit modelType override", async () => {
-			const { useModel, promise } = extract({
-				existingParams: { subaction: null },
-				modelType: ModelType.TEXT_LARGE,
-			});
-			await promise;
-			expect(useModel).toHaveBeenCalledWith(
-				ModelType.TEXT_LARGE,
-				expect.objectContaining({ stopSequences: [] }),
-			);
-		});
+    it("forwards an explicit modelType override", async () => {
+      const { useModel, promise } = extract({
+        existingParams: { subaction: null },
+        modelType: ModelType.TEXT_LARGE,
+      });
+      await promise;
+      expect(useModel).toHaveBeenCalledWith(
+        ModelType.TEXT_LARGE,
+        expect.objectContaining({ stopSequences: [] }),
+      );
+    });
 
-		it("renders schema types, enums, and [REQUIRED] only for still-missing fields", async () => {
-			const { useModel, promise } = extract({
-				existingParams: { query: "github", subaction: "" },
-				requiredFields: ["subaction"],
-			});
-			await promise;
-			const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
-				.prompt as string;
-			expect(prompt).toContain("MESSAGE");
-			expect(prompt).toContain(
-				"Cross-channel inbox: triage / digest / respond / search",
-			);
-			expect(prompt).toContain(
-				"  - subaction (string) [one of: search | digest | respond] [REQUIRED]: Inbox operation to run",
-			);
-			expect(prompt).toContain("  - query (string): Search query");
-			expect(prompt).not.toContain("query (string) [REQUIRED]");
-			expect(prompt).toContain(
-				"Missing required fields you must extract: subaction",
-			);
-			expect(prompt).toContain('{"query":"github","subaction":""}');
-		});
+    it("renders schema types, enums, and [REQUIRED] only for still-missing fields", async () => {
+      const { useModel, promise } = extract({
+        existingParams: { query: "github", subaction: "" },
+        requiredFields: ["subaction"],
+      });
+      await promise;
+      const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
+        .prompt as string;
+      expect(prompt).toContain("MESSAGE");
+      expect(prompt).toContain(
+        "Cross-channel inbox: triage / digest / respond / search",
+      );
+      expect(prompt).toContain(
+        "  - subaction (string) [one of: search | digest | respond] [REQUIRED]: Inbox operation to run",
+      );
+      expect(prompt).toContain("  - query (string): Search query");
+      expect(prompt).not.toContain("query (string) [REQUIRED]");
+      expect(prompt).toContain(
+        "Missing required fields you must extract: subaction",
+      );
+      expect(prompt).toContain('{"query":"github","subaction":""}');
+    });
 
-		it("trims the current message and substitutes (empty) when text is blank or non-string", async () => {
-			const { useModel: trimmedModel, promise: trimmed } = extract({
-				message: message("  search github  "),
-				existingParams: { subaction: null },
-			});
-			await trimmed;
-			const trimmedPrompt = (trimmedModel as ReturnType<typeof vi.fn>).mock
-				.calls[0][1].prompt as string;
-			expect(trimmedPrompt).toContain("Current user message: search github");
+    it("trims the current message and substitutes (empty) when text is blank or non-string", async () => {
+      const { useModel: trimmedModel, promise: trimmed } = extract({
+        message: message("  search github  "),
+        existingParams: { subaction: null },
+      });
+      await trimmed;
+      const trimmedPrompt = (trimmedModel as ReturnType<typeof vi.fn>).mock
+        .calls[0][1].prompt as string;
+      expect(trimmedPrompt).toContain("Current user message: search github");
 
-			const { useModel: emptyModel, promise: empty } = extract({
-				runtime: runtime(vi.fn(async () => '{"subaction":"search"}')).runtime,
-				message: message("   "),
-				existingParams: { subaction: null },
-			});
-			await empty;
-			expect(
-				(emptyModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
-			).toContain("Current user message: (empty)");
+      const { useModel: emptyModel, promise: empty } = extract({
+        runtime: runtime(vi.fn(async () => '{"subaction":"search"}')).runtime,
+        message: message("   "),
+        existingParams: { subaction: null },
+      });
+      await empty;
+      expect(
+        (emptyModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
+      ).toContain("Current user message: (empty)");
 
-			const { useModel: nonStringModel, promise: nonString } = extract({
-				runtime: runtime(vi.fn(async () => '{"subaction":"search"}')).runtime,
-				message: message(42),
-				existingParams: { subaction: null },
-			});
-			await nonString;
-			expect(
-				(nonStringModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
-			).toContain("Current user message: (empty)");
-		});
-	});
+      const { useModel: nonStringModel, promise: nonString } = extract({
+        runtime: runtime(vi.fn(async () => '{"subaction":"search"}')).runtime,
+        message: message(42),
+        existingParams: { subaction: null },
+      });
+      await nonString;
+      expect(
+        (nonStringModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
+      ).toContain("Current user message: (empty)");
+    });
+  });
 
-	describe("conversation context and speaker names", () => {
-		it("uses the no-conversation placeholder when state is absent or empty", async () => {
-			const { useModel: noStateModel, promise: noState } = extract({
-				existingParams: { subaction: null },
-			});
-			await noState;
-			expect(
-				(noStateModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
-			).toContain("(no recent conversation context)");
+  describe("conversation context and speaker names", () => {
+    it("uses the no-conversation placeholder when state is absent or empty", async () => {
+      const { useModel: noStateModel, promise: noState } = extract({
+        existingParams: { subaction: null },
+      });
+      await noState;
+      expect(
+        (noStateModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
+      ).toContain("(no recent conversation context)");
 
-			const { useModel: emptyModel, promise: empty } = extract({
-				runtime: runtime(vi.fn(async () => '{"subaction":"search"}')).runtime,
-				state: conversationState([]),
-				existingParams: { subaction: null },
-			});
-			await empty;
-			expect(
-				(emptyModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
-			).toContain("(no recent conversation context)");
-		});
+      const { useModel: emptyModel, promise: empty } = extract({
+        runtime: runtime(vi.fn(async () => '{"subaction":"search"}')).runtime,
+        state: conversationState([]),
+        existingParams: { subaction: null },
+      });
+      await empty;
+      expect(
+        (emptyModel as ReturnType<typeof vi.fn>).mock.calls[0][1].prompt,
+      ).toContain("(no recent conversation context)");
+    });
 
-		it("formats oldest-first conversation lines and drops empty / non-object content", async () => {
-			const { useModel, promise } = extract({
-				existingParams: { subaction: null },
-				recentMessagesLimit: 1,
-				state: conversationState([
-					{ text: "first" },
-					{ text: "   " },
-					{ content: "not-an-object" },
-					{ content: { text: 7 } },
-					{ text: "second" },
-				]),
-			});
-			await promise;
-			const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
-				.prompt as string;
-			expect(prompt).toContain(
-				"Recent conversation (oldest first):\nuser: first\nuser: second",
-			);
-			// Deprecated limit is ignored — both real lines remain.
-			expect(prompt).toContain("user: first");
-			expect(prompt).toContain("user: second");
-		});
+    it("formats oldest-first conversation lines and drops empty / non-object content", async () => {
+      const { useModel, promise } = extract({
+        existingParams: { subaction: null },
+        recentMessagesLimit: 1,
+        state: conversationState([
+          { text: "first" },
+          { text: "   " },
+          { content: "not-an-object" },
+          { content: { text: 7 } },
+          { text: "second" },
+        ]),
+      });
+      await promise;
+      const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
+        .prompt as string;
+      expect(prompt).toContain(
+        "Recent conversation (oldest first):\nuser: first\nuser: second",
+      );
+      // Deprecated limit is ignored — both real lines remain.
+      expect(prompt).toContain("user: first");
+      expect(prompt).toContain("user: second");
+    });
 
-		it("prefers sender.name, then entityName, then entityUserName, else user", async () => {
-			const { useModel, promise } = extract({
-				existingParams: { subaction: null },
-				state: conversationState([
-					{
-						text: "from-sender",
-						metadata: {
-							sender: { name: "Alice" },
-							entityName: "Ignored",
-							entityUserName: "also-ignored",
-						} as Memory["metadata"],
-					},
-					{
-						text: "from-entity",
-						metadata: {
-							sender: "not-an-object",
-							entityName: "Bob",
-							entityUserName: "bob-user",
-						} as unknown as Memory["metadata"],
-					},
-					{
-						text: "from-username",
-						metadata: {
-							entityName: 12,
-							entityUserName: "carol",
-						} as unknown as Memory["metadata"],
-					},
-					{ text: "anonymous" },
-				]),
-			});
-			await promise;
-			const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
-				.prompt as string;
-			expect(prompt).toContain("Alice: from-sender");
-			expect(prompt).toContain("Bob: from-entity");
-			expect(prompt).toContain("carol: from-username");
-			expect(prompt).toContain("user: anonymous");
-		});
-	});
+    it("prefers sender.name, then entityName, then entityUserName, else user", async () => {
+      const { useModel, promise } = extract({
+        existingParams: { subaction: null },
+        state: conversationState([
+          {
+            text: "from-sender",
+            metadata: {
+              sender: { name: "Alice" },
+              entityName: "Ignored",
+              entityUserName: "also-ignored",
+            } as Memory["metadata"],
+          },
+          {
+            text: "from-entity",
+            metadata: {
+              sender: "not-an-object",
+              entityName: "Bob",
+              entityUserName: "bob-user",
+            } as unknown as Memory["metadata"],
+          },
+          {
+            text: "from-username",
+            metadata: {
+              entityName: 12,
+              entityUserName: "carol",
+            } as unknown as Memory["metadata"],
+          },
+          { text: "anonymous" },
+        ]),
+      });
+      await promise;
+      const prompt = (useModel as ReturnType<typeof vi.fn>).mock.calls[0][1]
+        .prompt as string;
+      expect(prompt).toContain("Alice: from-sender");
+      expect(prompt).toContain("Bob: from-entity");
+      expect(prompt).toContain("carol: from-username");
+      expect(prompt).toContain("user: anonymous");
+    });
+  });
 
-	describe("parse, merge, and fallbacks", () => {
-		it("fills missing slots from extracted JSON while planner values win on collision", async () => {
-			const { runtime: rt } = runtime(
-				vi.fn(
-					async () => '{"subaction":"search","query":"extracted","limit":5}',
-				),
-			);
-			const existingParams = { subaction: "", query: "planner-query" };
-			const { promise } = extract({
-				runtime: rt,
-				existingParams,
-				requiredFields: ["subaction"],
-			});
-			expect(await promise).toEqual({
-				subaction: "search",
-				query: "planner-query",
-				limit: 5,
-			});
-		});
+  describe("parse, merge, and fallbacks", () => {
+    it("fills missing slots from extracted JSON while planner values win on collision", async () => {
+      const { runtime: rt } = runtime(
+        vi.fn(
+          async () => '{"subaction":"search","query":"extracted","limit":5}',
+        ),
+      );
+      const existingParams = { subaction: "", query: "planner-query" };
+      const { promise } = extract({
+        runtime: rt,
+        existingParams,
+        requiredFields: ["subaction"],
+      });
+      expect(await promise).toEqual({
+        subaction: "search",
+        query: "planner-query",
+        limit: 5,
+      });
+    });
 
-		it("drops null extracted fields so they cannot clobber a later merge", async () => {
-			const { runtime: rt } = runtime(
-				vi.fn(async () => '{"subaction":null,"query":"kept"}'),
-			);
-			const { promise } = extract({
-				runtime: rt,
-				existingParams: { subaction: null },
-			});
-			expect(await promise).toEqual({ query: "kept" });
-		});
+    it("drops null extracted fields so they cannot clobber a later merge", async () => {
+      const { runtime: rt } = runtime(
+        vi.fn(async () => '{"subaction":null,"query":"kept"}'),
+      );
+      const { promise } = extract({
+        runtime: rt,
+        existingParams: { subaction: null },
+      });
+      expect(await promise).toEqual({ query: "kept" });
+    });
 
-		it("parses fenced JSON through the real object parser", async () => {
-			const { runtime: rt } = runtime(
-				vi.fn(async () => 'sure:\n```json\n{"subaction":"digest"}\n```\ndone'),
-			);
-			const { promise } = extract({
-				runtime: rt,
-				existingParams: { subaction: null },
-			});
-			expect(await promise).toEqual({ subaction: "digest" });
-		});
+    it("parses fenced JSON through the real object parser", async () => {
+      const { runtime: rt } = runtime(
+        vi.fn(async () => 'sure:\n```json\n{"subaction":"digest"}\n```\ndone'),
+      );
+      const { promise } = extract({
+        runtime: rt,
+        existingParams: { subaction: null },
+      });
+      expect(await promise).toEqual({ subaction: "digest" });
+    });
 
-		it.each([
-			{ label: "empty string", raw: "   " },
-			{ label: "non-object JSON", raw: "[1,2,3]" },
-			{ label: "unparseable prose", raw: "not json at all" },
-			{ label: "non-string model result", raw: { not: "json" } },
-		])(
-			"returns existingParams unchanged when the model yields $label",
-			async ({ raw }) => {
-				const existingParams = { subaction: null, query: "keep-me" };
-				const { runtime: rt } = runtime(vi.fn(async () => raw as never));
-				const { promise } = extract({ runtime: rt, existingParams });
-				expect(await promise).toBe(existingParams);
-			},
-		);
+    it.each([
+      { label: "empty string", raw: "   " },
+      { label: "non-object JSON", raw: "[1,2,3]" },
+      { label: "unparseable prose", raw: "not json at all" },
+      { label: "non-string model result", raw: { not: "json" } },
+    ])(
+      "returns existingParams unchanged when the model yields $label",
+      async ({ raw }) => {
+        const existingParams = { subaction: null, query: "keep-me" };
+        const { runtime: rt } = runtime(vi.fn(async () => raw as never));
+        const { promise } = extract({ runtime: rt, existingParams });
+        expect(await promise).toBe(existingParams);
+      },
+    );
 
-		it("keeps existingParams when useModel throws, and logs the action-scoped warning", async () => {
-			const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
-			const existingParams = { query: "keep-me" };
-			const { runtime: rt } = runtime(
-				vi.fn(async () => {
-					throw new Error("provider down");
-				}),
-			);
-			const { promise } = extract({
-				runtime: rt,
-				existingParams,
-				actionName: "MESSAGE",
-			});
-			expect(await promise).toBe(existingParams);
-			expect(warn).toHaveBeenCalledWith(
-				"[MESSAGE] LLM param extraction failed: provider down",
-			);
+    it("keeps existingParams when useModel throws, and logs the action-scoped warning", async () => {
+      const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      const existingParams = { query: "keep-me" };
+      const { runtime: rt } = runtime(
+        vi.fn(async () => {
+          throw new Error("provider down");
+        }),
+      );
+      const { promise } = extract({
+        runtime: rt,
+        existingParams,
+        actionName: "MESSAGE",
+      });
+      expect(await promise).toBe(existingParams);
+      expect(warn).toHaveBeenCalledWith(
+        "[MESSAGE] LLM param extraction failed: provider down",
+      );
 
-			const { runtime: rt2 } = runtime(
-				vi.fn(async () => {
-					throw "bare-string";
-				}),
-			);
-			const existing2 = { query: "still" };
-			const { promise: p2 } = extract({
-				runtime: rt2,
-				existingParams: existing2,
-				actionName: "MESSAGE",
-			});
-			expect(await p2).toBe(existing2);
-			expect(warn).toHaveBeenCalledWith(
-				"[MESSAGE] LLM param extraction failed: bare-string",
-			);
-		});
+      const { runtime: rt2 } = runtime(
+        vi.fn(async () => {
+          throw "bare-string";
+        }),
+      );
+      const existing2 = { query: "still" };
+      const { promise: p2 } = extract({
+        runtime: rt2,
+        existingParams: existing2,
+        actionName: "MESSAGE",
+      });
+      expect(await p2).toBe(existing2);
+      expect(warn).toHaveBeenCalledWith(
+        "[MESSAGE] LLM param extraction failed: bare-string",
+      );
+    });
 
-		it("copies extra non-empty planner keys onto the merged result", async () => {
-			const { runtime: rt } = runtime(
-				vi.fn(async () => '{"subaction":"respond"}'),
-			);
-			const { promise } = extract({
-				runtime: rt,
-				existingParams: { extra: { nested: true }, subaction: "" },
-			});
-			expect(await promise).toEqual({
-				extra: { nested: true },
-				subaction: "respond",
-			});
-		});
-	});
+    it("copies extra non-empty planner keys onto the merged result", async () => {
+      const { runtime: rt } = runtime(
+        vi.fn(async () => '{"subaction":"respond"}'),
+      );
+      const { promise } = extract({
+        runtime: rt,
+        existingParams: { extra: { nested: true }, subaction: "" },
+      });
+      expect(await promise).toEqual({
+        extra: { nested: true },
+        subaction: "respond",
+      });
+    });
+  });
 });

--- a/packages/agent/src/actions/grounded-action-reply.test.ts
+++ b/packages/agent/src/actions/grounded-action-reply.test.ts
@@ -9,664 +9,664 @@ import type { ActionResult, IAgentRuntime, Memory, State } from "@elizaos/core";
 import { ModelType, runWithTrajectoryContext } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-	extractActionResultsFromState,
-	renderGroundedActionReply,
-	summarizeActiveTrajectory,
-	summarizeRecentActionHistory,
+  extractActionResultsFromState,
+  renderGroundedActionReply,
+  summarizeActiveTrajectory,
+  summarizeRecentActionHistory,
 } from "./grounded-action-reply.ts";
 
 const { loadTrajectoryByStepId } = vi.hoisted(() => ({
-	loadTrajectoryByStepId: vi.fn(),
+  loadTrajectoryByStepId: vi.fn(),
 }));
 
 vi.mock("../runtime/trajectory-internals.ts", () => ({
-	loadTrajectoryByStepId,
+  loadTrajectoryByStepId,
 }));
 
 function stateFrom(data: Record<string, unknown>): State {
-	return { data } as unknown as State;
+  return { data } as unknown as State;
 }
 
 function result(partial: {
-	actionName?: string;
-	text?: string;
-	success?: boolean;
-	data?: Record<string, unknown>;
+  actionName?: string;
+  text?: string;
+  success?: boolean;
+  data?: Record<string, unknown>;
 }): ActionResult {
-	const { actionName, text, success, data } = partial;
-	return {
-		success,
-		text,
-		data: {
-			...(actionName ? { actionName } : {}),
-			...data,
-		},
-	} as ActionResult;
+  const { actionName, text, success, data } = partial;
+  return {
+    success,
+    text,
+    data: {
+      ...(actionName ? { actionName } : {}),
+      ...data,
+    },
+  } as ActionResult;
 }
 
 function runtimeForReply(options?: {
-	useModel?: IAgentRuntime["useModel"] | null;
-	character?: IAgentRuntime["character"];
-	getSetting?: IAgentRuntime["getSetting"];
+  useModel?: IAgentRuntime["useModel"] | null;
+  character?: IAgentRuntime["character"];
+  getSetting?: IAgentRuntime["getSetting"];
 }): IAgentRuntime {
-	const runtime: Record<string, unknown> = {
-		getMemories: vi.fn(async () => []),
-		character: options?.character ?? { name: "TestAgent" },
-	};
-	if (options?.useModel !== null) {
-		runtime.useModel =
-			options?.useModel ??
-			(vi.fn(async () => "Handled it.") as IAgentRuntime["useModel"]);
-	}
-	if (options?.getSetting) {
-		runtime.getSetting = options.getSetting;
-	}
-	return runtime as unknown as IAgentRuntime;
+  const runtime: Record<string, unknown> = {
+    getMemories: vi.fn(async () => []),
+    character: options?.character ?? { name: "TestAgent" },
+  };
+  if (options?.useModel !== null) {
+    runtime.useModel =
+      options?.useModel ??
+      (vi.fn(async () => "Handled it.") as IAgentRuntime["useModel"]);
+  }
+  if (options?.getSetting) {
+    runtime.getSetting = options.getSetting;
+  }
+  return runtime as unknown as IAgentRuntime;
 }
 
 async function renderWith(options: {
-	useModel?: IAgentRuntime["useModel"] | null;
-	character?: IAgentRuntime["character"];
-	getSetting?: IAgentRuntime["getSetting"];
-	messageText?: unknown;
-	state?: State;
-	intent?: string;
-	domain?: "lifeops" | "gmail" | "calendar";
-	scenario?: string;
-	fallback?: string;
-	context?: Record<string, unknown>;
-	additionalRules?: string[];
-	preferCharacterVoice?: boolean;
+  useModel?: IAgentRuntime["useModel"] | null;
+  character?: IAgentRuntime["character"];
+  getSetting?: IAgentRuntime["getSetting"];
+  messageText?: unknown;
+  state?: State;
+  intent?: string;
+  domain?: "lifeops" | "gmail" | "calendar";
+  scenario?: string;
+  fallback?: string;
+  context?: Record<string, unknown>;
+  additionalRules?: string[];
+  preferCharacterVoice?: boolean;
 }): Promise<{ reply: string; prompt: string; useModel: unknown }> {
-	let prompt = "";
-	const useModel =
-		options.useModel === null
-			? null
-			: (options.useModel ??
-				(vi.fn(async (_model: unknown, params: { prompt: string }) => {
-					prompt = params.prompt;
-					return "Handled it.";
-				}) as IAgentRuntime["useModel"]));
-	const runtime = runtimeForReply({
-		useModel: useModel ?? undefined,
-		character: options.character,
-		getSetting: options.getSetting,
-	});
-	if (options.useModel === null) {
-		delete (runtime as { useModel?: unknown }).useModel;
-	}
-	const reply = await renderGroundedActionReply({
-		runtime,
-		message: { content: { text: options.messageText ?? "add milk" } } as Memory,
-		state: options.state,
-		intent: options.intent ?? "confirm",
-		domain: options.domain ?? "lifeops",
-		scenario: options.scenario ?? "confirm item",
-		fallback: options.fallback ?? "I've handled that.",
-		context: options.context,
-		additionalRules: options.additionalRules,
-		preferCharacterVoice: options.preferCharacterVoice,
-	});
-	return { reply, prompt, useModel };
+  let prompt = "";
+  const useModel =
+    options.useModel === null
+      ? null
+      : (options.useModel ??
+        (vi.fn(async (_model: unknown, params: { prompt: string }) => {
+          prompt = params.prompt;
+          return "Handled it.";
+        }) as IAgentRuntime["useModel"]));
+  const runtime = runtimeForReply({
+    useModel: useModel ?? undefined,
+    character: options.character,
+    getSetting: options.getSetting,
+  });
+  if (options.useModel === null) {
+    delete (runtime as { useModel?: unknown }).useModel;
+  }
+  const reply = await renderGroundedActionReply({
+    runtime,
+    message: { content: { text: options.messageText ?? "add milk" } } as Memory,
+    state: options.state,
+    intent: options.intent ?? "confirm",
+    domain: options.domain ?? "lifeops",
+    scenario: options.scenario ?? "confirm item",
+    fallback: options.fallback ?? "I've handled that.",
+    context: options.context,
+    additionalRules: options.additionalRules,
+    preferCharacterVoice: options.preferCharacterVoice,
+  });
+  return { reply, prompt, useModel };
 }
 
 afterEach(() => {
-	loadTrajectoryByStepId.mockReset();
-	vi.restoreAllMocks();
+  loadTrajectoryByStepId.mockReset();
+  vi.restoreAllMocks();
 });
 
 describe("extractActionResultsFromState", () => {
-	it("returns an empty list for missing or non-object state", () => {
-		expect(extractActionResultsFromState(undefined)).toEqual([]);
-		expect(extractActionResultsFromState({} as State)).toEqual([]);
-	});
+  it("returns an empty list for missing or non-object state", () => {
+    expect(extractActionResultsFromState(undefined)).toEqual([]);
+    expect(extractActionResultsFromState({} as State)).toEqual([]);
+  });
 
-	it("ignores non-array candidate queues", () => {
-		expect(
-			extractActionResultsFromState(
-				stateFrom({
-					actionResults: { not: "an array" },
-					providers: {
-						ACTION_STATE: { data: { actionResults: "nope" } },
-					},
-				}),
-			),
-		).toEqual([]);
-	});
+  it("ignores non-array candidate queues", () => {
+    expect(
+      extractActionResultsFromState(
+        stateFrom({
+          actionResults: { not: "an array" },
+          providers: {
+            ACTION_STATE: { data: { actionResults: "nope" } },
+          },
+        }),
+      ),
+    ).toEqual([]);
+  });
 
-	it("drops non-object entries from a queue", () => {
-		const extracted = extractActionResultsFromState(
-			stateFrom({
-				actionResults: [
-					null,
-					"skip",
-					3,
-					{ success: true, text: "kept", data: { actionName: "KEEP" } },
-				],
-			}),
-		);
-		expect(extracted).toHaveLength(1);
-		expect(extracted[0]).toMatchObject({
-			success: true,
-			text: "kept",
-			data: { actionName: "KEEP" },
-		});
-	});
+  it("drops non-object entries from a queue", () => {
+    const extracted = extractActionResultsFromState(
+      stateFrom({
+        actionResults: [
+          null,
+          "skip",
+          3,
+          { success: true, text: "kept", data: { actionName: "KEEP" } },
+        ],
+      }),
+    );
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0]).toMatchObject({
+      success: true,
+      text: "kept",
+      data: { actionName: "KEEP" },
+    });
+  });
 
-	it("passes through a plain ActionResult that has no content field", () => {
-		const entry = {
-			success: false,
-			text: "boom",
-			data: { actionName: "PLAIN" },
-		};
-		expect(
-			extractActionResultsFromState(stateFrom({ actionResults: [entry] })),
-		).toEqual([entry]);
-	});
+  it("passes through a plain ActionResult that has no content field", () => {
+    const entry = {
+      success: false,
+      text: "boom",
+      data: { actionName: "PLAIN" },
+    };
+    expect(
+      extractActionResultsFromState(stateFrom({ actionResults: [entry] })),
+    ).toEqual([entry]);
+  });
 
-	it("skips a content-shaped entry whose content is not a record", () => {
-		expect(
-			extractActionResultsFromState(
-				stateFrom({
-					actionResults: [{ content: null }, { content: "plain" }],
-				}),
-			),
-		).toEqual([]);
-	});
+  it("skips a content-shaped entry whose content is not a record", () => {
+    expect(
+      extractActionResultsFromState(
+        stateFrom({
+          actionResults: [{ content: null }, { content: "plain" }],
+        }),
+      ),
+    ).toEqual([]);
+  });
 
-	it("maps content.actionStatus failed to success:false and copies actionName", () => {
-		const extracted = extractActionResultsFromState(
-			stateFrom({
-				actionResults: [
-					{
-						content: {
-							actionName: "SEND_MAIL",
-							actionStatus: "failed",
-							text: "smtp timeout",
-							error: "timeout",
-							data: { to: "ada@example.com" },
-						},
-					},
-				],
-			}),
-		);
-		expect(extracted).toEqual([
-			{
-				success: false,
-				text: "smtp timeout",
-				error: "timeout",
-				data: { to: "ada@example.com", actionName: "SEND_MAIL" },
-			},
-		]);
-	});
+  it("maps content.actionStatus failed to success:false and copies actionName", () => {
+    const extracted = extractActionResultsFromState(
+      stateFrom({
+        actionResults: [
+          {
+            content: {
+              actionName: "SEND_MAIL",
+              actionStatus: "failed",
+              text: "smtp timeout",
+              error: "timeout",
+              data: { to: "ada@example.com" },
+            },
+          },
+        ],
+      }),
+    );
+    expect(extracted).toEqual([
+      {
+        success: false,
+        text: "smtp timeout",
+        error: "timeout",
+        data: { to: "ada@example.com", actionName: "SEND_MAIL" },
+      },
+    ]);
+  });
 
-	it("treats a non-failed actionStatus as success and ignores non-string text/error", () => {
-		const extracted = extractActionResultsFromState(
-			stateFrom({
-				actionResults: [
-					{
-						content: {
-							actionStatus: "completed",
-							text: 42,
-							error: { code: 1 },
-							data: { actionName: "DONE" },
-						},
-					},
-				],
-			}),
-		);
-		expect(extracted[0]).toMatchObject({
-			success: true,
-			text: undefined,
-			error: undefined,
-			data: { actionName: "DONE" },
-		});
-	});
+  it("treats a non-failed actionStatus as success and ignores non-string text/error", () => {
+    const extracted = extractActionResultsFromState(
+      stateFrom({
+        actionResults: [
+          {
+            content: {
+              actionStatus: "completed",
+              text: 42,
+              error: { code: 1 },
+              data: { actionName: "DONE" },
+            },
+          },
+        ],
+      }),
+    );
+    expect(extracted[0]).toMatchObject({
+      success: true,
+      text: undefined,
+      error: undefined,
+      data: { actionName: "DONE" },
+    });
+  });
 
-	it("does not overwrite an existing content.data.actionName", () => {
-		const extracted = extractActionResultsFromState(
-			stateFrom({
-				actionResults: [
-					{
-						content: {
-							actionName: "IGNORE_ME",
-							text: "ok",
-							data: { actionName: "KEEP_ME" },
-						},
-					},
-				],
-			}),
-		);
-		expect(extracted[0]?.data).toMatchObject({ actionName: "KEEP_ME" });
-	});
+  it("does not overwrite an existing content.data.actionName", () => {
+    const extracted = extractActionResultsFromState(
+      stateFrom({
+        actionResults: [
+          {
+            content: {
+              actionName: "IGNORE_ME",
+              text: "ok",
+              data: { actionName: "KEEP_ME" },
+            },
+          },
+        ],
+      }),
+    );
+    expect(extracted[0]?.data).toMatchObject({ actionName: "KEEP_ME" });
+  });
 
-	it("flattens every candidate queue in source order", () => {
-		const extracted = extractActionResultsFromState(
-			stateFrom({
-				actionResults: [result({ actionName: "DATA", text: "from data" })],
-				providers: {
-					ACTION_STATE: {
-						data: {
-							actionResults: [
-								result({ actionName: "STATE", text: "from action state" }),
-							],
-							recentActionMemories: [
-								result({ actionName: "MEM", text: "from memories" }),
-							],
-						},
-					},
-					RECENT_MESSAGES: {
-						data: {
-							actionResults: [
-								result({ actionName: "RECENT", text: "from recent" }),
-							],
-						},
-					},
-				},
-			}),
-		);
-		expect(extracted.map((entry) => entry.data?.actionName)).toEqual([
-			"DATA",
-			"STATE",
-			"MEM",
-			"RECENT",
-		]);
-	});
+  it("flattens every candidate queue in source order", () => {
+    const extracted = extractActionResultsFromState(
+      stateFrom({
+        actionResults: [result({ actionName: "DATA", text: "from data" })],
+        providers: {
+          ACTION_STATE: {
+            data: {
+              actionResults: [
+                result({ actionName: "STATE", text: "from action state" }),
+              ],
+              recentActionMemories: [
+                result({ actionName: "MEM", text: "from memories" }),
+              ],
+            },
+          },
+          RECENT_MESSAGES: {
+            data: {
+              actionResults: [
+                result({ actionName: "RECENT", text: "from recent" }),
+              ],
+            },
+          },
+        },
+      }),
+    );
+    expect(extracted.map((entry) => entry.data?.actionName)).toEqual([
+      "DATA",
+      "STATE",
+      "MEM",
+      "RECENT",
+    ]);
+  });
 });
 
 describe("summarizeRecentActionHistory", () => {
-	it("returns an empty list for an empty queue", () => {
-		expect(summarizeRecentActionHistory(undefined)).toEqual([]);
-		expect(summarizeRecentActionHistory(stateFrom({}))).toEqual([]);
-	});
+  it("returns an empty list for an empty queue", () => {
+    expect(summarizeRecentActionHistory(undefined)).toEqual([]);
+    expect(summarizeRecentActionHistory(stateFrom({}))).toEqual([]);
+  });
 
-	it("summarizes a single element", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [result({ actionName: "SHOP", text: "added milk" })],
-				}),
-			),
-		).toEqual(["SHOP ok: added milk"]);
-	});
+  it("summarizes a single element", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [result({ actionName: "SHOP", text: "added milk" })],
+        }),
+      ),
+    ).toEqual(["SHOP ok: added milk"]);
+  });
 
-	it("orders newest-first by reversing the extracted queue", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						result({ actionName: "A", text: "first" }),
-						result({ actionName: "B", text: "second" }),
-						result({ actionName: "C", text: "third" }),
-					],
-				}),
-			),
-		).toEqual(["C ok: third", "B ok: second", "A ok: first"]);
-	});
+  it("orders newest-first by reversing the extracted queue", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            result({ actionName: "A", text: "first" }),
+            result({ actionName: "B", text: "second" }),
+            result({ actionName: "C", text: "third" }),
+          ],
+        }),
+      ),
+    ).toEqual(["C ok: third", "B ok: second", "A ok: first"]);
+  });
 
-	it("dedupes case-insensitive actionName:text ties, keeping the newest", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						result({ actionName: "SHOP", text: "Added milk" }),
-						result({ actionName: "shop", text: "added milk" }),
-					],
-				}),
-			),
-		).toEqual(["shop ok: added milk"]);
-	});
+  it("dedupes case-insensitive actionName:text ties, keeping the newest", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            result({ actionName: "SHOP", text: "Added milk" }),
+            result({ actionName: "shop", text: "added milk" }),
+          ],
+        }),
+      ),
+    ).toEqual(["shop ok: added milk"]);
+  });
 
-	it("caps overflow at the default limit of 4 newest unique items", () => {
-		const actionResults = [1, 2, 3, 4, 5, 6].map((n) =>
-			result({ actionName: "STEP", text: `item ${n}` }),
-		);
-		expect(summarizeRecentActionHistory(stateFrom({ actionResults }))).toEqual([
-			"STEP ok: item 6",
-			"STEP ok: item 5",
-			"STEP ok: item 4",
-			"STEP ok: item 3",
-		]);
-	});
+  it("caps overflow at the default limit of 4 newest unique items", () => {
+    const actionResults = [1, 2, 3, 4, 5, 6].map((n) =>
+      result({ actionName: "STEP", text: `item ${n}` }),
+    );
+    expect(summarizeRecentActionHistory(stateFrom({ actionResults }))).toEqual([
+      "STEP ok: item 6",
+      "STEP ok: item 5",
+      "STEP ok: item 4",
+      "STEP ok: item 3",
+    ]);
+  });
 
-	it("honors a smaller custom limit", () => {
-		const actionResults = [1, 2, 3].map((n) =>
-			result({ actionName: "STEP", text: `item ${n}` }),
-		);
-		expect(
-			summarizeRecentActionHistory(stateFrom({ actionResults }), 1),
-		).toEqual(["STEP ok: item 3"]);
-	});
+  it("honors a smaller custom limit", () => {
+    const actionResults = [1, 2, 3].map((n) =>
+      result({ actionName: "STEP", text: `item ${n}` }),
+    );
+    expect(
+      summarizeRecentActionHistory(stateFrom({ actionResults }), 1),
+    ).toEqual(["STEP ok: item 3"]);
+  });
 
-	it("skips items with no text and no title instead of inventing a row", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						result({ actionName: "EMPTY", text: "   " }),
-						result({ actionName: "GONE" }),
-						result({ actionName: "KEPT", text: "visible" }),
-					],
-				}),
-			),
-		).toEqual(["KEPT ok: visible"]);
-	});
+  it("skips items with no text and no title instead of inventing a row", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            result({ actionName: "EMPTY", text: "   " }),
+            result({ actionName: "GONE" }),
+            result({ actionName: "KEPT", text: "visible" }),
+          ],
+        }),
+      ),
+    ).toEqual(["KEPT ok: visible"]);
+  });
 
-	it("falls back to ACTION when actionName is missing or whitespace", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						{ success: true, text: "bare", data: { actionName: "  " } },
-					],
-				}),
-			),
-		).toEqual(["ACTION ok: bare"]);
-	});
+  it("falls back to ACTION when actionName is missing or whitespace", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            { success: true, text: "bare", data: { actionName: "  " } },
+          ],
+        }),
+      ),
+    ).toEqual(["ACTION ok: bare"]);
+  });
 
-	it("labels success !== false as ok and success false as failed", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						{ text: "implicit", data: { actionName: "IMPLICIT" } },
-						result({ actionName: "FAIL", text: "nope", success: false }),
-					],
-				}),
-			),
-		).toEqual(["FAIL failed: nope", "IMPLICIT ok: implicit"]);
-	});
+  it("labels success !== false as ok and success false as failed", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            { text: "implicit", data: { actionName: "IMPLICIT" } },
+            result({ actionName: "FAIL", text: "nope", success: false }),
+          ],
+        }),
+      ),
+    ).toEqual(["FAIL failed: nope", "IMPLICIT ok: implicit"]);
+  });
 
-	it("uses title fallbacks in definition / goal / event / title / subject / query order", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						result({
-							actionName: "DEF",
-							data: { definition: { title: "from definition" } },
-						}),
-						result({
-							actionName: "GOAL",
-							data: { goal: { title: "from goal" } },
-						}),
-						result({
-							actionName: "EVENT",
-							data: { event: { title: "from event" } },
-						}),
-						result({ actionName: "TITLE", data: { title: "from title" } }),
-						result({
-							actionName: "SUBJECT",
-							data: { subject: "from subject" },
-						}),
-						result({ actionName: "QUERY", data: { query: "from query" } }),
-					],
-				}),
-				6,
-			),
-		).toEqual([
-			"QUERY ok: from query",
-			"SUBJECT ok: from subject",
-			"TITLE ok: from title",
-			"EVENT ok: from event",
-			"GOAL ok: from goal",
-			"DEF ok: from definition",
-		]);
-	});
+  it("uses title fallbacks in definition / goal / event / title / subject / query order", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            result({
+              actionName: "DEF",
+              data: { definition: { title: "from definition" } },
+            }),
+            result({
+              actionName: "GOAL",
+              data: { goal: { title: "from goal" } },
+            }),
+            result({
+              actionName: "EVENT",
+              data: { event: { title: "from event" } },
+            }),
+            result({ actionName: "TITLE", data: { title: "from title" } }),
+            result({
+              actionName: "SUBJECT",
+              data: { subject: "from subject" },
+            }),
+            result({ actionName: "QUERY", data: { query: "from query" } }),
+          ],
+        }),
+        6,
+      ),
+    ).toEqual([
+      "QUERY ok: from query",
+      "SUBJECT ok: from subject",
+      "TITLE ok: from title",
+      "EVENT ok: from event",
+      "GOAL ok: from goal",
+      "DEF ok: from definition",
+    ]);
+  });
 
-	it("collapses whitespace in the snippet", () => {
-		expect(
-			summarizeRecentActionHistory(
-				stateFrom({
-					actionResults: [
-						result({ actionName: "SHOP", text: "added\n\n  milk" }),
-					],
-				}),
-			),
-		).toEqual(["SHOP ok: added milk"]);
-	});
+  it("collapses whitespace in the snippet", () => {
+    expect(
+      summarizeRecentActionHistory(
+        stateFrom({
+          actionResults: [
+            result({ actionName: "SHOP", text: "added\n\n  milk" }),
+          ],
+        }),
+      ),
+    ).toEqual(["SHOP ok: added milk"]);
+  });
 
-	it("prefers projected model text over raw result.text when projection is on", () => {
-		const state = stateFrom({
-			actionResults: [result({ actionName: "FILE", text: "RAW_PAGE_CANARY" })],
-		});
-		const raw = summarizeRecentActionHistory(state, 4, false);
-		const projected = summarizeRecentActionHistory(state, 4, true);
-		expect(raw).toEqual(["FILE ok: RAW_PAGE_CANARY"]);
-		expect(projected).toHaveLength(1);
-		expect(projected[0]).toMatch(/^FILE ok: /);
-		expect(projected[0]).not.toBe(raw[0]);
-		expect(projected[0]).toContain("FILE");
-	});
+  it("prefers projected model text over raw result.text when projection is on", () => {
+    const state = stateFrom({
+      actionResults: [result({ actionName: "FILE", text: "RAW_PAGE_CANARY" })],
+    });
+    const raw = summarizeRecentActionHistory(state, 4, false);
+    const projected = summarizeRecentActionHistory(state, 4, true);
+    expect(raw).toEqual(["FILE ok: RAW_PAGE_CANARY"]);
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toMatch(/^FILE ok: /);
+    expect(projected[0]).not.toBe(raw[0]);
+    expect(projected[0]).toContain("FILE");
+  });
 });
 
 describe("summarizeActiveTrajectory", () => {
-	it("returns null when no trajectory step is active", async () => {
-		expect(await summarizeActiveTrajectory({} as IAgentRuntime)).toBeNull();
-	});
+  it("returns null when no trajectory step is active", async () => {
+    expect(await summarizeActiveTrajectory({} as IAgentRuntime)).toBeNull();
+  });
 
-	it("falls back when the loader returns nothing or throws", async () => {
-		loadTrajectoryByStepId.mockResolvedValueOnce(null);
-		const missing = await runWithTrajectoryContext(
-			{ trajectoryStepId: "step-missing" },
-			() => summarizeActiveTrajectory({ agentId: "agent-1" } as IAgentRuntime),
-		);
-		expect(missing).toBe("active trajectory step step-missing");
+  it("falls back when the loader returns nothing or throws", async () => {
+    loadTrajectoryByStepId.mockResolvedValueOnce(null);
+    const missing = await runWithTrajectoryContext(
+      { trajectoryStepId: "step-missing" },
+      () => summarizeActiveTrajectory({ agentId: "agent-1" } as IAgentRuntime),
+    );
+    expect(missing).toBe("active trajectory step step-missing");
 
-		loadTrajectoryByStepId.mockRejectedValueOnce(new Error("db down"));
-		const thrown = await runWithTrajectoryContext(
-			{ trajectoryStepId: "step-throw" },
-			() => summarizeActiveTrajectory({} as IAgentRuntime),
-		);
-		expect(thrown).toBe("active trajectory step step-throw");
-	});
+    loadTrajectoryByStepId.mockRejectedValueOnce(new Error("db down"));
+    const thrown = await runWithTrajectoryContext(
+      { trajectoryStepId: "step-throw" },
+      () => summarizeActiveTrajectory({} as IAgentRuntime),
+    );
+    expect(thrown).toBe("active trajectory step step-throw");
+  });
 
-	it("formats an empty step list with the plural", async () => {
-		loadTrajectoryByStepId.mockResolvedValue({
-			id: "traj-empty",
-			steps: [],
-		});
-		const summary = await runWithTrajectoryContext(
-			{ trajectoryStepId: "step-empty" },
-			() => summarizeActiveTrajectory({} as IAgentRuntime),
-		);
-		expect(summary).toBe("trajectory traj-empty; 0 steps");
-	});
+  it("formats an empty step list with the plural", async () => {
+    loadTrajectoryByStepId.mockResolvedValue({
+      id: "traj-empty",
+      steps: [],
+    });
+    const summary = await runWithTrajectoryContext(
+      { trajectoryStepId: "step-empty" },
+      () => summarizeActiveTrajectory({} as IAgentRuntime),
+    );
+    expect(summary).toBe("trajectory traj-empty; 0 steps");
+  });
 
-	it("uses singular step, latest llm purpose, and non-empty providers", async () => {
-		loadTrajectoryByStepId.mockResolvedValue({
-			id: "traj-one",
-			steps: [
-				{
-					llmCalls: [{ purpose: "plan" }, { purpose: "reply" }],
-					providerAccesses: [
-						{ providerName: "TIME" },
-						{ providerName: "  " },
-						{ providerName: 12 },
-						{ providerName: "ACTION_STATE" },
-					],
-				},
-			],
-		});
-		const summary = await runWithTrajectoryContext(
-			{ trajectoryStepId: "step-one" },
-			() => summarizeActiveTrajectory({} as IAgentRuntime),
-		);
-		expect(summary).toBe(
-			"trajectory traj-one; 1 step; latest llm purpose: reply; recent providers: TIME, ACTION_STATE",
-		);
-	});
+  it("uses singular step, latest llm purpose, and non-empty providers", async () => {
+    loadTrajectoryByStepId.mockResolvedValue({
+      id: "traj-one",
+      steps: [
+        {
+          llmCalls: [{ purpose: "plan" }, { purpose: "reply" }],
+          providerAccesses: [
+            { providerName: "TIME" },
+            { providerName: "  " },
+            { providerName: 12 },
+            { providerName: "ACTION_STATE" },
+          ],
+        },
+      ],
+    });
+    const summary = await runWithTrajectoryContext(
+      { trajectoryStepId: "step-one" },
+      () => summarizeActiveTrajectory({} as IAgentRuntime),
+    );
+    expect(summary).toBe(
+      "trajectory traj-one; 1 step; latest llm purpose: reply; recent providers: TIME, ACTION_STATE",
+    );
+  });
 
-	it("uses the last step of a multi-step trajectory and omits empty purpose/providers", async () => {
-		loadTrajectoryByStepId.mockResolvedValue({
-			id: "traj-two",
-			steps: [
-				{
-					llmCalls: [{ purpose: "stale" }],
-					providerAccesses: [{ providerName: "OLD" }],
-				},
-				{ llmCalls: [], providerAccesses: [] },
-			],
-		});
-		const summary = await runWithTrajectoryContext(
-			{ trajectoryStepId: "step-two" },
-			() => summarizeActiveTrajectory({} as IAgentRuntime),
-		);
-		expect(summary).toBe("trajectory traj-two; 2 steps");
-	});
+  it("uses the last step of a multi-step trajectory and omits empty purpose/providers", async () => {
+    loadTrajectoryByStepId.mockResolvedValue({
+      id: "traj-two",
+      steps: [
+        {
+          llmCalls: [{ purpose: "stale" }],
+          providerAccesses: [{ providerName: "OLD" }],
+        },
+        { llmCalls: [], providerAccesses: [] },
+      ],
+    });
+    const summary = await runWithTrajectoryContext(
+      { trajectoryStepId: "step-two" },
+      () => summarizeActiveTrajectory({} as IAgentRuntime),
+    );
+    expect(summary).toBe("trajectory traj-two; 2 steps");
+  });
 });
 
 describe("renderGroundedActionReply", () => {
-	it("returns the fallback when useModel is missing", async () => {
-		const { reply } = await renderWith({
-			useModel: null,
-			fallback: "Canonical fallback.",
-		});
-		expect(reply).toBe("Canonical fallback.");
-	});
+  it("returns the fallback when useModel is missing", async () => {
+    const { reply } = await renderWith({
+      useModel: null,
+      fallback: "Canonical fallback.",
+    });
+    expect(reply).toBe("Canonical fallback.");
+  });
 
-	it("returns the fallback when useModel throws", async () => {
-		const { reply } = await renderWith({
-			useModel: vi.fn(async () => {
-				throw new Error("model down");
-			}) as IAgentRuntime["useModel"],
-			fallback: "Canonical fallback.",
-		});
-		expect(reply).toBe("Canonical fallback.");
-	});
+  it("returns the fallback when useModel throws", async () => {
+    const { reply } = await renderWith({
+      useModel: vi.fn(async () => {
+        throw new Error("model down");
+      }) as IAgentRuntime["useModel"],
+      fallback: "Canonical fallback.",
+    });
+    expect(reply).toBe("Canonical fallback.");
+  });
 
-	it("returns the fallback when useModel emits a non-string", async () => {
-		const { reply } = await renderWith({
-			useModel: vi.fn(async () => ({
-				text: "nope",
-			})) as unknown as IAgentRuntime["useModel"],
-			fallback: "Canonical fallback.",
-		});
-		expect(reply).toBe("Canonical fallback.");
-	});
+  it("returns the fallback when useModel emits a non-string", async () => {
+    const { reply } = await renderWith({
+      useModel: vi.fn(async () => ({
+        text: "nope",
+      })) as unknown as IAgentRuntime["useModel"],
+      fallback: "Canonical fallback.",
+    });
+    expect(reply).toBe("Canonical fallback.");
+  });
 
-	it("returns the fallback for remaining structured schema-key replies", async () => {
-		for (const output of [
-			"operation: create",
-			"confidence: 0.9",
-			"missing: due date",
-			"subaction: confirm",
-		]) {
-			const { reply } = await renderWith({
-				useModel: vi.fn(async () => output) as IAgentRuntime["useModel"],
-				fallback: "Canonical fallback.",
-			});
-			expect(reply).toBe("Canonical fallback.");
-		}
-	});
+  it("returns the fallback for remaining structured schema-key replies", async () => {
+    for (const output of [
+      "operation: create",
+      "confidence: 0.9",
+      "missing: due date",
+      "subaction: confirm",
+    ]) {
+      const { reply } = await renderWith({
+        useModel: vi.fn(async () => output) as IAgentRuntime["useModel"],
+        fallback: "Canonical fallback.",
+      });
+      expect(reply).toBe("Canonical fallback.");
+    }
+  });
 
-	it("prompts TEXT_SMALL and returns normalized prose", async () => {
-		const useModel = vi.fn(async (model: unknown) => {
-			expect(model).toBe(ModelType.TEXT_SMALL);
-			return '  "Added milk to the list."  ';
-		}) as IAgentRuntime["useModel"];
-		const { reply } = await renderWith({ useModel });
-		expect(reply).toBe("Added milk to the list.");
-		expect(useModel).toHaveBeenCalledTimes(1);
-	});
+  it("prompts TEXT_SMALL and returns normalized prose", async () => {
+    const useModel = vi.fn(async (model: unknown) => {
+      expect(model).toBe(ModelType.TEXT_SMALL);
+      return '  "Added milk to the list."  ';
+    }) as IAgentRuntime["useModel"];
+    const { reply } = await renderWith({ useModel });
+    expect(reply).toBe("Added milk to the list.");
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
 
-	it("labels gmail, calendar, and lifeops domains in the prompt", async () => {
-		const gmail = await renderWith({ domain: "gmail" });
-		expect(gmail.prompt).toContain(
-			"Write the assistant's user-facing reply for a Gmail interaction.",
-		);
-		expect(gmail.prompt).toContain("Domain: gmail");
+  it("labels gmail, calendar, and lifeops domains in the prompt", async () => {
+    const gmail = await renderWith({ domain: "gmail" });
+    expect(gmail.prompt).toContain(
+      "Write the assistant's user-facing reply for a Gmail interaction.",
+    );
+    expect(gmail.prompt).toContain("Domain: gmail");
 
-		const calendar = await renderWith({ domain: "calendar" });
-		expect(calendar.prompt).toContain(
-			"Write the assistant's user-facing reply for a calendar interaction.",
-		);
-		expect(calendar.prompt).toContain("Domain: calendar");
+    const calendar = await renderWith({ domain: "calendar" });
+    expect(calendar.prompt).toContain(
+      "Write the assistant's user-facing reply for a calendar interaction.",
+    );
+    expect(calendar.prompt).toContain("Domain: calendar");
 
-		const lifeops = await renderWith({ domain: "lifeops" });
-		expect(lifeops.prompt).toContain(
-			"Write the assistant's user-facing reply for a LifeOps interaction.",
-		);
-		expect(lifeops.prompt).toContain("Domain: lifeops");
-	});
+    const lifeops = await renderWith({ domain: "lifeops" });
+    expect(lifeops.prompt).toContain(
+      "Write the assistant's user-facing reply for a LifeOps interaction.",
+    );
+    expect(lifeops.prompt).toContain("Domain: lifeops");
+  });
 
-	it("serializes a non-string user message as an empty current message", async () => {
-		const { prompt } = await renderWith({ messageText: { nested: true } });
-		expect(prompt).toContain('Current user message: ""');
-	});
+  it("serializes a non-string user message as an empty current message", async () => {
+    const { prompt } = await renderWith({ messageText: { nested: true } });
+    expect(prompt).toContain('Current user message: ""');
+  });
 
-	it("includes additionalRules before the reply-only instruction", async () => {
-		const { prompt } = await renderWith({
-			additionalRules: ["Never mention the weather."],
-		});
-		expect(prompt).toContain("Never mention the weather.");
-		expect(prompt.indexOf("Never mention the weather.")).toBeLessThan(
-			prompt.indexOf("Return only the reply text."),
-		);
-	});
+  it("includes additionalRules before the reply-only instruction", async () => {
+    const { prompt } = await renderWith({
+      additionalRules: ["Never mention the weather."],
+    });
+    expect(prompt).toContain("Never mention the weather.");
+    expect(prompt.indexOf("Never mention the weather.")).toBeLessThan(
+      prompt.indexOf("Return only the reply text."),
+    );
+  });
 
-	it("omits character voice unless preferCharacterVoice is set", async () => {
-		const { prompt } = await renderWith({
-			character: {
-				name: "Eliza",
-				system: "You are Eliza.",
-			} as IAgentRuntime["character"],
-		});
-		expect(prompt).toContain('Character voice: ""');
-		expect(prompt).not.toContain(
-			"Stay within the assistant's established character voice when it fits the task.",
-		);
-	});
+  it("omits character voice unless preferCharacterVoice is set", async () => {
+    const { prompt } = await renderWith({
+      character: {
+        name: "Eliza",
+        system: "You are Eliza.",
+      } as IAgentRuntime["character"],
+    });
+    expect(prompt).toContain('Character voice: ""');
+    expect(prompt).not.toContain(
+      "Stay within the assistant's established character voice when it fits the task.",
+    );
+  });
 
-	it("builds character voice from system, bio, and style when requested", async () => {
-		const { prompt } = await renderWith({
-			preferCharacterVoice: true,
-			character: {
-				name: "Eliza",
-				system: "  You are Eliza.  ",
-				bio: ["  ", "A helpful operator", 3, "Speaks plainly"],
-				style: {
-					all: ["Be brief", ""],
-					chat: ["Use contractions"],
-				},
-			} as unknown as IAgentRuntime["character"],
-		});
-		expect(prompt).toContain(
-			"Stay within the assistant's established character voice when it fits the task.",
-		);
-		expect(prompt).toContain("System:\\nYou are Eliza.");
-		expect(prompt).toContain("- A helpful operator");
-		expect(prompt).toContain("- Speaks plainly");
-		expect(prompt).toContain("- Be brief");
-		expect(prompt).toContain("- Use contractions");
-		expect(prompt).not.toContain("- 3");
-	});
+  it("builds character voice from system, bio, and style when requested", async () => {
+    const { prompt } = await renderWith({
+      preferCharacterVoice: true,
+      character: {
+        name: "Eliza",
+        system: "  You are Eliza.  ",
+        bio: ["  ", "A helpful operator", 3, "Speaks plainly"],
+        style: {
+          all: ["Be brief", ""],
+          chat: ["Use contractions"],
+        },
+      } as unknown as IAgentRuntime["character"],
+    });
+    expect(prompt).toContain(
+      "Stay within the assistant's established character voice when it fits the task.",
+    );
+    expect(prompt).toContain("System:\\nYou are Eliza.");
+    expect(prompt).toContain("- A helpful operator");
+    expect(prompt).toContain("- Speaks plainly");
+    expect(prompt).toContain("- Be brief");
+    expect(prompt).toContain("- Use contractions");
+    expect(prompt).not.toContain("- 3");
+  });
 
-	it("accepts a string bio when preferring character voice", async () => {
-		const { prompt } = await renderWith({
-			preferCharacterVoice: true,
-			character: {
-				name: "Eliza",
-				bio: "  One-line bio.  ",
-			} as unknown as IAgentRuntime["character"],
-		});
-		expect(prompt).toContain("Bio:\\n- One-line bio.");
-	});
+  it("accepts a string bio when preferring character voice", async () => {
+    const { prompt } = await renderWith({
+      preferCharacterVoice: true,
+      character: {
+        name: "Eliza",
+        bio: "  One-line bio.  ",
+      } as unknown as IAgentRuntime["character"],
+    });
+    expect(prompt).toContain("Bio:\\n- One-line bio.");
+  });
 
-	it("stringifies circular context via the catch path instead of throwing", async () => {
-		const context: Record<string, unknown> = { label: "loop" };
-		context.self = context;
-		const { prompt, reply } = await renderWith({ context });
-		expect(reply).toBe("Handled it.");
-		expect(prompt).toContain("Structured context: [object Object]");
-	});
+  it("stringifies circular context via the catch path instead of throwing", async () => {
+    const context: Record<string, unknown> = { label: "loop" };
+    context.self = context;
+    const { prompt, reply } = await renderWith({ context });
+    expect(reply).toBe("Handled it.");
+    expect(prompt).toContain("Structured context: [object Object]");
+  });
 
-	it("embeds recent action history from state into the prompt", async () => {
-		const { prompt } = await renderWith({
-			state: stateFrom({
-				actionResults: [result({ actionName: "SHOP", text: "added milk" })],
-			}),
-		});
-		expect(prompt).toContain("SHOP ok: added milk");
-	});
+  it("embeds recent action history from state into the prompt", async () => {
+    const { prompt } = await renderWith({
+      state: stateFrom({
+        actionResults: [result({ actionName: "SHOP", text: "added milk" })],
+      }),
+    });
+    expect(prompt).toContain("SHOP ok: added milk");
+  });
 });

--- a/packages/agent/src/api/__fixtures__/skip-listen-boot-harness.test.ts
+++ b/packages/agent/src/api/__fixtures__/skip-listen-boot-harness.test.ts
@@ -20,196 +20,196 @@ const SERVER_PATH = join(import.meta.dirname, "../server.ts");
 const HARNESS_SRC = readFileSync(HARNESS_PATH, "utf8");
 
 const USAGE = {
-	ok: false,
-	error: "usage: <skip|bind|invalid> <port>",
+  ok: false,
+  error: "usage: <skip|bind|invalid> <port>",
 } as const;
 
 function resolveBunExecutable(): string | null {
-	if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
-		return process.execPath;
-	}
-	const locator = process.platform === "win32" ? "where" : "which";
-	try {
-		const resolved = execFileSync(locator, ["bun"], { encoding: "utf8" })
-			.split("\n")
-			.map((line) => line.trim())
-			.find(Boolean);
-		if (resolved && existsSync(resolved)) return resolved;
-	} catch {
-		/* not on PATH; try absolute fallbacks */
-	}
-	const candidates = [
-		process.env.BUN_INSTALL ? join(process.env.BUN_INSTALL, "bin", "bun") : "",
-		"/usr/local/bin/bun",
-		"/opt/homebrew/bin/bun",
-	].filter(Boolean);
-	for (const candidate of candidates) {
-		if (existsSync(candidate)) return candidate;
-	}
-	return null;
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
+    return process.execPath;
+  }
+  const locator = process.platform === "win32" ? "where" : "which";
+  try {
+    const resolved = execFileSync(locator, ["bun"], { encoding: "utf8" })
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (resolved && existsSync(resolved)) return resolved;
+  } catch {
+    /* not on PATH; try absolute fallbacks */
+  }
+  const candidates = [
+    process.env.BUN_INSTALL ? join(process.env.BUN_INSTALL, "bin", "bun") : "",
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 function lastJsonLine(stdout: string): unknown {
-	const lastLine = stdout.trim().split("\n").filter(Boolean).at(-1) ?? "{}";
-	return JSON.parse(lastLine) as unknown;
+  const lastLine = stdout.trim().split("\n").filter(Boolean).at(-1) ?? "{}";
+  return JSON.parse(lastLine) as unknown;
 }
 
 function execErrorFields(err: unknown): {
-	stdout: string;
-	stderr: string;
-	code: number | null;
+  stdout: string;
+  stderr: string;
+  code: number | null;
 } {
-	if (typeof err !== "object" || err === null) {
-		return { stdout: "", stderr: "", code: null };
-	}
-	const rec = err as { stdout?: unknown; stderr?: unknown; code?: unknown };
-	return {
-		stdout: typeof rec.stdout === "string" ? rec.stdout : "",
-		stderr: typeof rec.stderr === "string" ? rec.stderr : "",
-		code: typeof rec.code === "number" ? rec.code : null,
-	};
+  if (typeof err !== "object" || err === null) {
+    return { stdout: "", stderr: "", code: null };
+  }
+  const rec = err as { stdout?: unknown; stderr?: unknown; code?: unknown };
+  return {
+    stdout: typeof rec.stdout === "string" ? rec.stdout : "",
+    stderr: typeof rec.stderr === "string" ? rec.stderr : "",
+    code: typeof rec.code === "number" ? rec.code : null,
+  };
 }
 
 async function runHarness(args: string[]): Promise<{
-	exitCode: number | null;
-	stdout: string;
-	parsed: unknown;
+  exitCode: number | null;
+  stdout: string;
+  parsed: unknown;
 }> {
-	const bun = resolveBunExecutable();
-	if (!bun) {
-		throw new Error("bun executable not found on this host");
-	}
-	try {
-		const { stdout } = await execFileAsync(bun, [HARNESS_PATH, ...args], {
-			timeout: 15_000,
-			env: { ...process.env },
-		});
-		return { exitCode: 0, stdout, parsed: lastJsonLine(stdout) };
-	} catch (err) {
-		const fields = execErrorFields(err);
-		return {
-			exitCode: fields.code,
-			stdout: fields.stdout,
-			parsed: lastJsonLine(fields.stdout),
-		};
-	}
+  const bun = resolveBunExecutable();
+  if (!bun) {
+    throw new Error("bun executable not found on this host");
+  }
+  try {
+    const { stdout } = await execFileAsync(bun, [HARNESS_PATH, ...args], {
+      timeout: 15_000,
+      env: { ...process.env },
+    });
+    return { exitCode: 0, stdout, parsed: lastJsonLine(stdout) };
+  } catch (err) {
+    const fields = execErrorFields(err);
+    return {
+      exitCode: fields.code,
+      stdout: fields.stdout,
+      parsed: lastJsonLine(fields.stdout),
+    };
+  }
 }
 
 describe("skip-listen-boot-harness", () => {
-	const usageCases: Array<{ name: string; args: string[] }> = [
-		{ name: "missing argv", args: [] },
-		{ name: "skip without a port", args: ["skip"] },
-		{ name: "bind without a port", args: ["bind"] },
-		{ name: "invalid without a port", args: ["invalid"] },
-		{ name: "an unknown mode", args: ["listen", "39421"] },
-		{ name: "an uppercase mode", args: ["SKIP", "39421"] },
-		{ name: "a leading-space mode", args: [" skip", "39421"] },
-		{ name: "a non-numeric port", args: ["skip", "abc"] },
-		{ name: "a non-integer port", args: ["skip", "3.14"] },
-		{ name: "a port with trailing junk", args: ["skip", "10foo"] },
-		{ name: "NaN as the port", args: ["skip", "NaN"] },
-		{ name: "Infinity as the port", args: ["skip", "Infinity"] },
-	];
+  const usageCases: Array<{ name: string; args: string[] }> = [
+    { name: "missing argv", args: [] },
+    { name: "skip without a port", args: ["skip"] },
+    { name: "bind without a port", args: ["bind"] },
+    { name: "invalid without a port", args: ["invalid"] },
+    { name: "an unknown mode", args: ["listen", "39421"] },
+    { name: "an uppercase mode", args: ["SKIP", "39421"] },
+    { name: "a leading-space mode", args: [" skip", "39421"] },
+    { name: "a non-numeric port", args: ["skip", "abc"] },
+    { name: "a non-integer port", args: ["skip", "3.14"] },
+    { name: "a port with trailing junk", args: ["skip", "10foo"] },
+    { name: "NaN as the port", args: ["skip", "NaN"] },
+    { name: "Infinity as the port", args: ["skip", "Infinity"] },
+  ];
 
-	for (const { name, args } of usageCases) {
-		it(`rejects ${name} with usage JSON and exit 2`, async () => {
-			const result = await runHarness(args);
-			expect(result.exitCode).toBe(2);
-			expect(result.parsed).toEqual(USAGE);
-		});
-	}
+  for (const { name, args } of usageCases) {
+    it(`rejects ${name} with usage JSON and exit 2`, async () => {
+      const result = await runHarness(args);
+      expect(result.exitCode).toBe(2);
+      expect(result.parsed).toEqual(USAGE);
+    });
+  }
 
-	it("writes the usage JSON as a single stdout line", async () => {
-		const result = await runHarness(["nope"]);
-		expect(result.stdout.trim()).toBe(JSON.stringify(USAGE));
-	});
+  it("writes the usage JSON as a single stdout line", async () => {
+    const result = await runHarness(["nope"]);
+    expect(result.stdout.trim()).toBe(JSON.stringify(USAGE));
+  });
 
-	it("does not treat a trailing extra argv as a valid mode when argv[2] is unusable", async () => {
-		const result = await runHarness(["abc", "39421", "skip"]);
-		expect(result.exitCode).toBe(2);
-		expect(result.parsed).toEqual(USAGE);
-	});
+  it("does not treat a trailing extra argv as a valid mode when argv[2] is unusable", async () => {
+    const result = await runHarness(["abc", "39421", "skip"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.parsed).toEqual(USAGE);
+  });
 
-	const proceedsPastUsage: Array<{ name: string; args: string[] }> = [
-		{ name: "an empty-string port (Number('') === 0)", args: ["skip", ""] },
-		{ name: "port 0", args: ["skip", "0"] },
-		{ name: "a negative integer port", args: ["skip", "-1"] },
-		{ name: "signed zero as the port", args: ["skip", "-0"] },
-		{
-			name: "a trailing-zero float that Number() coerces to an integer",
-			args: ["skip", "1.0"],
-		},
-		{ name: "hex that Number() coerces to an integer", args: ["skip", "0x10"] },
-		{
-			name: "scientific notation that Number() coerces to an integer",
-			args: ["skip", "1e3"],
-		},
-		{ name: "a padded decimal port", args: ["skip", " 39421"] },
-		{
-			name: "trailing extra argv after a valid mode and port",
-			args: ["skip", "39421", "extra"],
-		},
-		{ name: "bind with an integer port", args: ["bind", "39423"] },
-		{ name: "invalid with an integer port", args: ["invalid", "39425"] },
-	];
+  const proceedsPastUsage: Array<{ name: string; args: string[] }> = [
+    { name: "an empty-string port (Number('') === 0)", args: ["skip", ""] },
+    { name: "port 0", args: ["skip", "0"] },
+    { name: "a negative integer port", args: ["skip", "-1"] },
+    { name: "signed zero as the port", args: ["skip", "-0"] },
+    {
+      name: "a trailing-zero float that Number() coerces to an integer",
+      args: ["skip", "1.0"],
+    },
+    { name: "hex that Number() coerces to an integer", args: ["skip", "0x10"] },
+    {
+      name: "scientific notation that Number() coerces to an integer",
+      args: ["skip", "1e3"],
+    },
+    { name: "a padded decimal port", args: ["skip", " 39421"] },
+    {
+      name: "trailing extra argv after a valid mode and port",
+      args: ["skip", "39421", "extra"],
+    },
+    { name: "bind with an integer port", args: ["bind", "39423"] },
+    { name: "invalid with an integer port", args: ["invalid", "39425"] },
+  ];
 
-	for (const { name, args } of proceedsPastUsage) {
-		it.skipIf(existsSync(SERVER_PATH))(
-			`does not usage-reject ${name}`,
-			async () => {
-				const result = await runHarness(args);
-				expect(result.exitCode).not.toBe(2);
-				expect(result.parsed).not.toEqual(USAGE);
-				expect(result.parsed).toMatchObject({ ok: false });
-				const parsed = result.parsed as { ok: false; error: string };
-				expect(parsed.error.length).toBeGreaterThan(0);
-			},
-		);
-	}
+  for (const { name, args } of proceedsPastUsage) {
+    it.skipIf(existsSync(SERVER_PATH))(
+      `does not usage-reject ${name}`,
+      async () => {
+        const result = await runHarness(args);
+        expect(result.exitCode).not.toBe(2);
+        expect(result.parsed).not.toEqual(USAGE);
+        expect(result.parsed).toMatchObject({ ok: false });
+        const parsed = result.parsed as { ok: false; error: string };
+        expect(parsed.error.length).toBeGreaterThan(0);
+      },
+    );
+  }
 
-	it.skipIf(existsSync(SERVER_PATH))(
-		"reports a non-usage load failure as ok:false on stdout and exits 1 when server.ts is absent",
-		async () => {
-			const result = await runHarness(["skip", "39421"]);
-			expect(result.exitCode).toBe(1);
-			expect(result.parsed).toMatchObject({ ok: false });
-			expect(result.parsed).not.toEqual(USAGE);
-			const parsed = result.parsed as { ok: false; error: string };
-			expect(parsed.error.length).toBeGreaterThan(0);
-		},
-	);
+  it.skipIf(existsSync(SERVER_PATH))(
+    "reports a non-usage load failure as ok:false on stdout and exits 1 when server.ts is absent",
+    async () => {
+      const result = await runHarness(["skip", "39421"]);
+      expect(result.exitCode).toBe(1);
+      expect(result.parsed).toMatchObject({ ok: false });
+      expect(result.parsed).not.toEqual(USAGE);
+      const parsed = result.parsed as { ok: false; error: string };
+      expect(parsed.error.length).toBeGreaterThan(0);
+    },
+  );
 
-	it("wires skipListen only for skip mode and probes the returned server port", () => {
-		expect(HARNESS_SRC).toContain('skipListen: mode === "skip"');
-		expect(HARNESS_SRC).toContain('initialAgentState: "starting"');
-		expect(HARNESS_SRC).toContain("isPortBound(server.port)");
-		expect(HARNESS_SRC).toContain("ELIZA_API_PORT");
-	});
+  it("wires skipListen only for skip mode and probes the returned server port", () => {
+    expect(HARNESS_SRC).toContain('skipListen: mode === "skip"');
+    expect(HARNESS_SRC).toContain('initialAgentState: "starting"');
+    expect(HARNESS_SRC).toContain("isPortBound(server.port)");
+    expect(HARNESS_SRC).toContain("ELIZA_API_PORT");
+  });
 
-	it("rejects a malformed connector interval before bind and reports rejected", () => {
-		expect(HARNESS_SRC).toContain('CONNECTOR_HEALTH_INTERVAL_MS = "10000junk"');
-		expect(HARNESS_SRC).toContain("rejected: true");
-		expect(HARNESS_SRC).toContain("invalid interval was accepted");
-		expect(HARNESS_SRC).toContain("isPortBound(port)");
-	});
+  it("rejects a malformed connector interval before bind and reports rejected", () => {
+    expect(HARNESS_SRC).toContain('CONNECTOR_HEALTH_INTERVAL_MS = "10000junk"');
+    expect(HARNESS_SRC).toContain("rejected: true");
+    expect(HARNESS_SRC).toContain("invalid interval was accepted");
+    expect(HARNESS_SRC).toContain("isPortBound(port)");
+  });
 
-	it("settles isPortBound on the first of connect, error, or timeout", () => {
-		expect(HARNESS_SRC).toContain('host = "127.0.0.1"');
-		expect(HARNESS_SRC).toContain("timeoutMs = 1000");
-		expect(HARNESS_SRC).toContain("if (settled) return");
-		expect(HARNESS_SRC).toContain('socket.once("connect"');
-		expect(HARNESS_SRC).toContain('socket.once("error"');
-		expect(HARNESS_SRC).toContain("socket.destroy()");
-	});
+  it("settles isPortBound on the first of connect, error, or timeout", () => {
+    expect(HARNESS_SRC).toContain('host = "127.0.0.1"');
+    expect(HARNESS_SRC).toContain("timeoutMs = 1000");
+    expect(HARNESS_SRC).toContain("if (settled) return");
+    expect(HARNESS_SRC).toContain('socket.once("connect"');
+    expect(HARNESS_SRC).toContain('socket.once("error"');
+    expect(HARNESS_SRC).toContain("socket.destroy()");
+  });
 
-	it("closes the server after reporting and uses the JSON/exit contract", () => {
-		expect(HARNESS_SRC).toContain("await server.close()");
-		expect(HARNESS_SRC).toContain("process.exit(0)");
-		expect(HARNESS_SRC).toContain("process.exit(1)");
-		expect(HARNESS_SRC).toContain("process.exit(2)");
-		expect(HARNESS_SRC).toContain(
-			'mode !== "skip" && mode !== "bind" && mode !== "invalid"',
-		);
-		expect(HARNESS_SRC).toContain("!Number.isInteger(port)");
-	});
+  it("closes the server after reporting and uses the JSON/exit contract", () => {
+    expect(HARNESS_SRC).toContain("await server.close()");
+    expect(HARNESS_SRC).toContain("process.exit(0)");
+    expect(HARNESS_SRC).toContain("process.exit(1)");
+    expect(HARNESS_SRC).toContain("process.exit(2)");
+    expect(HARNESS_SRC).toContain(
+      'mode !== "skip" && mode !== "bind" && mode !== "invalid"',
+    );
+    expect(HARNESS_SRC).toContain("!Number.isInteger(port)");
+  });
 });

--- a/packages/agent/src/api/__fixtures__/stream-cors-preflight-harness.test.ts
+++ b/packages/agent/src/api/__fixtures__/stream-cors-preflight-harness.test.ts
@@ -140,9 +140,7 @@ describe("stream-cors-preflight-harness", () => {
 
   it("sends the Capacitor stream preflight the parent test asserts", () => {
     expect(HARNESS_SRC).toContain('method: "OPTIONS"');
-    expect(HARNESS_SRC).toContain(
-      "/api/conversations/conv-1/messages/stream",
-    );
+    expect(HARNESS_SRC).toContain("/api/conversations/conv-1/messages/stream");
     expect(HARNESS_SRC).toContain('origin: "https://localhost"');
     expect(HARNESS_SRC).toContain(
       "authorization,content-type,x-elizaos-client-id",

--- a/packages/agent/src/api/__tests__/platform-detect.test.ts
+++ b/packages/agent/src/api/__tests__/platform-detect.test.ts
@@ -1,49 +1,49 @@
 import { describe, expect, it } from "vitest";
 import {
-	detectClientPlatform,
-	isDynamicLoadingAllowed,
+  detectClientPlatform,
+  isDynamicLoadingAllowed,
 } from "./platform-detect.ts";
 
 function req(headers: Record<string, string | undefined>) {
-	return { headers } as never;
+  return { headers } as never;
 }
 
 describe("detectClientPlatform", () => {
-	it("detects from the X-Eliza-Platform header", () => {
-		expect(detectClientPlatform(req({ "x-eliza-platform": "ios" }))).toBe(
-			"ios",
-		);
-		expect(detectClientPlatform(req({ "x-eliza-platform": "android" }))).toBe(
-			"android",
-		);
-	});
+  it("detects from the X-Eliza-Platform header", () => {
+    expect(detectClientPlatform(req({ "x-eliza-platform": "ios" }))).toBe(
+      "ios",
+    );
+    expect(detectClientPlatform(req({ "x-eliza-platform": "android" }))).toBe(
+      "android",
+    );
+  });
 
-	it("detects from Capacitor user agents", () => {
-		expect(
-			detectClientPlatform(req({ "user-agent": "Capacitor...iOS App" })),
-		).toBe("ios");
-		expect(
-			detectClientPlatform(req({ "user-agent": "Capacitor...Android App" })),
-		).toBe("android");
-	});
+  it("detects from Capacitor user agents", () => {
+    expect(
+      detectClientPlatform(req({ "user-agent": "Capacitor...iOS App" })),
+    ).toBe("ios");
+    expect(
+      detectClientPlatform(req({ "user-agent": "Capacitor...Android App" })),
+    ).toBe("android");
+  });
 
-	it("detects Electrobun desktop", () => {
-		expect(detectClientPlatform(req({ "user-agent": "Electrobun/1.0" }))).toBe(
-			"desktop",
-		);
-	});
+  it("detects Electrobun desktop", () => {
+    expect(detectClientPlatform(req({ "user-agent": "Electrobun/1.0" }))).toBe(
+      "desktop",
+    );
+  });
 
-	it("defaults to web", () => {
-		expect(detectClientPlatform(req({}))).toBe("web");
-		expect(detectClientPlatform(req({ "user-agent": "curl/8" }))).toBe("web");
-	});
+  it("defaults to web", () => {
+    expect(detectClientPlatform(req({}))).toBe("web");
+    expect(detectClientPlatform(req({ "user-agent": "curl/8" }))).toBe("web");
+  });
 });
 
 describe("isDynamicLoadingAllowed", () => {
-	it("blocks store platforms, allows others", () => {
-		expect(isDynamicLoadingAllowed("ios")).toBe(false);
-		expect(isDynamicLoadingAllowed("android")).toBe(false);
-		expect(isDynamicLoadingAllowed("web")).toBe(true);
-		expect(isDynamicLoadingAllowed("desktop")).toBe(true);
-	});
+  it("blocks store platforms, allows others", () => {
+    expect(isDynamicLoadingAllowed("ios")).toBe(false);
+    expect(isDynamicLoadingAllowed("android")).toBe(false);
+    expect(isDynamicLoadingAllowed("web")).toBe(true);
+    expect(isDynamicLoadingAllowed("desktop")).toBe(true);
+  });
 });

--- a/packages/agent/src/api/__tests__/platform-detect.test.ts
+++ b/packages/agent/src/api/__tests__/platform-detect.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   detectClientPlatform,
   isDynamicLoadingAllowed,
-} from "./platform-detect.ts";
+} from "../platform-detect.ts";
 
 function req(headers: Record<string, string | undefined>) {
   return { headers } as never;

--- a/packages/agent/src/services/__tests__/send-handler-availability.test.ts
+++ b/packages/agent/src/services/__tests__/send-handler-availability.test.ts
@@ -1,55 +1,55 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", () => ({
-	logger: { info: vi.fn() },
+  logger: { info: vi.fn() },
 }));
 
 import { logger } from "@elizaos/core";
 import {
-	_resetMissingSendHandlerLogsForTests,
-	hasRuntimeSendHandler,
-	logMissingSendHandlerOnce,
+  _resetMissingSendHandlerLogsForTests,
+  hasRuntimeSendHandler,
+  logMissingSendHandlerOnce,
 } from "./send-handler-availability.ts";
 
 beforeEach(() => {
-	_resetMissingSendHandlerLogsForTests();
-	vi.clearAllMocks();
+  _resetMissingSendHandlerLogsForTests();
+  vi.clearAllMocks();
 });
 afterEach(() => _resetMissingSendHandlerLogsForTests());
 
 describe("hasRuntimeSendHandler", () => {
-	it("checks the sendHandlers map", () => {
-		const runtime = { sendHandlers: new Map([["telegram", {}]]) } as never;
-		expect(hasRuntimeSendHandler(runtime, "telegram")).toBe(true);
-		expect(hasRuntimeSendHandler(runtime, "discord")).toBe(false);
-	});
+  it("checks the sendHandlers map", () => {
+    const runtime = { sendHandlers: new Map([["telegram", {}]]) } as never;
+    expect(hasRuntimeSendHandler(runtime, "telegram")).toBe(true);
+    expect(hasRuntimeSendHandler(runtime, "discord")).toBe(false);
+  });
 
-	it("returns false when sendHandlers is absent or not a Map", () => {
-		expect(hasRuntimeSendHandler({} as never, "telegram")).toBe(false);
-		expect(
-			hasRuntimeSendHandler({ sendHandlers: [] } as never, "telegram"),
-		).toBe(false);
-	});
+  it("returns false when sendHandlers is absent or not a Map", () => {
+    expect(hasRuntimeSendHandler({} as never, "telegram")).toBe(false);
+    expect(
+      hasRuntimeSendHandler({ sendHandlers: [] } as never, "telegram"),
+    ).toBe(false);
+  });
 });
 
 describe("logMissingSendHandlerOnce", () => {
-	it("logs once per context:source pair", () => {
-		logMissingSendHandlerOnce("ctx", "src");
-		logMissingSendHandlerOnce("ctx", "src");
-		logMissingSendHandlerOnce("ctx", "src");
-		expect(logger.info).toHaveBeenCalledTimes(1);
-	});
+  it("logs once per context:source pair", () => {
+    logMissingSendHandlerOnce("ctx", "src");
+    logMissingSendHandlerOnce("ctx", "src");
+    logMissingSendHandlerOnce("ctx", "src");
+    expect(logger.info).toHaveBeenCalledTimes(1);
+  });
 
-	it("logs separately for different sources", () => {
-		logMissingSendHandlerOnce("ctx", "a");
-		logMissingSendHandlerOnce("ctx", "b");
-		expect(logger.info).toHaveBeenCalledTimes(2);
-	});
+  it("logs separately for different sources", () => {
+    logMissingSendHandlerOnce("ctx", "a");
+    logMissingSendHandlerOnce("ctx", "b");
+    expect(logger.info).toHaveBeenCalledTimes(2);
+  });
 
-	it("re-logs after reset", () => {
-		logMissingSendHandlerOnce("ctx", "a");
-		_resetMissingSendHandlerLogsForTests();
-		logMissingSendHandlerOnce("ctx", "a");
-		expect(logger.info).toHaveBeenCalledTimes(2);
-	});
+  it("re-logs after reset", () => {
+    logMissingSendHandlerOnce("ctx", "a");
+    _resetMissingSendHandlerLogsForTests();
+    logMissingSendHandlerOnce("ctx", "a");
+    expect(logger.info).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
Closes #25244.

Formatting-only repair for seven recently merged agent test files that fail every broad affected-workspace lint closure. Pinned repository Biome changed indentation/import layout/line wrapping only; no production files and no test tokens or behavior were authored.

Evidence:
- pinned Biome fixed 7 files, then check passed
- `git diff --check` passed
- failure reproduced in unrelated WhatsApp PR #25227 run 32622741047
