### PR TITLE
fix(personal-assistant): restore Biome compliance

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("scheduling-handler surrogate handling", () => {
   it("4096 backs off at surrogate", () => {
-    const input = "a".repeat(4095) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(4095)}🦊${"b".repeat(20)}`;
     const out = truncate4096(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(4096);
@@ -29,14 +29,14 @@ describe("scheduling-handler surrogate handling", () => {
   });
 
   it("4096 preserves fitting emoji", () => {
-    const input = "a".repeat(4094) + "🦊";
+    const input = `${"a".repeat(4094)}🦊`;
     const out = truncate4096(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(4094) + "🦊");
+    expect(out).toBe(`${"a".repeat(4094)}🦊`);
   });
 
   it("1024 backs off at surrogate", () => {
-    const input = "a".repeat(1023) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(1023)}🦊${"b".repeat(20)}`;
     const out = truncate1024(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1024);
@@ -44,7 +44,7 @@ describe("scheduling-handler surrogate handling", () => {
   });
 
   it("sanitizes lone surrogate", () => {
-    const lone = "ok \ud800 value " + "a".repeat(5000);
+    const lone = `ok \ud800 value ${"a".repeat(5000)}`;
     const out = truncate4096(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts
@@ -18,7 +18,7 @@ function isWellFormed(s: string): boolean {
 
 describe("website-block surrogate handling", () => {
   it("1024 backs off at surrogate (1023+fox->1023)", () => {
-    const input = "a".repeat(1023) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(1023)}🦊${"b".repeat(50)}`;
     const out = truncate1024(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1024);
@@ -26,10 +26,10 @@ describe("website-block surrogate handling", () => {
   });
 
   it("1024 preserves fitting emoji (1022+fox intact)", () => {
-    const input = "a".repeat(1022) + "🦊";
+    const input = `${"a".repeat(1022)}🦊`;
     const out = truncate1024(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(1022) + "🦊");
+    expect(out).toBe(`${"a".repeat(1022)}🦊`);
   });
 
   it("trims before truncation", () => {
@@ -39,8 +39,7 @@ describe("website-block surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `site ${String.fromCharCode(0xd800)} example ` + "a".repeat(2000);
+    const lone = `site ${String.fromCharCode(0xd800)} example ${"a".repeat(2000)}`;
     const out = truncate1024(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/bill-extraction.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/bill-extraction.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("bill-extraction surrogate handling", () => {
   it("1000 backs off at surrogate", () => {
-    const input = "a".repeat(999) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(999)}🦊${"b".repeat(20)}`;
     const out = truncate1000(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1000);
@@ -29,21 +29,21 @@ describe("bill-extraction surrogate handling", () => {
   });
 
   it("1000 preserves fitting emoji", () => {
-    const input = "a".repeat(998) + "🦊";
+    const input = `${"a".repeat(998)}🦊`;
     const out = truncate1000(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(998) + "🦊");
+    expect(out).toBe(`${"a".repeat(998)}🦊`);
   });
 
   it("120 backs off at surrogate", () => {
-    const input = "a".repeat(119) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(119)}🦊${"b".repeat(20)}`;
     const out = truncate120(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(120);
   });
 
   it("sanitizes lone surrogate", () => {
-    const lone = "ok \ud800 snippet " + "a".repeat(2000);
+    const lone = `ok \ud800 snippet ${"a".repeat(2000)}`;
     const out = truncate1000(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.surrogate.test.ts
@@ -24,7 +24,7 @@ function isWellFormed(s: string): boolean {
 
 describe("cross-channel-search surrogate handling", () => {
   it("label 80 backs off at surrogate boundary", () => {
-    const snippet = "a".repeat(79) + "🦊" + "b".repeat(20);
+    const snippet = `${"a".repeat(79)}🦊${"b".repeat(20)}`;
     const out = truncateLabel(snippet);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(80);
@@ -32,15 +32,15 @@ describe("cross-channel-search surrogate handling", () => {
   });
 
   it("label 80 preserves fitting emoji", () => {
-    const snippet = "a".repeat(78) + "🦊";
+    const snippet = `${"a".repeat(78)}🦊`;
     const out = truncateLabel(snippet);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(78) + "🦊");
+    expect(out).toBe(`${"a".repeat(78)}🦊`);
   });
 
   it("text 600 caps and stays well-formed sweep", () => {
     for (let off = 0; off < 20; off++) {
-      const input = "a".repeat(590 + off) + "🦊😀" + "b".repeat(50);
+      const input = `${"a".repeat(590 + off)}🦊😀${"b".repeat(50)}`;
       const out = truncateText(input);
       expect(isWellFormed(out)).toBe(true);
       expect(out.length).toBeLessThanOrEqual(600);
@@ -48,12 +48,12 @@ describe("cross-channel-search surrogate handling", () => {
   });
 
   it("sourceRef 48 backs off and sanitizes lone surrogate", () => {
-    const lone = "ok \ud800 end " + "a".repeat(100);
+    const lone = `ok \ud800 end ${"a".repeat(100)}`;
     const out = truncateSourceRef(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);
     expect(out.length).toBeLessThanOrEqual(48);
-    const emoji = "a".repeat(47) + "🦊" + "b".repeat(20);
+    const emoji = `${"a".repeat(47)}🦊${"b".repeat(20)}`;
     const out2 = truncateSourceRef(emoji);
     expect(isWellFormed(out2)).toBe(true);
     expect(out2.length).toBeLessThanOrEqual(48);

--- a/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts
@@ -18,7 +18,7 @@ function isWellFormed(s: string): boolean {
 
 describe("google-plugin-delegates snippet surrogate handling", () => {
   it("240 backs off at surrogate (239+fox->239)", () => {
-    const input = "a".repeat(239) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(239)}🦊${"b".repeat(50)}`;
     const out = truncate240(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(240);
@@ -26,10 +26,10 @@ describe("google-plugin-delegates snippet surrogate handling", () => {
   });
 
   it("240 preserves fitting emoji (238+fox intact)", () => {
-    const input = "a".repeat(238) + "🦊";
+    const input = `${"a".repeat(238)}🦊`;
     const out = truncate240(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(238) + "🦊");
+    expect(out).toBe(`${"a".repeat(238)}🦊`);
   });
 
   it("short bodyText passes through", () => {
@@ -40,7 +40,7 @@ describe("google-plugin-delegates snippet surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone = `body ${String.fromCharCode(0xd800)} text ` + "a".repeat(500);
+    const lone = `body ${String.fromCharCode(0xd800)} text ${"a".repeat(500)}`;
     const out = truncate240(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/household/repository.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/repository.surrogate.test.ts
@@ -18,7 +18,7 @@ function isWellFormed(s: string): boolean {
 
 describe("household repository surrogate handling", () => {
   it("512 backs off at surrogate", () => {
-    const input = "a".repeat(511) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(511)}🦊${"b".repeat(20)}`;
     const out = truncate512(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(512);
@@ -26,14 +26,14 @@ describe("household repository surrogate handling", () => {
   });
 
   it("512 preserves fitting emoji", () => {
-    const input = "a".repeat(510) + "🦊";
+    const input = `${"a".repeat(510)}🦊`;
     const out = truncate512(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(510) + "🦊");
+    expect(out).toBe(`${"a".repeat(510)}🦊`);
   });
 
   it("sanitizes lone surrogate", () => {
-    const lone = "error \ud800 details " + "a".repeat(1000);
+    const lone = `error \ud800 details ${"a".repeat(1000)}`;
     const out = truncate512(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("candidate-sources surrogate handling", () => {
   it("59 backs off at surrogate (58+fox->58 before …)", () => {
-    const input = "a".repeat(58) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(58)}🦊${"b".repeat(50)}`;
     const out = label59(input);
     expect(isWellFormed(out)).toBe(true);
     const core = out.slice(0, -1).trimEnd();
@@ -29,10 +29,10 @@ describe("candidate-sources surrogate handling", () => {
   });
 
   it("59 preserves fitting emoji (57+fox intact before …)", () => {
-    const input = "a".repeat(57) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(57)}🦊${"b".repeat(50)}`;
     const out = label59(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out.slice(0, -1).trimEnd()).toBe("a".repeat(57) + "🦊");
+    expect(out.slice(0, -1).trimEnd()).toBe(`${"a".repeat(57)}🦊`);
   });
 
   it("short summary passes through", () => {
@@ -43,8 +43,7 @@ describe("candidate-sources surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `summary ${String.fromCharCode(0xd800)} text ` + "a".repeat(100);
+    const lone = `summary ${String.fromCharCode(0xd800)} text ${"a".repeat(100)}`;
     const out = label59(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/screen-context.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/screen-context.surrogate.test.ts
@@ -22,7 +22,7 @@ function isWellFormed(s: string): boolean {
 
 describe("screen-context surrogate handling", () => {
   it("1024 backs off at surrogate (1023+fox->1023)", () => {
-    const input = "a".repeat(1023) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(1023)}🦊${"b".repeat(50)}`;
     const out = normalizeText(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1024);
@@ -30,10 +30,10 @@ describe("screen-context surrogate handling", () => {
   });
 
   it("1024 preserves fitting emoji (1022+fox intact)", () => {
-    const input = "a".repeat(1022) + "🦊";
+    const input = `${"a".repeat(1022)}🦊`;
     const out = normalizeText(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(1022) + "🦊");
+    expect(out).toBe(`${"a".repeat(1022)}🦊`);
   });
 
   it("normalizes whitespace and trims", () => {
@@ -43,8 +43,7 @@ describe("screen-context surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `text ${String.fromCharCode(0xd800)} content ` + "a".repeat(2000);
+    const lone = `text ${String.fromCharCode(0xd800)} content ${"a".repeat(2000)}`;
     const out = normalizeText(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -138,7 +138,9 @@ export function buildUtcDateFromLocalParts(
 ): Date {
   const baseUtcMs = localPartsToEpochMs(parts);
   if (!Number.isFinite(baseUtcMs)) {
-    throw new RangeError(`Local date-time cannot be resolved in timezone ${timeZone}`);
+    throw new RangeError(
+      `Local date-time cannot be resolved in timezone ${timeZone}`,
+    );
   }
   const offsets = new Set(
     OFFSET_SAMPLE_HOURS.map((hours) =>
@@ -166,7 +168,9 @@ export function buildUtcDateFromLocalParts(
     .map((candidate) => {
       let wallDeltaMs: number;
       try {
-        wallDeltaMs = localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) - baseUtcMs;
+        wallDeltaMs =
+          localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) -
+          baseUtcMs;
       } catch {
         wallDeltaMs = Number.NaN;
       }
@@ -174,7 +178,9 @@ export function buildUtcDateFromLocalParts(
     })
     .filter(
       ({ wallDeltaMs, candidate }) =>
-        Number.isFinite(wallDeltaMs) && wallDeltaMs > 0 && Number.isFinite(candidate.getTime()),
+        Number.isFinite(wallDeltaMs) &&
+        wallDeltaMs > 0 &&
+        Number.isFinite(candidate.getTime()),
     )
     .sort(
       (left, right) =>

--- a/plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("cross-channel-context surrogate handling", () => {
   it("180 backs off at surrogate (179+fox->179)", () => {
-    const input = "a".repeat(179) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(179)}🦊${"b".repeat(50)}`;
     const out = truncate180(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(180);
@@ -29,10 +29,10 @@ describe("cross-channel-context surrogate handling", () => {
   });
 
   it("180 preserves fitting emoji (178+fox intact)", () => {
-    const input = "a".repeat(178) + "🦊";
+    const input = `${"a".repeat(178)}🦊`;
     const out = truncate180(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(178) + "🦊");
+    expect(out).toBe(`${"a".repeat(178)}🦊`);
   });
 
   it("trims and normalizes whitespace before truncation", () => {
@@ -42,8 +42,7 @@ describe("cross-channel-context surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `text ${String.fromCharCode(0xd800)} content ` + "a".repeat(500);
+    const lone = `text ${String.fromCharCode(0xd800)} content ${"a".repeat(500)}`;
     const out = truncate180(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
@@ -19,7 +19,7 @@ function isWellFormed(s: string): boolean {
 
 describe("room-policy surrogate handling", () => {
   it("240 backs off at surrogate (239+fox->239)", () => {
-    const input = "a".repeat(239) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(239)}🦊${"b".repeat(50)}`;
     const out = truncateDirective(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(240);
@@ -27,10 +27,10 @@ describe("room-policy surrogate handling", () => {
   });
 
   it("240 preserves fitting emoji (238+fox intact)", () => {
-    const input = "a".repeat(238) + "🦊";
+    const input = `${"a".repeat(238)}🦊`;
     const out = truncateDirective(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(238) + "🦊");
+    expect(out).toBe(`${"a".repeat(238)}🦊`);
   });
 
   it("short directive passes through", () => {
@@ -41,8 +41,7 @@ describe("room-policy surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `directive ${String.fromCharCode(0xd800)} content ` + "a".repeat(500);
+    const lone = `directive ${String.fromCharCode(0xd800)} content ${"a".repeat(500)}`;
     const out = truncateDirective(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);


### PR DESCRIPTION
## Summary

- convert all Biome-rejected surrogate fixture concatenations to equivalent template literals
- format the timezone resolution expressions required by the pinned formatter
- preserve every UTF-16 boundary input, output, and assertion

Closes #25311.
Closes #25323.

## Verification

- `bun install`
- `bun run --cwd packages/core build`
- all 11 `*.surrogate.test.ts` files — 45/45 tests passed
- default-pack lint — clean
- `bun run --cwd plugins/plugin-personal-assistant lint:check` — 1,700 files clean
- `git diff --check`
- standalone package typecheck is not a valid fresh-checkout lane until its workspace dependencies are built; root Turbo provides that order
- root `bun run verify` currently stops at the independent five-key connector i18n blocker fixed in #25313

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->