### PR TITLE
test(shared): supply traceable grounding history fixtures

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -19,6 +19,12 @@ const scheduledInputs: Array<Record<string, unknown>> = [];
 type StoredTodo = Awaited<ReturnType<TodoStore["create"]>>;
 const storedTodos: StoredTodo[] = [];
 const storedTodoMutations: TodoMutationRecord[] = [];
+function testPublicGroundingEvidence(url: string, text: string) {
+  return {
+    sourceUrls: [url],
+    sources: [{ url, text }],
+  };
+}
 function createStoredTodo(input: CreateTodoInput): StoredTodo {
   const now = new Date();
   const todo: StoredTodo = {
@@ -1262,6 +1268,10 @@ describe("Shared Eliza Workerd runtime", () => {
             query: adversarialQuery,
             provider: "exa",
             text: "OBSOLETE: Tessera is a generic scraper.",
+            ...testPublicGroundingEvidence(
+              "https://example.com/tessera-obsolete",
+              "OBSOLETE: Tessera is a generic scraper.",
+            ),
             observedAt: observedAt - 2,
             truncated: false,
           },
@@ -1276,6 +1286,10 @@ describe("Shared Eliza Workerd runtime", () => {
             query: adversarialQuery,
             provider: "parallel",
             text: adversarialResult,
+            ...testPublicGroundingEvidence(
+              "https://example.com/tessera-current",
+              adversarialResult,
+            ),
             observedAt: observedAt - 1,
             truncated: false,
           },
@@ -1510,6 +1524,10 @@ describe("Shared Eliza Workerd runtime", () => {
             query: "Tessera architecture GitHub project",
             provider: "exa",
             text: "OBSOLETE: Tessera is a generic scraper.",
+            ...testPublicGroundingEvidence(
+              "https://example.com/tessera-obsolete",
+              "OBSOLETE: Tessera is a generic scraper.",
+            ),
             observedAt: observedAt - 2,
             truncated: false,
           },
@@ -1524,6 +1542,10 @@ describe("Shared Eliza Workerd runtime", () => {
             query: "Tessera architecture",
             provider: "parallel",
             text: "Tessera validates ARC resources through an origin guard and credential relay.",
+            ...testPublicGroundingEvidence(
+              "https://example.com/tessera-current",
+              "Tessera validates ARC resources through an origin guard and credential relay.",
+            ),
             observedAt: observedAt - 1,
             truncated: false,
           },


### PR DESCRIPTION
## Scope

Stacked test-only follow-up for #25361. The successor correctly rejects persisted public grounding that lacks complete source evidence, but two runtime-history fixtures still used the older incomplete shape and therefore failed locally.

This patch adds traceable `sourceUrls` and structured `{ url, text }` evidence to those four fixture records. It changes no runtime behavior.

## Exact base and checkpoint

- base: `codex/review-pr24779-corrective` at `0c4e91e472d648d465413e37701267eb4c55aae0`
- head: `487e8eccba6d816640dc7dd2849615ebceb48f96`
- annotated tag: `shared-agent-grounding-successor-runtime-fixtures-v1-20260823`
- changed files: one test file, 22 insertions

## Proof

- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts`: 26 pass, 0 fail, 170 expectations
- `bunx biome check packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts`: pass
- `bun run --cwd packages/cloud/shared typecheck`: pass
- `git diff --check`: pass

## Publication

This PR is intentionally draft and stacked onto #25361. Please cherry-pick or merge this fixture-only commit into the successor branch if desired. It must not be deployed independently and does not satisfy the live model/Telegram promotion gates.

@lalalune
