### PR TITLE
fix(cloud): gate, dedupe, and degrade inbound Blooio media vision

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.ledger.pglite.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.ledger.pglite.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Proves the inbound-media admission ledger at the real boundary: the trusted
+ * messaging route, the real enrichment orchestrator and describe helper, and
+ * the production repository against isolated PGlite with the real 0310
+ * migration. Only the network edges are faked (the SSRF-guarded fetch, the
+ * vision provider factory, and the AI SDK call) plus the unrelated turn
+ * collaborators. Pinned here: a redelivery reuses the stored description
+ * without a second provider call, a body-stream failure degrades to the raw
+ * media text with a 200 and a recorded terminal failure, the per-sender and
+ * per-connector daily ceilings deny at the route, and a ledger outage fails
+ * closed without spending or failing the delivery.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+setDefaultTimeout(120_000);
+
+const ORG_A = "73000000-0000-4000-8000-000000000001";
+const ORG_B = "73000000-0000-4000-8000-000000000002";
+const USER_A = "73000000-0000-4000-8000-000000000011";
+const USER_B = "73000000-0000-4000-8000-000000000012";
+const PHONE_A = "+15551234567";
+const PHONE_B = "+15557654321";
+const CONNECTOR_ID = "+15550001111";
+const MEDIA_URL = "https://media.blooio.com/files/photo-1.jpeg";
+const RAW_MEDIA_MESSAGE = `[media: ${MEDIA_URL}]`;
+const DESCRIPTION = "A tabby cat sitting on a mechanical keyboard.";
+
+const resolvePersonalDelivery = mock(
+  async (params: { phoneNumber?: string }) =>
+    params.phoneNumber === PHONE_B
+      ? {
+          userId: USER_B,
+          organizationId: ORG_B,
+          dedicatedTarget: null,
+          isNew: false,
+          resolution: "single-query-repeat" as const,
+        }
+      : {
+          userId: USER_A,
+          organizationId: ORG_A,
+          dedicatedTarget: null,
+          isNew: false,
+          resolution: "single-query-repeat" as const,
+        },
+);
+const sharedRestMessageSend = mock(async (..._args: unknown[]) => ({
+  text: "hello from Eliza",
+}));
+const namespace = {
+  getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
+};
+const runtimeExecutionCtx = {
+  waitUntil: mock((_promise: Promise<unknown>) => undefined),
+};
+
+// Network edges of the describe helper: the SSRF-guarded fetch and the
+// vision provider. Everything between the route and these edges is real.
+const safeFetch = mock(
+  async (_url: string, _init?: RequestInit): Promise<Response> =>
+    new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    }),
+);
+const getLanguageModel = mock((_model: string): unknown => "vision-model");
+const generateText = mock(
+  async (
+    _options: unknown,
+  ): Promise<{ text: string; finishReason: string }> => ({
+    text: DESCRIPTION,
+    finishReason: "stop",
+  }),
+);
+const actualSafeFetch = await import("@/lib/security/safe-fetch");
+mock.module("@/lib/security/safe-fetch", () => ({
+  ...actualSafeFetch,
+  safeFetch,
+}));
+const actualLanguageModel = await import("@/lib/providers/language-model");
+mock.module("@/lib/providers/language-model", () => ({
+  ...actualLanguageModel,
+  getLanguageModel,
+}));
+const actualAi = await import("ai");
+mock.module("ai", () => ({ ...actualAi, generateText }));
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppUserService: { resolvePersonalDelivery },
+}));
+const { sharedTurnServerTiming } = await import(
+  "@/lib/services/shared-runtime/shared-rest-adapter"
+);
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  sharedRestMessageSend,
+  sharedTurnServerTiming,
+}));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches: mock(async () => undefined),
+}));
+mock.module("@/lib/services/eliza-app/onboarding-chat", () => ({
+  runOnboardingChat: mock(async () => ({
+    loginUrl: "https://cloud-staging.eliza.app/get-started",
+  })),
+}));
+mock.module("@/lib/services/agent-tier-upgrade-target", () => ({
+  findActivePersonalDedicatedTarget: mock(async () => null),
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: async () => ({ allowed: true, balance: 10 }),
+}));
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: async () => ({ ok: true, required: false }),
+}));
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentResumeOnce: mock(async () => ({ created: true })),
+    enqueueAgentWakeOnce: mock(async () => ({ created: true })),
+    triggerImmediate: mock(async () => undefined),
+  },
+}));
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    bridge: mock(async () => ({
+      jsonrpc: "2.0",
+      id: "x",
+      result: { text: "" },
+    })),
+    importCanonicalConversation: mock(async () => null),
+  },
+}));
+mock.module("@/lib/services/shared-runtime/conversation-coordinator", () => ({
+  coordinateSharedHistory: mock(async () => []),
+}));
+mock.module("@/db/repositories/personal-shared-groups", () => ({
+  personalSharedGroupsRepository: {
+    issueClaim: mock(async () => undefined),
+    consumeClaimAndBind: mock(async () => ({ status: "invalid" })),
+    resolveBinding: mock(async () => null),
+    setResponsePolicy: mock(async () => null),
+    revokeBinding: mock(async () => false),
+    applyMembershipChange: mock(async () => null),
+    recordDeliveryReceipts: mock(async () => 0),
+    hasDeliveryReceipt: mock(async () => false),
+  },
+}));
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  resolveSharedRuntimeWorkerRequestContext: () => ({
+    namespace,
+    executionCtx: runtimeExecutionCtx,
+  }),
+}));
+
+const { closeDatabaseConnectionsForTests, getPgliteClientForTests } =
+  await import("@/db/client");
+const { default: app } = await import("./route");
+const executionCtx = { waitUntil() {}, passThroughOnException() {}, props: {} };
+
+function request(body: unknown, env: Record<string, unknown> = {}) {
+  return app.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-secret",
+        "content-type": "application/json",
+        "x-eliza-trace-id": "11111111-1111-4111-8111-111111111111",
+      },
+      body: JSON.stringify(body),
+    },
+    {
+      INTERNAL_SECRET: "test-secret",
+      SHARED_RUNTIME_CONVERSATIONS: namespace,
+      ELIZA_APP_INBOUND_MEDIA_VISION: "true",
+      ...env,
+    } as never,
+    executionCtx as never,
+  );
+}
+
+function blooioDelivery(
+  messageId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR_ID,
+    phoneNumber: PHONE_A,
+    messageId: `blooio:eliza-app:${messageId}`,
+    message: RAW_MEDIA_MESSAGE,
+    mediaUrls: [MEDIA_URL],
+    ...overrides,
+  };
+}
+
+async function deliver(
+  messageId: string,
+  overrides: Record<string, unknown> = {},
+  env: Record<string, unknown> = {},
+): Promise<string> {
+  sharedRestMessageSend.mockClear();
+  const response = await request(blooioDelivery(messageId, overrides), env);
+  expect(response.status).toBe(200);
+  expect(response.headers.get("X-Eliza-Failure-Stage")).toBeNull();
+  expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+  return sharedRestMessageSend.mock.calls[0]?.[2] as string;
+}
+
+async function ledgerRow(messageId: string) {
+  const { rows } = await getPgliteClientForTests().query<{
+    state: string;
+    description: string | null;
+    failure_reason: string | null;
+    attempt_count: number;
+    organization_id: string;
+  }>(
+    `SELECT state, description, failure_reason, attempt_count, organization_id
+     FROM personal_shared_inbound_media_descriptions WHERE source_message_id = $1`,
+    [`blooio:eliza-app:${messageId}`],
+  );
+  return rows[0];
+}
+
+async function quotaRows() {
+  const { rows } = await getPgliteClientForTests().query<{
+    scope: string;
+    scope_key: string;
+    image_count: number;
+  }>(
+    `SELECT scope, scope_key, image_count FROM personal_shared_inbound_media_quotas
+     ORDER BY scope, scope_key`,
+  );
+  return rows;
+}
+
+const ENRICHED = `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n${DESCRIPTION}`;
+
+beforeAll(async () => {
+  const database = getPgliteClientForTests();
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+  `);
+  const migration = await Bun.file(
+    new URL(
+      "../../../../../shared/src/db/migrations/0310_personal_shared_inbound_media_admission.sql",
+      import.meta.url,
+    ),
+  ).text();
+  await database.exec(migration);
+});
+
+beforeEach(async () => {
+  await getPgliteClientForTests().exec(`
+    TRUNCATE personal_shared_inbound_media_descriptions,
+      personal_shared_inbound_media_quotas,
+      users,
+      organizations CASCADE;
+    INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
+    INSERT INTO users (id) VALUES ('${USER_A}'), ('${USER_B}');
+  `);
+  safeFetch.mockClear();
+  safeFetch.mockImplementation(
+    async () =>
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+  );
+  generateText.mockClear();
+  generateText.mockResolvedValue({ text: DESCRIPTION, finishReason: "stop" });
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("inbound media admission ledger through the messaging route", () => {
+  test("a redelivery of the same connector message id reuses the stored description without re-spending", async () => {
+    expect(await deliver("message-1")).toBe(ENRICHED);
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(await ledgerRow("message-1")).toMatchObject({
+      state: "described",
+      description: DESCRIPTION,
+      organization_id: ORG_A,
+    });
+
+    // The provider redelivers (or the gateway reopens) the same message.
+    expect(await deliver("message-1")).toBe(ENRICHED);
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(await quotaRows()).toEqual([
+      {
+        scope: "connector",
+        scope_key: `blooio:eliza-app:${CONNECTOR_ID}`,
+        image_count: 1,
+      },
+      { scope: "sender", scope_key: ORG_A, image_count: 1 },
+    ]);
+
+    // A redelivery carrying different media under the same id is not reused
+    // and, being the same message, is not a second claim either.
+    expect(
+      await deliver("message-1", {
+        mediaUrls: ["https://media.blooio.com/files/photo-2.jpeg"],
+        message: "[media: https://media.blooio.com/files/photo-2.jpeg]",
+      }),
+    ).toBe("[media: https://media.blooio.com/files/photo-2.jpeg]");
+    expect(generateText).toHaveBeenCalledTimes(1);
+  });
+
+  test("a body stream that fails mid-read keeps the raw media message with a 200 and records the failure", async () => {
+    let pulls = 0;
+    safeFetch.mockImplementation(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (pulls++ === 0) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+              } else {
+                controller.error(
+                  new DOMException(
+                    "The operation was aborted due to timeout",
+                    "TimeoutError",
+                  ),
+                );
+              }
+            },
+          }),
+          { status: 200, headers: { "content-type": "image/jpeg" } },
+        ),
+    );
+    expect(await deliver("message-2")).toBe(RAW_MEDIA_MESSAGE);
+    expect(generateText).not.toHaveBeenCalled();
+    expect(await ledgerRow("message-2")).toMatchObject({
+      state: "failed",
+      failure_reason: "media_read_failed",
+      description: null,
+    });
+
+    // The redelivery neither refetches nor retries the terminal attempt.
+    safeFetch.mockClear();
+    expect(await deliver("message-2")).toBe(RAW_MEDIA_MESSAGE);
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("the sender ceiling is enforced at the route with no provider call past it", async () => {
+    const env = { ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "2" };
+    expect(await deliver("message-3a", {}, env)).toBe(ENRICHED);
+    expect(await deliver("message-3b", {}, env)).toBe(ENRICHED);
+    expect(await deliver("message-3c", {}, env)).toBe(RAW_MEDIA_MESSAGE);
+    expect(safeFetch).toHaveBeenCalledTimes(2);
+    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(await ledgerRow("message-3c")).toBeUndefined();
+    expect(await quotaRows()).toEqual([
+      {
+        scope: "connector",
+        scope_key: `blooio:eliza-app:${CONNECTOR_ID}`,
+        image_count: 2,
+      },
+      { scope: "sender", scope_key: ORG_A, image_count: 2 },
+    ]);
+    // Another sender of the same connector still has its own budget.
+    expect(await deliver("message-3d", { phoneNumber: PHONE_B }, env)).toBe(
+      ENRICHED,
+    );
+    expect(generateText).toHaveBeenCalledTimes(3);
+  });
+
+  test("the connector ceiling bounds pooled spend across every sender", async () => {
+    const env = { ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: "2" };
+    expect(await deliver("message-4a", {}, env)).toBe(ENRICHED);
+    expect(await deliver("message-4b", { phoneNumber: PHONE_B }, env)).toBe(
+      ENRICHED,
+    );
+    expect(await deliver("message-4c", { phoneNumber: PHONE_B }, env)).toBe(
+      RAW_MEDIA_MESSAGE,
+    );
+    expect(await deliver("message-4d", {}, env)).toBe(RAW_MEDIA_MESSAGE);
+    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(await quotaRows()).toEqual([
+      {
+        scope: "connector",
+        scope_key: `blooio:eliza-app:${CONNECTOR_ID}`,
+        image_count: 2,
+      },
+      { scope: "sender", scope_key: ORG_A, image_count: 1 },
+      { scope: "sender", scope_key: ORG_B, image_count: 1 },
+    ]);
+  });
+
+  test("a zero ceiling denies every description while the flag stays on", async () => {
+    expect(
+      await deliver(
+        "message-5",
+        {},
+        { ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "0" },
+      ),
+    ).toBe(RAW_MEDIA_MESSAGE);
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(await ledgerRow("message-5")).toBeUndefined();
+  });
+
+  test("a ledger outage fails closed: raw turn, 200, no spend", async () => {
+    const database = getPgliteClientForTests();
+    await database.exec(
+      "ALTER TABLE personal_shared_inbound_media_quotas RENAME TO quotas_offline",
+    );
+    try {
+      expect(await deliver("message-6")).toBe(RAW_MEDIA_MESSAGE);
+    } finally {
+      await database.exec(
+        "ALTER TABLE quotas_offline RENAME TO personal_shared_inbound_media_quotas",
+      );
+    }
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+    // The claim transaction rolled back with the outage.
+    expect(await ledgerRow("message-6")).toBeUndefined();
+    // Once the ledger is back the same message is admitted normally.
+    expect(await deliver("message-6")).toBe(ENRICHED);
+    expect(generateText).toHaveBeenCalledTimes(1);
+  });
+
+  test("a dark flag never touches the ledger", async () => {
+    expect(
+      await deliver(
+        "message-7",
+        {},
+        { ELIZA_APP_INBOUND_MEDIA_VISION: undefined },
+      ),
+    ).toBe(RAW_MEDIA_MESSAGE);
+    expect(await ledgerRow("message-7")).toBeUndefined();
+    expect(await quotaRows()).toEqual([]);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
@@ -2,11 +2,15 @@
  * Pins Blooio inbound-media enrichment at the trusted messaging route: the
  * additive mediaUrls schema (allowlist re-validation), the flag-off/disabled
  * path staying byte-identical to the current media-URL text, the flag-on
- * described turn, and the degrade contract — a typed enrichment failure keeps
- * the user's turn instead of failing the delivery, and a dedicated-runtime
- * turn bypassing pooled-key vision entirely. Collaborators are mocked; the
- * describe helper's real typed errors are used so the route's instanceof
- * branches are the code under test.
+ * described turn, the admission contract — every ledger decision other than
+ * a fresh claim (reuse, in flight, exhausted, prior failure) and a missing
+ * decision keep the raw turn without a provider call — and the degrade
+ * contract: a typed enrichment failure keeps the user's turn instead of
+ * failing the delivery, and a dedicated-runtime turn bypasses pooled-key
+ * vision entirely. Collaborators are mocked; the describe helper's real typed
+ * errors drive the real enrichment orchestrator, and the admission ledger is
+ * an in-memory fake whose decisions are the code under test at this layer
+ * (the PGlite sibling proves the real ledger).
  */
 
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
@@ -52,8 +56,28 @@ const runtimeExecutionCtx = {
 const {
   InboundMediaDescriptionError,
   InboundMediaVisionDisabledError,
+  isInboundMediaVisionEnabled,
   MAX_INBOUND_MEDIA_IMAGES,
 } = await import("@/lib/services/eliza-app/describe-inbound-media");
+type LedgerAdmission =
+  import("@/db/repositories/personal-shared-inbound-media").InboundMediaDescriptionAdmission;
+type LedgerClaim =
+  import("@/db/repositories/personal-shared-inbound-media").InboundMediaDescriptionClaim;
+const LEDGER_CLAIM: LedgerClaim = {
+  id: "00000000-0000-4000-8000-0000000000aa",
+  claimToken: "00000000-0000-4000-8000-0000000000ab",
+  attempt: 1,
+};
+const ledgerAdmit = mock(
+  async (_input: unknown): Promise<LedgerAdmission> => ({
+    kind: "claimed",
+    claim: LEDGER_CLAIM,
+  }),
+);
+const ledgerComplete = mock(
+  async (_claim: LedgerClaim, _description: string) => true,
+);
+const ledgerFail = mock(async (_claim: LedgerClaim, _reason: string) => true);
 const { isAllowedBlooioMediaUrl } = await import(
   "@/lib/services/eliza-app/blooio-media-allowlist"
 );
@@ -133,7 +157,15 @@ mock.module("@/lib/services/eliza-app/describe-inbound-media", () => ({
   describeInboundImageMedia,
   InboundMediaDescriptionError,
   InboundMediaVisionDisabledError,
+  isInboundMediaVisionEnabled,
   MAX_INBOUND_MEDIA_IMAGES,
+}));
+mock.module("@/db/repositories/personal-shared-inbound-media", () => ({
+  personalSharedInboundMediaRepository: {
+    admit: ledgerAdmit,
+    complete: ledgerComplete,
+    fail: ledgerFail,
+  },
 }));
 
 const { default: app } = await import("./route");
@@ -142,7 +174,7 @@ const executionCtx = { waitUntil() {}, passThroughOnException() {}, props: {} };
 const MEDIA_URL = "https://media.blooio.com/files/photo-1.jpeg";
 const RAW_MEDIA_MESSAGE = `[media: ${MEDIA_URL}]`;
 
-function request(body: unknown) {
+function request(body: unknown, env: Record<string, unknown> = {}) {
   return app.request(
     "/",
     {
@@ -158,6 +190,7 @@ function request(body: unknown) {
       INTERNAL_SECRET: "test-secret",
       SHARED_RUNTIME_CONVERSATIONS: namespace,
       ELIZA_APP_INBOUND_MEDIA_VISION: "true",
+      ...env,
     } as never,
     executionCtx as never,
   );
@@ -189,10 +222,16 @@ describe("blooio inbound media enrichment at the messaging route", () => {
     prewarmPersonalSharedAgentTurnCaches.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
     bridge.mockClear();
+    ledgerAdmit.mockReset();
+    ledgerAdmit.mockResolvedValue({ kind: "claimed", claim: LEDGER_CLAIM });
+    ledgerComplete.mockReset();
+    ledgerComplete.mockResolvedValue(true);
+    ledgerFail.mockReset();
+    ledgerFail.mockResolvedValue(true);
     describeInboundImageMedia.mockReset();
     describeInboundImageMedia.mockImplementation(async () => {
       throw new InboundMediaVisionDisabledError(
-        "Inbound media vision is disabled for this deployment",
+        "Inbound media vision has no configured provider",
       );
     });
   });
@@ -200,6 +239,7 @@ describe("blooio inbound media enrichment at the messaging route", () => {
   test("schema accepts allowlisted https media URLs on a Blooio delivery", async () => {
     const response = await request(blooioDelivery());
     expect(response.status).toBe(200);
+    expect(ledgerAdmit).toHaveBeenCalledTimes(1);
     expect(describeInboundImageMedia).toHaveBeenCalledTimes(1);
     expect(describeInboundImageMedia.mock.calls[0]?.[1]).toEqual([MEDIA_URL]);
     const env = describeInboundImageMedia.mock.calls[0]?.[0] as Record<
@@ -253,17 +293,29 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       blooioDelivery({ mediaUrls: undefined, message: "hey eliza" }),
     );
     expect(response.status).toBe(200);
+    expect(ledgerAdmit).not.toHaveBeenCalled();
     expect(describeInboundImageMedia).not.toHaveBeenCalled();
     expect(deliveredMessage()).toBe("hey eliza");
   });
 
-  test("disabled vision keeps the turn byte-identical to the raw media text", async () => {
+  test("a dark flag keeps the raw media text without touching the ledger", async () => {
+    const response = await request(blooioDelivery(), {
+      ELIZA_APP_INBOUND_MEDIA_VISION: undefined,
+    });
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(ledgerAdmit).not.toHaveBeenCalled();
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+  });
+
+  test("an enabled flag without a provider keeps the turn byte-identical and records the claim", async () => {
     const response = await request(blooioDelivery());
     expect(response.status).toBe(200);
     expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(ledgerFail).toHaveBeenCalledWith(LEDGER_CLAIM, "vision_disabled");
   });
 
-  test("an enabled description enriches the turn as an attached-image block", async () => {
+  test("an enabled description enriches the turn as an attached-image block and settles the claim", async () => {
     describeInboundImageMedia.mockResolvedValue(
       "A tabby cat sitting on a mechanical keyboard.",
     );
@@ -273,6 +325,94 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n` +
         "A tabby cat sitting on a mechanical keyboard.",
     );
+    expect(ledgerAdmit).toHaveBeenCalledTimes(1);
+    expect(ledgerAdmit.mock.calls[0]?.[0]).toMatchObject({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550001111",
+      sourceMessageId: "blooio:eliza-app:message-42",
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      userId: "00000000-0000-4000-8000-000000000002",
+      imageCount: 1,
+    });
+    expect(ledgerComplete).toHaveBeenCalledWith(
+      LEDGER_CLAIM,
+      "A tabby cat sitting on a mechanical keyboard.",
+    );
+  });
+
+  test("a redelivery whose description is already stored is enriched without a provider call", async () => {
+    ledgerAdmit.mockResolvedValue({
+      kind: "reused",
+      description: "A tabby cat sitting on a mechanical keyboard.",
+    });
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(
+      `${RAW_MEDIA_MESSAGE}\n\n[Attached image description]\n` +
+        "A tabby cat sitting on a mechanical keyboard.",
+    );
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(ledgerComplete).not.toHaveBeenCalled();
+  });
+
+  test("every denied admission keeps the raw turn and never calls the provider", async () => {
+    describeInboundImageMedia.mockResolvedValue("must not be used");
+    const denials: LedgerAdmission[] = [
+      { kind: "in_flight" },
+      { kind: "previously_failed", reason: "media_fetch_failed" },
+      { kind: "media_mismatch" },
+      { kind: "exhausted", scope: "sender", limit: 20, used: 20, requested: 1 },
+      {
+        kind: "exhausted",
+        scope: "connector",
+        limit: 1000,
+        used: 1000,
+        requested: 1,
+      },
+    ];
+    for (const denial of denials) {
+      sharedRestMessageSend.mockClear();
+      ledgerAdmit.mockResolvedValue(denial);
+      const response = await request(blooioDelivery());
+      expect(response.status).toBe(200);
+      expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    }
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(ledgerComplete).not.toHaveBeenCalled();
+    expect(ledgerFail).not.toHaveBeenCalled();
+  });
+
+  test("a missing admission decision fails closed: raw turn, no spend, no 500", async () => {
+    describeInboundImageMedia.mockResolvedValue("must not be used");
+    ledgerAdmit.mockRejectedValue(new Error("primary database unreachable"));
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Eliza-Failure-Stage")).toBeNull();
+    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+  });
+
+  test("a malformed ceiling binding fails closed before the ledger is consulted", async () => {
+    describeInboundImageMedia.mockResolvedValue("must not be used");
+    const response = await request(blooioDelivery(), {
+      ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: "unlimited",
+    });
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(ledgerAdmit).not.toHaveBeenCalled();
+    expect(describeInboundImageMedia).not.toHaveBeenCalled();
+  });
+
+  test("ceiling bindings reach the ledger as the admission policy", async () => {
+    describeInboundImageMedia.mockResolvedValue("described");
+    await request(blooioDelivery(), {
+      ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "3",
+      ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: "40",
+    });
+    expect(ledgerAdmit.mock.calls[0]?.[0]).toMatchObject({
+      ceilings: { senderDailyImages: 3, connectorDailyImages: 40 },
+    });
   });
 
   test("a dedicated-runtime turn skips pooled-key vision and bridges the raw media text", async () => {
@@ -294,28 +434,31 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       },
     });
     expect(describeInboundImageMedia).not.toHaveBeenCalled();
+    expect(ledgerAdmit).not.toHaveBeenCalled();
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
     expect(bridge).toHaveBeenCalledTimes(1);
     expect(bridge.mock.calls[0]?.[2].params.text).toBe(RAW_MEDIA_MESSAGE);
   });
 
-  test("a typed enrichment failure degrades to the raw text without dropping the turn", async () => {
+  test("a typed enrichment failure degrades to the raw text and records the claim failure", async () => {
     const errorSpy = spyOn(logger, "error");
     describeInboundImageMedia.mockRejectedValue(
       new InboundMediaDescriptionError(
-        "Inbound media fetch failed",
-        "media_fetch_failed",
+        "Inbound media body read failed",
+        "media_read_failed",
       ),
     );
     const response = await request(blooioDelivery());
     expect(response.status).toBe(200);
     expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(ledgerFail).toHaveBeenCalledWith(LEDGER_CLAIM, "media_read_failed");
+    expect(ledgerComplete).not.toHaveBeenCalled();
     const degradeLog = errorSpy.mock.calls.find(
       ([message]) =>
         message ===
-        "[personal-shared-messaging] inbound media description failed",
+        "[inbound-media-enrichment] inbound media description failed",
     );
-    expect(degradeLog?.[1]).toMatchObject({ reason: "media_fetch_failed" });
+    expect(degradeLog?.[1]).toMatchObject({ reason: "media_read_failed" });
     errorSpy.mockRestore();
   });
 
@@ -327,5 +470,9 @@ describe("blooio inbound media enrichment at the messaging route", () => {
       "media_description",
     );
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    // The claim is left to its lease rather than recorded as a terminal
+    // outcome the bug did not actually produce.
+    expect(ledgerComplete).not.toHaveBeenCalled();
+    expect(ledgerFail).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -16,12 +16,8 @@ import { sha256Hex } from "@/lib/oidc/crypto";
 import { findActivePersonalDedicatedTarget } from "@/lib/services/agent-tier-upgrade-target";
 import { elizaAppUserService } from "@/lib/services/eliza-app";
 import { isAllowedBlooioMediaUrl } from "@/lib/services/eliza-app/blooio-media-allowlist";
-import {
-  describeInboundImageMedia,
-  InboundMediaDescriptionError,
-  InboundMediaVisionDisabledError,
-  MAX_INBOUND_MEDIA_IMAGES,
-} from "@/lib/services/eliza-app/describe-inbound-media";
+import { MAX_INBOUND_MEDIA_IMAGES } from "@/lib/services/eliza-app/describe-inbound-media";
+import { enrichInboundImageMedia } from "@/lib/services/eliza-app/inbound-media-enrichment";
 import { runOnboardingChat } from "@/lib/services/eliza-app/onboarding-chat";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { preparePersonalDedicatedDelivery } from "@/lib/services/personal-dedicated-delivery";
@@ -927,48 +923,25 @@ app.post("/", async (c) => {
       !dedicated
     ) {
       stage = "media_description";
-      // Unmetered pooled-key spend (same posture as the Whisper voice path
-      // above, but reachable by any inbound sender): production enablement of
-      // ELIZA_APP_INBOUND_MEDIA_VISION requires a per-sender/per-connector
-      // rate limit or billing-meter gate at this stage first.
-      try {
-        const description = await describeInboundImageMedia(
-          c.env,
-          parsed.data.mediaUrls,
-        );
-        deliveryMessage = `${deliveryMessage}\n\n[Attached image description]\n${description}`;
-        logger.info(
-          "[personal-shared-messaging] Blooio inbound media described",
-          {
-            mediaCount: parsed.data.mediaUrls.length,
-            userId: account.userId,
-          },
-        );
-      } catch (error) {
-        if (error instanceof InboundMediaVisionDisabledError) {
-          // Disabled is the fleet default, not a fault; the turn keeps the
-          // raw media-URL text the adapter synthesized.
-          logger.debug(
-            "[personal-shared-messaging] inbound media vision disabled",
-            { mediaCount: parsed.data.mediaUrls.length },
-          );
-        } else if (error instanceof InboundMediaDescriptionError) {
-          // error-policy:J4 enrichment is additive: an expected fetch/vision
-          // failure degrades to the current media-URL text instead of
-          // dropping the user's turn. Reported here because the turn still
-          // returns success to the connector.
-          logger.error(
-            "[personal-shared-messaging] inbound media description failed",
-            {
-              reason: error.reason,
-              mediaCount: parsed.data.mediaUrls.length,
-              userId: account.userId,
-              error: error.message,
-            },
-          );
-        } else {
-          throw error;
-        }
+      // Pooled-key spend is reachable by any inbound sender, so it sits behind
+      // the durable admission ledger: one idempotency claim per connector
+      // message id (a redelivery reuses the stored description instead of
+      // re-spending) and atomic per-sender/per-connector daily image
+      // ceilings. Every skip, including a missing admission decision, keeps
+      // the raw media-URL text the adapter synthesized; only an untyped bug
+      // fails the delivery.
+      const enrichment = await enrichInboundImageMedia({
+        env: c.env,
+        platform: "blooio",
+        project: parsed.data.project,
+        connectorAccountId: parsed.data.connectorAccountId,
+        sourceMessageId: parsed.data.messageId,
+        organizationId: account.organizationId,
+        userId: account.userId,
+        mediaUrls: parsed.data.mediaUrls,
+      });
+      if (enrichment.kind === "described") {
+        deliveryMessage = `${deliveryMessage}\n\n[Attached image description]\n${enrichment.description}`;
       }
     }
     if (deliveryMessage && groupActorLabel) {

--- a/packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/blooio-inbound-media-forward.test.ts
@@ -3,12 +3,14 @@
  * set to "true", allowlisted media URLs ride the personal-Shared POST body only
  * for Blooio one-to-one turns and those turns take the voice-style long-turn
  * retry posture (no status/transport re-POST that could overlap a still-running
- * vision route); with the flag unset the same image turn is byte-identical to a
- * plain text turn (no mediaUrls, full retry budget); group media events keep
- * the plain text-turn posture either way; and the gateway's runtime-local media
- * allowlist stays byte-identical to the canonical cloud-shared copy the Worker
- * route validates against. Deterministic fixtures with a mocked cloud fetch —
- * no live services.
+ * vision route); a lost Worker response reopens the durable webhook claim and
+ * the redelivery re-POSTs the identical enrichment idempotency key (messageId
+ * plus mediaUrls) the Worker's description ledger is keyed by; with the flag
+ * unset the same image turn is byte-identical to a plain text turn (no
+ * mediaUrls, full retry budget); group media events keep the plain text-turn
+ * posture either way; and the gateway's runtime-local media allowlist stays
+ * byte-identical to the canonical cloud-shared copy the Worker route validates
+ * against. Deterministic fixtures with a mocked cloud fetch — no live services.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
@@ -358,6 +360,99 @@ describe("blooio media turn retry posture", () => {
     for (const body of bodies) {
       expect("mediaUrls" in body).toBe(false);
     }
+  });
+});
+
+describe("blooio media turn redelivery idempotency key", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    for (const key of envKeys) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    mock.restore();
+  });
+
+  test("a lost Worker response reopens the claim and the redelivery forwards the same key", async () => {
+    configureEnv();
+    const event = createEvent("blooio", { mediaUrls: [MEDIA_URL] });
+    const redis = new MemoryRedis();
+    const adapter = createAdapter(event);
+    const bodies: Record<string, unknown>[] = [];
+    let lostResponses = 0;
+
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (request.url.endsWith("/api/internal/identity/resolve")) {
+        return new Response(JSON.stringify({ success: false }), {
+          status: 404,
+        });
+      }
+      if (
+        request.url.endsWith("/api/internal/eliza-app/personal-shared/messages")
+      ) {
+        bodies.push((await request.json()) as Record<string, unknown>);
+        if (bodies.length === 1) {
+          // The Worker ran (and may have spent on vision) but its response
+          // never reached the gateway.
+          lostResponses += 1;
+          throw new TypeError("fetch failed: socket hang up");
+        }
+        return Response.json({ data: { reply: "seen" } });
+      }
+      throw new Error(`Unexpected fetch: ${request.url}`);
+    }) as typeof fetch;
+    const deps = {
+      redis,
+      cloudBaseUrl: "https://api.elizacloud.ai",
+      getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+    };
+    const dedupKey = `webhook:blooio:${event.messageId}`;
+
+    const first = await handleWebhook(
+      requestFor(event),
+      adapter,
+      deps,
+      "eliza-app",
+    );
+    expect(first.status).toBe(200);
+    await waitFor(() => bodies.length === 1, "first personal Shared POST");
+    await waitFor(
+      () => !redis.store.has(dedupKey),
+      "reopened webhook claim after the lost response",
+    );
+    expect(lostResponses).toBe(1);
+    expect(adapter.replies).toEqual([]);
+
+    // The provider redelivers the same inbound message.
+    const second = await handleWebhook(
+      requestFor(event),
+      adapter,
+      deps,
+      "eliza-app",
+    );
+    expect(second.status).toBe(200);
+    await waitFor(
+      () => bodies.length === 2,
+      "redelivered personal Shared POST",
+    );
+    await waitFor(() => adapter.replies.length === 1, "redelivered reply");
+
+    // The Worker's description ledger is keyed by exactly this forwarded
+    // identity, so the redelivery resolves to the stored description.
+    expect(bodies[1]).toEqual(bodies[0]);
+    expect(bodies[1]).toMatchObject({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550001111",
+      messageId: `blooio:eliza-app:${event.messageId}`,
+      mediaUrls: [MEDIA_URL],
+    });
+    expect(redis.store.get(dedupKey)).toBe("delivered");
   });
 });
 

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -633,9 +633,13 @@ export async function handleWebhook(
           err.deliveryStatus === "failed")
       ) {
         try {
-          // The Shared endpoint is idempotent. Blooio also keys provider
-          // egress by the inbound message id, so a lost receipt response can
-          // safely reopen the webhook without sending a second text.
+          // The Shared endpoint is idempotent, including its pooled-key media
+          // enrichment: the Worker keys a durable description record by the
+          // forwarded `<platform>:<project>:<messageId>`, so a reopened
+          // delivery reuses the stored description instead of re-spending.
+          // Blooio also keys provider egress by the inbound message id, so a
+          // lost receipt response can safely reopen the webhook without
+          // sending a second text.
           await redis.del(dedupKey);
         } catch (cleanupError) {
           // error-policy:J7 The original delivery failure is already observed;
@@ -1088,11 +1092,14 @@ async function sendPersonalSharedReply(
     );
   }
   // Media turns mirror voice: the cloud route may spend fetch + vision + the
-  // model turn, so a re-POST can overlap a still-running route execution and
-  // re-run the unbilled vision call. Group Blooio events carry mediaUrls too
-  // but are never forwarded as media (no vision runs), and with the vision
-  // flag off no media is forwarded at all, so both keep the plain text-turn
-  // retry/timeout posture.
+  // model turn, so an inline re-POST can overlap a still-running route
+  // execution. The Worker's per-message description claim makes the overlap
+  // spend-safe (the second execution sees the live claim and keeps the raw
+  // text), but that raw turn would only race the enriched one, so media turns
+  // still hand provider/transport failures to the durable redelivery path.
+  // Group Blooio events carry mediaUrls too but are never forwarded as media
+  // (no vision runs), and with the vision flag off no media is forwarded at
+  // all, so both keep the plain text-turn retry/timeout posture.
   const isMediaTurn =
     inboundMediaVisionEnabled() &&
     adapter.platform === "blooio" &&

--- a/packages/cloud/shared/src/db/migrations/0310_personal_shared_inbound_media_admission.sql
+++ b/packages/cloud/shared/src/db/migrations/0310_personal_shared_inbound_media_admission.sql
@@ -1,0 +1,64 @@
+-- Durable admission ledger for pooled-key vision descriptions of inbound
+-- Personal Shared media: one idempotency record per connector message id and
+-- atomic per-day image counters for the sending account and the connector.
+
+CREATE TABLE IF NOT EXISTS personal_shared_inbound_media_descriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  platform text NOT NULL CHECK (platform IN ('blooio')),
+  project text NOT NULL,
+  connector_account_id text NOT NULL,
+  source_message_id text NOT NULL,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  media_digest text NOT NULL,
+  image_count integer NOT NULL CHECK (image_count > 0),
+  state text NOT NULL DEFAULT 'pending'
+    CHECK (state IN ('pending', 'described', 'failed')),
+  claim_token uuid NOT NULL,
+  lease_expires_at timestamptz NOT NULL,
+  attempt_count integer NOT NULL DEFAULT 1 CHECK (attempt_count > 0),
+  description text,
+  failure_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT personal_shared_inbound_media_descriptions_terminal_shape_check CHECK (
+    (
+      state = 'pending'
+      AND description IS NULL
+      AND failure_reason IS NULL
+      AND completed_at IS NULL
+    ) OR (
+      state = 'described'
+      AND description IS NOT NULL
+      AND failure_reason IS NULL
+      AND completed_at IS NOT NULL
+    ) OR (
+      state = 'failed'
+      AND description IS NULL
+      AND failure_reason IS NOT NULL
+      AND completed_at IS NOT NULL
+    )
+  )
+);
+
+COMMENT ON TABLE personal_shared_inbound_media_descriptions IS
+  'Enrichment idempotency record: at most one pooled-key vision claim per connector message id. A redelivery reuses a described row, skips a failed row, and may only reclaim a pending row after its lease expired.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS personal_shared_inbound_media_descriptions_source_uidx
+  ON personal_shared_inbound_media_descriptions
+  (platform, project, connector_account_id, source_message_id);
+CREATE INDEX IF NOT EXISTS personal_shared_inbound_media_descriptions_org_created_idx
+  ON personal_shared_inbound_media_descriptions (organization_id, created_at);
+
+CREATE TABLE IF NOT EXISTS personal_shared_inbound_media_quotas (
+  scope text NOT NULL CHECK (scope IN ('sender', 'connector')),
+  scope_key text NOT NULL,
+  day date NOT NULL,
+  image_count integer NOT NULL CHECK (image_count >= 0),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT personal_shared_inbound_media_quotas_pkey PRIMARY KEY (scope, scope_key, day)
+);
+
+COMMENT ON TABLE personal_shared_inbound_media_quotas IS
+  'UTC-day image counters consumed atomically (conditional upsert) before any pooled-key vision call; the ceilings live in the Worker bindings, the used totals live here.';

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2052,6 +2052,13 @@
       "when": 1794254400000,
       "tag": "0309_retire_legacy_bluebubbles_gateways",
       "breakpoints": true
+    },
+    {
+      "idx": 293,
+      "version": "7",
+      "when": 1794254400001,
+      "tag": "0310_personal_shared_inbound_media_admission",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/personal-shared-inbound-media-admission.test.ts
+++ b/packages/cloud/shared/src/db/migrations/personal-shared-inbound-media-admission.test.ts
@@ -1,0 +1,124 @@
+/** Applies the inbound-media admission ledger migration to real PGlite. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+
+const migration = await Bun.file(
+  new URL("./0310_personal_shared_inbound_media_admission.sql", import.meta.url),
+).text();
+const databases: PGlite[] = [];
+const ORG = "22222222-2222-4222-8222-222222222222";
+const USER = "33333333-3333-4333-8333-333333333333";
+
+async function database(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    INSERT INTO organizations (id) VALUES ('${ORG}');
+    INSERT INTO users (id) VALUES ('${USER}');
+  `);
+  await db.exec(migration);
+  return db;
+}
+
+function insertDescription(
+  db: PGlite,
+  columns: Record<string, string | number | null>,
+): Promise<unknown> {
+  const base: Record<string, string | number | null> = {
+    platform: "blooio",
+    project: "eliza-app",
+    connector_account_id: "+15550000001",
+    source_message_id: "blooio:eliza-app:msg-1",
+    organization_id: ORG,
+    user_id: USER,
+    media_digest: "digest",
+    image_count: 1,
+    claim_token: "44444444-4444-4444-8444-444444444444",
+    lease_expires_at: "2026-08-23T00:02:00.000Z",
+    ...columns,
+  };
+  const names = Object.keys(base);
+  return db.query(
+    `INSERT INTO personal_shared_inbound_media_descriptions (${names.join(", ")})
+     VALUES (${names.map((_, index) => `$${index + 1}`).join(", ")})`,
+    names.map((name) => base[name]),
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0310 Personal Shared inbound media admission", () => {
+  test("keeps one claim per connector message id", async () => {
+    const db = await database();
+    await insertDescription(db, {});
+    await expect(
+      insertDescription(db, { claim_token: "55555555-5555-4555-8555-555555555555" }),
+    ).rejects.toThrow();
+    // The same provider message id under another connector account is distinct.
+    await insertDescription(db, { connector_account_id: "+15550000002" });
+  });
+
+  test("rejects terminal rows whose shape contradicts their state", async () => {
+    const db = await database();
+    await expect(
+      insertDescription(db, { state: "described", description: null, completed_at: null }),
+    ).rejects.toThrow();
+    await expect(
+      insertDescription(db, {
+        state: "described",
+        description: "a cat",
+        failure_reason: "leftover",
+        completed_at: "2026-08-23T00:01:00.000Z",
+      }),
+    ).rejects.toThrow();
+    await expect(
+      insertDescription(db, {
+        state: "failed",
+        failure_reason: null,
+        completed_at: "2026-08-23T00:01:00.000Z",
+      }),
+    ).rejects.toThrow();
+    await expect(
+      insertDescription(db, { state: "pending", description: "early" }),
+    ).rejects.toThrow();
+    await expect(insertDescription(db, { image_count: 0 })).rejects.toThrow();
+    await expect(insertDescription(db, { platform: "telegram" })).rejects.toThrow();
+    await insertDescription(db, {
+      state: "described",
+      description: "a cat",
+      completed_at: "2026-08-23T00:01:00.000Z",
+    });
+  });
+
+  test("cascades ledger rows with their account and keeps counters bounded to one day bucket", async () => {
+    const db = await database();
+    await insertDescription(db, {});
+    await db.exec(`DELETE FROM users WHERE id = '${USER}'`);
+    const { rows } = await db.query(
+      "SELECT count(*)::int AS count FROM personal_shared_inbound_media_descriptions",
+    );
+    expect(rows).toEqual([{ count: 0 }]);
+
+    await db.exec(`INSERT INTO personal_shared_inbound_media_quotas
+      (scope, scope_key, day, image_count) VALUES ('sender', '${ORG}', '2026-08-23', 3)`);
+    await expect(
+      db.exec(`INSERT INTO personal_shared_inbound_media_quotas
+        (scope, scope_key, day, image_count) VALUES ('sender', '${ORG}', '2026-08-23', 1)`),
+    ).rejects.toThrow();
+    await expect(
+      db.exec(`INSERT INTO personal_shared_inbound_media_quotas
+        (scope, scope_key, day, image_count) VALUES ('owner', '${ORG}', '2026-08-23', 1)`),
+    ).rejects.toThrow();
+    await expect(
+      db.exec(`INSERT INTO personal_shared_inbound_media_quotas
+        (scope, scope_key, day, image_count) VALUES ('sender', '${ORG}', '2026-08-24', -1)`),
+    ).rejects.toThrow();
+    await db.exec(`INSERT INTO personal_shared_inbound_media_quotas
+      (scope, scope_key, day, image_count) VALUES ('sender', '${ORG}', '2026-08-24', 0)`);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Exercises the inbound-media admission ledger against isolated PGlite with
+ * the real 0310 migration: one claim per connector message id under
+ * concurrency, reuse of a stored description, no retry after a terminal
+ * failure, lease-fenced reclaim, and the per-sender/per-connector daily image
+ * ceilings that roll a fresh claim back atomically.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_A = "72000000-0000-4000-8000-000000000001";
+const ORG_B = "72000000-0000-4000-8000-000000000002";
+const USER_A = "72000000-0000-4000-8000-000000000011";
+const USER_B = "72000000-0000-4000-8000-000000000012";
+const CONNECTOR_ID = "+15550000001";
+const OTHER_CONNECTOR_ID = "+15550000002";
+const DIGEST_A = "digest-a";
+const DIGEST_B = "digest-b";
+const CEILINGS = { senderDailyImages: 5, connectorDailyImages: 8 };
+
+let closeDatabaseConnectionsForTests:
+  | typeof import("../client").closeDatabaseConnectionsForTests
+  | undefined;
+let getPgliteClientForTests: typeof import("../client").getPgliteClientForTests;
+let repository: typeof import("./personal-shared-inbound-media").personalSharedInboundMediaRepository;
+let INBOUND_MEDIA_DESCRIPTION_LEASE_MS: number;
+
+function admission(
+  overrides: Partial<Parameters<typeof repository.admit>[0]> & { sourceMessageId: string },
+) {
+  return repository.admit({
+    platform: "blooio",
+    project: "eliza-app",
+    connectorAccountId: CONNECTOR_ID,
+    organizationId: ORG_A,
+    userId: USER_A,
+    mediaDigest: DIGEST_A,
+    imageCount: 1,
+    ceilings: CEILINGS,
+    ...overrides,
+  });
+}
+
+async function claimOf(sourceMessageId: string, overrides: Record<string, unknown> = {}) {
+  const result = await admission({ sourceMessageId, ...overrides });
+  if (result.kind !== "claimed") {
+    throw new Error(`expected a claim, got ${result.kind}`);
+  }
+  return result.claim;
+}
+
+async function ledgerRow(sourceMessageId: string) {
+  const { rows } = await getPgliteClientForTests().query<{
+    state: string;
+    description: string | null;
+    failure_reason: string | null;
+    attempt_count: number;
+    claim_token: string;
+    media_digest: string;
+    organization_id: string;
+    completed_at: string | null;
+  }>(
+    `SELECT state, description, failure_reason, attempt_count, claim_token,
+       media_digest, organization_id, completed_at
+     FROM personal_shared_inbound_media_descriptions
+     WHERE source_message_id = $1`,
+    [sourceMessageId],
+  );
+  return rows[0];
+}
+
+async function quotaRows() {
+  const { rows } = await getPgliteClientForTests().query<{
+    scope: string;
+    scope_key: string;
+    image_count: number;
+  }>(
+    `SELECT scope, scope_key, image_count FROM personal_shared_inbound_media_quotas
+     ORDER BY scope, scope_key`,
+  );
+  return rows;
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests, getPgliteClientForTests } = await import("../client"));
+  ({ personalSharedInboundMediaRepository: repository, INBOUND_MEDIA_DESCRIPTION_LEASE_MS } =
+    await import("./personal-shared-inbound-media"));
+  const database = getPgliteClientForTests();
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+  `);
+  const migration = await Bun.file(
+    new URL("../migrations/0310_personal_shared_inbound_media_admission.sql", import.meta.url),
+  ).text();
+  await database.exec(migration);
+});
+
+beforeEach(async () => {
+  await getPgliteClientForTests().exec(`
+    TRUNCATE personal_shared_inbound_media_descriptions,
+      personal_shared_inbound_media_quotas,
+      users,
+      organizations CASCADE;
+    INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
+    INSERT INTO users (id) VALUES ('${USER_A}'), ('${USER_B}');
+  `);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+});
+
+describe("personalSharedInboundMediaRepository admission ledger", () => {
+  test("claims a message once and consumes both daily ceilings atomically", async () => {
+    const claim = await claimOf("msg-1", { imageCount: 2 });
+    expect(claim.attempt).toBe(1);
+    expect(claim.claimToken).toMatch(/^[0-9a-f-]{36}$/);
+
+    expect(await ledgerRow("msg-1")).toMatchObject({
+      state: "pending",
+      attempt_count: 1,
+      claim_token: claim.claimToken,
+      media_digest: DIGEST_A,
+      organization_id: ORG_A,
+    });
+    expect(await quotaRows()).toEqual([
+      { scope: "connector", scope_key: `blooio:eliza-app:${CONNECTOR_ID}`, image_count: 2 },
+      { scope: "sender", scope_key: ORG_A, image_count: 2 },
+    ]);
+  });
+
+  test("concurrent claims of the same message admit exactly one claimant", async () => {
+    const results = await Promise.all([
+      admission({ sourceMessageId: "msg-race" }),
+      admission({ sourceMessageId: "msg-race" }),
+      admission({ sourceMessageId: "msg-race" }),
+    ]);
+    expect(results.map(({ kind }) => kind).sort()).toEqual(["claimed", "in_flight", "in_flight"]);
+    // The losers consumed nothing: one image against each ceiling.
+    expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([1, 1]);
+  });
+
+  test("a live claim is reported in flight, not re-spent", async () => {
+    await claimOf("msg-2");
+    expect(await admission({ sourceMessageId: "msg-2" })).toEqual({ kind: "in_flight" });
+    expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([1, 1]);
+  });
+
+  test("a completed description is reused for the same media and never re-claimed", async () => {
+    const claim = await claimOf("msg-3");
+    expect(await repository.complete(claim, "a cat on a keyboard")).toBe(true);
+    expect(await ledgerRow("msg-3")).toMatchObject({
+      state: "described",
+      description: "a cat on a keyboard",
+      failure_reason: null,
+    });
+    expect((await ledgerRow("msg-3"))?.completed_at).not.toBeNull();
+
+    expect(await admission({ sourceMessageId: "msg-3" })).toEqual({
+      kind: "reused",
+      description: "a cat on a keyboard",
+    });
+    // A redelivery whose media differs from the described claim is not a reuse.
+    expect(await admission({ sourceMessageId: "msg-3", mediaDigest: DIGEST_B })).toEqual({
+      kind: "media_mismatch",
+    });
+    // Neither redelivery touched the ceilings.
+    expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([1, 1]);
+  });
+
+  test("a terminal failure is recorded once and never retried", async () => {
+    const claim = await claimOf("msg-4");
+    expect(await repository.fail(claim, "media_fetch_failed")).toBe(true);
+    expect(await ledgerRow("msg-4")).toMatchObject({
+      state: "failed",
+      description: null,
+      failure_reason: "media_fetch_failed",
+    });
+    expect(await admission({ sourceMessageId: "msg-4" })).toEqual({
+      kind: "previously_failed",
+      reason: "media_fetch_failed",
+    });
+    expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([1, 1]);
+  });
+
+  test("settlement is fenced to the live claim token and pending state", async () => {
+    const claim = await claimOf("msg-5");
+    const stale = { ...claim, claimToken: "00000000-0000-4000-8000-0000000000ff" };
+    expect(await repository.complete(stale, "forged")).toBe(false);
+    expect(await repository.fail(stale, "forged")).toBe(false);
+    expect(await repository.complete(claim, "real description")).toBe(true);
+    // A settled claim accepts no second outcome.
+    expect(await repository.fail(claim, "late failure")).toBe(false);
+    expect(await repository.complete(claim, "second description")).toBe(false);
+    expect(await ledgerRow("msg-5")).toMatchObject({
+      state: "described",
+      description: "real description",
+    });
+  });
+
+  test("only an expired lease can be reclaimed, and the reclaim fences the dead claimant", async () => {
+    const dead = await claimOf("msg-6");
+    await getPgliteClientForTests().query(
+      `UPDATE personal_shared_inbound_media_descriptions
+       SET lease_expires_at = now() - interval '1 second'
+       WHERE source_message_id = $1`,
+      ["msg-6"],
+    );
+
+    const reclaimed = await claimOf("msg-6", { organizationId: ORG_B, userId: USER_B });
+    expect(reclaimed.id).toBe(dead.id);
+    expect(reclaimed.attempt).toBe(2);
+    expect(reclaimed.claimToken).not.toBe(dead.claimToken);
+    expect(await ledgerRow("msg-6")).toMatchObject({
+      state: "pending",
+      attempt_count: 2,
+      organization_id: ORG_B,
+    });
+    // The reclaim is a new attempt and pays the ceilings again.
+    expect(await quotaRows()).toEqual([
+      { scope: "connector", scope_key: `blooio:eliza-app:${CONNECTOR_ID}`, image_count: 2 },
+      { scope: "sender", scope_key: ORG_A, image_count: 1 },
+      { scope: "sender", scope_key: ORG_B, image_count: 1 },
+    ]);
+
+    // The dead claimant's late settlement is rejected; the live one lands.
+    expect(await repository.complete(dead, "zombie description")).toBe(false);
+    expect(await repository.complete(reclaimed, "live description")).toBe(true);
+    expect(await ledgerRow("msg-6")).toMatchObject({
+      state: "described",
+      description: "live description",
+    });
+  });
+
+  test("the lease horizon outlives the gateway media-turn budget", () => {
+    expect(INBOUND_MEDIA_DESCRIPTION_LEASE_MS).toBeGreaterThan(90_000);
+  });
+
+  test("an exhausted sender ceiling denies the claim and rolls the ledger back", async () => {
+    await claimOf("msg-7a", { imageCount: 4 });
+    const denied = await admission({ sourceMessageId: "msg-7b", imageCount: 2 });
+    expect(denied).toEqual({
+      kind: "exhausted",
+      scope: "sender",
+      limit: CEILINGS.senderDailyImages,
+      used: 4,
+      requested: 2,
+    });
+    // The denied claim never became visible, so the same message can be
+    // admitted later (for example, on the next UTC day) instead of being
+    // treated as an in-flight or failed attempt.
+    expect(await ledgerRow("msg-7b")).toBeUndefined();
+    expect(await quotaRows()).toEqual([
+      { scope: "connector", scope_key: `blooio:eliza-app:${CONNECTOR_ID}`, image_count: 4 },
+      { scope: "sender", scope_key: ORG_A, image_count: 4 },
+    ]);
+    // Exactly the remaining budget is still admitted.
+    expect((await admission({ sourceMessageId: "msg-7c", imageCount: 1 })).kind).toBe("claimed");
+    expect((await admission({ sourceMessageId: "msg-7d", imageCount: 1 })).kind).toBe("exhausted");
+  });
+
+  test("an exhausted connector ceiling denies across senders and rolls the sender increment back", async () => {
+    await claimOf("msg-8a", { imageCount: 4 });
+    await claimOf("msg-8b", { imageCount: 4, organizationId: ORG_B, userId: USER_B });
+    const denied = await admission({
+      sourceMessageId: "msg-8c",
+      imageCount: 1,
+      organizationId: ORG_B,
+      userId: USER_B,
+    });
+    expect(denied).toEqual({
+      kind: "exhausted",
+      scope: "connector",
+      limit: CEILINGS.connectorDailyImages,
+      used: 8,
+      requested: 1,
+    });
+    expect(await ledgerRow("msg-8c")).toBeUndefined();
+    expect(await quotaRows()).toEqual([
+      { scope: "connector", scope_key: `blooio:eliza-app:${CONNECTOR_ID}`, image_count: 8 },
+      { scope: "sender", scope_key: ORG_A, image_count: 4 },
+      { scope: "sender", scope_key: ORG_B, image_count: 4 },
+    ]);
+    // Another connector account has its own ceiling.
+    expect(
+      (
+        await admission({
+          sourceMessageId: "msg-8d",
+          connectorAccountId: OTHER_CONNECTOR_ID,
+          organizationId: ORG_B,
+          userId: USER_B,
+        })
+      ).kind,
+    ).toBe("claimed");
+  });
+
+  test("a zero ceiling denies every description before any claim", async () => {
+    expect(
+      await admission({
+        sourceMessageId: "msg-9",
+        ceilings: { senderDailyImages: 0, connectorDailyImages: 8 },
+      }),
+    ).toEqual({ kind: "exhausted", scope: "sender", limit: 0, used: 0, requested: 1 });
+    expect(await ledgerRow("msg-9")).toBeUndefined();
+    expect(await quotaRows()).toEqual([]);
+  });
+
+  test("concurrent claimants cannot overshoot a ceiling together", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        admission({ sourceMessageId: `msg-burst-${index}`, imageCount: 1 }),
+      ),
+    );
+    const kinds = results.map(({ kind }) => kind);
+    expect(kinds.filter((kind) => kind === "claimed")).toHaveLength(CEILINGS.senderDailyImages);
+    expect(kinds.filter((kind) => kind === "exhausted")).toHaveLength(
+      8 - CEILINGS.senderDailyImages,
+    );
+    expect(await quotaRows()).toEqual([
+      {
+        scope: "connector",
+        scope_key: `blooio:eliza-app:${CONNECTOR_ID}`,
+        image_count: CEILINGS.senderDailyImages,
+      },
+      { scope: "sender", scope_key: ORG_A, image_count: CEILINGS.senderDailyImages },
+    ]);
+  });
+
+  test("rejects malformed admission input before touching the ledger", async () => {
+    await expect(admission({ sourceMessageId: "bad", imageCount: 0 })).rejects.toThrow(TypeError);
+    await expect(
+      admission({
+        sourceMessageId: "bad",
+        ceilings: { senderDailyImages: -1, connectorDailyImages: 1 },
+      }),
+    ).rejects.toThrow(TypeError);
+    await expect(admission({ sourceMessageId: "bad", mediaDigest: "" })).rejects.toThrow(TypeError);
+    expect(await ledgerRow("bad")).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
@@ -1,0 +1,351 @@
+/**
+ * Atomic admission and idempotency authority for pooled-key vision descriptions
+ * of inbound Personal Shared media. One primary-database transaction claims
+ * the connector message id (the enrichment idempotency record) and consumes
+ * the sender and connector per-day image ceilings; a denied ceiling rolls the
+ * claim back, so a provider call is only ever reachable behind a committed
+ * claim plus committed quota. The injectable database keeps the production
+ * queries testable against an isolated PostgreSQL-compatible engine.
+ */
+import { ElizaError } from "@elizaos/core";
+import { and, eq, sql } from "drizzle-orm";
+import type { Database, DbTransaction } from "../client";
+import { sqlRows } from "../execute-helpers";
+import { dbWrite } from "../helpers";
+import {
+  type PersonalSharedInboundMediaPlatform,
+  type PersonalSharedInboundMediaQuotaScope,
+  personalSharedInboundMediaDescriptions,
+  personalSharedInboundMediaQuotas,
+} from "../schemas/personal-shared-inbound-media";
+import { readPostLockDatabaseNow } from "./primary-database-clock";
+
+/**
+ * Longer than the gateway's 90s media-turn budget and the helper's fetch +
+ * vision timeouts: a live execution always finishes (or fails) inside this
+ * lease, so only a dead claimant's row is ever reclaimed.
+ */
+export const INBOUND_MEDIA_DESCRIPTION_LEASE_MS = 120_000;
+
+export interface InboundMediaDescriptionIdentity {
+  platform: PersonalSharedInboundMediaPlatform;
+  project: string;
+  connectorAccountId: string;
+  /** The connector message id the gateway forwards as the turn's clientMessageId. */
+  sourceMessageId: string;
+}
+
+export interface InboundMediaDescriptionCeilings {
+  /** Images per UTC day for the resolved sending account (organization). */
+  senderDailyImages: number;
+  /** Images per UTC day across every sender of one connector account. */
+  connectorDailyImages: number;
+}
+
+export interface AdmitInboundMediaDescriptionInput extends InboundMediaDescriptionIdentity {
+  organizationId: string;
+  userId: string;
+  /** Digest of the exact media URL list; a reuse only matches the same digest. */
+  mediaDigest: string;
+  imageCount: number;
+  ceilings: InboundMediaDescriptionCeilings;
+}
+
+export interface InboundMediaDescriptionClaim {
+  id: string;
+  claimToken: string;
+  attempt: number;
+}
+
+export type InboundMediaDescriptionAdmission =
+  | { kind: "claimed"; claim: InboundMediaDescriptionClaim }
+  | { kind: "reused"; description: string }
+  | { kind: "in_flight" }
+  | { kind: "previously_failed"; reason: string }
+  | { kind: "media_mismatch" }
+  | {
+      kind: "exhausted";
+      scope: PersonalSharedInboundMediaQuotaScope;
+      limit: number;
+      used: number;
+      requested: number;
+    };
+
+class QuotaExhaustedSignal extends Error {
+  constructor(readonly denial: Extract<InboundMediaDescriptionAdmission, { kind: "exhausted" }>) {
+    super(`Inbound media ${denial.scope} ceiling exhausted`);
+    this.name = "QuotaExhaustedSignal";
+  }
+}
+
+function storageFailure(message: string, context: Record<string, unknown>): ElizaError {
+  return new ElizaError(message, {
+    code: "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE",
+    severity: "fatal",
+    context,
+  });
+}
+
+function assertPositiveSafeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`Inbound media admission ${field} must be a positive integer`);
+  }
+}
+
+function assertNonNegativeSafeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`Inbound media admission ${field} must be a non-negative integer`);
+  }
+}
+
+function identityPredicate(identity: InboundMediaDescriptionIdentity) {
+  return and(
+    eq(personalSharedInboundMediaDescriptions.platform, identity.platform),
+    eq(personalSharedInboundMediaDescriptions.project, identity.project),
+    eq(personalSharedInboundMediaDescriptions.connector_account_id, identity.connectorAccountId),
+    eq(personalSharedInboundMediaDescriptions.source_message_id, identity.sourceMessageId),
+  );
+}
+
+export function inboundMediaConnectorQuotaKey(
+  identity: Pick<InboundMediaDescriptionIdentity, "platform" | "project" | "connectorAccountId">,
+): string {
+  return `${identity.platform}:${identity.project}:${identity.connectorAccountId}`;
+}
+
+export class PersonalSharedInboundMediaRepository {
+  constructor(private readonly database: Database) {}
+
+  /**
+   * Claims the connector message id and consumes both per-day ceilings in one
+   * transaction. Every non-`claimed` outcome leaves the ledger untouched and
+   * must keep the turn un-enriched: a stored description is reused, a live
+   * claim or an earlier failure is never retried, and an exhausted ceiling
+   * rolls the fresh claim back.
+   */
+  async admit(input: AdmitInboundMediaDescriptionInput): Promise<InboundMediaDescriptionAdmission> {
+    assertPositiveSafeInteger(input.imageCount, "imageCount");
+    assertNonNegativeSafeInteger(input.ceilings.senderDailyImages, "senderDailyImages");
+    assertNonNegativeSafeInteger(input.ceilings.connectorDailyImages, "connectorDailyImages");
+    if (!input.mediaDigest || !input.organizationId || !input.userId) {
+      throw new TypeError("Inbound media admission identity is incomplete");
+    }
+    try {
+      return await this.database.transaction(async (tx) => {
+        const now = await readPostLockDatabaseNow(tx);
+        const claimToken = crypto.randomUUID();
+        const leaseExpiresAt = new Date(now.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS);
+        const [inserted] = await tx
+          .insert(personalSharedInboundMediaDescriptions)
+          .values({
+            platform: input.platform,
+            project: input.project,
+            connector_account_id: input.connectorAccountId,
+            source_message_id: input.sourceMessageId,
+            organization_id: input.organizationId,
+            user_id: input.userId,
+            media_digest: input.mediaDigest,
+            image_count: input.imageCount,
+            state: "pending",
+            claim_token: claimToken,
+            lease_expires_at: leaseExpiresAt,
+            created_at: now,
+            updated_at: now,
+          })
+          .onConflictDoNothing({
+            target: [
+              personalSharedInboundMediaDescriptions.platform,
+              personalSharedInboundMediaDescriptions.project,
+              personalSharedInboundMediaDescriptions.connector_account_id,
+              personalSharedInboundMediaDescriptions.source_message_id,
+            ],
+          })
+          .returning({
+            id: personalSharedInboundMediaDescriptions.id,
+            attempt_count: personalSharedInboundMediaDescriptions.attempt_count,
+          });
+        let claim: InboundMediaDescriptionClaim;
+        if (inserted) {
+          claim = { id: inserted.id, claimToken, attempt: inserted.attempt_count };
+        } else {
+          // The conflicting row is locked for the rest of the transaction, so
+          // a concurrent redelivery observes either this claim or its outcome.
+          const [existing] = await tx
+            .select()
+            .from(personalSharedInboundMediaDescriptions)
+            .where(identityPredicate(input))
+            .for("update");
+          if (!existing) {
+            throw storageFailure("Inbound media description claim vanished under lock", {
+              sourceMessageId: input.sourceMessageId,
+            });
+          }
+          if (existing.state === "described") {
+            if (existing.media_digest !== input.mediaDigest) {
+              return { kind: "media_mismatch" };
+            }
+            if (existing.description === null) {
+              throw storageFailure("Described inbound media row carries no description", {
+                id: existing.id,
+              });
+            }
+            return { kind: "reused", description: existing.description };
+          }
+          if (existing.state === "failed") {
+            return { kind: "previously_failed", reason: existing.failure_reason ?? "unknown" };
+          }
+          if (existing.lease_expires_at.getTime() > now.getTime()) {
+            return { kind: "in_flight" };
+          }
+          // The previous claimant is dead (its lease lapsed without a terminal
+          // state); take the claim over under a fresh token and attempt count.
+          const [reclaimed] = await tx
+            .update(personalSharedInboundMediaDescriptions)
+            .set({
+              organization_id: input.organizationId,
+              user_id: input.userId,
+              media_digest: input.mediaDigest,
+              image_count: input.imageCount,
+              claim_token: claimToken,
+              lease_expires_at: leaseExpiresAt,
+              attempt_count: sql`${personalSharedInboundMediaDescriptions.attempt_count} + 1`,
+              updated_at: now,
+            })
+            .where(
+              and(
+                eq(personalSharedInboundMediaDescriptions.id, existing.id),
+                eq(personalSharedInboundMediaDescriptions.state, "pending"),
+              ),
+            )
+            .returning({ attempt_count: personalSharedInboundMediaDescriptions.attempt_count });
+          if (!reclaimed) {
+            throw storageFailure("Expired inbound media claim could not be reclaimed", {
+              id: existing.id,
+            });
+          }
+          claim = { id: existing.id, claimToken, attempt: reclaimed.attempt_count };
+        }
+        const day = now.toISOString().slice(0, 10);
+        await consumeQuota(tx, {
+          scope: "sender",
+          scopeKey: input.organizationId,
+          day,
+          now,
+          requested: input.imageCount,
+          limit: input.ceilings.senderDailyImages,
+        });
+        await consumeQuota(tx, {
+          scope: "connector",
+          scopeKey: inboundMediaConnectorQuotaKey(input),
+          day,
+          now,
+          requested: input.imageCount,
+          limit: input.ceilings.connectorDailyImages,
+        });
+        return { kind: "claimed", claim };
+      });
+    } catch (error) {
+      if (error instanceof QuotaExhaustedSignal) {
+        // The transaction rolled back with the signal, so the claim row and
+        // any sender increment never became visible.
+        return error.denial;
+      }
+      throw error;
+    }
+  }
+
+  /** Persists the description for a live claim; false when the claim was lost. */
+  async complete(claim: InboundMediaDescriptionClaim, description: string): Promise<boolean> {
+    if (!description) {
+      throw new TypeError("Inbound media description completion requires a description");
+    }
+    return this.settle(claim, { state: "described", description, failure_reason: null });
+  }
+
+  /** Records a terminal failure for a live claim; false when the claim was lost. */
+  async fail(claim: InboundMediaDescriptionClaim, reason: string): Promise<boolean> {
+    if (!reason) {
+      throw new TypeError("Inbound media description failure requires a reason");
+    }
+    return this.settle(claim, { state: "failed", description: null, failure_reason: reason });
+  }
+
+  private async settle(
+    claim: InboundMediaDescriptionClaim,
+    outcome:
+      | { state: "described"; description: string; failure_reason: null }
+      | { state: "failed"; description: null; failure_reason: string },
+  ): Promise<boolean> {
+    const now = new Date();
+    const [settled] = await this.database
+      .update(personalSharedInboundMediaDescriptions)
+      .set({ ...outcome, completed_at: now, updated_at: now })
+      .where(
+        and(
+          eq(personalSharedInboundMediaDescriptions.id, claim.id),
+          eq(personalSharedInboundMediaDescriptions.claim_token, claim.claimToken),
+          eq(personalSharedInboundMediaDescriptions.state, "pending"),
+        ),
+      )
+      .returning({ id: personalSharedInboundMediaDescriptions.id });
+    return settled !== undefined;
+  }
+}
+
+async function consumeQuota(
+  tx: DbTransaction,
+  input: {
+    scope: PersonalSharedInboundMediaQuotaScope;
+    scopeKey: string;
+    day: string;
+    now: Date;
+    requested: number;
+    limit: number;
+  },
+): Promise<void> {
+  const quotas = personalSharedInboundMediaQuotas;
+  const used = async (): Promise<number> => {
+    const [row] = await sqlRows<{ image_count: number | string }>(
+      tx,
+      sql`SELECT ${quotas.image_count} AS image_count FROM ${quotas}
+        WHERE ${quotas.scope} = ${input.scope}
+          AND ${quotas.scope_key} = ${input.scopeKey}
+          AND ${quotas.day} = ${input.day}`,
+    );
+    return row ? Number(row.image_count) : 0;
+  };
+  if (input.requested > input.limit) {
+    throw new QuotaExhaustedSignal({
+      kind: "exhausted",
+      scope: input.scope,
+      limit: input.limit,
+      used: await used(),
+      requested: input.requested,
+    });
+  }
+  // The conditional upsert is the atomic ceiling check: the conflicting row is
+  // locked while the predicate runs, so concurrent claimants serialize here.
+  const consumed = await sqlRows<{ image_count: number | string }>(
+    tx,
+    sql`INSERT INTO ${quotas} (scope, scope_key, day, image_count, updated_at)
+      VALUES (${input.scope}, ${input.scopeKey}, ${input.day}, ${input.requested}, ${input.now})
+      ON CONFLICT (scope, scope_key, day) DO UPDATE SET
+        image_count = ${quotas.image_count} + EXCLUDED.image_count,
+        updated_at = EXCLUDED.updated_at
+      WHERE ${quotas.image_count} + EXCLUDED.image_count <= ${input.limit}
+      RETURNING ${quotas.image_count} AS image_count`,
+  );
+  if (consumed.length === 0) {
+    throw new QuotaExhaustedSignal({
+      kind: "exhausted",
+      scope: input.scope,
+      limit: input.limit,
+      used: await used(),
+      requested: input.requested,
+    });
+  }
+}
+
+export const personalSharedInboundMediaRepository = new PersonalSharedInboundMediaRepository(
+  dbWrite,
+);

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -98,6 +98,7 @@ export * from "./payment-request-receipts";
 export * from "./payment-requests";
 export * from "./personal-account-convergences";
 export * from "./personal-shared-groups";
+export * from "./personal-shared-inbound-media";
 export * from "./phone-gateway-devices";
 export * from "./pii-scrub-markers";
 export * from "./platform-credentials";

--- a/packages/cloud/shared/src/db/schemas/personal-shared-inbound-media.ts
+++ b/packages/cloud/shared/src/db/schemas/personal-shared-inbound-media.ts
@@ -1,0 +1,143 @@
+/**
+ * Durable admission ledger for pooled-key vision descriptions of inbound
+ * Personal Shared media. One description row per connector message id is the
+ * enrichment idempotency record (a provider redelivery reuses the stored text
+ * instead of re-spending); the quota rows are atomic per-day image counters
+ * for the sending account and for the connector as a whole.
+ */
+import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
+import {
+  check,
+  date,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+export type PersonalSharedInboundMediaPlatform = "blooio";
+export type PersonalSharedInboundMediaDescriptionState = "pending" | "described" | "failed";
+export type PersonalSharedInboundMediaQuotaScope = "sender" | "connector";
+
+export const personalSharedInboundMediaDescriptions = pgTable(
+  "personal_shared_inbound_media_descriptions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    platform: text("platform").$type<PersonalSharedInboundMediaPlatform>().notNull(),
+    project: text("project").notNull(),
+    connector_account_id: text("connector_account_id").notNull(),
+    /** The connector message id the gateway forwards as the turn's clientMessageId. */
+    source_message_id: text("source_message_id").notNull(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    user_id: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** Digest of the exact media URL list the claim covers. */
+    media_digest: text("media_digest").notNull(),
+    image_count: integer("image_count").notNull(),
+    state: text("state")
+      .$type<PersonalSharedInboundMediaDescriptionState>()
+      .notNull()
+      .default("pending"),
+    /** Fences completion to the execution that holds the live claim. */
+    claim_token: uuid("claim_token").notNull(),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }).notNull(),
+    attempt_count: integer("attempt_count").notNull().default(1),
+    description: text("description"),
+    failure_reason: text("failure_reason"),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    completed_at: timestamp("completed_at", { withTimezone: true }),
+  },
+  (table) => ({
+    platform_check: check(
+      "personal_shared_inbound_media_descriptions_platform_check",
+      sql`${table.platform} IN ('blooio')`,
+    ),
+    state_check: check(
+      "personal_shared_inbound_media_descriptions_state_check",
+      sql`${table.state} IN ('pending', 'described', 'failed')`,
+    ),
+    image_count_check: check(
+      "personal_shared_inbound_media_descriptions_image_count_check",
+      sql`${table.image_count} > 0`,
+    ),
+    attempt_count_check: check(
+      "personal_shared_inbound_media_descriptions_attempt_count_check",
+      sql`${table.attempt_count} > 0`,
+    ),
+    terminal_shape_check: check(
+      "personal_shared_inbound_media_descriptions_terminal_shape_check",
+      sql`(
+        ${table.state} = 'pending'
+        AND ${table.description} IS NULL
+        AND ${table.failure_reason} IS NULL
+        AND ${table.completed_at} IS NULL
+      ) OR (
+        ${table.state} = 'described'
+        AND ${table.description} IS NOT NULL
+        AND ${table.failure_reason} IS NULL
+        AND ${table.completed_at} IS NOT NULL
+      ) OR (
+        ${table.state} = 'failed'
+        AND ${table.description} IS NULL
+        AND ${table.failure_reason} IS NOT NULL
+        AND ${table.completed_at} IS NOT NULL
+      )`,
+    ),
+    source_unique: uniqueIndex("personal_shared_inbound_media_descriptions_source_uidx").on(
+      table.platform,
+      table.project,
+      table.connector_account_id,
+      table.source_message_id,
+    ),
+    organization_created_idx: index(
+      "personal_shared_inbound_media_descriptions_org_created_idx",
+    ).on(table.organization_id, table.created_at),
+  }),
+);
+
+export const personalSharedInboundMediaQuotas = pgTable(
+  "personal_shared_inbound_media_quotas",
+  {
+    scope: text("scope").$type<PersonalSharedInboundMediaQuotaScope>().notNull(),
+    /** `sender`: the resolved account's organization id; `connector`: platform:project:connector account. */
+    scope_key: text("scope_key").notNull(),
+    /** UTC day bucket (YYYY-MM-DD). */
+    day: date("day").notNull(),
+    image_count: integer("image_count").notNull(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      name: "personal_shared_inbound_media_quotas_pkey",
+      columns: [table.scope, table.scope_key, table.day],
+    }),
+    scope_check: check(
+      "personal_shared_inbound_media_quotas_scope_check",
+      sql`${table.scope} IN ('sender', 'connector')`,
+    ),
+    image_count_check: check(
+      "personal_shared_inbound_media_quotas_image_count_check",
+      sql`${table.image_count} >= 0`,
+    ),
+  }),
+);
+
+export type PersonalSharedInboundMediaDescription = InferSelectModel<
+  typeof personalSharedInboundMediaDescriptions
+>;
+export type NewPersonalSharedInboundMediaDescription = InferInsertModel<
+  typeof personalSharedInboundMediaDescriptions
+>;
+export type PersonalSharedInboundMediaQuota = InferSelectModel<
+  typeof personalSharedInboundMediaQuotas
+>;

--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.test.ts
@@ -1,10 +1,10 @@
 /**
  * Pins the fail-closed contract of inbound-media vision enrichment: the flag
- * and provider gates throw the typed disabled error, every fetch/size/type/
- * model failure throws the typed description error (so callers degrade instead
- * of dropping the turn), and a truncated or empty completion is rejected, never
- * returned. Deterministic mocks stand in for safe-fetch, the provider factory,
- * and the AI SDK — no network.
+ * and provider gates throw the typed disabled error, every fetch/body-read/
+ * cancellation/size/type/model failure throws the typed description error (so
+ * callers degrade instead of dropping the turn), and a truncated or empty
+ * completion is rejected, never returned. Deterministic mocks stand in for
+ * safe-fetch, the provider factory, and the AI SDK — no network.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -274,6 +274,98 @@ describe("describeInboundImageMedia — enrichment path", () => {
     });
     safeFetch.mockResolvedValue(
       new Response(stream, {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+    await expectDescriptionFailure(describeInboundImageMedia(ENABLED, [URL_A]), "media_too_large");
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("a body stream that errors mid-read becomes media_read_failed", async () => {
+    const streamFault = new TypeError("terminated");
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        // First pull delivers bytes; the connection drops on the second.
+        if (pulls++ === 0) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        } else {
+          controller.error(streamFault);
+        }
+      },
+    });
+    safeFetch.mockResolvedValue(
+      new Response(stream, { status: 200, headers: { "content-type": "image/jpeg" } }),
+    );
+    const error = await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "media_read_failed",
+    );
+    expect(error.cause).toBe(streamFault);
+    expect(error.context).toMatchObject({ url: URL_A, bytesRead: 3 });
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("a fetch timeout that fires during the body read becomes media_read_failed", async () => {
+    const timeout = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(timeout);
+      },
+    });
+    safeFetch.mockResolvedValue(
+      new Response(stream, { status: 200, headers: { "content-type": "image/jpeg" } }),
+    );
+    const error = await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "media_read_failed",
+    );
+    expect(error.cause).toBe(timeout);
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("a failing cancel while discarding a body keeps the typed degrade error", async () => {
+    const bodyThatCannotCancel = () =>
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new Uint8Array(4 * 1024 * 1024));
+        },
+        cancel() {
+          throw new Error("socket already closed");
+        },
+      });
+    // Declared above the ceiling: discarded before any read.
+    safeFetch.mockResolvedValue(
+      new Response(bodyThatCannotCancel(), {
+        status: 200,
+        headers: {
+          "content-type": "image/jpeg",
+          "content-length": String(MAX_INBOUND_IMAGE_BYTES + 1),
+        },
+      }),
+    );
+    await expectDescriptionFailure(describeInboundImageMedia(ENABLED, [URL_A]), "media_too_large");
+    // Not an image: discarded before any read.
+    safeFetch.mockResolvedValue(
+      new Response(bodyThatCannotCancel(), {
+        status: 200,
+        headers: { "content-type": "application/pdf" },
+      }),
+    );
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "unsupported_media_type",
+    );
+    // Non-2xx: discarded before any read.
+    safeFetch.mockResolvedValue(new Response(bodyThatCannotCancel(), { status: 503 }));
+    await expectDescriptionFailure(
+      describeInboundImageMedia(ENABLED, [URL_A]),
+      "media_fetch_failed",
+    );
+    // Streamed past the ceiling without Content-Length: discarded mid-read.
+    safeFetch.mockResolvedValue(
+      new Response(bodyThatCannotCancel(), {
         status: 200,
         headers: { "content-type": "image/jpeg" },
       }),

--- a/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/describe-inbound-media.ts
@@ -11,11 +11,13 @@
  * compromised or spoofed gateway payload cannot make this Worker read
  * arbitrary or unbounded bytes.
  *
- * Every enrichment failure is a typed `InboundMediaDescriptionError`; callers
- * degrade to the raw media-URL text on it and must never fabricate a
- * description. A truncated completion is rejected, not returned: a clipped
- * description entering conversation history as if complete violates the
- * repository prompt-integrity rule.
+ * Every enrichment failure is a typed `InboundMediaDescriptionError` — the
+ * fetch, the body stream (timeout, disconnect, stream error), body
+ * cancellation, and the vision call alike; callers degrade to the raw
+ * media-URL text on it and must never fabricate a description. A truncated
+ * completion is rejected, not returned: a clipped description entering
+ * conversation history as if complete violates the repository
+ * prompt-integrity rule.
  */
 
 import { ElizaError } from "@elizaos/core";
@@ -56,6 +58,7 @@ export class InboundMediaVisionDisabledError extends ElizaError {
 
 export type InboundMediaDescriptionFailureReason =
   | "media_fetch_failed"
+  | "media_read_failed"
   | "unsupported_media_type"
   | "media_too_large"
   | "vision_model_failed"
@@ -87,10 +90,27 @@ interface FetchedInboundImage {
   mediaType: string;
 }
 
+/**
+ * Best-effort release of a body this helper will not read further. The body
+ * is being discarded because of a failure already typed for the caller, so a
+ * cancel that itself fails (stream already errored, socket gone) must neither
+ * mask that typed error nor escape as an untyped one.
+ */
+async function discardBody(
+  body: ReadableStream<Uint8Array> | ReadableStreamDefaultReader<Uint8Array> | null,
+): Promise<void> {
+  try {
+    await body?.cancel();
+  } catch {
+    // error-policy:J7 the typed failure that triggered the discard is the
+    // caller's signal; a failed cancel of an already-dead body adds nothing.
+  }
+}
+
 async function readImageBytesWithCap(response: Response, url: string): Promise<Uint8Array> {
   const declaredLength = Number(response.headers.get("content-length"));
   if (Number.isFinite(declaredLength) && declaredLength > MAX_INBOUND_IMAGE_BYTES) {
-    await response.body?.cancel();
+    await discardBody(response.body);
     throw new InboundMediaDescriptionError(
       "Inbound media declares a size above the image ceiling",
       "media_too_large",
@@ -110,11 +130,27 @@ async function readImageBytesWithCap(response: Response, url: string): Promise<U
   const chunks: Uint8Array[] = [];
   let total = 0;
   for (;;) {
-    const { done, value } = await reader.read();
+    let chunk: Awaited<ReturnType<typeof reader.read>>;
+    try {
+      chunk = await reader.read();
+    } catch (error) {
+      // error-policy:J2 the fetch timeout, a provider disconnect, or a stream
+      // error surfaces here rather than from safeFetch; retype it so the
+      // caller degrades instead of treating a transport fault as a bug.
+      throw new InboundMediaDescriptionError(
+        "Inbound media body read failed",
+        "media_read_failed",
+        {
+          cause: error,
+          context: { url, bytesRead: total },
+        },
+      );
+    }
+    const { done, value } = chunk;
     if (done) break;
     total += value.byteLength;
     if (total > MAX_INBOUND_IMAGE_BYTES) {
-      await reader.cancel();
+      await discardBody(reader);
       throw new InboundMediaDescriptionError(
         "Inbound media exceeds the image ceiling",
         "media_too_large",
@@ -160,7 +196,7 @@ async function fetchInboundImage(url: string): Promise<FetchedInboundImage> {
     });
   }
   if (!response.ok) {
-    await response.body?.cancel();
+    await discardBody(response.body);
     throw new InboundMediaDescriptionError(
       `Inbound media fetch returned HTTP ${response.status}`,
       "media_fetch_failed",
@@ -169,7 +205,7 @@ async function fetchInboundImage(url: string): Promise<FetchedInboundImage> {
   }
   const mediaType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
   if (!mediaType.startsWith("image/")) {
-    await response.body?.cancel();
+    await discardBody(response.body);
     throw new InboundMediaDescriptionError(
       "Inbound media is not an image",
       "unsupported_media_type",
@@ -177,6 +213,13 @@ async function fetchInboundImage(url: string): Promise<FetchedInboundImage> {
     );
   }
   return { bytes: await readImageBytesWithCap(response, url), mediaType };
+}
+
+/** The activation switch: exactly "true" enables pooled-key vision for this deployment. */
+export function isInboundMediaVisionEnabled(
+  env: Pick<Bindings, "ELIZA_APP_INBOUND_MEDIA_VISION">,
+): boolean {
+  return env.ELIZA_APP_INBOUND_MEDIA_VISION?.trim() === "true";
 }
 
 /**
@@ -189,7 +232,7 @@ export async function describeInboundImageMedia(
   env: Pick<Bindings, "ELIZA_APP_INBOUND_MEDIA_VISION">,
   urls: readonly string[],
 ): Promise<string> {
-  if (env.ELIZA_APP_INBOUND_MEDIA_VISION?.trim() !== "true") {
+  if (!isInboundMediaVisionEnabled(env)) {
     throw new InboundMediaVisionDisabledError(
       "Inbound media vision is disabled for this deployment",
     );

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Pins the spend boundary of admission-gated inbound media enrichment: the
+ * flag and the ceiling bindings are checked before the ledger, the ledger is
+ * consulted before the provider, every non-claimed admission and every ledger
+ * failure skips without calling the provider, and a claim is settled with the
+ * provider's real outcome. The ledger and the describe helper are injected
+ * fakes; the helper's real typed errors drive the settlement branches.
+ */
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type {
+  AdmitInboundMediaDescriptionInput,
+  InboundMediaDescriptionAdmission,
+  InboundMediaDescriptionClaim,
+  PersonalSharedInboundMediaRepository,
+} from "../../../db/repositories/personal-shared-inbound-media";
+import { sha256Hex } from "../../oidc/crypto";
+import { logger } from "../../utils/logger";
+import {
+  InboundMediaDescriptionError,
+  InboundMediaVisionDisabledError,
+} from "./describe-inbound-media";
+import {
+  DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
+  DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
+  enrichInboundImageMedia,
+  type InboundMediaEnrichmentEnv,
+  resolveInboundMediaVisionCeilings,
+} from "./inbound-media-enrichment";
+
+const URL_A = "https://media.blooio.com/files/photo-a.jpg";
+const URL_B = "https://backend.blooio.com/files/photo-b.png";
+const CLAIM: InboundMediaDescriptionClaim = {
+  id: "10000000-0000-4000-8000-000000000001",
+  claimToken: "10000000-0000-4000-8000-000000000002",
+  attempt: 1,
+};
+
+const admit = mock(
+  async (_input: AdmitInboundMediaDescriptionInput): Promise<InboundMediaDescriptionAdmission> => ({
+    kind: "claimed",
+    claim: CLAIM,
+  }),
+);
+const complete = mock(async (_claim: InboundMediaDescriptionClaim, _description: string) => true);
+const fail = mock(async (_claim: InboundMediaDescriptionClaim, _reason: string) => true);
+const repository = { admit, complete, fail } as unknown as PersonalSharedInboundMediaRepository;
+const describeMedia = mock(
+  async (_env: unknown, _urls: readonly string[]): Promise<string> => "a cat on a keyboard",
+);
+const deps = { repository, describe: describeMedia };
+
+function enrich(env: InboundMediaEnrichmentEnv = { ELIZA_APP_INBOUND_MEDIA_VISION: "true" }) {
+  return enrichInboundImageMedia(
+    {
+      env,
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550001111",
+      sourceMessageId: "blooio:eliza-app:message-42",
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      userId: "00000000-0000-4000-8000-000000000002",
+      mediaUrls: [URL_A, URL_B],
+    },
+    deps,
+  );
+}
+
+beforeEach(() => {
+  admit.mockReset();
+  complete.mockReset();
+  fail.mockReset();
+  describeMedia.mockReset();
+  admit.mockResolvedValue({ kind: "claimed", claim: CLAIM });
+  complete.mockResolvedValue(true);
+  fail.mockResolvedValue(true);
+  describeMedia.mockResolvedValue("a cat on a keyboard");
+});
+
+describe("resolveInboundMediaVisionCeilings", () => {
+  test("unset or blank bindings keep the defaults", () => {
+    expect(resolveInboundMediaVisionCeilings({})).toEqual({
+      senderDailyImages: DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
+      connectorDailyImages: DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
+    });
+    expect(
+      resolveInboundMediaVisionCeilings({
+        ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "  ",
+        ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: "",
+      }),
+    ).toEqual({
+      senderDailyImages: DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
+      connectorDailyImages: DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
+    });
+  });
+
+  test("non-negative integer bindings tune each ceiling, zero included", () => {
+    expect(
+      resolveInboundMediaVisionCeilings({
+        ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: " 7 ",
+        ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: "0",
+      }),
+    ).toEqual({ senderDailyImages: 7, connectorDailyImages: 0 });
+  });
+
+  test("a malformed binding yields no ceilings at all", () => {
+    for (const raw of ["-1", "1.5", "1e3", "unlimited", "12abc", "1000000000000"]) {
+      expect(
+        resolveInboundMediaVisionCeilings({
+          ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: raw,
+        }),
+      ).toBeNull();
+      expect(
+        resolveInboundMediaVisionCeilings({
+          ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: raw,
+        }),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("enrichInboundImageMedia — gates before the ledger", () => {
+  test("a dark flag skips before the ledger or provider is touched", async () => {
+    expect(await enrich({})).toEqual({ kind: "skipped", reason: "vision_disabled" });
+    expect(await enrich({ ELIZA_APP_INBOUND_MEDIA_VISION: "1" })).toEqual({
+      kind: "skipped",
+      reason: "vision_disabled",
+    });
+    expect(admit).not.toHaveBeenCalled();
+    expect(describeMedia).not.toHaveBeenCalled();
+  });
+
+  test("a malformed ceiling binding fails closed before the ledger or provider", async () => {
+    const errorSpy = spyOn(logger, "error");
+    expect(
+      await enrich({
+        ELIZA_APP_INBOUND_MEDIA_VISION: "true",
+        ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "unlimited",
+      }),
+    ).toEqual({ kind: "skipped", reason: "invalid_ceilings" });
+    expect(admit).not.toHaveBeenCalled();
+    expect(describeMedia).not.toHaveBeenCalled();
+    expect(
+      errorSpy.mock.calls.some(([message]) => String(message).includes("ceiling bindings")),
+    ).toBe(true);
+    errorSpy.mockRestore();
+  });
+
+  test("the ledger is asked with the exact identity, digest, image count, and ceilings", async () => {
+    await enrich({
+      ELIZA_APP_INBOUND_MEDIA_VISION: "true",
+      ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "3",
+    });
+    expect(admit).toHaveBeenCalledTimes(1);
+    expect(admit.mock.calls[0]?.[0]).toEqual({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: "+15550001111",
+      sourceMessageId: "blooio:eliza-app:message-42",
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      userId: "00000000-0000-4000-8000-000000000002",
+      mediaDigest: await sha256Hex(`${URL_A}\n${URL_B}`),
+      imageCount: 2,
+      ceilings: {
+        senderDailyImages: 3,
+        connectorDailyImages: DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
+      },
+    });
+  });
+
+  test("an unavailable ledger skips without spending and reports the fault", async () => {
+    const errorSpy = spyOn(logger, "error");
+    admit.mockRejectedValue(new Error("connection refused"));
+    expect(await enrich()).toEqual({ kind: "skipped", reason: "admission_unavailable" });
+    expect(describeMedia).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+    expect(fail).not.toHaveBeenCalled();
+    const fault = errorSpy.mock.calls.find(([message]) =>
+      String(message).includes("admission ledger unavailable"),
+    );
+    expect(fault?.[1]).toMatchObject({ error: "connection refused" });
+    errorSpy.mockRestore();
+  });
+});
+
+describe("enrichInboundImageMedia — ledger decisions", () => {
+  test("a stored description is reused without calling the provider", async () => {
+    admit.mockResolvedValue({ kind: "reused", description: "the earlier description" });
+    expect(await enrich()).toEqual({
+      kind: "described",
+      description: "the earlier description",
+      reused: true,
+    });
+    expect(describeMedia).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+  });
+
+  test("every non-claimed decision skips without calling the provider", async () => {
+    const cases: Array<[InboundMediaDescriptionAdmission, string]> = [
+      [{ kind: "in_flight" }, "in_flight"],
+      [{ kind: "previously_failed", reason: "media_fetch_failed" }, "previously_failed"],
+      [{ kind: "media_mismatch" }, "media_mismatch"],
+      [{ kind: "exhausted", scope: "sender", limit: 20, used: 20, requested: 2 }, "exhausted"],
+      [
+        { kind: "exhausted", scope: "connector", limit: 1000, used: 999, requested: 2 },
+        "exhausted",
+      ],
+    ];
+    for (const [decision, reason] of cases) {
+      admit.mockResolvedValue(decision);
+      expect(await enrich()).toEqual({ kind: "skipped", reason: reason as never });
+    }
+    expect(describeMedia).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+    expect(fail).not.toHaveBeenCalled();
+  });
+});
+
+describe("enrichInboundImageMedia — behind a claim", () => {
+  test("a described claim is completed with the provider's text", async () => {
+    expect(await enrich()).toEqual({
+      kind: "described",
+      description: "a cat on a keyboard",
+      reused: false,
+    });
+    expect(describeMedia).toHaveBeenCalledTimes(1);
+    expect(describeMedia.mock.calls[0]?.[1]).toEqual([URL_A, URL_B]);
+    expect(complete).toHaveBeenCalledWith(CLAIM, "a cat on a keyboard");
+    expect(fail).not.toHaveBeenCalled();
+  });
+
+  test("a typed enrichment failure is recorded against the claim and skips", async () => {
+    const errorSpy = spyOn(logger, "error");
+    describeMedia.mockRejectedValue(
+      new InboundMediaDescriptionError("Inbound media body read failed", "media_read_failed"),
+    );
+    expect(await enrich()).toEqual({ kind: "skipped", reason: "description_failed" });
+    expect(fail).toHaveBeenCalledWith(CLAIM, "media_read_failed");
+    expect(complete).not.toHaveBeenCalled();
+    const degrade = errorSpy.mock.calls.find(([message]) =>
+      String(message).includes("inbound media description failed"),
+    );
+    expect(degrade?.[1]).toMatchObject({ reason: "media_read_failed", claimId: CLAIM.id });
+    errorSpy.mockRestore();
+  });
+
+  test("a missing provider behind an enabled flag is recorded so redeliveries do not re-claim", async () => {
+    const errorSpy = spyOn(logger, "error");
+    describeMedia.mockRejectedValue(
+      new InboundMediaVisionDisabledError("Inbound media vision has no configured provider"),
+    );
+    expect(await enrich()).toEqual({ kind: "skipped", reason: "vision_disabled" });
+    expect(fail).toHaveBeenCalledWith(CLAIM, "vision_disabled");
+    expect(
+      errorSpy.mock.calls.some(([message]) =>
+        String(message).includes("without a configured provider"),
+      ),
+    ).toBe(true);
+    errorSpy.mockRestore();
+  });
+
+  test("an untyped provider-path failure propagates and leaves the claim to its lease", async () => {
+    const bug = new Error("bug");
+    describeMedia.mockRejectedValue(bug);
+    await expect(enrich()).rejects.toBe(bug);
+    expect(complete).not.toHaveBeenCalled();
+    expect(fail).not.toHaveBeenCalled();
+  });
+
+  test("a lost or unwritable settlement never discards a paid-for description", async () => {
+    const errorSpy = spyOn(logger, "error");
+    const warnSpy = spyOn(logger, "warn");
+    complete.mockResolvedValue(false);
+    expect(await enrich()).toEqual({
+      kind: "described",
+      description: "a cat on a keyboard",
+      reused: false,
+    });
+    expect(
+      warnSpy.mock.calls.some(([message]) => String(message).includes("reclaimed before")),
+    ).toBe(true);
+
+    complete.mockRejectedValue(new Error("ledger down"));
+    expect(await enrich()).toEqual({
+      kind: "described",
+      description: "a cat on a keyboard",
+      reused: false,
+    });
+    const settlementFault = errorSpy.mock.calls.find(([message]) =>
+      String(message).includes("failed to settle"),
+    );
+    expect(settlementFault?.[1]).toMatchObject({ error: "ledger down" });
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
@@ -1,0 +1,242 @@
+/**
+ * Admission-gated vision enrichment for one inbound Personal Shared media
+ * turn. The order is the spend boundary: the activation flag, then the
+ * operator ceilings, then one primary-database transaction that claims the
+ * connector message id (the enrichment idempotency record) and consumes the
+ * sender and connector per-day image ceilings, and only behind a committed
+ * claim the pooled-key vision call. Every outcome other than `described` is a
+ * skip the caller answers with the raw media-URL text: a missing or broken
+ * admission decision never spends and never fails the turn. A provider
+ * redelivery of the same message reuses the stored description, waits out a
+ * live claim, and never retries a terminal failure.
+ */
+
+import {
+  type InboundMediaDescriptionCeilings,
+  type InboundMediaDescriptionClaim,
+  type InboundMediaDescriptionIdentity,
+  type PersonalSharedInboundMediaRepository,
+  personalSharedInboundMediaRepository,
+} from "../../../db/repositories/personal-shared-inbound-media";
+import type { Bindings } from "../../../types/cloud-worker-env";
+import { sha256Hex } from "../../oidc/crypto";
+import { logger } from "../../utils/logger";
+import {
+  describeInboundImageMedia,
+  InboundMediaDescriptionError,
+  InboundMediaVisionDisabledError,
+  isInboundMediaVisionEnabled,
+} from "./describe-inbound-media";
+
+/** Conversational photo volume for one account; tune per deployment via bindings. */
+export const DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES = 20;
+/** Pooled-key spend ceiling across every sender of one connector account. */
+export const DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES = 1_000;
+
+export type InboundMediaEnrichmentEnv = Pick<
+  Bindings,
+  | "ELIZA_APP_INBOUND_MEDIA_VISION"
+  | "ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES"
+  | "ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES"
+>;
+
+export type InboundMediaEnrichmentSkipReason =
+  | "vision_disabled"
+  | "invalid_ceilings"
+  | "admission_unavailable"
+  | "in_flight"
+  | "previously_failed"
+  | "media_mismatch"
+  | "exhausted"
+  | "description_failed";
+
+export type InboundMediaEnrichmentOutcome =
+  | { kind: "described"; description: string; reused: boolean }
+  | { kind: "skipped"; reason: InboundMediaEnrichmentSkipReason };
+
+export interface InboundMediaEnrichmentInput extends InboundMediaDescriptionIdentity {
+  env: InboundMediaEnrichmentEnv;
+  organizationId: string;
+  userId: string;
+  mediaUrls: readonly string[];
+}
+
+export interface InboundMediaEnrichmentDeps {
+  repository: PersonalSharedInboundMediaRepository;
+  describe: typeof describeInboundImageMedia;
+}
+
+const LOG_PREFIX = "[inbound-media-enrichment]";
+
+function parseCeiling(raw: string | undefined, fallback: number): number | null {
+  if (raw === undefined) return fallback;
+  const trimmed = raw.trim();
+  if (trimmed === "") return fallback;
+  if (!/^\d{1,9}$/.test(trimmed)) return null;
+  return Number(trimmed);
+}
+
+/**
+ * Operator ceilings for this deployment. `null` means a binding is malformed:
+ * a money gate with an unreadable ceiling fails closed rather than guessing.
+ */
+export function resolveInboundMediaVisionCeilings(
+  env: InboundMediaEnrichmentEnv,
+): InboundMediaDescriptionCeilings | null {
+  const senderDailyImages = parseCeiling(
+    env.ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES,
+    DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
+  );
+  const connectorDailyImages = parseCeiling(
+    env.ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES,
+    DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
+  );
+  if (senderDailyImages === null || connectorDailyImages === null) return null;
+  return { senderDailyImages, connectorDailyImages };
+}
+
+/** Canonical digest of the exact URL list so a reuse only matches the same media. */
+export async function inboundMediaDigest(mediaUrls: readonly string[]): Promise<string> {
+  return sha256Hex(mediaUrls.join("\n"));
+}
+
+async function settleClaim(
+  settle: () => Promise<boolean>,
+  context: Record<string, unknown>,
+): Promise<void> {
+  let settled: boolean;
+  try {
+    settled = await settle();
+  } catch (error) {
+    // error-policy:J7 the provider outcome is already final for this turn; a
+    // ledger write failure is reported and the pending claim lapses with its
+    // lease instead of failing the delivery.
+    logger.error(`${LOG_PREFIX} failed to settle the description claim`, {
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  if (!settled) {
+    logger.warn(`${LOG_PREFIX} description claim was reclaimed before settlement`, context);
+  }
+}
+
+export async function enrichInboundImageMedia(
+  input: InboundMediaEnrichmentInput,
+  deps: InboundMediaEnrichmentDeps = {
+    repository: personalSharedInboundMediaRepository,
+    describe: describeInboundImageMedia,
+  },
+): Promise<InboundMediaEnrichmentOutcome> {
+  const context = {
+    platform: input.platform,
+    project: input.project,
+    connectorAccountId: input.connectorAccountId,
+    sourceMessageId: input.sourceMessageId,
+    organizationId: input.organizationId,
+    userId: input.userId,
+    mediaCount: input.mediaUrls.length,
+  };
+  if (!isInboundMediaVisionEnabled(input.env)) {
+    // Disabled is the fleet default, not a fault.
+    logger.debug(`${LOG_PREFIX} vision disabled for this deployment`, context);
+    return { kind: "skipped", reason: "vision_disabled" };
+  }
+  const ceilings = resolveInboundMediaVisionCeilings(input.env);
+  if (!ceilings) {
+    logger.error(`${LOG_PREFIX} ceiling bindings are malformed; vision fails closed`, context);
+    return { kind: "skipped", reason: "invalid_ceilings" };
+  }
+  let admission: Awaited<ReturnType<PersonalSharedInboundMediaRepository["admit"]>>;
+  try {
+    admission = await deps.repository.admit({
+      platform: input.platform,
+      project: input.project,
+      connectorAccountId: input.connectorAccountId,
+      sourceMessageId: input.sourceMessageId,
+      organizationId: input.organizationId,
+      userId: input.userId,
+      mediaDigest: await inboundMediaDigest(input.mediaUrls),
+      imageCount: input.mediaUrls.length,
+      ceilings,
+    });
+  } catch (error) {
+    // error-policy:J4 no admission decision means no spend: the turn keeps the
+    // raw media text instead of failing or calling the provider ungated.
+    logger.error(`${LOG_PREFIX} admission ledger unavailable; vision fails closed`, {
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { kind: "skipped", reason: "admission_unavailable" };
+  }
+  switch (admission.kind) {
+    case "reused":
+      logger.info(`${LOG_PREFIX} reused the stored description for a redelivery`, context);
+      return { kind: "described", description: admission.description, reused: true };
+    case "in_flight":
+      logger.warn(`${LOG_PREFIX} a live claim already covers this message`, context);
+      return { kind: "skipped", reason: "in_flight" };
+    case "previously_failed":
+      logger.info(`${LOG_PREFIX} an earlier attempt already failed; not retrying`, {
+        ...context,
+        failureReason: admission.reason,
+      });
+      return { kind: "skipped", reason: "previously_failed" };
+    case "media_mismatch":
+      logger.warn(
+        `${LOG_PREFIX} redelivery carries different media than the stored claim`,
+        context,
+      );
+      return { kind: "skipped", reason: "media_mismatch" };
+    case "exhausted":
+      logger.warn(`${LOG_PREFIX} daily image ceiling exhausted; vision denied`, {
+        ...context,
+        scope: admission.scope,
+        limit: admission.limit,
+        used: admission.used,
+        requested: admission.requested,
+      });
+      return { kind: "skipped", reason: "exhausted" };
+    case "claimed":
+      return describeBehindClaim(input, deps, admission.claim, context);
+  }
+}
+
+async function describeBehindClaim(
+  input: InboundMediaEnrichmentInput,
+  deps: InboundMediaEnrichmentDeps,
+  claim: InboundMediaDescriptionClaim,
+  context: Record<string, unknown>,
+): Promise<InboundMediaEnrichmentOutcome> {
+  const claimContext = { ...context, claimId: claim.id, attempt: claim.attempt };
+  let description: string;
+  try {
+    description = await deps.describe(input.env, input.mediaUrls);
+  } catch (error) {
+    if (error instanceof InboundMediaVisionDisabledError) {
+      // The flag is on but no vision provider is configured: an operator
+      // misconfiguration, recorded so a redelivery does not claim again.
+      await settleClaim(() => deps.repository.fail(claim, "vision_disabled"), claimContext);
+      logger.error(`${LOG_PREFIX} vision enabled without a configured provider`, claimContext);
+      return { kind: "skipped", reason: "vision_disabled" };
+    }
+    if (error instanceof InboundMediaDescriptionError) {
+      // error-policy:J4 enrichment is additive: an expected fetch/vision
+      // failure degrades to the raw media text instead of dropping the turn.
+      // Reported here because the turn still returns success to the connector.
+      await settleClaim(() => deps.repository.fail(claim, error.reason), claimContext);
+      logger.error(`${LOG_PREFIX} inbound media description failed`, {
+        ...claimContext,
+        reason: error.reason,
+        error: error.message,
+      });
+      return { kind: "skipped", reason: "description_failed" };
+    }
+    // An untyped failure is a bug; the pending claim lapses with its lease.
+    throw error;
+  }
+  await settleClaim(() => deps.repository.complete(claim, description), claimContext);
+  logger.info(`${LOG_PREFIX} inbound media described`, claimContext);
+  return { kind: "described", description, reused: false };
+}

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -489,6 +489,17 @@ export interface Bindings {
    * forward media URLs at all, so enable both deployments together.
    */
   ELIZA_APP_INBOUND_MEDIA_VISION?: string;
+  /**
+   * Per-UTC-day image ceilings for pooled-key inbound media vision, consumed
+   * atomically from the primary-database ledger before any provider call: one
+   * for the resolved sending account and one across every sender of a
+   * connector account. Unset keeps the conservative defaults in
+   * `inbound-media-enrichment.ts`; "0" denies every description; any value
+   * that is not a non-negative integer fails closed (no vision, raw media
+   * text kept) and is logged as a configuration error.
+   */
+  ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES?: string;
+  ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
   /** Collision-free secret used by the protected staging edge cutover. */


### PR DESCRIPTION
# Relates to

Follow-up to #25011 (flag-gated vision descriptions for inbound Blooio images), which merged with three blocking findings from @standujar's review left open: https://github.com/elizaOS/eliza/pull/25011#pullrequestreview-5001645926. This closes all three. The flag stays dark by default; nothing here changes the dark posture.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`0c204214afa`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**Medium (money path), reduced by failing closed.** New: one migration (`0310_personal_shared_inbound_media_admission`: an idempotency/description ledger keyed by platform + project + connector account + source message id, and a per-day quota table), a repository whose `admit()` runs as one primary-database transaction (`INSERT … ON CONFLICT DO NOTHING` → `SELECT … FOR UPDATE` → conditional quota upsert `WHERE used + requested <= limit`; an exhausted ceiling rolls the fresh claim back), an orchestrator the route's `media_description` stage now calls, and two Worker bindings for the ceilings. Every fault — ledger outage, malformed ceiling, exhausted ceiling, in-flight claim, prior failure, media mismatch, provider missing, fetch/read/stream error — degrades to the pre-feature raw `[media: url]` text with HTTP 200 and no provider call; only untyped bugs still 500, and a claim then lapses with its 120 s lease. Group turns and Dedicated runtimes are unchanged (still no pooled vision). Defaults: 20 images/day per sender (account organization), 1000/day per connector account.

# Background

## What does this PR do?

**1. Billing/abuse gate (finding 1).** `packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts` — `PersonalSharedInboundMediaRepository.admit()` claims the connector message id and consumes both per-UTC-day ceilings (`sender` scope = resolved account organization; `connector` scope = `platform:project:connectorAccountId`) in a single transaction before any pooled-key call. `complete()` / `fail()` are fenced by `id + claim_token + state='pending'`. `inbound-media-enrichment.ts` orchestrates flag → ceilings → admit → provider → settle; `resolveInboundMediaVisionCeilings()` reads `ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES` / `…_CONNECTOR_DAILY_IMAGES` (unset = default, `"0"` denies everything, anything else fails closed with an error log). The route's "requires a gate before production enablement" comment is gone because the gate exists.

**2. Idempotent spend (finding 2).** The description row *is* the enrichment idempotency record, keyed by the forwarded message id (`blooio:<project>:<event.messageId>`, the value the gateway already sends). On redelivery: `described` → reuse the stored text (no fetch, no provider); `pending` with a live lease → `in_flight` (raw text); `failed` → never retried; `pending` with a lapsed 120 s lease (> the gateway's 90 s media budget) → reclaimed under a new token, and the dead claimant's late settlement is rejected. The gateway's claim-deletion path is now documented as spend-safe; the media retry posture is intentionally unchanged. A new gateway test pins that a lost-response reopen forwards the identical `messageId` + `mediaUrls` on redelivery.

**3. Degrade path (finding 3).** `describe-inbound-media.ts`: `reader.read()` failures are retyped as `InboundMediaDescriptionError` (`media_read_failed`, cause preserved, `bytesRead` in context); every `body.cancel()` / `reader.cancel()` goes through `discardBody()` so a cancel failure can neither mask nor escape a typed error.

Migration numbering: authored as 0309, renumbered to 0310 on rebase because develop gained `0309_retire_legacy_bluebubbles_gateways` in the meantime (`drizzle-kit check` clean, journal idx 293).

## What kind of change is this?

Bug fixes (non-breaking; the feature flag is dark by default).

# Documentation changes needed?

My changes do not require a change to the project documentation; the two new Worker bindings are documented on `CloudWorkerEnv` next to `ELIZA_APP_INBOUND_MEDIA_VISION`, and the gate semantics are in the orchestrator's header.

# Testing

## Where should a reviewer start?

`inbound-media-enrichment.ts` (the outcome enum and every fail-closed branch), then `personal-shared-inbound-media.ts` `admit()`, then the route's `media_description` stage, then `route.inbound-media.ledger.pglite.test.ts` (real route + real orchestrator + real describe helper + production repository on PGlite with the real 0310 migration; only safeFetch / provider / AI SDK faked).

## Detailed testing steps

- `cd packages/cloud/shared && bun test src/lib/services/eliza-app/describe-inbound-media.test.ts src/lib/services/eliza-app/blooio-media-allowlist.test.ts src/lib/services/eliza-app/inbound-media-enrichment.test.ts src/db/repositories/personal-shared-inbound-media.integration.test.ts src/db/migrations/personal-shared-inbound-media-admission.test.ts src/db/migration-journal-registration.test.ts` → **60 pass / 0 fail**.
- `cd packages/cloud/api && node test/run-unit-isolated.mjs route.inbound-media` → `route.inbound-media.test.ts` 16 pass; `route.inbound-media.ledger.pglite.test.ts` 7 pass / 96 expects.
- `cd packages/cloud/services/gateway-webhook && bun test __tests__/blooio-inbound-media-forward.test.ts` → 11 pass.
- `drizzle-kit check` clean; journal registration test green; `bun run typecheck` in cloud/shared exit 0; gateway `tsc --noEmit` exit 0; cloud/api `tsc --noEmit` 0 errors (after building `plugin-doordash`, whose missing dist is a pre-existing develop error) and `check:worker-bundle` exit 0; biome clean on every touched file.

Mutation checks (each applied alone, then restored; restored tree re-run green):
- remove the read wrap + cancel guard → 3 describe tests + the PGlite "body stream fails mid-read" test fail
- drop the `WHERE used + requested <= limit` predicate → 4 repository + 3 PGlite ceiling tests fail
- bypass the ledger in the orchestrator (pre-fix behavior) → 7 orchestrator + 8 route-unit + 6 PGlite tests fail
- rethrow on a ledger fault instead of failing closed → the three "no 500" tests fail
- re-claim instead of reuse on redelivery → 4 repository + 2 PGlite tests fail (provider called twice)

# Evidence Gate

<!-- evidence-head:4c6cf4bc0a3729ec69a73b6836338e6dc8bccffd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] Every outcome logs under `[inbound-media-enrichment]` with sourceMessageId / org / claimId / scope / used / limit; the PGlite route tests assert the route's 200 + raw-media degrade on each fault class.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The ledger rows themselves: `personal_shared_inbound_media_descriptions` (state, claim token, lease, attempt count, description) and `personal_shared_inbound_media_quotas` (per scope/day image counts) — asserted directly in the repository and PGlite route tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
Every outcome logs under `[inbound-media-enrichment]` with sourceMessageId / org / claimId / scope / used / limit; the PGlite route tests assert the route's 200 + raw-media degrade on each fault class.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- No live signed Blooio / staging / provider trace — the same gap the reviewer noted on #25011; proof here is through the real route and the real Postgres engine (PGlite), not production.
- PGlite serializes transactions, so the concurrency tests prove ordering-independence of the claim/ceiling logic rather than true parallel row-lock interleaving; the SQL relies on standard Postgres `ON CONFLICT` / `FOR UPDATE` semantics.
- No retention purge for description rows (parity with `personal_shared_group_delivery_receipts`); an `(organization_id, created_at)` index exists for a later cron.
- Default ceilings (20 / 1000 images per day) are a proposal — easy to change via the bindings.
- Pre-existing on `origin/develop`, not touched: `route.groups-adversarial.test.ts` › "answers a Blooio reply only after its receipt verifies the reply target" fails (its pin predates #25013's `groupTrustedDelivery`; fix in a separate PR); gateway `dockerfile-workspace-context.test.ts` gateway-discord case.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

