### PR TITLE
fix(app-core): use surrogate-safe truncateWellFormed on dev screenshot error detail

### DIFF
--- a/packages/app-core/src/api/dev-compat-routes.ts
+++ b/packages/app-core/src/api/dev-compat-routes.ts
@@ -7,6 +7,7 @@
  * true once it owns a request, false to let the caller keep dispatching.
  */
 import type http from "node:http";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { InferenceTurnSummary, Log } from "@elizaos/core";
 import { INFERENCE_TRACE_ID_PATTERN } from "@elizaos/core";
 import { parseCanonicalInteger } from "@elizaos/shared";
@@ -251,7 +252,7 @@ export async function handleDevCompatRoutes(
           {
             error: "upstream screenshot failed",
             status: r.status,
-            detail: text.slice(0, 200),
+            detail: truncateWellFormed(toWellFormedUnicode(text), 200),
           },
         );
         return true;


### PR DESCRIPTION
## Summary

Use surrogate-safe `truncateWellFormed(toWellFormedUnicode(text), 200)` for dev screenshot upstream error detail in `packages/app-core/src/api/dev-compat-routes.ts:254`. External screenshot response body truncated with `slice(0,200)` could split astral surrogate at boundary, emitting lone surrogate via `JSON.stringify` (`\uD8xx`) rejected by strict parsers.

Mirrors merged precedent `#25282`, `#25280`, `#25250` (surrogate-safe error detail).

## Changes

- `packages/app-core/src/api/dev-compat-routes.ts:1` import `toWellFormedUnicode, truncateWellFormed` from `@elizaos/core`.
- `packages/app-core/src/api/dev-compat-routes.ts:254` `text.slice(0,200)` → `truncateWellFormed(toWellFormedUnicode(text), 200)`.
- `packages/app-core/src/api/dev-compat-routes.surrogate.test.ts` 4 tests: lone surrogate → U+FFFD, astral boundary not split, cap 200, short preserved.

## Exact-head verification

| Check | Base (origin/develop@c713ee0) | Head |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/api/dev-compat-routes.surrogate.test.ts` | N/A | 4 pass |
| `bunx biome check` | 0 | 0 |

## Risks

Low. Only affects upstream error detail truncation; valid ASCII/UTF-8 unchanged, well-formed guarantee added.
