### PR TITLE
fix(local-inference): safe NaN handling in model recommendation and routing policy priority sort comparators

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -981,9 +981,31 @@ function recommendedChatModel(): CatalogModel | null {
 	const totalRamGb = os.totalmem() / 1024 ** 3;
 	const candidates = chatModels()
 		.filter((model) => totalRamGb >= model.minRamGb)
-		.sort((left, right) => right.sizeGb - left.sizeGb);
+		.sort((left, right) => {
+			const rightSize =
+				typeof right.sizeGb === "number" && Number.isFinite(right.sizeGb)
+					? right.sizeGb
+					: 0;
+			const leftSize =
+				typeof left.sizeGb === "number" && Number.isFinite(left.sizeGb)
+					? left.sizeGb
+					: 0;
+			return rightSize - leftSize || left.id.localeCompare(right.id);
+		});
 	return (
-		candidates[0] ?? chatModels().sort((a, b) => a.sizeGb - b.sizeGb)[0] ?? null
+		candidates[0] ??
+		chatModels().sort((a, b) => {
+			const aSize =
+				typeof a.sizeGb === "number" && Number.isFinite(a.sizeGb)
+					? a.sizeGb
+					: 0;
+			const bSize =
+				typeof b.sizeGb === "number" && Number.isFinite(b.sizeGb)
+					? b.sizeGb
+					: 0;
+			return aSize - bSize || a.id.localeCompare(b.id);
+		})[0] ??
+		null
 	);
 }
 
@@ -1145,7 +1167,17 @@ async function resolveDefaultChatModel(
 			CATALOG.find((model) => model.id === entry.id && model.role === "chat"),
 		)
 		.filter((model): model is CatalogModel => Boolean(model))
-		.sort((a, b) => a.sizeGb - b.sizeGb)[0];
+		.sort((a, b) => {
+			const aSize =
+				typeof a.sizeGb === "number" && Number.isFinite(a.sizeGb)
+					? a.sizeGb
+					: 0;
+			const bSize =
+				typeof b.sizeGb === "number" && Number.isFinite(b.sizeGb)
+					? b.sizeGb
+					: 0;
+			return aSize - bSize || a.id.localeCompare(b.id);
+		})[0];
 	return installedCatalog ?? recommendedChatModel();
 }
 

--- a/plugins/plugin-local-inference/src/services/routing-policy.test.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.test.ts
@@ -365,4 +365,19 @@ describe("assessVoiceModality (#12253 voice-modality visibility)", () => {
 		expect(result.viable).toBe(false);
 		expect(result.reason).toBe("device-tier-unknown");
 	});
+
+	it("sorts eligible candidates safely when priority contains NaN", () => {
+		const candidates = [
+			registration("provider-nan", NaN),
+			registration("provider-valid", 100),
+		];
+		const pick = policyEngine.pickProvider({
+			modelType: "TEXT_LARGE",
+			policy: "manual",
+			preferredProvider: null,
+			candidates,
+			selfProvider: "eliza-router",
+		});
+		expect(pick?.provider).toBe("provider-valid");
+	});
 });

--- a/plugins/plugin-local-inference/src/services/routing-policy.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.ts
@@ -292,10 +292,17 @@ class PolicyEngine {
 		const eligible = args.candidates
 			.filter((c) => c.provider !== args.selfProvider)
 			.slice()
-			// Defensive sort — real callers already sort, but test fixtures and
-			// non-registry callers might not, and a silent "pick-wrong" would be
-			// worse than the extra O(n log n).
-			.sort((a, b) => b.priority - a.priority);
+			.sort((a, b) => {
+				const bPriority =
+					typeof b.priority === "number" && Number.isFinite(b.priority)
+						? b.priority
+						: 0;
+				const aPriority =
+					typeof a.priority === "number" && Number.isFinite(a.priority)
+						? a.priority
+						: 0;
+				return bPriority - aPriority || a.provider.localeCompare(b.provider);
+			});
 		if (eligible.length === 0) return null;
 
 		switch (args.policy) {


### PR DESCRIPTION
## Summary

Validates numeric model sizes and routing priorities with `Number.isFinite(...)` across chat model recommendation, installed model fallback, and policy engine candidate sorting (`plugins/plugin-local-inference/src/local-inference-routes.ts:984, 986, 1148`, `plugins/plugin-local-inference/src/services/routing-policy.ts:298`) to prevent `NaN` comparator return values when candidate records contain missing or non-numeric values.

## Changes

- In `plugins/plugin-local-inference/src/local-inference-routes.ts:984, 986, 1148`, guard `sizeGb` numeric comparisons with `Number.isFinite(...)` and fallback to 0 before model ID tiebreaking.
- In `plugins/plugin-local-inference/src/services/routing-policy.ts:298`, guard `priority` numeric comparison with `Number.isFinite(...)` and fallback to 0 before provider name tiebreaking.
- In `plugins/plugin-local-inference/src/services/routing-policy.test.ts`, add unit test verifying that policy candidate selection gracefully handles `NaN` priorities while preserving strict total ordering.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`afddd32eb4`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-local-inference/src/services/routing-policy.test.ts` | 22 pass (22 tests) | 23 pass (23 tests) |
| `bunx @biomejs/biome check plugins/plugin-local-inference/src/services/routing-policy.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-local-inference/src/local-inference-routes.ts:980-995`
- `plugins/plugin-local-inference/src/services/routing-policy.ts:290-305`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric sizes/priorities are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Local inference plugin routing and route service; no UI layout touched)
- [x] `audit:browser` — N/A (Model recommendation sort comparators)
- [x] `build` — Clean build across workspace
- [x] `test` — 23/23 pass in `routing-policy.test.ts`
- [x] `lint` — Biome clean
