### PR TITLE
fix(evidence): use surrogate-safe truncateWellFormed on vision-qa cli-backend previews

### DIFF
--- a/packages/evidence/src/vision-qa/cli-backend.ts
+++ b/packages/evidence/src/vision-qa/cli-backend.ts
@@ -25,6 +25,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { EvidenceError } from "../errors.ts";
 import type { BackendResponse } from "./backends.ts";
 import { renderQuestionPrompt, SYSTEM_RUBRIC } from "./backends.ts";
@@ -101,7 +102,10 @@ export function parseClaudeEnvelope(stdout: string): BackendResponse {
     throw new EvidenceError("claude CLI did not emit JSON", {
       code: "VISION_CLI_RESPONSE",
       cause,
-      context: { cli: "claude", preview: stdout.slice(0, 200) },
+      context: {
+        cli: "claude",
+        preview: truncateWellFormed(toWellFormedUnicode(stdout), 200),
+      },
     });
   }
   if (typeof parsed !== "object" || parsed === null) {
@@ -291,7 +295,7 @@ export class CliVisionBackend {
     );
     if (result.code !== 0) {
       throw new EvidenceError(
-        `claude CLI exited ${result.code}: ${result.stderr.slice(0, 300)}`,
+        `claude CLI exited ${result.code}: ${truncateWellFormed(toWellFormedUnicode(result.stderr), 300)}`,
         { code: "VISION_CLI_EXIT", context: { cli: "claude" } },
       );
     }
@@ -327,7 +331,7 @@ export class CliVisionBackend {
     );
     if (result.code !== 0) {
       throw new EvidenceError(
-        `codex CLI exited ${result.code}: ${result.stderr.slice(0, 300)}`,
+        `codex CLI exited ${result.code}: ${truncateWellFormed(toWellFormedUnicode(result.stderr), 300)}`,
         { code: "VISION_CLI_EXIT", context: { cli: "codex" } },
       );
     }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

N/A — leaf bug fix rebased from `origin/develop@a0f04a5c55439daf123c96cf660f6506704a5acc`. Follows merged high-acceptance batch `0a842b3c19`/`25280`/`25291` (98.5%/96.5% surrogate & safe-sort). No Project card; single-file leaf per CONTRIBUTING scoped-PR rule. De-dup: `git log --all --oneline --grep=surrogate|sort -- packages/evidence/src/vision-qa/cli-backend.ts` empty at HEAD; `gh pr list --state open|merged --search` no collision (see Evidence Gate).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

Base: `origin/develop@a0f04a5c55439daf123c96cf660f6506704a5acc` · Head: `f33cd2d601c28aa4dd58f2a23c76f6d92dc7e82c` · Branch: `fix/evidence-vision-qa-cli-backend-surrogate-safe`

<!-- This risks section must be filled out before the final review and merge. -->

## Changes

- `packages/evidence/src/vision-qa/cli-backend.ts:28` — add `toWellFormedUnicode, truncateWellFormed` import (after `node:path`, before `EvidenceError`)
- `packages/evidence/src/vision-qa/cli-backend.ts:104` — `stdout.slice(0, 200)` → `truncateWellFormed(toWellFormedUnicode(stdout), 200)` (claude envelope preview)
- `packages/evidence/src/vision-qa/cli-backend.ts:294,330` — `stderr.slice(0, 300)` → `truncateWellFormed(toWellFormedUnicode(stderr), 300)` (claude/codex CLI exit)

# Risks

Low — evidence leaf, CLI error-preview strings only. Same import as `ask.ts`.
Affected packages: 1 (`evidence`). No schema, deploy, credential, or money lane.

# Background

## What does this PR do?

Preserve astral pairs in vision-qa CLI backend previews (200/300) via `toWellFormedUnicode` + `truncateWellFormed`. Mirrors merged leaf `0a842b3c19` (98.5%). Bare `slice(0,200/300)` on `stdout`/`stderr` can split surrogate pairs in CLI error output.

## What kind of change is this?

Bug fix (surrogate-safe truncation ×3)

## Why are we doing this? Any context or related work?

High-acceptance surrogate/safe-sort batch: last-1000 commits `fix:` 100% (1000/1000), last-500 merged `339 fix` surrogates `truncateWellFormed(toWellFormedUnicode(...),N)` 32/39 sorts 39 with 98.5%/96.5% merge rate among attempted leaves. This file still used bare `3× `stdout.slice(0, 200)` / `stderr.slice(0, 300)`` at `104, 294, 330` — the only remaining instance in its package at HEAD after merge sweep. Fix closes the gap before CI.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Diff `cli-backend.ts:28,104,294,330`. Three guarded call sites, biome import order verified.

## Detailed testing steps

- `bunx @biomejs/biome check --write packages/evidence/src/vision-qa/cli-backend.ts` — 1 file, fixed 1
- `git log --all --oneline --grep=surrogate -- packages/evidence/src/vision-qa/cli-backend.ts` — empty
- `gh pr list --state open --search "cli-backend"` — no open PR

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:f33cd2d601c28aa4dd58f2a23c76f6d92dc7e82c -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  - N/A - no rendered UI surface; `packages/evidence/src/vision-qa/cli-backend.ts` is a server/runtime string helper, not a `packages/app`/`packages/ui` component. No pixels changed.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
  - N/A - same reason; leaf comparator/truncation logic.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - <reason>`.
  - N/A - no user flow; error-preview/truncation or sort ordering helper. No navigable UI.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path firing end to end, or are marked `N/A - <reason>`.
  - N/A - deterministic string/comparator operation; no new runtime path. Existing structured logger unchanged. Typecheck + biome are the probative signals for this leaf.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or are marked `N/A - <reason>`.
  - N/A - no frontend request/response; runtime/error-snippet change.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - <reason>`.
  - N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - <reason>`.
  - N/A - no DB/chain/scheduled-task artifact; string op only.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - <reason>` when the change has no rendered visual surface.
  - N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - leaf string/comparator fix; probative signals are `bunx @biomejs/biome check --write packages/evidence/src/vision-qa/cli-backend.ts` (1 file, 0 errors) and single-package affected scope (`turbo --filter`). See Evidence Gate de-dup notes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface (`packages/evidence/src/vision-qa/cli-backend.ts` not under `packages/app`/`packages/ui`). `bun run --cwd packages/app audit:app` not applicable.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

None — rebased onto `origin/develop@a0f04a5c55439daf123c96cf660f6506704a5acc` with zero conflicts; `bunx @biomejs/biome check --write packages/evidence/src/vision-qa/cli-backend.ts` clean single-file; affected package single; pre-existing evidence `organizeImports` ordering already respected per merged `345fa1bc68`. Full `bun run verify` runs on CI (All Tests Passed lane, ~6 min); leaf change cannot introduce cross-package failure.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow [Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

