### PR TITLE
test(agent): cover plugin-auto-enable

### DIFF
--- a/packages/shared/src/config/plugin-auto-enable.test.ts
+++ b/packages/shared/src/config/plugin-auto-enable.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit tests for the backward-compat plugin-auto-enable wrapper. The suite
+ * drives the real re-export surface (CONNECTOR_PLUGINS and
+ * isConnectorConfigured) without mocks: the map must stay sourced from the
+ * generated first-party channel-plugin-map, and configured-detection must
+ * follow the live connector-specific branches.
+ */
+import { describe, expect, it } from "vitest";
+
+import { CONNECTOR_PLUGINS, isConnectorConfigured } from "./plugin-auto-enable";
+import { CONNECTOR_PLUGINS as ENGINE_CONNECTOR_PLUGINS } from "./plugin-auto-enable-engine";
+
+describe("plugin-auto-enable wrapper surface", () => {
+  it("re-exports the engine CONNECTOR_PLUGINS map by identity", () => {
+    expect(CONNECTOR_PLUGINS).toBe(ENGINE_CONNECTOR_PLUGINS);
+  });
+
+  it("exposes isConnectorConfigured as a function and does not re-export isWechatConfigured", async () => {
+    const wrapper = await import("./plugin-auto-enable");
+    expect(typeof wrapper.isConnectorConfigured).toBe("function");
+    expect(wrapper).toHaveProperty("CONNECTOR_PLUGINS");
+    expect(wrapper).not.toHaveProperty("isWechatConfigured");
+  });
+});
+
+describe("CONNECTOR_PLUGINS", () => {
+  it("uses the generated first-party channel map for WeChat", () => {
+    expect(CONNECTOR_PLUGINS.wechat).toBe("@elizaos/plugin-wechat");
+    expect(Object.values(CONNECTOR_PLUGINS)).not.toContain("elizaoswechat");
+  });
+
+  it("maps every first-party connector key to an @elizaos/plugin-* package", () => {
+    const entries = Object.entries(CONNECTOR_PLUGINS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [key, pkg] of entries) {
+      expect(key.length).toBeGreaterThan(0);
+      expect(pkg).toMatch(/^@elizaos\/plugin-/);
+    }
+  });
+
+  it("keeps aliased connector keys pointing at the same plugin package", () => {
+    expect(CONNECTOR_PLUGINS.discord).toBe("@elizaos/plugin-discord");
+    expect(CONNECTOR_PLUGINS.discordLocal).toBe(CONNECTOR_PLUGINS.discord);
+    expect(CONNECTOR_PLUGINS.twitter).toBe("@elizaos/plugin-x");
+    expect(CONNECTOR_PLUGINS.x).toBe(CONNECTOR_PLUGINS.twitter);
+  });
+
+  it("does not invent a missing connector key", () => {
+    expect(CONNECTOR_PLUGINS.notAConnector).toBeUndefined();
+    expect("" in CONNECTOR_PLUGINS).toBe(false);
+  });
+});
+
+describe("isConnectorConfigured", () => {
+  it("rejects nullish, primitive, and empty non-object configuration", () => {
+    expect(isConnectorConfigured("discord", undefined)).toBe(false);
+    expect(isConnectorConfigured("discord", null)).toBe(false);
+    expect(isConnectorConfigured("discord", "")).toBe(false);
+    expect(isConnectorConfigured("discord", 0)).toBe(false);
+    expect(isConnectorConfigured("discord", false)).toBe(false);
+    expect(isConnectorConfigured("discord", true)).toBe(false);
+    expect(isConnectorConfigured("discord", "token")).toBe(false);
+  });
+
+  it("rejects an empty config object and a config with enabled:false even when credentials exist", () => {
+    expect(isConnectorConfigured("discord", {})).toBe(false);
+    expect(
+      isConnectorConfigured("discord", {
+        enabled: false,
+        apiKey: "secret",
+        botToken: "tok",
+      }),
+    ).toBe(false);
+    expect(
+      isConnectorConfigured("wechat", { enabled: false, apiKey: "secret" }),
+    ).toBe(false);
+  });
+
+  it("accepts the universal credential fields botToken, token, and apiKey", () => {
+    expect(isConnectorConfigured("discord", { botToken: "b" })).toBe(true);
+    expect(isConnectorConfigured("slack", { token: "t" })).toBe(true);
+    expect(isConnectorConfigured("unknown", { apiKey: "k" })).toBe(true);
+    expect(isConnectorConfigured("discord", { botToken: "" })).toBe(false);
+    expect(isConnectorConfigured("discord", { token: 0 })).toBe(false);
+  });
+
+  it("requires both serverUrl and password for bluebubbles", () => {
+    expect(
+      isConnectorConfigured("bluebubbles", { serverUrl: "https://x" }),
+    ).toBe(false);
+    expect(isConnectorConfigured("bluebubbles", { password: "p" })).toBe(false);
+    expect(
+      isConnectorConfigured("bluebubbles", {
+        serverUrl: "https://x",
+        password: "p",
+      }),
+    ).toBe(true);
+  });
+
+  it("requires both clientId and clientSecret for discordLocal, not discord", () => {
+    expect(
+      isConnectorConfigured("discordLocal", {
+        clientId: "id",
+        clientSecret: "secret",
+      }),
+    ).toBe(true);
+    expect(isConnectorConfigured("discordLocal", { clientId: "id" })).toBe(
+      false,
+    );
+    expect(
+      isConnectorConfigured("discord", {
+        clientId: "id",
+        clientSecret: "secret",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats imessage as configured when enabled, cliPath, or dbPath is set", () => {
+    expect(isConnectorConfigured("imessage", {})).toBe(false);
+    expect(isConnectorConfigured("imessage", { enabled: true })).toBe(true);
+    expect(isConnectorConfigured("imessage", { cliPath: "/usr/bin/im" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("imessage", { dbPath: "/tmp/chat.db" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("imessage", { enabled: "true" })).toBe(false);
+  });
+
+  it("accepts whatsapp legacy session fields and any enabled account with authDir", () => {
+    expect(isConnectorConfigured("whatsapp", { authState: "state" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("whatsapp", { sessionPath: "/tmp/s" })).toBe(
+      true,
+    );
+    expect(isConnectorConfigured("whatsapp", { authDir: "/tmp/auth" })).toBe(
+      true,
+    );
+    expect(
+      isConnectorConfigured("whatsapp", {
+        accounts: { a: { authDir: "/tmp/a" } },
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("whatsapp", {
+        accounts: { a: { authDir: "/tmp/a", enabled: false } },
+      }),
+    ).toBe(false);
+    expect(
+      isConnectorConfigured("whatsapp", {
+        accounts: { a: null, b: "skip", c: { authDir: "/tmp/c" } },
+      }),
+    ).toBe(true);
+    expect(isConnectorConfigured("whatsapp", { accounts: {} })).toBe(false);
+    expect(
+      isConnectorConfigured("whatsapp", { accounts: "not-an-object" }),
+    ).toBe(false);
+    expect(isConnectorConfigured("whatsapp", {})).toBe(false);
+  });
+
+  it("accepts twitch accessToken, clientId, or enabled:true", () => {
+    expect(isConnectorConfigured("twitch", { accessToken: "tok" })).toBe(true);
+    expect(isConnectorConfigured("twitch", { clientId: "id" })).toBe(true);
+    expect(isConnectorConfigured("twitch", { enabled: true })).toBe(true);
+    expect(isConnectorConfigured("twitch", {})).toBe(false);
+  });
+
+  it("detects wechat via top-level apiKey or any enabled account apiKey", () => {
+    expect(isConnectorConfigured("wechat", { apiKey: "k" })).toBe(true);
+    expect(
+      isConnectorConfigured("wechat", {
+        accounts: { a: { apiKey: "k" } },
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("wechat", {
+        accounts: { a: { apiKey: "k", enabled: false } },
+      }),
+    ).toBe(false);
+    expect(
+      isConnectorConfigured("wechat", {
+        accounts: { a: null, b: { apiKey: "k" } },
+      }),
+    ).toBe(true);
+    expect(isConnectorConfigured("wechat", { accounts: {} })).toBe(false);
+    expect(isConnectorConfigured("wechat", {})).toBe(false);
+  });
+
+  it("detects googlechat via service-account material at the top level or on an enabled account", () => {
+    expect(
+      isConnectorConfigured("googlechat", { serviceAccount: "sa.json" }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("googlechat", {
+        serviceAccount: { client_email: "x" },
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("googlechat", {
+        serviceAccountFile: "/tmp/sa.json",
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("googlechat", { serviceAccountKey: "key" }),
+    ).toBe(true);
+    expect(isConnectorConfigured("googlechat", { serviceAccount: "   " })).toBe(
+      false,
+    );
+    expect(isConnectorConfigured("googlechat", { serviceAccount: [] })).toBe(
+      false,
+    );
+    expect(isConnectorConfigured("googlechat", { projectId: "p" })).toBe(false);
+    expect(
+      isConnectorConfigured("googlechat", {
+        accounts: { a: { serviceAccountFile: "/tmp/a.json" } },
+      }),
+    ).toBe(true);
+    expect(
+      isConnectorConfigured("googlechat", {
+        accounts: {
+          a: { serviceAccountFile: "/tmp/a.json", enabled: false },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isConnectorConfigured("googlechat", {
+        accounts: { a: ["not", "a", "record"] },
+      }),
+    ).toBe(false);
+    expect(
+      isConnectorConfigured("googlechat", {
+        accounts: [{ serviceAccount: "sa.json" }],
+      }),
+    ).toBe(false);
+    expect(isConnectorConfigured("googlechat", {})).toBe(false);
+  });
+
+  it("returns false for unknown connector names without universal credentials", () => {
+    expect(isConnectorConfigured("matrix", { clientId: "id" })).toBe(false);
+    expect(isConnectorConfigured("", { enabled: true })).toBe(false);
+    expect(isConnectorConfigured("not-a-connector", { serverUrl: "x" })).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION

# Relates to

Operator-selected coverage gap: `packages/agent/src/config/plugin-auto-enable.ts`
no longer exists at that path. The live backward-compat wrapper is
`packages/shared/src/config/plugin-auto-enable.ts` and had no same-named test
file. This PR adds one colocated vitest suite and does not change runtime
behavior.

Definition of Done: focused behavioral tests for the public wrapper surface,
recorded at the exact pushed head.

- [x] Targets `develop` and was rebased onto the latest fetched `origin/develop` before the final proof.
- [x] Reviewers can confirm the changed behavior from the committed focused test and inline red/green output.

# Risks

Low. Tests only. No production source, export, or auto-enable logic change.
The wrapper remains a two-symbol re-export of `CONNECTOR_PLUGINS` and
`isConnectorConfigured`.

# Background

## What does this PR do?

Adds `packages/shared/src/config/plugin-auto-enable.test.ts`, which imports
through the public wrapper (`./plugin-auto-enable`, the same path remaining
callers use) and drives the real `CONNECTOR_PLUGINS` map and
`isConnectorConfigured` helper.

The wrapper itself is a re-export. The suite therefore:

1. Asserts runtime identity with `./plugin-auto-enable-engine` (`CONNECTOR_PLUGINS`
   is the same object) and that `isWechatConfigured` is **not** re-exported
   from the wrapper.
2. Asserts the generated first-party channel map: WeChat maps to
   `@elizaos/plugin-wechat` (not the stale `elizaoswechat` name), every value
   is an `@elizaos/plugin-*` package, `discord`/`discordLocal` and
   `twitter`/`x` aliases share a package, and a missing key is undefined.
3. Exercises every `isConnectorConfigured` branch: nullish/primitive configs,
   empty object, `enabled: false` short-circuit even with credentials,
   universal `{botToken,token,apiKey}`, bluebubbles (both serverUrl+password),
   discordLocal vs discord, imessage (`enabled === true` / cliPath / dbPath),
   whatsapp (legacy session fields, accounts with authDir, disabled/missing
   accounts, non-object accounts), twitch, wechat multi-account apiKey,
   googlechat service-account material (string, record, file, key, whitespace,
   array rejection, accounts record vs array), and unknown connector names.

The system under test is never replaced with a mock.

## What kind of change is this?

Test-only, non-breaking.

# Documentation changes needed?

No. The public API is unchanged.

# Testing

## Where should a reviewer start?

`packages/shared/src/config/plugin-auto-enable.test.ts`.

## Detailed testing steps

Focused proof at the pushed head (`4a92212269388c692c15e0b2c95f095be2e48112`):

```bash
cd packages/shared && bunx vitest run src/config/plugin-auto-enable.test.ts --config ./vitest.config.ts
bunx biome check --write packages/shared/src/config/plugin-auto-enable.test.ts
cd packages/shared && bunx tsc --noEmit
```

```text
 RUN  v4.1.10 packages/shared
 ✓ src/config/plugin-auto-enable.test.ts (17 tests) 5ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  13:17:11
   Duration  7.80s (transform 5.99s, setup 146ms, import 7.40s, tests 5ms, environment 0ms)
```

`bunx biome check --write packages/shared/src/config/plugin-auto-enable.test.ts`
— checked 1 file in 206ms; formatted the new file; clean.

`cd packages/shared && bunx tsc --noEmit 2>&1 | grep plugin-auto-enable.test.ts`
returned empty (grep exit 1). The package reports two pre-existing errors in
other files (`src/i18n/keyword-matching.ts` TS2307 and `src/todo-cutover.ts`
TS2305). This test file appears nowhere in that output. No production file
changed, so the typecheck delta versus an untouched control is zero new errors.

Hosted GitHub Actions CI does **not** run on this fork-authored PR. This body
does not imply CI passed.

# Evidence Gate

<!-- evidence-head:4a92212269388c692c15e0b2c95f095be2e48112 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - unit-test-only change; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head: 17/17 passed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network client changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Inline above - the domain artifact is the colocated vitest file asserting real CONNECTOR_PLUGINS and isConnectorConfigured behavior through the public wrapper.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Known gaps / failures

- Fork-authored PR: hosted CI does not run, and this PR does not imply that it passed.
- Unattended session cannot finalize an interactive identity.slop.cash OAuth trace; filed without a private-trace receipt.
- `plugin-auto-enable-engine.test.ts` already asserts the WeChat map entry; this PR covers the wrapper re-export contract and the previously untested `isConnectorConfigured` branches, not a rewrite of the engine file.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
