### PR TITLE
fix(ci): restore workspace lint closure

### DIFF
--- a/packages/agent/src/api/audio-redaction-verify.surrogate.test.ts
+++ b/packages/agent/src/api/audio-redaction-verify.surrogate.test.ts
@@ -2,8 +2,8 @@
  * Verifies surrogate-safe truncation for STT verifier error bodies.
  */
 
-import { describe, expect, it } from "vitest";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("audio-redaction-verify surrogate-safe truncation", () => {
   it("replaces lone high surrogate", () => {
@@ -13,7 +13,7 @@ describe("audio-redaction-verify surrogate-safe truncation", () => {
   });
 
   it("does not split astral pair at 300", () => {
-    const text = "a".repeat(299) + "🦊" + "b".repeat(10);
+    const text = `${"a".repeat(299)}🦊${"b".repeat(10)}`;
     const truncated = truncateWellFormed(toWellFormedUnicode(text), 300);
     expect(truncated.length).toBe(299);
     expect(truncated).toBe("a".repeat(299));
@@ -21,11 +21,14 @@ describe("audio-redaction-verify surrogate-safe truncation", () => {
 
   it("truncates ASCII verbatim", () => {
     const ascii = "x".repeat(500);
-    expect(truncateWellFormed(toWellFormedUnicode(ascii), 300).length).toBe(300);
+    expect(truncateWellFormed(toWellFormedUnicode(ascii), 300).length).toBe(
+      300,
+    );
   });
 
   it("handles lone at boundary", () => {
-    const loneAtBoundary = "a".repeat(299) + String.fromCharCode(0xd800) + "b".repeat(200);
+    const loneAtBoundary =
+      "a".repeat(299) + String.fromCharCode(0xd800) + "b".repeat(200);
     const result = truncateWellFormed(toWellFormedUnicode(loneAtBoundary), 300);
     expect(result.length).toBeLessThanOrEqual(300);
     expect(() => JSON.stringify(result)).not.toThrow();

--- a/packages/cloud/services/_common/src/text.ts
+++ b/packages/cloud/services/_common/src/text.ts
@@ -4,23 +4,53 @@
  * Well-formed truncation prevents lone-surrogate \uD8xx escapes and
  * split emoji in provider error diagnostics.
  */
-const HIGH_START = 0xd800, HIGH_END = 0xdbff, LOW_START = 0xdc00, LOW_END = 0xdfff;
+const HIGH_START = 0xd800;
+const HIGH_END = 0xdbff;
+const LOW_START = 0xdc00;
+const LOW_END = 0xdfff;
 const REPLACEMENT = "�";
-function isHigh(c: number){ return c>=HIGH_START && c<=HIGH_END; }
-function isLow(c: number){ return c>=LOW_START && c<=LOW_END; }
-function replaceLone(text: string){
-  let out=""; for(let i=0;i<text.length;i++){ const cc=text.charCodeAt(i); if(isHigh(cc)){ if(i+1<text.length && isLow(text.charCodeAt(i+1))){ out+=text[i]!+text[i+1]!; i++; } else out+=REPLACEMENT; } else if(isLow(cc)) out+=REPLACEMENT; else out+=text[i]!; } return out;
+function isHigh(c: number): boolean {
+  return c >= HIGH_START && c <= HIGH_END;
+}
+function isLow(c: number): boolean {
+  return c >= LOW_START && c <= LOW_END;
+}
+function replaceLone(text: string): string {
+  let out = "";
+  for (let index = 0; index < text.length; index++) {
+    const codeUnit = text.charCodeAt(index);
+    if (isHigh(codeUnit)) {
+      if (index + 1 < text.length && isLow(text.charCodeAt(index + 1))) {
+        out += text.charAt(index) + text.charAt(index + 1);
+        index++;
+      } else {
+        out += REPLACEMENT;
+      }
+    } else if (isLow(codeUnit)) {
+      out += REPLACEMENT;
+    } else {
+      out += text.charAt(index);
+    }
+  }
+  return out;
 }
 export function toWellFormedUnicode(text: string): string {
-  const n = (String.prototype as {toWellFormed?:(this:string)=>string}).toWellFormed;
-  if(n) return n.call(text);
-  const w=(String.prototype as {isWellFormed?:(this:string)=>boolean}).isWellFormed;
-  if(w?.call(text)) return text;
+  const toWellFormed = (
+    String.prototype as { toWellFormed?: (this: string) => string }
+  ).toWellFormed;
+  if (toWellFormed) return toWellFormed.call(text);
+  const isWellFormed = (
+    String.prototype as { isWellFormed?: (this: string) => boolean }
+  ).isWellFormed;
+  if (isWellFormed?.call(text)) return text;
   return replaceLone(text);
 }
 export function truncateWellFormed(text: string, max: number): string {
-  if(!Number.isFinite(max)||max<=0) return "";
-  if(text.length<=max) return text;
-  const end=isHigh(text.charCodeAt(max-1)) && isLow(text.charCodeAt(max)) ? max-1 : max;
-  return text.slice(0,end);
+  if (!Number.isFinite(max) || max <= 0) return "";
+  if (text.length <= max) return text;
+  const end =
+    isHigh(text.charCodeAt(max - 1)) && isLow(text.charCodeAt(max))
+      ? max - 1
+      : max;
+  return text.slice(0, end);
 }

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.groups-adversarial.test.ts
@@ -9,11 +9,7 @@
  * edge-forward.
  */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import type {
-  ChatEvent,
-  PlatformAdapter,
-  WebhookConfig,
-} from "../src/adapters/types";
+import type { ChatEvent, PlatformAdapter } from "../src/adapters/types";
 import { logger } from "../src/logger";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -1,4 +1,9 @@
 /** Handles authenticated connector webhooks from verification through reply delivery. */
+
+import {
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/cloud-services-common";
 import {
   executeResponseAttempts,
   type ResponseAttemptsResult,
@@ -16,7 +21,6 @@ import type {
   PlatformAdapter,
   WebhookConfig,
 } from "./adapters/types";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/cloud-services-common";
 import { PlatformDeliveryError } from "./adapters/types";
 import { reacquireAuthHeader } from "./auth";
 import { resolveConnectorAccountId } from "./connector-account";
@@ -1255,7 +1259,10 @@ async function sendPersonalSharedReply(
   if (!response.ok) {
     let diagnostics: string;
     try {
-      diagnostics = truncateWellFormed(toWellFormedUnicode(await response.text()), 200);
+      diagnostics = truncateWellFormed(
+        toWellFormedUnicode(await response.text()),
+        200,
+      );
     } catch (error) {
       // error-policy:J1 preserve a failed optional diagnostic body read.
       diagnostics = `unable to read response body: ${error instanceof Error ? error.message : String(error)}`;
@@ -1605,7 +1612,10 @@ async function sendOnboardingReply(
   if (!response.ok) {
     let diagnostics: string;
     try {
-      diagnostics = truncateWellFormed(toWellFormedUnicode(await response.text()), 200);
+      diagnostics = truncateWellFormed(
+        toWellFormedUnicode(await response.text()),
+        200,
+      );
     } catch (error) {
       // error-policy:J1 The HTTP status is authoritative at this delivery
       // boundary; preserve a failed optional body read in its diagnostic.

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.surrogate.test.ts
@@ -18,7 +18,16 @@ describe("buildUtcDateFromLocalParts NaN handling (#24990)", () => {
   });
 
   test("filters invalid candidates and does not select epoch-zero for non-finite", () => {
-    expect(() => buildUtcDateFromLocalParts("UTC", { year: NaN, month: NaN, day: NaN, hour: NaN, minute: NaN, second: NaN } as any)).toThrow(RangeError);
+    expect(() =>
+      buildUtcDateFromLocalParts("UTC", {
+        year: NaN,
+        month: NaN,
+        day: NaN,
+        hour: NaN,
+        minute: NaN,
+        second: NaN,
+      } as any),
+    ).toThrow(RangeError);
   });
 
   test("existing valid disambiguation still chooses earliest repeat and skips correctly", () => {

--- a/packages/cloud/shared/src/lib/services/agent-plaid-connector.ts
+++ b/packages/cloud/shared/src/lib/services/agent-plaid-connector.ts
@@ -17,8 +17,8 @@
  * secret. PLAID_SECRET remains an active-environment compatibility alias.
  */
 
-import { z } from "zod";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { z } from "zod";
 
 const PLAID_DEFAULT_HOST = "https://sandbox.plaid.com";
 const PLAID_REQUEST_TIMEOUT_MS = 30_000;

--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -3,6 +3,8 @@
  * attempt is claimed and fully snapshotted before Stripe is called; provider
  * retries reuse that attempt's stable idempotency key and fenced lease.
  */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import Decimal from "decimal.js";
 import type Stripe from "stripe";
 import type {
@@ -26,7 +28,6 @@ import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { requireStripe } from "../stripe";
 import { logger } from "../utils/logger";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { emailService } from "./email";
 import { invalidateOrgTierCache } from "./org-rate-limits";
 import {

--- a/packages/cloud/shared/src/lib/services/content-safety.ts
+++ b/packages/cloud/shared/src/lib/services/content-safety.ts
@@ -1,9 +1,10 @@
 // Coordinates cloud service content safety behavior behind route handlers.
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { ApiError } from "../api/cloud-worker-errors";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 const OPENAI_MODERATIONS_URL = "https://api.openai.com/v1/moderations";
 const DEFAULT_MODERATION_MODEL = "omni-moderation-latest";
@@ -99,7 +100,10 @@ function redactProviderErrorDetail(detail: string): string {
 
 async function readModerationErrorDetail(response: Response): Promise<string> {
   try {
-    return truncateWellFormed(toWellFormedUnicode(redactProviderErrorDetail(await response.text())), 300);
+    return truncateWellFormed(
+      toWellFormedUnicode(redactProviderErrorDetail(await response.text())),
+      300,
+    );
   } catch (error) {
     // error-policy:J7 diagnostics-must-not-kill-the-loop — the moderation
     // response is already failed; keep that boundary decision intact while

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/probe.ts
@@ -12,8 +12,8 @@
  * reject the contribution before it ever enters rotation.
  */
 
-import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
 import type { PooledDirectProvider } from "./provider-map";
 

--- a/packages/vault/src/__tests__/vault-internal-utils.test.ts
+++ b/packages/vault/src/__tests__/vault-internal-utils.test.ts
@@ -27,5 +27,19 @@ describe("optsCaller", () => {
     expect(optsCaller({} as never)).toEqual({});
   });
 });
+
 import { toWellFormedUnicode, truncateWellFormed } from "../internal-utils.js";
-describe("well-formed truncation", () => { it("normalizes lone surrogate to U+FFFD", () => { expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb"); }); it("does not split surrogate pair at truncation boundary", () => { expect(truncateWellFormed("x".repeat(199)+"🦊"+"y".repeat(10),200)).toBe("x".repeat(199)); expect(truncateWellFormed("x".repeat(198)+"🦊",200)).toBe("x".repeat(198)+"🦊"); }); });
+
+describe("well-formed truncation", () => {
+  it("normalizes lone surrogate to U+FFFD", () => {
+    expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
+  });
+  it("does not split surrogate pair at truncation boundary", () => {
+    expect(
+      truncateWellFormed("x".repeat(199) + "🦊" + "y".repeat(10), 200),
+    ).toBe("x".repeat(199));
+    expect(truncateWellFormed("x".repeat(198) + "🦊", 200)).toBe(
+      "x".repeat(198) + "🦊",
+    );
+  });
+});

--- a/packages/vault/src/__tests__/vault-internal-utils.test.ts
+++ b/packages/vault/src/__tests__/vault-internal-utils.test.ts
@@ -36,10 +36,10 @@ describe("well-formed truncation", () => {
   });
   it("does not split surrogate pair at truncation boundary", () => {
     expect(
-      truncateWellFormed("x".repeat(199) + "🦊" + "y".repeat(10), 200),
+      truncateWellFormed(`${"x".repeat(199)}🦊${"y".repeat(10)}`, 200),
     ).toBe("x".repeat(199));
-    expect(truncateWellFormed("x".repeat(198) + "🦊", 200)).toBe(
-      "x".repeat(198) + "🦊",
+    expect(truncateWellFormed(`${"x".repeat(198)}🦊`, 200)).toBe(
+      `${"x".repeat(198)}🦊`,
     );
   });
 });

--- a/packages/vault/src/internal-utils.ts
+++ b/packages/vault/src/internal-utils.ts
@@ -26,29 +26,52 @@ const HIGH_SURROGATE_END = 0xdbff;
 const LOW_SURROGATE_START = 0xdc00;
 const LOW_SURROGATE_END = 0xdfff;
 const REPLACEMENT_CHARACTER = "�";
-function isHighSurrogate(code: number): boolean { return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END; }
-function isLowSurrogate(code: number): boolean { return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END; }
+function isHighSurrogate(code: number): boolean {
+  return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
+}
+function isLowSurrogate(code: number): boolean {
+  return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
+}
 function replaceLoneSurrogates(text: string): string {
   let out = "";
-  for (let i = 0; i < text.length; i++) {
-    const code = text.charCodeAt(i);
+  for (let index = 0; index < text.length; index++) {
+    const code = text.charCodeAt(index);
     if (isHighSurrogate(code)) {
-      if (i + 1 < text.length && isLowSurrogate(text.charCodeAt(i + 1))) { out += text[i]! + text[i + 1]!; i++; } else { out += REPLACEMENT_CHARACTER; }
-    } else if (isLowSurrogate(code)) { out += REPLACEMENT_CHARACTER; } else { out += text[i]!; }
+      if (
+        index + 1 < text.length &&
+        isLowSurrogate(text.charCodeAt(index + 1))
+      ) {
+        out += text.charAt(index) + text.charAt(index + 1);
+        index++;
+      } else {
+        out += REPLACEMENT_CHARACTER;
+      }
+    } else if (isLowSurrogate(code)) {
+      out += REPLACEMENT_CHARACTER;
+    } else {
+      out += text.charAt(index);
+    }
   }
   return out;
 }
 export function toWellFormedUnicode(text: string): string {
-  const nativeToWellFormed = (String.prototype as { toWellFormed?: (this: string) => string }).toWellFormed;
+  const nativeToWellFormed = (
+    String.prototype as { toWellFormed?: (this: string) => string }
+  ).toWellFormed;
   if (nativeToWellFormed) return nativeToWellFormed.call(text);
-  const nativeIsWellFormed = (String.prototype as { isWellFormed?: (this: string) => boolean }).isWellFormed;
+  const nativeIsWellFormed = (
+    String.prototype as { isWellFormed?: (this: string) => boolean }
+  ).isWellFormed;
   if (nativeIsWellFormed?.call(text)) return text;
   return replaceLoneSurrogates(text);
 }
 export function truncateWellFormed(text: string, maxLength: number): string {
   if (!Number.isFinite(maxLength) || maxLength <= 0) return "";
   if (text.length <= maxLength) return text;
-  const end = isHighSurrogate(text.charCodeAt(maxLength - 1)) && isLowSurrogate(text.charCodeAt(maxLength)) ? maxLength - 1 : maxLength;
+  const end =
+    isHighSurrogate(text.charCodeAt(maxLength - 1)) &&
+    isLowSurrogate(text.charCodeAt(maxLength))
+      ? maxLength - 1
+      : maxLength;
   return text.slice(0, end);
 }
-

--- a/packages/vault/src/pglite-vault.ts
+++ b/packages/vault/src/pglite-vault.ts
@@ -13,7 +13,12 @@ import { join } from "node:path";
 import { PGlite } from "@electric-sql/pglite";
 import { AuditLog } from "./audit.js";
 import { decrypt, encrypt } from "./crypto.js";
-import { assertKey, optsCaller, toWellFormedUnicode, truncateWellFormed } from "./internal-utils.js";
+import {
+  assertKey,
+  optsCaller,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "./internal-utils.js";
 import type { MasterKeyResolver } from "./master-key.js";
 import { resolveReference } from "./password-managers.js";
 import { readStore, type StoreData } from "./store.js";

--- a/plugins/plugin-local-inference/src/services/handler-registry.ts
+++ b/plugins/plugin-local-inference/src/services/handler-registry.ts
@@ -90,10 +90,22 @@ class HandlerRegistry {
 		const filtered = existing.filter((r) => r.provider !== reg.provider);
 		filtered.push(reg);
 		filtered.sort((a, b) => {
-        const aP = Number.isFinite(a.priority) ? a.priority : a.priority === Infinity ? Number.MAX_SAFE_INTEGER : a.priority === -Infinity ? Number.MIN_SAFE_INTEGER : 0;
-        const bP = Number.isFinite(b.priority) ? b.priority : b.priority === Infinity ? Number.MAX_SAFE_INTEGER : b.priority === -Infinity ? Number.MIN_SAFE_INTEGER : 0;
-        return bP - aP;
-      });
+			const aP = Number.isFinite(a.priority)
+				? a.priority
+				: a.priority === Infinity
+					? Number.MAX_SAFE_INTEGER
+					: a.priority === -Infinity
+						? Number.MIN_SAFE_INTEGER
+						: 0;
+			const bP = Number.isFinite(b.priority)
+				? b.priority
+				: b.priority === Infinity
+					? Number.MAX_SAFE_INTEGER
+					: b.priority === -Infinity
+						? Number.MIN_SAFE_INTEGER
+						: 0;
+			return bP - aP;
+		});
 		this.registrations.set(reg.modelType, filtered);
 		this.emit();
 	}

--- a/plugins/plugin-matrix/src/service.ts
+++ b/plugins/plugin-matrix/src/service.ts
@@ -539,9 +539,7 @@ async function readJoinedRoomMessages(
           ? right.createdAt
           : 0;
       const l =
-        typeof left.createdAt === "number" && Number.isFinite(left.createdAt)
-          ? left.createdAt
-          : 0;
+        typeof left.createdAt === "number" && Number.isFinite(left.createdAt) ? left.createdAt : 0;
       return r - l;
     })
     .slice(0, limit);
@@ -674,13 +672,9 @@ export class MatrixService extends Service implements IMatrixService {
             .filter(({ score }) => score > 0)
             .sort((left, right) => {
               const r =
-                typeof right.score === "number" && Number.isFinite(right.score)
-                  ? right.score
-                  : 0;
+                typeof right.score === "number" && Number.isFinite(right.score) ? right.score : 0;
               const l =
-                typeof left.score === "number" && Number.isFinite(left.score)
-                  ? left.score
-                  : 0;
+                typeof left.score === "number" && Number.isFinite(left.score) ? left.score : 0;
               return r - l;
             })
             .map(({ room, score }) => matrixRoomToConnectorTarget(room, score, accountId));

--- a/plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("scheduling-handler surrogate handling", () => {
   it("4096 backs off at surrogate", () => {
-    const input = "a".repeat(4095) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(4095)}🦊${"b".repeat(20)}`;
     const out = truncate4096(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(4096);
@@ -29,14 +29,14 @@ describe("scheduling-handler surrogate handling", () => {
   });
 
   it("4096 preserves fitting emoji", () => {
-    const input = "a".repeat(4094) + "🦊";
+    const input = `${"a".repeat(4094)}🦊`;
     const out = truncate4096(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(4094) + "🦊");
+    expect(out).toBe(`${"a".repeat(4094)}🦊`);
   });
 
   it("1024 backs off at surrogate", () => {
-    const input = "a".repeat(1023) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(1023)}🦊${"b".repeat(20)}`;
     const out = truncate1024(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1024);
@@ -44,7 +44,7 @@ describe("scheduling-handler surrogate handling", () => {
   });
 
   it("sanitizes lone surrogate", () => {
-    const lone = "ok \ud800 value " + "a".repeat(5000);
+    const lone = `ok \ud800 value ${"a".repeat(5000)}`;
     const out = truncate4096(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts
@@ -18,7 +18,7 @@ function isWellFormed(s: string): boolean {
 
 describe("website-block surrogate handling", () => {
   it("1024 backs off at surrogate (1023+fox->1023)", () => {
-    const input = "a".repeat(1023) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(1023)}🦊${"b".repeat(50)}`;
     const out = truncate1024(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1024);
@@ -26,10 +26,10 @@ describe("website-block surrogate handling", () => {
   });
 
   it("1024 preserves fitting emoji (1022+fox intact)", () => {
-    const input = "a".repeat(1022) + "🦊";
+    const input = `${"a".repeat(1022)}🦊`;
     const out = truncate1024(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(1022) + "🦊");
+    expect(out).toBe(`${"a".repeat(1022)}🦊`);
   });
 
   it("trims before truncation", () => {
@@ -39,8 +39,7 @@ describe("website-block surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `site ${String.fromCharCode(0xd800)} example ` + "a".repeat(2000);
+    const lone = `site ${String.fromCharCode(0xd800)} example ${"a".repeat(2000)}`;
     const out = truncate1024(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/anticipation/store.safe-sort.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/anticipation/store.safe-sort.test.ts
@@ -5,7 +5,10 @@
 
 import { describe, expect, it } from "vitest";
 
-function liveMarkers(markers: { firedAt: string }[], now: Date): { firedAt: string }[] {
+function liveMarkers(
+  markers: { firedAt: string }[],
+  now: Date,
+): { firedAt: string }[] {
   const MARKER_RETENTION_HOURS = 24;
   const cutoffMs = now.getTime() - MARKER_RETENTION_HOURS * 3_600_000;
   return markers
@@ -14,8 +17,12 @@ function liveMarkers(markers: { firedAt: string }[], now: Date): { firedAt: stri
       return Number.isFinite(firedMs) && firedMs >= cutoffMs;
     })
     .sort((a, b) => {
-      const aTime = Number.isFinite(Date.parse(a.firedAt)) ? Date.parse(a.firedAt) : 0;
-      const bTime = Number.isFinite(Date.parse(b.firedAt)) ? Date.parse(b.firedAt) : 0;
+      const aTime = Number.isFinite(Date.parse(a.firedAt))
+        ? Date.parse(a.firedAt)
+        : 0;
+      const bTime = Number.isFinite(Date.parse(b.firedAt))
+        ? Date.parse(b.firedAt)
+        : 0;
       return aTime - bTime;
     });
 }
@@ -41,7 +48,10 @@ describe("anticipation store safe sort", () => {
       { firedAt: "2026-08-22T11:00:00.000Z" },
     ];
     const result = liveMarkers(markers, now);
-    expect(result.map((m) => m.firedAt)).toEqual(["2026-08-22T09:00:00.000Z", "2026-08-22T11:00:00.000Z"]);
+    expect(result.map((m) => m.firedAt)).toEqual([
+      "2026-08-22T09:00:00.000Z",
+      "2026-08-22T11:00:00.000Z",
+    ]);
   });
 
   it("handles empty without throwing", () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/anticipation/store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/anticipation/store.ts
@@ -148,8 +148,12 @@ function liveMarkers(
       return Number.isFinite(firedMs) && firedMs >= cutoffMs;
     })
     .sort((a, b) => {
-      const aTime = Number.isFinite(Date.parse(a.firedAt)) ? Date.parse(a.firedAt) : 0;
-      const bTime = Number.isFinite(Date.parse(b.firedAt)) ? Date.parse(b.firedAt) : 0;
+      const aTime = Number.isFinite(Date.parse(a.firedAt))
+        ? Date.parse(a.firedAt)
+        : 0;
+      const bTime = Number.isFinite(Date.parse(b.firedAt))
+        ? Date.parse(b.firedAt)
+        : 0;
       return aTime - bTime;
     });
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/bill-extraction.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/bill-extraction.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("bill-extraction surrogate handling", () => {
   it("1000 backs off at surrogate", () => {
-    const input = "a".repeat(999) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(999)}🦊${"b".repeat(20)}`;
     const out = truncate1000(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1000);
@@ -29,21 +29,21 @@ describe("bill-extraction surrogate handling", () => {
   });
 
   it("1000 preserves fitting emoji", () => {
-    const input = "a".repeat(998) + "🦊";
+    const input = `${"a".repeat(998)}🦊`;
     const out = truncate1000(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(998) + "🦊");
+    expect(out).toBe(`${"a".repeat(998)}🦊`);
   });
 
   it("120 backs off at surrogate", () => {
-    const input = "a".repeat(119) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(119)}🦊${"b".repeat(20)}`;
     const out = truncate120(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(120);
   });
 
   it("sanitizes lone surrogate", () => {
-    const lone = "ok \ud800 snippet " + "a".repeat(2000);
+    const lone = `ok \ud800 snippet ${"a".repeat(2000)}`;
     const out = truncate1000(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/cross-channel-search.surrogate.test.ts
@@ -24,7 +24,7 @@ function isWellFormed(s: string): boolean {
 
 describe("cross-channel-search surrogate handling", () => {
   it("label 80 backs off at surrogate boundary", () => {
-    const snippet = "a".repeat(79) + "🦊" + "b".repeat(20);
+    const snippet = `${"a".repeat(79)}🦊${"b".repeat(20)}`;
     const out = truncateLabel(snippet);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(80);
@@ -32,15 +32,15 @@ describe("cross-channel-search surrogate handling", () => {
   });
 
   it("label 80 preserves fitting emoji", () => {
-    const snippet = "a".repeat(78) + "🦊";
+    const snippet = `${"a".repeat(78)}🦊`;
     const out = truncateLabel(snippet);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(78) + "🦊");
+    expect(out).toBe(`${"a".repeat(78)}🦊`);
   });
 
   it("text 600 caps and stays well-formed sweep", () => {
     for (let off = 0; off < 20; off++) {
-      const input = "a".repeat(590 + off) + "🦊😀" + "b".repeat(50);
+      const input = `${"a".repeat(590 + off)}🦊😀${"b".repeat(50)}`;
       const out = truncateText(input);
       expect(isWellFormed(out)).toBe(true);
       expect(out.length).toBeLessThanOrEqual(600);
@@ -48,12 +48,12 @@ describe("cross-channel-search surrogate handling", () => {
   });
 
   it("sourceRef 48 backs off and sanitizes lone surrogate", () => {
-    const lone = "ok \ud800 end " + "a".repeat(100);
+    const lone = `ok \ud800 end ${"a".repeat(100)}`;
     const out = truncateSourceRef(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);
     expect(out.length).toBeLessThanOrEqual(48);
-    const emoji = "a".repeat(47) + "🦊" + "b".repeat(20);
+    const emoji = `${"a".repeat(47)}🦊${"b".repeat(20)}`;
     const out2 = truncateSourceRef(emoji);
     expect(isWellFormed(out2)).toBe(true);
     expect(out2.length).toBeLessThanOrEqual(48);

--- a/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts
@@ -18,7 +18,7 @@ function isWellFormed(s: string): boolean {
 
 describe("google-plugin-delegates snippet surrogate handling", () => {
   it("240 backs off at surrogate (239+fox->239)", () => {
-    const input = "a".repeat(239) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(239)}🦊${"b".repeat(50)}`;
     const out = truncate240(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(240);
@@ -26,10 +26,10 @@ describe("google-plugin-delegates snippet surrogate handling", () => {
   });
 
   it("240 preserves fitting emoji (238+fox intact)", () => {
-    const input = "a".repeat(238) + "🦊";
+    const input = `${"a".repeat(238)}🦊`;
     const out = truncate240(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(238) + "🦊");
+    expect(out).toBe(`${"a".repeat(238)}🦊`);
   });
 
   it("short bodyText passes through", () => {
@@ -40,7 +40,7 @@ describe("google-plugin-delegates snippet surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone = `body ${String.fromCharCode(0xd800)} text ` + "a".repeat(500);
+    const lone = `body ${String.fromCharCode(0xd800)} text ${"a".repeat(500)}`;
     const out = truncate240(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/household/repository.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/repository.surrogate.test.ts
@@ -18,7 +18,7 @@ function isWellFormed(s: string): boolean {
 
 describe("household repository surrogate handling", () => {
   it("512 backs off at surrogate", () => {
-    const input = "a".repeat(511) + "🦊" + "b".repeat(20);
+    const input = `${"a".repeat(511)}🦊${"b".repeat(20)}`;
     const out = truncate512(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(512);
@@ -26,14 +26,14 @@ describe("household repository surrogate handling", () => {
   });
 
   it("512 preserves fitting emoji", () => {
-    const input = "a".repeat(510) + "🦊";
+    const input = `${"a".repeat(510)}🦊`;
     const out = truncate512(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(510) + "🦊");
+    expect(out).toBe(`${"a".repeat(510)}🦊`);
   });
 
   it("sanitizes lone surrogate", () => {
-    const lone = "error \ud800 details " + "a".repeat(1000);
+    const lone = `error \ud800 details ${"a".repeat(1000)}`;
     const out = truncate512(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("candidate-sources surrogate handling", () => {
   it("59 backs off at surrogate (58+fox->58 before …)", () => {
-    const input = "a".repeat(58) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(58)}🦊${"b".repeat(50)}`;
     const out = label59(input);
     expect(isWellFormed(out)).toBe(true);
     const core = out.slice(0, -1).trimEnd();
@@ -29,10 +29,10 @@ describe("candidate-sources surrogate handling", () => {
   });
 
   it("59 preserves fitting emoji (57+fox intact before …)", () => {
-    const input = "a".repeat(57) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(57)}🦊${"b".repeat(50)}`;
     const out = label59(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out.slice(0, -1).trimEnd()).toBe("a".repeat(57) + "🦊");
+    expect(out.slice(0, -1).trimEnd()).toBe(`${"a".repeat(57)}🦊`);
   });
 
   it("short summary passes through", () => {
@@ -43,8 +43,7 @@ describe("candidate-sources surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `summary ${String.fromCharCode(0xd800)} text ` + "a".repeat(100);
+    const lone = `summary ${String.fromCharCode(0xd800)} text ${"a".repeat(100)}`;
     const out = label59(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/screen-context.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/screen-context.surrogate.test.ts
@@ -22,7 +22,7 @@ function isWellFormed(s: string): boolean {
 
 describe("screen-context surrogate handling", () => {
   it("1024 backs off at surrogate (1023+fox->1023)", () => {
-    const input = "a".repeat(1023) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(1023)}🦊${"b".repeat(50)}`;
     const out = normalizeText(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(1024);
@@ -30,10 +30,10 @@ describe("screen-context surrogate handling", () => {
   });
 
   it("1024 preserves fitting emoji (1022+fox intact)", () => {
-    const input = "a".repeat(1022) + "🦊";
+    const input = `${"a".repeat(1022)}🦊`;
     const out = normalizeText(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(1022) + "🦊");
+    expect(out).toBe(`${"a".repeat(1022)}🦊`);
   });
 
   it("normalizes whitespace and trims", () => {
@@ -43,8 +43,7 @@ describe("screen-context surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `text ${String.fromCharCode(0xd800)} content ` + "a".repeat(2000);
+    const lone = `text ${String.fromCharCode(0xd800)} content ${"a".repeat(2000)}`;
     const out = normalizeText(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -138,7 +138,9 @@ export function buildUtcDateFromLocalParts(
 ): Date {
   const baseUtcMs = localPartsToEpochMs(parts);
   if (!Number.isFinite(baseUtcMs)) {
-    throw new RangeError(`Local date-time cannot be resolved in timezone ${timeZone}`);
+    throw new RangeError(
+      `Local date-time cannot be resolved in timezone ${timeZone}`,
+    );
   }
   const offsets = new Set(
     OFFSET_SAMPLE_HOURS.map((hours) =>
@@ -166,7 +168,9 @@ export function buildUtcDateFromLocalParts(
     .map((candidate) => {
       let wallDeltaMs: number;
       try {
-        wallDeltaMs = localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) - baseUtcMs;
+        wallDeltaMs =
+          localPartsToEpochMs(getZonedDateParts(candidate, timeZone)) -
+          baseUtcMs;
       } catch {
         wallDeltaMs = Number.NaN;
       }
@@ -174,7 +178,9 @@ export function buildUtcDateFromLocalParts(
     })
     .filter(
       ({ wallDeltaMs, candidate }) =>
-        Number.isFinite(wallDeltaMs) && wallDeltaMs > 0 && Number.isFinite(candidate.getTime()),
+        Number.isFinite(wallDeltaMs) &&
+        wallDeltaMs > 0 &&
+        Number.isFinite(candidate.getTime()),
     )
     .sort(
       (left, right) =>

--- a/plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts
@@ -21,7 +21,7 @@ function isWellFormed(s: string): boolean {
 
 describe("cross-channel-context surrogate handling", () => {
   it("180 backs off at surrogate (179+fox->179)", () => {
-    const input = "a".repeat(179) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(179)}🦊${"b".repeat(50)}`;
     const out = truncate180(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(180);
@@ -29,10 +29,10 @@ describe("cross-channel-context surrogate handling", () => {
   });
 
   it("180 preserves fitting emoji (178+fox intact)", () => {
-    const input = "a".repeat(178) + "🦊";
+    const input = `${"a".repeat(178)}🦊`;
     const out = truncate180(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(178) + "🦊");
+    expect(out).toBe(`${"a".repeat(178)}🦊`);
   });
 
   it("trims and normalizes whitespace before truncation", () => {
@@ -42,8 +42,7 @@ describe("cross-channel-context surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `text ${String.fromCharCode(0xd800)} content ` + "a".repeat(500);
+    const lone = `text ${String.fromCharCode(0xd800)} content ${"a".repeat(500)}`;
     const out = truncate180(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
@@ -19,7 +19,7 @@ function isWellFormed(s: string): boolean {
 
 describe("room-policy surrogate handling", () => {
   it("240 backs off at surrogate (239+fox->239)", () => {
-    const input = "a".repeat(239) + "🦊" + "b".repeat(50);
+    const input = `${"a".repeat(239)}🦊${"b".repeat(50)}`;
     const out = truncateDirective(input);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBeLessThanOrEqual(240);
@@ -27,10 +27,10 @@ describe("room-policy surrogate handling", () => {
   });
 
   it("240 preserves fitting emoji (238+fox intact)", () => {
-    const input = "a".repeat(238) + "🦊";
+    const input = `${"a".repeat(238)}🦊`;
     const out = truncateDirective(input);
     expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe("a".repeat(238) + "🦊");
+    expect(out).toBe(`${"a".repeat(238)}🦊`);
   });
 
   it("short directive passes through", () => {
@@ -41,8 +41,7 @@ describe("room-policy surrogate handling", () => {
   });
 
   it("sanitizes lone high surrogate", () => {
-    const lone =
-      `directive ${String.fromCharCode(0xd800)} content ` + "a".repeat(500);
+    const lone = `directive ${String.fromCharCode(0xd800)} content ${"a".repeat(500)}`;
     const out = truncateDirective(lone);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("�")).toBe(true);

--- a/plugins/plugin-x/src/client/auth-providers/broker.ts
+++ b/plugins/plugin-x/src/client/auth-providers/broker.ts
@@ -166,7 +166,7 @@ export class BrokerAuthProvider implements TwitterBrokerProvider {
       try {
         const body = await response.text();
         errorBodyPreview = truncateWellFormed(toWellFormedUnicode(body), 200);
-      } catch (error) {
+      } catch (_error) {
         // error-policy:J1 translate body-read failure explicitly without fabricating an empty body.
         errorBodyPreview = "[unreadable]";
       }


### PR DESCRIPTION
## Summary

- restores the complete 151-workspace lint closure on current `develop`
- persists deterministic Biome formatting/import organization that package lint scripts otherwise rewrite silently
- removes only imports or bindings proven unused by the configured checks
- repairs malformed leaf-local surrogate-safe helpers in cloud services and vault with bounded `charAt` access while preserving behavior
- keeps migrations, public APIs, and product behavior unchanged

Exact head: `f40e2b1da16f8719b3700dff747f758c6dd2a0d0` (base `c713ee051bc735c2597ae8b1d694d81f4690adb9`).

## Verification

- full repository Turbo lint: 141/141 tasks PASS across 151 packages; second exact-head run produced no rewrites
- Matrix typecheck PASS; hardening suite 15/15 PASS
- personal-assistant changed time/sort/surrogate suites PASS
- vault + agent focused surrogate/helper suites 11/11 PASS, 18 assertions
- gateway-webhook, cloud-services-common, vault, local-inference, and plugin-x typechecks PASS
- prior focused cloud-services-common tests: 54 PASS / 112 assertions
- prior focused cloud-shared safety/probe/top-up tests: 84 PASS / 290 assertions
- prior local-inference handler-registry tests: 5 PASS / 9 assertions
- `git diff --check` PASS and worktree clean

## Known repository gate

Root `bun run verify` remains blocked before lint by the pre-existing `check:i18n` failure on `develop` (missing connector-card English keys and locale gaps). This PR does not alter localization contracts.

## Hosted proof

Do not merge until the required hosted checks pass on exact head `f40e2b1da16f8719b3700dff747f758c6dd2a0d0` and the independent exact-head review returns GO.