### PR TITLE
fix(computeruse): safe NaN handling in scene OCR confidence sort comparator

### DIFF
--- a/plugins/plugin-computeruse/src/scene/serialize.test.ts
+++ b/plugins/plugin-computeruse/src/scene/serialize.test.ts
@@ -157,4 +157,13 @@ describe("serializeSceneForPrompt", () => {
     expect(keptApps[0]?.window_count).toBe(2);
     expect(keptApps[0]?.windows).toHaveLength(2);
   });
+
+  it("sorts OCR boxes safely when confidence contains NaN", () => {
+    const ocr = [ocrBox(1, NaN, 0), ocrBox(2, 0.95, 0)];
+    const parsed = parseFenced(serializeSceneForPrompt(baseScene({ ocr })));
+    const kept = parsed.ocr as Array<{ text: string; conf?: number }>;
+    expect(kept).toHaveLength(2);
+    expect(kept[0]?.text).toBe("line 2");
+    expect(kept[1]?.text).toBe("line 1");
+  });
 });

--- a/plugins/plugin-computeruse/src/scene/serialize.ts
+++ b/plugins/plugin-computeruse/src/scene/serialize.ts
@@ -36,7 +36,13 @@ export function serializeSceneForPrompt(
   }
   const completeOcr: typeof scene.ocr = [];
   for (const [, arr] of ocrByDisplay) {
-    arr.sort((a, b) => b.conf - a.conf);
+    arr.sort((a, b) => {
+      const bConf =
+        typeof b.conf === "number" && Number.isFinite(b.conf) ? b.conf : 0;
+      const aConf =
+        typeof a.conf === "number" && Number.isFinite(a.conf) ? a.conf : 0;
+      return bConf - aConf || a.text.localeCompare(b.text);
+    });
     completeOcr.push(...arr);
   }
 


### PR DESCRIPTION
## Summary

Validates numeric OCR confidence ratings with `Number.isFinite(...)` in `plugins/plugin-computeruse/src/scene/serialize.ts:39` to prevent `NaN` comparator return values from corrupting OCR bounding box prioritization when engines report missing or invalid confidence numbers.

## Changes

- In `plugins/plugin-computeruse/src/scene/serialize.ts:39`, guard `conf` numeric comparison with `Number.isFinite(...)` and fallback to 0 before text tiebreaking.
- In `plugins/plugin-computeruse/src/scene/serialize.test.ts`, add unit test verifying that `serializeSceneForPrompt` gracefully sorts OCR boxes when confidence ratings evaluate to `NaN` while preserving strict total ordering.

## Exact-head verification

| Check | Base (`origin/develop`) | Head (`fc09b47c74`) |
| --- | --- | --- |
| `bunx vitest run plugins/plugin-computeruse/src/scene/serialize.test.ts` | 5 pass (5 tests) | 6 pass (6 tests) |
| `bunx @biomejs/biome check plugins/plugin-computeruse/src/scene/serialize.ts` | 0 errors | 0 errors |

## Reviewer start

- `plugins/plugin-computeruse/src/scene/serialize.ts:35-45`
- `plugins/plugin-computeruse/src/scene/serialize.test.ts:155-170`

## Risks

Low. Fallback to 0 ensures invalid or non-numeric confidence ratings are sorted predictably without breaking comparison transitivity.

## Attribution

Authored by @byt61.

## Evidence Gate

- [x] `audit:app` — N/A (Computer use plugin scene serialization; no UI layout touched)
- [x] `audit:browser` — N/A (Scene OCR confidence sort comparator)
- [x] `build` — Clean build across workspace
- [x] `test` — 6/6 pass in `serialize.test.ts`
- [x] `lint` — Biome clean
