### PR TITLE
chore(agent): restore formatter closure

### DIFF
--- a/packages/agent/src/api/wallet-trading-profile.test.ts
+++ b/packages/agent/src/api/wallet-trading-profile.test.ts
@@ -8,21 +8,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
-	WalletTradeLedgerEntry,
-	WalletTradingProfileSourceFilter,
-	WalletTradingProfileWindow,
+  WalletTradeLedgerEntry,
+  WalletTradingProfileSourceFilter,
+  WalletTradingProfileWindow,
 } from "@elizaos/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	buildWalletTradingProfile,
-	loadWalletTradingProfile,
-	readWalletTradeLedgerStore,
-	recordWalletTradeLedgerEntry,
-	resolveWalletTradingProfileFilePath,
-	updateWalletTradeLedgerEntryStatus,
-	type WalletTradeLedgerRecordInput,
-	type WalletTradeLedgerStatusPatch,
-	writeWalletTradeLedgerStore,
+  buildWalletTradingProfile,
+  loadWalletTradingProfile,
+  readWalletTradeLedgerStore,
+  recordWalletTradeLedgerEntry,
+  resolveWalletTradingProfileFilePath,
+  updateWalletTradeLedgerEntryStatus,
+  type WalletTradeLedgerRecordInput,
+  type WalletTradeLedgerStatusPatch,
+  writeWalletTradeLedgerStore,
 } from "./wallet-trading-profile.ts";
 
 const TOKEN_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -33,832 +33,832 @@ const TOKEN_WEI = "100000000000000000000";
 const tempDirs: string[] = [];
 
 afterEach(() => {
-	while (tempDirs.length > 0) {
-		const dir = tempDirs.pop();
-		if (dir) fs.rmSync(dir, { recursive: true, force: true });
-	}
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 function makeStateDir(): string {
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wallet-trading-profile-"));
-	tempDirs.push(dir);
-	return dir;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wallet-trading-profile-"));
+  tempDirs.push(dir);
+  return dir;
 }
 
 function bnbLeg(amount: string, symbol = "BNB") {
-	return { symbol, amount, amountWei: BNB_WEI };
+  return { symbol, amount, amountWei: BNB_WEI };
 }
 
 function tokenLeg(amount: string, symbol = "TKN") {
-	return { symbol, amount, amountWei: TOKEN_WEI };
+  return { symbol, amount, amountWei: TOKEN_WEI };
 }
 
 function makeInput(overrides: {
-	hash: string;
-	side?: WalletTradeLedgerRecordInput["side"];
-	source?: WalletTradeLedgerRecordInput["source"];
-	status?: WalletTradeLedgerRecordInput["status"];
-	tokenAddress?: string;
-	slippageBps?: number;
-	route?: string[];
-	quoteIn?: WalletTradeLedgerRecordInput["quoteIn"];
-	quoteOut?: WalletTradeLedgerRecordInput["quoteOut"];
-	confirmations?: number;
-	nonce?: number | null;
-	blockNumber?: number | null;
-	gasUsed?: string | null;
-	effectiveGasPriceWei?: string | null;
-	reason?: string;
-	explorerUrl?: string;
-	createdAt?: string;
-	updatedAt?: string;
+  hash: string;
+  side?: WalletTradeLedgerRecordInput["side"];
+  source?: WalletTradeLedgerRecordInput["source"];
+  status?: WalletTradeLedgerRecordInput["status"];
+  tokenAddress?: string;
+  slippageBps?: number;
+  route?: string[];
+  quoteIn?: WalletTradeLedgerRecordInput["quoteIn"];
+  quoteOut?: WalletTradeLedgerRecordInput["quoteOut"];
+  confirmations?: number;
+  nonce?: number | null;
+  blockNumber?: number | null;
+  gasUsed?: string | null;
+  effectiveGasPriceWei?: string | null;
+  reason?: string;
+  explorerUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }): WalletTradeLedgerRecordInput {
-	const side = overrides.side ?? "buy";
-	return {
-		hash: overrides.hash,
-		source: overrides.source ?? "manual",
-		side,
-		tokenAddress: overrides.tokenAddress ?? TOKEN_A,
-		slippageBps: overrides.slippageBps ?? 100,
-		route: overrides.route ?? ["WBNB", "TKN"],
-		quoteIn:
-			overrides.quoteIn ?? (side === "buy" ? bnbLeg("1") : tokenLeg("10")),
-		quoteOut:
-			overrides.quoteOut ?? (side === "buy" ? tokenLeg("10") : bnbLeg("1.2")),
-		status: overrides.status ?? "success",
-		confirmations: overrides.confirmations ?? 12,
-		nonce: overrides.nonce === undefined ? 1 : overrides.nonce,
-		blockNumber:
-			overrides.blockNumber === undefined ? 100 : overrides.blockNumber,
-		gasUsed: overrides.gasUsed === undefined ? "21000" : overrides.gasUsed,
-		effectiveGasPriceWei:
-			overrides.effectiveGasPriceWei === undefined
-				? "5000000000"
-				: overrides.effectiveGasPriceWei,
-		...(overrides.reason !== undefined ? { reason: overrides.reason } : {}),
-		explorerUrl:
-			overrides.explorerUrl ?? `https://bscscan.com/tx/${overrides.hash}`,
-		...(overrides.createdAt !== undefined
-			? { createdAt: overrides.createdAt }
-			: {}),
-		...(overrides.updatedAt !== undefined
-			? { updatedAt: overrides.updatedAt }
-			: {}),
-	};
+  const side = overrides.side ?? "buy";
+  return {
+    hash: overrides.hash,
+    source: overrides.source ?? "manual",
+    side,
+    tokenAddress: overrides.tokenAddress ?? TOKEN_A,
+    slippageBps: overrides.slippageBps ?? 100,
+    route: overrides.route ?? ["WBNB", "TKN"],
+    quoteIn:
+      overrides.quoteIn ?? (side === "buy" ? bnbLeg("1") : tokenLeg("10")),
+    quoteOut:
+      overrides.quoteOut ?? (side === "buy" ? tokenLeg("10") : bnbLeg("1.2")),
+    status: overrides.status ?? "success",
+    confirmations: overrides.confirmations ?? 12,
+    nonce: overrides.nonce === undefined ? 1 : overrides.nonce,
+    blockNumber:
+      overrides.blockNumber === undefined ? 100 : overrides.blockNumber,
+    gasUsed: overrides.gasUsed === undefined ? "21000" : overrides.gasUsed,
+    effectiveGasPriceWei:
+      overrides.effectiveGasPriceWei === undefined
+        ? "5000000000"
+        : overrides.effectiveGasPriceWei,
+    ...(overrides.reason !== undefined ? { reason: overrides.reason } : {}),
+    explorerUrl:
+      overrides.explorerUrl ?? `https://bscscan.com/tx/${overrides.hash}`,
+    ...(overrides.createdAt !== undefined
+      ? { createdAt: overrides.createdAt }
+      : {}),
+    ...(overrides.updatedAt !== undefined
+      ? { updatedAt: overrides.updatedAt }
+      : {}),
+  };
 }
 
 function makeEntry(overrides: {
-	hash: string;
-	createdAt: string;
-	side?: WalletTradeLedgerEntry["side"];
-	source?: WalletTradeLedgerEntry["source"];
-	status?: WalletTradeLedgerEntry["status"];
-	tokenAddress?: string;
-	quoteInAmount?: string;
-	quoteOutAmount?: string;
-	quoteInSymbol?: string;
-	quoteOutSymbol?: string;
-	reason?: string;
+  hash: string;
+  createdAt: string;
+  side?: WalletTradeLedgerEntry["side"];
+  source?: WalletTradeLedgerEntry["source"];
+  status?: WalletTradeLedgerEntry["status"];
+  tokenAddress?: string;
+  quoteInAmount?: string;
+  quoteOutAmount?: string;
+  quoteInSymbol?: string;
+  quoteOutSymbol?: string;
+  reason?: string;
 }): WalletTradeLedgerEntry {
-	const side = overrides.side ?? "buy";
-	const quoteInSymbol =
-		overrides.quoteInSymbol ?? (side === "buy" ? "BNB" : "TKN");
-	const quoteOutSymbol =
-		overrides.quoteOutSymbol ?? (side === "buy" ? "TKN" : "BNB");
-	const quoteInAmount =
-		overrides.quoteInAmount ?? (side === "buy" ? "1" : "10");
-	const quoteOutAmount =
-		overrides.quoteOutAmount ?? (side === "buy" ? "10" : "1.2");
-	return {
-		hash: overrides.hash,
-		createdAt: overrides.createdAt,
-		updatedAt: overrides.createdAt,
-		source: overrides.source ?? "manual",
-		side,
-		tokenAddress: overrides.tokenAddress ?? TOKEN_A,
-		slippageBps: 100,
-		route: ["WBNB", "TKN"],
-		quoteIn: {
-			symbol: quoteInSymbol,
-			amount: quoteInAmount,
-			amountWei: BNB_WEI,
-		},
-		quoteOut: {
-			symbol: quoteOutSymbol,
-			amount: quoteOutAmount,
-			amountWei: TOKEN_WEI,
-		},
-		status: overrides.status ?? "success",
-		confirmations: 1,
-		nonce: 1,
-		blockNumber: 1,
-		gasUsed: "21000",
-		effectiveGasPriceWei: "5000000000",
-		...(overrides.reason !== undefined ? { reason: overrides.reason } : {}),
-		explorerUrl: `https://bscscan.com/tx/${overrides.hash}`,
-	};
+  const side = overrides.side ?? "buy";
+  const quoteInSymbol =
+    overrides.quoteInSymbol ?? (side === "buy" ? "BNB" : "TKN");
+  const quoteOutSymbol =
+    overrides.quoteOutSymbol ?? (side === "buy" ? "TKN" : "BNB");
+  const quoteInAmount =
+    overrides.quoteInAmount ?? (side === "buy" ? "1" : "10");
+  const quoteOutAmount =
+    overrides.quoteOutAmount ?? (side === "buy" ? "10" : "1.2");
+  return {
+    hash: overrides.hash,
+    createdAt: overrides.createdAt,
+    updatedAt: overrides.createdAt,
+    source: overrides.source ?? "manual",
+    side,
+    tokenAddress: overrides.tokenAddress ?? TOKEN_A,
+    slippageBps: 100,
+    route: ["WBNB", "TKN"],
+    quoteIn: {
+      symbol: quoteInSymbol,
+      amount: quoteInAmount,
+      amountWei: BNB_WEI,
+    },
+    quoteOut: {
+      symbol: quoteOutSymbol,
+      amount: quoteOutAmount,
+      amountWei: TOKEN_WEI,
+    },
+    status: overrides.status ?? "success",
+    confirmations: 1,
+    nonce: 1,
+    blockNumber: 1,
+    gasUsed: "21000",
+    effectiveGasPriceWei: "5000000000",
+    ...(overrides.reason !== undefined ? { reason: overrides.reason } : {}),
+    explorerUrl: `https://bscscan.com/tx/${overrides.hash}`,
+  };
 }
 
 function isoDaysAgo(days: number): string {
-	return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
 describe("resolveWalletTradingProfileFilePath", () => {
-	it("places the v1 ledger under stateDir/wallet/", () => {
-		expect(resolveWalletTradingProfileFilePath("/tmp/eliza-state")).toBe(
-			path.join("/tmp/eliza-state", "wallet", "trading-profile.v1.json"),
-		);
-	});
+  it("places the v1 ledger under stateDir/wallet/", () => {
+    expect(resolveWalletTradingProfileFilePath("/tmp/eliza-state")).toBe(
+      path.join("/tmp/eliza-state", "wallet", "trading-profile.v1.json"),
+    );
+  });
 });
 
 describe("readWalletTradeLedgerStore / writeWalletTradeLedgerStore", () => {
-	it("returns an empty v1 store when the ledger file is missing", () => {
-		const stateDir = makeStateDir();
-		const store = readWalletTradeLedgerStore(stateDir);
-		expect(store.version).toBe(1);
-		expect(store.entries).toEqual([]);
-		expect(Number.isFinite(Date.parse(store.updatedAt))).toBe(true);
-	});
+  it("returns an empty v1 store when the ledger file is missing", () => {
+    const stateDir = makeStateDir();
+    const store = readWalletTradeLedgerStore(stateDir);
+    expect(store.version).toBe(1);
+    expect(store.entries).toEqual([]);
+    expect(Number.isFinite(Date.parse(store.updatedAt))).toBe(true);
+  });
 
-	it("round-trips a written store and sorts by createdAt then hash", () => {
-		const stateDir = makeStateDir();
-		const later = makeEntry({
-			hash: "0xbbb",
-			createdAt: "2026-08-20T00:00:00.000Z",
-		});
-		const earlier = makeEntry({
-			hash: "0xaaa",
-			createdAt: "2026-08-10T00:00:00.000Z",
-		});
-		const tiedLaterHash = makeEntry({
-			hash: "0xccc",
-			createdAt: "2026-08-10T00:00:00.000Z",
-		});
-		const empty = readWalletTradeLedgerStore(stateDir);
-		const written = writeWalletTradeLedgerStore(
-			{ ...empty, entries: [later, tiedLaterHash, earlier] },
-			stateDir,
-		);
-		expect(written.entries.map((e) => e.hash)).toEqual([
-			"0xaaa",
-			"0xccc",
-			"0xbbb",
-		]);
-		const reread = readWalletTradeLedgerStore(stateDir);
-		expect(reread.entries.map((e) => e.hash)).toEqual([
-			"0xaaa",
-			"0xccc",
-			"0xbbb",
-		]);
-	});
+  it("round-trips a written store and sorts by createdAt then hash", () => {
+    const stateDir = makeStateDir();
+    const later = makeEntry({
+      hash: "0xbbb",
+      createdAt: "2026-08-20T00:00:00.000Z",
+    });
+    const earlier = makeEntry({
+      hash: "0xaaa",
+      createdAt: "2026-08-10T00:00:00.000Z",
+    });
+    const tiedLaterHash = makeEntry({
+      hash: "0xccc",
+      createdAt: "2026-08-10T00:00:00.000Z",
+    });
+    const empty = readWalletTradeLedgerStore(stateDir);
+    const written = writeWalletTradeLedgerStore(
+      { ...empty, entries: [later, tiedLaterHash, earlier] },
+      stateDir,
+    );
+    expect(written.entries.map((e) => e.hash)).toEqual([
+      "0xaaa",
+      "0xccc",
+      "0xbbb",
+    ]);
+    const reread = readWalletTradeLedgerStore(stateDir);
+    expect(reread.entries.map((e) => e.hash)).toEqual([
+      "0xaaa",
+      "0xccc",
+      "0xbbb",
+    ]);
+  });
 
-	it("drops the oldest entries when the ledger overflows 2000", () => {
-		const stateDir = makeStateDir();
-		const entries = Array.from({ length: 2001 }, (_, i) =>
-			makeEntry({
-				hash: `0x${i.toString(16).padStart(8, "0")}`,
-				createdAt: new Date(Date.UTC(2020, 0, 1, 0, 0, i)).toISOString(),
-			}),
-		);
-		const empty = readWalletTradeLedgerStore(stateDir);
-		const written = writeWalletTradeLedgerStore(
-			{ ...empty, entries },
-			stateDir,
-		);
-		expect(written.entries).toHaveLength(2000);
-		expect(written.entries[0]?.hash).toBe(
-			`0x${(1).toString(16).padStart(8, "0")}`,
-		);
-		expect(written.entries[1999]?.hash).toBe(
-			`0x${(2000).toString(16).padStart(8, "0")}`,
-		);
-	});
+  it("drops the oldest entries when the ledger overflows 2000", () => {
+    const stateDir = makeStateDir();
+    const entries = Array.from({ length: 2001 }, (_, i) =>
+      makeEntry({
+        hash: `0x${i.toString(16).padStart(8, "0")}`,
+        createdAt: new Date(Date.UTC(2020, 0, 1, 0, 0, i)).toISOString(),
+      }),
+    );
+    const empty = readWalletTradeLedgerStore(stateDir);
+    const written = writeWalletTradeLedgerStore(
+      { ...empty, entries },
+      stateDir,
+    );
+    expect(written.entries).toHaveLength(2000);
+    expect(written.entries[0]?.hash).toBe(
+      `0x${(1).toString(16).padStart(8, "0")}`,
+    );
+    expect(written.entries[1999]?.hash).toBe(
+      `0x${(2000).toString(16).padStart(8, "0")}`,
+    );
+  });
 
-	it("quarantines a corrupt ledger and returns an empty store", () => {
-		const stateDir = makeStateDir();
-		const filePath = resolveWalletTradingProfileFilePath(stateDir);
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, "{not-json", "utf-8");
+  it("quarantines a corrupt ledger and returns an empty store", () => {
+    const stateDir = makeStateDir();
+    const filePath = resolveWalletTradingProfileFilePath(stateDir);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "{not-json", "utf-8");
 
-		const store = readWalletTradeLedgerStore(stateDir);
-		expect(store.entries).toEqual([]);
-		expect(fs.existsSync(filePath)).toBe(false);
-		const backups = fs
-			.readdirSync(path.dirname(filePath))
-			.filter((name) => name.startsWith("trading-profile.v1.json.corrupt-"));
-		expect(backups).toHaveLength(1);
-	});
+    const store = readWalletTradeLedgerStore(stateDir);
+    expect(store.entries).toEqual([]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    const backups = fs
+      .readdirSync(path.dirname(filePath))
+      .filter((name) => name.startsWith("trading-profile.v1.json.corrupt-"));
+    expect(backups).toHaveLength(1);
+  });
 
-	it("skips invalid entries and treats a non-array entries field as empty", () => {
-		const stateDir = makeStateDir();
-		const filePath = resolveWalletTradingProfileFilePath(stateDir);
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(
-			filePath,
-			JSON.stringify({
-				version: 1,
-				updatedAt: "2026-08-01T00:00:00.000Z",
-				entries: [
-					null,
-					12,
-					[],
-					{ hash: "", tokenAddress: TOKEN_A },
-					{
-						hash: "0xdead",
-						tokenAddress: TOKEN_A,
-						quoteIn: { symbol: "BNB", amount: "1" },
-						quoteOut: tokenLeg("10"),
-					},
-					{
-						hash: "  0xGOOD  ",
-						createdAt: "2026-08-02T00:00:00.000Z",
-						updatedAt: "2026-08-02T00:00:00.000Z",
-						source: "AGENT",
-						side: "SELL",
-						tokenAddress: TOKEN_A.toUpperCase(),
-						slippageBps: -3.2,
-						route: ["WBNB", "", 99, "TKN"],
-						quoteIn: tokenLeg("10"),
-						quoteOut: bnbLeg("1.1"),
-						status: "SUCCESS",
-						confirmations: -2.7,
-						nonce: -3.2,
-						blockNumber: -9,
-						gasUsed: "   ",
-						effectiveGasPriceWei: "",
-						explorerUrl: "  https://bscscan.com/tx/0xGOOD  ",
-					},
-				],
-			}),
-			"utf-8",
-		);
+  it("skips invalid entries and treats a non-array entries field as empty", () => {
+    const stateDir = makeStateDir();
+    const filePath = resolveWalletTradingProfileFilePath(stateDir);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        updatedAt: "2026-08-01T00:00:00.000Z",
+        entries: [
+          null,
+          12,
+          [],
+          { hash: "", tokenAddress: TOKEN_A },
+          {
+            hash: "0xdead",
+            tokenAddress: TOKEN_A,
+            quoteIn: { symbol: "BNB", amount: "1" },
+            quoteOut: tokenLeg("10"),
+          },
+          {
+            hash: "  0xGOOD  ",
+            createdAt: "2026-08-02T00:00:00.000Z",
+            updatedAt: "2026-08-02T00:00:00.000Z",
+            source: "AGENT",
+            side: "SELL",
+            tokenAddress: TOKEN_A.toUpperCase(),
+            slippageBps: -3.2,
+            route: ["WBNB", "", 99, "TKN"],
+            quoteIn: tokenLeg("10"),
+            quoteOut: bnbLeg("1.1"),
+            status: "SUCCESS",
+            confirmations: -2.7,
+            nonce: -3.2,
+            blockNumber: -9,
+            gasUsed: "   ",
+            effectiveGasPriceWei: "",
+            explorerUrl: "  https://bscscan.com/tx/0xGOOD  ",
+          },
+        ],
+      }),
+      "utf-8",
+    );
 
-		const store = readWalletTradeLedgerStore(stateDir);
-		expect(store.entries).toHaveLength(1);
-		const entry = store.entries[0];
-		expect(entry?.hash).toBe("0xGOOD");
-		expect(entry?.source).toBe("agent");
-		expect(entry?.side).toBe("sell");
-		expect(entry?.tokenAddress).toBe(TOKEN_A);
-		expect(entry?.status).toBe("success");
-		expect(entry?.slippageBps).toBe(0);
-		expect(entry?.confirmations).toBe(0);
-		expect(entry?.nonce).toBe(0);
-		expect(entry?.blockNumber).toBe(0);
-		expect(entry?.gasUsed).toBeNull();
-		expect(entry?.effectiveGasPriceWei).toBeNull();
-		expect(entry?.route).toEqual(["WBNB", "TKN"]);
-		expect(entry?.explorerUrl).toBe("https://bscscan.com/tx/0xGOOD");
-	});
+    const store = readWalletTradeLedgerStore(stateDir);
+    expect(store.entries).toHaveLength(1);
+    const entry = store.entries[0];
+    expect(entry?.hash).toBe("0xGOOD");
+    expect(entry?.source).toBe("agent");
+    expect(entry?.side).toBe("sell");
+    expect(entry?.tokenAddress).toBe(TOKEN_A);
+    expect(entry?.status).toBe("success");
+    expect(entry?.slippageBps).toBe(0);
+    expect(entry?.confirmations).toBe(0);
+    expect(entry?.nonce).toBe(0);
+    expect(entry?.blockNumber).toBe(0);
+    expect(entry?.gasUsed).toBeNull();
+    expect(entry?.effectiveGasPriceWei).toBeNull();
+    expect(entry?.route).toEqual(["WBNB", "TKN"]);
+    expect(entry?.explorerUrl).toBe("https://bscscan.com/tx/0xGOOD");
+  });
 
-	it("treats a missing entries array as empty", () => {
-		const stateDir = makeStateDir();
-		const filePath = resolveWalletTradingProfileFilePath(stateDir);
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(
-			filePath,
-			JSON.stringify({ version: 1, updatedAt: "not-a-date", entries: "nope" }),
-			"utf-8",
-		);
-		const store = readWalletTradeLedgerStore(stateDir);
-		expect(store.entries).toEqual([]);
-		expect(Number.isFinite(Date.parse(store.updatedAt))).toBe(true);
-	});
+  it("treats a missing entries array as empty", () => {
+    const stateDir = makeStateDir();
+    const filePath = resolveWalletTradingProfileFilePath(stateDir);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ version: 1, updatedAt: "not-a-date", entries: "nope" }),
+      "utf-8",
+    );
+    const store = readWalletTradeLedgerStore(stateDir);
+    expect(store.entries).toEqual([]);
+    expect(Number.isFinite(Date.parse(store.updatedAt))).toBe(true);
+  });
 });
 
 describe("recordWalletTradeLedgerEntry", () => {
-	it("appends a new trade and upserts an existing hash", () => {
-		const stateDir = makeStateDir();
-		const first = recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: " 0xabc ",
-				createdAt: "2026-08-01T00:00:00.000Z",
-				tokenAddress: ` ${TOKEN_A.toUpperCase()} `,
-				status: "pending",
-				source: "agent",
-				side: "buy",
-				nonce: 3.9,
-				blockNumber: -4,
-				gasUsed: "  ",
-				explorerUrl: "   ",
-				route: [" WBNB ", "", "TKN"],
-			}),
-			stateDir,
-		);
-		expect(first.hash).toBe("0xabc");
-		expect(first.tokenAddress).toBe(TOKEN_A);
-		expect(first.status).toBe("pending");
-		expect(first.source).toBe("agent");
-		expect(first.nonce).toBe(3);
-		expect(first.blockNumber).toBe(0);
-		expect(first.gasUsed).toBeNull();
-		expect(first.explorerUrl).toBe("https://bscscan.com/tx/0xabc");
-		expect(first.route).toEqual(["WBNB", "TKN"]);
+  it("appends a new trade and upserts an existing hash", () => {
+    const stateDir = makeStateDir();
+    const first = recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: " 0xabc ",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        tokenAddress: ` ${TOKEN_A.toUpperCase()} `,
+        status: "pending",
+        source: "agent",
+        side: "buy",
+        nonce: 3.9,
+        blockNumber: -4,
+        gasUsed: "  ",
+        explorerUrl: "   ",
+        route: [" WBNB ", "", "TKN"],
+      }),
+      stateDir,
+    );
+    expect(first.hash).toBe("0xabc");
+    expect(first.tokenAddress).toBe(TOKEN_A);
+    expect(first.status).toBe("pending");
+    expect(first.source).toBe("agent");
+    expect(first.nonce).toBe(3);
+    expect(first.blockNumber).toBe(0);
+    expect(first.gasUsed).toBeNull();
+    expect(first.explorerUrl).toBe("https://bscscan.com/tx/0xabc");
+    expect(first.route).toEqual(["WBNB", "TKN"]);
 
-		const updated = recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: "0xabc",
-				status: "success",
-				createdAt: "2026-08-01T00:00:00.000Z",
-				confirmations: 30,
-			}),
-			stateDir,
-		);
-		expect(updated.status).toBe("success");
-		expect(updated.confirmations).toBe(30);
+    const updated = recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: "0xabc",
+        status: "success",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        confirmations: 30,
+      }),
+      stateDir,
+    );
+    expect(updated.status).toBe("success");
+    expect(updated.confirmations).toBe(30);
 
-		const store = readWalletTradeLedgerStore(stateDir);
-		expect(store.entries).toHaveLength(1);
-		expect(store.entries[0]?.status).toBe("success");
-	});
+    const store = readWalletTradeLedgerStore(stateDir);
+    expect(store.entries).toHaveLength(1);
+    expect(store.entries[0]?.status).toBe("success");
+  });
 
-	it("defaults unknown source/side/status and omits a blank reason", () => {
-		const stateDir = makeStateDir();
-		const entry = recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: "0xdef",
-				source: "user" as WalletTradeLedgerRecordInput["source"],
-				side: "swap" as WalletTradeLedgerRecordInput["side"],
-				status: "mined" as WalletTradeLedgerRecordInput["status"],
-				reason: "   ",
-				slippageBps: -1.4,
-			}),
-			stateDir,
-		);
-		expect(entry.source).toBe("manual");
-		expect(entry.side).toBe("buy");
-		expect(entry.status).toBe("pending");
-		expect(entry.reason).toBeUndefined();
-		expect(entry.slippageBps).toBe(0);
-	});
+  it("defaults unknown source/side/status and omits a blank reason", () => {
+    const stateDir = makeStateDir();
+    const entry = recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: "0xdef",
+        source: "user" as WalletTradeLedgerRecordInput["source"],
+        side: "swap" as WalletTradeLedgerRecordInput["side"],
+        status: "mined" as WalletTradeLedgerRecordInput["status"],
+        reason: "   ",
+        slippageBps: -1.4,
+      }),
+      stateDir,
+    );
+    expect(entry.source).toBe("manual");
+    expect(entry.side).toBe("buy");
+    expect(entry.status).toBe("pending");
+    expect(entry.reason).toBeUndefined();
+    expect(entry.slippageBps).toBe(0);
+  });
 });
 
 describe("updateWalletTradeLedgerEntryStatus", () => {
-	it("returns null for a blank hash or a missing ledger item", () => {
-		const stateDir = makeStateDir();
-		recordWalletTradeLedgerEntry(makeInput({ hash: "0xpresent" }), stateDir);
-		const patch: WalletTradeLedgerStatusPatch = {
-			status: "success",
-			confirmations: 1,
-			nonce: 1,
-			blockNumber: 1,
-			gasUsed: "1",
-			effectiveGasPriceWei: "1",
-		};
-		expect(
-			updateWalletTradeLedgerEntryStatus("   ", patch, stateDir),
-		).toBeNull();
-		expect(
-			updateWalletTradeLedgerEntryStatus("0xmissing", patch, stateDir),
-		).toBeNull();
-	});
+  it("returns null for a blank hash or a missing ledger item", () => {
+    const stateDir = makeStateDir();
+    recordWalletTradeLedgerEntry(makeInput({ hash: "0xpresent" }), stateDir);
+    const patch: WalletTradeLedgerStatusPatch = {
+      status: "success",
+      confirmations: 1,
+      nonce: 1,
+      blockNumber: 1,
+      gasUsed: "1",
+      effectiveGasPriceWei: "1",
+    };
+    expect(
+      updateWalletTradeLedgerEntryStatus("   ", patch, stateDir),
+    ).toBeNull();
+    expect(
+      updateWalletTradeLedgerEntryStatus("0xmissing", patch, stateDir),
+    ).toBeNull();
+  });
 
-	it("allows pending → success and refuses success → reverted", () => {
-		const stateDir = makeStateDir();
-		recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: "0xflow",
-				status: "pending",
-				reason: "waiting",
-				createdAt: "2026-08-01T00:00:00.000Z",
-			}),
-			stateDir,
-		);
+  it("allows pending → success and refuses success → reverted", () => {
+    const stateDir = makeStateDir();
+    recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: "0xflow",
+        status: "pending",
+        reason: "waiting",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      }),
+      stateDir,
+    );
 
-		const succeeded = updateWalletTradeLedgerEntryStatus(
-			"0xflow",
-			{
-				status: "success",
-				confirmations: 8,
-				nonce: null,
-				blockNumber: 55,
-				gasUsed: " 12345 ",
-				effectiveGasPriceWei: " 9 ",
-				explorerUrl: " https://bscscan.com/tx/0xflow ",
-			},
-			stateDir,
-		);
-		expect(succeeded?.status).toBe("success");
-		expect(succeeded?.nonce).toBeNull();
-		expect(succeeded?.blockNumber).toBe(55);
-		expect(succeeded?.gasUsed).toBe("12345");
-		expect(succeeded?.reason).toBeUndefined();
-		expect(succeeded?.explorerUrl).toBe("https://bscscan.com/tx/0xflow");
+    const succeeded = updateWalletTradeLedgerEntryStatus(
+      "0xflow",
+      {
+        status: "success",
+        confirmations: 8,
+        nonce: null,
+        blockNumber: 55,
+        gasUsed: " 12345 ",
+        effectiveGasPriceWei: " 9 ",
+        explorerUrl: " https://bscscan.com/tx/0xflow ",
+      },
+      stateDir,
+    );
+    expect(succeeded?.status).toBe("success");
+    expect(succeeded?.nonce).toBeNull();
+    expect(succeeded?.blockNumber).toBe(55);
+    expect(succeeded?.gasUsed).toBe("12345");
+    expect(succeeded?.reason).toBeUndefined();
+    expect(succeeded?.explorerUrl).toBe("https://bscscan.com/tx/0xflow");
 
-		const refused = updateWalletTradeLedgerEntryStatus(
-			"0xflow",
-			{
-				status: "reverted",
-				confirmations: 99,
-				nonce: 9,
-				blockNumber: 9,
-				gasUsed: "9",
-				effectiveGasPriceWei: "9",
-			},
-			stateDir,
-		);
-		expect(refused?.status).toBe("success");
-		expect(refused?.confirmations).toBe(8);
-		const stored = readWalletTradeLedgerStore(stateDir).entries[0];
-		expect(stored?.status).toBe("success");
-		expect(stored?.confirmations).toBe(8);
-	});
+    const refused = updateWalletTradeLedgerEntryStatus(
+      "0xflow",
+      {
+        status: "reverted",
+        confirmations: 99,
+        nonce: 9,
+        blockNumber: 9,
+        gasUsed: "9",
+        effectiveGasPriceWei: "9",
+      },
+      stateDir,
+    );
+    expect(refused?.status).toBe("success");
+    expect(refused?.confirmations).toBe(8);
+    const stored = readWalletTradeLedgerStore(stateDir).entries[0];
+    expect(stored?.status).toBe("success");
+    expect(stored?.confirmations).toBe(8);
+  });
 
-	it("allows not_found to recover and clears an empty reason string", () => {
-		const stateDir = makeStateDir();
-		recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: "0xnf",
-				status: "not_found",
-				reason: "rpc miss",
-			}),
-			stateDir,
-		);
-		const recovered = updateWalletTradeLedgerEntryStatus(
-			"0xnf",
-			{
-				status: "pending",
-				confirmations: 0,
-				nonce: 2,
-				blockNumber: null,
-				gasUsed: null,
-				effectiveGasPriceWei: null,
-				reason: "   ",
-			},
-			stateDir,
-		);
-		expect(recovered?.status).toBe("pending");
-		expect(recovered?.reason).toBeUndefined();
-		expect(recovered?.blockNumber).toBeNull();
-	});
+  it("allows not_found to recover and clears an empty reason string", () => {
+    const stateDir = makeStateDir();
+    recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: "0xnf",
+        status: "not_found",
+        reason: "rpc miss",
+      }),
+      stateDir,
+    );
+    const recovered = updateWalletTradeLedgerEntryStatus(
+      "0xnf",
+      {
+        status: "pending",
+        confirmations: 0,
+        nonce: 2,
+        blockNumber: null,
+        gasUsed: null,
+        effectiveGasPriceWei: null,
+        reason: "   ",
+      },
+      stateDir,
+    );
+    expect(recovered?.status).toBe("pending");
+    expect(recovered?.reason).toBeUndefined();
+    expect(recovered?.blockNumber).toBeNull();
+  });
 
-	it("keeps a reason when transitioning to reverted without a reason patch", () => {
-		const stateDir = makeStateDir();
-		recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: "0xrev",
-				status: "pending",
-				reason: "mempool",
-			}),
-			stateDir,
-		);
-		const reverted = updateWalletTradeLedgerEntryStatus(
-			"0xrev",
-			{
-				status: "reverted",
-				confirmations: 1,
-				nonce: 1,
-				blockNumber: 1,
-				gasUsed: "1",
-				effectiveGasPriceWei: "1",
-				reason: "slippage",
-			},
-			stateDir,
-		);
-		expect(reverted?.status).toBe("reverted");
-		expect(reverted?.reason).toBe("slippage");
+  it("keeps a reason when transitioning to reverted without a reason patch", () => {
+    const stateDir = makeStateDir();
+    recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: "0xrev",
+        status: "pending",
+        reason: "mempool",
+      }),
+      stateDir,
+    );
+    const reverted = updateWalletTradeLedgerEntryStatus(
+      "0xrev",
+      {
+        status: "reverted",
+        confirmations: 1,
+        nonce: 1,
+        blockNumber: 1,
+        gasUsed: "1",
+        effectiveGasPriceWei: "1",
+        reason: "slippage",
+      },
+      stateDir,
+    );
+    expect(reverted?.status).toBe("reverted");
+    expect(reverted?.reason).toBe("slippage");
 
-		const stillReverted = updateWalletTradeLedgerEntryStatus(
-			"0xrev",
-			{
-				status: "success",
-				confirmations: 2,
-				nonce: 1,
-				blockNumber: 1,
-				gasUsed: "1",
-				effectiveGasPriceWei: "1",
-			},
-			stateDir,
-		);
-		expect(stillReverted?.status).toBe("reverted");
-		expect(stillReverted?.reason).toBe("slippage");
-	});
+    const stillReverted = updateWalletTradeLedgerEntryStatus(
+      "0xrev",
+      {
+        status: "success",
+        confirmations: 2,
+        nonce: 1,
+        blockNumber: 1,
+        gasUsed: "1",
+        effectiveGasPriceWei: "1",
+      },
+      stateDir,
+    );
+    expect(stillReverted?.status).toBe("reverted");
+    expect(stillReverted?.reason).toBe("slippage");
+  });
 });
 
 describe("buildWalletTradingProfile", () => {
-	it("returns zeroed summary, empty series, and empty recent swaps for an empty queue", () => {
-		const profile = buildWalletTradingProfile([], {
-			window: "all",
-			source: "all",
-		});
-		expect(profile.window).toBe("all");
-		expect(profile.source).toBe("all");
-		expect(profile.summary).toEqual({
-			totalSwaps: 0,
-			buyCount: 0,
-			sellCount: 0,
-			settledCount: 0,
-			successCount: 0,
-			revertedCount: 0,
-			tradeWinRate: null,
-			txSuccessRate: null,
-			winningTrades: 0,
-			evaluatedTrades: 0,
-			realizedPnlBnb: "0",
-			volumeBnb: "0",
-		});
-		expect(profile.pnlSeries).toEqual([]);
-		expect(profile.tokenBreakdown).toEqual([]);
-		expect(profile.recentSwaps).toEqual([]);
-	});
+  it("returns zeroed summary, empty series, and empty recent swaps for an empty queue", () => {
+    const profile = buildWalletTradingProfile([], {
+      window: "all",
+      source: "all",
+    });
+    expect(profile.window).toBe("all");
+    expect(profile.source).toBe("all");
+    expect(profile.summary).toEqual({
+      totalSwaps: 0,
+      buyCount: 0,
+      sellCount: 0,
+      settledCount: 0,
+      successCount: 0,
+      revertedCount: 0,
+      tradeWinRate: null,
+      txSuccessRate: null,
+      winningTrades: 0,
+      evaluatedTrades: 0,
+      realizedPnlBnb: "0",
+      volumeBnb: "0",
+    });
+    expect(profile.pnlSeries).toEqual([]);
+    expect(profile.tokenBreakdown).toEqual([]);
+    expect(profile.recentSwaps).toEqual([]);
+  });
 
-	it("handles a single successful buy without throwing", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({
-					hash: "0xonly",
-					createdAt: "2026-08-01T00:00:00.000Z",
-				}),
-			],
-			{ window: "all", source: "all" },
-		);
-		expect(profile.summary.totalSwaps).toBe(1);
-		expect(profile.summary.buyCount).toBe(1);
-		expect(profile.summary.sellCount).toBe(0);
-		expect(profile.summary.evaluatedTrades).toBe(0);
-		expect(profile.summary.tradeWinRate).toBeNull();
-		expect(profile.summary.volumeBnb).toBe("1");
-		expect(profile.recentSwaps).toHaveLength(1);
-		expect(profile.recentSwaps[0]?.tokenSymbol).toBe("TKN");
-		expect(profile.tokenBreakdown[0]?.symbol).toBe("TKN");
-	});
+  it("handles a single successful buy without throwing", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({
+          hash: "0xonly",
+          createdAt: "2026-08-01T00:00:00.000Z",
+        }),
+      ],
+      { window: "all", source: "all" },
+    );
+    expect(profile.summary.totalSwaps).toBe(1);
+    expect(profile.summary.buyCount).toBe(1);
+    expect(profile.summary.sellCount).toBe(0);
+    expect(profile.summary.evaluatedTrades).toBe(0);
+    expect(profile.summary.tradeWinRate).toBeNull();
+    expect(profile.summary.volumeBnb).toBe("1");
+    expect(profile.recentSwaps).toHaveLength(1);
+    expect(profile.recentSwaps[0]?.tokenSymbol).toBe("TKN");
+    expect(profile.tokenBreakdown[0]?.symbol).toBe("TKN");
+  });
 
-	it("defaults an unknown window to 30d and an unknown source to all", () => {
-		const profile = buildWalletTradingProfile([], {
-			window: "lifetime" as unknown as WalletTradingProfileWindow,
-			source: "bots" as unknown as WalletTradingProfileSourceFilter,
-		});
-		expect(profile.window).toBe("30d");
-		expect(profile.source).toBe("all");
-	});
+  it("defaults an unknown window to 30d and an unknown source to all", () => {
+    const profile = buildWalletTradingProfile([], {
+      window: "lifetime" as unknown as WalletTradingProfileWindow,
+      source: "bots" as unknown as WalletTradingProfileSourceFilter,
+    });
+    expect(profile.window).toBe("30d");
+    expect(profile.source).toBe("all");
+  });
 
-	it("filters by rolling window and source", () => {
-		const entries = [
-			makeEntry({
-				hash: "0xold",
-				createdAt: isoDaysAgo(40),
-				source: "manual",
-			}),
-			makeEntry({
-				hash: "0xweek-agent",
-				createdAt: isoDaysAgo(3),
-				source: "agent",
-			}),
-			makeEntry({
-				hash: "0xtoday-manual",
-				createdAt: isoDaysAgo(0.2),
-				source: "manual",
-			}),
-		];
+  it("filters by rolling window and source", () => {
+    const entries = [
+      makeEntry({
+        hash: "0xold",
+        createdAt: isoDaysAgo(40),
+        source: "manual",
+      }),
+      makeEntry({
+        hash: "0xweek-agent",
+        createdAt: isoDaysAgo(3),
+        source: "agent",
+      }),
+      makeEntry({
+        hash: "0xtoday-manual",
+        createdAt: isoDaysAgo(0.2),
+        source: "manual",
+      }),
+    ];
 
-		const last30 = buildWalletTradingProfile(entries, { window: "30d" });
-		expect(last30.recentSwaps.map((s) => s.hash)).toEqual([
-			"0xtoday-manual",
-			"0xweek-agent",
-		]);
+    const last30 = buildWalletTradingProfile(entries, { window: "30d" });
+    expect(last30.recentSwaps.map((s) => s.hash)).toEqual([
+      "0xtoday-manual",
+      "0xweek-agent",
+    ]);
 
-		const last24h = buildWalletTradingProfile(entries, { window: "24h" });
-		expect(last24h.recentSwaps.map((s) => s.hash)).toEqual(["0xtoday-manual"]);
+    const last24h = buildWalletTradingProfile(entries, { window: "24h" });
+    expect(last24h.recentSwaps.map((s) => s.hash)).toEqual(["0xtoday-manual"]);
 
-		const last7d = buildWalletTradingProfile(entries, { window: "7d" });
-		expect(last7d.summary.totalSwaps).toBe(2);
+    const last7d = buildWalletTradingProfile(entries, { window: "7d" });
+    expect(last7d.summary.totalSwaps).toBe(2);
 
-		const agentOnly = buildWalletTradingProfile(entries, {
-			window: "all",
-			source: "agent",
-		});
-		expect(agentOnly.recentSwaps.map((s) => s.hash)).toEqual(["0xweek-agent"]);
+    const agentOnly = buildWalletTradingProfile(entries, {
+      window: "all",
+      source: "agent",
+    });
+    expect(agentOnly.recentSwaps.map((s) => s.hash)).toEqual(["0xweek-agent"]);
 
-		const all = buildWalletTradingProfile(entries, { window: "all" });
-		expect(all.summary.totalSwaps).toBe(3);
-	});
+    const all = buildWalletTradingProfile(entries, { window: "all" });
+    expect(all.summary.totalSwaps).toBe(3);
+  });
 
-	it("excludes unparseable createdAt values from a bounded window", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({ hash: "0xbad", createdAt: "not-a-date" }),
-				makeEntry({
-					hash: "0xok",
-					createdAt: isoDaysAgo(1),
-				}),
-			],
-			{ window: "7d", source: "all" },
-		);
-		expect(profile.recentSwaps.map((s) => s.hash)).toEqual(["0xok"]);
-	});
+  it("excludes unparseable createdAt values from a bounded window", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({ hash: "0xbad", createdAt: "not-a-date" }),
+        makeEntry({
+          hash: "0xok",
+          createdAt: isoDaysAgo(1),
+        }),
+      ],
+      { window: "7d", source: "all" },
+    );
+    expect(profile.recentSwaps.map((s) => s.hash)).toEqual(["0xok"]);
+  });
 
-	it("realizes FIFO PnL across lots, including a leftover unmatched sell", () => {
-		const entries = [
-			makeEntry({
-				hash: "0xbuy1",
-				createdAt: "2026-08-01T00:00:00.000Z",
-				side: "buy",
-				quoteInAmount: "2",
-				quoteOutAmount: "10",
-			}),
-			makeEntry({
-				hash: "0xbuy2",
-				createdAt: "2026-08-02T00:00:00.000Z",
-				side: "buy",
-				quoteInAmount: "6",
-				quoteOutAmount: "10",
-			}),
-			makeEntry({
-				hash: "0xsell-full",
-				createdAt: "2026-08-03T00:00:00.000Z",
-				side: "sell",
-				quoteInAmount: "20",
-				quoteOutAmount: "9",
-				quoteInSymbol: "TKN",
-				quoteOutSymbol: "BNB",
-			}),
-			makeEntry({
-				hash: "0xsell-unmatched",
-				createdAt: "2026-08-04T00:00:00.000Z",
-				side: "sell",
-				quoteInAmount: "5",
-				quoteOutAmount: "1",
-				quoteInSymbol: "TKN",
-				quoteOutSymbol: "BNB",
-			}),
-		];
-		const profile = buildWalletTradingProfile(entries, { window: "all" });
-		// First sell consumes both lots (cost 2+6=8, proceeds 9 → pnl 1).
-		// Second sell has no remaining lots (cost 0, proceeds 1 → pnl 1).
-		expect(profile.summary.realizedPnlBnb).toBe("2");
-		expect(profile.summary.winningTrades).toBe(2);
-		expect(profile.summary.evaluatedTrades).toBe(2);
-		expect(profile.summary.tradeWinRate).toBe(100);
-		expect(profile.summary.volumeBnb).toBe("18");
-		expect(profile.pnlSeries.map((p) => p.day)).toEqual([
-			"2026-08-01",
-			"2026-08-02",
-			"2026-08-03",
-			"2026-08-04",
-		]);
-	});
+  it("realizes FIFO PnL across lots, including a leftover unmatched sell", () => {
+    const entries = [
+      makeEntry({
+        hash: "0xbuy1",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        side: "buy",
+        quoteInAmount: "2",
+        quoteOutAmount: "10",
+      }),
+      makeEntry({
+        hash: "0xbuy2",
+        createdAt: "2026-08-02T00:00:00.000Z",
+        side: "buy",
+        quoteInAmount: "6",
+        quoteOutAmount: "10",
+      }),
+      makeEntry({
+        hash: "0xsell-full",
+        createdAt: "2026-08-03T00:00:00.000Z",
+        side: "sell",
+        quoteInAmount: "20",
+        quoteOutAmount: "9",
+        quoteInSymbol: "TKN",
+        quoteOutSymbol: "BNB",
+      }),
+      makeEntry({
+        hash: "0xsell-unmatched",
+        createdAt: "2026-08-04T00:00:00.000Z",
+        side: "sell",
+        quoteInAmount: "5",
+        quoteOutAmount: "1",
+        quoteInSymbol: "TKN",
+        quoteOutSymbol: "BNB",
+      }),
+    ];
+    const profile = buildWalletTradingProfile(entries, { window: "all" });
+    // First sell consumes both lots (cost 2+6=8, proceeds 9 → pnl 1).
+    // Second sell has no remaining lots (cost 0, proceeds 1 → pnl 1).
+    expect(profile.summary.realizedPnlBnb).toBe("2");
+    expect(profile.summary.winningTrades).toBe(2);
+    expect(profile.summary.evaluatedTrades).toBe(2);
+    expect(profile.summary.tradeWinRate).toBe(100);
+    expect(profile.summary.volumeBnb).toBe("18");
+    expect(profile.pnlSeries.map((p) => p.day)).toEqual([
+      "2026-08-01",
+      "2026-08-02",
+      "2026-08-03",
+      "2026-08-04",
+    ]);
+  });
 
-	it("does not count a break-even sell as a winning trade", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({
-					hash: "0xbuy",
-					createdAt: "2026-08-01T00:00:00.000Z",
-					side: "buy",
-					quoteInAmount: "1",
-					quoteOutAmount: "10",
-				}),
-				makeEntry({
-					hash: "0xsell",
-					createdAt: "2026-08-02T00:00:00.000Z",
-					side: "sell",
-					quoteInAmount: "10",
-					quoteOutAmount: "1",
-					quoteInSymbol: "TKN",
-					quoteOutSymbol: "BNB",
-				}),
-			],
-			{ window: "all" },
-		);
-		expect(profile.summary.realizedPnlBnb).toBe("0");
-		expect(profile.summary.winningTrades).toBe(0);
-		expect(profile.summary.evaluatedTrades).toBe(1);
-		expect(profile.summary.tradeWinRate).toBe(0);
-	});
+  it("does not count a break-even sell as a winning trade", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({
+          hash: "0xbuy",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          side: "buy",
+          quoteInAmount: "1",
+          quoteOutAmount: "10",
+        }),
+        makeEntry({
+          hash: "0xsell",
+          createdAt: "2026-08-02T00:00:00.000Z",
+          side: "sell",
+          quoteInAmount: "10",
+          quoteOutAmount: "1",
+          quoteInSymbol: "TKN",
+          quoteOutSymbol: "BNB",
+        }),
+      ],
+      { window: "all" },
+    );
+    expect(profile.summary.realizedPnlBnb).toBe("0");
+    expect(profile.summary.winningTrades).toBe(0);
+    expect(profile.summary.evaluatedTrades).toBe(1);
+    expect(profile.summary.tradeWinRate).toBe(0);
+  });
 
-	it("ignores pending and reverted fills for PnL while still counting them", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({
-					hash: "0xok",
-					createdAt: "2026-08-01T00:00:00.000Z",
-					status: "success",
-				}),
-				makeEntry({
-					hash: "0xpend",
-					createdAt: "2026-08-02T00:00:00.000Z",
-					status: "pending",
-				}),
-				makeEntry({
-					hash: "0xrev",
-					createdAt: "2026-08-03T00:00:00.000Z",
-					status: "reverted",
-					reason: "slippage",
-				}),
-			],
-			{ window: "all" },
-		);
-		expect(profile.summary.totalSwaps).toBe(3);
-		expect(profile.summary.successCount).toBe(1);
-		expect(profile.summary.revertedCount).toBe(1);
-		expect(profile.summary.settledCount).toBe(2);
-		expect(profile.summary.txSuccessRate).toBe(50);
-		expect(profile.summary.volumeBnb).toBe("1");
-		expect(profile.recentSwaps[0]?.reason).toBe("slippage");
-	});
+  it("ignores pending and reverted fills for PnL while still counting them", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({
+          hash: "0xok",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          status: "success",
+        }),
+        makeEntry({
+          hash: "0xpend",
+          createdAt: "2026-08-02T00:00:00.000Z",
+          status: "pending",
+        }),
+        makeEntry({
+          hash: "0xrev",
+          createdAt: "2026-08-03T00:00:00.000Z",
+          status: "reverted",
+          reason: "slippage",
+        }),
+      ],
+      { window: "all" },
+    );
+    expect(profile.summary.totalSwaps).toBe(3);
+    expect(profile.summary.successCount).toBe(1);
+    expect(profile.summary.revertedCount).toBe(1);
+    expect(profile.summary.settledCount).toBe(2);
+    expect(profile.summary.txSuccessRate).toBe(50);
+    expect(profile.summary.volumeBnb).toBe("1");
+    expect(profile.recentSwaps[0]?.reason).toBe("slippage");
+  });
 
-	it("skips dust-sized buys as lots and dust-sized sells as cost", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({
-					hash: "0xdust-buy",
-					createdAt: "2026-08-01T00:00:00.000Z",
-					side: "buy",
-					quoteInAmount: "1",
-					quoteOutAmount: "1e-13",
-				}),
-				makeEntry({
-					hash: "0xdust-sell",
-					createdAt: "2026-08-02T00:00:00.000Z",
-					side: "sell",
-					quoteInAmount: "1e-13",
-					quoteOutAmount: "2",
-					quoteInSymbol: "TKN",
-					quoteOutSymbol: "BNB",
-				}),
-			],
-			{ window: "all" },
-		);
-		// Dust buy never queued a lot; dust sell matches cost 0; proceeds 2.
-		expect(profile.summary.realizedPnlBnb).toBe("2");
-		expect(profile.summary.evaluatedTrades).toBe(1);
-	});
+  it("skips dust-sized buys as lots and dust-sized sells as cost", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({
+          hash: "0xdust-buy",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          side: "buy",
+          quoteInAmount: "1",
+          quoteOutAmount: "1e-13",
+        }),
+        makeEntry({
+          hash: "0xdust-sell",
+          createdAt: "2026-08-02T00:00:00.000Z",
+          side: "sell",
+          quoteInAmount: "1e-13",
+          quoteOutAmount: "2",
+          quoteInSymbol: "TKN",
+          quoteOutSymbol: "BNB",
+        }),
+      ],
+      { window: "all" },
+    );
+    // Dust buy never queued a lot; dust sell matches cost 0; proceeds 2.
+    expect(profile.summary.realizedPnlBnb).toBe("2");
+    expect(profile.summary.evaluatedTrades).toBe(1);
+  });
 
-	it("sorts token breakdown by volume descending and caps recent swaps at 20 newest", () => {
-		const entries: WalletTradeLedgerEntry[] = [];
-		for (let i = 0; i < 21; i += 1) {
-			entries.push(
-				makeEntry({
-					hash: `0x${(i + 1).toString(16).padStart(4, "0")}`,
-					createdAt: new Date(Date.UTC(2026, 7, 1, 0, 0, i)).toISOString(),
-					tokenAddress: i === 0 ? TOKEN_B : TOKEN_A,
-					quoteInAmount: i === 0 ? "50" : "1",
-				}),
-			);
-		}
-		const profile = buildWalletTradingProfile(entries, { window: "all" });
-		expect(profile.tokenBreakdown.map((t) => t.tokenAddress)).toEqual([
-			TOKEN_B,
-			TOKEN_A,
-		]);
-		expect(profile.recentSwaps).toHaveLength(20);
-		expect(profile.recentSwaps[0]?.hash).toBe(
-			`0x${(21).toString(16).padStart(4, "0")}`,
-		);
-		expect(profile.recentSwaps[19]?.hash).toBe(
-			`0x${(2).toString(16).padStart(4, "0")}`,
-		);
-	});
+  it("sorts token breakdown by volume descending and caps recent swaps at 20 newest", () => {
+    const entries: WalletTradeLedgerEntry[] = [];
+    for (let i = 0; i < 21; i += 1) {
+      entries.push(
+        makeEntry({
+          hash: `0x${(i + 1).toString(16).padStart(4, "0")}`,
+          createdAt: new Date(Date.UTC(2026, 7, 1, 0, 0, i)).toISOString(),
+          tokenAddress: i === 0 ? TOKEN_B : TOKEN_A,
+          quoteInAmount: i === 0 ? "50" : "1",
+        }),
+      );
+    }
+    const profile = buildWalletTradingProfile(entries, { window: "all" });
+    expect(profile.tokenBreakdown.map((t) => t.tokenAddress)).toEqual([
+      TOKEN_B,
+      TOKEN_A,
+    ]);
+    expect(profile.recentSwaps).toHaveLength(20);
+    expect(profile.recentSwaps[0]?.hash).toBe(
+      `0x${(21).toString(16).padStart(4, "0")}`,
+    );
+    expect(profile.recentSwaps[19]?.hash).toBe(
+      `0x${(2).toString(16).padStart(4, "0")}`,
+    );
+  });
 
-	it("falls back to TOKEN when the fill symbol is blank", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({
-					hash: "0xnosym",
-					createdAt: "2026-08-01T00:00:00.000Z",
-					quoteOutSymbol: "",
-				}),
-			],
-			{ window: "all" },
-		);
-		expect(profile.tokenBreakdown[0]?.symbol).toBe("TOKEN");
-		expect(profile.recentSwaps[0]?.tokenSymbol).toBe("");
-	});
+  it("falls back to TOKEN when the fill symbol is blank", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({
+          hash: "0xnosym",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          quoteOutSymbol: "",
+        }),
+      ],
+      { window: "all" },
+    );
+    expect(profile.tokenBreakdown[0]?.symbol).toBe("TOKEN");
+    expect(profile.recentSwaps[0]?.tokenSymbol).toBe("");
+  });
 
-	it("orders same-timestamp fills by hash when building the profile", () => {
-		const profile = buildWalletTradingProfile(
-			[
-				makeEntry({ hash: "0xcc", createdAt: "2026-08-01T00:00:00.000Z" }),
-				makeEntry({ hash: "0xaa", createdAt: "2026-08-01T00:00:00.000Z" }),
-				makeEntry({ hash: "0xbb", createdAt: "2026-08-01T00:00:00.000Z" }),
-			],
-			{ window: "all" },
-		);
-		// FIFO walk uses createdAt then hash; recent swaps are newest-first and
-		// tied timestamps stay in that processed order after the reverse-time sort.
-		expect(profile.pnlSeries[0]?.swaps).toBe(3);
-		expect(profile.summary.totalSwaps).toBe(3);
-	});
+  it("orders same-timestamp fills by hash when building the profile", () => {
+    const profile = buildWalletTradingProfile(
+      [
+        makeEntry({ hash: "0xcc", createdAt: "2026-08-01T00:00:00.000Z" }),
+        makeEntry({ hash: "0xaa", createdAt: "2026-08-01T00:00:00.000Z" }),
+        makeEntry({ hash: "0xbb", createdAt: "2026-08-01T00:00:00.000Z" }),
+      ],
+      { window: "all" },
+    );
+    // FIFO walk uses createdAt then hash; recent swaps are newest-first and
+    // tied timestamps stay in that processed order after the reverse-time sort.
+    expect(profile.pnlSeries[0]?.swaps).toBe(3);
+    expect(profile.summary.totalSwaps).toBe(3);
+  });
 });
 
 describe("loadWalletTradingProfile", () => {
-	it("reads the on-disk ledger through the same builder", () => {
-		const stateDir = makeStateDir();
-		recordWalletTradeLedgerEntry(
-			makeInput({
-				hash: "0xload",
-				createdAt: "2026-08-01T00:00:00.000Z",
-				source: "agent",
-			}),
-			stateDir,
-		);
-		const profile = loadWalletTradingProfile({
-			stateDir,
-			window: "all",
-			source: "agent",
-		});
-		expect(profile.summary.totalSwaps).toBe(1);
-		expect(profile.recentSwaps[0]?.hash).toBe("0xload");
-		expect(profile.source).toBe("agent");
-	});
+  it("reads the on-disk ledger through the same builder", () => {
+    const stateDir = makeStateDir();
+    recordWalletTradeLedgerEntry(
+      makeInput({
+        hash: "0xload",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        source: "agent",
+      }),
+      stateDir,
+    );
+    const profile = loadWalletTradingProfile({
+      stateDir,
+      window: "all",
+      source: "agent",
+    });
+    expect(profile.summary.totalSwaps).toBe(1);
+    expect(profile.recentSwaps[0]?.hash).toBe("0xload");
+    expect(profile.source).toBe("agent");
+  });
 });

--- a/packages/agent/src/config/character-schema.test.ts
+++ b/packages/agent/src/config/character-schema.test.ts
@@ -8,236 +8,236 @@ import { describe, expect, it } from "vitest";
 import { CharacterSchema } from "./character-schema.ts";
 
 function parsed(value: unknown) {
-	return CharacterSchema.safeParse(value);
+  return CharacterSchema.safeParse(value);
 }
 
 function expectOk(value: unknown, data: unknown = value) {
-	const result = parsed(value);
-	expect(result.success).toBe(true);
-	if (result.success) expect(result.data).toEqual(data);
+  const result = parsed(value);
+  expect(result.success).toBe(true);
+  if (result.success) expect(result.data).toEqual(data);
 }
 
 function expectFail(value: unknown) {
-	expect(parsed(value).success).toBe(false);
+  expect(parsed(value).success).toBe(false);
 }
 
 describe("CharacterSchema", () => {
-	it("accepts an empty object because every field is optional", () => {
-		expectOk({});
-	});
+  it("accepts an empty object because every field is optional", () => {
+    expectOk({});
+  });
 
-	it("round-trips a fully populated valid character", () => {
-		const character = {
-			name: "Ada",
-			username: "ada",
-			bio: ["mathematician"],
-			system: "Be precise.",
-			adjectives: ["curious"],
-			topics: ["math"],
-			style: { all: ["terse"], chat: ["warm"], post: ["witty"] },
-			messageExamples: [
-				{
-					examples: [
-						{
-							name: "Ada",
-							content: { text: "hello", actions: ["REPLY"] },
-						},
-					],
-				},
-			],
-			postExamples: ["A note on analysis."],
-		};
-		expectOk(character);
-	});
+  it("round-trips a fully populated valid character", () => {
+    const character = {
+      name: "Ada",
+      username: "ada",
+      bio: ["mathematician"],
+      system: "Be precise.",
+      adjectives: ["curious"],
+      topics: ["math"],
+      style: { all: ["terse"], chat: ["warm"], post: ["witty"] },
+      messageExamples: [
+        {
+          examples: [
+            {
+              name: "Ada",
+              content: { text: "hello", actions: ["REPLY"] },
+            },
+          ],
+        },
+      ],
+      postExamples: ["A note on analysis."],
+    };
+    expectOk(character);
+  });
 
-	it("rejects a non-object root", () => {
-		expectFail(null);
-		expectFail(undefined);
-		expectFail("Ada");
-		expectFail(1);
-		expectFail([]);
-	});
+  it("rejects a non-object root", () => {
+    expectFail(null);
+    expectFail(undefined);
+    expectFail("Ada");
+    expectFail(1);
+    expectFail([]);
+  });
 
-	it("rejects unknown top-level keys (strict)", () => {
-		expectFail({ extra: true });
-		expectFail({ name: "Ada", plugins: [] });
-	});
+  it("rejects unknown top-level keys (strict)", () => {
+    expectFail({ extra: true });
+    expectFail({ name: "Ada", plugins: [] });
+  });
 });
 
 describe("CharacterSchema name", () => {
-	it("accepts a single in-range name and the max length", () => {
-		expectOk({ name: "Ada" });
-		expectOk({ name: "a".repeat(100) });
-	});
+  it("accepts a single in-range name and the max length", () => {
+    expectOk({ name: "Ada" });
+    expectOk({ name: "a".repeat(100) });
+  });
 
-	it("rejects an empty name and overflow past 100", () => {
-		expectFail({ name: "" });
-		expectFail({ name: "a".repeat(101) });
-		expectFail({ name: 1 });
-	});
+  it("rejects an empty name and overflow past 100", () => {
+    expectFail({ name: "" });
+    expectFail({ name: "a".repeat(101) });
+    expectFail({ name: 1 });
+  });
 });
 
 describe("CharacterSchema username", () => {
-	it("accepts the empty string as the documented clear form", () => {
-		expectOk({ username: "" });
-	});
+  it("accepts the empty string as the documented clear form", () => {
+    expectOk({ username: "" });
+  });
 
-	it("accepts a username at the 50-character cap", () => {
-		expectOk({ username: "a".repeat(50) });
-	});
+  it("accepts a username at the 50-character cap", () => {
+    expectOk({ username: "a".repeat(50) });
+  });
 
-	it("rejects overflow past 50 and a non-string", () => {
-		expectFail({ username: "a".repeat(51) });
-		expectFail({ username: 1 });
-	});
+  it("rejects overflow past 50 and a non-string", () => {
+    expectFail({ username: "a".repeat(51) });
+    expectFail({ username: 1 });
+  });
 });
 
 describe("CharacterSchema bio", () => {
-	it("accepts a string, including the empty clear form", () => {
-		expectOk({ bio: "mathematician" });
-		expectOk({ bio: "" });
-	});
+  it("accepts a string, including the empty clear form", () => {
+    expectOk({ bio: "mathematician" });
+    expectOk({ bio: "" });
+  });
 
-	it("accepts an array of strings, including the empty queue", () => {
-		expectOk({ bio: [] });
-		expectOk({ bio: ["one"] });
-		expectOk({ bio: ["one", "two"] });
-	});
+  it("accepts an array of strings, including the empty queue", () => {
+    expectOk({ bio: [] });
+    expectOk({ bio: ["one"] });
+    expectOk({ bio: ["one", "two"] });
+  });
 
-	it("rejects a non-string bio and a non-string array element", () => {
-		expectFail({ bio: 1 });
-		expectFail({ bio: [1] });
-		expectFail({ bio: ["ok", null] });
-	});
+  it("rejects a non-string bio and a non-string array element", () => {
+    expectFail({ bio: 1 });
+    expectFail({ bio: [1] });
+    expectFail({ bio: ["ok", null] });
+  });
 });
 
 describe("CharacterSchema system", () => {
-	it("accepts empty text and the 10000-character cap", () => {
-		expectOk({ system: "" });
-		expectOk({ system: "a".repeat(10000) });
-	});
+  it("accepts empty text and the 10000-character cap", () => {
+    expectOk({ system: "" });
+    expectOk({ system: "a".repeat(10000) });
+  });
 
-	it("rejects overflow past 10000 and a non-string", () => {
-		expectFail({ system: "a".repeat(10001) });
-		expectFail({ system: ["prompt"] });
-	});
+  it("rejects overflow past 10000 and a non-string", () => {
+    expectFail({ system: "a".repeat(10001) });
+    expectFail({ system: ["prompt"] });
+  });
 });
 
 describe("CharacterSchema adjectives and topics", () => {
-	it("accepts an empty queue and a single in-range element", () => {
-		expectOk({ adjectives: [] });
-		expectOk({ topics: [] });
-		expectOk({ adjectives: ["curious"] });
-		expectOk({ topics: ["math"] });
-		expectOk({ adjectives: ["a".repeat(100)] });
-		expectOk({ topics: ["a".repeat(100)] });
-	});
+  it("accepts an empty queue and a single in-range element", () => {
+    expectOk({ adjectives: [] });
+    expectOk({ topics: [] });
+    expectOk({ adjectives: ["curious"] });
+    expectOk({ topics: ["math"] });
+    expectOk({ adjectives: ["a".repeat(100)] });
+    expectOk({ topics: ["a".repeat(100)] });
+  });
 
-	it("rejects an empty item, overflow past 100, and a non-string item", () => {
-		expectFail({ adjectives: [""] });
-		expectFail({ topics: [""] });
-		expectFail({ adjectives: ["a".repeat(101)] });
-		expectFail({ topics: ["a".repeat(101)] });
-		expectFail({ adjectives: [1] });
-		expectFail({ topics: [null] });
-	});
+  it("rejects an empty item, overflow past 100, and a non-string item", () => {
+    expectFail({ adjectives: [""] });
+    expectFail({ topics: [""] });
+    expectFail({ adjectives: ["a".repeat(101)] });
+    expectFail({ topics: ["a".repeat(101)] });
+    expectFail({ adjectives: [1] });
+    expectFail({ topics: [null] });
+  });
 });
 
 describe("CharacterSchema style", () => {
-	it("accepts an empty object as the documented clear form", () => {
-		expectOk({ style: {} });
-	});
+  it("accepts an empty object as the documented clear form", () => {
+    expectOk({ style: {} });
+  });
 
-	it("accepts optional all/chat/post arrays, including empty queues", () => {
-		expectOk({ style: { all: [], chat: [], post: [] } });
-		expectOk({ style: { all: ["terse"] } });
-		expectOk({ style: { chat: ["warm"], post: ["witty"] } });
-	});
+  it("accepts optional all/chat/post arrays, including empty queues", () => {
+    expectOk({ style: { all: [], chat: [], post: [] } });
+    expectOk({ style: { all: ["terse"] } });
+    expectOk({ style: { chat: ["warm"], post: ["witty"] } });
+  });
 
-	it("rejects unknown style keys, a non-array list, and null", () => {
-		expectFail({ style: { extra: [] } });
-		expectFail({ style: { all: "terse" } });
-		expectFail({ style: null });
-	});
+  it("rejects unknown style keys, a non-array list, and null", () => {
+    expectFail({ style: { extra: [] } });
+    expectFail({ style: { all: "terse" } });
+    expectFail({ style: null });
+  });
 });
 
 describe("CharacterSchema messageExamples", () => {
-	it("accepts an empty outer queue and a single valid group", () => {
-		expectOk({ messageExamples: [] });
-		expectOk({
-			messageExamples: [
-				{ examples: [{ name: "Ada", content: { text: "hello" } }] },
-			],
-		});
-	});
+  it("accepts an empty outer queue and a single valid group", () => {
+    expectOk({ messageExamples: [] });
+    expectOk({
+      messageExamples: [
+        { examples: [{ name: "Ada", content: { text: "hello" } }] },
+      ],
+    });
+  });
 
-	it("rejects a group whose examples queue is empty", () => {
-		expectFail({ messageExamples: [{ examples: [] }] });
-	});
+  it("rejects a group whose examples queue is empty", () => {
+    expectFail({ messageExamples: [{ examples: [] }] });
+  });
 
-	it("rejects a missing examples key and extra group keys", () => {
-		expectFail({ messageExamples: [{}] });
-		expectFail({
-			messageExamples: [
-				{
-					examples: [{ name: "Ada", content: { text: "hello" } }],
-					extra: true,
-				},
-			],
-		});
-	});
+  it("rejects a missing examples key and extra group keys", () => {
+    expectFail({ messageExamples: [{}] });
+    expectFail({
+      messageExamples: [
+        {
+          examples: [{ name: "Ada", content: { text: "hello" } }],
+          extra: true,
+        },
+      ],
+    });
+  });
 
-	it("rejects an empty example name or empty content text", () => {
-		expectFail({
-			messageExamples: [
-				{ examples: [{ name: "", content: { text: "hello" } }] },
-			],
-		});
-		expectFail({
-			messageExamples: [{ examples: [{ name: "Ada", content: { text: "" } }] }],
-		});
-	});
+  it("rejects an empty example name or empty content text", () => {
+    expectFail({
+      messageExamples: [
+        { examples: [{ name: "", content: { text: "hello" } }] },
+      ],
+    });
+    expectFail({
+      messageExamples: [{ examples: [{ name: "Ada", content: { text: "" } }] }],
+    });
+  });
 
-	it("rejects extra keys on an example or its content", () => {
-		expectFail({
-			messageExamples: [
-				{
-					examples: [{ name: "Ada", content: { text: "hello" }, extra: true }],
-				},
-			],
-		});
-		expectFail({
-			messageExamples: [
-				{
-					examples: [{ name: "Ada", content: { text: "hello", extra: true } }],
-				},
-			],
-		});
-	});
+  it("rejects extra keys on an example or its content", () => {
+    expectFail({
+      messageExamples: [
+        {
+          examples: [{ name: "Ada", content: { text: "hello" }, extra: true }],
+        },
+      ],
+    });
+    expectFail({
+      messageExamples: [
+        {
+          examples: [{ name: "Ada", content: { text: "hello", extra: true } }],
+        },
+      ],
+    });
+  });
 
-	it("accepts optional actions and rejects a missing content object", () => {
-		expectOk({
-			messageExamples: [
-				{
-					examples: [{ name: "Ada", content: { text: "hello", actions: [] } }],
-				},
-			],
-		});
-		expectFail({
-			messageExamples: [{ examples: [{ name: "Ada" }] }],
-		});
-	});
+  it("accepts optional actions and rejects a missing content object", () => {
+    expectOk({
+      messageExamples: [
+        {
+          examples: [{ name: "Ada", content: { text: "hello", actions: [] } }],
+        },
+      ],
+    });
+    expectFail({
+      messageExamples: [{ examples: [{ name: "Ada" }] }],
+    });
+  });
 });
 
 describe("CharacterSchema postExamples", () => {
-	it("accepts an empty queue, a single string, and an empty string item", () => {
-		expectOk({ postExamples: [] });
-		expectOk({ postExamples: ["A note."] });
-		expectOk({ postExamples: [""] });
-	});
+  it("accepts an empty queue, a single string, and an empty string item", () => {
+    expectOk({ postExamples: [] });
+    expectOk({ postExamples: ["A note."] });
+    expectOk({ postExamples: [""] });
+  });
 
-	it("rejects a non-array and a non-string item", () => {
-		expectFail({ postExamples: "A note." });
-		expectFail({ postExamples: [1] });
-	});
+  it("rejects a non-array and a non-string item", () => {
+    expectFail({ postExamples: "A note." });
+    expectFail({ postExamples: [1] });
+  });
 });

--- a/packages/agent/src/config/env-vars.test.ts
+++ b/packages/agent/src/config/env-vars.test.ts
@@ -7,424 +7,424 @@
 import { describe, expect, it } from "vitest";
 import { isBlockedEnvKey } from "./blocked-env-keys.ts";
 import {
-	CONNECTOR_ENV_MAP,
-	collectConfigEnvVars,
-	collectConnectorEnvVars,
+  CONNECTOR_ENV_MAP,
+  collectConfigEnvVars,
+  collectConnectorEnvVars,
 } from "./env-vars.ts";
 import type { ElizaConfig } from "./types.ts";
 
 function configEnv(env: NonNullable<ElizaConfig["env"]>) {
-	return collectConfigEnvVars({ env });
+  return collectConfigEnvVars({ env });
 }
 
 function connectorEnv(connectors: NonNullable<ElizaConfig["connectors"]>) {
-	return collectConnectorEnvVars({ connectors });
+  return collectConnectorEnvVars({ connectors });
 }
 
 describe("CONNECTOR_ENV_MAP", () => {
-	it("exports a field-to-env mapping for every supported connector", () => {
-		expect(Object.keys(CONNECTOR_ENV_MAP).sort()).toEqual(
-			[
-				"blooio",
-				"discord",
-				"discordLocal",
-				"googlechat",
-				"imessage",
-				"mattermost",
-				"msteams",
-				"slack",
-				"telegram",
-				"telegramAccount",
-				"whatsapp",
-			].sort(),
-		);
-	});
+  it("exports a field-to-env mapping for every supported connector", () => {
+    expect(Object.keys(CONNECTOR_ENV_MAP).sort()).toEqual(
+      [
+        "blooio",
+        "discord",
+        "discordLocal",
+        "googlechat",
+        "imessage",
+        "mattermost",
+        "msteams",
+        "slack",
+        "telegram",
+        "telegramAccount",
+        "whatsapp",
+      ].sort(),
+    );
+  });
 
-	it("maps Discord token aliases onto the same API token env key", () => {
-		expect(CONNECTOR_ENV_MAP.discord.token).toBe("DISCORD_API_TOKEN");
-		expect(CONNECTOR_ENV_MAP.discord.botToken).toBe("DISCORD_API_TOKEN");
-	});
+  it("maps Discord token aliases onto the same API token env key", () => {
+    expect(CONNECTOR_ENV_MAP.discord.token).toBe("DISCORD_API_TOKEN");
+    expect(CONNECTOR_ENV_MAP.discord.botToken).toBe("DISCORD_API_TOKEN");
+  });
 
-	it("maps WhatsApp authDir and sessionPath onto the same auth dir env key", () => {
-		expect(CONNECTOR_ENV_MAP.whatsapp.authDir).toBe("WHATSAPP_AUTH_DIR");
-		expect(CONNECTOR_ENV_MAP.whatsapp.sessionPath).toBe("WHATSAPP_AUTH_DIR");
-	});
+  it("maps WhatsApp authDir and sessionPath onto the same auth dir env key", () => {
+    expect(CONNECTOR_ENV_MAP.whatsapp.authDir).toBe("WHATSAPP_AUTH_DIR");
+    expect(CONNECTOR_ENV_MAP.whatsapp.sessionPath).toBe("WHATSAPP_AUTH_DIR");
+  });
 
-	it("does not map any destination env key that isBlockedEnvKey would drop", () => {
-		for (const envMap of Object.values(CONNECTOR_ENV_MAP)) {
-			for (const envKey of Object.values(envMap)) {
-				expect(isBlockedEnvKey(envKey), envKey).toBe(false);
-			}
-		}
-	});
+  it("does not map any destination env key that isBlockedEnvKey would drop", () => {
+    for (const envMap of Object.values(CONNECTOR_ENV_MAP)) {
+      for (const envKey of Object.values(envMap)) {
+        expect(isBlockedEnvKey(envKey), envKey).toBe(false);
+      }
+    }
+  });
 });
 
 describe("collectConfigEnvVars", () => {
-	it("returns an empty record when cfg or cfg.env is missing", () => {
-		expect(collectConfigEnvVars()).toEqual({});
-		expect(collectConfigEnvVars({})).toEqual({});
-		expect(collectConfigEnvVars({ env: undefined })).toEqual({});
-	});
+  it("returns an empty record when cfg or cfg.env is missing", () => {
+    expect(collectConfigEnvVars()).toEqual({});
+    expect(collectConfigEnvVars({})).toEqual({});
+    expect(collectConfigEnvVars({ env: undefined })).toEqual({});
+  });
 
-	it("copies nested vars and skips empty values", () => {
-		expect(
-			configEnv({
-				vars: {
-					OPENAI_API_KEY: "sk-test",
-					EMPTY: "",
-				},
-			}),
-		).toEqual({ OPENAI_API_KEY: "sk-test" });
-	});
+  it("copies nested vars and skips empty values", () => {
+    expect(
+      configEnv({
+        vars: {
+          OPENAI_API_KEY: "sk-test",
+          EMPTY: "",
+        },
+      }),
+    ).toEqual({ OPENAI_API_KEY: "sk-test" });
+  });
 
-	it("keeps whitespace-only nested vars (only empty string is dropped)", () => {
-		expect(configEnv({ vars: { PADDED: "   " } })).toEqual({ PADDED: "   " });
-	});
+  it("keeps whitespace-only nested vars (only empty string is dropped)", () => {
+    expect(configEnv({ vars: { PADDED: "   " } })).toEqual({ PADDED: "   " });
+  });
 
-	it("copies top-level string env keys and skips shellEnv/vars", () => {
-		expect(
-			configEnv({
-				vars: { FROM_VARS: "vars" },
-				shellEnv: { enabled: true, timeoutMs: 1000 },
-				FROM_TOP: "top",
-			}),
-		).toEqual({ FROM_VARS: "vars", FROM_TOP: "top" });
-	});
+  it("copies top-level string env keys and skips shellEnv/vars", () => {
+    expect(
+      configEnv({
+        vars: { FROM_VARS: "vars" },
+        shellEnv: { enabled: true, timeoutMs: 1000 },
+        FROM_TOP: "top",
+      }),
+    ).toEqual({ FROM_VARS: "vars", FROM_TOP: "top" });
+  });
 
-	it("lets a later top-level string overwrite a nested vars key of the same name", () => {
-		expect(
-			configEnv({
-				vars: { SHARED: "from-vars" },
-				SHARED: "from-top",
-			}),
-		).toEqual({ SHARED: "from-top" });
-	});
+  it("lets a later top-level string overwrite a nested vars key of the same name", () => {
+    expect(
+      configEnv({
+        vars: { SHARED: "from-vars" },
+        SHARED: "from-top",
+      }),
+    ).toEqual({ SHARED: "from-top" });
+  });
 
-	it("skips top-level non-strings and whitespace-only strings", () => {
-		expect(
-			configEnv({
-				BLANK: "  ",
-				NESTED: { inner: "nope" },
-				OK: "kept",
-			}),
-		).toEqual({ OK: "kept" });
-	});
+  it("skips top-level non-strings and whitespace-only strings", () => {
+    expect(
+      configEnv({
+        BLANK: "  ",
+        NESTED: { inner: "nope" },
+        OK: "kept",
+      }),
+    ).toEqual({ OK: "kept" });
+  });
 
-	it("drops nested and top-level keys rejected by isBlockedEnvKey", () => {
-		expect(
-			configEnv({
-				vars: {
-					DATABASE_URL: "postgres://secret",
-					GITHUB_TOKEN: "ghp_secret",
-					SAFE_VAR: "ok",
-				},
-				LD_PRELOAD: "/tmp/evil.so",
-				NPM_CONFIG_REGISTRY: "https://evil.example",
-				SAFE_TOP: "ok-top",
-			}),
-		).toEqual({ SAFE_VAR: "ok", SAFE_TOP: "ok-top" });
-	});
+  it("drops nested and top-level keys rejected by isBlockedEnvKey", () => {
+    expect(
+      configEnv({
+        vars: {
+          DATABASE_URL: "postgres://secret",
+          GITHUB_TOKEN: "ghp_secret",
+          SAFE_VAR: "ok",
+        },
+        LD_PRELOAD: "/tmp/evil.so",
+        NPM_CONFIG_REGISTRY: "https://evil.example",
+        SAFE_TOP: "ok-top",
+      }),
+    ).toEqual({ SAFE_VAR: "ok", SAFE_TOP: "ok-top" });
+  });
 
-	it("blocks whitespace-padded secret keys because isBlockedEnvKey trims", () => {
-		expect(
-			configEnv({
-				vars: { " GITHUB_TOKEN": "padded-nested" },
-				" DATABASE_URL ": "padded-top",
-				PUBLIC: "yes",
-			}),
-		).toEqual({ PUBLIC: "yes" });
-	});
+  it("blocks whitespace-padded secret keys because isBlockedEnvKey trims", () => {
+    expect(
+      configEnv({
+        vars: { " GITHUB_TOKEN": "padded-nested" },
+        " DATABASE_URL ": "padded-top",
+        PUBLIC: "yes",
+      }),
+    ).toEqual({ PUBLIC: "yes" });
+  });
 });
 
 describe("collectConnectorEnvVars", () => {
-	it("returns an empty record when connectors/channels are missing or not a map", () => {
-		expect(collectConnectorEnvVars()).toEqual({});
-		expect(collectConnectorEnvVars({})).toEqual({});
-		expect(
-			collectConnectorEnvVars({
-				connectors: [],
-			} as unknown as ElizaConfig),
-		).toEqual({});
-		expect(
-			collectConnectorEnvVars({
-				connectors: "discord",
-			} as unknown as ElizaConfig),
-		).toEqual({});
-	});
+  it("returns an empty record when connectors/channels are missing or not a map", () => {
+    expect(collectConnectorEnvVars()).toEqual({});
+    expect(collectConnectorEnvVars({})).toEqual({});
+    expect(
+      collectConnectorEnvVars({
+        connectors: [],
+      } as unknown as ElizaConfig),
+    ).toEqual({});
+    expect(
+      collectConnectorEnvVars({
+        connectors: "discord",
+      } as unknown as ElizaConfig),
+    ).toEqual({});
+  });
 
-	it("skips a missing connector, a non-object entry, and an array entry", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				telegram: { botToken: "tg-token" },
-				slack: null,
-				discord: ["not", "a", "map"],
-				unknown: { token: "ignored" },
-			},
-		} as unknown as ElizaConfig);
+  it("skips a missing connector, a non-object entry, and an array entry", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        telegram: { botToken: "tg-token" },
+        slack: null,
+        discord: ["not", "a", "map"],
+        unknown: { token: "ignored" },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env).toEqual({ TELEGRAM_BOT_TOKEN: "tg-token" });
-	});
+    expect(env).toEqual({ TELEGRAM_BOT_TOKEN: "tg-token" });
+  });
 
-	it("falls back to channels when connectors is absent", () => {
-		const env = collectConnectorEnvVars({
-			channels: {
-				telegram: { botToken: "from-channels" },
-			},
-		} as unknown as ElizaConfig);
-		expect(env.TELEGRAM_BOT_TOKEN).toBe("from-channels");
-	});
+  it("falls back to channels when connectors is absent", () => {
+    const env = collectConnectorEnvVars({
+      channels: {
+        telegram: { botToken: "from-channels" },
+      },
+    } as unknown as ElizaConfig);
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("from-channels");
+  });
 
-	it("prefers connectors over channels when both are present", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				telegram: { botToken: "from-connectors" },
-			},
-			channels: {
-				telegram: { botToken: "from-channels" },
-			},
-		} as unknown as ElizaConfig);
-		expect(env.TELEGRAM_BOT_TOKEN).toBe("from-connectors");
-	});
+  it("prefers connectors over channels when both are present", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        telegram: { botToken: "from-connectors" },
+      },
+      channels: {
+        telegram: { botToken: "from-channels" },
+      },
+    } as unknown as ElizaConfig);
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("from-connectors");
+  });
 
-	it("mirrors Discord token onto DISCORD_API_TOKEN and DISCORD_BOT_TOKEN", () => {
-		const env = connectorEnv({
-			discord: { token: "bot-token" },
-		});
-		expect(env.DISCORD_API_TOKEN).toBe("bot-token");
-		expect(env.DISCORD_BOT_TOKEN).toBe("bot-token");
-	});
+  it("mirrors Discord token onto DISCORD_API_TOKEN and DISCORD_BOT_TOKEN", () => {
+    const env = connectorEnv({
+      discord: { token: "bot-token" },
+    });
+    expect(env.DISCORD_API_TOKEN).toBe("bot-token");
+    expect(env.DISCORD_BOT_TOKEN).toBe("bot-token");
+  });
 
-	it("gives Discord token precedence over botToken so the generic loop cannot overwrite", () => {
-		const env = connectorEnv({
-			discord: { token: "from-token", botToken: "from-bot-token" },
-		});
-		expect(env.DISCORD_API_TOKEN).toBe("from-token");
-		expect(env.DISCORD_BOT_TOKEN).toBe("from-token");
-	});
+  it("gives Discord token precedence over botToken so the generic loop cannot overwrite", () => {
+    const env = connectorEnv({
+      discord: { token: "from-token", botToken: "from-bot-token" },
+    });
+    expect(env.DISCORD_API_TOKEN).toBe("from-token");
+    expect(env.DISCORD_BOT_TOKEN).toBe("from-token");
+  });
 
-	it("falls back to Discord botToken when token is missing or whitespace", () => {
-		expect(
-			connectorEnv({ discord: { botToken: "only-bot" } }).DISCORD_API_TOKEN,
-		).toBe("only-bot");
-		expect(
-			connectorEnv({
-				discord: { token: "   ", botToken: "from-bot" },
-			}).DISCORD_API_TOKEN,
-		).toBe("from-bot");
-	});
+  it("falls back to Discord botToken when token is missing or whitespace", () => {
+    expect(
+      connectorEnv({ discord: { botToken: "only-bot" } }).DISCORD_API_TOKEN,
+    ).toBe("only-bot");
+    expect(
+      connectorEnv({
+        discord: { token: "   ", botToken: "from-bot" },
+      }).DISCORD_API_TOKEN,
+    ).toBe("from-bot");
+  });
 
-	it("omits Discord token aliases when both token fields are empty", () => {
-		const env = connectorEnv({
-			discord: { token: "  ", botToken: "", applicationId: "app-id" },
-		});
-		expect(env.DISCORD_API_TOKEN).toBeUndefined();
-		expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
-		expect(env.DISCORD_APPLICATION_ID).toBe("app-id");
-	});
+  it("omits Discord token aliases when both token fields are empty", () => {
+    const env = connectorEnv({
+      discord: { token: "  ", botToken: "", applicationId: "app-id" },
+    });
+    expect(env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(env.DISCORD_APPLICATION_ID).toBe("app-id");
+  });
 
-	it("JSON-stringifies Discord ownerUserIds, including finite numbers, and drops junk", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				discord: {
-					ownerUserIds: [
-						" 111 ",
-						222,
-						Number.NaN,
-						Number.POSITIVE_INFINITY,
-						{ id: "nope" },
-						"  ",
-						"",
-					],
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("JSON-stringifies Discord ownerUserIds, including finite numbers, and drops junk", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        discord: {
+          ownerUserIds: [
+            " 111 ",
+            222,
+            Number.NaN,
+            Number.POSITIVE_INFINITY,
+            { id: "nope" },
+            "  ",
+            "",
+          ],
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.ELIZA_DISCORD_OWNER_USER_IDS_JSON).toBe(
-			JSON.stringify(["111", "222"]),
-		);
-	});
+    expect(env.ELIZA_DISCORD_OWNER_USER_IDS_JSON).toBe(
+      JSON.stringify(["111", "222"]),
+    );
+  });
 
-	it("omits owner snowflakes when the array is missing, not an array, or empty after filtering", () => {
-		expect(
-			connectorEnv({ discord: { token: "t" } })
-				.ELIZA_DISCORD_OWNER_USER_IDS_JSON,
-		).toBeUndefined();
-		expect(
-			collectConnectorEnvVars({
-				connectors: { discord: { ownerUserIds: "111" } },
-			} as unknown as ElizaConfig).ELIZA_DISCORD_OWNER_USER_IDS_JSON,
-		).toBeUndefined();
-		expect(
-			collectConnectorEnvVars({
-				connectors: { discord: { ownerUserIds: ["  ", Number.NaN] } },
-			} as unknown as ElizaConfig).ELIZA_DISCORD_OWNER_USER_IDS_JSON,
-		).toBeUndefined();
-	});
+  it("omits owner snowflakes when the array is missing, not an array, or empty after filtering", () => {
+    expect(
+      connectorEnv({ discord: { token: "t" } })
+        .ELIZA_DISCORD_OWNER_USER_IDS_JSON,
+    ).toBeUndefined();
+    expect(
+      collectConnectorEnvVars({
+        connectors: { discord: { ownerUserIds: "111" } },
+      } as unknown as ElizaConfig).ELIZA_DISCORD_OWNER_USER_IDS_JSON,
+    ).toBeUndefined();
+    expect(
+      collectConnectorEnvVars({
+        connectors: { discord: { ownerUserIds: ["  ", Number.NaN] } },
+      } as unknown as ElizaConfig).ELIZA_DISCORD_OWNER_USER_IDS_JSON,
+    ).toBeUndefined();
+  });
 
-	it("normalizes string, finite number, boolean, and array connector fields", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				discordLocal: {
-					enabled: false,
-					clientId: "  client-id  ",
-					sendDelayMs: 0,
-					scopes: ["identify", "  guilds  ", 42, Number.NaN, ""],
-					messageChannelIds: [],
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("normalizes string, finite number, boolean, and array connector fields", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        discordLocal: {
+          enabled: false,
+          clientId: "  client-id  ",
+          sendDelayMs: 0,
+          scopes: ["identify", "  guilds  ", 42, Number.NaN, ""],
+          messageChannelIds: [],
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.DISCORD_LOCAL_ENABLED).toBe("false");
-		expect(env.DISCORD_LOCAL_CLIENT_ID).toBe("  client-id  ");
-		expect(env.DISCORD_LOCAL_SEND_DELAY_MS).toBe("0");
-		expect(env.DISCORD_LOCAL_SCOPES).toBe("identify,guilds,42");
-		expect(env.DISCORD_LOCAL_MESSAGE_CHANNEL_IDS).toBeUndefined();
-	});
+    expect(env.DISCORD_LOCAL_ENABLED).toBe("false");
+    expect(env.DISCORD_LOCAL_CLIENT_ID).toBe("  client-id  ");
+    expect(env.DISCORD_LOCAL_SEND_DELAY_MS).toBe("0");
+    expect(env.DISCORD_LOCAL_SCOPES).toBe("identify,guilds,42");
+    expect(env.DISCORD_LOCAL_MESSAGE_CHANNEL_IDS).toBeUndefined();
+  });
 
-	it("serializes true booleans and skips non-finite numbers and nested objects", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				discordLocal: {
-					enabled: true,
-					sendDelayMs: Number.POSITIVE_INFINITY,
-					clientSecret: { nested: true },
-				},
-				imessage: {
-					pollIntervalMs: Number.NaN,
-					enabled: true,
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("serializes true booleans and skips non-finite numbers and nested objects", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        discordLocal: {
+          enabled: true,
+          sendDelayMs: Number.POSITIVE_INFINITY,
+          clientSecret: { nested: true },
+        },
+        imessage: {
+          pollIntervalMs: Number.NaN,
+          enabled: true,
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.DISCORD_LOCAL_ENABLED).toBe("true");
-		expect(env.DISCORD_LOCAL_SEND_DELAY_MS).toBeUndefined();
-		expect(env.DISCORD_LOCAL_CLIENT_SECRET).toBeUndefined();
-		expect(env.IMESSAGE_POLL_INTERVAL_MS).toBeUndefined();
-		expect(env.IMESSAGE_ENABLED).toBe("true");
-	});
+    expect(env.DISCORD_LOCAL_ENABLED).toBe("true");
+    expect(env.DISCORD_LOCAL_SEND_DELAY_MS).toBeUndefined();
+    expect(env.DISCORD_LOCAL_CLIENT_SECRET).toBeUndefined();
+    expect(env.IMESSAGE_POLL_INTERVAL_MS).toBeUndefined();
+    expect(env.IMESSAGE_ENABLED).toBe("true");
+  });
 
-	it("projects remaining connector families from a single populated config", () => {
-		const env = connectorEnv({
-			telegram: { botToken: "tg" },
-			telegramAccount: { phone: "+1555", appId: 1234 },
-			slack: { botToken: "xoxb", appToken: "xapp" },
-			imessage: { cliPath: "/usr/bin/imsg", allowFrom: ["a", "b"] },
-			msteams: { appId: "teams-id", appPassword: "teams-pw" },
-			mattermost: { botToken: "mm-token", baseUrl: "https://mm.example" },
-			googlechat: { serviceAccountKey: "{}" },
-			blooio: { apiKey: "bloo", fromNumber: "+100", webhookPort: 8080 },
-		});
+  it("projects remaining connector families from a single populated config", () => {
+    const env = connectorEnv({
+      telegram: { botToken: "tg" },
+      telegramAccount: { phone: "+1555", appId: 1234 },
+      slack: { botToken: "xoxb", appToken: "xapp" },
+      imessage: { cliPath: "/usr/bin/imsg", allowFrom: ["a", "b"] },
+      msteams: { appId: "teams-id", appPassword: "teams-pw" },
+      mattermost: { botToken: "mm-token", baseUrl: "https://mm.example" },
+      googlechat: { serviceAccountKey: "{}" },
+      blooio: { apiKey: "bloo", fromNumber: "+100", webhookPort: 8080 },
+    });
 
-		expect(env.TELEGRAM_BOT_TOKEN).toBe("tg");
-		expect(env.TELEGRAM_ACCOUNT_PHONE).toBe("+1555");
-		expect(env.TELEGRAM_ACCOUNT_APP_ID).toBe("1234");
-		expect(env.SLACK_BOT_TOKEN).toBe("xoxb");
-		expect(env.SLACK_APP_TOKEN).toBe("xapp");
-		expect(env.IMESSAGE_CLI_PATH).toBe("/usr/bin/imsg");
-		expect(env.IMESSAGE_ALLOW_FROM).toBe("a,b");
-		expect(env.MSTEAMS_APP_ID).toBe("teams-id");
-		expect(env.MSTEAMS_APP_PASSWORD).toBe("teams-pw");
-		expect(env.MATTERMOST_BOT_TOKEN).toBe("mm-token");
-		expect(env.MATTERMOST_BASE_URL).toBe("https://mm.example");
-		expect(env.GOOGLE_CHAT_SERVICE_ACCOUNT_KEY).toBe("{}");
-		expect(env.BLOOIO_API_KEY).toBe("bloo");
-		expect(env.BLOOIO_PHONE_NUMBER).toBe("+100");
-		expect(env.BLOOIO_WEBHOOK_PORT).toBe("8080");
-	});
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("tg");
+    expect(env.TELEGRAM_ACCOUNT_PHONE).toBe("+1555");
+    expect(env.TELEGRAM_ACCOUNT_APP_ID).toBe("1234");
+    expect(env.SLACK_BOT_TOKEN).toBe("xoxb");
+    expect(env.SLACK_APP_TOKEN).toBe("xapp");
+    expect(env.IMESSAGE_CLI_PATH).toBe("/usr/bin/imsg");
+    expect(env.IMESSAGE_ALLOW_FROM).toBe("a,b");
+    expect(env.MSTEAMS_APP_ID).toBe("teams-id");
+    expect(env.MSTEAMS_APP_PASSWORD).toBe("teams-pw");
+    expect(env.MATTERMOST_BOT_TOKEN).toBe("mm-token");
+    expect(env.MATTERMOST_BASE_URL).toBe("https://mm.example");
+    expect(env.GOOGLE_CHAT_SERVICE_ACCOUNT_KEY).toBe("{}");
+    expect(env.BLOOIO_API_KEY).toBe("bloo");
+    expect(env.BLOOIO_PHONE_NUMBER).toBe("+100");
+    expect(env.BLOOIO_WEBHOOK_PORT).toBe("8080");
+  });
 
-	it("lets WhatsApp sessionPath overwrite authDir, then the first enabled account overwrite both", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				whatsapp: {
-					authDir: "/from-auth-dir",
-					sessionPath: "/from-session-path",
-					dmPolicy: "open",
-					accounts: {
-						disabled: { enabled: false, authDir: "/disabled" },
-						skip: "not-an-object",
-						first: { enabled: true, authDir: " /from-account " },
-						later: { authDir: "/later-account" },
-					},
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("lets WhatsApp sessionPath overwrite authDir, then the first enabled account overwrite both", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        whatsapp: {
+          authDir: "/from-auth-dir",
+          sessionPath: "/from-session-path",
+          dmPolicy: "open",
+          accounts: {
+            disabled: { enabled: false, authDir: "/disabled" },
+            skip: "not-an-object",
+            first: { enabled: true, authDir: " /from-account " },
+            later: { authDir: "/later-account" },
+          },
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.WHATSAPP_AUTH_DIR).toBe("/from-account");
-		expect(env.WHATSAPP_DM_POLICY).toBe("open");
-	});
+    expect(env.WHATSAPP_AUTH_DIR).toBe("/from-account");
+    expect(env.WHATSAPP_DM_POLICY).toBe("open");
+  });
 
-	it("does not keep scanning WhatsApp accounts after the first enabled string authDir is blank", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				whatsapp: {
-					sessionPath: "/from-session-path",
-					accounts: {
-						empty: { enabled: true, authDir: "  " },
-						later: { authDir: "/later-account" },
-					},
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("does not keep scanning WhatsApp accounts after the first enabled string authDir is blank", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        whatsapp: {
+          sessionPath: "/from-session-path",
+          accounts: {
+            empty: { enabled: true, authDir: "  " },
+            later: { authDir: "/later-account" },
+          },
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.WHATSAPP_AUTH_DIR).toBe("/from-session-path");
-	});
+    expect(env.WHATSAPP_AUTH_DIR).toBe("/from-session-path");
+  });
 
-	it("comma-joins WhatsApp allowFrom and groupAllowFrom after String() coercion", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				whatsapp: {
-					allowFrom: ["  alice  ", 7, "", "  "],
-					groupAllowFrom: [" g1 ", "g2"],
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("comma-joins WhatsApp allowFrom and groupAllowFrom after String() coercion", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        whatsapp: {
+          allowFrom: ["  alice  ", 7, "", "  "],
+          groupAllowFrom: [" g1 ", "g2"],
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.WHATSAPP_ALLOW_FROM).toBe("alice,7");
-		expect(env.WHATSAPP_GROUP_ALLOW_FROM).toBe("g1,g2");
-	});
+    expect(env.WHATSAPP_ALLOW_FROM).toBe("alice,7");
+    expect(env.WHATSAPP_GROUP_ALLOW_FROM).toBe("g1,g2");
+  });
 
-	it("omits WhatsApp allow-lists and authDir overrides that are empty or the wrong shape", () => {
-		const env = collectConnectorEnvVars({
-			connectors: {
-				whatsapp: {
-					authDir: "/kept",
-					allowFrom: [],
-					groupAllowFrom: ["  ", ""],
-					accounts: [{ authDir: "/from-array" }],
-				},
-			},
-		} as unknown as ElizaConfig);
+  it("omits WhatsApp allow-lists and authDir overrides that are empty or the wrong shape", () => {
+    const env = collectConnectorEnvVars({
+      connectors: {
+        whatsapp: {
+          authDir: "/kept",
+          allowFrom: [],
+          groupAllowFrom: ["  ", ""],
+          accounts: [{ authDir: "/from-array" }],
+        },
+      },
+    } as unknown as ElizaConfig);
 
-		expect(env.WHATSAPP_AUTH_DIR).toBe("/kept");
-		expect(env.WHATSAPP_ALLOW_FROM).toBeUndefined();
-		expect(env.WHATSAPP_GROUP_ALLOW_FROM).toBeUndefined();
-	});
+    expect(env.WHATSAPP_AUTH_DIR).toBe("/kept");
+    expect(env.WHATSAPP_ALLOW_FROM).toBeUndefined();
+    expect(env.WHATSAPP_GROUP_ALLOW_FROM).toBeUndefined();
+  });
 
-	it("skips WhatsApp accounts that are not a map or have no enabled string authDir", () => {
-		expect(
-			collectConnectorEnvVars({
-				connectors: {
-					whatsapp: {
-						authDir: "/kept",
-						accounts: null,
-					},
-				},
-			} as unknown as ElizaConfig).WHATSAPP_AUTH_DIR,
-		).toBe("/kept");
-		expect(
-			collectConnectorEnvVars({
-				connectors: {
-					whatsapp: {
-						authDir: "/kept",
-						accounts: {
-							a: null,
-							b: ["nope"],
-							c: { enabled: false, authDir: "/no" },
-							d: { authDir: 12 },
-						},
-					},
-				},
-			} as unknown as ElizaConfig).WHATSAPP_AUTH_DIR,
-		).toBe("/kept");
-	});
+  it("skips WhatsApp accounts that are not a map or have no enabled string authDir", () => {
+    expect(
+      collectConnectorEnvVars({
+        connectors: {
+          whatsapp: {
+            authDir: "/kept",
+            accounts: null,
+          },
+        },
+      } as unknown as ElizaConfig).WHATSAPP_AUTH_DIR,
+    ).toBe("/kept");
+    expect(
+      collectConnectorEnvVars({
+        connectors: {
+          whatsapp: {
+            authDir: "/kept",
+            accounts: {
+              a: null,
+              b: ["nope"],
+              c: { enabled: false, authDir: "/no" },
+              d: { authDir: 12 },
+            },
+          },
+        },
+      } as unknown as ElizaConfig).WHATSAPP_AUTH_DIR,
+    ).toBe("/kept");
+  });
 });

--- a/packages/agent/src/config/includes.test.ts
+++ b/packages/agent/src/config/includes.test.ts
@@ -8,591 +8,591 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	CircularIncludeError,
-	ConfigIncludeError,
-	deepMerge,
-	INCLUDE_KEY,
-	type IncludeResolver,
-	MAX_INCLUDE_DEPTH,
-	resolveConfigIncludes,
+  CircularIncludeError,
+  ConfigIncludeError,
+  deepMerge,
+  INCLUDE_KEY,
+  type IncludeResolver,
+  MAX_INCLUDE_DEPTH,
+  resolveConfigIncludes,
 } from "./includes.ts";
 
 const roots: string[] = [];
 
 afterEach(() => {
-	for (const root of roots.splice(0))
-		fs.rmSync(root, { recursive: true, force: true });
+  for (const root of roots.splice(0))
+    fs.rmSync(root, { recursive: true, force: true });
 });
 
 function tempRoot(): string {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-includes-"));
-	roots.push(root);
-	return root;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-includes-"));
+  roots.push(root);
+  return root;
 }
 
 function memoryResolver(files: Map<string, string>): IncludeResolver {
-	return {
-		readFile: (file) => {
-			const raw = files.get(path.normalize(file));
-			if (raw === undefined) throw new Error(`missing ${file}`);
-			return raw;
-		},
-		parseJson: JSON.parse,
-	};
+  return {
+    readFile: (file) => {
+      const raw = files.get(path.normalize(file));
+      if (raw === undefined) throw new Error(`missing ${file}`);
+      return raw;
+    },
+    parseJson: JSON.parse,
+  };
 }
 
 function resolveMemory(
-	obj: unknown,
-	files: Map<string, string>,
-	configPath = "/cfg/root.json5",
+  obj: unknown,
+  files: Map<string, string>,
+  configPath = "/cfg/root.json5",
 ): unknown {
-	return resolveConfigIncludes(obj, configPath, memoryResolver(files));
+  return resolveConfigIncludes(obj, configPath, memoryResolver(files));
 }
 
 describe("include constants and errors", () => {
-	it("exports the $include key and a depth cap of 10", () => {
-		expect(INCLUDE_KEY).toBe("$include");
-		expect(MAX_INCLUDE_DEPTH).toBe(10);
-	});
+  it("exports the $include key and a depth cap of 10", () => {
+    expect(INCLUDE_KEY).toBe("$include");
+    expect(MAX_INCLUDE_DEPTH).toBe(10);
+  });
 
-	it("preserves includePath and optional cause on ConfigIncludeError", () => {
-		const cause = new Error("disk");
-		const err = new ConfigIncludeError("failed", "./missing.json5", cause);
-		expect(err).toBeInstanceOf(Error);
-		expect(err.name).toBe("ConfigIncludeError");
-		expect(err.message).toBe("failed");
-		expect(err.includePath).toBe("./missing.json5");
-		expect(err.cause).toBe(cause);
-		expect(new ConfigIncludeError("no cause", "x").cause).toBeUndefined();
-	});
+  it("preserves includePath and optional cause on ConfigIncludeError", () => {
+    const cause = new Error("disk");
+    const err = new ConfigIncludeError("failed", "./missing.json5", cause);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ConfigIncludeError");
+    expect(err.message).toBe("failed");
+    expect(err.includePath).toBe("./missing.json5");
+    expect(err.cause).toBe(cause);
+    expect(new ConfigIncludeError("no cause", "x").cause).toBeUndefined();
+  });
 
-	it("CircularIncludeError records the chain and uses the last hop as includePath", () => {
-		const chain = ["/cfg/a.json5", "/cfg/b.json5", "/cfg/a.json5"];
-		const err = new CircularIncludeError(chain);
-		expect(err).toBeInstanceOf(ConfigIncludeError);
-		expect(err.name).toBe("CircularIncludeError");
-		expect(err.chain).toEqual(chain);
-		expect(err.includePath).toBe("/cfg/a.json5");
-		expect(err.message).toBe(
-			"Circular include detected: /cfg/a.json5 -> /cfg/b.json5 -> /cfg/a.json5",
-		);
-		expect(new CircularIncludeError([]).includePath).toBe("");
-	});
+  it("CircularIncludeError records the chain and uses the last hop as includePath", () => {
+    const chain = ["/cfg/a.json5", "/cfg/b.json5", "/cfg/a.json5"];
+    const err = new CircularIncludeError(chain);
+    expect(err).toBeInstanceOf(ConfigIncludeError);
+    expect(err.name).toBe("CircularIncludeError");
+    expect(err.chain).toEqual(chain);
+    expect(err.includePath).toBe("/cfg/a.json5");
+    expect(err.message).toBe(
+      "Circular include detected: /cfg/a.json5 -> /cfg/b.json5 -> /cfg/a.json5",
+    );
+    expect(new CircularIncludeError([]).includePath).toBe("");
+  });
 });
 
 describe("deepMerge", () => {
-	it("concatenates arrays and does not mutate the inputs", () => {
-		const target = [1];
-		const source = [2, 3];
-		expect(deepMerge(target, source)).toEqual([1, 2, 3]);
-		expect(target).toEqual([1]);
-		expect(source).toEqual([2, 3]);
-		expect(deepMerge([], [])).toEqual([]);
-		expect(deepMerge(["only"], [])).toEqual(["only"]);
-		expect(deepMerge([], ["only"])).toEqual(["only"]);
-	});
+  it("concatenates arrays and does not mutate the inputs", () => {
+    const target = [1];
+    const source = [2, 3];
+    expect(deepMerge(target, source)).toEqual([1, 2, 3]);
+    expect(target).toEqual([1]);
+    expect(source).toEqual([2, 3]);
+    expect(deepMerge([], [])).toEqual([]);
+    expect(deepMerge(["only"], [])).toEqual(["only"]);
+    expect(deepMerge([], ["only"])).toEqual(["only"]);
+  });
 
-	it("merges nested objects left-to-right, with later primitives winning ties", () => {
-		expect(
-			deepMerge(
-				{ a: 1, nested: { x: 1, keep: true }, extra: "stay" },
-				{ a: 2, nested: { x: 2, y: 3 }, added: 4 },
-			),
-		).toEqual({
-			a: 2,
-			nested: { x: 2, keep: true, y: 3 },
-			extra: "stay",
-			added: 4,
-		});
-	});
+  it("merges nested objects left-to-right, with later primitives winning ties", () => {
+    expect(
+      deepMerge(
+        { a: 1, nested: { x: 1, keep: true }, extra: "stay" },
+        { a: 2, nested: { x: 2, y: 3 }, added: 4 },
+      ),
+    ).toEqual({
+      a: 2,
+      nested: { x: 2, keep: true, y: 3 },
+      extra: "stay",
+      added: 4,
+    });
+  });
 
-	it("skips prototype-polluting keys on the source object", () => {
-		const source: Record<string, unknown> = {
-			safe: 1,
-			constructor: { pwned: true },
-			prototype: { pwned: true },
-		};
-		Object.defineProperty(source, "__proto__", {
-			value: { pwned: true },
-			enumerable: true,
-			configurable: true,
-		});
-		expect(deepMerge({ keep: true }, source)).toEqual({ keep: true, safe: 1 });
-	});
+  it("skips prototype-polluting keys on the source object", () => {
+    const source: Record<string, unknown> = {
+      safe: 1,
+      constructor: { pwned: true },
+      prototype: { pwned: true },
+    };
+    Object.defineProperty(source, "__proto__", {
+      value: { pwned: true },
+      enumerable: true,
+      configurable: true,
+    });
+    expect(deepMerge({ keep: true }, source)).toEqual({ keep: true, safe: 1 });
+  });
 
-	it("returns the source when the types cannot merge", () => {
-		expect(deepMerge({ a: 1 }, 2)).toBe(2);
-		expect(deepMerge([1], { a: 1 })).toEqual({ a: 1 });
-		expect(deepMerge({ a: 1 }, [2])).toEqual([2]);
-		expect(deepMerge(1, { a: 1 })).toEqual({ a: 1 });
-		expect(deepMerge("a", "b")).toBe("b");
-		expect(deepMerge(null, "x")).toBe("x");
-		expect(deepMerge(undefined, false)).toBe(false);
-	});
+  it("returns the source when the types cannot merge", () => {
+    expect(deepMerge({ a: 1 }, 2)).toBe(2);
+    expect(deepMerge([1], { a: 1 })).toEqual({ a: 1 });
+    expect(deepMerge({ a: 1 }, [2])).toEqual([2]);
+    expect(deepMerge(1, { a: 1 })).toEqual({ a: 1 });
+    expect(deepMerge("a", "b")).toBe("b");
+    expect(deepMerge(null, "x")).toBe("x");
+    expect(deepMerge(undefined, false)).toBe(false);
+  });
 });
 
 describe("resolveConfigIncludes without $include", () => {
-	it("returns primitives, null, and empty collections unchanged", () => {
-		const files = new Map<string, string>();
-		expect(resolveMemory("hello", files)).toBe("hello");
-		expect(resolveMemory(0, files)).toBe(0);
-		expect(resolveMemory(true, files)).toBe(true);
-		expect(resolveMemory(null, files)).toBeNull();
-		expect(resolveMemory([], files)).toEqual([]);
-		expect(resolveMemory({}, files)).toEqual({});
-	});
+  it("returns primitives, null, and empty collections unchanged", () => {
+    const files = new Map<string, string>();
+    expect(resolveMemory("hello", files)).toBe("hello");
+    expect(resolveMemory(0, files)).toBe(0);
+    expect(resolveMemory(true, files)).toBe(true);
+    expect(resolveMemory(null, files)).toBeNull();
+    expect(resolveMemory([], files)).toEqual([]);
+    expect(resolveMemory({}, files)).toEqual({});
+  });
 
-	it("walks arrays and nested objects and drops blocked keys", () => {
-		const input: Record<string, unknown> = {
-			keep: { inner: 1 },
-			list: [{ n: 1 }, "x", null],
-			constructor: { pwned: true },
-			prototype: { pwned: true },
-		};
-		Object.defineProperty(input, "__proto__", {
-			value: { pwned: true },
-			enumerable: true,
-			configurable: true,
-		});
-		expect(resolveMemory(input, new Map())).toEqual({
-			keep: { inner: 1 },
-			list: [{ n: 1 }, "x", null],
-		});
-	});
+  it("walks arrays and nested objects and drops blocked keys", () => {
+    const input: Record<string, unknown> = {
+      keep: { inner: 1 },
+      list: [{ n: 1 }, "x", null],
+      constructor: { pwned: true },
+      prototype: { pwned: true },
+    };
+    Object.defineProperty(input, "__proto__", {
+      value: { pwned: true },
+      enumerable: true,
+      configurable: true,
+    });
+    expect(resolveMemory(input, new Map())).toEqual({
+      keep: { inner: 1 },
+      list: [{ n: 1 }, "x", null],
+    });
+  });
 });
 
 describe("resolveConfigIncludes string and array $include", () => {
-	it("loads a single relative include and an empty include array", () => {
-		const files = new Map<string, string>([
-			[path.normalize("/cfg/child.json5"), JSON.stringify({ enabled: true })],
-		]);
-		expect(resolveMemory({ $include: "./child.json5" }, files)).toEqual({
-			enabled: true,
-		});
-		expect(resolveMemory({ $include: [] }, files)).toEqual({});
-	});
+  it("loads a single relative include and an empty include array", () => {
+    const files = new Map<string, string>([
+      [path.normalize("/cfg/child.json5"), JSON.stringify({ enabled: true })],
+    ]);
+    expect(resolveMemory({ $include: "./child.json5" }, files)).toEqual({
+      enabled: true,
+    });
+    expect(resolveMemory({ $include: [] }, files)).toEqual({});
+  });
 
-	it("resolves an absolute include path without joining the config directory", () => {
-		const abs = path.normalize("/elsewhere/base.json5");
-		const files = new Map<string, string>([
-			[abs, JSON.stringify({ from: "abs" })],
-		]);
-		expect(resolveMemory({ $include: abs }, files, "/cfg/root.json5")).toEqual({
-			from: "abs",
-		});
-	});
+  it("resolves an absolute include path without joining the config directory", () => {
+    const abs = path.normalize("/elsewhere/base.json5");
+    const files = new Map<string, string>([
+      [abs, JSON.stringify({ from: "abs" })],
+    ]);
+    expect(resolveMemory({ $include: abs }, files, "/cfg/root.json5")).toEqual({
+      from: "abs",
+    });
+  });
 
-	it("merges array includes left-to-right, concatenating nested arrays", () => {
-		const files = new Map<string, string>([
-			[
-				path.normalize("/cfg/a.json5"),
-				JSON.stringify({ k: 1, arr: [1], keep: true }),
-			],
-			[
-				path.normalize("/cfg/b.json5"),
-				JSON.stringify({ k: 2, arr: [2], extra: 3 }),
-			],
-		]);
-		expect(
-			resolveMemory({ $include: ["./a.json5", "./b.json5"] }, files),
-		).toEqual({
-			k: 2,
-			arr: [1, 2],
-			keep: true,
-			extra: 3,
-		});
-	});
+  it("merges array includes left-to-right, concatenating nested arrays", () => {
+    const files = new Map<string, string>([
+      [
+        path.normalize("/cfg/a.json5"),
+        JSON.stringify({ k: 1, arr: [1], keep: true }),
+      ],
+      [
+        path.normalize("/cfg/b.json5"),
+        JSON.stringify({ k: 2, arr: [2], extra: 3 }),
+      ],
+    ]);
+    expect(
+      resolveMemory({ $include: ["./a.json5", "./b.json5"] }, files),
+    ).toEqual({
+      k: 2,
+      arr: [1, 2],
+      keep: true,
+      extra: 3,
+    });
+  });
 
-	it("treats a single-element include array as one merge into {}", () => {
-		const files = new Map<string, string>([
-			[path.normalize("/cfg/only.json5"), JSON.stringify({ only: true })],
-		]);
-		expect(resolveMemory({ $include: ["./only.json5"] }, files)).toEqual({
-			only: true,
-		});
-	});
+  it("treats a single-element include array as one merge into {}", () => {
+    const files = new Map<string, string>([
+      [path.normalize("/cfg/only.json5"), JSON.stringify({ only: true })],
+    ]);
+    expect(resolveMemory({ $include: ["./only.json5"] }, files)).toEqual({
+      only: true,
+    });
+  });
 
-	it("rejects non-string array items and invalid $include values", () => {
-		const files = new Map<string, string>();
-		expect(() => resolveMemory({ $include: [1] }, files)).toThrow(
-			/Invalid \$include array item: expected string, got number/,
-		);
-		expect(() => resolveMemory({ $include: [null] }, files)).toThrow(
-			/Invalid \$include array item: expected string, got object/,
-		);
-		expect(() =>
-			resolveMemory({ $include: [{ path: "./x.json5" }] }, files),
-		).toThrow(/Invalid \$include array item: expected string, got object/);
-		expect(() => resolveMemory({ $include: 3 }, files)).toThrow(
-			/Invalid \$include value: expected string or array of strings, got number/,
-		);
-		expect(() => resolveMemory({ $include: true }, files)).toThrow(
-			/got boolean/,
-		);
-		expect(() => resolveMemory({ $include: { path: "x" } }, files)).toThrow(
-			/got object/,
-		);
-		expect(() => resolveMemory({ $include: null }, files)).toThrow(
-			/got object/,
-		);
+  it("rejects non-string array items and invalid $include values", () => {
+    const files = new Map<string, string>();
+    expect(() => resolveMemory({ $include: [1] }, files)).toThrow(
+      /Invalid \$include array item: expected string, got number/,
+    );
+    expect(() => resolveMemory({ $include: [null] }, files)).toThrow(
+      /Invalid \$include array item: expected string, got object/,
+    );
+    expect(() =>
+      resolveMemory({ $include: [{ path: "./x.json5" }] }, files),
+    ).toThrow(/Invalid \$include array item: expected string, got object/);
+    expect(() => resolveMemory({ $include: 3 }, files)).toThrow(
+      /Invalid \$include value: expected string or array of strings, got number/,
+    );
+    expect(() => resolveMemory({ $include: true }, files)).toThrow(
+      /got boolean/,
+    );
+    expect(() => resolveMemory({ $include: { path: "x" } }, files)).toThrow(
+      /got object/,
+    );
+    expect(() => resolveMemory({ $include: null }, files)).toThrow(
+      /got object/,
+    );
 
-		try {
-			resolveMemory({ $include: [2] }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			expect((err as ConfigIncludeError).includePath).toBe("2");
-		}
-	});
+    try {
+      resolveMemory({ $include: [2] }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      expect((err as ConfigIncludeError).includePath).toBe("2");
+    }
+  });
 
-	it("resolves nested $include values inside objects and arrays", () => {
-		const files = new Map<string, string>([
-			[path.normalize("/cfg/inner.json5"), JSON.stringify({ inner: true })],
-			[path.normalize("/cfg/item.json5"), JSON.stringify({ item: 1 })],
-		]);
-		expect(
-			resolveMemory(
-				{
-					nested: { $include: "./inner.json5" },
-					list: [{ $include: "./item.json5" }],
-				},
-				files,
-			),
-		).toEqual({
-			nested: { inner: true },
-			list: [{ item: 1 }],
-		});
-	});
+  it("resolves nested $include values inside objects and arrays", () => {
+    const files = new Map<string, string>([
+      [path.normalize("/cfg/inner.json5"), JSON.stringify({ inner: true })],
+      [path.normalize("/cfg/item.json5"), JSON.stringify({ item: 1 })],
+    ]);
+    expect(
+      resolveMemory(
+        {
+          nested: { $include: "./inner.json5" },
+          list: [{ $include: "./item.json5" }],
+        },
+        files,
+      ),
+    ).toEqual({
+      nested: { inner: true },
+      list: [{ item: 1 }],
+    });
+  });
 });
 
 describe("resolveConfigIncludes sibling keys", () => {
-	it("deep-merges sibling keys over included objects, processing nested includes", () => {
-		const files = new Map<string, string>([
-			[
-				path.normalize("/cfg/base.json5"),
-				JSON.stringify({ a: 1, nested: { x: 1 } }),
-			],
-			[
-				path.normalize("/cfg/over.json5"),
-				JSON.stringify({ fromInclude: true }),
-			],
-		]);
-		expect(
-			resolveMemory(
-				{
-					$include: "./base.json5",
-					a: 2,
-					nested: { y: 2 },
-					extra: { $include: "./over.json5" },
-				},
-				files,
-			),
-		).toEqual({
-			a: 2,
-			nested: { x: 1, y: 2 },
-			extra: { fromInclude: true },
-		});
-	});
+  it("deep-merges sibling keys over included objects, processing nested includes", () => {
+    const files = new Map<string, string>([
+      [
+        path.normalize("/cfg/base.json5"),
+        JSON.stringify({ a: 1, nested: { x: 1 } }),
+      ],
+      [
+        path.normalize("/cfg/over.json5"),
+        JSON.stringify({ fromInclude: true }),
+      ],
+    ]);
+    expect(
+      resolveMemory(
+        {
+          $include: "./base.json5",
+          a: 2,
+          nested: { y: 2 },
+          extra: { $include: "./over.json5" },
+        },
+        files,
+      ),
+    ).toEqual({
+      a: 2,
+      nested: { x: 1, y: 2 },
+      extra: { fromInclude: true },
+    });
+  });
 
-	it("rejects sibling keys when the included value is not an object", () => {
-		const files = new Map<string, string>([
-			[path.normalize("/cfg/list.json5"), JSON.stringify([1, 2])],
-			[path.normalize("/cfg/num.json5"), JSON.stringify(4)],
-		]);
-		expect(() =>
-			resolveMemory({ $include: "./list.json5", extra: 1 }, files),
-		).toThrow(/Sibling keys require included content to be an object/);
-		try {
-			resolveMemory({ $include: "./num.json5", extra: 1 }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			expect((err as ConfigIncludeError).includePath).toBe("./num.json5");
-		}
-		try {
-			resolveMemory({ $include: ["./list.json5"], extra: 1 }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			expect((err as ConfigIncludeError).includePath).toBe(INCLUDE_KEY);
-		}
-	});
+  it("rejects sibling keys when the included value is not an object", () => {
+    const files = new Map<string, string>([
+      [path.normalize("/cfg/list.json5"), JSON.stringify([1, 2])],
+      [path.normalize("/cfg/num.json5"), JSON.stringify(4)],
+    ]);
+    expect(() =>
+      resolveMemory({ $include: "./list.json5", extra: 1 }, files),
+    ).toThrow(/Sibling keys require included content to be an object/);
+    try {
+      resolveMemory({ $include: "./num.json5", extra: 1 }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      expect((err as ConfigIncludeError).includePath).toBe("./num.json5");
+    }
+    try {
+      resolveMemory({ $include: ["./list.json5"], extra: 1 }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      expect((err as ConfigIncludeError).includePath).toBe(INCLUDE_KEY);
+    }
+  });
 });
 
 describe("resolveConfigIncludes cycles, missing files, and parse failures", () => {
-	it("detects a self-include and an A→B→A cycle, including normalized aliases", () => {
-		const files = new Map<string, string>([
-			[
-				path.normalize("/cfg/self.json5"),
-				JSON.stringify({ $include: "./self.json5" }),
-			],
-			[
-				path.normalize("/cfg/a.json5"),
-				JSON.stringify({ $include: "./b.json5" }),
-			],
-			[
-				path.normalize("/cfg/b.json5"),
-				JSON.stringify({ $include: "./nested/../a.json5" }),
-			],
-		]);
-		expect(() =>
-			resolveConfigIncludes(
-				{ $include: "./self.json5" },
-				"/cfg/self.json5",
-				memoryResolver(files),
-			),
-		).toThrow(CircularIncludeError);
+  it("detects a self-include and an A→B→A cycle, including normalized aliases", () => {
+    const files = new Map<string, string>([
+      [
+        path.normalize("/cfg/self.json5"),
+        JSON.stringify({ $include: "./self.json5" }),
+      ],
+      [
+        path.normalize("/cfg/a.json5"),
+        JSON.stringify({ $include: "./b.json5" }),
+      ],
+      [
+        path.normalize("/cfg/b.json5"),
+        JSON.stringify({ $include: "./nested/../a.json5" }),
+      ],
+    ]);
+    expect(() =>
+      resolveConfigIncludes(
+        { $include: "./self.json5" },
+        "/cfg/self.json5",
+        memoryResolver(files),
+      ),
+    ).toThrow(CircularIncludeError);
 
-		try {
-			resolveMemory({ $include: "./a.json5" }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(CircularIncludeError);
-			const circular = err as CircularIncludeError;
-			expect(circular.chain.at(-1)).toBe(path.normalize("/cfg/a.json5"));
-			expect(circular.message).toMatch(/Circular include detected:/);
-		}
-	});
+    try {
+      resolveMemory({ $include: "./a.json5" }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CircularIncludeError);
+      const circular = err as CircularIncludeError;
+      expect(circular.chain.at(-1)).toBe(path.normalize("/cfg/a.json5"));
+      expect(circular.message).toMatch(/Circular include detected:/);
+    }
+  });
 
-	it("wraps read failures, including non-Error throws, and does not skip a missing file", () => {
-		const files = new Map<string, string>();
-		try {
-			resolveMemory({ $include: "./missing.json5" }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			const includeErr = err as ConfigIncludeError;
-			expect(includeErr.message).toMatch(
-				/Failed to read include file: \.\/missing\.json5/,
-			);
-			expect(includeErr.includePath).toBe("./missing.json5");
-			expect(includeErr.cause).toBeInstanceOf(Error);
-		}
+  it("wraps read failures, including non-Error throws, and does not skip a missing file", () => {
+    const files = new Map<string, string>();
+    try {
+      resolveMemory({ $include: "./missing.json5" }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      const includeErr = err as ConfigIncludeError;
+      expect(includeErr.message).toMatch(
+        /Failed to read include file: \.\/missing\.json5/,
+      );
+      expect(includeErr.includePath).toBe("./missing.json5");
+      expect(includeErr.cause).toBeInstanceOf(Error);
+    }
 
-		const throwing: IncludeResolver = {
-			readFile: () => {
-				throw "not-an-error";
-			},
-			parseJson: JSON.parse,
-		};
-		try {
-			resolveConfigIncludes(
-				{ $include: "./x.json5" },
-				"/cfg/root.json5",
-				throwing,
-			);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			expect((err as ConfigIncludeError).cause).toBeUndefined();
-		}
-	});
+    const throwing: IncludeResolver = {
+      readFile: () => {
+        throw "not-an-error";
+      },
+      parseJson: JSON.parse,
+    };
+    try {
+      resolveConfigIncludes(
+        { $include: "./x.json5" },
+        "/cfg/root.json5",
+        throwing,
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      expect((err as ConfigIncludeError).cause).toBeUndefined();
+    }
+  });
 
-	it("wraps parse failures and drops a non-Error parser throw", () => {
-		const files = new Map<string, string>([
-			[path.normalize("/cfg/bad.json5"), "{ not json"],
-		]);
-		try {
-			resolveMemory({ $include: "./bad.json5" }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			const includeErr = err as ConfigIncludeError;
-			expect(includeErr.message).toMatch(
-				/Failed to parse include file: \.\/bad\.json5/,
-			);
-			expect(includeErr.cause).toBeInstanceOf(Error);
-		}
+  it("wraps parse failures and drops a non-Error parser throw", () => {
+    const files = new Map<string, string>([
+      [path.normalize("/cfg/bad.json5"), "{ not json"],
+    ]);
+    try {
+      resolveMemory({ $include: "./bad.json5" }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      const includeErr = err as ConfigIncludeError;
+      expect(includeErr.message).toMatch(
+        /Failed to parse include file: \.\/bad\.json5/,
+      );
+      expect(includeErr.cause).toBeInstanceOf(Error);
+    }
 
-		const throwing: IncludeResolver = {
-			readFile: () => "{}",
-			parseJson: () => {
-				throw "parse-blew";
-			},
-		};
-		try {
-			resolveConfigIncludes(
-				{ $include: "./x.json5" },
-				"/cfg/root.json5",
-				throwing,
-			);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			expect((err as ConfigIncludeError).cause).toBeUndefined();
-		}
-	});
+    const throwing: IncludeResolver = {
+      readFile: () => "{}",
+      parseJson: () => {
+        throw "parse-blew";
+      },
+    };
+    try {
+      resolveConfigIncludes(
+        { $include: "./x.json5" },
+        "/cfg/root.json5",
+        throwing,
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      expect((err as ConfigIncludeError).cause).toBeUndefined();
+    }
+  });
 });
 
 describe("resolveConfigIncludes depth and graph budgets", () => {
-	it("allows a chain of MAX_INCLUDE_DEPTH includes and rejects one more", () => {
-		const files = new Map<string, string>();
-		for (let i = 1; i <= MAX_INCLUDE_DEPTH; i += 1) {
-			files.set(
-				path.normalize(`/cfg/d${i}.json5`),
-				JSON.stringify({ $include: `./d${i + 1}.json5` }),
-			);
-		}
-		files.set(
-			path.normalize(`/cfg/d${MAX_INCLUDE_DEPTH}.json5`),
-			JSON.stringify({ ok: true }),
-		);
-		expect(resolveMemory({ $include: "./d1.json5" }, files)).toEqual({
-			ok: true,
-		});
+  it("allows a chain of MAX_INCLUDE_DEPTH includes and rejects one more", () => {
+    const files = new Map<string, string>();
+    for (let i = 1; i <= MAX_INCLUDE_DEPTH; i += 1) {
+      files.set(
+        path.normalize(`/cfg/d${i}.json5`),
+        JSON.stringify({ $include: `./d${i + 1}.json5` }),
+      );
+    }
+    files.set(
+      path.normalize(`/cfg/d${MAX_INCLUDE_DEPTH}.json5`),
+      JSON.stringify({ ok: true }),
+    );
+    expect(resolveMemory({ $include: "./d1.json5" }, files)).toEqual({
+      ok: true,
+    });
 
-		files.set(
-			path.normalize(`/cfg/d${MAX_INCLUDE_DEPTH}.json5`),
-			JSON.stringify({ $include: `./d${MAX_INCLUDE_DEPTH + 1}.json5` }),
-		);
-		files.set(
-			path.normalize(`/cfg/d${MAX_INCLUDE_DEPTH + 1}.json5`),
-			JSON.stringify({ too: "deep" }),
-		);
-		try {
-			resolveMemory({ $include: "./d1.json5" }, files);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(ConfigIncludeError);
-			expect(err).not.toBeInstanceOf(CircularIncludeError);
-			const includeErr = err as ConfigIncludeError;
-			expect(includeErr.message).toBe(
-				`Maximum include depth (${MAX_INCLUDE_DEPTH}) exceeded at: ./d${MAX_INCLUDE_DEPTH + 1}.json5`,
-			);
-			expect(includeErr.includePath).toBe(`./d${MAX_INCLUDE_DEPTH + 1}.json5`);
-		}
-	});
+    files.set(
+      path.normalize(`/cfg/d${MAX_INCLUDE_DEPTH}.json5`),
+      JSON.stringify({ $include: `./d${MAX_INCLUDE_DEPTH + 1}.json5` }),
+    );
+    files.set(
+      path.normalize(`/cfg/d${MAX_INCLUDE_DEPTH + 1}.json5`),
+      JSON.stringify({ too: "deep" }),
+    );
+    try {
+      resolveMemory({ $include: "./d1.json5" }, files);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigIncludeError);
+      expect(err).not.toBeInstanceOf(CircularIncludeError);
+      const includeErr = err as ConfigIncludeError;
+      expect(includeErr.message).toBe(
+        `Maximum include depth (${MAX_INCLUDE_DEPTH}) exceeded at: ./d${MAX_INCLUDE_DEPTH + 1}.json5`,
+      );
+      expect(includeErr.includePath).toBe(`./d${MAX_INCLUDE_DEPTH + 1}.json5`);
+    }
+  });
 
-	it("rejects a single include over 1 MiB after the resolver returns it", () => {
-		const oversized = "x".repeat(1_048_577);
-		const files = new Map<string, string>([
-			[path.normalize("/cfg/big.json5"), oversized],
-		]);
-		const resolver: IncludeResolver = {
-			readFile: (file) => {
-				const raw = files.get(path.normalize(file));
-				if (raw === undefined) throw new Error(`missing ${file}`);
-				return raw;
-			},
-			parseJson: () => ({}),
-		};
-		expect(() =>
-			resolveConfigIncludes(
-				{ $include: "./big.json5" },
-				"/cfg/root.json5",
-				resolver,
-			),
-		).toThrow(/Include file exceeds 1048576 bytes at: \.\/big\.json5/);
-	});
+  it("rejects a single include over 1 MiB after the resolver returns it", () => {
+    const oversized = "x".repeat(1_048_577);
+    const files = new Map<string, string>([
+      [path.normalize("/cfg/big.json5"), oversized],
+    ]);
+    const resolver: IncludeResolver = {
+      readFile: (file) => {
+        const raw = files.get(path.normalize(file));
+        if (raw === undefined) throw new Error(`missing ${file}`);
+        return raw;
+      },
+      parseJson: () => ({}),
+    };
+    expect(() =>
+      resolveConfigIncludes(
+        { $include: "./big.json5" },
+        "/cfg/root.json5",
+        resolver,
+      ),
+    ).toThrow(/Include file exceeds 1048576 bytes at: \.\/big\.json5/);
+  });
 
-	it("rejects a graph of 257 files even when each file is tiny", () => {
-		const files = new Map<string, string>();
-		const names: string[] = [];
-		for (let i = 0; i < 257; i += 1) {
-			const name = `./f${i}.json5`;
-			names.push(name);
-			files.set(path.normalize(`/cfg/f${i}.json5`), "{}");
-		}
-		const resolver: IncludeResolver = {
-			readFile: (file) => files.get(path.normalize(file)) ?? "{}",
-			parseJson: () => ({}),
-		};
-		expect(() =>
-			resolveConfigIncludes({ $include: names }, "/cfg/root.json5", resolver),
-		).toThrow(/Include graph exceeds 256 files or 8388608 bytes/);
-	});
+  it("rejects a graph of 257 files even when each file is tiny", () => {
+    const files = new Map<string, string>();
+    const names: string[] = [];
+    for (let i = 0; i < 257; i += 1) {
+      const name = `./f${i}.json5`;
+      names.push(name);
+      files.set(path.normalize(`/cfg/f${i}.json5`), "{}");
+    }
+    const resolver: IncludeResolver = {
+      readFile: (file) => files.get(path.normalize(file)) ?? "{}",
+      parseJson: () => ({}),
+    };
+    expect(() =>
+      resolveConfigIncludes({ $include: names }, "/cfg/root.json5", resolver),
+    ).toThrow(/Include graph exceeds 256 files or 8388608 bytes/);
+  });
 
-	it("rejects an aggregate byte budget overflow across files under the per-file cap", () => {
-		const chunk = "x".repeat(1_000_000);
-		const files = new Map<string, string>();
-		const names: string[] = [];
-		for (let i = 0; i < 9; i += 1) {
-			names.push(`./c${i}.json5`);
-			files.set(path.normalize(`/cfg/c${i}.json5`), chunk);
-		}
-		const resolver: IncludeResolver = {
-			readFile: (file) => {
-				const raw = files.get(path.normalize(file));
-				if (raw === undefined) throw new Error(`missing ${file}`);
-				return raw;
-			},
-			parseJson: () => ({}),
-		};
-		expect(() =>
-			resolveConfigIncludes({ $include: names }, "/cfg/root.json5", resolver),
-		).toThrow(/Include graph exceeds 256 files or 8388608 bytes/);
-	});
+  it("rejects an aggregate byte budget overflow across files under the per-file cap", () => {
+    const chunk = "x".repeat(1_000_000);
+    const files = new Map<string, string>();
+    const names: string[] = [];
+    for (let i = 0; i < 9; i += 1) {
+      names.push(`./c${i}.json5`);
+      files.set(path.normalize(`/cfg/c${i}.json5`), chunk);
+    }
+    const resolver: IncludeResolver = {
+      readFile: (file) => {
+        const raw = files.get(path.normalize(file));
+        if (raw === undefined) throw new Error(`missing ${file}`);
+        return raw;
+      },
+      parseJson: () => ({}),
+    };
+    expect(() =>
+      resolveConfigIncludes({ $include: names }, "/cfg/root.json5", resolver),
+    ).toThrow(/Include graph exceeds 256 files or 8388608 bytes/);
+  });
 });
 
 describe("resolveConfigIncludes production filesystem resolver", () => {
-	it("parses JSON5 with comments and unquoted keys", () => {
-		const root = tempRoot();
-		fs.writeFileSync(
-			path.join(root, "child.json5"),
-			`{
+  it("parses JSON5 with comments and unquoted keys", () => {
+    const root = tempRoot();
+    fs.writeFileSync(
+      path.join(root, "child.json5"),
+      `{
         // comment
         enabled: true,
       }`,
-		);
-		expect(
-			resolveConfigIncludes(
-				{ $include: "./child.json5" },
-				path.join(root, "root.json5"),
-			),
-		).toEqual({ enabled: true });
-	});
+    );
+    expect(
+      resolveConfigIncludes(
+        { $include: "./child.json5" },
+        path.join(root, "root.json5"),
+      ),
+    ).toEqual({ enabled: true });
+  });
 
-	it("follows a relative nested include on disk", () => {
-		const root = tempRoot();
-		fs.mkdirSync(path.join(root, "nested"));
-		fs.writeFileSync(
-			path.join(root, "nested", "leaf.json5"),
-			JSON.stringify({ leaf: true }),
-		);
-		fs.writeFileSync(
-			path.join(root, "mid.json5"),
-			JSON.stringify({ $include: "./nested/leaf.json5" }),
-		);
-		expect(
-			resolveConfigIncludes(
-				{ $include: "./mid.json5", extra: 1 },
-				path.join(root, "root.json5"),
-			),
-		).toEqual({ leaf: true, extra: 1 });
-	});
+  it("follows a relative nested include on disk", () => {
+    const root = tempRoot();
+    fs.mkdirSync(path.join(root, "nested"));
+    fs.writeFileSync(
+      path.join(root, "nested", "leaf.json5"),
+      JSON.stringify({ leaf: true }),
+    );
+    fs.writeFileSync(
+      path.join(root, "mid.json5"),
+      JSON.stringify({ $include: "./nested/leaf.json5" }),
+    );
+    expect(
+      resolveConfigIncludes(
+        { $include: "./mid.json5", extra: 1 },
+        path.join(root, "root.json5"),
+      ),
+    ).toEqual({ leaf: true, extra: 1 });
+  });
 
-	it("wraps a missing file and a directory include as ConfigIncludeError", () => {
-		const root = tempRoot();
-		fs.mkdirSync(path.join(root, "not-a-file"));
-		expect(() =>
-			resolveConfigIncludes(
-				{ $include: "./absent.json5" },
-				path.join(root, "root.json5"),
-			),
-		).toThrow(ConfigIncludeError);
-		expect(() =>
-			resolveConfigIncludes(
-				{ $include: "./not-a-file" },
-				path.join(root, "root.json5"),
-			),
-		).toThrow(ConfigIncludeError);
-	});
+  it("wraps a missing file and a directory include as ConfigIncludeError", () => {
+    const root = tempRoot();
+    fs.mkdirSync(path.join(root, "not-a-file"));
+    expect(() =>
+      resolveConfigIncludes(
+        { $include: "./absent.json5" },
+        path.join(root, "root.json5"),
+      ),
+    ).toThrow(ConfigIncludeError);
+    expect(() =>
+      resolveConfigIncludes(
+        { $include: "./not-a-file" },
+        path.join(root, "root.json5"),
+      ),
+    ).toThrow(ConfigIncludeError);
+  });
 
-	it("detects a real-filesystem include cycle", () => {
-		const root = tempRoot();
-		fs.writeFileSync(
-			path.join(root, "a.json5"),
-			JSON.stringify({ $include: "./b.json5" }),
-		);
-		fs.writeFileSync(
-			path.join(root, "b.json5"),
-			JSON.stringify({ $include: "./a.json5" }),
-		);
-		expect(() =>
-			resolveConfigIncludes(
-				{ $include: "./a.json5" },
-				path.join(root, "root.json5"),
-			),
-		).toThrow(CircularIncludeError);
-	});
+  it("detects a real-filesystem include cycle", () => {
+    const root = tempRoot();
+    fs.writeFileSync(
+      path.join(root, "a.json5"),
+      JSON.stringify({ $include: "./b.json5" }),
+    );
+    fs.writeFileSync(
+      path.join(root, "b.json5"),
+      JSON.stringify({ $include: "./a.json5" }),
+    );
+    expect(() =>
+      resolveConfigIncludes(
+        { $include: "./a.json5" },
+        path.join(root, "root.json5"),
+      ),
+    ).toThrow(CircularIncludeError);
+  });
 });

--- a/packages/agent/src/services/pending-prompts/store.safe-sort.test.ts
+++ b/packages/agent/src/services/pending-prompts/store.safe-sort.test.ts
@@ -5,10 +5,16 @@
 
 import { describe, expect, it } from "vitest";
 
-function sortPendingPrompts(entries: { firedAt: string }[]): { firedAt: string }[] {
+function sortPendingPrompts(
+  entries: { firedAt: string }[],
+): { firedAt: string }[] {
   return [...entries].sort((a, b) => {
-    const aTime = Number.isFinite(Date.parse(a.firedAt)) ? Date.parse(a.firedAt) : 0;
-    const bTime = Number.isFinite(Date.parse(b.firedAt)) ? Date.parse(b.firedAt) : 0;
+    const aTime = Number.isFinite(Date.parse(a.firedAt))
+      ? Date.parse(a.firedAt)
+      : 0;
+    const bTime = Number.isFinite(Date.parse(b.firedAt))
+      ? Date.parse(b.firedAt)
+      : 0;
     return bTime - aTime;
   });
 }
@@ -38,7 +44,10 @@ describe("pending-prompts store safe sort", () => {
   });
 
   it("handles all invalid without throwing", () => {
-    const sorted = sortPendingPrompts([{ firedAt: "bad" }, { firedAt: "also-bad" }]);
+    const sorted = sortPendingPrompts([
+      { firedAt: "bad" },
+      { firedAt: "also-bad" },
+    ]);
     expect(sorted).toHaveLength(2);
   });
 });

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -265,8 +265,12 @@ export function createPendingPromptsStore(
     return visible
       .slice()
       .sort((a, b) => {
-        const aTime = Number.isFinite(Date.parse(a.firedAt)) ? Date.parse(a.firedAt) : 0;
-        const bTime = Number.isFinite(Date.parse(b.firedAt)) ? Date.parse(b.firedAt) : 0;
+        const aTime = Number.isFinite(Date.parse(a.firedAt))
+          ? Date.parse(a.firedAt)
+          : 0;
+        const bTime = Number.isFinite(Date.parse(b.firedAt))
+          ? Date.parse(b.firedAt)
+          : 0;
         return bTime - aTime;
       })
       .map<PendingPrompt>((entry) => {
@@ -349,13 +353,15 @@ export function createPendingPromptsStore(
           })),
         ),
       );
-      return perRoom
-        .flat()
-        .sort((a, b) => {
-          const aTime = Number.isFinite(Date.parse(a.firedAt)) ? Date.parse(a.firedAt) : 0;
-          const bTime = Number.isFinite(Date.parse(b.firedAt)) ? Date.parse(b.firedAt) : 0;
-          return bTime - aTime;
-        });
+      return perRoom.flat().sort((a, b) => {
+        const aTime = Number.isFinite(Date.parse(a.firedAt))
+          ? Date.parse(a.firedAt)
+          : 0;
+        const bTime = Number.isFinite(Date.parse(b.firedAt))
+          ? Date.parse(b.firedAt)
+          : 0;
+        return bTime - aTime;
+      });
     },
 
     async resolve(roomId: string, taskId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- restore pinned Biome formatting in six newly merged agent files spanning wallet profile, configuration, and pending prompts
- preserve executable output; TypeScript-emitted tokens are identical, except formatter-owned trailing commas at multiline boundaries
- keep the tx-service formatting repair isolated in #25443

Closes #25444.

## Verification

- `bun install`
- clean-checkout core/shared prerequisite builds
- pinned Biome check over the six touched files — clean
- eight focused suites — 127 tests passed
- `git diff --check`
- full agent lint is clean for these six files and reports only the separate `tx-service.test.ts` formatter regression fixed by #25443
- the older `pending-prompts/store.test.ts` suite has five clock-dependent failures because its fixed `2026-08-22` fixtures now fall outside the 24-hour retention window; this is a separate deterministic-test defect, not caused by formatting

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
