### PR TITLE
fix(computeruse): surrogate-safe trajectory truncation + reject malformed Unicode

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.fidelity.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.fidelity.test.ts
@@ -1,0 +1,54 @@
+// Regression coverage for trajectory fidelity: surrogate-safe truncation
+// (a naive slice splits emoji pairs at the 256-char boundary) and malformed
+// Unicode rejection (a corrupted payload must not masquerade as clean).
+
+import { logger } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { emitAndroidAction } from "../mobile/android-trajectory.js";
+
+describe("emitAndroidAction — trajectory fidelity", () => {
+  it("truncates at 256 chars without splitting a surrogate pair", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      // 250 ASCII chars + an emoji that straddles the 256 boundary
+      const boundary = "x".repeat(254) + "🧠"; // 🧠 is 2 code units
+      const payload = emitAndroidAction({
+        kind: "tap",
+        success: false,
+        errorCode: "accessibility_unavailable",
+        errorMessage: boundary,
+      });
+      // truncateWellFormed must not cut inside the surrogate pair
+      expect(payload.errorMessage?.length).toBeLessThanOrEqual(256);
+      expect(payload.errorMessage).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects malformed Unicode in the error message", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    try {
+      // Lone high surrogate = malformed
+      const malformed = "driver failed \uD800 tail";
+      expect(() =>
+        emitAndroidAction({
+          kind: "tap",
+          success: false,
+          errorCode: "driver_error",
+          errorMessage: malformed,
+        }),
+      ).toThrowError(
+        expect.objectContaining({
+          name: "ElizaError",
+          code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+          context: { field: "error" },
+        }),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
+++ b/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
@@ -24,7 +24,12 @@
  * log-capture pipeline.
  */
 
-import { logger } from "@elizaos/core";
+import {
+  ElizaError,
+  logger,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 
 export type AndroidActionKind =
   | "tap"
@@ -76,8 +81,26 @@ export function emitAndroidAction(
   event: AndroidTrajectoryActionEvent,
 ): AndroidTrajectoryActionEvent {
   const trimmed: AndroidTrajectoryActionEvent = { ...event };
-  if (trimmed.errorMessage) {
-    trimmed.errorMessage = trimmed.errorMessage.slice(0, MAX_ERROR_MSG);
+  if (trimmed.errorMessage !== undefined) {
+    // Trajectory fidelity: reject malformed Unicode outright so a corrupted
+    // payload can never masquerade as a clean one (a naive replacement would
+    // silently log U+FFFD where the operator needs the real text).
+    if (toWellFormedUnicode(trimmed.errorMessage) !== trimmed.errorMessage) {
+      throw new ElizaError(
+        "Android trajectory action error contains malformed Unicode",
+        {
+          code: "COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE",
+          context: { field: "error" },
+        },
+      );
+    }
+    // Surrogate-safe truncation: a naive slice can split a surrogate pair
+    // (e.g. an emoji straddling the 256-char boundary) and emit malformed
+    // Unicode into the structured log stream.
+    trimmed.errorMessage = truncateWellFormed(
+      trimmed.errorMessage,
+      MAX_ERROR_MSG,
+    );
   }
   logger.info(
     {


### PR DESCRIPTION
## Problem

`emitAndroidAction` sliced `errorMessage` at 256 chars naively — a **surrogate pair** (e.g. an emoji straddling the boundary) could be split, emitting **malformed Unicode into the structured log stream**. Malformed input was also silently logged as U+FFFD replacement chars, so a corrupted payload could masquerade as clean.

## Fix

- **Reject malformed Unicode outright** — `COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE` (`context.field=error`) so a corrupted payload can never masquerade as clean.
- **Surrogate-safe truncation** via `truncateWellFormed` — never cuts inside a surrogate pair.
- Existing 256-char trim contract preserved (5/5 existing tests pass).

## Tests

```text
$ bunx vitest run android-trajectory      # 5 passed (existing)
$ bunx vitest run android-trajectory.fidelity  # 2 passed (new)
  ✓ truncates at 256 without splitting a surrogate pair
  ✓ rejects malformed Unicode (ElizaError COMPUTERUSE_TRAJECTORY_MALFORMED_UNICODE)
```

AI provider/model: deepseek / deepseek-v4-flash
<!-- eliza-computer-attribution:v1 -->