### PR TITLE
feat(auth): add canonical membership authority foundation

### DIFF
--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -6,6 +6,7 @@
  */
 import type { HandlerCallback } from "./components";
 import type { Entity, Room, World } from "./environment";
+import type { MembershipMutationReceipt, MembershipScope } from "./membership";
 import type { Memory } from "./memory";
 import type { ControlMessage } from "./messaging";
 import type {
@@ -31,6 +32,7 @@ export enum EventType {
 	ENTITY_JOINED = "ENTITY_JOINED",
 	ENTITY_LEFT = "ENTITY_LEFT",
 	ENTITY_UPDATED = "ENTITY_UPDATED",
+	MEMBERSHIP_AUTHORITY_CHANGED = "MEMBERSHIP_AUTHORITY_CHANGED",
 
 	// Room events
 	ROOM_JOINED = "ROOM_JOINED",
@@ -190,6 +192,12 @@ export interface EntityPayload extends EventPayload {
 		displayName?: string;
 		type?: string;
 	};
+}
+
+/** Emitted only after authority commit and local authorization-cache invalidation. */
+export interface MembershipAuthorityChangedPayload extends EventPayload {
+	scope: MembershipScope;
+	receipt: MembershipMutationReceipt;
 }
 
 /**
@@ -797,6 +805,7 @@ export interface EventPayloadMap {
 	[EventType.ENTITY_JOINED]: EntityPayload;
 	[EventType.ENTITY_LEFT]: EntityPayload;
 	[EventType.ENTITY_UPDATED]: EntityPayload;
+	[EventType.MEMBERSHIP_AUTHORITY_CHANGED]: MembershipAuthorityChangedPayload;
 	[EventType.MESSAGE_RECEIVED]: MessagePayload;
 	[EventType.MESSAGE_SENT]: MessagePayload;
 	[EventType.MESSAGE_DELETED]: MessagePayload;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -41,6 +41,7 @@ export * from "./events";
 export * from "./hook";
 export * from "./identity";
 export * from "./interactions";
+export * from "./membership";
 export * from "./memory";
 export * from "./memory-storage";
 export * from "./message-source";

--- a/packages/core/src/types/membership.ts
+++ b/packages/core/src/types/membership.ts
@@ -1,0 +1,170 @@
+/**
+ * Canonical connector-room membership authority contracts. Connector evidence
+ * advances one fenced scope state machine; protected operations fail closed
+ * whenever that evidence is absent, revoked, stale, unavailable, or explicitly
+ * unsupported.
+ */
+
+import type { JsonObject, UUID } from "./primitives";
+import { Service, ServiceType } from "./service";
+
+export const MEMBERSHIP_AUTHORITY_CONTRACT_VERSION = 1 as const;
+
+export const MEMBERSHIP_STATES = ["active", "revoked"] as const;
+export type MembershipState = (typeof MEMBERSHIP_STATES)[number];
+
+export const MEMBERSHIP_HEALTH_STATES = [
+	"current",
+	"stale",
+	"unavailable",
+	"unsupported",
+] as const;
+export type MembershipHealthState = (typeof MEMBERSHIP_HEALTH_STATES)[number];
+
+export const MEMBERSHIP_REASONS = [
+	"joined",
+	"reconciled_present",
+	"permission_restored",
+	"left",
+	"kicked",
+	"banned",
+	"permission_lost",
+	"account_removed",
+	"reconciled_absent",
+] as const;
+export type MembershipReason = (typeof MEMBERSHIP_REASONS)[number];
+
+export interface MembershipScope {
+	agentId: UUID;
+	connectorId: string;
+	connectorAccountId: UUID;
+	/** Provider organization, server, workspace, tenant, or world identifier. */
+	externalWorldId: string;
+	externalRoomId: string;
+}
+
+export interface MembershipRuntimeMapping {
+	worldId: UUID | null;
+	roomId: UUID | null;
+	entityId: UUID | null;
+}
+
+export interface MembershipRecord extends MembershipScope {
+	contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
+	canonicalPrincipalId: UUID;
+	state: MembershipState;
+	reason: MembershipReason;
+	roles: readonly string[];
+	permissionSnapshot: JsonObject;
+	runtime: MembershipRuntimeMapping;
+	generation: number;
+	sourceVersion: number;
+	sourceCursor: string | null;
+	observedAt: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface MembershipScopeHealth extends MembershipScope {
+	contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
+	health: MembershipHealthState;
+	reason: string;
+	generation: number;
+	sourceVersion: number;
+	sourceCursor: string | null;
+	observedAt: string;
+	updatedAt: string;
+}
+
+interface MembershipFencedCommand extends MembershipScope {
+	expectedGeneration: number;
+	sourceVersion: number;
+	sourceCursor: string | null;
+	idempotencyKey: string;
+	observedAt: string;
+}
+
+export interface ApplyMembershipCommand extends MembershipFencedCommand {
+	canonicalPrincipalId: UUID;
+	state: MembershipState;
+	reason: MembershipReason;
+	roles: readonly string[];
+	permissionSnapshot: JsonObject;
+	runtime: MembershipRuntimeMapping;
+}
+
+export interface SetMembershipHealthCommand extends MembershipFencedCommand {
+	health: MembershipHealthState;
+	reason: string;
+}
+
+export type MembershipMutationReceipt =
+	| {
+			contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
+			operation: "membership";
+			idempotentReplay: boolean;
+			committedGeneration: number;
+			membership: MembershipRecord;
+	  }
+	| {
+			contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
+			operation: "health";
+			idempotentReplay: boolean;
+			committedGeneration: number;
+			health: MembershipScopeHealth;
+	  };
+
+/** Security-cache invalidator run synchronously before observers see a commit. */
+export type MembershipAuthorityInvalidator = (
+	scope: MembershipScope,
+	receipt: MembershipMutationReceipt,
+) => void;
+
+export type MembershipAuthorizationDecision =
+	| {
+			decision: "allowed";
+			reason: "active_membership";
+			generation: number;
+			health: "current";
+			membership: MembershipRecord;
+	  }
+	| {
+			decision: "denied";
+			reason:
+				| "no_scope_evidence"
+				| "authority_stale"
+				| "authority_unavailable"
+				| "authority_unsupported"
+				| "no_membership"
+				| "membership_revoked";
+			generation: number | null;
+			health: MembershipHealthState | null;
+	  };
+
+/** Single runtime authority for connector-room participation decisions. */
+export abstract class MembershipService extends Service {
+	static override readonly serviceType = ServiceType.MEMBERSHIP;
+	public readonly capabilityDescription =
+		"Owns version-fenced connector-room membership and reconciliation health.";
+
+	abstract applyMembership(
+		command: ApplyMembershipCommand,
+	): Promise<MembershipMutationReceipt>;
+	abstract setScopeHealth(
+		command: SetMembershipHealthCommand,
+	): Promise<MembershipMutationReceipt>;
+	abstract authorize(
+		scope: MembershipScope,
+		canonicalPrincipalId: UUID,
+	): Promise<MembershipAuthorizationDecision>;
+	abstract getMembership(
+		scope: MembershipScope,
+		canonicalPrincipalId: UUID,
+	): Promise<MembershipRecord | null>;
+	abstract getScopeHealth(
+		scope: MembershipScope,
+	): Promise<MembershipScopeHealth | null>;
+	abstract registerInvalidator(
+		invalidator: MembershipAuthorityInvalidator,
+	): () => void;
+}

--- a/packages/core/src/types/membership.ts
+++ b/packages/core/src/types/membership.ts
@@ -1,18 +1,10 @@
-/**
- * Canonical connector-room membership authority contracts. Connector evidence
- * advances one fenced scope state machine; protected operations fail closed
- * whenever that evidence is absent, revoked, stale, unavailable, or explicitly
- * unsupported.
- */
-
+/** Canonical bounded, publisher-fenced connector-room membership contracts. */
 import type { JsonObject, UUID } from "./primitives";
 import { Service, ServiceType } from "./service";
 
 export const MEMBERSHIP_AUTHORITY_CONTRACT_VERSION = 1 as const;
-
 export const MEMBERSHIP_STATES = ["active", "revoked"] as const;
 export type MembershipState = (typeof MEMBERSHIP_STATES)[number];
-
 export const MEMBERSHIP_HEALTH_STATES = [
 	"current",
 	"stale",
@@ -20,7 +12,12 @@ export const MEMBERSHIP_HEALTH_STATES = [
 	"unsupported",
 ] as const;
 export type MembershipHealthState = (typeof MEMBERSHIP_HEALTH_STATES)[number];
-
+export const MEMBERSHIP_EVIDENCE_MODES = [
+	"complete_snapshot",
+	"ordered_delta",
+	"point_query",
+] as const;
+export type MembershipEvidenceMode = (typeof MEMBERSHIP_EVIDENCE_MODES)[number];
 export const MEMBERSHIP_REASONS = [
 	"joined",
 	"reconciled_present",
@@ -38,18 +35,23 @@ export interface MembershipScope {
 	agentId: UUID;
 	connectorId: string;
 	connectorAccountId: UUID;
-	/** Provider organization, server, workspace, tenant, or world identifier. */
 	externalWorldId: string;
 	externalRoomId: string;
 }
-
 export interface MembershipRuntimeMapping {
 	worldId: UUID | null;
 	roomId: UUID | null;
 	entityId: UUID | null;
 }
+export interface MembershipPublisherBinding {
+	publisherInstanceId: string;
+	publisherGeneration: number;
+	evidenceMode: MembershipEvidenceMode;
+}
 
-export interface MembershipRecord extends MembershipScope {
+export interface MembershipRecord
+	extends MembershipScope,
+		MembershipPublisherBinding {
 	contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
 	canonicalPrincipalId: UUID;
 	state: MembershipState;
@@ -59,8 +61,9 @@ export interface MembershipRecord extends MembershipScope {
 	runtime: MembershipRuntimeMapping;
 	generation: number;
 	sourceVersion: number;
-	sourceCursor: string | null;
+	sourceCursor: string;
 	observedAt: string;
+	validUntil: string;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -72,19 +75,44 @@ export interface MembershipScopeHealth extends MembershipScope {
 	generation: number;
 	sourceVersion: number;
 	sourceCursor: string | null;
+	validUntil: string | null;
+	publisherInstanceId: string | null;
+	publisherGeneration: number | null;
+	evidenceMode: MembershipEvidenceMode | null;
 	observedAt: string;
 	updatedAt: string;
 }
 
-interface MembershipFencedCommand extends MembershipScope {
+interface MembershipCommandBase extends MembershipScope {
 	expectedGeneration: number;
-	sourceVersion: number;
-	sourceCursor: string | null;
 	idempotencyKey: string;
 	observedAt: string;
 }
-
-export interface ApplyMembershipCommand extends MembershipFencedCommand {
+export interface RegisterMembershipPublisherCommand
+	extends MembershipCommandBase,
+		MembershipPublisherBinding {}
+interface MembershipEvidenceCommand
+	extends MembershipCommandBase,
+		MembershipPublisherBinding {
+	sourceVersion: number;
+	previousSourceCursor: string | null;
+	sourceCursor: string;
+	validUntil: string;
+}
+export interface MembershipSnapshotMember {
+	canonicalPrincipalId: UUID;
+	roles: readonly string[];
+	permissionSnapshot: JsonObject;
+	runtime: MembershipRuntimeMapping;
+}
+export interface ApplyCompleteMembershipSnapshotCommand
+	extends MembershipEvidenceCommand {
+	evidenceMode: "complete_snapshot" | "ordered_delta";
+	completeness: "complete";
+	members: readonly MembershipSnapshotMember[];
+}
+export interface ApplyMembershipCommand extends MembershipEvidenceCommand {
+	evidenceMode: "ordered_delta" | "point_query";
 	canonicalPrincipalId: UUID;
 	state: MembershipState;
 	reason: MembershipReason;
@@ -92,34 +120,46 @@ export interface ApplyMembershipCommand extends MembershipFencedCommand {
 	permissionSnapshot: JsonObject;
 	runtime: MembershipRuntimeMapping;
 }
-
-export interface SetMembershipHealthCommand extends MembershipFencedCommand {
-	health: MembershipHealthState;
+export interface SetMembershipHealthCommand extends MembershipCommandBase {
+	health: Exclude<MembershipHealthState, "current">;
 	reason: string;
 }
 
 export type MembershipMutationReceipt =
 	| {
-			contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
+			contractVersion: 1;
+			operation: "publisher";
+			idempotentReplay: boolean;
+			committedGeneration: number;
+			health: MembershipScopeHealth;
+	  }
+	| {
+			contractVersion: 1;
+			operation: "snapshot";
+			idempotentReplay: boolean;
+			committedGeneration: number;
+			health: MembershipScopeHealth;
+			memberships: readonly MembershipRecord[];
+			revokedPrincipalIds: readonly UUID[];
+	  }
+	| {
+			contractVersion: 1;
 			operation: "membership";
 			idempotentReplay: boolean;
 			committedGeneration: number;
 			membership: MembershipRecord;
 	  }
 	| {
-			contractVersion: typeof MEMBERSHIP_AUTHORITY_CONTRACT_VERSION;
+			contractVersion: 1;
 			operation: "health";
 			idempotentReplay: boolean;
 			committedGeneration: number;
 			health: MembershipScopeHealth;
 	  };
-
-/** Security-cache invalidator run synchronously before observers see a commit. */
 export type MembershipAuthorityInvalidator = (
 	scope: MembershipScope,
 	receipt: MembershipMutationReceipt,
 ) => void;
-
 export type MembershipAuthorizationDecision =
 	| {
 			decision: "allowed";
@@ -135,6 +175,8 @@ export type MembershipAuthorizationDecision =
 				| "authority_stale"
 				| "authority_unavailable"
 				| "authority_unsupported"
+				| "authority_expired"
+				| "membership_evidence_expired"
 				| "no_membership"
 				| "membership_revoked";
 			generation: number | null;
@@ -145,8 +187,13 @@ export type MembershipAuthorizationDecision =
 export abstract class MembershipService extends Service {
 	static override readonly serviceType = ServiceType.MEMBERSHIP;
 	public readonly capabilityDescription =
-		"Owns version-fenced connector-room membership and reconciliation health.";
-
+		"Owns bounded publisher-fenced connector-room membership evidence.";
+	abstract registerPublisher(
+		command: RegisterMembershipPublisherCommand,
+	): Promise<MembershipMutationReceipt>;
+	abstract applyCompleteSnapshot(
+		command: ApplyCompleteMembershipSnapshotCommand,
+	): Promise<MembershipMutationReceipt>;
 	abstract applyMembership(
 		command: ApplyMembershipCommand,
 	): Promise<MembershipMutationReceipt>;

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -54,6 +54,7 @@ export interface ServiceTypeRegistry {
 	DOCUMENTS: "documents";
 	RELATIONSHIPS: "relationships";
 	PRINCIPAL: "principal";
+	MEMBERSHIP: "membership";
 	FOLLOW_UP: "follow_up";
 	TRAJECTORIES: "trajectories";
 	SWARM_COORDINATOR: "SWARM_COORDINATOR";
@@ -162,6 +163,7 @@ export const ServiceType = {
 	DOCUMENTS: "documents",
 	RELATIONSHIPS: "relationships",
 	PRINCIPAL: "principal",
+	MEMBERSHIP: "membership",
 	FOLLOW_UP: "follow_up",
 	TRAJECTORIES: "trajectories",
 	SWARM_COORDINATOR: "SWARM_COORDINATOR",

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -14,7 +14,7 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
 | Service | `SqlPrincipalService` (`serviceType = "principal"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
-| Service | `SqlMembershipService` (`serviceType = "membership"`) | Canonical generation- and source-version-fenced connector-room membership authority with durable reconciliation health, exact idempotent receipts, and fail-closed authorization |
+| Service | `SqlMembershipService` (`serviceType = "membership"`) | Canonical publisher-generation and cursor-fenced connector-room authority with atomic complete snapshots, bounded freshness, exact idempotency, and fail-closed authorization |
 | Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
 | Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -14,6 +14,7 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
 | Service | `SqlPrincipalService` (`serviceType = "principal"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
+| Service | `SqlMembershipService` (`serviceType = "membership"`) | Canonical generation- and source-version-fenced connector-room membership authority with durable reconciliation health, exact idempotent receipts, and fail-closed authorization |
 | Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
 | Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |
@@ -59,6 +60,7 @@ plugins/plugin-sql/
     services/
       advanced-memory-storage.ts  AdvancedMemoryStorageService implementation
       sql-principal.ts  Canonical identity authority implementation
+      sql-membership.ts  Canonical connector-room membership authority implementation
     stores/
       agent.store.ts / memory.store.ts / room.store.ts / ...  Query logic split by domain
     runtime-migrator/

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -14,7 +14,7 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
 | Service | `SqlPrincipalService` (`serviceType = "principal"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
-| Service | `SqlMembershipService` (`serviceType = "membership"`) | Canonical generation- and source-version-fenced connector-room membership authority with durable reconciliation health, exact idempotent receipts, and fail-closed authorization |
+| Service | `SqlMembershipService` (`serviceType = "membership"`) | Canonical publisher-generation and cursor-fenced connector-room authority with atomic complete snapshots, bounded freshness, exact idempotency, and fail-closed authorization |
 | Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
 | Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -14,6 +14,7 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
 | Service | `SqlPrincipalService` (`serviceType = "principal"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
+| Service | `SqlMembershipService` (`serviceType = "membership"`) | Canonical generation- and source-version-fenced connector-room membership authority with durable reconciliation health, exact idempotent receipts, and fail-closed authorization |
 | Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
 | Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |
@@ -59,6 +60,7 @@ plugins/plugin-sql/
     services/
       advanced-memory-storage.ts  AdvancedMemoryStorageService implementation
       sql-principal.ts  Canonical identity authority implementation
+      sql-membership.ts  Canonical connector-room membership authority implementation
     stores/
       agent.store.ts / memory.store.ts / room.store.ts / ...  Query logic split by domain
     runtime-migrator/

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -33,18 +33,21 @@ audit evidence and never create canonical redirects or merge-journal rows.
 ## Membership authority
 
 `SqlMembershipService` is the durable authority for connector-account room
-membership. Commands are fenced by both the scope generation and the
-connector's monotonically increasing source version, with account-scoped
-idempotency receipts so duplicate or out-of-order evidence cannot resurrect a
-newer revocation. Authorization permits only an active canonical principal in
-a scope whose reconciliation health is `current`; missing, stale, unavailable,
-and unsupported authority all deny explicitly.
+membership. Each scope first registers a publisher instance, generation, and
+evidence mode. Only an atomic explicitly complete roster snapshot, an ordered
+delta following a complete snapshot in the same publisher generation, or a
+bounded point-query proof can make evidence current. Durable cursor continuity,
+scope generations, and exact idempotency receipts prevent duplicate or
+out-of-order evidence from resurrecting a newer revocation.
 
-The service commits security state before clearing its internal decision cache,
-running registered cache invalidators synchronously, and notifying runtime
-observers. Connector event and roster-reconciliation adapters are responsible
-for supplying typed commands; the membership service has no model-callable
-mutation action.
+Every authorization rechecks persisted `validUntil` values against the trusted
+service clock. Missing, expired, stale, unavailable, and unsupported authority
+deny explicitly. Complete snapshots atomically upsert observed members and
+retain absent active members as revoked facts; incomplete or failed pagination
+changes no roster. Point proof for one principal creates no fact about another.
+The service invalidates registered dependent caches before notifying observers.
+Connector composition and document authorization remain separate slices, and
+the service exposes no model-callable mutation action.
 
 ## Database Schema
 

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -30,6 +30,22 @@ The attestation request rejects unknown fields, including client-authored
 `confirmed`, `verified`, actor, and role values. Attestations are immutable
 audit evidence and never create canonical redirects or merge-journal rows.
 
+## Membership authority
+
+`SqlMembershipService` is the durable authority for connector-account room
+membership. Commands are fenced by both the scope generation and the
+connector's monotonically increasing source version, with account-scoped
+idempotency receipts so duplicate or out-of-order evidence cannot resurrect a
+newer revocation. Authorization permits only an active canonical principal in
+a scope whose reconciliation health is `current`; missing, stale, unavailable,
+and unsupported authority all deny explicitly.
+
+The service commits security state before clearing its internal decision cache,
+running registered cache invalidators synchronously, and notifying runtime
+observers. Connector event and roster-reconciliation adapters are responsible
+for supplying typed commands; the membership service has no model-callable
+mutation action.
+
 ## Database Schema
 
 The plugin uses the following main tables:

--- a/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
@@ -169,6 +169,46 @@ describe("SqlMembershipService real authority", () => {
     await expect(apply("revoked", "left", 2, 3, "join-once")).rejects.toMatchObject({
       code: "MEMBERSHIP_IDEMPOTENCY_CONFLICT",
     });
+
+    const restarted = new SqlMembershipService(runtime);
+    await expect(restarted.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+      generation: 2,
+    });
+    await expect(
+      restarted.applyMembership({
+        ...scope,
+        canonicalPrincipalId: principalId,
+        state: "active",
+        reason: "joined",
+        roles: ["member"],
+        permissionSnapshot: { canRead: true },
+        runtime: { worldId: null, roomId: null, entityId: principalId },
+        expectedGeneration: 1,
+        sourceVersion: 2,
+        sourceCursor: "cursor-2",
+        idempotencyKey: "join-once",
+        observedAt: new Date(1_700_000_000_002).toISOString(),
+      })
+    ).resolves.toEqual(replay);
+    await restarted.stop();
+  });
+
+  it("invalidates a warm allow decision when reconciliation becomes stale", async () => {
+    await setHealth("current", 0, 1);
+    await apply("active", "joined", 1, 2);
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+      generation: 2,
+    });
+
+    await setHealth("stale", 2, 3);
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_stale",
+      health: "stale",
+      generation: 3,
+    });
   });
 
   it("commits denial and invalidates a warm allow cache before observers run", async () => {
@@ -208,6 +248,38 @@ describe("SqlMembershipService real authority", () => {
       reason: "membership_revoked",
       generation: 3,
     });
+  });
+
+  it("reports a failed invalidator after commit without suppressing later invalidators or observers", async () => {
+    await setHealth("current", 0, 1);
+    await apply("active", "joined", 1, 2);
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+    });
+
+    const order: string[] = [];
+    service.registerInvalidator(() => {
+      order.push("failed-invalidator");
+      throw new Error("test invalidator failure");
+    });
+    service.registerInvalidator(() => {
+      order.push("later-invalidator");
+    });
+    runtime.registerEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, async (event) => {
+      if (event.receipt.committedGeneration !== 3) return;
+      order.push("observer");
+      await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+        decision: "denied",
+        reason: "membership_revoked",
+        generation: 3,
+      });
+    });
+
+    await expect(apply("revoked", "left", 2, 3)).resolves.toMatchObject({
+      committedGeneration: 3,
+      membership: { state: "revoked" },
+    });
+    expect(order).toEqual(["failed-invalidator", "later-invalidator", "observer"]);
   });
 
   it("prevents duplicate, stale, and out-of-order evidence from resurrecting a revocation", async () => {
@@ -267,5 +339,53 @@ describe("SqlMembershipService real authority", () => {
     await expect(apply("active", "joined", 1, 2)).rejects.toMatchObject({
       code: "MEMBERSHIP_PRINCIPAL_NOT_FOUND",
     });
+  });
+
+  it("isolates identical external scope and idempotency values by connector account", async () => {
+    const secondAccountId = crypto.randomUUID() as UUID;
+    await db.insert(connectorAccountsTable).values({
+      id: secondAccountId,
+      agentId,
+      provider: "test-connector",
+      accountKey: `account-${secondAccountId}`,
+    });
+    const secondScope = { ...scope, connectorAccountId: secondAccountId };
+    const observedAt = new Date(1_700_000_000_001).toISOString();
+    await service.setScopeHealth({
+      ...scope,
+      health: "current",
+      reason: "current-by-test",
+      expectedGeneration: 0,
+      sourceVersion: 1,
+      sourceCursor: "cursor-1",
+      idempotencyKey: "shared-health-key",
+      observedAt,
+    });
+    await service.setScopeHealth({
+      ...secondScope,
+      health: "current",
+      reason: "current-by-test",
+      expectedGeneration: 0,
+      sourceVersion: 1,
+      sourceCursor: "cursor-1",
+      idempotencyKey: "shared-health-key",
+      observedAt,
+    });
+
+    await expect(service.getScopeHealth(scope)).resolves.toMatchObject({
+      connectorAccountId: accountId,
+      generation: 1,
+    });
+    await expect(service.getScopeHealth(secondScope)).resolves.toMatchObject({
+      connectorAccountId: secondAccountId,
+      generation: 1,
+    });
+    const journalRows = await db
+      .select()
+      .from(membershipAuthorityJournalTable)
+      .where(eq(membershipAuthorityJournalTable.idempotencyKey, "shared-health-key"));
+    expect(journalRows.map((row) => row.connectorAccountId).sort()).toEqual(
+      [accountId, secondAccountId].sort()
+    );
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Real PGlite integration coverage for the canonical membership authority.
+ * The harness runs actual dynamic migrations, SQL transactions, runtime event
+ * observers, and service reads without mocking the authority under test.
+ */
+import {
+  EventType,
+  type MembershipAuthorizationDecision,
+  type MembershipScope,
+  type UUID,
+} from "@elizaos/core";
+import { count, eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connectorAccountsTable } from "../../schema/connectorAccounts";
+import { entityTable } from "../../schema/entity";
+import { membershipAuthorityJournalTable } from "../../schema/membershipAuthority";
+import { SqlMembershipService } from "../../services/sql-membership";
+import { type DrizzleDatabase, getDb } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+describe("SqlMembershipService real authority", () => {
+  let testSequence = 0;
+  let cleanup: () => Promise<void>;
+  let service: SqlMembershipService;
+  let db: DrizzleDatabase;
+  let agentId: UUID;
+  let accountId: UUID;
+  let principalId: UUID;
+  let scope: MembershipScope;
+  let runtime: Awaited<ReturnType<typeof createIsolatedTestDatabase>>["runtime"];
+
+  beforeEach(async () => {
+    testSequence += 1;
+    const setup = await createIsolatedTestDatabase(`membership_${testSequence}`);
+    cleanup = setup.cleanup;
+    runtime = setup.runtime;
+    agentId = setup.testAgentId;
+    db = getDb(setup.adapter);
+    service = new SqlMembershipService(runtime);
+    accountId = crypto.randomUUID() as UUID;
+    principalId = crypto.randomUUID() as UUID;
+    await db.insert(connectorAccountsTable).values({
+      id: accountId,
+      agentId,
+      provider: "test-connector",
+      accountKey: `account-${accountId}`,
+    });
+    await db.insert(entityTable).values({ id: principalId, agentId, names: ["Member"] });
+    scope = {
+      agentId,
+      connectorId: "test-connector",
+      connectorAccountId: accountId,
+      externalWorldId: "world-1",
+      externalRoomId: "room-1",
+    };
+  }, 20_000);
+
+  afterEach(async () => {
+    await service.stop();
+    await cleanup();
+  }, 20_000);
+
+  async function setHealth(
+    health: "current" | "stale" | "unavailable" | "unsupported",
+    expectedGeneration: number,
+    sourceVersion: number,
+    idempotencyKey = `health-${sourceVersion}`
+  ) {
+    return service.setScopeHealth({
+      ...scope,
+      health,
+      reason: `${health}-by-test`,
+      expectedGeneration,
+      sourceVersion,
+      sourceCursor: `cursor-${sourceVersion}`,
+      idempotencyKey,
+      observedAt: new Date(1_700_000_000_000 + sourceVersion).toISOString(),
+    });
+  }
+
+  async function apply(
+    state: "active" | "revoked",
+    reason:
+      | "joined"
+      | "reconciled_present"
+      | "permission_restored"
+      | "left"
+      | "kicked"
+      | "banned"
+      | "permission_lost"
+      | "account_removed"
+      | "reconciled_absent",
+    expectedGeneration: number,
+    sourceVersion: number,
+    idempotencyKey = `membership-${sourceVersion}`
+  ) {
+    return service.applyMembership({
+      ...scope,
+      canonicalPrincipalId: principalId,
+      state,
+      reason,
+      roles: state === "active" ? ["member"] : [],
+      permissionSnapshot: { canRead: state === "active" },
+      runtime: { worldId: null, roomId: null, entityId: principalId },
+      expectedGeneration,
+      sourceVersion,
+      sourceCursor: `cursor-${sourceVersion}`,
+      idempotencyKey,
+      observedAt: new Date(1_700_000_000_000 + sourceVersion).toISOString(),
+    });
+  }
+
+  it("fails closed without current evidence and persists explicit health states", async () => {
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "no_scope_evidence",
+      generation: null,
+    });
+
+    await setHealth("unsupported", 0, 1);
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_unsupported",
+      health: "unsupported",
+      generation: 1,
+    });
+
+    await setHealth("unavailable", 1, 2);
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_unavailable",
+      health: "unavailable",
+      generation: 2,
+    });
+
+    await setHealth("stale", 2, 3);
+    const restarted = new SqlMembershipService(runtime);
+    await expect(restarted.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_stale",
+      health: "stale",
+      generation: 3,
+    });
+  });
+
+  it("applies an idempotent join and rejects conflicting key reuse", async () => {
+    await setHealth("current", 0, 1);
+    const joined = await apply("active", "joined", 1, 2, "join-once");
+    expect(joined).toMatchObject({
+      operation: "membership",
+      idempotentReplay: false,
+      committedGeneration: 2,
+      membership: { state: "active", roles: ["member"] },
+    });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+      reason: "active_membership",
+      generation: 2,
+    });
+
+    const replay = await apply("active", "joined", 1, 2, "join-once");
+    expect(replay).toEqual({ ...joined, idempotentReplay: true });
+    const [journalCount] = await db
+      .select({ value: count() })
+      .from(membershipAuthorityJournalTable)
+      .where(eq(membershipAuthorityJournalTable.idempotencyKey, "join-once"));
+    expect(journalCount?.value).toBe(1);
+
+    await expect(apply("revoked", "left", 2, 3, "join-once")).rejects.toMatchObject({
+      code: "MEMBERSHIP_IDEMPOTENCY_CONFLICT",
+    });
+  });
+
+  it("commits denial and invalidates a warm allow cache before observers run", async () => {
+    await setHealth("current", 0, 1);
+    await apply("active", "joined", 1, 2);
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+    });
+    const sibling = new SqlMembershipService(runtime);
+    await expect(sibling.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+    });
+
+    const dependentAllowCache = new Set([principalId]);
+    let invalidatedGeneration: number | null = null;
+    service.registerInvalidator((_changedScope, receipt) => {
+      dependentAllowCache.delete(principalId);
+      invalidatedGeneration = receipt.committedGeneration;
+    });
+
+    let observerDecision: MembershipAuthorizationDecision | null = null;
+    runtime.registerEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, async (event) => {
+      if (event.receipt.committedGeneration === 3) {
+        expect(dependentAllowCache.has(principalId)).toBe(false);
+        expect(invalidatedGeneration).toBe(3);
+        observerDecision = await service.authorize(scope, principalId);
+      }
+    });
+    await apply("revoked", "kicked", 2, 3);
+    expect(observerDecision).toMatchObject({
+      decision: "denied",
+      reason: "membership_revoked",
+      generation: 3,
+    });
+    await expect(sibling.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "membership_revoked",
+      generation: 3,
+    });
+  });
+
+  it("prevents duplicate, stale, and out-of-order evidence from resurrecting a revocation", async () => {
+    await setHealth("current", 0, 10);
+    await apply("active", "joined", 1, 11);
+    await apply("revoked", "banned", 2, 12);
+
+    await expect(
+      apply("active", "permission_restored", 3, 11, "late-restore")
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_SOURCE_VERSION_STALE" });
+    await expect(
+      apply("active", "permission_restored", 2, 13, "wrong-generation")
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_GENERATION_MISMATCH" });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "membership_revoked",
+      generation: 3,
+    });
+  });
+
+  it("serializes concurrent commands so only one expected generation can commit", async () => {
+    await setHealth("current", 0, 1);
+    const outcomes = await Promise.allSettled([
+      apply("active", "joined", 1, 2, "concurrent-join"),
+      apply("revoked", "reconciled_absent", 1, 3, "concurrent-absent"),
+    ]);
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+    expect(
+      (outcomes.find((outcome) => outcome.status === "rejected") as PromiseRejectedResult).reason
+    ).toMatchObject({ code: "MEMBERSHIP_GENERATION_MISMATCH" });
+  });
+
+  it("coalesces concurrent exact retries into one commit and one observer notification", async () => {
+    await setHealth("current", 0, 1);
+    let membershipNotifications = 0;
+    runtime.registerEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, async (event) => {
+      if (event.receipt.operation === "membership") membershipNotifications += 1;
+    });
+
+    const receipts = await Promise.all([
+      apply("active", "joined", 1, 2, "same-concurrent-join"),
+      apply("active", "joined", 1, 2, "same-concurrent-join"),
+    ]);
+    expect(receipts.map((receipt) => receipt.idempotentReplay).sort()).toEqual([false, true]);
+    expect(membershipNotifications).toBe(1);
+  });
+
+  it("rejects cross-tenant scopes and cross-tenant principal mappings", async () => {
+    const otherAgentId = crypto.randomUUID() as UUID;
+    await expect(
+      service.authorize({ ...scope, agentId: otherAgentId }, principalId)
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_TENANT_MISMATCH" });
+
+    await setHealth("current", 0, 1);
+    await db.delete(entityTable).where(eq(entityTable.id, principalId));
+    await expect(apply("active", "joined", 1, 2)).rejects.toMatchObject({
+      code: "MEMBERSHIP_PRINCIPAL_NOT_FOUND",
+    });
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
@@ -1,101 +1,124 @@
 /**
- * Real PGlite integration coverage for the canonical membership authority.
- * The harness runs actual dynamic migrations, SQL transactions, runtime event
- * observers, and service reads without mocking the authority under test.
+ * Real PGlite coverage for publisher registration, complete-snapshot atomicity,
+ * bounded freshness, cursor fencing, restart, and concurrent revocation.
  */
-import {
-  EventType,
-  type MembershipAuthorizationDecision,
-  type MembershipScope,
-  type UUID,
-} from "@elizaos/core";
+import type { MembershipScope, UUID } from "@elizaos/core";
 import { count, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connectorAccountsTable } from "../../schema/connectorAccounts";
 import { entityTable } from "../../schema/entity";
-import { membershipAuthorityJournalTable } from "../../schema/membershipAuthority";
+import {
+  membershipAuthorityJournalTable,
+  membershipAuthorityTable,
+} from "../../schema/membershipAuthority";
 import { SqlMembershipService } from "../../services/sql-membership";
 import { type DrizzleDatabase, getDb } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
 describe("SqlMembershipService real authority", () => {
-  let testSequence = 0;
+  let sequence = 0;
   let cleanup: () => Promise<void>;
   let service: SqlMembershipService;
   let db: DrizzleDatabase;
-  let agentId: UUID;
-  let accountId: UUID;
-  let principalId: UUID;
-  let scope: MembershipScope;
   let runtime: Awaited<ReturnType<typeof createIsolatedTestDatabase>>["runtime"];
+  let scope: MembershipScope;
+  let principalId: UUID;
+  let secondPrincipalId: UUID;
+  let nowMs: number;
+  const publisher = {
+    publisherInstanceId: "test-process-a",
+    publisherGeneration: 0,
+    evidenceMode: "ordered_delta" as const,
+  };
 
   beforeEach(async () => {
-    testSequence += 1;
-    const setup = await createIsolatedTestDatabase(`membership_${testSequence}`);
+    const setup = await createIsolatedTestDatabase(`membership_v2_${++sequence}`);
     cleanup = setup.cleanup;
     runtime = setup.runtime;
-    agentId = setup.testAgentId;
     db = getDb(setup.adapter);
-    service = new SqlMembershipService(runtime);
-    accountId = crypto.randomUUID() as UUID;
+    nowMs = Date.parse("2026-08-22T12:00:00.000Z");
+    service = new SqlMembershipService(runtime, () => new Date(nowMs));
+    const accountId = crypto.randomUUID() as UUID;
     principalId = crypto.randomUUID() as UUID;
+    secondPrincipalId = crypto.randomUUID() as UUID;
     await db.insert(connectorAccountsTable).values({
       id: accountId,
-      agentId,
+      agentId: setup.testAgentId,
       provider: "test-connector",
       accountKey: `account-${accountId}`,
     });
-    await db.insert(entityTable).values({ id: principalId, agentId, names: ["Member"] });
+    await db.insert(entityTable).values([
+      { id: principalId, agentId: setup.testAgentId, names: ["One"] },
+      { id: secondPrincipalId, agentId: setup.testAgentId, names: ["Two"] },
+    ]);
     scope = {
-      agentId,
+      agentId: setup.testAgentId,
       connectorId: "test-connector",
       connectorAccountId: accountId,
-      externalWorldId: "world-1",
-      externalRoomId: "room-1",
+      externalWorldId: "world",
+      externalRoomId: "room",
     };
   }, 20_000);
-
   afterEach(async () => {
     await service.stop();
     await cleanup();
   }, 20_000);
 
-  async function setHealth(
-    health: "current" | "stale" | "unavailable" | "unsupported",
-    expectedGeneration: number,
-    sourceVersion: number,
-    idempotencyKey = `health-${sourceVersion}`
+  const observedAt = () => new Date(nowMs).toISOString();
+  const validUntil = () => new Date(nowMs + 60_000).toISOString();
+  const member = (canonicalPrincipalId: UUID) => ({
+    canonicalPrincipalId,
+    roles: ["member"],
+    permissionSnapshot: { canRead: true, limits: [1, null] },
+    runtime: { worldId: null, roomId: null, entityId: canonicalPrincipalId },
+  });
+  async function register(
+    expectedGeneration = 0,
+    idempotencyKey = "publisher-register",
+    binding = publisher
   ) {
-    return service.setScopeHealth({
+    return service.registerPublisher({
       ...scope,
-      health,
-      reason: `${health}-by-test`,
+      ...binding,
       expectedGeneration,
-      sourceVersion,
-      sourceCursor: `cursor-${sourceVersion}`,
       idempotencyKey,
-      observedAt: new Date(1_700_000_000_000 + sourceVersion).toISOString(),
+      observedAt: observedAt(),
     });
   }
-
-  async function apply(
+  async function snapshot(
+    members = [member(principalId)],
+    expectedGeneration = 1,
+    sourceVersion = 0,
+    previousSourceCursor: string | null = null,
+    sourceCursor = "snapshot-0",
+    idempotencyKey = `snapshot-${sourceVersion}`
+  ) {
+    return service.applyCompleteSnapshot({
+      ...scope,
+      ...publisher,
+      completeness: "complete",
+      members,
+      expectedGeneration,
+      sourceVersion,
+      previousSourceCursor,
+      sourceCursor,
+      validUntil: validUntil(),
+      idempotencyKey,
+      observedAt: observedAt(),
+    });
+  }
+  async function delta(
     state: "active" | "revoked",
-    reason:
-      | "joined"
-      | "reconciled_present"
-      | "permission_restored"
-      | "left"
-      | "kicked"
-      | "banned"
-      | "permission_lost"
-      | "account_removed"
-      | "reconciled_absent",
+    reason: "joined" | "left" | "kicked" | "permission_restored",
     expectedGeneration: number,
     sourceVersion: number,
-    idempotencyKey = `membership-${sourceVersion}`
+    previousSourceCursor: string,
+    sourceCursor: string,
+    idempotencyKey = `delta-${sourceVersion}`
   ) {
     return service.applyMembership({
       ...scope,
+      ...publisher,
       canonicalPrincipalId: principalId,
       state,
       reason,
@@ -104,288 +127,293 @@ describe("SqlMembershipService real authority", () => {
       runtime: { worldId: null, roomId: null, entityId: principalId },
       expectedGeneration,
       sourceVersion,
-      sourceCursor: `cursor-${sourceVersion}`,
+      previousSourceCursor,
+      sourceCursor,
+      validUntil: validUntil(),
       idempotencyKey,
-      observedAt: new Date(1_700_000_000_000 + sourceVersion).toISOString(),
+      observedAt: observedAt(),
     });
   }
 
-  it("fails closed without current evidence and persists explicit health states", async () => {
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "denied",
-      reason: "no_scope_evidence",
-      generation: null,
+  it("cannot manufacture current authority with health and requires a complete snapshot before ordered deltas", async () => {
+    await register();
+    await expect(
+      service.setScopeHealth({
+        ...scope,
+        health: "current",
+        reason: "trust-me",
+        expectedGeneration: 1,
+        idempotencyKey: "bad-health",
+        observedAt: observedAt(),
+      } as never)
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    await expect(delta("active", "joined", 1, 0, "", "delta-0")).rejects.toMatchObject({
+      code: "MEMBERSHIP_SNAPSHOT_REQUIRED",
     });
-
-    await setHealth("unsupported", 0, 1);
     await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "denied",
-      reason: "authority_unsupported",
-      health: "unsupported",
-      generation: 1,
-    });
-
-    await setHealth("unavailable", 1, 2);
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "denied",
-      reason: "authority_unavailable",
-      health: "unavailable",
-      generation: 2,
-    });
-
-    await setHealth("stale", 2, 3);
-    const restarted = new SqlMembershipService(runtime);
-    await expect(restarted.authorize(scope, principalId)).resolves.toMatchObject({
       decision: "denied",
       reason: "authority_stale",
-      health: "stale",
-      generation: 3,
     });
   });
 
-  it("applies an idempotent join and rejects conflicting key reuse", async () => {
-    await setHealth("current", 0, 1);
-    const joined = await apply("active", "joined", 1, 2, "join-once");
-    expect(joined).toMatchObject({
-      operation: "membership",
-      idempotentReplay: false,
-      committedGeneration: 2,
-      membership: { state: "active", roles: ["member"] },
-    });
+  it("atomically upserts a complete snapshot and revokes every absent active fact", async () => {
+    await register();
+    await snapshot([member(principalId), member(secondPrincipalId)]);
     await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
       decision: "allowed",
-      reason: "active_membership",
-      generation: 2,
     });
-
-    const replay = await apply("active", "joined", 1, 2, "join-once");
-    expect(replay).toEqual({ ...joined, idempotentReplay: true });
-    const [journalCount] = await db
-      .select({ value: count() })
-      .from(membershipAuthorityJournalTable)
-      .where(eq(membershipAuthorityJournalTable.idempotencyKey, "join-once"));
-    expect(journalCount?.value).toBe(1);
-
-    await expect(apply("revoked", "left", 2, 3, "join-once")).rejects.toMatchObject({
-      code: "MEMBERSHIP_IDEMPOTENCY_CONFLICT",
+    const receipt = await snapshot([member(secondPrincipalId)], 2, 1, "snapshot-0", "snapshot-1");
+    expect(receipt).toMatchObject({ operation: "snapshot", revokedPrincipalIds: [principalId] });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "membership_revoked",
     });
+    await expect(service.authorize(scope, secondPrincipalId)).resolves.toMatchObject({
+      decision: "allowed",
+    });
+    expect(await service.getMembership(scope, principalId)).toMatchObject({
+      state: "revoked",
+      reason: "reconciled_absent",
+    });
+  });
 
-    const restarted = new SqlMembershipService(runtime);
-    await expect(restarted.authorize(scope, principalId)).resolves.toMatchObject({
+  it("accepts an explicitly complete empty roster but rejects incomplete/paginated input without changing facts", async () => {
+    await register();
+    await snapshot();
+    await expect(
+      service.applyCompleteSnapshot({
+        ...scope,
+        ...publisher,
+        completeness: "partial",
+        members: [],
+        expectedGeneration: 2,
+        sourceVersion: 1,
+        previousSourceCursor: "snapshot-0",
+        sourceCursor: "page-1",
+        validUntil: validUntil(),
+        idempotencyKey: "partial",
+        observedAt: observedAt(),
+      } as never)
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_SNAPSHOT_INCOMPLETE" });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
       decision: "allowed",
       generation: 2,
     });
+    const empty = await snapshot([], 2, 1, "snapshot-0", "empty-complete");
+    expect(empty).toMatchObject({
+      operation: "snapshot",
+      memberships: [],
+      revokedPrincipalIds: [principalId],
+    });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "membership_revoked",
+    });
+  });
+
+  it("checks persisted validity against the injected trusted clock on every authorization", async () => {
+    await register();
+    await snapshot();
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
+    });
+    nowMs += 60_001;
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_expired",
+    });
+    await expect(delta("revoked", "left", 2, 1, "snapshot-0", "late-delta")).rejects.toMatchObject({
+      code: "MEMBERSHIP_SNAPSHOT_REQUIRED",
+    });
+    const restarted = new SqlMembershipService(runtime, () => new Date(nowMs));
+    await expect(restarted.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_expired",
+    });
+    await restarted.stop();
+  });
+
+  it("binds evidence to publisher instance, generation, mode, and exact cursor continuity", async () => {
+    await register();
+    await snapshot();
     await expect(
-      restarted.applyMembership({
+      service.applyMembership({
         ...scope,
+        ...publisher,
+        publisherInstanceId: "other-process",
+        canonicalPrincipalId: principalId,
+        state: "revoked",
+        reason: "left",
+        roles: [],
+        permissionSnapshot: {},
+        runtime: { worldId: null, roomId: null, entityId: principalId },
+        expectedGeneration: 2,
+        sourceVersion: 1,
+        previousSourceCursor: "snapshot-0",
+        sourceCursor: "delta-1",
+        validUntil: validUntil(),
+        idempotencyKey: "wrong-publisher",
+        observedAt: observedAt(),
+      })
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_PUBLISHER_MISMATCH" });
+    await expect(
+      delta("revoked", "left", 2, 2, "snapshot-0", "skipped-version")
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_CURSOR_DISCONTINUITY" });
+    await expect(delta("revoked", "left", 2, 1, "wrong-cursor", "delta-1")).rejects.toMatchObject({
+      code: "MEMBERSHIP_CURSOR_DISCONTINUITY",
+    });
+    await delta("revoked", "left", 2, 1, "snapshot-0", "delta-1");
+    await register(3, "publisher-generation-1", {
+      ...publisher,
+      publisherInstanceId: "replacement",
+      publisherGeneration: 1,
+    });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "authority_stale",
+    });
+    await expect(
+      delta("active", "permission_restored", 4, 2, "delta-1", "delta-2")
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_PUBLISHER_MISMATCH" });
+  });
+
+  it("preserves revocation against old evidence and exact idempotency across restart", async () => {
+    await register();
+    const first = await snapshot();
+    await delta("revoked", "kicked", 2, 1, "snapshot-0", "delta-1", "kick-once");
+    await expect(
+      delta("active", "permission_restored", 3, 1, "snapshot-0", "old-restore")
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_CURSOR_DISCONTINUITY" });
+    const restarted = new SqlMembershipService(runtime, () => new Date(nowMs));
+    const replay = await restarted.applyCompleteSnapshot({
+      ...scope,
+      ...publisher,
+      completeness: "complete",
+      members: [member(principalId)],
+      expectedGeneration: 1,
+      sourceVersion: 0,
+      previousSourceCursor: null,
+      sourceCursor: "snapshot-0",
+      validUntil: validUntil(),
+      idempotencyKey: "snapshot-0",
+      observedAt: observedAt(),
+    });
+    expect(replay).toEqual({ ...first, idempotentReplay: true });
+    await expect(restarted.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "membership_revoked",
+    });
+    await restarted.stop();
+  });
+
+  it("serializes a concurrent complete snapshot against a revocation and coalesces exact retries", async () => {
+    await register();
+    const same = await Promise.all([snapshot(), snapshot()]);
+    expect(same.map((receipt) => receipt.idempotentReplay).sort()).toEqual([false, true]);
+    const raced = await Promise.allSettled([
+      snapshot([], 2, 1, "snapshot-0", "race-snapshot", "race-snapshot"),
+      delta("revoked", "left", 2, 1, "snapshot-0", "race-revocation", "race-revocation"),
+    ]);
+    expect(raced.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    expect(raced.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+    expect(
+      (raced.find((outcome) => outcome.status === "rejected") as PromiseRejectedResult).reason
+    ).toMatchObject({ code: "MEMBERSHIP_GENERATION_MISMATCH" });
+    const [journal] = await db
+      .select({ value: count() })
+      .from(membershipAuthorityJournalTable)
+      .where(eq(membershipAuthorityJournalTable.idempotencyKey, "snapshot-0"));
+    expect(journal?.value).toBe(1);
+  });
+
+  it("validates unknown fields, roles, and nested JSON before persistence", async () => {
+    await expect(
+      service.registerPublisher({
+        ...scope,
+        ...publisher,
+        expectedGeneration: 0,
+        idempotencyKey: "extra",
+        observedAt: observedAt(),
+        trusted: true,
+      } as never)
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    await register();
+    await expect(
+      snapshot([{ ...member(principalId), roles: ["member", "member"] }])
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    await expect(
+      snapshot([{ ...member(principalId), permissionSnapshot: { impossible: Number.NaN } }])
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    await expect(
+      service.applyCompleteSnapshot({
+        ...scope,
+        ...publisher,
+        evidenceMode: "point_query",
+        completeness: "complete",
+        members: [member(principalId)],
+        expectedGeneration: 1,
+        sourceVersion: 0,
+        previousSourceCursor: null,
+        sourceCursor: "invalid-point-snapshot",
+        validUntil: validUntil(),
+        idempotencyKey: "invalid-point-snapshot",
+        observedAt: observedAt(),
+      } as never)
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    await expect(
+      service.applyMembership({
+        ...scope,
+        ...publisher,
+        evidenceMode: "complete_snapshot",
         canonicalPrincipalId: principalId,
         state: "active",
         reason: "joined",
         roles: ["member"],
-        permissionSnapshot: { canRead: true },
+        permissionSnapshot: {},
         runtime: { worldId: null, roomId: null, entityId: principalId },
         expectedGeneration: 1,
-        sourceVersion: 2,
-        sourceCursor: "cursor-2",
-        idempotencyKey: "join-once",
-        observedAt: new Date(1_700_000_000_002).toISOString(),
-      })
-    ).resolves.toEqual(replay);
-    await restarted.stop();
+        sourceVersion: 0,
+        previousSourceCursor: null,
+        sourceCursor: "invalid-single-snapshot",
+        validUntil: validUntil(),
+        idempotencyKey: "invalid-single-snapshot",
+        observedAt: observedAt(),
+      } as never)
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    expect(await db.select().from(membershipAuthorityTable)).toHaveLength(0);
   });
 
-  it("invalidates a warm allow decision when reconciliation becomes stale", async () => {
-    await setHealth("current", 0, 1);
-    await apply("active", "joined", 1, 2);
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "allowed",
-      generation: 2,
-    });
-
-    await setHealth("stale", 2, 3);
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "denied",
-      reason: "authority_stale",
-      health: "stale",
-      generation: 3,
-    });
-  });
-
-  it("commits denial and invalidates a warm allow cache before observers run", async () => {
-    await setHealth("current", 0, 1);
-    await apply("active", "joined", 1, 2);
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "allowed",
-    });
-    const sibling = new SqlMembershipService(runtime);
-    await expect(sibling.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "allowed",
-    });
-
-    const dependentAllowCache = new Set([principalId]);
-    let invalidatedGeneration: number | null = null;
-    service.registerInvalidator((_changedScope, receipt) => {
-      dependentAllowCache.delete(principalId);
-      invalidatedGeneration = receipt.committedGeneration;
-    });
-
-    let observerDecision: MembershipAuthorizationDecision | null = null;
-    runtime.registerEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, async (event) => {
-      if (event.receipt.committedGeneration === 3) {
-        expect(dependentAllowCache.has(principalId)).toBe(false);
-        expect(invalidatedGeneration).toBe(3);
-        observerDecision = await service.authorize(scope, principalId);
-      }
-    });
-    await apply("revoked", "kicked", 2, 3);
-    expect(observerDecision).toMatchObject({
-      decision: "denied",
-      reason: "membership_revoked",
-      generation: 3,
-    });
-    await expect(sibling.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "denied",
-      reason: "membership_revoked",
-      generation: 3,
-    });
-  });
-
-  it("reports a failed invalidator after commit without suppressing later invalidators or observers", async () => {
-    await setHealth("current", 0, 1);
-    await apply("active", "joined", 1, 2);
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "allowed",
-    });
-
-    const order: string[] = [];
-    service.registerInvalidator(() => {
-      order.push("failed-invalidator");
-      throw new Error("test invalidator failure");
-    });
-    service.registerInvalidator(() => {
-      order.push("later-invalidator");
-    });
-    runtime.registerEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, async (event) => {
-      if (event.receipt.committedGeneration !== 3) return;
-      order.push("observer");
-      await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-        decision: "denied",
-        reason: "membership_revoked",
-        generation: 3,
-      });
-    });
-
-    await expect(apply("revoked", "left", 2, 3)).resolves.toMatchObject({
-      committedGeneration: 3,
-      membership: { state: "revoked" },
-    });
-    expect(order).toEqual(["failed-invalidator", "later-invalidator", "observer"]);
-  });
-
-  it("prevents duplicate, stale, and out-of-order evidence from resurrecting a revocation", async () => {
-    await setHealth("current", 0, 10);
-    await apply("active", "joined", 1, 11);
-    await apply("revoked", "banned", 2, 12);
-
-    await expect(
-      apply("active", "permission_restored", 3, 11, "late-restore")
-    ).rejects.toMatchObject({ code: "MEMBERSHIP_SOURCE_VERSION_STALE" });
-    await expect(
-      apply("active", "permission_restored", 2, 13, "wrong-generation")
-    ).rejects.toMatchObject({ code: "MEMBERSHIP_GENERATION_MISMATCH" });
-    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "denied",
-      reason: "membership_revoked",
-      generation: 3,
-    });
-  });
-
-  it("serializes concurrent commands so only one expected generation can commit", async () => {
-    await setHealth("current", 0, 1);
-    const outcomes = await Promise.allSettled([
-      apply("active", "joined", 1, 2, "concurrent-join"),
-      apply("revoked", "reconciled_absent", 1, 3, "concurrent-absent"),
-    ]);
-    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
-    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
-    expect(
-      (outcomes.find((outcome) => outcome.status === "rejected") as PromiseRejectedResult).reason
-    ).toMatchObject({ code: "MEMBERSHIP_GENERATION_MISMATCH" });
-  });
-
-  it("coalesces concurrent exact retries into one commit and one observer notification", async () => {
-    await setHealth("current", 0, 1);
-    let membershipNotifications = 0;
-    runtime.registerEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, async (event) => {
-      if (event.receipt.operation === "membership") membershipNotifications += 1;
-    });
-
-    const receipts = await Promise.all([
-      apply("active", "joined", 1, 2, "same-concurrent-join"),
-      apply("active", "joined", 1, 2, "same-concurrent-join"),
-    ]);
-    expect(receipts.map((receipt) => receipt.idempotentReplay).sort()).toEqual([false, true]);
-    expect(membershipNotifications).toBe(1);
-  });
-
-  it("rejects cross-tenant scopes and cross-tenant principal mappings", async () => {
-    const otherAgentId = crypto.randomUUID() as UUID;
-    await expect(
-      service.authorize({ ...scope, agentId: otherAgentId }, principalId)
-    ).rejects.toMatchObject({ code: "MEMBERSHIP_TENANT_MISMATCH" });
-
-    await setHealth("current", 0, 1);
-    await db.delete(entityTable).where(eq(entityTable.id, principalId));
-    await expect(apply("active", "joined", 1, 2)).rejects.toMatchObject({
-      code: "MEMBERSHIP_PRINCIPAL_NOT_FOUND",
-    });
-  });
-
-  it("isolates identical external scope and idempotency values by connector account", async () => {
-    const secondAccountId = crypto.randomUUID() as UUID;
-    await db.insert(connectorAccountsTable).values({
-      id: secondAccountId,
-      agentId,
-      provider: "test-connector",
-      accountKey: `account-${secondAccountId}`,
-    });
-    const secondScope = { ...scope, connectorAccountId: secondAccountId };
-    const observedAt = new Date(1_700_000_000_001).toISOString();
-    await service.setScopeHealth({
+  it("supports bounded point-query proof without claiming connector or document integration", async () => {
+    const pointPublisher = {
+      publisherInstanceId: "point-query",
+      publisherGeneration: 0,
+      evidenceMode: "point_query" as const,
+    };
+    await register(0, "point-register", pointPublisher);
+    await service.applyMembership({
       ...scope,
-      health: "current",
-      reason: "current-by-test",
-      expectedGeneration: 0,
-      sourceVersion: 1,
-      sourceCursor: "cursor-1",
-      idempotencyKey: "shared-health-key",
-      observedAt,
+      ...pointPublisher,
+      canonicalPrincipalId: principalId,
+      state: "active",
+      reason: "reconciled_present",
+      roles: ["member"],
+      permissionSnapshot: { canRead: true },
+      runtime: { worldId: null, roomId: null, entityId: principalId },
+      expectedGeneration: 1,
+      sourceVersion: 0,
+      previousSourceCursor: null,
+      sourceCursor: "point-0",
+      validUntil: validUntil(),
+      idempotencyKey: "point-proof",
+      observedAt: observedAt(),
     });
-    await service.setScopeHealth({
-      ...secondScope,
-      health: "current",
-      reason: "current-by-test",
-      expectedGeneration: 0,
-      sourceVersion: 1,
-      sourceCursor: "cursor-1",
-      idempotencyKey: "shared-health-key",
-      observedAt,
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "allowed",
     });
-
-    await expect(service.getScopeHealth(scope)).resolves.toMatchObject({
-      connectorAccountId: accountId,
-      generation: 1,
+    await expect(service.authorize(scope, secondPrincipalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "no_membership",
     });
-    await expect(service.getScopeHealth(secondScope)).resolves.toMatchObject({
-      connectorAccountId: secondAccountId,
-      generation: 1,
-    });
-    const journalRows = await db
-      .select()
-      .from(membershipAuthorityJournalTable)
-      .where(eq(membershipAuthorityJournalTable.idempotencyKey, "shared-health-key"));
-    expect(journalRows.map((row) => row.connectorAccountId).sort()).toEqual(
-      [accountId, secondAccountId].sort()
-    );
+    await expect(service.getMembership(scope, secondPrincipalId)).resolves.toBeNull();
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
@@ -383,6 +383,30 @@ describe("SqlMembershipService real authority", () => {
     expect(await db.select().from(membershipAuthorityTable)).toHaveLength(0);
   });
 
+  it("rejects contradictory membership state at the database boundary", async () => {
+    await register();
+    await expect(
+      db.insert(membershipAuthorityTable).values({
+        ...scope,
+        canonicalPrincipalId: principalId,
+        state: "active",
+        reason: "left",
+        roles: ["member"],
+        permissionSnapshot: { canRead: true },
+        runtimeWorldId: null,
+        runtimeRoomId: null,
+        runtimeEntityId: principalId,
+        ...publisher,
+        generation: 1,
+        sourceVersion: 0,
+        sourceCursor: "forged",
+        observedAt: new Date(nowMs),
+        validUntil: new Date(nowMs + 60_000),
+      })
+    ).rejects.toThrow();
+    expect(await db.select().from(membershipAuthorityTable)).toHaveLength(0);
+  });
+
   it("supports bounded point-query proof without claiming connector or document integration", async () => {
     const pointPublisher = {
       publisherInstanceId: "point-query",

--- a/plugins/plugin-sql/src/__tests__/membership-authority-schema.test.ts
+++ b/plugins/plugin-sql/src/__tests__/membership-authority-schema.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Deterministically verifies the canonical membership tables and plugin
+ * registration expose one durable authority with relational fencing and no
+ * model-callable mutation surface.
+ */
+import { MembershipService } from "@elizaos/core";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import { plugin, SqlMembershipService } from "../index";
+import {
+  membershipAuthorityJournalTable,
+  membershipAuthorityScopeTable,
+  membershipAuthorityTable,
+} from "../schema/membershipAuthority";
+
+describe("canonical membership authority schema", () => {
+  it("registers one canonical service without a model-callable action", () => {
+    expect(
+      plugin.services?.filter((service) => service.serviceType === MembershipService.serviceType)
+    ).toEqual([SqlMembershipService]);
+    expect(plugin.actions).toBeUndefined();
+  });
+
+  it("keys current state by the complete connector-room-principal tuple", () => {
+    const config = getTableConfig(membershipAuthorityTable);
+    expect(config.primaryKeys[0]?.columns.map((column) => column.name)).toEqual([
+      "agent_id",
+      "connector_id",
+      "connector_account_id",
+      "external_world_id",
+      "external_room_id",
+      "canonical_principal_id",
+    ]);
+    expect(config.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "membership_authority_state_check",
+        "membership_authority_reason_check",
+        "membership_authority_generation_check",
+        "membership_authority_version_check",
+      ])
+    );
+    expect(
+      config.foreignKeys.map((constraint) => constraint.reference().foreignTable)
+    ).toHaveLength(3);
+  });
+
+  it("persists explicit scope health and exact idempotent command receipts", () => {
+    const scope = getTableConfig(membershipAuthorityScopeTable);
+    const journal = getTableConfig(membershipAuthorityJournalTable);
+    expect(scope.checks.map((constraint) => constraint.name)).toContain(
+      "membership_authority_scope_health_check"
+    );
+    expect(scope.columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining(["health", "reason", "generation", "source_version", "source_cursor"])
+    );
+    expect(journal.uniqueConstraints.map((constraint) => constraint.name)).toContain(
+      "membership_authority_journal_idempotency_unique"
+    );
+    expect(journal.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "membership_authority_journal_operation_check",
+        "membership_authority_journal_generation_check",
+        "membership_authority_journal_version_check",
+      ])
+    );
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/membership-authority-schema.test.ts
+++ b/plugins/plugin-sql/src/__tests__/membership-authority-schema.test.ts
@@ -35,7 +35,7 @@ describe("canonical membership authority schema", () => {
       expect.arrayContaining([
         "membership_authority_state_check",
         "membership_authority_reason_check",
-        "membership_authority_generation_check",
+        "membership_authority_evidence_check",
         "membership_authority_version_check",
       ])
     );
@@ -44,14 +44,23 @@ describe("canonical membership authority schema", () => {
     ).toHaveLength(3);
   });
 
-  it("persists explicit scope health and exact idempotent command receipts", () => {
+  it("persists publisher fencing, bounded freshness, and exact command receipts", () => {
     const scope = getTableConfig(membershipAuthorityScopeTable);
     const journal = getTableConfig(membershipAuthorityJournalTable);
     expect(scope.checks.map((constraint) => constraint.name)).toContain(
       "membership_authority_scope_health_check"
     );
     expect(scope.columns.map((column) => column.name)).toEqual(
-      expect.arrayContaining(["health", "reason", "generation", "source_version", "source_cursor"])
+      expect.arrayContaining([
+        "health",
+        "generation",
+        "source_version",
+        "source_cursor",
+        "valid_until",
+        "publisher_instance_id",
+        "publisher_generation",
+        "evidence_mode",
+      ])
     );
     expect(journal.uniqueConstraints.map((constraint) => constraint.name)).toContain(
       "membership_authority_journal_idempotency_unique"
@@ -60,7 +69,12 @@ describe("canonical membership authority schema", () => {
       expect.arrayContaining([
         "membership_authority_journal_operation_check",
         "membership_authority_journal_generation_check",
-        "membership_authority_journal_version_check",
+      ])
+    );
+    expect(scope.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "membership_authority_scope_publisher_check",
+        "membership_authority_scope_current_check",
       ])
     );
   });

--- a/plugins/plugin-sql/src/__tests__/membership-authority-schema.test.ts
+++ b/plugins/plugin-sql/src/__tests__/membership-authority-schema.test.ts
@@ -35,6 +35,7 @@ describe("canonical membership authority schema", () => {
       expect.arrayContaining([
         "membership_authority_state_check",
         "membership_authority_reason_check",
+        "membership_authority_state_reason_check",
         "membership_authority_evidence_check",
         "membership_authority_version_check",
       ])

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -29,6 +29,7 @@ import {
 import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlMembershipService } from "./services/sql-membership";
 import { SqlPrincipalService } from "./services/sql-principal";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
@@ -116,7 +117,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access (PGlite WASM in browser).",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService, SqlPrincipalService],
+  services: [AdvancedMemoryStorageService, SqlPrincipalService, SqlMembershipService],
   routes: [...identityPersonLinkRoutes],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
@@ -198,6 +199,7 @@ export type {
 } from "./pglite/manager-cache";
 export * from "./schema";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+export { SqlMembershipService } from "./services/sql-membership";
 export {
   computeIdentityRequestDigest,
   SqlPrincipalService,

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -54,6 +54,7 @@ import {
 import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlMembershipService } from "./services/sql-membership";
 import { SqlPrincipalService } from "./services/sql-principal";
 import { stringToUuid } from "./utils/string-to-uuid";
 import { resolvePgliteDir } from "./utils.node.ts";
@@ -181,7 +182,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService, SqlPrincipalService],
+  services: [AdvancedMemoryStorageService, SqlPrincipalService, SqlMembershipService],
   routes: [...identityPersonLinkRoutes],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
@@ -257,6 +258,7 @@ export {
   uninstallRLS,
 } from "./rls";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+export { SqlMembershipService } from "./services/sql-membership";
 export {
   computeIdentityRequestDigest,
   SqlPrincipalService,

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -54,6 +54,7 @@ import {
 import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlMembershipService } from "./services/sql-membership";
 import { SqlPrincipalService } from "./services/sql-principal";
 import { resolvePgliteDir } from "./utils";
 import { stringToUuid } from "./utils/string-to-uuid";
@@ -176,7 +177,7 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  services: [AdvancedMemoryStorageService, SqlPrincipalService],
+  services: [AdvancedMemoryStorageService, SqlPrincipalService, SqlMembershipService],
   routes: [...identityPersonLinkRoutes],
   init: async (_, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
@@ -268,6 +269,7 @@ export {
 } from "./rls";
 export * from "./schema";
 export { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+export { SqlMembershipService } from "./services/sql-membership";
 export {
   computeIdentityRequestDigest,
   SqlPrincipalService,

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -44,6 +44,11 @@ export {
 } from "./identityAuthority";
 export { logTable } from "./log";
 export { longTermMemories } from "./longTermMemories";
+export {
+  membershipAuthorityJournalTable,
+  membershipAuthorityScopeTable,
+  membershipAuthorityTable,
+} from "./membershipAuthority";
 export { memoryTable } from "./memory";
 export { memoryAccessLogs } from "./memoryAccessLogs";
 export { messageTable } from "./message";

--- a/plugins/plugin-sql/src/schema/membershipAuthority.ts
+++ b/plugins/plugin-sql/src/schema/membershipAuthority.ts
@@ -1,0 +1,201 @@
+/**
+ * Durable connector-room membership authority tables. Scope rows serialize
+ * ordered evidence and expose reconciliation health; current rows retain the
+ * latest principal state; the journal makes command retries exact and
+ * conflicting idempotency-key reuse detectable.
+ */
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  check,
+  foreignKey,
+  index,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { agentTable } from "./agent";
+import { connectorAccountsTable } from "./connectorAccounts";
+import { entityTable } from "./entity";
+
+function scopeColumns() {
+  return {
+    agentId: uuid("agent_id").notNull(),
+    connectorId: text("connector_id").notNull(),
+    connectorAccountId: uuid("connector_account_id").notNull(),
+    externalWorldId: text("external_world_id").notNull(),
+    externalRoomId: text("external_room_id").notNull(),
+  };
+}
+
+export const membershipAuthorityScopeTable = pgTable(
+  "membership_authority_scopes",
+  {
+    ...scopeColumns(),
+    health: text("health").notNull().default("stale"),
+    reason: text("reason").notNull().default("awaiting_reconciliation"),
+    generation: bigint("generation", { mode: "number" }).notNull().default(0),
+    sourceVersion: bigint("source_version", { mode: "number" }).notNull().default(-1),
+    sourceCursor: text("source_cursor"),
+    observedAt: timestamp("observed_at", { withTimezone: true }).notNull().default(sql`now()`),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    primaryKey({
+      name: "membership_authority_scope_pk",
+      columns: [
+        table.agentId,
+        table.connectorId,
+        table.connectorAccountId,
+        table.externalWorldId,
+        table.externalRoomId,
+      ],
+    }),
+    index("membership_authority_scope_health_idx").on(table.agentId, table.health),
+    foreignKey({
+      name: "fk_membership_authority_scope_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_membership_authority_scope_account",
+      columns: [table.connectorAccountId, table.agentId],
+      foreignColumns: [connectorAccountsTable.id, connectorAccountsTable.agentId],
+    }).onDelete("cascade"),
+    check(
+      "membership_authority_scope_health_check",
+      sql`${table.health} IN ('current', 'stale', 'unavailable', 'unsupported')`
+    ),
+    check("membership_authority_scope_generation_check", sql`${table.generation} >= 0`),
+    check("membership_authority_scope_version_check", sql`${table.sourceVersion} >= -1`),
+    check(
+      "membership_authority_scope_ids_check",
+      sql`
+      length(trim(${table.connectorId})) > 0 AND
+      length(trim(${table.externalWorldId})) > 0 AND
+      length(trim(${table.externalRoomId})) > 0 AND
+      length(trim(${table.reason})) > 0
+    `
+    ),
+  ]
+);
+
+export const membershipAuthorityTable = pgTable(
+  "membership_authority",
+  {
+    ...scopeColumns(),
+    canonicalPrincipalId: uuid("canonical_principal_id").notNull(),
+    state: text("state").notNull(),
+    reason: text("reason").notNull(),
+    roles: jsonb("roles").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+    permissionSnapshot: jsonb("permission_snapshot")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    runtimeWorldId: uuid("runtime_world_id"),
+    runtimeRoomId: uuid("runtime_room_id"),
+    runtimeEntityId: uuid("runtime_entity_id"),
+    generation: bigint("generation", { mode: "number" }).notNull(),
+    sourceVersion: bigint("source_version", { mode: "number" }).notNull(),
+    sourceCursor: text("source_cursor"),
+    observedAt: timestamp("observed_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    primaryKey({
+      name: "membership_authority_pk",
+      columns: [
+        table.agentId,
+        table.connectorId,
+        table.connectorAccountId,
+        table.externalWorldId,
+        table.externalRoomId,
+        table.canonicalPrincipalId,
+      ],
+    }),
+    index("membership_authority_principal_idx").on(table.agentId, table.canonicalPrincipalId),
+    index("membership_authority_state_idx").on(table.agentId, table.state),
+    foreignKey({
+      name: "fk_membership_authority_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_membership_authority_account",
+      columns: [table.connectorAccountId, table.agentId],
+      foreignColumns: [connectorAccountsTable.id, connectorAccountsTable.agentId],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_membership_authority_principal",
+      columns: [table.canonicalPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
+    }).onDelete("restrict"),
+    check("membership_authority_state_check", sql`${table.state} IN ('active', 'revoked')`),
+    check(
+      "membership_authority_reason_check",
+      sql`${table.reason} IN ('joined', 'reconciled_present', 'permission_restored', 'left', 'kicked', 'banned', 'permission_lost', 'account_removed', 'reconciled_absent')`
+    ),
+    check("membership_authority_generation_check", sql`${table.generation} > 0`),
+    check("membership_authority_version_check", sql`${table.sourceVersion} >= 0`),
+  ]
+);
+
+export const membershipAuthorityJournalTable = pgTable(
+  "membership_authority_journal",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    ...scopeColumns(),
+    operation: text("operation").notNull(),
+    canonicalPrincipalId: uuid("canonical_principal_id"),
+    idempotencyKey: text("idempotency_key").notNull(),
+    requestDigest: text("request_digest").notNull(),
+    expectedGeneration: bigint("expected_generation", { mode: "number" }).notNull(),
+    committedGeneration: bigint("committed_generation", { mode: "number" }).notNull(),
+    sourceVersion: bigint("source_version", { mode: "number" }).notNull(),
+    sourceCursor: text("source_cursor"),
+    result: jsonb("result").$type<Record<string, unknown>>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    unique("membership_authority_journal_idempotency_unique").on(
+      table.agentId,
+      table.connectorAccountId,
+      table.idempotencyKey
+    ),
+    index("membership_authority_journal_scope_idx").on(
+      table.agentId,
+      table.connectorAccountId,
+      table.externalWorldId,
+      table.externalRoomId,
+      table.createdAt
+    ),
+    foreignKey({
+      name: "fk_membership_authority_journal_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_membership_authority_journal_account",
+      columns: [table.connectorAccountId, table.agentId],
+      foreignColumns: [connectorAccountsTable.id, connectorAccountsTable.agentId],
+    }).onDelete("cascade"),
+    check(
+      "membership_authority_journal_operation_check",
+      sql`${table.operation} IN ('membership', 'health')`
+    ),
+    check(
+      "membership_authority_journal_generation_check",
+      sql`${table.expectedGeneration} >= 0 AND ${table.committedGeneration} = ${table.expectedGeneration} + 1`
+    ),
+    check("membership_authority_journal_version_check", sql`${table.sourceVersion} >= 0`),
+    check(
+      "membership_authority_journal_idempotency_check",
+      sql`length(trim(${table.idempotencyKey})) > 0`
+    ),
+  ]
+);

--- a/plugins/plugin-sql/src/schema/membershipAuthority.ts
+++ b/plugins/plugin-sql/src/schema/membershipAuthority.ts
@@ -1,9 +1,4 @@
-/**
- * Durable connector-room membership authority tables. Scope rows serialize
- * ordered evidence and expose reconciliation health; current rows retain the
- * latest principal state; the journal makes command retries exact and
- * conflicting idempotency-key reuse detectable.
- */
+/** Durable publisher-fenced membership scopes, retained facts, and exact command receipts. */
 import { sql } from "drizzle-orm";
 import {
   bigint,
@@ -31,16 +26,19 @@ function scopeColumns() {
     externalRoomId: text("external_room_id").notNull(),
   };
 }
-
 export const membershipAuthorityScopeTable = pgTable(
   "membership_authority_scopes",
   {
     ...scopeColumns(),
     health: text("health").notNull().default("stale"),
-    reason: text("reason").notNull().default("awaiting_reconciliation"),
+    reason: text("reason").notNull().default("publisher_not_registered"),
     generation: bigint("generation", { mode: "number" }).notNull().default(0),
     sourceVersion: bigint("source_version", { mode: "number" }).notNull().default(-1),
     sourceCursor: text("source_cursor"),
+    validUntil: timestamp("valid_until", { withTimezone: true }),
+    publisherInstanceId: text("publisher_instance_id"),
+    publisherGeneration: bigint("publisher_generation", { mode: "number" }),
+    evidenceMode: text("evidence_mode"),
     observedAt: timestamp("observed_at", { withTimezone: true }).notNull().default(sql`now()`),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
   },
@@ -68,18 +66,19 @@ export const membershipAuthorityScopeTable = pgTable(
     }).onDelete("cascade"),
     check(
       "membership_authority_scope_health_check",
-      sql`${table.health} IN ('current', 'stale', 'unavailable', 'unsupported')`
+      sql`${table.health} IN ('current','stale','unavailable','unsupported')`
     ),
-    check("membership_authority_scope_generation_check", sql`${table.generation} >= 0`),
-    check("membership_authority_scope_version_check", sql`${table.sourceVersion} >= -1`),
     check(
-      "membership_authority_scope_ids_check",
-      sql`
-      length(trim(${table.connectorId})) > 0 AND
-      length(trim(${table.externalWorldId})) > 0 AND
-      length(trim(${table.externalRoomId})) > 0 AND
-      length(trim(${table.reason})) > 0
-    `
+      "membership_authority_scope_generation_check",
+      sql`${table.generation} >= 0 AND ${table.sourceVersion} >= -1`
+    ),
+    check(
+      "membership_authority_scope_publisher_check",
+      sql`(${table.publisherInstanceId} IS NULL AND ${table.publisherGeneration} IS NULL AND ${table.evidenceMode} IS NULL) OR (${table.publisherInstanceId} IS NOT NULL AND ${table.publisherGeneration} >= 0 AND ${table.evidenceMode} IN ('complete_snapshot','ordered_delta','point_query'))`
+    ),
+    check(
+      "membership_authority_scope_current_check",
+      sql`${table.health} <> 'current' OR (${table.validUntil} IS NOT NULL AND ${table.publisherInstanceId} IS NOT NULL AND ${table.sourceCursor} IS NOT NULL)`
     ),
   ]
 );
@@ -91,18 +90,19 @@ export const membershipAuthorityTable = pgTable(
     canonicalPrincipalId: uuid("canonical_principal_id").notNull(),
     state: text("state").notNull(),
     reason: text("reason").notNull(),
-    roles: jsonb("roles").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
-    permissionSnapshot: jsonb("permission_snapshot")
-      .$type<Record<string, unknown>>()
-      .notNull()
-      .default(sql`'{}'::jsonb`),
+    roles: jsonb("roles").$type<string[]>().notNull(),
+    permissionSnapshot: jsonb("permission_snapshot").$type<Record<string, unknown>>().notNull(),
     runtimeWorldId: uuid("runtime_world_id"),
     runtimeRoomId: uuid("runtime_room_id"),
     runtimeEntityId: uuid("runtime_entity_id"),
+    publisherInstanceId: text("publisher_instance_id").notNull(),
+    publisherGeneration: bigint("publisher_generation", { mode: "number" }).notNull(),
+    evidenceMode: text("evidence_mode").notNull(),
     generation: bigint("generation", { mode: "number" }).notNull(),
     sourceVersion: bigint("source_version", { mode: "number" }).notNull(),
-    sourceCursor: text("source_cursor"),
+    sourceCursor: text("source_cursor").notNull(),
     observedAt: timestamp("observed_at", { withTimezone: true }).notNull(),
+    validUntil: timestamp("valid_until", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().default(sql`now()`),
   },
@@ -119,7 +119,6 @@ export const membershipAuthorityTable = pgTable(
       ],
     }),
     index("membership_authority_principal_idx").on(table.agentId, table.canonicalPrincipalId),
-    index("membership_authority_state_idx").on(table.agentId, table.state),
     foreignKey({
       name: "fk_membership_authority_agent",
       columns: [table.agentId],
@@ -135,13 +134,19 @@ export const membershipAuthorityTable = pgTable(
       columns: [table.canonicalPrincipalId, table.agentId],
       foreignColumns: [entityTable.id, entityTable.agentId],
     }).onDelete("restrict"),
-    check("membership_authority_state_check", sql`${table.state} IN ('active', 'revoked')`),
+    check("membership_authority_state_check", sql`${table.state} IN ('active','revoked')`),
     check(
       "membership_authority_reason_check",
-      sql`${table.reason} IN ('joined', 'reconciled_present', 'permission_restored', 'left', 'kicked', 'banned', 'permission_lost', 'account_removed', 'reconciled_absent')`
+      sql`${table.reason} IN ('joined','reconciled_present','permission_restored','left','kicked','banned','permission_lost','account_removed','reconciled_absent')`
     ),
-    check("membership_authority_generation_check", sql`${table.generation} > 0`),
-    check("membership_authority_version_check", sql`${table.sourceVersion} >= 0`),
+    check(
+      "membership_authority_evidence_check",
+      sql`${table.evidenceMode} IN ('complete_snapshot','ordered_delta','point_query') AND ${table.publisherGeneration} >= 0`
+    ),
+    check(
+      "membership_authority_version_check",
+      sql`${table.generation} > 0 AND ${table.sourceVersion} >= 0`
+    ),
   ]
 );
 
@@ -151,13 +156,10 @@ export const membershipAuthorityJournalTable = pgTable(
     id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
     ...scopeColumns(),
     operation: text("operation").notNull(),
-    canonicalPrincipalId: uuid("canonical_principal_id"),
     idempotencyKey: text("idempotency_key").notNull(),
     requestDigest: text("request_digest").notNull(),
     expectedGeneration: bigint("expected_generation", { mode: "number" }).notNull(),
     committedGeneration: bigint("committed_generation", { mode: "number" }).notNull(),
-    sourceVersion: bigint("source_version", { mode: "number" }).notNull(),
-    sourceCursor: text("source_cursor"),
     result: jsonb("result").$type<Record<string, unknown>>().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
   },
@@ -169,6 +171,7 @@ export const membershipAuthorityJournalTable = pgTable(
     ),
     index("membership_authority_journal_scope_idx").on(
       table.agentId,
+      table.connectorId,
       table.connectorAccountId,
       table.externalWorldId,
       table.externalRoomId,
@@ -186,16 +189,11 @@ export const membershipAuthorityJournalTable = pgTable(
     }).onDelete("cascade"),
     check(
       "membership_authority_journal_operation_check",
-      sql`${table.operation} IN ('membership', 'health')`
+      sql`${table.operation} IN ('publisher','snapshot','membership','health')`
     ),
     check(
       "membership_authority_journal_generation_check",
       sql`${table.expectedGeneration} >= 0 AND ${table.committedGeneration} = ${table.expectedGeneration} + 1`
-    ),
-    check("membership_authority_journal_version_check", sql`${table.sourceVersion} >= 0`),
-    check(
-      "membership_authority_journal_idempotency_check",
-      sql`length(trim(${table.idempotencyKey})) > 0`
     ),
   ]
 );

--- a/plugins/plugin-sql/src/schema/membershipAuthority.ts
+++ b/plugins/plugin-sql/src/schema/membershipAuthority.ts
@@ -78,7 +78,7 @@ export const membershipAuthorityScopeTable = pgTable(
     ),
     check(
       "membership_authority_scope_current_check",
-      sql`${table.health} <> 'current' OR (${table.validUntil} IS NOT NULL AND ${table.publisherInstanceId} IS NOT NULL AND ${table.sourceCursor} IS NOT NULL)`
+      sql`${table.health} <> 'current' OR (${table.validUntil} IS NOT NULL AND ${table.validUntil} > ${table.observedAt} AND ${table.publisherInstanceId} IS NOT NULL AND ${table.sourceVersion} >= 0 AND ${table.sourceCursor} IS NOT NULL)`
     ),
   ]
 );
@@ -140,12 +140,16 @@ export const membershipAuthorityTable = pgTable(
       sql`${table.reason} IN ('joined','reconciled_present','permission_restored','left','kicked','banned','permission_lost','account_removed','reconciled_absent')`
     ),
     check(
+      "membership_authority_state_reason_check",
+      sql`(${table.state} = 'active' AND ${table.reason} IN ('joined','reconciled_present','permission_restored')) OR (${table.state} = 'revoked' AND ${table.reason} IN ('left','kicked','banned','permission_lost','account_removed','reconciled_absent'))`
+    ),
+    check(
       "membership_authority_evidence_check",
       sql`${table.evidenceMode} IN ('complete_snapshot','ordered_delta','point_query') AND ${table.publisherGeneration} >= 0`
     ),
     check(
       "membership_authority_version_check",
-      sql`${table.generation} > 0 AND ${table.sourceVersion} >= 0`
+      sql`${table.generation} > 0 AND ${table.sourceVersion} >= 0 AND ${table.validUntil} > ${table.observedAt}`
     ),
   ]
 );

--- a/plugins/plugin-sql/src/services/sql-membership.ts
+++ b/plugins/plugin-sql/src/services/sql-membership.ts
@@ -1,0 +1,703 @@
+/**
+ * SQL-backed canonical connector-room membership authority. Every mutation is
+ * an idempotent, generation-fenced, monotonically ordered command committed to
+ * the durable scope state machine before authorization caches are invalidated
+ * and observers are notified.
+ */
+import {
+  type ApplyMembershipCommand,
+  ElizaError,
+  EventType,
+  type IAgentRuntime,
+  type JsonObject,
+  MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+  MEMBERSHIP_HEALTH_STATES,
+  MEMBERSHIP_REASONS,
+  MEMBERSHIP_STATES,
+  type MembershipAuthorityInvalidator,
+  type MembershipAuthorizationDecision,
+  type MembershipHealthState,
+  type MembershipMutationReceipt,
+  type MembershipRecord,
+  type MembershipScope,
+  type MembershipScopeHealth,
+  MembershipService,
+  type Service,
+  type SetMembershipHealthCommand,
+  type UUID,
+} from "@elizaos/core";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { and, eq, lt } from "drizzle-orm";
+import { connectorAccountsTable } from "../schema/connectorAccounts";
+import { entityTable } from "../schema/entity";
+import {
+  membershipAuthorityJournalTable,
+  membershipAuthorityScopeTable,
+  membershipAuthorityTable,
+} from "../schema/membershipAuthority";
+import { roomTable } from "../schema/room";
+import { worldTable } from "../schema/world";
+import { type DrizzleDatabase, getDb } from "../types";
+
+const MAX_ROLES = 100;
+const MAX_IDENTIFIER_LENGTH = 1_024;
+const ACTIVE_REASONS = new Set(["joined", "reconciled_present", "permission_restored"]);
+const HEALTH_REASON_BY_STATE = {
+  stale: "authority_stale",
+  unavailable: "authority_unavailable",
+  unsupported: "authority_unsupported",
+} as const;
+
+type ScopeRow = typeof membershipAuthorityScopeTable.$inferSelect;
+type MembershipRow = typeof membershipAuthorityTable.$inferSelect;
+type JournalRow = typeof membershipAuthorityJournalTable.$inferSelect;
+
+function fail(code: string, message: string, context: Record<string, unknown> = {}): never {
+  throw new ElizaError(message, { code, context, severity: "fatal" });
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (typeof value !== "object") {
+    return fail("MEMBERSHIP_COMMAND_INVALID", "Membership command is not canonical JSON.");
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function commandDigest(operation: "membership" | "health", command: unknown): string {
+  const bytes = sha256(
+    new TextEncoder().encode(`elizaos:membership:${operation}:v1\n${stableJson(command)}`)
+  );
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function iso(value: Date): string {
+  return value.toISOString();
+}
+
+function mapScope(row: ScopeRow): MembershipScopeHealth {
+  return {
+    contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+    agentId: row.agentId as UUID,
+    connectorId: row.connectorId,
+    connectorAccountId: row.connectorAccountId as UUID,
+    externalWorldId: row.externalWorldId,
+    externalRoomId: row.externalRoomId,
+    health: row.health as MembershipHealthState,
+    reason: row.reason,
+    generation: row.generation,
+    sourceVersion: row.sourceVersion,
+    sourceCursor: row.sourceCursor,
+    observedAt: iso(row.observedAt),
+    updatedAt: iso(row.updatedAt),
+  };
+}
+
+function mapMembership(row: MembershipRow): MembershipRecord {
+  if (
+    typeof row.permissionSnapshot !== "object" ||
+    row.permissionSnapshot === null ||
+    Array.isArray(row.permissionSnapshot)
+  ) {
+    return fail(
+      "MEMBERSHIP_PERSISTED_STATE_INVALID",
+      "Persisted permission snapshot is not an object."
+    );
+  }
+  return {
+    contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+    agentId: row.agentId as UUID,
+    connectorId: row.connectorId,
+    connectorAccountId: row.connectorAccountId as UUID,
+    externalWorldId: row.externalWorldId,
+    externalRoomId: row.externalRoomId,
+    canonicalPrincipalId: row.canonicalPrincipalId as UUID,
+    state: row.state as MembershipRecord["state"],
+    reason: row.reason as MembershipRecord["reason"],
+    roles: row.roles,
+    permissionSnapshot: row.permissionSnapshot as JsonObject,
+    runtime: {
+      worldId: row.runtimeWorldId as UUID | null,
+      roomId: row.runtimeRoomId as UUID | null,
+      entityId: row.runtimeEntityId as UUID | null,
+    },
+    generation: row.generation,
+    sourceVersion: row.sourceVersion,
+    sourceCursor: row.sourceCursor,
+    observedAt: iso(row.observedAt),
+    createdAt: iso(row.createdAt),
+    updatedAt: iso(row.updatedAt),
+  };
+}
+
+function scopeWhere(scope: MembershipScope) {
+  return and(
+    eq(membershipAuthorityScopeTable.agentId, scope.agentId),
+    eq(membershipAuthorityScopeTable.connectorId, scope.connectorId),
+    eq(membershipAuthorityScopeTable.connectorAccountId, scope.connectorAccountId),
+    eq(membershipAuthorityScopeTable.externalWorldId, scope.externalWorldId),
+    eq(membershipAuthorityScopeTable.externalRoomId, scope.externalRoomId)
+  );
+}
+
+function membershipWhere(scope: MembershipScope, canonicalPrincipalId: UUID) {
+  return and(
+    eq(membershipAuthorityTable.agentId, scope.agentId),
+    eq(membershipAuthorityTable.connectorId, scope.connectorId),
+    eq(membershipAuthorityTable.connectorAccountId, scope.connectorAccountId),
+    eq(membershipAuthorityTable.externalWorldId, scope.externalWorldId),
+    eq(membershipAuthorityTable.externalRoomId, scope.externalRoomId),
+    eq(membershipAuthorityTable.canonicalPrincipalId, canonicalPrincipalId)
+  );
+}
+
+function scopeKey(scope: MembershipScope): string {
+  return stableJson([
+    scope.agentId,
+    scope.connectorId,
+    scope.connectorAccountId,
+    scope.externalWorldId,
+    scope.externalRoomId,
+  ]);
+}
+
+function decisionKey(scope: MembershipScope, canonicalPrincipalId: UUID): string {
+  return `${scopeKey(scope)}\n${canonicalPrincipalId}`;
+}
+
+function parseReceipt(row: JournalRow): MembershipMutationReceipt {
+  const result = row.result as Partial<MembershipMutationReceipt>;
+  if (
+    result.contractVersion !== MEMBERSHIP_AUTHORITY_CONTRACT_VERSION ||
+    (result.operation !== "membership" && result.operation !== "health") ||
+    result.committedGeneration !== row.committedGeneration
+  ) {
+    return fail("MEMBERSHIP_JOURNAL_INVALID", "Persisted membership receipt is invalid.", {
+      journalId: row.id,
+    });
+  }
+  return { ...result, idempotentReplay: true } as MembershipMutationReceipt;
+}
+
+export class SqlMembershipService extends MembershipService {
+  static override readonly serviceType = MembershipService.serviceType;
+
+  private readonly decisionCache = new Map<
+    string,
+    { generation: number; decision: MembershipAuthorizationDecision }
+  >();
+  private readonly invalidators = new Set<MembershipAuthorityInvalidator>();
+
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new SqlMembershipService(runtime);
+    if (!service.db) {
+      fail(
+        "MEMBERSHIP_SQL_ADAPTER_REQUIRED",
+        "SQL membership authority requires a Drizzle-backed adapter."
+      );
+    }
+    return service;
+  }
+
+  async stop(): Promise<void> {
+    this.decisionCache.clear();
+    this.invalidators.clear();
+  }
+
+  registerInvalidator(invalidator: MembershipAuthorityInvalidator): () => void {
+    this.invalidators.add(invalidator);
+    return () => this.invalidators.delete(invalidator);
+  }
+
+  private get db(): DrizzleDatabase {
+    return getDb(this.runtime.adapter);
+  }
+
+  private assertScope(scope: MembershipScope): void {
+    if (scope.agentId !== this.runtime.agentId) {
+      fail("MEMBERSHIP_TENANT_MISMATCH", "Membership request is outside this runtime tenant.", {
+        agentId: scope.agentId,
+      });
+    }
+    for (const [field, value] of Object.entries({
+      connectorId: scope.connectorId,
+      externalWorldId: scope.externalWorldId,
+      externalRoomId: scope.externalRoomId,
+    })) {
+      if (value.trim().length === 0 || value.length > MAX_IDENTIFIER_LENGTH) {
+        fail("MEMBERSHIP_COMMAND_INVALID", `Membership ${field} is invalid.`, { field });
+      }
+    }
+  }
+
+  private assertCommand(command: ApplyMembershipCommand | SetMembershipHealthCommand): Date {
+    this.assertScope(command);
+    if (
+      !Number.isSafeInteger(command.expectedGeneration) ||
+      command.expectedGeneration < 0 ||
+      command.expectedGeneration === Number.MAX_SAFE_INTEGER
+    ) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Expected generation must be a nonnegative integer.");
+    }
+    if (!Number.isSafeInteger(command.sourceVersion) || command.sourceVersion < 0) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Source version must be a nonnegative integer.");
+    }
+    if (
+      command.idempotencyKey.trim().length === 0 ||
+      command.idempotencyKey.length > MAX_IDENTIFIER_LENGTH
+    ) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Idempotency key is invalid.");
+    }
+    if (command.sourceCursor && command.sourceCursor.length > MAX_IDENTIFIER_LENGTH) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Source cursor is invalid.");
+    }
+    const observedAt = new Date(command.observedAt);
+    if (!Number.isFinite(observedAt.getTime())) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Observed timestamp is invalid.");
+    }
+    return observedAt;
+  }
+
+  private assertMembershipCommand(command: ApplyMembershipCommand): void {
+    if (
+      !MEMBERSHIP_STATES.includes(command.state) ||
+      !MEMBERSHIP_REASONS.includes(command.reason)
+    ) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Membership state or reason is invalid.");
+    }
+    const activeReason = ACTIVE_REASONS.has(command.reason);
+    if ((command.state === "active") !== activeReason) {
+      fail(
+        "MEMBERSHIP_COMMAND_INVALID",
+        "Membership reason is incompatible with the requested state."
+      );
+    }
+    if (
+      command.roles.length > MAX_ROLES ||
+      new Set(command.roles).size !== command.roles.length ||
+      command.roles.some((role) => role.trim().length === 0 || role.length > 256)
+    ) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Membership roles are invalid.");
+    }
+    if (
+      typeof command.permissionSnapshot !== "object" ||
+      command.permissionSnapshot === null ||
+      Array.isArray(command.permissionSnapshot)
+    ) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Permission snapshot must be an object.");
+    }
+  }
+
+  private async assertReferences(
+    tx: DrizzleDatabase,
+    command: ApplyMembershipCommand | SetMembershipHealthCommand
+  ): Promise<void> {
+    const [account] = await tx
+      .select({ provider: connectorAccountsTable.provider })
+      .from(connectorAccountsTable)
+      .where(
+        and(
+          eq(connectorAccountsTable.id, command.connectorAccountId),
+          eq(connectorAccountsTable.agentId, command.agentId)
+        )
+      )
+      .limit(1);
+    if (!account || account.provider !== command.connectorId) {
+      fail(
+        "MEMBERSHIP_CONNECTOR_ACCOUNT_MISMATCH",
+        "Connector account does not belong to this connector and tenant."
+      );
+    }
+    if (!("canonicalPrincipalId" in command)) return;
+
+    const requiredEntityIds = new Set<UUID>([command.canonicalPrincipalId]);
+    if (command.runtime.entityId) requiredEntityIds.add(command.runtime.entityId);
+    const entities = await Promise.all(
+      [...requiredEntityIds].map((id) =>
+        tx
+          .select({ id: entityTable.id })
+          .from(entityTable)
+          .where(and(eq(entityTable.id, id), eq(entityTable.agentId, command.agentId)))
+          .limit(1)
+      )
+    );
+    if (entities.some((rows) => rows.length !== 1)) {
+      fail(
+        "MEMBERSHIP_PRINCIPAL_NOT_FOUND",
+        "Membership principal or runtime entity mapping does not exist in this tenant."
+      );
+    }
+    if (command.runtime.roomId) {
+      const [room] = await tx
+        .select({ id: roomTable.id })
+        .from(roomTable)
+        .where(
+          and(eq(roomTable.id, command.runtime.roomId), eq(roomTable.agentId, command.agentId))
+        )
+        .limit(1);
+      if (!room) fail("MEMBERSHIP_RUNTIME_MAPPING_INVALID", "Runtime room mapping is invalid.");
+    }
+    if (command.runtime.worldId) {
+      const [world] = await tx
+        .select({ id: worldTable.id })
+        .from(worldTable)
+        .where(
+          and(eq(worldTable.id, command.runtime.worldId), eq(worldTable.agentId, command.agentId))
+        )
+        .limit(1);
+      if (!world) fail("MEMBERSHIP_RUNTIME_MAPPING_INVALID", "Runtime world mapping is invalid.");
+    }
+  }
+
+  private async replay(
+    tx: DrizzleDatabase,
+    command: ApplyMembershipCommand | SetMembershipHealthCommand,
+    digest: string
+  ): Promise<MembershipMutationReceipt | null> {
+    const [journal] = await tx
+      .select()
+      .from(membershipAuthorityJournalTable)
+      .where(
+        and(
+          eq(membershipAuthorityJournalTable.agentId, command.agentId),
+          eq(membershipAuthorityJournalTable.connectorAccountId, command.connectorAccountId),
+          eq(membershipAuthorityJournalTable.idempotencyKey, command.idempotencyKey)
+        )
+      )
+      .limit(1);
+    if (!journal) return null;
+    if (journal.requestDigest !== digest) {
+      fail(
+        "MEMBERSHIP_IDEMPOTENCY_CONFLICT",
+        "Membership idempotency key was reused for a different command."
+      );
+    }
+    return parseReceipt(journal);
+  }
+
+  private async advanceScope(
+    tx: DrizzleDatabase,
+    command: ApplyMembershipCommand | SetMembershipHealthCommand,
+    observedAt: Date,
+    digest: string,
+    healthUpdate?: { health: MembershipHealthState; reason: string }
+  ): Promise<{ scope: ScopeRow } | { replay: MembershipMutationReceipt }> {
+    await tx
+      .insert(membershipAuthorityScopeTable)
+      .values({
+        agentId: command.agentId,
+        connectorId: command.connectorId,
+        connectorAccountId: command.connectorAccountId,
+        externalWorldId: command.externalWorldId,
+        externalRoomId: command.externalRoomId,
+        observedAt,
+      })
+      .onConflictDoNothing();
+
+    const [advanced] = await tx
+      .update(membershipAuthorityScopeTable)
+      .set({
+        generation: command.expectedGeneration + 1,
+        sourceVersion: command.sourceVersion,
+        sourceCursor: command.sourceCursor,
+        observedAt,
+        updatedAt: new Date(),
+        ...(healthUpdate ?? {}),
+      })
+      .where(
+        and(
+          scopeWhere(command),
+          eq(membershipAuthorityScopeTable.generation, command.expectedGeneration),
+          lt(membershipAuthorityScopeTable.sourceVersion, command.sourceVersion)
+        )
+      )
+      .returning();
+    if (advanced) return { scope: advanced };
+
+    // A concurrent exact retry can block behind the winner's generation write.
+    // Re-read the journal after that wait so idempotency remains exact rather
+    // than leaking a generation error to one of two identical callers.
+    const concurrentReplay = await this.replay(tx, command, digest);
+    if (concurrentReplay) return { replay: concurrentReplay };
+
+    const [current] = await tx
+      .select()
+      .from(membershipAuthorityScopeTable)
+      .where(scopeWhere(command))
+      .limit(1);
+    if (!current) {
+      fail("MEMBERSHIP_SCOPE_WRITE_FAILED", "Membership scope could not be initialized.");
+    }
+    if (current.generation !== command.expectedGeneration) {
+      fail("MEMBERSHIP_GENERATION_MISMATCH", "Membership scope generation changed.", {
+        expectedGeneration: command.expectedGeneration,
+        actualGeneration: current.generation,
+      });
+    }
+    fail("MEMBERSHIP_SOURCE_VERSION_STALE", "Membership command is out of order.", {
+      sourceVersion: command.sourceVersion,
+      currentSourceVersion: current.sourceVersion,
+    });
+  }
+
+  private async recordJournal(
+    tx: DrizzleDatabase,
+    operation: "membership" | "health",
+    command: ApplyMembershipCommand | SetMembershipHealthCommand,
+    digest: string,
+    receipt: MembershipMutationReceipt
+  ): Promise<void> {
+    await tx.insert(membershipAuthorityJournalTable).values({
+      agentId: command.agentId,
+      connectorId: command.connectorId,
+      connectorAccountId: command.connectorAccountId,
+      externalWorldId: command.externalWorldId,
+      externalRoomId: command.externalRoomId,
+      operation,
+      canonicalPrincipalId: "canonicalPrincipalId" in command ? command.canonicalPrincipalId : null,
+      idempotencyKey: command.idempotencyKey,
+      requestDigest: digest,
+      expectedGeneration: command.expectedGeneration,
+      committedGeneration: receipt.committedGeneration,
+      sourceVersion: command.sourceVersion,
+      sourceCursor: command.sourceCursor,
+      result: JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>,
+    });
+  }
+
+  private invalidateScope(scope: MembershipScope, receipt: MembershipMutationReceipt): boolean {
+    const prefix = `${scopeKey(scope)}\n`;
+    for (const key of this.decisionCache.keys()) {
+      if (key.startsWith(prefix)) this.decisionCache.delete(key);
+    }
+    let succeeded = true;
+    for (const invalidator of this.invalidators) {
+      try {
+        invalidator(scope, receipt);
+      } catch (error) {
+        succeeded = false;
+        // error-policy:J7 cache-invalidation diagnostics must not fabricate a rollback after commit.
+        this.runtime.reportError("membership-authority-invalidator", error, {
+          operation: receipt.operation,
+          committedGeneration: receipt.committedGeneration,
+        });
+      }
+    }
+    return succeeded;
+  }
+
+  private async notify(scope: MembershipScope, receipt: MembershipMutationReceipt): Promise<void> {
+    try {
+      await this.runtime.emitEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, {
+        runtime: this.runtime,
+        source: "membership-authority",
+        scope,
+        receipt,
+      });
+    } catch (error) {
+      // error-policy:J7 observer diagnostics must not turn a committed authority change into failure.
+      this.runtime.reportError("membership-authority-observer", error, {
+        operation: receipt.operation,
+        committedGeneration: receipt.committedGeneration,
+      });
+    }
+  }
+
+  async applyMembership(command: ApplyMembershipCommand): Promise<MembershipMutationReceipt> {
+    const observedAt = this.assertCommand(command);
+    this.assertMembershipCommand(command);
+    const digest = commandDigest("membership", command);
+    const receipt = await this.db.transaction(async (tx) => {
+      const replay = await this.replay(tx, command, digest);
+      if (replay) return replay;
+      await this.assertReferences(tx, command);
+      const advanced = await this.advanceScope(tx, command, observedAt, digest);
+      if ("replay" in advanced) return advanced.replay;
+      const { scope } = advanced;
+      const now = new Date();
+      const [row] = await tx
+        .insert(membershipAuthorityTable)
+        .values({
+          agentId: command.agentId,
+          connectorId: command.connectorId,
+          connectorAccountId: command.connectorAccountId,
+          externalWorldId: command.externalWorldId,
+          externalRoomId: command.externalRoomId,
+          canonicalPrincipalId: command.canonicalPrincipalId,
+          state: command.state,
+          reason: command.reason,
+          roles: [...command.roles],
+          permissionSnapshot: command.permissionSnapshot,
+          runtimeWorldId: command.runtime.worldId,
+          runtimeRoomId: command.runtime.roomId,
+          runtimeEntityId: command.runtime.entityId,
+          generation: scope.generation,
+          sourceVersion: command.sourceVersion,
+          sourceCursor: command.sourceCursor,
+          observedAt,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            membershipAuthorityTable.agentId,
+            membershipAuthorityTable.connectorId,
+            membershipAuthorityTable.connectorAccountId,
+            membershipAuthorityTable.externalWorldId,
+            membershipAuthorityTable.externalRoomId,
+            membershipAuthorityTable.canonicalPrincipalId,
+          ],
+          set: {
+            state: command.state,
+            reason: command.reason,
+            roles: [...command.roles],
+            permissionSnapshot: command.permissionSnapshot,
+            runtimeWorldId: command.runtime.worldId,
+            runtimeRoomId: command.runtime.roomId,
+            runtimeEntityId: command.runtime.entityId,
+            generation: scope.generation,
+            sourceVersion: command.sourceVersion,
+            sourceCursor: command.sourceCursor,
+            observedAt,
+            updatedAt: now,
+          },
+        })
+        .returning();
+      if (!row) fail("MEMBERSHIP_WRITE_FAILED", "Membership state was not persisted.");
+      const result: MembershipMutationReceipt = {
+        contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+        operation: "membership",
+        idempotentReplay: false,
+        committedGeneration: scope.generation,
+        membership: mapMembership(row),
+      };
+      await this.recordJournal(tx, "membership", command, digest, result);
+      return result;
+    });
+    if (!receipt.idempotentReplay) {
+      const invalidated = this.invalidateScope(command, receipt);
+      if (invalidated) await this.notify(command, receipt);
+    }
+    return receipt;
+  }
+
+  async setScopeHealth(command: SetMembershipHealthCommand): Promise<MembershipMutationReceipt> {
+    const observedAt = this.assertCommand(command);
+    if (!MEMBERSHIP_HEALTH_STATES.includes(command.health)) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Membership health state is invalid.");
+    }
+    if (command.reason.trim().length === 0 || command.reason.length > MAX_IDENTIFIER_LENGTH) {
+      fail("MEMBERSHIP_COMMAND_INVALID", "Membership health reason is invalid.");
+    }
+    const digest = commandDigest("health", command);
+    const receipt = await this.db.transaction(async (tx) => {
+      const replay = await this.replay(tx, command, digest);
+      if (replay) return replay;
+      await this.assertReferences(tx, command);
+      const advanced = await this.advanceScope(tx, command, observedAt, digest, {
+        health: command.health,
+        reason: command.reason,
+      });
+      if ("replay" in advanced) return advanced.replay;
+      const { scope: row } = advanced;
+      const result: MembershipMutationReceipt = {
+        contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+        operation: "health",
+        idempotentReplay: false,
+        committedGeneration: row.generation,
+        health: mapScope(row),
+      };
+      await this.recordJournal(tx, "health", command, digest, result);
+      return result;
+    });
+    if (!receipt.idempotentReplay) {
+      const invalidated = this.invalidateScope(command, receipt);
+      if (invalidated) await this.notify(command, receipt);
+    }
+    return receipt;
+  }
+
+  async getScopeHealth(scope: MembershipScope): Promise<MembershipScopeHealth | null> {
+    this.assertScope(scope);
+    const [row] = await this.db
+      .select()
+      .from(membershipAuthorityScopeTable)
+      .where(scopeWhere(scope))
+      .limit(1);
+    return row ? mapScope(row) : null;
+  }
+
+  async getMembership(
+    scope: MembershipScope,
+    canonicalPrincipalId: UUID
+  ): Promise<MembershipRecord | null> {
+    this.assertScope(scope);
+    const [row] = await this.db
+      .select()
+      .from(membershipAuthorityTable)
+      .where(membershipWhere(scope, canonicalPrincipalId))
+      .limit(1);
+    return row ? mapMembership(row) : null;
+  }
+
+  async authorize(
+    scope: MembershipScope,
+    canonicalPrincipalId: UUID
+  ): Promise<MembershipAuthorizationDecision> {
+    this.assertScope(scope);
+    const health = await this.getScopeHealth(scope);
+    if (!health) {
+      return {
+        decision: "denied",
+        reason: "no_scope_evidence",
+        generation: null,
+        health: null,
+      };
+    }
+    const key = decisionKey(scope, canonicalPrincipalId);
+    const cached = this.decisionCache.get(key);
+    if (cached?.generation === health.generation) return cached.decision;
+
+    let decision: MembershipAuthorizationDecision;
+    if (health.health !== "current") {
+      decision = {
+        decision: "denied",
+        reason: HEALTH_REASON_BY_STATE[health.health],
+        generation: health.generation,
+        health: health.health,
+      };
+    } else {
+      const membership = await this.getMembership(scope, canonicalPrincipalId);
+      decision = membership
+        ? membership.state === "active"
+          ? {
+              decision: "allowed",
+              reason: "active_membership",
+              generation: health.generation,
+              health: "current",
+              membership,
+            }
+          : {
+              decision: "denied",
+              reason: "membership_revoked",
+              generation: health.generation,
+              health: health.health,
+            }
+        : {
+            decision: "denied",
+            reason: "no_membership",
+            generation: health.generation,
+            health: health.health,
+          };
+    }
+    this.decisionCache.set(key, { generation: health.generation, decision });
+    return decision;
+  }
+}

--- a/plugins/plugin-sql/src/services/sql-membership.ts
+++ b/plugins/plugin-sql/src/services/sql-membership.ts
@@ -1,33 +1,35 @@
 /**
- * SQL-backed canonical connector-room membership authority. Every mutation is
- * an idempotent, generation-fenced, monotonically ordered command committed to
- * the durable scope state machine before authorization caches are invalidated
- * and observers are notified.
+ * SQL-backed membership authority. Registered publisher generations submit
+ * bounded complete snapshots, ordered post-snapshot deltas, or point proofs;
+ * every command is atomically fenced and exactly replayable.
  */
 import {
+  type ApplyCompleteMembershipSnapshotCommand,
   type ApplyMembershipCommand,
   ElizaError,
   EventType,
   type IAgentRuntime,
   type JsonObject,
-  MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
-  MEMBERSHIP_HEALTH_STATES,
+  MEMBERSHIP_EVIDENCE_MODES,
   MEMBERSHIP_REASONS,
   MEMBERSHIP_STATES,
   type MembershipAuthorityInvalidator,
   type MembershipAuthorizationDecision,
+  type MembershipEvidenceMode,
   type MembershipHealthState,
   type MembershipMutationReceipt,
   type MembershipRecord,
   type MembershipScope,
   type MembershipScopeHealth,
   MembershipService,
+  type MembershipSnapshotMember,
+  type RegisterMembershipPublisherCommand,
   type Service,
   type SetMembershipHealthCommand,
   type UUID,
 } from "@elizaos/core";
 import { sha256 } from "@noble/hashes/sha2.js";
-import { and, eq, lt } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { connectorAccountsTable } from "../schema/connectorAccounts";
 import { entityTable } from "../schema/entity";
 import {
@@ -39,10 +41,15 @@ import { roomTable } from "../schema/room";
 import { worldTable } from "../schema/world";
 import { type DrizzleDatabase, getDb } from "../types";
 
-const MAX_ROLES = 100;
 const MAX_IDENTIFIER_LENGTH = 1_024;
+const MAX_ROLE_LENGTH = 256;
+const MAX_ROLES = 100;
+const MAX_SNAPSHOT_MEMBERS = 100_000;
+const MAX_VALIDITY_MS = 24 * 60 * 60 * 1_000;
+const MAX_FUTURE_OBSERVATION_MS = 5 * 60 * 1_000;
 const ACTIVE_REASONS = new Set(["joined", "reconciled_present", "permission_restored"]);
-const HEALTH_REASON_BY_STATE = {
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEGRADE_REASON = {
   stale: "authority_stale",
   unavailable: "authority_unavailable",
   unsupported: "authority_unsupported",
@@ -50,42 +57,110 @@ const HEALTH_REASON_BY_STATE = {
 
 type ScopeRow = typeof membershipAuthorityScopeTable.$inferSelect;
 type MembershipRow = typeof membershipAuthorityTable.$inferSelect;
-type JournalRow = typeof membershipAuthorityJournalTable.$inferSelect;
+type Clock = () => Date;
 
 function fail(code: string, message: string, context: Record<string, unknown> = {}): never {
   throw new ElizaError(message, { code, context, severity: "fatal" });
 }
-
-function stableJson(value: unknown): string {
-  if (value === null || typeof value === "boolean" || typeof value === "string") {
-    return JSON.stringify(value);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+  );
+}
+function assertExactKeys<T>(
+  value: T,
+  allowed: readonly string[],
+  label: string
+): asserts value is T & Record<string, unknown> {
+  if (!isRecord(value)) fail("MEMBERSHIP_COMMAND_INVALID", `${label} must be a plain object.`);
+  const allowedSet = new Set(allowed);
+  const extra = Object.keys(value).filter((key) => !allowedSet.has(key));
+  if (extra.length > 0)
+    fail("MEMBERSHIP_COMMAND_INVALID", `${label} contains unknown fields.`, { fields: extra });
+}
+function assertJson(value: unknown, path = "permissionSnapshot", seen = new Set<object>()): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number" && Number.isFinite(value)) return;
+  if (typeof value !== "object")
+    fail("MEMBERSHIP_COMMAND_INVALID", "Permission snapshot is not valid JSON.", { path });
+  if (seen.has(value))
+    fail("MEMBERSHIP_COMMAND_INVALID", "Permission snapshot is cyclic.", { path });
+  seen.add(value);
+  if (Array.isArray(value))
+    value.forEach((item, index) => {
+      assertJson(item, `${path}[${index}]`, seen);
+    });
+  else {
+    if (!isRecord(value))
+      fail("MEMBERSHIP_COMMAND_INVALID", "Permission snapshot contains a non-JSON object.", {
+        path,
+      });
+    for (const [key, item] of Object.entries(value)) assertJson(item, `${path}.${key}`, seen);
   }
+  seen.delete(value);
+}
+function stableJson(value: unknown): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string")
+    return JSON.stringify(value);
   if (typeof value === "number" && Number.isFinite(value)) return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-  if (typeof value !== "object") {
-    return fail("MEMBERSHIP_COMMAND_INVALID", "Membership command is not canonical JSON.");
-  }
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
+  if (!isRecord(value))
+    fail("MEMBERSHIP_COMMAND_INVALID", "Membership command is not canonical JSON.");
+  return `{${Object.keys(value)
     .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
     .join(",")}}`;
 }
-
-function commandDigest(operation: "membership" | "health", command: unknown): string {
+function digest(operation: MembershipMutationReceipt["operation"], command: unknown): string {
   const bytes = sha256(
     new TextEncoder().encode(`elizaos:membership:${operation}:v1\n${stableJson(command)}`)
   );
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
-
 function iso(value: Date): string {
   return value.toISOString();
 }
-
+function scopeWhere(scope: MembershipScope) {
+  return and(
+    eq(membershipAuthorityScopeTable.agentId, scope.agentId),
+    eq(membershipAuthorityScopeTable.connectorId, scope.connectorId),
+    eq(membershipAuthorityScopeTable.connectorAccountId, scope.connectorAccountId),
+    eq(membershipAuthorityScopeTable.externalWorldId, scope.externalWorldId),
+    eq(membershipAuthorityScopeTable.externalRoomId, scope.externalRoomId)
+  );
+}
+function memberWhere(scope: MembershipScope, principalId: UUID) {
+  return and(
+    eq(membershipAuthorityTable.agentId, scope.agentId),
+    eq(membershipAuthorityTable.connectorId, scope.connectorId),
+    eq(membershipAuthorityTable.connectorAccountId, scope.connectorAccountId),
+    eq(membershipAuthorityTable.externalWorldId, scope.externalWorldId),
+    eq(membershipAuthorityTable.externalRoomId, scope.externalRoomId),
+    eq(membershipAuthorityTable.canonicalPrincipalId, principalId)
+  );
+}
+function allMembersWhere(scope: MembershipScope) {
+  return and(
+    eq(membershipAuthorityTable.agentId, scope.agentId),
+    eq(membershipAuthorityTable.connectorId, scope.connectorId),
+    eq(membershipAuthorityTable.connectorAccountId, scope.connectorAccountId),
+    eq(membershipAuthorityTable.externalWorldId, scope.externalWorldId),
+    eq(membershipAuthorityTable.externalRoomId, scope.externalRoomId)
+  );
+}
 function mapScope(row: ScopeRow): MembershipScopeHealth {
+  if (!["current", "stale", "unavailable", "unsupported"].includes(row.health))
+    fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted membership health is invalid.");
+  if (
+    row.evidenceMode !== null &&
+    !MEMBERSHIP_EVIDENCE_MODES.includes(row.evidenceMode as MembershipEvidenceMode)
+  )
+    fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted evidence mode is invalid.");
   return {
-    contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+    contractVersion: 1,
     agentId: row.agentId as UUID,
     connectorId: row.connectorId,
     connectorAccountId: row.connectorAccountId as UUID,
@@ -96,24 +171,27 @@ function mapScope(row: ScopeRow): MembershipScopeHealth {
     generation: row.generation,
     sourceVersion: row.sourceVersion,
     sourceCursor: row.sourceCursor,
+    validUntil: row.validUntil ? iso(row.validUntil) : null,
+    publisherInstanceId: row.publisherInstanceId,
+    publisherGeneration: row.publisherGeneration,
+    evidenceMode: row.evidenceMode as MembershipEvidenceMode | null,
     observedAt: iso(row.observedAt),
     updatedAt: iso(row.updatedAt),
   };
 }
-
-function mapMembership(row: MembershipRow): MembershipRecord {
+function mapMember(row: MembershipRow): MembershipRecord {
   if (
-    typeof row.permissionSnapshot !== "object" ||
-    row.permissionSnapshot === null ||
-    Array.isArray(row.permissionSnapshot)
-  ) {
-    return fail(
-      "MEMBERSHIP_PERSISTED_STATE_INVALID",
-      "Persisted permission snapshot is not an object."
-    );
-  }
+    !MEMBERSHIP_STATES.includes(row.state as MembershipRecord["state"]) ||
+    !MEMBERSHIP_REASONS.includes(row.reason as MembershipRecord["reason"]) ||
+    !MEMBERSHIP_EVIDENCE_MODES.includes(row.evidenceMode as MembershipEvidenceMode)
+  )
+    fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted membership enum is invalid.");
+  assertRoles(row.roles);
+  if (!isRecord(row.permissionSnapshot))
+    fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted permission snapshot is not an object.");
+  assertJson(row.permissionSnapshot);
   return {
-    contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+    contractVersion: 1,
     agentId: row.agentId as UUID,
     connectorId: row.connectorId,
     connectorAccountId: row.connectorAccountId as UUID,
@@ -129,240 +207,257 @@ function mapMembership(row: MembershipRow): MembershipRecord {
       roomId: row.runtimeRoomId as UUID | null,
       entityId: row.runtimeEntityId as UUID | null,
     },
+    publisherInstanceId: row.publisherInstanceId,
+    publisherGeneration: row.publisherGeneration,
+    evidenceMode: row.evidenceMode as MembershipEvidenceMode,
     generation: row.generation,
     sourceVersion: row.sourceVersion,
     sourceCursor: row.sourceCursor,
     observedAt: iso(row.observedAt),
+    validUntil: iso(row.validUntil),
     createdAt: iso(row.createdAt),
     updatedAt: iso(row.updatedAt),
   };
 }
-
-function scopeWhere(scope: MembershipScope) {
-  return and(
-    eq(membershipAuthorityScopeTable.agentId, scope.agentId),
-    eq(membershipAuthorityScopeTable.connectorId, scope.connectorId),
-    eq(membershipAuthorityScopeTable.connectorAccountId, scope.connectorAccountId),
-    eq(membershipAuthorityScopeTable.externalWorldId, scope.externalWorldId),
-    eq(membershipAuthorityScopeTable.externalRoomId, scope.externalRoomId)
-  );
-}
-
-function membershipWhere(scope: MembershipScope, canonicalPrincipalId: UUID) {
-  return and(
-    eq(membershipAuthorityTable.agentId, scope.agentId),
-    eq(membershipAuthorityTable.connectorId, scope.connectorId),
-    eq(membershipAuthorityTable.connectorAccountId, scope.connectorAccountId),
-    eq(membershipAuthorityTable.externalWorldId, scope.externalWorldId),
-    eq(membershipAuthorityTable.externalRoomId, scope.externalRoomId),
-    eq(membershipAuthorityTable.canonicalPrincipalId, canonicalPrincipalId)
-  );
-}
-
-function scopeKey(scope: MembershipScope): string {
-  return stableJson([
-    scope.agentId,
-    scope.connectorId,
-    scope.connectorAccountId,
-    scope.externalWorldId,
-    scope.externalRoomId,
-  ]);
-}
-
-function decisionKey(scope: MembershipScope, canonicalPrincipalId: UUID): string {
-  return `${scopeKey(scope)}\n${canonicalPrincipalId}`;
-}
-
-function parseReceipt(row: JournalRow): MembershipMutationReceipt {
-  const result = row.result as Partial<MembershipMutationReceipt>;
+function assertRoles(roles: unknown): asserts roles is string[] {
   if (
-    result.contractVersion !== MEMBERSHIP_AUTHORITY_CONTRACT_VERSION ||
-    (result.operation !== "membership" && result.operation !== "health") ||
-    result.committedGeneration !== row.committedGeneration
-  ) {
-    return fail("MEMBERSHIP_JOURNAL_INVALID", "Persisted membership receipt is invalid.", {
-      journalId: row.id,
-    });
-  }
-  return { ...result, idempotentReplay: true } as MembershipMutationReceipt;
+    !Array.isArray(roles) ||
+    roles.length > MAX_ROLES ||
+    new Set(roles).size !== roles.length ||
+    roles.some(
+      (role) =>
+        typeof role !== "string" || role.trim().length === 0 || role.length > MAX_ROLE_LENGTH
+    )
+  )
+    fail("MEMBERSHIP_COMMAND_INVALID", "Membership roles are invalid.");
+}
+
+function assertUuid(value: unknown, field: string, nullable = false): asserts value is UUID | null {
+  if (nullable && value === null) return;
+  if (typeof value !== "string" || !UUID_PATTERN.test(value))
+    fail("MEMBERSHIP_COMMAND_INVALID", `Membership ${field} is not a UUID.`);
 }
 
 export class SqlMembershipService extends MembershipService {
   static override readonly serviceType = MembershipService.serviceType;
-
-  private readonly decisionCache = new Map<
-    string,
-    { generation: number; decision: MembershipAuthorizationDecision }
-  >();
   private readonly invalidators = new Set<MembershipAuthorityInvalidator>();
-
+  constructor(
+    runtime?: IAgentRuntime,
+    private readonly clock: Clock = () => new Date()
+  ) {
+    super(runtime);
+  }
   static async start(runtime: IAgentRuntime): Promise<Service> {
     const service = new SqlMembershipService(runtime);
-    if (!service.db) {
+    service.db;
+    return service;
+  }
+  async stop(): Promise<void> {
+    this.invalidators.clear();
+  }
+  private get db(): DrizzleDatabase {
+    const db = getDb(this.runtime.adapter);
+    if (!db)
       fail(
         "MEMBERSHIP_SQL_ADAPTER_REQUIRED",
         "SQL membership authority requires a Drizzle-backed adapter."
       );
-    }
-    return service;
+    return db;
   }
-
-  async stop(): Promise<void> {
-    this.decisionCache.clear();
-    this.invalidators.clear();
-  }
-
   registerInvalidator(invalidator: MembershipAuthorityInvalidator): () => void {
     this.invalidators.add(invalidator);
     return () => this.invalidators.delete(invalidator);
   }
 
-  private get db(): DrizzleDatabase {
-    return getDb(this.runtime.adapter);
-  }
-
   private assertScope(scope: MembershipScope): void {
-    if (scope.agentId !== this.runtime.agentId) {
-      fail("MEMBERSHIP_TENANT_MISMATCH", "Membership request is outside this runtime tenant.", {
-        agentId: scope.agentId,
-      });
-    }
+    assertExactKeys(
+      scope,
+      ["agentId", "connectorId", "connectorAccountId", "externalWorldId", "externalRoomId"],
+      "Membership scope"
+    );
+    if (scope.agentId !== this.runtime.agentId)
+      fail("MEMBERSHIP_TENANT_MISMATCH", "Membership request is outside this runtime tenant.");
+    assertUuid(scope.agentId, "agentId");
+    assertUuid(scope.connectorAccountId, "connectorAccountId");
     for (const [field, value] of Object.entries({
       connectorId: scope.connectorId,
       externalWorldId: scope.externalWorldId,
       externalRoomId: scope.externalRoomId,
-    })) {
-      if (value.trim().length === 0 || value.length > MAX_IDENTIFIER_LENGTH) {
-        fail("MEMBERSHIP_COMMAND_INVALID", `Membership ${field} is invalid.`, { field });
-      }
-    }
+    }))
+      if (
+        typeof value !== "string" ||
+        value.trim().length === 0 ||
+        value.length > MAX_IDENTIFIER_LENGTH
+      )
+        fail("MEMBERSHIP_COMMAND_INVALID", `Membership ${field} is invalid.`);
   }
-
-  private assertCommand(command: ApplyMembershipCommand | SetMembershipHealthCommand): Date {
-    this.assertScope(command);
+  private assertBase(
+    command: MembershipScope & {
+      expectedGeneration: number;
+      idempotencyKey: string;
+      observedAt: string;
+    },
+    keys: readonly string[]
+  ): Date {
+    assertExactKeys(command, keys, "Membership command");
+    this.assertScope({
+      agentId: command.agentId,
+      connectorId: command.connectorId,
+      connectorAccountId: command.connectorAccountId,
+      externalWorldId: command.externalWorldId,
+      externalRoomId: command.externalRoomId,
+    });
     if (
       !Number.isSafeInteger(command.expectedGeneration) ||
       command.expectedGeneration < 0 ||
       command.expectedGeneration === Number.MAX_SAFE_INTEGER
-    ) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Expected generation must be a nonnegative integer.");
-    }
-    if (!Number.isSafeInteger(command.sourceVersion) || command.sourceVersion < 0) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Source version must be a nonnegative integer.");
-    }
+    )
+      fail("MEMBERSHIP_COMMAND_INVALID", "Expected generation is invalid.");
     if (
+      typeof command.idempotencyKey !== "string" ||
       command.idempotencyKey.trim().length === 0 ||
       command.idempotencyKey.length > MAX_IDENTIFIER_LENGTH
-    ) {
+    )
       fail("MEMBERSHIP_COMMAND_INVALID", "Idempotency key is invalid.");
-    }
-    if (command.sourceCursor && command.sourceCursor.length > MAX_IDENTIFIER_LENGTH) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Source cursor is invalid.");
-    }
-    const observedAt = new Date(command.observedAt);
-    if (!Number.isFinite(observedAt.getTime())) {
+    if (typeof command.observedAt !== "string")
+      fail("MEMBERSHIP_COMMAND_INVALID", "Observed timestamp must be a string.");
+    const observed = new Date(command.observedAt);
+    if (
+      !Number.isFinite(observed.getTime()) ||
+      observed.getTime() > this.clock().getTime() + MAX_FUTURE_OBSERVATION_MS
+    )
       fail("MEMBERSHIP_COMMAND_INVALID", "Observed timestamp is invalid.");
-    }
-    return observedAt;
+    return observed;
   }
-
-  private assertMembershipCommand(command: ApplyMembershipCommand): void {
+  private assertPublisher(binding: {
+    publisherInstanceId: string;
+    publisherGeneration: number;
+    evidenceMode: MembershipEvidenceMode;
+  }): void {
     if (
-      !MEMBERSHIP_STATES.includes(command.state) ||
-      !MEMBERSHIP_REASONS.includes(command.reason)
-    ) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Membership state or reason is invalid.");
-    }
-    const activeReason = ACTIVE_REASONS.has(command.reason);
-    if ((command.state === "active") !== activeReason) {
-      fail(
-        "MEMBERSHIP_COMMAND_INVALID",
-        "Membership reason is incompatible with the requested state."
-      );
-    }
-    if (
-      command.roles.length > MAX_ROLES ||
-      new Set(command.roles).size !== command.roles.length ||
-      command.roles.some((role) => role.trim().length === 0 || role.length > 256)
-    ) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Membership roles are invalid.");
-    }
-    if (
-      typeof command.permissionSnapshot !== "object" ||
-      command.permissionSnapshot === null ||
-      Array.isArray(command.permissionSnapshot)
-    ) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Permission snapshot must be an object.");
-    }
+      typeof binding.publisherInstanceId !== "string" ||
+      binding.publisherInstanceId.trim().length === 0 ||
+      binding.publisherInstanceId.length > MAX_IDENTIFIER_LENGTH ||
+      !Number.isSafeInteger(binding.publisherGeneration) ||
+      binding.publisherGeneration < 0 ||
+      !MEMBERSHIP_EVIDENCE_MODES.includes(binding.evidenceMode)
+    )
+      fail("MEMBERSHIP_COMMAND_INVALID", "Publisher binding is invalid.");
   }
-
-  private async assertReferences(
-    tx: DrizzleDatabase,
-    command: ApplyMembershipCommand | SetMembershipHealthCommand
-  ): Promise<void> {
+  private assertEvidence(
+    command: ApplyMembershipCommand | ApplyCompleteMembershipSnapshotCommand,
+    observed: Date
+  ): Date {
+    this.assertPublisher(command);
+    if (
+      !Number.isSafeInteger(command.sourceVersion) ||
+      command.sourceVersion < 0 ||
+      typeof command.sourceCursor !== "string" ||
+      command.sourceCursor.trim().length === 0 ||
+      command.sourceCursor.length > MAX_IDENTIFIER_LENGTH ||
+      (command.previousSourceCursor !== null &&
+        (typeof command.previousSourceCursor !== "string" ||
+          command.previousSourceCursor.length > MAX_IDENTIFIER_LENGTH))
+    )
+      fail("MEMBERSHIP_COMMAND_INVALID", "Evidence cursor or version is invalid.");
+    if (typeof command.validUntil !== "string")
+      fail("MEMBERSHIP_COMMAND_INVALID", "Evidence validity must be a string.");
+    const validUntil = new Date(command.validUntil);
+    if (
+      !Number.isFinite(validUntil.getTime()) ||
+      validUntil <= observed ||
+      validUntil.getTime() > this.clock().getTime() + MAX_VALIDITY_MS
+    )
+      fail("MEMBERSHIP_COMMAND_INVALID", "Evidence validity is invalid.");
+    return validUntil;
+  }
+  private assertMember(member: MembershipSnapshotMember | ApplyMembershipCommand): void {
+    assertRoles(member.roles);
+    if (!isRecord(member.permissionSnapshot))
+      fail("MEMBERSHIP_COMMAND_INVALID", "Permission snapshot must be a JSON object.");
+    assertJson(member.permissionSnapshot);
+    assertExactKeys(
+      member.runtime,
+      ["worldId", "roomId", "entityId"],
+      "Membership runtime mapping"
+    );
+    assertUuid(member.canonicalPrincipalId, "canonicalPrincipalId");
+    assertUuid(member.runtime.worldId, "runtime.worldId", true);
+    assertUuid(member.runtime.roomId, "runtime.roomId", true);
+    assertUuid(member.runtime.entityId, "runtime.entityId", true);
+  }
+  private async assertAccount(tx: DrizzleDatabase, scope: MembershipScope): Promise<void> {
     const [account] = await tx
       .select({ provider: connectorAccountsTable.provider })
       .from(connectorAccountsTable)
       .where(
         and(
-          eq(connectorAccountsTable.id, command.connectorAccountId),
-          eq(connectorAccountsTable.agentId, command.agentId)
+          eq(connectorAccountsTable.id, scope.connectorAccountId),
+          eq(connectorAccountsTable.agentId, scope.agentId)
         )
       )
       .limit(1);
-    if (!account || account.provider !== command.connectorId) {
+    if (!account || account.provider !== scope.connectorId)
       fail(
         "MEMBERSHIP_CONNECTOR_ACCOUNT_MISMATCH",
-        "Connector account does not belong to this connector and tenant."
+        "Connector account does not match the connector and tenant."
       );
+  }
+  private async assertMembers(
+    tx: DrizzleDatabase,
+    scope: MembershipScope,
+    members: readonly MembershipSnapshotMember[]
+  ): Promise<void> {
+    const entityIds = new Set<UUID>();
+    const roomIds = new Set<UUID>();
+    const worldIds = new Set<UUID>();
+    for (const member of members) {
+      entityIds.add(member.canonicalPrincipalId);
+      if (member.runtime.entityId) entityIds.add(member.runtime.entityId);
+      if (member.runtime.roomId) roomIds.add(member.runtime.roomId);
+      if (member.runtime.worldId) worldIds.add(member.runtime.worldId);
     }
-    if (!("canonicalPrincipalId" in command)) return;
-
-    const requiredEntityIds = new Set<UUID>([command.canonicalPrincipalId]);
-    if (command.runtime.entityId) requiredEntityIds.add(command.runtime.entityId);
     const entities = await Promise.all(
-      [...requiredEntityIds].map((id) =>
+      [...entityIds].map((id) =>
         tx
           .select({ id: entityTable.id })
           .from(entityTable)
-          .where(and(eq(entityTable.id, id), eq(entityTable.agentId, command.agentId)))
+          .where(and(eq(entityTable.id, id), eq(entityTable.agentId, scope.agentId)))
           .limit(1)
       )
     );
-    if (entities.some((rows) => rows.length !== 1)) {
+    if (entities.some((rows) => rows.length !== 1))
       fail(
         "MEMBERSHIP_PRINCIPAL_NOT_FOUND",
-        "Membership principal or runtime entity mapping does not exist in this tenant."
+        "Membership principal or runtime entity does not exist in this tenant."
       );
-    }
-    if (command.runtime.roomId) {
-      const [room] = await tx
-        .select({ id: roomTable.id })
-        .from(roomTable)
-        .where(
-          and(eq(roomTable.id, command.runtime.roomId), eq(roomTable.agentId, command.agentId))
-        )
-        .limit(1);
-      if (!room) fail("MEMBERSHIP_RUNTIME_MAPPING_INVALID", "Runtime room mapping is invalid.");
-    }
-    if (command.runtime.worldId) {
-      const [world] = await tx
-        .select({ id: worldTable.id })
-        .from(worldTable)
-        .where(
-          and(eq(worldTable.id, command.runtime.worldId), eq(worldTable.agentId, command.agentId))
-        )
-        .limit(1);
-      if (!world) fail("MEMBERSHIP_RUNTIME_MAPPING_INVALID", "Runtime world mapping is invalid.");
-    }
+    const rooms = await Promise.all(
+      [...roomIds].map((id) =>
+        tx
+          .select({ id: roomTable.id })
+          .from(roomTable)
+          .where(and(eq(roomTable.id, id), eq(roomTable.agentId, scope.agentId)))
+          .limit(1)
+      )
+    );
+    const worlds = await Promise.all(
+      [...worldIds].map((id) =>
+        tx
+          .select({ id: worldTable.id })
+          .from(worldTable)
+          .where(and(eq(worldTable.id, id), eq(worldTable.agentId, scope.agentId)))
+          .limit(1)
+      )
+    );
+    if (rooms.some((rows) => rows.length !== 1) || worlds.some((rows) => rows.length !== 1))
+      fail("MEMBERSHIP_RUNTIME_MAPPING_INVALID", "Membership runtime mapping is invalid.");
   }
-
   private async replay(
     tx: DrizzleDatabase,
-    command: ApplyMembershipCommand | SetMembershipHealthCommand,
-    digest: string
+    command: MembershipScope & { idempotencyKey: string },
+    requestDigest: string
   ): Promise<MembershipMutationReceipt | null> {
-    const [journal] = await tx
+    const [row] = await tx
       .select()
       .from(membershipAuthorityJournalTable)
       .where(
@@ -373,86 +468,32 @@ export class SqlMembershipService extends MembershipService {
         )
       )
       .limit(1);
-    if (!journal) return null;
-    if (journal.requestDigest !== digest) {
-      fail(
-        "MEMBERSHIP_IDEMPOTENCY_CONFLICT",
-        "Membership idempotency key was reused for a different command."
-      );
-    }
-    return parseReceipt(journal);
+    if (!row) return null;
+    if (row.requestDigest !== requestDigest)
+      fail("MEMBERSHIP_IDEMPOTENCY_CONFLICT", "Membership idempotency key was reused.");
+    const result = row.result as Partial<MembershipMutationReceipt>;
+    if (
+      result.contractVersion !== 1 ||
+      result.committedGeneration !== row.committedGeneration ||
+      !["publisher", "snapshot", "membership", "health"].includes(result.operation ?? "")
+    )
+      fail("MEMBERSHIP_JOURNAL_INVALID", "Persisted membership receipt is invalid.");
+    return { ...result, idempotentReplay: true } as MembershipMutationReceipt;
   }
-
-  private async advanceScope(
-    tx: DrizzleDatabase,
-    command: ApplyMembershipCommand | SetMembershipHealthCommand,
-    observedAt: Date,
-    digest: string,
-    healthUpdate?: { health: MembershipHealthState; reason: string }
-  ): Promise<{ scope: ScopeRow } | { replay: MembershipMutationReceipt }> {
-    await tx
-      .insert(membershipAuthorityScopeTable)
-      .values({
-        agentId: command.agentId,
-        connectorId: command.connectorId,
-        connectorAccountId: command.connectorAccountId,
-        externalWorldId: command.externalWorldId,
-        externalRoomId: command.externalRoomId,
-        observedAt,
-      })
-      .onConflictDoNothing();
-
-    const [advanced] = await tx
-      .update(membershipAuthorityScopeTable)
-      .set({
-        generation: command.expectedGeneration + 1,
-        sourceVersion: command.sourceVersion,
-        sourceCursor: command.sourceCursor,
-        observedAt,
-        updatedAt: new Date(),
-        ...(healthUpdate ?? {}),
-      })
-      .where(
-        and(
-          scopeWhere(command),
-          eq(membershipAuthorityScopeTable.generation, command.expectedGeneration),
-          lt(membershipAuthorityScopeTable.sourceVersion, command.sourceVersion)
-        )
-      )
-      .returning();
-    if (advanced) return { scope: advanced };
-
-    // A concurrent exact retry can block behind the winner's generation write.
-    // Re-read the journal after that wait so idempotency remains exact rather
-    // than leaking a generation error to one of two identical callers.
-    const concurrentReplay = await this.replay(tx, command, digest);
-    if (concurrentReplay) return { replay: concurrentReplay };
-
-    const [current] = await tx
+  private async row(tx: DrizzleDatabase, scope: MembershipScope): Promise<ScopeRow> {
+    const [row] = await tx
       .select()
       .from(membershipAuthorityScopeTable)
-      .where(scopeWhere(command))
+      .where(scopeWhere(scope))
       .limit(1);
-    if (!current) {
-      fail("MEMBERSHIP_SCOPE_WRITE_FAILED", "Membership scope could not be initialized.");
-    }
-    if (current.generation !== command.expectedGeneration) {
-      fail("MEMBERSHIP_GENERATION_MISMATCH", "Membership scope generation changed.", {
-        expectedGeneration: command.expectedGeneration,
-        actualGeneration: current.generation,
-      });
-    }
-    fail("MEMBERSHIP_SOURCE_VERSION_STALE", "Membership command is out of order.", {
-      sourceVersion: command.sourceVersion,
-      currentSourceVersion: current.sourceVersion,
-    });
+    if (!row) fail("MEMBERSHIP_SCOPE_WRITE_FAILED", "Membership scope is absent.");
+    return row;
   }
-
-  private async recordJournal(
+  private async record(
     tx: DrizzleDatabase,
-    operation: "membership" | "health",
-    command: ApplyMembershipCommand | SetMembershipHealthCommand,
-    digest: string,
+    operation: MembershipMutationReceipt["operation"],
+    command: MembershipScope & { idempotencyKey: string; expectedGeneration: number },
+    requestDigest: string,
     receipt: MembershipMutationReceipt
   ): Promise<void> {
     await tx.insert(membershipAuthorityJournalTable).values({
@@ -462,36 +503,174 @@ export class SqlMembershipService extends MembershipService {
       externalWorldId: command.externalWorldId,
       externalRoomId: command.externalRoomId,
       operation,
-      canonicalPrincipalId: "canonicalPrincipalId" in command ? command.canonicalPrincipalId : null,
       idempotencyKey: command.idempotencyKey,
-      requestDigest: digest,
+      requestDigest,
       expectedGeneration: command.expectedGeneration,
       committedGeneration: receipt.committedGeneration,
-      sourceVersion: command.sourceVersion,
-      sourceCursor: command.sourceCursor,
       result: JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>,
     });
   }
-
-  private invalidateScope(scope: MembershipScope, receipt: MembershipMutationReceipt): void {
-    const prefix = `${scopeKey(scope)}\n`;
-    for (const key of this.decisionCache.keys()) {
-      if (key.startsWith(prefix)) this.decisionCache.delete(key);
+  private async advanceEvidence(
+    tx: DrizzleDatabase,
+    command: ApplyMembershipCommand | ApplyCompleteMembershipSnapshotCommand,
+    observed: Date,
+    validUntil: Date,
+    requestDigest: string
+  ): Promise<{ scope: ScopeRow } | { replay: MembershipMutationReceipt }> {
+    const current = await this.row(tx, command);
+    if (current.generation !== command.expectedGeneration) {
+      const replay = await this.replay(tx, command, requestDigest);
+      if (replay) return { replay };
+      fail("MEMBERSHIP_GENERATION_MISMATCH", "Membership scope generation changed.", {
+        actualGeneration: current.generation,
+      });
     }
+    if (
+      current.publisherInstanceId !== command.publisherInstanceId ||
+      current.publisherGeneration !== command.publisherGeneration ||
+      current.evidenceMode !== command.evidenceMode
+    )
+      fail(
+        "MEMBERSHIP_PUBLISHER_MISMATCH",
+        "Evidence does not match the registered publisher generation and mode."
+      );
+    if (
+      command.evidenceMode === "ordered_delta" &&
+      "state" in command &&
+      (current.health !== "current" ||
+        !current.sourceCursor ||
+        !current.validUntil ||
+        current.validUntil.getTime() <= this.clock().getTime())
+    )
+      fail(
+        "MEMBERSHIP_SNAPSHOT_REQUIRED",
+        "Ordered deltas require a current complete snapshot in this publisher generation."
+      );
+    if (
+      command.sourceVersion !== current.sourceVersion + 1 ||
+      command.previousSourceCursor !== current.sourceCursor
+    )
+      fail(
+        "MEMBERSHIP_CURSOR_DISCONTINUITY",
+        "Membership evidence is not the next durable cursor."
+      );
+    const [advanced] = await tx
+      .update(membershipAuthorityScopeTable)
+      .set({
+        generation: current.generation + 1,
+        sourceVersion: command.sourceVersion,
+        sourceCursor: command.sourceCursor,
+        validUntil,
+        health: "current",
+        reason: command.evidenceMode === "point_query" ? "point_query_proof" : "complete_evidence",
+        observedAt: observed,
+        updatedAt: this.clock(),
+      })
+      .where(
+        and(scopeWhere(command), eq(membershipAuthorityScopeTable.generation, current.generation))
+      )
+      .returning();
+    if (!advanced) {
+      const replay = await this.replay(tx, command, requestDigest);
+      if (replay) return { replay };
+      fail("MEMBERSHIP_GENERATION_MISMATCH", "Concurrent membership command committed first.");
+    }
+    return { scope: advanced };
+  }
+  private async upsertMember(
+    tx: DrizzleDatabase,
+    scope: ScopeRow,
+    member: MembershipSnapshotMember,
+    state: "active" | "revoked",
+    reason: MembershipRecord["reason"],
+    observed: Date,
+    validUntil: Date
+  ): Promise<MembershipRecord> {
+    const now = this.clock();
+    if (
+      scope.publisherInstanceId === null ||
+      scope.publisherGeneration === null ||
+      scope.evidenceMode === null ||
+      scope.sourceCursor === null
+    ) {
+      fail(
+        "MEMBERSHIP_PERSISTED_STATE_INVALID",
+        "Current scope has incomplete publisher evidence."
+      );
+    }
+    const publisherInstanceId = scope.publisherInstanceId;
+    const publisherGeneration = scope.publisherGeneration;
+    const evidenceMode = scope.evidenceMode;
+    const sourceCursor = scope.sourceCursor;
+    const [row] = await tx
+      .insert(membershipAuthorityTable)
+      .values({
+        agentId: scope.agentId,
+        connectorId: scope.connectorId,
+        connectorAccountId: scope.connectorAccountId,
+        externalWorldId: scope.externalWorldId,
+        externalRoomId: scope.externalRoomId,
+        canonicalPrincipalId: member.canonicalPrincipalId,
+        state,
+        reason,
+        roles: state === "active" ? [...member.roles] : [],
+        permissionSnapshot: state === "active" ? member.permissionSnapshot : {},
+        runtimeWorldId: member.runtime.worldId,
+        runtimeRoomId: member.runtime.roomId,
+        runtimeEntityId: member.runtime.entityId,
+        publisherInstanceId,
+        publisherGeneration,
+        evidenceMode,
+        generation: scope.generation,
+        sourceVersion: scope.sourceVersion,
+        sourceCursor,
+        observedAt: observed,
+        validUntil,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          membershipAuthorityTable.agentId,
+          membershipAuthorityTable.connectorId,
+          membershipAuthorityTable.connectorAccountId,
+          membershipAuthorityTable.externalWorldId,
+          membershipAuthorityTable.externalRoomId,
+          membershipAuthorityTable.canonicalPrincipalId,
+        ],
+        set: {
+          state,
+          reason,
+          roles: state === "active" ? [...member.roles] : [],
+          permissionSnapshot: state === "active" ? member.permissionSnapshot : {},
+          runtimeWorldId: member.runtime.worldId,
+          runtimeRoomId: member.runtime.roomId,
+          runtimeEntityId: member.runtime.entityId,
+          publisherInstanceId,
+          publisherGeneration,
+          evidenceMode,
+          generation: scope.generation,
+          sourceVersion: scope.sourceVersion,
+          sourceCursor,
+          observedAt: observed,
+          validUntil,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    if (!row) fail("MEMBERSHIP_WRITE_FAILED", "Membership fact was not persisted.");
+    return mapMember(row);
+  }
+  private async publish(scope: MembershipScope, receipt: MembershipMutationReceipt): Promise<void> {
     for (const invalidator of this.invalidators) {
       try {
         invalidator(scope, receipt);
       } catch (error) {
-        // error-policy:J7 cache-invalidation diagnostics must not fabricate a rollback after commit.
+        // error-policy:J7 invalidator diagnostics cannot roll back committed authority.
         this.runtime.reportError("membership-authority-invalidator", error, {
           operation: receipt.operation,
-          committedGeneration: receipt.committedGeneration,
         });
       }
     }
-  }
-
-  private async notify(scope: MembershipScope, receipt: MembershipMutationReceipt): Promise<void> {
     try {
       await this.runtime.emitEvent(EventType.MEMBERSHIP_AUTHORITY_CHANGED, {
         runtime: this.runtime,
@@ -500,124 +679,341 @@ export class SqlMembershipService extends MembershipService {
         receipt,
       });
     } catch (error) {
-      // error-policy:J7 observer diagnostics must not turn a committed authority change into failure.
+      // error-policy:J7 observer diagnostics cannot roll back committed authority.
       this.runtime.reportError("membership-authority-observer", error, {
         operation: receipt.operation,
-        committedGeneration: receipt.committedGeneration,
       });
     }
   }
 
-  async applyMembership(command: ApplyMembershipCommand): Promise<MembershipMutationReceipt> {
-    const observedAt = this.assertCommand(command);
-    this.assertMembershipCommand(command);
-    const digest = commandDigest("membership", command);
+  async registerPublisher(
+    command: RegisterMembershipPublisherCommand
+  ): Promise<MembershipMutationReceipt> {
+    const observed = this.assertBase(command, [
+      "agentId",
+      "connectorId",
+      "connectorAccountId",
+      "externalWorldId",
+      "externalRoomId",
+      "expectedGeneration",
+      "idempotencyKey",
+      "observedAt",
+      "publisherInstanceId",
+      "publisherGeneration",
+      "evidenceMode",
+    ]);
+    this.assertPublisher(command);
+    const requestDigest = digest("publisher", command);
     const receipt = await this.db.transaction(async (tx) => {
-      const replay = await this.replay(tx, command, digest);
+      const replay = await this.replay(tx, command, requestDigest);
       if (replay) return replay;
-      await this.assertReferences(tx, command);
-      const advanced = await this.advanceScope(tx, command, observedAt, digest);
-      if ("replay" in advanced) return advanced.replay;
-      const { scope } = advanced;
-      const now = new Date();
-      const [row] = await tx
-        .insert(membershipAuthorityTable)
+      await this.assertAccount(tx, command);
+      await tx
+        .insert(membershipAuthorityScopeTable)
         .values({
           agentId: command.agentId,
           connectorId: command.connectorId,
           connectorAccountId: command.connectorAccountId,
           externalWorldId: command.externalWorldId,
           externalRoomId: command.externalRoomId,
-          canonicalPrincipalId: command.canonicalPrincipalId,
-          state: command.state,
-          reason: command.reason,
-          roles: [...command.roles],
-          permissionSnapshot: command.permissionSnapshot,
-          runtimeWorldId: command.runtime.worldId,
-          runtimeRoomId: command.runtime.roomId,
-          runtimeEntityId: command.runtime.entityId,
-          generation: scope.generation,
-          sourceVersion: command.sourceVersion,
-          sourceCursor: command.sourceCursor,
-          observedAt,
-          updatedAt: now,
+          observedAt: observed,
         })
-        .onConflictDoUpdate({
-          target: [
-            membershipAuthorityTable.agentId,
-            membershipAuthorityTable.connectorId,
-            membershipAuthorityTable.connectorAccountId,
-            membershipAuthorityTable.externalWorldId,
-            membershipAuthorityTable.externalRoomId,
-            membershipAuthorityTable.canonicalPrincipalId,
-          ],
-          set: {
-            state: command.state,
-            reason: command.reason,
-            roles: [...command.roles],
-            permissionSnapshot: command.permissionSnapshot,
-            runtimeWorldId: command.runtime.worldId,
-            runtimeRoomId: command.runtime.roomId,
-            runtimeEntityId: command.runtime.entityId,
-            generation: scope.generation,
-            sourceVersion: command.sourceVersion,
-            sourceCursor: command.sourceCursor,
-            observedAt,
-            updatedAt: now,
-          },
+        .onConflictDoNothing();
+      const current = await this.row(tx, command);
+      if (current.generation !== command.expectedGeneration) {
+        const concurrentReplay = await this.replay(tx, command, requestDigest);
+        if (concurrentReplay) return concurrentReplay;
+        fail("MEMBERSHIP_GENERATION_MISMATCH", "Membership scope generation changed.");
+      }
+      if (
+        current.publisherGeneration !== null &&
+        command.publisherGeneration <= current.publisherGeneration
+      )
+        fail("MEMBERSHIP_PUBLISHER_GENERATION_STALE", "Publisher generation must advance.");
+      const [advanced] = await tx
+        .update(membershipAuthorityScopeTable)
+        .set({
+          generation: current.generation + 1,
+          health: "stale",
+          reason: "awaiting_publisher_evidence",
+          sourceVersion: -1,
+          sourceCursor: null,
+          validUntil: null,
+          publisherInstanceId: command.publisherInstanceId,
+          publisherGeneration: command.publisherGeneration,
+          evidenceMode: command.evidenceMode,
+          observedAt: observed,
+          updatedAt: this.clock(),
         })
+        .where(
+          and(scopeWhere(command), eq(membershipAuthorityScopeTable.generation, current.generation))
+        )
         .returning();
-      if (!row) fail("MEMBERSHIP_WRITE_FAILED", "Membership state was not persisted.");
+      if (!advanced) {
+        const concurrentReplay = await this.replay(tx, command, requestDigest);
+        if (concurrentReplay) return concurrentReplay;
+        fail(
+          "MEMBERSHIP_GENERATION_MISMATCH",
+          "Concurrent publisher registration committed first."
+        );
+      }
       const result: MembershipMutationReceipt = {
-        contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+        contractVersion: 1,
+        operation: "publisher",
+        idempotentReplay: false,
+        committedGeneration: advanced.generation,
+        health: mapScope(advanced),
+      };
+      await this.record(tx, "publisher", command, requestDigest, result);
+      return result;
+    });
+    if (!receipt.idempotentReplay) await this.publish(command, receipt);
+    return receipt;
+  }
+
+  async applyCompleteSnapshot(
+    command: ApplyCompleteMembershipSnapshotCommand
+  ): Promise<MembershipMutationReceipt> {
+    const observed = this.assertBase(command, [
+      "agentId",
+      "connectorId",
+      "connectorAccountId",
+      "externalWorldId",
+      "externalRoomId",
+      "expectedGeneration",
+      "idempotencyKey",
+      "observedAt",
+      "publisherInstanceId",
+      "publisherGeneration",
+      "evidenceMode",
+      "sourceVersion",
+      "previousSourceCursor",
+      "sourceCursor",
+      "validUntil",
+      "completeness",
+      "members",
+    ]);
+    const validUntil = this.assertEvidence(command, observed);
+    if (!["complete_snapshot", "ordered_delta"].includes(command.evidenceMode))
+      fail(
+        "MEMBERSHIP_COMMAND_INVALID",
+        "Complete snapshots require a snapshot-capable publisher mode."
+      );
+    if (
+      command.completeness !== "complete" ||
+      !Array.isArray(command.members) ||
+      command.members.length > MAX_SNAPSHOT_MEMBERS
+    )
+      fail(
+        "MEMBERSHIP_SNAPSHOT_INCOMPLETE",
+        "Only an explicitly complete bounded snapshot is authoritative."
+      );
+    const ids = new Set<UUID>();
+    for (const member of command.members) {
+      assertExactKeys(
+        member,
+        ["canonicalPrincipalId", "roles", "permissionSnapshot", "runtime"],
+        "Snapshot member"
+      );
+      this.assertMember(member);
+      if (ids.has(member.canonicalPrincipalId))
+        fail("MEMBERSHIP_COMMAND_INVALID", "Snapshot contains duplicate principals.");
+      ids.add(member.canonicalPrincipalId);
+    }
+    const requestDigest = digest("snapshot", command);
+    const receipt = await this.db.transaction(async (tx) => {
+      const replay = await this.replay(tx, command, requestDigest);
+      if (replay) return replay;
+      await this.assertAccount(tx, command);
+      await this.assertMembers(tx, command, command.members);
+      const advanced = await this.advanceEvidence(tx, command, observed, validUntil, requestDigest);
+      if ("replay" in advanced) return advanced.replay;
+      const { scope } = advanced;
+      const existing = await tx
+        .select()
+        .from(membershipAuthorityTable)
+        .where(allMembersWhere(command));
+      const memberships: MembershipRecord[] = [];
+      for (const member of command.members)
+        memberships.push(
+          await this.upsertMember(
+            tx,
+            scope,
+            member,
+            "active",
+            "reconciled_present",
+            observed,
+            validUntil
+          )
+        );
+      const revokedPrincipalIds: UUID[] = [];
+      for (const old of existing)
+        if (old.state === "active" && !ids.has(old.canonicalPrincipalId as UUID)) {
+          revokedPrincipalIds.push(old.canonicalPrincipalId as UUID);
+          await this.upsertMember(
+            tx,
+            scope,
+            {
+              canonicalPrincipalId: old.canonicalPrincipalId as UUID,
+              roles: [],
+              permissionSnapshot: {},
+              runtime: {
+                worldId: old.runtimeWorldId as UUID | null,
+                roomId: old.runtimeRoomId as UUID | null,
+                entityId: old.runtimeEntityId as UUID | null,
+              },
+            },
+            "revoked",
+            "reconciled_absent",
+            observed,
+            validUntil
+          );
+        }
+      const result: MembershipMutationReceipt = {
+        contractVersion: 1,
+        operation: "snapshot",
+        idempotentReplay: false,
+        committedGeneration: scope.generation,
+        health: mapScope(scope),
+        memberships,
+        revokedPrincipalIds,
+      };
+      await this.record(tx, "snapshot", command, requestDigest, result);
+      return result;
+    });
+    if (!receipt.idempotentReplay) await this.publish(command, receipt);
+    return receipt;
+  }
+
+  async applyMembership(command: ApplyMembershipCommand): Promise<MembershipMutationReceipt> {
+    const observed = this.assertBase(command, [
+      "agentId",
+      "connectorId",
+      "connectorAccountId",
+      "externalWorldId",
+      "externalRoomId",
+      "expectedGeneration",
+      "idempotencyKey",
+      "observedAt",
+      "publisherInstanceId",
+      "publisherGeneration",
+      "evidenceMode",
+      "sourceVersion",
+      "previousSourceCursor",
+      "sourceCursor",
+      "validUntil",
+      "canonicalPrincipalId",
+      "state",
+      "reason",
+      "roles",
+      "permissionSnapshot",
+      "runtime",
+    ]);
+    const validUntil = this.assertEvidence(command, observed);
+    if (!["ordered_delta", "point_query"].includes(command.evidenceMode))
+      fail(
+        "MEMBERSHIP_COMMAND_INVALID",
+        "Single-member evidence requires ordered-delta or point-query mode."
+      );
+    this.assertMember(command);
+    if (
+      !MEMBERSHIP_STATES.includes(command.state) ||
+      !MEMBERSHIP_REASONS.includes(command.reason) ||
+      (command.state === "active") !== ACTIVE_REASONS.has(command.reason)
+    )
+      fail("MEMBERSHIP_COMMAND_INVALID", "Membership state and reason are incompatible.");
+    const requestDigest = digest("membership", command);
+    const receipt = await this.db.transaction(async (tx) => {
+      const replay = await this.replay(tx, command, requestDigest);
+      if (replay) return replay;
+      await this.assertAccount(tx, command);
+      await this.assertMembers(tx, command, [command]);
+      const advanced = await this.advanceEvidence(tx, command, observed, validUntil, requestDigest);
+      if ("replay" in advanced) return advanced.replay;
+      const { scope } = advanced;
+      const membership = await this.upsertMember(
+        tx,
+        scope,
+        command,
+        command.state,
+        command.reason,
+        observed,
+        validUntil
+      );
+      const result: MembershipMutationReceipt = {
+        contractVersion: 1,
         operation: "membership",
         idempotentReplay: false,
         committedGeneration: scope.generation,
-        membership: mapMembership(row),
+        membership,
       };
-      await this.recordJournal(tx, "membership", command, digest, result);
+      await this.record(tx, "membership", command, requestDigest, result);
       return result;
     });
-    if (!receipt.idempotentReplay) {
-      this.invalidateScope(command, receipt);
-      await this.notify(command, receipt);
-    }
+    if (!receipt.idempotentReplay) await this.publish(command, receipt);
     return receipt;
   }
 
   async setScopeHealth(command: SetMembershipHealthCommand): Promise<MembershipMutationReceipt> {
-    const observedAt = this.assertCommand(command);
-    if (!MEMBERSHIP_HEALTH_STATES.includes(command.health)) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Membership health state is invalid.");
-    }
-    if (command.reason.trim().length === 0 || command.reason.length > MAX_IDENTIFIER_LENGTH) {
-      fail("MEMBERSHIP_COMMAND_INVALID", "Membership health reason is invalid.");
-    }
-    const digest = commandDigest("health", command);
+    const observed = this.assertBase(command, [
+      "agentId",
+      "connectorId",
+      "connectorAccountId",
+      "externalWorldId",
+      "externalRoomId",
+      "expectedGeneration",
+      "idempotencyKey",
+      "observedAt",
+      "health",
+      "reason",
+    ]);
+    if (
+      !["stale", "unavailable", "unsupported"].includes(command.health) ||
+      typeof command.reason !== "string" ||
+      command.reason.trim().length === 0 ||
+      command.reason.length > MAX_IDENTIFIER_LENGTH
+    )
+      fail("MEMBERSHIP_COMMAND_INVALID", "Health updates may only degrade authority.");
+    const requestDigest = digest("health", command);
     const receipt = await this.db.transaction(async (tx) => {
-      const replay = await this.replay(tx, command, digest);
+      const replay = await this.replay(tx, command, requestDigest);
       if (replay) return replay;
-      await this.assertReferences(tx, command);
-      const advanced = await this.advanceScope(tx, command, observedAt, digest, {
-        health: command.health,
-        reason: command.reason,
-      });
-      if ("replay" in advanced) return advanced.replay;
-      const { scope: row } = advanced;
+      await this.assertAccount(tx, command);
+      const current = await this.row(tx, command);
+      if (current.generation !== command.expectedGeneration) {
+        const concurrentReplay = await this.replay(tx, command, requestDigest);
+        if (concurrentReplay) return concurrentReplay;
+        fail("MEMBERSHIP_GENERATION_MISMATCH", "Membership scope generation changed.");
+      }
+      const [advanced] = await tx
+        .update(membershipAuthorityScopeTable)
+        .set({
+          generation: current.generation + 1,
+          health: command.health,
+          reason: command.reason,
+          observedAt: observed,
+          updatedAt: this.clock(),
+        })
+        .where(
+          and(scopeWhere(command), eq(membershipAuthorityScopeTable.generation, current.generation))
+        )
+        .returning();
+      if (!advanced) {
+        const concurrentReplay = await this.replay(tx, command, requestDigest);
+        if (concurrentReplay) return concurrentReplay;
+        fail("MEMBERSHIP_GENERATION_MISMATCH", "Concurrent health update committed first.");
+      }
       const result: MembershipMutationReceipt = {
-        contractVersion: MEMBERSHIP_AUTHORITY_CONTRACT_VERSION,
+        contractVersion: 1,
         operation: "health",
         idempotentReplay: false,
-        committedGeneration: row.generation,
-        health: mapScope(row),
+        committedGeneration: advanced.generation,
+        health: mapScope(advanced),
       };
-      await this.recordJournal(tx, "health", command, digest, result);
+      await this.record(tx, "health", command, requestDigest, result);
       return result;
     });
-    if (!receipt.idempotentReplay) {
-      this.invalidateScope(command, receipt);
-      await this.notify(command, receipt);
-    }
+    if (!receipt.idempotentReplay) await this.publish(command, receipt);
     return receipt;
   }
 
@@ -630,7 +1026,6 @@ export class SqlMembershipService extends MembershipService {
       .limit(1);
     return row ? mapScope(row) : null;
   }
-
   async getMembership(
     scope: MembershipScope,
     canonicalPrincipalId: UUID
@@ -639,62 +1034,61 @@ export class SqlMembershipService extends MembershipService {
     const [row] = await this.db
       .select()
       .from(membershipAuthorityTable)
-      .where(membershipWhere(scope, canonicalPrincipalId))
+      .where(memberWhere(scope, canonicalPrincipalId))
       .limit(1);
-    return row ? mapMembership(row) : null;
+    return row ? mapMember(row) : null;
   }
-
   async authorize(
     scope: MembershipScope,
     canonicalPrincipalId: UUID
   ): Promise<MembershipAuthorizationDecision> {
     this.assertScope(scope);
     const health = await this.getScopeHealth(scope);
-    if (!health) {
+    if (!health)
+      return { decision: "denied", reason: "no_scope_evidence", generation: null, health: null };
+    if (health.health !== "current")
       return {
         decision: "denied",
-        reason: "no_scope_evidence",
-        generation: null,
-        health: null,
-      };
-    }
-    const key = decisionKey(scope, canonicalPrincipalId);
-    const cached = this.decisionCache.get(key);
-    if (cached?.generation === health.generation) return cached.decision;
-
-    let decision: MembershipAuthorizationDecision;
-    if (health.health !== "current") {
-      decision = {
-        decision: "denied",
-        reason: HEALTH_REASON_BY_STATE[health.health],
+        reason: DEGRADE_REASON[health.health],
         generation: health.generation,
         health: health.health,
       };
-    } else {
-      const membership = await this.getMembership(scope, canonicalPrincipalId);
-      decision = membership
-        ? membership.state === "active"
-          ? {
-              decision: "allowed",
-              reason: "active_membership",
-              generation: health.generation,
-              health: "current",
-              membership,
-            }
-          : {
-              decision: "denied",
-              reason: "membership_revoked",
-              generation: health.generation,
-              health: health.health,
-            }
-        : {
-            decision: "denied",
-            reason: "no_membership",
-            generation: health.generation,
-            health: health.health,
-          };
-    }
-    this.decisionCache.set(key, { generation: health.generation, decision });
-    return decision;
+    const now = this.clock().getTime();
+    if (!health.validUntil || new Date(health.validUntil).getTime() <= now)
+      return {
+        decision: "denied",
+        reason: "authority_expired",
+        generation: health.generation,
+        health: "current",
+      };
+    const membership = await this.getMembership(scope, canonicalPrincipalId);
+    if (!membership)
+      return {
+        decision: "denied",
+        reason: "no_membership",
+        generation: health.generation,
+        health: "current",
+      };
+    if (membership.state === "revoked")
+      return {
+        decision: "denied",
+        reason: "membership_revoked",
+        generation: health.generation,
+        health: "current",
+      };
+    if (new Date(membership.validUntil).getTime() <= now)
+      return {
+        decision: "denied",
+        reason: "membership_evidence_expired",
+        generation: health.generation,
+        health: "current",
+      };
+    return {
+      decision: "allowed",
+      reason: "active_membership",
+      generation: health.generation,
+      health: "current",
+      membership,
+    };
   }
 }

--- a/plugins/plugin-sql/src/services/sql-membership.ts
+++ b/plugins/plugin-sql/src/services/sql-membership.ts
@@ -473,17 +473,15 @@ export class SqlMembershipService extends MembershipService {
     });
   }
 
-  private invalidateScope(scope: MembershipScope, receipt: MembershipMutationReceipt): boolean {
+  private invalidateScope(scope: MembershipScope, receipt: MembershipMutationReceipt): void {
     const prefix = `${scopeKey(scope)}\n`;
     for (const key of this.decisionCache.keys()) {
       if (key.startsWith(prefix)) this.decisionCache.delete(key);
     }
-    let succeeded = true;
     for (const invalidator of this.invalidators) {
       try {
         invalidator(scope, receipt);
       } catch (error) {
-        succeeded = false;
         // error-policy:J7 cache-invalidation diagnostics must not fabricate a rollback after commit.
         this.runtime.reportError("membership-authority-invalidator", error, {
           operation: receipt.operation,
@@ -491,7 +489,6 @@ export class SqlMembershipService extends MembershipService {
         });
       }
     }
-    return succeeded;
   }
 
   private async notify(scope: MembershipScope, receipt: MembershipMutationReceipt): Promise<void> {
@@ -582,8 +579,8 @@ export class SqlMembershipService extends MembershipService {
       return result;
     });
     if (!receipt.idempotentReplay) {
-      const invalidated = this.invalidateScope(command, receipt);
-      if (invalidated) await this.notify(command, receipt);
+      this.invalidateScope(command, receipt);
+      await this.notify(command, receipt);
     }
     return receipt;
   }
@@ -618,8 +615,8 @@ export class SqlMembershipService extends MembershipService {
       return result;
     });
     if (!receipt.idempotentReplay) {
-      const invalidated = this.invalidateScope(command, receipt);
-      if (invalidated) await this.notify(command, receipt);
+      this.invalidateScope(command, receipt);
+      await this.notify(command, receipt);
     }
     return receipt;
   }

--- a/plugins/plugin-sql/src/services/sql-membership.ts
+++ b/plugins/plugin-sql/src/services/sql-membership.ts
@@ -183,7 +183,9 @@ function mapMember(row: MembershipRow): MembershipRecord {
   if (
     !MEMBERSHIP_STATES.includes(row.state as MembershipRecord["state"]) ||
     !MEMBERSHIP_REASONS.includes(row.reason as MembershipRecord["reason"]) ||
-    !MEMBERSHIP_EVIDENCE_MODES.includes(row.evidenceMode as MembershipEvidenceMode)
+    !MEMBERSHIP_EVIDENCE_MODES.includes(row.evidenceMode as MembershipEvidenceMode) ||
+    (row.state === "active") !== ACTIVE_REASONS.has(row.reason) ||
+    row.validUntil <= row.observedAt
   )
     fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted membership enum is invalid.");
   assertRoles(row.roles);


### PR DESCRIPTION
## Summary

Foundation for #23101: add the canonical SQL-backed membership authority contract and state machine that connector adapters and authorization consumers will share.

This slice provides:

- authority scoped by connector, connector account, external world/room, and canonical principal
- publisher instance/generation/mode binding
- complete-snapshot, ordered-delta, and bounded point-query evidence modes
- atomic snapshot replacement with absent-member revocation
- cursor/version ordering and revocation anti-resurrection
- injected-clock freshness checks and visible stale/degraded health
- invalidation observers after committed security state
- database constraints that reject contradictory state/reason, invalid validity windows, and malformed versions
- real PGlite restart, concurrency, pagination, empty-roster, expiry, and direct-constraint proof

## Evidence

Exact head `9ceb153934f` rebased on `develop@c713ee051bc`:

- frozen install: 3,724 installs / 4,000 packages, no changes
- focused real PGlite + schema: 13/13 passed (60-second setup allowance; assertions unchanged)
- full plugin-sql: 183 passed, 3 explicitly skipped
- plugin-sql typecheck passed
- plugin-sql Biome: 224 files, no findings
- plugin-sql Node/browser/CJS/declarations build passed
- guide parity and diff integrity passed in prior slice review; rebased diff is clean

The earlier loaded run's sole failure was a PGlite `beforeEach` exceeding Vitest's fixed 20-second hook timeout. The exact case passed alone in 2.4 seconds and the complete exact-head suite above passed with only the setup allowance raised.

## Deliberate remaining #23101 work

This does **not** close #23101. Follow-up slices must integrate Telegram, Slack, Discord, and iMessage publishers; wire final document/read/send authorization and direct grants; qualify live PostgreSQL/RLS and provider events; and prove same-turn read→leave→read denial plus missed-event reconciliation on real providers. Unknown/stale authority already fails closed rather than fabricating membership.

## Attribution

- AI provider/model: OpenAI / gpt-5.6-sol
- Client/agent tooling: Codex Desktop / multi-agent
- Contribution skill revision: N/A — no repository contribution skill used
