### PR TITLE
chore(lint): clean surrogate diagnostic callsites

### DIFF
--- a/packages/cloud/shared/src/lib/services/content-safety.ts
+++ b/packages/cloud/shared/src/lib/services/content-safety.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service content safety behavior behind route handlers.
+/** Coordinates cloud service content safety behavior behind route handlers. */
 
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { ApiError } from "../api/cloud-worker-errors";


### PR DESCRIPTION
## Summary

- restore pinned Biome formatting/import order at the surrogate-safe diagnostic call sites
- remove the unused gateway test import and Plugin X catch binding
- normalize the touched content-safety file header to the repository prose-header contract

Closes #25363.

## Verification

- `bun run --cwd packages/cloud/shared lint` — 2,341 files clean
- `bun run --cwd packages/cloud/shared typecheck`
- focused cloud-shared tests — 98 passed, 316 expectations
- `bun run --cwd packages/cloud/services/gateway-webhook lint` — 55 files clean
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck`
- gateway-webhook tests — 267 passed, 769 expectations
- `bun run --cwd plugins/plugin-x lint` — 100 files clean
- `bun run --cwd plugins/plugin-x typecheck`
- Plugin X broker tests — 7 passed
- `git diff --check`

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
