### PR TITLE
fix(core): preserve reply bypasses in ambient triage

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -7312,6 +7312,24 @@ function withReplyGateMode(
 	return runtime;
 }
 
+function withReplyGateSlots(
+	runtime: IAgentRuntime,
+	userMode: string,
+	globalMode: string,
+): IAgentRuntime {
+	(runtime as unknown as Record<string, unknown>).getService = vi.fn(
+		(type: string) =>
+			type === "PERSONALITY_STORE"
+				? {
+						getSlot: (id: UUID | "global") => ({
+							reply_gate: id === "global" ? globalMode : userMode,
+						}),
+					}
+				: null,
+	);
+	return runtime;
+}
+
 describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 	// Live incident: in a busy multi-user group channel the agent replied to
 	// turns its own Stage-1 output tagged as addressed to another participant
@@ -7572,7 +7590,7 @@ describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 	});
 
 	it("bypasses the gate when the effective personality reply_gate is an explicit 'always'", async () => {
-		const runtime = withReplyGateMode(
+		const runtime = withReplyGateSlots(
 			withRoomEntities(
 				makeRuntime([
 					stage1Response({
@@ -7584,6 +7602,7 @@ describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 				]),
 			),
 			"always",
+			"addressed_or_ambient",
 		);
 		const result = await runV5MessageRuntimeStage1({
 			runtime,
@@ -7597,6 +7616,74 @@ describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 		expect(result.kind).toBe("direct_reply");
 		if (result.kind === "direct_reply") {
 			expect(result.result.responseContent?.text).toBe("Jumping in anyway!");
+		}
+		const stage1Params = useModelCalls(runtime)[0]?.[1] as {
+			messages?: Array<{ content?: string | null }>;
+		};
+		const stage1Content = (stage1Params.messages ?? [])
+			.map((entry) => entry.content ?? "")
+			.join("\n");
+		expect(stage1Content).not.toContain("ambient_turn_policy:");
+	});
+
+	it("does not inject ambient policy for canonical or configured response bypasses", async () => {
+		const cases = [
+			{
+				label: "scheduled trigger",
+				content: {
+					channelType: ChannelType.GROUP,
+					source: "trigger-prompt",
+				},
+				settings: undefined,
+			},
+			{
+				label: "configured source",
+				content: {
+					channelType: ChannelType.GROUP,
+					source: "trusted_dispatch",
+				},
+				settings: { ALWAYS_RESPOND_SOURCES: "trusted_dispatch" },
+			},
+			{
+				label: "configured channel",
+				content: {
+					channelType: ChannelType.GROUP,
+					source: "test",
+				},
+				settings: { ALWAYS_RESPOND_CHANNELS: "group" },
+			},
+		] satisfies Array<{
+			label: string;
+			content: Partial<Memory["content"]>;
+			settings: Record<string, string> | undefined;
+		}>;
+
+		for (const testCase of cases) {
+			const runtime = makeRuntime(
+				[
+					stage1Response({
+						thought: "Bypass response.",
+						contexts: ["simple"],
+						replyText: "Delivered.",
+					}),
+				],
+				testCase.settings,
+			);
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage(testCase.content),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-0000000000bd" as UUID,
+			});
+			const params = useModelCalls(runtime)[0]?.[1] as {
+				messages?: Array<{ content?: string | null }>;
+			};
+			const prompt = (params.messages ?? [])
+				.map((entry) => entry.content ?? "")
+				.join("\n");
+
+			expect(result.kind, testCase.label).toBe("direct_reply");
+			expect(prompt, testCase.label).not.toContain("ambient_turn_policy:");
 		}
 	});
 

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -7687,6 +7687,50 @@ describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 		}
 	});
 
+	it("fails open without ambient silence when personality lookup throws", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Personality state is unavailable.",
+				contexts: ["simple"],
+				replyText: "Still delivered.",
+			}),
+		]);
+		(runtime as unknown as Record<string, unknown>).getService = vi.fn(
+			(type: string) =>
+				type === "PERSONALITY_STORE"
+					? {
+							getSlot: () => {
+								throw new Error("personality store unavailable");
+							},
+						}
+					: null,
+		);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "ambient group message",
+				channelType: ChannelType.GROUP,
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-0000000000be" as UUID,
+		});
+		const params = useModelCalls(runtime)[0]?.[1] as {
+			messages?: Array<{ content?: string | null }>;
+		};
+		const prompt = (params.messages ?? [])
+			.map((entry) => entry.content ?? "")
+			.join("\n");
+
+		expect(result.kind).toBe("direct_reply");
+		expect(prompt).not.toContain("ambient_turn_policy:");
+		expect(reportErrorCalls(runtime)).toContainEqual([
+			"MessageService.resolveAmbientReplyGate",
+			expect.any(Error),
+			expect.objectContaining({ roomId: expect.any(String) }),
+		]);
+	});
+
 	it("keeps the gate armed under reply_gate 'addressed_or_ambient' (only 'always' bypasses)", async () => {
 		const runtime = withReplyGateMode(
 			withRoomEntities(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -565,6 +565,7 @@ function resolveStage1ReplyGateMode(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): ReplyGateMode | null {
+	if (typeof runtime.getService !== "function") return null;
 	const store = getPersonalityStore(runtime);
 	if (!store || message.entityId === runtime.agentId) {
 		return null;
@@ -573,6 +574,77 @@ function resolveStage1ReplyGateMode(
 		store.getSlot(message.entityId),
 		store.getSlot("global"),
 	).mode;
+}
+
+const BUILTIN_ALWAYS_RESPOND_CHANNELS: readonly ChannelType[] = [
+	ChannelType.DM,
+	ChannelType.VOICE_DM,
+	ChannelType.SELF,
+	ChannelType.API,
+];
+
+const BUILTIN_ALWAYS_RESPOND_SOURCES: readonly string[] = [
+	MESSAGE_SOURCE_CLIENT_CHAT,
+	MESSAGE_SOURCE_TRIGGER_PROMPT,
+];
+
+function normalizeResponseBypassList(value: unknown): string[] {
+	if (typeof value !== "string") return [];
+	return value
+		.trim()
+		.replace(/^\[|\]$/g, "")
+		.split(",")
+		.map((entry) => entry.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+/**
+ * Canonical structural response bypass used before Stage 1 and by the legacy
+ * response gate. A bypassed turn must never receive an ambient-silence prompt
+ * that contradicts the routing contract which guarantees a response.
+ */
+function messageBypassesResponseEvaluation(
+	runtime: IAgentRuntime,
+	message: Memory,
+): boolean {
+	const configuredChannels = normalizeResponseBypassList(
+		runtime.getSetting("ALWAYS_RESPOND_CHANNELS") ??
+			runtime.getSetting("SHOULD_RESPOND_BYPASS_TYPES"),
+	);
+	const configuredSources = normalizeResponseBypassList(
+		runtime.getSetting("ALWAYS_RESPOND_SOURCES") ??
+			runtime.getSetting("SHOULD_RESPOND_BYPASS_SOURCES"),
+	);
+	const channel = String(message.content?.channelType ?? "")
+		.trim()
+		.toLowerCase();
+	const source = String(message.content?.source ?? "")
+		.trim()
+		.toLowerCase();
+	const channels = [
+		...BUILTIN_ALWAYS_RESPOND_CHANNELS.map((entry) =>
+			String(entry).toLowerCase(),
+		),
+		...configuredChannels,
+	];
+	const sources = [
+		...BUILTIN_ALWAYS_RESPOND_SOURCES.map((entry) => entry.toLowerCase()),
+		...configuredSources,
+	];
+	return (
+		channels.includes(channel) ||
+		sources.some((pattern) => pattern.length > 0 && source.includes(pattern))
+	);
+}
+
+function isAmbientStage1Turn(
+	runtime: IAgentRuntime,
+	message: Memory,
+	explicitlyAddressesAgent: boolean,
+): boolean {
+	if (resolveStage1ReplyGateMode(runtime, message) === "always") return false;
+	if (messageBypassesResponseEvaluation(runtime, message)) return false;
+	return isUnaddressedTextGroupTurn(message, explicitlyAddressesAgent);
 }
 
 function getPlannerActionObjectName(action: Record<string, unknown>): string {
@@ -946,7 +1018,8 @@ function ambientTurnProviderExclusions(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): readonly string[] {
-	return isUnaddressedTextGroupTurn(
+	return isAmbientStage1Turn(
+		runtime,
 		message,
 		messageExplicitlyAddressesAgent(runtime, message),
 	)
@@ -7968,6 +8041,11 @@ export async function runV5MessageRuntimeStage1(args: {
 		args.runtime.contexts,
 		senderRole,
 	);
+	const directMessageChannel =
+		args.message.content?.channelType === ChannelType.DM ||
+		args.message.content?.channelType === ChannelType.VOICE_DM ||
+		args.message.content?.channelType === ChannelType.API ||
+		args.message.content?.channelType === ChannelType.SELF;
 	// Ambient turn = a positively-identified unaddressed text-group turn
 	// (structural classifier only — channel type + addressing + source
 	// metadata, never message text; anything uncertain fails open to
@@ -7977,17 +8055,11 @@ export async function runV5MessageRuntimeStage1(args: {
 	// got a reply to nearly every message — the Stage-1 field guidance alone
 	// ("active in the conversation") reads as RESPOND. Also drives the planner's
 	// ambient-turn policy instruction and the deliberate-silence terminal below.
-	const directMessageChannel =
-		args.message.content?.channelType === ChannelType.DM ||
-		args.message.content?.channelType === ChannelType.VOICE_DM ||
-		args.message.content?.channelType === ChannelType.API ||
-		args.message.content?.channelType === ChannelType.SELF;
-	const ambientTurn =
-		!directMessageChannel &&
-		isUnaddressedTextGroupTurn(
-			args.message,
-			messageExplicitlyAddressesAgent(args.runtime, args.message),
-		);
+	const ambientTurn = isAmbientStage1Turn(
+		args.runtime,
+		args.message,
+		messageExplicitlyAddressesAgent(args.runtime, args.message),
+	);
 	const context = await createV5MessageContextObject({
 		...args,
 		userRoles: [senderRole],
@@ -14764,39 +14836,22 @@ export class DefaultMessageService implements IMessageService {
 			};
 		}
 
-		function normalizeEnvList(value: unknown): string[] {
-			if (!value || typeof value !== "string") return [];
-			const cleaned = value.trim().replace(/^\[|\]$/g, "");
-			return cleaned
-				.split(",")
-				.map((v) => v.trim())
-				.filter(Boolean);
-		}
-
 		// Channel types that always trigger a response (private channels)
-		const alwaysRespondChannels = [
-			ChannelType.DM,
-			ChannelType.VOICE_DM,
-			ChannelType.SELF,
-			ChannelType.API,
-		];
+		const alwaysRespondChannels = BUILTIN_ALWAYS_RESPOND_CHANNELS;
 
 		// Sources that always trigger a response. A trigger-prompt message is
 		// the agent's OWN scheduled intent firing (a reminder or prompt
 		// automation it created earlier) — gating it behind "should I respond
 		// to this ambient message?" is a category error and silently eats
 		// reminders.
-		const alwaysRespondSources = [
-			MESSAGE_SOURCE_CLIENT_CHAT,
-			MESSAGE_SOURCE_TRIGGER_PROMPT,
-		];
+		const alwaysRespondSources = BUILTIN_ALWAYS_RESPOND_SOURCES;
 
 		// Support runtime-configurable overrides via env settings
-		const customChannels = normalizeEnvList(
+		const customChannels = normalizeResponseBypassList(
 			runtime.getSetting("ALWAYS_RESPOND_CHANNELS") ??
 				runtime.getSetting("SHOULD_RESPOND_BYPASS_TYPES"),
 		);
-		const customSources = normalizeEnvList(
+		const customSources = normalizeResponseBypassList(
 			runtime.getSetting("ALWAYS_RESPOND_SOURCES") ??
 				runtime.getSetting("SHOULD_RESPOND_BYPASS_SOURCES"),
 		);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -642,7 +642,20 @@ function isAmbientStage1Turn(
 	message: Memory,
 	explicitlyAddressesAgent: boolean,
 ): boolean {
-	if (resolveStage1ReplyGateMode(runtime, message) === "always") return false;
+	let replyGateMode: ReplyGateMode | null;
+	try {
+		replyGateMode = resolveStage1ReplyGateMode(runtime, message);
+	} catch (error) {
+		// error-policy:J7 personality lookup is advisory routing context. A store
+		// failure must fail open to the ordinary addressed prompt, not convert a
+		// potentially explicit always-response turn into silence.
+		runtime.reportError("MessageService.resolveAmbientReplyGate", error, {
+			roomId: message.roomId,
+			entityId: message.entityId,
+		});
+		return false;
+	}
+	if (replyGateMode === "always") return false;
 	if (messageBypassesResponseEvaluation(runtime, message)) return false;
 	return isUnaddressedTextGroupTurn(message, explicitlyAddressesAgent);
 }

--- a/packages/core/src/services/message/bot-noise-triage.test.ts
+++ b/packages/core/src/services/message/bot-noise-triage.test.ts
@@ -143,6 +143,13 @@ describe("isTriagableBotNoiseMessage — deterministic preconditions", () => {
 		const clientChat = relayEmbedMessage();
 		clientChat.content = { ...clientChat.content, source: "client_chat" };
 		expect(isTriagableBotNoiseMessage(clientChat, false)).toBe(false);
+
+		const scheduledTrigger = relayEmbedMessage();
+		scheduledTrigger.content = {
+			...scheduledTrigger.content,
+			source: "trigger-prompt",
+		};
+		expect(isTriagableBotNoiseMessage(scheduledTrigger, false)).toBe(false);
 	});
 });
 

--- a/packages/core/src/services/message/stage1-prompt-tier.ts
+++ b/packages/core/src/services/message/stage1-prompt-tier.ts
@@ -10,6 +10,7 @@ import type { Memory } from "../../types/memory";
 import {
 	MESSAGE_SOURCE_CLIENT_CHAT,
 	MESSAGE_SOURCE_SUB_AGENT,
+	MESSAGE_SOURCE_TRIGGER_PROMPT,
 } from "../../types/message-source";
 import { ChannelType } from "../../types/primitives";
 /**
@@ -31,7 +32,10 @@ export const TEXT_GROUP_CHANNEL_TYPES: ReadonlySet<string> = new Set([
 const SUB_AGENT_SOURCE = MESSAGE_SOURCE_SUB_AGENT;
 
 /** Sources that bypass should-respond entirely — always respond-likely. */
-const ALWAYS_RESPOND_SOURCES: readonly string[] = [MESSAGE_SOURCE_CLIENT_CHAT];
+const ALWAYS_RESPOND_SOURCES: readonly string[] = [
+	MESSAGE_SOURCE_CLIENT_CHAT,
+	MESSAGE_SOURCE_TRIGGER_PROMPT,
+];
 
 function metadataRecord(value: unknown): Record<string, unknown> | undefined {
 	return typeof value === "object" && value !== null && !Array.isArray(value)


### PR DESCRIPTION
Corrects the post-merge routing regression in #25279.

The merged Stage-1 ambient policy was derived only from channel/addressing structure. That contradicted existing response contracts: an effective personality reply_gate of always, scheduled trigger-prompt delivery, runtime-configured response bypass sources/channels, and fail-open behavior when advisory personality state is unavailable. Those turns could be told to IGNORE even though the canonical router deliberately guarantees or conservatively preserves a response.

This change centralizes the built-in/configured bypass lists inside the message service, derives ambient policy from the effective user-over-global personality slot, keeps bot-noise triage aligned for scheduled triggers, and reports personality lookup failures while retaining the ordinary addressed prompt.

Validation on exact head b6ae5a2dcad0e8ca1de97f2be8b3ce1f85f8ec6c with pinned Bun 1.3.14 and Node 24.15.0:

- 203 focused Stage-1, prompt-tier, and bot-noise tests pass.
- packages/core typecheck passes.
- Biome passes on all changed files.
- git diff --check passes.
- bun run verify reaches the repository i18n gate and fails on five pre-existing missing connectorcard English keys; the same check fails identically on clean origin/develop a0f04a5c55439.

Evidence: deterministic prompt captures assert ambient_turn_policy is absent for user-scoped reply_gate=always over a conflicting global slot, trigger-prompt, configured source/channel, and personality-store failure; ordinary ambient turns retain the policy.

Known gap: repository-required live-model trajectory has not yet been captured, so this PR is intentionally draft.

Evidence rows:
- UI screenshots/video: N/A - no rendered UI.
- Backend/frontend logs: N/A - pure routing/prompt construction.
- LLM trajectory: pending before ready/merge.
- Domain artifact: test-captured complete Stage-1 prompts, reported error, and terminal routing outcomes.