### PR TITLE
fix(whatsapp): canonicalize personal media transport

### DIFF
--- a/packages/agent/src/services/file-storage.test.ts
+++ b/packages/agent/src/services/file-storage.test.ts
@@ -1,8 +1,8 @@
 /**
  * Exercises LocalFileStorageService against a real on-disk media store rooted at
  * a temp `ELIZA_STATE_DIR` (no mocks): store, content-hash dedup, base64 data-URL
- * ingest, list metadata, existence, `getUrl`, and delete — including traversal-safe
- * rejection of malformed file names.
+ * ingest, exact byte readback, list metadata, existence, `getUrl`, and delete —
+ * including traversal-safe rejection of malformed file names.
  */
 
 import { Buffer } from "node:buffer";
@@ -51,6 +51,15 @@ describe("LocalFileStorageService", () => {
     const out = await svc().store(new Uint8Array([1, 2, 3, 4]), "audio/mpeg");
     expect(out.size).toBe(4);
     expect(out.url).toMatch(/\.mp3$/);
+  });
+
+  it("reads exact content-addressed bytes and rejects malformed names", async () => {
+    const s = svc();
+    const bytes = Buffer.from([0, 1, 2, 255]);
+    const stored = await s.store(bytes, "application/octet-stream");
+    await expect(s.read(stored.fileName)).resolves.toEqual(bytes);
+    await expect(s.read("../../etc/passwd")).resolves.toBeNull();
+    await expect(s.read("not-a-content-address.bin")).resolves.toBeNull();
   });
 
   it("stores a base64 data URL", async () => {

--- a/packages/agent/src/services/file-storage.ts
+++ b/packages/agent/src/services/file-storage.ts
@@ -19,6 +19,7 @@ import {
   listMediaFiles,
   mediaFileNameFromUrl,
   persistMediaBytes,
+  readStoredMediaBytes,
 } from "../api/media-store.ts";
 
 const DATA_URL_RE = /^data:([^;,]*)(;base64)?,([\s\S]*)$/;
@@ -80,6 +81,10 @@ export class LocalFileStorageService extends IFileStorageService {
   async exists(fileName: string): Promise<boolean> {
     if (!this.getUrl(fileName)) return false;
     return listMediaFiles().some((file) => file.fileName === fileName);
+  }
+
+  async read(fileName: string): Promise<Buffer | null> {
+    return readStoredMediaBytes(fileName);
   }
 
   async list(): Promise<StoredFileListItem[]> {

--- a/packages/core/src/types/service-interfaces.ts
+++ b/packages/core/src/types/service-interfaces.ts
@@ -529,6 +529,9 @@ export abstract class IFileStorageService extends Service {
 	/** True when a stored file with this filename exists. */
 	abstract exists(fileName: string): Promise<boolean>;
 
+	/** Read exact stored bytes by content-addressed filename, or null when absent. */
+	abstract read(fileName: string): Promise<Buffer | null>;
+
 	/** List all stored files (for the Files surface). */
 	abstract list(): Promise<StoredFileListItem[]>;
 

--- a/plugins/plugin-whatsapp/__tests__/media-validation.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/media-validation.test.ts
@@ -1,7 +1,6 @@
 /**
- * Guards the SSRF check on outbound media links: both the Cloud API client and
- * the Baileys message adapter must reject file://, data:, javascript:, and
- * malformed URLs before dispatch. Deterministic — stubs global fetch, no network.
+ * Guards Cloud media URLs and proves the personal Baileys adapter requires
+ * connector-verified canonical bytes instead of initiating its own download.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MessageAdapter } from "../src/baileys/message-adapter";
@@ -66,11 +65,9 @@ describe("WhatsApp media URL validation", () => {
     );
   });
 
-  it.each([
-    "file:///tmp/secret.jpg",
-    "ftp://example.com/file.mp3",
-    "https://u:p@example.com/a.mp3",
-  ])("rejects hostile Baileys media links: %s", (link) => {
+  it.each(["file:///tmp/secret.jpg", "https://example.com/a.mp3"])(
+    "rejects Baileys media links without canonical bytes: %s",
+    (link) => {
     const adapter = new MessageAdapter();
 
     expect(() =>
@@ -79,6 +76,19 @@ describe("WhatsApp media URL validation", () => {
         to: "14155552671@s.whatsapp.net",
         content: { link },
       })
-    ).toThrow("audio message requires a valid http(s) media link");
+    ).toThrow("requires canonical local bytes");
+    }
+  );
+
+  it("passes exact canonical bytes to Baileys without a URL payload", () => {
+    const adapter = new MessageAdapter();
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(
+      adapter.toBaileys({
+        type: "audio",
+        to: "14155552671@s.whatsapp.net",
+        content: { link: "/api/media/hash.mp3", bytes },
+      })
+    ).toEqual({ audio: Buffer.from(bytes) });
   });
 });

--- a/plugins/plugin-whatsapp/__tests__/outbound-media.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/outbound-media.test.ts
@@ -5,6 +5,7 @@
  * build their payload from the same WhatsAppMessage media type, so one path
  * covers both. Mocked runtime — runs offline.
  */
+import crypto from "node:crypto";
 import type { IAgentRuntime, Media, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { BaileysClient } from "../src/clients/baileys-client";
@@ -241,6 +242,68 @@ describe("WhatsApp sendMediaMessage — transport-agnostic media call", () => {
   });
 });
 
+describe("WhatsApp sendMediaMessage — canonical personal bytes", () => {
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  );
+
+  function personalService(storedBytes: Buffer | null = png) {
+    const clientSend = vi.fn(async () => ({ messages: [{ id: "x" }] }));
+    const storage = { read: vi.fn(async () => storedBytes) };
+    const svc = Object.create(
+      WhatsAppConnectorService.prototype,
+    ) as WhatsAppConnectorService;
+    Object.assign(svc as object, {
+      runtime: { getService: vi.fn(() => storage) },
+      getClientForAccount: vi.fn(() => ({ sendMessage: clientSend })),
+      getConfigForAccount: vi.fn(() => ({
+        accountId: "default",
+        transport: "baileys",
+        authDir: "/tmp/auth",
+        mediaMaxMb: 1,
+      })),
+    });
+    return { svc, clientSend, storage };
+  }
+
+  function canonicalMedia(bytes = png): Media {
+    const hash = crypto.createHash("sha256").update(bytes).digest("hex");
+    return {
+      id: hash,
+      checksum: hash,
+      url: `/api/media/${hash}.png`,
+      contentType: "image",
+      mimeType: "image/png",
+    } as Media;
+  }
+
+  it("reads and hash-verifies canonical bytes before the personal client call", async () => {
+    const { svc, clientSend, storage } = personalService();
+    const media = canonicalMedia();
+    await svc.sendMediaMessage("default", "14155552671@s.whatsapp.net", media);
+
+    expect(storage.read).toHaveBeenCalledWith(`${media.checksum}.png`);
+    expect(clientSend).toHaveBeenCalledWith({
+      type: "image",
+      to: "14155552671@s.whatsapp.net",
+      content: { link: media.url, bytes: png },
+    });
+  });
+
+  it.each([
+    ["external URL", { ...canonicalMedia(), url: "https://cdn.example.com/image.png" }, png],
+    ["missing bytes", canonicalMedia(), null],
+    ["corrupt store", canonicalMedia(), Buffer.from("wrong bytes")],
+  ])("fails before personal client I/O for %s", async (_label, media, storedBytes) => {
+    const { svc, clientSend } = personalService(storedBytes as Buffer | null);
+    await expect(
+      svc.sendMediaMessage("default", "14155552671@s.whatsapp.net", media as Media),
+    ).rejects.toBeInstanceOf(Error);
+    expect(clientSend).not.toHaveBeenCalled();
+  });
+});
+
 describe("WhatsApp personal quoted delivery", () => {
   it("uses the same account-and-chat scope for default and named inbound reply identities", () => {
     const runtime = { agentId: "00000000-0000-0000-0000-000000000010" } as IAgentRuntime;
@@ -267,72 +330,82 @@ describe("WhatsApp personal quoted delivery", () => {
   it.each(["default", "work"])(
     "preserves %s-account group participant and image payload for text and media",
     async (accountId) => {
-    const registrations: MessageConnectorRegistration[] = [];
-    const socketSend = vi.fn(async () => ({ key: { id: "wamid.sent" } }));
-    const client = new BaileysClient({ authDir: "/tmp/whatsapp-quote-test" });
-    (
-      client as unknown as { connection: { getSocket: () => unknown } }
-    ).connection.getSocket = () => ({ sendMessage: socketSend });
-    const runtime = makeRuntime(registrations);
-    vi.mocked(runtime.getMemoryById).mockResolvedValueOnce({
-      content: {
-        text: "photo caption",
-        attachments: [
-          { id: "parent", contentType: "image", url: "/api/media/parent.png" },
-        ],
-      },
-      metadata: {
-        messageIdFull: "wamid.group-parent",
-        rawSenderId: "14155552671@s.whatsapp.net",
-        fromBot: false,
-      },
-    } as never);
-    const service = Object.create(
-      WhatsAppConnectorService.prototype,
-    ) as WhatsAppConnectorService;
-    Object.assign(service as object, {
-      runtime,
-      connected: true,
-      defaultAccountId: accountId,
-      configs: new Map([
-        [accountId, { accountId, transport: "baileys", authDir: "/tmp/quote" }],
-      ]),
-      clients: new Map([[accountId, client]]),
-      knownTargets: new Map(),
-    });
-    WhatsAppConnectorService.registerSendHandlers(runtime, service);
-
-    await registrations[0].sendHandler?.(
-      runtime,
-      { source: "whatsapp", channelId: "120363000000@g.us" } as ConnectorTargetInfo,
-      {
-        text: "reply text",
-        inReplyTo: "00000000-0000-0000-0000-000000000001" as UUID,
-        attachments: [
-          {
-            id: "reply",
-            url: "https://cdn.example.com/reply.png",
-            contentType: "image",
-          },
-        ],
-      } as ConnectorContent,
-    );
-
-    expect(socketSend).toHaveBeenCalledTimes(2);
-    for (const call of socketSend.mock.calls) {
-      expect(call[0]).toBe("120363000000@g.us");
-      expect(call[2]).toEqual({
-        quoted: {
-          key: {
-            remoteJid: "120363000000@g.us",
-            id: "wamid.group-parent",
-            fromMe: false,
-            participant: "14155552671@s.whatsapp.net",
-          },
-          message: { imageMessage: { caption: "photo caption" } },
+      const registrations: MessageConnectorRegistration[] = [];
+      const socketSend = vi.fn(async () => ({ key: { id: "wamid.sent" } }));
+      const client = new BaileysClient({ authDir: "/tmp/whatsapp-quote-test" });
+      (
+        client as unknown as { connection: { getSocket: () => unknown } }
+      ).connection.getSocket = () => ({ sendMessage: socketSend });
+      const runtime = makeRuntime(registrations);
+      const replyBytes = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      );
+      const replyHash = crypto.createHash("sha256").update(replyBytes).digest("hex");
+      (runtime as unknown as { getService: ReturnType<typeof vi.fn> }).getService = vi.fn(() => ({
+        read: vi.fn(async () => replyBytes),
+      }));
+      vi.mocked(runtime.getMemoryById).mockResolvedValueOnce({
+        content: {
+          text: "photo caption",
+          attachments: [
+            { id: "parent", contentType: "image", url: "/api/media/parent.png" },
+          ],
         },
+        metadata: {
+          messageIdFull: "wamid.group-parent",
+          rawSenderId: "14155552671@s.whatsapp.net",
+          fromBot: false,
+        },
+      } as never);
+      const service = Object.create(
+        WhatsAppConnectorService.prototype,
+      ) as WhatsAppConnectorService;
+      Object.assign(service as object, {
+        runtime,
+        connected: true,
+        defaultAccountId: accountId,
+        configs: new Map([
+          [accountId, { accountId, transport: "baileys", authDir: "/tmp/quote" }],
+        ]),
+        clients: new Map([[accountId, client]]),
+        knownTargets: new Map(),
       });
-    }
+      WhatsAppConnectorService.registerSendHandlers(runtime, service);
+
+      await registrations[0].sendHandler?.(
+        runtime,
+        { source: "whatsapp", channelId: "120363000000@g.us" } as ConnectorTargetInfo,
+        {
+          text: "reply text",
+          inReplyTo: "00000000-0000-0000-0000-000000000001" as UUID,
+          attachments: [
+            {
+              id: replyHash,
+              checksum: replyHash,
+              url: `/api/media/${replyHash}.png`,
+              contentType: "image",
+              mimeType: "image/png",
+            },
+          ],
+        } as ConnectorContent,
+      );
+
+      expect(socketSend).toHaveBeenCalledTimes(2);
+      for (const call of socketSend.mock.calls) {
+        expect(call[0]).toBe("120363000000@g.us");
+        expect(call[2]).toEqual({
+          quoted: {
+            key: {
+              remoteJid: "120363000000@g.us",
+              id: "wamid.group-parent",
+              fromMe: false,
+              participant: "14155552671@s.whatsapp.net",
+            },
+            message: { imageMessage: { caption: "photo caption" } },
+          },
+        });
+      }
     },
   );
 

--- a/plugins/plugin-whatsapp/__tests__/personal-media-ingress.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/personal-media-ingress.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Verifies personal media ingress crosses the authenticated fetch boundary and
+ * canonical file service with exact hash and readback checks before attachment creation.
+ */
+import crypto from "node:crypto";
+import type { Media } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PersonalMediaMetadata } from "../src/types";
+
+const fetchVerifiedPersonalMedia = vi.hoisted(() => vi.fn());
+vi.mock("../src/baileys/media", () => ({ fetchVerifiedPersonalMedia }));
+
+import { WhatsAppConnectorService } from "../src/runtime-service";
+
+const bytes = Buffer.from("verified personal attachment");
+const hash = crypto.createHash("sha256").update(bytes).digest("hex");
+const metadata: PersonalMediaMetadata = {
+  kind: "document",
+  url: "https://media.whatsapp.net/file.enc",
+  mediaKey: new Uint8Array(32),
+  fileSha256: new Uint8Array(32),
+  fileEncSha256: new Uint8Array(32),
+  fileLength: bytes.length,
+  mimeType: "application/pdf",
+  fileName: "evidence.pdf",
+};
+
+function harness(readback: Buffer | null = bytes) {
+  const storage = {
+    store: vi.fn(async () => ({
+      hash,
+      fileName: `${hash}.pdf`,
+      url: `/api/media/${hash}.pdf`,
+      mimeType: "application/pdf",
+      size: bytes.length,
+    })),
+    read: vi.fn(async () => readback),
+  };
+  const service = Object.create(
+    WhatsAppConnectorService.prototype,
+  ) as WhatsAppConnectorService;
+  Object.assign(service as object, {
+    runtime: { getService: vi.fn(() => storage) },
+    defaultAccountId: "default",
+    configs: new Map([
+      ["default", { accountId: "default", transport: "baileys", authDir: "/tmp/auth" }],
+    ]),
+  });
+  const ingest = (
+    service as unknown as {
+      ingestPersonalMedia: (accountId: string, value: PersonalMediaMetadata) => Promise<Media>;
+    }
+  ).ingestPersonalMedia.bind(service);
+  return { ingest, storage };
+}
+
+beforeEach(() => {
+  fetchVerifiedPersonalMedia.mockReset();
+  fetchVerifiedPersonalMedia.mockResolvedValue({
+    bytes,
+    mimeType: "application/pdf",
+    fileName: "evidence.pdf",
+  });
+});
+
+describe("personal WhatsApp canonical media ingress", () => {
+  it("stores and reads back exact verified bytes under their SHA-256 handle", async () => {
+    const { ingest, storage } = harness();
+    const attachment = await ingest("default", metadata);
+
+    expect(fetchVerifiedPersonalMedia).toHaveBeenCalledWith(metadata, 50 * 1024 * 1024);
+    expect(storage.store).toHaveBeenCalledWith(bytes, "application/pdf");
+    expect(storage.read).toHaveBeenCalledWith(`${hash}.pdf`);
+    expect(attachment).toEqual({
+      id: hash,
+      url: `/api/media/${hash}.pdf`,
+      source: "whatsapp",
+      contentType: "document",
+      mimeType: "application/pdf",
+      size: bytes.length,
+      checksum: hash,
+      filename: "evidence.pdf",
+    });
+  });
+
+  it("performs no store I/O when guarded provider fetch fails", async () => {
+    const { ingest, storage } = harness();
+    fetchVerifiedPersonalMedia.mockRejectedValueOnce(new Error("SSRF denied"));
+    await expect(ingest("default", metadata)).rejects.toThrow("SSRF denied");
+    expect(storage.store).not.toHaveBeenCalled();
+    expect(storage.read).not.toHaveBeenCalled();
+  });
+
+  it("fails visibly when canonical readback differs", async () => {
+    const { ingest, storage } = harness(Buffer.from("corrupt"));
+    await expect(ingest("default", metadata)).rejects.toMatchObject({
+      code: "WHATSAPP_MEDIA_STORE_READBACK_MISMATCH",
+    });
+    expect(storage.store).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-whatsapp/src/baileys/media.test.ts
+++ b/plugins/plugin-whatsapp/src/baileys/media.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Exercises personal WhatsApp media authentication through the real crypto and
+ * core guarded-fetch contracts with deterministic pinned transport doubles.
+ */
+
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:https";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { nodePinnedFetch } from "@elizaos/core";
+import { getMediaKeys } from "@whiskeysockets/baileys";
+import { describe, expect, it, vi } from "vitest";
+import type { PersonalMediaMetadata } from "../types";
+import { fetchVerifiedPersonalMedia } from "./media";
+
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64"
+);
+
+async function encryptedFixture(
+  plaintext: Buffer,
+  kind: PersonalMediaMetadata["kind"] = "image",
+  mimeType = "image/png"
+): Promise<{ metadata: PersonalMediaMetadata; encrypted: Buffer }> {
+  const mediaKey = crypto.randomBytes(32);
+  const { cipherKey, iv, macKey } = await getMediaKeys(mediaKey, kind);
+  const cipher = crypto.createCipheriv("aes-256-cbc", cipherKey, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const mac = crypto
+    .createHmac("sha256", macKey)
+    .update(iv)
+    .update(ciphertext)
+    .digest()
+    .subarray(0, 10);
+  const encrypted = Buffer.concat([ciphertext, mac]);
+  return {
+    encrypted,
+    metadata: {
+      kind,
+      url: "https://media.whatsapp.net/media.enc",
+      mediaKey,
+      fileSha256: crypto.createHash("sha256").update(plaintext).digest(),
+      fileEncSha256: crypto.createHash("sha256").update(encrypted).digest(),
+      fileLength: plaintext.length,
+      mimeType,
+    },
+  };
+}
+
+function guardedOptions(encrypted: Buffer) {
+  return {
+    lookupFn: vi.fn(async () => [{ address: "127.0.0.1", family: 4 as const }]),
+    pinnedFetchImpl: vi.fn(
+      async () =>
+        new Response(encrypted, {
+          headers: {
+            "content-length": String(encrypted.length),
+            "content-type": "application/octet-stream",
+          },
+        })
+    ),
+    ssrfPolicy: { allowedHostnames: ["media.whatsapp.net"] },
+  };
+}
+
+describe("personal Baileys media ingress", () => {
+  it("decrypts authenticated bytes through the DNS-pinned guard", async () => {
+    const fixture = await encryptedFixture(PNG);
+    const options = guardedOptions(fixture.encrypted);
+    const result = await fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, options);
+
+    expect(result.bytes).toEqual(PNG);
+    expect(result.mimeType).toBe("image/png");
+    expect(options.lookupFn).toHaveBeenCalledWith("media.whatsapp.net", { all: true });
+    expect(options.pinnedFetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks private resolution before provider transport I/O", async () => {
+    const fixture = await encryptedFixture(PNG);
+    const pinnedFetchImpl = vi.fn(async () => new Response(fixture.encrypted));
+    await expect(
+      fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, {
+        lookupFn: async () => [{ address: "127.0.0.1", family: 4 }],
+        pinnedFetchImpl,
+      })
+    ).rejects.toThrow();
+    expect(pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("keeps certificate verification enabled on the real pinned HTTPS transport", async () => {
+    const fixture = await encryptedFixture(PNG);
+    const tlsRoot = await mkdtemp(path.join(tmpdir(), "whatsapp-media-tls-"));
+    const keyPath = path.join(tlsRoot, "key.pem");
+    const certPath = path.join(tlsRoot, "cert.pem");
+    execFileSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-subj",
+        "/CN=media.whatsapp.net",
+        "-days",
+        "1",
+      ],
+      { stdio: "ignore" }
+    );
+    let requests = 0;
+    const server = createServer(
+      { key: await readFile(keyPath), cert: await readFile(certPath) },
+      (_request, response) => {
+        requests += 1;
+        response.end(fixture.encrypted);
+      }
+    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    fixture.metadata.url = `https://media.whatsapp.net:${port}/media.enc`;
+    try {
+      await expect(
+        fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, {
+          lookupFn: async () => [{ address: "127.0.0.1", family: 4 }],
+          pinnedFetchImpl: nodePinnedFetch,
+          ssrfPolicy: { allowedHostnames: ["media.whatsapp.net"] },
+        })
+      ).rejects.toMatchObject({ code: "WHATSAPP_PERSONAL_MEDIA_FETCH_FAILED" });
+      expect(requests).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      );
+      await rm(tlsRoot, { recursive: true });
+    }
+  });
+
+  it("rejects declared oversize before DNS or provider transport I/O", async () => {
+    const fixture = await encryptedFixture(PNG);
+    const options = guardedOptions(fixture.encrypted);
+    await expect(
+      fetchVerifiedPersonalMedia(fixture.metadata, PNG.length - 1, options)
+    ).rejects.toThrow("exceeds the configured byte limit");
+    expect(options.lookupFn).not.toHaveBeenCalled();
+    expect(options.pinnedFetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects redirects and encoded responses", async () => {
+    const fixture = await encryptedFixture(PNG);
+    const lookupFn = async () => [{ address: "127.0.0.1", family: 4 as const }];
+    const policy = { allowedHostnames: ["media.whatsapp.net"] };
+    await expect(
+      fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, {
+        lookupFn,
+        ssrfPolicy: policy,
+        pinnedFetchImpl: async () =>
+          new Response(null, { status: 302, headers: { location: "https://evil.example/media" } }),
+      })
+    ).rejects.toThrow();
+    await expect(
+      fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, {
+        lookupFn,
+        ssrfPolicy: policy,
+        pinnedFetchImpl: async () =>
+          new Response(fixture.encrypted, { headers: { "content-encoding": "gzip" } }),
+      })
+    ).rejects.toMatchObject({ code: "WHATSAPP_PERSONAL_MEDIA_FETCH_FAILED" });
+  });
+
+  it("rejects corrupt ciphertext and plaintext type confusion", async () => {
+    const fixture = await encryptedFixture(PNG);
+    const corrupt = Buffer.from(fixture.encrypted);
+    corrupt[0] ^= 0xff;
+    await expect(
+      fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, guardedOptions(corrupt))
+    ).rejects.toMatchObject({ code: "WHATSAPP_PERSONAL_MEDIA_ENCRYPTED_HASH_MISMATCH" });
+
+    const pdfFixture = await encryptedFixture(
+      Buffer.from("%PDF-1.7\nnot an image"),
+      "image",
+      "image/png"
+    );
+    await expect(
+      fetchVerifiedPersonalMedia(
+        pdfFixture.metadata,
+        pdfFixture.metadata.fileLength,
+        guardedOptions(pdfFixture.encrypted)
+      )
+    ).rejects.toMatchObject({ code: "WHATSAPP_PERSONAL_MEDIA_CONTENT_TYPE_MISMATCH" });
+  });
+});

--- a/plugins/plugin-whatsapp/src/baileys/media.ts
+++ b/plugins/plugin-whatsapp/src/baileys/media.ts
@@ -1,0 +1,298 @@
+/**
+ * Authorizes, downloads, authenticates, and decrypts personal WhatsApp media.
+ * Provider metadata is validated before the core DNS-pinned fetch boundary;
+ * only integrity-checked plaintext bytes leave this module.
+ */
+import crypto from "node:crypto";
+import { detectMime, ElizaError, type FetchMediaOptions, fetchRemoteMedia } from "@elizaos/core";
+import {
+  extractMessageContent,
+  getMediaKeys,
+  getUrlFromDirectPath,
+  type proto,
+} from "@whiskeysockets/baileys";
+import type { PersonalMediaMetadata } from "../types";
+
+export type PersonalMediaKind = "image" | "audio" | "video" | "document";
+
+export interface VerifiedPersonalMedia {
+  bytes: Buffer;
+  mimeType: string;
+  fileName?: string;
+}
+
+type MediaProto =
+  | proto.Message.IImageMessage
+  | proto.Message.IAudioMessage
+  | proto.Message.IVideoMessage
+  | proto.Message.IDocumentMessage;
+
+function mediaError(
+  code: string,
+  message: string,
+  context: Record<string, unknown>,
+  cause?: unknown
+): ElizaError {
+  return new ElizaError(message, { code, context, cause, severity: "fatal" });
+}
+
+function exactBytes(value: Uint8Array | null | undefined, length: number): Uint8Array | undefined {
+  return value?.byteLength === length ? value : undefined;
+}
+
+function readFileLength(value: unknown): number | undefined {
+  const numberValue = Number(value);
+  return Number.isSafeInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+}
+
+function normalizeDeclaredMime(value: string | null | undefined): string | undefined {
+  const mime = value?.split(";")[0]?.trim().toLowerCase();
+  return mime || undefined;
+}
+
+function mimeMatchesKind(mimeType: string | undefined, kind: PersonalMediaKind): boolean {
+  if (mimeType === undefined) return false;
+  return mimeType.startsWith(`${kind}/`);
+}
+
+function mediaProtoForMessage(message: proto.IMessage): {
+  kind: PersonalMediaKind;
+  media: MediaProto;
+} | null {
+  if (message.imageMessage) return { kind: "image", media: message.imageMessage };
+  if (message.audioMessage) return { kind: "audio", media: message.audioMessage };
+  if (message.videoMessage) return { kind: "video", media: message.videoMessage };
+  if (message.documentMessage) return { kind: "document", media: message.documentMessage };
+  return null;
+}
+
+/** Extract and structurally authorize provider media metadata without network I/O. */
+export function extractPersonalMediaMetadata(
+  message: proto.IWebMessageInfo
+): PersonalMediaMetadata | undefined {
+  const content = extractMessageContent(message.message);
+  const selected = content ? mediaProtoForMessage(content) : null;
+  if (!selected) return undefined;
+
+  const mediaKey = exactBytes(selected.media.mediaKey, 32);
+  const fileSha256 = exactBytes(selected.media.fileSha256, 32);
+  const fileEncSha256 = exactBytes(selected.media.fileEncSha256, 32);
+  const fileLength = readFileLength(selected.media.fileLength);
+  const mimeType = normalizeDeclaredMime(selected.media.mimetype);
+  const directPath = selected.media.directPath?.trim() || undefined;
+  const url = selected.media.url?.trim() || undefined;
+
+  if (!mediaKey || !fileSha256 || !fileEncSha256 || !fileLength || !mimeType) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_METADATA_INVALID",
+      "Personal WhatsApp media metadata is incomplete or malformed",
+      { messageType: selected.kind }
+    );
+  }
+  if (!directPath && !url) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_LOCATION_MISSING",
+      "Personal WhatsApp media has no provider download location",
+      { messageType: selected.kind }
+    );
+  }
+  if (directPath && (!directPath.startsWith("/") || directPath.startsWith("//"))) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_LOCATION_INVALID",
+      "Personal WhatsApp media direct path is invalid",
+      { messageType: selected.kind }
+    );
+  }
+  if (selected.kind !== "document" && !mimeType.startsWith(`${selected.kind}/`)) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_TYPE_MISMATCH",
+      "Personal WhatsApp media type does not match its message envelope",
+      { messageType: selected.kind, mimeType }
+    );
+  }
+
+  return {
+    kind: selected.kind,
+    mediaKey,
+    fileSha256,
+    fileEncSha256,
+    fileLength,
+    mimeType,
+    ...(directPath ? { directPath } : {}),
+    ...(url ? { url } : {}),
+    ...(selected.kind === "document" && (selected.media as proto.Message.IDocumentMessage).fileName
+      ? { fileName: (selected.media as proto.Message.IDocumentMessage).fileName ?? undefined }
+      : {}),
+  };
+}
+
+function authorizedDownloadUrl(metadata: PersonalMediaMetadata): string {
+  let parsed: URL;
+  try {
+    const value = metadata.directPath ? getUrlFromDirectPath(metadata.directPath) : metadata.url;
+    parsed = new URL(value ?? "");
+  } catch (error) {
+    // error-policy:J2 Provider locations are untrusted and retain their parse cause.
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_LOCATION_INVALID",
+      "Personal WhatsApp media location is not a valid URL",
+      { messageType: metadata.kind },
+      error
+    );
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (
+    parsed.protocol !== "https:" ||
+    !(host === "whatsapp.net" || host.endsWith(".whatsapp.net") || host.endsWith(".fbcdn.net"))
+  ) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_LOCATION_DENIED",
+      "Personal WhatsApp media must use an authorized HTTPS provider host",
+      { messageType: metadata.kind, protocol: parsed.protocol, hostname: host }
+    );
+  }
+  return parsed.toString();
+}
+
+function digest(bytes: Uint8Array): Buffer {
+  return crypto.createHash("sha256").update(bytes).digest();
+}
+
+function assertEqualDigest(
+  actual: Uint8Array,
+  expected: Uint8Array,
+  code: string,
+  kind: PersonalMediaKind
+): void {
+  if (actual.byteLength !== expected.byteLength || !crypto.timingSafeEqual(actual, expected)) {
+    throw mediaError(code, "Personal WhatsApp media failed provider integrity verification", {
+      messageType: kind,
+    });
+  }
+}
+
+function decryptAuthenticatedMedia(metadata: PersonalMediaMetadata, encrypted: Buffer): Buffer {
+  if (encrypted.length < 26) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_RESPONSE_CORRUPT",
+      "Personal WhatsApp media response is too short",
+      { messageType: metadata.kind, encryptedBytes: encrypted.length }
+    );
+  }
+  assertEqualDigest(
+    digest(encrypted),
+    metadata.fileEncSha256,
+    "WHATSAPP_PERSONAL_MEDIA_ENCRYPTED_HASH_MISMATCH",
+    metadata.kind
+  );
+
+  return Buffer.from(encrypted);
+}
+
+export async function fetchVerifiedPersonalMedia(
+  metadata: PersonalMediaMetadata,
+  maxBytes: number,
+  fetchOptions: Pick<
+    FetchMediaOptions,
+    "fetchImpl" | "lookupFn" | "pinnedFetchImpl" | "ssrfPolicy" | "timeoutMs"
+  > = {}
+): Promise<VerifiedPersonalMedia> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0 || metadata.fileLength > maxBytes) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_SIZE_DENIED",
+      "Personal WhatsApp media exceeds the configured byte limit",
+      { messageType: metadata.kind, declaredBytes: metadata.fileLength, maxBytes }
+    );
+  }
+  const url = authorizedDownloadUrl(metadata);
+  let encrypted: Buffer;
+  try {
+    const result = await fetchRemoteMedia({
+      url,
+      maxBytes: maxBytes + 32,
+      maxRedirects: 0,
+      timeoutMs: fetchOptions.timeoutMs ?? 15_000,
+      rejectContentEncoding: true,
+      ...fetchOptions,
+    });
+    encrypted = decryptAuthenticatedMedia(metadata, result.buffer);
+  } catch (error) {
+    if (error instanceof ElizaError) throw error;
+    // error-policy:J2 Guarded transport failures are classified for the connector boundary.
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_FETCH_FAILED",
+      "Personal WhatsApp media could not be fetched through the guarded transport",
+      { messageType: metadata.kind },
+      error
+    );
+  }
+
+  const { cipherKey, iv, macKey } = await getMediaKeys(metadata.mediaKey, metadata.kind);
+  if (!cipherKey || !iv || !macKey) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_KEYS_INVALID",
+      "Personal WhatsApp media key derivation returned incomplete material",
+      { messageType: metadata.kind }
+    );
+  }
+  const ciphertext = encrypted.subarray(0, -10);
+  const receivedMac = encrypted.subarray(-10);
+  const expectedMac = crypto
+    .createHmac("sha256", macKey)
+    .update(iv)
+    .update(ciphertext)
+    .digest()
+    .subarray(0, 10);
+  assertEqualDigest(
+    receivedMac,
+    expectedMac,
+    "WHATSAPP_PERSONAL_MEDIA_MAC_MISMATCH",
+    metadata.kind
+  );
+
+  let bytes: Buffer;
+  try {
+    const decipher = crypto.createDecipheriv("aes-256-cbc", cipherKey, iv);
+    bytes = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch (error) {
+    // error-policy:J2 Authenticated ciphertext that cannot decrypt remains a provider-integrity failure.
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_DECRYPT_FAILED",
+      "Personal WhatsApp media could not be decrypted",
+      { messageType: metadata.kind },
+      error
+    );
+  }
+  if (bytes.length !== metadata.fileLength || bytes.length > maxBytes) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_LENGTH_MISMATCH",
+      "Personal WhatsApp media plaintext length does not match provider metadata",
+      { messageType: metadata.kind, actualBytes: bytes.length, declaredBytes: metadata.fileLength }
+    );
+  }
+  assertEqualDigest(
+    digest(bytes),
+    metadata.fileSha256,
+    "WHATSAPP_PERSONAL_MEDIA_PLAINTEXT_HASH_MISMATCH",
+    metadata.kind
+  );
+
+  const detectedMime = await detectMime({ buffer: bytes, headerMime: metadata.mimeType });
+  if (metadata.kind !== "document" && !mimeMatchesKind(detectedMime, metadata.kind)) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_CONTENT_TYPE_MISMATCH",
+      "Personal WhatsApp media bytes do not match the declared message type",
+      {
+        messageType: metadata.kind,
+        declaredMimeType: metadata.mimeType,
+        detectedMimeType: detectedMime,
+      }
+    );
+  }
+
+  return {
+    bytes,
+    mimeType: detectedMime ?? metadata.mimeType,
+    ...(metadata.fileName ? { fileName: metadata.fileName } : {}),
+  };
+}

--- a/plugins/plugin-whatsapp/src/baileys/message-adapter.ts
+++ b/plugins/plugin-whatsapp/src/baileys/message-adapter.ts
@@ -4,20 +4,23 @@
  * (chat id, type, content, reply target); `toBaileys` builds the outbound
  * Baileys payload from a WhatsAppMessage, validating media links before send.
  */
+import { Buffer } from "node:buffer";
+import { ElizaError } from "@elizaos/core";
 import type { proto } from "@whiskeysockets/baileys";
-import { assertValidWhatsAppMediaLink } from "../media";
 import type {
   NormalizedMessage,
   WhatsAppMediaMessage,
   WhatsAppMessage,
   WhatsAppTemplate,
 } from "../types";
+import { extractPersonalMediaMetadata } from "./media";
 
 export class MessageAdapter {
   toNormalized(msg: proto.IWebMessageInfo): NormalizedMessage {
     const chatId = msg.key?.remoteJid ?? "";
     const senderId = msg.key?.participant ?? chatId;
 
+    const personalMedia = extractPersonalMediaMetadata(msg);
     return {
       id: msg.key?.id ?? "",
       from: chatId,
@@ -27,6 +30,7 @@ export class MessageAdapter {
       chatId,
       senderId,
       replyToId: this.extractReplyToId(msg),
+      ...(personalMedia ? { personalMedia } : {}),
     };
   }
 
@@ -53,25 +57,32 @@ export class MessageAdapter {
     key: "image" | "video",
     media: WhatsAppMediaMessage
   ): Record<string, unknown> {
-    const link = assertValidWhatsAppMediaLink(media.link, key);
     return {
-      [key]: { url: link },
+      [key]: this.requiredCanonicalBytes(media, key),
       ...(media.caption ? { caption: media.caption } : {}),
     };
   }
 
   private mediaNoCaption(key: "audio", media: WhatsAppMediaMessage): Record<string, unknown> {
-    const link = assertValidWhatsAppMediaLink(media.link, key);
-    return { [key]: { url: link } };
+    return { [key]: this.requiredCanonicalBytes(media, key) };
   }
 
   private mediaWithFilename(media: WhatsAppMediaMessage): Record<string, unknown> {
-    const link = assertValidWhatsAppMediaLink(media.link, "document");
     return {
-      document: { url: link },
+      document: this.requiredCanonicalBytes(media, "document"),
       ...(media.filename ? { fileName: media.filename } : {}),
       ...(media.caption ? { caption: media.caption } : {}),
     };
+  }
+
+  private requiredCanonicalBytes(media: WhatsAppMediaMessage, kind: string): Buffer {
+    if (!media.bytes || media.bytes.byteLength === 0) {
+      throw new ElizaError("Personal WhatsApp media requires canonical local bytes", {
+        code: "WHATSAPP_PERSONAL_MEDIA_BYTES_REQUIRED",
+        context: { messageType: kind },
+      });
+    }
+    return Buffer.from(media.bytes);
   }
 
   private detectType(

--- a/plugins/plugin-whatsapp/src/clients/baileys-client.ts
+++ b/plugins/plugin-whatsapp/src/clients/baileys-client.ts
@@ -65,10 +65,15 @@ export class BaileysClient extends EventEmitter implements IWhatsAppClient {
           message?: unknown;
         };
         if (!maybe.key?.fromMe && maybe.message) {
-          this.emit(
-            "message",
-            this.adapter.toNormalized(message as Parameters<MessageAdapter["toNormalized"]>[0])
-          );
+          try {
+            this.emit(
+              "message",
+              this.adapter.toNormalized(message as Parameters<MessageAdapter["toNormalized"]>[0])
+            );
+          } catch (error) {
+            // error-policy:J1 Invalid provider metadata is reported at the socket event boundary.
+            this.emit("error", error);
+          }
         }
       }
     });

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -16,17 +16,21 @@
  * messages, chunking long text per the configured limit. Access is gated by the
  * DM/group policies resolved in accounts.ts.
  */
+import crypto from "node:crypto";
 import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  detectMime,
   ElizaError,
   type IAgentRuntime,
+  type IFileStorageService,
   lifeOpsPassiveConnectorsEnabled,
   type Media,
   type Memory,
   type Room,
   Service,
+  ServiceType,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -39,6 +43,7 @@ import {
   resolveWhatsAppAccount,
   resolveWhatsAppAccountConfig,
 } from "./accounts";
+import { fetchVerifiedPersonalMedia } from "./baileys/media";
 import { WhatsAppClient } from "./client";
 import { BaileysClient } from "./clients/baileys-client";
 import {
@@ -62,6 +67,7 @@ import type {
   CloudAPIConfig,
   ConnectionStatus,
   NormalizedMessage,
+  PersonalMediaMetadata,
   WhatsAppIncomingMessage,
   WhatsAppMediaMessage,
   WhatsAppMessageResponse,
@@ -79,6 +85,7 @@ type RuntimeServiceConfig =
       groupPolicy?: "open" | "allowlist" | "disabled";
       allowFrom?: string[];
       groupAllowFrom?: string[];
+      mediaMaxMb?: number;
     }
   | {
       accountId: string;
@@ -93,7 +100,25 @@ type RuntimeServiceConfig =
       groupPolicy?: "open" | "allowlist" | "disabled";
       allowFrom?: string[];
       groupAllowFrom?: string[];
+      mediaMaxMb?: number;
     };
+
+const DEFAULT_WHATSAPP_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
+const CONTENT_ADDRESSED_MEDIA_URL = /^\/api\/media\/([a-f0-9]{64}\.[a-z0-9]{1,8})$/;
+
+function sha256Hex(bytes: Uint8Array): string {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function exactBytesEqual(left: Buffer | null, right: Uint8Array): boolean {
+  if (left === null) return false;
+  return left.equals(right);
+}
+
+function mimeMatchesMediaType(mimeType: string | undefined, type: string): boolean {
+  if (mimeType === undefined) return false;
+  return mimeType.startsWith(`${type}/`);
+}
 
 function readStringSetting(runtime: IAgentRuntime, key: string): string | undefined {
   const value = runtime.getSetting(key);
@@ -189,6 +214,7 @@ function resolveRuntimeConfigs(runtime: IAgentRuntime): RuntimeServiceConfig[] {
         groupPolicy: accountConfig.groupPolicy,
         allowFrom: accountConfig.allowFrom?.map(String),
         groupAllowFrom: accountConfig.groupAllowFrom?.map(String),
+        mediaMaxMb: accountConfig.mediaMaxMb,
       });
       continue;
     }
@@ -208,6 +234,7 @@ function resolveRuntimeConfigs(runtime: IAgentRuntime): RuntimeServiceConfig[] {
         groupPolicy: cloud.config.groupPolicy,
         allowFrom: cloud.config.allowFrom?.map(String),
         groupAllowFrom: cloud.config.groupAllowFrom?.map(String),
+        mediaMaxMb: cloud.config.mediaMaxMb,
       });
     }
   }
@@ -1207,7 +1234,7 @@ export class WhatsAppConnectorService extends Service {
     const senderId = message.senderId ?? message.from;
     const text = typeof message.content === "string" ? message.content.trim() : "";
 
-    if (!chatId || !senderId || !text) {
+    if (!chatId || !senderId || (!text && !message.personalMedia)) {
       return;
     }
 
@@ -1218,6 +1245,7 @@ export class WhatsAppConnectorService extends Service {
       externalMessageId: message.id,
       replyToExternalMessageId: message.replyToId,
       messageType: message.type,
+      personalMedia: message.personalMedia,
       createdAt: toTimestampMs(message.timestamp),
       accountId,
     });
@@ -1245,6 +1273,69 @@ export class WhatsAppConnectorService extends Service {
     });
   }
 
+  private mediaMaxBytes(accountId: string): number {
+    const configuredMb = this.getConfigForAccount(accountId)?.mediaMaxMb;
+    if (configuredMb === undefined) return DEFAULT_WHATSAPP_MEDIA_MAX_BYTES;
+    if (!Number.isSafeInteger(configuredMb) || configuredMb <= 0 || configuredMb > 1024) {
+      throw new ElizaError("WhatsApp mediaMaxMb must be an integer from 1 through 1024", {
+        code: "WHATSAPP_MEDIA_LIMIT_INVALID",
+        context: { accountId, configuredMb },
+      });
+    }
+    return configuredMb * 1024 * 1024;
+  }
+
+  private fileStorage(accountId: string): IFileStorageService {
+    const storage = this.runtime.getService<IFileStorageService>(ServiceType.REMOTE_FILES);
+    if (!storage) {
+      throw new ElizaError("WhatsApp media requires the canonical file-storage service", {
+        code: "WHATSAPP_MEDIA_STORAGE_UNAVAILABLE",
+        context: { accountId },
+      });
+    }
+    return storage;
+  }
+
+  private async ingestPersonalMedia(
+    accountId: string,
+    metadata: PersonalMediaMetadata
+  ): Promise<Media> {
+    const storage = this.fileStorage(accountId);
+    const verified = await fetchVerifiedPersonalMedia(metadata, this.mediaMaxBytes(accountId));
+    const stored = await storage.store(verified.bytes, verified.mimeType);
+    const expectedHash = sha256Hex(verified.bytes);
+    if (
+      stored.hash !== expectedHash ||
+      !stored.fileName.startsWith(`${expectedHash}.`) ||
+      stored.url !== `/api/media/${stored.fileName}`
+    ) {
+      throw new ElizaError(
+        "Canonical WhatsApp media storage returned a mismatched content address",
+        {
+          code: "WHATSAPP_MEDIA_STORE_HASH_MISMATCH",
+          context: { accountId, expectedHash, storedHash: stored.hash },
+        }
+      );
+    }
+    const readback = await storage.read(stored.fileName);
+    if (!exactBytesEqual(readback, verified.bytes)) {
+      throw new ElizaError("Canonical WhatsApp media readback did not match stored bytes", {
+        code: "WHATSAPP_MEDIA_STORE_READBACK_MISMATCH",
+        context: { accountId, fileName: stored.fileName },
+      });
+    }
+    return {
+      id: stored.hash,
+      url: stored.url,
+      source: "whatsapp",
+      contentType: metadata.kind,
+      mimeType: verified.mimeType,
+      size: verified.bytes.length,
+      checksum: stored.hash,
+      ...(verified.fileName ? { filename: verified.fileName } : {}),
+    };
+  }
+
   private async processIncomingMessage(params: {
     accountId: string;
     chatId: string;
@@ -1253,6 +1344,7 @@ export class WhatsAppConnectorService extends Service {
     externalMessageId: string;
     replyToExternalMessageId?: string;
     messageType?: "text" | "image" | "audio" | "video" | "document";
+    personalMedia?: PersonalMediaMetadata;
     createdAt: number;
   }): Promise<void> {
     if (!this.runtime.messageService) {
@@ -1372,6 +1464,12 @@ export class WhatsAppConnectorService extends Service {
         return;
       }
 
+      // Access policy and provider metadata authorization both complete before
+      // the guarded network fetch or canonical-store write can occur.
+      const inboundAttachment = params.personalMedia
+        ? await this.ingestPersonalMedia(accountId, params.personalMedia)
+        : undefined;
+
       const channelType = isGroup ? ChannelType.GROUP : ChannelType.DM;
       const roomId = this.roomIdFor(params.chatId, accountId);
       const worldId = this.worldIdFor(params.chatId, accountId);
@@ -1441,6 +1539,7 @@ export class WhatsAppConnectorService extends Service {
           channelType,
           from: normalizedSender,
           messageId: params.externalMessageId,
+          ...(inboundAttachment ? { attachments: [inboundAttachment] } : {}),
           ...(params.replyToExternalMessageId
             ? {
                 inReplyTo: toInboundWhatsAppMemoryId(
@@ -1688,11 +1787,67 @@ export class WhatsAppConnectorService extends Service {
     return "document";
   }
 
+  private async canonicalPersonalMediaBytes(
+    accountId: string,
+    media: Media,
+    type: "image" | "video" | "audio" | "document"
+  ): Promise<Buffer> {
+    const match = media.url?.match(CONTENT_ADDRESSED_MEDIA_URL);
+    if (!match) {
+      throw new ElizaError(
+        "Personal WhatsApp media must use the canonical content-addressed media handle",
+        {
+          code: "WHATSAPP_PERSONAL_MEDIA_CANONICAL_URL_REQUIRED",
+          context: { accountId, messageType: type },
+        }
+      );
+    }
+    const fileName = match[1];
+    const expectedHash = fileName.slice(0, 64);
+    if (media.checksum && media.checksum !== expectedHash) {
+      throw new ElizaError("Personal WhatsApp media checksum does not match its canonical handle", {
+        code: "WHATSAPP_PERSONAL_MEDIA_HANDLE_MISMATCH",
+        context: { accountId, messageType: type, expectedHash },
+      });
+    }
+    const bytes = await this.fileStorage(accountId).read(fileName);
+    if (!bytes) {
+      throw new ElizaError("Canonical personal WhatsApp media bytes are unavailable", {
+        code: "WHATSAPP_PERSONAL_MEDIA_NOT_FOUND",
+        context: { accountId, messageType: type, fileName },
+      });
+    }
+    const maxBytes = this.mediaMaxBytes(accountId);
+    if (bytes.length === 0 || bytes.length > maxBytes) {
+      throw new ElizaError("Canonical personal WhatsApp media violates the configured byte limit", {
+        code: "WHATSAPP_PERSONAL_MEDIA_SIZE_DENIED",
+        context: { accountId, messageType: type, actualBytes: bytes.length, maxBytes },
+      });
+    }
+    const actualHash = sha256Hex(bytes);
+    if (actualHash !== expectedHash) {
+      throw new ElizaError(
+        "Canonical personal WhatsApp media failed content-address verification",
+        {
+          code: "WHATSAPP_PERSONAL_MEDIA_STORE_CORRUPT",
+          context: { accountId, messageType: type, expectedHash, actualHash },
+        }
+      );
+    }
+    const detectedMime = await detectMime({ buffer: bytes, headerMime: media.mimeType });
+    if (type !== "document" && !mimeMatchesMediaType(detectedMime, type)) {
+      throw new ElizaError("Canonical personal WhatsApp media bytes do not match the send type", {
+        code: "WHATSAPP_PERSONAL_MEDIA_CONTENT_TYPE_MISMATCH",
+        context: { accountId, messageType: type, detectedMime },
+      });
+    }
+    return bytes;
+  }
+
   /**
    * Send an agent attachment as a native WhatsApp media message (#8876). Works
-   * across both transports: the Cloud-API client and the Baileys client each
-   * build their own payload from the shared `WhatsAppMessage` media type, both
-   * keyed on a media URL (`link`).
+   * The official Cloud transport retains its URL contract. Personal Baileys
+   * sends only hash-verified bytes read from the canonical agent media store.
    */
   async sendMediaMessage(
     accountId: string | null | undefined,
@@ -1711,6 +1866,9 @@ export class WhatsAppConnectorService extends Service {
     const filename = media.filename ?? media.title ?? undefined;
     const mediaContent: WhatsAppMediaMessage = {
       link: media.url,
+      ...(config.transport === "baileys"
+        ? { bytes: await this.canonicalPersonalMediaBytes(config.accountId, media, type) }
+        : {}),
       ...(media.description ? { caption: media.description } : {}),
       ...(type === "document" && filename ? { filename } : {}),
     };

--- a/plugins/plugin-whatsapp/src/types.ts
+++ b/plugins/plugin-whatsapp/src/types.ts
@@ -80,6 +80,8 @@ export interface WhatsAppTemplate {
  */
 export interface WhatsAppMediaMessage {
   link?: string;
+  /** Canonical bounded bytes required by the personal Baileys transport. */
+  bytes?: Uint8Array;
   id?: string;
   caption?: string;
   filename?: string;
@@ -351,6 +353,19 @@ export interface QRCodeData {
 
 export type ConnectionStatus = "connecting" | "open" | "close";
 
+/** Structurally authorized Baileys media metadata; contains no downloaded bytes. */
+export interface PersonalMediaMetadata {
+  kind: "image" | "audio" | "video" | "document";
+  mediaKey: Uint8Array;
+  directPath?: string;
+  url?: string;
+  fileSha256: Uint8Array;
+  fileEncSha256: Uint8Array;
+  fileLength: number;
+  mimeType: string;
+  fileName?: string;
+}
+
 export interface NormalizedMessage {
   id: string;
   from: string;
@@ -360,6 +375,7 @@ export interface NormalizedMessage {
   chatId?: string;
   senderId?: string;
   replyToId?: string;
+  personalMedia?: PersonalMediaMetadata;
 }
 
 /**


### PR DESCRIPTION
Closes #25229.

## What changed
- authenticates/decrypts personal Baileys image, audio, video, and document ingress after strict provider metadata validation
- routes downloads through the core SSRF guard and DNS-pinned transport with HTTPS-only WhatsApp/CDN host authorization, no redirects, bounded bytes, and encoded-response rejection
- verifies encrypted SHA-256, truncated HMAC, plaintext length/SHA-256, and MIME kind before storing
- persists exclusively through the canonical agent content-addressed media service and verifies hash, URL, and exact byte readback
- sends personal Baileys media only from canonical hash-verified local bytes; rejects external, missing, oversize, type-confused, or corrupt handles before socket I/O
- preserves official Cloud API URL payload behavior
- adds exact canonical byte reads to the existing file-storage service; no second store or file identifier

## Verification
- `bun install --frozen-lockfile`
- `bun run --cwd plugins/plugin-whatsapp test` — 21 files, 174 tests passed
- `bun run --cwd plugins/plugin-whatsapp typecheck`
- `bun run --cwd plugins/plugin-whatsapp lint`
- `bun run --cwd plugins/plugin-whatsapp build`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build`
- focused Biome check for the widened core file-service contract
- `bun x vitest run --config packages/agent/vitest.config.ts packages/agent/src/services/file-storage.test.ts --maxWorkers=1` — 9 tests passed against the real temp-backed store
- `bun run --cwd packages/agent build`

The HTTPS loopback test deliberately presents a self-signed certificate and proves the real pinned transport rejects it before an HTTP request is accepted; it is TLS-verification evidence, not a successful trusted-TLS transport claim. Deterministic success proof uses the guarded pinned-transport seam plus real Baileys crypto. A live WhatsApp-device media round trip remains required for final native integration evidence.