### PR TITLE
test(agent): cover client-chat-admin

### DIFF
--- a/packages/agent/src/api/client-chat-admin.test.ts
+++ b/packages/agent/src/api/client-chat-admin.test.ts
@@ -23,7 +23,10 @@ const AGENT_NAME = "Eliza";
 const CONFIGURED_OWNER = "7b3e2f7a-1111-4222-8333-944445555666" as UUID;
 
 type ParityState = {
-  runtime: IAgentRuntime | null;
+  runtime?:
+    | IAgentRuntime
+    | { agentId?: UUID; getSetting?: (key: string) => unknown }
+    | null;
   agentName: string;
   adminEntityId?: UUID | null;
   chatUserId?: UUID | null;
@@ -95,5 +98,222 @@ describe("resolveClientChatAdminEntityId — owner-entity parity", () => {
     expect(resolveClientChatAdminEntityId(state)).toBe(
       stringToUuid(`${AGENT_NAME}-admin-entity`),
     );
+  });
+});
+
+const CACHED_OWNER = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" as UUID;
+const NAME_SEED = stringToUuid(`${AGENT_NAME}-admin-entity`);
+
+describe("resolveClientChatAdminEntityId — resolution order and edges", () => {
+  it("reuses a previously resolved adminEntityId when no canonical owner is set", () => {
+    const state: ParityState = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      adminEntityId: CACHED_OWNER,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(CACHED_OWNER);
+    expect(state.adminEntityId).toBe(CACHED_OWNER);
+    expect(state.chatUserId).toBe(CACHED_OWNER);
+  });
+
+  it("a cached adminEntityId wins over agents.defaults.adminEntityId", () => {
+    const state: ParityState = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      adminEntityId: CACHED_OWNER,
+      config: { agents: { defaults: { adminEntityId: CONFIGURED_OWNER } } },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(CACHED_OWNER);
+    expect(state.chatUserId).toBe(CACHED_OWNER);
+  });
+
+  it("a non-UUID canonical owner is ignored so a cached id is used", () => {
+    const runtime = runtimeStub((key) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? "not-a-uuid" : null,
+    );
+    const state: ParityState = {
+      runtime,
+      agentName: AGENT_NAME,
+      adminEntityId: CACHED_OWNER,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(CACHED_OWNER);
+    expect(state.chatUserId).toBe(CACHED_OWNER);
+  });
+
+  it("a non-UUID canonical owner with no cache falls through to the agent-id seed", () => {
+    const runtime = runtimeStub((key) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? "not-a-uuid" : null,
+    );
+    const state: ParityState = { runtime, agentName: AGENT_NAME };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+  });
+
+  it("skips canonical lookup when runtime.getSetting is not a function", () => {
+    const state: ParityState = {
+      runtime: { agentId: AGENT_ID },
+      agentName: AGENT_NAME,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+    expect(state.adminEntityId).toBe(deterministicOwnerEntityId(AGENT_ID));
+    expect(state.chatUserId).toBe(deterministicOwnerEntityId(AGENT_ID));
+  });
+
+  it("skips canonical lookup when runtime is undefined", () => {
+    const state: ParityState = { agentName: AGENT_NAME };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(NAME_SEED);
+    expect(state.adminEntityId).toBe(NAME_SEED);
+    expect(state.chatUserId).toBe(NAME_SEED);
+  });
+
+  it("trims surrounding whitespace on a configured adminEntityId UUID", () => {
+    const state: ParityState = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      config: {
+        agents: { defaults: { adminEntityId: `  ${CONFIGURED_OWNER}  ` } },
+      },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(CONFIGURED_OWNER);
+    expect(state.adminEntityId).toBe(CONFIGURED_OWNER);
+    expect(state.chatUserId).toBe(CONFIGURED_OWNER);
+  });
+
+  it("accepts an uppercase configured adminEntityId UUID", () => {
+    const upper = CONFIGURED_OWNER.toUpperCase();
+    const state = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      config: { agents: { defaults: { adminEntityId: upper } } },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(upper);
+  });
+
+  it("treats a whitespace-only configured adminEntityId as absent", () => {
+    const state = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      config: { agents: { defaults: { adminEntityId: "   " } } },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+  });
+
+  it("ignores a non-string configured adminEntityId", () => {
+    const state = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      config: {
+        agents: {
+          defaults: {
+            adminEntityId: 42 as unknown as string,
+          },
+        },
+      },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+  });
+
+  it("ignores an empty-string cached adminEntityId as missing", () => {
+    const state = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      adminEntityId: "" as UUID,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+  });
+
+  it("falls back to the agent-name seed when runtime has no string agentId", () => {
+    const state: ParityState = {
+      runtime: {
+        getSetting: () => null,
+      },
+      agentName: AGENT_NAME,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(NAME_SEED);
+    expect(state.adminEntityId).toBe(NAME_SEED);
+    expect(state.chatUserId).toBe(NAME_SEED);
+  });
+
+  it("falls back to the agent-name seed when agentId is not a string", () => {
+    const state = {
+      runtime: {
+        agentId: 123 as unknown as UUID,
+        getSetting: () => null,
+      },
+      agentName: AGENT_NAME,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(NAME_SEED);
+  });
+
+  it("treats missing config.agents.defaults as unconfigured", () => {
+    const state: ParityState = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      config: { agents: {} },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+  });
+
+  it("treats a null config object as unconfigured", () => {
+    const state: ParityState = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      config: null,
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(
+      deterministicOwnerEntityId(AGENT_ID),
+    );
+  });
+
+  it("a malformed configured id without a runtime uses the agent-name seed", () => {
+    const state: ParityState = {
+      runtime: null,
+      agentName: AGENT_NAME,
+      config: { agents: { defaults: { adminEntityId: "not-a-uuid" } } },
+    };
+
+    expect(resolveClientChatAdminEntityId(state)).toBe(NAME_SEED);
+    expect(state.adminEntityId).toBe(NAME_SEED);
+    expect(state.chatUserId).toBe(NAME_SEED);
+  });
+
+  it("does not overwrite a cached id when writing chatUserId", () => {
+    const state: ParityState = {
+      runtime: runtimeStub(),
+      agentName: AGENT_NAME,
+      adminEntityId: CACHED_OWNER,
+      chatUserId: "00000000-0000-4000-8000-000000000000" as UUID,
+    };
+
+    const result = resolveClientChatAdminEntityId(state);
+    expect(result).toBe(CACHED_OWNER);
+    expect(state.adminEntityId).toBe(CACHED_OWNER);
+    expect(state.chatUserId).toBe(CACHED_OWNER);
   });
 });


### PR DESCRIPTION

## Summary

Adds behavioral unit coverage for `resolveClientChatAdminEntityId` in `packages/agent/src/api/client-chat-admin.ts`.

The same-named test file already existed on `develop` with five owner-parity cases. This PR keeps those tests and covers the remaining resolution branches: cached `adminEntityId`, invalid canonical owner ids, config UUID trimming / case / non-string / whitespace, missing `getSetting` / `agentId` / runtime, and the write-back of `adminEntityId` + `chatUserId`. Tests drive the real module with hand-built state; they do not mock the resolver or assert mock return values.

No production code changes.

## Evidence

1. `bunx vitest run src/api/client-chat-admin.test.ts` (from `packages/agent`) — **1 file, 22 tests passed** (10ms; duration 9.14s).
2. `bunx biome check --write packages/agent/src/api/client-chat-admin.test.ts` — clean (exit 0).
3. `tsc --noEmit -p tsconfig.json` in `packages/agent` — **zero errors in the added/changed test file**. Other pre-existing package errors are unchanged versus develop; this diff does not add any.
4. Diff touches **only** `packages/agent/src/api/client-chat-admin.test.ts`.

Hosted CI does not run on this fork contributor's PRs; the counts above are local.

## Test plan

- [x] `bunx vitest run src/api/client-chat-admin.test.ts` passes (22 tests)
- [x] biome clean on the test file
- [x] tsc adds no new errors in the touched file

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7161758b905e635e66030a3161763dfa615acf4c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
