### PR TITLE
fix(whatsapp): make personal auth state crash-durable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3377,7 +3377,7 @@
       "version": "2.0.3-beta.7",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@whiskeysockets/baileys": "^7.0.0-rc.9",
+        "@whiskeysockets/baileys": "7.0.0-rc14",
         "pino": "^10.3.1",
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",

--- a/plugins/plugin-whatsapp/AGENTS.md
+++ b/plugins/plugin-whatsapp/AGENTS.md
@@ -89,8 +89,7 @@ Config is read from `runtime.getSetting(key)` first, then `process.env[key]`. Al
 ### Baileys (personal account / QR) transport
 | Env var | Required | Description |
 |---------|----------|-------------|
-| `WHATSAPP_AUTH_DIR` | Yes (Baileys) | Directory for multi-file Baileys auth state |
-| `WHATSAPP_SESSION_PATH` | No | Alternative name for `WHATSAPP_AUTH_DIR` |
+| `WHATSAPP_AUTH_DIR` | Yes (manual Baileys config) | Exact connector-owned account directory below the resolved elizaOS state directory; arbitrary paths are rejected |
 | `WHATSAPP_AUTH_METHOD` | No | Force transport (`cloudapi` / `baileys`); overrides auto-detection |
 
 ### Access control (both transports)
@@ -127,7 +126,7 @@ Configure multiple accounts under `character.settings.whatsapp.accounts.<id>` us
 
 ## Conventions / Gotchas
 
-- **Transport detection:** `WHATSAPP_AUTH_METHOD` (`cloudapi` / `baileys`) wins when set. Otherwise `WHATSAPP_AUTH_DIR` present → Baileys; `WHATSAPP_ACCESS_TOKEN` + `WHATSAPP_PHONE_NUMBER_ID` present → Cloud API. Baileys takes precedence when both are set (see `resolveRuntimeConfig` in `runtime-service.ts`, transport resolution in `accounts.ts`).
+- **Transport detection:** `WHATSAPP_AUTH_METHOD` (`cloudapi` / `baileys`) wins when set. Otherwise `WHATSAPP_AUTH_DIR` present → Baileys; `WHATSAPP_ACCESS_TOKEN` + `WHATSAPP_PHONE_NUMBER_ID` present → Cloud API. Baileys auth uses one atomic credentials-and-keys snapshot per account under `<state-dir>/connectors/whatsapp/accounts/<accountId>`; configured paths must equal that authority.
 - **Auto-reply is off by default.** Inbound messages are stored in memory. The agent only replies when `WHATSAPP_AUTO_REPLY=true` or when the connector is triggered through the message connector protocol (e.g., a workflow or orchestrator sends on `source: "whatsapp"`).
 - **Webhook security:** Cloud API webhook POSTs are rejected without a valid `X-Hub-Signature-256` (uses `WHATSAPP_APP_SECRET`). The GET verification route is public by design (Meta requires it).
 - **Managed webhook contract:** `whatsapp-cloud-webhook` promotes the real signed route and `phone_number_id` account parser. Its loopback suite proves invalid signatures and unknown tenant identifiers remain effect-free.

--- a/plugins/plugin-whatsapp/CLAUDE.md
+++ b/plugins/plugin-whatsapp/CLAUDE.md
@@ -89,8 +89,7 @@ Config is read from `runtime.getSetting(key)` first, then `process.env[key]`. Al
 ### Baileys (personal account / QR) transport
 | Env var | Required | Description |
 |---------|----------|-------------|
-| `WHATSAPP_AUTH_DIR` | Yes (Baileys) | Directory for multi-file Baileys auth state |
-| `WHATSAPP_SESSION_PATH` | No | Alternative name for `WHATSAPP_AUTH_DIR` |
+| `WHATSAPP_AUTH_DIR` | Yes (manual Baileys config) | Exact connector-owned account directory below the resolved elizaOS state directory; arbitrary paths are rejected |
 | `WHATSAPP_AUTH_METHOD` | No | Force transport (`cloudapi` / `baileys`); overrides auto-detection |
 
 ### Access control (both transports)
@@ -127,7 +126,7 @@ Configure multiple accounts under `character.settings.whatsapp.accounts.<id>` us
 
 ## Conventions / Gotchas
 
-- **Transport detection:** `WHATSAPP_AUTH_METHOD` (`cloudapi` / `baileys`) wins when set. Otherwise `WHATSAPP_AUTH_DIR` present → Baileys; `WHATSAPP_ACCESS_TOKEN` + `WHATSAPP_PHONE_NUMBER_ID` present → Cloud API. Baileys takes precedence when both are set (see `resolveRuntimeConfig` in `runtime-service.ts`, transport resolution in `accounts.ts`).
+- **Transport detection:** `WHATSAPP_AUTH_METHOD` (`cloudapi` / `baileys`) wins when set. Otherwise `WHATSAPP_AUTH_DIR` present → Baileys; `WHATSAPP_ACCESS_TOKEN` + `WHATSAPP_PHONE_NUMBER_ID` present → Cloud API. Baileys auth uses one atomic credentials-and-keys snapshot per account under `<state-dir>/connectors/whatsapp/accounts/<accountId>`; configured paths must equal that authority.
 - **Auto-reply is off by default.** Inbound messages are stored in memory. The agent only replies when `WHATSAPP_AUTO_REPLY=true` or when the connector is triggered through the message connector protocol (e.g., a workflow or orchestrator sends on `source: "whatsapp"`).
 - **Webhook security:** Cloud API webhook POSTs are rejected without a valid `X-Hub-Signature-256` (uses `WHATSAPP_APP_SECRET`). The GET verification route is public by design (Meta requires it).
 - **Managed webhook contract:** `whatsapp-cloud-webhook` promotes the real signed route and `phone_number_id` account parser. Its loopback suite proves invalid signatures and unknown tenant identifiers remain effect-free.

--- a/plugins/plugin-whatsapp/README.md
+++ b/plugins/plugin-whatsapp/README.md
@@ -52,11 +52,10 @@ The plugin also auto-enables when a `connectors.whatsapp` block is present in ag
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `WHATSAPP_AUTH_DIR` | Yes (Baileys) | Directory to persist multi-file Baileys auth state |
-| `WHATSAPP_SESSION_PATH` | No | Alternative name for `WHATSAPP_AUTH_DIR` |
+| `WHATSAPP_AUTH_DIR` | Yes (manual Baileys config) | Exact connector-owned account directory below the resolved elizaOS state directory |
 | `WHATSAPP_AUTH_METHOD` | No | Force transport: `cloudapi` or `baileys` (overrides auto-detection) |
 
-**Transport detection:** `WHATSAPP_AUTH_METHOD` wins when set. Otherwise: `WHATSAPP_AUTH_DIR` present → Baileys; `WHATSAPP_ACCESS_TOKEN` + `WHATSAPP_PHONE_NUMBER_ID` present → Cloud API. Baileys takes precedence when both are set.
+**Transport detection:** `WHATSAPP_AUTH_METHOD` wins when set. Otherwise: `WHATSAPP_AUTH_DIR` present → Baileys; `WHATSAPP_ACCESS_TOKEN` + `WHATSAPP_PHONE_NUMBER_ID` present → Cloud API. Pairing derives `<state-dir>/connectors/whatsapp/accounts/<accountId>` automatically. Manual paths must match that exact authority; broad or arbitrary paths are rejected.
 
 ### Access Control
 
@@ -109,13 +108,17 @@ await service?.sendMessage({
 Use `ClientFactory` when you need direct access to Cloud API media endpoints:
 
 ```typescript
-import { ClientFactory } from "@elizaos/plugin-whatsapp";
+import { ClientFactory, resolveWhatsAppAuthDirectory } from "@elizaos/plugin-whatsapp";
 
 // Cloud API
 const client = ClientFactory.create({ accessToken: "...", phoneNumberId: "..." });
 
 // Baileys
-const client = ClientFactory.create({ authMethod: "baileys", authDir: "./wa-auth" });
+const client = ClientFactory.create({
+  authMethod: "baileys",
+  accountId: "default",
+  authDir: resolveWhatsAppAuthDirectory("default"),
+});
 ```
 
 ### Webhook Setup (Cloud API)

--- a/plugins/plugin-whatsapp/package.json
+++ b/plugins/plugin-whatsapp/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@whiskeysockets/baileys": "^7.0.0-rc.9",
+    "@whiskeysockets/baileys": "7.0.0-rc14",
     "pino": "^10.3.1",
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0"
@@ -118,7 +118,7 @@
       },
       "WHATSAPP_AUTH_DIR": {
         "type": "string",
-        "description": "Directory used to persist Baileys session files (required for baileys auth)",
+        "description": "Exact connector-owned account directory below the resolved elizaOS state directory",
         "required": false,
         "sensitive": false
       },

--- a/plugins/plugin-whatsapp/src/accounts.ts
+++ b/plugins/plugin-whatsapp/src/accounts.ts
@@ -169,9 +169,7 @@ export function listWhatsAppAccountIds(runtime: IAgentRuntime): string[] {
   // Check if default account is configured
   const envToken = runtime.getSetting("WHATSAPP_ACCESS_TOKEN") as string | undefined;
   const envPhoneId = runtime.getSetting("WHATSAPP_PHONE_NUMBER_ID") as string | undefined;
-  const envAuthDir =
-    (runtime.getSetting("WHATSAPP_AUTH_DIR") as string | undefined) ??
-    (runtime.getSetting("WHATSAPP_SESSION_PATH") as string | undefined);
+  const envAuthDir = runtime.getSetting("WHATSAPP_AUTH_DIR") as string | undefined;
 
   const baseConfigured = Boolean(config.accessToken?.trim() && config.phoneNumberId?.trim());
   const envConfigured = Boolean(envToken?.trim() && envPhoneId?.trim());
@@ -309,9 +307,7 @@ export function resolveWhatsAppAccountConfig(
   const envWebhookToken = runtime.getSetting("WHATSAPP_WEBHOOK_VERIFY_TOKEN") as string | undefined;
   const envDmPolicy = runtime.getSetting("WHATSAPP_DM_POLICY") as string | undefined;
   const envGroupPolicy = runtime.getSetting("WHATSAPP_GROUP_POLICY") as string | undefined;
-  const envAuthDir =
-    (runtime.getSetting("WHATSAPP_AUTH_DIR") as string | undefined) ??
-    (runtime.getSetting("WHATSAPP_SESSION_PATH") as string | undefined);
+  const envAuthDir = runtime.getSetting("WHATSAPP_AUTH_DIR") as string | undefined;
   const envTransport = runtime.getSetting("WHATSAPP_AUTH_METHOD") as string | undefined;
 
   const envConfig: WhatsAppAccountRuntimeConfig = {

--- a/plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts
+++ b/plugins/plugin-whatsapp/src/api/whatsapp-routes.auth-scope.test.ts
@@ -64,7 +64,7 @@ describe("GET /api/whatsapp/status authScope identity", () => {
       ).resolves.toBe(true);
       expect(res.statusCode).toBe(200);
       expect(parsed(chunks).authScope).toBe("platform");
-      expect(whatsappAuthExists).toHaveBeenCalledWith(state.workspaceDir, "default");
+      expect(whatsappAuthExists).toHaveBeenCalledWith("default");
     }
   );
 
@@ -79,11 +79,7 @@ describe("GET /api/whatsapp/status authScope identity", () => {
       ).resolves.toBe(true);
       expect(res.statusCode).toBe(200);
       expect(parsed(chunks).authScope).toBe(token);
-      if (token === "platform") {
-        expect(whatsappAuthExists).toHaveBeenCalled();
-      } else {
-        expect(whatsappAuthExists).not.toHaveBeenCalled();
-      }
+      expect(whatsappAuthExists).toHaveBeenCalled();
     }
   );
 
@@ -222,6 +218,6 @@ describe("WhatsApp pairing route teardown ordering", () => {
 
     releaseStop?.();
     await expect(handling).resolves.toBe(true);
-    expect(deps.whatsappLogout).toHaveBeenCalledWith(state.workspaceDir, "default");
+    expect(deps.whatsappLogout).toHaveBeenCalledWith("default");
   });
 });

--- a/plugins/plugin-whatsapp/src/api/whatsapp-routes.ts
+++ b/plugins/plugin-whatsapp/src/api/whatsapp-routes.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { logger } from "@elizaos/core";
+import { resolveWhatsAppAuthDirectory } from "../baileys/auth.js";
 import type { WhatsAppPairingEvent } from "../services/whatsapp-pairing.js";
 
 export type WhatsAppPairingEventLike = WhatsAppPairingEvent;
@@ -49,8 +50,8 @@ type WhatsAppPluginConfig = Record<string, unknown> & {
 
 export interface WhatsAppRouteDeps {
   sanitizeAccountId: (accountId: string) => string;
-  whatsappAuthExists: (workspaceDir: string, accountId: string) => boolean;
-  whatsappLogout: (workspaceDir: string, accountId: string) => Promise<void>;
+  whatsappAuthExists: (accountId: string) => boolean | Promise<boolean>;
+  whatsappLogout: (accountId: string) => Promise<void>;
   createWhatsAppPairingSession: (options: {
     authDir: string;
     accountId: string;
@@ -214,29 +215,19 @@ function resolveSessionKey(authScope: WhatsAppAuthScope, accountId: string): str
 }
 
 function resolveAuthDir(
-  workspaceDir: string,
+  _workspaceDir: string,
   accountId: string,
-  authScope: WhatsAppAuthScope
+  _authScope: WhatsAppAuthScope
 ): string {
-  return path.join(
-    workspaceDir,
-    authScope === "lifeops" ? "lifeops-whatsapp-auth" : "whatsapp-auth",
-    accountId
-  );
+  return resolveWhatsAppAuthDirectory(accountId);
 }
 
-function authExistsForScope(
-  state: WhatsAppRouteState,
+async function authExistsForScope(
   deps: WhatsAppRouteDeps,
   accountId: string,
-  authScope: WhatsAppAuthScope
-): boolean {
-  if (authScope === "platform") {
-    return deps.whatsappAuthExists(state.workspaceDir, accountId);
-  }
-  return fs.existsSync(
-    path.join(resolveAuthDir(state.workspaceDir, accountId, authScope), "creds.json")
-  );
+  _authScope: WhatsAppAuthScope
+): Promise<boolean> {
+  return await deps.whatsappAuthExists(accountId);
 }
 
 export async function handleWhatsAppRoute(
@@ -440,7 +431,7 @@ export async function handleWhatsAppRoute(
       accountId,
       authScope,
       status: session?.getStatus() ?? "idle",
-      authExists: authExistsForScope(state, deps, accountId, authScope),
+      authExists: await authExistsForScope(deps, accountId, authScope),
       serviceConnected,
       servicePhone,
     });
@@ -500,26 +491,17 @@ export async function handleWhatsAppRoute(
     try {
       await stopPairingSession(state.whatsappPairingSessions, sessionKey);
 
-      const authDir = resolveAuthDir(state.workspaceDir, accountId, authScope);
       try {
-        if (authScope === "platform") {
-          await deps.whatsappLogout(state.workspaceDir, accountId);
-        } else {
-          fs.rmSync(authDir, { recursive: true, force: true });
-        }
+        await deps.whatsappLogout(accountId);
       } catch (logoutErr) {
         logger.warn(
           {
             accountId,
             error: logoutErr instanceof Error ? logoutErr.message : String(logoutErr),
           },
-          "[whatsapp] Logout failed, deleting auth files directly"
+          "[whatsapp] Logout failed"
         );
-        try {
-          fs.rmSync(authDir, { recursive: true, force: true });
-        } catch {
-          /* may not exist */
-        }
+        throw logoutErr;
       }
 
       if (configurePlugin && state.config.connectors) {
@@ -548,10 +530,10 @@ export function applyWhatsAppQrOverride(
     configured: boolean;
     qrConnected?: boolean;
   }[],
-  workspaceDir: string
+  _workspaceDir: string
 ): void {
   try {
-    const waCredsPath = path.join(workspaceDir, "whatsapp-auth", "default", "creds.json");
+    const waCredsPath = path.join(resolveWhatsAppAuthDirectory("default"), "auth-state.json");
     if (fs.existsSync(waCredsPath)) {
       const waPlugin = plugins.find((plugin) => plugin.id === "whatsapp");
       if (waPlugin) {

--- a/plugins/plugin-whatsapp/src/baileys/auth.test.ts
+++ b/plugins/plugin-whatsapp/src/baileys/auth.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Exercises the real filesystem contract for connector-owned Baileys auth:
+ * authority confinement, atomic snapshot recovery, restart, and logout.
+ */
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import { BufferJSON } from "@whiskeysockets/baileys";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadDurableBaileysAuthState,
+  removeDurableBaileysAuthState,
+  resolveWhatsAppAuthDirectory,
+  whatsappDurableAuthExists,
+} from "./auth";
+
+let testRoot: string;
+let priorStateDir: string | undefined;
+
+function expectAuthCode(code: string) {
+  return expect.objectContaining({ name: "ElizaError", code });
+}
+
+beforeEach(async () => {
+  priorStateDir = process.env.ELIZA_STATE_DIR;
+  testRoot = await mkdtemp(path.join(tmpdir(), "whatsapp-auth-state-"));
+  process.env.ELIZA_STATE_DIR = path.join(testRoot, "state");
+});
+
+afterEach(async () => {
+  if (priorStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = priorStateDir;
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+describe("durable Baileys auth state", () => {
+  it("round-trips credentials and keys across a restart in one snapshot", async () => {
+    const first = await loadDurableBaileysAuthState("default");
+    first.state.creds.registered = true;
+    await first.state.keys.set({ "lid-mapping": { alice: "alice@lid" } });
+    await first.saveCreds();
+
+    const restarted = await loadDurableBaileysAuthState("default");
+    expect(restarted.state.creds.registered).toBe(true);
+    await expect(restarted.state.keys.get("lid-mapping", ["alice"])).resolves.toEqual({
+      alice: "alice@lid",
+    });
+    expect(await readdir(first.authDir)).toEqual(
+      expect.arrayContaining([".eliza-whatsapp-auth.json", "auth-state.json"])
+    );
+    expect((await readdir(first.authDir)).some((name) => name.includes(".tmp-"))).toBe(false);
+  });
+
+  it("serializes concurrent key saves without dropping either update", async () => {
+    const auth = await loadDurableBaileysAuthState("concurrent");
+    await Promise.all([
+      auth.state.keys.set({ "lid-mapping": { first: "one" } }),
+      auth.state.keys.set({ "lid-mapping": { second: "two" } }),
+      auth.saveCreds(),
+    ]);
+    const restarted = await loadDurableBaileysAuthState("concurrent");
+    await expect(restarted.state.keys.get("lid-mapping", ["first", "second"])).resolves.toEqual({
+      first: "one",
+      second: "two",
+    });
+  });
+
+  it("allows only the latest loaded state to own account writes", async () => {
+    const first = await loadDurableBaileysAuthState("single-owner");
+    const replacement = await loadDurableBaileysAuthState("single-owner");
+    first.state.creds.registered = true;
+    await expect(first.saveCreds()).rejects.toEqual(expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED"));
+    replacement.state.creds.registered = true;
+    await replacement.saveCreds();
+    const restarted = await loadDurableBaileysAuthState("single-owner");
+    expect(restarted.state.creds.registered).toBe(true);
+  });
+
+  it("retires key reads after replacement and logout", async () => {
+    const first = await loadDurableBaileysAuthState("stale-read");
+    await first.state.keys.set({ "lid-mapping": { alice: "alice@lid" } });
+    await loadDurableBaileysAuthState("stale-read");
+    await expect(first.state.keys.get("lid-mapping", ["alice"])).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED")
+    );
+
+    const logoutState = await loadDurableBaileysAuthState("stale-read-logout");
+    await removeDurableBaileysAuthState("stale-read-logout");
+    await expect(logoutState.state.keys.get("lid-mapping", ["alice"])).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED")
+    );
+  });
+
+  it("rejects broad or operator-selected auth directories", async () => {
+    await expect(loadDurableBaileysAuthState("default", testRoot)).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_DIRECTORY_OUTSIDE_STATE_AUTHORITY")
+    );
+  });
+
+  it("rejects foreign content and child symlinks", async () => {
+    const authDir = resolveWhatsAppAuthDirectory("foreign");
+    await mkdir(authDir, { recursive: true });
+    await writeFile(path.join(authDir, "operator.txt"), "do not touch");
+    await expect(loadDurableBaileysAuthState("foreign")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_FOREIGN_CONTENT")
+    );
+
+    await rm(path.join(authDir, "operator.txt"));
+    await symlink(testRoot, path.join(authDir, "keys"));
+    await expect(loadDurableBaileysAuthState("foreign")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_SYMLINK_REJECTED")
+    );
+  });
+
+  it("rejects interrupted-looking content until ownership is proven", async () => {
+    const authDir = resolveWhatsAppAuthDirectory("unowned-temp");
+    await mkdir(authDir, { recursive: true });
+    await writeFile(
+      path.join(authDir, ".auth-state.json.tmp-1-1-00000000-0000-4000-8000-000000000000"),
+      "foreign"
+    );
+    await expect(loadDurableBaileysAuthState("unowned-temp")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_FOREIGN_CONTENT")
+    );
+  });
+
+  it("checks auth status without claiming or cleaning an existing directory", async () => {
+    const emptyDir = resolveWhatsAppAuthDirectory("status-empty");
+    await mkdir(emptyDir, { recursive: true });
+    await expect(whatsappDurableAuthExists("status-empty")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_FOREIGN_CONTENT")
+    );
+    expect(await readdir(emptyDir)).toEqual([]);
+
+    const tempDir = resolveWhatsAppAuthDirectory("status-temp");
+    await mkdir(tempDir, { recursive: true });
+    const tempName = ".auth-state.json.tmp-1-1-00000000-0000-4000-8000-000000000000";
+    await writeFile(path.join(tempDir, tempName), "operator bytes");
+    await expect(whatsappDurableAuthExists("status-temp")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_FOREIGN_CONTENT")
+    );
+    expect(await readFile(path.join(tempDir, tempName), "utf8")).toBe("operator bytes");
+  });
+
+  it("rejects hard-linked connector metadata and snapshots", async () => {
+    const ownerAuth = await loadDurableBaileysAuthState("hard-owner");
+    await link(
+      path.join(ownerAuth.authDir, ".eliza-whatsapp-auth.json"),
+      path.join(testRoot, "owner-link")
+    );
+    await expect(loadDurableBaileysAuthState("hard-owner")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_HARDLINK_REJECTED")
+    );
+
+    const snapshotAuth = await loadDurableBaileysAuthState("hard-snapshot");
+    await link(
+      path.join(snapshotAuth.authDir, "auth-state.json"),
+      path.join(testRoot, "state-link")
+    );
+    await expect(loadDurableBaileysAuthState("hard-snapshot")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_HARDLINK_REJECTED")
+    );
+  });
+
+  it("does not chmod a preexisting operator directory", async () => {
+    const authDir = resolveWhatsAppAuthDirectory("permissions");
+    await mkdir(authDir, { recursive: true });
+    await chmod(authDir, 0o750);
+    await loadDurableBaileysAuthState("permissions");
+    expect((await stat(authDir)).mode & 0o777).toBe(0o750);
+    expect((await stat(path.join(authDir, "auth-state.json"))).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects a symlinked state authority", async () => {
+    const actual = path.join(testRoot, "actual");
+    await mkdir(actual);
+    const linked = path.join(testRoot, "linked");
+    await symlink(actual, linked);
+    process.env.ELIZA_STATE_DIR = linked;
+    await expect(loadDurableBaileysAuthState("default")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_SYMLINK_REJECTED")
+    );
+  });
+
+  it("fails closed on corrupt, unsupported, and mismatched committed snapshots", async () => {
+    const auth = await loadDurableBaileysAuthState("broken");
+    const snapshotPath = path.join(auth.authDir, "auth-state.json");
+    await writeFile(snapshotPath, "{");
+    await expect(loadDurableBaileysAuthState("broken")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_SNAPSHOT_CORRUPT")
+    );
+
+    const healthy = await loadDurableBaileysAuthState("versioned");
+    const parsed = JSON.parse(
+      await readFile(path.join(healthy.authDir, "auth-state.json"), "utf8"),
+      BufferJSON.reviver
+    );
+    parsed.version = 99;
+    await writeFile(
+      path.join(healthy.authDir, "auth-state.json"),
+      JSON.stringify(parsed, BufferJSON.replacer)
+    );
+    await expect(loadDurableBaileysAuthState("versioned")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_VERSION_UNSUPPORTED")
+    );
+
+    const mismatch = await loadDurableBaileysAuthState("mismatch");
+    const mismatchPath = path.join(mismatch.authDir, "auth-state.json");
+    const mismatched = JSON.parse(await readFile(mismatchPath, "utf8"), BufferJSON.reviver);
+    mismatched.accountId = "other";
+    await writeFile(mismatchPath, JSON.stringify(mismatched, BufferJSON.replacer));
+    await expect(loadDurableBaileysAuthState("mismatch")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_SNAPSHOT_INVALID")
+    );
+  });
+
+  it("rejects unknown top-level fields and malformed nested credentials and keys", async () => {
+    const cases: Array<(snapshot: Record<string, unknown>) => void> = [
+      (snapshot) => {
+        snapshot.extra = true;
+      },
+      (snapshot) => {
+        (snapshot.creds as Record<string, unknown>).noiseKey = { public: "not-bytes" };
+      },
+      (snapshot) => {
+        (snapshot.keys as Record<string, unknown>)["unknown-key-type"] = {};
+      },
+      (snapshot) => {
+        (snapshot.keys as Record<string, unknown>)["pre-key"] = {
+          broken: { public: new Uint8Array([1]), private: "not-bytes" },
+        };
+      },
+      (snapshot) => {
+        (snapshot.keys as Record<string, unknown>)["app-state-sync-key"] = {
+          broken: { keyData: new Uint8Array([1]), fingerprint: { deviceIndexes: [1, "bad"] } },
+        };
+      },
+      (snapshot) => {
+        (snapshot.keys as Record<string, unknown>)["app-state-sync-key"] = { broken: {} };
+      },
+      (snapshot) => {
+        (snapshot.keys as Record<string, unknown>).tctoken = {
+          broken: { token: new Uint8Array([1]), arbitrary: true },
+        };
+      },
+    ];
+
+    for (const [index, mutate] of cases.entries()) {
+      const accountId = `malformed-${index}`;
+      const auth = await loadDurableBaileysAuthState(accountId);
+      const snapshotPath = path.join(auth.authDir, "auth-state.json");
+      const snapshot = JSON.parse(
+        await readFile(snapshotPath, "utf8"),
+        BufferJSON.reviver
+      ) as Record<string, unknown>;
+      mutate(snapshot);
+      await writeFile(snapshotPath, JSON.stringify(snapshot, BufferJSON.replacer));
+      await expect(loadDurableBaileysAuthState(accountId)).rejects.toEqual(
+        expectAuthCode("WHATSAPP_AUTH_SNAPSHOT_INVALID")
+      );
+    }
+  });
+
+  it("discards an interrupted temp snapshot and retains the last committed state", async () => {
+    const auth = await loadDurableBaileysAuthState("partial");
+    auth.state.creds.registered = true;
+    await auth.saveCreds();
+    await writeFile(
+      path.join(auth.authDir, ".auth-state.json.tmp-1-1-00000000-0000-4000-8000-000000000000"),
+      "partial"
+    );
+
+    const restarted = await loadDurableBaileysAuthState("partial");
+    expect(restarted.state.creds.registered).toBe(true);
+    expect(await readdir(auth.authDir)).not.toContain(
+      ".auth-state.json.tmp-1-1-00000000-0000-4000-8000-000000000000"
+    );
+  });
+
+  it("surfaces post-rename durability failures as an ambiguous commit", async () => {
+    let injectFailure = false;
+    const auth = await loadDurableBaileysAuthState("ambiguous", undefined, {
+      afterRename: async (filename) => {
+        if (injectFailure && filename === "auth-state.json")
+          throw new Error("injected dir fsync failure");
+      },
+    });
+    injectFailure = true;
+    auth.state.creds.registered = true;
+    await expect(auth.saveCreds()).rejects.toEqual(
+      expect.objectContaining({
+        name: "ElizaError",
+        code: "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+        context: expect.objectContaining({ phase: "snapshot" }),
+      })
+    );
+    const committed = JSON.parse(
+      await readFile(path.join(auth.authDir, "auth-state.json"), "utf8"),
+      BufferJSON.reviver
+    );
+    expect(committed.creds.registered).toBe(true);
+    await expect(auth.state.keys.get("lid-mapping", ["alice"])).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED")
+    );
+    injectFailure = false;
+    await expect(loadDurableBaileysAuthState("ambiguous")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED")
+    );
+  });
+
+  it("keeps memory and the committed snapshot unchanged after a pre-rename key failure", async () => {
+    let injectFailure = false;
+    const auth = await loadDurableBaileysAuthState("staged-key-failure", undefined, {
+      beforeRename: async (filename) => {
+        if (injectFailure && filename === "auth-state.json")
+          throw new Error("injected rename failure");
+      },
+    });
+    const snapshotPath = path.join(auth.authDir, "auth-state.json");
+    const before = await readFile(snapshotPath, "utf8");
+    injectFailure = true;
+    await expect(auth.state.keys.set({ "lid-mapping": { alice: "alice@lid" } })).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_ATOMIC_WRITE_FAILED")
+    );
+    await expect(auth.state.keys.get("lid-mapping", ["alice"])).resolves.toEqual({
+      alice: undefined,
+    });
+    expect(await readFile(snapshotPath, "utf8")).toBe(before);
+    injectFailure = false;
+    const restarted = await loadDurableBaileysAuthState("staged-key-failure");
+    await expect(restarted.state.keys.get("lid-mapping", ["alice"])).resolves.toEqual({
+      alice: undefined,
+    });
+  });
+
+  it.each([
+    ["beforeRename", false],
+    ["afterRename", true],
+  ] as const)(
+    "retires after commit confirmation %s failure and exposes the exact restart state",
+    async (hookName, confirmedVisible) => {
+      let injectFailure = false;
+      const hook = async (_filename: string, phase: string) => {
+        if (injectFailure && phase === "commit-confirmed")
+          throw new Error("injected confirm failure");
+      };
+      const auth = await loadDurableBaileysAuthState("confirm-failure", undefined, {
+        [hookName]: hook,
+      });
+      injectFailure = true;
+      await expect(
+        auth.state.keys.set({ "lid-mapping": { alice: "alice@lid" } })
+      ).rejects.toMatchObject({
+        code: "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+        context: expect.objectContaining({ phase: "commit-confirmed" }),
+      });
+      await expect(auth.state.keys.get("lid-mapping", ["alice"])).rejects.toEqual(
+        expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED")
+      );
+      injectFailure = false;
+      if (!confirmedVisible) {
+        await expect(loadDurableBaileysAuthState("confirm-failure")).rejects.toEqual(
+          expectAuthCode("WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED")
+        );
+      } else {
+        const restarted = await loadDurableBaileysAuthState("confirm-failure");
+        await expect(restarted.state.keys.get("lid-mapping", ["alice"])).resolves.toEqual({
+          alice: "alice@lid",
+        });
+      }
+    }
+  );
+
+  it("preserves a pre-rename typed failure when temporary cleanup also fails", async () => {
+    let injectFailure = false;
+    const auth = await loadDurableBaileysAuthState("cleanup-failure", undefined, {
+      beforeRename: async (filename) => {
+        if (injectFailure && filename === "auth-state.json")
+          throw new Error("injected rename failure");
+      },
+      beforeTempCleanup: async (filename) => {
+        if (injectFailure && filename === "auth-state.json")
+          throw new Error("injected cleanup failure");
+      },
+    });
+    injectFailure = true;
+    await expect(auth.saveCreds()).rejects.toMatchObject({
+      code: "WHATSAPP_AUTH_ATOMIC_WRITE_FAILED",
+      context: expect.objectContaining({ commitState: "unchanged" }),
+    });
+    expect(
+      (await readdir(auth.authDir)).some((name) => name.startsWith(".auth-state.json.tmp-"))
+    ).toBe(true);
+    await expect(auth.state.keys.get("lid-mapping", ["alice"])).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED")
+    );
+  });
+
+  it("rejects account ownership collisions", async () => {
+    const auth = await loadDurableBaileysAuthState("owned");
+    await writeFile(
+      path.join(auth.authDir, ".eliza-whatsapp-auth.json"),
+      JSON.stringify({ version: 1, accountId: "different" })
+    );
+    await expect(loadDurableBaileysAuthState("owned")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_ACCOUNT_COLLISION")
+    );
+  });
+
+  it("logout removes only the dedicated account directory", async () => {
+    await loadDurableBaileysAuthState("logout");
+    const sibling = await loadDurableBaileysAuthState("sibling");
+    expect(await whatsappDurableAuthExists("logout")).toBe(true);
+    await removeDurableBaileysAuthState("logout");
+    expect(await whatsappDurableAuthExists("logout")).toBe(false);
+    expect(await whatsappDurableAuthExists("sibling")).toBe(true);
+    expect(sibling.authDir).toBe(resolveWhatsAppAuthDirectory("sibling"));
+  });
+
+  it("deletes an owned corrupt snapshot but never claims an unowned directory", async () => {
+    const corrupt = await loadDurableBaileysAuthState("logout-corrupt");
+    await writeFile(path.join(corrupt.authDir, "auth-state.json"), "{");
+    await removeDurableBaileysAuthState("logout-corrupt");
+    await expect(lstat(path.join(corrupt.authDir))).rejects.toMatchObject({ code: "ENOENT" });
+
+    const unowned = resolveWhatsAppAuthDirectory("logout-unowned");
+    await mkdir(unowned, { recursive: true });
+    await expect(removeDurableBaileysAuthState("logout-unowned")).rejects.toEqual(
+      expectAuthCode("WHATSAPP_AUTH_OWNER_MISSING")
+    );
+    expect(await readdir(unowned)).toEqual([]);
+  });
+
+  it("retires saves queued while logout is paused and never recreates the account", async () => {
+    const auth = await loadDurableBaileysAuthState("logout-race");
+    let releaseDelete!: () => void;
+    let enteredDelete!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      enteredDelete = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+
+    const logout = removeDurableBaileysAuthState("logout-race", {
+      beforeLogoutDelete: async () => {
+        enteredDelete();
+        await release;
+      },
+    });
+    await entered;
+    auth.state.creds.registered = true;
+    const staleSave = auth.saveCreds();
+    releaseDelete();
+    await logout;
+    await expect(staleSave).rejects.toEqual(expectAuthCode("WHATSAPP_AUTH_STATE_RETIRED"));
+    expect(await whatsappDurableAuthExists("logout-race")).toBe(false);
+  });
+
+  it("uses typed errors without exposing credential material", async () => {
+    await expect(loadDurableBaileysAuthState("../secret")).rejects.toBeInstanceOf(ElizaError);
+    await expect(loadDurableBaileysAuthState("../secret")).rejects.not.toHaveProperty(
+      "context.rawKeyMaterial"
+    );
+  });
+});

--- a/plugins/plugin-whatsapp/src/baileys/auth.ts
+++ b/plugins/plugin-whatsapp/src/baileys/auth.ts
@@ -1,30 +1,1099 @@
 /**
- * Wraps Baileys' multi-file auth state for a single account: loads and persists
- * credentials under a given directory so a paired personal WhatsApp session can
- * reconnect across restarts. Owned by BaileysConnection / BaileysClient.
+ * Owns crash-durable Baileys authentication state for personal WhatsApp accounts.
+ * Each account is confined to connector-owned state; credentials and Signal keys
+ * commit together as one atomic snapshot.
  */
-import type { AuthenticationState } from "@whiskeysockets/baileys";
-import { useMultiFileAuthState as loadMultiFileAuthState } from "@whiskeysockets/baileys";
+
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { lstat, mkdir, open, readdir, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { ElizaError, logger, resolveStateDir } from "@elizaos/core";
+import {
+  type AuthenticationCreds,
+  type AuthenticationState,
+  BufferJSON,
+  initAuthCreds,
+  proto,
+  type SignalDataSet,
+  type SignalDataTypeMap,
+} from "@whiskeysockets/baileys";
+
+const AUTH_VERSION = 1;
+const OWNER_FILE = ".eliza-whatsapp-auth.json";
+const SNAPSHOT_FILE = "auth-state.json";
+const COMMIT_FILE = ".auth-state.commit.json";
+const TEMP_PREFIX = ".auth-state.json.tmp-";
+const TEMP_PATTERN =
+  /^\.auth-state\.json\.tmp-\d+-\d+-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const ACCOUNT_ID_PATTERN = /^[a-z0-9_-]+$/;
+const SIGNAL_KEY_TYPES = new Set<keyof SignalDataTypeMap>([
+  "pre-key",
+  "session",
+  "sender-key",
+  "sender-key-memory",
+  "app-state-sync-key",
+  "app-state-sync-version",
+  "lid-mapping",
+  "device-list",
+  "tctoken",
+  "identity-key",
+]);
+
+export interface BaileysAuthPersistenceHooks {
+  beforeRename?: (filename: string, phase: AuthWritePhase) => Promise<void>;
+  afterRename?: (filename: string, phase: AuthWritePhase) => Promise<void>;
+  beforeLogoutDelete?: () => Promise<void>;
+  beforeTempCleanup?: (filename: string) => Promise<void>;
+}
+
+export type AuthWritePhase =
+  | "owner"
+  | "commit-pending"
+  | "snapshot"
+  | "commit-confirmed"
+  | "commit-restore";
+
+interface PersistedAuthState {
+  version: typeof AUTH_VERSION;
+  accountId: string;
+  creds: AuthenticationCreds;
+  keys: Partial<{ [K in keyof SignalDataTypeMap]: Record<string, SignalDataTypeMap[K]> }>;
+}
+
+interface OwnerRecord {
+  version: typeof AUTH_VERSION;
+  accountId: string;
+}
+
+interface CommitRecord {
+  version: typeof AUTH_VERSION;
+  accountId: string;
+  state: "pending" | "confirmed";
+  snapshotHash: string;
+}
+
+const activeAccountPaths = new Map<string, string>();
+interface AccountLifecycle {
+  tail: Promise<void>;
+  generation: number;
+  active: boolean;
+}
+const accountLifecycles = new Map<string, AccountLifecycle>();
+
+function authError(
+  code: string,
+  message: string,
+  context: Record<string, unknown>,
+  cause?: unknown
+): ElizaError {
+  return new ElizaError(message, { code, context, cause, severity: "fatal" });
+}
+
+export function validateWhatsAppAccountId(accountId: string): string {
+  if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+    throw authError(
+      "WHATSAPP_AUTH_INVALID_ACCOUNT_ID",
+      "WhatsApp account IDs must use lowercase letters, numbers, dashes, or underscores",
+      { accountId }
+    );
+  }
+  return accountId;
+}
+
+export function resolveWhatsAppAuthDirectory(
+  accountId: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  return path.join(
+    resolveStateDir(env),
+    "connectors",
+    "whatsapp",
+    "accounts",
+    validateWhatsAppAccountId(accountId)
+  );
+}
+
+function assertAuthoritativeDirectory(accountId: string, configuredAuthDir?: string): string {
+  const expected = resolveWhatsAppAuthDirectory(accountId);
+  if (configuredAuthDir && path.resolve(configuredAuthDir) !== expected) {
+    throw authError(
+      "WHATSAPP_AUTH_DIRECTORY_OUTSIDE_STATE_AUTHORITY",
+      "Personal WhatsApp auth must use its connector-owned account directory",
+      { accountId, configuredAuthDir: path.resolve(configuredAuthDir), expectedAuthDir: expected }
+    );
+  }
+  const priorAccount = activeAccountPaths.get(expected);
+  if (priorAccount && priorAccount !== accountId) {
+    throw authError(
+      "WHATSAPP_AUTH_ACCOUNT_COLLISION",
+      "Two WhatsApp accounts resolved to the same auth directory",
+      { accountId, conflictingAccountId: priorAccount, authDir: expected }
+    );
+  }
+  activeAccountPaths.set(expected, accountId);
+  return expected;
+}
+
+async function lstatIfPresent(target: string) {
+  try {
+    return await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    // error-policy:J2 The auth boundary adds the exact path before rethrowing filesystem failures.
+    throw authError(
+      "WHATSAPP_AUTH_FILESYSTEM_FAILED",
+      "Could not inspect WhatsApp auth storage",
+      { target },
+      error
+    );
+  }
+}
+
+async function ensureOwnedDirectory(target: string): Promise<void> {
+  const existing = await lstatIfPresent(target);
+  if (existing) {
+    if (existing.isSymbolicLink()) {
+      throw authError("WHATSAPP_AUTH_SYMLINK_REJECTED", "WhatsApp auth paths cannot be symlinks", {
+        target,
+      });
+    }
+    if (!existing.isDirectory()) {
+      throw authError("WHATSAPP_AUTH_INVALID_PATH", "WhatsApp auth path must be a directory", {
+        target,
+      });
+    }
+    return;
+  }
+  try {
+    await mkdir(target, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return ensureOwnedDirectory(target);
+    }
+    // error-policy:J2 Directory creation failures retain their filesystem cause and target.
+    throw authError(
+      "WHATSAPP_AUTH_FILESYSTEM_FAILED",
+      "Could not create WhatsApp auth storage",
+      { target },
+      error
+    );
+  }
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  const handle = await open(directory, fsConstants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function atomicWrite(
+  directory: string,
+  filename: string,
+  contents: string,
+  phase: AuthWritePhase,
+  hooks?: BaileysAuthPersistenceHooks
+): Promise<void> {
+  const target = path.join(directory, filename);
+  const temp = path.join(
+    directory,
+    `${TEMP_PREFIX}${process.pid}-${Date.now()}-${crypto.randomUUID()}`
+  );
+  let handle: FileHandle | undefined;
+  let renamed = false;
+  try {
+    handle = await open(temp, "wx", 0o600);
+    await handle.writeFile(contents, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await hooks?.beforeRename?.(filename, phase);
+    await rename(temp, target);
+    renamed = true;
+    await hooks?.afterRename?.(filename, phase);
+    await syncDirectory(directory);
+  } catch (error) {
+    // error-policy:J2 Commit failures preserve their cause and distinguish pre-rename failure from ambiguous durability.
+    throw authError(
+      renamed ? "WHATSAPP_AUTH_COMMIT_AMBIGUOUS" : "WHATSAPP_AUTH_ATOMIC_WRITE_FAILED",
+      renamed
+        ? "WhatsApp auth state was renamed but directory durability could not be confirmed"
+        : "Could not atomically persist WhatsApp auth state",
+      { directory, filename, phase, commitState: renamed ? "ambiguous" : "unchanged" },
+      error
+    );
+  } finally {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {
+        // error-policy:J6 A primary atomic-write failure remains authoritative over handle cleanup.
+        logger.warn(
+          { directory, filename },
+          "[WhatsAppAuth] Failed to close a temporary auth file after write failure"
+        );
+      }
+    }
+    if (!renamed) {
+      try {
+        await hooks?.beforeTempCleanup?.(filename);
+        await rm(temp, { force: true });
+      } catch {
+        // error-policy:J6 A primary atomic-write failure remains authoritative over temporary-file cleanup.
+        logger.warn(
+          { directory, filename },
+          "[WhatsAppAuth] Failed to clean a temporary auth file after write failure"
+        );
+      }
+    }
+  }
+}
+
+function lifecycleFor(authDir: string): AccountLifecycle {
+  let lifecycle = accountLifecycles.get(authDir);
+  if (!lifecycle) {
+    lifecycle = { tail: Promise.resolve(), generation: 0, active: false };
+    accountLifecycles.set(authDir, lifecycle);
+  }
+  return lifecycle;
+}
+
+async function enqueueAccountOperation<T>(
+  authDir: string,
+  operation: (lifecycle: AccountLifecycle) => Promise<T>
+): Promise<T> {
+  const lifecycle = lifecycleFor(authDir);
+  const next = lifecycle.tail.then(() => operation(lifecycle));
+  // error-policy:J5 The returned `await next` is the sole observer; the lifecycle tail only keeps later work ordered.
+  lifecycle.tail = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return await next;
+}
+
+async function prepareAccountDirectory(
+  accountId: string,
+  configuredAuthDir?: string,
+  hooks?: BaileysAuthPersistenceHooks
+): Promise<string> {
+  const authDir = assertAuthoritativeDirectory(accountId, configuredAuthDir);
+  const stateDir = resolveStateDir();
+  if (!(await lstatIfPresent(stateDir))) {
+    try {
+      await mkdir(stateDir, { recursive: true, mode: 0o700 });
+    } catch (error) {
+      // error-policy:J2 State-authority creation retains the selected root and filesystem cause.
+      throw authError(
+        "WHATSAPP_AUTH_FILESYSTEM_FAILED",
+        "Could not create the elizaOS state authority for WhatsApp auth",
+        { stateDir },
+        error
+      );
+    }
+  }
+  const segments = [
+    stateDir,
+    path.join(stateDir, "connectors"),
+    path.join(stateDir, "connectors", "whatsapp"),
+    path.join(stateDir, "connectors", "whatsapp", "accounts"),
+    authDir,
+  ];
+  for (const segment of segments) await ensureOwnedDirectory(segment);
+
+  const entries = await readdir(authDir, { withFileTypes: true });
+  const ownerPath = path.join(authDir, OWNER_FILE);
+  const ownerStat = await lstatIfPresent(ownerPath);
+  if (!ownerStat) {
+    if (entries.length > 0) {
+      const entry = entries[0];
+      throw authError(
+        entry.isSymbolicLink() ? "WHATSAPP_AUTH_SYMLINK_REJECTED" : "WHATSAPP_AUTH_FOREIGN_CONTENT",
+        "An unowned WhatsApp auth directory must be empty",
+        { accountId, authDir, entry: entry.name }
+      );
+    }
+    await atomicWrite(
+      authDir,
+      OWNER_FILE,
+      JSON.stringify({ version: AUTH_VERSION, accountId }),
+      "owner",
+      hooks
+    );
+  } else {
+    if (ownerStat.isSymbolicLink() || !ownerStat.isFile() || ownerStat.nlink !== 1) {
+      throw authError(
+        ownerStat.isSymbolicLink()
+          ? "WHATSAPP_AUTH_SYMLINK_REJECTED"
+          : ownerStat.nlink !== 1
+            ? "WHATSAPP_AUTH_HARDLINK_REJECTED"
+            : "WHATSAPP_AUTH_FOREIGN_CONTENT",
+        "WhatsApp auth ownership metadata must be one regular, unlinked file",
+        { accountId, authDir, entry: OWNER_FILE }
+      );
+    }
+    let owner: OwnerRecord;
+    try {
+      owner = JSON.parse(await readFile(ownerPath, "utf8")) as OwnerRecord;
+    } catch (error) {
+      // error-policy:J2 Ownership metadata corruption must remain visible at the authority boundary.
+      throw authError(
+        "WHATSAPP_AUTH_OWNER_CORRUPT",
+        "WhatsApp auth ownership metadata is corrupt",
+        { accountId, authDir },
+        error
+      );
+    }
+    if (
+      !isPlainRecord(owner) ||
+      !hasExactKeys(owner, ["version", "accountId"]) ||
+      owner.version !== AUTH_VERSION ||
+      owner.accountId !== accountId
+    ) {
+      throw authError(
+        "WHATSAPP_AUTH_ACCOUNT_COLLISION",
+        "WhatsApp auth directory belongs to another account",
+        { accountId, ownerAccountId: owner.accountId, authDir }
+      );
+    }
+  }
+
+  for (const entry of entries) {
+    if (entry.name === OWNER_FILE) continue;
+    const entryPath = path.join(authDir, entry.name);
+    const entryStat = await lstatIfPresent(entryPath);
+    if (!entryStat) continue;
+    if (entryStat.isSymbolicLink()) {
+      throw authError("WHATSAPP_AUTH_SYMLINK_REJECTED", "WhatsApp auth paths cannot be symlinks", {
+        accountId,
+        authDir,
+        entry: entry.name,
+      });
+    }
+    if (!entryStat.isFile() || entryStat.nlink !== 1) {
+      throw authError(
+        entryStat.nlink !== 1 ? "WHATSAPP_AUTH_HARDLINK_REJECTED" : "WHATSAPP_AUTH_FOREIGN_CONTENT",
+        "WhatsApp auth directory entries must be connector-owned regular files",
+        { accountId, authDir, entry: entry.name }
+      );
+    }
+    if (entry.name === SNAPSHOT_FILE || entry.name === COMMIT_FILE) continue;
+    if (TEMP_PATTERN.test(entry.name)) {
+      await rm(entryPath);
+      continue;
+    }
+    throw authError(
+      "WHATSAPP_AUTH_FOREIGN_CONTENT",
+      "WhatsApp auth directory contains content not owned by this connector",
+      { accountId, authDir, entry: entry.name }
+    );
+  }
+  return authDir;
+}
+
+async function validateAccountDirectoryReadOnly(accountId: string, authDir: string): Promise<void> {
+  const directoryStat = await lstatIfPresent(authDir);
+  if (!directoryStat) {
+    throw authError("WHATSAPP_AUTH_NOT_FOUND", "WhatsApp auth directory does not exist", {
+      accountId,
+      authDir,
+    });
+  }
+  if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
+    throw authError(
+      directoryStat.isSymbolicLink()
+        ? "WHATSAPP_AUTH_SYMLINK_REJECTED"
+        : "WHATSAPP_AUTH_INVALID_PATH",
+      "WhatsApp auth account path must be a dedicated directory",
+      { accountId, authDir }
+    );
+  }
+  const entries = await readdir(authDir, { withFileTypes: true });
+  const names = entries.map((entry) => entry.name).sort();
+  if (
+    !hasExactKeys(Object.fromEntries(names.map((name) => [name, true])), [
+      OWNER_FILE,
+      SNAPSHOT_FILE,
+      COMMIT_FILE,
+    ])
+  ) {
+    throw authError(
+      "WHATSAPP_AUTH_FOREIGN_CONTENT",
+      "WhatsApp auth status requires exactly one owner record and one committed snapshot",
+      { accountId, authDir, entries: names }
+    );
+  }
+  for (const filename of [OWNER_FILE, SNAPSHOT_FILE, COMMIT_FILE]) {
+    const fileStat = await lstatIfPresent(path.join(authDir, filename));
+    if (!fileStat?.isFile() || fileStat.isSymbolicLink() || fileStat.nlink !== 1) {
+      throw authError(
+        fileStat?.isSymbolicLink()
+          ? "WHATSAPP_AUTH_SYMLINK_REJECTED"
+          : fileStat && fileStat.nlink !== 1
+            ? "WHATSAPP_AUTH_HARDLINK_REJECTED"
+            : "WHATSAPP_AUTH_FOREIGN_CONTENT",
+        "WhatsApp auth status requires regular, unlinked connector files",
+        { accountId, authDir, entry: filename }
+      );
+    }
+  }
+
+  let owner: unknown;
+  try {
+    owner = JSON.parse(await readFile(path.join(authDir, OWNER_FILE), "utf8"));
+  } catch (error) {
+    // error-policy:J2 Read-only status retains corrupt owner metadata and its parse cause.
+    throw authError(
+      "WHATSAPP_AUTH_OWNER_CORRUPT",
+      "WhatsApp auth ownership metadata is corrupt",
+      { accountId, authDir },
+      error
+    );
+  }
+  if (
+    !isPlainRecord(owner) ||
+    !hasExactKeys(owner, ["version", "accountId"]) ||
+    owner.version !== AUTH_VERSION ||
+    owner.accountId !== accountId
+  ) {
+    throw authError(
+      "WHATSAPP_AUTH_ACCOUNT_COLLISION",
+      "WhatsApp auth directory belongs to another account",
+      { accountId, authDir, ownerAccountId: isPlainRecord(owner) ? owner.accountId : undefined }
+    );
+  }
+
+  let snapshotText: string;
+  let snapshot: unknown;
+  try {
+    snapshotText = await readFile(path.join(authDir, SNAPSHOT_FILE), "utf8");
+    snapshot = JSON.parse(snapshotText, BufferJSON.reviver);
+  } catch (error) {
+    // error-policy:J2 Read-only status retains corrupt snapshot bytes and their parse cause.
+    throw authError(
+      "WHATSAPP_AUTH_SNAPSHOT_CORRUPT",
+      "WhatsApp auth snapshot is corrupt",
+      { accountId, authDir },
+      error
+    );
+  }
+  validateSnapshot(snapshot, accountId, authDir);
+  validateCommitRecord(
+    await readFile(path.join(authDir, COMMIT_FILE), "utf8"),
+    accountId,
+    authDir,
+    snapshotText
+  );
+}
+
+async function validateAccountOwnershipForDeletion(
+  accountId: string,
+  authDir: string
+): Promise<void> {
+  const directoryStat = await lstatIfPresent(authDir);
+  if (!directoryStat?.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw authError(
+      directoryStat?.isSymbolicLink()
+        ? "WHATSAPP_AUTH_SYMLINK_REJECTED"
+        : "WHATSAPP_AUTH_INVALID_PATH",
+      "WhatsApp auth deletion requires a dedicated account directory",
+      { accountId, authDir }
+    );
+  }
+  const entries = await readdir(authDir, { withFileTypes: true });
+  if (!entries.some((entry) => entry.name === OWNER_FILE)) {
+    throw authError(
+      "WHATSAPP_AUTH_OWNER_MISSING",
+      "WhatsApp auth deletion requires connector ownership metadata",
+      { accountId, authDir }
+    );
+  }
+  for (const entry of entries) {
+    if (
+      entry.name !== OWNER_FILE &&
+      entry.name !== SNAPSHOT_FILE &&
+      entry.name !== COMMIT_FILE &&
+      !TEMP_PATTERN.test(entry.name)
+    ) {
+      throw authError(
+        "WHATSAPP_AUTH_FOREIGN_CONTENT",
+        "WhatsApp auth deletion refused a directory containing foreign content",
+        { accountId, authDir, entry: entry.name }
+      );
+    }
+    const fileStat = await lstatIfPresent(path.join(authDir, entry.name));
+    if (!fileStat?.isFile() || fileStat.isSymbolicLink() || fileStat.nlink !== 1) {
+      throw authError(
+        fileStat?.isSymbolicLink()
+          ? "WHATSAPP_AUTH_SYMLINK_REJECTED"
+          : fileStat && fileStat.nlink !== 1
+            ? "WHATSAPP_AUTH_HARDLINK_REJECTED"
+            : "WHATSAPP_AUTH_FOREIGN_CONTENT",
+        "WhatsApp auth deletion requires regular, unlinked connector files",
+        { accountId, authDir, entry: entry.name }
+      );
+    }
+  }
+  let owner: unknown;
+  try {
+    owner = JSON.parse(await readFile(path.join(authDir, OWNER_FILE), "utf8"));
+  } catch (error) {
+    // error-policy:J2 Deletion cannot proceed without parseable ownership metadata.
+    throw authError(
+      "WHATSAPP_AUTH_OWNER_CORRUPT",
+      "WhatsApp auth ownership metadata is corrupt",
+      { accountId, authDir },
+      error
+    );
+  }
+  if (
+    !isPlainRecord(owner) ||
+    !hasExactKeys(owner, ["version", "accountId"]) ||
+    owner.version !== AUTH_VERSION ||
+    owner.accountId !== accountId
+  ) {
+    throw authError(
+      "WHATSAPP_AUTH_ACCOUNT_COLLISION",
+      "WhatsApp auth directory belongs to another account",
+      { accountId, authDir, ownerAccountId: isPlainRecord(owner) ? owner.accountId : undefined }
+    );
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function isBytes(value: unknown): value is Uint8Array {
+  return value instanceof Uint8Array;
+}
+
+function isKeyPair(value: unknown): boolean {
+  return (
+    isPlainRecord(value) &&
+    hasExactKeys(value, ["public", "private"]) &&
+    isBytes(value.public) &&
+    isBytes(value.private)
+  );
+}
+
+function isSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function validateCredentials(creds: unknown): creds is AuthenticationCreds {
+  if (!isPlainRecord(creds)) return false;
+  if (!isKeyPair(creds.noiseKey) || !isKeyPair(creds.pairingEphemeralKeyPair)) return false;
+  if (!isKeyPair(creds.signedIdentityKey) || !isPlainRecord(creds.signedPreKey)) return false;
+  const signedPreKey = creds.signedPreKey;
+  if (!isKeyPair(signedPreKey.keyPair) || !isBytes(signedPreKey.signature)) return false;
+  if (!isSafeInteger(signedPreKey.keyId) || !isSafeInteger(creds.registrationId)) return false;
+  if (typeof creds.advSecretKey !== "string" || !Array.isArray(creds.processedHistoryMessages))
+    return false;
+  if (!isSafeInteger(creds.firstUnuploadedPreKeyId) || !isSafeInteger(creds.nextPreKeyId))
+    return false;
+  if (!isSafeInteger(creds.accountSyncCounter) || !isPlainRecord(creds.accountSettings))
+    return false;
+  if (typeof creds.accountSettings.unarchiveChats !== "boolean") return false;
+  if (typeof creds.registered !== "boolean") return false;
+  if (creds.pairingCode !== undefined && typeof creds.pairingCode !== "string") return false;
+  if (creds.lastPropHash !== undefined && typeof creds.lastPropHash !== "string") return false;
+  if (creds.routingInfo !== undefined && !isBytes(creds.routingInfo)) return false;
+  return true;
+}
+
+function validateSignalValue(type: keyof SignalDataTypeMap, value: unknown): boolean {
+  if (type === "pre-key") return isKeyPair(value);
+  if (type === "session" || type === "sender-key" || type === "identity-key") return isBytes(value);
+  if (type === "lid-mapping") return typeof value === "string";
+  if (type === "device-list")
+    return Array.isArray(value) && value.every((item) => typeof item === "string");
+  if (!isPlainRecord(value)) return false;
+  if (type === "sender-key-memory")
+    return Object.values(value).every((item) => typeof item === "boolean");
+  if (type === "app-state-sync-key") {
+    if (!Object.keys(value).every((key) => ["keyData", "fingerprint", "timestamp"].includes(key))) {
+      return false;
+    }
+    const fingerprint = value.fingerprint;
+    const validFingerprint =
+      fingerprint === undefined ||
+      fingerprint === null ||
+      (isPlainRecord(fingerprint) &&
+        Object.keys(fingerprint).every((key) =>
+          ["rawId", "currentIndex", "deviceIndexes"].includes(key)
+        ) &&
+        (fingerprint.rawId === undefined || isSafeInteger(fingerprint.rawId)) &&
+        (fingerprint.currentIndex === undefined || isSafeInteger(fingerprint.currentIndex)) &&
+        (fingerprint.deviceIndexes === undefined ||
+          (Array.isArray(fingerprint.deviceIndexes) &&
+            fingerprint.deviceIndexes.every(isSafeInteger))));
+    const timestamp = value.timestamp;
+    const validTimestamp =
+      timestamp === undefined ||
+      timestamp === null ||
+      isSafeInteger(timestamp) ||
+      (isPlainRecord(timestamp) &&
+        hasExactKeys(timestamp, ["low", "high", "unsigned"]) &&
+        Number.isInteger(timestamp.low) &&
+        Number.isInteger(timestamp.high) &&
+        typeof timestamp.unsigned === "boolean");
+    return isBytes(value.keyData) && validFingerprint && validTimestamp;
+  }
+  if (type === "app-state-sync-version") {
+    return (
+      isSafeInteger(value.version) &&
+      isBytes(value.hash) &&
+      isPlainRecord(value.indexValueMap) &&
+      Object.values(value.indexValueMap).every(
+        (entry) =>
+          isPlainRecord(entry) && hasExactKeys(entry, ["valueMac"]) && isBytes(entry.valueMac)
+      )
+    );
+  }
+  return (
+    type === "tctoken" &&
+    Object.keys(value).every((key) => ["token", "timestamp", "senderTimestamp"].includes(key)) &&
+    isBytes(value.token) &&
+    (value.timestamp === undefined || typeof value.timestamp === "string") &&
+    (value.senderTimestamp === undefined || isSafeInteger(value.senderTimestamp))
+  );
+}
+
+function validateSnapshot(value: unknown, accountId: string, authDir: string): PersistedAuthState {
+  if (!isPlainRecord(value) || !hasExactKeys(value, ["version", "accountId", "creds", "keys"])) {
+    throw authError("WHATSAPP_AUTH_SNAPSHOT_INVALID", "WhatsApp auth snapshot shape is invalid", {
+      accountId,
+      authDir,
+    });
+  }
+  if (value.version !== AUTH_VERSION) {
+    throw authError(
+      "WHATSAPP_AUTH_VERSION_UNSUPPORTED",
+      "WhatsApp auth snapshot version is unsupported",
+      {
+        accountId,
+        authDir,
+        version: value.version,
+      }
+    );
+  }
+  if (
+    value.accountId !== accountId ||
+    !validateCredentials(value.creds) ||
+    !isPlainRecord(value.keys)
+  ) {
+    throw authError(
+      "WHATSAPP_AUTH_SNAPSHOT_INVALID",
+      "WhatsApp auth snapshot identity or shape is invalid",
+      { accountId, authDir }
+    );
+  }
+  for (const [rawType, rawCategory] of Object.entries(value.keys)) {
+    if (!SIGNAL_KEY_TYPES.has(rawType as keyof SignalDataTypeMap) || !isPlainRecord(rawCategory)) {
+      throw authError(
+        "WHATSAPP_AUTH_SNAPSHOT_INVALID",
+        "WhatsApp auth snapshot contains an invalid key category",
+        { accountId, authDir, keyType: rawType }
+      );
+    }
+    const type = rawType as keyof SignalDataTypeMap;
+    for (const [id, item] of Object.entries(rawCategory)) {
+      if (id.length === 0 || !validateSignalValue(type, item)) {
+        throw authError(
+          "WHATSAPP_AUTH_SNAPSHOT_INVALID",
+          "WhatsApp auth snapshot contains malformed key material",
+          { accountId, authDir, keyType: type, keyId: id }
+        );
+      }
+    }
+  }
+  return value as unknown as PersistedAuthState;
+}
+
+function serializeSnapshot(snapshot: PersistedAuthState): string {
+  return JSON.stringify(snapshot, BufferJSON.replacer);
+}
+
+function snapshotHash(serialized: string): string {
+  return createHash("sha256").update(serialized).digest("hex");
+}
+
+function commitRecord(accountId: string, state: CommitRecord["state"], hash: string): string {
+  return JSON.stringify({ version: AUTH_VERSION, accountId, state, snapshotHash: hash });
+}
+
+function validateCommitRecord(
+  serialized: string,
+  accountId: string,
+  authDir: string,
+  serializedSnapshot: string
+): void {
+  let record: unknown;
+  try {
+    record = JSON.parse(serialized);
+  } catch (error) {
+    // error-policy:J2 Commit-journal corruption cannot be treated as a healthy snapshot.
+    throw authError(
+      "WHATSAPP_AUTH_COMMIT_RECORD_CORRUPT",
+      "WhatsApp auth commit journal is corrupt",
+      { accountId, authDir },
+      error
+    );
+  }
+  if (
+    !isPlainRecord(record) ||
+    !hasExactKeys(record, ["version", "accountId", "state", "snapshotHash"]) ||
+    record.version !== AUTH_VERSION ||
+    record.accountId !== accountId ||
+    typeof record.snapshotHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(record.snapshotHash)
+  ) {
+    throw authError(
+      "WHATSAPP_AUTH_COMMIT_RECORD_INVALID",
+      "WhatsApp auth commit journal shape is invalid",
+      { accountId, authDir }
+    );
+  }
+  if (record.state !== "confirmed" || record.snapshotHash !== snapshotHash(serializedSnapshot)) {
+    throw authError(
+      "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+      "WhatsApp auth snapshot has an unconfirmed or mismatched commit",
+      { accountId, authDir, commitState: record.state }
+    );
+  }
+}
+
+async function persistSnapshot(
+  authDir: string,
+  accountId: string,
+  snapshot: PersistedAuthState,
+  previousSnapshot: PersistedAuthState | undefined,
+  hooks?: BaileysAuthPersistenceHooks
+): Promise<void> {
+  const serialized = serializeSnapshot(snapshot);
+  const hash = snapshotHash(serialized);
+  try {
+    await atomicWrite(
+      authDir,
+      COMMIT_FILE,
+      commitRecord(accountId, "pending", hash),
+      "commit-pending",
+      hooks
+    );
+  } catch (error) {
+    if (error instanceof ElizaError && error.code === "WHATSAPP_AUTH_ATOMIC_WRITE_FAILED") {
+      throw error;
+    }
+    throw authError(
+      "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+      "WhatsApp auth commit intent has ambiguous durability; reload is required",
+      { accountId, authDir, phase: "commit-pending" },
+      error
+    );
+  }
+
+  try {
+    await atomicWrite(authDir, SNAPSHOT_FILE, serialized, "snapshot", hooks);
+  } catch (error) {
+    if (
+      previousSnapshot &&
+      error instanceof ElizaError &&
+      error.code === "WHATSAPP_AUTH_ATOMIC_WRITE_FAILED"
+    ) {
+      const previousSerialized = serializeSnapshot(previousSnapshot);
+      try {
+        await atomicWrite(
+          authDir,
+          COMMIT_FILE,
+          commitRecord(accountId, "confirmed", snapshotHash(previousSerialized)),
+          "commit-restore",
+          hooks
+        );
+        throw error;
+      } catch (restoreError) {
+        if (restoreError === error) throw error;
+        throw authError(
+          "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+          "WhatsApp auth could not durably restore its prior commit after a failed snapshot write",
+          { accountId, authDir, phase: "commit-restore" },
+          restoreError
+        );
+      }
+    }
+    throw authError(
+      "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+      "WhatsApp auth snapshot commit is ambiguous; reload is required",
+      { accountId, authDir, phase: "snapshot" },
+      error
+    );
+  }
+
+  try {
+    await atomicWrite(
+      authDir,
+      COMMIT_FILE,
+      commitRecord(accountId, "confirmed", hash),
+      "commit-confirmed",
+      hooks
+    );
+  } catch (error) {
+    throw authError(
+      "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+      "WhatsApp auth snapshot committed but confirmation failed; reload is required",
+      { accountId, authDir, phase: "commit-confirmed" },
+      error
+    );
+  }
+}
+
+function cloneSnapshot(
+  snapshot: PersistedAuthState,
+  accountId: string,
+  authDir: string
+): PersistedAuthState {
+  return validateSnapshot(
+    JSON.parse(serializeSnapshot(snapshot), BufferJSON.reviver),
+    accountId,
+    authDir
+  );
+}
+
+function assertCurrentGeneration(
+  lifecycle: AccountLifecycle,
+  generation: number,
+  accountId: string,
+  authDir: string
+): void {
+  if (!lifecycle.active || lifecycle.generation !== generation) {
+    throw authError(
+      "WHATSAPP_AUTH_STATE_RETIRED",
+      "This WhatsApp auth state was retired by logout or replacement and cannot be written",
+      { accountId, authDir, generation, currentGeneration: lifecycle.generation }
+    );
+  }
+}
+
+export async function loadDurableBaileysAuthState(
+  accountId: string,
+  configuredAuthDir?: string,
+  hooks?: BaileysAuthPersistenceHooks
+): Promise<{ state: AuthenticationState; saveCreds: () => Promise<void>; authDir: string }> {
+  const authDir = assertAuthoritativeDirectory(accountId, configuredAuthDir);
+  return enqueueAccountOperation(authDir, async (lifecycle) => {
+    await prepareAccountDirectory(accountId, configuredAuthDir, hooks);
+    lifecycle.generation += 1;
+    lifecycle.active = true;
+    const generation = lifecycle.generation;
+    const snapshotPath = path.join(authDir, SNAPSHOT_FILE);
+    let snapshot: PersistedAuthState;
+    const snapshotStat = await lstatIfPresent(snapshotPath);
+    if (!snapshotStat) {
+      if (await lstatIfPresent(path.join(authDir, COMMIT_FILE))) {
+        throw authError(
+          "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED",
+          "WhatsApp auth has a commit journal without a committed snapshot",
+          { accountId, authDir }
+        );
+      }
+      snapshot = { version: AUTH_VERSION, accountId, creds: initAuthCreds(), keys: {} };
+      await persistSnapshot(authDir, accountId, snapshot, undefined, hooks);
+    } else {
+      const serializedSnapshot = await readFile(snapshotPath, "utf8");
+      const serializedCommit = await readFile(path.join(authDir, COMMIT_FILE), "utf8");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(serializedSnapshot, BufferJSON.reviver);
+      } catch (error) {
+        // error-policy:J2 Unparseable committed auth bytes retain their parse or filesystem cause.
+        throw authError(
+          "WHATSAPP_AUTH_SNAPSHOT_CORRUPT",
+          "WhatsApp auth snapshot is corrupt",
+          { accountId, authDir },
+          error
+        );
+      }
+      snapshot = validateSnapshot(parsed, accountId, authDir);
+      validateCommitRecord(serializedCommit, accountId, authDir, serializedSnapshot);
+    }
+    const liveCreds = cloneSnapshot(snapshot, accountId, authDir).creds;
+
+    const persist = () =>
+      enqueueAccountOperation(authDir, async (current) => {
+        assertCurrentGeneration(current, generation, accountId, authDir);
+        const candidate = cloneSnapshot(snapshot, accountId, authDir);
+        candidate.creds = cloneSnapshot(
+          { ...candidate, creds: liveCreds },
+          accountId,
+          authDir
+        ).creds;
+        try {
+          await persistSnapshot(authDir, accountId, candidate, snapshot, hooks);
+          snapshot = candidate;
+        } catch (error) {
+          current.active = false;
+          current.generation += 1;
+          throw error;
+        }
+      });
+
+    const keys: AuthenticationState["keys"] = {
+      get: async <T extends keyof SignalDataTypeMap>(type: T, ids: string[]) => {
+        return enqueueAccountOperation(authDir, async (current) => {
+          assertCurrentGeneration(current, generation, accountId, authDir);
+          const values: { [id: string]: SignalDataTypeMap[T] } = {};
+          const category = snapshot.keys[type] as Record<string, SignalDataTypeMap[T]> | undefined;
+          for (const id of ids) {
+            let value = category?.[id];
+            if (type === "app-state-sync-key" && value) {
+              value = proto.Message.AppStateSyncKeyData.fromObject(
+                value as proto.Message.IAppStateSyncKeyData
+              ) as unknown as SignalDataTypeMap[T];
+            }
+            values[id] = value as SignalDataTypeMap[T];
+          }
+          return values;
+        });
+      },
+      set: async (data: SignalDataSet) => {
+        await enqueueAccountOperation(authDir, async (current) => {
+          assertCurrentGeneration(current, generation, accountId, authDir);
+          const candidate = cloneSnapshot(snapshot, accountId, authDir);
+          for (const type of Object.keys(data) as Array<keyof SignalDataTypeMap>) {
+            const updates = data[type];
+            if (!candidate.keys[type]) candidate.keys[type] = {};
+            const category = candidate.keys[type] as Record<string, SignalDataTypeMap[typeof type]>;
+            if (!updates) continue;
+            for (const [id, value] of Object.entries(updates)) {
+              if (value === null || value === undefined) delete category[id];
+              else category[id] = value as SignalDataTypeMap[typeof type];
+            }
+          }
+          try {
+            await persistSnapshot(authDir, accountId, candidate, snapshot, hooks);
+            snapshot = candidate;
+          } catch (error) {
+            if (
+              error instanceof ElizaError &&
+              (error.code === "WHATSAPP_AUTH_COMMIT_AMBIGUOUS" ||
+                error.code === "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED")
+            ) {
+              current.active = false;
+              current.generation += 1;
+            }
+            throw error;
+          }
+        });
+      },
+      clear: async () => {
+        await enqueueAccountOperation(authDir, async (current) => {
+          assertCurrentGeneration(current, generation, accountId, authDir);
+          const candidate = cloneSnapshot(snapshot, accountId, authDir);
+          candidate.keys = {};
+          try {
+            await persistSnapshot(authDir, accountId, candidate, snapshot, hooks);
+            snapshot = candidate;
+          } catch (error) {
+            if (
+              error instanceof ElizaError &&
+              (error.code === "WHATSAPP_AUTH_COMMIT_AMBIGUOUS" ||
+                error.code === "WHATSAPP_AUTH_COMMIT_RELOAD_REQUIRED")
+            ) {
+              current.active = false;
+              current.generation += 1;
+            }
+            throw error;
+          }
+        });
+      },
+    };
+
+    return {
+      state: { creds: liveCreds, keys },
+      saveCreds: persist,
+      authDir,
+    };
+  });
+}
+
+export async function removeDurableBaileysAuthState(
+  accountId: string,
+  hooks?: BaileysAuthPersistenceHooks
+): Promise<void> {
+  const authDir = resolveWhatsAppAuthDirectory(accountId);
+  await enqueueAccountOperation(authDir, async (lifecycle) => {
+    if (!(await lstatIfPresent(authDir))) {
+      lifecycle.active = false;
+      lifecycle.generation += 1;
+      return;
+    }
+    await validateAccountOwnershipForDeletion(accountId, authDir);
+    lifecycle.active = false;
+    lifecycle.generation += 1;
+    try {
+      await hooks?.beforeLogoutDelete?.();
+      await rm(authDir, { recursive: true });
+      await syncDirectory(path.dirname(authDir));
+    } catch (error) {
+      // error-policy:J2 Logout deletion failures retain the dedicated account path and cause.
+      throw authError(
+        "WHATSAPP_AUTH_LOGOUT_DELETE_FAILED",
+        "Could not remove the dedicated WhatsApp auth directory",
+        { accountId, authDir },
+        error
+      );
+    }
+    activeAccountPaths.delete(authDir);
+  });
+}
+
+export async function whatsappDurableAuthExists(accountId: string): Promise<boolean> {
+  const authDir = resolveWhatsAppAuthDirectory(accountId);
+  return enqueueAccountOperation(authDir, async () => {
+    if (!(await lstatIfPresent(authDir))) return false;
+    await validateAccountDirectoryReadOnly(accountId, authDir);
+    return true;
+  });
+}
 
 export class BaileysAuthManager {
-  private readonly authDir: string;
+  private readonly accountId: string;
+  private readonly configuredAuthDir?: string;
   private state?: AuthenticationState;
   private saveCreds?: () => Promise<void>;
 
-  constructor(authDir: string) {
-    this.authDir = authDir;
+  constructor(accountId: string, configuredAuthDir?: string) {
+    this.accountId = accountId;
+    this.configuredAuthDir = configuredAuthDir;
   }
 
   async initialize(): Promise<AuthenticationState> {
-    const result = await loadMultiFileAuthState(this.authDir);
+    const result = await loadDurableBaileysAuthState(this.accountId, this.configuredAuthDir);
     this.state = result.state;
     this.saveCreds = result.saveCreds;
     return this.state;
   }
 
   async save(): Promise<void> {
-    if (this.saveCreds) {
-      await this.saveCreds();
+    if (!this.saveCreds) {
+      throw authError(
+        "WHATSAPP_AUTH_NOT_INITIALIZED",
+        "WhatsApp auth cannot be saved before initialization",
+        { accountId: this.accountId }
+      );
     }
+    await this.saveCreds();
   }
 }

--- a/plugins/plugin-whatsapp/src/clients/baileys-client.ts
+++ b/plugins/plugin-whatsapp/src/clients/baileys-client.ts
@@ -30,7 +30,7 @@ export class BaileysClient extends EventEmitter implements IWhatsAppClient {
   constructor(config: BaileysConfig) {
     super();
     this.config = config;
-    this.authManager = new BaileysAuthManager(config.authDir);
+    this.authManager = new BaileysAuthManager(config.accountId, config.authDir);
     this.connection = new BaileysConnection(this.authManager);
     this.qrGenerator = new QRCodeGenerator();
     this.adapter = new MessageAdapter();

--- a/plugins/plugin-whatsapp/src/config.ts
+++ b/plugins/plugin-whatsapp/src/config.ts
@@ -74,7 +74,7 @@ export type WhatsAppAccountConfig = {
   sendReadReceipts?: boolean;
   /** Inbound message prefix override for this account (WhatsApp only). */
   messagePrefix?: string;
-  /** Override auth directory (Baileys multi-file auth state). */
+  /** Exact connector-owned account directory for the atomic Baileys auth snapshot. */
   authDir?: string;
   /** Direct message access policy (default: pairing). */
   dmPolicy?: DmPolicy;

--- a/plugins/plugin-whatsapp/src/index.ts
+++ b/plugins/plugin-whatsapp/src/index.ts
@@ -89,6 +89,7 @@ export {
   type WhatsAppRouteDeps,
   type WhatsAppRouteState,
 } from "./api/whatsapp-routes";
+export { resolveWhatsAppAuthDirectory } from "./baileys/auth";
 export { ClientFactory } from "./clients/factory";
 // Channel configuration types
 export type {
@@ -158,6 +159,7 @@ import {
   handleWhatsAppRoute as _bs_14_handleWhatsAppRoute,
   MAX_PAIRING_SESSIONS as _bs_15_MAX_PAIRING_SESSIONS,
 } from "./api/whatsapp-routes";
+import { resolveWhatsAppAuthDirectory as _bs_40_resolveWhatsAppAuthDirectory } from "./baileys/auth";
 import { ClientFactory as _bs_16_ClientFactory } from "./clients/factory";
 import {
   createWhatsAppConnectorAccountProvider as _bs_17_createWhatsAppConnectorAccountProvider,
@@ -233,6 +235,7 @@ const __bundle_safety_PLUGINS_PLUGIN_WHATSAPP_SRC_INDEX__ = [
   _bs_37_WhatsAppConnectorService,
   _bs_38_stopAllPairingSessions,
   _bs_39_whatsappSetupRoutes,
+  _bs_40_resolveWhatsAppAuthDirectory,
 ];
 const bundleSafetyGlobal = globalThis as typeof globalThis & {
   __bundle_safety_PLUGINS_PLUGIN_WHATSAPP_SRC_INDEX__?: typeof __bundle_safety_PLUGINS_PLUGIN_WHATSAPP_SRC_INDEX__;

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -136,9 +136,7 @@ function resolveRuntimeConfig(runtime: IAgentRuntime): RuntimeServiceConfig | nu
   const allowFrom = readCsvSetting(runtime, "WHATSAPP_ALLOW_FROM");
   const groupAllowFrom = readCsvSetting(runtime, "WHATSAPP_GROUP_ALLOW_FROM");
 
-  const authDir =
-    readStringSetting(runtime, "WHATSAPP_AUTH_DIR") ??
-    readStringSetting(runtime, "WHATSAPP_SESSION_PATH");
+  const authDir = readStringSetting(runtime, "WHATSAPP_AUTH_DIR");
   if (authDir) {
     return {
       accountId: DEFAULT_ACCOUNT_ID,
@@ -980,6 +978,7 @@ export class WhatsAppConnectorService extends Service {
         config.transport === "baileys"
           ? new BaileysClient({
               authMethod: "baileys",
+              accountId: config.accountId,
               authDir: config.authDir,
               printQRInTerminal: false,
             } satisfies BaileysConfig)

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.test.ts
@@ -3,14 +3,24 @@
  * restarted, and replaced Baileys sockets.
  */
 import { EventEmitter } from "node:events";
-import fs from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const sockets: FakeSocket[] = [];
 const credentialSaves: ReturnType<typeof vi.fn>[] = [];
+const authRemovals: string[] = [];
+
+vi.mock("../baileys/auth", () => ({
+  validateWhatsAppAccountId: (accountId: string) => accountId,
+  whatsappDurableAuthExists: vi.fn(async () => true),
+  loadDurableBaileysAuthState: vi.fn(async () => {
+    const saveCreds = vi.fn(async () => undefined);
+    credentialSaves.push(saveCreds);
+    return { state: {}, saveCreds, authDir: "/owned/auth" };
+  }),
+  removeDurableBaileysAuthState: vi.fn(async (accountId: string) => {
+    authRemovals.push(accountId);
+  }),
+}));
 
 class FakeSocket {
   readonly ev = new EventEmitter();
@@ -24,11 +34,6 @@ vi.mock("@whiskeysockets/baileys", () => ({
     const socket = new FakeSocket();
     sockets.push(socket);
     return socket;
-  }),
-  useMultiFileAuthState: vi.fn(async () => {
-    const saveCreds = vi.fn(async () => undefined);
-    credentialSaves.push(saveCreds);
-    return { state: {}, saveCreds };
   }),
   fetchLatestBaileysVersion: vi.fn(async () => ({ version: [2, 3000, 0] })),
   DisconnectReason: {
@@ -60,6 +65,11 @@ vi.mock("pino", () => ({
 
 import makeWASocket, { fetchLatestBaileysVersion } from "@whiskeysockets/baileys";
 import QRCode from "qrcode";
+import {
+  loadDurableBaileysAuthState,
+  removeDurableBaileysAuthState,
+  whatsappDurableAuthExists,
+} from "../baileys/auth";
 import { WhatsAppPairingSession, whatsappLogout } from "./whatsapp-pairing";
 
 afterEach(() => {
@@ -67,6 +77,7 @@ afterEach(() => {
   vi.clearAllMocks();
   sockets.length = 0;
   credentialSaves.length = 0;
+  authRemovals.length = 0;
 });
 
 describe("WhatsAppPairingSession stop/restart race", () => {
@@ -465,11 +476,20 @@ describe("WhatsAppPairingSession stop/restart race", () => {
 });
 
 describe("whatsappLogout teardown ordering", () => {
+  it("continues to separately validated local removal when snapshot loading is corrupt", async () => {
+    vi.mocked(whatsappDurableAuthExists).mockRejectedValueOnce(
+      Object.assign(new Error("corrupt snapshot"), {
+        code: "WHATSAPP_AUTH_SNAPSHOT_CORRUPT",
+      })
+    );
+
+    await expect(whatsappLogout("acct-corrupt")).resolves.toBeUndefined();
+    expect(loadDurableBaileysAuthState).not.toHaveBeenCalled();
+    expect(removeDurableBaileysAuthState).toHaveBeenCalledWith("acct-corrupt");
+    expect(authRemovals).toEqual(["acct-corrupt"]);
+  });
+
   it("settles the logout socket before deleting its authentication directory", async () => {
-    const workspaceDir = await mkdtemp(path.join(tmpdir(), "whatsapp-logout-test-"));
-    const authDir = path.join(workspaceDir, "whatsapp-auth", "acct-1");
-    await mkdir(authDir, { recursive: true });
-    await writeFile(path.join(authDir, "creds.json"), "{}");
     let releaseEnd: (() => void) | undefined;
     const endGate = new Promise<void>((resolve) => {
       releaseEnd = resolve;
@@ -477,7 +497,7 @@ describe("whatsappLogout teardown ordering", () => {
 
     try {
       let finished = false;
-      const loggingOut = whatsappLogout(workspaceDir, "acct-1").then(() => {
+      const loggingOut = whatsappLogout("acct-1").then(() => {
         finished = true;
       });
       await vi.waitFor(() => expect(sockets).toHaveLength(1));
@@ -489,14 +509,13 @@ describe("whatsappLogout teardown ordering", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(finished).toBe(false);
-      expect(fs.existsSync(authDir)).toBe(true);
+      expect(authRemovals).toEqual([]);
 
       releaseEnd?.();
       await loggingOut;
-      expect(fs.existsSync(authDir)).toBe(false);
+      expect(authRemovals).toEqual(["acct-1"]);
     } finally {
       releaseEnd?.();
-      await rm(workspaceDir, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
+++ b/plugins/plugin-whatsapp/src/services/whatsapp-pairing.ts
@@ -7,21 +7,19 @@
  * can reconnect automatically on subsequent startups.
  */
 
-import fs from "node:fs";
-import path from "node:path";
 import { logger as coreLogger } from "@elizaos/core";
+import {
+  loadDurableBaileysAuthState,
+  removeDurableBaileysAuthState,
+  validateWhatsAppAccountId,
+  whatsappDurableAuthExists,
+} from "../baileys/auth";
 
 const LOG_PREFIX = "[whatsapp-pairing]";
 
 /** Validate accountId to prevent path traversal. Only allows alphanumeric, dash, underscore. */
 export function sanitizeAccountId(raw: string): string {
-  const cleaned = raw.replace(/[^a-zA-Z0-9_-]/g, "");
-  if (!cleaned || cleaned !== raw) {
-    throw new Error(
-      `Invalid accountId: must only contain alphanumeric characters, dashes, and underscores`
-    );
-  }
-  return cleaned;
+  return validateWhatsAppAccountId(raw);
 }
 
 export type WhatsAppPairingStatus =
@@ -80,17 +78,14 @@ export class WhatsAppPairingSession {
 
     const baileys = await import("@whiskeysockets/baileys");
     const makeWASocket = baileys.default;
-    const {
-      useMultiFileAuthState: loadMultiFileAuthState,
-      fetchLatestBaileysVersion,
-      DisconnectReason,
-    } = baileys;
+    const { fetchLatestBaileysVersion, DisconnectReason } = baileys;
     const QRCode = (await import("qrcode")).default;
     const { Boom } = await import("@hapi/boom");
 
-    fs.mkdirSync(this.options.authDir, { recursive: true });
-
-    const { state, saveCreds } = await loadMultiFileAuthState(this.options.authDir);
+    const { state, saveCreds } = await loadDurableBaileysAuthState(
+      this.options.accountId,
+      this.options.authDir
+    );
     const { version } = await fetchLatestBaileysVersion();
 
     const pino = (await import("pino")).default;
@@ -258,24 +253,20 @@ export class WhatsAppPairingSession {
   }
 }
 
-export function whatsappAuthExists(workspaceDir: string, accountId = "default"): boolean {
-  const credsPath = path.join(workspaceDir, "whatsapp-auth", accountId, "creds.json");
-  return fs.existsSync(credsPath);
+export function whatsappAuthExists(accountId = "default"): Promise<boolean> {
+  return whatsappDurableAuthExists(accountId);
 }
 
-export async function whatsappLogout(workspaceDir: string, accountId = "default"): Promise<void> {
-  const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
-  const credsPath = path.join(authDir, "creds.json");
-
-  if (fs.existsSync(credsPath)) {
-    try {
+export async function whatsappLogout(accountId = "default"): Promise<void> {
+  try {
+    if (await whatsappDurableAuthExists(accountId)) {
       const baileys = await import("@whiskeysockets/baileys");
       const makeWASocket = baileys.default;
-      const { useMultiFileAuthState: loadMultiFileAuthState, fetchLatestBaileysVersion } = baileys;
+      const { fetchLatestBaileysVersion } = baileys;
       const pino = (await import("pino")).default;
       const logger = pino({ level: "silent" });
 
-      const { state } = await loadMultiFileAuthState(authDir);
+      const { state } = await loadDurableBaileysAuthState(accountId);
       const { version } = await fetchLatestBaileysVersion();
 
       const sock = makeWASocket({
@@ -322,11 +313,11 @@ export async function whatsappLogout(workspaceDir: string, accountId = "default"
           }
         });
       });
-    } catch {
-      // error-policy:J6 Local auth deletion remains valid if the remote logout cannot connect.
-      // If Baileys can't connect, just delete files anyway.
     }
+  } catch {
+    // error-policy:J6 Remote logout and snapshot loading are best-effort; local removal separately proves ownership.
+    coreLogger.warn(`${LOG_PREFIX} Remote logout unavailable for account ${accountId}`);
   }
 
-  fs.rmSync(authDir, { recursive: true, force: true });
+  await removeDurableBaileysAuthState(accountId);
 }

--- a/plugins/plugin-whatsapp/src/setup-routes.ts
+++ b/plugins/plugin-whatsapp/src/setup-routes.ts
@@ -14,9 +14,8 @@
  * legacy paths without the plugin-name prefix.
  */
 
-import fs from "node:fs";
-import path from "node:path";
 import type { IAgentRuntime, Route, RouteRequest, RouteResponse } from "@elizaos/core";
+import { resolveWhatsAppAuthDirectory } from "./baileys/auth.js";
 import type { WhatsAppPairingEvent } from "./pairing-service.js";
 import {
   sanitizeAccountId,
@@ -254,8 +253,7 @@ async function handlePair(
       return;
     }
 
-    const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
-    const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
+    const authDir = resolveWhatsAppAuthDirectory(accountId);
     await stopPairingSession(accountId);
 
     const session = new WhatsAppPairingSession({
@@ -328,7 +326,6 @@ async function handleStatus(
 ): Promise<void> {
   await cleanupStaleSessions();
 
-  const setupService = getSetupService(runtime);
   const url = new URL(req.url ?? "/", `http://${routeHost(req)}`);
 
   let accountId: string;
@@ -340,8 +337,6 @@ async function handleStatus(
   }
 
   const session = whatsappPairingSessions.get(accountId);
-  const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
-
   let serviceConnected = false;
   let servicePhone: string | null = null;
   try {
@@ -358,7 +353,7 @@ async function handleStatus(
   res.status(200).json({
     accountId,
     status: session?.getStatus() ?? "idle",
-    authExists: whatsappAuthExists(workspaceDir, accountId),
+    authExists: await whatsappAuthExists(accountId),
     serviceConnected,
     servicePhone,
   });
@@ -419,22 +414,7 @@ async function handleDisconnect(
   try {
     await stopPairingSession(accountId);
 
-    const workspaceDir = setupService?.getWorkspaceDir() ?? ".";
-
-    try {
-      await whatsappLogout(workspaceDir, accountId);
-    } catch (logoutErr) {
-      console.warn(
-        `[whatsapp] Logout failed for ${accountId}, deleting auth files directly:`,
-        String(logoutErr)
-      );
-      const authDir = path.join(workspaceDir, "whatsapp-auth", accountId);
-      try {
-        fs.rmSync(authDir, { recursive: true, force: true });
-      } catch {
-        /* may not exist */
-      }
-    }
+    await whatsappLogout(accountId);
 
     if (setupService) {
       setupService.updateConfig((config) => {

--- a/plugins/plugin-whatsapp/src/types.ts
+++ b/plugins/plugin-whatsapp/src/types.ts
@@ -19,9 +19,9 @@ export interface CloudAPIConfig {
 
 export interface BaileysConfig {
   authMethod?: "baileys";
+  accountId: string;
   authDir: string;
   printQRInTerminal?: boolean;
-  sessionPath?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #25228
Parent: #25210

## Outcome

Personal WhatsApp now stores Baileys credentials and Signal keys in one connector-owned per-account snapshot under the canonical elizaOS state directory. The hard cut removes Baileys multi-file auth authority and rejects broad/operator directories, foreign files, symlinks, hard links, account collisions, corruption, partial writes, and stale state handles.

The commit protocol durably records pending and confirmed snapshot hashes. Known pre-snapshot failure restores the prior confirmed hash before the live generation can continue. Any ambiguous or post-snapshot failure retires that generation and requires restart readback; logout independently proves directory ownership before local deletion and can recover an owned corrupt snapshot without deleting foreign content. Status is strictly read-only.

Baileys is pinned exactly at `7.0.0-rc14` in the manifest and lockfile and remains bundled in-process; no external bridge application or daemon is introduced.

## Verification

Exact head `01f049f66a20e67e354c272b87b50e7a801ff835` rebased onto `origin/develop@a0f04a5c55439daf123c96cf660f6506704a5acc`:

- frozen install: 3,724 installs / 4,000 packages, no changes
- plugin Vitest: 18 files, 160 tests passed
- plugin TypeScript typecheck passed
- pinned Biome check: 41 files, no fixes
- plugin Node build and declaration generation passed
- `git diff --check` passed; worktree clean

Adversarial coverage includes concurrent saves, replacement/logout generation fencing, corrupt/unsupported/mismatched snapshots, foreign/symlink/hardlink paths, read-only status, temp interruption, every snapshot/confirmation rename phase, pre-rename memory rollback, restart reconciliation, corrupt-state logout, and secret-free typed errors.

## Evidence boundary

Backend persistence only; screenshots/video/frontend/LLM evidence are N/A. Live QR/send/receive/media/reconnect and independent official Meta Cloud qualification remain #25229–#25231 and are not claimed here.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported

<!-- evidence-head:01f049f66a20e67e354c272b87b50e7a801ff835 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow change
<!-- evidence-row:backend-logs -->
- [x] Focused exact-head transcript summarized above
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior
<!-- evidence-row:domain-artifacts -->
- [x] Real filesystem snapshots, commit records, restart readback, and deletion proofs are asserted by the focused suite
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface