### PR TITLE
test(core): cover loopback bind probe

### DIFF
--- a/packages/core/src/testing/__tests__/loopback.test.ts
+++ b/packages/core/src/testing/__tests__/loopback.test.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	createServer: vi.fn(),
+}));
+
+vi.mock("node:net", () => ({
+	default: { createServer: (...a: unknown[]) => mocks.createServer(...a) },
+}));
+
+import { canBindLoopback } from "./loopback.ts";
+
+function fakeServer() {
+	const s = new EventEmitter() as EventEmitter & {
+		listen: ReturnType<typeof vi.fn>;
+		close: ReturnType<typeof vi.fn>;
+		removeAllListeners: ReturnType<typeof vi.fn>;
+	};
+	s.listen = vi.fn((_port: number, _host: string, cb: () => void) => {
+		// 模拟绑定成功后 close
+		process.nextTick(() => cb());
+	});
+	s.close = vi.fn((cb?: () => void) => {
+		process.nextTick(() => cb?.());
+	});
+	s.removeAllListeners = vi.fn();
+	return s;
+}
+
+describe("canBindLoopback", () => {
+	beforeEach(() => {
+		mocks.createServer.mockReset();
+	});
+
+	it("resolves false on server error", async () => {
+		const s = fakeServer();
+		mocks.createServer.mockReturnValue(s);
+		const p = canBindLoopback();
+		s.emit("error", new Error("EACCES"));
+		expect(await p).toBe(false);
+	});
+
+	it("resolves true when binding succeeds", async () => {
+		const s = fakeServer();
+		mocks.createServer.mockReturnValue(s);
+		expect(await canBindLoopback()).toBe(true);
+	});
+});

--- a/packages/core/src/testing/__tests__/loopback.test.ts
+++ b/packages/core/src/testing/__tests__/loopback.test.ts
@@ -9,8 +9,6 @@ vi.mock("node:net", () => ({
 	default: { createServer: (...a: unknown[]) => mocks.createServer(...a) },
 }));
 
-import { canBindLoopback } from "./loopback.ts";
-
 function fakeServer() {
 	const s = new EventEmitter() as EventEmitter & {
 		listen: ReturnType<typeof vi.fn>;
@@ -18,7 +16,6 @@ function fakeServer() {
 		removeAllListeners: ReturnType<typeof vi.fn>;
 	};
 	s.listen = vi.fn((_port: number, _host: string, cb: () => void) => {
-		// 模拟绑定成功后 close
 		process.nextTick(() => cb());
 	});
 	s.close = vi.fn((cb?: () => void) => {
@@ -31,9 +28,11 @@ function fakeServer() {
 describe("canBindLoopback", () => {
 	beforeEach(() => {
 		mocks.createServer.mockReset();
+		vi.resetModules();
 	});
 
 	it("resolves false on server error", async () => {
+		const { canBindLoopback } = await import("./loopback.ts");
 		const s = fakeServer();
 		mocks.createServer.mockReturnValue(s);
 		const p = canBindLoopback();
@@ -42,6 +41,7 @@ describe("canBindLoopback", () => {
 	});
 
 	it("resolves true when binding succeeds", async () => {
+		const { canBindLoopback } = await import("./loopback.ts");
 		const s = fakeServer();
 		mocks.createServer.mockReturnValue(s);
 		expect(await canBindLoopback()).toBe(true);


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
