### PR TITLE
fix(whatsapp): close personal media review gaps

### DIFF
--- a/plugins/plugin-whatsapp/__tests__/runtime-diagnostics.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/runtime-diagnostics.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Proves inbound Baileys metadata and per-message media failures reach runtime
+ * diagnostics while the connector event loop remains available for later work.
+ */
+
+import { EventEmitter } from "node:events";
+import { ElizaError, type IAgentRuntime, type UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { BaileysClient } from "../src/clients/baileys-client";
+import { WhatsAppConnectorService } from "../src/runtime-service";
+import type { NormalizedMessage } from "../src/types";
+
+function diagnosticRuntime() {
+  return {
+    agentId: "agent-diagnostics" as UUID,
+    getSetting: vi.fn(() => undefined),
+    reportError: vi.fn(),
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  } as never as IAgentRuntime;
+}
+
+function bindFakeBaileysClient(service: WhatsAppConnectorService): EventEmitter {
+  const emitter = new EventEmitter();
+  const client = Object.assign(Object.create(BaileysClient.prototype), {
+    on: emitter.on.bind(emitter),
+  }) as BaileysClient;
+  const bindClientEvents = Reflect.get(service, "bindClientEvents") as (
+    client: BaileysClient,
+    accountId: string
+  ) => void;
+  bindClientEvents.call(service, client, "named-account");
+  return emitter;
+}
+
+describe("WhatsApp runtime diagnostics", () => {
+  it("reports Baileys metadata failures with account and stage context", () => {
+    const runtime = diagnosticRuntime();
+    const service = new WhatsAppConnectorService(runtime);
+    const emitter = bindFakeBaileysClient(service);
+    const error = new ElizaError("provider filename is unsafe", {
+      code: "WHATSAPP_PERSONAL_MEDIA_FILENAME_INVALID",
+      severity: "ephemeral",
+    });
+
+    emitter.emit("error", error);
+
+    expect(runtime.reportError).toHaveBeenCalledWith("plugin:whatsapp:client", error, {
+      accountId: "named-account",
+      stage: "baileys-metadata-or-socket",
+    });
+  });
+
+  it("reports a media fetch/store/decrypt failure and continues handling later messages", async () => {
+    const runtime = diagnosticRuntime();
+    const service = new WhatsAppConnectorService(runtime);
+    const failure = new ElizaError("guarded fetch denied", {
+      code: "WHATSAPP_PERSONAL_MEDIA_LOCATION_DENIED",
+      severity: "ephemeral",
+    });
+    const handleNormalizedMessage = vi
+      .fn<(message: NormalizedMessage, accountId: string) => Promise<void>>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(undefined);
+    Reflect.set(service, "handleNormalizedMessage", handleNormalizedMessage);
+    const emitter = bindFakeBaileysClient(service);
+    const message = {
+      id: "provider-media-1",
+      from: "group@g.us",
+      chatId: "group@g.us",
+      senderId: "user@s.whatsapp.net",
+      timestamp: 1,
+      type: "image",
+      content: "caption",
+      personalMedia: {
+        kind: "image",
+        mediaKey: new Uint8Array(32),
+        fileSha256: new Uint8Array(32),
+        fileEncSha256: new Uint8Array(32),
+        fileLength: 1,
+        mimeType: "image/png",
+        url: "https://media.whatsapp.net/media.enc",
+      },
+    } satisfies NormalizedMessage;
+
+    emitter.emit("message", message);
+    await vi.waitFor(() =>
+      expect(runtime.reportError).toHaveBeenCalledWith(
+        "plugin:whatsapp:inbound-message",
+        failure,
+        {
+          accountId: "named-account",
+          chatId: "group@g.us",
+          externalMessageId: "provider-media-1",
+          stage: "media-fetch-store-decrypt",
+        }
+      )
+    );
+
+    emitter.emit("message", { ...message, id: "provider-media-2" });
+    await vi.waitFor(() => expect(handleNormalizedMessage).toHaveBeenCalledTimes(2));
+  });
+});

--- a/plugins/plugin-whatsapp/src/baileys/media.test.ts
+++ b/plugins/plugin-whatsapp/src/baileys/media.test.ts
@@ -79,6 +79,29 @@ describe("personal Baileys media ingress", () => {
     expect(options.pinnedFetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("uses the metadata URL host for a direct-path CDN fallback", async () => {
+    const fixture = await encryptedFixture(PNG);
+    fixture.metadata.url = "https://media-cdg4-1.cdn.fbcdn.net/original.enc";
+    fixture.metadata.directPath = "/whatsapp/new.enc";
+    const options = {
+      ...guardedOptions(fixture.encrypted),
+      ssrfPolicy: { allowedHostnames: ["media-cdg4-1.cdn.fbcdn.net"] },
+    };
+
+    const result = await fetchVerifiedPersonalMedia(fixture.metadata, PNG.length, options);
+
+    expect(result.bytes).toEqual(PNG);
+    expect(options.lookupFn).toHaveBeenCalledWith("media-cdg4-1.cdn.fbcdn.net", { all: true });
+    expect(options.pinnedFetchImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.objectContaining({
+          hostname: "media-cdg4-1.cdn.fbcdn.net",
+          pathname: "/whatsapp/new.enc",
+        }),
+      })
+    );
+  });
+
   it("blocks private resolution before provider transport I/O", async () => {
     const fixture = await encryptedFixture(PNG);
     const pinnedFetchImpl = vi.fn(async () => new Response(fixture.encrypted));
@@ -148,7 +171,10 @@ describe("personal Baileys media ingress", () => {
     const options = guardedOptions(fixture.encrypted);
     await expect(
       fetchVerifiedPersonalMedia(fixture.metadata, PNG.length - 1, options)
-    ).rejects.toThrow("exceeds the configured byte limit");
+    ).rejects.toMatchObject({
+      code: "WHATSAPP_PERSONAL_MEDIA_SIZE_DENIED",
+      severity: "ephemeral",
+    });
     expect(options.lookupFn).not.toHaveBeenCalled();
     expect(options.pinnedFetchImpl).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-whatsapp/src/baileys/media.ts
+++ b/plugins/plugin-whatsapp/src/baileys/media.ts
@@ -4,13 +4,14 @@
  * only integrity-checked plaintext bytes leave this module.
  */
 import crypto from "node:crypto";
-import { detectMime, ElizaError, type FetchMediaOptions, fetchRemoteMedia } from "@elizaos/core";
 import {
-  extractMessageContent,
-  getMediaKeys,
-  getUrlFromDirectPath,
-  type proto,
-} from "@whiskeysockets/baileys";
+  detectMime,
+  ElizaError,
+  type ElizaErrorSeverity,
+  type FetchMediaOptions,
+  fetchRemoteMedia,
+} from "@elizaos/core";
+import { getMediaKeys, getUrlFromDirectPath, type proto } from "@whiskeysockets/baileys";
 import type { PersonalMediaMetadata } from "../types";
 
 export type PersonalMediaKind = "image" | "audio" | "video" | "document";
@@ -27,13 +28,19 @@ type MediaProto =
   | proto.Message.IVideoMessage
   | proto.Message.IDocumentMessage;
 
+const MAX_DECLARED_MIME_LENGTH = 127;
+const MAX_PROVIDER_FILENAME_LENGTH = 240;
+const MIME_TOKEN = /^[a-z0-9!#$%&'*+.^_`|~-]+\/[a-z0-9!#$%&'*+.^_`|~-]+$/;
+const UNSAFE_FILENAME_CODEPOINT = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+
 function mediaError(
   code: string,
   message: string,
   context: Record<string, unknown>,
-  cause?: unknown
+  cause?: unknown,
+  severity: ElizaErrorSeverity = "ephemeral"
 ): ElizaError {
-  return new ElizaError(message, { code, context, cause, severity: "fatal" });
+  return new ElizaError(message, { code, context, cause, severity });
 }
 
 function exactBytes(value: Uint8Array | null | undefined, length: number): Uint8Array | undefined {
@@ -45,9 +52,59 @@ function readFileLength(value: unknown): number | undefined {
   return Number.isSafeInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
 }
 
+function isWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function normalizeDeclaredMime(value: string | null | undefined): string | undefined {
-  const mime = value?.split(";")[0]?.trim().toLowerCase();
-  return mime || undefined;
+  if (typeof value !== "string" || !isWellFormedUnicode(value)) return undefined;
+  const mime = value.trim().toLowerCase();
+  if (mime.length === 0 || mime.length > MAX_DECLARED_MIME_LENGTH || !MIME_TOKEN.test(mime)) {
+    return undefined;
+  }
+  return mime;
+}
+
+function normalizeProviderFilename(
+  value: string | null | undefined,
+  kind: PersonalMediaKind
+): string | undefined {
+  if (value === null || value === undefined || value.length === 0) return undefined;
+  if (!isWellFormedUnicode(value)) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_FILENAME_INVALID",
+      "Personal WhatsApp media filename is malformed",
+      { messageType: kind }
+    );
+  }
+  const normalized = value.normalize("NFC").trim();
+  if (
+    normalized.length === 0 ||
+    Buffer.byteLength(normalized, "utf8") > MAX_PROVIDER_FILENAME_LENGTH ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.includes("/") ||
+    normalized.includes("\\") ||
+    /^[a-z]:/iu.test(normalized) ||
+    UNSAFE_FILENAME_CODEPOINT.test(normalized)
+  ) {
+    throw mediaError(
+      "WHATSAPP_PERSONAL_MEDIA_FILENAME_INVALID",
+      "Personal WhatsApp media filename is not a safe display name",
+      { messageType: kind }
+    );
+  }
+  return normalized;
 }
 
 function mimeMatchesKind(mimeType: string | undefined, kind: PersonalMediaKind): boolean {
@@ -68,10 +125,9 @@ function mediaProtoForMessage(message: proto.IMessage): {
 
 /** Extract and structurally authorize provider media metadata without network I/O. */
 export function extractPersonalMediaMetadata(
-  message: proto.IWebMessageInfo
+  content: proto.IMessage
 ): PersonalMediaMetadata | undefined {
-  const content = extractMessageContent(message.message);
-  const selected = content ? mediaProtoForMessage(content) : null;
+  const selected = mediaProtoForMessage(content);
   if (!selected) return undefined;
 
   const mediaKey = exactBytes(selected.media.mediaKey, 32);
@@ -79,6 +135,13 @@ export function extractPersonalMediaMetadata(
   const fileEncSha256 = exactBytes(selected.media.fileEncSha256, 32);
   const fileLength = readFileLength(selected.media.fileLength);
   const mimeType = normalizeDeclaredMime(selected.media.mimetype);
+  const fileName =
+    selected.kind === "document"
+      ? normalizeProviderFilename(
+          (selected.media as proto.Message.IDocumentMessage).fileName,
+          selected.kind
+        )
+      : undefined;
   const directPath = selected.media.directPath?.trim() || undefined;
   const url = selected.media.url?.trim() || undefined;
 
@@ -120,16 +183,26 @@ export function extractPersonalMediaMetadata(
     mimeType,
     ...(directPath ? { directPath } : {}),
     ...(url ? { url } : {}),
-    ...(selected.kind === "document" && (selected.media as proto.Message.IDocumentMessage).fileName
-      ? { fileName: (selected.media as proto.Message.IDocumentMessage).fileName ?? undefined }
-      : {}),
+    ...(fileName ? { fileName } : {}),
   };
+}
+
+function extractUrlHost(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).host;
+  } catch {
+    // error-policy:J3 A malformed optional URL cannot supply a direct-path fallback host.
+    return undefined;
+  }
 }
 
 function authorizedDownloadUrl(metadata: PersonalMediaMetadata): string {
   let parsed: URL;
   try {
-    const value = metadata.directPath ? getUrlFromDirectPath(metadata.directPath) : metadata.url;
+    const value = metadata.directPath
+      ? getUrlFromDirectPath(metadata.directPath, extractUrlHost(metadata.url))
+      : metadata.url;
     parsed = new URL(value ?? "");
   } catch (error) {
     // error-policy:J2 Provider locations are untrusted and retain their parse cause.
@@ -143,6 +216,8 @@ function authorizedDownloadUrl(metadata: PersonalMediaMetadata): string {
   const host = parsed.hostname.toLowerCase();
   if (
     parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
     !(host === "whatsapp.net" || host.endsWith(".whatsapp.net") || host.endsWith(".fbcdn.net"))
   ) {
     throw mediaError(

--- a/plugins/plugin-whatsapp/src/baileys/message-adapter.test.ts
+++ b/plugins/plugin-whatsapp/src/baileys/message-adapter.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Verifies that wrapped Baileys messages are normalized through one shared
+ * content envelope before type, caption, reply, and media metadata extraction.
+ */
+
+import crypto from "node:crypto";
+import type { proto } from "@whiskeysockets/baileys";
+import { describe, expect, it } from "vitest";
+import { MessageAdapter } from "./message-adapter";
+
+function mediaFields(mimetype: string, overrides: Record<string, unknown> = {}) {
+  return {
+    mediaKey: crypto.randomBytes(32),
+    fileSha256: crypto.randomBytes(32),
+    fileEncSha256: crypto.randomBytes(32),
+    fileLength: 10,
+    mimetype,
+    directPath: "/v/t62.7118-24/media.enc",
+    ...overrides,
+  };
+}
+
+function inbound(message: proto.IMessage): proto.IWebMessageInfo {
+  return {
+    key: { id: "provider-message", remoteJid: "group@g.us", participant: "user@s.whatsapp.net" },
+    messageTimestamp: 123,
+    message,
+  };
+}
+
+describe("MessageAdapter wrapped inbound messages", () => {
+  it("derives image caption and quote identity from an ephemeral envelope", () => {
+    const normalized = new MessageAdapter().toNormalized(
+      inbound({
+        ephemeralMessage: {
+          message: {
+            imageMessage: {
+              ...mediaFields("image/png"),
+              caption: "ephemeral caption",
+              contextInfo: {
+                stanzaId: "quoted-image-id",
+                participant: "quoted-user@s.whatsapp.net",
+                quotedMessage: { conversation: "quoted text" },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(normalized).toMatchObject({
+      type: "image",
+      content: "ephemeral caption",
+      replyToId: "quoted-image-id",
+      personalMedia: { kind: "image", mimeType: "image/png" },
+    });
+  });
+
+  it("derives video metadata, caption, and quote identity from a view-once envelope", () => {
+    const normalized = new MessageAdapter().toNormalized(
+      inbound({
+        viewOnceMessage: {
+          message: {
+            videoMessage: {
+              ...mediaFields("video/mp4"),
+              caption: "view once caption",
+              contextInfo: { stanzaId: "quoted-video-id" },
+            },
+          },
+        },
+      })
+    );
+
+    expect(normalized).toMatchObject({
+      type: "video",
+      content: "view once caption",
+      replyToId: "quoted-video-id",
+      personalMedia: { kind: "video", mimeType: "video/mp4" },
+    });
+  });
+
+  it("normalizes a document-with-caption filename exactly once", () => {
+    const normalized = new MessageAdapter().toNormalized(
+      inbound({
+        documentWithCaptionMessage: {
+          message: {
+            documentMessage: {
+              ...mediaFields("application/pdf"),
+              caption: "document caption",
+              fileName: "  résumé.pdf  ",
+              contextInfo: { stanzaId: "quoted-document-id" },
+            },
+          },
+        },
+      })
+    );
+
+    expect(normalized).toMatchObject({
+      type: "document",
+      content: "document caption",
+      replyToId: "quoted-document-id",
+      personalMedia: {
+        kind: "document",
+        mimeType: "application/pdf",
+        fileName: "résumé.pdf",
+      },
+    });
+  });
+
+  it.each([
+    "../secret.pdf",
+    "folder\\secret.pdf",
+    "C:\\secret.pdf",
+    "report\u0000.pdf",
+    "report\u202Efdp.exe",
+    "report\u2028forged.pdf",
+    "report\u2029forged.pdf",
+    `${"x".repeat(241)}.pdf`,
+    "broken\uD800.pdf",
+  ])("rejects an unsafe provider filename: %j", (fileName) => {
+    expect(() =>
+      new MessageAdapter().toNormalized(
+        inbound({ documentMessage: { ...mediaFields("application/pdf"), fileName } })
+      )
+    ).toThrowError(expect.objectContaining({ code: "WHATSAPP_PERSONAL_MEDIA_FILENAME_INVALID" }));
+  });
+
+  it.each([
+    "image/png; charset=binary",
+    "image",
+    "image/ bad",
+    `image/${"x".repeat(128)}`,
+    "image/\uD800",
+  ])("rejects a malformed provider MIME declaration: %j", (mimetype) => {
+    expect(() =>
+      new MessageAdapter().toNormalized(inbound({ imageMessage: mediaFields(mimetype) }))
+    ).toThrowError(expect.objectContaining({ code: "WHATSAPP_PERSONAL_MEDIA_METADATA_INVALID" }));
+  });
+});

--- a/plugins/plugin-whatsapp/src/baileys/message-adapter.ts
+++ b/plugins/plugin-whatsapp/src/baileys/message-adapter.ts
@@ -6,7 +6,7 @@
  */
 import { Buffer } from "node:buffer";
 import { ElizaError } from "@elizaos/core";
-import type { proto } from "@whiskeysockets/baileys";
+import { extractMessageContent, type proto } from "@whiskeysockets/baileys";
 import type {
   NormalizedMessage,
   WhatsAppMediaMessage,
@@ -19,17 +19,18 @@ export class MessageAdapter {
   toNormalized(msg: proto.IWebMessageInfo): NormalizedMessage {
     const chatId = msg.key?.remoteJid ?? "";
     const senderId = msg.key?.participant ?? chatId;
+    const content = extractMessageContent(msg.message);
 
-    const personalMedia = extractPersonalMediaMetadata(msg);
+    const personalMedia = content ? extractPersonalMediaMetadata(content) : undefined;
     return {
       id: msg.key?.id ?? "",
       from: chatId,
       timestamp: Number(msg.messageTimestamp ?? 0),
-      type: this.detectType(msg),
-      content: this.extractContent(msg),
+      type: this.detectType(content),
+      content: this.extractContent(content),
       chatId,
       senderId,
-      replyToId: this.extractReplyToId(msg),
+      replyToId: this.extractReplyToId(content),
       ...(personalMedia ? { personalMedia } : {}),
     };
   }
@@ -86,43 +87,43 @@ export class MessageAdapter {
   }
 
   private detectType(
-    msg: proto.IWebMessageInfo
+    content: proto.IMessage | undefined
   ): "text" | "image" | "audio" | "video" | "document" {
-    if (msg.message?.conversation || msg.message?.extendedTextMessage) {
+    if (content?.conversation || content?.extendedTextMessage) {
       return "text";
     }
-    if (msg.message?.imageMessage) {
+    if (content?.imageMessage) {
       return "image";
     }
-    if (msg.message?.audioMessage) {
+    if (content?.audioMessage) {
       return "audio";
     }
-    if (msg.message?.videoMessage) {
+    if (content?.videoMessage) {
       return "video";
     }
-    if (msg.message?.documentMessage) {
+    if (content?.documentMessage) {
       return "document";
     }
     return "text";
   }
 
-  private extractContent(msg: proto.IWebMessageInfo): string {
+  private extractContent(content: proto.IMessage | undefined): string {
     return (
-      msg.message?.conversation ??
-      msg.message?.extendedTextMessage?.text ??
-      msg.message?.imageMessage?.caption ??
-      msg.message?.videoMessage?.caption ??
-      msg.message?.documentMessage?.caption ??
+      content?.conversation ??
+      content?.extendedTextMessage?.text ??
+      content?.imageMessage?.caption ??
+      content?.videoMessage?.caption ??
+      content?.documentMessage?.caption ??
       ""
     );
   }
 
-  private extractReplyToId(msg: proto.IWebMessageInfo): string | undefined {
+  private extractReplyToId(content: proto.IMessage | undefined): string | undefined {
     const contextInfo =
-      msg.message?.extendedTextMessage?.contextInfo ??
-      msg.message?.imageMessage?.contextInfo ??
-      msg.message?.videoMessage?.contextInfo ??
-      msg.message?.documentMessage?.contextInfo;
+      content?.extendedTextMessage?.contextInfo ??
+      content?.imageMessage?.contextInfo ??
+      content?.videoMessage?.contextInfo ??
+      content?.documentMessage?.contextInfo;
 
     return typeof contextInfo?.stanzaId === "string" ? contextInfo.stanzaId : undefined;
   }

--- a/plugins/plugin-whatsapp/src/runtime-service.ts
+++ b/plugins/plugin-whatsapp/src/runtime-service.ts
@@ -1201,28 +1201,22 @@ export class WhatsAppConnectorService extends Service {
 
     client.on("message", (message: NormalizedMessage) => {
       void this.handleNormalizedMessage(message, accountId).catch((error: unknown) => {
-        this.runtime.logger.error(
-          {
-            src: "plugin:whatsapp",
-            agentId: this.runtime.agentId,
-            accountId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Failed to process inbound WhatsApp message"
-        );
+        // error-policy:J7 Per-message transport failures are reported without killing the client loop.
+        this.runtime.reportError("plugin:whatsapp:inbound-message", error, {
+          accountId,
+          chatId: message.chatId ?? message.from,
+          externalMessageId: message.id,
+          stage: message.personalMedia ? "media-fetch-store-decrypt" : "message-processing",
+        });
       });
     });
 
     client.on("error", (error: unknown) => {
-      this.runtime.logger.error(
-        {
-          src: "plugin:whatsapp",
-          agentId: this.runtime.agentId,
-          accountId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "WhatsApp client error"
-      );
+      // error-policy:J7 Baileys metadata and socket failures are diagnostic events, not loop exits.
+      this.runtime.reportError("plugin:whatsapp:client", error, {
+        accountId,
+        stage: client instanceof BaileysClient ? "baileys-metadata-or-socket" : "cloud-client",
+      });
     });
   }
 


### PR DESCRIPTION
Closes the review gaps identified after #25375 for #25229. The original PR was merged externally while its requested hold was still active, so this is a review-only follow-up on current `develop`.

## Review repairs

- Match Baileys rc14 direct-path fallback semantics by deriving the authorized CDN host from `metadata.url`, including nondefault allowed `fbcdn.net` hosts, while retaining HTTPS allowlisting and DNS pinning.
- Normalize wrapped inbound content exactly once with `extractMessageContent`, then derive type, caption, reply id, and media metadata from the same envelope. Tests cover ephemeral, view-once, and document-with-caption wrappers.
- Report Baileys metadata/socket failures and per-message media fetch/store/decrypt failures through `runtime.reportError` with account/message/stage context; tests prove diagnostics and later-message loop continuity.
- Validate provider MIME tokens and filenames once at ingress. Filenames are NFC-normalized, UTF-8 byte bounded display names; path-like names, controls, bidi formatting, malformed Unicode, and invalid MIME declarations fail typed and ephemeral.

## Verification

- `bun install --frozen-lockfile`
- WhatsApp: 23 files / 192 tests passed
- WhatsApp typecheck passed
- WhatsApp Biome passed (44 files)
- WhatsApp build passed
- Core guarded media/network: 8 files / 82 tests passed
- Agent canonical media store: 72 tests passed
- Agent build passed
- Diff check passed

## Evidence limits

- The self-signed pinned HTTPS loopback test proves certificate verification rejects an untrusted certificate; it is not a successful trusted-TLS transport proof.
- A successful trusted-certificate transport run and a live paired-device WhatsApp media roundtrip remain unavailable in this environment and are not claimed here.
- Official WhatsApp Cloud clients/webhooks are unchanged by this follow-up.
