### PR TITLE
test(cloud): derive the post-barrier pending count from the journal

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -108,10 +108,39 @@ async function journalEntries(): Promise<JournalEntry[]> {
  * breaks on every new migration.
  */
 const CHECKPOINT_PREFIX_LENGTH = 184;
+const USAGE_QUOTAS_DROP_TAG = "0282_drop_unused_usage_quotas_table";
+const USAGE_QUOTAS_RESTORE_TAG = "0282_01_restore_usage_quotas_compatibility";
 
-async function expectedPendingBanner(): Promise<string> {
-  const total = (await journalEntries()).length;
-  return `pending migrations: ${total - CHECKPOINT_PREFIX_LENGTH}`;
+/**
+ * Exact migrator banner once the ledger is complete through `appliedLength`
+ * journal entries. The count comes from the live journal, so the expectations
+ * around the release-barrier pause and repair keep tracking appended
+ * migrations too, and the whole line is anchored so a smaller count cannot
+ * match inside a larger one (`: 1` inside `: 16`).
+ */
+async function expectedPendingBanner(
+  appliedLength = CHECKPOINT_PREFIX_LENGTH,
+): Promise<RegExp> {
+  const pending = (await journalEntries()).length - appliedLength;
+  return new RegExp(`^\\[db:migrate\\] pending migrations: ${pending}$`, "m");
+}
+
+/** Journal position of the guarded usage-quotas drop and its adjacent restore. */
+async function usageQuotasBarrier(): Promise<{
+  dropIndex: number;
+  drop: JournalEntry;
+  restore: JournalEntry;
+}> {
+  const entries = await journalEntries();
+  const dropIndex = entries.findIndex(
+    (entry) => entry.tag === USAGE_QUOTAS_DROP_TAG,
+  );
+  const drop = entries[dropIndex];
+  const restore = entries[dropIndex + 1];
+  if (!drop || !restore || restore.tag !== USAGE_QUOTAS_RESTORE_TAG) {
+    throw new Error("Missing guarded usage-quotas migration pair");
+  }
+  return { dropIndex, drop, restore };
 }
 
 /**
@@ -1015,7 +1044,7 @@ describe.skipIf(!ENABLED)(
 
       const first = await runScript(MIGRATOR, database.url);
       expect(first.exitCode, first.output).toBe(0);
-      expect(first.output).toContain(await expectedPendingBanner());
+      expect(first.output).toMatch(await expectedPendingBanner());
 
       const catalog = await database.client.query<{
         data_type: string;
@@ -1062,7 +1091,13 @@ describe.skipIf(!ENABLED)(
 
       const second = await runScript(MIGRATOR, database.url);
       expect(second.exitCode, second.output).toBe(0);
-      expect(second.output).toContain("pending migrations: 2");
+      // The first run paused before the drop, so the drop and everything the
+      // journal appends after the guarded pair are still pending.
+      const { dropIndex } = await usageQuotasBarrier();
+      expect(second.output).toMatch(await expectedPendingBanner(dropIndex));
+      expect(second.output).toContain(
+        "release barrier permits 0 safe pending migrations before 0282",
+      );
       expect(second.output).toContain(
         "release barrier paused before 0282_drop_unused_usage_quotas_table",
       );
@@ -1083,19 +1118,7 @@ describe.skipIf(!ENABLED)(
         "release barrier paused before 0282_drop_unused_usage_quotas_table",
       );
 
-      const entries = await journalEntries();
-      const dropIndex = entries.findIndex(
-        (entry) => entry.tag === "0282_drop_unused_usage_quotas_table",
-      );
-      const drop = entries[dropIndex];
-      const restore = entries[dropIndex + 1];
-      if (
-        !drop ||
-        restore?.tag !== "0282_01_restore_usage_quotas_compatibility"
-      ) {
-        throw new Error("Missing guarded usage-quotas migration pair");
-      }
-
+      const { dropIndex, drop, restore } = await usageQuotasBarrier();
       const dropSql = await readFile(
         path.join(MIGRATIONS_DIR, `${drop.tag}.sql`),
         "utf8",
@@ -1108,7 +1131,10 @@ describe.skipIf(!ENABLED)(
 
       const repaired = await runScript(MIGRATOR, database.url);
       expect(repaired.exitCode, repaired.output).toBe(0);
-      expect(repaired.output).toContain("pending migrations: 1");
+      // 0282 is ledgered, so the restore and every later migration are pending.
+      expect(repaired.output).toMatch(
+        await expectedPendingBanner(dropIndex + 1),
+      );
       expect(repaired.output).toContain(
         "applying 0282_01_restore_usage_quotas_compatibility",
       );
@@ -1168,7 +1194,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain(await expectedPendingBanner());
+      expect(migrated.output).toMatch(await expectedPendingBanner());
 
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'checkpoint-drift' WHERE created_at = $1",
@@ -1218,7 +1244,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain(await expectedPendingBanner());
+      expect(migrated.output).toMatch(await expectedPendingBanner());
       await database.client.end();
     }, 120_000);
 
@@ -1232,7 +1258,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain(await expectedPendingBanner());
+      expect(migrated.output).toMatch(await expectedPendingBanner());
       await database.client.end();
     }, 120_000);
 
@@ -1268,7 +1294,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain(await expectedPendingBanner());
+      expect(migrated.output).toMatch(await expectedPendingBanner());
       await database.client.end();
     }, 120_000);
 
@@ -1292,7 +1318,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain(await expectedPendingBanner());
+      expect(migrated.output).toMatch(await expectedPendingBanner());
 
       const remaining = await database.client.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",
@@ -1418,7 +1444,11 @@ describe.skipIf(!ENABLED)(
       const output = `${first.output}${second.output}`;
       expect(output).toContain("lock timeout on attempt");
       expect(output).toContain("migration lock busy on attempt");
-      expect(output).toContain("pending migrations: 2");
+      // Whichever migrator won the lock applied the safe prefix; the other then
+      // found the ledger already at 0281 with the guarded tail still pending.
+      const { dropIndex } = await usageQuotasBarrier();
+      expect(output).toMatch(await expectedPendingBanner());
+      expect(output).toMatch(await expectedPendingBanner(dropIndex));
       expect(output).toContain(
         "release barrier paused before 0282_drop_unused_usage_quotas_table",
       );


### PR DESCRIPTION
# Relates to

Usage-quotas release barrier (#23829 / #23859); companion to #25306. Found while proving #25306 against a real Postgres.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`0c204214afa`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** Test-only change to the gated `migrate-with-diagnostics.postgres.test.ts` lane (`RUN_REAL_POSTGRES_MIGRATION_TESTS=1` + real Postgres).

# Background

## What does this PR do?

The gated Postgres migration tests hard-coded the `[db:migrate] pending migrations: N` banner after the barrier pause (`2`, and `1` in the restore test). Every migration appended after `0282_01` drifts those numbers — the true count is already 17 on this develop — so the lane fails whenever it runs. The expectations are now derived from the journal the test loads: `expectedPendingBanner(appliedLength)` returns a line-anchored regex (`^\[db:migrate\] pending migrations: N$`, multiline — substring matching could have let `: 1` pass against `: 16`), a `usageQuotasBarrier()` helper locates the guarded pair (failing closed if missing or non-adjacent), and the three pins (post-pause, post-0282-ledgered, concurrent migrators) compute N from `dropIndex`. The post-pause case additionally asserts `permits 0 safe pending migrations before 0282`, so the test still fails if the runner applied anything it should not have.

## What kind of change is this?

Tests (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`expectedPendingBanner` and `usageQuotasBarrier` at the top of the test file, then the three call sites.

## Detailed testing steps

- Gated lane against a disposable `pgvector/pgvector:pg16` container (trust auth, free port, removed afterwards): `origin/develop` file **6 pass / 6 fail** of 12 → this branch **8 pass / 4 fail**. The two cases that go fail → pass are the ones the drift broke (`applies the append-only fix-forward…`, `serializes concurrent migrators…`).
- `bun test --config=/dev/null --isolate <file>` with the gate off: 0 pass / 14 skip / 0 fail (module-level code executes).
- biome: no errors (3 pre-existing `noUndeclaredEnvVars` warnings on the gate reads); `tsc --noEmit` on the file: no new errors (pre-existing `pg` typing noise identical on develop).

# Evidence Gate

<!-- evidence-head:5d6c726bbeb1c7350d633d28e9601be32317952a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] The migrator's own `[db:migrate] pending migrations: 17` line on the live journal (293 entries) is what the derived expectation now matches.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test expectations only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
The migrator's own `[db:migrate] pending migrations: 17` line on the live journal (293 entries) is what the derived expectation now matches.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).
- The remaining 4 failures in the gated lane are pre-existing and unrelated to the count, left as findings: (1) `restores the legacy usage-quota shape…` now continues past `0282_01` into `0295_phone_message_payload_jsonb` (#23860), which hits `42P01` on `phone_message_log` because the dependency-minimal `seedPreCheckpointSchema` fixture never creates it — extending the fixture is a separate change; (2–4) `accepts historical production hash drift…`, `rejects historical rows appended after…`, `rejects incompatible catalog drift…` expect message substrings that `formatDatabaseError` has redacted to `code=DATABASE_OPERATION_FAILED [database_code=SQLSTATE]` since #23860 — whether the tests should assert the redacted code or the migrator should expose detail under a test flag is a product call.

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

