### PR TITLE
test(cloud): pin the owner's group reply to the trusted-delivery destination

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
@@ -352,7 +352,23 @@ describe("adversarial Personal Shared group routing", () => {
       namespace,
       validBlooioGroup.messageId,
       "platform",
-      undefined,
+      // The replying actor is the binding owner, so the turn carries the
+      // group trusted-delivery destination (owner-scheduled group reminders,
+      // #25013) pinned to this binding generation.
+      {
+        platform: "blooio",
+        kind: "group",
+        project: "eliza-app",
+        connectorAccountId: "blooio:test-number",
+        chatId: "chat_group_123",
+        ownerLabel: "Ada",
+        authority: {
+          bindingId: blooioGroupBinding.id,
+          ownerUserId: blooioGroupBinding.owner_user_id,
+          personalAgentId: blooioGroupBinding.personal_agent_id,
+          version: blooioGroupBinding.authority_version,
+        },
+      },
       undefined,
       { type: "GROUP", source: "blooio" },
     );


### PR DESCRIPTION
# Relates to

#25010 (adversarial group tests) and #25013 (owner-scheduled group reminders) merged within minutes of each other; this is the one pin that needed the other's change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync — `bun install` yes; `bun run verify` not run (repository-wide lane); the targeted gates below were run on the exact head.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` (`0c204214afa`); zero conflicts.
- [ ] `bun run verify` — see Known gaps.

# Risks

**None to runtime.** One expectation in one test file.

# Background

## What does this PR do?

`route.groups-adversarial.test.ts` › "answers a Blooio reply only after its receipt verifies the reply target" expected the replying owner's turn to pass no delivery destination to `sharedRestMessageSend`, which was true when #25010 was written. #25013 then made an owner's group turn carry the group trusted-delivery destination (`platform`, `kind:"group"`, `project`, `connectorAccountId`, `chatId`, `ownerLabel`, binding `authority`) so owner-scheduled group reminders pin the binding generation. The pin now states that exact payload — the same shape `route.test.ts` pins for the Telegram sibling. Suite: 13 pass / 1 fail → 14 / 0.

## What kind of change is this?

Tests (non-breaking).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The one hunk.

## Detailed testing steps

`cd packages/cloud/api && node test/run-unit-isolated.mjs personal-shared/messages/route.groups-adversarial.test.ts` → 14 pass / 0 fail (13 / 1 on `origin/develop`). Biome clean.

# Evidence Gate

<!-- evidence-head:ee88c549d08e585d897a9b78186f8c6d22c13e73 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - test expectation only.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - test expectation only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory
N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs
N/A - test expectation only.

## Screenshots / video / audio
N/A - no UI, no voice.

## Known gaps / failures
- `bun run verify` not run (repository-wide lane).

## Maintainer CI exception record
N/A - no exception requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

