### PR TITLE
test(app-core): cover json response helpers

### DIFF
--- a/packages/app-core/src/api/__tests__/api-response.test.ts
+++ b/packages/app-core/src/api/__tests__/api-response.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendJson, sendJsonError } from "./response.ts";
+
+function mockRes() {
+  return {
+    headersSent: false,
+    statusCode: 0,
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  } as unknown as import("node:http").ServerResponse;
+}
+
+describe("sendJson", () => {
+  it("writes status, content-type, and json body", () => {
+    const res = mockRes();
+    sendJson(res, 200, { ok: true });
+    expect(res.statusCode).toBe(200);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "content-type",
+      "application/json; charset=utf-8",
+    );
+    const body = JSON.parse(
+      (res.end as ReturnType<typeof vi.fn>).mock.calls[0][0],
+    );
+    expect(body).toEqual({ ok: true });
+  });
+
+  it("strips stack traces from error payloads", () => {
+    const res = mockRes();
+    sendJson(res, 500, { err: new Error("boom") });
+    const body = JSON.parse(
+      (res.end as ReturnType<typeof vi.fn>).mock.calls[0][0],
+    );
+    expect(body).toEqual({ err: { error: "boom" } });
+    expect(JSON.stringify(body)).not.toContain("stack");
+  });
+
+  it("is a no-op once headers are sent", () => {
+    const res = mockRes();
+    res.headersSent = true;
+    sendJson(res, 500, {});
+    expect(res.end).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendJsonError", () => {
+  it("wraps the message as an error object", () => {
+    const res = mockRes();
+    sendJsonError(res, 400, "bad request");
+    const body = JSON.parse(
+      (res.end as ReturnType<typeof vi.fn>).mock.calls[0][0],
+    );
+    expect(body).toEqual({ error: "bad request" });
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 4 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
