### PR TITLE
test(app): reconcile Cloud diagnostic artifact contract

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -527,7 +527,8 @@ jobs:
           name: app-live-e2e-cloud-staging
           path: |
             artifacts/app-live-e2e/cloud-staging-receipt.json
-            packages/app/test-results/**/privacy-safe-*-history-network-diagnostics.json
+            packages/app/test-results/**/privacy-safe-post-reload-history-network-diagnostics.json
+            packages/app/test-results/**/privacy-safe-fresh-context-history-network-diagnostics.json
           if-no-files-found: error
           retention-days: 7
 

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -44,7 +44,10 @@ interface Workflow {
 }
 
 interface WorkflowDispatch {
-  inputs?: Record<string, { default?: boolean; type?: string }>;
+  inputs?: Record<
+    string,
+    { default?: boolean; description?: string; type?: string }
+  >;
 }
 
 const workflow = Bun.YAML.parse(
@@ -136,7 +139,9 @@ describe("App Live E2E real Cloud job (#14357, #16194)", () => {
     expect(spec).toContain(
       "const HAS_CLOUD_KEY = Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim())",
     );
-    expect(spec).toContain("test.skip(\n    !HAS_CLOUD_KEY,");
+    expect(spec).toContain(
+      "test.skip(\n    !HAS_CLOUD_KEY && !REQUIRE_NAMED_WARMING,",
+    );
   });
 
   test("hands the job credential to the browser without retaining secret-bearing traces", () => {
@@ -206,6 +211,31 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
     expect(stagingJob?.if).toContain("inputs.run_cloud_staging");
   });
 
+  test("can isolate explicitly requested live lanes without changing defaults", () => {
+    const dispatch = workflow.on?.workflow_dispatch as
+      | WorkflowDispatch
+      | undefined;
+    expect(dispatch?.inputs?.run_only_requested).toEqual({
+      description:
+        "Skip the default local/walkthrough/desktop lanes and run only explicitly selected opt-in lanes.",
+      type: "boolean",
+      default: false,
+    });
+
+    for (const jobName of [
+      "app-live-chat",
+      "walkthrough-live",
+      "desktop-packaged",
+    ]) {
+      expect(workflow.jobs?.[jobName]?.if).toBe(
+        "$" +
+          "{{ github.event_name != 'workflow_dispatch' || !inputs.run_only_requested }}",
+      );
+    }
+    expect(stagingJob?.if).not.toContain("run_only_requested");
+    expect(cloudJob?.if).not.toContain("run_only_requested");
+  });
+
   test("fails closed before setup on a missing credential or a wrong origin", () => {
     const steps = stagingJob?.steps ?? [];
     const guardIndex = steps.findIndex(
@@ -268,7 +298,7 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
     expect(spec).toContain("renderer-source");
   });
 
-  test("uploads only the staging closed receipt, never credentialed Playwright output", () => {
+  test("uploads only allowlisted closed staging artifacts", () => {
     expect(cloudJob?.env?.ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV).toBe("production");
     const prodUploads = cloudJob?.steps?.filter((step) =>
       step.uses?.startsWith("actions/upload-artifact"),
@@ -278,6 +308,18 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
     );
     expect(prodUploads).toEqual([]);
     expect(stagingUpload?.with?.name).toBe("app-live-e2e-cloud-staging");
+    const uploadedPaths = stagingUpload?.with?.path
+      ?.split("\n")
+      .map((path) => path.trim())
+      .filter(Boolean);
+    expect(uploadedPaths).toEqual([
+      "artifacts/app-live-e2e/cloud-staging-receipt.json",
+      "packages/app/test-results/**/privacy-safe-post-reload-history-network-diagnostics.json",
+      "packages/app/test-results/**/privacy-safe-fresh-context-history-network-diagnostics.json",
+    ]);
+    expect(stagingUpload?.with?.path).not.toMatch(
+      /playwright-report|trace|screenshot|video/i,
+    );
   });
 
   test("uploads a mandatory exact-SHA, secret-free receipt for every executed smoke", () => {
@@ -386,10 +428,12 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
       /ELIZAOS_CLOUD_API_KEY|authorization|bearer/i,
     );
     expect(upload.if).toBe(receipt.if);
-    expect(upload.with?.path).toBe(
+    expect(upload.with?.path).toContain(
       "artifacts/app-live-e2e/cloud-staging-receipt.json",
     );
-    expect(upload.with?.path).not.toMatch(/playwright-report|test-results/);
+    expect(upload.with?.path).not.toMatch(
+      /playwright-report|test-results\/\*\*\/\*|trace|screenshot|video/i,
+    );
     expect(upload.with?.["if-no-files-found"]).toBe("error");
   });
 


### PR DESCRIPTION
## Summary

- reconcile the Cloud-live workflow contract with #25117's closed history diagnostics
- narrow the upload allowlist from a wildcard phase to the two actual diagnostic phase filenames
- cover `run_only_requested` lane isolation and the named-warming fail-closed key guard

Closes #25290.

## Why

#25117 merged with a green static smoke, but that check did not execute `packages/scripts/__tests__/app-live-e2e-workflow.test.ts`. The merged workflow changed an exact single-path upload into a receipt-plus-diagnostics list while the owning test still required the former path and rejected all `test-results`; the test suite therefore failed on current `develop`.

## Verification

Exact head: `733ba1d37a81d0d0155a047e45f2e3b684b333eb`
Validated base: `a0f04a5c55439daf123c96cf660f6506704a5acc`
Toolchain: Bun 1.3.14, Node 24.15.0, fresh frozen-lockfile install.

- `bun test packages/scripts/__tests__/app-live-e2e-workflow.test.ts packages/app/test/cloud-live-continuity-contract.test.ts` — 37 passed, 0 failed
- `bun x biome check packages/scripts/__tests__/app-live-e2e-workflow.test.ts` — passed
- `actionlint .github/workflows/app-live-e2e.yml` — passed
- `bun run audit:workflow-triggers` — passed (61 workflows)
- `bun run audit:scripts` — passed
- `bun run audit:test-lane-membership` — passed
- `bun run check:agents-claude` — passed
- `git diff origin/develop...HEAD --check` — passed
- `bun run verify` — attempted; stopped at unchanged `check:i18n` debt (five missing English `connectorcard.*` keys plus existing translation debt). Reproduced identically on untouched base `a0f04a5c55439daf123c96cf660f6506704a5acc` with `bun run check:i18n`; this PR changes only one workflow and its contract test.

## Evidence

- UI screenshots: N/A — no rendered UI code changes.
- Walkthrough video: N/A — no user-visible flow changes.
- Frontend/backend logs: N/A — this is a deterministic workflow contract correction.
- Live-model trajectory: N/A — no agent, prompt, provider, or model behavior changes.
- Real artifact inspection: the parsed workflow allowlist is asserted exactly as receipt + post-reload diagnostic + fresh-context diagnostic, and broad reports/traces/screenshots/videos remain rejected.

## Attribution

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: self-reported
