### PR TITLE
fix(scenario-runner): use surrogate-safe truncateWellFormed on cerebras judge error detail

### DIFF
--- a/packages/scenario-runner/src/cerebras-judge.surrogate.test.ts
+++ b/packages/scenario-runner/src/cerebras-judge.surrogate.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Verifies surrogate-safe truncation for Cerebras judge error bodies.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+describe("cerebras-judge surrogate-safe truncation", () => {
+  it("replaces lone high surrogate with replacement character", () => {
+    const lone = String.fromCharCode(0xd800);
+    const wellFormed = toWellFormedUnicode(lone);
+    expect(wellFormed).toBe("�");
+    const truncated = truncateWellFormed(wellFormed, 300);
+    expect(truncated).toBe("�");
+  });
+
+  it("does not split astral pair at 300 boundary", () => {
+    const astral = "🦊";
+    const text = "a".repeat(299) + astral + "b".repeat(10);
+    const wellFormed = toWellFormedUnicode(text);
+    const truncated = truncateWellFormed(wellFormed, 300);
+    // High surrogate at 299, low at 300 -> truncate to 299 to avoid lone
+    expect(truncated.length).toBe(299);
+    expect(truncated).toBe("a".repeat(299));
+    expect(() => JSON.stringify(truncated)).not.toThrow();
+  });
+
+  it("truncates ASCII verbatim at 300", () => {
+    const ascii = "x".repeat(500);
+    const truncated = truncateWellFormed(toWellFormedUnicode(ascii), 300);
+    expect(truncated.length).toBe(300);
+    expect(truncated).toBe("x".repeat(300));
+  });
+
+  it("handles lone surrogate at boundary without producing invalid JSON", () => {
+    const loneAtBoundary = "a".repeat(299) + String.fromCharCode(0xd800) + "b".repeat(200);
+    const result = truncateWellFormed(toWellFormedUnicode(loneAtBoundary), 300);
+    expect(result.length).toBeLessThanOrEqual(300);
+    expect(result.isWellFormed?.() ?? !result.includes("\uD800")).toBe(true);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+});

--- a/packages/scenario-runner/src/cerebras-judge.ts
+++ b/packages/scenario-runner/src/cerebras-judge.ts
@@ -10,6 +10,8 @@
  * owns transport, retry, tolerant JSON parsing, and a canonical verdict
  * shape. Callers map the canonical shape back to their own return types.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 /** Canonical verdict alias re-exported for callers that don't pull types.ts. */
 export type CerebrasJudgeVerdict = "PASS" | "FAIL" | "REVIEW";
 
@@ -343,7 +345,7 @@ export class CerebrasJudge {
             continue;
           }
           throw new CerebrasJudgeError(
-            `cerebras error ${response.status}: ${errBody.slice(0, 300)}`,
+            `cerebras error ${response.status}: ${truncateWellFormed(toWellFormedUnicode(errBody), 300)}`,
             response.status,
             errBody,
           );


### PR DESCRIPTION
## Summary

Use surrogate-safe `truncateWellFormed(toWellFormedUnicode(errBody), 300)` for Cerebras judge error detail at `packages/scenario-runner/src/cerebras-judge.ts:346`. Prevents lone surrogate `\uD800` persistence and astral pair split at 300-char transport limit, which strict JSON parsers reject as "lone leading surrogate in hex escape".

Mirrors merged `#25173`, `#25172`, `#25170` surrogate-safe precedent.

## Changes

- `packages/scenario-runner/src/cerebras-judge.ts:1` import `toWellFormedUnicode, truncateWellFormed` from `@elizaos/core`
- `packages/scenario-runner/src/cerebras-judge.ts:346` `errBody.slice(0,300)` → `truncateWellFormed(toWellFormedUnicode(errBody),300)`
- `packages/scenario-runner/src/cerebras-judge.surrogate.test.ts` 4 tests: lone surrogate → �, astral boundary 299+2, ASCII 500→300, lone at boundary

## Risks

Low. Pure truncation helper, no behavior change for well-formed ASCII.

## Verification

- `bunx vitest run packages/scenario-runner/src/cerebras-judge.surrogate.test.ts` 4 pass
- `bunx @biomejs/biome check` 0
