### PR TITLE
test(app-core): repair Electrobun registry test

### DIFF
--- a/packages/app-core/platforms/electrobun/src/__tests__/local-agent-dispatcher-registry.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/local-agent-dispatcher-registry.test.ts
@@ -1,39 +1,39 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-	getActiveLocalAgentDispatcher,
-	requireActiveLocalAgentDispatcher,
-	setActiveLocalAgentDispatcher,
-} from "./local-agent-dispatcher-registry.ts";
+  getActiveLocalAgentDispatcher,
+  requireActiveLocalAgentDispatcher,
+  setActiveLocalAgentDispatcher,
+} from "../local-agent-dispatcher-registry.ts";
 
 describe("local-agent-dispatcher-registry", () => {
-	beforeEach(() => setActiveLocalAgentDispatcher(null));
-	afterEach(() => setActiveLocalAgentDispatcher(null));
+  beforeEach(() => setActiveLocalAgentDispatcher(null));
+  afterEach(() => setActiveLocalAgentDispatcher(null));
 
-	it("starts with no dispatcher", () => {
-		expect(getActiveLocalAgentDispatcher()).toBeNull();
-	});
+  it("starts with no dispatcher", () => {
+    expect(getActiveLocalAgentDispatcher()).toBeNull();
+  });
 
-	it("returns the registered dispatcher", () => {
-		const dispatcher = { name: "ipc" } as never;
-		setActiveLocalAgentDispatcher(dispatcher);
-		expect(getActiveLocalAgentDispatcher()).toBe(dispatcher);
-	});
+  it("returns the registered dispatcher", () => {
+    const dispatcher = { name: "ipc" } as never;
+    setActiveLocalAgentDispatcher(dispatcher);
+    expect(getActiveLocalAgentDispatcher()).toBe(dispatcher);
+  });
 
-	it("requireActiveLocalAgentDispatcher returns the dispatcher when set", () => {
-		const dispatcher = {} as never;
-		setActiveLocalAgentDispatcher(dispatcher);
-		expect(requireActiveLocalAgentDispatcher()).toBe(dispatcher);
-	});
+  it("requireActiveLocalAgentDispatcher returns the dispatcher when set", () => {
+    const dispatcher = {} as never;
+    setActiveLocalAgentDispatcher(dispatcher);
+    expect(requireActiveLocalAgentDispatcher()).toBe(dispatcher);
+  });
 
-	it("requireActiveLocalAgentDispatcher throws when unset", () => {
-		expect(() => requireActiveLocalAgentDispatcher()).toThrow(
-			"no local-agent IPC dispatcher",
-		);
-	});
+  it("requireActiveLocalAgentDispatcher throws when unset", () => {
+    expect(() => requireActiveLocalAgentDispatcher()).toThrow(
+      "no local-agent IPC dispatcher",
+    );
+  });
 
-	it("clearing with null resets the registry", () => {
-		setActiveLocalAgentDispatcher({} as never);
-		setActiveLocalAgentDispatcher(null);
-		expect(getActiveLocalAgentDispatcher()).toBeNull();
-	});
+  it("clearing with null resets the registry", () => {
+    setActiveLocalAgentDispatcher({} as never);
+    setActiveLocalAgentDispatcher(null);
+    expect(getActiveLocalAgentDispatcher()).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #25248

## What changed

- points the registry test at the real sibling implementation instead of a nonexistent file inside `__tests__`
- removes the unused `vi` import
- applies the repository-pinned Biome formatting to the one test file

No production bytes changed.

## Proof

- `bun test src/__tests__/local-agent-dispatcher-registry.test.ts` — 5/5 pass
- pinned Biome check — pass
- `git diff --check` — pass

## Attribution

- OpenAI / gpt-5.6-sol
- Codex Desktop / multi-agent
- N/A — no repository contribution skill used