### PR TITLE
test(agent): cover plugin-widgets

### DIFF
--- a/packages/agent/src/config/plugin-widgets.test.ts
+++ b/packages/agent/src/config/plugin-widgets.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Behavioral coverage for `getPluginWidgets`: identity matching after scope
+ * and prefix stripping, empty/missing runtime lists, first-match wins, and
+ * shallow-copy of the matched plugin's widgets array.
+ */
+import type { Plugin, PluginWidgetDeclaration } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { getPluginWidgets } from "./plugin-widgets.ts";
+
+function widget(
+  id: string,
+  pluginId: string,
+  slot: PluginWidgetDeclaration["slot"] = "home",
+  label = "Overview",
+): PluginWidgetDeclaration {
+  return { id, pluginId, slot, label };
+}
+
+function plugin(name: string, widgets?: PluginWidgetDeclaration[]): Plugin {
+  const declared: Plugin = { name, description: "fixture plugin" };
+  if (widgets !== undefined) {
+    declared.widgets = widgets;
+  }
+  return declared;
+}
+
+describe("getPluginWidgets", () => {
+  it("returns an empty list when runtimePlugins is omitted", () => {
+    expect(getPluginWidgets("discord")).toEqual([]);
+  });
+
+  it("returns an empty list when runtimePlugins is undefined", () => {
+    expect(getPluginWidgets("discord", undefined)).toEqual([]);
+  });
+
+  it("returns an empty list for an empty runtime plugin queue", () => {
+    expect(getPluginWidgets("discord", [])).toEqual([]);
+  });
+
+  it("returns an empty list when no plugin identity matches", () => {
+    const widgets = [widget("overview", "telegram")];
+    expect(getPluginWidgets("discord", [plugin("telegram", widgets)])).toEqual(
+      [],
+    );
+  });
+
+  it("returns an empty list when the matched plugin omits widgets", () => {
+    expect(getPluginWidgets("discord", [plugin("discord")])).toEqual([]);
+  });
+
+  it("returns an empty list when the matched plugin declares an empty widgets array", () => {
+    expect(getPluginWidgets("discord", [plugin("discord", [])])).toEqual([]);
+  });
+
+  it("returns the single declared widget for an exact name match", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("discord", [plugin("discord", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("preserves widget order for a plugin that declares several widgets", () => {
+    const first = widget("overview", "discord", "home", "Overview");
+    const second = widget("inbox", "discord", "chat-sidebar", "Inbox");
+    const third = widget("profile", "discord", "character", "Profile");
+    expect(
+      getPluginWidgets("discord", [plugin("discord", [first, second, third])]),
+    ).toEqual([first, second, third]);
+  });
+
+  it("matches after trimming whitespace on the plugin id and plugin name", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("  discord  ", [plugin("  discord  ", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("matches a plugin- prefixed id against an unprefixed Plugin.name", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("plugin-discord", [plugin("discord", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("matches an unprefixed id against a plugin- prefixed Plugin.name", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("discord", [plugin("plugin-discord", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("matches an app- prefixed id against an unprefixed Plugin.name", () => {
+    const overview = widget("overview", "wallet");
+    expect(
+      getPluginWidgets("app-wallet", [plugin("wallet", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("matches an unprefixed id against an app- prefixed Plugin.name", () => {
+    const overview = widget("overview", "wallet");
+    expect(
+      getPluginWidgets("wallet", [plugin("app-wallet", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("strips an npm scope before comparing identities", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("@elizaos/discord", [plugin("discord", [overview])]),
+    ).toEqual([overview]);
+    expect(
+      getPluginWidgets("discord", [plugin("@elizaos/discord", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("strips scope then plugin- so @scope/plugin-name matches a bare id", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("discord", [
+        plugin("@elizaos/plugin-discord", [overview]),
+      ]),
+    ).toEqual([overview]);
+    expect(
+      getPluginWidgets("@elizaos/plugin-discord", [
+        plugin("plugin-discord", [overview]),
+      ]),
+    ).toEqual([overview]);
+  });
+
+  it("strips plugin- then app- so plugin-app-wallet matches wallet", () => {
+    const overview = widget("overview", "wallet");
+    expect(
+      getPluginWidgets("plugin-app-wallet", [plugin("wallet", [overview])]),
+    ).toEqual([overview]);
+    expect(
+      getPluginWidgets("wallet", [plugin("plugin-app-wallet", [overview])]),
+    ).toEqual([overview]);
+  });
+
+  it("does not strip plugin- after an app- prefix (app- is applied second, once)", () => {
+    const overview = widget("overview", "plugin-wallet");
+    // "app-plugin-wallet" -> "plugin-wallet"; "plugin-wallet" -> "wallet"
+    expect(
+      getPluginWidgets("app-plugin-wallet", [
+        plugin("plugin-wallet", [overview]),
+      ]),
+    ).toEqual([]);
+    expect(
+      getPluginWidgets("app-plugin-wallet", [
+        plugin("app-plugin-wallet", [overview]),
+      ]),
+    ).toEqual([overview]);
+    expect(
+      getPluginWidgets("wallet", [plugin("app-plugin-wallet", [overview])]),
+    ).toEqual([]);
+  });
+
+  it("strips the plugin- prefix only once", () => {
+    const overview = widget("overview", "plugin-discord");
+    // "plugin-plugin-discord" -> "plugin-discord"; "plugin-discord" -> "discord"
+    expect(
+      getPluginWidgets("plugin-plugin-discord", [
+        plugin("plugin-discord", [overview]),
+      ]),
+    ).toEqual([]);
+    expect(
+      getPluginWidgets("plugin-plugin-discord", [
+        plugin("plugin-plugin-discord", [overview]),
+      ]),
+    ).toEqual([overview]);
+    expect(
+      getPluginWidgets("discord", [
+        plugin("plugin-plugin-discord", [overview]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("leaves an @-prefixed name without a slash unscoped", () => {
+    const overview = widget("overview", "noscoped");
+    expect(
+      getPluginWidgets("@noscoped", [plugin("@noscoped", [overview])]),
+    ).toEqual([overview]);
+    expect(
+      getPluginWidgets("noscoped", [plugin("@noscoped", [overview])]),
+    ).toEqual([]);
+  });
+
+  it("treats identity comparison as case-sensitive", () => {
+    const overview = widget("overview", "discord");
+    expect(
+      getPluginWidgets("Discord", [plugin("discord", [overview])]),
+    ).toEqual([]);
+    expect(
+      getPluginWidgets("plugin-Discord", [
+        plugin("plugin-discord", [overview]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("returns the first identity match when several plugins normalize to the same id", () => {
+    const first = widget("first", "discord", "home", "First");
+    const second = widget("second", "discord", "home", "Second");
+    expect(
+      getPluginWidgets("discord", [
+        plugin("other", [widget("noise", "other")]),
+        plugin("plugin-discord", [first]),
+        plugin("discord", [second]),
+      ]),
+    ).toEqual([first]);
+  });
+
+  it("does not fall through to a later same-identity plugin when the first match has no widgets", () => {
+    const later = widget("later", "discord");
+    expect(
+      getPluginWidgets("discord", [
+        plugin("plugin-discord"),
+        plugin("discord", [later]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores a later plugin's widgets when its identity does not match", () => {
+    const telegram = widget("overview", "telegram");
+    expect(
+      getPluginWidgets("discord", [
+        plugin("discord"),
+        plugin("telegram", [telegram]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("returns a shallow copy so mutating the result does not change the plugin", () => {
+    const overview = widget("overview", "discord");
+    const inbox = widget("inbox", "discord", "chat-sidebar", "Inbox");
+    const widgets = [overview, inbox];
+    const runtime = [plugin("discord", widgets)];
+
+    const result = getPluginWidgets("discord", runtime);
+    expect(result).toEqual(widgets);
+    expect(result).not.toBe(widgets);
+    expect(result[0]).toBe(overview);
+
+    result.pop();
+    result[0] = widget("mutated", "discord");
+
+    expect(runtime[0]?.widgets).toEqual([overview, inbox]);
+    expect(getPluginWidgets("discord", runtime)).toEqual([overview, inbox]);
+  });
+
+  it("matches an empty plugin id only against a name that also normalizes to empty", () => {
+    const emptyName = widget("empty", "");
+    const discord = widget("overview", "discord");
+    expect(getPluginWidgets("", [plugin("discord", [discord])])).toEqual([]);
+    expect(getPluginWidgets("", [plugin("", [emptyName])])).toEqual([
+      emptyName,
+    ]);
+    expect(getPluginWidgets("plugin-", [plugin("app-", [emptyName])])).toEqual([
+      emptyName,
+    ]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds a same-named vitest suite for `packages/agent/src/config/plugin-widgets.ts`. That module had no co-located test file. The production module is unchanged.

`getPluginWidgets` matches a plugin id against a runtime plugin list after trimming, stripping an npm scope, then stripping a single `plugin-` prefix and a single `app-` prefix. It returns a shallow copy of the first match's `widgets`, or `[]` when the list is missing/empty, no identity matches, or the first match declares no widgets.

The suite drives the real module (no mocks) and covers:

- omitted / undefined / empty `runtimePlugins`
- unmatched identity, omitted widgets, empty widgets array
- single widget and preserved multi-widget order
- whitespace trim, `plugin-` / `app-` prefix matching, npm-scope stripping, sequential `plugin-` then `app-` stripping
- one-pass prefix rules (`plugin-` is not re-applied after `app-`; `plugin-` strips only once)
- case-sensitive comparison; `@name` without a slash stays unscoped
- first-match wins, including when the first same-identity plugin has no widgets
- returned array is a shallow copy (mutating it does not change the plugin)

## Evidence

Hosted CI does not run on this fork contributor's PRs. Local checks only:

1. `bunx vitest run packages/agent/src/config/plugin-widgets.test.ts` — 1 file, 25 tests passed.
2. `bunx biome check --write packages/agent/src/config/plugin-widgets.test.ts` — clean (1 file checked).
3. `bunx tsc --noEmit` in `packages/agent`: `plugin-widgets.test.ts` appears nowhere in the output (pre-existing package errors elsewhere are unchanged).
4. Diff touches only `packages/agent/src/config/plugin-widgets.test.ts`.

No `proof-run.mjs` — this is a test-only, behavior-preserving change.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:1132524fc16d1848ca6606f6f774fd75bf955a15 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
