### PR TITLE
fix(local-inference): normalize handler priorities safely

### DIFF
--- a/plugins/plugin-local-inference/src/services/handler-registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/handler-registry.test.ts
@@ -115,6 +115,29 @@ describe("local-inference handler-registry mirrors via the core API, not a patch
 		expect(rows[0]).not.toHaveProperty("handler");
 	});
 
+	it("orders non-finite priorities without producing an unstable comparator", async () => {
+		const { runtime, fire } = makeFakeRuntime([]);
+		handlerRegistry.installOn(runtime);
+
+		for (const [provider, priority] of [
+			["not-a-number", Number.NaN],
+			["negative-infinity", Number.NEGATIVE_INFINITY],
+			["finite", 12],
+			["positive-infinity", Number.POSITIVE_INFINITY],
+		] as const) {
+			await fire(payload({ modelType: "NON_FINITE_TYPE", provider, priority }));
+		}
+
+		expect(
+			handlerRegistry.getForType("NON_FINITE_TYPE").map((row) => row.provider),
+		).toEqual([
+			"positive-infinity",
+			"finite",
+			"not-a-number",
+			"negative-infinity",
+		]);
+	});
+
 	it("getForTypeExcluding drops the named provider", async () => {
 		const { runtime, fire } = makeFakeRuntime([]);
 		handlerRegistry.installOn(runtime);


### PR DESCRIPTION
## Summary

- format the handler-registry non-finite priority comparator with the pinned repository formatter
- preserve the explicit ordering contract: `+Infinity`, finite values, `NaN` as zero, then `-Infinity`
- add focused coverage for each priority class

Closes #25397.

## Verification

- `bun install`
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/shared build`
- `bun run --cwd plugins/plugin-local-inference lint:check` — 511 files clean
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bunx vitest run src/services/handler-registry.test.ts` — 6 tests passed
- `git diff --check`

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
