### PR TITLE
test(agent): pin pending prompt retention clock

### DIFF
--- a/packages/agent/src/services/pending-prompts/store.test.ts
+++ b/packages/agent/src/services/pending-prompts/store.test.ts
@@ -1,6 +1,6 @@
 /** Verifies indexed pending-prompt rooms retire when empty while live room behavior remains stable, using a deterministic serialized cache double. */
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { createPendingPromptsStore } from "./store.ts";
 
 const ROOM_INDEX_KEY = "eliza:lifeops:pending-prompts:rooms:v1";
@@ -54,6 +54,16 @@ function makeCache(): CacheDouble {
 }
 
 const firedAt = "2026-08-22T00:00:00.000Z";
+const testNow = new Date("2026-08-22T12:00:00.000Z");
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(testNow);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("pending-prompts room index", () => {
   test("500 recorded-then-resolved rooms leave an empty index and no cache rows", async () => {


### PR DESCRIPTION
## Summary

- pin only `Date` to a stable instant inside the pending-prompt retention window
- restore real timers after every test
- retain the explicit `now` override that proves expired prompts are purged

Closes #25451.

## Verification

- `bun install`
- clean-checkout core/shared prerequisite builds
- pending-prompt store suite alone — 10 tests passed
- store + safe-sort suites together — 14 tests passed
- pinned Biome check on the touched file — clean
- `git diff --check`

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
