### PR TITLE
test(cloud): prove deletion refusal preserves account authority

### DIFF
--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -98,6 +98,8 @@ interface CloudAuditCase {
   route: string;
   /** Seed the persisted Steward token before boot (authed cloud pages). */
   auth: boolean;
+  /** Capture the complete scroll surface when this route has reviewable content below the fold. */
+  fullPageEvidence?: boolean;
   /**
    * Routes that always redirect on localhost (role-gated, environment-bound)
    * cannot be visually inspected in this harness. Instead of recording a
@@ -357,6 +359,7 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
     path: "/account-deletion?requested=untrusted-audit-receipt",
     route: "account-deletion",
     auth: AUTH,
+    fullPageEvidence: true,
   },
   { slug: "bsc", path: "/bsc", route: "bsc", auth: PUBLIC },
   // api-explorer/
@@ -829,6 +832,34 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
         readableChars = await readPaintAfterNavigation(10);
 
         const restPath = path.join(shotDir, `${auditCase.slug}.png`);
+        const fullPage = auditCase.fullPageEvidence ?? false;
+        if (fullPage) {
+          const scrollRegion = page
+            .locator("[data-scroll-cert-scroller]")
+            .first();
+          await expect(scrollRegion).toHaveCount(1);
+          const scrollMetrics = await scrollRegion.evaluate((element) => ({
+            clientHeight: element.clientHeight,
+            scrollHeight: element.scrollHeight,
+          }));
+          if (scrollMetrics.scrollHeight > scrollMetrics.clientHeight) {
+            await scrollRegion.evaluate((element) => {
+              element.scrollTop = element.scrollHeight;
+            });
+            expect(
+              await scrollRegion.evaluate((element) => element.scrollTop),
+              `${auditCase.slug} owns a working vertical scroll region`,
+            ).toBeGreaterThan(0);
+            await scrollRegion.evaluate((element) => {
+              element.scrollTop = 0;
+            });
+          }
+          await page.setViewportSize({
+            width: vp.width,
+            height: Math.ceil(scrollMetrics.scrollHeight),
+          });
+          await page.waitForTimeout(100);
+        }
         // Billing's server-authoritative resource fields sit below the initial
         // viewport inside an app-owned scroll container. Capture the complete
         // Active Compute card in both states instead of green-lighting a frame
@@ -848,7 +879,7 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
         const captureEvidence = (targetPath: string) =>
           billingEvidenceTarget
             ? billingEvidenceTarget.screenshot({ path: targetPath })
-            : page.screenshot({ path: targetPath, fullPage: false });
+            : page.screenshot({ path: targetPath, fullPage });
         let buffer = await captureEvidence(restPath);
         let quality = await analyzeScreenshot(buffer).catch(() => null);
         for (

--- a/packages/cloud/e2e/tests/account-deletion.spec.ts
+++ b/packages/cloud/e2e/tests/account-deletion.spec.ts
@@ -3,14 +3,181 @@
 import { seedTestUser } from "../src/fixtures/seed";
 import { expect, test } from "../src/helpers/test-fixtures";
 
+type CanonicalValue =
+  | null
+  | boolean
+  | number
+  | string
+  | CanonicalValue[]
+  | { [key: string]: CanonicalValue };
+
+function canonicalize(value: unknown): CanonicalValue {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return value;
+  }
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  throw new Error(
+    `Unsupported account-deletion snapshot value: ${typeof value}`,
+  );
+}
+
+const SENSITIVE_EVIDENCE_FIELDS = new Set([
+  "anonymous_session_id",
+  "avatar",
+  "billing_email",
+  "description",
+  "discord_avatar_url",
+  "discord_global_name",
+  "discord_id",
+  "discord_username",
+  "email",
+  "name",
+  "nickname",
+  "phone_number",
+  "preferences",
+  "settings",
+  "slug",
+  "steward_tenant_id",
+  "steward_tenant_api_key",
+  "steward_user_id",
+  "stripe_customer_id",
+  "stripe_default_payment_method",
+  "stripe_payment_method_id",
+  "telegram_first_name",
+  "telegram_id",
+  "telegram_photo_url",
+  "telegram_username",
+  "wallet_address",
+  "whatsapp_id",
+  "whatsapp_name",
+  "work_function",
+  "userId",
+  "key_auth_tag",
+  "key_ciphertext",
+  "key_hash",
+  "key_kms_key_id",
+  "key_nonce",
+  "key_prefix",
+]);
+
+const SENSITIVE_EVIDENCE_FIELD_SUFFIXES = [
+  "_auth_tag",
+  "_blind_index",
+  "_ciphertext",
+  "_nonce",
+] as const;
+
+function isSensitiveEvidenceField(key: string): boolean {
+  return (
+    SENSITIVE_EVIDENCE_FIELDS.has(key) ||
+    SENSITIVE_EVIDENCE_FIELD_SUFFIXES.some((suffix) => key.endsWith(suffix))
+  );
+}
+
+function redactDeletionAuthorityEvidence(
+  value: CanonicalValue,
+): CanonicalValue {
+  if (Array.isArray(value)) return value.map(redactDeletionAuthorityEvidence);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      isSensitiveEvidenceField(key)
+        ? "[redacted]"
+        : redactDeletionAuthorityEvidence(entry),
+    ]),
+  );
+}
+
+async function snapshotDeletionAuthority(stack: {
+  mocks: {
+    steward: {
+      users: Map<string, string>;
+      calls: Array<{ method: string; path: string; userId: string }>;
+    };
+  };
+}): Promise<CanonicalValue> {
+  const [
+    { dbWrite },
+    userSchema,
+    organizationSchema,
+    apiKeySchema,
+    requestSchema,
+  ] = await Promise.all([
+    import("@elizaos/cloud-shared/db/helpers"),
+    import("@elizaos/cloud-shared/db/schemas/users"),
+    import("@elizaos/cloud-shared/db/schemas/organizations"),
+    import("@elizaos/cloud-shared/db/schemas/api-keys"),
+    import("@elizaos/cloud-shared/db/schemas/account-deletion-requests"),
+  ]);
+  const [userRows, organizationRows, apiKeyRows, requestRows] =
+    await Promise.all([
+      dbWrite.select().from(userSchema.users),
+      dbWrite.select().from(organizationSchema.organizations),
+      dbWrite.select().from(apiKeySchema.apiKeys),
+      dbWrite.select().from(requestSchema.accountDeletionRequests),
+    ]);
+  const byId = <T extends { id: string }>(rows: T[]) =>
+    [...rows].sort((left, right) => left.id.localeCompare(right.id));
+
+  return canonicalize({
+    database: {
+      users: byId(userRows),
+      organizations: byId(organizationRows),
+      apiKeys: byId(apiKeyRows),
+      accountDeletionRequests: byId(requestRows),
+    },
+    steward: {
+      userStates: [...stack.mocks.steward.users.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([userId, state]) => ({ userId, state })),
+      calls: stack.mocks.steward.calls,
+    },
+  });
+}
+
 test.describe("account deletion", () => {
   test("fails closed without mutating the account or another tenant", async ({
     authenticatedPage,
     stack,
     seededUser,
-  }) => {
+  }, testInfo) => {
     const other = await seedTestUser({
       slug: `account-deletion-control-${Date.now()}`,
+    });
+    stack.mocks.steward.users.set(seededUser.stewardUserId, "active");
+    stack.mocks.steward.users.set(other.stewardUserId, "active");
+    const frontendEvents: Array<Record<string, unknown>> = [];
+    authenticatedPage.on("console", (message) => {
+      frontendEvents.push({
+        type: `console:${message.type()}`,
+        text: message.text(),
+      });
+    });
+    authenticatedPage.on("pageerror", (error) => {
+      frontendEvents.push({ type: "pageerror", text: error.message });
+    });
+    authenticatedPage.on("requestfailed", (request) => {
+      frontendEvents.push({
+        type: "requestfailed",
+        method: request.method(),
+        url: request.url(),
+        error: request.failure()?.errorText,
+      });
     });
     await authenticatedPage.goto(
       `${stack.urls.frontend}/account-deletion?requested=untrusted-receipt`,
@@ -23,8 +190,9 @@ test.describe("account deletion", () => {
     await expect(
       authenticatedPage.getByRole("heading", { name: "Deletion scheduled" }),
     ).toHaveCount(0);
-    const request = (method: "GET" | "POST", confirmation?: string) =>
-      authenticatedPage.evaluate(
+    const httpEvidence: Array<Record<string, unknown>> = [];
+    const request = async (method: "GET" | "POST", confirmation?: string) => {
+      const result = await authenticatedPage.evaluate(
         async ({ method, confirmation }) => {
           const response = await fetch("/api/v1/me/account-deletion", {
             method,
@@ -38,6 +206,9 @@ test.describe("account deletion", () => {
         },
         { method, confirmation },
       );
+      httpEvidence.push({ method, confirmation, ...result });
+      return result;
+    };
 
     const initial = await request("GET");
     expect(initial.status).toBe(200);
@@ -57,30 +228,7 @@ test.describe("account deletion", () => {
     const { accountDeletionRequestsRepository } = await import(
       "@elizaos/cloud-shared/db/repositories/account-deletion-requests"
     );
-    const { apiKeysRepository } = await import(
-      "@elizaos/cloud-shared/db/repositories/api-keys"
-    );
-    const { organizationsRepository } = await import(
-      "@elizaos/cloud-shared/db/repositories/organizations"
-    );
-    const { usersRepository } = await import(
-      "@elizaos/cloud-shared/db/repositories/users"
-    );
-
-    const stewardStateBefore = stack.mocks.steward.users.get(
-      seededUser.stewardUserId,
-    );
-    const userBefore = await usersRepository.findByIdForWrite(
-      seededUser.userId,
-    );
-    const organizationBefore = await organizationsRepository.findById(
-      seededUser.organizationId,
-    );
-    const [keyBefore] = await apiKeysRepository.listByUser(seededUser.userId);
-    const [otherKeyBefore] = await apiKeysRepository.listByUser(other.userId);
-    const otherStewardStateBefore = stack.mocks.steward.users.get(
-      other.stewardUserId,
-    );
+    const authorityBefore = await snapshotDeletionAuthority(stack);
     expect(
       await accountDeletionRequestsRepository.findOpenByUserId(
         other.userId,
@@ -106,43 +254,15 @@ test.describe("account deletion", () => {
       },
     });
 
-    const userAfter = await usersRepository.findByIdForWrite(seededUser.userId);
-    const organizationAfter = await organizationsRepository.findById(
-      seededUser.organizationId,
-    );
-    const [keyAfter] = await apiKeysRepository.listByUser(seededUser.userId);
-    const [otherKeyAfter] = await apiKeysRepository.listByUser(other.userId);
-    const otherUser = await usersRepository.findByIdForWrite(other.userId);
-    const otherOrganization = await organizationsRepository.findById(
-      other.organizationId,
-    );
-
-    expect(userAfter).toMatchObject({
-      is_active: userBefore?.is_active,
-      deleted_at: userBefore?.deleted_at,
-    });
-    expect(organizationAfter).toMatchObject({
-      is_active: organizationBefore?.is_active,
-    });
-    expect(keyAfter).toMatchObject({ is_active: keyBefore?.is_active });
-    expect(stack.mocks.steward.users.get(seededUser.stewardUserId)).toBe(
-      stewardStateBefore,
-    );
+    const authorityAfter = await snapshotDeletionAuthority(stack);
+    expect(authorityAfter).toEqual(authorityBefore);
+    expect(stack.mocks.steward.calls).toEqual([]);
     expect(
       await accountDeletionRequestsRepository.findOpenByUserId(
         seededUser.userId,
         true,
       ),
     ).toBeUndefined();
-    expect(otherUser).toMatchObject({ is_active: true });
-    expect(otherOrganization).toMatchObject({ is_active: true });
-    expect(otherKeyAfter).toMatchObject({
-      id: otherKeyBefore?.id,
-      is_active: otherKeyBefore?.is_active,
-    });
-    expect(stack.mocks.steward.users.get(other.stewardUserId)).toBe(
-      otherStewardStateBefore,
-    );
     expect(
       await accountDeletionRequestsRepository.findOpenByUserId(
         other.userId,
@@ -152,5 +272,106 @@ test.describe("account deletion", () => {
 
     const after = await request("GET");
     expect(after).toEqual(initial);
+    expect(
+      frontendEvents.filter(
+        (event) => event.type === "pageerror" || event.type === "requestfailed",
+      ),
+    ).toEqual([]);
+    expect(
+      frontendEvents.filter((event) => event.type === "console:error"),
+    ).toEqual([
+      {
+        type: "console:error",
+        text: "Failed to load resource: the server responded with a status of 400 (Bad Request)",
+      },
+      {
+        type: "console:error",
+        text: "Failed to load resource: the server responded with a status of 409 (Conflict)",
+      },
+    ]);
+
+    await testInfo.attach("account-deletion-authority-before.json", {
+      body: JSON.stringify(
+        redactDeletionAuthorityEvidence(authorityBefore),
+        null,
+        2,
+      ),
+      contentType: "application/json",
+    });
+    await testInfo.attach("account-deletion-authority-after.json", {
+      body: JSON.stringify(
+        redactDeletionAuthorityEvidence(authorityAfter),
+        null,
+        2,
+      ),
+      contentType: "application/json",
+    });
+    await testInfo.attach("account-deletion-http.json", {
+      body: JSON.stringify(httpEvidence, null, 2),
+      contentType: "application/json",
+    });
+    await testInfo.attach("account-deletion-frontend-events.json", {
+      body: JSON.stringify(frontendEvents, null, 2),
+      contentType: "application/json",
+    });
+  });
+
+  test("canonical authority snapshots detect nested, row-set, and provider-call mutations", () => {
+    const source = {
+      database: {
+        users: [{ id: "user-1", preferences: { theme: "dark" } }],
+        organizations: [{ id: "org-1", settings: { locale: "en" } }],
+        apiKeys: [
+          {
+            id: "key-1",
+            key_ciphertext: "secret",
+            key_prefix: "eliz_fixture",
+            usage_count: 0,
+          },
+        ],
+        accountDeletionRequests: [],
+      },
+      steward: {
+        userStates: [{ userId: "steward-1", state: "active" }],
+        calls: [] as Array<{ method: string; path: string; userId: string }>,
+      },
+    };
+    const before = canonicalize(source);
+
+    source.database.organizations[0].settings.locale = "fr";
+    expect(canonicalize(source)).not.toEqual(before);
+    source.database.organizations[0].settings.locale = "en";
+    source.database.apiKeys.push({
+      id: "key-2",
+      key_ciphertext: "other-secret",
+      key_prefix: "eliz_fixture_2",
+      usage_count: 0,
+    });
+    expect(canonicalize(source)).not.toEqual(before);
+    source.database.apiKeys.pop();
+    source.steward.calls.push({
+      method: "PATCH",
+      path: "/deactivate",
+      userId: "steward-1",
+    });
+    expect(canonicalize(source)).not.toEqual(before);
+    source.steward.calls.pop();
+    source.steward.userStates[0].state = "deactivated";
+    expect(canonicalize(source)).not.toEqual(before);
+    expect(redactDeletionAuthorityEvidence(canonicalize(source))).toMatchObject(
+      {
+        database: {
+          apiKeys: [
+            {
+              key_ciphertext: "[redacted]",
+              key_prefix: "[redacted]",
+            },
+          ],
+        },
+        steward: {
+          userStates: [{ userId: "[redacted]", state: "deactivated" }],
+        },
+      },
+    );
   });
 });

--- a/packages/cloud/e2e/tests/account-deletion.spec.ts
+++ b/packages/cloud/e2e/tests/account-deletion.spec.ts
@@ -35,72 +35,96 @@ function canonicalize(value: unknown): CanonicalValue {
   );
 }
 
-const SENSITIVE_EVIDENCE_FIELDS = new Set([
-  "anonymous_session_id",
-  "avatar",
-  "billing_email",
-  "description",
-  "discord_avatar_url",
-  "discord_global_name",
-  "discord_id",
-  "discord_username",
-  "email",
-  "name",
-  "nickname",
-  "phone_number",
-  "preferences",
-  "settings",
-  "slug",
-  "steward_tenant_id",
-  "steward_tenant_api_key",
-  "steward_user_id",
-  "stripe_customer_id",
-  "stripe_default_payment_method",
-  "stripe_payment_method_id",
-  "telegram_first_name",
-  "telegram_id",
-  "telegram_photo_url",
-  "telegram_username",
-  "wallet_address",
-  "whatsapp_id",
-  "whatsapp_name",
-  "work_function",
-  "userId",
-  "key_auth_tag",
-  "key_ciphertext",
-  "key_hash",
-  "key_kms_key_id",
-  "key_nonce",
-  "key_prefix",
-]);
+const REDACTED_EVIDENCE_VALUE = "[redacted]";
+const SAFE_EVIDENCE_STRING_VALUES: Readonly<
+  Record<string, ReadonlySet<string>>
+> = {
+  method: new Set(["DELETE", "GET", "PATCH", "POST"]),
+  state: new Set(["active", "deactivated", "deleted"]),
+};
 
-const SENSITIVE_EVIDENCE_FIELD_SUFFIXES = [
-  "_auth_tag",
-  "_blind_index",
-  "_ciphertext",
-  "_nonce",
-] as const;
+function normalizedEvidenceField(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .toLowerCase();
+}
 
 function isSensitiveEvidenceField(key: string): boolean {
+  const normalized = normalizedEvidenceField(key);
   return (
-    SENSITIVE_EVIDENCE_FIELDS.has(key) ||
-    SENSITIVE_EVIDENCE_FIELD_SUFFIXES.some((suffix) => key.endsWith(suffix))
+    /(^|_)(?:id|identifier|email|phone|wallet|address|avatar|name|slug|description|preferences|settings)$/.test(
+      normalized,
+    ) ||
+    /_(?:id|identifier|key|token|secret|credential|auth_tag|blind_index|ciphertext|nonce|hash|prefix|url)$/.test(
+      normalized,
+    ) ||
+    normalized.startsWith("kms_") ||
+    normalized.includes("_kms_")
   );
 }
 
 function redactDeletionAuthorityEvidence(
   value: CanonicalValue,
+  field = "",
 ): CanonicalValue {
-  if (Array.isArray(value)) return value.map(redactDeletionAuthorityEvidence);
+  if (typeof value === "string") {
+    return SAFE_EVIDENCE_STRING_VALUES[field]?.has(value)
+      ? value
+      : REDACTED_EVIDENCE_VALUE;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactDeletionAuthorityEvidence(entry, field));
+  }
   if (value === null || typeof value !== "object") return value;
   return Object.fromEntries(
     Object.entries(value).map(([key, entry]) => [
       key,
       isSensitiveEvidenceField(key)
-        ? "[redacted]"
-        : redactDeletionAuthorityEvidence(entry),
+        ? REDACTED_EVIDENCE_VALUE
+        : redactDeletionAuthorityEvidence(entry, key),
     ]),
   );
+}
+
+function assertPublishableDeletionEvidence(
+  value: CanonicalValue,
+  field = "",
+): void {
+  if (typeof value === "string") {
+    if (
+      value !== REDACTED_EVIDENCE_VALUE &&
+      !SAFE_EVIDENCE_STRING_VALUES[field]?.has(value)
+    ) {
+      throw new Error(
+        `Account-deletion evidence retained an unapproved string at ${field || "<root>"}`,
+      );
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) assertPublishableDeletionEvidence(entry, field);
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  for (const [key, entry] of Object.entries(value)) {
+    // Snapshot schemas use ordinary field identifiers. A dynamic path, ARN,
+    // URL, UUID, or row identifier used as an object key is not publishable:
+    // changing it to a placeholder could collide with another key and silently
+    // discard evidence, so publication fails closed instead.
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(
+        `Account-deletion evidence contained an unsafe structural key at ${key}`,
+      );
+    }
+    assertPublishableDeletionEvidence(entry, key);
+  }
+}
+
+function serializeDeletionAuthorityEvidence(value: CanonicalValue): string {
+  const redacted = redactDeletionAuthorityEvidence(value);
+  assertPublishableDeletionEvidence(redacted);
+  return JSON.stringify(redacted, null, 2);
 }
 
 async function snapshotDeletionAuthority(stack: {
@@ -244,6 +268,10 @@ test.describe("account deletion", () => {
         code: "confirmation_required",
       },
     });
+    const authorityAfterUnconfirmed = await snapshotDeletionAuthority(stack);
+    expect(authorityAfterUnconfirmed).toEqual(authorityBefore);
+    expect(stack.mocks.steward.calls).toEqual([]);
+
     const refused = await request("POST", "DELETE");
     expect(refused).toEqual({
       status: 409,
@@ -253,9 +281,9 @@ test.describe("account deletion", () => {
         code: "LIFECYCLE_RESERVATION_REQUIRED",
       },
     });
-
-    const authorityAfter = await snapshotDeletionAuthority(stack);
-    expect(authorityAfter).toEqual(authorityBefore);
+    const authorityAfterConfirmedRefusal =
+      await snapshotDeletionAuthority(stack);
+    expect(authorityAfterConfirmedRefusal).toEqual(authorityBefore);
     expect(stack.mocks.steward.calls).toEqual([]);
     expect(
       await accountDeletionRequestsRepository.findOpenByUserId(
@@ -291,21 +319,22 @@ test.describe("account deletion", () => {
     ]);
 
     await testInfo.attach("account-deletion-authority-before.json", {
-      body: JSON.stringify(
-        redactDeletionAuthorityEvidence(authorityBefore),
-        null,
-        2,
-      ),
+      body: serializeDeletionAuthorityEvidence(authorityBefore),
       contentType: "application/json",
     });
-    await testInfo.attach("account-deletion-authority-after.json", {
-      body: JSON.stringify(
-        redactDeletionAuthorityEvidence(authorityAfter),
-        null,
-        2,
-      ),
+    await testInfo.attach("account-deletion-authority-after-unconfirmed.json", {
+      body: serializeDeletionAuthorityEvidence(authorityAfterUnconfirmed),
       contentType: "application/json",
     });
+    await testInfo.attach(
+      "account-deletion-authority-after-confirmed-refusal.json",
+      {
+        body: serializeDeletionAuthorityEvidence(
+          authorityAfterConfirmedRefusal,
+        ),
+        contentType: "application/json",
+      },
+    );
     await testInfo.attach("account-deletion-http.json", {
       body: JSON.stringify(httpEvidence, null, 2),
       contentType: "application/json",
@@ -316,7 +345,7 @@ test.describe("account deletion", () => {
     });
   });
 
-  test("canonical authority snapshots detect nested, row-set, and provider-call mutations", () => {
+  test("canonical authority snapshots detect mutations and publish only structurally redacted evidence", () => {
     const source = {
       database: {
         users: [{ id: "user-1", preferences: { theme: "dark" } }],
@@ -373,5 +402,32 @@ test.describe("account deletion", () => {
         },
       },
     );
+
+    const adversarial = canonicalize({
+      id: "row-user-1",
+      row_id: "row-2",
+      stewardUserId: "steward-user-3",
+      kms_key_id: "arn:aws:kms:us-west-2:123:key/private",
+      path: "/platform/users/steward-user-3/delete",
+      note: "embedded row-user-1 and steward-user-3",
+      method: "DELETE",
+      state: "deactivated",
+    });
+    const published = serializeDeletionAuthorityEvidence(adversarial);
+    expect(published).not.toContain("row-user-1");
+    expect(published).not.toContain("row-2");
+    expect(published).not.toContain("steward-user-3");
+    expect(published).not.toContain("arn:aws:kms");
+    expect(published).not.toContain("/platform/users/");
+    expect(published).toContain('"method": "DELETE"');
+    expect(published).toContain('"state": "deactivated"');
+
+    expect(() =>
+      serializeDeletionAuthorityEvidence(
+        canonicalize({
+          "arn:aws:kms:us-west-2:123:key/private": "embedded-secret",
+        }),
+      ),
+    ).toThrow("unsafe structural key");
   });
 });

--- a/packages/cloud/test-mocks/src/steward/index.ts
+++ b/packages/cloud/test-mocks/src/steward/index.ts
@@ -5,17 +5,25 @@ import { startFetchServer } from "../fetch-server";
 
 export type StewardMockUserState = "active" | "deactivated" | "deleted";
 
+export interface StewardMockCall {
+  method: "PATCH" | "DELETE";
+  path: string;
+  userId: string;
+}
+
 export interface RunningStewardMock {
   stop(): Promise<void>;
   url: string;
   port: number;
   users: Map<string, StewardMockUserState>;
+  calls: StewardMockCall[];
 }
 
 export async function startStewardMock(
   options: { port?: number; hostname?: string; platformKey?: string } = {},
 ): Promise<RunningStewardMock> {
   const users = new Map<string, StewardMockUserState>();
+  const calls: StewardMockCall[] = [];
   const platformKey = options.platformKey ?? "steward-e2e-platform-key";
   const app = new Hono();
 
@@ -28,12 +36,14 @@ export async function startStewardMock(
 
   app.patch("/platform/users/:id/deactivate", (c) => {
     const userId = c.req.param("id");
+    calls.push({ method: "PATCH", path: c.req.path, userId });
     users.set(userId, "deactivated");
     return c.json({ ok: true, data: { userId } });
   });
 
   app.delete("/platform/users/:id", (c) => {
     const userId = c.req.param("id");
+    calls.push({ method: "DELETE", path: c.req.path, userId });
     users.set(userId, "deleted");
     return c.json({ ok: true, data: { userId } });
   });
@@ -48,5 +58,6 @@ export async function startStewardMock(
     url: `http://${server.hostname}:${server.port}`,
     port: server.port,
     users,
+    calls,
   };
 }

--- a/packages/cloud/test-mocks/test/steward-platform-users.test.ts
+++ b/packages/cloud/test-mocks/test/steward-platform-users.test.ts
@@ -23,6 +23,7 @@ describe("Steward platform user lifecycle mock", () => {
       },
     );
     expect(unauthorized.status).toBe(401);
+    expect(mock.calls).toEqual([]);
 
     const headers = { "x-steward-platform-key": "steward-e2e-platform-key" };
     const deactivated = await fetch(
@@ -34,6 +35,13 @@ describe("Steward platform user lifecycle mock", () => {
     );
     expect(deactivated.status).toBe(200);
     expect(mock.users.get(userId)).toBe("deactivated");
+    expect(mock.calls).toEqual([
+      {
+        method: "PATCH",
+        path: `/platform/users/${userId}/deactivate`,
+        userId,
+      },
+    ]);
 
     const deleted = await fetch(`${mock.url}/platform/users/${userId}`, {
       method: "DELETE",
@@ -41,5 +49,13 @@ describe("Steward platform user lifecycle mock", () => {
     });
     expect(deleted.status).toBe(200);
     expect(mock.users.get(userId)).toBe("deleted");
+    expect(mock.calls).toEqual([
+      {
+        method: "PATCH",
+        path: `/platform/users/${userId}/deactivate`,
+        userId,
+      },
+      { method: "DELETE", path: `/platform/users/${userId}`, userId },
+    ]);
   });
 });

--- a/packages/ui/src/cloud/account-security/components/account-deletion-dialog.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-deletion-dialog.test.tsx
@@ -144,4 +144,53 @@ describe("AccountDeletionDialog", () => {
     expect(deletionClient.endLocalSessionAfterDeletion).not.toHaveBeenCalled();
     expect(window.location.href).toBe(locationBefore);
   });
+
+  it("does not retire the session when the server refuses the confirmed request", async () => {
+    deletionClient.getAccountDeletionStatus.mockResolvedValue({
+      state: "available",
+      request: null,
+    });
+    deletionClient.submitAccountDeletion.mockRejectedValue(
+      new Error("Permanent account deletion is unavailable"),
+    );
+    render(<AccountDeletionDialog />);
+
+    fireEvent.click(await screen.findByText("Delete account"));
+    fireEvent.change(screen.getByLabelText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByTestId("delete-account-confirm"));
+
+    await screen.findByText("Permanent account deletion is unavailable");
+    expect(deletionClient.endLocalSessionAfterDeletion).not.toHaveBeenCalled();
+  });
+
+  it("retires the local authority only after a validated confirmed receipt", async () => {
+    deletionClient.getAccountDeletionStatus.mockResolvedValue({
+      state: "available",
+      request: null,
+    });
+    deletionClient.submitAccountDeletion.mockResolvedValue({
+      requestId: "request-validated",
+      status: "scheduled",
+      requestedAt: "2026-08-23T00:00:00.000Z",
+      scheduledDeletionAt: "2026-09-22T00:00:00.000Z",
+      identityDeactivated: true,
+      completedAt: null,
+    });
+    deletionClient.endLocalSessionAfterDeletion.mockResolvedValue(undefined);
+    render(<AccountDeletionDialog />);
+
+    fireEvent.click(await screen.findByText("Delete account"));
+    fireEvent.change(screen.getByLabelText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByTestId("delete-account-confirm"));
+
+    await waitFor(() => {
+      expect(deletionClient.endLocalSessionAfterDeletion).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+  });
 });

--- a/packages/ui/src/cloud/account-security/components/account-deletion-dialog.test.tsx
+++ b/packages/ui/src/cloud/account-security/components/account-deletion-dialog.test.tsx
@@ -1,7 +1,13 @@
 /** Renders every account-deletion admission state with deterministic client responses. */
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const deletionClient = vi.hoisted(() => ({
@@ -14,7 +20,11 @@ vi.mock("../data/account-deletion-client", () => deletionClient);
 
 import { AccountDeletionDialog } from "./account-deletion-dialog";
 
-beforeEach(() => deletionClient.getAccountDeletionStatus.mockReset());
+beforeEach(() => {
+  deletionClient.getAccountDeletionStatus.mockReset();
+  deletionClient.submitAccountDeletion.mockReset();
+  deletionClient.endLocalSessionAfterDeletion.mockReset();
+});
 afterEach(cleanup);
 
 describe("AccountDeletionDialog", () => {
@@ -107,5 +117,31 @@ describe("AccountDeletionDialog", () => {
       (screen.getByTestId("delete-account-confirm") as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+  });
+
+  it("does not retire the session when the POST receipt is malformed", async () => {
+    deletionClient.getAccountDeletionStatus.mockResolvedValue({
+      state: "available",
+      request: null,
+    });
+    deletionClient.submitAccountDeletion.mockRejectedValue(
+      new Error("Account deletion response was malformed"),
+    );
+    const locationBefore = window.location.href;
+    render(<AccountDeletionDialog />);
+
+    fireEvent.click(await screen.findByText("Delete account"));
+    fireEvent.change(screen.getByLabelText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByTestId("delete-account-confirm"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Account deletion response was malformed"),
+      ).toBeTruthy();
+    });
+    expect(deletionClient.endLocalSessionAfterDeletion).not.toHaveBeenCalled();
+    expect(window.location.href).toBe(locationBefore);
   });
 });

--- a/packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts
+++ b/packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts
@@ -108,7 +108,7 @@ describe("submitAccountDeletion", () => {
     );
   });
 
-  it("rejects unknown receipt statuses and invalid timestamps", async () => {
+  it("rejects unknown receipt statuses, blank ids, and invalid timestamps", async () => {
     const request = {
       requestId: "request-2",
       status: "scheduled",
@@ -117,6 +117,13 @@ describe("submitAccountDeletion", () => {
       identityDeactivated: true,
       completedAt: null,
     };
+
+    apiMock.mockResolvedValueOnce({
+      request: { ...request, requestId: "  " },
+    });
+    await expect(submitAccountDeletion()).rejects.toThrow(
+      "Account deletion receipt was malformed",
+    );
 
     apiMock.mockResolvedValueOnce({
       request: { ...request, status: "unexpected" },

--- a/packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts
+++ b/packages/ui/src/cloud/account-security/data/account-deletion-client.test.ts
@@ -1,12 +1,26 @@
-/** Verifies that account-deletion transport data is validated before the UI trusts it. */
+/** Verifies deletion receipts and the real local authority teardown that follows confirmed success. */
+// @vitest-environment jsdom
 
+import { getElizaApiToken, setElizaApiToken } from "@elizaos/shared";
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { client } from "../../../api";
+import { getBootConfig, setBootConfig } from "../../../config/boot-config";
+import {
+  loadAgentProfileRegistry,
+  saveAgentProfileRegistry,
+} from "../../../state/agent-profiles";
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../../../state/persistence";
 
 const apiMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../lib/api-client", () => ({ api: apiMock }));
 
 import {
+  endLocalSessionAfterDeletion,
   getAccountDeletionStatus,
   submitAccountDeletion,
 } from "./account-deletion-client";
@@ -145,5 +159,63 @@ describe("submitAccountDeletion", () => {
     await expect(submitAccountDeletion()).rejects.toThrow(
       "Account deletion receipt was malformed",
     );
+  });
+});
+
+describe("endLocalSessionAfterDeletion", () => {
+  it("retires every canonical Steward and owner-key mirror before returning", async () => {
+    const sharedBase =
+      "https://api.eliza.app/api/v1/eliza/agents/deleted-account-agent";
+    localStorage.clear();
+    sessionStorage.clear();
+    setBootConfig({ branding: {}, apiBase: sharedBase });
+    client.setToken("eliza_deleted-owner-key");
+    setElizaApiToken("eliza_deleted-owner-key");
+    localStorage.setItem(STEWARD_TOKEN_KEY, "deleted.steward.jwt");
+    savePersistedActiveServer({
+      id: "cloud:deleted-account-agent",
+      kind: "cloud",
+      label: "Deleted account agent",
+      apiBase: sharedBase,
+      accessToken: "eliza_deleted-owner-key",
+    });
+    saveAgentProfileRegistry({
+      version: 1,
+      activeProfileId: "deleted-account-profile",
+      profiles: [
+        {
+          id: "deleted-account-profile",
+          kind: "cloud",
+          label: "Deleted account agent",
+          apiBase: sharedBase,
+          accessToken: "eliza_deleted-owner-key",
+          createdAt: "2026-08-23T00:00:00.000Z",
+        },
+      ],
+    });
+    const sessionSync = vi.fn();
+    window.addEventListener("steward-token-sync", sessionSync);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    try {
+      await endLocalSessionAfterDeletion();
+    } finally {
+      window.removeEventListener("steward-token-sync", sessionSync);
+      fetchSpy.mockRestore();
+    }
+
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(getBootConfig().apiToken).toBeUndefined();
+    expect(getElizaApiToken()).toBeUndefined();
+    expect(client.apiToken).toBeNull();
+    expect(loadPersistedActiveServer()).toBeNull();
+    expect(loadAgentProfileRegistry()).toEqual({
+      version: 1,
+      activeProfileId: null,
+      profiles: [],
+    });
+    expect(sessionSync).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/cloud/account-security/data/account-deletion-client.ts
+++ b/packages/ui/src/cloud/account-security/data/account-deletion-client.ts
@@ -64,6 +64,7 @@ function parseRequest(value: unknown): AccountDeletionRequestDto {
   const completedAt = value.completedAt;
   if (
     typeof value.requestId !== "string" ||
+    value.requestId.trim().length === 0 ||
     !isAccountDeletionRequestStatus(value.status) ||
     !isServerTimestamp(value.requestedAt) ||
     !isServerTimestamp(value.scheduledDeletionAt) ||

--- a/packages/ui/src/cloud/account-security/data/account-deletion-client.ts
+++ b/packages/ui/src/cloud/account-security/data/account-deletion-client.ts
@@ -1,7 +1,7 @@
 /** Provides the typed browser client for account-deletion status and request endpoints. */
 
-import { logger } from "@elizaos/logger";
 import { api } from "../../lib/api-client";
+import { signOutFromSsoBridgedHost } from "../../sso-bridge/sso-bridge";
 
 export interface AccountDeletionRequestDto {
   requestId: string;
@@ -137,15 +137,10 @@ export async function submitAccountDeletion(): Promise<AccountDeletionRequestDto
 }
 
 export async function endLocalSessionAfterDeletion(): Promise<void> {
-  try {
-    await api("/api/auth/logout", { method: "POST" });
-  } catch (error) {
-    // error-policy:J6 Logout is best-effort teardown after the server has retired the account.
-    // The account is already inactive, so the logout endpoint can reject its
-    // now-invalid token. Navigation still leaves the protected application.
-    logger.warn(
-      { error },
-      "[AccountDeletionClient] Logout failed after account deletion",
-    );
-  }
+  // Account deletion ends the same complete authority epoch as explicit
+  // sign-out: server sessions, Steward JWT storage, native/desktop owner-key
+  // mirrors, active-server/profile copies, and mounted auth consumers. The
+  // canonical teardown is intentionally awaited so a protected-store denial
+  // cannot be presented as a completed local retirement.
+  await signOutFromSsoBridgedHost();
 }

--- a/packages/ui/src/cloud/public-pages/pages/legal/account-deletion-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/legal/account-deletion-page.tsx
@@ -11,7 +11,10 @@ export default function AccountDeletionPage() {
   const session = useSessionAuth();
 
   return (
-    <div className="theme-cloud min-h-[100dvh] bg-bg px-6 py-16 font-sans text-txt sm:px-8">
+    <div
+      className="theme-cloud h-[100dvh] overflow-y-auto bg-bg px-6 py-16 font-sans text-txt sm:px-8"
+      data-scroll-cert-scroller
+    >
       <main className="mx-auto max-w-3xl space-y-8">
         <div className="space-y-3 border-b border-border pb-6">
           <p className="text-sm font-medium text-accent">

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -10,12 +10,14 @@ import {
   StewardTokenRemovalError,
 } from "@elizaos/shared/steward-session-client";
 import { createContext } from "react";
+import { client } from "../../api";
 import {
   removeManagedSharedCloudAgentProfiles,
   scrubPersistedAgentProfileTokens,
 } from "../../state/agent-profiles";
 import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { clearSharedCloudAccountBinding } from "../../state/shared-cloud-account-binding";
+import { clearElizaApiToken } from "../../utils/eliza-globals";
 import { decodeJwtPayload } from "../lib/jwt";
 import { invalidateStewardServerCookieSyncMarker } from "../lib/steward-session-cookie-sync-marker";
 import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "./steward-url";
@@ -179,6 +181,14 @@ export async function clearStaleStewardSession(): Promise<void> {
     // then rethrow the original storage error with its stack intact.
     storedTokenClearError = error;
   }
+  // `ElizaClient` mirrors its live bearer into boot config, while native and
+  // desktop hosts can independently inject the same owner key through the
+  // window-scoped API token. Both are canonical request-authority sources and
+  // must end in the same teardown transaction as the Steward JWT. Clearing
+  // only persisted profiles would leave the running renderer authenticated
+  // until reload (and native Cloud calls could keep using the injected key).
+  client.setToken(null);
+  clearElizaApiToken();
   // Every shared-agent profile belongs to the ending Steward account, even
   // when a dedicated or self-hosted target happens to be active at sign-out.
   removeManagedSharedCloudAgentProfiles();


### PR DESCRIPTION
## Summary

- compare canonical user, organization, API-key, deletion-request, and Steward authority before and independently after an invalid request and an otherwise-valid confirmed refusal
- retire the complete canonical renderer/native session only after a validated successful receipt: server session, Steward JWT, live client/boot owner key, persisted server/profile copies, and the established sync event
- keep malformed and refused responses outside teardown
- make publishable evidence fail closed: snake/camel IDs, row IDs, KMS identifiers, encrypted fields, paths, and every other unapproved string are redacted; unsafe dynamic structural keys reject publication
- keep the public account-deletion page explicitly scrollable and capture its complete desktop/mobile content

This remains a deliberately narrow refusal-proof slice. The runtime still honestly refuses and parks deletion until lifecycle recovery/provider reconciliation are reserved, so the PR remains draft.

Closes #25259

## Exact revision

- head: `1a8ad7017fc107c5a197316fd1b88da4493a8207`
- base: `c556bc4645fd9b914702c6e0fd3f8ec882cc1e34`
- target: `develop`
- state: draft; do not merge until the refusal slice and evidence receive independent review

## Verification

- `bun install --frozen-lockfile` — passed with pinned Bun 1.3.14; no lockfile changes
- focused UI/session production-contract suite — 28/28 passed
- `packages/ui typecheck` and `packages/cloud/e2e typecheck` — passed
- `packages/ui lint:check` — passed (five existing noDocumentCookie warnings, zero errors)
- `packages/app lint:check` — passed
- `packages/cloud/test-mocks typecheck` — passed
- deterministic Steward HTTP fixture — 1/1 passed, 8 assertions
- `E2E_RECORD=1 bun run --cwd packages/cloud/e2e test -- tests/account-deletion.spec.ts` — 2/2 passed against the real Worker/PGlite application and loopback Steward service
- recorded trace proves the three redacted authority attachments have the same content hash before, after the invalid request, and after the confirmed refusal; HTTP and frontend-event attachments are included
- focused production-bundle Cloud audit — desktop/mobile 2/2 passed
- audit result: 1,151 readable characters per viewport; zero console errors, blue colors, hover violations/failures, or quality issues
- Biome on every changed source/test file and `git diff --check` — passed

## Reviewed artifacts

I opened the recorded desktop and mobile captures from pre-rebase head `7fc96fa7886d2b9a2be8e952cff3c7a74575a0b7`; `git range-diff` proves the two PR commits are byte-equivalent at final head `1a8ad7017fc107c5a197316fd1b88da4493a8207`. Both show the complete support section and footer without clipping, and the mobile page remains scrollable through all content.

- desktop PNG SHA-256: `bd67bdcf4dd9936c8ed3833630b693e0ce9e881f5d5e428fe61785c1ccc3c9b8`
- mobile PNG SHA-256: `0b53fa5f3ad204f11824bbe4b0fe38e66eb0f8054906c2d59f546102a06f4310`
- Worker/PGlite/Steward trace SHA-256: `0733fd8751309902c08400907a3866ca9b83bf29dfac1bf6e91cd54226c63163`
- Worker/PGlite/Steward video SHA-256: `a8bd7203a21196c67bb3e77b77b4952f154433d844ae2ad17b1a86d41aae99f7`

Five desktop/mobile review cycles plus the post-repair captures are byte-identical. Evidence artifacts remain outside the repository, per CONTRIBUTING.

## Root/static status

The scoped affected surfaces and every changed-file Biome check are green. Root `bun run verify` is not claimed green: the repository-wide i18n baseline remains tracked separately. Hosted exact-head static smoke [run 32628670281](https://github.com/elizaOS/eliza/actions/runs/32628670281) reached the affected-workspace closure and failed only on untouched `packages/app/src/ios-attachment-smoke*` formatting from the moving `develop` base; this branch changes neither file. The draft cannot advance until the repository closure is green.

## Review focus

- canonical teardown completeness across web/native owner-key mirrors
- refusal/malformed isolation from teardown
- independently sampled authority after each request
- adversarial evidence redaction and fail-closed publication
- full-page scroll/capture behavior



