### PR TITLE
fix(agent): use surrogate-safe truncateWellFormed on STT verifier error detail

### DIFF
--- a/packages/agent/src/api/audio-redaction-verify.surrogate.test.ts
+++ b/packages/agent/src/api/audio-redaction-verify.surrogate.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Verifies surrogate-safe truncation for STT verifier error bodies.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+describe("audio-redaction-verify surrogate-safe truncation", () => {
+  it("replaces lone high surrogate", () => {
+    const lone = String.fromCharCode(0xd800);
+    expect(toWellFormedUnicode(lone)).toBe("�");
+    expect(truncateWellFormed(toWellFormedUnicode(lone), 300)).toBe("�");
+  });
+
+  it("does not split astral pair at 300", () => {
+    const text = "a".repeat(299) + "🦊" + "b".repeat(10);
+    const truncated = truncateWellFormed(toWellFormedUnicode(text), 300);
+    expect(truncated.length).toBe(299);
+    expect(truncated).toBe("a".repeat(299));
+  });
+
+  it("truncates ASCII verbatim", () => {
+    const ascii = "x".repeat(500);
+    expect(truncateWellFormed(toWellFormedUnicode(ascii), 300).length).toBe(300);
+  });
+
+  it("handles lone at boundary", () => {
+    const loneAtBoundary = "a".repeat(299) + String.fromCharCode(0xd800) + "b".repeat(200);
+    const result = truncateWellFormed(toWellFormedUnicode(loneAtBoundary), 300);
+    expect(result.length).toBeLessThanOrEqual(300);
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+});

--- a/packages/agent/src/api/audio-redaction-verify.ts
+++ b/packages/agent/src/api/audio-redaction-verify.ts
@@ -30,6 +30,8 @@ import {
   fetchWithSsrfGuard,
   type IAgentRuntime,
   ModelType,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import type {
   RedactionTranscribeInput,
@@ -166,7 +168,7 @@ export function openAiCompatSttTranscriber(
         const textBody = await readResponseTextLimited(response, 1024 * 1024);
         if (!response.ok) {
           throw new ElizaError(
-            `STT verifier answered HTTP ${response.status}: ${textBody.slice(0, 300)}`,
+            `STT verifier answered HTTP ${response.status}: ${truncateWellFormed(toWellFormedUnicode(textBody), 300)}`,
             {
               code: "AUDIO_REDACTION_VERIFY_REQUEST_FAILED",
               context: { host: endpoint.host, status: response.status },


### PR DESCRIPTION
## Summary

Use surrogate-safe `truncateWellFormed(toWellFormedUnicode(textBody),300)` at `packages/agent/src/api/audio-redaction-verify.ts:169`. Prevents lone surrogate persistence in STT verifier HTTP error bodies.

Mirrors `#25217`, `#25216` surrogate-safe precedent.

## Changes

- `packages/agent/src/api/audio-redaction-verify.ts:28` import `toWellFormedUnicode, truncateWellFormed` from `@elizaos/core`
- `packages/agent/src/api/audio-redaction-verify.ts:169` `textBody.slice(0,300)` → `truncateWellFormed(toWellFormedUnicode(textBody),300)`
- `packages/agent/src/api/audio-redaction-verify.surrogate.test.ts` 4 tests

## Risks

Low. Pure truncation helper.