### PR TITLE
fix(cloud): harden diagnostic Unicode helpers

### DIFF
--- a/packages/cloud/services/_common/src/text.ts
+++ b/packages/cloud/services/_common/src/text.ts
@@ -4,23 +4,51 @@
  * Well-formed truncation prevents lone-surrogate \uD8xx escapes and
  * split emoji in provider error diagnostics.
  */
-const HIGH_START = 0xd800, HIGH_END = 0xdbff, LOW_START = 0xdc00, LOW_END = 0xdfff;
+const HIGH_START = 0xd800,
+  HIGH_END = 0xdbff,
+  LOW_START = 0xdc00,
+  LOW_END = 0xdfff;
 const REPLACEMENT = "�";
-function isHigh(c: number){ return c>=HIGH_START && c<=HIGH_END; }
-function isLow(c: number){ return c>=LOW_START && c<=LOW_END; }
-function replaceLone(text: string){
-  let out=""; for(let i=0;i<text.length;i++){ const cc=text.charCodeAt(i); if(isHigh(cc)){ if(i+1<text.length && isLow(text.charCodeAt(i+1))){ out+=text[i]!+text[i+1]!; i++; } else out+=REPLACEMENT; } else if(isLow(cc)) out+=REPLACEMENT; else out+=text[i]!; } return out;
+function isHigh(c: number) {
+  return c >= HIGH_START && c <= HIGH_END;
+}
+function isLow(c: number) {
+  return c >= LOW_START && c <= LOW_END;
+}
+function replaceLone(text: string) {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const cc = text.charCodeAt(i);
+    if (isHigh(cc)) {
+      if (i + 1 < text.length && isLow(text.charCodeAt(i + 1))) {
+        out += text.charAt(i) + text.charAt(i + 1);
+        i++;
+      } else {
+        out += REPLACEMENT;
+      }
+    } else if (isLow(cc)) {
+      out += REPLACEMENT;
+    } else {
+      out += text.charAt(i);
+    }
+  }
+  return out;
 }
 export function toWellFormedUnicode(text: string): string {
-  const n = (String.prototype as {toWellFormed?:(this:string)=>string}).toWellFormed;
-  if(n) return n.call(text);
-  const w=(String.prototype as {isWellFormed?:(this:string)=>boolean}).isWellFormed;
-  if(w?.call(text)) return text;
+  const n = (String.prototype as { toWellFormed?: (this: string) => string })
+    .toWellFormed;
+  if (n) return n.call(text);
+  const w = (String.prototype as { isWellFormed?: (this: string) => boolean })
+    .isWellFormed;
+  if (w?.call(text)) return text;
   return replaceLone(text);
 }
 export function truncateWellFormed(text: string, max: number): string {
-  if(!Number.isFinite(max)||max<=0) return "";
-  if(text.length<=max) return text;
-  const end=isHigh(text.charCodeAt(max-1)) && isLow(text.charCodeAt(max)) ? max-1 : max;
-  return text.slice(0,end);
+  if (!Number.isFinite(max) || max <= 0) return "";
+  if (text.length <= max) return text;
+  const end =
+    isHigh(text.charCodeAt(max - 1)) && isLow(text.charCodeAt(max))
+      ? max - 1
+      : max;
+  return text.slice(0, end);
 }

--- a/packages/cloud/services/_common/tests/text.test.ts
+++ b/packages/cloud/services/_common/tests/text.test.ts
@@ -1,0 +1,31 @@
+/** Verifies dependency-free Unicode repair and UTF-16-safe diagnostic truncation. */
+
+import { describe, expect, test } from "bun:test";
+import { toWellFormedUnicode, truncateWellFormed } from "../src/text";
+
+describe("cloud service diagnostic text", () => {
+  test("preserves valid surrogate pairs", () => {
+    expect(toWellFormedUnicode("before 🦊 after")).toBe("before 🦊 after");
+  });
+
+  test("replaces lone high and low surrogates", () => {
+    expect(toWellFormedUnicode("before\ud83dafter")).toBe("before�after");
+    expect(toWellFormedUnicode("before\udc00after")).toBe("before�after");
+  });
+
+  test("backs off instead of splitting a surrogate pair", () => {
+    expect(truncateWellFormed("ab🦊cd", 3)).toBe("ab");
+  });
+
+  test("preserves ordinary truncation and fitting text", () => {
+    expect(truncateWellFormed("abcdef", 3)).toBe("abc");
+    expect(truncateWellFormed("abc", 3)).toBe("abc");
+  });
+
+  test.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "returns empty text for invalid budget %s",
+    (max) => {
+      expect(truncateWellFormed("diagnostic", max)).toBe("");
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- format the dependency-free cloud-service Unicode helper with the pinned Biome version
- replace indexed non-null assertions with bounded `charAt` access
- add package-local coverage for valid pairs, lone surrogates, split-pair truncation, ordinary truncation, and invalid budgets

Closes #25342.

## Verification

- `bun install`
- `bun run --cwd packages/cloud/services/_common test` — 62/62 passed
- `bun run --cwd packages/cloud/services/_common typecheck`
- `bun run --cwd packages/cloud/services/_common lint:check` — 21 files clean
- `git diff --check`
- combined root verification reached this package only after composing the independent fixes in #25313 and #25327; this PR will be recomposed into that disposable checkout to continue the gate

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->