### PR TITLE
fix(cloud): make Personal Shared lifecycle E2E self-contained

### DIFF
--- a/packages/cloud/e2e/tests/personal-eliza-group-lifecycle.spec.ts
+++ b/packages/cloud/e2e/tests/personal-eliza-group-lifecycle.spec.ts
@@ -21,13 +21,9 @@
  * group repository (cloud-shared db/repositories/personal-shared-groups.ts).
  *
  * Harness notes:
- * - Env passthrough: the Worker only sees env keys sync-api-dev-vars knows
- *   (.env.example keys, real values in cloud/shared/.env[.local], and the
- *   provider-key allowlist). OPENROUTER_BASE_URL is not in .env.example, so
- *   this spec requires an `OPENROUTER_BASE_URL=` line in cloud/shared/.env or
- *   .env.local (any value — the spec's override wins). The worker fixture
- *   fails fast with that instruction instead of letting the Worker dial the
- *   real OpenRouter host with the scripted key.
+ * - Env passthrough: sync-api-dev-vars treats OPENROUTER_BASE_URL as a provider
+ *   override, so the worker fixture can route the scripted key to its loopback
+ *   model without requiring or persisting developer-local configuration.
  * - Schema seam: the fresh-DB migrate lane pauses at the 0282 usage-quotas
  *   release barrier, so the group tables (0297) and their authority-version
  *   (0303) and delivery-lease (0304) columns never exist on a booted e2e
@@ -41,7 +37,7 @@
  *   command says "remind us", which the explicit-delay parser does not own.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import {
   createServer,
   type IncomingMessage,
@@ -472,29 +468,6 @@ function createGatewayCaptureServer(captured: CapturedDelivery[]): Server {
   });
 }
 
-/**
- * sync-api-dev-vars forwards a process-env override into the Worker's
- * `.dev.vars` only for keys it already knows. Fail before the stack boots when
- * OPENROUTER_BASE_URL cannot reach the Worker, naming the fix.
- */
-function assertScriptedModelRouteIsForwardable(): void {
-  const known = [".env.example", ".env", ".env.local"].some((name) => {
-    const file = resolve(CLOUD_SHARED_DIR, name);
-    return (
-      existsSync(file) &&
-      /^\s*OPENROUTER_BASE_URL\s*=\s*\S/m.test(readFileSync(file, "utf8"))
-    );
-  });
-  if (!known) {
-    throw new Error(
-      "personal-eliza-group-lifecycle needs the Worker to honour OPENROUTER_BASE_URL, " +
-        "which sync-api-dev-vars only forwards for keys present in cloud/shared/.env[.local]. " +
-        "Add a line `OPENROUTER_BASE_URL=http://127.0.0.1:1/v1` to packages/cloud/shared/.env.local " +
-        "(any value; this spec overrides it with the scripted model URL).",
-    );
-  }
-}
-
 interface GroupHarness {
   /** Scripted OpenAI-compatible `/v1` base the Worker's OpenRouter client dials. */
   modelUrl: string;
@@ -512,7 +485,6 @@ const test = base.extend<Record<never, never>, { groupHarness: GroupHarness }>({
   groupHarness: [
     // biome-ignore lint/correctness/noEmptyPattern: Playwright derives fixture dependencies from this destructuring pattern; the harness has none.
     async ({}, use) => {
-      assertScriptedModelRouteIsForwardable();
       const deliveries: CapturedDelivery[] = [];
       const model = createScriptedModelServer();
       const gateway = createGatewayCaptureServer(deliveries);

--- a/packages/cloud/scripts/admin/sync-api-dev-vars.ts
+++ b/packages/cloud/scripts/admin/sync-api-dev-vars.ts
@@ -110,6 +110,9 @@ const sourceEnvFiles = [
 const env: Record<string, string> = {};
 const providerOverrideKeys = new Set([
   "OPENROUTER_API_KEY",
+  // Deterministic and local test stacks may route the OpenRouter-compatible
+  // client to a loopback server without mutating developer .env files.
+  "OPENROUTER_BASE_URL",
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
   "ANTHROPIC_API_KEY",


### PR DESCRIPTION
## Post-merge correction for #25349

#25349 merged while its exact-head review was running. This follow-up removes the hidden-machine-state requirement discovered during independent execution.

## Correction

`sync-api-dev-vars` now treats `OPENROUTER_BASE_URL` as an explicit provider override, alongside the corresponding API key and the existing OpenAI base URL. The E2E can therefore route its scripted model to an ephemeral loopback server from a clean checkout without asking the developer to create `.env.local` or relying on stale generated `.dev.vars`.

The obsolete file-probing assertion and manual setup instructions are removed.

## Exact validation

Pinned Bun 1.3.14 / Node 24.15.0:

- Original #25349 exact head `92f6ff6df6eac3762542ff7535059c20b2fe6812`: full dependency build 60/60; cloud-e2e typecheck; Biome; hosted Static Smoke; real local Worker/PGlite/Durable Objects lifecycle run passed (26.5 s test body, 1.5 min wall).
- Pre-rebase corrected head `12792ce77db0d8157c00d204dc97ac989584607d`: removed both `.env.local` and generated cloud-api `.dev.vars`, then reran the same real lifecycle successfully (1.4 min test body, 2.6 min wall); touched-file Biome passed with only the script's existing undeclared-env warnings; `git diff --check` passed.
- Current exact rebased head: `abcc65d6f2a0ab6bb06234224b2fa4580bd276c9`; #25349 is now in the base, so this PR contains only the two-file correction above.
- Rebuilt current `@elizaos/core` artifacts after the rebase, then reran the current-head lifecycle successfully: 1.6 min test body, 3.7 min wall.

No runtime route, persistence, scheduler, or connector behavior changes. The only production-adjacent change is honoring an explicitly supplied local/provider base URL in the existing dev-var synchronization path.
