### PR TITLE
fix(cloud): prove fresh ledgers and atomize usage-quota repair

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
@@ -1,6 +1,8 @@
 /**
  * Proves the temporary usage-quotas release barrier pauses the destructive
- * pair before SQL, repairs ledgers already at 0282, and rejects suffix drift.
+ * pair before SQL, repairs ledgers already at 0282, rejects suffix drift, and
+ * lets an empty ledger (a fresh database with no served Worker) apply the
+ * whole journal.
  */
 
 import { describe, expect, spyOn, test } from "bun:test";
@@ -234,6 +236,144 @@ describe("usage-quotas migration release barrier", () => {
       action: "pause",
       stopBeforeJournalIndex: 2,
     });
+  });
+
+  // The barrier protects a LIVE deployment: a Worker already serving traffic
+  // must never see the window between the drop and the restore. An empty
+  // ledger has no served Worker and no rows, so pausing there protects
+  // nothing; it only strands fresh environments at 0281. A ledger with even
+  // one applied migration is still a barrier target and still pauses.
+  test("continues from an empty ledger but still pauses any older validated ledger", () => {
+    const migrations = barrierMigrations();
+
+    expect(evaluateMigrationReleaseBarrier(migrations, -1)).toEqual({
+      action: "continue",
+    });
+    expect(evaluateMigrationReleaseBarrier(migrations, 0)).toEqual({
+      action: "pause",
+      stopBeforeJournalIndex: 2,
+    });
+    expect(evaluateMigrationReleaseBarrier(migrations, 1)).toEqual({
+      action: "pause",
+      stopBeforeJournalIndex: 2,
+    });
+  });
+
+  // The fresh-ledger carve-out sits behind the structural checks, so a fresh
+  // database still refuses a journal whose guarded pair is missing, duplicated,
+  // interleaved, or reversed instead of applying it without the barrier.
+  test("still validates the guarded pair's shape for an empty ledger", () => {
+    const [checkpoint, before, drop, restore] = barrierMigrations();
+
+    expect(() =>
+      evaluateMigrationReleaseBarrier(
+        [
+          checkpoint,
+          before,
+          drop,
+          migration(2825, "0282b_interleaved", "SELECT interleaved"),
+          restore,
+        ],
+        -1,
+      ),
+    ).toThrow("adjacent journal entries");
+    expect(() =>
+      evaluateMigrationReleaseBarrier([checkpoint, before, restore, drop], -1),
+    ).toThrow("adjacent journal entries");
+    expect(() =>
+      evaluateMigrationReleaseBarrier([checkpoint, before, drop], -1),
+    ).toThrow("requires exactly one of each suffix entry");
+    expect(() =>
+      evaluateMigrationReleaseBarrier(
+        [
+          checkpoint,
+          before,
+          drop,
+          restore,
+          migration(284, RESTORE_TAG, "SELECT duplicate"),
+        ],
+        -1,
+      ),
+    ).toThrow("requires exactly one of each suffix entry");
+  });
+
+  // End to end through runMigrations: an empty ledger applies every journal
+  // entry in order, the drop immediately followed by the restore and then the
+  // later suffixes, each individually ledgered, with no pause reported.
+  test("applies the whole journal from an empty ledger, including 0282, 0282_01, and later suffixes", async () => {
+    const migrations = [
+      ...barrierMigrations(),
+      migration(284, "0284_first_future_feature", "SELECT future_one"),
+      migration(285, "0285_second_future_feature", "SELECT future_two"),
+    ];
+    const harness = migrationClient(appliedRows(migrations, -1));
+    let convergenceCalls = 0;
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+    const warnings: string[] = [];
+    const warningLog = spyOn(console, "warn").mockImplementation(
+      (message: string) => {
+        warnings.push(message);
+      },
+    );
+
+    try {
+      await runMigrations(
+        harness.client,
+        migrations,
+        OPTIONS,
+        undefined,
+        undefined,
+        async () => {
+          convergenceCalls += 1;
+        },
+      );
+    } finally {
+      outputLog.mockRestore();
+      warningLog.mockRestore();
+    }
+
+    const appliedInOrder = [
+      ["SELECT checkpoint", CHECKPOINT_TAG],
+      ["SELECT before_drop", "0281_before_usage_quotas_release"],
+      ["DROP TABLE usage_quotas", DROP_TAG],
+      ["CREATE TABLE usage_quotas (id uuid)", RESTORE_TAG],
+      ["SELECT future_one", "0284_first_future_feature"],
+      ["SELECT future_two", "0285_second_future_feature"],
+    ] as const;
+    let searchFrom = 0;
+    for (const [statement, tag] of appliedInOrder) {
+      const begin = harness.queries.indexOf("BEGIN", searchFrom);
+      const run = harness.queries.indexOf(statement, searchFrom);
+      const ledgered = harness.queries.findIndex(
+        (query, index) =>
+          index > run &&
+          query.includes("INSERT INTO") &&
+          query.includes("__drizzle_migrations"),
+      );
+      const commit = harness.queries.indexOf("COMMIT", ledgered);
+      expect(begin).toBeGreaterThanOrEqual(0);
+      expect(run).toBeGreaterThan(begin);
+      expect(ledgered).toBeGreaterThan(run);
+      expect(commit).toBeGreaterThan(ledgered);
+      expect(harness.queryParams[ledgered]).toContain(`hash-${tag}`);
+      searchFrom = commit + 1;
+    }
+    expect(harness.queries.filter((query) => query === "BEGIN")).toHaveLength(
+      appliedInOrder.length,
+    );
+    expect(harness.queries.filter((query) => query === "COMMIT")).toHaveLength(
+      appliedInOrder.length,
+    );
+    // Journal order end to end, with the restore directly after the drop.
+    const statements = new Set(migrations.flatMap((item) => item.statements));
+    expect(harness.queries.filter((query) => statements.has(query))).toEqual(
+      appliedInOrder.map(([statement]) => statement),
+    );
+    expect(
+      warnings.some((message) => message.includes("release barrier paused")),
+    ).toBe(false);
+    expect(convergenceCalls).toBe(1);
+    expect(harness.ended()).toBe(true);
   });
 
   test("fails closed when either guarded migration is missing or duplicated", () => {

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
@@ -1,8 +1,8 @@
 /**
  * Proves the temporary usage-quotas release barrier pauses the destructive
  * pair before SQL, repairs ledgers already at 0282, rejects suffix drift, and
- * lets an empty ledger (a fresh database with no served Worker) apply the
- * whole journal.
+ * admits an empty ledger only after a relation-free catalog proof while
+ * committing the destructive pair atomically.
  */
 
 import { describe, expect, spyOn, test } from "bun:test";
@@ -58,7 +58,13 @@ function appliedRows(
   }));
 }
 
-function migrationClient(applied: ReturnType<typeof appliedRows>): {
+function migrationClient(
+  applied: ReturnType<typeof appliedRows>,
+  options: {
+    failOnStatement?: string;
+    hasUserRelations?: boolean;
+  } = {},
+): {
   client: {
     backend: "pglite";
     query<T = unknown>(
@@ -83,8 +89,18 @@ function migrationClient(applied: ReturnType<typeof appliedRows>): {
       ): Promise<{ rows: T[] }> => {
         queries.push(text);
         queryParams.push(params ?? []);
+        if (text.includes("AS has_user_relations")) {
+          return {
+            rows: [
+              { has_user_relations: options.hasUserRelations ?? false },
+            ] as T[],
+          };
+        }
         if (text.includes(`FROM "drizzle"."__drizzle_migrations"`)) {
           return { rows: applied as T[] };
+        }
+        if (options.failOnStatement === text) {
+          throw new Error("injected migration failure");
         }
         return { rows: [] };
       },
@@ -238,16 +254,14 @@ describe("usage-quotas migration release barrier", () => {
     });
   });
 
-  // The barrier protects a LIVE deployment: a Worker already serving traffic
-  // must never see the window between the drop and the restore. An empty
-  // ledger has no served Worker and no rows, so pausing there protects
-  // nothing; it only strands fresh environments at 0281. A ledger with even
-  // one applied migration is still a barrier target and still pauses.
-  test("continues from an empty ledger but still pauses any older validated ledger", () => {
+  // The empty-ledger plan explicitly requires atomic execution of the pair;
+  // the runner separately proves the database has no application relations.
+  test("plans an atomic pair for an empty ledger but still pauses any older validated ledger", () => {
     const migrations = barrierMigrations();
 
     expect(evaluateMigrationReleaseBarrier(migrations, -1)).toEqual({
       action: "continue",
+      atomicPairStartIndex: 2,
     });
     expect(evaluateMigrationReleaseBarrier(migrations, 0)).toEqual({
       action: "pause",
@@ -297,10 +311,120 @@ describe("usage-quotas migration release barrier", () => {
     ).toThrow("requires exactly one of each suffix entry");
   });
 
-  // End to end through runMigrations: an empty ledger applies every journal
-  // entry in order, the drop immediately followed by the restore and then the
-  // later suffixes, each individually ledgered, with no pause reported.
-  test("applies the whole journal from an empty ledger, including 0282, 0282_01, and later suffixes", async () => {
+  test("fails closed when an empty ledger belongs to a nonempty schema", async () => {
+    const migrations = barrierMigrations();
+    const harness = migrationClient(appliedRows(migrations, -1), {
+      hasUserRelations: true,
+    });
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+    const errorLog = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        runMigrations(harness.client, migrations, OPTIONS),
+      ).rejects.toThrow(
+        "ledger is empty but the database contains application relations",
+      );
+    } finally {
+      outputLog.mockRestore();
+      errorLog.mockRestore();
+    }
+
+    expect(harness.queries).not.toContain("BEGIN");
+    expect(harness.queries).not.toContain("DROP TABLE usage_quotas");
+    expect(harness.ended()).toBe(true);
+  });
+
+  test("preserves a real nonempty PGlite schema whose ledger was wiped", async () => {
+    const { PGlite } = await import("@electric-sql/pglite");
+    const db = await PGlite.create();
+    await db.exec(
+      "CREATE TABLE live_data (id integer PRIMARY KEY, value text NOT NULL); INSERT INTO live_data VALUES (1, 'preserve-me')",
+    );
+    let ended = false;
+    const client = {
+      backend: "pglite" as const,
+      query: async <T = unknown>(text: string, params?: unknown[]) => {
+        if (params && params.length > 0) {
+          const result = await db.query<T>(text, params);
+          return { rows: result.rows };
+        }
+        const results = await db.exec(text);
+        return { rows: (results.at(-1)?.rows as T[] | undefined) ?? [] };
+      },
+      end: async () => {
+        ended = true;
+      },
+    };
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+    const errorLog = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        runMigrations(client, barrierMigrations(), OPTIONS),
+      ).rejects.toThrow(
+        "ledger is empty but the database contains application relations",
+      );
+      const preserved = await db.query<{ value: string }>(
+        "SELECT value FROM live_data WHERE id = 1",
+      );
+      expect(preserved.rows).toEqual([{ value: "preserve-me" }]);
+      expect(ended).toBe(true);
+    } finally {
+      outputLog.mockRestore();
+      errorLog.mockRestore();
+      await db.close();
+    }
+  });
+
+  test("migrates a real relation-free PGlite database through the atomic pair", async () => {
+    const { PGlite } = await import("@electric-sql/pglite");
+    const db = await PGlite.create();
+    const client = {
+      backend: "pglite" as const,
+      query: async <T = unknown>(text: string, params?: unknown[]) => {
+        if (params && params.length > 0) {
+          const result = await db.query<T>(text, params);
+          return { rows: result.rows };
+        }
+        const results = await db.exec(text);
+        return { rows: (results.at(-1)?.rows as T[] | undefined) ?? [] };
+      },
+      end: async () => {},
+    };
+    const migrations = barrierMigrations();
+    migrations[0] = migration(194, CHECKPOINT_TAG, "SELECT 1");
+    migrations[1] = migration(
+      281,
+      "0281_before_usage_quotas_release",
+      "SELECT 2",
+    );
+    migrations[2] = migration(
+      282,
+      DROP_TAG,
+      "DROP TABLE IF EXISTS usage_quotas",
+    );
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await runMigrations(client, migrations, OPTIONS);
+      const table = await db.query<{ exists: boolean }>(
+        "SELECT to_regclass('public.usage_quotas') IS NOT NULL AS exists",
+      );
+      expect(table.rows).toEqual([{ exists: true }]);
+      const ledger = await db.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations",
+      );
+      expect(ledger.rows).toEqual([{ count: "4" }]);
+    } finally {
+      outputLog.mockRestore();
+      await db.close();
+    }
+  });
+
+  // End to end through runMigrations: the drop, restore, and both ledger rows
+  // share one transaction. Prefix/suffix migrations keep their own commits.
+  test("applies the guarded pair atomically when a relation-free database has an empty ledger", async () => {
     const migrations = [
       ...barrierMigrations(),
       migration(284, "0284_first_future_feature", "SELECT future_one"),
@@ -340,29 +464,33 @@ describe("usage-quotas migration release barrier", () => {
       ["SELECT future_one", "0284_first_future_feature"],
       ["SELECT future_two", "0285_second_future_feature"],
     ] as const;
-    let searchFrom = 0;
-    for (const [statement, tag] of appliedInOrder) {
-      const begin = harness.queries.indexOf("BEGIN", searchFrom);
-      const run = harness.queries.indexOf(statement, searchFrom);
-      const ledgered = harness.queries.findIndex(
-        (query, index) =>
-          index > run &&
-          query.includes("INSERT INTO") &&
-          query.includes("__drizzle_migrations"),
-      );
-      const commit = harness.queries.indexOf("COMMIT", ledgered);
-      expect(begin).toBeGreaterThanOrEqual(0);
-      expect(run).toBeGreaterThan(begin);
-      expect(ledgered).toBeGreaterThan(run);
-      expect(commit).toBeGreaterThan(ledgered);
-      expect(harness.queryParams[ledgered]).toContain(`hash-${tag}`);
-      searchFrom = commit + 1;
-    }
+    const drop = harness.queries.indexOf("DROP TABLE usage_quotas");
+    const restore = harness.queries.indexOf(
+      "CREATE TABLE usage_quotas (id uuid)",
+    );
+    const pairBegin = harness.queries.lastIndexOf("BEGIN", drop);
+    const pairCommit = harness.queries.indexOf("COMMIT", restore);
+    expect(pairBegin).toBeGreaterThanOrEqual(0);
+    expect(drop).toBeGreaterThan(pairBegin);
+    expect(restore).toBeGreaterThan(drop);
+    expect(pairCommit).toBeGreaterThan(restore);
+    expect(harness.queries.slice(drop, restore)).not.toContain("COMMIT");
+    const pairLedgerParams = harness.queryParams
+      .slice(drop, pairCommit)
+      .filter((params) => params.length > 0);
+    expect(pairLedgerParams).toContainEqual([
+      `hash-${DROP_TAG}`,
+      expect.any(Number),
+    ]);
+    expect(pairLedgerParams).toContainEqual([
+      `hash-${RESTORE_TAG}`,
+      expect.any(Number),
+    ]);
     expect(harness.queries.filter((query) => query === "BEGIN")).toHaveLength(
-      appliedInOrder.length,
+      appliedInOrder.length - 1,
     );
     expect(harness.queries.filter((query) => query === "COMMIT")).toHaveLength(
-      appliedInOrder.length,
+      appliedInOrder.length - 1,
     );
     // Journal order end to end, with the restore directly after the drop.
     const statements = new Set(migrations.flatMap((item) => item.statements));
@@ -373,6 +501,36 @@ describe("usage-quotas migration release barrier", () => {
       warnings.some((message) => message.includes("release barrier paused")),
     ).toBe(false);
     expect(convergenceCalls).toBe(1);
+    expect(harness.ended()).toBe(true);
+  });
+
+  test("rolls back both guarded entries when the restore fails", async () => {
+    const migrations = barrierMigrations();
+    const harness = migrationClient(appliedRows(migrations, -1), {
+      failOnStatement: "CREATE TABLE usage_quotas (id uuid)",
+    });
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+    const errorLog = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        runMigrations(harness.client, migrations, OPTIONS),
+      ).rejects.toThrow("injected migration failure");
+    } finally {
+      outputLog.mockRestore();
+      errorLog.mockRestore();
+    }
+
+    const drop = harness.queries.indexOf("DROP TABLE usage_quotas");
+    const restore = harness.queries.indexOf(
+      "CREATE TABLE usage_quotas (id uuid)",
+    );
+    expect(drop).toBeGreaterThanOrEqual(0);
+    expect(restore).toBeGreaterThan(drop);
+    expect(harness.queries.indexOf("ROLLBACK", restore)).toBeGreaterThan(
+      restore,
+    );
+    expect(harness.queries.slice(drop, restore)).not.toContain("COMMIT");
     expect(harness.ended()).toBe(true);
   });
 

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.error-precedence.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.error-precedence.test.ts
@@ -119,6 +119,9 @@ test("deploy-time convergence runs before success and fails the migration gate c
       if (text.includes("pg_advisory_unlock")) {
         return { rows: [{ unlocked: true }] as T[] };
       }
+      if (text.includes("AS has_user_relations")) {
+        return { rows: [{ has_user_relations: false }] as T[] };
+      }
       return { rows: [] };
     },
     end: async () => {},

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -9,6 +9,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import pg from "pg";
+import { runMigrations } from "./migrate-with-diagnostics";
 
 const { Client } = pg;
 const ROOT = path.resolve(import.meta.dir, "../../../..");
@@ -57,6 +58,17 @@ const BASE_URL =
 const ENABLED =
   process.env.RUN_REAL_POSTGRES_MIGRATION_TESTS === "1" &&
   BASE_URL.startsWith("postgres");
+const RELEASE_BARRIER_CHECKPOINT_TAG =
+  "0194_job_execution_interruptions_catalog_guard";
+const RELEASE_BARRIER_DROP_TAG = "0282_drop_unused_usage_quotas_table";
+const RELEASE_BARRIER_RESTORE_TAG =
+  "0282_01_restore_usage_quotas_compatibility";
+const RELEASE_BARRIER_OPTIONS = {
+  timeoutMs: 250,
+  maxAttempts: 2,
+  baseDelayMs: 1,
+  maxDelayMs: 1,
+};
 
 interface JournalEntry {
   when: number;
@@ -92,6 +104,62 @@ async function createDatabase(): Promise<{
   const client = new Client({ connectionString: databaseUrl(name) });
   await client.connect();
   return { name, url: databaseUrl(name), client };
+}
+
+function releaseBarrierMigration(idx: number, tag: string, statement: string) {
+  return {
+    entry: {
+      idx,
+      version: "7",
+      when: 1_900_000_000_000 + idx,
+      tag,
+      breakpoints: true,
+    },
+    hash: `hash-${tag}`,
+    statements: [statement],
+  };
+}
+
+function releaseBarrierMigrations() {
+  return [
+    releaseBarrierMigration(
+      194,
+      RELEASE_BARRIER_CHECKPOINT_TAG,
+      "CREATE TABLE usage_quotas (id uuid, legacy_marker text)",
+    ),
+    releaseBarrierMigration(
+      281,
+      "0281_before_usage_quotas_release",
+      "SELECT 1",
+    ),
+    releaseBarrierMigration(
+      282,
+      RELEASE_BARRIER_DROP_TAG,
+      "DROP TABLE usage_quotas",
+    ),
+    releaseBarrierMigration(
+      283,
+      RELEASE_BARRIER_RESTORE_TAG,
+      "CREATE TABLE usage_quotas (id uuid)",
+    ),
+  ];
+}
+
+function migrationClient(
+  client: pg.Client,
+  beforeQuery: (text: string) => Promise<void> = async () => {},
+) {
+  return {
+    backend: "postgres" as const,
+    query: async <T = unknown>(text: string, params?: unknown[]) => {
+      await beforeQuery(text);
+      const result = await client.query(text, params);
+      return { rows: result.rows as T[] };
+    },
+    end: async () => {
+      await client.end();
+    },
+  };
 }
 
 async function journalEntries(): Promise<JournalEntry[]> {
@@ -611,7 +679,9 @@ async function runScript(
 }
 
 async function waitForAdvisoryLock(client: pg.Client): Promise<void> {
-  const deadline = Date.now() + 5_000;
+  // The migrator is a fresh Bun subprocess and may need to load the workspace
+  // graph before opening its session on a busy CI host.
+  const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     const result = await client.query<{ count: string }>(`
       SELECT count(*)::text AS count
@@ -1175,7 +1245,7 @@ describe.skipIf(!ENABLED)(
       expect(preflight.exitCode, preflight.output).toBe(0);
       expect(preflight.output).toContain("catalog and journal verified");
       await database.client.end();
-    }, 30_000);
+    }, 120_000);
 
     test("rejects a wiped empty ledger without changing a nonempty live schema", async () => {
       const database = await createDatabase();
@@ -1197,6 +1267,131 @@ describe.skipIf(!ENABLED)(
       );
       expect(ledger.rows[0]?.count).toBe("0");
       await database.client.end();
+    }, 30_000);
+
+    test("migrates a fresh PostgreSQL database through the full journal exactly once", async () => {
+      const database = await createDatabase();
+      const entries = await journalEntries();
+
+      const first = await runScript(MIGRATOR, database.url);
+      expect(first.exitCode, first.output).toBe(0);
+      expect(first.output).toMatch(await expectedPendingBanner(0));
+      expect(first.output).toContain(
+        "applying 0282_drop_unused_usage_quotas_table",
+      );
+      expect(first.output).toContain(
+        "applying 0282_01_restore_usage_quotas_compatibility",
+      );
+      expect(first.output).toContain("migrations complete");
+
+      const state = await database.client.query<{
+        ledger_count: string;
+        usage_quotas_table: string | null;
+      }>(`
+        SELECT
+          (SELECT count(*)::text FROM drizzle.__drizzle_migrations)
+            AS ledger_count,
+          to_regclass('public.usage_quotas')::text AS usage_quotas_table
+      `);
+      expect(state.rows).toEqual([
+        {
+          ledger_count: String(entries.length),
+          usage_quotas_table: "usage_quotas",
+        },
+      ]);
+
+      const second = await runScript(MIGRATOR, database.url);
+      expect(second.exitCode, second.output).toBe(0);
+      expect(second.output).toMatch(/^\[db:migrate\] pending migrations: 0$/m);
+      expect(second.output).not.toContain("applying ");
+      await database.client.end();
+    }, 120_000);
+
+    test("keeps the guarded table continuously available to a concurrent PostgreSQL session", async () => {
+      const database = await createDatabase();
+      const observer = new Client({ connectionString: database.url });
+      await observer.connect();
+      let signalRestoreReached: (() => void) | undefined;
+      let releaseRestore: (() => void) | undefined;
+      const restoreReached = new Promise<void>((resolve) => {
+        signalRestoreReached = resolve;
+      });
+      const restoreMayRun = new Promise<void>((resolve) => {
+        releaseRestore = resolve;
+      });
+      const restoreStatement = "CREATE TABLE usage_quotas (id uuid)";
+      const migrations = releaseBarrierMigrations();
+      const migrationRun = runMigrations(
+        migrationClient(database.client, async (text) => {
+          if (text !== restoreStatement) return;
+          signalRestoreReached?.();
+          await restoreMayRun;
+        }),
+        migrations,
+        RELEASE_BARRIER_OPTIONS,
+        undefined,
+        undefined,
+        async () => {},
+      );
+
+      await restoreReached;
+      let observerSettled = false;
+      const concurrentRead = observer
+        .query<{ count: string }>(
+          "SELECT count(*)::text AS count FROM usage_quotas",
+        )
+        .finally(() => {
+          observerSettled = true;
+        });
+      await Bun.sleep(100);
+      expect(observerSettled).toBe(false);
+
+      releaseRestore?.();
+      await migrationRun;
+      expect((await concurrentRead).rows).toEqual([{ count: "0" }]);
+      const pairLedger = await observer.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",
+        [migrations.slice(2).map((migration) => migration.entry.when)],
+      );
+      expect(pairLedger.rows).toEqual([{ count: "2" }]);
+      await observer.end();
+    }, 30_000);
+
+    test("rolls back the guarded drop and both ledger rows when PostgreSQL restore fails", async () => {
+      const database = await createDatabase();
+      const observer = new Client({ connectionString: database.url });
+      await observer.connect();
+      const migrations = releaseBarrierMigrations();
+      const restoreStatement = "CREATE TABLE usage_quotas (id uuid)";
+
+      await expect(
+        runMigrations(
+          migrationClient(database.client, async (text) => {
+            if (text === restoreStatement) {
+              throw new Error("injected restore failure");
+            }
+          }),
+          migrations,
+          RELEASE_BARRIER_OPTIONS,
+          undefined,
+          undefined,
+          async () => {},
+        ),
+      ).rejects.toThrow("injected restore failure");
+
+      const table = await observer.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM usage_quotas",
+      );
+      expect(table.rows).toEqual([{ count: "0" }]);
+      const ledger = await observer.query<{ created_at: string }>(
+        "SELECT created_at::text FROM drizzle.__drizzle_migrations ORDER BY id",
+      );
+      expect(ledger.rows).toEqual(
+        migrations.slice(0, 2).map((migration) => ({
+          created_at: String(migration.entry.when),
+        })),
+      );
+      await observer.end();
     }, 30_000);
 
     test("restores the legacy usage-quota shape when 0282 is already ledgered", async () => {

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -1177,6 +1177,28 @@ describe.skipIf(!ENABLED)(
       await database.client.end();
     }, 30_000);
 
+    test("rejects a wiped empty ledger without changing a nonempty live schema", async () => {
+      const database = await createDatabase();
+      await database.client.query(
+        "CREATE TABLE live_data (id integer PRIMARY KEY, value text NOT NULL)",
+      );
+      await database.client.query(
+        "INSERT INTO live_data (id, value) VALUES (1, 'preserve-me')",
+      );
+
+      const result = await runScript(MIGRATOR, database.url);
+      expect(result.exitCode).toBe(1);
+      const preserved = await database.client.query<{ value: string }>(
+        "SELECT value FROM live_data WHERE id = 1",
+      );
+      expect(preserved.rows).toEqual([{ value: "preserve-me" }]);
+      const ledger = await database.client.query<{ count: string }>(
+        "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations",
+      );
+      expect(ledger.rows[0]?.count).toBe("0");
+      await database.client.end();
+    }, 30_000);
+
     test("restores the legacy usage-quota shape when 0282 is already ledgered", async () => {
       const database = await createDatabase();
       await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
@@ -128,7 +128,7 @@ const USAGE_QUOTAS_RELEASE_BARRIER_TAGS = [
 ] as const;
 
 type MigrationReleaseBarrierDecision =
-  | { action: "continue" }
+  | { action: "continue"; atomicPairStartIndex?: number }
   | { action: "pause"; stopBeforeJournalIndex: number };
 
 async function readJournal(): Promise<Journal> {
@@ -302,6 +302,57 @@ async function getAppliedMigrations(
   return result.rows;
 }
 
+/**
+ * Proves that an empty ledger belongs to a database with no application
+ * relations. The migration lock and this query share one session, so a wiped
+ * or truncated ledger cannot impersonate a new database and replay destructive
+ * historical DDL over a live schema.
+ */
+async function assertEmptyLedgerDatabaseIsFresh(
+  client: MigrationClient,
+): Promise<void> {
+  const result = await client.query<{ has_user_relations: boolean }>(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_class AS relation
+      JOIN pg_catalog.pg_namespace AS namespace
+        ON namespace.oid = relation.relnamespace
+      WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+        AND namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND NOT (
+          namespace.nspname = '${MIGRATIONS_SCHEMA}'
+          AND relation.relname IN (
+            '${MIGRATIONS_TABLE}',
+            '${MIGRATIONS_TABLE}_id_seq'
+          )
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_class'::regclass
+            AND dependency.objid = relation.oid
+            AND dependency.deptype = 'e'
+        )
+    ) AS has_user_relations
+  `);
+  if (
+    result.rows.length !== 1 ||
+    typeof result.rows[0]?.has_user_relations !== "boolean"
+  ) {
+    throw new Error(
+      "Fresh-database migration proof returned an invalid catalog result",
+    );
+  }
+  if (result.rows[0].has_user_relations) {
+    console.error(
+      "[db:migrate] refusing empty-ledger replay because application relations already exist",
+    );
+    throw new Error(
+      "Migration ledger is empty but the database contains application relations; refusing to replay historical migrations",
+    );
+  }
+}
+
 export function validateAppliedMigrationLedger(
   applied: AppliedMigration[],
   migrations: Migration[],
@@ -418,14 +469,12 @@ export function validateAppliedMigrationLedger(
  * prefix but pauses before the drop, and the deploy continues without exposing
  * the currently-served Worker to the missing table.
  *
- * An empty ledger (no applied migration, lastAppliedJournalIndex === -1) is
- * outside that contract. No Worker has ever been served from a database with
- * no migrations and no rows exist to expose, so pausing there protects nothing;
- * it only strands every fresh environment (e2e stacks, cloud:mock, a new PGlite
- * data dir) at 0281 with every later migration unapplied. A fresh ledger
- * therefore continues through the whole journal: the drop runs immediately
- * followed by the restore, whose adjacency is still validated above. Production
- * and staging ledgers are never empty, so their semantics are unchanged.
+ * An empty ledger alone is not evidence of a fresh database: a live database
+ * can have its ledger truncated or lost. The runner separately proves under
+ * the migration lock that no application relations exist before taking the
+ * empty-ledger path. It also applies the drop, restore, and both ledger rows in
+ * one transaction, so no concurrent Worker can observe the missing-table
+ * window even if the freshness assumption is ever weakened accidentally.
  *
  * Environments that already recorded 0282 must proceed directly to the
  * restoring 0282_01 migration. Any other suffix is unsafe and fails closed
@@ -476,9 +525,12 @@ export function evaluateMigrationReleaseBarrier(
     );
   }
 
-  // A fresh database has no served Worker to protect. Only ledgers that have
-  // already applied at least one migration are release-barrier targets.
-  if (lastAppliedJournalIndex === -1) return { action: "continue" };
+  // runMigrations proves an empty ledger belongs to a relation-free database
+  // before honoring this plan. The explicit index also makes atomic pairing a
+  // required execution contract rather than an adjacency assumption.
+  if (lastAppliedJournalIndex === -1) {
+    return { action: "continue", atomicPairStartIndex: dropIndex };
+  }
 
   if (lastAppliedJournalIndex < dropIndex) {
     return { action: "pause", stopBeforeJournalIndex: dropIndex };
@@ -544,48 +596,55 @@ async function releaseMigrationLock(client: MigrationClient): Promise<void> {
   console.log("[db:migrate] released migration lock");
 }
 
-/** Applies one journal migration atomically and retries only after rollback. */
-export async function applyMigration(
+/** Applies one or more journal entries in one transaction and ledger commit. */
+async function applyMigrationBatch(
   client: MigrationClient,
-  migration: Migration,
+  migrations: readonly Migration[],
   options: LockRetryOptions,
 ): Promise<void> {
-  const { entry, statements, hash } = migration;
+  if (migrations.length === 0) {
+    throw new Error("Migration batch must contain at least one journal entry");
+  }
+  const batchLabel = migrations
+    .map((migration) => migration.entry.tag)
+    .join(" + ");
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
-    console.log(
-      `[db:migrate] applying ${entry.tag} (${statements.length} statements, attempt ${attempt}/${options.maxAttempts})`,
-    );
     await client.query("BEGIN");
 
     try {
       await client.query("SELECT set_config('lock_timeout', $1, true)", [
         `${options.timeoutMs}ms`,
       ]);
-      for (const [index, statement] of statements.entries()) {
-        try {
-          await client.query(statement);
-        } catch (error) {
-          console.error(
-            `[db:migrate] failed ${entry.tag} statement ${index + 1}/${statements.length}`,
-          );
-          console.error(`[db:migrate] sql: ${summarizeStatement(statement)}`);
-          console.error(`[db:migrate] error: ${formatDatabaseError(error)}`);
-          throw error;
+      for (const { entry, statements, hash } of migrations) {
+        console.log(
+          `[db:migrate] applying ${entry.tag} (${statements.length} statements, attempt ${attempt}/${options.maxAttempts})`,
+        );
+        for (const [index, statement] of statements.entries()) {
+          try {
+            await client.query(statement);
+          } catch (error) {
+            console.error(
+              `[db:migrate] failed ${entry.tag} statement ${index + 1}/${statements.length}`,
+            );
+            console.error(`[db:migrate] sql: ${summarizeStatement(statement)}`);
+            console.error(`[db:migrate] error: ${formatDatabaseError(error)}`);
+            throw error;
+          }
         }
-      }
 
-      await client.query(
-        `INSERT INTO "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}" (hash, created_at) VALUES ($1, $2)`,
-        [hash, entry.when],
-      );
+        await client.query(
+          `INSERT INTO "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}" (hash, created_at) VALUES ($1, $2)`,
+          [hash, entry.when],
+        );
+      }
       await client.query("COMMIT");
       return;
     } catch (error) {
       await runCleanupSteps(
         [
           {
-            label: `rollback for ${entry.tag}`,
+            label: `rollback for ${batchLabel}`,
             run: async () => {
               await client.query("ROLLBACK");
             },
@@ -597,17 +656,26 @@ export async function applyMigration(
       if (!isLockTimeout(error)) throw error;
       if (attempt === options.maxAttempts) {
         console.error(
-          `[db:migrate] ${entry.tag} exhausted ${options.maxAttempts} lock-timeout attempts`,
+          `[db:migrate] ${batchLabel} exhausted ${options.maxAttempts} lock-timeout attempts`,
         );
         throw error;
       }
       const delayMs = retryDelayMs(attempt, options);
       console.warn(
-        `[db:migrate] ${entry.tag} lock timeout on attempt ${attempt}/${options.maxAttempts}; retrying in ${delayMs}ms`,
+        `[db:migrate] ${batchLabel} lock timeout on attempt ${attempt}/${options.maxAttempts}; retrying in ${delayMs}ms`,
       );
       await sleep(delayMs);
     }
   }
+}
+
+/** Applies one journal migration atomically and retries only after rollback. */
+export async function applyMigration(
+  client: MigrationClient,
+  migration: Migration,
+  options: LockRetryOptions,
+): Promise<void> {
+  await applyMigrationBatch(client, [migration], options);
 }
 
 async function createPGliteClient(url: string): Promise<MigrationClient> {
@@ -688,6 +756,9 @@ export async function runMigrations(
       await ensureMigrationsTable(client);
 
       const applied = await getAppliedMigrations(client);
+      if (applied.length === 0) {
+        await assertEmptyLedgerDatabaseIsFresh(client);
+      }
       const validatedLedger = validateAppliedMigrationLedger(
         applied,
         migrations,
@@ -723,7 +794,34 @@ export async function runMigrations(
         );
       }
 
-      for (const migration of pending) {
+      for (
+        let pendingIndex = 0;
+        pendingIndex < pending.length;
+        pendingIndex++
+      ) {
+        const journalIndex =
+          validatedLedger.lastAppliedJournalIndex + 1 + pendingIndex;
+        if (
+          releaseBarrier.action === "continue" &&
+          releaseBarrier.atomicPairStartIndex === journalIndex
+        ) {
+          const atomicPair = pending.slice(pendingIndex, pendingIndex + 2);
+          if (
+            atomicPair.length !== 2 ||
+            atomicPair[0]?.entry.tag !== USAGE_QUOTAS_RELEASE_BARRIER_TAGS[0] ||
+            atomicPair[1]?.entry.tag !== USAGE_QUOTAS_RELEASE_BARRIER_TAGS[1]
+          ) {
+            throw new Error(
+              "Migration release barrier atomic pair no longer matches the validated journal",
+            );
+          }
+          await applyMigrationBatch(client, atomicPair, retryOptions);
+          pendingIndex += 1;
+          continue;
+        }
+        const migration = pending[pendingIndex];
+        if (!migration)
+          throw new Error("Migration plan contains an empty entry");
         await applyMigration(client, migration, retryOptions);
       }
 

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.ts
@@ -411,11 +411,25 @@ export function validateAppliedMigrationLedger(
 
 /**
  * Fences the two-step usage-quotas repair while the compatibility Worker is
- * being rolled out. Any validated ledger before 0282 may apply its safe prefix
- * but pauses before the drop so the deploy can continue without exposing the
- * old Worker to the missing table. Environments that already recorded 0282
- * must proceed directly to the restoring 0282_01 migration. Any other suffix is
- * unsafe and fails closed before the first pending migration is applied.
+ * being rolled out (#23829 Phase A, #23859). What the barrier protects is a
+ * LIVE deployment: a Worker already serving traffic against this database must
+ * never run against the window between 0282 (drop) and 0282_01 (restore). So a
+ * validated ledger that already carries applied migrations may apply its safe
+ * prefix but pauses before the drop, and the deploy continues without exposing
+ * the currently-served Worker to the missing table.
+ *
+ * An empty ledger (no applied migration, lastAppliedJournalIndex === -1) is
+ * outside that contract. No Worker has ever been served from a database with
+ * no migrations and no rows exist to expose, so pausing there protects nothing;
+ * it only strands every fresh environment (e2e stacks, cloud:mock, a new PGlite
+ * data dir) at 0281 with every later migration unapplied. A fresh ledger
+ * therefore continues through the whole journal: the drop runs immediately
+ * followed by the restore, whose adjacency is still validated above. Production
+ * and staging ledgers are never empty, so their semantics are unchanged.
+ *
+ * Environments that already recorded 0282 must proceed directly to the
+ * restoring 0282_01 migration. Any other suffix is unsafe and fails closed
+ * before the first pending migration is applied.
  */
 export function evaluateMigrationReleaseBarrier(
   migrations: Migration[],
@@ -461,6 +475,10 @@ export function evaluateMigrationReleaseBarrier(
       `Migration release barrier expected adjacent journal entries (${expectedSuffix}); found (${actualSuffix || "empty"})`,
     );
   }
+
+  // A fresh database has no served Worker to protect. Only ledgers that have
+  // already applied at least one migration are release-barrier targets.
+  if (lastAppliedJournalIndex === -1) return { action: "continue" };
 
   if (lastAppliedJournalIndex < dropIndex) {
     return { action: "pause", stopBeforeJournalIndex: dropIndex };


### PR DESCRIPTION
## Successor to #25306

This draft keeps the fresh-database unblock from #25306 but removes its unsafe assumption that an empty migration ledger proves an empty database.

### Safety contract

- Under the migration lock, an empty ledger must also prove there are no non-extension application relations. A wiped or truncated ledger on a live schema fails closed before historical migration SQL.
- On the admitted fresh path, `0282_drop_unused_usage_quotas_table`, `0282_01_restore_usage_quotas_compatibility`, and both migration-ledger rows commit in one transaction. Failure or lock-timeout retry rolls back the pair together, and a concurrent Worker cannot observe a committed missing-table interval.
- Non-empty deployed ledgers retain the existing pause and repair-forward behavior.
- Real-Postgres pending-count expectations now derive from the journal instead of stale literals.

### Exact validation

Validated commit: `bde2a52014e08de6d6c7a972454ee97170089b69`
Base: `c713ee051bc735c2597ae8b1d694d81f4690adb9`
Toolchain: Bun 1.3.14, Node 24.15.0.

- Focused migration suites: 29 pass / 0 fail.
- Real PGlite: wiped-ledger/nonempty-schema case rejected before migration SQL and preserved sentinel data.
- Real PGlite: relation-free case crossed the guarded pair atomically and ledgered both entries.
- Full fresh PGlite: 292 migrations completed; second run reported 0 pending.
- Full migrated PGlite with deliberately deleted ledger: exited 1 before any `applying` line with the static empty-ledger refusal diagnostic.
- Cloud shared typecheck passed.
- Cloud API typecheck and Worker bundle dry-run passed.
- Biome and diff checks passed. The gated Postgres test file retains three pre-existing environment-registration warnings.

### Evidence hold

Do not merge this draft until the gated real PostgreSQL lane is run on this exact head. It must prove advisory-lock serialization, transactional DDL visibility across a concurrent session, atomic rollback of the drop/restore pair, wiped-ledger preservation, and the journal-derived pending counts. The local environment had no `RUN_REAL_POSTGRES_MIGRATION_TESTS=1` database, so that lane remains explicitly unverified here.

No production database, deployment, or cloud resource was mutated.