### PR TITLE
fix(app-core): stop post-ready boot tail when runtime loses ownership mid-flight

### DIFF
--- a/packages/app-core/src/runtime/repair-boot-phase.test.ts
+++ b/packages/app-core/src/runtime/repair-boot-phase.test.ts
@@ -196,4 +196,78 @@ describe("runPostReadyBootTail — phase split", () => {
     // The throw short-circuits the remaining tail steps.
     expect(steps.registerCoreSensitiveRequestAdapters).not.toHaveBeenCalled();
   });
+
+  it("(mid-tail teardown) the started contributor finishes but later contributors and the completion stamp do not run (#25110)", async () => {
+    const runtime = makeFakeRuntime();
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = runtime;
+    const { steps, order } = makeSteps();
+
+    // Hold the FIRST contributor open, exactly like a slow app-route load.
+    let releaseAppRoutes!: () => void;
+    const appRoutesGate = new Promise<void>((resolve) => {
+      releaseAppRoutes = resolve;
+    });
+    steps.registerAppRoutePlugins = vi.fn(() => {
+      order.push("appRoutes");
+      return appRoutesGate;
+    });
+
+    let tailSettled = false;
+    const tail = runPostReadyBootTail(runtime, steps, resources).then(() => {
+      tailSettled = true;
+    });
+
+    // While the first contributor is awaiting, teardown clears ownership —
+    // the same thing stopRuntimeBootResources does during shutdown/hot restart.
+    await Promise.resolve();
+    resources.tailRuntime = null;
+
+    releaseAppRoutes();
+    await tail;
+
+    // The already-started contributor was allowed to finish...
+    expect(order).toEqual(["appRoutes"]);
+    // ...but nothing after it ran: no hooks, no bridges, no catalog, no
+    // warmup, and no completion stamp for a stopped runtime's work.
+    expect(steps.registerRuntimeHooks).not.toHaveBeenCalled();
+    expect(steps.ensureTriggerEventBridge).not.toHaveBeenCalled();
+    expect(steps.ensureConnectorTargetCatalog).not.toHaveBeenCalled();
+    expect(steps.startDeferredVoiceWarmup).not.toHaveBeenCalled();
+    expect(tailSettled).toBe(true);
+  });
+
+  it("(mid-tail ownership transfer) a superseding boot attempt stops the old tail before its remaining contributors", async () => {
+    const oldRuntime = makeFakeRuntime();
+    const liveRuntime = makeFakeRuntime();
+    const resources = createRuntimeBootResources();
+    resources.tailRuntime = oldRuntime;
+    const { steps, order } = makeSteps();
+
+    let releaseCredentialBridge!: () => void;
+    const credentialGate = new Promise<void>((resolve) => {
+      releaseCredentialBridge = resolve;
+    });
+    steps.registerSubAgentCredentialBridge = vi.fn(() => {
+      order.push("credentialBridgeWiring");
+      return credentialGate;
+    });
+
+    const tail = runPostReadyBootTail(oldRuntime, steps, resources);
+
+    // Hot restart publishes the newer runtime into the same resource slot.
+    await Promise.resolve();
+    resources.tailRuntime = liveRuntime;
+
+    releaseCredentialBridge();
+    await tail;
+
+    // The synchronous sensitive/adapter registrations and the gated bridge
+    // call sit behind the same microtask queue as the ownership re-check, so
+    // once the newer runtime is published the old tail stops before them.
+    expect(order).toEqual(["appRoutes", "runtimeHooks"]);
+    expect(steps.registerCoreSensitiveRequestAdapters).not.toHaveBeenCalled();
+    expect(steps.ensureTriggerEventBridge).not.toHaveBeenCalled();
+    expect(steps.ensureConnectorTargetCatalog).not.toHaveBeenCalled();
+  });
 });

--- a/packages/app-core/src/runtime/startup/post-ready.ts
+++ b/packages/app-core/src/runtime/startup/post-ready.ts
@@ -45,21 +45,64 @@ export async function runPostReadyBootTail(
 ): Promise<void> {
   // Hot restart may publish another runtime before this deferred promise runs.
   // Only the boot attempt that owns this resource slot may mutate its runtime.
-  if (resources.tailRuntime !== runtime) {
+  if (!ownsBootResources(runtime, resources)) {
     logger.info("[eliza] post-ready boot tail skipped — runtime superseded");
     return;
   }
 
   await steps.registerAppRoutePlugins(runtime);
+  // Teardown or hot restart can clear `resources.tailRuntime` while any later
+  // step is awaiting. Ownership is re-checked between every contributor so a
+  // torn-down runtime never registers hooks, bridges, catalogs, or warmup
+  // after teardown (#25110): the already-started contributor may finish, but
+  // no subsequent contributor or completion stamp may run.
+  if (!ownsBootResources(runtime, resources)) {
+    logger.info(
+      "[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail",
+    );
+    return;
+  }
   await steps.registerRuntimeHooks(runtime);
+  if (!ownsBootResources(runtime, resources)) {
+    logger.info(
+      "[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail",
+    );
+    return;
+  }
   steps.registerCoreSensitiveRequestAdapters(runtime);
   steps.registerSubAgentCredentialBridgeAdapter(runtime);
   await steps.registerSubAgentCredentialBridge(runtime);
+  if (!ownsBootResources(runtime, resources)) {
+    logger.info(
+      "[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail",
+    );
+    return;
+  }
   await steps.ensureTriggerEventBridge(runtime);
+  if (!ownsBootResources(runtime, resources)) {
+    logger.info(
+      "[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail",
+    );
+    return;
+  }
   await steps.ensureConnectorTargetCatalog(runtime);
+  if (!ownsBootResources(runtime, resources)) {
+    logger.info(
+      "[eliza] post-ready boot tail aborted — runtime lost ownership mid-tail",
+    );
+    return;
+  }
   void steps.startDeferredVoiceWarmup(runtime);
 
   // Completion is stamped inside the liveness guard so a superseded tail
   // cannot overwrite the phase belonging to a newer boot attempt.
   markDeferredBootPhase("app-route-tail", "complete");
+}
+
+/** True only while this runtime still owns its boot resource slot. */
+function ownsBootResources(
+  runtime: AgentRuntime,
+  resources: RuntimeBootResources,
+): boolean {
+  return resources.tailRuntime === runtime;
 }


### PR DESCRIPTION
## Summary

Fixes #25110.

`runPostReadyBootTail` checked `resources.tailRuntime` ownership only once, before its first asynchronous contributor. If shutdown or hot restart cleared the resource slot while any later step was awaiting, the old continuation resumed and registered the remaining hooks, adapters, credential bridges, trigger bridge, connector catalog, and voice warmup **after teardown had already completed**, then stamped the deferred boot phase complete for work belonging to a stopped runtime.

### What changed

- Ownership is re-checked between every contributor: an already-started contributor may finish, but once the boot attempt loses the resource slot no later contributor runs and no completion stamp is written.
- The pre-flight superseded-runtime guard is unchanged; the existing ordered pipeline for a still-live runtime is unchanged.

### Verification

<!-- evidence-head:915d1c85e52651269c3fa4a5a43911bac23547d5 -->

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is boot-tail lifecycle ownership.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; the changed surface is boot-tail lifecycle ownership.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow change beyond correct teardown behavior; verified by deterministic tests.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation run at `915d1c85e52651269c3fa4a5a43911bac23547d5`:

```
## bun test: repair-boot-phase.test.ts (packages/app-core)
  8 pass
  0 fail
  37 expect() calls
Ran 8 tests across 1 file. [693.00ms]

## Biome changed files
Checked 2 files in 21ms. No fixes applied.

## git diff --check
OK
```

Two regression tests reproduce the issue shapes: (1) the first contributor held open while teardown clears ownership mid-tail — it finishes but no later contributor or completion stamp runs; (2) a hot-restart ownership flip to a newer runtime — the old tail stops before its remaining contributors. All six pre-existing tests pass unchanged.

Note: `packages/app-core` typecheck has a PRE-EXISTING failure on clean `develop` (`../agent/src/api/conversation-routes.ts` imports `isScheduledTask`/`importTask` missing from `@elizaos/plugin-scheduling`). Verified identical with these changes stashed — unrelated to this PR.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic lifecycle enforcement; no LLM execution involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; unit coverage proves the behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or scanned artifacts in this change.

## Attribution

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2

<!-- attribution-row:models -->
z.ai/glm-5.2

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
self-reported
