### PR TITLE
test(agent): cover inline-script-serialization

### DIFF
--- a/packages/agent/src/api/inline-script-serialization.test.ts
+++ b/packages/agent/src/api/inline-script-serialization.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Coverage for `serializeInlineScriptValue`, the encoder that turns server
+ * values into JavaScript literals inside HTML `<script>` elements. JSON
+ * quoting alone does not stop a literal `</script>` from closing the element.
+ * Drive the real module: no mocks.
+ */
+import { describe, expect, it } from "vitest";
+import { serializeInlineScriptValue } from "./inline-script-serialization.ts";
+
+function parseSerialized(serialized: string): unknown {
+  return JSON.parse(serialized);
+}
+
+describe("serializeInlineScriptValue", () => {
+  it("serializes JSON primitives, empty containers, and a single-element payload", () => {
+    expect(serializeInlineScriptValue(null)).toBe("null");
+    expect(serializeInlineScriptValue(true)).toBe("true");
+    expect(serializeInlineScriptValue(false)).toBe("false");
+    expect(serializeInlineScriptValue(0)).toBe("0");
+    expect(serializeInlineScriptValue(-0)).toBe("0");
+    expect(serializeInlineScriptValue(42)).toBe("42");
+    expect(serializeInlineScriptValue(1.5)).toBe("1.5");
+    expect(serializeInlineScriptValue("")).toBe('""');
+    expect(serializeInlineScriptValue("hello")).toBe('"hello"');
+    expect(serializeInlineScriptValue([])).toBe("[]");
+    expect(serializeInlineScriptValue({})).toBe("{}");
+    expect(serializeInlineScriptValue(["only"])).toBe('["only"]');
+    expect(serializeInlineScriptValue({ only: 1 })).toBe('{"only":1}');
+  });
+
+  it("stringifies NaN and ±Infinity as null, matching JSON", () => {
+    expect(serializeInlineScriptValue(Number.NaN)).toBe("null");
+    expect(serializeInlineScriptValue(Number.POSITIVE_INFINITY)).toBe("null");
+    expect(serializeInlineScriptValue(Number.NEGATIVE_INFINITY)).toBe("null");
+  });
+
+  it("omits undefined object fields and turns undefined array holes into null", () => {
+    expect(serializeInlineScriptValue({ a: 1, b: undefined })).toBe('{"a":1}');
+    expect(serializeInlineScriptValue([1, undefined, 3])).toBe("[1,null,3]");
+  });
+
+  it("throws TypeError when JSON.stringify yields undefined", () => {
+    const message = "Inline script values must be JSON-serializable";
+    expect(() => serializeInlineScriptValue(undefined)).toThrowError(TypeError);
+    expect(() => serializeInlineScriptValue(undefined)).toThrowError(message);
+    expect(() => serializeInlineScriptValue(() => "nope")).toThrowError(
+      TypeError,
+    );
+    expect(() => serializeInlineScriptValue(() => "nope")).toThrowError(
+      message,
+    );
+    expect(() => serializeInlineScriptValue(Symbol("x"))).toThrowError(
+      TypeError,
+    );
+    expect(() => serializeInlineScriptValue(Symbol("x"))).toThrowError(message);
+  });
+
+  it("lets JSON.stringify TypeErrors surface for BigInt and cycles", () => {
+    expect(() => serializeInlineScriptValue(1n)).toThrowError(TypeError);
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    expect(() => serializeInlineScriptValue(cyclic)).toThrowError(TypeError);
+  });
+
+  it("escapes & < > so a payload cannot terminate an HTML script element", () => {
+    expect(serializeInlineScriptValue("</script>")).toBe(
+      '"\\u003c/script\\u003e"',
+    );
+    expect(serializeInlineScriptValue("</SCRIPT>")).toBe(
+      '"\\u003c/SCRIPT\\u003e"',
+    );
+    expect(serializeInlineScriptValue("</sCrIpT>")).toBe(
+      '"\\u003c/sCrIpT\\u003e"',
+    );
+    expect(serializeInlineScriptValue("<")).toBe('"\\u003c"');
+    expect(serializeInlineScriptValue(">")).toBe('"\\u003e"');
+    expect(serializeInlineScriptValue("&")).toBe('"\\u0026"');
+    expect(serializeInlineScriptValue("a&b<c>d")).toBe(
+      '"a\\u0026b\\u003cc\\u003ed"',
+    );
+    expect(serializeInlineScriptValue("<<>>&&")).toBe(
+      '"\\u003c\\u003c\\u003e\\u003e\\u0026\\u0026"',
+    );
+  });
+
+  it("escapes the same characters inside object keys and nested values", () => {
+    const payload = {
+      "a<b": "c&d",
+      nested: { inner: "</script>", amp: "x&y" },
+    };
+    const serialized = serializeInlineScriptValue(payload);
+    expect(serialized).toBe(
+      '{"a\\u003cb":"c\\u0026d","nested":{"inner":"\\u003c/script\\u003e","amp":"x\\u0026y"}}',
+    );
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain(">");
+    expect(serialized).not.toContain("&");
+    expect(parseSerialized(serialized)).toEqual(payload);
+  });
+
+  it("applies replacements globally rather than stopping at the first match", () => {
+    const serialized = serializeInlineScriptValue(
+      "</script></script>&<&><script>",
+    );
+    expect(serialized).toBe(
+      '"\\u003c/script\\u003e\\u003c/script\\u003e\\u0026\\u003c\\u0026\\u003e\\u003cscript\\u003e"',
+    );
+  });
+
+  it("does not leave U+2028 or U+2029 as raw line terminators in the output", () => {
+    const lineSeparator = "\u2028";
+    const paragraphSeparator = "\u2029";
+    const mixed = `keep${lineSeparator}and${paragraphSeparator}end`;
+
+    const serializedLine = serializeInlineScriptValue(lineSeparator);
+    const serializedParagraph = serializeInlineScriptValue(paragraphSeparator);
+    const serializedMixed = serializeInlineScriptValue(mixed);
+
+    expect(serializedLine).not.toContain(lineSeparator);
+    expect(serializedParagraph).not.toContain(paragraphSeparator);
+    expect(serializedMixed).not.toContain(lineSeparator);
+    expect(serializedMixed).not.toContain(paragraphSeparator);
+    expect(parseSerialized(serializedLine)).toBe(lineSeparator);
+    expect(parseSerialized(serializedParagraph)).toBe(paragraphSeparator);
+    expect(parseSerialized(serializedMixed)).toBe(mixed);
+  });
+
+  it("round-trips JSON-serializable values, including boot-config shaped objects", () => {
+    const bootOverrides = {
+      apiBase: "https://example.invalid/base",
+      webPushVapidPublicKey: "vapid-public",
+    };
+    const token = "tok_live_not-a-secret-for-this-test";
+    expect(parseSerialized(serializeInlineScriptValue(bootOverrides))).toEqual(
+      bootOverrides,
+    );
+    expect(parseSerialized(serializeInlineScriptValue(token))).toBe(token);
+    expect(
+      parseSerialized(
+        serializeInlineScriptValue({
+          apiBase: "https://x.example/</script>?q=1&b=2",
+        }),
+      ),
+    ).toEqual({ apiBase: "https://x.example/</script>?q=1&b=2" });
+  });
+
+  it("escapes toJSON results the same way as ordinary values", () => {
+    const hostile = {
+      toJSON() {
+        return "</script>&";
+      },
+    };
+    const serialized = serializeInlineScriptValue(hostile);
+    expect(serialized).toBe('"\\u003c/script\\u003e\\u0026"');
+    expect(parseSerialized(serialized)).toBe("</script>&");
+  });
+
+  it("produces a JS-literal-safe encoding for the static-file-server injection shape", () => {
+    const bootOverrides = {
+      apiBase: "https://evil.example/</script><script>alert(1)</script>",
+    };
+    const serialized = serializeInlineScriptValue(bootOverrides);
+    expect(serialized.toLowerCase()).not.toContain("</script");
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain("&");
+    const recovered = Function(`"use strict"; return (${serialized});`)() as {
+      apiBase: string;
+    };
+    expect(recovered).toEqual(bootOverrides);
+  });
+});


### PR DESCRIPTION

## Summary

Adds real unit coverage for `packages/agent/src/api/inline-script-serialization.ts`. That module had no same-named test file. Production code is unchanged.

`serializeInlineScriptValue` is the encoder `static-file-server` uses to interpolate boot-config objects and API tokens into HTML `<script>` elements. JSON quoting alone does not stop a literal `</script>` from closing the element. The suite drives the real export (no mocks) and locks:

- JSON primitives, empty containers, and single-element payloads
- `NaN` / `±Infinity` → `null` (JSON semantics)
- omitted `undefined` object fields and `undefined` array holes → `null`
- `TypeError("Inline script values must be JSON-serializable")` when `JSON.stringify` yields `undefined` (`undefined`, functions, symbols)
- `JSON.stringify` TypeErrors for `BigInt` and cyclic objects (not swallowed)
- HTML script-breaker escaping of `&`, `<`, `>` (including `</script>` / `</SCRIPT>` and the same characters in object keys / nested values)
- global replacement (not first-match-only)
- U+2028 / U+2029 never left as raw line terminators
- `JSON.parse` round-trip for boot-config shaped objects and hostile `toJSON` results
- recovered JS-literal evaluation for the static-file-server injection shape, with no `</script` substring remaining

Import path is `./inline-script-serialization.ts`, matching sibling colocated agent API tests.

## Evidence

This is a test-only change. Hosted CI does **not** run on our fork PRs; the counts below are from the local checkout.

1. `bunx vitest run packages/agent/src/api/inline-script-serialization.test.ts`

```
 Test Files  1 passed (1)
      Tests  12 passed (12)
   Duration  202ms
```

2. `bunx biome check --write packages/agent/src/api/inline-script-serialization.test.ts` — clean (`Checked 1 file in 127ms`).

3. `cd packages/agent && bunx tsc --noEmit` — `inline-script-serialization.test.ts` appears **nowhere** in the output (`grep` exit 1). Pre-existing package errors (missing `viem` types, other test files) are not from this change.

4. Diff touches only `packages/agent/src/api/inline-script-serialization.test.ts`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:3c5bbcde44340561d9c317b46e46e94c94ab387c -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
