### PR TITLE
fix(cloud): filter undisplayable gallery rows in SQL, not after pagination

### DIFF
--- a/packages/cloud/api/v1/gallery/route.ts
+++ b/packages/cloud/api/v1/gallery/route.ts
@@ -62,6 +62,7 @@ app.get("/", async (c) => {
         {
           userId: user.id,
           type,
+          requireStorageUrl: true,
           limit: fetchLimit,
           offset,
         },

--- a/packages/cloud/shared/src/db/repositories/__tests__/generations-gallery-pagination.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/generations-gallery-pagination.pglite.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Real-PGlite proof that the gallery listing applies its displayability filter
+ * in SQL rather than after LIMIT/OFFSET.
+ *
+ * The gallery route pages with LIMIT/OFFSET and then drops rows without a
+ * storage_url in JavaScript. Rows that can never be displayed therefore consume
+ * slots in the database page, so a full page can come back short and, once every
+ * row in the final page is undisplayable, hasMore flips false while completed
+ * rows remain unread.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { dbWrite } from "../../client";
+import { apiKeys } from "../../schemas/api-keys";
+import { generations } from "../../schemas/generations";
+import { organizations } from "../../schemas/organizations";
+import { usageRecords } from "../../schemas/usage-records";
+import { users } from "../../schemas/users";
+import { GenerationsRepository } from "../generations";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORG_ID = "00000000-0000-4000-8000-0000000a0001";
+
+let schemaFailure = "";
+
+beforeAll(async () => {
+  try {
+    const { apply } = await pushSchema(
+      { organizations, users, apiKeys, usageRecords, generations } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  await dbWrite.delete(generations);
+  await dbWrite.delete(organizations);
+  await dbWrite
+    .insert(organizations)
+    .values({ id: ORG_ID, name: "gallery-org", slug: "gallery-org" } as never);
+});
+
+async function seed(rows: Array<{ storageUrl: string | null; createdAt: Date }>): Promise<void> {
+  for (const [index, row] of rows.entries()) {
+    await dbWrite.insert(generations).values({
+      organization_id: ORG_ID,
+      type: "image",
+      model: "test-model",
+      provider: "test-provider",
+      prompt: `prompt-${index}`,
+      status: "completed",
+      storage_url: row.storageUrl,
+      created_at: row.createdAt,
+    } as never);
+  }
+}
+
+describe("gallery listing pagination", () => {
+  test(
+    "applies the storage-url filter in SQL so LIMIT counts only displayable rows",
+    async () => {
+      // Newest first: three undisplayable rows ahead of two displayable ones.
+      await seed([
+        { storageUrl: "https://cdn.test/older-b", createdAt: new Date("2026-01-01T00:00:00Z") },
+        { storageUrl: "https://cdn.test/older-a", createdAt: new Date("2026-01-02T00:00:00Z") },
+        { storageUrl: null, createdAt: new Date("2026-01-03T00:00:00Z") },
+        { storageUrl: null, createdAt: new Date("2026-01-04T00:00:00Z") },
+        { storageUrl: null, createdAt: new Date("2026-01-05T00:00:00Z") },
+      ]);
+
+      const repository = new GenerationsRepository();
+      const limit = 2;
+      const page = await repository.listByOrganizationAndStatusSummary(ORG_ID, "completed", {
+        requireStorageUrl: true,
+        limit: limit + 1,
+        offset: 0,
+      });
+
+      // Without the SQL filter the first page is consumed entirely by the three
+      // null-storage rows, so the caller sees zero items and hasMore === false
+      // while two displayable rows remain permanently unreachable.
+      const displayable = page.filter((row) => row.storage_url);
+      expect(displayable.length).toBe(2);
+      expect(displayable.map((row) => row.storage_url)).toEqual([
+        "https://cdn.test/older-a",
+        "https://cdn.test/older-b",
+      ]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "still returns undisplayable rows when the caller does not ask for the filter",
+    async () => {
+      await seed([
+        { storageUrl: null, createdAt: new Date("2026-01-03T00:00:00Z") },
+        { storageUrl: "https://cdn.test/one", createdAt: new Date("2026-01-02T00:00:00Z") },
+      ]);
+
+      const repository = new GenerationsRepository();
+      const page = await repository.listByOrganizationAndStatusSummary(ORG_ID, "completed", {
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(page.length).toBe(2);
+      expect(page.some((row) => row.storage_url === null)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/generations.ts
+++ b/packages/cloud/shared/src/db/repositories/generations.ts
@@ -1,6 +1,6 @@
 // Persists generations records for cloud services through the shared DB boundary.
 import { randomUUID } from "node:crypto";
-import { and, asc, count, desc, eq, sql, sum } from "drizzle-orm";
+import { and, asc, count, desc, eq, isNotNull, sql, sum } from "drizzle-orm";
 import { VIDEO_PENDING_SETTLEMENT_MARKER } from "../../lib/providers/video/types";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import {
@@ -310,6 +310,7 @@ export class GenerationsRepository {
     options?: {
       userId?: string;
       type?: string;
+      requireStorageUrl?: boolean;
       limit?: number;
       offset?: number;
     },
@@ -325,6 +326,10 @@ export class GenerationsRepository {
 
     if (options?.type) {
       conditions.push(eq(generations.type, options.type));
+    }
+
+    if (options?.requireStorageUrl) {
+      conditions.push(isNotNull(generations.storage_url));
     }
 
     const rows = await dbRead.query.generations.findMany({

--- a/packages/cloud/shared/src/lib/services/generations.ts
+++ b/packages/cloud/shared/src/lib/services/generations.ts
@@ -71,6 +71,7 @@ export class GenerationsService {
     options?: {
       userId?: string;
       type?: string;
+      requireStorageUrl?: boolean;
       limit?: number;
       offset?: number;
     },


### PR DESCRIPTION
# Relates to

No separate issue — the defect and its user-visible consequence are described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`, built directly on the current `origin/develop` tree, zero conflicts.
- [x] Proven against a real PGlite database, with the mutation output quoted below.
- [x] A reviewer can confirm the behaviour from the test output without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Four files differ from `develop`; three are one-line additions.

# Risks

Low, and the new behaviour is opt-in. The repository predicate applies only when a caller passes `requireStorageUrl: true`, which today is the gallery route alone. Every other caller of `listByOrganizationAndStatusSummary` keeps its current result set unchanged, pinned by the second test below.

# Background

## What does this PR do?

`GET /api/v1/gallery` pages with `LIMIT/OFFSET` at the database, then removes rows that cannot be rendered in JavaScript:

```ts
const allGenerations = await generationsService.listByOrganizationAndStatusSummary(
  user.organization_id, "completed", { userId: user.id, type, limit: fetchLimit, offset },
);
const generations = allGenerations.filter((gen) => gen.storage_url);
```

A completed generation can have a null `storage_url`. Those rows still occupy slots in the database page, so the page returns fewer items than `limit`.

The serious part is the cursor. `hasMore` is computed from the **post-filter** array:

```ts
hasMore: generations.length > limit
```

When every row in a page lacks `storage_url`, `generations.length` is `0`, `hasMore` is `false`, and the client stops paging — while displayable rows still sit behind that offset. They are not merely delayed; they become **unreachable**, because no subsequent request is ever issued.

## What is the fix?

Push the predicate into the query so `LIMIT` counts only displayable rows:

```ts
if (options?.requireStorageUrl) {
  conditions.push(isNotNull(generations.storage_url));
}
```

The gallery route opts in; the service and repository option is threaded through. The route's existing JS filter is left in place as a harmless belt-and-braces guard, so this PR does not change what the route emits — only which rows the database returns.

# Documentation changes needed?

No. The new option is internal to the repository and service; no public HTTP contract, response shape, or setting changes.

# Testing

## Where should a reviewer start?

The mutation block below. It shows the exact scenario in which a user loses access to their own completed generations.

## Detailed testing steps

New suite `generations-gallery-pagination.pglite.test.ts` runs against a **real PGlite database** through the actual `GenerationsRepository` — no stubbed query builder and no reimplemented pagination.

The fixture seeds five completed rows, newest first: three with `storage_url = NULL`, then two displayable ones. With `limit = 2` the route requests `limit + 1 = 3` rows at offset 0, so the three undisplayable rows fill the entire first page.

| Gate | Result |
| --- | --- |
| `bun test packages/cloud/shared/src/db/repositories/__tests__/generations-gallery-pagination.pglite.test.ts` | **2 pass, 0 fail** |
| `biome check` (repository-pinned 2.5.8) on all four files | `No fixes applied.` |

Mutation resistance — reverting **only** the four-line SQL predicate and keeping the tests:

```
Expected: 2
Received: 0
(fail) gallery listing pagination > applies the storage-url filter in SQL so LIMIT counts only displayable rows
 1 pass
 1 fail
```

Without the fix the caller receives **zero** displayable rows even though two exist and are reachable in the same query — the state in which `hasMore` goes false and the remaining generations can never be paged to.

The second test is the guard in the other direction: a caller that omits `requireStorageUrl` still receives rows with a null `storage_url`. It passes in both directions by design, which is what keeps this change opt-in.

# Evidence Gate

<!-- evidence-head:6340cf32e43187e896a139dc82ad9e8a0d95d138 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend pagination change; the observable artifact is the row set returned by the query, shown in the test output above`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend pagination change; no rendered surface is modified by this diff`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the behaviour is a database result set, asserted directly against real PGlite rather than demonstrated visually`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; the repository is exercised directly against a real PGlite database in the suite above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model call is involved in gallery pagination`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — real PGlite rows returned by the repository.

<details>
<summary>Seeded rows and the exact result set asserted</summary>

Seed (newest first), all `status = completed` in one organization:

```
created_at                 storage_url
2026-01-05T00:00:00Z       NULL
2026-01-04T00:00:00Z       NULL
2026-01-03T00:00:00Z       NULL
2026-01-02T00:00:00Z       https://cdn.test/older-a
2026-01-01T00:00:00Z       https://cdn.test/older-b
```

Query: `listByOrganizationAndStatusSummary(ORG, "completed", { requireStorageUrl: true, limit: 3, offset: 0 })`

With the fix — the two displayable rows are returned in `created_at DESC` order:

```
2 pass
0 fail
Ran 2 tests across 1 file.
```

Reverting only the SQL predicate, same rows, same query:

```
Expected: 2
Received: 0
(fail) gallery listing pagination > applies the storage-url filter in SQL so LIMIT counts only displayable rows
 1 pass
 1 fail
```

</details>
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a boundary-condition sweep of `packages/cloud`.
- Independent verification, the real-PGlite regression suite replacing the originally proposed in-test reimplementation, and the mutation proof by Claude Code (`claude-opus-5`).

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Attribution status: self-reported
