### PR TITLE
fix(ci): restore the plugin-sql lint gate by formatting the memory sorter

### DIFF
--- a/plugins/plugin-sql/src/services/advanced-memory-storage.ts
+++ b/plugins/plugin-sql/src/services/advanced-memory-storage.ts
@@ -389,27 +389,19 @@ export class AdvancedMemoryStorageService extends Service implements MemoryStora
 
   private sortLongTermMemories(memories: LongTermMemoryRecord[]): LongTermMemoryRecord[] {
     return [...memories].sort((left, right) => {
-      const leftUpdated = Number.isFinite(left.updatedAt.getTime())
-        ? left.updatedAt.getTime()
-        : 0;
+      const leftUpdated = Number.isFinite(left.updatedAt.getTime()) ? left.updatedAt.getTime() : 0;
       const rightUpdated = Number.isFinite(right.updatedAt.getTime())
         ? right.updatedAt.getTime()
         : 0;
       if (rightUpdated !== leftUpdated) {
         return rightUpdated - leftUpdated;
       }
-      const leftConfidence = Number.isFinite(left.confidence)
-        ? (left.confidence as number)
-        : 0;
-      const rightConfidence = Number.isFinite(right.confidence)
-        ? (right.confidence as number)
-        : 0;
+      const leftConfidence = Number.isFinite(left.confidence) ? (left.confidence as number) : 0;
+      const rightConfidence = Number.isFinite(right.confidence) ? (right.confidence as number) : 0;
       if (rightConfidence !== leftConfidence) {
         return rightConfidence - leftConfidence;
       }
-      const leftCreated = Number.isFinite(left.createdAt.getTime())
-        ? left.createdAt.getTime()
-        : 0;
+      const leftCreated = Number.isFinite(left.createdAt.getTime()) ? left.createdAt.getTime() : 0;
       const rightCreated = Number.isFinite(right.createdAt.getTime())
         ? right.createdAt.getTime()
         : 0;
@@ -419,18 +411,14 @@ export class AdvancedMemoryStorageService extends Service implements MemoryStora
 
   private sortSessionSummaries(summaries: SessionSummaryRecord[]): SessionSummaryRecord[] {
     return [...summaries].sort((left, right) => {
-      const leftUpdated = Number.isFinite(left.updatedAt.getTime())
-        ? left.updatedAt.getTime()
-        : 0;
+      const leftUpdated = Number.isFinite(left.updatedAt.getTime()) ? left.updatedAt.getTime() : 0;
       const rightUpdated = Number.isFinite(right.updatedAt.getTime())
         ? right.updatedAt.getTime()
         : 0;
       if (rightUpdated !== leftUpdated) {
         return rightUpdated - leftUpdated;
       }
-      const leftCreated = Number.isFinite(left.createdAt.getTime())
-        ? left.createdAt.getTime()
-        : 0;
+      const leftCreated = Number.isFinite(left.createdAt.getTime()) ? left.createdAt.getTime() : 0;
       const rightCreated = Number.isFinite(right.createdAt.getTime())
         ? right.createdAt.getTime()
         : 0;


### PR DESCRIPTION
# Relates to

No separate issue — this restores a repository-wide CI gate and is described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Formatting-only, proven by token-stream comparison below.
- [x] A reviewer can confirm it by running the package's own lint command.

# Sync with develop

- [x] Built on `origin/develop@1fc3c5af`; zero conflicts.
- [x] One file differs from `develop`.

# Risks

None. The change is whitespace. The token stream is identical before and after, so no expression, cast, comparison or control-flow construct is altered.

# Background

## What does this PR do?

`@elizaos/plugin-sql` fails `lint:check` on current `develop`:

```
services/advanced-memory-storage.ts format ━━━━━━━━━━━━━━━━━━━
  × Formatter would have printed the following content:
    392 │ - ······const·leftUpdated·=·Number.isFinite(left.updatedAt.getTime())
    393 │ - ········?·left.updatedAt.getTime()
    394 │ - ········:·0;
        │ + ······const·leftUpdated·=·Number.isFinite(left.updatedAt.getTime())·?·left.updatedAt.getTime()·:·0;
```

`sortLongTermMemories` has six multi-line ternaries that repository-pinned Biome 2.5.8 collapses onto single lines.

This is not local to plugin-sql. The static-smoke lane runs **Lint affected workspace closure**, and plugin-sql is inside that closure for most changed paths, so unrelated pull requests inherit the red stage:

```
@elizaos/plugin-sql:lint:check: error: script "lint:check" exited with code 1
Failed:    @elizaos/plugin-sql#lint:check
ERROR  run failed: command  exited (1)
```

Worth noting for anyone reproducing: plugin-sql does not lint from its package root. `package.json` defines `"lint:check": "cd src && bun run lint:check"`, and `src/package.json` defines `"lint:check": "bunx @biomejs/biome check --config-path ./biome.json ."`. Checking the file from the repository root with the root config does **not** reproduce the failure — the package's own nested config must be used.

## What is the fix?

Run the repository-pinned formatter. Nothing else.

```bash
cd plugins/plugin-sql/src
bunx @biomejs/biome@2.5.8 check --write --config-path ./biome.json services/advanced-memory-storage.ts
```

# Documentation changes needed?

No. No public surface, export, setting, or behaviour changes.

# Testing

## Where should a reviewer start?

Run the package's own command and confirm it now exits 0:

```
$ cd plugins/plugin-sql/src
$ bunx @biomejs/biome@2.5.8 check --config-path ./biome.json services/advanced-memory-storage.ts
Checked 1 file in 16ms. No fixes applied.
EXIT=0
```

## Detailed testing steps

| Gate | Before | After |
| --- | --- | --- |
| `biome check` (pinned 2.5.8, package config) | exits 1, formatter diff on six ternaries | `No fixes applied.`, exits 0 |
| token-stream comparison vs `develop` | — | **3579 tokens on both sides, identical** |
| diff vs `develop` | — | `+6/-18`, one file |

Formatting-only proof. A tokenizer that preserves string literals intact, strips comments and whitespace, and ignores `,` and `;` (the punctuation a formatter may legitimately add or remove) reports:

```
tokens develop: 3579  tokens fixed: 3579
IDENTICAL TOKEN STREAM — formatting-only
```

Every identifier, operator, cast and literal is unchanged and in the same order; only line breaks and indentation differ.

# Evidence Gate

<!-- evidence-head:ff673c283c6c13878b35918339f134b92640390c -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - whitespace-only change to a backend service file; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - whitespace-only change to a backend service file; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the formatter's exit code, quoted above in both directions`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the artifact is the lint command's output`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in formatting`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the artifact is the formatter result and the token-stream comparison above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by diagnosing an unrelated pull request's red static-smoke stage back to its shared cause.
- Diagnosis, formatter run, and token-stream verification by Claude Code (`claude-opus-5`).

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Attribution status: self-reported
