### PR TITLE
fix(cloud): let a fresh ledger pass the usage-quotas release barrier

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
@@ -1,6 +1,8 @@
 /**
  * Proves the temporary usage-quotas release barrier pauses the destructive
- * pair before SQL, repairs ledgers already at 0282, and rejects suffix drift.
+ * pair before SQL, repairs ledgers already at 0282, rejects suffix drift, and
+ * lets an empty ledger (a fresh database with no served Worker) apply the
+ * whole journal.
  */
 
 import { describe, expect, spyOn, test } from "bun:test";
@@ -234,6 +236,144 @@ describe("usage-quotas migration release barrier", () => {
       action: "pause",
       stopBeforeJournalIndex: 2,
     });
+  });
+
+  // The barrier protects a LIVE deployment: a Worker already serving traffic
+  // must never see the window between the drop and the restore. An empty
+  // ledger has no served Worker and no rows, so pausing there protects
+  // nothing; it only strands fresh environments at 0281. A ledger with even
+  // one applied migration is still a barrier target and still pauses.
+  test("continues from an empty ledger but still pauses any older validated ledger", () => {
+    const migrations = barrierMigrations();
+
+    expect(evaluateMigrationReleaseBarrier(migrations, -1)).toEqual({
+      action: "continue",
+    });
+    expect(evaluateMigrationReleaseBarrier(migrations, 0)).toEqual({
+      action: "pause",
+      stopBeforeJournalIndex: 2,
+    });
+    expect(evaluateMigrationReleaseBarrier(migrations, 1)).toEqual({
+      action: "pause",
+      stopBeforeJournalIndex: 2,
+    });
+  });
+
+  // The fresh-ledger carve-out sits behind the structural checks, so a fresh
+  // database still refuses a journal whose guarded pair is missing, duplicated,
+  // interleaved, or reversed instead of applying it without the barrier.
+  test("still validates the guarded pair's shape for an empty ledger", () => {
+    const [checkpoint, before, drop, restore] = barrierMigrations();
+
+    expect(() =>
+      evaluateMigrationReleaseBarrier(
+        [
+          checkpoint,
+          before,
+          drop,
+          migration(2825, "0282b_interleaved", "SELECT interleaved"),
+          restore,
+        ],
+        -1,
+      ),
+    ).toThrow("adjacent journal entries");
+    expect(() =>
+      evaluateMigrationReleaseBarrier([checkpoint, before, restore, drop], -1),
+    ).toThrow("adjacent journal entries");
+    expect(() =>
+      evaluateMigrationReleaseBarrier([checkpoint, before, drop], -1),
+    ).toThrow("requires exactly one of each suffix entry");
+    expect(() =>
+      evaluateMigrationReleaseBarrier(
+        [
+          checkpoint,
+          before,
+          drop,
+          restore,
+          migration(284, RESTORE_TAG, "SELECT duplicate"),
+        ],
+        -1,
+      ),
+    ).toThrow("requires exactly one of each suffix entry");
+  });
+
+  // End to end through runMigrations: an empty ledger applies every journal
+  // entry in order, the drop immediately followed by the restore and then the
+  // later suffixes, each individually ledgered, with no pause reported.
+  test("applies the whole journal from an empty ledger, including 0282, 0282_01, and later suffixes", async () => {
+    const migrations = [
+      ...barrierMigrations(),
+      migration(284, "0284_first_future_feature", "SELECT future_one"),
+      migration(285, "0285_second_future_feature", "SELECT future_two"),
+    ];
+    const harness = migrationClient(appliedRows(migrations, -1));
+    let convergenceCalls = 0;
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+    const warnings: string[] = [];
+    const warningLog = spyOn(console, "warn").mockImplementation(
+      (message: string) => {
+        warnings.push(message);
+      },
+    );
+
+    try {
+      await runMigrations(
+        harness.client,
+        migrations,
+        OPTIONS,
+        undefined,
+        undefined,
+        async () => {
+          convergenceCalls += 1;
+        },
+      );
+    } finally {
+      outputLog.mockRestore();
+      warningLog.mockRestore();
+    }
+
+    const appliedInOrder = [
+      ["SELECT checkpoint", CHECKPOINT_TAG],
+      ["SELECT before_drop", "0281_before_usage_quotas_release"],
+      ["DROP TABLE usage_quotas", DROP_TAG],
+      ["CREATE TABLE usage_quotas (id uuid)", RESTORE_TAG],
+      ["SELECT future_one", "0284_first_future_feature"],
+      ["SELECT future_two", "0285_second_future_feature"],
+    ] as const;
+    let searchFrom = 0;
+    for (const [statement, tag] of appliedInOrder) {
+      const begin = harness.queries.indexOf("BEGIN", searchFrom);
+      const run = harness.queries.indexOf(statement, searchFrom);
+      const ledgered = harness.queries.findIndex(
+        (query, index) =>
+          index > run &&
+          query.includes("INSERT INTO") &&
+          query.includes("__drizzle_migrations"),
+      );
+      const commit = harness.queries.indexOf("COMMIT", ledgered);
+      expect(begin).toBeGreaterThanOrEqual(0);
+      expect(run).toBeGreaterThan(begin);
+      expect(ledgered).toBeGreaterThan(run);
+      expect(commit).toBeGreaterThan(ledgered);
+      expect(harness.queryParams[ledgered]).toContain(`hash-${tag}`);
+      searchFrom = commit + 1;
+    }
+    expect(harness.queries.filter((query) => query === "BEGIN")).toHaveLength(
+      appliedInOrder.length,
+    );
+    expect(harness.queries.filter((query) => query === "COMMIT")).toHaveLength(
+      appliedInOrder.length,
+    );
+    // Journal order end to end, with the restore directly after the drop.
+    const statements = new Set(migrations.flatMap((item) => item.statements));
+    expect(harness.queries.filter((query) => statements.has(query))).toEqual(
+      appliedInOrder.map(([statement]) => statement),
+    );
+    expect(
+      warnings.some((message) => message.includes("release barrier paused")),
+    ).toBe(false);
+    expect(convergenceCalls).toBe(1);
+    expect(harness.ended()).toBe(true);
   });
 
   test("fails closed when either guarded migration is missing or duplicated", () => {

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
@@ -411,11 +411,25 @@ export function validateAppliedMigrationLedger(
 
 /**
  * Fences the two-step usage-quotas repair while the compatibility Worker is
- * being rolled out. Any validated ledger before 0282 may apply its safe prefix
- * but pauses before the drop so the deploy can continue without exposing the
- * old Worker to the missing table. Environments that already recorded 0282
- * must proceed directly to the restoring 0282_01 migration. Any other suffix is
- * unsafe and fails closed before the first pending migration is applied.
+ * being rolled out (#23829 Phase A, #23859). What the barrier protects is a
+ * LIVE deployment: a Worker already serving traffic against this database must
+ * never run against the window between 0282 (drop) and 0282_01 (restore). So a
+ * validated ledger that already carries applied migrations may apply its safe
+ * prefix but pauses before the drop, and the deploy continues without exposing
+ * the currently-served Worker to the missing table.
+ *
+ * An empty ledger (no applied migration, lastAppliedJournalIndex === -1) is
+ * outside that contract. No Worker has ever been served from a database with
+ * no migrations and no rows exist to expose, so pausing there protects nothing;
+ * it only strands every fresh environment (e2e stacks, cloud:mock, a new PGlite
+ * data dir) at 0281 with every later migration unapplied. A fresh ledger
+ * therefore continues through the whole journal: the drop runs immediately
+ * followed by the restore, whose adjacency is still validated above. Production
+ * and staging ledgers are never empty, so their semantics are unchanged.
+ *
+ * Environments that already recorded 0282 must proceed directly to the
+ * restoring 0282_01 migration. Any other suffix is unsafe and fails closed
+ * before the first pending migration is applied.
  */
 export function evaluateMigrationReleaseBarrier(
   migrations: Migration[],
@@ -461,6 +475,10 @@ export function evaluateMigrationReleaseBarrier(
       `Migration release barrier expected adjacent journal entries (${expectedSuffix}); found (${actualSuffix || "empty"})`,
     );
   }
+
+  // A fresh database has no served Worker to protect. Only ledgers that have
+  // already applied at least one migration are release-barrier targets.
+  if (lastAppliedJournalIndex === -1) return { action: "continue" };
 
   if (lastAppliedJournalIndex < dropIndex) {
     return { action: "pause", stopBeforeJournalIndex: dropIndex };


### PR DESCRIPTION
# Relates to

#23829 (usage-quotas drop/restore rollout) — Phase A landed the fail-closed release barrier in #23859. This does not change Phase A's contract for deployed environments; it stops the barrier from stranding fresh databases.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun run verify` — not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the migrate logs below.

# Sync with develop

- [x] Based on `origin/develop` (`1fc3c5af789`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**Low for deployed environments, by construction.** The only new branch is `if (lastAppliedJournalIndex === -1) return { action: "continue" }`, placed after the existing structural validation of the guarded pair (exactly one of each tag, restore adjacent to the drop). Production and staging ledgers carry hundreds of applied rows, so `lastAppliedJournalIndex` is never `-1` there and every pause / repair / fail-closed path is byte-for-byte unchanged (the 12 existing barrier tests are untouched and green). Residual exposure is a database with an empty ledger that is nonetheless serving a Worker — outside the barrier's own contract and not a deployed configuration. No new flags, env vars, or log formats.

# Background

## What does this PR do?

`evaluateMigrationReleaseBarrier` pauses before 0282 for any ledger with `lastAppliedJournalIndex < dropIndex` — including `-1`, a fresh database with nothing applied. The barrier exists to protect a **live** deployment: a Worker already serving traffic must never see the window between 0282 (drop) and 0282_01 (restore). A fresh database has no served Worker and no rows, so pausing there protects nothing; it strands every fresh environment at 0281 with every later migration unapplied — concretely, every cloud e2e stack (`packages/cloud/e2e` boots a fresh PGlite and runs `db:migrate`) and every fresh `cloud:mock` stack has been running without 0282…0308 (including the Personal Shared group tables 0297/0303/0304), and a second `db:migrate` run pauses again forever.

Change: an empty ledger continues through the whole journal (the drop runs immediately followed by the restore; adjacency is still validated). Doc comment rewritten to state exactly what the barrier protects and why an empty ledger is outside it.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation; the function's doc comment carries the rationale.

# Testing

## Where should a reviewer start?

`packages/cloud/scripts/admin/migrate-with-diagnostics.ts` (one guard + doc comment), then the three new tests in `migrate-with-diagnostics-release-barrier.test.ts`: `(…, -1)` → continue while `(…, 0)` / `(…, 1)` still pause; the guarded pair's shape is still validated for an empty ledger (interleaved / reversed / missing / duplicated throw); and `runMigrations` from an empty ledger applies the whole journal in order — drop, restore immediately after, later suffixes — each individually ledgered, with no pause warning.

## Detailed testing steps

- `bun test --config=packages/scripts/bunfig.script-tests.toml packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts` → **15 pass / 0 fail** (12 before the change, all unchanged).
- `…migrate-with-diagnostics-ledger.test.ts` 4/4, `…database-identity.test.ts` 2/2, `…error-precedence.test.ts` 4/4; `…postgres.test.ts` 14 skipped (gated on `RUN_REAL_POSTGRES_MIGRATION_TESTS=1`).
- biome clean on both touched files; `packages/cloud/api` `tsc --noEmit` unaffected.

Fresh throwaway PGlite, `bun run --cwd packages/cloud/shared db:migrate`:

Before (`origin/develop`):
```
[db:migrate] last applied migration: none
[db:migrate] pending migrations: 292
[db:migrate] release barrier permits 276 safe pending migrations before 0282
…
[db:migrate] release barrier paused before 0282_drop_unused_usage_quotas_table; deploy the compatibility Worker before advancing the migration ledger
```
A second run on that database: `pending migrations: 16` → `permits 0 safe pending` → paused again.

After (this branch): 292 `applying` lines including `0282_drop…`, `0282_01_restore…`, `0297_personal_shared_group_bindings`, `0303…`, `0304…`, `0308_remove_conversation_token_default`, then `[db:migrate] migrations complete`; a second run: `pending migrations: 0`.

Cloud e2e stack (`packages/cloud/e2e/.logs/cloud-migrate.log`, fresh PGlite booted by `stack.ts`): `origin/develop` → 276 applied, paused before 0282; this branch → 292 applied, `migrations complete`, no pause.

# Evidence Gate

<!-- evidence-head:1b5f7568dafd5dd4dbc7335b3b10a98d50799232 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the `[db:migrate]` lines above, before and after, on a fresh PGlite and on the e2e stack's fresh PGlite.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the migration ledger rows — 292 applied on a fresh database versus 276 before (second run `pending migrations: 0` versus paused again).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no model-facing change.

## Backend + frontend logs
See Testing.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- Found while proving this end to end, pre-existing on `origin/develop` and deliberately not widened into this PR: `packages/cloud/e2e/tests/personal-eliza-first-five-minutes.spec.ts` fails at its first delivery with `400 Invalid messaging delivery` because the Telegram DM branch of `sharedMessageSchema` has required `connectorAccountId` since #24356 while the spec never sends it (and, once that is patched locally, the fully-migrated stack answers "Eliza is temporarily unavailable (no shared model configured)" instead of the expected capability refusal). Separate follow-up.
- `migrate-with-diagnostics.postgres.test.ts` (gated lane) pins `pending migrations: 2` at two places; with 14 migrations appended after 0282_01 the real count after the pause is 16. Unaffected by this change (those cases seed non-empty ledgers), will fail whenever the gated lane runs. Separate follow-up.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
