### PR TITLE
fix(shared): repair nested test import paths

### DIFF
--- a/packages/shared/src/__tests__/dev-settings-banner-style.test.ts
+++ b/packages/shared/src/__tests__/dev-settings-banner-style.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   colorizeDevSettingsBanner,
   colorizeDevSettingsStartupBanner,
-} from "./dev-settings-banner-style.ts";
+} from "../dev-settings-banner-style.ts";
 
 const KEYS = ["NO_COLOR", "FORCE_COLOR"] as const;
 

--- a/packages/shared/src/__tests__/dev-settings-figlet-heading.test.ts
+++ b/packages/shared/src/__tests__/dev-settings-figlet-heading.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   prependDevSubsystemFigletHeading,
   renderDevSubsystemFigletHeading,
-} from "./dev-settings-figlet-heading.ts";
+} from "../dev-settings-figlet-heading.ts";
 
 describe("renderDevSubsystemFigletHeading", () => {
   it("renders a boxed marker with the subsystem text", () => {

--- a/packages/shared/src/apps/__tests__/detail-extension-registry.test.ts
+++ b/packages/shared/src/apps/__tests__/detail-extension-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   getAppDetailExtension,
   registerDetailExtension,
-} from "./detail-extension-registry.ts";
+} from "../detail-extension-registry.ts";
 
 describe("detail-extension-registry", () => {
   it("returns null when the app has no detail panel id", () => {

--- a/packages/shared/src/email-classification/__tests__/wrap-untrusted-email-content.test.ts
+++ b/packages/shared/src/email-classification/__tests__/wrap-untrusted-email-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { wrapUntrustedEmailContent } from "./wrap-untrusted-email-content.ts";
+import { wrapUntrustedEmailContent } from "../wrap-untrusted-email-content.ts";
 
 describe("wrapUntrustedEmailContent", () => {
   it("fences content with the untrusted boundary", () => {

--- a/packages/shared/src/platform/__tests__/aosp-user-agent.test.ts
+++ b/packages/shared/src/platform/__tests__/aosp-user-agent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isAospElizaUserAgent,
   userAgentHasElizaOSMarker,
-} from "./aosp-user-agent.ts";
+} from "../aosp-user-agent.ts";
 
 describe("userAgentHasElizaOSMarker", () => {
   it("detects the ElizaOS marker", () => {

--- a/packages/shared/src/test-support/__tests__/process-helpers.test.ts
+++ b/packages/shared/src/test-support/__tests__/process-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createMockChildProcess } from "./process-helpers.ts";
+import { createMockChildProcess } from "../process-helpers.ts";
 
 describe("createMockChildProcess", () => {
   it("emits close with the exit code", async () => {

--- a/packages/shared/src/utils/__tests__/safe-diagnostic-error.test.ts
+++ b/packages/shared/src/utils/__tests__/safe-diagnostic-error.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatDiagnosticError,
   readDiagnosticProperty,
-} from "./safe-diagnostic-error.ts";
+} from "../safe-diagnostic-error.ts";
 
 describe("readDiagnosticProperty", () => {
   it("reads properties from objects and functions", () => {


### PR DESCRIPTION
# Relates to

No separate issue — this repairs a defect class that reached `develop` today across several packages, described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] One specifier per file; every path verified against the real tree.
- [x] A reviewer can confirm it from the path listing without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Only import specifiers differ from `develop`.

# Risks

None to production code. Each change is one relative-path specifier inside a test file. No test body, assertion, or source module is touched.

# Background

## What does this PR do?

7 suites in this package sit in a `__tests__/` subdirectory but import their subject as a sibling:

```ts
import { ... } from "./<name>.ts";   // resolves to __tests__/<name>.ts — does not exist
```

The subject is one directory up. Verified against the tree at `develop` for every file below — the sibling path returns `404`, the parent path returns `200`:

```
  packages/shared/src/__tests__/dev-settings-banner-style.test.ts
  packages/shared/src/__tests__/dev-settings-figlet-heading.test.ts
  packages/shared/src/apps/__tests__/detail-extension-registry.test.ts
  packages/shared/src/email-classification/__tests__/wrap-untrusted-email-content.test.ts
  packages/shared/src/platform/__tests__/aosp-user-agent.test.ts
  packages/shared/src/test-support/__tests__/process-helpers.test.ts
  packages/shared/src/utils/__tests__/safe-diagnostic-error.test.ts
```

`packages/shared/tsconfig.json` sets `"include": ["src"]`, so all seven are inside the typecheck program and fail with TS2307 as well as at runtime. Shared sits in the affected-workspace closure of most packages, so unrelated pull requests inherit the red static-smoke stage.

The runtime consequence is the more serious one: a suite whose import cannot resolve **never loads, so none of its cases execute** while the file still reports as collected. That failure mode was confirmed independently by a maintainer on #25197, where a suite reporting `Tests 3 passed (3)` had in fact never run.

This is the same defect class as #24905 (repaired by #24977) and #25205 (repaired by #25281): a test generated into a new `__tests__/` directory keeping the sibling-relative specifier from before the move. A repository-wide sweep of all 2,122 `__tests__/` suites on `develop` found 30 instances across 7 packages; this PR covers the shared ones.

## What is the fix?

Point each specifier one level up. Nothing else changes.

```diff
-import { ... } from "./<name>.ts";
+import { ... } from "../<name>.ts";
```

# Documentation changes needed?

No. No public surface, export, setting, or documented behaviour changes.

# Testing

## Where should a reviewer start?

The path listing above. For each file, `<name>.ts` is a sibling of `__tests__/`, not a member of it, so `../<name>.ts` is the only specifier that resolves.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| sibling path `__tests__/<name>.ts` on `develop` | `404 Not Found` for all 7 — the path the current specifier resolves to |
| parent path `<name>.ts` on `develop` | `200` for all 7 — the path this PR points at |
| post-fix scan for a remaining `from "./<name>"` | none |
| diff vs `develop` | `+1/-1` per file, 7 files, imports only |

Test bodies are unchanged, so each suite keeps exactly the coverage it was reviewed with; it can now resolve the module it was written against.

# Evidence Gate

<!-- evidence-head:78fe1173e0f77e8c9d033dd273e4bca2cb396d86 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - module specifiers in test files; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - module specifiers in test files; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is module resolution, shown by the 404/200 path evidence above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the failure is a module-resolution error`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in module resolution`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the artifact is the resolution result above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by sweeping every `__tests__/` suite on `develop` for sibling-relative specifiers after diagnosing #25205.
- Sweep, verification, and fix by Claude Code (`claude-opus-5`).

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Attribution status: self-reported
