### PR TITLE
fix(inbox): safe NaN handling in Gmail normalization and message fetcher sort comparators

### DIFF
--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractNormalizedEmailAddress,
   filterGmailMessagesBySearch,
+  findLinkedMailForCalendarEvent,
   normalizeGmailSearchQueryMatches,
   normalizeOptionalGmailLabelIdArray,
   normalizeOptionalMessageIdArray,
@@ -266,5 +267,49 @@ describe("normalizeGmailSearchQueryMatches — standalone OR", () => {
     });
     expect(result).toHaveLength(2);
     expect(result.map((m) => m.id).sort()).toEqual(["m1", "m2"]);
+  });
+
+  it("sorts linked mail safely when receivedAt contains invalid date strings", () => {
+    const event = {
+      id: "ev1",
+      title: "Team Sync Meeting",
+      start: "2026-08-20T10:00:00Z",
+      end: "2026-08-20T11:00:00Z",
+      attendees: [{ email: "alice@example.com" }],
+    };
+    const msg1 = {
+      id: "m1",
+      threadId: "t1",
+      subject: "Team Sync agenda",
+      snippet: "",
+      from: "alice@example.com",
+      fromEmail: "alice@example.com",
+      to: [],
+      cc: [],
+      receivedAt: "invalid-date-string",
+      labels: [],
+      hasAttachments: false,
+    };
+    const msg2 = {
+      id: "m2",
+      threadId: "t2",
+      subject: "Team Sync notes",
+      snippet: "",
+      from: "alice@example.com",
+      fromEmail: "alice@example.com",
+      to: [],
+      cc: [],
+      receivedAt: "2026-08-20T12:00:00Z",
+      labels: [],
+      hasAttachments: false,
+    };
+
+    const linked = findLinkedMailForCalendarEvent(event as never, [
+      msg1 as never,
+      msg2 as never,
+    ]);
+    expect(linked).toHaveLength(2);
+    expect(linked[0]?.id).toBe("m2"); // newest first
+    expect(linked[1]?.id).toBe("m1"); // invalid fallback to 0
   });
 });

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -625,8 +625,17 @@ export function findLinkedMailForCalendarEvent(
       return messageTokens.some((token) => subjectTokens.has(token));
     })
     .sort((left, right) => {
-      const receivedDelta =
-        Date.parse(right.receivedAt) - Date.parse(left.receivedAt);
+      const rightTime =
+        typeof right.receivedAt === "string" &&
+        Number.isFinite(Date.parse(right.receivedAt))
+          ? Date.parse(right.receivedAt)
+          : 0;
+      const leftTime =
+        typeof left.receivedAt === "string" &&
+        Number.isFinite(Date.parse(left.receivedAt))
+          ? Date.parse(left.receivedAt)
+          : 0;
+      const receivedDelta = rightTime - leftTime;
       if (receivedDelta !== 0) {
         return receivedDelta;
       }

--- a/plugins/plugin-inbox/src/inbox/message-fetcher.ts
+++ b/plugins/plugin-inbox/src/inbox/message-fetcher.ts
@@ -774,7 +774,17 @@ export async function fetchAllMessages(
     (result): result is InboxSourceFetchResult => result !== null,
   );
   const combined = results.flatMap((result) => result.messages);
-  combined.sort((a, b) => b.timestamp - a.timestamp);
+  combined.sort((a, b) => {
+    const bTime =
+      typeof b.timestamp === "number" && Number.isFinite(b.timestamp)
+        ? b.timestamp
+        : 0;
+    const aTime =
+      typeof a.timestamp === "number" && Number.isFinite(a.timestamp)
+        ? a.timestamp
+        : 0;
+    return bTime - aTime;
+  });
   return {
     messages: opts.limit ? combined.slice(0, opts.limit) : combined,
     sources: results.map((result) => result.status),


### PR DESCRIPTION
## Summary

Validates date parsing and numeric timestamps with `Number.isFinite(...)` across Gmail linked mail filtering and combined inbox message fetcher sort comparators (`plugins/plugin-inbox/src/inbox/gmail-normalize.ts:628`, `plugins/plugin-inbox/src/inbox/message-fetcher.ts:777`) to prevent `NaN` return values when messages contain unparseable dates or non-numeric timestamps.

## Changes

- In `plugins/plugin-inbox/src/inbox/gmail-normalize.ts:628`, guard `Date.parse(receivedAt)` with `Number.isFinite(...)` and fallback to 0 before priority tiebreaking.
- In `plugins/plugin-inbox/src/inbox/message-fetcher.ts:777`, guard combined message `timestamp` numeric comparison with `Number.isFinite(...)`.
- In `plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts`, add unit test verifying that `findLinkedMailForCalendarEvent` maintains strict newest-first total ordering when `receivedAt` contains invalid date strings.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`6d1f9f7688`) |
| --- | --- | --- |
| `bun run --cwd plugins/plugin-inbox test src/inbox/gmail-normalize.test.ts` | 18 pass (18 tests) | 19 pass (19 tests) |
| `bunx @biomejs/biome check plugins/plugin-inbox/src/inbox/gmail-normalize.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-inbox/src/inbox/gmail-normalize.ts:625-640`
- `plugins/plugin-inbox/src/inbox/message-fetcher.ts:770-785`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric timestamps are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Inbox plugin message normalization and fetcher; no UI layout touched)
- [x] `audit:browser` — N/A (Message normalization sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 19/19 pass in `gmail-normalize.test.ts`
- [x] `lint` — Biome clean
