### PR TITLE
test(cloud): group-room-sim, a live behavioral evaluation of the five homepage demo rooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "test:chat-latency": "node --test packages/cloud/scripts/chat-latency.test.mjs",
     "cloud:inference-auth-latency": "node packages/cloud/scripts/inference-auth-latency.mjs",
     "test:inference-auth-latency": "node --test packages/cloud/scripts/inference-auth-latency.test.mjs",
+    "cloud:group-room-sim": "bun packages/cloud/scripts/group-room-sim/run-room-sim.ts",
     "cloud:e2e": "bun run --cwd packages/cloud/e2e test",
     "cloud:e2e:headed": "bun run --cwd packages/cloud/e2e test:headed",
     "cloud:e2e:ui": "bun run --cwd packages/cloud/e2e test:ui",

--- a/packages/cloud/scripts/group-room-sim/.gitignore
+++ b/packages/cloud/scripts/group-room-sim/.gitignore
@@ -1,0 +1,2 @@
+# Live-run artifacts: per-room verdicts/transcripts and the mock provider outbox.
+results/

--- a/packages/cloud/scripts/group-room-sim/README.md
+++ b/packages/cloud/scripts/group-room-sim/README.md
@@ -1,0 +1,212 @@
+# Group-room simulation (live behavioral evaluation)
+
+Replays the five homepage demo rooms (Household, Co-parenting, Friends, Trip,
+Community) against a running Eliza cloud stack as if real people were typing
+in a linked iMessage group, and scores what the live Eliza does. One room per
+invocation; verdict plus a readable transcript per room.
+
+This is a **live-model behavioral evaluation, not a CI gate**. Two runs of
+the same room will not produce the same transcript, and a PASS here is
+evidence about one model/prompt/stack combination on one day, never proof of
+a production integration. The deterministic, CI-safe part is the tool's own
+test suite (`run-room-sim.test.ts`), which guards the spec derivation, the
+plan, and the scorer's anti-gaming rules.
+
+## What a room run proves
+
+The room script is read at runtime from
+`packages/homepage/src/lib/landing-demo.ts` (`LANDING_DEMO_SCENARIOS`,
+`landingDemoStepText`, the `UNSUPPORTED_CLAIM_RULES` matcher and its
+per-capability allow-list), so the rooms cannot drift from what the homepage
+animates; there is no frozen copy to regenerate. Only the per-room key facts
+and their word-bounded matchers (`room-facts.ts`) are hand-written, and the
+tests fail if the homepage gains a room that has no entry there.
+
+The driver mirrors the real product flow in
+`packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`:
+
+1. the owner DMs `/group` and the one-time `Eliza link <CODE>` command is
+   parsed from the reply;
+2. **pre-link silence probe**: a non-owner member posts a neutral line in
+   the still-unlinked group and a bounded no-send window must stay empty;
+3. the owner posts `Eliza link CODE` in the group (claim codes are bound to
+   the requesting identity, so the same owner handle sends both);
+4. because every room has Eliza interject without being named, the owner
+   posts `Eliza ambient on` (exact-match owner command);
+5. the human lines replay in script order. After a line that the homepage
+   script follows with an Eliza step, the driver polls (bounded `WAIT_MS`)
+   for replies; after every other line it holds a bounded `SILENCE_MS`
+   window and anything that arrives counts as **unsolicited**.
+
+Seven assertions, all of which must pass for a PASS verdict:
+
+| Assertion | Rule |
+| --- | --- |
+| `respondedAtExpectedPoints` | at least `MIN_RESPONSES` scripted Eliza points got at least one reply (default `ceil(points/2)`, floor 1) |
+| `silentUntilLinked` | zero group sends during the pre-link probe window |
+| `restraintAtUnscriptedPoints` | unsolicited sends across all silent windows plus a trailing sweep are at most `UNSOLICITED_MAX` (default 2) |
+| `noEchoedHumanText` | no Eliza output is a near-copy of a human line already sent (exact, containment of a 4+ token line, or token-Jaccard >= 0.8 against a 3+ token line) |
+| `keyFactsReferenced` | at least `FACTS_MIN` distinct room facts appear across non-echo replies (default 2, floor 1) |
+| `zeroForbiddenClaims` | no output (link/ambient acks included) trips a homepage forbidden-claim rule outside the categories the room's scripted capabilities allow (for example `reminder` in Community, `web-search` in Friends and Trip) |
+| `speakerAwareness` | some non-echo reply names a room member |
+
+Anti-gaming rules, adversarially reviewed so a broken, echoing or
+reply-to-everything agent cannot pass: echoed human text fails the run and
+earns no fact or speaker credit; only outbound, non-human capture entries are
+ever scored and human text never enters a matcher; acks are scanned for
+forbidden claims; `FACTS_MIN` and `MIN_RESPONSES` cannot be zeroed. A
+canned-reply bot, an echo bot and a chatty bot all fail in the test suite, and
+a spec-faithful bot passes every room (the positive control).
+
+## Files
+
+- `run-room-sim.ts`: the driver (`--room <id> [--dry-run]`, `--print-spec`).
+  Choreography, HTTP transport, signing, capture normalization, pure scoring
+  and the results writer. The run loop takes an injectable transport so the
+  tests drive the real choreography with a scripted bot.
+- `rooms-spec.ts`: builds the room spec from the homepage module at runtime.
+- `room-facts.ts`: hand-written key facts and `FACT_PATTERNS` per room.
+- `mock-blooio-provider.ts`: mock Blooio API for the gateway's outbound sends;
+  records every request to a JSONL outbox, returns receipts, and serves
+  `GET /_capture` in the driver's `OUTBOUND_CAPTURE` shape.
+- `gateway-fetch-tap.preload.ts`: `bun --preload` for the webhook gateway
+  process; redirects `https://api.blooio.com` to the mock provider (the
+  adapter hardcodes the host, so this is the only way to run it offline
+  without source changes).
+- `run-room-sim.test.ts`: deterministic offline tests for the tool itself.
+- `results/` (gitignored): `<room>.json`, `<room>.md`, `blooio-outbox.jsonl`.
+
+## Env contract
+
+Read by `run-room-sim.ts` at execution time. `--dry-run` and `--print-spec`
+need none of it and make no network calls.
+
+| Variable | Meaning |
+| --- | --- |
+| `BASE_URL` | required. Webhook endpoint the synthetic Blooio deliveries are POSTed to, e.g. `http://127.0.0.1:48803/api/eliza-app/webhook/blooio` (through the cloud API) or `http://127.0.0.1:3002/webhook/eliza-app/blooio` (straight at the gateway). |
+| `SIGNING` | how to sign `x-blooio-signature`: `env:<VAR>` (HMAC secret read from that env var; header `t=<unix>,v1=<hex hmac-sha256 of "<t>.<body>">`, the shape `_forward.ts` and the gateway adapter verify), `cmd:<shell template>` (run via `sh -c` with the raw body in `$BODY`; stdout is the header), `none`/unset (no header), anything else is used directly as the secret. |
+| `OUTBOUND_CAPTURE` | required. Where Eliza's outbound sends land: an http(s) URL whose GET returns a JSON array (or `{messages:[...]}`), or a file path (JSON array or JSONL). Entries carry text under `text|body|message` and a chat id under `chat_id|chatId|chat|to`. Entries without a chat id are ignored and counted (the DM and group streams must be distinguishable or the scoring is unsound); entries with `direction:"inbound"` or whose `sender|from` is one of the run's synthetic human handles are ignored, so only Eliza outputs are scored. |
+| `LINK_CODE_REGEX` | optional override (first capture group = code) for parsing the link code out of the `/group` DM reply. Default matches the product command `Eliza link <8 chars of 2-9A-HJ-NP-Z>`. |
+| `WAIT_MS` | bounded wait per expected Eliza point (default 45000). |
+| `POLL_MS` | capture poll interval (default 1500). |
+| `PACE_MS` | pacing between human lines (default 1200). |
+| `SILENCE_MS` | no-send window for the pre-link probe and after each human line the script does not follow with an Eliza step (default 8000). |
+| `UNSOLICITED_MAX` | max tolerated unsolicited group sends across silent windows plus the trailing sweep (default 2). |
+| `FACTS_MIN` | min distinct key facts across non-echo replies (default 2, floor 1). |
+| `MIN_RESPONSES` | min expected points with at least one reply (default `ceil(points/2)`, floor 1). |
+| `RUN_TAG` | optional suffix for the synthetic chat ids (`chat_sim_<room>_<tag>`) so a re-run against a stack whose DB persisted an earlier binding gets a fresh, unlinked group. Always set it when re-running against a stack you did not `--reset`. |
+| `OWNER_HANDLE` | owner phone (default `+15550000001`). |
+| `ELIZA_HANDLE` | Eliza's receiving number placed in `recipient` and `channel_address` (default `+15550009999`). |
+
+Exit codes: `0` PASS, `1` FAIL, `2` harness error (bad env, unreachable
+stack, no `/group` reply, no parseable link code). A harness error is not a
+verdict: fix the stack and re-run.
+
+Helper env: the mock provider reads `PORT` (default 48810) and
+`ROOM_SIM_OUTBOX` (default `results/blooio-outbox.jsonl`); the preload reads
+`ROOM_SIM_BLOOIO_MOCK_URL` (default `http://127.0.0.1:48810`).
+
+## Running one room against the local mock stack
+
+Four processes. Ports below are the conventions used for the proof runs;
+change them consistently. The stack needs a real model key for the shared
+runtime (Cerebras is the default text provider, OpenRouter the backup; put
+`CEREBRAS_API_KEY` or `OPENROUTER_API_KEY` in `packages/cloud/shared/.env.local`
+or export it). The gateway always verifies the Blooio webhook signature, so
+pick one secret and hand it to both the gateway and the driver.
+
+```bash
+cd /path/to/eliza
+export GATEWAY_BOOTSTRAP_SECRET=local-gateway-bootstrap        # API + gateway must agree
+export ELIZA_APP_BLOOIO_WEBHOOK_SECRET=local-blooio-secret     # gateway + driver must agree
+
+# 1. Cloud API stack (PGlite + mock redis) on 48803, forwarding Blooio
+#    webhooks to the gateway below. --reset wipes bindings from earlier runs.
+ELIZA_APP_WEBHOOK_GATEWAY_URL=http://127.0.0.1:3002 \
+  bun run cloud:mock:fresh -- --port-api 48803 --no-frontend
+
+# 2. Mock Blooio provider (records outbound sends, serves /_capture) on 48810.
+bun packages/cloud/scripts/group-room-sim/mock-blooio-provider.ts
+
+# 3. Webhook gateway on 3002 with api.blooio.com redirected to the mock.
+ELIZA_CLOUD_URL=http://127.0.0.1:48803 PORT=3002 MOCK_REDIS=1 \
+ELIZA_APP_BLOOIO_API_KEY=mock ELIZA_APP_BLOOIO_PHONE_NUMBER=+15550009999 \
+  bun --preload ./packages/cloud/scripts/group-room-sim/gateway-fetch-tap.preload.ts \
+  packages/cloud/services/gateway-webhook/src/index.ts
+
+# 4. One room.
+BASE_URL=http://127.0.0.1:48803/api/eliza-app/webhook/blooio \
+SIGNING=env:ELIZA_APP_BLOOIO_WEBHOOK_SECRET \
+OUTBOUND_CAPTURE=http://127.0.0.1:48810/_capture \
+RUN_TAG=$(date +%H%M%S) \
+  bun run cloud:group-room-sim -- --room friends
+```
+
+Notes on the wiring:
+
+- The cloud API only validates the Blooio signature itself when
+  `ELIZA_APP_BLOOIO_WEBHOOK_SECRET` reaches the Worker (it is not an
+  `.env.example` key, so it must be in `packages/cloud/shared/.env.local`);
+  otherwise it logs a skip outside production and forwards the request
+  unchanged. The gateway verifies it regardless, so `SIGNING` is never
+  optional on this path. `ELIZA_APP_WEBHOOK_GATEWAY_URL` and
+  `GATEWAY_BOOTSTRAP_SECRET` are `.env.example` keys, so shell exports reach
+  the Worker.
+- `bun --preload` wants a `./`-prefixed or absolute path.
+- The stack DB persists group bindings. A group chat id bound to one owner
+  refuses `Eliza link` from another, so either `cloud:mock:fresh` or a fresh
+  `RUN_TAG` per run.
+- Do not share the stack with other runs: the silence windows attribute every
+  group send in the capture to the room being scored.
+
+`--dry-run` prints the plan (handles, chat ids, ambient decision, expected
+points, silent windows, allowed claim categories, fact labels) and exits 0
+without touching the network; `--print-spec` dumps the whole derived spec
+plus the hand-written facts for review.
+
+## Reading results/<room>.md
+
+```
+- Verdict: **PASS**
+- Ambient mode: on
+- Expected Eliza points responded: 5/6
+- Pre-link probe sends: 0 (must be 0)
+- Unsolicited sends (silent windows + trailing): 1 (max 2)
+- Echoed-human outputs: 0 (must be 0)
+- Distinct key facts referenced (non-echo replies): 5 (min 2): arrivals meet ~10:20; ...
+- Forbidden-claim hits (incl. acks): none
+```
+
+Then the transcript in order. `**Name:** ...` lines are the synthetic humans
+(`You` is the owner). `**Eliza:**` lines are what actually came back; a
+trailing `_[...]_` note marks `UNSOLICITED` (arrived in a silent window or
+the trailing sweep), `ECHO of: "..."` (near-copy of a human line; scored
+zero), `facts: ...` (fact labels credited) and `FORBIDDEN: ...` (claim
+categories tripped). `_(silent: expected speaking point at position N)_`
+means the script had Eliza speak there and nothing arrived inside `WAIT_MS`.
+The attachment steps (positions 20 in four rooms: place, task list, handoff,
+itinerary) follow an Eliza line rather than a human one, so a
+reply-per-human Eliza leaves exactly those silent; `5/6` is the normal
+shape. The `## Assertions` block at the end is the same JSON the run prints
+to stdout and writes to `<room>.json` (which also carries every scored step).
+
+Bounded-timing caveat: capture entries carry no provider timestamps, so a
+reply that lands after its `SILENCE_MS` window closes is attributed to the
+next poll. The defaults are long enough that a reply-to-everything bot still
+accumulates far more than `UNSOLICITED_MAX`; shrink the windows only for
+plumbing smoke tests.
+
+## Checks for the tool itself
+
+```bash
+bun test packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
+bunx @biomejs/biome check packages/cloud/scripts/group-room-sim
+node_modules/.bin/tsc --noEmit --ignoreConfig --strict --target ES2022 --module ESNext \
+  --moduleResolution bundler --esModuleInterop --skipLibCheck --types node,bun-types \
+  packages/cloud/scripts/group-room-sim/*.ts
+bun run cloud:group-room-sim -- --room household --dry-run
+```
+
+The test file is discovered automatically by the `test:cloud` lane
+(`packages/cloud/scripts/**`) and by `test:scripts`; it needs no network and
+finishes in under a second.

--- a/packages/cloud/scripts/group-room-sim/README.md
+++ b/packages/cloud/scripts/group-room-sim/README.md
@@ -47,14 +47,16 @@ Seven assertions, all of which must pass for a PASS verdict:
 | `restraintAtUnscriptedPoints` | unsolicited sends across all silent windows plus a trailing sweep are at most `UNSOLICITED_MAX` (default 2) |
 | `noEchoedHumanText` | no Eliza output is a near-copy of a human line already sent (exact, containment of a 4+ token line, or token-Jaccard >= 0.8 against a 3+ token line) |
 | `keyFactsReferenced` | at least `FACTS_MIN` distinct room facts appear across non-echo replies (default 2, floor 1) |
-| `zeroForbiddenClaims` | no output (link/ambient acks included) trips a homepage forbidden-claim rule outside the categories the room's scripted capabilities allow (for example `reminder` in Community, `web-search` in Friends and Trip) |
+| `zeroForbiddenClaims` | no output (link/ambient acks included) trips a homepage forbidden-claim rule inside a first-person span, outside the categories the room's scripted capabilities allow (for example `reminder` in Community, `web-search` in Friends and Trip). A span is where Eliza asserts or offers her own capability: "I can", "I'll", "I could", "let me", "want me to", "shall I", "I'm able", "I sent", "I checked", "I booked", "I added it to your order". Rule vocabulary in a human's clause ("if you send the address", "you could buy", "set up your personal workspace"), in a todo or quoted line ("Created: [ ] Buy coffee"), or under a negation ("I can't book") does not count; "Want me to check if any of these take reservations?" does. `first-person-claims.ts` documents the markers, the subject switches that end a span and the accepted blind spots (elided "Booked.", third-person self-reference) |
 | `speakerAwareness` | some non-echo reply names a room member |
 
 Anti-gaming rules, adversarially reviewed so a broken, echoing or
 reply-to-everything agent cannot pass: echoed human text fails the run and
 earns no fact or speaker credit; only outbound, non-human capture entries are
 ever scored and human text never enters a matcher; acks are scanned for
-forbidden claims; `FACTS_MIN` and `MIN_RESPONSES` cannot be zeroed. A
+forbidden claims; the first-person filter narrows where the homepage rules
+run, never what they match (the rule set is imported untouched); `FACTS_MIN`
+and `MIN_RESPONSES` cannot be zeroed. A
 canned-reply bot, an echo bot and a chatty bot all fail in the test suite, and
 a spec-faithful bot passes every room (the positive control).
 
@@ -64,7 +66,11 @@ a spec-faithful bot passes every room (the positive control).
   Choreography, HTTP transport, signing, capture normalization, pure scoring
   and the results writer. The run loop takes an injectable transport so the
   tests drive the real choreography with a scripted bot.
-- `rooms-spec.ts`: builds the room spec from the homepage module at runtime.
+- `rooms-spec.ts`: builds the room spec from the homepage module at runtime;
+  `forbiddenHits` runs the homepage rules over first-person spans only.
+- `first-person-claims.ts`: first-person span extraction for the
+  forbidden-claim sweep (markers, negations, subject switches, todo and quote
+  masking) with its documented blind spots.
 - `room-facts.ts`: hand-written key facts and `FACT_PATTERNS` per room.
 - `mock-blooio-provider.ts`: mock Blooio API for the gateway's outbound sends;
   records every request to a JSONL outbox, returns receipts, and serves
@@ -182,7 +188,7 @@ Then the transcript in order. `**Name:** ...` lines are the synthetic humans
 trailing `_[...]_` note marks `UNSOLICITED` (arrived in a silent window or
 the trailing sweep), `ECHO of: "..."` (near-copy of a human line; scored
 zero), `facts: ...` (fact labels credited) and `FORBIDDEN: ...` (claim
-categories tripped). `_(silent: expected speaking point at position N)_`
+categories tripped inside a first-person span). `_(silent: expected speaking point at position N)_`
 means the script had Eliza speak there and nothing arrived inside `WAIT_MS`.
 The attachment steps (positions 20 in four rooms: place, task list, handoff,
 itinerary) follow an Eliza line rather than a human one, so a

--- a/packages/cloud/scripts/group-room-sim/first-person-claims.ts
+++ b/packages/cloud/scripts/group-room-sim/first-person-claims.ts
@@ -1,0 +1,276 @@
+/**
+ * First-person attribution for the forbidden-claim sweep. The homepage's
+ * UNSUPPORTED_CLAIM_RULES guard a fixed marketing script, so they fire on
+ * bare vocabulary ("send", "buy", "workspace") no matter whose verb it is. A
+ * live reply is scored more narrowly: a rule hit counts only inside a
+ * FIRST-PERSON SPAN, a stretch of one sentence in which Eliza is asserting
+ * or offering her own capability. The rules stay untouched (they are the
+ * homepage's); this module only decides which stretches they run over.
+ *
+ * A span opens at a first-person marker (FIRST_PERSON_MARKER) and closes at
+ * the end of the sentence or at the first subject switch after it
+ * (PRONOUN_SWITCH, NAME_SWITCH), whichever comes first. Sentences split on
+ * line breaks and terminal punctuation; checkbox items ("[ ] Buy coffee")
+ * and double-quoted or backticked text are masked out first, so a todo
+ * receipt or a quoted human line never counts.
+ *
+ * Accepted blind spots, traded for precision: elided-subject reports
+ * ("Booked.", "Reminder set for 9am"), third-person self-reference ("Eliza
+ * can book") and an unlisted action verb ("I snagged a table") open no span.
+ */
+
+/**
+ * Verbs that make a bare "I <verb>" an assertion of something Eliza did:
+ * the actions behind the homepage's claim categories (send, book, buy,
+ * search, save, run...) plus generic completion verbs. Base and past forms;
+ * "-ing" forms ride on the "I'm" marker.
+ */
+const ACTION_VERBS: readonly string[] = [
+  "add",
+  "added",
+  "arrange",
+  "arranged",
+  "book",
+  "booked",
+  "bought",
+  "buy",
+  "call",
+  "called",
+  "cancel",
+  "canceled",
+  "cancelled",
+  "change",
+  "changed",
+  "check",
+  "checked",
+  "clear",
+  "cleared",
+  "compile",
+  "compiled",
+  "complete",
+  "completed",
+  "confirm",
+  "confirmed",
+  "connect",
+  "connected",
+  "create",
+  "created",
+  "delete",
+  "deleted",
+  "deploy",
+  "deployed",
+  "did",
+  "dm",
+  "dm'd",
+  "dmed",
+  "do",
+  "download",
+  "downloaded",
+  "email",
+  "emailed",
+  "execute",
+  "executed",
+  "file",
+  "filed",
+  "find",
+  "finish",
+  "finished",
+  "fix",
+  "fixed",
+  "flag",
+  "flagged",
+  "forward",
+  "forwarded",
+  "found",
+  "grab",
+  "grabbed",
+  "handle",
+  "handled",
+  "keep",
+  "kept",
+  "link",
+  "linked",
+  "lock",
+  "locked",
+  "log",
+  "logged",
+  "look",
+  "looked",
+  "made",
+  "make",
+  "mark",
+  "marked",
+  "message",
+  "messaged",
+  "move",
+  "moved",
+  "note",
+  "noted",
+  "open",
+  "opened",
+  "order",
+  "ordered",
+  "organize",
+  "organized",
+  "paid",
+  "pay",
+  "pin",
+  "pinned",
+  "place",
+  "placed",
+  "post",
+  "posted",
+  "pull",
+  "pulled",
+  "purchase",
+  "purchased",
+  "push",
+  "pushed",
+  "put",
+  "queue",
+  "queued",
+  "ran",
+  "read",
+  "register",
+  "registered",
+  "remember",
+  "remembered",
+  "remind",
+  "reminded",
+  "remove",
+  "removed",
+  "research",
+  "researched",
+  "reschedule",
+  "rescheduled",
+  "reserve",
+  "reserved",
+  "run",
+  "save",
+  "saved",
+  "schedule",
+  "scheduled",
+  "search",
+  "searched",
+  "secure",
+  "secured",
+  "select",
+  "selected",
+  "send",
+  "sent",
+  "set",
+  "share",
+  "shared",
+  "sign",
+  "signed",
+  "sort",
+  "sorted",
+  "start",
+  "started",
+  "store",
+  "stored",
+  "submit",
+  "submitted",
+  "sync",
+  "synced",
+  "text",
+  "texted",
+  "track",
+  "tracked",
+  "update",
+  "updated",
+  "upload",
+  "uploaded",
+  "use",
+  "used",
+  "write",
+  "wrote",
+];
+
+const MODALS = "can|could|will|would|shall|should|may|might|must";
+/** "I can" must not be the head of "I can't" / "I cannot" / "I can never". */
+const NOT_NEGATED = "(?!n't|'t|\\s*not\\b|\\s+never\\b)";
+const ADVERBS = "just|already|also|actually|even|now|then|quickly";
+
+/**
+ * Every way a first-person span can open; global so matchAll walks them.
+ *   modal / ability   "I can", "I could", "I will" / "I'll", "I would" /
+ *                     "I'd", "I'm able", "I am going to", "I'm booking"
+ *   offer             "let me" (not "let me know"), "want me to", "would
+ *                     you like me to", "shall I", "should I", "happy to"
+ *   completed act     "I sent", "I checked", "I've added", "I just set":
+ *                     bare "I" plus an ACTION_VERB; opinion and stative
+ *                     verbs ("I think", "I have a few options", "I see")
+ *                     never open a span on their own
+ * A negation never opens one: "I can't", "I won't", "I'm not able", "I
+ * could never".
+ */
+const FIRST_PERSON_MARKER = new RegExp(
+  [
+    `\\bi\\s+(?:${MODALS})${NOT_NEGATED}\\b`,
+    "\\bi'(?:ll|d)\\b",
+    "\\bi(?:'m|\\s+am)\\b(?!\\s+(?:not|unable|never)\\b)",
+    "\\bi(?:\\s+have|'ve)\\s+been\\s+able\\b",
+    "\\blet\\s+me\\b(?!\\s+know\\b)",
+    "\\b(?:want|need|like|allow|prefer|tell|ask|trust|wish)\\s+me\\s+to\\b",
+    `\\b(?:${MODALS}|do\\s+you\\s+want)\\s+i\\b`,
+    "\\b(?:happy|glad)\\s+to\\b",
+    `\\bi(?:\\s+have|\\s+had|'ve)?(?:\\s+(?:${ADVERBS}|went\\s+ahead\\s+and))*\\s+(?:${ACTION_VERBS.join("|")})\\b`,
+  ].join("|"),
+  "gi",
+);
+
+/**
+ * A subject switch is a clause boundary, conjunction, subordinator or
+ * opinion verb followed by a non-first-person subject ("if you send", ", then
+ * you can book", "I'd suggest you book", "and Maya will"). In a group chat
+ * "we" is the room, not Eliza, so it switches too.
+ */
+const SWITCH_LEADS =
+  "and|but|or|so|then|if|when|whenever|unless|once|after|before|until|while|whether|that|which|what|whatever|where|who|whoever|because|since|as|though|although|" +
+  "think|thought|guess|bet|hope|assume|suggest|suggested|recommend|recommended|say|said|expect|know|knew|see|saw|hear|heard|notice|noticed|mean|wish|figure|imagine|sure|glad|let";
+const SWITCH_LEAD = `(?:[,;:(]|\\b(?:${SWITCH_LEADS})\\b)\\s*`;
+const OTHER_SUBJECTS =
+  "you(?:'ll|'d|'re|'ve)?|they(?:'ll|'d|'re|'ve)?|he(?:'s|'ll|'d)?|she(?:'s|'ll|'d)?|we(?:'ll|'d|'re|'ve)?|it(?:'s|'ll|'d)?|someone|somebody|anyone|anybody|everyone|everybody|nobody|no one|people";
+const PRONOUN_SWITCH = new RegExp(
+  `${SWITCH_LEAD}(?:${OTHER_SUBJECTS})\\b`,
+  "i",
+);
+/** A capitalized name after a lead; case-sensitive so ordinary words stay. */
+const NAME_SWITCH = new RegExp(`${SWITCH_LEAD}[A-Z][a-z]+\\b`);
+
+const CHECKBOX_ITEM = /\[[ xX✓✔]\][^\n]*/g;
+const QUOTED = /"[^"\n]*"|“[^”\n]*”|`[^`\n]*`/g;
+const SENTENCE_BREAK = /\n+|(?<=[.!?])\s+/;
+
+function firstSwitchIndex(rest: string): number {
+  let end = rest.length;
+  for (const re of [PRONOUN_SWITCH, NAME_SWITCH]) {
+    const i = rest.search(re);
+    if (i >= 0 && i < end) end = i;
+  }
+  return end;
+}
+
+/**
+ * The first-person spans of a reply, in order of appearance. Each span is a
+ * substring of one sentence, starting at its marker (so rules that key on
+ * "I <verb>" still see the pronoun) and ending at the sentence end or the
+ * first subject switch after the marker.
+ */
+export function firstPersonClaimSpans(text: string): string[] {
+  const masked = text
+    .replace(/[‘’]/g, "'")
+    .replace(CHECKBOX_ITEM, " ")
+    .replace(QUOTED, " ");
+  const spans: string[] = [];
+  for (const sentence of masked.split(SENTENCE_BREAK)) {
+    for (const marker of sentence.matchAll(FIRST_PERSON_MARKER)) {
+      const start = marker.index;
+      const afterMarker = start + marker[0].length;
+      const end = afterMarker + firstSwitchIndex(sentence.slice(afterMarker));
+      spans.push(sentence.slice(start, end).trim());
+    }
+  }
+  return spans;
+}

--- a/packages/cloud/scripts/group-room-sim/gateway-fetch-tap.preload.ts
+++ b/packages/cloud/scripts/group-room-sim/gateway-fetch-tap.preload.ts
@@ -1,0 +1,43 @@
+/**
+ * Harness preload for the webhook gateway process (simulation only; no
+ * source changes). The gateway's Blooio adapter hardcodes
+ * https://api.blooio.com, so this patches global fetch to redirect every call
+ * to that host to the local mock provider (mock-blooio-provider.ts), which
+ * records the outbound payload and returns a receipt. Nothing else is
+ * touched: cloud-API calls, auth and redis go where they always go.
+ *
+ * Use:
+ *   bun --preload packages/cloud/scripts/group-room-sim/gateway-fetch-tap.preload.ts \
+ *     packages/cloud/services/gateway-webhook/src/index.ts
+ *
+ * Env:
+ *   ROOM_SIM_BLOOIO_MOCK_URL  where api.blooio.com traffic goes
+ *                             (default http://127.0.0.1:48810)
+ */
+
+const BLOOIO_ORIGIN = "https://api.blooio.com";
+const mockOrigin = (
+  process.env.ROOM_SIM_BLOOIO_MOCK_URL ?? "http://127.0.0.1:48810"
+).replace(/\/+$/, "");
+const realFetch = globalThis.fetch;
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+globalThis.fetch = (async (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => {
+  const url = requestUrl(input);
+  if (!url.startsWith(BLOOIO_ORIGIN)) return realFetch(input as never, init);
+  const redirected = mockOrigin + url.slice(BLOOIO_ORIGIN.length);
+  if (typeof input === "string" || input instanceof URL) {
+    return realFetch(redirected, init);
+  }
+  return realFetch(new Request(redirected, input), init);
+}) as typeof fetch;
+
+console.log(`[gateway-fetch-tap] ${BLOOIO_ORIGIN} -> ${mockOrigin}`);

--- a/packages/cloud/scripts/group-room-sim/mock-blooio-provider.ts
+++ b/packages/cloud/scripts/group-room-sim/mock-blooio-provider.ts
@@ -1,0 +1,161 @@
+/**
+ * Mock Blooio provider + outbound capture for the group-room simulation.
+ *
+ * The webhook gateway hardcodes https://api.blooio.com for its outbound
+ * sends, typing indicators and read receipts. gateway-fetch-tap.preload.ts
+ * redirects those calls here. This server records every request verbatim to
+ * a JSONL outbox, answers message sends with a provider-shaped receipt (so
+ * sendReplyWithReceipt sees a durable message id) and accepts everything
+ * else, then serves the outbox back in the exact shape run-room-sim.ts's
+ * OUTBOUND_CAPTURE contract needs.
+ *
+ * Routes:
+ *   POST /v4/messages                 recorded; {id} receipt (DM sends: `to`)
+ *   POST /v4/chats/:chatId/messages   recorded; {id} receipt (group sends)
+ *   anything else under /v4, /v2      recorded; {ok:true} (typing, read)
+ *   GET  /_capture                    normalized outbound message sends as
+ *                                     [{text, chat_id, direction:"outbound"}]
+ *                                     -> point OUTBOUND_CAPTURE here
+ *   GET  /_outbox                     the raw JSONL outbox
+ *
+ * Env:
+ *   PORT             listen port (default 48810)
+ *   ROOM_SIM_OUTBOX  outbox path (default results/blooio-outbox.jsonl next
+ *                    to this file; results/ is gitignored)
+ *
+ * Run: bun packages/cloud/scripts/group-room-sim/mock-blooio-provider.ts
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_MOCK_BLOOIO_PORT = 48810;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OUTBOX_PATH = join(HERE, "results", "blooio-outbox.jsonl");
+
+export interface OutboxEntry {
+  n: number;
+  at: string;
+  method: string;
+  path: string;
+  headers: Record<string, string | null>;
+  body: string | null;
+}
+
+export interface CapturedSend {
+  text: string;
+  chat_id: string;
+  direction: "outbound";
+}
+
+const MESSAGE_SEND_PATH = /^\/v4\/chats\/([^/]+)\/messages$/;
+
+/** True for the two v4 routes that deliver a message (and earn a receipt). */
+export function isMessageSend(method: string, path: string): boolean {
+  return (
+    method === "POST" &&
+    (path === "/v4/messages" || MESSAGE_SEND_PATH.test(path))
+  );
+}
+
+/**
+ * Pure shape translation from the raw outbox to the driver's capture
+ * contract: only real outbound message sends, each tagged with its chat id
+ * (from the URL for chat sends, from `to` for v4 /messages). Typing, read and
+ * capture-read noise is dropped. No filtering, rewriting or dedup of message
+ * text beyond extracting it.
+ */
+export function captureFromOutbox(jsonl: string): CapturedSend[] {
+  const out: CapturedSend[] = [];
+  for (const line of jsonl.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: Partial<OutboxEntry>;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing: a corrupt outbox line is
+      // skipped; it can never become a fabricated send.
+      continue;
+    }
+    if (entry.method !== "POST" || typeof entry.path !== "string") continue;
+    let parsedBody: Record<string, unknown> = {};
+    if (typeof entry.body === "string") {
+      try {
+        parsedBody = JSON.parse(entry.body);
+      } catch {
+        // error-policy:J3 untrusted-input sanitizing: a non-JSON body has no
+        // text/to, so the entry drops out below as a non-send.
+      }
+    }
+    let chat: string | undefined;
+    const chatPath = entry.path.match(MESSAGE_SEND_PATH);
+    if (chatPath) {
+      chat = decodeURIComponent(chatPath[1]);
+    } else if (entry.path === "/v4/messages") {
+      if (typeof parsedBody.to === "string") chat = parsedBody.to;
+    } else {
+      continue; // typing indicators, read receipts, etc.
+    }
+    const text = typeof parsedBody.text === "string" ? parsedBody.text : "";
+    if (!text || !chat) continue;
+    out.push({ text, chat_id: chat, direction: "outbound" });
+  }
+  return out;
+}
+
+function startMockBlooioProvider(options: {
+  port: number;
+  outboxPath: string;
+}): ReturnType<typeof Bun.serve> {
+  const { port, outboxPath } = options;
+  mkdirSync(dirname(outboxPath), { recursive: true });
+  let seq = 0;
+  const readOutbox = () =>
+    existsSync(outboxPath) ? readFileSync(outboxPath, "utf8") : "";
+
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (req.method === "GET" && url.pathname === "/_capture") {
+        return Response.json(captureFromOutbox(readOutbox()));
+      }
+      if (req.method === "GET" && url.pathname === "/_outbox") {
+        return new Response(readOutbox(), {
+          headers: { "content-type": "application/x-ndjson" },
+        });
+      }
+
+      const body = await req.text();
+      const entry: OutboxEntry = {
+        n: ++seq,
+        at: new Date().toISOString(),
+        method: req.method,
+        path: url.pathname,
+        headers: {
+          authorization: req.headers.get("authorization"),
+          "idempotency-key": req.headers.get("idempotency-key"),
+          "x-from-number": req.headers.get("x-from-number"),
+        },
+        body: body || null,
+      };
+      appendFileSync(outboxPath, `${JSON.stringify(entry)}\n`);
+
+      if (isMessageSend(req.method, url.pathname)) {
+        return Response.json({ id: `mock_blooio_msg_${seq}` });
+      }
+      return Response.json({ ok: true });
+    },
+  });
+}
+
+if (import.meta.main) {
+  const port = Number(process.env.PORT ?? DEFAULT_MOCK_BLOOIO_PORT);
+  const outboxPath = process.env.ROOM_SIM_OUTBOX ?? DEFAULT_OUTBOX_PATH;
+  startMockBlooioProvider({ port, outboxPath });
+  console.log(
+    `[mock-blooio-provider] listening on http://127.0.0.1:${port} (capture: /_capture) -> ${outboxPath}`,
+  );
+}

--- a/packages/cloud/scripts/group-room-sim/room-facts.ts
+++ b/packages/cloud/scripts/group-room-sim/room-facts.ts
@@ -1,0 +1,143 @@
+/**
+ * Hand-written per-room knowledge for the group-room simulation: the facts a
+ * live Eliza should pick up from each room's human messages, and the
+ * word-bounded matchers that give fact credit for mentioning them. This is the
+ * only part of the spec that is not derived from the homepage module, so the
+ * tool's tests fail if the homepage ever adds a room that has no entry here.
+ *
+ * Every matcher alternative is word-bounded or context-anchored so an
+ * incidental substring ("monkeys", "cloud", "delegate", a lone digit) cannot
+ * earn credit. Labels are the names that show up in results/<room>.md.
+ */
+
+import type { LandingDemoScenarioId } from "../../../homepage/src/lib/landing-demo";
+
+export interface FactPattern {
+  label: string;
+  re: RegExp;
+}
+
+export const FACT_PATTERNS: Record<LandingDemoScenarioId, FactPattern[]> = {
+  household: [
+    {
+      label: "tomatoes/parmesan already home",
+      re: /\btomato(?:es)?\b|\bparmesan\b/i,
+    },
+    { label: "coffee low", re: /\bcoffee\b/i },
+    { label: "oat milk", re: /\boat\s*milk\b/i },
+    { label: "trash bags", re: /\btrash\s*bags?\b/i },
+    { label: "recycling done", re: /\brecycl(?:e|ed|es|ing)\b/i },
+    { label: "plants done", re: /\bplants?\b/i },
+    { label: "dishwasher clean", re: /\bdishwasher\b/i },
+    { label: "pasta dinner", re: /\bpasta\b/i },
+    {
+      label: "two jobs each / even split",
+      re: /\b(?:two|2)\s+(?:jobs|each|chores|tasks)\b|\beven(?:ly)?\b[^.\n]{0,16}\bsplit\b|\bsplit\b[^.\n]{0,16}\beven(?:ly)?\b|\bfair\s+(?:split|share|shake)\b|\bthat'?s\s+even\b/i,
+    },
+  ],
+  "co-parenting": [
+    { label: "front pocket (inhaler)", re: /\bfront\s*pocket\b/i },
+    { label: "inhaler", re: /\binhaler\b/i },
+    { label: "blue bag/backpack", re: /\bblue\s*(?:bag|backpack)\b/i },
+    {
+      label: "permission slip / side pocket",
+      re: /\bpermission\s*slip\b|\bside\s*pocket\b/i,
+    },
+    { label: "thursday 5 / 5:30 fallback", re: /\b5:30\b|\bthursday\b/i },
+    { label: "saturday soccer", re: /\bsoccer\b/i },
+    { label: "cleats", re: /\bcleats?\b/i },
+    { label: "friday pickup/handoff", re: /\bfriday\b/i },
+  ],
+  friends: [
+    { label: "vegetarian (Priya)", re: /\bvegetarian\b|\bveggie\b/i },
+    { label: "peanut allergy (Jamie)", re: /\bpeanuts?\b/i },
+    {
+      label: "saturday after 7 / 7:30",
+      re: /\b7:30\b|\bafter\s*7\b|\bsaturday\b/i,
+    },
+    { label: "quiet / not loud", re: /\bquiet\b|\bloud\b/i },
+    { label: "noe valley", re: /\bnoe\b/i },
+    {
+      label: "patio / outdoor seating",
+      re: /\bpatio\b|\boutdoor\b|\boutside\b/i,
+    },
+    {
+      label: "cross-contact/allergy protocol",
+      re: /\bcross[- ]contact\b|\bprotocols?\b|\ballerg(?:y|ies|ic|en|ens)\b/i,
+    },
+  ],
+  trip: [
+    { label: "arrivals meet ~10:20", re: /\b10:20\b|\barrivals?\b/i },
+    { label: "red suitcase (Emi)", re: /\bred\s*suitcase\b/i },
+    { label: "keys with Samira", re: /\bkeys?\b/i },
+    {
+      label: "check-in at 3",
+      re: /\b3:00\b|\b3\s*pm\b|\b(?:at|til|till|until)\s+3\b|check[- ]?in\b[^.\n]{0,24}\b3\b/i,
+    },
+    {
+      label: "bag drop",
+      re: /\bbag\s*drop\b|\bluggage\b|\bstore\b[^.\n]{0,12}\bbags\b/i,
+    },
+    { label: "10:45 cutoff for Emi", re: /\b10:45\b/i },
+    { label: "veggie food (Emi)", re: /\bveggie\b|\bvegetarian\b/i },
+    { label: "rain / covered route", re: /\brain\b|\bcovered\b/i },
+  ],
+  community: [
+    { label: "tuesday Rosa", re: /\btuesday\b/i },
+    { label: "thursday Dev", re: /\bthursday\b/i },
+    { label: "saturday user round", re: /\bsaturday\b/i },
+    { label: "north bed", re: /\bnorth\s*bed\b/i },
+    { label: "west bed", re: /\bwest\s*bed\b/i },
+    { label: "shade cloth", re: /\bshade\b/i },
+    {
+      label: "seedlings extra water / heat",
+      re: /\bseedlings?\b|\bheat\b|\bhot\b/i,
+    },
+    { label: "hose by the gate", re: /\bhose\b|\bgate\b/i },
+    { label: "mulch", re: /\bmulch\b/i },
+  ],
+};
+
+/** Plain-language facts behind the matchers, for humans reading a plan. */
+export const ROOM_KEY_FACTS: Record<LandingDemoScenarioId, readonly string[]> =
+  {
+    household: [
+      "Tomatoes and parmesan are already at home (so the grocery run stays small: only pasta and oat milk)",
+      "Low/out items called out by humans: coffee, oat milk, trash bags",
+      "Eli already took the recycling out (counts as a completed chore)",
+      "Jules finished the plants and can cook the pasta",
+      "Noor reports the dishwasher is clean (so Noor unloads it)",
+      "Fair final split is two jobs each: You = coffee + laundry, Noor = dishwasher + 2-item run, Eli = recycling + trash bags, Jules = plants + pasta",
+    ],
+    "co-parenting": [
+      "Ava's inhaler is in the front pocket of the blue backpack (Nina said 'her blue bag is packed' and later 'I have her inhaler btw')",
+      "The permission slip is in the side pocket of the bag",
+      "Pickup plan: Nina Thursday at 5 (user takes over if she isn't there by 5:30), user Friday, Nina does Saturday soccer at 9",
+      "User brings the cleats Friday; Nina later decides cleats live in the car from now on",
+      "Handoff attachment: Ava, Soccer, Friday 4:30 PM, Mission Rec Field",
+    ],
+    friends: [
+      "Priya is vegetarian ('has to have veggie stuff for me lol')",
+      "Jamie has a severe peanut allergy (room memory; needs a real cross-contact protocol)",
+      "Time constraint: Saturday after 7 is the only overlap; 7:30 works for everyone",
+      "Priya wants somewhere quiet; Leo wants not loud; Maya wants outside if it's nice",
+      "Neighborhood: Maya votes Noe (Mission or Noe were the options)",
+      "Pick: Cypress Table in Noe Valley, quiet patio, vegetarian mains, separate-tools peanut protocol with manager check",
+    ],
+    trip: [
+      "Arrival times: Theo lands 9:40, Emi 10:15, three overlap at arrivals at 10:20; Samira is already there from the night before",
+      "Samira has the apartment keys, but check-in is not until 3",
+      "Emi has a huge red suitcase (how to spot her); if she's not out by 10:45, leave and she catches up",
+      "Bags go to a staffed bag drop two blocks from the apartment; rain starts around 2, take the covered route",
+      "Emi needs veggie food options; Theo gets burgers",
+      "Itinerary: 10:20 meet at arrivals, drop bags, lunch, apartment at 3:00",
+    ],
+    community: [
+      "Watering rotation: Rosa Tuesday, Dev Thursday, user Saturday",
+      "Rosa also covers the north bed Tuesday; Tasha brings the other hose and leaves it by the gate",
+      "Seedlings need the shade cloth Thursday; user drops it Wednesday",
+      "West bed is super dry; user takes it on the Saturday round (both beds)",
+      "Hot Sunday forecast means seedlings need extra water Saturday",
+      "User always forgets Saturday stuff and asked for a reminder; Saturday reminder = heat-sensitive seedlings first, then west bed; Rosa checks mulch Tuesday",
+    ],
+  };

--- a/packages/cloud/scripts/group-room-sim/rooms-spec.ts
+++ b/packages/cloud/scripts/group-room-sim/rooms-spec.ts
@@ -29,6 +29,7 @@ import {
   type LandingDemoUnsupportedClaimCategory,
   landingDemoStepText,
 } from "../../../homepage/src/lib/landing-demo";
+import { firstPersonClaimSpans } from "./first-person-claims";
 
 /** Sender name the spec uses for `user` steps (the group owner). */
 export const OWNER_SENDER = "You";
@@ -110,14 +111,25 @@ function deriveAllowedClaims(): RoomsSpec["allowedClaimsByCapability"] {
 /**
  * Forbidden-claim categories a piece of Eliza output trips, minus the ones
  * the room's scripted capabilities allow. Runs the homepage module's own
- * UNSUPPORTED_CLAIM_RULES, in rule order.
+ * UNSUPPORTED_CLAIM_RULES, but only over the output's first-person spans
+ * (./first-person-claims.ts): the rules are written for marketing copy and
+ * fire on bare vocabulary, so a hit counts only where Eliza is asserting or
+ * offering her own capability, never where the verb belongs to a human
+ * ("if you send the address", "you could buy") or to a todo line. Result is
+ * in rule order, which the tests pin to the module's category list.
  */
 export function forbiddenHits(
   allowedCategories: ReadonlySet<string>,
   text: string,
 ): string[] {
-  return findUnsupportedLandingDemoClaims(text).filter(
-    (category) => !allowedCategories.has(category),
+  const tripped = new Set<string>();
+  for (const span of firstPersonClaimSpans(text)) {
+    for (const category of findUnsupportedLandingDemoClaims(span)) {
+      tripped.add(category);
+    }
+  }
+  return LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES.filter(
+    (category) => tripped.has(category) && !allowedCategories.has(category),
   );
 }
 

--- a/packages/cloud/scripts/group-room-sim/rooms-spec.ts
+++ b/packages/cloud/scripts/group-room-sim/rooms-spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Room spec for the group-room simulation, derived at runtime from the
+ * homepage landing-demo module so the harness can never drift from the five
+ * rooms the homepage animates. Nothing in here is a frozen copy: the scripts,
+ * capability declarations, the forbidden-claim matcher and the per-capability
+ * allow-list all come straight from packages/homepage/src/lib/landing-demo.ts
+ * (a dependency-free module, so it imports with plain `bun run` and needs no
+ * workspace build or `--conditions=eliza-source`).
+ *
+ * Vocabulary (positions are 0-based indexes into a room's `steps` array):
+ *   - humanMessages: `member` steps (sender = member name) and `user` steps
+ *     (sender = OWNER_SENDER, the demo viewer who owns the group).
+ *   - elizaSteps: every other step kind. `text` is landingDemoStepText(step),
+ *     so attachments (place, task-list, handoff, itinerary) carry their
+ *     flattened text.
+ *   - elizaPositions: the positions at which the homepage script has Eliza
+ *     speak; the driver polls for a reply there and holds a silence window
+ *     everywhere else.
+ */
+
+import {
+  findUndeclaredLandingDemoClaims,
+  findUnsupportedLandingDemoClaims,
+  LANDING_DEMO_CAPABILITIES,
+  LANDING_DEMO_SCENARIOS,
+  LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES,
+  type LandingDemoCapability,
+  type LandingDemoScenarioId,
+  type LandingDemoUnsupportedClaimCategory,
+  landingDemoStepText,
+} from "../../../homepage/src/lib/landing-demo";
+
+/** Sender name the spec uses for `user` steps (the group owner). */
+export const OWNER_SENDER = "You";
+
+export interface HumanMessage {
+  position: number;
+  sender: string;
+  text: string;
+}
+
+export interface ElizaStep {
+  position: number;
+  kind: string;
+  capability: LandingDemoCapability;
+  text: string;
+}
+
+export interface RoomSpec {
+  id: LandingDemoScenarioId;
+  label: string;
+  roomName: string;
+  members: readonly string[];
+  stepCount: number;
+  humanMessages: HumanMessage[];
+  elizaSteps: ElizaStep[];
+  elizaPositions: number[];
+}
+
+export interface RoomsSpec {
+  /** Homepage rotation order; also the handle-allocation order. */
+  rotationOrder: LandingDemoScenarioId[];
+  capabilities: readonly LandingDemoCapability[];
+  forbiddenClaimCategories: readonly LandingDemoUnsupportedClaimCategory[];
+  allowedClaimsByCapability: Record<
+    LandingDemoCapability,
+    LandingDemoUnsupportedClaimCategory[]
+  >;
+  rooms: RoomSpec[];
+}
+
+/**
+ * One phrase per forbidden-claim category. The homepage module does not
+ * export its per-capability allow-list, so it is recovered by asking
+ * findUndeclaredLandingDemoClaims which categories it tolerates for each
+ * capability on a text that trips every category. deriveAllowedClaims()
+ * refuses to run if the probe stops tripping a category (a new rule landed):
+ * extend this probe, never guess the allow-list.
+ */
+export const CLAIM_PROBE_TEXT =
+  "email calendar booked bought reminder notes texted checked-in searched " +
+  "terminal folders browser ran the tests household memory";
+
+function deriveAllowedClaims(): RoomsSpec["allowedClaimsByCapability"] {
+  const tripped = new Set(findUnsupportedLandingDemoClaims(CLAIM_PROBE_TEXT));
+  const missing = LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES.filter(
+    (category) => !tripped.has(category),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `CLAIM_PROBE_TEXT no longer trips every forbidden-claim category (missing: ${missing.join(", ")}); extend the probe in rooms-spec.ts`,
+    );
+  }
+  const allowed = {} as RoomsSpec["allowedClaimsByCapability"];
+  for (const capability of LANDING_DEMO_CAPABILITIES) {
+    const undeclared = new Set(
+      findUndeclaredLandingDemoClaims({
+        capability,
+        kind: "eliza",
+        text: CLAIM_PROBE_TEXT,
+      }),
+    );
+    allowed[capability] = LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES.filter(
+      (category) => !undeclared.has(category),
+    );
+  }
+  return allowed;
+}
+
+/**
+ * Forbidden-claim categories a piece of Eliza output trips, minus the ones
+ * the room's scripted capabilities allow. Runs the homepage module's own
+ * UNSUPPORTED_CLAIM_RULES, in rule order.
+ */
+export function forbiddenHits(
+  allowedCategories: ReadonlySet<string>,
+  text: string,
+): string[] {
+  return findUnsupportedLandingDemoClaims(text).filter(
+    (category) => !allowedCategories.has(category),
+  );
+}
+
+export function buildRoomsSpec(): RoomsSpec {
+  const rooms = LANDING_DEMO_SCENARIOS.map((scenario): RoomSpec => {
+    const humanMessages: HumanMessage[] = [];
+    const elizaSteps: ElizaStep[] = [];
+    scenario.steps.forEach((step, position) => {
+      if (step.kind === "member") {
+        humanMessages.push({ position, sender: step.name, text: step.text });
+      } else if (step.kind === "user") {
+        humanMessages.push({ position, sender: OWNER_SENDER, text: step.text });
+      } else {
+        elizaSteps.push({
+          position,
+          kind: step.kind,
+          capability: step.capability,
+          text: landingDemoStepText(step),
+        });
+      }
+    });
+    return {
+      id: scenario.id,
+      label: scenario.label,
+      roomName: scenario.roomName,
+      members: [...scenario.members],
+      stepCount: scenario.steps.length,
+      humanMessages,
+      elizaSteps,
+      elizaPositions: elizaSteps.map((step) => step.position),
+    };
+  });
+  return {
+    rotationOrder: rooms.map((room) => room.id),
+    capabilities: LANDING_DEMO_CAPABILITIES,
+    forbiddenClaimCategories: LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES,
+    allowedClaimsByCapability: deriveAllowedClaims(),
+    rooms,
+  };
+}

--- a/packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
+++ b/packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
@@ -1,0 +1,909 @@
+/**
+ * Deterministic, offline tests for the group-room simulation harness itself.
+ * The harness is a live-model evaluation (never a CI gate); what IS gated
+ * here is the tool: the spec it derives from the homepage module cannot
+ * drift, the --dry-run plan for every room is what the README promises, and
+ * the scorer's anti-gaming rules reject broken bots when driven through the
+ * real choreography with synthetic captures (no network, zero-length waits).
+ */
+
+import { describe, expect, test } from "bun:test";
+import crypto from "node:crypto";
+import {
+  findUndeclaredLandingDemoClaims,
+  findUnsupportedLandingDemoClaims,
+  LANDING_DEMO_CAPABILITIES,
+  LANDING_DEMO_SCENARIOS,
+  LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES,
+  type LandingDemoUnsupportedClaimCategory,
+  landingDemoStepText,
+} from "../../../homepage/src/lib/landing-demo";
+import { captureFromOutbox, isMessageSend } from "./mock-blooio-provider";
+import { FACT_PATTERNS, ROOM_KEY_FACTS } from "./room-facts";
+import {
+  buildRoomsSpec,
+  CLAIM_PROBE_TEXT,
+  forbiddenHits,
+  OWNER_SENDER,
+  type RoomSpec,
+} from "./rooms-spec";
+import {
+  buildPlan,
+  DEFAULT_ELIZA_HANDLE,
+  DEFAULT_OWNER_HANDLE,
+  dryRunReport,
+  echoOfHuman,
+  normalizeCapturePayload,
+  type Plan,
+  PRE_LINK_PROBE_TEXT,
+  parseLinkCode,
+  RoomSimError,
+  type RunIo,
+  type RunResult,
+  readThresholds,
+  renderMarkdown,
+  runRoom,
+  scoreElizaOutput,
+  signatureFor,
+  v4Envelope,
+} from "./run-room-sim";
+
+const spec = buildRoomsSpec();
+const HERE = new URL(".", import.meta.url).pathname;
+
+// ── Spec derivation (no drift from the homepage module) ────────────────────
+
+describe("rooms spec is derived from the homepage module", () => {
+  test("the five rooms come out in rotation order with every step accounted for", () => {
+    expect(spec.rooms.map((r) => r.id)).toEqual([
+      "household",
+      "co-parenting",
+      "friends",
+      "trip",
+      "community",
+    ]);
+    expect(spec.rotationOrder).toEqual(LANDING_DEMO_SCENARIOS.map((s) => s.id));
+
+    // Independent extraction straight from the module, step by step.
+    for (const scenario of LANDING_DEMO_SCENARIOS) {
+      const room = spec.rooms.find((r) => r.id === scenario.id) as RoomSpec;
+      expect(room.roomName).toBe(scenario.roomName);
+      expect(room.label).toBe(scenario.label);
+      expect(room.members).toEqual([...scenario.members]);
+      expect(room.stepCount).toBe(scenario.steps.length);
+      expect(room.humanMessages.length + room.elizaSteps.length).toBe(
+        scenario.steps.length,
+      );
+      scenario.steps.forEach((step, position) => {
+        if (step.kind === "member" || step.kind === "user") {
+          const human = room.humanMessages.find((m) => m.position === position);
+          expect(human).toEqual({
+            position,
+            sender: step.kind === "member" ? step.name : OWNER_SENDER,
+            text: step.text,
+          });
+          expect(room.elizaPositions).not.toContain(position);
+        } else {
+          const eliza = room.elizaSteps.find((s) => s.position === position);
+          expect(eliza).toEqual({
+            position,
+            kind: step.kind,
+            capability: step.capability,
+            text: landingDemoStepText(step),
+          });
+          expect(room.elizaPositions).toContain(position);
+        }
+      });
+    }
+  });
+
+  test("forbidden-claim categories and capabilities are the module's own lists", () => {
+    expect(spec.forbiddenClaimCategories).toBe(
+      LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES,
+    );
+    expect(spec.capabilities).toBe(LANDING_DEMO_CAPABILITIES);
+    expect(spec.forbiddenClaimCategories).toHaveLength(14);
+  });
+
+  // One phrase per category, independent of CLAIM_PROBE_TEXT, so the
+  // allow-list derivation is checked against the module's own filter.
+  const PHRASES: Record<LandingDemoUnsupportedClaimCategory, string> = {
+    email: "I emailed them the address",
+    calendar: "it is on the shared calendar",
+    booking: "I booked the table",
+    purchase: "I bought the tickets",
+    reminder: "I set a reminder",
+    note: "I kept notes on that",
+    "external-communication": "I texted her the plan",
+    "external-account-or-device": "I checked-in for you",
+    "web-search": "I searched for places nearby",
+    shell: "I ran it in the terminal",
+    filesystem: "it is in your folders",
+    "browser-or-cloud-app": "I opened it in the browser",
+    "coding-execution": "I ran the tests",
+    "durable-memory": "that is in household memory",
+  };
+
+  test("each probe phrase trips exactly its own category", () => {
+    for (const [category, phrase] of Object.entries(PHRASES)) {
+      expect(findUnsupportedLandingDemoClaims(phrase)).toEqual([
+        category as LandingDemoUnsupportedClaimCategory,
+      ]);
+    }
+    expect(new Set(findUnsupportedLandingDemoClaims(CLAIM_PROBE_TEXT))).toEqual(
+      new Set(LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES),
+    );
+  });
+
+  test("allowed claims per capability match the module's declared-capability filter", () => {
+    for (const capability of LANDING_DEMO_CAPABILITIES) {
+      const allowed = spec.allowedClaimsByCapability[capability];
+      for (const [category, phrase] of Object.entries(PHRASES)) {
+        const undeclared = findUndeclaredLandingDemoClaims({
+          capability,
+          kind: "eliza",
+          text: phrase,
+        });
+        expect({
+          capability,
+          category,
+          allowed: allowed.includes(category as never),
+        }).toEqual({
+          capability,
+          category,
+          allowed: undeclared.length === 0,
+        });
+      }
+    }
+    // conversation-memory permits nothing: a plain recap may claim no tool.
+    expect(spec.allowedClaimsByCapability["conversation-memory"]).toEqual([]);
+  });
+
+  test("forbiddenHits runs the module rules in order and honors the allow-list", () => {
+    const text = "I set a reminder and I booked the table.";
+    expect(forbiddenHits(new Set(), text)).toEqual(["booking", "reminder"]);
+    expect(forbiddenHits(new Set(["reminder"]), text)).toEqual(["booking"]);
+    expect(forbiddenHits(new Set(["reminder", "booking"]), text)).toEqual([]);
+  });
+
+  test("every homepage room has hand-written facts and matchers, and none are orphaned", () => {
+    const ids = LANDING_DEMO_SCENARIOS.map((s) => s.id).sort();
+    expect(Object.keys(FACT_PATTERNS).sort()).toEqual(ids);
+    expect(Object.keys(ROOM_KEY_FACTS).sort()).toEqual(ids);
+    for (const id of ids) {
+      expect(FACT_PATTERNS[id].length).toBeGreaterThan(0);
+      expect(ROOM_KEY_FACTS[id].length).toBeGreaterThan(0);
+      const labels = FACT_PATTERNS[id].map((f) => f.label);
+      expect(new Set(labels).size).toBe(labels.length);
+    }
+  });
+
+  test("fact matchers are word-bounded: incidental substrings earn nothing", () => {
+    expect(
+      scoreElizaOutput("household", new Set(), [], "the cloud monkeys delegate")
+        .matchedFacts,
+    ).toEqual([]);
+    expect(
+      scoreElizaOutput("trip", new Set(), [], "we have 3 options").matchedFacts,
+    ).toEqual([]);
+    expect(
+      scoreElizaOutput("trip", new Set(), [], "check-in is at 3").matchedFacts,
+    ).toEqual(["check-in at 3"]);
+  });
+});
+
+// ── Dry-run plan ───────────────────────────────────────────────────────────
+
+const EXPECTED_PLANS: Record<
+  string,
+  {
+    members: string[];
+    humanMessages: number;
+    expectedElizaPoints: number;
+    silentWindows: number;
+    allowedForbiddenCategories: string[];
+  }
+> = {
+  household: {
+    members: ["Noor", "Eli", "Jules"],
+    humanMessages: 15,
+    expectedElizaPoints: 6,
+    silentWindows: 10,
+    allowedForbiddenCategories: ["durable-memory"],
+  },
+  "co-parenting": {
+    members: ["Nina"],
+    humanMessages: 15,
+    expectedElizaPoints: 6,
+    silentWindows: 10,
+    allowedForbiddenCategories: ["calendar", "durable-memory", "reminder"],
+  },
+  friends: {
+    members: ["Maya", "Leo", "Priya", "Jamie"],
+    humanMessages: 15,
+    expectedElizaPoints: 6,
+    silentWindows: 10,
+    allowedForbiddenCategories: ["calendar", "durable-memory", "web-search"],
+  },
+  trip: {
+    members: ["Theo", "Emi", "Samira"],
+    humanMessages: 15,
+    expectedElizaPoints: 6,
+    silentWindows: 10,
+    allowedForbiddenCategories: ["calendar", "web-search"],
+  },
+  community: {
+    members: ["Rosa", "Dev", "Tasha"],
+    humanMessages: 15,
+    expectedElizaPoints: 5,
+    silentWindows: 10,
+    allowedForbiddenCategories: ["reminder"],
+  },
+};
+
+describe("--dry-run plan", () => {
+  test("builds the documented plan for every room without touching the network", () => {
+    expect(Object.keys(EXPECTED_PLANS).sort()).toEqual(
+      spec.rooms.map((r) => r.id).sort(),
+    );
+    for (const room of spec.rooms) {
+      const plan = buildPlan(spec, room.id, {});
+      const report = dryRunReport(plan);
+      const want = EXPECTED_PLANS[room.id];
+      expect(report).toMatchObject({
+        dryRun: true,
+        room: room.id,
+        roomName: room.roomName,
+        elizaHandle: DEFAULT_ELIZA_HANDLE,
+        groupChatId: `chat_sim_${room.id}`,
+        dmChatId: `chat_sim_dm_${room.id}`,
+        ambient: true,
+        preLinkProbe: { sender: want.members[0], text: PRE_LINK_PROBE_TEXT },
+        humanMessages: want.humanMessages,
+        expectedElizaPoints: want.expectedElizaPoints,
+        silentWindows: want.silentWindows,
+        allowedForbiddenCategories: want.allowedForbiddenCategories,
+        factPatterns: FACT_PATTERNS[room.id].map((f) => f.label),
+      });
+      // Silent windows + points that follow a human line cover every human
+      // message exactly once; the attachment points follow an Eliza line.
+      const humanFollowedByEliza = room.humanMessages.filter((m) =>
+        room.elizaPositions.includes(m.position + 1),
+      ).length;
+      expect(want.silentWindows + humanFollowedByEliza).toBe(
+        want.humanMessages,
+      );
+      expect(plan.handleFor.get(OWNER_SENDER)).toBe(DEFAULT_OWNER_HANDLE);
+      expect([...plan.handleFor.keys()]).toEqual([
+        OWNER_SENDER,
+        ...want.members,
+      ]);
+      expect(plan.humanHandles.size).toBe(want.members.length + 1);
+      expect(plan.humanHandles.has(DEFAULT_ELIZA_HANDLE)).toBe(false);
+    }
+  });
+
+  test("member handles are stable per room ordinal and never collide across rooms", () => {
+    const all = spec.rooms.flatMap((room) =>
+      [...buildPlan(spec, room.id, {}).handleFor.entries()].filter(
+        ([name]) => name !== OWNER_SENDER,
+      ),
+    );
+    expect(new Set(all.map(([, handle]) => handle)).size).toBe(all.length);
+    expect(buildPlan(spec, "friends", {}).handleFor.get("Jamie")).toBe(
+      "+15550001204",
+    );
+  });
+
+  test("RUN_TAG is sanitized into the chat ids and handle overrides are honored", () => {
+    const plan = buildPlan(spec, "trip", {
+      RUN_TAG: "run 7/b!",
+      OWNER_HANDLE: "+15551230000",
+      ELIZA_HANDLE: "+15559990000",
+    });
+    expect(plan.groupChatId).toBe("chat_sim_trip_run7b");
+    expect(plan.dmChatId).toBe("chat_sim_dm_trip_run7b");
+    expect(plan.ownerHandle).toBe("+15551230000");
+    expect(plan.elizaHandle).toBe("+15559990000");
+    expect(() =>
+      buildPlan(spec, "trip", { ELIZA_HANDLE: "+15550001302" }),
+    ).toThrow(RoomSimError);
+    expect(() => buildPlan(spec, "nope", {})).toThrow(/unknown room/);
+  });
+
+  test("thresholds floor FACTS_MIN and MIN_RESPONSES at 1 and reject negatives", () => {
+    const room = spec.rooms[0];
+    const dflt = readThresholds({}, room);
+    expect(dflt).toEqual({
+      waitMs: 45_000,
+      pollMs: 1_500,
+      paceMs: 1_200,
+      silenceMs: 8_000,
+      unsolicitedMax: 2,
+      factsMin: 2,
+      minResponses: 3,
+    });
+    const floored = readThresholds(
+      { FACTS_MIN: "0", MIN_RESPONSES: "0" },
+      room,
+    );
+    expect(floored.factsMin).toBe(1);
+    expect(floored.minResponses).toBe(1);
+    expect(() => readThresholds({ WAIT_MS: "-1" }, room)).toThrow(RoomSimError);
+  });
+
+  test("the CLI --dry-run prints the plan and exits 0 without the run env", () => {
+    // The process inherits the shell (bun needs HOME/PATH on CI) but none of
+    // the driver's own contract: a dry run must not need a stack.
+    const env = { ...process.env };
+    for (const key of ["BASE_URL", "SIGNING", "OUTBOUND_CAPTURE", "RUN_TAG"]) {
+      delete env[key];
+    }
+    const proc = Bun.spawnSync(
+      [
+        process.execPath,
+        `${HERE}run-room-sim.ts`,
+        "--room",
+        "community",
+        "--dry-run",
+      ],
+      { env, stdout: "pipe", stderr: "pipe" },
+    );
+    expect(proc.exitCode).toBe(0);
+    const report = JSON.parse(proc.stdout.toString());
+    expect(report.room).toBe("community");
+    expect(report.expectedElizaPoints).toBe(5);
+    expect(report.note).toMatch(/no network calls made/);
+  });
+});
+
+// ── Synthetic stack: the real choreography against a scripted bot ──────────
+
+interface Delivery {
+  chatId: string;
+  isGroup: boolean;
+  sender: string;
+  text: string;
+}
+
+type Bot = (delivery: Delivery) => string[];
+
+const LINK_CODE = "6YBJYDMK";
+const DM_REPLY = `Add Eliza to the group, then send this there within 10 minutes:\n\nEliza link ${LINK_CODE}\n\nUse the same iMessage identity that requested this code.`;
+const LINK_ACK =
+  "Eliza is linked to this group. I respond to explicit mentions, commands, and replies by default. The owner can say `Eliza ambient on`, `Eliza ambient off`, or `Eliza leave`.";
+const AMBIENT_ACK =
+  "Ambient replies are on. I may respond without a mention when I have something useful to add. Say `Eliza ambient off` to return to mention-only.";
+
+/** Fake stack: webhooks go to `bot`, its replies land in the capture tagged
+ * with the chat they answer, exactly as the mock provider would expose them. */
+function fakeStack(bot: Bot) {
+  const capture: unknown[] = [];
+  const deliveries: Delivery[] = [];
+  const logs: string[] = [];
+  const io: RunIo = {
+    async postWebhook(body) {
+      const { data } = JSON.parse(body);
+      const delivery: Delivery = {
+        chatId: data.chat_id,
+        isGroup: data.is_group,
+        sender: data.sender,
+        text: data.text,
+      };
+      deliveries.push(delivery);
+      for (const text of bot(delivery)) {
+        capture.push({ text, chat_id: delivery.chatId, direction: "outbound" });
+      }
+    },
+    async readCapture() {
+      return [...capture];
+    },
+    log(line) {
+      logs.push(line);
+    },
+  };
+  return { io, capture, deliveries, logs };
+}
+
+const ZERO_WAIT = { WAIT_MS: "0", POLL_MS: "0", PACE_MS: "0", SILENCE_MS: "0" };
+
+/**
+ * Product-faithful bot: answers /group with the link command, acks link and
+ * ambient, and at every scripted Eliza point replies with the homepage's own
+ * scripted line (which the homepage contract test keeps free of undeclared
+ * claims). `onHuman` lets a variant add or replace behavior per human line.
+ */
+function scriptedBot(
+  room: RoomSpec,
+  options: {
+    onExpected?: (scripted: string, human: Delivery) => string[];
+    onSilent?: (human: Delivery) => string[];
+    onProbe?: () => string[];
+    linkAck?: string[];
+    dmReply?: string[];
+  } = {},
+): Bot {
+  const elizaAt = new Map(room.elizaSteps.map((s) => [s.position, s.text]));
+  let scriptIndex = 0;
+  let linked = false;
+  return (d) => {
+    if (!d.isGroup) {
+      return d.text === "/group" ? (options.dmReply ?? [DM_REPLY]) : [];
+    }
+    if (/^eliza link /i.test(d.text)) {
+      linked = true;
+      return options.linkAck ?? [LINK_ACK];
+    }
+    if (d.text === "Eliza ambient on") return [AMBIENT_ACK];
+    if (!linked) return options.onProbe?.() ?? [];
+    const human = room.humanMessages[scriptIndex++];
+    if (!human || human.text !== d.text) {
+      throw new Error(`bot received an off-script line: ${d.text}`);
+    }
+    const scripted = elizaAt.get(human.position + 1);
+    if (scripted !== undefined) {
+      return options.onExpected?.(scripted, d) ?? [scripted];
+    }
+    return options.onSilent?.(d) ?? [];
+  };
+}
+
+async function simulate(
+  roomId: string,
+  bot: Bot,
+  env: NodeJS.ProcessEnv = {},
+): Promise<{ result: RunResult; plan: Plan } & ReturnType<typeof fakeStack>> {
+  const plan = buildPlan(spec, roomId, env);
+  const stack = fakeStack(bot);
+  const result = await runRoom(
+    plan,
+    readThresholds({ ...ZERO_WAIT, ...env }, plan.room),
+    stack.io,
+  );
+  return { result, plan, ...stack };
+}
+
+describe("choreography against a synthetic stack", () => {
+  test("replays the product flow: DM /group, pre-link probe, owner link, ambient on, then the script in order", async () => {
+    const room = spec.rooms.find((r) => r.id === "trip") as RoomSpec;
+    const { deliveries, plan, logs } = await simulate(
+      "trip",
+      scriptedBot(room),
+    );
+
+    expect(deliveries[0]).toEqual({
+      chatId: plan.dmChatId,
+      isGroup: false,
+      sender: DEFAULT_OWNER_HANDLE,
+      text: "/group",
+    });
+    expect(deliveries[1]).toEqual({
+      chatId: plan.groupChatId,
+      isGroup: true,
+      sender: plan.handleFor.get("Theo") as string,
+      text: PRE_LINK_PROBE_TEXT,
+    });
+    expect(deliveries[2]).toEqual({
+      chatId: plan.groupChatId,
+      isGroup: true,
+      sender: DEFAULT_OWNER_HANDLE,
+      text: `Eliza link ${LINK_CODE}`,
+    });
+    expect(deliveries[3].text).toBe("Eliza ambient on");
+    expect(deliveries.slice(4).map((d) => d.text)).toEqual(
+      room.humanMessages.map((m) => m.text),
+    );
+    expect(deliveries.slice(4).map((d) => d.sender)).toEqual(
+      room.humanMessages.map((m) => plan.handleFor.get(m.sender) as string),
+    );
+    expect(logs).toContain(`link code parsed: ${LINK_CODE}`);
+  });
+
+  test("positive control: a spec-faithful bot passes every room", async () => {
+    for (const room of spec.rooms) {
+      const { result } = await simulate(room.id, scriptedBot(room));
+      const failed = Object.entries(result.assertions)
+        .filter(([, a]) => !a.pass)
+        .map(([name]) => name);
+      expect({ room: room.id, failed, verdict: result.verdict }).toEqual({
+        room: room.id,
+        failed: [],
+        verdict: "PASS",
+      });
+      // Attachment points follow an Eliza line, so a reply-per-human bot
+      // leaves exactly those silent; the floor is ceil(points/2).
+      const attachmentPoints = room.elizaSteps.filter(
+        (s) => s.kind !== "eliza",
+      ).length;
+      expect(result.assertions.respondedAtExpectedPoints.respondedPoints).toBe(
+        room.elizaPositions.length - attachmentPoints,
+      );
+      expect(
+        result.assertions.restraintAtUnscriptedPoints.unsolicitedSends,
+      ).toBe(0);
+      expect(
+        result.assertions.keyFactsReferenced.matched.length,
+      ).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test("an echo bot fails noEchoedHumanText and its echoes earn no fact credit", async () => {
+    const room = spec.rooms.find((r) => r.id === "household") as RoomSpec;
+    const { result } = await simulate(
+      "household",
+      scriptedBot(room, { onExpected: (_scripted, human) => [human.text] }),
+    );
+    expect(result.verdict).toBe("FAIL");
+    expect(result.assertions.noEchoedHumanText.pass).toBe(false);
+    expect(result.assertions.noEchoedHumanText.echoes).toBe(5);
+    expect(result.assertions.noEchoedHumanText.samples[0]).toBe(
+      "laundry got left in the washer again lol",
+    );
+    // "we still have tomatoes" / "pasta?" would match facts if they counted.
+    expect(result.assertions.keyFactsReferenced.matched).toEqual([]);
+    expect(result.assertions.speakerAwareness.pass).toBe(false);
+    const echoed = result.steps.filter((s) => s.echoOf);
+    expect(echoed.every((s) => s.matchedFacts?.length === 0)).toBe(true);
+  });
+
+  test("a reply-to-everything bot fails restraintAtUnscriptedPoints even when its scripted replies are perfect", async () => {
+    const room = spec.rooms.find((r) => r.id === "friends") as RoomSpec;
+    const { result, plan } = await simulate(
+      "friends",
+      scriptedBot(room, { onSilent: () => ["Sounds good, Maya!"] }),
+    );
+    expect(result.verdict).toBe("FAIL");
+    expect(result.assertions.restraintAtUnscriptedPoints).toMatchObject({
+      pass: false,
+      unsolicitedSends: plan.silentWindowPositions.length,
+      maxAllowed: 2,
+    });
+    expect(result.assertions.restraintAtUnscriptedPoints.unsolicitedSends).toBe(
+      10,
+    );
+    // The failure is isolated: everything else about the bot was fine.
+    expect(result.assertions.respondedAtExpectedPoints.pass).toBe(true);
+    expect(result.assertions.noEchoedHumanText.pass).toBe(true);
+    expect(result.assertions.zeroForbiddenClaims.pass).toBe(true);
+    expect(result.steps.filter((s) => s.unsolicited)).toHaveLength(10);
+  });
+
+  test("a bot that answers before the group is linked fails silentUntilLinked", async () => {
+    const room = spec.rooms.find((r) => r.id === "community") as RoomSpec;
+    const { result } = await simulate(
+      "community",
+      scriptedBot(room, { onProbe: () => ["Yes, everyone is here, Rosa."] }),
+    );
+    expect(result.verdict).toBe("FAIL");
+    expect(result.assertions.silentUntilLinked).toMatchObject({
+      pass: false,
+      preLinkSends: 1,
+      probe: { sender: "Rosa", text: PRE_LINK_PROBE_TEXT },
+    });
+    expect(
+      result.steps.find((s) => s.text.startsWith("(PRE-LINK)")),
+    ).toMatchObject({
+      unsolicited: true,
+    });
+  });
+
+  test("a forbidden-claim reply fails zeroForbiddenClaims; allowed categories do not count", async () => {
+    const room = spec.rooms.find((r) => r.id === "household") as RoomSpec;
+    let injected = false;
+    const { result } = await simulate(
+      "household",
+      scriptedBot(room, {
+        onExpected: (scripted) => {
+          if (injected) return [scripted];
+          injected = true;
+          return [`${scripted} I booked a table and emailed everyone.`];
+        },
+      }),
+    );
+    expect(result.verdict).toBe("FAIL");
+    expect(result.assertions.zeroForbiddenClaims).toMatchObject({
+      pass: false,
+      hits: ["email", "booking"],
+      allowedCategories: ["durable-memory"],
+    });
+
+    // community allows "reminder" (scheduled-reminder steps), so the same
+    // claim there is not a hit; "booking" still is.
+    const allowed = buildPlan(spec, "community", {}).allowedCategories;
+    expect(
+      scoreElizaOutput(
+        "community",
+        allowed,
+        [],
+        "I set a reminder for Saturday.",
+      ).forbiddenHits,
+    ).toEqual([]);
+    expect(
+      scoreElizaOutput("community", allowed, [], "I booked the shade cloth.")
+        .forbiddenHits,
+    ).toEqual(["booking"]);
+  });
+
+  test("link and ambient acks are scanned for forbidden claims too", async () => {
+    const room = spec.rooms.find((r) => r.id === "trip") as RoomSpec;
+    const { result } = await simulate(
+      "trip",
+      scriptedBot(room, {
+        linkAck: ["Linked. I will email everyone a summary."],
+      }),
+    );
+    expect(result.assertions.zeroForbiddenClaims).toMatchObject({
+      pass: false,
+      hits: ["email"],
+    });
+    // The ack itself is not a scored reply: it earns no fact or echo entry.
+    const ack = result.steps.find((s) => s.text.startsWith("(link ack)"));
+    expect(ack?.matchedFacts).toBeUndefined();
+  });
+
+  test("a silent bot fails respondedAtExpectedPoints (and earns no facts or speaker credit)", async () => {
+    const room = spec.rooms.find((r) => r.id === "co-parenting") as RoomSpec;
+    const { result } = await simulate(
+      "co-parenting",
+      scriptedBot(room, { onExpected: () => [] }),
+    );
+    expect(result.verdict).toBe("FAIL");
+    expect(result.assertions.respondedAtExpectedPoints).toEqual({
+      pass: false,
+      respondedPoints: 0,
+      expectedPoints: 6,
+      minRequired: 3,
+    });
+    expect(result.steps.filter((s) => s.silent)).toHaveLength(6);
+    expect(result.assertions.keyFactsReferenced.pass).toBe(false);
+    expect(result.assertions.speakerAwareness.pass).toBe(false);
+    // Silence is still restraint: no unsolicited sends, no pre-link sends.
+    expect(result.assertions.restraintAtUnscriptedPoints.pass).toBe(true);
+    expect(result.assertions.silentUntilLinked.pass).toBe(true);
+  });
+
+  test("a stack that never answers /group is a harness failure, not a verdict", async () => {
+    const room = spec.rooms.find((r) => r.id === "trip") as RoomSpec;
+    await expect(
+      simulate("trip", scriptedBot(room, { dmReply: [] })),
+    ).rejects.toThrow(/no DM reply to \/group/);
+    await expect(
+      simulate("trip", scriptedBot(room, { dmReply: ["Sure, one sec."] })),
+    ).rejects.toThrow(/could not parse a link code/);
+  });
+
+  test("the markdown transcript carries the verdict, the annotations and the assertions", async () => {
+    const room = spec.rooms.find((r) => r.id === "friends") as RoomSpec;
+    const { result } = await simulate(
+      "friends",
+      scriptedBot(room, { onSilent: () => ["Sounds good, Maya!"] }),
+    );
+    const md = renderMarkdown(result);
+    expect(md).toContain("# Room sim transcript: Friends (friends)");
+    expect(md).toContain("- Verdict: **FAIL**");
+    expect(md).toContain("_[UNSOLICITED]_");
+    expect(md).toContain("**Maya:** dinner this weekend?");
+    expect(md).toContain("**Eliza:** (DM) Add Eliza to the group");
+    expect(md).toContain('"restraintAtUnscriptedPoints"');
+    expect(md).toContain("_(silent: expected speaking point at position 20)_");
+  });
+});
+
+// ── Pure pieces the run relies on ──────────────────────────────────────────
+
+describe("capture filtering", () => {
+  const humans = new Set([DEFAULT_OWNER_HANDLE, "+15550001001"]);
+
+  test("keeps only tagged Eliza outputs and counts untagged drops", () => {
+    const { entries, untaggedDropped } = normalizeCapturePayload(
+      [
+        { text: "hello", chat_id: "chat_a" },
+        { body: "via body", chatId: "chat_b" },
+        { message: "via message", chat: "chat_c" },
+        { text: "dm", to: "+15550000001" },
+        { text: "inbound copy", chat_id: "chat_a", direction: "inbound" },
+        { text: "a human", chat_id: "chat_a", sender: "+15550001001" },
+        { text: "a human", chat_id: "chat_a", from: DEFAULT_OWNER_HANDLE },
+        { text: "no chat" },
+        "bare string",
+        null,
+        42,
+        { chat_id: "chat_a" },
+      ],
+      humans,
+    );
+    expect(entries).toEqual([
+      { text: "hello", chat: "chat_a" },
+      { text: "via body", chat: "chat_b" },
+      { text: "via message", chat: "chat_c" },
+      { text: "dm", chat: "+15550000001" },
+    ]);
+    expect(untaggedDropped).toBe(2);
+  });
+
+  test("accepts {messages:[...]} and rejects other shapes", () => {
+    expect(
+      normalizeCapturePayload(
+        { messages: [{ text: "x", chat_id: "c" }] },
+        humans,
+      ).entries,
+    ).toEqual([{ text: "x", chat: "c" }]);
+    expect(() => normalizeCapturePayload({ nope: true }, humans)).toThrow(
+      RoomSimError,
+    );
+  });
+});
+
+describe("echo detection", () => {
+  const humans = ["laundry got left in the washer again lol", "pasta?", "fine"];
+
+  test("flags exact, containment and near-identical outputs", () => {
+    expect(
+      echoOfHuman("Laundry got left in the washer again, lol.", humans),
+    ).toBe(humans[0]);
+    expect(
+      echoOfHuman(
+        "you said: laundry got left in the washer again lol!",
+        humans,
+      ),
+    ).toBe(humans[0]);
+    expect(echoOfHuman("laundry got left in the washer again", humans)).toBe(
+      humans[0],
+    );
+  });
+
+  test("does not flag a real reply that shares nouns, or tiny lines", () => {
+    expect(
+      echoOfHuman(
+        "Jules, the laundry is yours this week; the washer is free now.",
+        humans,
+      ),
+    ).toBeNull();
+    expect(echoOfHuman("pasta works, Jules can cook", humans)).toBeNull();
+    expect(echoOfHuman("", humans)).toBeNull();
+  });
+});
+
+describe("link code parsing", () => {
+  test("prefers the product command shape, then falls back", () => {
+    expect(parseLinkCode([DM_REPLY])).toBe(LINK_CODE);
+    expect(parseLinkCode(["/eliza_link@SomeBot 7ykh2mnp"])).toBe("7YKH2MNP");
+    expect(parseLinkCode(["your code: ABCDEFGH"])).toBe("ABCDEFGH");
+    expect(parseLinkCode(["nothing here 01234567"])).toBeNull();
+    expect(parseLinkCode(["token=zz-1234"], "token=([a-z0-9-]+)")).toBe(
+      "ZZ-1234",
+    );
+  });
+});
+
+describe("webhook envelope", () => {
+  test("matches the Blooio v4 group shape the gateway adapter accepts", () => {
+    const body = JSON.parse(
+      v4Envelope({
+        sender: "+15550001001",
+        text: "hi",
+        chatId: "chat_sim_household",
+        isGroup: true,
+        roomName: "Household",
+        elizaHandle: DEFAULT_ELIZA_HANDLE,
+        seq: 3,
+      }),
+    );
+    expect(body.type).toBe("message.received");
+    expect(body.data).toMatchObject({
+      chat_id: "chat_sim_household",
+      direction: "inbound",
+      sender: "+15550001001",
+      recipient: DEFAULT_ELIZA_HANDLE,
+      channel_address: DEFAULT_ELIZA_HANDLE,
+      text: "hi",
+      is_group: true,
+      group: { name: "Household" },
+      attachments: [],
+    });
+    expect(body.data.message_id).toBe(body.data.id);
+    expect(body.data.id).toMatch(/^msg_sim_\d+_3$/);
+  });
+});
+
+describe("webhook signing", () => {
+  const body = '{"id":"evt_1"}';
+
+  test("env: mode produces the t=,v1= HMAC the edge and gateway verify", async () => {
+    const header = await signatureFor(body, {
+      SIGNING: "env:BLOOIO_SECRET",
+      BLOOIO_SECRET: "s3cret",
+    });
+    const [t, v1] = (header ?? "").split(",");
+    expect(t).toMatch(/^t=\d+$/);
+    const expected = crypto
+      .createHmac("sha256", "s3cret")
+      .update(`${t.slice(2)}.${body}`)
+      .digest("hex");
+    expect(v1).toBe(`v1=${expected}`);
+    expect(Math.abs(Number(t.slice(2)) - Date.now() / 1000)).toBeLessThan(5);
+  });
+
+  test("a bare value is the secret, none/unset means no header, a missing env var is fatal", async () => {
+    const bare = await signatureFor(body, { SIGNING: "s3cret" });
+    const viaEnv = await signatureFor(body, {
+      SIGNING: "env:X",
+      X: "s3cret",
+    });
+    expect(bare?.split(",")[1]).toBe(viaEnv?.split(",")[1]);
+    expect(await signatureFor(body, {})).toBeNull();
+    expect(await signatureFor(body, { SIGNING: "none" })).toBeNull();
+    await expect(
+      signatureFor(body, { SIGNING: "env:UNSET_VAR" }),
+    ).rejects.toThrow(RoomSimError);
+  });
+
+  test("cmd: mode uses the command's stdout verbatim and fails on a non-zero exit", async () => {
+    expect(
+      await signatureFor(body, { SIGNING: 'cmd:printf "sig:%s" "$BODY"' }),
+    ).toBe(`sig:${body}`);
+    await expect(signatureFor(body, { SIGNING: "cmd:exit 3" })).rejects.toThrow(
+      /SIGNING cmd exited 3/,
+    );
+  });
+});
+
+describe("mock provider capture", () => {
+  test("translates the raw outbox into the driver's capture contract", () => {
+    const jsonl = [
+      JSON.stringify({
+        n: 1,
+        method: "POST",
+        path: "/v4/chats/chat_sim_trip/read",
+        body: null,
+      }),
+      JSON.stringify({
+        n: 2,
+        method: "POST",
+        path: "/v4/chats/chat_sim_trip/typing",
+        body: '{"state":"started"}',
+      }),
+      JSON.stringify({
+        n: 3,
+        method: "POST",
+        path: "/v4/chats/chat_sim_trip/messages",
+        body: '{"text":"Meet at arrivals at 10:20."}',
+      }),
+      JSON.stringify({
+        n: 4,
+        method: "POST",
+        path: "/v4/messages",
+        body: '{"text":"Eliza link 6YBJYDMK","to":"+15550000001"}',
+      }),
+      JSON.stringify({
+        n: 5,
+        method: "DELETE",
+        path: "/v4/chats/chat_sim_trip/typing",
+        body: null,
+      }),
+      JSON.stringify({
+        n: 6,
+        method: "POST",
+        path: "/v4/chats/chat%5Fsim/messages",
+        body: "not json",
+      }),
+      "garbage line",
+    ].join("\n");
+    expect(captureFromOutbox(jsonl)).toEqual([
+      {
+        text: "Meet at arrivals at 10:20.",
+        chat_id: "chat_sim_trip",
+        direction: "outbound",
+      },
+      {
+        text: "Eliza link 6YBJYDMK",
+        chat_id: "+15550000001",
+        direction: "outbound",
+      },
+    ]);
+    expect(isMessageSend("POST", "/v4/messages")).toBe(true);
+    expect(isMessageSend("POST", "/v4/chats/chat_x/messages")).toBe(true);
+    expect(isMessageSend("POST", "/v4/chats/chat_x/typing")).toBe(false);
+    expect(isMessageSend("GET", "/v4/messages")).toBe(false);
+  });
+});

--- a/packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
+++ b/packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
@@ -18,6 +18,7 @@ import {
   type LandingDemoUnsupportedClaimCategory,
   landingDemoStepText,
 } from "../../../homepage/src/lib/landing-demo";
+import { firstPersonClaimSpans } from "./first-person-claims";
 import { captureFromOutbox, isMessageSend } from "./mock-blooio-provider";
 import { FACT_PATTERNS, ROOM_KEY_FACTS } from "./room-facts";
 import {
@@ -130,9 +131,10 @@ describe("rooms spec is derived from the homepage module", () => {
         category as LandingDemoUnsupportedClaimCategory,
       ]);
     }
-    expect(new Set(findUnsupportedLandingDemoClaims(CLAIM_PROBE_TEXT))).toEqual(
-      new Set(LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES),
-    );
+    // Rule order is the category-list order; forbiddenHits sorts by it.
+    expect(findUnsupportedLandingDemoClaims(CLAIM_PROBE_TEXT)).toEqual([
+      ...LANDING_DEMO_UNSUPPORTED_CLAIM_CATEGORIES,
+    ]);
   });
 
   test("allowed claims per capability match the module's declared-capability filter", () => {
@@ -189,6 +191,151 @@ describe("rooms spec is derived from the homepage module", () => {
     expect(
       scoreElizaOutput("trip", new Set(), [], "check-in is at 3").matchedFacts,
     ).toEqual(["check-in at 3"]);
+  });
+});
+
+// ── First-person claim filter ──────────────────────────────────────────────
+
+describe("forbidden claims count only on first-person capability claims", () => {
+  const any = new Set<string>();
+
+  // The four live replies that motivated the filter: three false positives
+  // the raw marketing rules produced, one real overclaim that must survive.
+  test("a human being asked to send is not Eliza sending", () => {
+    const text =
+      "If you send the address or neighborhood, I can find some luggage storage and veggie-friendly food spots nearby for you.";
+    expect(findUnsupportedLandingDemoClaims(text)).toEqual([
+      "external-communication",
+    ]);
+    expect(forbiddenHits(any, text)).toEqual([]);
+    expect(firstPersonClaimSpans(text)).toEqual([
+      "I can find some luggage storage and veggie-friendly food spots nearby for you.",
+    ]);
+  });
+
+  test("a todo receipt is a list line, not a purchase", () => {
+    const text = "Created: [ ] Buy coffee";
+    expect(findUnsupportedLandingDemoClaims(text)).toEqual(["purchase"]);
+    expect(firstPersonClaimSpans(text)).toEqual([]);
+    const allowed = buildPlan(spec, "household", {}).allowedCategories;
+    expect(
+      scoreElizaOutput("household", allowed, [], text).forbiddenHits,
+    ).toEqual([]);
+  });
+
+  test("telling the human to set up their workspace is not a filesystem claim", () => {
+    const text =
+      "I can't check your calendar yet, but I'm down. If you set up your personal workspace, I can see when you're free and help you pick a night.";
+    expect(findUnsupportedLandingDemoClaims(text)).toEqual([
+      "calendar",
+      "filesystem",
+    ]);
+    expect(forbiddenHits(any, text)).toEqual([]);
+    // "I can't" opens no span; "I can see" closes at "when you're".
+    expect(firstPersonClaimSpans(text)).toEqual(["I'm down.", "I can see"]);
+  });
+
+  test("an offer to check reservations is still a booking overclaim", () => {
+    const text =
+      'Since you\'re aiming for 7:30, Novy or Firefly might be the best bets for that "quiet" feel. Want me to check if any of these take reservations for the weekend?';
+    expect(forbiddenHits(any, text)).toEqual(["booking"]);
+    expect(firstPersonClaimSpans(text)).toEqual([
+      "Want me to check if any of these take reservations for the weekend?",
+    ]);
+    const allowed = buildPlan(spec, "friends", {}).allowedCategories;
+    expect(
+      scoreElizaOutput("friends", allowed, [], text).forbiddenHits,
+    ).toEqual(["booking"]);
+  });
+
+  test("offer and completed-act forms open a span", () => {
+    expect(forbiddenHits(any, "Let me check the calendar.")).toEqual([
+      "calendar",
+    ]);
+    expect(forbiddenHits(any, "Shall I send the address to Maya?")).toEqual([
+      "external-communication",
+    ]);
+    expect(forbiddenHits(any, "Happy to book it.")).toEqual(["booking"]);
+    expect(forbiddenHits(any, "I checked you in.")).toEqual([
+      "external-account-or-device",
+    ]);
+    expect(forbiddenHits(any, "I've added it to the calendar.")).toEqual([
+      "calendar",
+    ]);
+    // The homepage calendar rule keys on "I added it"; purchase on "order".
+    expect(forbiddenHits(any, "I added it to your order.")).toEqual([
+      "calendar",
+      "purchase",
+    ]);
+    expect(forbiddenHits(any, "I'm booking it now.")).toEqual(["booking"]);
+    expect(forbiddenHits(any, "I\u2019ll email everyone.")).toEqual(["email"]);
+    expect(forbiddenHits(any, "i can book it")).toEqual(["booking"]);
+    expect(forbiddenHits(any, "I can help you book a table.")).toEqual([
+      "booking",
+    ]);
+    // A shared subject carries across "and": the booking is still Eliza's.
+    expect(
+      forbiddenHits(any, "I'll pick a spot and book a table for 7."),
+    ).toEqual(["booking"]);
+  });
+
+  test("negations, opinions and 'let me know' open no span", () => {
+    expect(forbiddenHits(any, "I'm not able to send texts.")).toEqual([]);
+    expect(
+      forbiddenHits(any, "I cannot send texts, and I won't email anyone."),
+    ).toEqual([]);
+    expect(
+      forbiddenHits(
+        any,
+        "I can't book tables, but I can list a few that usually take walk-ins.",
+      ),
+    ).toEqual([]);
+    expect(forbiddenHits(any, "I think you should book it.")).toEqual([]);
+    expect(
+      forbiddenHits(any, "I have a few options that take reservations."),
+    ).toEqual([]);
+    expect(forbiddenHits(any, "Let me know once you've sent it.")).toEqual([]);
+    expect(forbiddenHits(any, "Booked.")).toEqual([]);
+  });
+
+  test("a subject switch hands the rest of the sentence to the human", () => {
+    expect(
+      forbiddenHits(any, "I can list a few, but you'd have to book."),
+    ).toEqual([]);
+    expect(forbiddenHits(any, "I'd suggest you book early.")).toEqual([]);
+    expect(forbiddenHits(any, "I'll find spots, and Maya can book.")).toEqual(
+      [],
+    );
+    expect(
+      firstPersonClaimSpans("I'll find spots, and Maya can book."),
+    ).toEqual(["I'll find spots,"]);
+    expect(forbiddenHits(any, "You could buy the tickets online.")).toEqual([]);
+    expect(forbiddenHits(any, "Maya booked the table.")).toEqual([]);
+    expect(
+      forbiddenHits(any, "Send me the address and I'll find spots."),
+    ).toEqual([]);
+  });
+
+  test("quoted item text and checkbox lines are masked before matching", () => {
+    expect(forbiddenHits(any, 'I added "Buy coffee" to the list.')).toEqual([]);
+    expect(forbiddenHits(any, "- [ ] Buy coffee\n- [x] Trash bags")).toEqual(
+      [],
+    );
+    // Masking never hides Eliza's own claim around the quote.
+    expect(
+      forbiddenHits(any, 'Maya said "book it" so I booked the table.'),
+    ).toEqual(["booking"]);
+  });
+
+  test("hits are unioned across spans in rule order and still honor the allow-list", () => {
+    const text = "Want me to book it? I could also call Maya.";
+    expect(forbiddenHits(any, text)).toEqual([
+      "booking",
+      "external-communication",
+    ]);
+    expect(forbiddenHits(new Set(["booking"]), text)).toEqual([
+      "external-communication",
+    ]);
   });
 });
 

--- a/packages/cloud/scripts/group-room-sim/run-room-sim.ts
+++ b/packages/cloud/scripts/group-room-sim/run-room-sim.ts
@@ -1,0 +1,1079 @@
+/**
+ * Five-room synthetic group-chat simulation driver: replays one homepage demo
+ * room (packages/homepage/src/lib/landing-demo.ts, read at runtime through
+ * ./rooms-spec.ts) against a running cloud stack by POSTing synthetic Blooio
+ * v4 webhooks, reads Eliza's outbound group sends back from the mock
+ * provider's capture surface, and scores BEHAVIORAL assertions. It is a
+ * live-model evaluation, never a CI gate; the homepage lines are not expected
+ * verbatim. README.md carries the env contract, the boot recipe and how to
+ * read results/<room>.{json,md}.
+ *
+ * Choreography (mirrors packages/cloud/api/internal/eliza-app/personal-shared/
+ * messages/route.ts): owner DMs /group and the link code is parsed from the
+ * reply; a non-owner member speaks in the still-unlinked group and a bounded
+ * no-send window must stay empty; the owner posts "Eliza link CODE" (and
+ * "Eliza ambient on" when the script has Eliza interject unprompted); then
+ * the human lines replay in script order, polling for replies only where the
+ * script has an Eliza step next and holding a silence window everywhere else.
+ *
+ * Anti-gaming invariants: echoed human text (exact / containment /
+ * token-Jaccard >= 0.8) fails the run and earns no fact or speaker credit;
+ * only outbound, non-human capture entries are ever scored; link/ambient acks
+ * are scanned for forbidden claims; FACTS_MIN and MIN_RESPONSES floor at 1.
+ * Captures carry no provider timestamps, so a reply landing after its window
+ * closes is attributed to the next poll (windows default long enough that a
+ * reply-to-everything bot still blows past UNSOLICITED_MAX).
+ */
+
+import crypto from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FACT_PATTERNS, ROOM_KEY_FACTS } from "./room-facts";
+import {
+  buildRoomsSpec,
+  forbiddenHits,
+  OWNER_SENDER,
+  type RoomSpec,
+  type RoomsSpec,
+} from "./rooms-spec";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RESULTS_DIR = join(HERE, "results");
+
+export const DEFAULT_OWNER_HANDLE = "+15550000001";
+export const DEFAULT_ELIZA_HANDLE = "+15550009999";
+/** Neutral text for the pre-link probe: no Eliza mention/command, and no
+ * overlap with any room's fact vocabulary. */
+export const PRE_LINK_PROBE_TEXT = "hey did everyone make it in here";
+
+// ── Result types ───────────────────────────────────────────────────────────
+
+export interface StepRecord {
+  human?: string; // sender name for human steps
+  eliza?: boolean;
+  position?: number;
+  expected?: boolean; // eliza: was this an expected speaking point
+  silent?: boolean; // eliza expected point with no reply inside the wait
+  unsolicited?: boolean; // eliza send in a scripted-silence window / trailing
+  echoOf?: string; // human message this output near-copies, if any
+  text: string;
+  matchedFacts?: string[];
+  forbiddenHits?: string[];
+}
+
+export interface CaptureEntry {
+  text: string;
+  chat: string;
+}
+
+export interface Thresholds {
+  waitMs: number;
+  pollMs: number;
+  paceMs: number;
+  silenceMs: number;
+  unsolicitedMax: number;
+  factsMin: number;
+  minResponses: number;
+}
+
+export interface Plan {
+  room: RoomSpec;
+  roomOrdinal: number;
+  ownerHandle: string;
+  elizaHandle: string;
+  /** Cast name -> synthetic phone handle (owner included as OWNER_SENDER). */
+  handleFor: Map<string, string>;
+  humanHandles: Set<string>;
+  groupChatId: string;
+  dmChatId: string;
+  probe: { sender: string; text: string };
+  /** True when some scripted Eliza point is not preceded by a mention. */
+  ambient: boolean;
+  /** Forbidden-claim categories the room's scripted capabilities allow. */
+  allowedCategories: Set<string>;
+  /** Human positions after which the script has NO Eliza step next. */
+  silentWindowPositions: number[];
+}
+
+export interface Assertions {
+  respondedAtExpectedPoints: {
+    pass: boolean;
+    respondedPoints: number;
+    expectedPoints: number;
+    minRequired: number;
+  };
+  silentUntilLinked: {
+    pass: boolean;
+    probe: { sender: string; text: string; windowMs: number };
+    preLinkSends: number;
+  };
+  restraintAtUnscriptedPoints: {
+    pass: boolean;
+    unsolicitedSends: number;
+    maxAllowed: number;
+    windowMs: number;
+  };
+  noEchoedHumanText: { pass: boolean; echoes: number; samples: string[] };
+  keyFactsReferenced: {
+    pass: boolean;
+    matched: string[];
+    minRequired: number;
+    available: number;
+  };
+  zeroForbiddenClaims: {
+    pass: boolean;
+    hits: string[];
+    allowedCategories: string[];
+  };
+  speakerAwareness: { pass: boolean; members: readonly string[] };
+}
+
+export interface RunResult {
+  room: string;
+  roomName: string;
+  ambient: boolean;
+  steps: StepRecord[];
+  assertions: Assertions;
+  verdict: "PASS" | "FAIL";
+}
+
+/** The I/O seam of a run: the real one speaks HTTP, tests script a bot. */
+export interface RunIo {
+  /** POST one synthetic Blooio delivery (raw JSON body) to the webhook. */
+  postWebhook(body: string): Promise<void>;
+  /** Read the whole outbound capture: a JSON array or {messages:[...]}. */
+  readCapture(): Promise<unknown>;
+  log(line: string): void;
+}
+
+/** Fatal harness condition (bad env, unreachable stack, no link code). The
+ * CLI reports it and exits 2; a FAIL verdict is a different, exit-1 outcome. */
+export class RoomSimError extends Error {}
+
+function fail(msg: string, cause?: unknown): never {
+  throw new RoomSimError(msg, cause === undefined ? undefined : { cause });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function intEnv(env: NodeJS.ProcessEnv, name: string, dflt: number): number {
+  const v = env[name];
+  if (!v) return dflt;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    fail(`${name} must be a non-negative integer, got: ${v}`);
+  }
+  return n;
+}
+
+// ── Echo detection ─────────────────────────────────────────────────────────
+
+function normText(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function tokenSet(s: string): Set<string> {
+  return new Set(normText(s).split(" ").filter(Boolean));
+}
+
+/**
+ * Returns the human message this output near-copies, or null. An echo is an
+ * exact normalized match, containment of a >=4-token human line, or a
+ * token-Jaccard >= 0.8 against a >=3-token human line. Legitimate replies
+ * that merely reference the same nouns score far below these thresholds.
+ */
+export function echoOfHuman(
+  text: string,
+  humanTexts: readonly string[],
+): string | null {
+  const no = normText(text);
+  if (!no) return null;
+  const to = tokenSet(text);
+  for (const h of humanTexts) {
+    const nh = normText(h);
+    if (!nh) continue;
+    if (no === nh) return h;
+    const th = tokenSet(h);
+    if (th.size >= 4 && no.includes(nh)) return h;
+    if (th.size >= 3) {
+      let inter = 0;
+      for (const t of th) if (to.has(t)) inter += 1;
+      const union = to.size + th.size - inter;
+      if (union > 0 && inter / union >= 0.8) return h;
+    }
+  }
+  return null;
+}
+
+// ── Scoring (pure) ─────────────────────────────────────────────────────────
+
+function matchFacts(roomId: RoomSpec["id"], text: string): string[] {
+  return FACT_PATTERNS[roomId]
+    .filter((f) => f.re.test(text))
+    .map((f) => f.label);
+}
+
+/**
+ * Score one Eliza group output against the human messages sent SO FAR. Echoed
+ * human text earns no fact credit; forbidden claims always count.
+ */
+export function scoreElizaOutput(
+  roomId: RoomSpec["id"],
+  allowedCategories: ReadonlySet<string>,
+  humanTextsSent: readonly string[],
+  text: string,
+): StepRecord {
+  const echo = echoOfHuman(text, humanTextsSent);
+  return {
+    eliza: true,
+    text,
+    ...(echo ? { echoOf: echo } : {}),
+    matchedFacts: echo ? [] : matchFacts(roomId, text),
+    forbiddenHits: forbiddenHits(allowedCategories, text),
+  };
+}
+
+export interface AssertionInputs {
+  room: RoomSpec;
+  steps: readonly StepRecord[];
+  respondedPoints: number;
+  preLinkSends: number;
+  unsolicitedSends: number;
+  /** Forbidden-claim hits found in the link/ambient acks. */
+  ackForbidden: readonly string[];
+  probe: { sender: string; text: string };
+  allowedCategories: ReadonlySet<string>;
+  thresholds: Thresholds;
+}
+
+/**
+ * Totals come from the step records, which scored each output at record
+ * time, so echo classification only compares an output against human
+ * messages that had already been sent, never against later ones. All
+ * matchers run ONLY over Eliza group outputs; echoed human text earns no
+ * fact or speaker credit.
+ */
+export function computeAssertions(input: AssertionInputs): Assertions {
+  const { room, thresholds } = input;
+  const allFacts = new Set<string>();
+  const allForbidden: string[] = [...input.ackForbidden];
+  const echoes: string[] = [];
+  const nonEchoOutputs: string[] = [];
+  for (const s of input.steps) {
+    if (!s.eliza || s.silent || s.matchedFacts === undefined) continue; // humans, acks, DM
+    if (s.echoOf) {
+      echoes.push(s.text);
+    } else {
+      nonEchoOutputs.push(s.text);
+      for (const f of s.matchedFacts) allFacts.add(f);
+    }
+    allForbidden.push(...(s.forbiddenHits ?? []));
+  }
+
+  return {
+    respondedAtExpectedPoints: {
+      pass: input.respondedPoints >= thresholds.minResponses,
+      respondedPoints: input.respondedPoints,
+      expectedPoints: room.elizaPositions.length,
+      minRequired: thresholds.minResponses,
+    },
+    silentUntilLinked: {
+      pass: input.preLinkSends === 0,
+      probe: { ...input.probe, windowMs: thresholds.silenceMs },
+      preLinkSends: input.preLinkSends,
+    },
+    restraintAtUnscriptedPoints: {
+      pass: input.unsolicitedSends <= thresholds.unsolicitedMax,
+      unsolicitedSends: input.unsolicitedSends,
+      maxAllowed: thresholds.unsolicitedMax,
+      windowMs: thresholds.silenceMs,
+    },
+    noEchoedHumanText: {
+      pass: echoes.length === 0,
+      echoes: echoes.length,
+      samples: echoes.slice(0, 3),
+    },
+    keyFactsReferenced: {
+      pass: allFacts.size >= thresholds.factsMin,
+      matched: [...allFacts],
+      minRequired: thresholds.factsMin,
+      available: FACT_PATTERNS[room.id].length,
+    },
+    zeroForbiddenClaims: {
+      pass: allForbidden.length === 0,
+      hits: allForbidden,
+      allowedCategories: [...input.allowedCategories],
+    },
+    speakerAwareness: {
+      pass: nonEchoOutputs.some((t) =>
+        room.members.some((m) => new RegExp(`\\b${m}\\b`, "i").test(t)),
+      ),
+      members: room.members,
+    },
+  };
+}
+
+function verdictOf(assertions: Assertions): RunResult["verdict"] {
+  return Object.values(assertions).every((a) => a.pass) ? "PASS" : "FAIL";
+}
+
+// ── Plan ───────────────────────────────────────────────────────────────────
+
+export function buildPlan(
+  spec: RoomsSpec,
+  roomId: string,
+  env: NodeJS.ProcessEnv,
+): Plan {
+  const room = spec.rooms.find((r) => r.id === roomId);
+  if (!room) {
+    fail(
+      `unknown room "${roomId}"; valid: ${spec.rooms.map((r) => r.id).join(", ")}`,
+    );
+  }
+  if (!FACT_PATTERNS[room.id]) {
+    fail(`no fact patterns defined for room ${room.id}`);
+  }
+
+  const ownerHandle = env.OWNER_HANDLE ?? DEFAULT_OWNER_HANDLE;
+  const elizaHandle = env.ELIZA_HANDLE ?? DEFAULT_ELIZA_HANDLE;
+  const roomOrdinal = spec.rooms.findIndex((r) => r.id === room.id);
+  const handleFor = new Map<string, string>();
+  handleFor.set(OWNER_SENDER, ownerHandle);
+  room.members.forEach((name, i) => {
+    handleFor.set(name, `+1555000${1000 + roomOrdinal * 100 + i + 1}`);
+  });
+  const humanHandles = new Set(handleFor.values());
+  if (humanHandles.size !== handleFor.size) {
+    fail("handle collision between cast members");
+  }
+  if (humanHandles.has(elizaHandle)) {
+    fail("ELIZA_HANDLE collides with a human handle");
+  }
+
+  // RUN_TAG suffixes the chat ids so a re-run against a stack whose DB
+  // persisted an earlier binding gets a fresh, unlinked group (a group chat
+  // id bound to one owner refuses "Eliza link" from any other owner).
+  const runTag = (env.RUN_TAG ?? "").replace(/[^A-Za-z0-9_-]/g, "");
+  const suffix = runTag ? `_${runTag}` : "";
+
+  // Ambient decision: unprompted interjection = some eliza position whose
+  // preceding human message never mentions her by name.
+  const humansByPos = new Map(room.humanMessages.map((m) => [m.position, m]));
+  const ambient = room.elizaPositions.some((p) => {
+    const prev = humansByPos.get(p - 1);
+    return prev ? !/\beliza\b/i.test(prev.text) : true;
+  });
+
+  const elizaSet = new Set(room.elizaPositions);
+  const allowedCategories = new Set<string>();
+  for (const step of room.elizaSteps) {
+    for (const cat of spec.allowedClaimsByCapability[step.capability] ?? []) {
+      allowedCategories.add(cat);
+    }
+  }
+
+  return {
+    room,
+    roomOrdinal,
+    ownerHandle,
+    elizaHandle,
+    handleFor,
+    humanHandles,
+    groupChatId: `chat_sim_${room.id}${suffix}`,
+    dmChatId: `chat_sim_dm_${room.id}${suffix}`,
+    // A NON-owner member speaks in the unlinked group.
+    probe: { sender: room.members[0], text: PRE_LINK_PROBE_TEXT },
+    ambient,
+    allowedCategories,
+    silentWindowPositions: Array.from(
+      { length: room.stepCount },
+      (_, p) => p,
+    ).filter((p) => humansByPos.has(p) && !elizaSet.has(p + 1)),
+  };
+}
+
+export function dryRunReport(plan: Plan): Record<string, unknown> {
+  return {
+    dryRun: true,
+    room: plan.room.id,
+    roomName: plan.room.roomName,
+    handles: Object.fromEntries(plan.handleFor),
+    elizaHandle: plan.elizaHandle,
+    groupChatId: plan.groupChatId,
+    dmChatId: plan.dmChatId,
+    ambient: plan.ambient,
+    preLinkProbe: plan.probe,
+    humanMessages: plan.room.humanMessages.length,
+    expectedElizaPoints: plan.room.elizaPositions.length,
+    silentWindows: plan.silentWindowPositions.length,
+    allowedForbiddenCategories: [...plan.allowedCategories],
+    factPatterns: FACT_PATTERNS[plan.room.id].map((f) => f.label),
+    note: "spec loaded and plan built; no network calls made",
+  };
+}
+
+export function readThresholds(
+  env: NodeJS.ProcessEnv,
+  room: RoomSpec,
+): Thresholds {
+  return {
+    waitMs: intEnv(env, "WAIT_MS", 45_000),
+    pollMs: intEnv(env, "POLL_MS", 1_500),
+    paceMs: intEnv(env, "PACE_MS", 1_200),
+    silenceMs: intEnv(env, "SILENCE_MS", 8_000),
+    unsolicitedMax: intEnv(env, "UNSOLICITED_MAX", 2),
+    // Floored at 1: these thresholds must not be zeroed into no-op assertions.
+    factsMin: Math.max(1, intEnv(env, "FACTS_MIN", 2)),
+    minResponses: Math.max(
+      1,
+      intEnv(env, "MIN_RESPONSES", Math.ceil(room.elizaPositions.length / 2)),
+    ),
+  };
+}
+
+// ── Webhook envelope ───────────────────────────────────────────────────────
+
+export function v4Envelope(opts: {
+  sender: string;
+  text: string;
+  chatId: string;
+  isGroup: boolean;
+  roomName: string;
+  elizaHandle: string;
+  seq: number;
+}): string {
+  const id = `sim_${Date.now()}_${opts.seq}`;
+  // recipient is the RECEIVING (Eliza) number: the adapter maps it to
+  // internal_id; it must match channel_address, never the sender's own phone.
+  return JSON.stringify({
+    id: `evt_${id}`,
+    type: "message.received",
+    created_at: Date.now(),
+    data: {
+      id: `msg_${id}`,
+      message_id: `msg_${id}`,
+      chat_id: opts.chatId,
+      channel_id: "ch_sim",
+      channel_type: "blooio",
+      direction: "inbound",
+      sender: opts.sender,
+      recipient: opts.elizaHandle,
+      channel_address: opts.elizaHandle,
+      text: opts.text,
+      protocol: "imessage",
+      is_group: opts.isGroup,
+      group: opts.isGroup ? { name: opts.roomName } : null,
+      attachments: [],
+    },
+  });
+}
+
+// ── Signing ────────────────────────────────────────────────────────────────
+
+export async function signatureFor(
+  body: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | null> {
+  const signing = env.SIGNING?.trim() ?? "";
+  if (!signing || signing === "none") return null;
+
+  if (signing.startsWith("cmd:")) {
+    const cmd = signing.slice(4);
+    const proc = Bun.spawn(["sh", "-c", cmd], {
+      env: { ...env, BODY: body },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const out = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    if (code !== 0) {
+      const err = await new Response(proc.stderr).text();
+      fail(`SIGNING cmd exited ${code}: ${err.trim()}`);
+    }
+    return out.trim();
+  }
+
+  let secret = signing;
+  if (signing.startsWith("env:")) {
+    const varName = signing.slice(4);
+    const v = env[varName];
+    if (!v) fail(`SIGNING=env:${varName} but ${varName} is unset`);
+    secret = v;
+  }
+  const t = Math.floor(Date.now() / 1000);
+  const hmac = crypto
+    .createHmac("sha256", secret)
+    .update(`${t}.${body}`)
+    .digest("hex");
+  return `t=${t},v1=${hmac}`;
+}
+
+// ── HTTP transport (the real RunIo) ────────────────────────────────────────
+
+function createHttpIo(env: NodeJS.ProcessEnv): RunIo {
+  const baseUrl = env.BASE_URL;
+  const captureSrc = env.OUTBOUND_CAPTURE;
+  if (!baseUrl) fail("BASE_URL is required (webhook endpoint)");
+  if (!captureSrc) {
+    fail("OUTBOUND_CAPTURE is required (mock provider outbound sends)");
+  }
+
+  return {
+    async postWebhook(body) {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      const sig = await signatureFor(body, env);
+      if (sig) headers["x-blooio-signature"] = sig;
+
+      let res: Response;
+      try {
+        res = await fetch(baseUrl, { method: "POST", headers, body });
+      } catch (err) {
+        // error-policy:J2 context-adding rethrow: name the endpoint, keep the cause
+        fail(
+          `could not reach BASE_URL (${baseUrl}): ${err instanceof Error ? err.message : String(err)}. ` +
+            "If this was a dry-run against a stub endpoint, that is the expected clean exit.",
+          err,
+        );
+      }
+      if (!res.ok) {
+        // error-policy:J7 diagnostics must not kill the loop: the rejection
+        // body is only quoted into the failure; an unreadable body still fails
+        // on the status.
+        const text = await res.text().catch(() => "");
+        fail(`webhook POST rejected: ${res.status} ${text.slice(0, 300)}`);
+      }
+    },
+
+    async readCapture() {
+      if (/^https?:\/\//i.test(captureSrc)) {
+        let res: Response;
+        try {
+          res = await fetch(captureSrc);
+        } catch (err) {
+          // error-policy:J2 context-adding rethrow: name the capture source, keep the cause
+          fail(
+            `could not reach OUTBOUND_CAPTURE (${captureSrc}): ${err instanceof Error ? err.message : String(err)}`,
+            err,
+          );
+        }
+        if (!res.ok) fail(`OUTBOUND_CAPTURE GET returned ${res.status}`);
+        // error-policy:J3 untrusted-input sanitizing: a non-JSON capture body
+        // becomes an explicit typed failure, never an empty capture.
+        return await res
+          .json()
+          .catch((err) => fail("OUTBOUND_CAPTURE returned invalid JSON", err));
+      }
+      if (!existsSync(captureSrc)) return []; // mock provider may not have written yet
+      const text = readFileSync(captureSrc, "utf8").trim();
+      if (!text) return [];
+      try {
+        return JSON.parse(text);
+      } catch {
+        // error-policy:J3 untrusted-input sanitizing: not one JSON document,
+        // so parse as JSONL; a line that is neither throws from here.
+        return text
+          .split("\n")
+          .filter((l) => l.trim())
+          .map((l) => JSON.parse(l));
+      }
+    },
+
+    log(line) {
+      console.error(`[run-room-sim] ${line}`);
+    },
+  };
+}
+
+// ── Outbound capture normalization (pure) ──────────────────────────────────
+
+/**
+ * Normalize one raw capture entry. Returns null for anything that is not a
+ * scoreable Eliza output; `untagged` marks entries dropped for carrying no
+ * chat attribution (a diagnostic the /group phase reports).
+ */
+function normalizeCaptureEntry(
+  raw: unknown,
+  humanHandles: ReadonlySet<string>,
+): { entry: CaptureEntry | null; untagged: boolean } {
+  if (raw == null) return { entry: null, untagged: false };
+  if (typeof raw === "string") {
+    return { entry: null, untagged: true }; // bare strings carry no chat attribution
+  }
+  if (typeof raw !== "object") return { entry: null, untagged: false };
+  const r = raw as Record<string, unknown>;
+  if (r.direction === "inbound") return { entry: null, untagged: false }; // only Eliza OUTPUTS are scored
+  const from = [r.sender, r.from].find((v) => typeof v === "string") as
+    | string
+    | undefined;
+  if (from && humanHandles.has(from)) return { entry: null, untagged: false }; // a human, not Eliza
+  const text = [r.text, r.body, r.message].find((v) => typeof v === "string") as
+    | string
+    | undefined;
+  if (!text) return { entry: null, untagged: false };
+  const chat = [r.chat_id, r.chatId, r.chat, r.to].find(
+    (v) => typeof v === "string",
+  ) as string | undefined;
+  if (!chat) {
+    return { entry: null, untagged: true }; // without chat attribution DM/group scoring is unsound
+  }
+  return { entry: { text, chat }, untagged: false };
+}
+
+export function normalizeCapturePayload(
+  payload: unknown,
+  humanHandles: ReadonlySet<string>,
+): { entries: CaptureEntry[]; untaggedDropped: number } {
+  const list = Array.isArray(payload)
+    ? payload
+    : payload &&
+        typeof payload === "object" &&
+        Array.isArray((payload as { messages?: unknown[] }).messages)
+      ? (payload as { messages: unknown[] }).messages
+      : fail(
+          "OUTBOUND_CAPTURE payload is neither an array nor {messages:[...]}",
+        );
+  const entries: CaptureEntry[] = [];
+  let untaggedDropped = 0;
+  for (const raw of list) {
+    const { entry, untagged } = normalizeCaptureEntry(raw, humanHandles);
+    if (untagged) untaggedDropped += 1;
+    if (entry) entries.push(entry);
+  }
+  return { entries, untaggedDropped };
+}
+
+function entriesForChat(
+  entries: readonly CaptureEntry[],
+  chatId: string,
+): CaptureEntry[] {
+  return entries.filter((e) => e.chat === chatId);
+}
+
+// ── Link code parsing ──────────────────────────────────────────────────────
+
+/**
+ * The product's /group DM reply embeds the literal command
+ * "Eliza link <CODE>" where CODE is exactly 8 chars of the group-claim
+ * alphabet 23456789ABCDEFGHJKLMNPQRSTUVWXYZ, and the group-side matcher is
+ * anchored on that exact shape, so parse that first; looser fallbacks only
+ * run when the primary shape is absent.
+ */
+export function parseLinkCode(
+  texts: readonly string[],
+  override?: string,
+): string | null {
+  const joined = texts.join("\n");
+  if (override) {
+    const m = joined.match(new RegExp(override, "i"));
+    if (m) return (m[1] ?? m[0]).trim().toUpperCase();
+    return null;
+  }
+  const product = joined.match(
+    /(?:eliza\s+link|\/eliza_link(?:@[a-z0-9_]{5,32})?)\s+([2-9A-HJ-NP-Z]{8})\b/i,
+  );
+  if (product?.[1]) return product[1].toUpperCase();
+  const near = joined.match(/(?:code|link)\W{0,12}([2-9A-HJ-NP-Z]{8})\b/i);
+  if (near?.[1]) return near[1].toUpperCase();
+  const caps = joined.match(/\b([2-9A-HJ-NP-Z]{8})\b/);
+  return caps?.[1]?.toUpperCase() ?? null;
+}
+
+// ── The run ────────────────────────────────────────────────────────────────
+
+export interface RunOptions {
+  linkCodeRegex?: string;
+}
+
+export async function runRoom(
+  plan: Plan,
+  thresholds: Thresholds,
+  io: RunIo,
+  options: RunOptions = {},
+): Promise<RunResult> {
+  const { room, groupChatId, dmChatId, probe, ambient, allowedCategories } =
+    plan;
+  const { waitMs, pollMs, paceMs, silenceMs } = thresholds;
+
+  /** Diagnostics: entries dropped on the latest read for missing chat
+   * attribution. */
+  let untaggedDropped = 0;
+  const readEntries = async (): Promise<CaptureEntry[]> => {
+    const normalized = normalizeCapturePayload(
+      await io.readCapture(),
+      plan.humanHandles,
+    );
+    untaggedDropped = normalized.untaggedDropped;
+    return normalized.entries;
+  };
+  const chatEntries = async (chatId: string) =>
+    entriesForChat(await readEntries(), chatId);
+
+  /** Poll for new entries in a chat beyond `seen`, up to waitMs; returns as
+   * soon as something arrives (plus one settle interval for multi-part
+   * sends). */
+  const pollNew = async (chatId: string, seen: number): Promise<string[]> => {
+    const deadline = Date.now() + waitMs;
+    for (;;) {
+      const all = await chatEntries(chatId);
+      if (all.length > seen) {
+        // settle: one extra poll interval so multi-part sends are captured
+        await sleep(pollMs);
+        const settled = await chatEntries(chatId);
+        return settled.slice(seen).map((e) => e.text);
+      }
+      if (Date.now() >= deadline) return [];
+      await sleep(pollMs);
+    }
+  };
+
+  /** Hold a bounded no-send window: wait the FULL windowMs, then report every
+   * new entry that arrived (plus one settle read). Used for silence checks;
+   * unlike pollNew it never returns early, so a late reply inside the window
+   * is still caught. */
+  const collectDuring = async (
+    chatId: string,
+    seen: number,
+    windowMs: number,
+  ): Promise<string[]> => {
+    await sleep(windowMs);
+    const first = await chatEntries(chatId);
+    if (first.length <= seen) return [];
+    await sleep(pollMs);
+    const settled = await chatEntries(chatId);
+    return settled.slice(seen).map((e) => e.text);
+  };
+
+  const steps: StepRecord[] = [];
+  const humanTextsSent: string[] = [];
+  const scoreEliza = (text: string): StepRecord =>
+    scoreElizaOutput(room.id, allowedCategories, humanTextsSent, text);
+
+  let seq = 0;
+  const send = async (
+    senderName: string,
+    text: string,
+    chatId: string,
+    isGroup: boolean,
+  ) => {
+    const sender = plan.handleFor.get(senderName);
+    if (!sender) fail(`no handle for sender ${senderName}`);
+    if (isGroup) humanTextsSent.push(text);
+    seq += 1;
+    await io.postWebhook(
+      v4Envelope({
+        sender,
+        text,
+        chatId,
+        isGroup,
+        roomName: room.roomName,
+        elizaHandle: plan.elizaHandle,
+        seq,
+      }),
+    );
+  };
+
+  io.log(`room=${room.id} ambient=${ambient} owner=${plan.ownerHandle}`);
+
+  // Stale-capture baseline: group entries that exist before this run sends
+  // anything are prior-run residue, never counted for or against this run.
+  let groupSeen = (await chatEntries(groupChatId)).length;
+  if (groupSeen > 0) {
+    io.log(
+      `warning: ${groupSeen} pre-existing group capture entries treated as stale baseline`,
+    );
+  }
+
+  // Phase 1: owner DM "/group" -> parse link code from DM reply.
+  const dmSeen = (await chatEntries(dmChatId)).length;
+  await send(OWNER_SENDER, "/group", dmChatId, false);
+  steps.push({ human: OWNER_SENDER, text: "/group (DM)" });
+  const dmReplies = await pollNew(dmChatId, dmSeen);
+  if (dmReplies.length === 0) {
+    fail(
+      "no DM reply to /group within the wait window" +
+        (untaggedDropped > 0
+          ? ` (${untaggedDropped} capture entries were dropped for missing chat attribution; the mock capture must tag each send with its chat id)`
+          : ""),
+    );
+  }
+  for (const t of dmReplies) steps.push({ eliza: true, text: `(DM) ${t}` });
+  const code = parseLinkCode(dmReplies, options.linkCodeRegex);
+  if (!code) {
+    fail(
+      `could not parse a link code from the /group DM reply: ${JSON.stringify(dmReplies)}`,
+    );
+  }
+  io.log(`link code parsed: ${code}`);
+
+  // Phase 2: PRE-LINK SILENCE PROBE: a member speaks in the unlinked group,
+  // then a bounded no-send window. Any group send before the link command is
+  // posted is a violation.
+  await send(probe.sender, probe.text, groupChatId, true);
+  steps.push({ human: probe.sender, text: `${probe.text} (pre-link probe)` });
+  const preLinkSends = await collectDuring(groupChatId, groupSeen, silenceMs);
+  groupSeen += preLinkSends.length;
+  for (const t of preLinkSends) {
+    steps.push({
+      ...scoreEliza(t),
+      unsolicited: true,
+      text: `(PRE-LINK) ${t}`,
+    });
+  }
+
+  // Phase 3: owner links the group (and enables ambient where warranted).
+  await send(OWNER_SENDER, `Eliza link ${code}`, groupChatId, true);
+  steps.push({ human: OWNER_SENDER, text: `Eliza link ${code}` });
+  const ackForbidden: string[] = [];
+  const linkAck = await pollNew(groupChatId, groupSeen);
+  for (const t of linkAck) {
+    ackForbidden.push(...forbiddenHits(allowedCategories, t));
+    steps.push({ eliza: true, text: `(link ack) ${t}` });
+  }
+  groupSeen += linkAck.length;
+
+  if (ambient) {
+    await send(OWNER_SENDER, "Eliza ambient on", groupChatId, true);
+    steps.push({ human: OWNER_SENDER, text: "Eliza ambient on" });
+    const ambAck = await pollNew(groupChatId, groupSeen);
+    for (const t of ambAck) {
+      ackForbidden.push(...forbiddenHits(allowedCategories, t));
+      steps.push({ eliza: true, text: `(ambient ack) ${t}` });
+    }
+    groupSeen += ambAck.length;
+  }
+
+  // Phase 4: replay the script in position order. Poll (bounded) at each
+  // scripted Eliza point; hold a bounded silence window after every other
+  // human message; sends arriving there are unsolicited.
+  const humansByPos = new Map(room.humanMessages.map((m) => [m.position, m]));
+  const elizaSet = new Set(room.elizaPositions);
+  let respondedPoints = 0;
+  const unsolicitedSends: string[] = [];
+
+  for (let pos = 0; pos < room.stepCount; pos++) {
+    const human = humansByPos.get(pos);
+    if (human) {
+      await send(human.sender, human.text, groupChatId, true);
+      steps.push({ human: human.sender, position: pos, text: human.text });
+      if (elizaSet.has(pos + 1)) {
+        await sleep(paceMs);
+      } else {
+        // Scripted silence: the homepage script has no Eliza step next, so a
+        // send arriving in this bounded window is unsolicited.
+        const stray = await collectDuring(groupChatId, groupSeen, silenceMs);
+        groupSeen += stray.length;
+        for (const t of stray) {
+          unsolicitedSends.push(t);
+          steps.push({ ...scoreEliza(t), position: pos, unsolicited: true });
+        }
+      }
+      continue;
+    }
+    if (elizaSet.has(pos)) {
+      const replies = await pollNew(groupChatId, groupSeen);
+      groupSeen += replies.length;
+      if (replies.length > 0) {
+        respondedPoints += 1;
+        for (const t of replies) {
+          steps.push({ ...scoreEliza(t), position: pos, expected: true });
+        }
+      } else {
+        steps.push({
+          eliza: true,
+          position: pos,
+          expected: true,
+          silent: true,
+          text: "",
+        });
+      }
+    }
+  }
+
+  // Final sweep: trailing sends after the last point are unsolicited too.
+  const trailing = await collectDuring(
+    groupChatId,
+    groupSeen,
+    Math.min(waitMs, 10_000),
+  );
+  for (const t of trailing) {
+    unsolicitedSends.push(t);
+    steps.push({ ...scoreEliza(t), expected: false, unsolicited: true });
+  }
+
+  const assertions = computeAssertions({
+    room,
+    steps,
+    respondedPoints,
+    preLinkSends: preLinkSends.length,
+    unsolicitedSends: unsolicitedSends.length,
+    ackForbidden,
+    probe,
+    allowedCategories,
+    thresholds,
+  });
+
+  return {
+    room: room.id,
+    roomName: room.roomName,
+    ambient,
+    steps,
+    assertions,
+    verdict: verdictOf(assertions),
+  };
+}
+
+// ── Reporting ──────────────────────────────────────────────────────────────
+
+export function renderMarkdown(result: RunResult): string {
+  const a = result.assertions;
+  const md: string[] = [
+    `# Room sim transcript: ${result.roomName} (${result.room})`,
+    "",
+    `- Verdict: **${result.verdict}**`,
+    `- Ambient mode: ${result.ambient ? "on" : "off (mention-only)"}`,
+    `- Expected Eliza points responded: ${a.respondedAtExpectedPoints.respondedPoints}/${a.respondedAtExpectedPoints.expectedPoints}`,
+    `- Pre-link probe sends: ${a.silentUntilLinked.preLinkSends} (must be 0)`,
+    `- Unsolicited sends (silent windows + trailing): ${a.restraintAtUnscriptedPoints.unsolicitedSends} (max ${a.restraintAtUnscriptedPoints.maxAllowed})`,
+    `- Echoed-human outputs: ${a.noEchoedHumanText.echoes} (must be 0)`,
+    `- Distinct key facts referenced (non-echo replies): ${a.keyFactsReferenced.matched.length} (min ${a.keyFactsReferenced.minRequired}): ${a.keyFactsReferenced.matched.join("; ") || "none"}`,
+    `- Forbidden-claim hits (incl. acks): ${a.zeroForbiddenClaims.hits.length ? a.zeroForbiddenClaims.hits.join(", ") : "none"}`,
+    "",
+    "## Transcript",
+    "",
+  ];
+  for (const s of result.steps) {
+    if (s.human) {
+      md.push(`**${s.human}:** ${s.text}`);
+    } else if (s.silent) {
+      md.push(
+        `**Eliza:** _(silent: expected speaking point at position ${s.position})_`,
+      );
+    } else {
+      const notes: string[] = [];
+      if (s.unsolicited) notes.push("UNSOLICITED");
+      if (s.echoOf) notes.push(`ECHO of: ${JSON.stringify(s.echoOf)}`);
+      if (s.matchedFacts?.length) {
+        notes.push(`facts: ${s.matchedFacts.join(", ")}`);
+      }
+      if (s.forbiddenHits?.length) {
+        notes.push(`FORBIDDEN: ${s.forbiddenHits.join(", ")}`);
+      }
+      md.push(
+        `**Eliza:** ${s.text}${notes.length ? `  \n  _[${notes.join(" | ")}]_` : ""}`,
+      );
+    }
+    md.push("");
+  }
+  md.push(
+    "## Assertions",
+    "",
+    "```json",
+    JSON.stringify(result.assertions, null, 2),
+    "```",
+    "",
+  );
+  return md.join("\n");
+}
+
+function writeResults(
+  resultsDir: string,
+  result: RunResult,
+): { jsonPath: string; mdPath: string } {
+  mkdirSync(resultsDir, { recursive: true });
+  const jsonPath = join(resultsDir, `${result.room}.json`);
+  writeFileSync(jsonPath, `${JSON.stringify(result, null, 2)}\n`);
+  const mdPath = join(resultsDir, `${result.room}.md`);
+  writeFileSync(mdPath, renderMarkdown(result));
+  return { jsonPath, mdPath };
+}
+
+/** The derived spec plus the hand-written facts, for review and diffing. */
+function printableSpec(spec: RoomsSpec): Record<string, unknown> {
+  return {
+    source: "packages/homepage/src/lib/landing-demo.ts (read at runtime)",
+    rotationOrder: spec.rotationOrder,
+    capabilities: spec.capabilities,
+    forbiddenClaimCategories: spec.forbiddenClaimCategories,
+    allowedClaimsByCapability: spec.allowedClaimsByCapability,
+    rooms: spec.rooms.map((room) => ({
+      ...room,
+      keyFacts: ROOM_KEY_FACTS[room.id],
+      factPatterns: FACT_PATTERNS[room.id].map((f) => ({
+        label: f.label,
+        pattern: f.re.source,
+      })),
+    })),
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+const USAGE =
+  "usage: bun run cloud:group-room-sim -- --room <household|co-parenting|friends|trip|community> [--dry-run] | --print-spec";
+
+async function main(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<number> {
+  const spec = buildRoomsSpec();
+  if (args.includes("--print-spec")) {
+    console.log(JSON.stringify(printableSpec(spec), null, 2));
+    return 0;
+  }
+  const roomIdx = args.indexOf("--room");
+  const roomId = roomIdx >= 0 ? args[roomIdx + 1] : undefined;
+  if (!roomId) fail(USAGE);
+
+  const plan = buildPlan(spec, roomId, env);
+  if (args.includes("--dry-run")) {
+    console.log(JSON.stringify(dryRunReport(plan), null, 2));
+    return 0;
+  }
+
+  const io = createHttpIo(env);
+  const thresholds = readThresholds(env, plan.room);
+  const result = await runRoom(plan, thresholds, io, {
+    linkCodeRegex: env.LINK_CODE_REGEX,
+  });
+  const { jsonPath, mdPath } = writeResults(RESULTS_DIR, result);
+  io.log(`wrote ${jsonPath} and ${mdPath}`);
+  console.log(
+    JSON.stringify(
+      {
+        room: result.room,
+        verdict: result.verdict,
+        assertions: result.assertions,
+      },
+      null,
+      2,
+    ),
+  );
+  return result.verdict === "PASS" ? 0 : 1;
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2), process.env).then(
+    (code) => process.exit(code),
+    (err: unknown) => {
+      // error-policy:J1 boundary translation: any harness failure is reported
+      // on stderr and exits 2, distinct from a FAIL verdict (exit 1). Typed
+      // failures print their message; anything else keeps its stack.
+      const detail =
+        err instanceof RoomSimError
+          ? err.message
+          : err instanceof Error
+            ? (err.stack ?? err.message)
+            : String(err);
+      console.error(`[run-room-sim] ${detail}`);
+      process.exit(2);
+    },
+  );
+}


### PR DESCRIPTION
# Relates to

Personal Shared group chats (#24322) and the homepage demo rooms (`packages/homepage/src/lib/landing-demo.ts`). This harness is what surfaced the Stage-1 ambient restraint gap fixed in #25279.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`a0f04a5c554`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** Adds a dev tool + its offline tests under `packages/cloud/scripts/group-room-sim/` and one root `package.json` script (`cloud:group-room-sim`). Nothing imports it. It is a live-model evaluation, not a CI gate; the CI-safe part is the tool's own 41 tests, auto-discovered by the scripts lanes like the existing `admin/hetzner-e2e/` tool.

# Background

## What does this PR do?

A repeatable behavioral evaluation of the five homepage demo rooms (Household, Co-parenting, Friends, Trip, Community) as synthetic multi-party iMessage groups through the real Blooio webhook → gateway → Personal Shared route path against a local cloud stack (`cloud:mock`). One room per run: owner DM `/group`, a pre-link silence probe, `Eliza link CODE`, `Eliza ambient on` where the script calls for unprompted interjections, then the room's human messages in script order with bounded waits at Eliza's scripted beats and bounded silence windows everywhere else.

Scored with assertions a broken or cheating agent cannot pass: silent until linked; replies at the scripted beats; restraint at unscripted points (`UNSOLICITED_MAX`, default 2); no echoed human text (exact / containment / token-Jaccard ≥ 0.8, and echoes earn no fact credit); key-fact recall from the room's own script; zero unsupported-capability claims; speaker awareness. Rooms and the 14 forbidden-claim rules derive from the homepage module at runtime, so the harness cannot drift from the marketing scripts (pinned by a test that re-extracts independently).

Second commit: forbidden-claim hits count only on **first-person capability claims**. The homepage rules are written for marketing copy and on live replies they false-positive on lines where the verb belongs to a human or a list ("If you *send* the address…", "Created: [ ] *Buy* coffee", "set up your personal *workspace*"); a real overclaim still fires ("Want me to check if any of these take reservations?" → booking). `first-person-claims.ts` opens a span at a first-person marker (modals, offers, "let me", "want me to", bare "I" + action verb; negations never open one), closes it at sentence end or subject switch, masks checkbox items and quoted text, and the untouched homepage rules run per span. Over the 125 distinct live replies from tonight's runs: raw hits 27 → 3, all three genuine.

Results from the live runs that motivated #25279, for context (same driver, real Cerebras): unsolicited group replies per room before/after the Stage-1 policy — household 7→1, co-parenting 10→0, friends 10→2, trip 8→2, community 8→1.

## What kind of change is this?

Tests / developer tooling (non-breaking).

# Documentation changes needed?

Included: `packages/cloud/scripts/group-room-sim/README.md` — what it proves, the full env contract, a copy-pasteable four-process recipe against `cloud:mock`, how to read `results/<room>.md`, the live-model caveat, and the tsc invocation (the scripts tree has no tsconfig lane).

# Testing

## Where should a reviewer start?

`README.md`, then `run-room-sim.test.ts` (the synthetic echo / chatty / pre-link / forbidden / silent bots each fail exactly one assertion; a faithful bot passes all five rooms), then `first-person-claims.ts`.

## Detailed testing steps

- `bun test packages/cloud/scripts/group-room-sim/run-room-sim.test.ts` → **41 pass / 0 fail** (32 + 9).
- `bun run cloud:group-room-sim -- --room <household|co-parenting|friends|trip|community> --dry-run` → exit 0 for all five (plan only, no network).
- `bun run audit:scripts`, `audit:scripts:inventory`, `audit:test-lane-membership` → OK; biome on the directory → 0 errors (3 `noUndeclaredEnvVars` warnings, the class the existing cloud scripts carry); the README's `tsc --noEmit` invocation → clean.
- Live (not CI): boot `cloud:mock`, the mock Blooio provider and the gateway with the preload per the README, then `--room friends` — results in `results/friends.{json,md}`.

# Evidence Gate

<!-- evidence-head:16b49ac69bc1fa67b1614f2cad0595eef00ad33d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] Per-turn gateway records during live runs carry `shared_model;…;desc="provider=cerebras calls=1 fallbacks=0"`; the tool's own tests are offline.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] The live transcripts behind the before/after numbers above were produced with this tool against real Cerebras (gemma-4-31b) through the cloud shared runtime; the tool writes them to `results/<room>.md`. The deterministic proxy is not the surface under test.
<!-- evidence-row:domain-artifacts -->
- [x] Live runs write `results/<room>.json` (steps, assertions, verdict) and `results/<room>.md` (transcript); gitignored.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
The live transcripts behind the before/after numbers above were produced with this tool against real Cerebras (gemma-4-31b) through the cloud shared runtime; the tool writes them to `results/<room>.md`. The deterministic proxy is not the surface under test.

## Backend + frontend logs
Per-turn gateway records during live runs carry `shared_model;…;desc="provider=cerebras calls=1 fallbacks=0"`; the tool's own tests are offline.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- Live runs are not reproducible in CI by design (real model); the tests cover the harness, not Eliza.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

