### PR TITLE
fix(app): repair nested test import paths

### DIFF
--- a/packages/app/src/__tests__/app-module-cache.test.ts
+++ b/packages/app/src/__tests__/app-module-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { cachedDynamicImport } from "./app-module-cache.ts";
+import { cachedDynamicImport } from "../app-module-cache.ts";
 
 describe("cachedDynamicImport", () => {
   it("invokes the loader once per key", async () => {

--- a/packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
+++ b/packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
@@ -4,7 +4,7 @@ import {
   registerAllCloudSurfaces,
   registerPrivateCloudSurfaces,
   registerPublicCloudSurfaces,
-} from "./cloud-register-all-stub.ts";
+} from "../cloud-register-all-stub.ts";
 
 describe("cloud-register-all-stub", () => {
   it("sync registrations are no-ops", () => {

--- a/packages/app/src/shims/__tests__/react-is.test.ts
+++ b/packages/app/src/shims/__tests__/react-is.test.ts
@@ -20,7 +20,7 @@ import {
   isMemo,
   isPortal,
   typeOf,
-} from "./react-is.ts";
+} from "../react-is.ts";
 
 describe("typeOf", () => {
   it("returns the type for elements", () => {


### PR DESCRIPTION
# Relates to

No separate issue — this repairs a defect class that reached `develop` today across several packages, described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] One specifier per file; every path verified against the real tree.
- [x] A reviewer can confirm it from the path listing without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Only import specifiers differ from `develop`.

# Risks

None to production code. Each change is one relative-path specifier inside a test file. No test body, assertion, or source module is touched.

# Background

## What does this PR do?

3 suites in this package sit in a `__tests__/` subdirectory but import their subject as a sibling:

```ts
import { ... } from "./<name>.ts";   // resolves to __tests__/<name>.ts — does not exist
```

The subject is one directory up. Verified against the tree at `develop` for every file below — the sibling path returns `404`, the parent path returns `200`:

```
  packages/app/src/__tests__/app-module-cache.test.ts
  packages/app/src/shims/__tests__/cloud-register-all-stub.test.ts
  packages/app/src/shims/__tests__/react-is.test.ts
```

These fail when the runner loads them; the suites never execute despite being collected.

The runtime consequence is the more serious one: a suite whose import cannot resolve **never loads, so none of its cases execute** while the file still reports as collected. That failure mode was confirmed independently by a maintainer on #25197, where a suite reporting `Tests 3 passed (3)` had in fact never run.

This is the same defect class as #24905 (repaired by #24977) and #25205 (repaired by #25281): a test generated into a new `__tests__/` directory keeping the sibling-relative specifier from before the move. A repository-wide sweep of all 2,122 `__tests__/` suites on `develop` found 30 instances across 7 packages; this PR covers the app ones.

## What is the fix?

Point each specifier one level up. Nothing else changes.

```diff
-import { ... } from "./<name>.ts";
+import { ... } from "../<name>.ts";
```

# Documentation changes needed?

No. No public surface, export, setting, or documented behaviour changes.

# Testing

## Where should a reviewer start?

The path listing above. For each file, `<name>.ts` is a sibling of `__tests__/`, not a member of it, so `../<name>.ts` is the only specifier that resolves.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| sibling path `__tests__/<name>.ts` on `develop` | `404 Not Found` for all 3 — the path the current specifier resolves to |
| parent path `<name>.ts` on `develop` | `200` for all 3 — the path this PR points at |
| post-fix scan for a remaining `from "./<name>"` | none |
| diff vs `develop` | `+1/-1` per file, 3 files, imports only |

Test bodies are unchanged, so each suite keeps exactly the coverage it was reviewed with; it can now resolve the module it was written against.

# Evidence Gate

<!-- evidence-head:35166a1dee9236510f951d4632ec42b2b0d81ac7 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - module specifiers in test files; no rendered surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - module specifiers in test files; no rendered surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is module resolution, shown by the 404/200 path evidence above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the failure is a module-resolution error`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in module resolution`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the artifact is the resolution result above`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by sweeping every `__tests__/` suite on `develop` for sibling-relative specifiers after diagnosing #25205.
- Sweep, verification, and fix by Claude Code (`claude-opus-5`).

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Attribution status: self-reported
