### PR TITLE
test(agent): cover owner-contacts

### DIFF
--- a/packages/agent/src/config/owner-contacts.test.ts
+++ b/packages/agent/src/config/owner-contacts.test.ts
@@ -1,0 +1,693 @@
+/**
+ * Behavioral coverage for owner-contact source resolution, config load, and
+ * routing-hint enrichment. Drives the real module with in-memory runtime
+ * doubles and on-disk config files — no mocked return-value theatre.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type IAgentRuntime,
+  MESSAGE_SOURCE_CLIENT_CHAT,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadOwnerContactRoutingHints,
+  loadOwnerContactsConfig,
+  resolveOwnerContactSource,
+  resolveOwnerContactWithFallback,
+  resolveScopedSendSource,
+} from "./owner-contacts.ts";
+import type { OwnerContactsConfig } from "./types.agent-defaults.ts";
+
+const OWNER = "11111111-1111-4111-8111-111111111111" as UUID;
+const OTHER = "33333333-3333-4333-8333-333333333333" as UUID;
+const ROOM_A = "22222222-2222-4222-8222-222222222222" as UUID;
+const ROOM_B = "44444444-4444-4444-8444-444444444444" as UUID;
+
+type RuntimeLike = Pick<
+  IAgentRuntime,
+  | "getService"
+  | "getEntityById"
+  | "getRoomsForParticipant"
+  | "getMemoriesByRoomIds"
+>;
+
+function runtime(parts: RuntimeLike): RuntimeLike {
+  return parts;
+}
+
+function memory(partial: {
+  entityId: UUID;
+  roomId: UUID | number;
+  createdAt?: number | null;
+}): Memory {
+  return {
+    entityId: partial.entityId,
+    roomId: partial.roomId as UUID,
+    createdAt: partial.createdAt === null ? undefined : partial.createdAt,
+    content: { text: "owner-message" },
+  };
+}
+
+describe("resolveScopedSendSource", () => {
+  const handlers = new Set(["discord", "telegram", "telegram-account"]);
+  const has = (source: string) => handlers.has(source);
+
+  it("trims whitespace before matching a registered handler", () => {
+    expect(resolveScopedSendSource("  discord  ", has)).toBe("discord");
+  });
+
+  it("an empty or whitespace key is an empty queue and returns the trimmed key", () => {
+    expect(resolveScopedSendSource("", has)).toBe("");
+    expect(resolveScopedSendSource("   ", has)).toBe("");
+  });
+
+  it("walks hyphen boundaries from longest prefix down to a registered handler", () => {
+    expect(resolveScopedSendSource("discord-nubs-test-backup", has)).toBe(
+      "discord",
+    );
+  });
+
+  it("does not treat a non-hyphen substring as a handler prefix", () => {
+    expect(resolveScopedSendSource("discordnubs", has)).toBe("discordnubs");
+  });
+
+  it("returns the full key when no hyphen-boundary prefix is registered", () => {
+    expect(resolveScopedSendSource("matrix-room-a", has)).toBe("matrix-room-a");
+  });
+});
+
+describe("resolveOwnerContactSource", () => {
+  const discord = { entityId: OWNER, channelId: "chan-d" };
+  const telegram = { entityId: OWNER, channelId: "chan-t" };
+  const telegramAccount = { entityId: OWNER, channelId: "chan-ta" };
+
+  it("returns null for a missing item, empty queue, and non-string source", () => {
+    expect(resolveOwnerContactSource({}, "discord")).toBeNull();
+    expect(resolveOwnerContactSource({ discord }, null)).toBeNull();
+    expect(resolveOwnerContactSource({ discord }, undefined)).toBeNull();
+    expect(resolveOwnerContactSource({ discord }, "")).toBeNull();
+    expect(resolveOwnerContactSource({ discord }, "   ")).toBeNull();
+    expect(
+      resolveOwnerContactSource({ discord }, 12 as unknown as string),
+    ).toBeNull();
+  });
+
+  it("resolves a single configured source after trimming", () => {
+    expect(resolveOwnerContactSource({ discord }, "  discord  ")).toEqual({
+      source: "discord",
+      contact: discord,
+    });
+  });
+
+  it("telegram candidates try telegram, then telegram-account, then telegramAccount", () => {
+    expect(resolveOwnerContactSource({ telegram }, "telegram")).toEqual({
+      source: "telegram",
+      contact: telegram,
+    });
+
+    expect(
+      resolveOwnerContactSource(
+        { "telegram-account": telegramAccount },
+        "telegram",
+      ),
+    ).toEqual({ source: "telegram-account", contact: telegramAccount });
+
+    expect(resolveOwnerContactSource({ telegramAccount }, "telegram")).toEqual({
+      source: "telegram-account",
+      contact: telegramAccount,
+    });
+  });
+
+  it("telegram-account candidates try the hyphenated key before camelCase and telegram", () => {
+    const contacts: OwnerContactsConfig = {
+      telegram,
+      "telegram-account": telegramAccount,
+      telegramAccount: { entityId: OTHER },
+    };
+    expect(resolveOwnerContactSource(contacts, "telegram-account")).toEqual({
+      source: "telegram-account",
+      contact: telegramAccount,
+    });
+  });
+
+  it("telegramAccount candidates try camelCase first, then hyphenated, then telegram", () => {
+    const contacts: OwnerContactsConfig = {
+      telegram,
+      "telegram-account": telegramAccount,
+      telegramAccount: { entityId: OTHER, channelId: "camel" },
+    };
+    expect(resolveOwnerContactSource(contacts, "telegramAccount")).toEqual({
+      source: "telegram-account",
+      contact: contacts.telegramAccount,
+    });
+  });
+
+  it("canonicalizes a camelCase telegramAccount hit to telegram-account", () => {
+    expect(
+      resolveOwnerContactSource(
+        { telegramAccount: { entityId: OWNER } },
+        "telegramAccount",
+      ),
+    ).toEqual({
+      source: "telegram-account",
+      contact: { entityId: OWNER },
+    });
+  });
+});
+
+describe("resolveOwnerContactWithFallback", () => {
+  const discord = { entityId: OWNER };
+
+  it("prefers a configured contact over the owner-entity fallback", () => {
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: { discord },
+        source: "discord",
+        ownerEntityId: OTHER,
+      }),
+    ).toEqual({
+      source: "discord",
+      contact: discord,
+      resolvedFrom: "config",
+    });
+  });
+
+  it("falls back to the owner entity for client_chat and discord when config misses", () => {
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+        ownerEntityId: `  ${OWNER}  `,
+      }),
+    ).toEqual({
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+      contact: { entityId: OWNER },
+      resolvedFrom: "owner_entity",
+    });
+
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "discord",
+        ownerEntityId: OWNER,
+      }),
+    ).toEqual({
+      source: "discord",
+      contact: { entityId: OWNER },
+      resolvedFrom: "owner_entity",
+    });
+  });
+
+  it("does not invent a fallback for telegram, missing source, or missing owner entity", () => {
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "telegram",
+        ownerEntityId: OWNER,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "discord",
+        ownerEntityId: "   ",
+      }),
+    ).toBeNull();
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "discord",
+        ownerEntityId: null,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "discord",
+        ownerEntityId: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "",
+        ownerEntityId: OWNER,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: null,
+        ownerEntityId: OWNER,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOwnerContactWithFallback({
+        ownerContacts: {},
+        source: "discord",
+        ownerEntityId: 7 as unknown as string,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("loadOwnerContactsConfig", () => {
+  const originalEnv = { ...process.env };
+  const roots: string[] = [];
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    for (const root of roots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function isolateConfig(body: string): void {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-owner-contacts-"),
+    );
+    roots.push(root);
+    const configPath = path.join(root, "eliza.json");
+    const stateDir = path.join(root, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, body);
+    process.env.ELIZA_CONFIG_PATH = configPath;
+    process.env.ELIZA_STATE_DIR = stateDir;
+    delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+  }
+
+  const loadContext = {
+    boundary: "owner_contacts",
+    operation: "test_load",
+    message: "[owner-contacts] test load failed",
+  };
+
+  it("returns configured owner contacts from a real eliza.json", () => {
+    isolateConfig(
+      JSON.stringify({
+        agents: {
+          defaults: {
+            ownerContacts: {
+              discord: { entityId: OWNER, channelId: "c1" },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(loadOwnerContactsConfig(loadContext)).toEqual({
+      discord: { entityId: OWNER, channelId: "c1" },
+    });
+  });
+
+  it("returns an empty map when agents.defaults.ownerContacts is absent", () => {
+    isolateConfig(JSON.stringify({ agents: { defaults: {} } }));
+    expect(loadOwnerContactsConfig(loadContext)).toEqual({});
+  });
+
+  it("returns an empty map when loadElizaConfig throws on invalid JSON", () => {
+    isolateConfig("{ this is not json");
+    expect(loadOwnerContactsConfig(loadContext)).toEqual({});
+  });
+});
+
+describe("loadOwnerContactRoutingHints", () => {
+  it("returns an empty map for an empty owner-contacts queue", async () => {
+    expect(await loadOwnerContactRoutingHints(null, {})).toEqual({});
+    expect(await loadOwnerContactRoutingHints(undefined, {})).toEqual({});
+  });
+
+  it("emits config-only hints when runtime or entity id is missing", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { channelId: "c-static", roomId: "r-static" },
+    };
+    expect(await loadOwnerContactRoutingHints(null, ownerContacts)).toEqual({
+      discord: {
+        source: "discord",
+        entityId: null,
+        channelId: "c-static",
+        roomId: "r-static",
+        preferredCommunicationChannel: null,
+        platformIdentities: [],
+        lastResponseAt: null,
+        lastResponseChannel: null,
+        resolvedFrom: "config",
+      },
+    });
+  });
+
+  it("ignores a relationships service that is not getContact-shaped", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER },
+    };
+    const rt = runtime({
+      getService: () => ({ notGetContact: true }) as never,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+    const hints = await loadOwnerContactRoutingHints(rt, ownerContacts);
+    expect(hints.discord?.resolvedFrom).toBe("config");
+    expect(hints.discord?.entityId).toBe(OWNER);
+  });
+
+  it("enriches from relationships using source-prefixed custom fields first", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER, channelId: "old-chan", roomId: "old-room" },
+    };
+    const rt = runtime({
+      getService: () =>
+        ({
+          getContact: async () => ({
+            preferences: { preferredCommunicationChannel: "  telegram  " },
+            customFields: {
+              discordChannelId: "  new-chan  ",
+              discordchannelId: "ignored-chan",
+              channelId: "generic-chan",
+              discordRoomId: "new-room",
+              discordroomId: "ignored-room",
+              roomId: "generic-room",
+              discordEntityId: OTHER,
+              discordentityId: OWNER,
+              entityId: OWNER,
+            },
+          }),
+        }) as never,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+
+    const hints = await loadOwnerContactRoutingHints(rt, ownerContacts);
+    expect(hints.discord).toMatchObject({
+      entityId: OTHER,
+      channelId: "new-chan",
+      roomId: "new-room",
+      preferredCommunicationChannel: "telegram",
+      resolvedFrom: "config+relationships",
+    });
+    expect(ownerContacts.discord?.entityId).toBe(OTHER);
+    expect(ownerContacts.discord?.channelId).toBe("new-chan");
+    expect(ownerContacts.discord?.roomId).toBe("new-room");
+  });
+
+  it("falls through custom-field aliases and skips blank or missing keys", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER },
+    };
+    const rt = runtime({
+      getService: () =>
+        ({
+          getContact: async () => ({
+            customFields: {
+              discordChannelId: "   ",
+              discordchannelId: "alt-chan",
+              discordRoomId: "",
+              discordroomId: "   ",
+              roomId: "generic-room",
+            },
+          }),
+        }) as never,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+
+    const hints = await loadOwnerContactRoutingHints(rt, ownerContacts);
+    expect(hints.discord?.channelId).toBe("alt-chan");
+    expect(hints.discord?.roomId).toBe("generic-room");
+    expect(hints.discord?.entityId).toBe(OWNER);
+    expect(hints.discord?.resolvedFrom).toBe("config+relationships");
+  });
+
+  it("keeps static config when getContact returns null or throws", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER, channelId: "static" },
+    };
+    const nullRt = runtime({
+      getService: () =>
+        ({
+          getContact: async () => null,
+        }) as never,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+    const throwRt = runtime({
+      getService: () =>
+        ({
+          getContact: async () => {
+            throw new Error("relationships down");
+          },
+        }) as never,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+
+    const fromNull = await loadOwnerContactRoutingHints(nullRt, ownerContacts);
+    const fromThrow = await loadOwnerContactRoutingHints(
+      throwRt,
+      ownerContacts,
+    );
+    expect(fromNull.discord?.resolvedFrom).toBe("config");
+    expect(fromNull.discord?.channelId).toBe("static");
+    expect(fromThrow.discord?.resolvedFrom).toBe("config");
+    expect(fromThrow.discord?.channelId).toBe("static");
+  });
+
+  it("normalizes platform identities and drops incomplete entries", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER },
+    };
+    const rt = runtime({
+      getService: () => null,
+      getEntityById: async () =>
+        ({
+          id: OWNER,
+          names: ["owner"],
+          agentId: OWNER,
+          metadata: {
+            platformIdentities: [
+              { platform: "  discord  ", handle: "  nubs  ", status: "  ok  " },
+              { platform: "telegram", handle: "nubs" },
+              { platform: "discord", handle: "   " },
+              { platform: "", handle: "nubs" },
+              { platform: "x", handle: "nubs", status: "   " },
+              null,
+              "not-an-object",
+              12,
+            ],
+          },
+        }) as Awaited<ReturnType<IAgentRuntime["getEntityById"]>>,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+
+    const hints = await loadOwnerContactRoutingHints(rt, ownerContacts);
+    expect(hints.discord?.platformIdentities).toEqual([
+      { platform: "discord", handle: "nubs", status: "ok" },
+      { platform: "telegram", handle: "nubs" },
+      { platform: "x", handle: "nubs" },
+    ]);
+  });
+
+  it("keeps going when entity lookup throws or identities are not an array", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER },
+    };
+    const throwRt = runtime({
+      getService: () => null,
+      getEntityById: async () => {
+        throw new Error("entity missing");
+      },
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+    const badMetaRt = runtime({
+      getService: () => null,
+      getEntityById: async () =>
+        ({
+          id: OWNER,
+          names: ["owner"],
+          agentId: OWNER,
+          metadata: { platformIdentities: { not: "array" } },
+        }) as Awaited<ReturnType<IAgentRuntime["getEntityById"]>>,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => [],
+    });
+
+    expect(
+      (await loadOwnerContactRoutingHints(throwRt, ownerContacts)).discord
+        ?.platformIdentities,
+    ).toEqual([]);
+    expect(
+      (await loadOwnerContactRoutingHints(badMetaRt, ownerContacts)).discord
+        ?.platformIdentities,
+    ).toEqual([]);
+  });
+
+  it("orders owner history newest-first and prefers roomId over channelId", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER, roomId: ROOM_A, channelId: ROOM_B },
+    };
+    let seenLimit: number | undefined;
+    const rt = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [ROOM_A, ROOM_B],
+      getMemoriesByRoomIds: async (params) => {
+        seenLimit = params.limit;
+        expect(params.tableName).toBe("messages");
+        expect(params.roomIds).toEqual([ROOM_A, ROOM_B]);
+        return [
+          memory({ entityId: OWNER, roomId: ROOM_A, createdAt: 100 }),
+          memory({ entityId: OWNER, roomId: ROOM_A, createdAt: 300 }),
+          memory({ entityId: OWNER, roomId: ROOM_A, createdAt: 200 }),
+          memory({ entityId: OTHER, roomId: ROOM_A, createdAt: 999 }),
+          memory({ entityId: OWNER, roomId: ROOM_B, createdAt: 500 }),
+        ];
+      },
+    });
+
+    const hints = await loadOwnerContactRoutingHints(rt, ownerContacts);
+    expect(seenLimit).toBe(20);
+    expect(hints.discord?.lastResponseAt).toBe("300");
+    expect(hints.discord?.lastResponseChannel).toBe("discord");
+  });
+
+  it("matches channelId when roomId is absent and treats missing createdAt as 0", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER, channelId: ROOM_A },
+    };
+    const rt = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [ROOM_A],
+      getMemoriesByRoomIds: async () => [
+        memory({ entityId: OWNER, roomId: ROOM_A }),
+        memory({ entityId: OWNER, roomId: ROOM_A, createdAt: 50 }),
+        memory({ entityId: OWNER, roomId: ROOM_A, createdAt: 50 }),
+      ],
+    });
+
+    const hints = await loadOwnerContactRoutingHints(rt, ownerContacts);
+    expect(hints.discord?.lastResponseAt).toBe("50");
+  });
+
+  it("does not invent last-response when neither room nor channel is set, rooms are empty, or roomId is non-string", async () => {
+    const noTarget: OwnerContactsConfig = { discord: { entityId: OWNER } };
+    const withRoom: OwnerContactsConfig = {
+      discord: { entityId: OWNER, roomId: ROOM_A },
+    };
+
+    const emptyRooms = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [],
+      getMemoriesByRoomIds: async () => {
+        throw new Error("should not be called for an empty room list");
+      },
+    });
+    const noMatch = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [ROOM_A],
+      getMemoriesByRoomIds: async () => [
+        memory({ entityId: OWNER, roomId: ROOM_A, createdAt: 9 }),
+      ],
+    });
+    const nonStringRoom = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [ROOM_A],
+      getMemoriesByRoomIds: async () => [
+        memory({
+          entityId: OWNER,
+          roomId: 99 as unknown as UUID,
+          createdAt: 9,
+        }),
+      ],
+    });
+    const nullCreatedAt = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [ROOM_A],
+      getMemoriesByRoomIds: async () => [
+        {
+          entityId: OWNER,
+          roomId: ROOM_A,
+          createdAt: null as unknown as number,
+          content: { text: "owner-message" },
+        },
+      ],
+    });
+
+    expect(
+      (await loadOwnerContactRoutingHints(emptyRooms, withRoom)).discord
+        ?.lastResponseAt,
+    ).toBeNull();
+    expect(
+      (await loadOwnerContactRoutingHints(noMatch, noTarget)).discord
+        ?.lastResponseAt,
+    ).toBeNull();
+    expect(
+      (await loadOwnerContactRoutingHints(nonStringRoom, withRoom)).discord
+        ?.lastResponseAt,
+    ).toBeNull();
+    expect(
+      (await loadOwnerContactRoutingHints(nullCreatedAt, withRoom)).discord
+        ?.lastResponseAt,
+    ).toBeNull();
+  });
+
+  it("survives rooms and memory lookup failures without dropping the config hint", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER, roomId: ROOM_A },
+    };
+    const roomsThrow = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => {
+        throw new Error("rooms failed");
+      },
+      getMemoriesByRoomIds: async () => [],
+    });
+    const memoriesThrow = runtime({
+      getService: () => null,
+      getEntityById: async () => null,
+      getRoomsForParticipant: async () => [ROOM_A],
+      getMemoriesByRoomIds: async () => {
+        throw "memory store down";
+      },
+    });
+
+    const fromRooms = await loadOwnerContactRoutingHints(
+      roomsThrow,
+      ownerContacts,
+    );
+    const fromMemories = await loadOwnerContactRoutingHints(
+      memoriesThrow,
+      ownerContacts,
+    );
+    expect(fromRooms.discord?.entityId).toBe(OWNER);
+    expect(fromRooms.discord?.lastResponseAt).toBeNull();
+    expect(fromMemories.discord?.entityId).toBe(OWNER);
+    expect(fromMemories.discord?.lastResponseAt).toBeNull();
+  });
+
+  it("emits independent hints for every configured source", async () => {
+    const ownerContacts: OwnerContactsConfig = {
+      discord: { entityId: OWNER },
+      telegram: { entityId: OTHER, channelId: "tg" },
+    };
+    const hints = await loadOwnerContactRoutingHints(null, ownerContacts);
+    expect(Object.keys(hints).sort()).toEqual(["discord", "telegram"]);
+    expect(hints.telegram?.channelId).toBe("tg");
+    expect(hints.discord?.entityId).toBe(OWNER);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/agent/src/config/owner-contacts.ts`. That module had no `owner-contacts.test.ts` anywhere in the repo (the existing `owner-contacts.scoped-source.test.ts` only covers `resolveScopedSendSource`). This PR does not change production behaviour.

The suite drives the real module: in-memory runtime doubles for routing-hint enrichment, and on-disk `eliza.json` files for config load. It does not mock the module under test and then assert the mock.

Covered behaviour:

- `resolveScopedSendSource`: trim, empty/whitespace queue, longest hyphen-boundary prefix, non-hyphen substring, missing handler
- `resolveOwnerContactSource`: empty map, missing/blank/non-string source, single hit, telegram / telegram-account / telegramAccount candidate order, camelCase canonicalization to `telegram-account`
- `resolveOwnerContactWithFallback`: configured contact wins; owner-entity fallback only for `client_chat` and `discord`; no fallback for telegram, missing source, missing/blank/non-string owner entity
- `loadOwnerContactsConfig`: real config file, absent `ownerContacts`, invalid JSON catch path
- `loadOwnerContactRoutingHints`: empty queue, config-only hints, non-getContact service, source-prefixed custom-field precedence, blank-key fallthrough, getContact null/throw, platform-identity normalization, entity lookup failures, newest-first history with roomId over channelId, channelId match, missing createdAt as 0, empty rooms, non-string roomId, null createdAt, rooms/memory throws, independent multi-source hints, `limit: 20`

## Evidence

1. `bunx vitest run packages/agent/src/config/owner-contacts.test.ts`

```
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

2. `bunx biome check --write packages/agent/src/config/owner-contacts.test.ts` — clean (`Checked 1 file in 50ms. Fixed 1 file.` import-order only, then clean).

3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'owner-contacts.test'` — empty; our file introduced no type errors. Pre-existing package errors elsewhere are not this change.

4. Diff touches only `packages/agent/src/config/owner-contacts.test.ts`.

Hosted CI does not run on this fork contributor PR. Local vitest / biome / tsc above are the verification.

## Test plan

- [x] `bunx vitest run packages/agent/src/config/owner-contacts.test.ts` — 1 file, 30 tests passed
- [x] biome check on the new test file
- [x] `bunx tsc --noEmit` in `packages/agent`; new file absent from the error stream

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:7cd5ccb656a18432116c3aad2167f0edf7de3c40 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
