### PR TITLE
test(app): cover host external importer registration

### DIFF
--- a/packages/app/src/__tests__/host-externals.test.ts
+++ b/packages/app/src/__tests__/host-externals.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  registerHostExternalImporter: vi.fn(),
+}));
+
+vi.mock("@elizaos/ui/app-shell-registry", () => ({
+  registerHostExternalImporter: (...a: unknown[]) =>
+    mocks.registerHostExternalImporter(...a),
+}));
+
+describe("registerAppHostExternalImporters", () => {
+  beforeEach(() => {
+    mocks.registerHostExternalImporter.mockReset();
+    vi.resetModules();
+  });
+
+  it("registers the plugin-browser and health specifiers once", async () => {
+    const { registerAppHostExternalImporters } = await import(
+      "./host-externals.ts"
+    );
+    registerAppHostExternalImporters();
+    registerAppHostExternalImporters(); // second call is a no-op
+    expect(mocks.registerHostExternalImporter).toHaveBeenCalledTimes(2);
+    expect(mocks.registerHostExternalImporter.mock.calls[0][0]).toBe(
+      "@elizaos/plugin-browser",
+    );
+    expect(mocks.registerHostExternalImporter.mock.calls[1][0]).toContain(
+      "@elizaos/plugin-health",
+    );
+  });
+
+  it("registers thunks that return promises", async () => {
+    const { registerAppHostExternalImporter } = await import(
+      "./host-externals.ts"
+    );
+    void registerAppHostExternalImporter;
+    const { registerAppHostExternalImporters } = await import(
+      "./host-externals.ts"
+    );
+    registerAppHostExternalImporters();
+    for (const call of mocks.registerHostExternalImporter.mock.calls) {
+      const thunk = call[1] as () => Promise<unknown>;
+      expect(typeof thunk).toBe("function");
+      const result = thunk();
+      expect(result).toBeInstanceOf(Promise);
+      await result.catch(() => undefined); // 动态 import 可能失败，吞掉
+    }
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 2 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
