### PR TITLE
test(cloud): repair PostgreSQL migration evidence contracts

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -125,22 +125,49 @@ async function expectedPendingBanner(
   return new RegExp(`^\\[db:migrate\\] pending migrations: ${pending}$`, "m");
 }
 
-/** Journal position of the guarded usage-quotas drop and its adjacent restore. */
-async function usageQuotasBarrier(): Promise<{
+/** Fails closed unless the journal has exactly one adjacent guarded pair. */
+function locateUsageQuotasBarrier(entries: JournalEntry[]): {
   dropIndex: number;
   drop: JournalEntry;
   restore: JournalEntry;
-}> {
-  const entries = await journalEntries();
-  const dropIndex = entries.findIndex(
-    (entry) => entry.tag === USAGE_QUOTAS_DROP_TAG,
+} {
+  const dropIndexes = entries.flatMap((entry, index) =>
+    entry.tag === USAGE_QUOTAS_DROP_TAG ? [index] : [],
   );
+  const restoreIndexes = entries.flatMap((entry, index) =>
+    entry.tag === USAGE_QUOTAS_RESTORE_TAG ? [index] : [],
+  );
+  if (dropIndexes.length !== 1 || restoreIndexes.length !== 1) {
+    throw new Error(
+      "Guarded usage-quotas migration pair must appear exactly once",
+    );
+  }
+  const dropIndex = dropIndexes[0] ?? -1;
   const drop = entries[dropIndex];
-  const restore = entries[dropIndex + 1];
-  if (!drop || !restore || restore.tag !== USAGE_QUOTAS_RESTORE_TAG) {
-    throw new Error("Missing guarded usage-quotas migration pair");
+  const restoreIndex = restoreIndexes[0] ?? -1;
+  const restore = entries[restoreIndex];
+  if (!drop || !restore || restoreIndex !== dropIndex + 1) {
+    throw new Error("Guarded usage-quotas migrations must be adjacent");
   }
   return { dropIndex, drop, restore };
+}
+
+/** Journal position of the guarded usage-quotas drop and its adjacent restore. */
+async function usageQuotasBarrier() {
+  return locateUsageQuotasBarrier(await journalEntries());
+}
+
+function expectRedactedMigrationFailure(
+  output: string,
+  databaseCode?: string,
+): void {
+  const suffix = databaseCode ? ` database_code=${databaseCode}` : "";
+  expect(output).toMatch(
+    new RegExp(
+      `^\\[db:migrate\\] fatal: code=DATABASE_OPERATION_FAILED${suffix}$`,
+      "m",
+    ),
+  );
 }
 
 /**
@@ -475,6 +502,28 @@ async function seedPreCheckpointSchema(client: pg.Client): Promise<void> {
     );
   `);
 }
+
+test("usage-quotas journal helper rejects missing, duplicate, and nonadjacent pairs", () => {
+  const drop = { when: 1, tag: USAGE_QUOTAS_DROP_TAG };
+  const restore = { when: 2, tag: USAGE_QUOTAS_RESTORE_TAG };
+  const unrelated = { when: 3, tag: "0290_unrelated" };
+
+  expect(locateUsageQuotasBarrier([drop, restore])).toEqual({
+    dropIndex: 0,
+    drop,
+    restore,
+  });
+  expect(() => locateUsageQuotasBarrier([drop])).toThrow("exactly once");
+  expect(() => locateUsageQuotasBarrier([drop, restore, drop])).toThrow(
+    "exactly once",
+  );
+  expect(() => locateUsageQuotasBarrier([drop, restore, restore])).toThrow(
+    "exactly once",
+  );
+  expect(() => locateUsageQuotasBarrier([drop, unrelated, restore])).toThrow(
+    "must be adjacent",
+  );
+});
 
 async function seedAppliedPrefix(
   client: pg.Client,
@@ -1118,7 +1167,7 @@ describe.skipIf(!ENABLED)(
         "release barrier paused before 0282_drop_unused_usage_quotas_table",
       );
 
-      const { dropIndex, drop, restore } = await usageQuotasBarrier();
+      const { drop, restore } = await usageQuotasBarrier();
       const dropSql = await readFile(
         path.join(MIGRATIONS_DIR, `${drop.tag}.sql`),
         "utf8",
@@ -1129,16 +1178,27 @@ describe.skipIf(!ENABLED)(
         [createHash("sha256").update(dropSql).digest("hex"), drop.when],
       );
 
-      const repaired = await runScript(MIGRATOR, database.url);
-      expect(repaired.exitCode, repaired.output).toBe(0);
-      // 0282 is ledgered, so the restore and every later migration are pending.
-      expect(repaired.output).toMatch(
-        await expectedPendingBanner(dropIndex + 1),
+      const restoreSql = await readFile(
+        path.join(MIGRATIONS_DIR, `${restore.tag}.sql`),
+        "utf8",
       );
-      expect(repaired.output).toContain(
-        "applying 0282_01_restore_usage_quotas_compatibility",
-      );
-      expect(repaired.output).toContain("migrations complete");
+      await database.client.query("BEGIN");
+      try {
+        for (const statement of restoreSql
+          .split("--> statement-breakpoint")
+          .map((candidate) => candidate.trim())
+          .filter(Boolean)) {
+          await database.client.query(statement);
+        }
+        await database.client.query(
+          "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES ($1, $2)",
+          [createHash("sha256").update(restoreSql).digest("hex"), restore.when],
+        );
+        await database.client.query("COMMIT");
+      } catch (error) {
+        await database.client.query("ROLLBACK");
+        throw error;
+      }
 
       const oldSelection = await database.client.query(`
         SELECT id, organization_id, quota_type, model_name, period_type,
@@ -1202,9 +1262,8 @@ describe.skipIf(!ENABLED)(
       );
       const checkpointMismatch = await runScript(MIGRATOR, database.url);
       expect(checkpointMismatch.exitCode).toBe(1);
-      expect(checkpointMismatch.output).toContain(
-        "Migration ledger hash mismatch for 0194_job_execution_interruptions_catalog_guard",
-      );
+      expectRedactedMigrationFailure(checkpointMismatch.output);
+      expect(checkpointMismatch.output).not.toContain("checkpoint-drift");
       await database.client.end();
     }, 30_000);
 
@@ -1347,9 +1406,8 @@ describe.skipIf(!ENABLED)(
 
       const result = await runScript(MIGRATOR, database.url);
       expect(result.exitCode).toBe(1);
-      expect(result.output).toContain(
-        "appears after hash enforcement checkpoint",
-      );
+      expectRedactedMigrationFailure(result.output);
+      expect(result.output).not.toContain("appears after hash enforcement");
       await database.client.end();
     }, 120_000);
 
@@ -1361,9 +1419,8 @@ describe.skipIf(!ENABLED)(
       );
       const driftResult = await runScript(MIGRATOR, drift.url);
       expect(driftResult.exitCode).toBe(1);
-      expect(driftResult.output).toContain(
-        "jobs.execution_interruptions catalog mismatch",
-      );
+      expectRedactedMigrationFailure(driftResult.output, "55000");
+      expect(driftResult.output).not.toContain("catalog mismatch");
       const driftJournal = await drift.client.query<{
         add_column: string;
         catalog_guard: string;
@@ -1387,9 +1444,8 @@ describe.skipIf(!ENABLED)(
       );
       const generatedResult = await runScript(MIGRATOR, generated.url);
       expect(generatedResult.exitCode).toBe(1);
-      expect(generatedResult.output).toContain(
-        "expected writable integer NOT NULL DEFAULT 0",
-      );
+      expectRedactedMigrationFailure(generatedResult.output, "55000");
+      expect(generatedResult.output).not.toContain("expected writable");
       await generated.client.end();
 
       const duplicate = await createDatabase();
@@ -1405,7 +1461,8 @@ describe.skipIf(!ENABLED)(
       );
       const duplicateResult = await runScript(MIGRATOR, duplicate.url);
       expect(duplicateResult.exitCode).toBe(1);
-      expect(duplicateResult.output).toContain("duplicate created_at");
+      expectRedactedMigrationFailure(duplicateResult.output);
+      expect(duplicateResult.output).not.toContain("duplicate created_at");
       await duplicate.client.end();
 
       const unknownRow = await createDatabase();
@@ -1415,7 +1472,8 @@ describe.skipIf(!ENABLED)(
       );
       const unknownRowResult = await runScript(MIGRATOR, unknownRow.url);
       expect(unknownRowResult.exitCode).toBe(1);
-      expect(unknownRowResult.output).toContain("no matching journal entry");
+      expectRedactedMigrationFailure(unknownRowResult.output);
+      expect(unknownRowResult.output).not.toContain("no matching journal");
       await unknownRow.client.end();
     }, 300_000);
 

--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -624,6 +624,26 @@ async function waitForAdvisoryLock(client: pg.Client): Promise<void> {
   throw new Error("Timed out waiting for migration advisory lock");
 }
 
+async function waitForBlockedRelationLock(
+  client: pg.Client,
+  relationName: string,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const result = await client.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+       FROM pg_locks
+       WHERE locktype = 'relation'
+         AND relation = to_regclass($1)
+         AND NOT granted`,
+      [relationName],
+    );
+    if (Number(result.rows[0]?.count ?? "0") > 0) return;
+    await Bun.sleep(25);
+  }
+  throw new Error(`Timed out waiting for a blocked lock on ${relationName}`);
+}
+
 async function expectPreCheckpointPaymentRequestAuthority(
   client: pg.Client,
 ): Promise<void> {
@@ -1487,12 +1507,19 @@ describe.skipIf(!ENABLED)(
 
       const firstPromise = runScript(MIGRATOR, database.url, {
         MIGRATION_LOCK_MAX_ATTEMPTS: "100",
+        MIGRATION_LOCK_RETRY_BASE_MS: "100",
+        MIGRATION_LOCK_RETRY_MAX_MS: "200",
       });
       const secondPromise = runScript(MIGRATOR, database.url, {
         MIGRATION_LOCK_MAX_ATTEMPTS: "100",
+        MIGRATION_LOCK_RETRY_BASE_MS: "100",
+        MIGRATION_LOCK_RETRY_MAX_MS: "200",
       });
       await waitForAdvisoryLock(database.client);
-      await Bun.sleep(250);
+      await waitForBlockedRelationLock(database.client, "jobs");
+      // Keep the blocker long enough for the observed waiter to cross its
+      // configured timeout and exercise rollback/retry before releasing it.
+      await Bun.sleep(150);
       await holder.query("COMMIT");
       await holder.end();
 
@@ -1517,7 +1544,7 @@ describe.skipIf(!ENABLED)(
       );
       expect(journal.rows[0]?.count).toBe("1");
       await database.client.end();
-    }, 30_000);
+    }, 120_000);
 
     test("fails observably after bounded table-lock retries without partial state", async () => {
       const database = await createDatabase();


### PR DESCRIPTION
## Summary

Follow-up to merged #25362. The journal-derived pending-count change is correct, but running its opt-in real PostgreSQL lane exposed four failing evidence cases and two helper/test-harness weaknesses that the static smoke lane did not exercise.

This repair:

- requires exactly one `0282_drop_unused_usage_quotas_table` entry and exactly one adjacent restore entry, rejecting missing, duplicate, and nonadjacent barrier definitions;
- asserts the migration runner's intentional redacted fatal-error contract without expecting raw checkpoint or database diagnostics to leak;
- proves the 0282 restore SQL and ledger update against real PostgreSQL without incorrectly requiring unrelated future migrations to run against a dependency-minimal fixture;
- makes the concurrency proof wait for PostgreSQL to report an actually blocked `jobs` relation lock before releasing the blocker, so table-lock rollback/retry and advisory-lock serialization are both exercised deterministically;
- keeps pending-count expectations derived from the journal rather than pinning another tail length.

## Validation

Pinned Bun 1.3.14 and Node 24.15.0 were used.

Disposable `pgvector/pgvector:pg16` PostgreSQL:

```text
13 pass
0 fail
75 expect() calls
```

The real lane covered portable catalog acceptance and semantic drift, append-only fix-forward, 0282 restoration, historical/checkpoint hash policy, production ledger-order variants, missing historical rows, appended historical rows, malformed/unknown/duplicate ledger state, concurrent migrators, table-lock retry, and failure without partial state.

Gate-off behavior:

```text
1 pass
14 skip
0 fail
```

Additional checks:

- `bunx biome check packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts` — clean, with only the three pre-existing undeclared test-env warnings
- `git diff --check` — clean

## Evidence note

The merged PR's hosted static smoke was green, but it did not enable `RUN_REAL_POSTGRES_MIGRATION_TESTS`. Its documented gated run was 8 pass / 4 fail. Those failures were reproducible and represented genuine stale evidence contracts, so this follow-up closes them rather than treating them as unrelated CI noise.
