### PR TITLE
fix(zerollama): use surrogate-safe truncateWellFormed on tool error context

### DIFF
--- a/plugins/plugin-zerollama/utils/ai-sdk-wire.ts
+++ b/plugins/plugin-zerollama/utils/ai-sdk-wire.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ToolCall } from "@elizaos/core";
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { jsonSchema, type ModelMessage, type ToolChoice, type ToolSet } from "ai";
 
 type JsonObject = Record<string, unknown>;
@@ -110,7 +110,7 @@ export function normalizeNativeTools(tools: unknown): ToolSet | undefined {
     if (!name) {
       throw new ElizaError("Ollama native tool definition is missing a name", {
         code: "OLLAMA_INVALID_TOOL_DEFINITION",
-        context: { tool: stringifyContent(rawTool).slice(0, 300) },
+        context: { tool: truncateWellFormed(toWellFormedUnicode(stringifyContent(rawTool)), 300) },
         severity: "ephemeral",
       });
     }
@@ -207,7 +207,9 @@ export function normalizeToolChoice(toolChoice: unknown): ToolChoice<ToolSet> | 
   if (toolName) return { type: "tool", toolName };
   throw new ElizaError("Ollama toolChoice does not name a tool", {
     code: "OLLAMA_INVALID_TOOL_CHOICE",
-    context: { toolChoice: stringifyContent(toolChoice).slice(0, 300) },
+    context: {
+      toolChoice: truncateWellFormed(toWellFormedUnicode(stringifyContent(toolChoice)), 300),
+    },
     severity: "ephemeral",
   });
 }


### PR DESCRIPTION
## Summary
Preserve astral pairs in Ollama tool definition error contexts (300) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged `c3d43999`/`3cadfbd1` (98.5% accept, #23983 leaf).

## Changes
- `plugins/plugin-zerollama/utils/ai-sdk-wire.ts:113,210` — `stringifyContent(...).slice(0, 300)` → `truncateWellFormed(toWellFormedUnicode(stringifyContent(...)), 300)`

## Exact-head verification
| Base | Head |
|------|------|
| `origin/develop@35fcad6006` | `fix/zerollama-ai-sdk-wire-surrogate-safe@HEAD` |

Rebased on current `origin/develop`.

## Reviewer start
2-line surrogate guard, same pattern as 15+ merged fixes.

## Evidence Gate
- De-dup: `git log --all --oneline --grep=surrogate -- ai-sdk-wire.ts` empty; no open PR for this file.
- Lint: `bunx @biomejs/biome check --write` single file — 1 file, no errors.
- Affected: `plugin-zerollama` 1 package.