### PR TITLE
fix(scenario-runner): do not import scenario-local fixture plugins at factory time

### DIFF
--- a/packages/scenario-runner/src/executor.encoding.test.ts
+++ b/packages/scenario-runner/src/executor.encoding.test.ts
@@ -30,6 +30,7 @@ vi.mock("./redaction.ts", () => ({
 }));
 vi.mock("./required-plugins.ts", () => ({
   assertProviderQualifiedPluginPackages: vi.fn(),
+  isResolvablePluginPackage: (name: string) => name.startsWith("@"),
   loadScenarioRequiredPlugin: vi.fn(),
   pluginPackageIsRegistered: () => false,
   resolveRequiredPluginPackages: () => [],

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -67,6 +67,7 @@ import {
 import { redactForScenarioReport } from "./redaction.ts";
 import {
   assertProviderQualifiedPluginPackages,
+  isResolvablePluginPackage,
   loadScenarioRequiredPlugin,
   pluginPackageIsRegistered,
   resolveRequiredPluginPackages,
@@ -2887,7 +2888,7 @@ export async function runScenario(
     // it as missing and skip a scenario whose required plugin is in fact loaded.
     const autoLoaded = new Set<string>();
     for (const pkg of requiredPlugins) {
-      if (!pkg.startsWith("@")) continue;
+      if (!isResolvablePluginPackage(pkg)) continue;
       if (pluginPackageIsRegistered(runtime, pkg)) continue;
       try {
         const candidate = await loadScenarioRequiredPlugin(pkg, "simulated");

--- a/packages/scenario-runner/src/required-plugins.test.ts
+++ b/packages/scenario-runner/src/required-plugins.test.ts
@@ -1,10 +1,16 @@
-/** Tests declared production-plugin resolution and pre-initialization runtime registration. */
+/**
+ * Tests declared production-plugin resolution and pre-initialization runtime
+ * registration, including the fixture-name skip the runtime factory and the
+ * executor share. Real package imports against a fake runtime.
+ */
 
 import type { AgentRuntime, Plugin } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   assertSharedRuntimePluginBatchSafe,
+  isResolvablePluginPackage,
   registerScenarioRequiredPlugins,
+  resolveRequiredPluginPackages,
 } from "./required-plugins.ts";
 
 describe("scenario required plugin registration", () => {
@@ -30,6 +36,74 @@ describe("scenario required plugin registration", () => {
     expect(plugins[0]?.actions?.map((action) => action.name)).toContain(
       "MAPS_SAVE",
     );
+  });
+
+  // Scenario-local fixture plugins (packages/test/scenarios/convo/*.scenario.ts
+  // declare "echo-test" and "greet-test"; the orchestrator scenarios declare
+  // "orchestrator-*-scenario") exist only once the scenario's seed runs, so
+  // importing them at factory time aborted the whole batch before any
+  // scenario executed.
+  it("skips scenario-local fixture plugin names instead of importing them", async () => {
+    const scenario = {
+      id: "fixture-plugin",
+      title: "fixture plugin",
+      domain: "other",
+      turns: [],
+      requires: {
+        plugins: [
+          "echo-test",
+          "orchestrator-watchdog-scenario",
+          "@elizaos/plugin-maps",
+        ],
+      },
+    } as const;
+    const plugins: Plugin[] = [];
+    const registerPlugin = vi.fn(async (plugin: Plugin) => {
+      plugins.push(plugin);
+    });
+    const runtime = { plugins, registerPlugin } as unknown as Pick<
+      AgentRuntime,
+      "plugins" | "registerPlugin"
+    >;
+
+    await expect(
+      registerScenarioRequiredPlugins(
+        runtime,
+        resolveRequiredPluginPackages(scenario),
+        "simulated",
+      ),
+    ).resolves.toEqual(["@elizaos/plugin-maps"]);
+    expect(registerPlugin).toHaveBeenCalledOnce();
+    expect(plugins.map((plugin) => plugin.name)).toEqual(["maps"]);
+  });
+
+  it("still fails clearly on a genuinely missing package plugin", async () => {
+    const registerPlugin = vi.fn(async (_plugin: Plugin) => undefined);
+    const runtime = { plugins: [], registerPlugin } as unknown as Pick<
+      AgentRuntime,
+      "plugins" | "registerPlugin"
+    >;
+
+    await expect(
+      registerScenarioRequiredPlugins(
+        runtime,
+        ["@elizaos/plugin-does-not-exist"],
+        "simulated",
+      ),
+    ).rejects.toThrow(/@elizaos\/plugin-does-not-exist/u);
+    expect(registerPlugin).not.toHaveBeenCalled();
+  });
+
+  it("classifies declared names the same way the executor guard does", () => {
+    expect(isResolvablePluginPackage("@elizaos/plugin-maps")).toBe(true);
+    expect(
+      isResolvablePluginPackage("@elizaos/plugin-meetings/test-support"),
+    ).toBe(true);
+    expect(isResolvablePluginPackage("echo-test")).toBe(false);
+    expect(isResolvablePluginPackage("greet-test")).toBe(false);
+    expect(
+      isResolvablePluginPackage("orchestrator-completion-residuals-scenario"),
+    ).toBe(false);
   });
 
   it("does not register an already-present declared plugin twice", async () => {

--- a/packages/scenario-runner/src/required-plugins.ts
+++ b/packages/scenario-runner/src/required-plugins.ts
@@ -3,6 +3,12 @@
  * provider-qualified profile accepts only installable production packages and
  * registers them before runtime initialization; simulated runs retain the
  * small compatibility wrapper needed by existing app-control fixtures.
+ *
+ * A scenario's `requires.plugins` mixes two kinds of name: resolvable package
+ * names the runner imports and registers, and scenario-local fixture plugin
+ * names that only the scenario's own seed can register (isResolvablePluginPackage
+ * tells them apart). Fixture names are never imported here; the executor
+ * verifies them after seeding.
  */
 
 import type { Action, AgentRuntime, Plugin } from "@elizaos/core";
@@ -34,6 +40,17 @@ function isPlugin(value: unknown): value is Plugin {
     typeof obj.init === "function" ||
     (obj.models !== null && typeof obj.models === "object")
   );
+}
+
+/**
+ * Whether a declared plugin name is a resolvable package (scoped, importable,
+ * registered by the runner before runtime initialization) rather than a
+ * scenario-local fixture plugin (a bare name such as "echo-test" that only the
+ * scenario's seed can register, so importing it can only fail). Shared by the
+ * runtime factory and the executor so both skip the same names.
+ */
+export function isResolvablePluginPackage(packageName: string): boolean {
+  return packageName.startsWith("@");
 }
 
 export function resolveRequiredPluginPackages(
@@ -189,7 +206,11 @@ export async function loadScenarioRequiredPlugin(
   return candidate;
 }
 
-/** Registers every declared package once before scenario runtime startup. */
+/**
+ * Registers every declared resolvable package once before scenario runtime
+ * startup and returns the names that are registered afterwards. Scenario-local
+ * fixture names are skipped, not reported: their seed has not run yet.
+ */
 export async function registerScenarioRequiredPlugins(
   runtime: Pick<AgentRuntime, "plugins" | "registerPlugin">,
   packageNames: readonly string[],
@@ -197,6 +218,7 @@ export async function registerScenarioRequiredPlugins(
 ): Promise<string[]> {
   const registered: string[] = [];
   for (const packageName of packageNames) {
+    if (!isResolvablePluginPackage(packageName)) continue;
     if (!pluginPackageIsRegistered(runtime, packageName)) {
       const plugin = await loadScenarioRequiredPlugin(
         packageName,


### PR DESCRIPTION
# Relates to

Scenario runner batch runs (`test:corpus:pr:e2e`, `test:orchestrator:pr:e2e`) — found by a keyless deterministic sweep over every scenario directory.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`a0f04a5c554`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**Low.** One predicate, shared by two existing call sites that already embodied it separately. Resolvable (scoped) package names are imported and registered exactly as before; a genuinely missing npm plugin still fails with the resolver error naming the package; a fixture name on a provider-qualified run still fails the post-init declared-plugin check. Only the factory-time `await import()` of bare fixture names changes, and that import could only ever throw.

# Background

## What does this PR do?

A scenario's `requires.plugins` mixes two kinds of name: resolvable package names the runner imports and registers before runtime initialization, and scenario-local fixture plugin names (`echo-test`, `orchestrator-completion-residuals-scenario`, …) that only the scenario's own seed can register. `executor.ts` already skips the bare names for exactly that reason ("Seeds may register fixture plugins"), but `registerScenarioRequiredPlugins` (`required-plugins.ts`, called from `runtime-factory.ts` before `runtime.initialize()`) had no such guard: `cli.ts` unions every discovered scenario's `requires.plugins`, so one fixture name anywhere in a directory made the CLI die with `[eliza-scenarios] fatal: ResolveMessage: Cannot find package '<name>'` before any scenario ran, and the whole batch produced no reports.

Fix: one exported predicate `isResolvablePluginPackage(name)` in `required-plugins.ts`, used by the executor guard (replacing its inline `startsWith("@")`) and by `registerScenarioRequiredPlugins`, which now skips fixture names and returns only the names actually registered. The `executor.encoding.test.ts` core mock gained the new export.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation; the module header explains the two kinds of plugin name.

# Testing

## Where should a reviewer start?

`packages/scenario-runner/src/required-plugins.ts` (`isResolvablePluginPackage`, the skip in `registerScenarioRequiredPlugins`), then `executor.ts` (same predicate), then the three new cases in `required-plugins.test.ts`.

## Detailed testing steps

- `cd packages/scenario-runner && bunx vitest run src/required-plugins.test.ts` → 9/9 (6 existing + 3 new: fixture names skipped at factory time, a missing real package still fails naming it, resolvable names still registered).
- Batch evidence, `SCENARIO_USE_DETERMINISTIC_MODEL=1 … --lane pr-deterministic`:
  - `plugins/plugin-agent-orchestrator/test/scenarios`: before — discovered 15, `fatal: ResolveMessage: Cannot find package 'orchestrator-completion-residuals-scenario'`, 0 reports; after — 15/15 executed, 15 reports + matrix.json (12 passed / 3 failed / 0 skipped).
  - `packages/test/scenarios`: before — discovered 7, fatal `Cannot find package 'echo-test'`, 0 reports; after — 7/7 executed, 7 reports + matrix.json. Their per-scenario assertion failures reproduce identically on pristine develop when run one at a time (checked `reminder.escalation.intensity-up` both ways) — develop drift, separate from this fix.
- Scenario-runner unit lane 484/485 tests; biome clean on the four files.

# Evidence Gate

<!-- evidence-head:703bbb7074721acfe5e953ff62001b1fb43b2e09 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The before/after batch logs above (`[eliza-scenarios] fatal: ResolveMessage…` with 0 reports, then 15/15 and 7/7 executed with matrix.json written).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Scenario reports + `matrix.json` now produced for both directories where none could be before.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The before/after batch logs above (`[eliza-scenarios] fatal: ResolveMessage…` with 0 reports, then 15/15 and 7/7 executed with matrix.json written).

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- Pre-existing on `origin/develop` (stash → rerun): `executor.encoding.test.ts` cannot load because the `@elizaos/core` mock lacks `DOCUMENT_LIST_QUERY_CAPABILITY_VERSION`; `echo-assertion-integrity.test.ts` fails on five `packages/test/scenarios/conversation-quality/convq.*` files; two TS18048 in `packages/agent/src/providers/recent-conversations.ts:158`. Not touched here.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

