### PR TITLE
fix(app-core): use surrogate-safe truncateWellFormed on auth User-Agent truncation

### DIFF
--- a/packages/app-core/src/api/auth/audit.surrogate.test.ts
+++ b/packages/app-core/src/api/auth/audit.surrogate.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Surrogate-safe truncation for auth audit User-Agent.
+ */
+import { describe, expect, it } from "vitest";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+describe("auth audit userAgent surrogate-safe", () => {
+  it("replaces lone surrogate", () => {
+    expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
+  });
+  it("does not split astral at 200", () => {
+    const astral = "🦊";
+    const atBoundary = "x".repeat(199) + astral;
+    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200)).toBe("x".repeat(198) + astral);
+  });
+  it("caps at 200", () => {
+    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);
+  });
+  it("preserves short", () => {
+    expect(truncateWellFormed(toWellFormedUnicode("Mozilla/5.0"), 200)).toBe("Mozilla/5.0");
+  });
+});

--- a/packages/app-core/src/api/auth/audit.ts
+++ b/packages/app-core/src/api/auth/audit.ts
@@ -18,6 +18,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { RuntimeEnvRecord } from "@elizaos/shared";
 import type { AuthStore } from "../../services/auth-store";
 import { resolveElizaStateDir } from "../../services/cloud-jwks-store";
@@ -44,7 +45,7 @@ export interface AuditEmitterOptions {
 
 function truncateUserAgent(value: string | null): string | null {
   if (!value) return null;
-  return value.length > 200 ? value.slice(0, 200) : value;
+  return value.length > 200 ? truncateWellFormed(toWellFormedUnicode(value), 200) : value;
 }
 
 /**


### PR DESCRIPTION
## Summary

Use surrogate-safe `truncateWellFormed(toWellFormedUnicode(value), 200)` for `truncateUserAgent` in `packages/app-core/src/api/auth/audit.ts:47`. `User-Agent` header truncated at 200 with `slice(0,200)` could split astral surrogate, emitting lone surrogate into `auth_audit_events` DB and JSONL audit log.

Mirrors merged precedent `#25282`, `#25280`, `#25335` (surrogate-safe truncation on external header/body).

## Changes

- `packages/app-core/src/api/auth/audit.ts:1` import `toWellFormedUnicode, truncateWellFormed` from `@elizaos/core`.
- `packages/app-core/src/api/auth/audit.ts:47` `value.slice(0,200)` → `truncateWellFormed(toWellFormedUnicode(value), 200)`.
- `packages/app-core/src/api/auth/audit.surrogate.test.ts` 4 tests: lone surrogate → U+FFFD, astral boundary not split, cap 200, short preserved.

## Exact-head verification

| Check | Base (origin/develop@c713ee0) | Head |
| --- | --- | --- |
| `bunx vitest run packages/app-core/src/api/auth/audit.surrogate.test.ts` | N/A | 4 pass |
| `bunx biome check` | 0 | 0 |

## Risks

Low. Only affects truncation path when length>200; preserves well-formed guarantee for DB/JSONL consumers.
