### PR TITLE
test(app-core): cover models command registration

### DIFF
--- a/packages/app-core/src/cli/program/__tests__/register-models.test.ts
+++ b/packages/app-core/src/cli/program/__tests__/register-models.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getLogPrefix: vi.fn(() => "[eliza]"),
+}));
+
+vi.mock("@elizaos/shared", () => ({
+  getLogPrefix: (...a: unknown[]) => mocks.getLogPrefix(...a),
+}));
+
+import { registerModelsCli } from "./register.models.ts";
+
+function fakeProgram() {
+  const cmd: {
+    description: ReturnType<typeof vi.fn>;
+    action: ReturnType<typeof vi.fn>;
+  } = {
+    description: vi.fn(() => cmd),
+    action: vi.fn(() => cmd),
+  };
+  const program = { command: vi.fn(() => cmd) };
+  return { program, cmd };
+}
+
+const KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_CLOUD_API_KEY",
+  "GROQ_API_KEY",
+  "XAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "TOGETHER_API_KEY",
+  "MISTRAL_API_KEY",
+  "COHERE_API_KEY",
+  "PERPLEXITY_API_KEY",
+  "ZAI_API_KEY",
+  "MOONSHOT_API_KEY",
+  "OLLAMA_BASE_URL",
+  "ELIZAOS_CLOUD_API_KEY",
+];
+
+describe("registerModelsCli", () => {
+  afterEach(() => {
+    for (const k of KEYS) delete process.env[k];
+  });
+
+  it("registers a models command", () => {
+    const { program, cmd } = fakeProgram();
+    registerModelsCli(program as never);
+    expect(program.command).toHaveBeenCalledWith("models");
+    expect(cmd.description).toHaveBeenCalledWith(
+      "Show configured model providers",
+    );
+  });
+
+  it("reports configured and unset providers from env", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const { program, cmd } = fakeProgram();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    registerModelsCli(program as never);
+    const action = cmd.action.mock.calls[0][0] as () => void;
+    action();
+    const all = log.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(all).toContain("[eliza] Model providers:");
+    expect(all).toContain("OpenAI (GPT): configured");
+    expect(all).toContain("Anthropic (Claude): not set");
+    expect(all).toContain("DeepSeek: not set");
+    log.mockRestore();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
