### PR TITLE
fix(plugin-capacitor-bridge): safe NaN handling in iOS installed model and conversation sort comparators

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts
@@ -804,4 +804,36 @@ describe("iOS bridge — unmatched routes still fall through", () => {
 		);
 		expect(res).toBeNull();
 	});
+
+	it("sorts conversations safely when updatedAt contains invalid date strings", async () => {
+		const backend = makeBackend(createFakeRuntime());
+		backend.conversations.set("conv-invalid", {
+			id: "conv-invalid",
+			name: "Invalid Date Conv",
+			createdAt: "2026-08-01T00:00:00Z",
+			updatedAt: "not-a-real-date",
+			messageCount: 1,
+			isUnread: false,
+		});
+		backend.conversations.set("conv-valid", {
+			id: "conv-valid",
+			name: "Valid Date Conv",
+			createdAt: "2026-08-01T00:00:00Z",
+			updatedAt: "2026-08-20T00:00:00Z",
+			messageCount: 1,
+			isUnread: false,
+		});
+
+		const res = await handleDirectCoreRoute(
+			backend,
+			"GET",
+			"/api/conversations",
+			{},
+		);
+		expect(res?.status).toBe(200);
+		const json = JSON.parse(res?.body ?? "{}");
+		expect(json.conversations).toHaveLength(2);
+		expect(json.conversations[0]?.id).toBe("conv-valid");
+		expect(json.conversations[1]?.id).toBe("conv-invalid");
+	});
 });

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1197,7 +1197,10 @@ type TaggedMemory = Memory & { _table: string };
 
 /** Ordering key — `Memory.createdAt` is optional; rows without one sort oldest. */
 function memoryCreatedAt(memory: { createdAt?: number }): number {
-	return memory.createdAt ?? 0;
+	return typeof memory.createdAt === "number" &&
+		Number.isFinite(memory.createdAt)
+		? memory.createdAt
+		: 0;
 }
 
 /** Newest-first comparator shared by the browse/feed list routes. */
@@ -2596,10 +2599,20 @@ function resolveAssignedModel(slot: string): InstalledModelEntry | null {
 	}
 	return (
 		installed.sort((left, right) => {
-			const leftUsed = left.lastUsedAt ? Date.parse(left.lastUsedAt) : 0;
-			const rightUsed = right.lastUsedAt ? Date.parse(right.lastUsedAt) : 0;
+			const leftTime = left.lastUsedAt ? Date.parse(left.lastUsedAt) : 0;
+			const rightTime = right.lastUsedAt ? Date.parse(right.lastUsedAt) : 0;
+			const leftUsed = Number.isFinite(leftTime) ? leftTime : 0;
+			const rightUsed = Number.isFinite(rightTime) ? rightTime : 0;
 			if (rightUsed !== leftUsed) return rightUsed - leftUsed;
-			return (right.sizeBytes ?? 0) - (left.sizeBytes ?? 0);
+			const rightBytes =
+				typeof right.sizeBytes === "number" && Number.isFinite(right.sizeBytes)
+					? right.sizeBytes
+					: 0;
+			const leftBytes =
+				typeof left.sizeBytes === "number" && Number.isFinite(left.sizeBytes)
+					? left.sizeBytes
+					: 0;
+			return rightBytes - leftBytes;
 		})[0] ?? null
 	);
 }
@@ -4583,10 +4596,15 @@ export async function handleDirectCoreRoute(
 
 	if (method === "GET" && pathname === "/api/conversations") {
 		return jsonResponse(200, {
-			conversations: Array.from(backend.conversations.values()).sort(
-				(a, b) =>
-					new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-			),
+			conversations: Array.from(backend.conversations.values()).sort((a, b) => {
+				const bTime = Number.isFinite(new Date(b.updatedAt).getTime())
+					? new Date(b.updatedAt).getTime()
+					: 0;
+				const aTime = Number.isFinite(new Date(a.updatedAt).getTime())
+					? new Date(a.updatedAt).getTime()
+					: 0;
+				return bTime - aTime;
+			}),
 		});
 	}
 


### PR DESCRIPTION
## Summary

Validates date parsing and numeric comparisons with `Number.isFinite(...)` across installed model selection, memory created timestamps, and `/api/conversations` list sort comparators in `bridge.ts` (`plugins/plugin-capacitor-bridge/src/ios/bridge.ts:1198, 2598, 4586`) to prevent `NaN` return values and unstable sorting when records contain unparseable dates or non-numeric timestamps.

## Changes

- In `plugins/plugin-capacitor-bridge/src/ios/bridge.ts:1198, 2598, 4586`, guard `memoryCreatedAt`, `lastUsedAt`, `sizeBytes`, and `updatedAt` date/timestamp comparisons with `Number.isFinite(...)`.
- In `plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts`, add dedicated unit test verifying that `/api/conversations` maintains strict newest-first total ordering even when conversations contain invalid `updatedAt` date strings.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`9c3dd37276`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts` | 25 pass (25 tests) | 26 pass (26 tests) |
| `bunx vitest run plugins/plugin-capacitor-bridge/src/ios/` | 90 pass (7 suites) | 91 pass (7 suites) |
| `bunx @biomejs/biome check plugins/plugin-capacitor-bridge/src/ios/bridge.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-capacitor-bridge/src/ios/bridge.ts:2595-2610`
- `plugins/plugin-capacitor-bridge/src/ios/bridge.routes.test.ts:800-835`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric timestamps are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Capacitor bridge iOS router and model selector; no UI layout touched)
- [x] `audit:browser` — N/A (Bridge route sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 91/91 pass across plugin-capacitor-bridge iOS test suites
- [x] `lint` — Biome clean
