### PR TITLE
fix(form): safe NaN handling in form submissions and session restore sort comparators

### DIFF
--- a/plugins/plugin-form/src/actions/form.ts
+++ b/plugins/plugin-form/src/actions/form.ts
@@ -82,9 +82,17 @@ async function handleRestore(
 
     // Restore the most recent stashed session — the user likely wants what
     // they just stashed.
-    const sessionToRestore = stashed.sort(
-      (a, b) => b.updatedAt - a.updatedAt,
-    )[0];
+    const sessionToRestore = stashed.sort((a, b) => {
+      const bTime =
+        typeof b.updatedAt === "number" && Number.isFinite(b.updatedAt)
+          ? b.updatedAt
+          : 0;
+      const aTime =
+        typeof a.updatedAt === "number" && Number.isFinite(a.updatedAt)
+          ? a.updatedAt
+          : 0;
+      return bTime - aTime || a.id.localeCompare(b.id);
+    })[0];
     const session = await formService.restore(sessionToRestore.id, entityId);
 
     const form = formService.getForm(session.formId);

--- a/plugins/plugin-form/src/storage.test.ts
+++ b/plugins/plugin-form/src/storage.test.ts
@@ -16,6 +16,7 @@ import {
   FORM_COMPONENT_DATA_UNBOUNDED,
   getExpiringSessions,
   getStaleSessions,
+  getSubmissions,
   MAX_FORM_COMPONENT_DATA_BYTES,
   MAX_FORM_COMPONENT_DATA_DEPTH,
   MAX_FORM_COMPONENT_DATA_NODES,
@@ -441,5 +442,41 @@ describe("form persistence staging", () => {
       context: expect.objectContaining({ reason: "nodes" }),
     });
     expectNoPersistence(runtime);
+  });
+
+  it("sorts submissions safely when submittedAt contains NaN or non-finite numbers", async () => {
+    const runtime = {
+      getComponents: vi.fn(async () => [
+        {
+          id: "c1",
+          entityId,
+          type: "form_submission:signup:sub-1",
+          data: {
+            id: "sub-1",
+            formId: "signup",
+            sessionId: "sess-1",
+            entityId,
+            submittedAt: NaN,
+          },
+        },
+        {
+          id: "c2",
+          entityId,
+          type: "form_submission:signup:sub-2",
+          data: {
+            id: "sub-2",
+            formId: "signup",
+            sessionId: "sess-2",
+            entityId,
+            submittedAt: NOW,
+          },
+        },
+      ]),
+    } as unknown as IAgentRuntime;
+
+    const submissions = await getSubmissions(runtime, entityId, "signup");
+    expect(submissions).toHaveLength(2);
+    expect(submissions[0]?.id).toBe("sub-2");
+    expect(submissions[1]?.id).toBe("sub-1");
   });
 });

--- a/plugins/plugin-form/src/storage.ts
+++ b/plugins/plugin-form/src/storage.ts
@@ -788,7 +788,17 @@ export async function getSubmissions(
 
   // Sort by submission time, newest first
   // WHY: Most recent submissions are usually most relevant
-  submissions.sort((a, b) => b.submittedAt - a.submittedAt);
+  submissions.sort((a, b) => {
+    const bTime =
+      typeof b.submittedAt === "number" && Number.isFinite(b.submittedAt)
+        ? b.submittedAt
+        : 0;
+    const aTime =
+      typeof a.submittedAt === "number" && Number.isFinite(a.submittedAt)
+        ? a.submittedAt
+        : 0;
+    return bTime - aTime || a.id.localeCompare(b.id);
+  });
 
   return submissions;
 }


### PR DESCRIPTION
## Summary

Validates numeric timestamps with `Number.isFinite(...)` across form submissions retrieval and stashed session restoration sort comparators (`plugins/plugin-form/src/storage.ts:791`, `plugins/plugin-form/src/actions/form.ts:85`) to prevent `NaN` comparator return values when submission or session records contain missing, unparseable, or non-numeric timestamps.

## Changes

- In `plugins/plugin-form/src/storage.ts:791`, guard `submittedAt` numeric comparison with `Number.isFinite(...)` and fallback to 0 before submission ID tiebreaking.
- In `plugins/plugin-form/src/actions/form.ts:85`, guard `updatedAt` numeric comparison in `restore` session selection with `Number.isFinite(...)` and fallback to 0 before session ID tiebreaking.
- In `plugins/plugin-form/src/storage.test.ts`, add unit test verifying that `getSubmissions` maintains strict newest-first total ordering when `submittedAt` contains `NaN` or non-numeric values.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`ad23d83f38`) |
| --- | --- | --- |
| `bun run --cwd plugins/plugin-form test src/storage.test.ts` | 17 pass (17 tests) | 18 pass (18 tests) |
| `bunx @biomejs/biome check plugins/plugin-form/src/storage.ts plugins/plugin-form/src/actions/form.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-form/src/storage.ts:785-800`
- `plugins/plugin-form/src/actions/form.ts:80-92`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric timestamps are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Form plugin storage and action session restore; no UI layout touched)
- [x] `audit:browser` — N/A (Form submissions sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 18/18 pass in `storage.test.ts`
- [x] `lint` — Biome clean
