### PR TITLE
test(core): cover curated app registry

### DIFF
--- a/packages/core/src/__tests__/app-registry.test.ts
+++ b/packages/core/src/__tests__/app-registry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+const store: { entries: unknown[] } = { entries: [] };
+vi.mock("./ambient-context", () => ({
+	getAmbientSingleton: (_key: symbol, factory: () => unknown) => {
+		if (!store.entries.length && factory) factory();
+		return store;
+	},
+}));
+
+import {
+	getRegisteredCuratedApps,
+	registerCuratedApp,
+} from "./app-registry.ts";
+
+describe("app-registry", () => {
+	it("registers and returns curated apps", () => {
+		registerCuratedApp({ slug: "chat", canonicalName: "Chat", aliases: [] });
+		const apps = getRegisteredCuratedApps();
+		expect(apps.map((a) => a.slug)).toEqual(["chat"]);
+	});
+
+	it("replaces an existing slug on re-registration", () => {
+		registerCuratedApp({
+			slug: "chat",
+			canonicalName: "Chat v2",
+			aliases: ["c"],
+		});
+		const apps = getRegisteredCuratedApps();
+		expect(apps).toHaveLength(1);
+		expect(apps[0].canonicalName).toBe("Chat v2");
+	});
+
+	it("returns a copy so callers cannot mutate the store", () => {
+		const apps = getRegisteredCuratedApps();
+		apps.push({ slug: "x", canonicalName: "X", aliases: [] });
+		expect(getRegisteredCuratedApps()).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
