### PR TITLE
feat(synthetic-world): add lease-fenced command journal

### DIFF
--- a/.github/develop-surface-graph.json
+++ b/.github/develop-surface-graph.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "graphVersion": "2026-08-22.1",
+  "graphVersion": "2026-08-22.2",
   "evidenceTtlHours": 168,
   "reusePolicy": "current-run-only",
   "environment": {
@@ -37,6 +37,7 @@
         "packages/prompts",
         "packages/registry",
         "packages/shared",
+        "packages/synthetic-world",
         "packages/skills",
         "packages/vault",
         "plugins/**"

--- a/bun.lock
+++ b/bun.lock
@@ -1099,6 +1099,19 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/synthetic-world": {
+      "name": "@elizaos/synthetic-world",
+      "version": "0.0.0",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "@elizaos/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "@elizaos/cloud-test-mocks": "workspace:*",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "bun-types": "*",
+      },
+    },
     "packages/test": {
       "name": "@elizaos/test-corpus",
       "version": "0.0.0",
@@ -4331,6 +4344,8 @@
     "@elizaos/shared": ["@elizaos/shared@workspace:packages/shared"],
 
     "@elizaos/skills": ["@elizaos/skills@workspace:packages/skills"],
+
+    "@elizaos/synthetic-world": ["@elizaos/synthetic-world@workspace:packages/synthetic-world"],
 
     "@elizaos/test-corpus": ["@elizaos/test-corpus@workspace:packages/test"],
 

--- a/packages/synthetic-world/AGENTS.md
+++ b/packages/synthetic-world/AGENTS.md
@@ -1,0 +1,25 @@
+# Synthetic world command authority
+
+This package owns the durable, generation-fenced command journal used by
+synthetic-environment control callers. It composes over the shared lease store;
+it does not own leases, domain state, an HTTP control plane, or a simulator.
+
+## Invariants
+
+- Every command write runs through `withActiveGeneration` on the supplied lease
+  store and uses its transaction context.
+- A command ID is unique for a namespace across generations. Reuse requires the
+  same command type and canonical payload hash.
+- A rolled-back `EXECUTING` mutation is `FAILED` with `KNOWN_FAILURE`. Only a
+  `COMMITTED` mutation whose response was lost becomes `DIRTY`/`UNKNOWN`.
+- Domain mutations are synchronous and use the supplied SQLite transaction so
+  their commit is atomic with the journal's `COMMITTED` checkpoint.
+- Capability reporting must list unavailable surfaces explicitly. This package
+  does not claim production boot, manifests, virtual time, fault injection,
+  observation ledgers, or a Cloud adapter.
+
+## Verification
+
+Run `bun run --cwd packages/synthetic-world test`, `typecheck`, `lint:check`,
+and `build`. Process-crash tests are required for transaction rollback and
+commit-before-response recovery.

--- a/packages/synthetic-world/CLAUDE.md
+++ b/packages/synthetic-world/CLAUDE.md
@@ -1,0 +1,25 @@
+# Synthetic world command authority
+
+This package owns the durable, generation-fenced command journal used by
+synthetic-environment control callers. It composes over the shared lease store;
+it does not own leases, domain state, an HTTP control plane, or a simulator.
+
+## Invariants
+
+- Every command write runs through `withActiveGeneration` on the supplied lease
+  store and uses its transaction context.
+- A command ID is unique for a namespace across generations. Reuse requires the
+  same command type and canonical payload hash.
+- A rolled-back `EXECUTING` mutation is `FAILED` with `KNOWN_FAILURE`. Only a
+  `COMMITTED` mutation whose response was lost becomes `DIRTY`/`UNKNOWN`.
+- Domain mutations are synchronous and use the supplied SQLite transaction so
+  their commit is atomic with the journal's `COMMITTED` checkpoint.
+- Capability reporting must list unavailable surfaces explicitly. This package
+  does not claim production boot, manifests, virtual time, fault injection,
+  observation ledgers, or a Cloud adapter.
+
+## Verification
+
+Run `bun run --cwd packages/synthetic-world test`, `typecheck`, `lint:check`,
+and `build`. Process-crash tests are required for transaction rollback and
+commit-before-response recovery.

--- a/packages/synthetic-world/README.md
+++ b/packages/synthetic-world/README.md
@@ -1,0 +1,11 @@
+# `@elizaos/synthetic-world`
+
+SW-1 provides a durable SQLite command journal bound to the existing synthetic
+environment lease generation. Callers supply the lease store and execute domain
+mutations on the guarded SQLite transaction.
+
+The package currently proves local command ownership, success and failure
+replay, fencing, rollback-aware crash classification, and restart recovery.
+Production boot, full manifests, virtual
+clocks, fault injection, observation ledgers, and a Cloud journal adapter remain
+unavailable and are reported as such by `SYNTHETIC_WORLD_CAPABILITIES`.

--- a/packages/synthetic-world/package.json
+++ b/packages/synthetic-world/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@elizaos/synthetic-world",
+  "version": "0.0.0",
+  "description": "Lease-fenced durable command authority for synthetic environments.",
+  "type": "module",
+  "private": true,
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun --conditions=eliza-source test",
+    "lint:check": "bunx @biomejs/biome check package.json src test",
+    "format": "bunx @biomejs/biome format --write package.json src test",
+    "format:check": "bunx @biomejs/biome format package.json src test"
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "@elizaos/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@elizaos/cloud-test-mocks": "workspace:*",
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "bun-types": "*"
+  },
+  "elizaos": {
+    "scripts": {
+      "testLanes": [
+        "server"
+      ]
+    }
+  }
+}

--- a/packages/synthetic-world/src/index.ts
+++ b/packages/synthetic-world/src/index.ts
@@ -1,0 +1,19 @@
+/** Exports the SW-1 durable command journal without claiming later synthetic-world surfaces. */
+
+export { SqliteSyntheticCommandJournal } from "./sqlite-command-journal";
+export type {
+  SyntheticCommandCheckpoint,
+  SyntheticCommandExecution,
+  SyntheticCommandExecutionOptions,
+  SyntheticCommandHeartbeat,
+  SyntheticCommandOutcome,
+  SyntheticCommandPhase,
+  SyntheticCommandRecord,
+  SyntheticCommandRecovery,
+  SyntheticJson,
+  SyntheticWorldCommand,
+} from "./types";
+export {
+  SYNTHETIC_WORLD_CAPABILITIES,
+  SYNTHETIC_WORLD_COMMAND_VERSION,
+} from "./types";

--- a/packages/synthetic-world/src/sqlite-command-journal.ts
+++ b/packages/synthetic-world/src/sqlite-command-journal.ts
@@ -1,0 +1,826 @@
+/**
+ * Persists idempotent synthetic commands inside the existing lease store's
+ * guarded SQLite transaction and classifies ambiguous restarts as dirty.
+ */
+
+import type { Database } from "bun:sqlite";
+import { createHash, randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core/errors";
+import type {
+  SyntheticEnvironmentLeaseAuthority,
+  SyntheticEnvironmentLeaseStore,
+} from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { isSyntheticEnvironmentNamespace } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import type {
+  SyntheticCommandExecution,
+  SyntheticCommandExecutionOptions,
+  SyntheticCommandHeartbeat,
+  SyntheticCommandOutcome,
+  SyntheticCommandPhase,
+  SyntheticCommandRecord,
+  SyntheticCommandRecovery,
+  SyntheticJson,
+  SyntheticWorldCommand,
+} from "./types";
+import { SYNTHETIC_WORLD_COMMAND_VERSION } from "./types";
+
+interface CommandRow {
+  namespace: string;
+  command_id: string;
+  generation: number;
+  command_type: string;
+  payload_hash: string;
+  payload_json: string;
+  phase: SyntheticCommandPhase;
+  outcome: SyntheticCommandOutcome;
+  result_json: string | null;
+  error_code: string | null;
+  error_message: string | null;
+  execution_token: string | null;
+  created_at_ms: number;
+  heartbeat_at_ms: number;
+  updated_at_ms: number;
+  revision: number;
+}
+
+const IDENTIFIER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:@/-]{0,127}$/;
+
+function commandError(
+  code: string,
+  message: string,
+  context?: Record<string, string | number>,
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    severity: "fatal",
+    context,
+    cause,
+  });
+}
+
+function invalidJson(message: string, cause?: unknown): ElizaError {
+  return commandError(
+    "SYNTHETIC_COMMAND_INVALID_INPUT",
+    message,
+    undefined,
+    cause,
+  );
+}
+
+function compareUtf16(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function canonicalJson(
+  value: unknown,
+  ancestors = new WeakSet<object>(),
+): string {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "string"
+  ) {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw invalidJson("JSON numbers must be finite");
+    }
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object") {
+    throw invalidJson(
+      "JSON values cannot contain undefined, bigint, functions, or symbols",
+    );
+  }
+  if (ancestors.has(value)) {
+    throw invalidJson("JSON values cannot contain cycles");
+  }
+  ancestors.add(value);
+  if (Array.isArray(value)) {
+    if (Object.getPrototypeOf(value) !== Array.prototype) {
+      throw invalidJson("JSON arrays must use the built-in Array prototype");
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const keys = Reflect.ownKeys(descriptors);
+    const allowedKeys = new Set<PropertyKey>(["length"]);
+    for (let index = 0; index < value.length; index += 1) {
+      const key = String(index);
+      allowedKeys.add(key);
+      const descriptor = descriptors[key];
+      if (
+        descriptor === undefined ||
+        !("value" in descriptor) ||
+        !descriptor.enumerable
+      ) {
+        throw invalidJson("JSON arrays must be dense data-property arrays");
+      }
+    }
+    if (keys.some((key) => !allowedKeys.has(key))) {
+      throw invalidJson("JSON arrays cannot contain custom properties");
+    }
+    const encoded = value.map((entry) => canonicalJson(entry, ancestors));
+    ancestors.delete(value);
+    return `[${encoded.join(",")}]`;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw invalidJson("JSON objects must have a plain or null prototype");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const keys = Reflect.ownKeys(descriptors);
+  if (keys.some((key) => typeof key === "symbol")) {
+    throw invalidJson("JSON objects cannot contain symbol properties");
+  }
+  const stringKeys = keys as string[];
+  for (const key of stringKeys) {
+    const descriptor = descriptors[key];
+    if (!("value" in descriptor) || !descriptor.enumerable) {
+      throw invalidJson(
+        "JSON objects must contain only enumerable data properties",
+      );
+    }
+  }
+  stringKeys.sort(compareUtf16);
+  const encoded = stringKeys.map((key) => {
+    const descriptor = descriptors[key];
+    if (descriptor === undefined || !("value" in descriptor)) {
+      throw invalidJson("JSON object descriptor disappeared during encoding");
+    }
+    return `${JSON.stringify(key)}:${canonicalJson(descriptor.value, ancestors)}`;
+  });
+  ancestors.delete(value);
+  return `{${encoded.join(",")}}`;
+}
+
+function serializeJson(value: unknown): string {
+  try {
+    return canonicalJson(value);
+  } catch (error) {
+    // error-policy:J3 Unexpected reflection failures are invalid input, never raw boundary errors.
+    if (error instanceof ElizaError) throw error;
+    throw invalidJson("JSON value could not be inspected safely", error);
+  }
+}
+
+function validateCommand(
+  authority: SyntheticEnvironmentLeaseAuthority,
+  command: SyntheticWorldCommand,
+): { payloadJson: string; payloadHash: string } {
+  if (
+    command.version !== SYNTHETIC_WORLD_COMMAND_VERSION ||
+    !isSyntheticEnvironmentNamespace(command.namespace) ||
+    !Number.isSafeInteger(command.generation) ||
+    command.generation < 1 ||
+    !IDENTIFIER_PATTERN.test(command.commandId) ||
+    !IDENTIFIER_PATTERN.test(command.type)
+  ) {
+    throw commandError(
+      "SYNTHETIC_COMMAND_INVALID_INPUT",
+      "Command version, namespace, generation, ID, or type is invalid",
+    );
+  }
+  if (
+    command.namespace !== authority.namespace ||
+    command.generation !== authority.generation
+  ) {
+    throw commandError(
+      "SYNTHETIC_COMMAND_GENERATION_MISMATCH",
+      "Command namespace and generation must match its lease authority",
+      {
+        namespace: command.namespace,
+        generation: command.generation,
+        authorityGeneration: authority.generation,
+      },
+    );
+  }
+  const payloadJson = serializeJson(command.payload);
+  return {
+    payloadJson,
+    payloadHash: createHash("sha256").update(payloadJson).digest("hex"),
+  };
+}
+
+function ensureSchema(database: Database): void {
+  database.run(`
+    CREATE TABLE IF NOT EXISTS synthetic_world_commands (
+      namespace TEXT NOT NULL,
+      command_id TEXT NOT NULL,
+      generation INTEGER NOT NULL CHECK (generation > 0),
+      command_type TEXT NOT NULL,
+      payload_hash TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      phase TEXT NOT NULL CHECK (phase IN ('OWNED', 'EXECUTING', 'COMMITTED', 'SUCCEEDED', 'FAILED', 'DIRTY')),
+      outcome TEXT NOT NULL CHECK (outcome IN ('PENDING', 'KNOWN_SUCCESS', 'KNOWN_FAILURE', 'UNKNOWN')),
+      result_json TEXT,
+      error_code TEXT,
+      error_message TEXT,
+      execution_token TEXT,
+      created_at_ms INTEGER NOT NULL,
+      heartbeat_at_ms INTEGER NOT NULL,
+      updated_at_ms INTEGER NOT NULL,
+      revision INTEGER NOT NULL CHECK (revision > 0),
+      PRIMARY KEY (namespace, command_id)
+    )
+  `);
+}
+
+function selectRow(
+  database: Database,
+  namespace: string,
+  commandId: string,
+): CommandRow | null {
+  return database
+    .query<CommandRow, [string, string]>(
+      "SELECT * FROM synthetic_world_commands WHERE namespace = ? AND command_id = ?",
+    )
+    .get(namespace, commandId);
+}
+
+function iso(milliseconds: number): string {
+  return new Date(milliseconds).toISOString();
+}
+
+function parseJson(value: string, field: "payload" | "result"): SyntheticJson {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (serializeJson(parsed) !== value) {
+      throw new Error("stored JSON is not canonical");
+    }
+    return parsed as SyntheticJson;
+  } catch (error) {
+    // error-policy:J3 Corrupt journal JSON is translated to an explicit storage failure.
+    throw commandError(
+      "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+      `Stored command ${field} JSON is corrupt or non-canonical`,
+      undefined,
+      error,
+    );
+  }
+}
+
+function toRecord(row: CommandRow): SyntheticCommandRecord {
+  return {
+    version: SYNTHETIC_WORLD_COMMAND_VERSION,
+    namespace: row.namespace,
+    commandId: row.command_id,
+    generation: row.generation,
+    type: row.command_type,
+    payloadHash: row.payload_hash,
+    payload: parseJson(row.payload_json, "payload"),
+    phase: row.phase,
+    outcome: row.outcome,
+    result:
+      row.result_json === null ? null : parseJson(row.result_json, "result"),
+    error:
+      row.error_code === null || row.error_message === null
+        ? null
+        : { code: row.error_code, message: row.error_message },
+    executionToken: row.execution_token,
+    createdAt: iso(row.created_at_ms),
+    heartbeatAt: iso(row.heartbeat_at_ms),
+    updatedAt: iso(row.updated_at_ms),
+    revision: row.revision,
+  };
+}
+
+function assertSamePayload(
+  row: CommandRow,
+  command: SyntheticWorldCommand,
+  payloadHash: string,
+): void {
+  if (row.command_type !== command.type || row.payload_hash !== payloadHash) {
+    throw commandError(
+      "SYNTHETIC_COMMAND_ID_CONFLICT",
+      "Command ID was already used with a different type or payload",
+      { namespace: command.namespace, commandId: command.commandId },
+    );
+  }
+}
+
+interface ClaimResult {
+  replay: CommandRow | null;
+  executionToken: string | null;
+}
+
+/** Local SW-1 adapter composed over a lease store backed by the same database. */
+export class SqliteSyntheticCommandJournal {
+  constructor(
+    private readonly leaseStore: SyntheticEnvironmentLeaseStore<Database>,
+  ) {}
+
+  async execute(
+    authority: SyntheticEnvironmentLeaseAuthority,
+    command: SyntheticWorldCommand,
+    mutate: (database: Database) => SyntheticJson,
+    options: SyntheticCommandExecutionOptions = {},
+  ): Promise<SyntheticCommandExecution> {
+    const { payloadJson, payloadHash } = validateCommand(authority, command);
+    const now = Date.now();
+    const executionToken = randomUUID();
+    const claim = await this.leaseStore.withActiveGeneration(
+      authority,
+      (database): ClaimResult => {
+        ensureSchema(database);
+        const existing = selectRow(
+          database,
+          command.namespace,
+          command.commandId,
+        );
+        if (existing !== null) {
+          assertSamePayload(existing, command, payloadHash);
+          if (existing.generation > authority.generation) {
+            throw commandError(
+              "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+              "Command generation is newer than the active lease generation",
+              {
+                namespace: command.namespace,
+                commandId: command.commandId,
+                commandGeneration: existing.generation,
+                authorityGeneration: authority.generation,
+              },
+            );
+          }
+          if (existing.phase === "SUCCEEDED" && existing.result_json !== null) {
+            return { replay: existing, executionToken: null };
+          }
+          if (existing.phase === "FAILED") {
+            if (
+              existing.error_code === null ||
+              existing.error_message === null
+            ) {
+              throw commandError(
+                "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+                "Failed command is missing its stored error",
+              );
+            }
+            throw commandError(existing.error_code, existing.error_message, {
+              namespace: command.namespace,
+              commandId: command.commandId,
+            });
+          }
+          if (existing.phase === "DIRTY") {
+            throw commandError(
+              "SYNTHETIC_COMMAND_DIRTY",
+              "Command has an unknown outcome and cannot be replayed",
+              { namespace: command.namespace, commandId: command.commandId },
+            );
+          }
+          if (existing.execution_token !== null) {
+            throw commandError(
+              "SYNTHETIC_COMMAND_IN_PROGRESS",
+              "Command is already owned by another execution",
+              { namespace: command.namespace, commandId: command.commandId },
+            );
+          }
+          const claimed = database.run(
+            `UPDATE synthetic_world_commands
+             SET generation = ?, execution_token = ?, heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+             WHERE namespace = ? AND command_id = ? AND phase = 'OWNED' AND execution_token IS NULL`,
+            [
+              authority.generation,
+              executionToken,
+              now,
+              now,
+              command.namespace,
+              command.commandId,
+            ],
+          );
+          if (claimed.changes !== 1) {
+            throw commandError(
+              "SYNTHETIC_COMMAND_OWNERSHIP_LOST",
+              "Command ownership claim did not update exactly one record",
+              { namespace: command.namespace, commandId: command.commandId },
+            );
+          }
+          return { replay: null, executionToken };
+        }
+        const inserted = database.run(
+          `INSERT INTO synthetic_world_commands (
+            namespace, command_id, generation, command_type, payload_hash,
+            payload_json, phase, outcome, result_json, error_code, error_message, execution_token,
+            created_at_ms, heartbeat_at_ms, updated_at_ms, revision
+          ) VALUES (?, ?, ?, ?, ?, ?, 'OWNED', 'PENDING', NULL, NULL, NULL, ?, ?, ?, ?, 1)`,
+          [
+            command.namespace,
+            command.commandId,
+            authority.generation,
+            command.type,
+            payloadHash,
+            payloadJson,
+            executionToken,
+            now,
+            now,
+            now,
+          ],
+        );
+        if (inserted.changes !== 1) {
+          throw commandError(
+            "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+            "Command creation did not insert exactly one record",
+            { namespace: command.namespace, commandId: command.commandId },
+          );
+        }
+        return { replay: null, executionToken };
+      },
+    );
+    if (claim.value.replay !== null) {
+      const result = claim.value.replay.result_json;
+      if (result === null) {
+        throw commandError(
+          "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+          "Succeeded command is missing its result",
+        );
+      }
+      return {
+        record: toRecord(claim.value.replay),
+        result: parseJson(result, "result"),
+        replayed: true,
+      };
+    }
+    await options.onCheckpoint?.({
+      phase: "OWNED",
+      commandId: command.commandId,
+      executionToken,
+    });
+    await this.transition(
+      authority,
+      command.commandId,
+      executionToken,
+      "OWNED",
+      "EXECUTING",
+    );
+    await options.onCheckpoint?.({
+      phase: "EXECUTING",
+      commandId: command.commandId,
+      executionToken,
+    });
+
+    let result: SyntheticJson;
+    try {
+      const committed = await this.leaseStore.withActiveGeneration(
+        authority,
+        (database): SyntheticJson => {
+          ensureSchema(database);
+          const row = selectRow(database, command.namespace, command.commandId);
+          this.assertExecution(
+            row,
+            executionToken,
+            "EXECUTING",
+            command.commandId,
+          );
+          const mutationResult = mutate(database);
+          const resultJson = serializeJson(mutationResult);
+          const changedAt = Date.now();
+          database.run(
+            `UPDATE synthetic_world_commands
+             SET phase = 'COMMITTED', result_json = ?, heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+             WHERE namespace = ? AND command_id = ? AND execution_token = ? AND phase = 'EXECUTING'`,
+            [
+              resultJson,
+              changedAt,
+              changedAt,
+              command.namespace,
+              command.commandId,
+              executionToken,
+            ],
+          );
+          return mutationResult;
+        },
+      );
+      result = committed.value;
+    } catch (error) {
+      // error-policy:J2 The guarded transaction rolled back, so persist and rethrow a known failure.
+      const failureCode =
+        error instanceof ElizaError
+          ? error.code
+          : "SYNTHETIC_COMMAND_EXECUTION_FAILED";
+      const failureMessage =
+        error instanceof Error ? error.message : "Command mutation threw";
+      try {
+        await this.markFailed(
+          authority,
+          command.commandId,
+          executionToken,
+          failureCode,
+          failureMessage,
+        );
+      } catch (classificationError) {
+        // error-policy:J2 Lease loss while recording known failure is attached to the surfaced failure.
+        throw commandError(
+          "SYNTHETIC_COMMAND_FAILURE_CLASSIFICATION_FAILED",
+          "Mutation rolled back but the journal could not persist its failure",
+          { namespace: command.namespace, commandId: command.commandId },
+          { mutationError: error, classificationError },
+        );
+      }
+      throw commandError(
+        failureCode,
+        failureMessage,
+        { namespace: command.namespace, commandId: command.commandId },
+        error,
+      );
+    }
+
+    await options.onCheckpoint?.({
+      phase: "COMMITTED",
+      commandId: command.commandId,
+      executionToken,
+    });
+    const final = await this.transition(
+      authority,
+      command.commandId,
+      executionToken,
+      "COMMITTED",
+      "SUCCEEDED",
+    );
+    return { record: final, result, replayed: false };
+  }
+
+  async heartbeat(
+    input: SyntheticCommandHeartbeat,
+  ): Promise<SyntheticCommandRecord> {
+    const guarded = await this.leaseStore.withActiveGeneration(
+      input.authority,
+      (database) => {
+        ensureSchema(database);
+        const now = Date.now();
+        const result = database.run(
+          `UPDATE synthetic_world_commands
+           SET heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+           WHERE namespace = ? AND command_id = ? AND execution_token = ? AND phase IN ('OWNED', 'EXECUTING', 'COMMITTED')`,
+          [
+            now,
+            now,
+            input.authority.namespace,
+            input.commandId,
+            input.executionToken,
+          ],
+        );
+        if (result.changes !== 1) {
+          throw commandError(
+            "SYNTHETIC_COMMAND_OWNERSHIP_LOST",
+            "Command heartbeat token is stale or the command is no longer active",
+          );
+        }
+        return toRecord(
+          selectRow(
+            database,
+            input.authority.namespace,
+            input.commandId,
+          ) as CommandRow,
+        );
+      },
+    );
+    return guarded.value;
+  }
+
+  async inspect(
+    authority: SyntheticEnvironmentLeaseAuthority,
+    commandId: string,
+  ): Promise<SyntheticCommandRecord | null> {
+    const guarded = await this.leaseStore.withActiveGeneration(
+      authority,
+      (database) => {
+        ensureSchema(database);
+        const row = selectRow(database, authority.namespace, commandId);
+        return row === null ? null : toRecord(row);
+      },
+    );
+    return guarded.value;
+  }
+
+  async recover(
+    authority: SyntheticEnvironmentLeaseAuthority,
+  ): Promise<SyntheticCommandRecovery> {
+    const guarded = await this.leaseStore.withActiveGeneration(
+      authority,
+      (database): SyntheticCommandRecovery => {
+        ensureSchema(database);
+        const rows = database
+          .query<CommandRow, [string]>(
+            "SELECT * FROM synthetic_world_commands WHERE namespace = ? ORDER BY command_id",
+          )
+          .all(authority.namespace);
+        const retryableCommandIds: string[] = [];
+        const failedCommandIds: string[] = [];
+        const dirtyCommandIds: string[] = [];
+        const activeCommandIds: string[] = [];
+        const now = Date.now();
+        for (const row of rows) {
+          if (
+            row.phase === "SUCCEEDED" ||
+            row.phase === "FAILED" ||
+            row.phase === "DIRTY"
+          ) {
+            continue;
+          }
+          if (row.generation > authority.generation) {
+            throw commandError(
+              "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+              "Command generation is newer than the active lease generation",
+              {
+                namespace: authority.namespace,
+                commandId: row.command_id,
+                commandGeneration: row.generation,
+                authorityGeneration: authority.generation,
+              },
+            );
+          }
+          if (row.generation === authority.generation) {
+            activeCommandIds.push(row.command_id);
+            continue;
+          }
+          if (row.phase === "OWNED") {
+            const result = database.run(
+              `UPDATE synthetic_world_commands
+               SET generation = ?, execution_token = NULL, heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+               WHERE namespace = ? AND command_id = ? AND generation = ? AND phase = 'OWNED'`,
+              [
+                authority.generation,
+                now,
+                now,
+                authority.namespace,
+                row.command_id,
+                row.generation,
+              ],
+            );
+            this.assertRecoveryUpdate(result.changes, row.command_id);
+            retryableCommandIds.push(row.command_id);
+            continue;
+          }
+          if (row.phase === "EXECUTING") {
+            const result = database.run(
+              `UPDATE synthetic_world_commands
+               SET generation = ?, phase = 'FAILED', outcome = 'KNOWN_FAILURE', execution_token = NULL,
+                   error_code = 'SYNTHETIC_COMMAND_ABORTED_BEFORE_COMMIT',
+                   error_message = 'Prior process stopped before its atomic mutation committed',
+                   heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+               WHERE namespace = ? AND command_id = ? AND generation = ? AND phase = 'EXECUTING'`,
+              [
+                authority.generation,
+                now,
+                now,
+                authority.namespace,
+                row.command_id,
+                row.generation,
+              ],
+            );
+            this.assertRecoveryUpdate(result.changes, row.command_id);
+            failedCommandIds.push(row.command_id);
+            continue;
+          }
+          this.markDirty(database, authority, row, now);
+          dirtyCommandIds.push(row.command_id);
+        }
+        return {
+          retryableCommandIds,
+          failedCommandIds,
+          dirtyCommandIds,
+          activeCommandIds,
+        };
+      },
+    );
+    return guarded.value;
+  }
+
+  private async transition(
+    authority: SyntheticEnvironmentLeaseAuthority,
+    commandId: string,
+    executionToken: string,
+    from: SyntheticCommandPhase,
+    to: SyntheticCommandPhase,
+  ): Promise<SyntheticCommandRecord> {
+    const guarded = await this.leaseStore.withActiveGeneration(
+      authority,
+      (database) => {
+        ensureSchema(database);
+        const row = selectRow(database, authority.namespace, commandId);
+        this.assertExecution(row, executionToken, from, commandId);
+        const now = Date.now();
+        const outcome = to === "SUCCEEDED" ? "KNOWN_SUCCESS" : "PENDING";
+        const token = to === "SUCCEEDED" ? null : executionToken;
+        const transitioned = database.run(
+          `UPDATE synthetic_world_commands
+           SET phase = ?, outcome = ?, execution_token = ?, heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+           WHERE namespace = ? AND command_id = ? AND execution_token = ? AND phase = ?`,
+          [
+            to,
+            outcome,
+            token,
+            now,
+            now,
+            authority.namespace,
+            commandId,
+            executionToken,
+            from,
+          ],
+        );
+        if (transitioned.changes !== 1) {
+          throw commandError(
+            "SYNTHETIC_COMMAND_OWNERSHIP_LOST",
+            "Command transition did not update exactly one record",
+            { namespace: authority.namespace, commandId },
+          );
+        }
+        return toRecord(
+          selectRow(database, authority.namespace, commandId) as CommandRow,
+        );
+      },
+    );
+    return guarded.value;
+  }
+
+  private async markFailed(
+    authority: SyntheticEnvironmentLeaseAuthority,
+    commandId: string,
+    executionToken: string,
+    errorCode: string,
+    errorMessage: string,
+  ): Promise<void> {
+    await this.leaseStore.withActiveGeneration(authority, (database) => {
+      ensureSchema(database);
+      const now = Date.now();
+      const result = database.run(
+        `UPDATE synthetic_world_commands
+         SET phase = 'FAILED', outcome = 'KNOWN_FAILURE', execution_token = NULL,
+             error_code = ?, error_message = ?,
+             heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+         WHERE namespace = ? AND command_id = ? AND execution_token = ? AND phase = 'EXECUTING'`,
+        [
+          errorCode,
+          errorMessage,
+          now,
+          now,
+          authority.namespace,
+          commandId,
+          executionToken,
+        ],
+      );
+      if (result.changes !== 1) {
+        throw commandError(
+          "SYNTHETIC_COMMAND_OWNERSHIP_LOST",
+          "Failed command could not be durably classified",
+          { namespace: authority.namespace, commandId },
+        );
+      }
+    });
+  }
+
+  private markDirty(
+    database: Database,
+    authority: SyntheticEnvironmentLeaseAuthority,
+    row: CommandRow,
+    now: number,
+  ): void {
+    const result = database.run(
+      `UPDATE synthetic_world_commands
+       SET generation = ?, phase = 'DIRTY', outcome = 'UNKNOWN', execution_token = NULL,
+           error_code = 'SYNTHETIC_COMMAND_RECOVERED_AMBIGUOUS',
+           error_message = 'Prior mutation committed but its response was not durably acknowledged',
+           heartbeat_at_ms = ?, updated_at_ms = ?, revision = revision + 1
+       WHERE namespace = ? AND command_id = ? AND generation = ? AND phase = 'COMMITTED'`,
+      [
+        authority.generation,
+        now,
+        now,
+        authority.namespace,
+        row.command_id,
+        row.generation,
+      ],
+    );
+    this.assertRecoveryUpdate(result.changes, row.command_id);
+  }
+
+  private assertRecoveryUpdate(changes: number, commandId: string): void {
+    if (changes !== 1) {
+      throw commandError(
+        "SYNTHETIC_COMMAND_STORAGE_FAILURE",
+        "Recovery did not update exactly one command record",
+        { commandId, changes },
+      );
+    }
+  }
+
+  private assertExecution(
+    row: CommandRow | null,
+    executionToken: string,
+    phase: SyntheticCommandPhase,
+    commandId: string,
+  ): asserts row is CommandRow {
+    if (
+      row === null ||
+      row.execution_token !== executionToken ||
+      row.phase !== phase
+    ) {
+      throw commandError(
+        "SYNTHETIC_COMMAND_OWNERSHIP_LOST",
+        "Command execution token or phase no longer owns the journal record",
+        { commandId, expectedPhase: phase },
+      );
+    }
+  }
+}

--- a/packages/synthetic-world/src/types.ts
+++ b/packages/synthetic-world/src/types.ts
@@ -1,0 +1,98 @@
+/** Defines the public command-journal records and truthful SW-1 capability surface. */
+
+import type { SyntheticEnvironmentLeaseAuthority } from "@elizaos/shared/contracts/synthetic-environment-lease";
+
+export const SYNTHETIC_WORLD_COMMAND_VERSION = 1 as const;
+
+export type SyntheticJson =
+  | null
+  | boolean
+  | number
+  | string
+  | SyntheticJson[]
+  | { [key: string]: SyntheticJson };
+
+export type SyntheticCommandPhase =
+  | "OWNED"
+  | "EXECUTING"
+  | "COMMITTED"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "DIRTY";
+
+export type SyntheticCommandOutcome =
+  | "PENDING"
+  | "KNOWN_SUCCESS"
+  | "KNOWN_FAILURE"
+  | "UNKNOWN";
+
+export interface SyntheticWorldCommand {
+  version: typeof SYNTHETIC_WORLD_COMMAND_VERSION;
+  namespace: string;
+  generation: number;
+  commandId: string;
+  type: string;
+  payload: SyntheticJson;
+}
+
+export interface SyntheticCommandRecord {
+  version: typeof SYNTHETIC_WORLD_COMMAND_VERSION;
+  namespace: string;
+  commandId: string;
+  generation: number;
+  type: string;
+  payloadHash: string;
+  payload: SyntheticJson;
+  phase: SyntheticCommandPhase;
+  outcome: SyntheticCommandOutcome;
+  result: SyntheticJson | null;
+  error: { code: string; message: string } | null;
+  executionToken: string | null;
+  createdAt: string;
+  heartbeatAt: string;
+  updatedAt: string;
+  revision: number;
+}
+
+export interface SyntheticCommandExecution {
+  record: SyntheticCommandRecord;
+  result: SyntheticJson;
+  replayed: boolean;
+}
+
+export interface SyntheticCommandRecovery {
+  retryableCommandIds: string[];
+  failedCommandIds: string[];
+  dirtyCommandIds: string[];
+  activeCommandIds: string[];
+}
+
+export interface SyntheticCommandCheckpoint {
+  phase: "OWNED" | "EXECUTING" | "COMMITTED";
+  commandId: string;
+  executionToken: string;
+}
+
+export interface SyntheticCommandExecutionOptions {
+  onCheckpoint?: (
+    checkpoint: SyntheticCommandCheckpoint,
+  ) => void | Promise<void>;
+}
+
+export interface SyntheticCommandHeartbeat {
+  authority: SyntheticEnvironmentLeaseAuthority;
+  commandId: string;
+  executionToken: string;
+}
+
+export const SYNTHETIC_WORLD_CAPABILITIES = Object.freeze({
+  available: ["lease-generation-fence", "durable-command-journal"] as const,
+  unavailable: [
+    "production-boot",
+    "full-manifest",
+    "virtual-clock",
+    "fault-injection",
+    "observation-ledger",
+    "cloud-command-journal-adapter",
+  ] as const,
+});

--- a/packages/synthetic-world/test/fixtures/command-worker.ts
+++ b/packages/synthetic-world/test/fixtures/command-worker.ts
@@ -1,0 +1,68 @@
+/**
+ * Runs one real subprocess against the local lease and command stores for
+ * collision and uncatchable crash-checkpoint coverage.
+ */
+
+import type { SyntheticEnvironmentLeaseAuthority } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { SqliteSyntheticEnvironmentLeaseStore } from "../../../cloud/test-mocks/src/synthetic-environment";
+import {
+  SqliteSyntheticCommandJournal,
+  SYNTHETIC_WORLD_COMMAND_VERSION,
+} from "../../src";
+
+const databasePath = process.env.SYNTHETIC_TEST_DATABASE_PATH;
+const authorityJson = process.env.SYNTHETIC_TEST_AUTHORITY;
+const commandId = process.env.SYNTHETIC_TEST_COMMAND_ID;
+const crashAt = process.env.SYNTHETIC_TEST_CRASH_AT ?? "";
+if (!databasePath || !authorityJson || !commandId) {
+  throw new Error("Synthetic command worker environment is incomplete");
+}
+
+const authority = JSON.parse(
+  authorityJson,
+) as SyntheticEnvironmentLeaseAuthority;
+const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+const journal = new SqliteSyntheticCommandJournal(store);
+
+try {
+  const execution = await journal.execute(
+    authority,
+    {
+      version: SYNTHETIC_WORLD_COMMAND_VERSION,
+      namespace: authority.namespace,
+      generation: authority.generation,
+      commandId,
+      type: "test.write",
+      payload: { value: "once" },
+    },
+    (database) => {
+      database.run(
+        "CREATE TABLE IF NOT EXISTS synthetic_test_writes (command_id TEXT PRIMARY KEY)",
+      );
+      database.run(
+        "INSERT INTO synthetic_test_writes (command_id) VALUES (?)",
+        [commandId],
+      );
+      if (crashAt === "MUTATION") process.exit(86);
+      return { written: commandId };
+    },
+    {
+      onCheckpoint(checkpoint) {
+        if (checkpoint.phase === crashAt) process.exit(86);
+      },
+    },
+  );
+  process.stdout.write(`${JSON.stringify({ replayed: execution.replayed })}\n`);
+} catch (error) {
+  // error-policy:J1 The subprocess protocol exposes a typed collision to its parent test.
+  const errorCode =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+      ? error.code
+      : "UNCLASSIFIED";
+  process.stdout.write(`${JSON.stringify({ errorCode })}\n`);
+} finally {
+  store.close();
+}

--- a/packages/synthetic-world/test/sqlite-command-journal.test.ts
+++ b/packages/synthetic-world/test/sqlite-command-journal.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Proves SW-1 against real file-backed SQLite stores, including subprocess
+ * contention, process death, lease rollover, and durable restart recovery.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  SyntheticEnvironmentLeaseAuthority,
+  SyntheticEnvironmentLeaseOwner,
+} from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { SqliteSyntheticEnvironmentLeaseStore } from "../../cloud/test-mocks/src/synthetic-environment";
+import {
+  SqliteSyntheticCommandJournal,
+  SYNTHETIC_WORLD_CAPABILITIES,
+  SYNTHETIC_WORLD_COMMAND_VERSION,
+  type SyntheticCommandRecovery,
+  type SyntheticWorldCommand,
+} from "../src";
+
+const temporaryDirectories: string[] = [];
+const workerPath = path.join(import.meta.dir, "fixtures", "command-worker.ts");
+
+function tempDatabase(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), "eliza-sw1-"));
+  temporaryDirectories.push(directory);
+  return path.join(directory, "world.sqlite");
+}
+
+function owner(ownerId: string): SyntheticEnvironmentLeaseOwner {
+  return { ownerId, processId: process.pid, host: "local-test" };
+}
+
+function command(
+  authority: SyntheticEnvironmentLeaseAuthority,
+  commandId: string,
+  payload: SyntheticWorldCommand["payload"] = { value: "once" },
+): SyntheticWorldCommand {
+  return {
+    version: SYNTHETIC_WORLD_COMMAND_VERSION,
+    namespace: authority.namespace,
+    generation: authority.generation,
+    commandId,
+    type: "test.write",
+    payload,
+  };
+}
+
+async function acquire(
+  store: SqliteSyntheticEnvironmentLeaseStore,
+  namespace: string,
+  ownerId: string,
+  leaseDurationMs: number,
+): Promise<SyntheticEnvironmentLeaseAuthority> {
+  return (
+    await store.acquire({
+      namespace,
+      owner: owner(ownerId),
+      leaseDurationMs,
+    })
+  ).authority;
+}
+
+async function runWorker(
+  databasePath: string,
+  authority: SyntheticEnvironmentLeaseAuthority,
+  commandId: string,
+  crashAt?: "OWNED" | "MUTATION" | "COMMITTED",
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const subprocess = Bun.spawn(
+    [process.execPath, "--conditions=eliza-source", workerPath],
+    {
+      env: {
+        ...process.env,
+        SYNTHETIC_TEST_DATABASE_PATH: databasePath,
+        SYNTHETIC_TEST_AUTHORITY: JSON.stringify(authority),
+        SYNTHETIC_TEST_COMMAND_ID: commandId,
+        SYNTHETIC_TEST_CRASH_AT: crashAt ?? "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+async function expireAndRecover(
+  databasePath: string,
+  namespace: string,
+): Promise<{
+  store: SqliteSyntheticEnvironmentLeaseStore;
+  journal: SqliteSyntheticCommandJournal;
+  authority: SyntheticEnvironmentLeaseAuthority;
+}> {
+  await Bun.sleep(2_150);
+  const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+  const authority = await acquire(store, namespace, "recovery", 5_000);
+  return {
+    store,
+    journal: new SqliteSyntheticCommandJournal(store),
+    authority,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("SqliteSyntheticCommandJournal", () => {
+  test("reports only the capabilities SW-1 actually implements", () => {
+    expect(SYNTHETIC_WORLD_CAPABILITIES.available).toEqual([
+      "lease-generation-fence",
+      "durable-command-journal",
+    ]);
+    expect(SYNTHETIC_WORLD_CAPABILITIES.unavailable).toContain(
+      "cloud-command-journal-adapter",
+    );
+    expect(SYNTHETIC_WORLD_CAPABILITIES.unavailable).toContain(
+      "observation-ledger",
+    );
+  });
+
+  test("serializes two processes and mutates the domain exactly once", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "collision", "coordinator", 5_000);
+    store.close();
+
+    const results = await Promise.all([
+      runWorker(databasePath, authority, "same-command"),
+      runWorker(databasePath, authority, "same-command"),
+    ]);
+    expect(results.map((result) => result.exitCode)).toEqual([0, 0]);
+    const outcomes = results.map(
+      (result) =>
+        JSON.parse(result.stdout) as {
+          replayed?: boolean;
+          errorCode?: string;
+        },
+    );
+    expect(
+      outcomes.filter((outcome) => outcome.replayed === false),
+    ).toHaveLength(1);
+    expect(
+      outcomes.some(
+        (outcome) =>
+          outcome.replayed === true ||
+          outcome.errorCode === "SYNTHETIC_COMMAND_IN_PROGRESS",
+      ),
+    ).toBe(true);
+    const database = new Database(databasePath, {
+      readonly: true,
+      strict: true,
+    });
+    const count = database
+      .query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM synthetic_test_writes",
+      )
+      .get();
+    expect(count?.count).toBe(1);
+    database.close();
+  });
+
+  test("replays an exact result and rejects same-ID different-payload reuse", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "replay", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    let mutations = 0;
+    const mutate = () => {
+      mutations += 1;
+      return { mutation: mutations };
+    };
+    const first = await journal.execute(
+      authority,
+      command(authority, "stable", { b: 2, a: 1 }),
+      mutate,
+    );
+    const replay = await journal.execute(
+      authority,
+      command(authority, "stable", { a: 1, b: 2 }),
+      mutate,
+    );
+    expect(first.replayed).toBe(false);
+    expect(replay).toMatchObject({ replayed: true, result: { mutation: 1 } });
+    expect(mutations).toBe(1);
+    await expect(
+      journal.execute(
+        authority,
+        command(authority, "stable", { a: 2, b: 2 }),
+        mutate,
+      ),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_ID_CONFLICT" });
+    store.close();
+  });
+
+  test("hashes keys by deterministic UTF-16 order and rejects non-JSON runtime values", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "json", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    const execution = await journal.execute(
+      authority,
+      command(authority, "utf16", { ä: 2, z: 1 }),
+      () => null,
+    );
+    expect(execution.record.payloadHash).toBe(
+      createHash("sha256").update('{"z":1,"ä":2}').digest("hex"),
+    );
+
+    const sparse = new Array(1);
+    const accessor: Record<string, unknown> = {};
+    Object.defineProperty(accessor, "value", {
+      enumerable: true,
+      get() {
+        throw new Error("accessor must not execute");
+      },
+    });
+    const nonEnumerable = { visible: true };
+    Object.defineProperty(nonEnumerable, "hidden", { value: true });
+    const symbolProperty = { visible: true };
+    Object.defineProperty(symbolProperty, Symbol("hidden"), { value: true });
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const invalidValues: unknown[] = [
+      { value: undefined },
+      1n,
+      () => null,
+      Symbol("value"),
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      sparse,
+      Object.assign([], { custom: true }),
+      new Date(),
+      accessor,
+      nonEnumerable,
+      symbolProperty,
+      cyclic,
+    ];
+    for (const [index, payload] of invalidValues.entries()) {
+      await expect(
+        journal.execute(
+          authority,
+          command(
+            authority,
+            `invalid-${index}`,
+            payload as SyntheticWorldCommand["payload"],
+          ),
+          () => null,
+        ),
+      ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_INVALID_INPUT" });
+    }
+    await expect(
+      journal.execute(
+        authority,
+        command(authority, "invalid-result"),
+        () =>
+          ({ value: undefined }) as unknown as SyntheticWorldCommand["payload"],
+      ),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_INVALID_INPUT" });
+    expect(await journal.inspect(authority, "invalid-result")).toMatchObject({
+      phase: "FAILED",
+      outcome: "KNOWN_FAILURE",
+      error: { code: "SYNTHETIC_COMMAND_INVALID_INPUT" },
+    });
+    store.close();
+  });
+
+  test("heartbeats an owned command only with its execution token", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "heartbeat", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    let heartbeatRevision = 0;
+    await journal.execute(
+      authority,
+      command(authority, "heartbeat-command"),
+      () => ({ ok: true }),
+      {
+        async onCheckpoint(checkpoint) {
+          if (checkpoint.phase !== "OWNED") return;
+          const record = await journal.heartbeat({
+            authority,
+            commandId: checkpoint.commandId,
+            executionToken: checkpoint.executionToken,
+          });
+          heartbeatRevision = record.revision;
+          await expect(
+            journal.heartbeat({
+              authority,
+              commandId: checkpoint.commandId,
+              executionToken: "wrong-token",
+            }),
+          ).rejects.toMatchObject({
+            code: "SYNTHETIC_COMMAND_OWNERSHIP_LOST",
+          });
+        },
+      },
+    );
+    expect(heartbeatRevision).toBe(2);
+    store.close();
+  });
+
+  test("persists a typed error when a mutation fails", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "error", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    let mutations = 0;
+    const mutation = () => {
+      mutations += 1;
+      throw new Error("domain write failed");
+    };
+    await expect(
+      journal.execute(authority, command(authority, "failure"), mutation),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_EXECUTION_FAILED" });
+    await expect(
+      journal.execute(authority, command(authority, "failure"), () => {
+        throw new Error("domain write failed");
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_EXECUTION_FAILED" });
+    expect(mutations).toBe(1);
+    expect(await journal.inspect(authority, "failure")).toMatchObject({
+      phase: "FAILED",
+      outcome: "KNOWN_FAILURE",
+      error: {
+        code: "SYNTHETIC_COMMAND_EXECUTION_FAILED",
+        message: "domain write failed",
+      },
+    });
+    store.close();
+  });
+
+  test("translates corrupt stored payload and result JSON to storage failures", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "corrupt", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    await journal.execute(authority, command(authority, "bad-payload"), () => ({
+      ok: true,
+    }));
+    store.database.run(
+      "UPDATE synthetic_world_commands SET payload_json = '{' WHERE namespace = ? AND command_id = ?",
+      [authority.namespace, "bad-payload"],
+    );
+    await expect(
+      journal.inspect(authority, "bad-payload"),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_STORAGE_FAILURE" });
+
+    await journal.execute(authority, command(authority, "bad-result"), () => ({
+      ok: true,
+    }));
+    store.database.run(
+      "UPDATE synthetic_world_commands SET result_json = 'not-json' WHERE namespace = ? AND command_id = ?",
+      [authority.namespace, "bad-result"],
+    );
+    await expect(
+      journal.execute(authority, command(authority, "bad-result"), () => null),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_STORAGE_FAILURE" });
+    store.close();
+  });
+
+  test("concurrent recovery leaves same-generation active ownership untouched", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "active-recovery", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    const recoveries: SyntheticCommandRecovery[] = [];
+    const execution = await journal.execute(
+      authority,
+      command(authority, "live-command"),
+      () => ({ ok: true }),
+      {
+        async onCheckpoint(checkpoint) {
+          if (checkpoint.phase === "EXECUTING") {
+            recoveries.push(await journal.recover(authority));
+          }
+        },
+      },
+    );
+    expect(recoveries).toEqual([
+      {
+        retryableCommandIds: [],
+        failedCommandIds: [],
+        dirtyCommandIds: [],
+        activeCommandIds: ["live-command"],
+      },
+    ]);
+    expect(execution.result).toEqual({ ok: true });
+    store.close();
+  });
+
+  test("rejects stale and expired generations before command mutation", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const expired = await acquire(store, "fence", "old", 30);
+    await Bun.sleep(60);
+    let mutated = false;
+    const journal = new SqliteSyntheticCommandJournal(store);
+    await expect(
+      journal.execute(expired, command(expired, "expired"), () => {
+        mutated = true;
+        return null;
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    const current = await acquire(store, "fence", "new", 5_000);
+    expect(current.generation).toBe(2);
+    await expect(
+      journal.execute(expired, command(expired, "stale"), () => null),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    expect(mutated).toBe(false);
+    store.close();
+  });
+
+  test("rejects a journal row from a generation newer than the active lease", async () => {
+    const databasePath = tempDatabase();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(store, "future-row", "owner", 5_000);
+    const journal = new SqliteSyntheticCommandJournal(store);
+    const input = command(authority, "future-command", { value: 1 });
+    await journal.execute(authority, input, () => ({ accepted: true }));
+
+    const database = new Database(databasePath, { strict: true });
+    database.run(
+      `UPDATE synthetic_world_commands
+       SET generation = ?
+       WHERE namespace = ? AND command_id = ?`,
+      [authority.generation + 1, authority.namespace, input.commandId],
+    );
+    database.close();
+
+    await expect(
+      journal.execute(authority, input, () => ({ accepted: true })),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_STORAGE_FAILURE" });
+    store.close();
+  });
+
+  test("recovers an OWNED crash as retryable and executes it after restart", async () => {
+    const databasePath = tempDatabase();
+    const initial = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(initial, "owned-crash", "old", 2_000);
+    initial.close();
+    const crashed = await runWorker(
+      databasePath,
+      authority,
+      "owned-command",
+      "OWNED",
+    );
+    expect(crashed.exitCode).not.toBe(0);
+    expect(crashed.stderr).toBe("");
+    const recovered = await expireAndRecover(databasePath, "owned-crash");
+    const recovery = await recovered.journal.recover(recovered.authority);
+    expect(recovery).toEqual({
+      retryableCommandIds: ["owned-command"],
+      failedCommandIds: [],
+      dirtyCommandIds: [],
+      activeCommandIds: [],
+    });
+    const execution = await recovered.journal.execute(
+      recovered.authority,
+      command(recovered.authority, "owned-command"),
+      () => ({ recovered: true }),
+    );
+    expect(execution.result).toEqual({ recovered: true });
+    recovered.store.close();
+  });
+
+  test("rolls back a mutation-process crash and recovers EXECUTING as known failure", async () => {
+    const databasePath = tempDatabase();
+    const initial = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(initial, "mutation-crash", "old", 2_000);
+    initial.close();
+    const crashed = await runWorker(
+      databasePath,
+      authority,
+      "mutation-command",
+      "MUTATION",
+    );
+    expect(crashed.exitCode).not.toBe(0);
+    expect(crashed.stderr).toBe("");
+    const recovered = await expireAndRecover(databasePath, "mutation-crash");
+    expect(await recovered.journal.recover(recovered.authority)).toEqual({
+      retryableCommandIds: [],
+      failedCommandIds: ["mutation-command"],
+      dirtyCommandIds: [],
+      activeCommandIds: [],
+    });
+    expect(
+      await recovered.journal.inspect(recovered.authority, "mutation-command"),
+    ).toMatchObject({
+      phase: "FAILED",
+      outcome: "KNOWN_FAILURE",
+      error: { code: "SYNTHETIC_COMMAND_ABORTED_BEFORE_COMMIT" },
+    });
+    expect(() =>
+      recovered.store.database
+        .query("SELECT * FROM synthetic_test_writes")
+        .all(),
+    ).toThrow();
+    await expect(
+      recovered.journal.execute(
+        recovered.authority,
+        command(recovered.authority, "mutation-command"),
+        () => ({ impossible: true }),
+      ),
+    ).rejects.toMatchObject({
+      code: "SYNTHETIC_COMMAND_ABORTED_BEFORE_COMMIT",
+    });
+    recovered.store.close();
+  });
+
+  test("classifies commit-before-response as DIRTY/UNKNOWN after restart", async () => {
+    const databasePath = tempDatabase();
+    const initial = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const authority = await acquire(initial, "commit-crash", "old", 2_000);
+    initial.close();
+    const crashed = await runWorker(
+      databasePath,
+      authority,
+      "committed-command",
+      "COMMITTED",
+    );
+    expect(crashed.exitCode).not.toBe(0);
+    expect(crashed.stderr).toBe("");
+    const recovered = await expireAndRecover(databasePath, "commit-crash");
+    expect(await recovered.journal.recover(recovered.authority)).toEqual({
+      retryableCommandIds: [],
+      failedCommandIds: [],
+      dirtyCommandIds: ["committed-command"],
+      activeCommandIds: [],
+    });
+    expect(
+      await recovered.journal.inspect(recovered.authority, "committed-command"),
+    ).toMatchObject({
+      phase: "DIRTY",
+      outcome: "UNKNOWN",
+      error: { code: "SYNTHETIC_COMMAND_RECOVERED_AMBIGUOUS" },
+    });
+    const count = recovered.store.database
+      .query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM synthetic_test_writes WHERE command_id = 'committed-command'",
+      )
+      .get();
+    expect(count?.count).toBe(1);
+    await expect(
+      recovered.journal.execute(
+        recovered.authority,
+        command(recovered.authority, "committed-command"),
+        () => ({ impossible: true }),
+      ),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_COMMAND_DIRTY" });
+    recovered.store.close();
+  });
+});

--- a/packages/synthetic-world/tsconfig.json
+++ b/packages/synthetic-world/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "customConditions": ["eliza-source"],
+    "noEmit": true,
+    "composite": false,
+    "incremental": false,
+    "types": ["node", "bun-types"],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Closes #25213

## What changed

Introduces the private `@elizaos/synthetic-world` SW-1 package with one durable SQLite command journal composed over the existing synthetic-environment lease authority. Commands are namespace/generation fenced, canonical-payload idempotent, and transactionally couple synchronous domain writes to their `COMMITTED` checkpoint.

Recovery distinguishes rollback-proven `FAILED / KNOWN_FAILURE` from committed-response-loss `DIRTY / UNKNOWN`; active current-generation ownership is never stolen. Stored payloads/results use strict locale-independent canonical JSON and reject non-JSON runtime shapes. Every ownership/classification transition asserts an exact one-row mutation, and future-generation/corrupt stored state fails explicitly.

The package truthfully reports production boot, manifests, virtual time, fault injection, observation ledger, and Cloud adapter as unavailable; it does not introduce a parallel mutable world.

## Proof

- frozen Bun 1.3.14 install: pass
- synthetic-world: 13/13 tests, 58 assertions
- synthetic-world typecheck, lint:check, build: pass
- develop impact/workflow tests: 34/34 pass
- CLAUDE/AGENTS parity: pass
- `git diff --check`: pass
- independent root review added exact-one-row creation/claim/transition checks and a corrupt future-generation regression

## Attribution

- OpenAI / gpt-5.6-sol
- Codex Desktop / multi-agent
- N/A — no repository contribution skill used