### PR TITLE
feat(core,agent): group-chat conversational correctness — room recap, identity honesty, honest memory tools

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -87,9 +87,15 @@ function makeRuntime(options?: {
   return { runtime, rows };
 }
 
-function seedFact(
+function seedRow(
   rows: StoredRow[],
-  fields: { text: string; entityId: UUID; roomId?: UUID },
+  fields: {
+    text: string;
+    entityId: UUID;
+    tableName: string;
+    roomId?: UUID;
+    createdAt?: number;
+  },
 ): UUID {
   const id = crypto.randomUUID() as UUID;
   rows.push({
@@ -99,11 +105,18 @@ function seedFact(
       agentId: AGENT_ID,
       roomId: fields.roomId ?? ROOM_ID,
       content: { text: fields.text },
-      createdAt: Date.now(),
+      createdAt: fields.createdAt ?? Date.now(),
     } as Memory,
-    tableName: "facts",
+    tableName: fields.tableName,
   });
   return id;
+}
+
+function seedFact(
+  rows: StoredRow[],
+  fields: { text: string; entityId: UUID; roomId?: UUID },
+): UUID {
+  return seedRow(rows, { ...fields, tableName: "facts" });
 }
 
 function makeMessage(): Memory {
@@ -567,6 +580,105 @@ describe("MEMORY op:delete by query", () => {
       "MEMORY_CONFIRMATION_REQUIRED",
     );
     expect(rows).toHaveLength(1);
+  });
+
+  it("widens a typed miss across memories and facts and discloses it", async () => {
+    // Live 2026-08-23: "forget my dog's name" arrived as type=memories while
+    // the record was a FACT row — the typed miss must rescan the forget
+    // tables instead of reporting "no record exists".
+    const { runtime, rows } = makeRuntime();
+    seedRow(rows, {
+      text: "the dog is named biscuit",
+      entityId: USER_ID,
+      tableName: "facts",
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "the dog is named biscuit",
+      type: "memories",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows).toHaveLength(0);
+    expect(result.text).toContain(
+      'no match in the requested "memories" table; found in facts',
+    );
+  });
+
+  it("names every table the widened delete removed rows from", async () => {
+    // Dedup failures can leave identical text in more than one table; the
+    // disclosure must name the full matched set, not just the first row's.
+    const { runtime, rows } = makeRuntime();
+    seedRow(rows, {
+      text: "the dog is named biscuit",
+      entityId: USER_ID,
+      tableName: "memories",
+      createdAt: 2_000,
+    });
+    seedRow(rows, {
+      text: "the dog is named biscuit",
+      entityId: USER_ID,
+      tableName: "facts",
+      createdAt: 1_000,
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "the dog is named biscuit",
+      type: "documents",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows).toHaveLength(0);
+    expect((result.values as { deletedCount: number }).deletedCount).toBe(2);
+    expect(result.text).toContain(
+      'no match in the requested "documents" table; found in memories, facts',
+    );
+  });
+
+  it("never widens a typed miss into messages or documents", async () => {
+    // The transcript row matches the query text exactly, but "forget"
+    // widening may only reach memories + facts — chat history and documents
+    // are deleted only when named by an explicit type.
+    const { runtime, rows } = makeRuntime();
+    seedRow(rows, {
+      text: "the dog is named biscuit",
+      entityId: USER_ID,
+      tableName: "messages",
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "the dog is named biscuit",
+      type: "facts",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error: string }).error).toBe("MEMORY_NOT_FOUND");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("still deletes from messages when the caller names the table", async () => {
+    const { runtime, rows } = makeRuntime();
+    seedRow(rows, {
+      text: "the dog is named biscuit",
+      entityId: USER_ID,
+      tableName: "messages",
+    });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "delete",
+      query: "the dog is named biscuit",
+      type: "messages",
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows).toHaveLength(0);
   });
 });
 

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -569,21 +569,44 @@ async function doDeleteByQuery(
   const scopeEntityId = message.entityId ?? entityParam.id;
 
   const limit = clampLimit(params.limit, 50);
-  const scan = await collectCandidates(runtime, {
+  const strongMatches = (scan: Awaited<ReturnType<typeof collectCandidates>>) =>
+    // Deletion needs a stronger bar than search ranking: scoreText >= 1 means
+    // the whole phrase matched or every query term matched.
+    scan.matches.filter((c) => {
+      const text =
+        (c.memory.content as { text?: string } | undefined)?.text ?? "";
+      return scoreText(text, query) >= 1;
+    });
+
+  let scan = await collectCandidates(runtime, {
     type,
     entityId: scopeEntityId,
     roomId: roomParam.id,
     query,
     limit,
   });
+  let matched = strongMatches(scan);
+  let widenedNote = "";
 
-  // Deletion needs a stronger bar than search ranking: scoreText >= 1 means
-  // the whole phrase matched or every query term matched.
-  const matched = scan.matches.filter((c) => {
-    const text =
-      (c.memory.content as { text?: string } | undefined)?.text ?? "";
-    return scoreText(text, query) >= 1;
-  });
+  // The table is an implementation detail the caller routinely guesses wrong
+  // (live 2026-08-23: "forget my dog's name" arrived as type=memories while
+  // the record was a FACT row, and the miss read back as "no record exists" —
+  // a broken forget). When a type-scoped scan finds nothing, rescan every
+  // table before failing; the strong match bar, confirm gate, and
+  // distinct-text ambiguity guard below still bound what can be deleted, and
+  // the widening is disclosed in the result.
+  if (matched.length === 0 && type) {
+    scan = await collectCandidates(runtime, {
+      entityId: scopeEntityId,
+      roomId: roomParam.id,
+      query,
+      limit,
+    });
+    matched = strongMatches(scan);
+    if (matched.length > 0) {
+      widenedNote = ` (no match in the requested "${type}" table; found in ${matched[0]?.type}).`;
+    }
+  }
 
   if (matched.length === 0) {
     return fail(
@@ -621,7 +644,7 @@ async function doDeleteByQuery(
 
   return {
     success: true,
-    text: `Forgot ${deleted.length} memory record(s) matching "${query}": ${toWellFormedUnicode(deleted[0]?.text ?? "")}`,
+    text: `Forgot ${deleted.length} memory record(s) matching "${query}": ${toWellFormedUnicode(deleted[0]?.text ?? "")}${widenedNote}`,
     values: { deletedCount: deleted.length },
     data: {
       actionName: "MEMORY",

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -29,6 +29,17 @@ type MemoryOp = (typeof MEMORY_OPS)[number];
 const MEMORY_TYPES = ["messages", "memories", "facts", "documents"] as const;
 type MemoryType = (typeof MEMORY_TYPES)[number];
 
+/**
+ * Tables the delete-by-query type-miss widening may rescan. "Remember" and
+ * "forget" semantically cover the agent's own memory tables — memories and
+ * facts — so a typed miss widens only across those two. Chat transcripts
+ * (messages) and ingested documents are NEVER pulled into scope by a typed
+ * miss: deleting from those tables requires the caller to name them via an
+ * explicit `type` parameter (the untyped path, which scans every table, is
+ * likewise an explicit caller choice of full scope).
+ */
+const FORGET_WIDENING_TABLES: readonly MemoryType[] = ["memories", "facts"];
+
 const UUID_SCHEMA_PATTERN =
   "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
 
@@ -246,15 +257,16 @@ async function collectCandidates(
   runtime: IAgentRuntime,
   scope: {
     type?: MemoryType;
+    /** Explicit table set; takes precedence over `type`. */
+    tables?: readonly MemoryType[];
     entityId?: UUID;
     roomId?: UUID;
     query?: string;
     limit: number;
   },
 ): Promise<CandidateScan> {
-  const tables: readonly MemoryType[] = scope.type
-    ? [scope.type]
-    : MEMORY_TYPES;
+  const tables: readonly MemoryType[] =
+    scope.tables ?? (scope.type ? [scope.type] : MEMORY_TYPES);
   const perTable = Math.max(scope.limit * 2, 200);
   const collected: MemoryCandidate[] = [];
   const saturatedTables: MemoryType[] = [];
@@ -548,6 +560,10 @@ async function doDelete(
  * match in a multi-user room would also hit another user's identical-text
  * fact, so "forget that I play guitar" may only remove the asking user's own
  * rows. Cross-entity deletes must go through op:search + delete by memoryId.
+ *
+ * A typed scan that misses widens across FORGET_WIDENING_TABLES (memories +
+ * facts) only — never into messages or documents, which require an explicit
+ * `type` to be deleted from.
  */
 async function doDeleteByQuery(
   runtime: IAgentRuntime,
@@ -569,7 +585,7 @@ async function doDeleteByQuery(
   const scopeEntityId = message.entityId ?? entityParam.id;
 
   const limit = clampLimit(params.limit, 50);
-  const strongMatches = (scan: Awaited<ReturnType<typeof collectCandidates>>) =>
+  const strongMatches = (scan: CandidateScan) =>
     // Deletion needs a stronger bar than search ranking: scoreText >= 1 means
     // the whole phrase matched or every query term matched.
     scan.matches.filter((c) => {
@@ -591,12 +607,16 @@ async function doDeleteByQuery(
   // The table is an implementation detail the caller routinely guesses wrong
   // (live 2026-08-23: "forget my dog's name" arrived as type=memories while
   // the record was a FACT row, and the miss read back as "no record exists" —
-  // a broken forget). When a type-scoped scan finds nothing, rescan every
-  // table before failing; the strong match bar, confirm gate, and
+  // a broken forget). When a type-scoped scan finds nothing, rescan before
+  // failing — but only across FORGET_WIDENING_TABLES (memories + facts, the
+  // tables "remember/forget" semantically covers). Messages and documents
+  // stay out of a typed miss's blast radius and are deleted only when the
+  // caller explicitly targets them. The strong match bar, confirm gate, and
   // distinct-text ambiguity guard below still bound what can be deleted, and
   // the widening is disclosed in the result.
   if (matched.length === 0 && type) {
     scan = await collectCandidates(runtime, {
+      tables: FORGET_WIDENING_TABLES,
       entityId: scopeEntityId,
       roomId: roomParam.id,
       query,
@@ -604,7 +624,10 @@ async function doDeleteByQuery(
     });
     matched = strongMatches(scan);
     if (matched.length > 0) {
-      widenedNote = ` (no match in the requested "${type}" table; found in ${matched[0]?.type}).`;
+      // The delete loop removes EVERY matched row, and identical normalized
+      // text can exist in more than one table — name them all.
+      const matchedTables = [...new Set(matched.map((c) => c.type))];
+      widenedNote = ` (no match in the requested "${type}" table; found in ${matchedTables.join(", ")}).`;
     }
   }
 

--- a/packages/agent/src/actions/page-action-groups.test.ts
+++ b/packages/agent/src/actions/page-action-groups.test.ts
@@ -197,6 +197,7 @@ describe("PAGE_DELEGATE structured child-unavailable failure", () => {
       code: "PAGE_CHILD_UNAVAILABLE",
       page: "owner",
       requestedAction: "CREATE_HABIT",
+      directlyCallable: false,
       availableActions: ["OWNER_REMINDERS", "OWNER_ROUTINES"],
       retryable: false,
     });
@@ -219,6 +220,7 @@ describe("PAGE_DELEGATE structured child-unavailable failure", () => {
     expect(result.success).toBe(false);
     expect(result.data).toMatchObject({
       code: "PAGE_CHILD_UNAVAILABLE",
+      directlyCallable: false,
       availableActions: [],
       retryable: false,
     });
@@ -247,6 +249,81 @@ describe("PAGE_DELEGATE structured child-unavailable failure", () => {
     expect(availableActions[0]).toBe("CHILD_00");
     expect(availableActions[44]).toBe("CHILD_44");
     expect([...availableActions].sort()).toEqual(availableActions);
+  });
+
+  it("hints at the direct action (still non-retryable) when the wrapped name is a standalone tool", async () => {
+    // Live tj-…: the planner wrapped the DIRECT action CHANNEL_RECAP in
+    // PAGE_DELEGATE and then gave up. The hint must survive case
+    // normalization, and the recovery call has a different identity, so the
+    // failed wrapper call itself stays non-retryable.
+    const runtime = {
+      actions: [
+        pageDelegateAction,
+        makeChildAction({ name: "CHANNEL_RECAP", contexts: ["general"] }),
+      ],
+    } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "channel_recap");
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      code: "PAGE_CHILD_UNAVAILABLE",
+      directlyCallable: true,
+      retryable: false,
+    });
+    expect(result.text).toContain("directly callable tool on this turn");
+  });
+
+  it("resolves the direct-call hint through similes", async () => {
+    const runtime = {
+      actions: [
+        pageDelegateAction,
+        makeChildAction({
+          name: "CHANNEL_RECAP",
+          contexts: ["general"],
+          similes: ["ROOM_RECAP"],
+        }),
+      ],
+    } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "ROOM_RECAP");
+
+    expect(result.data).toMatchObject({ directlyCallable: true });
+  });
+
+  it("does not claim a different page's child is directly callable", async () => {
+    // BROWSER is registered, but only under the browser page's context set —
+    // it is not exposed in the chat this failure returns to, so the hint
+    // would misdirect the planner away from the availableActions correction.
+    const runtime = {
+      actions: [
+        pageDelegateAction,
+        makeChildAction({ name: "BROWSER", contexts: ["browser"] }),
+      ],
+    } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "BROWSER");
+
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({
+      code: "PAGE_CHILD_UNAVAILABLE",
+      directlyCallable: false,
+      retryable: false,
+    });
+    expect(result.text).not.toContain("directly callable");
+  });
+
+  it("never offers PAGE_DELEGATE itself as the direct-call recovery", async () => {
+    // PAGE_ACTIONS is a simile of PAGE_DELEGATE, whose contexts include
+    // "general" — without the self-exclusion the parent would recommend
+    // re-wrapping in itself.
+    const actions: Action[] = [pageDelegateAction];
+    const runtime = { actions } as IAgentRuntime;
+
+    const result = await invokeOnPage(runtime, "owner", "PAGE_ACTIONS");
+
+    expect(result.data).toMatchObject({ directlyCallable: false });
+    expect(result.text).not.toContain("directly callable");
   });
 
   it("returns a non-retryable PAGE_CHILD_VALIDATE_REJECTED failure when the child refuses", async () => {

--- a/packages/agent/src/actions/page-action-groups.ts
+++ b/packages/agent/src/actions/page-action-groups.ts
@@ -370,10 +370,20 @@ export const pageDelegateAction: PageActionGroup = {
         runtime,
         childContexts,
       );
+      // Self-correction affordance: planners routinely wrap a DIRECT action in
+      // PAGE_DELEGATE (live tj-…, PAGE_DELEGATE{action:"CHANNEL_RECAP"} then a
+      // bare stop). When the requested name exists as a directly callable tool,
+      // say so — the next iteration can recover instead of giving up.
+      const directlyCallable = runtime.actions.some(
+        (candidate) => candidate.name === requestedAction,
+      );
       return {
         success: false,
         text:
           `${requestedAction} is not available on the ${page} page.` +
+          (directlyCallable
+            ? ` ${requestedAction} IS a directly callable tool on this turn — call ${requestedAction} directly instead of wrapping it in PAGE_DELEGATE.`
+            : "") +
           (availableActions.length > 0
             ? ` Actions available on the ${page} page: ${availableActions.join(", ")}.`
             : ` No child actions are registered for the ${page} page in this deployment.`),
@@ -382,8 +392,9 @@ export const pageDelegateAction: PageActionGroup = {
           code: "PAGE_CHILD_UNAVAILABLE",
           page,
           requestedAction,
+          directlyCallable,
           availableActions,
-          retryable: false,
+          retryable: directlyCallable,
         },
       };
     }

--- a/packages/agent/src/actions/page-action-groups.ts
+++ b/packages/agent/src/actions/page-action-groups.ts
@@ -372,10 +372,23 @@ export const pageDelegateAction: PageActionGroup = {
       );
       // Self-correction affordance: planners routinely wrap a DIRECT action in
       // PAGE_DELEGATE (live tj-…, PAGE_DELEGATE{action:"CHANNEL_RECAP"} then a
-      // bare stop). When the requested name exists as a directly callable tool,
-      // say so — the next iteration can recover instead of giving up.
+      // bare stop). When the requested name resolves — through the same
+      // name/simile normalization findChildAction uses — to a registered
+      // action whose context set reaches beyond the page-only surfaces, say
+      // so: the next iteration can call it directly instead of giving up.
+      // Children of a DIFFERENT page are excluded: they surface only in
+      // page-scoped chats, so claiming direct callability here would
+      // misdirect the planner away from the availableActions correction.
+      // PAGE_DELEGATE itself never counts as its own recovery target.
+      const normalizedRequested = normalizeActionName(requestedAction);
+      const pageOnlyContexts = new Set(ALL_PAGE_CONTEXTS.map(normalizeContext));
       const directlyCallable = runtime.actions.some(
-        (candidate) => candidate.name === requestedAction,
+        (candidate) =>
+          !isPageDelegate(candidate) &&
+          actionMatchesName(candidate, normalizedRequested) &&
+          resolveActionContexts(candidate).some(
+            (context) => !pageOnlyContexts.has(normalizeContext(context)),
+          ),
       );
       return {
         success: false,
@@ -394,7 +407,13 @@ export const pageDelegateAction: PageActionGroup = {
           requestedAction,
           directlyCallable,
           availableActions,
-          retryable: directlyCallable,
+          // Non-retryable even when directlyCallable: the planner-loop dedup
+          // guard suppresses only the identical PAGE_DELEGATE call, and that
+          // exact call stays deterministic within the turn. The recovery is a
+          // DIFFERENT call (the direct action), carried by directlyCallable
+          // and the text hint; retryable:true would only re-enable the same
+          // failing wrapper call and burn iterations.
+          retryable: false,
         },
       };
     }

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5210,6 +5210,43 @@ describe("runV5MessageRuntimeStage1", () => {
 
 		// Pure decision seam: the exact source precedence, ack suppression,
 		// failure-aware wording, and the async-handoff silence gate.
+		it("renders the unresolved-vocative identity notice only on ambient group turns", async () => {
+			// Review (#25283): the first cut emitted the notice on every turn,
+			// including DMs. Eligibility mirrors the suppression gate.
+			const runFor = async (content: Partial<Memory["content"]>) => {
+				const runtime = makeRuntime([
+					stage1Response({
+						thought: "Greeting.",
+						contexts: ["simple"],
+						replyText: "hey.",
+					}),
+				]);
+				// The classifier resolves against room participants; the minimal
+				// harness runtime needs the lookup or classification fails open.
+				(runtime as { getEntitiesForRoom?: unknown }).getEntitiesForRoom =
+					vi.fn(async () => []);
+				await runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage({ text: "hey eliza", ...content }),
+					state: makeState(),
+					responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				});
+				const calls = useModelCalls(runtime);
+				return (
+					calls[0]?.[1] as { messages?: Array<{ content?: string }> }
+				).messages
+					?.map((m) => m.content ?? "")
+					.join("\n");
+			};
+
+			const ambient = await runFor({ channelType: ChannelType.GROUP });
+			expect(ambient).toContain("unresolved_vocative_notice");
+			expect(ambient).toContain('"eliza"');
+
+			const dm = await runFor({ channelType: ChannelType.DM });
+			expect(dm).not.toContain("unresolved_vocative_notice");
+		});
+
 		describe("resolveZeroDeliveryRecovery", () => {
 			it("never fabricates a failed-steps report on a toolless turn", () => {
 				// Effect honesty: with no action results at all, the fallback must

--- a/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
+++ b/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
@@ -14,16 +14,14 @@ import {
 } from "../runtime/builtin-field-evaluators";
 import { ContextRegistry } from "../runtime/context-registry";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
-import {
-	runV5MessageRuntimeStage1,
-	textContainsAgentName,
-} from "../services/message";
+import { runV5MessageRuntimeStage1 } from "../services/message";
 import { isUnaddressedTextGroupTurn } from "../services/message/stage1-prompt-tier";
 import type { ContextDefinition } from "../types/contexts";
 import type { Memory } from "../types/memory";
 import { ChannelType, type UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
 import type { State } from "../types/state";
+import { textContainsAgentName } from "../utils/agent-name-match.ts";
 
 const FULL_TEMPLATE_MARKER = "Domain routing (when context is available):";
 const FULL_SHOULD_RESPOND_DOCS = "DM usually RESPOND unless explicit stop.";

--- a/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
+++ b/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
@@ -1,0 +1,245 @@
+/**
+ * CHANNEL_RECAP — reads back the recent stored message history of the room the
+ * triggering message arrived in, so a group-chat sender can ask for a recap,
+ * summary, or "the last N messages" of their own channel. Live evidence
+ * 2026-08-21: that ask routed to contexts=["general"], whose planner surface
+ * carried no message-history tool (SEARCH_MESSAGES lives behind the ADMIN
+ * messaging/email umbrella), so the agent honestly refused a request whose
+ * content every room participant can already scroll.
+ *
+ * Room scoping is structural, not parametric: the handler reads only
+ * `message.roomId` and exposes no room/channel selector, so a request from
+ * room A can never return room B content and cross-room/inbox-wide search
+ * stays gated on the messaging umbrella exactly as before. The returned text
+ * is model-facing and complete — every rendered message carries its full
+ * stored text, chronologically ordered. The only bound is
+ * `CHANNEL_RECAP_MAX_FETCH`, a documented storage read bound on how many rows
+ * are pulled (never a text cap); exceeding it is reported explicitly in the
+ * result rather than silently clamped.
+ */
+import { getEntityDetails } from "../../../entities.ts";
+import { isInternalBridgeMessage } from "../../../messaging/automated-turns.ts";
+import type {
+	Action,
+	ActionExample,
+	ActionResult,
+	AgentContext,
+	CustomMetadata,
+	Entity,
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.ts";
+import { hasActionContext } from "../../../utils/action-validation.ts";
+import { formatMessages } from "../../../utils.ts";
+
+export const CHANNEL_RECAP_CONTEXTS = ["general"] satisfies AgentContext[];
+
+/** Messages rendered when the caller does not name a count. */
+export const CHANNEL_RECAP_DEFAULT_COUNT = 50;
+
+/**
+ * Storage read bound: the most rows a single recap pulls from the message
+ * store. A read bound on the DB fetch, not a cap on rendered text — every
+ * fetched message is rendered complete. Requests above it are answered with
+ * this many newest messages plus an explicit statement of the bound.
+ */
+export const CHANNEL_RECAP_MAX_FETCH = 500;
+
+function resolveRequestedCount(options?: HandlerOptions): number | undefined {
+	const raw =
+		options?.parameters && typeof options.parameters === "object"
+			? (options.parameters as Record<string, unknown>).count
+			: undefined;
+	if (typeof raw === "number" && Number.isFinite(raw)) return Math.floor(raw);
+	if (typeof raw === "string") {
+		const parsed = Number(raw.trim());
+		if (Number.isFinite(parsed)) return Math.floor(parsed);
+	}
+	return undefined;
+}
+
+/**
+ * Historical rooms can contain senders whose entity row is gone (they left the
+ * room). Mirror the RECENT_MESSAGES provider's fallback: synthesize a
+ * formatting entity from the message's stamped `entityName` metadata so the
+ * transcript keeps a real name instead of "Unknown User".
+ */
+function fallbackFormattingEntities(
+	known: readonly Entity[],
+	messages: readonly Memory[],
+): Entity[] {
+	const byId = new Map<UUID, Entity>();
+	for (const entity of known) {
+		if (entity.id) byId.set(entity.id, entity);
+	}
+	for (const memory of messages) {
+		if (!memory.entityId || byId.has(memory.entityId)) continue;
+		const metadata = memory.metadata as CustomMetadata | undefined;
+		const entityName =
+			typeof metadata?.entityName === "string"
+				? metadata.entityName.trim()
+				: "";
+		if (entityName.length === 0) continue;
+		byId.set(memory.entityId, {
+			id: memory.entityId,
+			agentId: memory.agentId,
+			names: [entityName],
+			metadata: { name: entityName, userName: entityName },
+		} as Entity);
+	}
+	return Array.from(byId.values());
+}
+
+export const channelRecapAction: Action = {
+	name: "CHANNEL_RECAP",
+	contexts: [...CHANNEL_RECAP_CONTEXTS],
+	// Deliberately no roleGate: this is the CURRENT room's transcript — content
+	// every participant can already read in their client (same GUEST-floor
+	// rationale as the RECENT_MESSAGES provider). Cross-room and inbox-wide
+	// reads stay on the ADMIN-gated MESSAGE umbrella.
+	description:
+		"Read back the recent message history of the CURRENT room/channel — the conversation this request arrived in — complete and in chronological order, so the reply can summarize, recap, or quote it: 'summarize this chat', 'recap the channel', 'what were the last 100 messages', 'what did people say here earlier'. Always scoped to this room only; searching other rooms, channels, or inboxes stays on MESSAGE.",
+	descriptionCompressed:
+		"read current room's own recent history for recap/summary/last-N-messages; this room only, cross-channel search stays on MESSAGE",
+	routingHint:
+		"recap/summarize/read back THIS chat's history -> CHANNEL_RECAP; cross-channel or inbox search -> MESSAGE (NOT this action)",
+	similes: [
+		"ROOM_HISTORY",
+		"CHAT_HISTORY",
+		"SUMMARIZE_CHAT",
+		"RECAP_CHANNEL",
+		"READ_RECENT_ROOM_MESSAGES",
+		"LAST_MESSAGES",
+	],
+	parameters: [
+		{
+			name: "count",
+			description: `How many most-recent messages to read back (default ${CHANNEL_RECAP_DEFAULT_COUNT}; storage read bound ${CHANNEL_RECAP_MAX_FETCH}).`,
+			required: false,
+			schema: {
+				type: "number" as const,
+				minimum: 1,
+				maximum: CHANNEL_RECAP_MAX_FETCH,
+			},
+		},
+	],
+	examples: [
+		[
+			{
+				name: "User",
+				content: {
+					text: "what were the last 100 messages in this chat? give me a summary",
+				},
+			},
+			{
+				name: "Agent",
+				content: {
+					text: "Reading back this channel's history.",
+					action: "CHANNEL_RECAP",
+				},
+			},
+		],
+	] as ActionExample[][],
+
+	validate: async (
+		_runtime: IAgentRuntime,
+		message: Memory,
+		state?: State,
+	): Promise<boolean> =>
+		hasActionContext(message, state, { contexts: CHANNEL_RECAP_CONTEXTS }),
+
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		_state?: State,
+		options?: HandlerOptions,
+	): Promise<ActionResult> => {
+		const roomId = message.roomId;
+		if (!roomId) {
+			return {
+				success: false,
+				text: "CHANNEL_RECAP requires a room-bound message; this message has no roomId.",
+				values: { success: false },
+				data: { actionName: "CHANNEL_RECAP" },
+			};
+		}
+
+		const requestedCount = resolveRequestedCount(options);
+		const validRequested =
+			requestedCount !== undefined && requestedCount >= 1
+				? requestedCount
+				: undefined;
+		const fetchCount = Math.min(
+			validRequested ?? CHANNEL_RECAP_DEFAULT_COUNT,
+			CHANNEL_RECAP_MAX_FETCH,
+		);
+
+		// Newest-first from the store (adapter default order); formatMessages
+		// walks its input from the last element backwards, so passing the
+		// newest-first rows renders the transcript oldest-first (chronological).
+		const rows = await runtime.getMemories({
+			tableName: "messages",
+			roomId,
+			count: fetchCount,
+			unique: false,
+		});
+
+		// Strip only the agent's own machinery rows (action_result records and
+		// internal bridge relays) — the same structural filter RECENT_MESSAGES
+		// applies so the model never re-reads its own tooling as conversation.
+		// Every retained dialogue row is rendered complete.
+		const dialogue = rows.filter(
+			(row) =>
+				row.content?.type !== "action_result" && !isInternalBridgeMessage(row),
+		);
+
+		const roomEntities = await getEntityDetails({ runtime, roomId });
+		const entities = fallbackFormattingEntities(roomEntities, dialogue);
+		const transcript = formatMessages({ messages: dialogue, entities });
+
+		const boundNote =
+			validRequested !== undefined && validRequested > CHANNEL_RECAP_MAX_FETCH
+				? ` The requested ${validRequested} exceeds the documented storage read bound of ${CHANNEL_RECAP_MAX_FETCH} messages per recap; the ${CHANNEL_RECAP_MAX_FETCH} newest were read.`
+				: "";
+		const depthNote =
+			rows.length < fetchCount
+				? ` This room's stored history holds ${rows.length} message(s); the read requested up to ${fetchCount}.`
+				: "";
+		const text =
+			dialogue.length === 0
+				? `No stored messages found in this room's history.${boundNote}${depthNote}`
+				: `Complete transcript of the last ${dialogue.length} stored message(s) in this room, oldest first:${boundNote}${depthNote}\n\n${transcript}`;
+
+		return {
+			success: true,
+			text,
+			values: { success: true, messageCount: dialogue.length },
+			data: {
+				actionName: "CHANNEL_RECAP",
+				roomId,
+				scope: {
+					roomScoped: true,
+					requestedCount: validRequested ?? null,
+					fetchCount,
+					storageReadBound: CHANNEL_RECAP_MAX_FETCH,
+					fetchedRows: rows.length,
+					renderedCount: dialogue.length,
+					order: "chronological",
+				},
+				messages: dialogue
+					.slice()
+					.reverse()
+					.map((row) => ({
+						id: row.id ?? null,
+						entityId: row.entityId,
+						createdAt: row.createdAt ?? null,
+						// Complete stored text — never a snippet.
+						text: row.content?.text ?? "",
+					})),
+			},
+		};
+	},
+};

--- a/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
+++ b/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
@@ -24,16 +24,15 @@ import type {
 	ActionExample,
 	ActionResult,
 	AgentContext,
-	CustomMetadata,
-	Entity,
 	HandlerOptions,
 	IAgentRuntime,
 	Memory,
 	State,
-	UUID,
 } from "../../../types/index.ts";
 import { hasActionContext } from "../../../utils/action-validation.ts";
+import { sliceToFitBudget } from "../../../utils/slice-to-fit-budget.ts";
 import { formatMessages } from "../../../utils.ts";
+import { ensureFormattingEntities } from "../providers/recentMessages.ts";
 
 export const CHANNEL_RECAP_CONTEXTS = ["general"] satisfies AgentContext[];
 
@@ -67,43 +66,12 @@ function resolveRequestedCount(options?: HandlerOptions): number | undefined {
 			? (options.parameters as Record<string, unknown>).count
 			: undefined;
 	if (typeof raw === "number" && Number.isFinite(raw)) return Math.floor(raw);
-	if (typeof raw === "string") {
-		const parsed = Number(raw.trim());
-		if (Number.isFinite(parsed)) return Math.floor(parsed);
+	// Same integer-digits-only rule as the offset parser: "50.9" or "1e2" is a
+	// malformed count, not a request — fall back to the default.
+	if (typeof raw === "string" && /^\d+$/.test(raw.trim())) {
+		return Number(raw.trim());
 	}
 	return undefined;
-}
-
-/**
- * Historical rooms can contain senders whose entity row is gone (they left the
- * room). Mirror the RECENT_MESSAGES provider's fallback: synthesize a
- * formatting entity from the message's stamped `entityName` metadata so the
- * transcript keeps a real name instead of "Unknown User".
- */
-function fallbackFormattingEntities(
-	known: readonly Entity[],
-	messages: readonly Memory[],
-): Entity[] {
-	const byId = new Map<UUID, Entity>();
-	for (const entity of known) {
-		if (entity.id) byId.set(entity.id, entity);
-	}
-	for (const memory of messages) {
-		if (!memory.entityId || byId.has(memory.entityId)) continue;
-		const metadata = memory.metadata as CustomMetadata | undefined;
-		const entityName =
-			typeof metadata?.entityName === "string"
-				? metadata.entityName.trim()
-				: "";
-		if (entityName.length === 0) continue;
-		byId.set(memory.entityId, {
-			id: memory.entityId,
-			agentId: memory.agentId,
-			names: [entityName],
-			metadata: { name: entityName, userName: entityName },
-		} as Entity);
-	}
-	return Array.from(byId.values());
 }
 
 export const channelRecapAction: Action = {
@@ -220,10 +188,12 @@ export const channelRecapAction: Action = {
 			unique: false,
 		});
 
-		// Strip only the agent's own machinery rows (action_result records and
-		// internal bridge relays) — the same structural filter RECENT_MESSAGES
-		// applies so the model never re-reads its own tooling as conversation.
-		// Every retained dialogue row is rendered complete.
+		// Strip only the agent's own structural machinery rows: action_result
+		// records and internal bridge relays. This is a SUBSET of the
+		// RECENT_MESSAGES filter (which additionally strips synthetic failure
+		// replies, transient status posts, leaked tool transcripts/path dumps,
+		// and dedupes) — a recap is a verbatim read-back, so only rows that are
+		// never conversation are removed. Every retained row renders complete.
 		const allDialogue = rows.filter(
 			(row) =>
 				row.content?.type !== "action_result" && !isInternalBridgeMessage(row),
@@ -233,33 +203,39 @@ export const channelRecapAction: Action = {
 		// documented transcript fit bound. Messages are always complete; only
 		// the served WINDOW shrinks, and the continuation offset is stated.
 		const ranged = allDialogue.slice(offset, offset + fetchCount);
-		let fitChars = 0;
-		let served = 0;
-		for (const row of ranged) {
-			const rowChars = (row.content?.text ?? "").length + 120;
-			if (
-				served > 0 &&
-				fitChars + rowChars > CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS
-			) {
-				break;
-			}
-			fitChars += rowChars;
-			served += 1;
+		let dialogue = sliceToFitBudget(
+			ranged,
+			(row) => (row.content?.text ?? "").length + 120,
+			CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS,
+		);
+		// A single message larger than the whole fit bound is served alone,
+		// complete — the bound shrinks the window, never a message.
+		if (dialogue.length === 0 && ranged.length > 0) {
+			dialogue = ranged.slice(0, 1);
 		}
-		const dialogue = ranged.slice(0, served);
-		const olderRemaining = ranged.length - served;
+		const olderRemaining = ranged.length - dialogue.length;
 
 		const roomEntities = await getEntityDetails({ runtime, roomId });
-		const entities = fallbackFormattingEntities(roomEntities, dialogue);
+		const entities = await ensureFormattingEntities(
+			runtime,
+			roomEntities,
+			dialogue,
+		);
 		const transcript = formatMessages({ messages: dialogue, entities });
 
 		const boundNote =
 			validRequested !== undefined && validRequested > CHANNEL_RECAP_MAX_FETCH
 				? ` The requested ${validRequested} exceeds the documented storage read bound of ${CHANNEL_RECAP_MAX_FETCH} messages per recap; the ${CHANNEL_RECAP_MAX_FETCH} newest were read.`
 				: "";
+		// Store-exhaustion is measured against the full fetch depth
+		// (count + offset): with a nonzero offset the store can satisfy
+		// `fetchCount` rows and still be exhausted short of the requested page.
+		const requestedDepth = fetchCount + offset;
 		const depthNote =
-			rows.length < fetchCount
-				? ` This room's stored history holds ${rows.length} message(s); the read requested up to ${fetchCount}.`
+			rows.length < requestedDepth
+				? ` This room's stored history holds ${rows.length} message(s); the read requested up to ${requestedDepth}${
+						offset > 0 ? ` (count ${fetchCount} + offset ${offset})` : ""
+					}.`
 				: "";
 		const rangeLabel =
 			offset > 0

--- a/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
+++ b/packages/core/src/features/basic-capabilities/actions/channel-recap.ts
@@ -48,6 +48,19 @@ export const CHANNEL_RECAP_DEFAULT_COUNT = 50;
  */
 export const CHANNEL_RECAP_MAX_FETCH = 500;
 
+/**
+ * Model-window fit bound on the rendered transcript per call, in characters
+ * (~15K tokens — comfortably inside the serving model's context even when the
+ * transcript re-enters the next planner prompt alongside the base context;
+ * live 2026-08-22: a 500-message read rendered past the provider's 131K-token
+ * window and killed the turn). Never a cap on any individual message — every
+ * served message is complete; when the requested range does not fit, the
+ * NEWEST messages that fit are served and the result states the exact range
+ * plus the offset that continues into older history. A single message larger
+ * than the bound is served alone, complete.
+ */
+export const CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS = 60_000;
+
 function resolveRequestedCount(options?: HandlerOptions): number | undefined {
 	const raw =
 		options?.parameters && typeof options.parameters === "object"
@@ -116,6 +129,13 @@ export const channelRecapAction: Action = {
 	],
 	parameters: [
 		{
+			name: "offset",
+			description:
+				"How many newest messages to skip before reading (default 0). Use the continuation offset a previous recap reported to page into older history.",
+			schema: { type: "number", minimum: 0 },
+			required: false,
+		},
+		{
 			name: "count",
 			description: `How many most-recent messages to read back (default ${CHANNEL_RECAP_DEFAULT_COUNT}; storage read bound ${CHANNEL_RECAP_MAX_FETCH}).`,
 			required: false,
@@ -168,6 +188,19 @@ export const channelRecapAction: Action = {
 		}
 
 		const requestedCount = resolveRequestedCount(options);
+		const rawOffset = (
+			options?.parameters as Record<string, unknown> | undefined
+		)?.offset;
+		const parsedOffset =
+			typeof rawOffset === "number"
+				? rawOffset
+				: typeof rawOffset === "string" && /^\d+$/.test(rawOffset.trim())
+					? Number(rawOffset.trim())
+					: 0;
+		const offset =
+			Number.isFinite(parsedOffset) && parsedOffset > 0
+				? Math.floor(parsedOffset)
+				: 0;
 		const validRequested =
 			requestedCount !== undefined && requestedCount >= 1
 				? requestedCount
@@ -183,7 +216,7 @@ export const channelRecapAction: Action = {
 		const rows = await runtime.getMemories({
 			tableName: "messages",
 			roomId,
-			count: fetchCount,
+			count: fetchCount + offset,
 			unique: false,
 		});
 
@@ -191,10 +224,30 @@ export const channelRecapAction: Action = {
 		// internal bridge relays) — the same structural filter RECENT_MESSAGES
 		// applies so the model never re-reads its own tooling as conversation.
 		// Every retained dialogue row is rendered complete.
-		const dialogue = rows.filter(
+		const allDialogue = rows.filter(
 			(row) =>
 				row.content?.type !== "action_result" && !isInternalBridgeMessage(row),
 		);
+		// Caller-requested pagination: skip the `offset` newest dialogue rows,
+		// then serve the newest messages of the remaining range that fit the
+		// documented transcript fit bound. Messages are always complete; only
+		// the served WINDOW shrinks, and the continuation offset is stated.
+		const ranged = allDialogue.slice(offset, offset + fetchCount);
+		let fitChars = 0;
+		let served = 0;
+		for (const row of ranged) {
+			const rowChars = (row.content?.text ?? "").length + 120;
+			if (
+				served > 0 &&
+				fitChars + rowChars > CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS
+			) {
+				break;
+			}
+			fitChars += rowChars;
+			served += 1;
+		}
+		const dialogue = ranged.slice(0, served);
+		const olderRemaining = ranged.length - served;
 
 		const roomEntities = await getEntityDetails({ runtime, roomId });
 		const entities = fallbackFormattingEntities(roomEntities, dialogue);
@@ -208,10 +261,18 @@ export const channelRecapAction: Action = {
 			rows.length < fetchCount
 				? ` This room's stored history holds ${rows.length} message(s); the read requested up to ${fetchCount}.`
 				: "";
+		const rangeLabel =
+			offset > 0
+				? `messages ${offset + 1}–${offset + dialogue.length} back (newest first)`
+				: `the last ${dialogue.length} stored message(s)`;
+		const fitNote =
+			olderRemaining > 0
+				? ` The requested range holds ${ranged.length} message(s), more than fits one model call; the ${dialogue.length} newest of the range are served complete. Continue into older history by calling CHANNEL_RECAP again with offset=${offset + dialogue.length}.`
+				: "";
 		const text =
 			dialogue.length === 0
-				? `No stored messages found in this room's history.${boundNote}${depthNote}`
-				: `Complete transcript of the last ${dialogue.length} stored message(s) in this room, oldest first:${boundNote}${depthNote}\n\n${transcript}`;
+				? `No stored messages found in this room's history at offset ${offset}.${boundNote}${depthNote}`
+				: `Complete transcript of ${rangeLabel} in this room, oldest first:${boundNote}${depthNote}${fitNote}\n\n${transcript}`;
 
 		return {
 			success: true,
@@ -224,9 +285,14 @@ export const channelRecapAction: Action = {
 					roomScoped: true,
 					requestedCount: validRequested ?? null,
 					fetchCount,
+					offset,
 					storageReadBound: CHANNEL_RECAP_MAX_FETCH,
+					transcriptFitChars: CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS,
 					fetchedRows: rows.length,
 					renderedCount: dialogue.length,
+					olderRemaining,
+					continuationOffset:
+						olderRemaining > 0 ? offset + dialogue.length : null,
 					order: "chronological",
 				},
 				messages: dialogue

--- a/packages/core/src/features/basic-capabilities/channel-recap.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-recap.test.ts
@@ -15,6 +15,7 @@ import { searchMessagesAction } from "../messaging/triage/actions/searchMessages
 import {
 	CHANNEL_RECAP_DEFAULT_COUNT,
 	CHANNEL_RECAP_MAX_FETCH,
+	CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS,
 	channelRecapAction,
 } from "./actions/channel-recap.ts";
 import { basicActions } from "./index.ts";
@@ -323,5 +324,76 @@ describe("CHANNEL_RECAP count contract", () => {
 				expect.objectContaining({ count: CHANNEL_RECAP_DEFAULT_COUNT }),
 			);
 		}
+	});
+});
+
+describe("CHANNEL_RECAP transcript fit bound and offset paging", () => {
+	const ROOM = "00000000-0000-4000-8000-00000000f1f1" as UUID;
+
+	it("serves only the newest messages that fit, complete, with an explicit continuation offset", async () => {
+		// 20 messages of ~9K chars each — far past the fit bound in aggregate.
+		const rows = Array.from({ length: 20 }, (_, i) =>
+			makeMessage(ROOM, 1_000 + i, `M${i}-${"x".repeat(9_000)}`),
+		);
+		const { runtime } = makeRuntime({ [ROOM]: rows });
+		const result = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 20 } },
+		)) as ActionResult;
+		expect(result.success).toBe(true);
+		const scope = (result.data as { scope: Record<string, unknown> }).scope;
+		const rendered = scope.renderedCount as number;
+		expect(rendered).toBeGreaterThan(0);
+		expect(rendered).toBeLessThan(20);
+		// Every served message is COMPLETE (newest ones), none clipped.
+		for (let i = 20 - rendered; i < 20; i++) {
+			expect(result.text).toContain(`M${i}-${"x".repeat(9_000)}`);
+		}
+		// The continuation contract is explicit.
+		expect(scope.olderRemaining).toBe(20 - rendered);
+		expect(scope.continuationOffset).toBe(rendered);
+		expect(result.text).toContain(`offset=${rendered}`);
+	});
+
+	it("offset pages into older history and reports the exact range", async () => {
+		const rows = Array.from({ length: 12 }, (_, i) =>
+			makeMessage(ROOM, 1_000 + i, `msg-${i}`),
+		);
+		const { runtime } = makeRuntime({ [ROOM]: rows });
+		const result = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 4, offset: 4 } },
+		)) as ActionResult;
+		expect(result.success).toBe(true);
+		// newest-first rows: offset 4 skips msg-11..msg-8; serves msg-7..msg-4.
+		for (const i of [7, 6, 5, 4]) expect(result.text).toContain(`msg-${i}`);
+		for (const i of [11, 10, 9, 8, 3]) {
+			expect(result.text).not.toContain(`msg-${i}\n`);
+		}
+		expect(result.text).toContain("messages 5–8 back");
+	});
+
+	it("a single message larger than the fit bound is served alone, complete", async () => {
+		const giant = "G".repeat(CHANNEL_RECAP_TRANSCRIPT_FIT_CHARS + 5_000);
+		const rows = [
+			makeMessage(ROOM, 1_000, "older small"),
+			makeMessage(ROOM, 2_000, giant),
+		];
+		const { runtime } = makeRuntime({ [ROOM]: rows });
+		const result = (await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM),
+			undefined,
+			{ parameters: { count: 2 } },
+		)) as ActionResult;
+		expect(result.success).toBe(true);
+		expect(result.text).toContain(giant);
+		const scope = (result.data as { scope: Record<string, unknown> }).scope;
+		expect(scope.renderedCount).toBe(1);
+		expect(scope.continuationOffset).toBe(1);
 	});
 });

--- a/packages/core/src/features/basic-capabilities/channel-recap.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-recap.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Deterministic unit tests for the CHANNEL_RECAP room-history action: general-
+ * context reachability through the exposure gate (with the ADMIN messaging
+ * search excluded from the same surface), structural room scoping (a message
+ * from room A can never surface room B content, even when the planner passes
+ * room-selector-shaped parameters), complete untruncated transcript content in
+ * chronological order, the caller-requested count contract with its documented
+ * storage read bound, and machinery-row filtering. Runtime is a vi.fn stub —
+ * no model, no database.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { filterByContextGate } from "../../runtime/context-gates.ts";
+import type { IAgentRuntime, Memory, UUID } from "../../types/index.ts";
+import { searchMessagesAction } from "../messaging/triage/actions/searchMessages.ts";
+import {
+	CHANNEL_RECAP_DEFAULT_COUNT,
+	CHANNEL_RECAP_MAX_FETCH,
+	channelRecapAction,
+} from "./actions/channel-recap.ts";
+import { basicActions } from "./index.ts";
+
+const AGENT_ID = "00000000-0000-4000-8000-00000000a9e7" as UUID;
+const USER_ID = "00000000-0000-4000-8000-00000000c0de" as UUID;
+const ROOM_A = "00000000-0000-4000-8000-00000000aaaa" as UUID;
+const ROOM_B = "00000000-0000-4000-8000-00000000bbbb" as UUID;
+
+function makeMessage(
+	roomId: UUID,
+	createdAt: number,
+	text: string,
+	extra: Partial<Memory> = {},
+): Memory {
+	return {
+		id: `00000000-0000-4000-8000-${String(createdAt).padStart(12, "0")}` as UUID,
+		entityId: USER_ID,
+		agentId: AGENT_ID,
+		roomId,
+		createdAt,
+		content: { text, source: "discord" },
+		...extra,
+	} as Memory;
+}
+
+interface RuntimeStub {
+	runtime: IAgentRuntime;
+	getMemories: ReturnType<typeof vi.fn>;
+}
+
+function makeRuntime(fixtures: Record<string, Memory[]>): RuntimeStub {
+	const getMemories = vi.fn(
+		async (params: { roomId?: UUID; count?: number; limit?: number }) => {
+			const rows = (fixtures[params.roomId ?? ""] ?? [])
+				.slice()
+				.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+			const limit = params.limit ?? params.count ?? Number.POSITIVE_INFINITY;
+			return rows.slice(0, limit);
+		},
+	);
+	const runtime = {
+		agentId: AGENT_ID,
+		getMemories,
+		getRoom: vi.fn(async (roomId: UUID) => ({
+			id: roomId,
+			source: "discord",
+		})),
+		getEntitiesForRoom: vi.fn(async () => [
+			{ id: USER_ID, agentId: AGENT_ID, names: ["Al"], metadata: {} },
+		]),
+	} as unknown as IAgentRuntime;
+	return { runtime, getMemories };
+}
+
+const incoming = (roomId: UUID): Memory =>
+	makeMessage(roomId, 9_999_000, "what were the last 100 messages here?");
+
+describe("CHANNEL_RECAP registration and general-context reachability", () => {
+	it("is part of the basic action bundle", () => {
+		expect(basicActions.map((action) => action.name)).toContain(
+			"CHANNEL_RECAP",
+		);
+	});
+
+	it("declares exactly the general context", () => {
+		expect(channelRecapAction.contexts).toEqual(["general"]);
+	});
+
+	it("passes the exposure gate for a general-context group sender while the messaging search stays out", () => {
+		const surfaced = filterByContextGate(
+			[channelRecapAction, searchMessagesAction],
+			["general"],
+			["GUEST"],
+		);
+		expect(surfaced.map((action) => action.name)).toEqual(["CHANNEL_RECAP"]);
+
+		// Even an ADMIN in a general-routed turn does not get the cross-channel
+		// search: its contexts stay messaging/email/documents.
+		const adminSurfaced = filterByContextGate(
+			[searchMessagesAction],
+			["general"],
+			["ADMIN"],
+		);
+		expect(adminSurfaced).toEqual([]);
+	});
+
+	it("validate accepts a routed turn (general is always in the active set)", async () => {
+		const message = incoming(ROOM_A);
+		message.content = {
+			...message.content,
+			metadata: {
+				__responseContext: { primaryContext: "general" },
+			},
+		};
+		await expect(
+			channelRecapAction.validate(makeRuntime({}).runtime, message, undefined),
+		).resolves.toBe(true);
+	});
+});
+
+describe("CHANNEL_RECAP room scoping", () => {
+	const fixtures = {
+		[ROOM_A]: [
+			makeMessage(ROOM_A, 1_000, "alpha one"),
+			makeMessage(ROOM_A, 2_000, "alpha two"),
+		],
+		[ROOM_B]: [makeMessage(ROOM_B, 1_500, "bravo secret")],
+	};
+
+	it("returns only the sender's current room, never another room", async () => {
+		const { runtime, getMemories } = makeRuntime(fixtures);
+		const result = await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			undefined,
+		);
+		expect(result.success).toBe(true);
+		expect(result.text).toContain("alpha one");
+		expect(result.text).toContain("alpha two");
+		expect(result.text).not.toContain("bravo secret");
+		expect(getMemories).toHaveBeenCalledWith(
+			expect.objectContaining({ roomId: ROOM_A, tableName: "messages" }),
+		);
+		const scope = (result.data as { scope: { roomId?: string } }).scope;
+		expect(scope).toMatchObject({ roomScoped: true });
+		expect((result.data as { roomId: string }).roomId).toBe(ROOM_A);
+	});
+
+	it("ignores room-selector-shaped parameters: scoping is structural", async () => {
+		const { runtime, getMemories } = makeRuntime(fixtures);
+		const result = await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			{
+				parameters: {
+					roomId: ROOM_B,
+					channelId: ROOM_B,
+					roomIds: [ROOM_B],
+					worldId: ROOM_B,
+				},
+			},
+		);
+		expect(result.success).toBe(true);
+		expect(result.text).not.toContain("bravo secret");
+		expect(result.text).toContain("alpha one");
+		for (const call of getMemories.mock.calls) {
+			expect(call[0].roomId).toBe(ROOM_A);
+		}
+	});
+
+	it("fails typed when the message has no roomId", async () => {
+		const { runtime } = makeRuntime(fixtures);
+		const message = incoming(ROOM_A);
+		(message as { roomId?: UUID }).roomId = undefined;
+		const result = await channelRecapAction.handler(
+			runtime,
+			message,
+			undefined,
+			undefined,
+		);
+		expect(result.success).toBe(false);
+		expect(result.text).toContain("roomId");
+	});
+});
+
+describe("CHANNEL_RECAP transcript completeness and order", () => {
+	it("renders every message complete — no truncation of long content", async () => {
+		const longText = `${"the quarterly numbers were discussed at length ".repeat(200)}FINAL_MARKER_END`;
+		const { runtime } = makeRuntime({
+			[ROOM_A]: [makeMessage(ROOM_A, 1_000, longText)],
+		});
+		const result = await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			undefined,
+		);
+		expect(result.text).toContain(longText);
+		const data = result.data as {
+			messages: Array<{ text: string }>;
+		};
+		expect(data.messages[0].text).toBe(longText);
+	});
+
+	it("renders chronologically, oldest first", async () => {
+		const { runtime } = makeRuntime({
+			[ROOM_A]: [
+				makeMessage(ROOM_A, 3_000, "third message"),
+				makeMessage(ROOM_A, 1_000, "first message"),
+				makeMessage(ROOM_A, 2_000, "second message"),
+			],
+		});
+		const result = await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			undefined,
+		);
+		const text = result.text ?? "";
+		expect(text.indexOf("first message")).toBeGreaterThan(-1);
+		expect(text.indexOf("first message")).toBeLessThan(
+			text.indexOf("second message"),
+		);
+		expect(text.indexOf("second message")).toBeLessThan(
+			text.indexOf("third message"),
+		);
+		const data = result.data as {
+			messages: Array<{ createdAt: number | null }>;
+		};
+		expect(data.messages.map((m) => m.createdAt)).toEqual([
+			1_000, 2_000, 3_000,
+		]);
+	});
+
+	it("strips only machinery rows (action results, internal bridge relays)", async () => {
+		const { runtime } = makeRuntime({
+			[ROOM_A]: [
+				makeMessage(ROOM_A, 1_000, "human line"),
+				makeMessage(ROOM_A, 2_000, "tool record", {
+					content: { type: "action_result", text: "tool record" },
+				} as Partial<Memory>),
+				makeMessage(ROOM_A, 3_000, "bridge relay", {
+					content: { text: "bridge relay", source: "swarm_synthesis" },
+				} as Partial<Memory>),
+			],
+		});
+		const result = await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			undefined,
+		);
+		expect(result.text).toContain("human line");
+		expect(result.text).not.toContain("tool record");
+		expect(result.text).not.toContain("bridge relay");
+		expect(result.values?.messageCount).toBe(1);
+	});
+});
+
+describe("CHANNEL_RECAP count contract", () => {
+	const many = Array.from({ length: 10 }, (_, index) =>
+		makeMessage(ROOM_A, (index + 1) * 1_000, `msg-${index + 1}`),
+	);
+
+	it("defaults to the documented default count", async () => {
+		const { runtime, getMemories } = makeRuntime({ [ROOM_A]: many });
+		await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			undefined,
+		);
+		expect(getMemories).toHaveBeenCalledWith(
+			expect.objectContaining({ count: CHANNEL_RECAP_DEFAULT_COUNT }),
+		);
+	});
+
+	it("honors an explicit caller-requested count, including numeric strings", async () => {
+		const { runtime, getMemories } = makeRuntime({ [ROOM_A]: many });
+		await channelRecapAction.handler(runtime, incoming(ROOM_A), undefined, {
+			parameters: { count: 100 },
+		});
+		expect(getMemories).toHaveBeenLastCalledWith(
+			expect.objectContaining({ count: 100 }),
+		);
+		await channelRecapAction.handler(runtime, incoming(ROOM_A), undefined, {
+			parameters: { count: "25" },
+		});
+		expect(getMemories).toHaveBeenLastCalledWith(
+			expect.objectContaining({ count: 25 }),
+		);
+	});
+
+	it("reads the storage bound and states it explicitly instead of silently clamping", async () => {
+		const { runtime, getMemories } = makeRuntime({ [ROOM_A]: many });
+		const result = await channelRecapAction.handler(
+			runtime,
+			incoming(ROOM_A),
+			undefined,
+			{ parameters: { count: 100_000 } },
+		);
+		expect(getMemories).toHaveBeenLastCalledWith(
+			expect.objectContaining({ count: CHANNEL_RECAP_MAX_FETCH }),
+		);
+		expect(result.text).toContain(String(CHANNEL_RECAP_MAX_FETCH));
+		expect(result.text).toContain("storage read bound");
+		const scope = (
+			result.data as {
+				scope: { requestedCount: number; storageReadBound: number };
+			}
+		).scope;
+		expect(scope.requestedCount).toBe(100_000);
+		expect(scope.storageReadBound).toBe(CHANNEL_RECAP_MAX_FETCH);
+	});
+
+	it("falls back to the default for non-positive or malformed counts", async () => {
+		const { runtime, getMemories } = makeRuntime({ [ROOM_A]: many });
+		for (const bad of [0, -5, "not-a-number", null]) {
+			await channelRecapAction.handler(runtime, incoming(ROOM_A), undefined, {
+				parameters: { count: bad },
+			});
+			expect(getMemories).toHaveBeenLastCalledWith(
+				expect.objectContaining({ count: CHANNEL_RECAP_DEFAULT_COUNT }),
+			);
+		}
+	});
+});

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -82,6 +82,7 @@ import {
 	type JsonValue,
 } from "../../types/primitives.ts";
 import { ServiceType } from "../../types/service.ts";
+import { textContainsAgentName } from "../../utils/agent-name-match.ts";
 import {
 	toWellFormedUnicode,
 	truncateWellFormed,
@@ -234,33 +235,6 @@ async function readBoundedMediaResponse(
 		}
 	}
 	return await readResponseWithLimit(response, MAX_MEDIA_BYTES);
-}
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function textContainsAgentName(
-	text: string | undefined,
-	names: Array<string | null | undefined>,
-): boolean {
-	if (!text) {
-		return false;
-	}
-
-	const safeText = toWellFormedUnicode(text);
-	return names.some((name) => {
-		const candidate = name?.trim();
-		if (!candidate) {
-			return false;
-		}
-
-		const pattern = new RegExp(
-			`(^|[^\\p{L}\\p{N}])${escapeRegex(candidate)}(?=$|[^\\p{L}\\p{N}])`,
-			"iu",
-		);
-		return pattern.test(safeText);
-	});
 }
 
 function textContainsUserTag(text: string | undefined): boolean {

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -138,6 +138,7 @@ import { readAttachmentAction } from "../working-memory/readAttachmentAction.ts"
 // Direct leaf imports — see comment in
 // ../advanced-capabilities/index.ts for the Bun.build mis-rewrite that
 // requires bypassing barrels here too.
+import { channelRecapAction } from "./actions/channel-recap.ts";
 import { channelTopicSearchAction } from "./actions/channel-topic-search.ts";
 import { choiceAction } from "./actions/choice.ts";
 import { ignoreAction } from "./actions/ignore.ts";
@@ -1447,6 +1448,7 @@ export const basicActions = [
 	withCanonicalActionDocs(ignoreAction),
 	withCanonicalActionDocs(noneAction),
 	withCanonicalActionDocs(channelTopicSearchAction),
+	withCanonicalActionDocs(channelRecapAction),
 ];
 
 /**

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -1,9 +1,11 @@
 /**
  * Behavioral tests for the RECENT_MESSAGES provider's transcript hygiene:
  * dropping internal bridge / sub-agent / tool / path-dump / synthetic-failure /
- * transient rows, deduping, compaction-ledger inclusion, and the conversation-
- * window cap. Deterministic — drives `recentMessagesProvider.get` against a
- * hand-built in-memory runtime of `vi.fn` stubs; no live model or database.
+ * transient rows, deduping, stale compact-ledger exclusion, and the
+ * complete-retained-history contract (no conversation-window cap: recall/recap
+ * asks and neutral chatter see the same full transcript). Deterministic —
+ * drives `recentMessagesProvider.get` against a hand-built in-memory runtime
+ * of `vi.fn` stubs; no live model or database.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -546,6 +548,159 @@ describe("recentMessagesProvider", () => {
 		expect(result.text).toContain("User: whats 23 times 19?");
 		expect(result.text).toContain("User: bitcoin price?");
 	});
+
+	// Live regression (Discord group chat): "what were last like 100 messages in
+	// this chat summary>" rendered only 10 prior messages because the deployed
+	// build clamped the fetch to a 50-row RAW-row window that machinery rows then
+	// consumed before filtering. On this branch the complete-context contract
+	// replaces the window entirely: recap/summary/recall phrasings and ordinary
+	// chatter alike must see every retained dialogue row, regardless of
+	// CONVERSATION_LENGTH.
+	const RECALL_RECAP_PHRASINGS = [
+		"summarize the last 100 messages",
+		"give me a summary of the last 100 messages",
+		"what were the last 100 messages",
+		"what were last like 100 messages in this chat summary>",
+		"recap this chat",
+		"recap this channel",
+		"give me a recap of this conversation",
+		"what has been said here",
+		"what has been discussed here",
+		"catch me up",
+	];
+
+	it.each(RECALL_RECAP_PHRASINGS)(
+		"renders the complete retained history for recall/recap ask: %s",
+		async (phrasing) => {
+			const memories = Array.from({ length: 120 }, (_, index) =>
+				makeMemory(
+					`msg-${index + 1}`,
+					index % 2 === 0 ? USER_ID : AGENT_ID,
+					`history line ${String(index + 1).padStart(3, "0")}`,
+					"discord",
+					(index + 1) * 1000,
+				),
+			);
+			const runtime = makeRuntime(memories, { conversationLength: 10 });
+
+			const result = await recentMessagesProvider.get(
+				runtime,
+				makeMemory("current", USER_ID, phrasing, "discord", 200_000),
+				{ values: {}, data: {}, text: "" },
+			);
+
+			expect(result.data?.recentMessages).toHaveLength(120);
+			expect(result.text).toContain("# Conversation Messages (120 retained)");
+			expect(result.text).toContain("history line 001");
+			expect(result.text).toContain("history line 120");
+			expect(runtime.getMemories).toHaveBeenCalledWith(
+				expect.not.objectContaining({ limit: expect.any(Number) }),
+			);
+		},
+	);
+
+	it("renders the same complete history for a neutral message — no phrase-gated window may shrink or grow the transcript", async () => {
+		const memories = Array.from({ length: 120 }, (_, index) =>
+			makeMemory(
+				`msg-${index + 1}`,
+				index % 2 === 0 ? USER_ID : AGENT_ID,
+				`history line ${String(index + 1).padStart(3, "0")}`,
+				"discord",
+				(index + 1) * 1000,
+			),
+		);
+
+		const result = await recentMessagesProvider.get(
+			makeRuntime(memories, { conversationLength: 10 }),
+			makeMemory("current", USER_ID, "nice weather today", "discord", 200_000),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.data?.recentMessages).toHaveLength(120);
+		expect(result.text).toContain("history line 001");
+		expect(result.text).toContain("history line 120");
+	});
+
+	it("machinery rows never consume the dialogue window: a newest burst of action results, transient statuses, bridge rows, and tool transcripts leaves every dialogue row rendered", async () => {
+		// Live failure shape: the deployed build fetched the newest 50 raw rows,
+		// then filtered — machinery consumed the window and only 10 dialogue rows
+		// rendered while older qualifying dialogue existed. Here 40 machinery rows
+		// are newer than 60 dialogue rows; all 60 must still render.
+		const dialogue = Array.from({ length: 60 }, (_, index) =>
+			makeMemory(
+				`dlg-${index + 1}`,
+				index % 2 === 0 ? USER_ID : AGENT_ID,
+				`dialogue ${String(index + 1).padStart(3, "0")}`,
+				"discord",
+				(index + 1) * 1000,
+			),
+		);
+		const machinery = Array.from({ length: 40 }, (_, index) => {
+			const createdAt = 61_000 + index * 1000;
+			switch (index % 4) {
+				case 0: {
+					const actionRow = makeMemory(
+						`act-${index}`,
+						AGENT_ID,
+						`ran step ${index}`,
+						"discord",
+						createdAt,
+					);
+					(actionRow.content as { type?: string }).type = "action_result";
+					return actionRow;
+				}
+				case 1:
+					return makeMemory(
+						`status-${index}`,
+						AGENT_ID,
+						`[worker] step ${index} still going`,
+						"discord",
+						createdAt,
+						{ transient: true },
+					);
+				case 2:
+					return makeMemory(
+						`bridge-${index}`,
+						AGENT_ID,
+						`bridge chunk ${index}`,
+						"swarm_synthesis",
+						createdAt,
+					);
+				default:
+					return makeMemory(
+						`tool-${index}`,
+						AGENT_ID,
+						`[tool output: step ${index}]\nnoise`,
+						"discord",
+						createdAt,
+					);
+			}
+		});
+
+		const result = await recentMessagesProvider.get(
+			makeRuntime([...dialogue, ...machinery], { conversationLength: 10 }),
+			makeMemory(
+				"current",
+				USER_ID,
+				"what were the last 100 messages",
+				"discord",
+				200_000,
+			),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.data?.recentMessages).toHaveLength(60);
+		expect(result.data?.actionResults).toHaveLength(10);
+		expect(result.text).toContain("# Conversation Messages (60 retained)");
+		expect(result.text).toContain("dialogue 001");
+		expect(result.text).toContain("dialogue 060");
+		expect(result.text).not.toContain("[tool output:");
+		expect(result.text).not.toContain("bridge chunk");
+		expect(result.text).not.toContain("still going");
+		expect(result.text).not.toContain("ran step");
+	});
+
+	it("skips the cross-room interactions fetch on the first compose of a turn", async () => {
 
 	it("renders authorized cross-room interactions on the first compose of a turn", async () => {
 		expect(recentMessagesProvider.alwaysInResponseState).toBe(true);

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -700,8 +700,6 @@ describe("recentMessagesProvider", () => {
 		expect(result.text).not.toContain("ran step");
 	});
 
-	it("skips the cross-room interactions fetch on the first compose of a turn", async () => {
-
 	it("renders authorized cross-room interactions on the first compose of a turn", async () => {
 		expect(recentMessagesProvider.alwaysInResponseState).toBe(true);
 		const OTHER_ROOM_ID = "00000000-0000-0000-0000-00000000000a";

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -267,7 +267,14 @@ function buildFormattingFallbackEntity(memory: Memory): Entity | null {
 	} as Entity;
 }
 
-async function ensureFormattingEntities(
+/**
+ * Backfill formatting entities for message senders missing from the room's
+ * entity list: re-resolve each missing sender by id (they may have left the
+ * room but still have an entity row), then fall back to a synthetic entity
+ * built from the message's stamped `entityName` metadata. Exported so the
+ * CHANNEL_RECAP action names historical senders identically to this provider.
+ */
+export async function ensureFormattingEntities(
 	runtime: IAgentRuntime,
 	entities: Entity[],
 	messages: Memory[],

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -14,7 +14,13 @@
  * model never re-reads its own machinery or paraphrases it as fact on a later
  * turn. Every retained dialogue row is rendered; runtime conversation-length
  * settings and old compaction timestamps must never silently remove prompt
- * history. On any error the provider degrades to an
+ * history. History-recall and recap asks ("summarize the last 100 messages",
+ * "recap this chat", "catch me up") are answered from this same complete
+ * transcript — there is no phrase-gated recall window to expand, and none may
+ * be reintroduced by capping the default fetch: a raw-row fetch limit lets
+ * machinery rows (action results, transient statuses, bridge posts) consume
+ * the window before filtering and silently thins the dialogue the model sees.
+ * On any error the provider degrades to an
  * empty, safe result rather than throwing — a throw here would drop the entire
  * turn's history.
  *

--- a/packages/core/src/features/messaging/triage/actions/searchMessages.test.ts
+++ b/packages/core/src/features/messaging/triage/actions/searchMessages.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Deterministic gate tests for the cross-channel SEARCH_MESSAGES triage
+ * action: pins that the inbox-wide search stays unreachable from a group
+ * chat's general-routed turn (its contexts and ADMIN role gate are the
+ * cross-room privacy boundary — the room-scoped CHANNEL_RECAP action serves
+ * current-room recaps instead) while remaining reachable on messaging-routed
+ * turns. Pure, no model, no database.
+ */
+import { describe, expect, it } from "vitest";
+import { filterByContextGate } from "../../../../runtime/context-gates.ts";
+import type { Memory, UUID } from "../../../../types/index.ts";
+import { searchMessagesAction } from "./searchMessages.ts";
+
+const ROOM = "00000000-0000-4000-8000-00000000d00d" as UUID;
+
+function routedMessage(primaryContext: string): Memory {
+	return {
+		id: "00000000-0000-4000-8000-000000000001" as UUID,
+		entityId: "00000000-0000-4000-8000-000000000002" as UUID,
+		roomId: ROOM,
+		content: {
+			text: "what were the last 100 messages in this chat? summary",
+			metadata: { __responseContext: { primaryContext } },
+		},
+	} as Memory;
+}
+
+describe("SEARCH_MESSAGES cross-room gating", () => {
+	it("declares only messaging/email/documents contexts — never general", () => {
+		expect(searchMessagesAction.contexts).toEqual([
+			"messaging",
+			"email",
+			"documents",
+		]);
+		expect(searchMessagesAction.contexts).not.toContain("general");
+	});
+
+	it("keeps the ADMIN role gate on inbox-wide search", () => {
+		expect(searchMessagesAction.roleGate).toEqual({ minRole: "ADMIN" });
+	});
+
+	it("stays off the exposure surface of a general-routed group turn for any role", () => {
+		for (const roles of [
+			["GUEST"],
+			["MEMBER"],
+			["ADMIN"],
+			["OWNER"],
+		] as const) {
+			const surfaced = filterByContextGate(
+				[searchMessagesAction],
+				["general"],
+				roles,
+			);
+			expect(surfaced).toEqual([]);
+		}
+	});
+
+	it("validate rejects a general-routed turn and accepts a messaging-routed one", async () => {
+		await expect(
+			searchMessagesAction.validate(
+				undefined as never,
+				routedMessage("general"),
+				undefined,
+			),
+		).resolves.toBe(false);
+		await expect(
+			searchMessagesAction.validate(
+				undefined as never,
+				routedMessage("messaging"),
+				undefined,
+			),
+		).resolves.toBe(true);
+	});
+});

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -3,8 +3,11 @@
  * returns true only when a turn is directed at a resolvable OTHER room
  * participant — bot or human alike — resolving @-names to ids via room
  * entities, treating platform-alias self-addresses as self, failing safe on
- * unresolvable names, and never consulting sender bot-ness. Runtime and its
- * entity lookup are vi-mocked; no model or database.
+ * unresolvable names, and never consulting sender bot-ness. The gate
+ * OR-composes its two independent evidence sources — a text-corroborated
+ * Stage-1 tag, or a structural leading vocative — over a single room-entity
+ * fetch, so a hallucinated tag never blocks the vocative evidence. Runtime
+ * and its entity lookup are vi-mocked; no model or database.
  */
 import { describe, expect, it, vi } from "vitest";
 import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
@@ -253,6 +256,28 @@ describe("messageAddressedToOtherParticipant (#9874 — uniform addressing gate)
 		).toBe(false);
 	});
 
+	it("performs exactly ONE room-entity fetch for resolution, corroboration, and the vocative fallback", async () => {
+		const runtime = makeRuntime(roomWithOthers());
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime,
+				message: makeMessage(undefined, undefined, "Alice do the thing"),
+				addressedTo: ["Alice"],
+			}),
+		).toBe(true);
+		expect(vi.mocked(runtime.getEntitiesForRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	it("gates a leading vocative even with EMPTY tags (OR-composition: vocative evidence alone)", async () => {
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(undefined, undefined, "hey Alice, you around?"),
+				addressedTo: [],
+			}),
+		).toBe(true);
+	});
+
 	it("propagates a room-lookup failure so the caller's fail-open catch owns it (J4 contract)", async () => {
 		// The helper itself does NOT swallow resolution errors: the message
 		// service wraps the call in a fail-open catch (a DB hiccup means "don't
@@ -332,6 +357,19 @@ describe("live 2026-08-22 Discord incident regression (nubilio test server)", ()
 				runtime: nubilio(),
 				message: makeMessage(undefined, undefined, "Hey Eliza why not respond"),
 				addressedTo: ["Eliza"],
+			}),
+		).toBe(true);
+	});
+
+	it('gates "hey eliza" even under a hallucinated shaw tag (OR-composition)', async () => {
+		// A tag the text never corroborates must not BLOCK the independent
+		// vocative evidence: the text verifiably opens by addressing Eliza,
+		// so the mis-tag cannot fail the turn open.
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: nubilio(),
+				message: makeMessage(undefined, undefined, "hey eliza"),
+				addressedTo: ["shaw"],
 			}),
 		).toBe(true);
 	});
@@ -435,5 +473,53 @@ describe("messageVocativelyAddressesOtherParticipant (structural vocative)", () 
 				message: makeMessage(undefined, undefined, "whats going on"),
 			}),
 		).toBe(false);
+	});
+
+	describe("greeting boundary — a greeting only counts when it ends the word", () => {
+		// Without the boundary, the greeting alternation consumed a PREFIX of an
+		// ordinary word and matched a short participant name against the
+		// remainder: "gmsol" parsed as "gm"+"sol", "hiro" as "hi"+"ro" — each
+		// false positive converting normal chatter into deliberate silence.
+		const roomWithSol = (): IAgentRuntime =>
+			makeRuntime({
+				character: { name: "remilio nubilio" },
+				getEntitiesForRoom: vi.fn(async () => [
+					{ id: AGENT_ID, names: ["remilio nubilio"] },
+					{ id: OTHER_BOT, names: ["sol"] },
+					{ id: HUMAN_X, names: ["ro"] },
+					{ id: SENDER_ID, names: ["nubs"] },
+				]),
+			} as unknown as Partial<IAgentRuntime>);
+
+		it('does NOT gate "gmsol what a chart" against participant "sol"', async () => {
+			expect(
+				await messageVocativelyAddressesOtherParticipant({
+					runtime: roomWithSol(),
+					message: makeMessage(undefined, undefined, "gmsol what a chart"),
+				}),
+			).toBe(false);
+		});
+
+		it('does NOT gate "hiro can you look at this" against participant "ro"', async () => {
+			expect(
+				await messageVocativelyAddressesOtherParticipant({
+					runtime: roomWithSol(),
+					message: makeMessage(
+						undefined,
+						undefined,
+						"hiro can you look at this",
+					),
+				}),
+			).toBe(false);
+		});
+
+		it('still gates "gm sol what a chart" — greeting, then a real vocative', async () => {
+			expect(
+				await messageVocativelyAddressesOtherParticipant({
+					runtime: roomWithSol(),
+					message: makeMessage(undefined, undefined, "gm sol what a chart"),
+				}),
+			).toBe(true);
+		});
 	});
 });

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
 import {
+	classifyLeadingVocative,
 	messageAddressedToOtherParticipant,
 	messageVocativelyAddressesOtherParticipant,
 } from "../addressed-to.ts";
@@ -521,5 +522,82 @@ describe("messageVocativelyAddressesOtherParticipant (structural vocative)", () 
 				}),
 			).toBe(true);
 		});
+	});
+});
+
+describe("classifyLeadingVocative (identity notice classifier)", () => {
+	const room = (): Partial<IAgentRuntime> =>
+		({
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, names: ["remilio nubilio"] },
+				{ id: HUMAN_X, names: ["shaw"] },
+				{ id: SENDER_ID, names: ["nubs"] },
+			]),
+		}) as unknown as Partial<IAgentRuntime>;
+	const rt = (): IAgentRuntime =>
+		makeRuntime({
+			character: { name: "remilio nubilio" },
+			...room(),
+		} as Partial<IAgentRuntime>);
+	const msg = (text: string) => makeMessage(undefined, undefined, text);
+
+	it('classifies "hey eliza" as unresolved in a room with no Eliza', async () => {
+		expect(
+			await classifyLeadingVocative({
+				runtime: rt(),
+				message: msg("hey eliza"),
+			}),
+		).toEqual({ kind: "unresolved", name: "eliza" });
+	});
+
+	it('classifies a bare "eliza" as unresolved', async () => {
+		expect(
+			await classifyLeadingVocative({ runtime: rt(), message: msg("eliza") }),
+		).toEqual({ kind: "unresolved", name: "eliza" });
+	});
+
+	it("classifies the agent's own name token as self", async () => {
+		expect(
+			await classifyLeadingVocative({
+				runtime: rt(),
+				message: msg("nubilio, you there?"),
+			}),
+		).toEqual({ kind: "self", name: "nubilio" });
+	});
+
+	it("classifies a real participant as participant", async () => {
+		expect(
+			await classifyLeadingVocative({
+				runtime: rt(),
+				message: msg("hey shaw what do you think"),
+			}),
+		).toEqual({ kind: "participant", name: "shaw" });
+	});
+
+	it("never classifies interjections or ordinary sentences", async () => {
+		for (const text of [
+			"ok cool",
+			"hey bro",
+			"whats my favorite color",
+			"thanks!",
+			"lol",
+			"yes please",
+		]) {
+			expect(
+				(await classifyLeadingVocative({ runtime: rt(), message: msg(text) }))
+					.kind,
+			).toBe("none");
+		}
+	});
+
+	it("mid-text names never classify (vocative position only)", async () => {
+		expect(
+			(
+				await classifyLeadingVocative({
+					runtime: rt(),
+					message: msg("i was talking to eliza"),
+				})
+			).kind,
+		).toBe("none");
 	});
 });

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -550,19 +550,53 @@ describe("classifyLeadingVocative (identity notice classifier)", () => {
 		).toEqual({ kind: "unresolved", name: "eliza" });
 	});
 
-	it('classifies a bare "eliza" as unresolved', async () => {
-		expect(
-			await classifyLeadingVocative({ runtime: rt(), message: msg("eliza") }),
-		).toEqual({ kind: "unresolved", name: "eliza" });
+	it("bare and comma-only openings never classify — greeting+NAME is the only shape", async () => {
+		// Review evidence: without participant resolution, bare/comma shapes
+		// classify ordinary words ("sorry, one sec"). Single-word and "X,"
+		// openings go to model judgment.
+		for (const text of ["eliza", "eliza, can you help", "sorry, one sec"]) {
+			expect(
+				(await classifyLeadingVocative({ runtime: rt(), message: msg(text) }))
+					.kind,
+			).toBe("none");
+		}
 	});
 
-	it("classifies the agent's own name token as self", async () => {
+	it("classifies the agent's own name token as self (greeting shape)", async () => {
 		expect(
 			await classifyLeadingVocative({
 				runtime: rt(),
-				message: msg("nubilio, you there?"),
+				message: msg("hey nubilio, you there?"),
 			}),
 		).toEqual({ kind: "self", name: "nubilio" });
+	});
+
+	it("reviewer false-positive corpus never classifies", async () => {
+		for (const text of [
+			"so, what now",
+			"hmm.",
+			"sorry,",
+			"well, maybe",
+			"actually, wait",
+			"really?",
+			"update?",
+			"nice.",
+			"interesting.",
+		]) {
+			expect(
+				(await classifyLeadingVocative({ runtime: rt(), message: msg(text) }))
+					.kind,
+			).toBe("none");
+		}
+	});
+
+	it("strips trailing punctuation from the captured token", async () => {
+		expect(
+			await classifyLeadingVocative({
+				runtime: rt(),
+				message: msg("hey eliza..."),
+			}),
+		).toEqual({ kind: "unresolved", name: "eliza" });
 	});
 
 	it("classifies a real participant as participant", async () => {

--- a/packages/core/src/runtime/__tests__/default-contexts.test.ts
+++ b/packages/core/src/runtime/__tests__/default-contexts.test.ts
@@ -1,12 +1,18 @@
 /**
  * Validates `DEFAULT_CONTEXT_DEFINITIONS`: unique ids and required fields, clean
- * idempotent registration into a `ContextRegistry`, and role-scoped
- * `listAvailable` filtering (OWNER-only vs USER vs GUEST contexts). Pure, no
- * model.
+ * idempotent registration into a `ContextRegistry`, role-scoped
+ * `listAvailable` filtering (OWNER-only vs USER vs GUEST contexts), and the
+ * channel-history routing vocabulary the Stage-1 catalog must keep on the
+ * `general` line so group-chat recap asks can route to the room-scoped
+ * CHANNEL_RECAP surface. Pure, no model.
  */
 import { describe, expect, it } from "vitest";
+import { formatAvailableContextsForPrompt } from "../../services/message";
 import { ContextRegistry } from "../context-registry";
-import { DEFAULT_CONTEXT_DEFINITIONS } from "../default-contexts";
+import {
+	DEFAULT_CONTEXT_DEFINITIONS,
+	getDefaultContextDefinitions,
+} from "../default-contexts";
 
 describe("default-contexts", () => {
 	it("has unique ids", () => {
@@ -102,5 +108,42 @@ describe("default-contexts", () => {
 		// USER-gated contexts are excluded from GUEST.
 		expect(guestContexts).not.toContain("memory");
 		expect(guestContexts).not.toContain("documents");
+	});
+});
+
+describe("general context channel-history routing vocabulary", () => {
+	// Live 2026-08-21 root cause: a Discord group sender asked "what were last
+	// like 100 messages in this chat summary>" and Stage 1 routed
+	// contexts=["general"], but the general catalog line carried no
+	// channel-history vocabulary and the surface had no message-history tool,
+	// so the planner honestly refused. The catalog renders the complete
+	// description, which must keep carrying this vocabulary (same contract as
+	// the #17059 tasks recap line).
+	it("keeps recap/summary phrasings for the current chat in the general line", () => {
+		const catalog = formatAvailableContextsForPrompt(
+			getDefaultContextDefinitions(),
+		);
+		const generalLine = catalog
+			.split("\n")
+			.find((line) => line.startsWith("- general"));
+		expect(generalLine).toBeDefined();
+		expect(generalLine).toMatch(/summarize this chat/i);
+		expect(generalLine).toMatch(/recap the channel/i);
+		expect(generalLine).toMatch(/what were the last 100 messages/i);
+		expect(generalLine).toMatch(/what did people say here earlier/i);
+	});
+
+	it("names the room-scoped surface and keeps cross-channel work in messaging", () => {
+		const definition = DEFAULT_CONTEXT_DEFINITIONS.find(
+			(entry) => entry.id === "general",
+		);
+		expect(definition).toBeDefined();
+		expect(definition?.description).toMatch(/CHANNEL_RECAP/);
+		expect(definition?.description).toMatch(
+			/cross-channel or inbox-wide message work stays in messaging/i,
+		);
+		expect(definition?.descriptionCompressed).toMatch(
+			/current-channel history/i,
+		);
 	});
 });

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -295,20 +295,6 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	FIX_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
 	REMINDER_UPDATE: ["OWNER_REMINDERS", "TRIGGER"],
 	RESCHEDULE_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
-	// Channel-recap-shaped candidates: Stage 1 invents these for "recap of
-	// everything today" / "summarize the chat" asks (live 2026-08-23: candidate
-	// TASKS_RECAP_DAY resolved to nothing, the planner fell back to a
-	// PAGE_DELEGATE guess on the owner page, and the turn degraded to an
-	// apology). Hinting CHANNEL_RECAP keeps the real room-transcript reader on
-	// the surface whichever context Stage 1 routed; the TASKS umbrella stays
-	// hinted for tracked-work day recaps.
-	TASKS_RECAP_DAY: ["CHANNEL_RECAP", "TASKS"],
-	GENERAL_SUMMARY: ["CHANNEL_RECAP"],
-	CHAT_SUMMARY: ["CHANNEL_RECAP"],
-	CHANNEL_SUMMARY: ["CHANNEL_RECAP"],
-	DAILY_RECAP: ["CHANNEL_RECAP", "TASKS"],
-	RECAP: ["CHANNEL_RECAP", "TASKS"],
-	SUMMARIZE: ["CHANNEL_RECAP"],
 	FINANCE: ["OWNER_FINANCES"],
 	SPENDING: ["OWNER_FINANCES"],
 	SPENDING_SUMMARY: ["OWNER_FINANCES"],

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -295,6 +295,20 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	FIX_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
 	REMINDER_UPDATE: ["OWNER_REMINDERS", "TRIGGER"],
 	RESCHEDULE_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	// Channel-recap-shaped candidates: Stage 1 invents these for "recap of
+	// everything today" / "summarize the chat" asks (live 2026-08-23: candidate
+	// TASKS_RECAP_DAY resolved to nothing, the planner fell back to a
+	// PAGE_DELEGATE guess on the owner page, and the turn degraded to an
+	// apology). Hinting CHANNEL_RECAP keeps the real room-transcript reader on
+	// the surface whichever context Stage 1 routed; the TASKS umbrella stays
+	// hinted for tracked-work day recaps.
+	TASKS_RECAP_DAY: ["CHANNEL_RECAP", "TASKS"],
+	GENERAL_SUMMARY: ["CHANNEL_RECAP"],
+	CHAT_SUMMARY: ["CHANNEL_RECAP"],
+	CHANNEL_SUMMARY: ["CHANNEL_RECAP"],
+	DAILY_RECAP: ["CHANNEL_RECAP", "TASKS"],
+	RECAP: ["CHANNEL_RECAP", "TASKS"],
+	SUMMARIZE: ["CHANNEL_RECAP"],
 	FINANCE: ["OWNER_FINANCES"],
 	SPENDING: ["OWNER_FINANCES"],
 	SPENDING_SUMMARY: ["OWNER_FINANCES"],
@@ -1171,7 +1185,18 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 
 function explicitParentAliasesForCandidateAction(actionName: string): string[] {
 	const normalized = normalizeActionName(actionName);
-	return [...(CANDIDATE_ACTION_PARENT_ALIASES[normalized] ?? [])];
+	const explicit = CANDIDATE_ACTION_PARENT_ALIASES[normalized];
+	if (explicit) return [...explicit];
+	// Recap/summary-shaped inventions are open-ended — Stage 1 produces a fresh
+	// spelling per turn (live 2026-08-23: TASKS_RECAP_DAY, then RECAP_DAY, then
+	// GET_TASKS_SUMMARY for the same ask), so exact-name aliases cannot keep
+	// up. Any candidate whose name carries the recap/summary stem hints the
+	// room-transcript reader plus the TASKS umbrella (tracked-work day recaps);
+	// admission still passes through appendIfAllowed's role/context gates.
+	if (/RECAP|SUMMAR/.test(normalized)) {
+		return ["CHANNEL_RECAP", "TASKS"];
+	}
+	return [];
 }
 
 const APP_SURFACE_TOKENS = new Set([

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -8,6 +8,11 @@
 import type { Entity, UUID } from "../types/index";
 import type { Memory } from "../types/memory";
 import type { IAgentRuntime } from "../types/runtime";
+import {
+	distinctiveNameTokens,
+	escapeRegex,
+	normalizeName,
+} from "../utils/agent-name-match";
 
 /**
  * Post-parse persistence for the messageHandler's `extract.addressedTo`
@@ -123,104 +128,165 @@ interface ResolveTargetsArgs {
 }
 
 /**
+ * Normalized set of the agent's own names: character name, username, and
+ * each distinctive (>= 4 char) token of a multi-word name, so
+ * "remilio nubilio" also answers to "nubilio" (live 2026-08-22).
+ */
+function agentSelfNames(runtime: IAgentRuntime): Set<string> {
+	const self = new Set<string>();
+	for (const name of [runtime.character?.name, runtime.character?.username]) {
+		if (!name) continue;
+		for (const token of distinctiveNameTokens(name)) {
+			self.add(normalizeName(token));
+		}
+	}
+	return self;
+}
+
+/**
  * True only when a turn is verifiably directed at a resolvable OTHER room
- * participant. Three invariants bound the answer, because a positive here
- * converts the turn into deliberate silence:
+ * participant. Two independent evidence sources are OR-composed — a
+ * text-corroborated Stage-1 tag, or a structural leading vocative — so a
+ * hallucinated tag never blocks the vocative evidence and an empty tag list
+ * never blocks the tag path. Three invariants bound the answer, because a
+ * positive here converts the turn into deliberate silence:
  *
- *  - addressed to US (by name, id, or platform alias) never gates;
+ *  - addressed to US (by name, name token, id, or platform alias) never
+ *    gates, and short-circuits both evidence sources — the turn is ours;
  *  - a tag that resolves to the message's own AUTHOR never gates (a message
  *    cannot be addressed to its own speaker — that is a Stage-1 extraction
  *    error);
  *  - corroboration: the gate may only silence on evidence it can verify
  *    itself — the message text must actually address the tagged participant
- *    by one of their names. An uncorroborated model tag never gates.
+ *    by one of their names ("Hey Eliza …" corroborates a tag of Eliza). An
+ *    uncorroborated model tag never gates on its own; it falls through to
+ *    the vocative check.
  *
- * Fails SAFE (returns false) whenever it cannot positively confirm all of the
- * above: empty `addressedTo`, unresolvable bare names, DMs and undirected
- * asks all return false and the agent keeps acting on requests meant for it.
+ * Fails SAFE (returns false) whenever it cannot positively confirm the
+ * above: unresolvable bare names, DMs and undirected asks all return false
+ * and the agent keeps acting on requests meant for it. The room's entity
+ * list is fetched ONCE and shared by tag resolution, corroboration, and the
+ * vocative fallback.
  */
 export async function messageAddressedToOtherParticipant(
 	args: ApplyAddressedToArgs,
 ): Promise<boolean> {
 	const { runtime, message, addressedTo } = args;
-	if (!addressedTo || addressedTo.length === 0) {
-		return false;
-	}
-
-	const normalize = (value: string) =>
-		value.trim().toLowerCase().replace(/^@/, "");
-	const self = new Set<string>();
-	const selfId = runtime.agentId;
-	if (selfId) self.add(selfId.toLowerCase());
-	const selfName = runtime.character?.name;
-	if (selfName) self.add(normalize(selfName));
-	const selfUsername = runtime.character?.username;
-	if (selfUsername) self.add(normalize(selfUsername));
-
-	const cleaned = addressedTo
-		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-		.filter((entry) => entry.length > 0);
-	if (cleaned.length === 0) {
-		return false;
-	}
-
-	// Addressed to us by literal name/id → handle normally, never suppress.
-	if (cleaned.some((entry) => self.has(normalize(entry)))) {
-		return false;
-	}
-
-	// Resolve names→ids against the room. This also maps the agent's OWN entity
-	// aliases (platform handles like @samantha_ai_bot that connectors store on
-	// the agent's entity) to selfId, so a turn addressed to us by an alias is NOT
-	// mistaken for an other-participant address.
-	const targets = await resolveAddressedTargets({
-		runtime,
-		message,
-		addressedTo,
-	});
-	if (selfId && targets.some((id) => id === selfId)) {
-		return false;
-	}
-
-	// A message cannot be addressed to its own author: a tag that resolves to
-	// the SPEAKER is a Stage-1 extraction error, never an other-participant
-	// address (live 2026-08-22: "hello?" / "did u see what i said?" were tagged
-	// with the asker's own name and silently suppressed).
-	const speakerId = message.entityId;
-	const others = speakerId ? targets.filter((id) => id !== speakerId) : targets;
-	if (others.length === 0) {
-		return false;
-	}
-
-	// Corroboration invariant: a deterministic gate may only SILENCE a turn on
-	// evidence it can verify itself. The Stage-1 tag picks WHO, but suppression
-	// additionally requires the message text to actually address that
-	// participant by one of their names ("Hey Eliza …" corroborates a tag of
-	// Eliza). An uncorroborated tag — the model hallucinating an addressee the
-	// text never names (live 2026-08-22: "nubilio whats the setting …" tagged
-	// as addressed to shaw) — must never convert a turn into silence.
-	const participants = await runtime.getEntitiesForRoom(message.roomId);
 	const text =
 		typeof message.content?.text === "string" ? message.content.text : "";
-	const othersSet = new Set(others);
-	const corroborated = participants.some((participant) => {
-		if (!participant.id || !othersSet.has(participant.id)) return false;
-		return (participant.names ?? []).some((name) => {
-			const candidate = normalize(name ?? "");
-			if (candidate.length < 2) return false;
-			return new RegExp(
-				`(^|[^\\p{L}\\p{N}])@?${candidate.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}(?=$|[^\\p{L}\\p{N}])`,
-				"iu",
-			).test(text);
+	const cleaned = (addressedTo ?? [])
+		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+		.filter((entry) => entry.length > 0);
+	if (cleaned.length === 0 && !text.trim()) {
+		return false;
+	}
+
+	const self = agentSelfNames(runtime);
+	const selfId = runtime.agentId;
+
+	// Addressed to us by literal name/name-token/id → handle normally, never
+	// suppress (and never consult the vocative fallback: the turn is ours).
+	if (
+		cleaned.some((entry) => {
+			const normalized = normalizeName(entry);
+			return (
+				self.has(normalized) ||
+				(selfId ? normalized === selfId.toLowerCase() : false)
+			);
+		})
+	) {
+		return false;
+	}
+
+	// ONE room fetch serves tag resolution, corroboration, and the vocative
+	// fallback below.
+	const participants = await runtime.getEntitiesForRoom(message.roomId);
+
+	if (cleaned.length > 0) {
+		// Resolve names→ids against the room. This also maps the agent's OWN
+		// entity aliases (platform handles like @samantha_ai_bot that connectors
+		// store on the agent's entity) to selfId, so a turn addressed to us by an
+		// alias is NOT mistaken for an other-participant address.
+		const targets = resolveAddressedTargetsFromParticipants({
+			runtime,
+			addressedTo: cleaned,
+			participants,
 		});
+		if (selfId && targets.some((id) => id === selfId)) {
+			return false;
+		}
+
+		// A message cannot be addressed to its own author: a tag that resolves to
+		// the SPEAKER is a Stage-1 extraction error, never an other-participant
+		// address (live 2026-08-22: "hello?" / "did u see what i said?" were
+		// tagged with the asker's own name and silently suppressed).
+		const speakerId = message.entityId;
+		const others = speakerId
+			? targets.filter((id) => id !== speakerId)
+			: targets;
+
+		// Corroboration invariant: a deterministic gate may only SILENCE a turn
+		// on evidence it can verify itself. The Stage-1 tag picks WHO, but
+		// suppression additionally requires the message text to actually address
+		// that participant by one of their names ("Hey Eliza …" corroborates a
+		// tag of Eliza). An uncorroborated tag — the model hallucinating an
+		// addressee the text never names (live 2026-08-22: "nubilio whats the
+		// setting …" tagged as addressed to shaw) — must never convert a turn
+		// into silence.
+		const othersSet = new Set(others);
+		const corroborated = participants.some((participant) => {
+			if (!participant.id || !othersSet.has(participant.id)) return false;
+			return entityNames(participant).some((name) => {
+				const candidate = normalizeName(name);
+				if (candidate.length < 2) return false;
+				return new RegExp(
+					`(^|[^\\p{L}\\p{N}])@?${escapeRegex(candidate)}(?=$|[^\\p{L}\\p{N}])`,
+					"iu",
+				).test(text);
+			});
+		});
+		if (corroborated) {
+			return true;
+		}
+	}
+
+	// OR-composition: the tag path found nothing it could verify (empty,
+	// unresolvable, author-only, or uncorroborated tags), but the text itself
+	// may still open by addressing another participant — a hallucinated tag
+	// must not block that independent evidence.
+	return vocativelyAddressesOtherParticipant({
+		runtime,
+		message,
+		participants,
+		self,
 	});
-	return corroborated;
 }
 
 export async function resolveAddressedTargets(
 	args: ResolveTargetsArgs,
 ): Promise<UUID[]> {
 	const { runtime, message, addressedTo } = args;
+	// Bare names need the room's entity list; pure-UUID tags resolve without it.
+	const needsRoomEntities = addressedTo.some((entry) => {
+		const cleaned = typeof entry === "string" ? entry.trim() : "";
+		return cleaned.length > 0 && !UUID_PATTERN.test(cleaned);
+	});
+	const participants = needsRoomEntities
+		? await runtime.getEntitiesForRoom(message.roomId)
+		: [];
+	return resolveAddressedTargetsFromParticipants({
+		runtime,
+		addressedTo,
+		participants,
+	});
+}
+
+function resolveAddressedTargetsFromParticipants(args: {
+	runtime: IAgentRuntime;
+	addressedTo: readonly string[];
+	participants: readonly Entity[];
+}): UUID[] {
+	const { runtime, addressedTo, participants } = args;
 	const cleaned = Array.from(
 		new Set(
 			addressedTo
@@ -244,23 +310,20 @@ export async function resolveAddressedTargets(
 	}
 
 	if (names.length > 0) {
-		const participants = await runtime.getEntitiesForRoom(message.roomId);
-		const normalize = (value: string) => value.trim().toLowerCase();
 		const byName = new Map<string, UUID>();
 		const agentName = runtime.character.name;
 		if (agentName) {
-			byName.set(normalize(agentName), runtime.agentId);
+			byName.set(normalizeName(agentName), runtime.agentId);
 		}
 		for (const entity of participants) {
 			const id = entity.id as UUID | undefined;
 			if (!id) continue;
 			for (const name of entityNames(entity)) {
-				byName.set(normalize(name), id);
+				byName.set(normalizeName(name), id);
 			}
 		}
 		for (const name of names) {
-			const stripped = name.replace(/^@/, "");
-			const hit = byName.get(normalize(stripped));
+			const hit = byName.get(normalizeName(name));
 			if (hit) {
 				uuids.add(hit);
 			}
@@ -291,6 +354,24 @@ function dedupeTags(tags: readonly string[]): string[] {
 }
 
 /**
+ * Optional greeting word before a leading vocative. The boundary lookahead
+ * is required so a greeting only counts when it ends the word — without it
+ * the alternation could consume a prefix of an ordinary word and match a
+ * short participant name against the remainder ("gmsol" parsing as
+ * "gm"+"sol", "hiro" as "hi"+"ro"), converting normal chatter into silence.
+ */
+const VOCATIVE_GREETING_PREFIX =
+	"(?:(?:hey|hi|yo|sup|hello|gm|gn|ok|okay)(?=$|[^\\p{L}\\p{N}]))?";
+
+/** Anchored leading-vocative matcher for one normalized participant name. */
+function leadingVocative(name: string): RegExp {
+	return new RegExp(
+		`^\\s*${VOCATIVE_GREETING_PREFIX}\\s*[,–—-]?\\s*@?${escapeRegex(name)}(?=$|[^\\p{L}\\p{N}])`,
+		"iu",
+	);
+}
+
+/**
  * Structural vocative detection: true when the message TEXT opens by
  * addressing another room participant by name — "hey eliza", "eliza, can you
  * …", "gm sol" — and that participant is not us. This needs no Stage-1 tag:
@@ -311,45 +392,47 @@ export async function messageVocativelyAddressesOtherParticipant(args: {
 		typeof message.content?.text === "string" ? message.content.text : "";
 	if (!text.trim()) return false;
 
-	const normalize = (value: string) =>
-		value.trim().toLowerCase().replace(/^@/, "");
-	const self = new Set<string>();
-	if (runtime.agentId) self.add(runtime.agentId.toLowerCase());
-	for (const name of [runtime.character?.name, runtime.character?.username]) {
-		const candidate = name?.trim();
-		if (!candidate) continue;
-		self.add(normalize(candidate));
-		for (const token of candidate.split(/\s+/u)) {
-			if (token.length >= 4) self.add(normalize(token));
-		}
+	const participants = await runtime.getEntitiesForRoom(message.roomId);
+	return vocativelyAddressesOtherParticipant({
+		runtime,
+		message,
+		participants,
+		self: agentSelfNames(runtime),
+	});
+}
+
+/**
+ * Core of the structural vocative check, operating on a pre-fetched room
+ * entity list so the combined addressing gate pays a single room lookup.
+ * `self` holds the agent's normalized names (see agentSelfNames).
+ */
+function vocativelyAddressesOtherParticipant(args: {
+	runtime: IAgentRuntime;
+	message: Memory;
+	participants: readonly Entity[];
+	self: ReadonlySet<string>;
+}): boolean {
+	const { runtime, message, participants, self } = args;
+	const text =
+		typeof message.content?.text === "string" ? message.content.text : "";
+	if (!text.trim()) return false;
+
+	const lead = text.slice(0, 80);
+	// A leading vocative of OUR name keeps the turn ours ("nubilio, ask
+	// eliza …" opens with us, not them). Loop-invariant: computed once.
+	for (const own of self) {
+		if (leadingVocative(own).test(lead)) return false;
 	}
 
-	const participants = await runtime.getEntitiesForRoom(message.roomId);
 	const speakerId = message.entityId;
 	for (const participant of participants) {
 		if (!participant.id) continue;
 		if (participant.id === runtime.agentId) continue;
 		if (speakerId && participant.id === speakerId) continue;
-		for (const rawName of participant.names ?? []) {
-			const name = normalize(rawName ?? "");
+		for (const rawName of entityNames(participant)) {
+			const name = normalizeName(rawName);
 			if (name.length < 2 || self.has(name)) continue;
-			const escaped = name.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-			const vocative = new RegExp(
-				`^\\s*(?:hey|hi|yo|sup|hello|gm|gn|ok|okay)?\\s*[,–—-]?\\s*@?${escaped}(?=$|[^\\p{L}\\p{N}])`,
-				"iu",
-			);
-			if (vocative.test(text)) {
-				// A leading vocative of OUR name keeps
-				// the turn ours ("nubilio, ask eliza …" opens with us, not them).
-				const oursFirst = [...self].some((own) => {
-					const ownEscaped = own.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-					return new RegExp(
-						`^\\s*(?:hey|hi|yo|sup|hello|gm|gn|ok|okay)?\\s*[,–—-]?\\s*@?${ownEscaped}(?=$|[^\\p{L}\\p{N}])`,
-						"iu",
-					).test(text);
-				});
-				if (!oursFirst) return true;
-			}
+			if (leadingVocative(name).test(lead)) return true;
 		}
 	}
 	return false;

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -437,3 +437,104 @@ function vocativelyAddressesOtherParticipant(args: {
 	}
 	return false;
 }
+
+/**
+ * Interjections and generic address words that occupy the vocative position
+ * in ordinary chat ("ok cool", "hey bro") without naming anyone. A token on
+ * this list never classifies as an unresolved vocative.
+ */
+const VOCATIVE_STOP_TOKENS = new Set([
+	"ok",
+	"okay",
+	"cool",
+	"thanks",
+	"thx",
+	"ty",
+	"lol",
+	"lmao",
+	"yes",
+	"no",
+	"yeah",
+	"yep",
+	"nah",
+	"sure",
+	"hey",
+	"hi",
+	"yo",
+	"sup",
+	"hello",
+	"gm",
+	"gn",
+	"wtf",
+	"omg",
+	"bro",
+	"dude",
+	"man",
+	"guys",
+	"everyone",
+	"all",
+	"team",
+	"chat",
+	"u",
+	"you",
+	"pls",
+	"please",
+	"wait",
+	"stop",
+	"what",
+	"whats",
+	"why",
+	"how",
+	"who",
+	"when",
+]);
+
+/** Vocative-position token: "hey NAME …", "NAME, …", or a bare "NAME". */
+const VOCATIVE_TOKEN_RE =
+	/^\s*(?:(?:hey|hi|yo|sup|hello|gm|gn)(?=$|[^\p{L}\p{N}])\s*[,–—-]?\s*@?([\p{L}\p{N}_.-]{2,32})(?=$|[^\p{L}\p{N}])|@?([\p{L}\p{N}_.-]{2,32})\s*(?:[,!?.:;]|$))/iu;
+
+export type LeadingVocativeClass =
+	| { kind: "none" }
+	| { kind: "self"; name: string }
+	| { kind: "participant"; name: string }
+	| { kind: "unresolved"; name: string };
+
+/**
+ * Classifies who a message's opening vocative addresses. Deliberately
+ * narrower than the suppression matcher above: only "greeting NAME …",
+ * "NAME, …" and a bare "NAME" shapes count, and interjection tokens never
+ * classify — so an ordinary sentence's first word is not read as a name.
+ * "unresolved" (a name that is neither the agent nor any room participant)
+ * feeds the Stage-1 identity notice: live 2026-08-23, "hey eliza" and then a
+ * bare "eliza" in a room with no Eliza drew "hey. what's on your mind?" and
+ * "yeah?" — the agent answering AS a name that is not its own.
+ */
+export async function classifyLeadingVocative(args: {
+	runtime: IAgentRuntime;
+	message: Memory;
+}): Promise<LeadingVocativeClass> {
+	const { runtime, message } = args;
+	const text =
+		typeof message.content?.text === "string" ? message.content.text : "";
+	const match = VOCATIVE_TOKEN_RE.exec(text.slice(0, 80));
+	const raw = match?.[1] ?? match?.[2];
+	if (!raw) return { kind: "none" };
+	const name = normalizeName(raw);
+	if (name.length < 2 || VOCATIVE_STOP_TOKENS.has(name))
+		return { kind: "none" };
+
+	if (agentSelfNames(runtime).has(name)) return { kind: "self", name };
+
+	const speakerId = message.entityId;
+	const participants = await runtime.getEntitiesForRoom(message.roomId);
+	for (const participant of participants) {
+		if (!participant.id || participant.id === runtime.agentId) continue;
+		if (speakerId && participant.id === speakerId) continue;
+		for (const rawName of entityNames(participant)) {
+			if (normalizeName(rawName) === name) {
+				return { kind: "participant", name };
+			}
+		}
+	}
+	return { kind: "unresolved", name };
+}

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -417,7 +417,7 @@ function vocativelyAddressesOtherParticipant(args: {
 		typeof message.content?.text === "string" ? message.content.text : "";
 	if (!text.trim()) return false;
 
-	const lead = text.slice(0, 80);
+	const lead = text;
 	// A leading vocative of OUR name keeps the turn ours ("nubilio, ask
 	// eliza …" opens with us, not them). Loop-invariant: computed once.
 	for (const own of self) {
@@ -516,7 +516,7 @@ export async function classifyLeadingVocative(args: {
 	const { runtime, message } = args;
 	const text =
 		typeof message.content?.text === "string" ? message.content.text : "";
-	const match = VOCATIVE_TOKEN_RE.exec(text.slice(0, 80));
+	const match = VOCATIVE_TOKEN_RE.exec(text);
 	const raw = match?.[1] ?? match?.[2];
 	if (!raw) return { kind: "none" };
 	const name = normalizeName(raw);

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -439,25 +439,24 @@ function vocativelyAddressesOtherParticipant(args: {
 }
 
 /**
- * Interjections and generic address words that occupy the vocative position
- * in ordinary chat ("ok cool", "hey bro") without naming anyone. A token on
- * this list never classifies as an unresolved vocative.
+ * Vocative-position token for the UNRESOLVED-name classifier: greeting+NAME
+ * only ("hey eliza", "gm sol"). This classifier has no participant
+ * resolution to discriminate names from ordinary words, so it keeps only the
+ * one shape with structural precision — review evidence on the first cut
+ * showed a bare-word alternative plus an enumerable stoplist classifying
+ * ordinary openings ("so,", "hmm.", "sorry,", "really?", "interesting.") as
+ * names, and a bare "NAME," shape has the same failure ("sorry, one sec").
+ * Comma and bare shapes remain valid only in the suppression matcher above,
+ * where resolution against real room participants is the discriminator.
  */
-const VOCATIVE_STOP_TOKENS = new Set([
-	"ok",
-	"okay",
-	"cool",
-	"thanks",
-	"thx",
-	"ty",
-	"lol",
-	"lmao",
-	"yes",
-	"no",
-	"yeah",
-	"yep",
-	"nah",
-	"sure",
+const VOCATIVE_TOKEN_RE =
+	/^\s*(?:hey|hi|yo|sup|hello|gm|gn)(?=$|[^\p{L}\p{N}])\s*[,–—-]?\s*@?([\p{L}\p{N}_.-]{2,32})(?=$|[^\p{L}\p{N}])/iu;
+
+/** Greeting words themselves never classify as the addressed name, and
+ * neither do generic second-person addressees ("hey bro", "gm everyone") — a
+ * small CLOSED grammatical class, unlike open-vocabulary stopword lists,
+ * which the review rejected as the sole guard for bare words. */
+const VOCATIVE_NON_NAME_WORDS = new Set([
 	"hey",
 	"hi",
 	"yo",
@@ -465,33 +464,22 @@ const VOCATIVE_STOP_TOKENS = new Set([
 	"hello",
 	"gm",
 	"gn",
-	"wtf",
-	"omg",
 	"bro",
 	"dude",
 	"man",
 	"guys",
 	"everyone",
+	"everybody",
 	"all",
 	"team",
 	"chat",
-	"u",
-	"you",
-	"pls",
-	"please",
-	"wait",
-	"stop",
-	"what",
-	"whats",
-	"why",
-	"how",
-	"who",
-	"when",
+	"folks",
+	"friend",
+	"buddy",
+	"mate",
+	"fam",
+	"yall",
 ]);
-
-/** Vocative-position token: "hey NAME …", "NAME, …", or a bare "NAME". */
-const VOCATIVE_TOKEN_RE =
-	/^\s*(?:(?:hey|hi|yo|sup|hello|gm|gn)(?=$|[^\p{L}\p{N}])\s*[,–—-]?\s*@?([\p{L}\p{N}_.-]{2,32})(?=$|[^\p{L}\p{N}])|@?([\p{L}\p{N}_.-]{2,32})\s*(?:[,!?.:;]|$))/iu;
 
 export type LeadingVocativeClass =
 	| { kind: "none" }
@@ -517,11 +505,14 @@ export async function classifyLeadingVocative(args: {
 	const text =
 		typeof message.content?.text === "string" ? message.content.text : "";
 	const match = VOCATIVE_TOKEN_RE.exec(text);
-	const raw = match?.[1] ?? match?.[2];
+	const raw = match?.[1];
 	if (!raw) return { kind: "none" };
-	const name = normalizeName(raw);
-	if (name.length < 2 || VOCATIVE_STOP_TOKENS.has(name))
+	// The character class admits dots/hyphens for platform handles; strip any
+	// trailing punctuation so "eliza." never yields "eliza." as the name.
+	const name = normalizeName(raw).replace(/[.,!?:;_-]+$/u, "");
+	if (name.length < 2 || VOCATIVE_NON_NAME_WORDS.has(name)) {
 		return { kind: "none" };
+	}
 
 	if (agentSelfNames(runtime).has(name)) return { kind: "self", name };
 

--- a/packages/core/src/runtime/default-contexts.ts
+++ b/packages/core/src/runtime/default-contexts.ts
@@ -38,8 +38,17 @@ export const DEFAULT_CONTEXT_DEFINITIONS: readonly ContextDefinition[] =
 		{
 			id: "general",
 			label: "General",
+			// The current conversation's own history must be nameable here: a
+			// group-chat "what were the last 100 messages in this chat, summary?"
+			// (live 2026-08-21) routed to contexts=["general"], whose catalog line
+			// carried no channel-history vocabulary and whose surface had no
+			// message-history tool, so the planner honestly refused content every
+			// participant can already scroll. CHANNEL_RECAP registers under this
+			// context; cross-channel/inbox search stays gated in messaging.
 			description:
-				"Normal conversation and public agent behavior. Use when the reply needs general agent state but no tool work.",
+				"Normal conversation and public agent behavior. Use when the reply needs general agent state but no other context's tools. Also covers reading back or summarizing the current chat itself — 'summarize this chat', 'recap the channel', 'what were the last 100 messages', 'what did people say here earlier' — via the room-scoped CHANNEL_RECAP tool; cross-channel or inbox-wide message work stays in messaging.",
+			descriptionCompressed:
+				"Chat + current-channel history recall: 'summarize this chat', 'recap the channel', last N messages here",
 			sensitivity: "public",
 			cacheStable: true,
 			cacheScope: "global",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -83,6 +83,7 @@ import {
 import { tierActionResults } from "../runtime/action-tiering";
 import {
 	applyAddressedTo,
+	classifyLeadingVocative,
 	messageAddressedToOtherParticipant,
 } from "../runtime/addressed-to";
 import { normalizeTopics } from "../runtime/builtin-field-evaluators";
@@ -3567,6 +3568,11 @@ async function createV5MessageContextObject(args: {
 	 * byte-identical to before, so addressed turns are untouched.
 	 */
 	ambientTurn?: boolean;
+	/** Set when the message opens by addressing a name that is neither the
+	 *  agent nor any room participant; renders the identity notice so the
+	 *  model never answers AS that name (live 2026-08-23: bare "eliza" drew
+	 *  "yeah?"). */
+	unresolvedVocativeName?: string;
 }): Promise<ContextObject> {
 	const events: ContextEvent[] = [];
 
@@ -3698,6 +3704,16 @@ async function createV5MessageContextObject(args: {
 	// the IGNORE terminal invoked here already flows to deliberate,
 	// recorded non-delivery (see the planner deliberate-silence terminal in
 	// runV5MessageRuntimeStage1).
+	if (args.unresolvedVocativeName) {
+		events.push({
+			id: "unresolved-vocative-notice",
+			type: "instruction",
+			source: "message-service",
+			stable: false,
+			content: `unresolved_vocative_notice: The final message:user opens by addressing "${args.unresolvedVocativeName}" — that is not your name and matches no participant of this room. Never answer as though you were "${args.unresolvedVocativeName}" or adopt that identity. If the sender plausibly means you (a nickname or a slip for your actual name), answer as yourself and briefly note your name. Otherwise the message is not addressed to you: end the turn with the IGNORE tool.`,
+		});
+	}
+
 	if (args.ambientTurn) {
 		events.push({
 			id: "ambient-turn-policy",
@@ -7896,10 +7912,29 @@ export async function runV5MessageRuntimeStage1(args: {
 		args.runtime.contexts,
 		senderRole,
 	);
+	// Identity notice: when the message opens by addressing a name that is
+	// neither the agent nor any room participant, both Stage 1 and the planner
+	// are told never to answer AS that name (live 2026-08-23: bare "eliza" in
+	// a room with no Eliza drew "yeah?"). Fails open on lookup errors — a
+	// missing notice degrades to today's behavior, never to silence.
+	const vocativeClass = await classifyLeadingVocative({
+		runtime: args.runtime,
+		message: args.message,
+	}).catch((error) => {
+		// error-policy:J4 a failed room lookup must not affect the turn; the
+		// notice is advisory evidence only.
+		args.runtime.reportError("MessageService.classifyLeadingVocative", error, {
+			roomId: args.message.roomId,
+		});
+		return { kind: "none" } as const;
+	});
+	const unresolvedVocativeName =
+		vocativeClass.kind === "unresolved" ? vocativeClass.name : undefined;
 	const context = await createV5MessageContextObject({
 		...args,
 		userRoles: [senderRole],
 		availableContexts,
+		unresolvedVocativeName,
 		extraProviderExclusions: ambientTurnProviderExclusions(
 			args.runtime,
 			args.message,
@@ -9101,6 +9136,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			...args,
 			state: plannerState,
 			selectedContexts,
+			unresolvedVocativeName,
 			includeTools: true,
 			userRoles: [senderRole],
 			availableContexts,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2422,8 +2422,12 @@ function appendPriorDialogueEvents(
 			return text.length > 0;
 		})
 		.sort((a, b) => {
-			const aTime = Number.isFinite(a.createdAt as unknown as number) ? (a.createdAt as unknown as number) : 0;
-			const bTime = Number.isFinite(b.createdAt as unknown as number) ? (b.createdAt as unknown as number) : 0;
+			const aTime = Number.isFinite(a.createdAt as unknown as number)
+				? (a.createdAt as unknown as number)
+				: 0;
+			const bTime = Number.isFinite(b.createdAt as unknown as number)
+				? (b.createdAt as unknown as number)
+				: 0;
 			return aTime - bTime;
 		});
 	// Bound how many of the agent's own turns render (newest win): the planner
@@ -2755,8 +2759,12 @@ function getRecentConversationSearchText(
 			return typeof memory.content?.text === "string";
 		})
 		.sort((a, b) => {
-			const aTime = Number.isFinite(a.createdAt as unknown as number) ? (a.createdAt as unknown as number) : 0;
-			const bTime = Number.isFinite(b.createdAt as unknown as number) ? (b.createdAt as unknown as number) : 0;
+			const aTime = Number.isFinite(a.createdAt as unknown as number)
+				? (a.createdAt as unknown as number)
+				: 0;
+			const bTime = Number.isFinite(b.createdAt as unknown as number)
+				? (b.createdAt as unknown as number)
+				: 0;
 			return bTime - aTime;
 		})
 		.map((memory) => memory.content.text.trim())
@@ -7917,17 +7925,32 @@ export async function runV5MessageRuntimeStage1(args: {
 	// are told never to answer AS that name (live 2026-08-23: bare "eliza" in
 	// a room with no Eliza drew "yeah?"). Fails open on lookup errors — a
 	// missing notice degrades to today's behavior, never to silence.
-	const vocativeClass = await classifyLeadingVocative({
-		runtime: args.runtime,
-		message: args.message,
-	}).catch((error) => {
-		// error-policy:J4 a failed room lookup must not affect the turn; the
-		// notice is advisory evidence only.
-		args.runtime.reportError("MessageService.classifyLeadingVocative", error, {
-			roomId: args.message.roomId,
-		});
-		return { kind: "none" } as const;
-	});
+	// Eligibility mirrors the suppression gate: only positively-identified
+	// unaddressed text-group turns are classified — DMs and addressed turns
+	// never carry the notice (review: the first cut emitted it on every turn).
+	const vocativeEligible =
+		args.message.content?.channelType !== ChannelType.DM &&
+		isUnaddressedTextGroupTurn(
+			args.message,
+			messageExplicitlyAddressesAgent(args.runtime, args.message),
+		);
+	const vocativeClass = !vocativeEligible
+		? ({ kind: "none" } as const)
+		: await classifyLeadingVocative({
+				runtime: args.runtime,
+				message: args.message,
+			}).catch((error) => {
+				// error-policy:J4 a failed room lookup must not affect the turn; the
+				// notice is advisory evidence only.
+				args.runtime.reportError(
+					"MessageService.classifyLeadingVocative",
+					error,
+					{
+						roomId: args.message.roomId,
+					},
+				);
+				return { kind: "none" } as const;
+			});
 	const unresolvedVocativeName =
 		vocativeClass.kind === "unresolved" ? vocativeClass.name : undefined;
 	const context = await createV5MessageContextObject({

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -84,7 +84,6 @@ import { tierActionResults } from "../runtime/action-tiering";
 import {
 	applyAddressedTo,
 	messageAddressedToOtherParticipant,
-	messageVocativelyAddressesOtherParticipant,
 } from "../runtime/addressed-to";
 import { normalizeTopics } from "../runtime/builtin-field-evaluators";
 import {
@@ -322,6 +321,7 @@ import {
 	formatActionResultsForPrompt,
 	trimActionResultForPromptState,
 } from "../utils/action-results";
+import { textContainsAgentName } from "../utils/agent-name-match";
 import {
 	AVAILABLE_CONTEXTS_STATE_KEY,
 	attachAvailableContexts,
@@ -466,63 +466,6 @@ function canonicalPlannerControlActionName(actionName: string): string | null {
 
 function isReplyActionIdentifier(actionName: string): boolean {
 	return canonicalPlannerControlActionName(actionName) === "REPLY";
-}
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-const NON_DISTINCTIVE_AGENT_NAME_TOKENS = new Set([
-	"agent",
-	"assistant",
-	"bot",
-	"chatbot",
-	"demo",
-	"helper",
-	"system",
-	"test",
-]);
-
-/** Returns whether text names the agent through a complete configured alias or
- * a distinctive token from a multi-word alias. */
-export function textContainsAgentName(
-	text: string | undefined,
-	names: Array<string | null | undefined>,
-): boolean {
-	if (!text) {
-		return false;
-	}
-
-	// A multi-word agent name is addressed by any of its distinctive tokens:
-	// "remilio nubilio" answers to "nubilio …" (live 2026-08-22: the full-phrase
-	// match classified "nubilio whats the setting …" as ambient, arming the
-	// engagement gate on a message that literally opens with the agent's name).
-	// Short fragments and generic role/test words stay excluded because length
-	// alone does not make "agent", "assistant", or "test" an identity signal.
-	// The complete configured name/username remains authoritative even when one
-	// of its component words is generic.
-	const candidates = new Set<string>();
-	for (const name of names) {
-		const candidate = name?.trim();
-		if (!candidate) continue;
-		candidates.add(candidate);
-		for (const token of candidate.split(/\s+/u)) {
-			if (
-				token.length >= 4 &&
-				!NON_DISTINCTIVE_AGENT_NAME_TOKENS.has(token.toLowerCase())
-			) {
-				candidates.add(token);
-			}
-		}
-	}
-
-	return [...candidates].some((candidate) => {
-		const pattern = new RegExp(
-			`(^|[^\\p{L}\\p{N}])${escapeRegex(candidate)}(?=$|[^\\p{L}\\p{N}])`,
-			"iu",
-		);
-		return pattern.test(text);
-	});
 }
 
 function textContainsUserTag(text: string | undefined): boolean {
@@ -8686,9 +8629,10 @@ export async function runV5MessageRuntimeStage1(args: {
 		// agent is overhearing — it must not reply, enter the planner, or
 		// fabricate a tool task. Uniform, NOT bot-specific: it fires the same
 		// for human and bot addressees (bot-ness is surfaced to the model as
-		// transcript context, not handled here). Undirected banter
-		// (addressedTo: []) never gates, so chatty agents still interject per
-		// their character. Eligibility is bounded by the canonical `ambientTurn`
+		// transcript context, not handled here). Undirected banter — no
+		// corroborated tag AND no leading vocative — never gates, so chatty
+		// agents still interject per their character. Eligibility is bounded by
+		// the canonical `ambientTurn`
 		// classifier: only positively identified unaddressed text-group traffic
 		// can be suppressed. Direct/API/self turns, client chat, autonomous and
 		// sub-agent traffic, explicit mentions/replies/names, and unknown channel
@@ -8699,28 +8643,21 @@ export async function runV5MessageRuntimeStage1(args: {
 		// transient failure must NOT convert a normal turn into silence — it
 		// just means "don't suppress", matching the conservative contract and
 		// the fire-and-forget addressee handling above.
-		// Candidate suppression first (corroborated Stage-1 tag, or — when the
-		// tag is empty — the structural vocative check: a message that OPENS by
-		// addressing another participant by name, "hey eliza", is evidence the
-		// gate verifies itself, closing the fail-open interjection path, live
-		// 2026-08-22). The personality reply_gate override is consulted LAST and
-		// only on a positive, so turns with no gating signal never pay the
-		// personality-store lookup.
+		// Candidate suppression first: the gate OR-composes its two independent
+		// evidence sources — a text-corroborated Stage-1 tag, or the structural
+		// vocative check (a message that OPENS by addressing another participant
+		// by name, "hey eliza", is evidence the gate verifies itself, closing
+		// the fail-open interjection path, live 2026-08-22) — over a single room
+		// lookup. The personality reply_gate override is consulted LAST and only
+		// on a positive.
 		const suppressionCandidate = ambientTurn
-			? await (addressedTo.length > 0
-					? messageAddressedToOtherParticipant({
-							runtime: args.runtime,
-							message: args.message,
-							addressedTo,
-						})
-					: messageVocativelyAddressesOtherParticipant({
-							runtime: args.runtime,
-							message: args.message,
-						})
-				).catch((error) => {
-					// error-policy:J7 addressee-resolution diagnostics must not kill
-					// the message loop or suppress a response, but the required runtime
-					// error stream still owns the failure.
+			? await messageAddressedToOtherParticipant({
+					runtime: args.runtime,
+					message: args.message,
+					addressedTo,
+				}).catch((error) => {
+					// error-policy:J4 an unresolved addressee must not suppress a
+					// response, but the failed room lookup remains observable.
 					args.runtime.reportError("MessageService.resolveAddressees", error, {
 						roomId: args.message.roomId,
 					});

--- a/packages/core/src/utils/agent-name-match.test.ts
+++ b/packages/core/src/utils/agent-name-match.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The shared agent-name matcher: normalization, distinctive-token expansion
+ * for multi-word names (>= 4-char tokens), and boundary-anchored text
+ * matching. Pins the live 2026-08-22 case where a single token of a
+ * multi-word agent name must count as addressing the agent.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	distinctiveNameTokens,
+	escapeRegex,
+	normalizeName,
+	textContainsAgentName,
+} from "./agent-name-match.ts";
+
+describe("normalizeName", () => {
+	it("trims, lowercases, and strips one leading @", () => {
+		expect(normalizeName("  @Eliza ")).toBe("eliza");
+		expect(normalizeName("Remilio Nubilio")).toBe("remilio nubilio");
+	});
+});
+
+describe("escapeRegex", () => {
+	it("escapes regex metacharacters so names embed literally", () => {
+		const escaped = escapeRegex("a.b*c(d)");
+		expect(new RegExp(`^${escaped}$`).test("a.b*c(d)")).toBe(true);
+		expect(new RegExp(`^${escaped}$`).test("axbbc(d)")).toBe(false);
+	});
+});
+
+describe("distinctiveNameTokens", () => {
+	it("returns the full name plus each token of at least 4 characters", () => {
+		expect(distinctiveNameTokens("remilio nubilio")).toEqual([
+			"remilio nubilio",
+			"remilio",
+			"nubilio",
+		]);
+	});
+
+	it("excludes short tokens that would match ordinary prose", () => {
+		expect(distinctiveNameTokens("Al Bot")).toEqual(["Al Bot"]);
+	});
+
+	it("returns nothing for blank input", () => {
+		expect(distinctiveNameTokens("   ")).toEqual([]);
+	});
+});
+
+describe("textContainsAgentName", () => {
+	it("matches the full name on word boundaries, case-insensitively", () => {
+		expect(textContainsAgentName("hey Eliza, you up?", ["eliza"])).toBe(true);
+		expect(textContainsAgentName("elizabeth was here", ["eliza"])).toBe(false);
+	});
+
+	it("a single distinctive TOKEN of a multi-word name counts (live 2026-08-22)", () => {
+		expect(
+			textContainsAgentName("nubilio whats the setting we use", [
+				"remilio nubilio",
+			]),
+		).toBe(true);
+	});
+
+	it("ignores empty text and nullish names", () => {
+		expect(textContainsAgentName(undefined, ["eliza"])).toBe(false);
+		expect(textContainsAgentName("hello", [null, undefined, "  "])).toBe(false);
+	});
+});

--- a/packages/core/src/utils/agent-name-match.ts
+++ b/packages/core/src/utils/agent-name-match.ts
@@ -1,0 +1,92 @@
+/**
+ * Single source of truth for matching an agent's name in message text.
+ * Three call paths must branch on the same ground truth — the Stage-1 prompt
+ * tier and engagement addressing gate (services/message.ts), the addressing
+ * gate's self-name set (runtime/addressed-to.ts), and the shouldRespond
+ * mention check (features/basic-capabilities) — so the name normalization,
+ * the distinctive-token expansion, and the boundary-anchored matcher live
+ * here once. Live 2026-08-22: two divergent copies of this matcher classified
+ * "nubilio whats the setting …" as ambient for agent "remilio nubilio"
+ * because only one copy expanded multi-word names into tokens.
+ */
+
+import { toWellFormedUnicode } from "./well-formed.ts";
+
+/** Escapes regex metacharacters so a name can be embedded in a pattern. */
+export function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Canonical name normalization: trimmed, lowercased, leading @ stripped. */
+export function normalizeName(value: string): string {
+	return value.trim().toLowerCase().replace(/^@/, "");
+}
+
+/**
+ * Expands a (possibly multi-word) name into the strings that count as
+ * addressing it: the full name plus each whitespace-separated token of at
+ * least 4 characters ("remilio nubilio" answers to "nubilio"). Shorter
+ * tokens stay excluded — fragments like "al" or "bot" would match ordinary
+ * prose.
+ */
+/** Generic role/test words that never count as an identity signal on their
+ * own, however long ("agent", "assistant", "test" — adopted from the
+ * upstream-merged variant of this matcher). */
+const NON_DISTINCTIVE_NAME_TOKENS = new Set([
+	"agent",
+	"assistant",
+	"bot",
+	"chatbot",
+	"demo",
+	"helper",
+	"system",
+	"test",
+]);
+
+export function distinctiveNameTokens(name: string): string[] {
+	const candidate = name.trim();
+	if (!candidate) {
+		return [];
+	}
+	const tokens = new Set<string>([candidate]);
+	for (const token of candidate.split(/\s+/u)) {
+		if (
+			token.length >= 4 &&
+			!NON_DISTINCTIVE_NAME_TOKENS.has(token.toLowerCase())
+		) {
+			tokens.add(token);
+		}
+	}
+	return [...tokens];
+}
+
+/**
+ * True when the text mentions the agent by any of its names or distinctive
+ * name tokens, on non-alphanumeric boundaries, case-insensitively. The text
+ * is sanitized to well-formed Unicode first so a lone surrogate from
+ * arbitrary connector input cannot break the match.
+ */
+export function textContainsAgentName(
+	text: string | undefined,
+	names: Array<string | null | undefined>,
+): boolean {
+	if (!text) {
+		return false;
+	}
+
+	const candidates = new Set<string>();
+	for (const name of names) {
+		for (const token of distinctiveNameTokens(name ?? "")) {
+			candidates.add(token);
+		}
+	}
+
+	const safeText = toWellFormedUnicode(text);
+	return [...candidates].some((candidate) => {
+		const pattern = new RegExp(
+			`(^|[^\\p{L}\\p{N}])${escapeRegex(candidate)}(?=$|[^\\p{L}\\p{N}])`,
+			"iu",
+		);
+		return pattern.test(safeText);
+	});
+}


### PR DESCRIPTION
Follows the merged engagement-gate fix (#24663 — thank you for the fast adoption; the `NON_DISTINCTIVE_AGENT_NAME_TOKENS` guard added there is preserved and now lives in the shared matcher). Everything here ran for a full day on a live multi-agent Discord deployment: ~60 webhook-driven scenarios graded turn-by-turn from trajectories, six live-found bugs fixed and retested live.

## What this delivers

**Channel recap, reachable from group chat.** "summarize the last 100 messages" routed to `general`, whose planner surface had no message-history tool (SEARCH_MESSAGES sits behind the ADMIN messaging umbrella), so the agent honestly refused a request whose content every participant can already scroll. `CHANNEL_RECAP`: room-scoped **by construction** (handler reads only `message.roomId`; adversarial room parameters are ignored), complete chronological transcript, caller-requested count (default 50, 500 storage read bound stated explicitly), and a model-window fit bound with a disclosed continuation `offset` — live: a 500-message read rendered past the provider's 131K-token window and killed the turn before this. Recap/summary-stem invented candidates (`TASKS_RECAP_DAY`, `RECAP_DAY`, `GET_TASKS_SUMMARY` — a fresh spelling per attempt) hint the action by family, since exact-name aliases lose to a generative router.

**Identity honesty for unresolved vocatives.** "hey eliza" and a bare "eliza" in a room with no Eliza drew "hey. what's on your mind?" and "yeah?" — the agent answering AS a name that is not its own. `classifyLeadingVocative` (narrow shapes: greeting+NAME / "NAME," / bare NAME; interjection stoplist; self/participant/unresolved) renders a Stage-1+planner notice for unresolved names: never adopt the name; answer as yourself with a brief name note when plausibly meant; IGNORE otherwise. Live retest: "still remilio here. what's up?" / "still me. you really want eliza?" — while "hey champ, tell me a fun fact" still engages normally.

**Honest memory tools.** "forget my dog's name" guessed the wrong table (`memories` vs the fact row) and read back "no record exists" — a broken forget. Delete-by-query now widens across memories+facts on a type-miss (messages/documents stay explicit-only), disclosed in the result. Post-delete, asked the name again, the agent searched and answered "i don't know it anymore. you asked me to forget" — honoring deletion over the visible window. `PAGE_DELEGATE`'s unavailable-child error names the direct call so the next planner iteration self-corrects instead of stopping.

**One shared name matcher.** `utils/agent-name-match.ts` (escapeRegex / normalizeName / distinctiveNameTokens with the generic-token guard / textContainsAgentName) replaces three divergent copies, including the stale one on the public export surface; the addressing gate composes its evidence (corroborated tag OR leading vocative) so one hallucinated tag can't disable the vocative check, with a single participants fetch per turn and complete-text evaluation (no preview slice).

## Verification

45+ new tests (recap contract incl. adversarial room-scoping and the fit/offset continuation; classifier shapes; forget-widening; gate composition with the live incident's ten turns pinned as fixtures); the touched suites 253/253 on a clean install; core typecheck and Biome clean. The 17 `packages/agent` tsc errors on this branch are pre-existing develop test-file debt (none in files this PR touches).

cc @lalalune

🤖 Generated with [Claude Code](https://claude.com/claude-code)
