### PR TITLE
fix(settings): gate the cloud panel to the Electrobun shell

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -35,6 +35,7 @@ import { SettingsView } from "./SettingsView";
 // refactor must keep stable.
 const appMock = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
 const bootConfigMock = vi.hoisted(() => ({ cloudOnly: false }));
+const electrobunRuntimeMock = vi.hoisted(() => ({ isElectrobun: false }));
 const permissionPrimingMock = vi.hoisted(() => ({
   calls: [] as Array<{ ids: string[]; open: boolean }>,
 }));
@@ -106,6 +107,10 @@ vi.mock("../../state", () => ({
 
 vi.mock("../../config/boot-config-store", () => ({
   getBootConfig: () => ({ branding: { cloudOnly: bootConfigMock.cloudOnly } }),
+}));
+
+vi.mock("../../bridge/electrobun-runtime", () => ({
+  isElectrobunRuntime: () => electrobunRuntimeMock.isElectrobun,
 }));
 
 vi.mock("../settings/cloud-panel/CloudSettingsPanel", () => ({
@@ -255,6 +260,7 @@ beforeEach(() => {
   window.history.replaceState(null, "", "/settings");
   appMock.value = makeContext();
   bootConfigMock.cloudOnly = false;
+  electrobunRuntimeMock.isElectrobun = false;
   permissionPrimingMock.calls = [];
   crashControl.shouldThrow = true;
 });
@@ -320,8 +326,9 @@ describe("SettingsView", () => {
     expect(screen.queryByTestId("cloud-settings-panel")).toBeNull();
   });
 
-  it("renders the consolidated panel only for explicit cloud-only branding", () => {
+  it("renders the consolidated panel only for cloud-only branding in the Electrobun shell", () => {
     bootConfigMock.cloudOnly = true;
+    electrobunRuntimeMock.isElectrobun = true;
 
     render(<SettingsView />);
 
@@ -329,8 +336,19 @@ describe("SettingsView", () => {
     expect(screen.queryByTestId("settings-hub-list")).toBeNull();
   });
 
+  it("keeps cloud-only web runtimes on the legacy view", () => {
+    bootConfigMock.cloudOnly = true;
+    electrobunRuntimeMock.isElectrobun = false;
+
+    render(<SettingsView />);
+
+    expect(screen.queryByTestId("cloud-settings-panel")).toBeNull();
+    expect(screen.getByTestId("settings-hub-list")).toBeTruthy();
+  });
+
   it("keeps modal settings on the legacy view in a cloud-only build", () => {
     bootConfigMock.cloudOnly = true;
+    electrobunRuntimeMock.isElectrobun = true;
 
     render(<SettingsView inModal />);
 

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -17,6 +17,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useAgentElement } from "../../agent-surface";
+import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { isManagedCloudRuntime } from "../../cloud/managed-cloud-runtime";
 import { getBootConfig } from "../../config/boot-config-store";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
@@ -240,13 +241,16 @@ export function SettingsView({
 } = {}) {
   // Gate: explicitly cloud-only desktop builds render the consolidated
   // CloudSettingsPanel instead of the legacy registry-driven view. Managed
-  // Cloud web runtimes still use the legacy view and its Cloud sections. This
-  // check lives in a thin wrapper so each branch has its own hook tree — an
-  // early return inside the legacy body would trigger React error #300
-  // (hooks-count mismatch) if the boot config settles after first render.
+  // Cloud web runtimes also resolve cloudOnly branding in production, so the
+  // branding flag alone cannot distinguish them; the Electrobun runtime check
+  // keeps web and mobile cloud builds on the legacy view and its Cloud
+  // sections. This check lives in a thin wrapper so each branch has its own
+  // hook tree — an early return inside the legacy body would trigger React
+  // error #300 (hooks-count mismatch) if the boot config settles after first
+  // render.
   const cloudOnlyBranding = getBootConfig().branding.cloudOnly === true;
 
-  if (cloudOnlyBranding && !inModal) {
+  if (cloudOnlyBranding && !inModal && isElectrobunRuntime()) {
     return <CloudSettingsPanel />;
   }
   return (


### PR DESCRIPTION
## Problem

The consolidated `CloudSettingsPanel` (from #24433) gates on `branding.cloudOnly` alone. The hosted web bundle also resolves `cloudOnly === true` in production (`packages/app/src/main.tsx` — 'The hosted web bundle stays cloud-only in production'), so the desktop-designed NuPhy panel renders in the browser too.

Verified live on **cloud-staging.eliza.app/settings** via browser QA: the staging web app shows the desktop panel — including macOS-only controls (Launch at login, Show in Dock, Record on tray click) that can do nothing in a web tab — and loses the managed-cloud settings hub (Account & Profile, Billing & Credits, API Keys, Vault, etc.). Production only still shows the legacy hub because its bundle predates the gate. This also broke the cloud-login callsite ui-smoke lane.

## Fix

Require the Electrobun renderer runtime in addition to cloud-only branding:

```ts
if (cloudOnlyBranding && !inModal && isElectrobunRuntime()) {
  return <CloudSettingsPanel />;
}
```

Web and mobile cloud builds stay on the legacy settings view and its Cloud sections; only the packaged desktop shell gets the NuPhy panel. A regression test pins the web branch.

This is the minimal runtime/experience split ahead of the full `SettingsExperience` unification tracked in #24495.

## Verification

- `packages/ui` `SettingsView.test.tsx`: 21 tests passed, including the new web-branch regression case.
- Live staging repro of the bug documented above (Computer-Use browser session, signed in via AgentMail magic link).

Related: #24433, #24495