### PR TITLE
fix(gateway-discord): load portable Opus prebuild

### DIFF
--- a/packages/cloud/services/gateway-discord/Dockerfile
+++ b/packages/cloud/services/gateway-discord/Dockerfile
@@ -28,6 +28,13 @@ ARG SERVICE_DIR=packages/cloud/services/gateway-discord
 ARG COMMON_DIR=packages/cloud/services/_common
 ARG SHARED_DIR=packages/shared
 ARG CORE_DIR=packages/core
+# @discordjs/opus publishes portable N-API v3 Alpine binaries, but its bundled
+# legacy node-pre-gyp crosswalk stops at Node 18 while Bun 1.3.14 identifies its
+# compatibility ABI as 137. Selecting the published Node 18 ABI only for native
+# dependency installation lets amd64 and arm64 use that N-API artifact instead
+# of entering the upstream ARM64-musl source-build failure. The service itself
+# still runs on the pinned Bun image above.
+ARG OPUS_PREBUILD_NODE_TARGET=18.4.0
 
 # Install dependencies
 FROM base AS deps
@@ -35,6 +42,7 @@ ARG SERVICE_DIR
 ARG COMMON_DIR
 ARG SHARED_DIR
 ARG CORE_DIR
+ARG OPUS_PREBUILD_NODE_TARGET
 RUN apk add --no-cache python3 make g++ pkgconf opus-dev
 COPY ${SERVICE_DIR}/package.json ${SERVICE_DIR}/
 COPY ${COMMON_DIR}/package.json ${COMMON_DIR}/
@@ -43,7 +51,8 @@ COPY ${CORE_DIR}/package.json ${CORE_DIR}/
 RUN bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./discord-dm-policy":"./src/discord-dm-policy.ts"}}));' "${SHARED_DIR}/package.json" \
     && bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./errors":"./src/errors.ts"}}));' "${CORE_DIR}/package.json" \
     && printf '{"name":"gateway-discord-build","private":true,"workspaces":["packages/shared","packages/cloud/services/*","packages/core"]}\n' > package.json \
-    && bun install --production
+    && npm_config_target="${OPUS_PREBUILD_NODE_TARGET}" bun install --production \
+    && bun -e 'import { existsSync, readdirSync } from "node:fs"; const root = `${Bun.argv.at(-1)}/node_modules/@discordjs/opus`; const builds = readdirSync(`${root}/prebuild`).filter((entry) => existsSync(`${root}/prebuild/${entry}/opus.node`)); if (builds.length !== 1) throw new Error(`expected one installed Opus N-API build, found ${builds.length}`); const path = `${root}/package.json`; const manifest = await Bun.file(path).json(); const modulePath = builds[0].replace(/napi-v\d+/, "napi-v{napi_build_version}"); if (modulePath === builds[0]) throw new Error("installed Opus build lacks an N-API version segment"); manifest.binary.module_path = `./prebuild/${modulePath}/`; await Bun.write(path, JSON.stringify(manifest));' "${SERVICE_DIR}"
 
 # Build stage
 FROM deps AS builder

--- a/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
@@ -151,6 +151,25 @@ describe("service Dockerfiles can resolve their workspace dependencies", () => {
     expect(installAt).toBeGreaterThan(pruneAt ?? Number.MAX_SAFE_INTEGER);
   });
 
+  test("gateway-discord selects a published N-API Opus prebuild", () => {
+    const gateway = services.find(
+      (service) => service.name === "gateway-discord",
+    );
+    expect(gateway?.dockerfile).toContain(
+      "ARG OPUS_PREBUILD_NODE_TARGET=18.4.0",
+    );
+    expect(gateway?.dockerfile).toContain(
+      'npm_config_target="$' +
+        '{OPUS_PREBUILD_NODE_TARGET}" bun install --production',
+    );
+    expect(gateway?.dockerfile).toContain(
+      'builds[0].replace(/napi-v\\d+/, "napi-v{napi_build_version}")',
+    );
+    expect(gateway?.dockerfile).toContain(
+      "manifest.binary.module_path = `./prebuild/$" + "{modulePath}/`",
+    );
+  });
+
   for (const service of services.filter((s) => s.workspaceDeps.length > 0)) {
     const shouldPass = !LOCKFILE_BLIND.has(service.name);
 


### PR DESCRIPTION
## Summary
- select the published N-API v3 `@discordjs/opus` Alpine prebuild during the gateway-discord production install instead of Bun ABI 137 source fallback
- rewrite only the container-local installed manifest so the legacy loader resolves the downloaded N-API build at runtime
- add a Dockerfile contract test covering the install selector and runtime module path

## Root cause
Bun 1.3.14 identifies its compatibility ABI as 137, while `@discordjs/opus@0.10.0` publishes N-API v3 binaries through Node ABI 127 and its bundled `@discordjs/node-pre-gyp@0.4.5` crosswalk stops at Node 18.4.0. The fallback native build fails on ARM64 Alpine/musl in upstream CELT NEON code.

## Exact proof
- base: `f43ecfe0679038579f291e003ef2820678970e06`
- head: `c70678bb1c685de73bcff75aeebba783cfde2a9b`
- range-diff against the preserved pre-rebase checkpoint is patch-identical
- Docker contract: 10/10
- gateway-discord tests: 175/175
- gateway-discord typecheck: pass
- gateway-discord build: pass
- Biome and diff/secret scan: pass
- Linux arm64 Alpine image build plus real Opus encode/decode: pass (`packetBytes=3`, `decodedBytes=3840`)
- Linux amd64 Alpine image build plus real Opus encode/decode: pass (`packetBytes=3`, `decodedBytes=3840`)

## Scope / release gate
This is a narrow staging-build repair. It does not deploy, send Discord/provider traffic, change provider settings, or alter Auth/Deletion ownership. Keep draft until normal maintainer review and green CI; then include only through the serialized exact-SHA Cloudflare to Railway staging lane.

@lalalune please review the Bun/legacy-node-pre-gyp compatibility approach and container-local manifest rewrite.
