### PR TITLE
test(app-core): cover launch diagnostics view manifest

### DIFF
--- a/packages/app-core/platforms/electrobun/src/launch/__tests__/launch-dynamic-view.test.ts
+++ b/packages/app-core/platforms/electrobun/src/launch/__tests__/launch-dynamic-view.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  join: vi.fn((...p: string[]) => p.join("/")),
+  dirname: vi.fn(() => "/views"),
+  fileURLToPath: vi.fn(() => "/views/launch-dynamic-view.ts"),
+  pathToFileURL: vi.fn((p: string) => ({ href: `file://${p}` })),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: (...a: unknown[]) => mocks.existsSync(...a),
+}));
+vi.mock("node:path", () => ({
+  join: (...a: unknown[]) => mocks.join(...(a as string[])),
+  dirname: (...a: unknown[]) => mocks.dirname(...a),
+}));
+vi.mock("node:url", () => ({
+  fileURLToPath: (...a: unknown[]) => mocks.fileURLToPath(...a),
+  pathToFileURL: (...a: unknown[]) => mocks.pathToFileURL(...a),
+}));
+
+import {
+  createLaunchDiagnosticsViewManifest,
+  LAUNCH_DIAGNOSTICS_VIEW_ID,
+} from "./launch-dynamic-view.ts";
+
+describe("createLaunchDiagnosticsViewManifest", () => {
+  it("builds the launch diagnostics manifest with resolved entrypoint", () => {
+    mocks.existsSync.mockReturnValue(true);
+    const manifest = createLaunchDiagnosticsViewManifest();
+    expect(manifest.id).toBe(LAUNCH_DIAGNOSTICS_VIEW_ID);
+    expect(manifest.title).toBe("Launch Diagnostics");
+    expect(manifest.source).toBe("system");
+    expect(manifest.placement).toBe("debug");
+    expect(manifest.metadata).toEqual({ launch: true, productionPanel: false });
+    expect(manifest.entrypoint).toContain("file://");
+    expect(manifest.entrypoint).toContain("launch-diagnostics.html");
+  });
+
+  it("falls back to the first candidate when the view file is missing", () => {
+    mocks.existsSync.mockReturnValue(false);
+    const manifest = createLaunchDiagnosticsViewManifest();
+    expect(manifest.entrypoint).toContain("launch-diagnostics.html");
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
