### PR TITLE
test(cloud): pin group reply authority generation

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
@@ -352,7 +352,23 @@ describe("adversarial Personal Shared group routing", () => {
       namespace,
       validBlooioGroup.messageId,
       "platform",
-      undefined,
+      // The replying actor is the binding owner, so the turn carries the
+      // group trusted-delivery destination (owner-scheduled group reminders,
+      // #25013) pinned to this binding generation.
+      {
+        platform: "blooio",
+        kind: "group",
+        project: "eliza-app",
+        connectorAccountId: "blooio:test-number",
+        chatId: "chat_group_123",
+        ownerLabel: "Ada",
+        authority: {
+          bindingId: blooioGroupBinding.id,
+          ownerUserId: blooioGroupBinding.owner_user_id,
+          personalAgentId: blooioGroupBinding.personal_agent_id,
+          version: blooioGroupBinding.authority_version,
+        },
+      },
       undefined,
       { type: "GROUP", source: "blooio" },
     );

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.groups-adversarial.test.ts
@@ -233,6 +233,7 @@ const canonicalGroupBinding = {
   conversation_id: "group:00000000-0000-5000-8000-000000000030",
   state: "active",
   response_policy: "mention_only",
+  authority_version: 3,
   created_by_platform_user_id: "123456789",
 };
 
@@ -343,6 +344,7 @@ describe("adversarial Personal Shared group routing", () => {
       bindingId: blooioGroupBinding.id,
       providerMessageId: "provider-eliza-reply-0",
     });
+    expect(blooioGroupBinding.authority_version).toBe(3);
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
       expect.objectContaining({ id: blooioGroupBinding.personal_agent_id }),
       blooioGroupBinding.conversation_id,


### PR DESCRIPTION
## Summary

Successor to #25368. Preserves its corrected trusted-delivery expectation and repairs the mocked group binding so the authority generation is an explicit non-default value instead of undefined on both sides of the assertion.

- adds authority_version: 3 to the canonical group-binding fixture
- asserts the fixture generation is 3 before verifying the dispatched destination
- pins the dispatched authority.version to that binding generation

## Exact revisions

- reviewed #25368 head: ee88c549d08e585d897a9b78186f8c6d22c13e73
- successor head: ef6300a71eeaf411b5a46255207234450858042c
- validated origin/develop: f43ecfe0679038579f291e003ef2820678970e06

## Validation

- pinned Bun 1.3.14 and Node 24.15.0
- bun install --frozen-lockfile: pass
- package core build: pass, including packed edge/runtime import verification
- isolated route.groups-adversarial.test.ts: 14 passed, 0 failed, 60 assertions
- cloud API typecheck: pass
- cloud API worker bundle dry-run: pass
- Biome on changed test: pass
- git diff --check origin/develop...HEAD: pass
- range-diff: original #25368 commit preserved exactly, followed by the fixture repair

## Evidence

- UI screenshots/video: N/A - test-only server-side assertion correction
- live-model trajectory: N/A - no model, prompt, provider, action, or runtime behavior changed
- deployment evidence: N/A - no production source changed

The original exact head fails hosted typecheck with TS2339 because authority_version is absent from its fixture. It also passes the runtime assertion only because the produced and expected authority versions are both undefined. This successor makes that security-relevant generation explicit and proven.