### PR TITLE
test(agent): cover model-metadata

### DIFF
--- a/packages/agent/src/config/model-metadata.test.ts
+++ b/packages/agent/src/config/model-metadata.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Behavioral coverage for model-definition normalization and per-model token
+ * metadata resolution. Drives the real module: no mocks. Deterministic.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MODEL_CONTEXT_WINDOW,
+  DEFAULT_MODEL_MAX_TOKENS,
+  normalizeModelDefinitionConfig,
+  normalizeModelMetadataInConfig,
+  resolveModelTokenMetadata,
+} from "./model-metadata.ts";
+import type {
+  ElizaConfig,
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "./types.ts";
+
+function definition(
+  partial: Partial<ModelDefinitionConfig> & { id: string },
+): ModelDefinitionConfig {
+  return {
+    name: partial.id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_MODEL_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MODEL_MAX_TOKENS,
+    ...partial,
+    id: partial.id,
+  };
+}
+
+function provider(models: ModelDefinitionConfig[]): ModelProviderConfig {
+  return {
+    baseUrl: "https://example.invalid",
+    models,
+  };
+}
+
+function configOf(
+  providers: Record<string, ModelProviderConfig>,
+  extras?: {
+    bedrockDiscovery?: NonNullable<ElizaConfig["models"]>["bedrockDiscovery"];
+    contextTokens?: number;
+  },
+): ElizaConfig {
+  const config: ElizaConfig = {
+    models: {
+      providers,
+      ...(extras?.bedrockDiscovery
+        ? { bedrockDiscovery: extras.bedrockDiscovery }
+        : {}),
+    },
+  };
+  if (extras?.contextTokens !== undefined) {
+    config.agents = { defaults: { contextTokens: extras.contextTokens } };
+  }
+  return config;
+}
+
+describe("model-metadata defaults", () => {
+  it("exposes the documented runtime fallbacks", () => {
+    expect(DEFAULT_MODEL_CONTEXT_WINDOW).toBe(128_000);
+    expect(DEFAULT_MODEL_MAX_TOKENS).toBe(8_192);
+  });
+});
+
+describe("normalizeModelDefinitionConfig", () => {
+  it("fills every required field from an id-only partial", () => {
+    const result = normalizeModelDefinitionConfig({ id: "gpt-4" });
+    expect(result).toEqual({
+      id: "gpt-4",
+      name: "gpt-4",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: DEFAULT_MODEL_CONTEXT_WINDOW,
+      maxTokens: DEFAULT_MODEL_MAX_TOKENS,
+    });
+  });
+
+  it("keeps a non-empty name and falls back to id for blank or non-string names", () => {
+    expect(normalizeModelDefinitionConfig({ id: "m", name: "Opus" }).name).toBe(
+      "Opus",
+    );
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", name: "  padded  " }).name,
+    ).toBe("  padded  ");
+    expect(normalizeModelDefinitionConfig({ id: "m", name: "" }).name).toBe(
+      "m",
+    );
+    expect(normalizeModelDefinitionConfig({ id: "m", name: "   " }).name).toBe(
+      "m",
+    );
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        name: 12 as unknown as string,
+      }).name,
+    ).toBe("m");
+  });
+
+  it("coerces reasoning through Boolean()", () => {
+    expect(normalizeModelDefinitionConfig({ id: "m" }).reasoning).toBe(false);
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", reasoning: false }).reasoning,
+    ).toBe(false);
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", reasoning: true }).reasoning,
+    ).toBe(true);
+  });
+
+  it("prefers the model's positive contextWindow, then defaults, then the runtime fallback", () => {
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", contextWindow: 32_000 })
+        .contextWindow,
+    ).toBe(32_000);
+    expect(
+      normalizeModelDefinitionConfig(
+        { id: "m", contextWindow: 0 },
+        { contextWindow: 64_000 },
+      ).contextWindow,
+    ).toBe(64_000);
+    expect(
+      normalizeModelDefinitionConfig(
+        { id: "m", contextWindow: -1 },
+        { contextWindow: 0 },
+      ).contextWindow,
+    ).toBe(DEFAULT_MODEL_CONTEXT_WINDOW);
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", contextWindow: 4096.9 })
+        .contextWindow,
+    ).toBe(4096);
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        contextWindow: Number.POSITIVE_INFINITY,
+      }).contextWindow,
+    ).toBe(DEFAULT_MODEL_CONTEXT_WINDOW);
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", contextWindow: Number.NaN })
+        .contextWindow,
+    ).toBe(DEFAULT_MODEL_CONTEXT_WINDOW);
+  });
+
+  it("prefers the model's positive maxTokens, then defaults, then the runtime fallback", () => {
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", maxTokens: 1024 }).maxTokens,
+    ).toBe(1024);
+    expect(
+      normalizeModelDefinitionConfig(
+        { id: "m", maxTokens: 0 },
+        { maxTokens: 2048 },
+      ).maxTokens,
+    ).toBe(2048);
+    expect(
+      normalizeModelDefinitionConfig({ id: "m" }, { maxTokens: Number.NaN })
+        .maxTokens,
+    ).toBe(DEFAULT_MODEL_MAX_TOKENS);
+    expect(
+      normalizeModelDefinitionConfig({ id: "m", maxTokens: 512.8 }).maxTokens,
+    ).toBe(512);
+  });
+
+  it("keeps only text/image modalities and defaults when the list is empty or invalid", () => {
+    expect(normalizeModelDefinitionConfig({ id: "m" }).input).toEqual(["text"]);
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        input: "text" as unknown as ModelDefinitionConfig["input"],
+      }).input,
+    ).toEqual(["text"]);
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        input: [],
+      }).input,
+    ).toEqual(["text"]);
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        input: ["audio", "video"] as unknown as ModelDefinitionConfig["input"],
+      }).input,
+    ).toEqual(["text"]);
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        input: [
+          "image",
+          "audio",
+          "text",
+        ] as unknown as ModelDefinitionConfig["input"],
+      }).input,
+    ).toEqual(["image", "text"]);
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        input: ["text", "text", "image"],
+      }).input,
+    ).toEqual(["text", "text", "image"]);
+  });
+
+  it("does not share the default input array across calls", () => {
+    const first = normalizeModelDefinitionConfig({ id: "a" });
+    first.input.push("image");
+    expect(normalizeModelDefinitionConfig({ id: "b" }).input).toEqual(["text"]);
+  });
+
+  it("normalizes cost, treating non-objects, negatives, and non-finite values as zero", () => {
+    expect(normalizeModelDefinitionConfig({ id: "m" }).cost).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        cost: null as unknown as ModelDefinitionConfig["cost"],
+      }).cost,
+    ).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        cost: [1, 2] as unknown as ModelDefinitionConfig["cost"],
+      }).cost,
+    ).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        cost: {
+          input: 1.5,
+          output: 0,
+          cacheRead: -3,
+          cacheWrite: Number.POSITIVE_INFINITY,
+        },
+      }).cost,
+    ).toEqual({
+      input: 1.5,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    expect(
+      normalizeModelDefinitionConfig({
+        id: "m",
+        cost: {
+          input: Number.NaN,
+          output: 2,
+          cacheRead: 3,
+          cacheWrite: 4,
+        },
+      }).cost,
+    ).toEqual({
+      input: 0,
+      output: 2,
+      cacheRead: 3,
+      cacheWrite: 4,
+    });
+  });
+
+  it("preserves extra model fields through the spread", () => {
+    const result = normalizeModelDefinitionConfig({
+      id: "m",
+      api: "openai-completions",
+      headers: { "x-test": "1" },
+      compat: { maxTokensField: "max_tokens" },
+    });
+    expect(result.api).toBe("openai-completions");
+    expect(result.headers).toEqual({ "x-test": "1" });
+    expect(result.compat).toEqual({ maxTokensField: "max_tokens" });
+  });
+});
+
+describe("normalizeModelMetadataInConfig", () => {
+  it("is a no-op when models or providers are missing", () => {
+    const empty: ElizaConfig = {};
+    normalizeModelMetadataInConfig(empty);
+    expect(empty).toEqual({});
+
+    const noProviders: ElizaConfig = { models: {} };
+    normalizeModelMetadataInConfig(noProviders);
+    expect(noProviders.models).toEqual({});
+  });
+
+  it("is a no-op on an empty providers record", () => {
+    const config: ElizaConfig = { models: { providers: {} } };
+    normalizeModelMetadataInConfig(config);
+    expect(config.models?.providers).toEqual({});
+  });
+
+  it("normalizes every model in place, including an empty models list", () => {
+    const config = configOf({
+      openai: provider([
+        definition({ id: "gpt-4", name: "", contextWindow: 0, maxTokens: -1 }),
+      ]),
+      empty: provider([]),
+    });
+    normalizeModelMetadataInConfig(config);
+    const openai = config.models?.providers?.openai.models[0];
+    expect(openai?.name).toBe("gpt-4");
+    expect(openai?.contextWindow).toBe(DEFAULT_MODEL_CONTEXT_WINDOW);
+    expect(openai?.maxTokens).toBe(DEFAULT_MODEL_MAX_TOKENS);
+    expect(config.models?.providers?.empty.models).toEqual([]);
+  });
+
+  it("applies bedrockDiscovery defaults only to the bedrock provider", () => {
+    const config = configOf(
+      {
+        bedrock: provider([
+          definition({ id: "titan", contextWindow: 0, maxTokens: 0 }),
+        ]),
+        openai: provider([
+          definition({ id: "gpt-4", contextWindow: 0, maxTokens: 0 }),
+        ]),
+      },
+      {
+        bedrockDiscovery: {
+          defaultContextWindow: 200_000,
+          defaultMaxTokens: 4_096,
+        },
+      },
+    );
+    normalizeModelMetadataInConfig(config);
+    expect(config.models?.providers?.bedrock.models[0]?.contextWindow).toBe(
+      200_000,
+    );
+    expect(config.models?.providers?.bedrock.models[0]?.maxTokens).toBe(4_096);
+    expect(config.models?.providers?.openai.models[0]?.contextWindow).toBe(
+      DEFAULT_MODEL_CONTEXT_WINDOW,
+    );
+    expect(config.models?.providers?.openai.models[0]?.maxTokens).toBe(
+      DEFAULT_MODEL_MAX_TOKENS,
+    );
+  });
+
+  it("does not let bedrockDiscovery override a model's own positive token fields", () => {
+    const config = configOf(
+      {
+        bedrock: provider([
+          definition({ id: "titan", contextWindow: 50_000, maxTokens: 1_024 }),
+        ]),
+      },
+      {
+        bedrockDiscovery: {
+          defaultContextWindow: 200_000,
+          defaultMaxTokens: 4_096,
+        },
+      },
+    );
+    normalizeModelMetadataInConfig(config);
+    expect(config.models?.providers?.bedrock.models[0]?.contextWindow).toBe(
+      50_000,
+    );
+    expect(config.models?.providers?.bedrock.models[0]?.maxTokens).toBe(1_024);
+  });
+
+  it("ignores invalid bedrockDiscovery defaults and does not leak them to other providers", () => {
+    const config = configOf(
+      {
+        bedrock: provider([definition({ id: "titan" })]),
+        openai: provider([definition({ id: "gpt-4" })]),
+      },
+      {
+        bedrockDiscovery: {
+          defaultContextWindow: 0,
+          defaultMaxTokens: -8,
+        },
+      },
+    );
+    normalizeModelMetadataInConfig(config);
+    expect(config.models?.providers?.bedrock.models[0]?.contextWindow).toBe(
+      DEFAULT_MODEL_CONTEXT_WINDOW,
+    );
+    expect(config.models?.providers?.openai.models[0]?.contextWindow).toBe(
+      DEFAULT_MODEL_CONTEXT_WINDOW,
+    );
+  });
+});
+
+describe("resolveModelTokenMetadata", () => {
+  it("returns runtime defaults when config, model id, or providers are missing", () => {
+    expect(resolveModelTokenMetadata()).toEqual({
+      modelId: "runtime-default",
+      contextWindow: DEFAULT_MODEL_CONTEXT_WINDOW,
+      maxTokens: DEFAULT_MODEL_MAX_TOKENS,
+      source: "runtime-default",
+    });
+    expect(resolveModelTokenMetadata({}, "gpt-4")).toEqual({
+      modelId: "gpt-4",
+      contextWindow: DEFAULT_MODEL_CONTEXT_WINDOW,
+      maxTokens: DEFAULT_MODEL_MAX_TOKENS,
+      source: "runtime-default",
+    });
+    expect(resolveModelTokenMetadata(configOf({}), "gpt-4").source).toBe(
+      "runtime-default",
+    );
+    expect(
+      resolveModelTokenMetadata(configOf({ openai: provider([]) }), "gpt-4")
+        .source,
+    ).toBe("runtime-default");
+  });
+
+  it("treats a blank or whitespace-only model id as missing", () => {
+    const cfg = configOf({
+      openai: provider([definition({ id: "gpt-4", contextWindow: 32_000 })]),
+    });
+    expect(resolveModelTokenMetadata(cfg, "").source).toBe("runtime-default");
+    expect(resolveModelTokenMetadata(cfg, "   ").source).toBe(
+      "runtime-default",
+    );
+    expect(resolveModelTokenMetadata(cfg, undefined).modelId).toBe(
+      "runtime-default",
+    );
+  });
+
+  it("matches a configured model by id, ignoring case and surrounding whitespace", () => {
+    const cfg = configOf({
+      openai: provider([
+        definition({
+          id: "GPT-4",
+          contextWindow: 32_000,
+          maxTokens: 4_096,
+        }),
+      ]),
+    });
+    expect(resolveModelTokenMetadata(cfg, "  gpt-4  ")).toEqual({
+      modelId: "GPT-4",
+      providerId: "openai",
+      contextWindow: 32_000,
+      maxTokens: 4_096,
+      source: "model-config",
+    });
+  });
+
+  it("matches provider/model, provider/suffix, and bare suffix keys", () => {
+    const cfg = configOf({
+      OpenAI: provider([
+        definition({
+          id: "org/gpt-4",
+          contextWindow: 10_000,
+          maxTokens: 111,
+        }),
+      ]),
+    });
+    expect(resolveModelTokenMetadata(cfg, "org/gpt-4").source).toBe(
+      "model-config",
+    );
+    expect(resolveModelTokenMetadata(cfg, "openai/org/gpt-4").modelId).toBe(
+      "org/gpt-4",
+    );
+    expect(resolveModelTokenMetadata(cfg, "openai/gpt-4").contextWindow).toBe(
+      10_000,
+    );
+    expect(resolveModelTokenMetadata(cfg, "gpt-4").providerId).toBe("OpenAI");
+  });
+
+  it("returns the first provider and first model that match in enumeration order", () => {
+    const cfg = configOf({
+      first: provider([
+        definition({ id: "shared", contextWindow: 1_000, maxTokens: 10 }),
+        definition({ id: "other", contextWindow: 2_000, maxTokens: 20 }),
+      ]),
+      second: provider([
+        definition({ id: "shared", contextWindow: 9_000, maxTokens: 90 }),
+      ]),
+    });
+    expect(resolveModelTokenMetadata(cfg, "shared")).toEqual({
+      modelId: "shared",
+      providerId: "first",
+      contextWindow: 1_000,
+      maxTokens: 10,
+      source: "model-config",
+    });
+  });
+
+  it("falls back to runtime token defaults when a matched model has invalid windows", () => {
+    const cfg = configOf({
+      openai: provider([
+        definition({
+          id: "gpt-4",
+          contextWindow: 0,
+          maxTokens: Number.NaN,
+        }),
+      ]),
+    });
+    expect(resolveModelTokenMetadata(cfg, "gpt-4")).toEqual({
+      modelId: "gpt-4",
+      providerId: "openai",
+      contextWindow: DEFAULT_MODEL_CONTEXT_WINDOW,
+      maxTokens: DEFAULT_MODEL_MAX_TOKENS,
+      source: "model-config",
+    });
+  });
+
+  it("uses agent-defaults contextTokens when no model config matches", () => {
+    const cfg = configOf(
+      {
+        openai: provider([definition({ id: "gpt-4", contextWindow: 32_000 })]),
+      },
+      { contextTokens: 64_000 },
+    );
+    expect(resolveModelTokenMetadata(cfg, "missing-model")).toEqual({
+      modelId: "missing-model",
+      contextWindow: 64_000,
+      maxTokens: DEFAULT_MODEL_MAX_TOKENS,
+      source: "agent-defaults",
+    });
+    expect(resolveModelTokenMetadata(cfg, "  claude  ").modelId).toBe("claude");
+    expect(resolveModelTokenMetadata(cfg).modelId).toBe("runtime-default");
+  });
+
+  it("ignores non-positive agent-defaults contextTokens and uses runtime defaults", () => {
+    expect(
+      resolveModelTokenMetadata(configOf({}, { contextTokens: 0 }), "gpt-4")
+        .source,
+    ).toBe("runtime-default");
+    expect(
+      resolveModelTokenMetadata(configOf({}, { contextTokens: -5 }), "gpt-4")
+        .source,
+    ).toBe("runtime-default");
+  });
+
+  it("prefers a matching model-config entry over agent-defaults", () => {
+    const cfg = configOf(
+      {
+        openai: provider([
+          definition({ id: "gpt-4", contextWindow: 8_000, maxTokens: 256 }),
+        ]),
+      },
+      { contextTokens: 64_000 },
+    );
+    expect(resolveModelTokenMetadata(cfg, "gpt-4")).toEqual({
+      modelId: "gpt-4",
+      providerId: "openai",
+      contextWindow: 8_000,
+      maxTokens: 256,
+      source: "model-config",
+    });
+  });
+
+  it("does not attach providerId on agent-defaults or runtime-default results", () => {
+    expect(
+      resolveModelTokenMetadata(configOf({}, { contextTokens: 4_000 }), "x"),
+    ).not.toHaveProperty("providerId");
+    expect(resolveModelTokenMetadata(undefined, "x")).not.toHaveProperty(
+      "providerId",
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/agent/src/config/model-metadata.ts`, which had no same-named test file.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and was rebased onto the latest fetched `origin/develop` before the focused proof.
- [x] Reviewers can confirm the changed behavior from the committed focused test.

# Sync with develop

- [x] Branched from fetched `origin/develop` at `1ae6e3887ece69a3bc20fcd348e2b9215d7c182c`; zero conflicts.
- [x] Focused vitest / biome / tsc on the new file (full `bun run verify` is out of scope for this test-only diff; hosted CI does not run on this fork).

# Risks

Low. Production `model-metadata.ts` is unchanged. The suite drives the real module: default constants, name/reasoning/input/cost/token-window normalization, in-place config mutation, bedrockDiscovery defaults (bedrock-only, invalid ignored, no override of a model's own positive fields), lookup keys (id / provider/model / suffix, case and trim), first-match order, and source precedence (model-config > agent-defaults > runtime-default).

# Background

## What does this PR do?

Adds `packages/agent/src/config/model-metadata.test.ts` next to `model-metadata.ts`. Import path is `./model-metadata.ts`. Layout and `vitest` imports match sibling config tests (`paths.test.ts`, `env-vars.discord-ownership.test.ts`, `owner-contacts.scoped-source.test.ts`).

Covered behaviour:

- `DEFAULT_MODEL_CONTEXT_WINDOW` / `DEFAULT_MODEL_MAX_TOKENS` documented values
- `normalizeModelDefinitionConfig`: id-only fill, name fallback (empty / whitespace / non-string vs padded keep), `Boolean()` reasoning, contextWindow and maxTokens preference (model → defaults → runtime; floor of positives; reject 0 / negative / NaN / Infinity), input filter (`text`/`image` only, empty/non-array → `["text"]`, no shared default array), cost (non-object/array/null → zeros; negatives and non-finite → 0; fractional input kept), extra fields preserved through the spread
- `normalizeModelMetadataInConfig`: no-op when models/providers missing or empty; in-place normalize including empty model lists; bedrockDiscovery defaults apply only to `bedrock` and only when the model's own fields are invalid; a model's own positive windows are not overwritten
- `resolveModelTokenMetadata`: missing config/id/providers/empty models → runtime-default; blank/whitespace id treated as missing; case-insensitive trimmed id match; provider/model, provider/suffix, and bare suffix keys; first provider/model in enumeration order wins; invalid matched windows fall back to runtime token defaults while keeping `model-config` source; agent-defaults `contextTokens` when no match (trim model id; ignore non-positive defaults); model-config beats agent-defaults; `providerId` only on model-config results

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/agent/src/config/model-metadata.test.ts` — colocated with `model-metadata.ts`. Import path is `./model-metadata.ts`.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/config/model-metadata.test.ts
bunx biome check --write packages/agent/src/config/model-metadata.test.ts
cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'model-metadata.test.ts'
```

Focused proof at the pushed head `8249979b2f169ee0348048e383f4c327d39c1159`:

```text
RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/lane-agent-model-metadata
 ✓ packages/agent/src/config/model-metadata.test.ts (26 tests) 5ms

 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  13:10:53
   Duration  138ms (transform 40ms, setup 0ms, import 48ms, tests 5ms, environment 0ms)
```

`bunx biome check --write` on the test file: checked 1 file in 76ms. Fixed 1 file (formatting). The formatted file is the one at this head.

`bunx tsc --noEmit` in `packages/agent`: `model-metadata.test.ts` appears nowhere in the output. Pre-existing errors elsewhere in the package/graph are unrelated (missing sibling-package modules in this checkout). This file adds zero new TypeScript errors.

The diff touches only `packages/agent/src/config/model-metadata.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:8249979b2f169ee0348048e383f4c327d39c1159 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (26 passed / 26).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] Concrete: test file diff in this PR (26 tests driving the real model-metadata module).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model production path changed.

## Backend + frontend logs

N/A - no server or UI code changed. Focused Vitest output is quoted in Testing.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changes.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Full `bun run verify` was not run; this PR adds tests only. Focused vitest (26/26), biome, and `tsc --noEmit` grepped for `model-metadata.test.ts` (empty) are the complete evidence set.

Hosted GitHub Actions CI does not run on this fork contributor's pull requests.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
