### PR TITLE
fix(app): reveal restored chat in continuity proof

### DIFF
--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -479,6 +479,13 @@ async function proveAnchoredTurnHistory(
       )
       .toBe(true);
     successfulHistoryResponseObserved = true;
+    // Completed-user chat deliberately cold-boots at the compact composer; the
+    // transcript is unmounted until the composer receives an explicit open
+    // gesture. Reproduce that real customer action after the server history
+    // response instead of treating the intentionally hidden DOM as lost data.
+    // Activating it also exercises the pending-expand-on-reveal path when
+    // hydration is still committing the restored messages.
+    await chatComposer(page).click();
     await expect
       .poll(
         async () => {


### PR DESCRIPTION
## Summary

- activate the compact composer after a successful restored-history response
- assert the anchored user and assistant rows only after the real transcript surface is mounted
- preserve the intended compact cold-boot chat behavior and privacy-safe diagnostics

Fixes #25388

## Verification

- Biome check: passed
- cloud-live-continuity-contract: 20/20 passed
- deployed Playwright config discovery: 1 exact test
- app typecheck: blocked by current develop baseline errors outside this diff (missing plugin-todos exports, existing recent-conversations strictness errors, and missing app test shim modules)