### PR TITLE
test(audit): cover the Eliza Cloud plugin view bundle

### DIFF
--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -32,6 +32,15 @@ import ts from "typescript";
  * Do NOT add a view here for a plugin that no longer exists.
  */
 export const smokeViewDeclarations = [
+  [
+    "cloud",
+    "Cloud",
+    "plugin-elizacloud",
+    "/cloud",
+    "CloudView",
+    "gui",
+    { capabilities: ["agent-surface"] },
+  ],
   ["contacts", "Contacts", "plugin-contacts", "/contacts", "ContactsView"],
   // The decomposed personal-assistant domain views are the real surfaces (the
   // old monolithic `lifeops` overview view was removed). `documents` is

--- a/packages/app-core/scripts/smoke-view-declarations.test.ts
+++ b/packages/app-core/scripts/smoke-view-declarations.test.ts
@@ -43,9 +43,18 @@ describe("smoke view declaration parity (#15791)", () => {
     }
   });
 
-  it("declares the canonical Notes and Calendar views used by the visual audit", () => {
+  it("declares the canonical Cloud, Notes, and Calendar views used by the visual audit", () => {
     expect(smokeViewDeclarations).toEqual(
       expect.arrayContaining([
+        [
+          "cloud",
+          "Cloud",
+          "plugin-elizacloud",
+          "/cloud",
+          "CloudView",
+          "gui",
+          { capabilities: ["agent-surface"] },
+        ],
         ["notes", "Notes", "plugin-notes", "/notes", "NotesView"],
         [
           "calendar",

--- a/packages/app/test/audit/ocr-view-expectations.test.ts
+++ b/packages/app/test/audit/ocr-view-expectations.test.ts
@@ -93,13 +93,19 @@ describe("aesthetic audit semantic OCR policy coverage", () => {
     }
   });
 
-  it("expects the local-agent Cloud route to return to the launcher", () => {
+  it("expects the production Cloud plugin bundle's signed-out state", () => {
     const policy = resolveViewOcrPolicy("plugin-cloud-gui");
     expect(policy).toEqual({
       kind: "expectation",
       expectation: {
-        requireAll: ["Settings", "Wallet"],
-        requireAny: ["Projects", "Calendar", "Automations"],
+        requireAll: ["Eliza Cloud"],
+        requireAny: [
+          "credits",
+          "hosted agents",
+          "API keys",
+          "billing",
+          "Connect in Settings",
+        ],
       },
     });
   });

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -240,10 +240,19 @@ export const VIEW_OCR_POLICIES = {
     requireAll: ["Misty Forest", "Desert Dusk"],
     requireAny: ["Ocean Deep", "Alpine Dawn", "Ember Night"],
   }),
-  // The hermetic audit runs a local agent topology. Direct Cloud navigation is
-  // deliberately unavailable there and returns to the normal launcher; Cloud
-  // routes are exercised separately with a managed-agent runtime fixture.
-  "plugin-cloud-gui": expected(LAUNCHER_FALLBACK),
+  // The hermetic audit serves the production plugin bundle with a disconnected
+  // Cloud status, so the designed signed-out state is the stable semantic
+  // contract. The real /cloud management route is intentionally bypassed.
+  "plugin-cloud-gui": expected({
+    requireAll: ["Eliza Cloud"],
+    requireAny: [
+      "credits",
+      "hosted agents",
+      "API keys",
+      "billing",
+      "Connect in Settings",
+    ],
+  }),
   "plugin-contacts-gui": expected({
     requireAny: ["address book", "phone, or email", "search"],
   }),

--- a/packages/ui/src/hooks/useAvailableViews.test.tsx
+++ b/packages/ui/src/hooks/useAvailableViews.test.tsx
@@ -256,6 +256,41 @@ describe("useAvailableViews", () => {
     );
   });
 
+  it("keeps a runtime bundle when an unavailable app-shell fallback shares its id", async () => {
+    registerAppShellPage({
+      id: "cloud",
+      pluginId: "@elizaos/ui",
+      label: "Managed Cloud",
+      path: "/cloud",
+      availability: "managed-cloud",
+      Component: () => null,
+    });
+    fetchWithCsrf.mockResolvedValueOnce(
+      response(200, {
+        views: [
+          view("cloud", {
+            label: "Cloud plugin",
+            path: "/__audit/plugin-view/cloud",
+            bundleUrl: "/api/views/cloud/bundle.js",
+          }),
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useAvailableViews());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.views).toContainEqual(
+      expect.objectContaining({
+        id: "cloud",
+        label: "Cloud plugin",
+        path: "/__audit/plugin-view/cloud",
+        bundleUrl: "/api/views/cloud/bundle.js",
+        pluginName: "test-plugin",
+      }),
+    );
+  });
+
   it("accepts the current view-capability transport contract", async () => {
     fetchWithCsrf.mockResolvedValueOnce(
       response(200, {

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -658,8 +658,14 @@ export function useAvailableViews(
         )
         .map((page) => page.id),
     );
+    // Availability gates apply to the in-process fallback registration, not to
+    // a richer network entry that won the web/desktop merge for the same id.
+    // Cloud intentionally has both: its managed console page is unavailable on
+    // a local runtime while plugin-elizacloud's remote account view is valid.
+    const networkEntries = new Set(networkViews);
     const runtimeAvailable = merged.filter(
-      (view) => !unavailableRegistrationIds.has(view.id),
+      (view) =>
+        !unavailableRegistrationIds.has(view.id) || networkEntries.has(view),
     );
     // Native device-OS surfaces (phone, messages, contacts, camera) exist only
     // on the AOSP ElizaOS fork. Each such view declares `nativeOs: true` on its


### PR DESCRIPTION
## Summary

- register plugin-elizacloud CloudView in the authoritative real-bundle UI-smoke inventory with its agent-surface capability
- preserve an authoritative web/desktop network view when an unavailable in-process fallback shares the same id
- replace the stale launcher OCR contract with CloudView signed-out semantics
- add registry-parity and merge-collision regressions

Closes #25255. Parent inventory initiative: #23110.

## Root cause

The smoke registry omitted the shipped Cloud view, so the audit fell through to production /cloud and correctly redirected unsigned browsers to /login. Once registered, a second id collision appeared: the unavailable managed-only in-process cloud page removed the richer plugin-elizacloud network entry on local runtimes, leaving the Views manager active. The merge now gates only the fallback entry that actually won, never the authoritative network entry.

## Verification

Exact rebased head: 751d204a8889565b65f38dfb330275cfd15e89a6

- bun install: pass with pinned Bun 1.3.14
- UI useAvailableViews owner test: 23/23 pass
- smoke registry + OCR policy tests: 14/14 pass
- UI typecheck: pass
- Biome on all six changed files: pass
- rebased targeted real-bundle audit: 4/4 good; broken=0, needs-work=0, needs-eyeball=0, hover/density failures=0
- rebased packaged OCR: 4/4 verified
- manual review: all four Cloud captures are minimal, readable, and clear of the chat composer
- full app capture before the final rebase: 226/227 tests passed; all four Cloud cases passed. The only strict failure was the four Settings findings already repaired separately by #25223. Three non-gating Vault hover probe timeouts are tracked in #25298.
- root bun run verify on the rebased head: guide parity and Biome version pass, then current develop fails check:i18n on five missing English connector-card keys. Tracked in #25299; this PR touches neither connector-card nor locale files.

## Screenshots

The four audited artifacts are generated outside the repository at /private/tmp/eliza-25255-cloud-audit-rebased/{mobile-portrait,mobile-landscape,desktop-landscape,ipad-portrait}/plugin-cloud-gui.png.

## Attribution

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [goal-14-15/cloud-view-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->