### PR TITLE
test(app-core): cover update notifier gating

### DIFF
--- a/packages/app-core/src/services/__tests__/update-notifier.test.ts
+++ b/packages/app-core/src/services/__tests__/update-notifier.test.ts
@@ -30,23 +30,24 @@ describe("scheduleUpdateNotification", () => {
     mocks.loadElizaConfig.mockReset();
     mocks.resolveChannel.mockReset();
     mocks.resolveChannel.mockReturnValue("stable");
-    originalIsTTY = process.stderr.isTTY;
+    originalIsTTY = (process.stderr as { isTTY?: boolean }).isTTY;
     originalCI = process.env.CI;
     mod = await import("./update-notifier.ts");
   });
 
   afterEach(() => {
-    Object.defineProperty(process.stderr, "isTTY", {
-      value: originalIsTTY,
-      configurable: true,
-    });
+    (process.stderr as { isTTY?: boolean }).isTTY = originalIsTTY;
     if (originalCI === undefined) delete process.env.CI;
     else process.env.CI = originalCI;
   });
 
+  function forceTTY(on: boolean) {
+    (process.stderr as { isTTY?: boolean }).isTTY = on;
+  }
+
   it("skips when checkOnStart is disabled", async () => {
     mocks.loadElizaConfig.mockReturnValue({ update: { checkOnStart: false } });
-    Object.defineProperty(process.stderr, "isTTY", { value: true });
+    forceTTY(true);
     mod.scheduleUpdateNotification();
     expect(mocks.checkForUpdate).not.toHaveBeenCalled();
   });
@@ -60,7 +61,7 @@ describe("scheduleUpdateNotification", () => {
 
   it("writes an update notice when a newer version exists", async () => {
     mocks.loadElizaConfig.mockReturnValue({});
-    Object.defineProperty(process.stderr, "isTTY", { value: true });
+    forceTTY(true);
     mocks.checkForUpdate.mockResolvedValue({
       updateAvailable: true,
       latestVersion: "2.0.0",

--- a/packages/app-core/src/services/__tests__/update-notifier.test.ts
+++ b/packages/app-core/src/services/__tests__/update-notifier.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+  loadElizaConfig: vi.fn(),
+  resolveChannel: vi.fn(() => "stable"),
+  theme: {
+    accent: vi.fn((t: string) => `a(${t})`),
+    muted: vi.fn((t: string) => `m(${t})`),
+    success: vi.fn((t: string) => `s(${t})`),
+    command: vi.fn((t: string) => `c(${t})`),
+  },
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  checkForUpdate: (...a: unknown[]) => mocks.checkForUpdate(...a),
+  loadElizaConfig: (...a: unknown[]) => mocks.loadElizaConfig(...a),
+  resolveChannel: (...a: unknown[]) => mocks.resolveChannel(...a),
+}));
+vi.mock("@elizaos/shared", () => ({ theme: mocks.theme }));
+
+describe("scheduleUpdateNotification", () => {
+  let originalIsTTY: boolean | undefined;
+  let originalCI: string | undefined;
+  let mod: typeof import("./update-notifier.ts");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mocks.checkForUpdate.mockReset();
+    mocks.loadElizaConfig.mockReset();
+    mocks.resolveChannel.mockReset();
+    mocks.resolveChannel.mockReturnValue("stable");
+    originalIsTTY = process.stderr.isTTY;
+    originalCI = process.env.CI;
+    mod = await import("./update-notifier.ts");
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    if (originalCI === undefined) delete process.env.CI;
+    else process.env.CI = originalCI;
+  });
+
+  it("skips when checkOnStart is disabled", async () => {
+    mocks.loadElizaConfig.mockReturnValue({ update: { checkOnStart: false } });
+    Object.defineProperty(process.stderr, "isTTY", { value: true });
+    mod.scheduleUpdateNotification();
+    expect(mocks.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("skips in CI", async () => {
+    mocks.loadElizaConfig.mockReturnValue({});
+    process.env.CI = "true";
+    mod.scheduleUpdateNotification();
+    expect(mocks.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("writes an update notice when a newer version exists", async () => {
+    mocks.loadElizaConfig.mockReturnValue({});
+    Object.defineProperty(process.stderr, "isTTY", { value: true });
+    mocks.checkForUpdate.mockResolvedValue({
+      updateAvailable: true,
+      latestVersion: "2.0.0",
+      currentVersion: "1.0.0",
+    });
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    mod.scheduleUpdateNotification();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(write).toHaveBeenCalledWith(
+      expect.stringContaining("Update available"),
+    );
+    write.mockRestore();
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
