### PR TITLE
test(agent): cover types.hooks

### DIFF
--- a/packages/agent/src/config/types.hooks.test.ts
+++ b/packages/agent/src/config/types.hooks.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Contract coverage for the config-scoped re-export of `@elizaos/shared`
+ * (`types.hooks.ts`). Consumers import HooksConfig, HookMappingConfig,
+ * HooksGmailConfig, InternalHooksConfig, and related shapes through this
+ * local path. Runtime values re-exported from the same barrel must stay the
+ * same identity as `@elizaos/shared`. Deterministic, no mocks.
+ */
+
+import {
+  AgentDefaultsSchema as SharedAgentDefaultsSchema,
+  CONNECTOR_IDS as SharedConnectorIds,
+} from "@elizaos/shared";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { checkEligibility, resolveHookConfig } from "../hooks/eligibility.ts";
+import type { ElizaHookMetadata } from "../hooks/types.ts";
+import type {
+  HookConfig,
+  HookInstallRecord,
+  HookMappingConfig,
+  HookMappingMatch,
+  HookMappingTransform,
+  HooksConfig,
+  HooksGmailConfig,
+  HooksGmailTailscaleMode,
+  InternalHookHandlerConfig,
+  InternalHooksConfig,
+} from "./types.hooks.ts";
+import { AgentDefaultsSchema, CONNECTOR_IDS } from "./types.hooks.ts";
+
+const UNIQUE_ENV_KEY = "ELIZA_TYPES_HOOKS_COVERAGE_UNIQUE_ENV";
+
+const BASE_METADATA: ElizaHookMetadata = { events: ["command:new"] };
+
+describe("types.hooks re-export", () => {
+  it("re-exports CONNECTOR_IDS from @elizaos/shared by identity", () => {
+    expect(CONNECTOR_IDS).toBe(SharedConnectorIds);
+  });
+
+  it("re-exports AgentDefaultsSchema from @elizaos/shared by identity", () => {
+    expect(AgentDefaultsSchema).toBe(SharedAgentDefaultsSchema);
+  });
+});
+
+describe("HookMappingMatch and HookMappingTransform", () => {
+  it("keeps every match field optional", () => {
+    expectTypeOf<HookMappingMatch>().toEqualTypeOf<{
+      path?: string;
+      source?: string;
+    }>();
+    const empty: HookMappingMatch = {};
+    expect(empty.path).toBeUndefined();
+    expect(empty.source).toBeUndefined();
+  });
+
+  it("requires transform.module and keeps export optional", () => {
+    expectTypeOf<HookMappingTransform>().toEqualTypeOf<{
+      module: string;
+      export?: string;
+    }>();
+    const transform: HookMappingTransform = { module: "./wake.ts" };
+    expect(transform.module).toBe("./wake.ts");
+    expect(transform.export).toBeUndefined();
+  });
+});
+
+describe("HookMappingConfig", () => {
+  it("accepts an empty mapping because every field is optional", () => {
+    const empty: HookMappingConfig = {};
+    expect(empty.action).toBeUndefined();
+    expect(empty.match).toBeUndefined();
+    expect(empty.transform).toBeUndefined();
+  });
+
+  it("narrows action and wakeMode unions", () => {
+    expectTypeOf<HookMappingConfig["action"]>().toEqualTypeOf<
+      "wake" | "agent" | undefined
+    >();
+    expectTypeOf<HookMappingConfig["wakeMode"]>().toEqualTypeOf<
+      "now" | "next-heartbeat" | undefined
+    >();
+    const mapping: HookMappingConfig = {
+      action: "wake",
+      wakeMode: "next-heartbeat",
+    };
+    expect(mapping.action).toBe("wake");
+    expect(mapping.wakeMode).toBe("next-heartbeat");
+  });
+
+  it("narrows the delivery channel union and treats thinking as a free string", () => {
+    expectTypeOf<NonNullable<HookMappingConfig["channel"]>>().toEqualTypeOf<
+      | "last"
+      | "whatsapp"
+      | "telegram"
+      | "discord"
+      | "googlechat"
+      | "slack"
+      | "imessage"
+      | "msteams"
+    >();
+    expectTypeOf<HookMappingConfig["thinking"]>().toEqualTypeOf<
+      string | undefined
+    >();
+    const mapping: HookMappingConfig = {
+      channel: "telegram",
+      thinking: "xhigh",
+      timeoutSeconds: 0,
+    };
+    expect(mapping.channel).toBe("telegram");
+    expect(mapping.thinking).toBe("xhigh");
+    expect(mapping.timeoutSeconds).toBe(0);
+  });
+
+  it("stores a single mapping and preserves order including equal-id ties", () => {
+    const mappings: HookMappingConfig[] = [
+      { id: "dup", name: "first" },
+      { id: "dup", name: "second" },
+    ];
+    expect(mappings).toHaveLength(2);
+    expect(mappings.map((item) => item.name)).toEqual(["first", "second"]);
+    mappings.splice(0, mappings.length);
+    expect(mappings).toEqual([]);
+  });
+});
+
+describe("HooksGmailConfig", () => {
+  it("keeps every gmail field optional, including nested serve/tailscale", () => {
+    const empty: HooksGmailConfig = {};
+    expect(empty.account).toBeUndefined();
+    expect(empty.serve).toBeUndefined();
+    expect(empty.tailscale).toBeUndefined();
+  });
+
+  it("narrows tailscale mode and gmail thinking unions", () => {
+    expectTypeOf<HooksGmailTailscaleMode>().toEqualTypeOf<
+      "off" | "serve" | "funnel"
+    >();
+    expectTypeOf<NonNullable<HooksGmailConfig["thinking"]>>().toEqualTypeOf<
+      "off" | "minimal" | "low" | "medium" | "high"
+    >();
+    const gmail: HooksGmailConfig = {
+      tailscale: { mode: "funnel", path: "/hooks", target: "8080" },
+      thinking: "minimal",
+      maxBytes: 1,
+      renewEveryMinutes: 1,
+      serve: { port: 1 },
+    };
+    expect(gmail.tailscale?.mode).toBe("funnel");
+    expect(gmail.thinking).toBe("minimal");
+  });
+
+  it("allows a zero maxBytes at the type layer (no positive constraint here)", () => {
+    const gmail: HooksGmailConfig = { maxBytes: 0, renewEveryMinutes: 0 };
+    expect(gmail.maxBytes).toBe(0);
+    expect(gmail.renewEveryMinutes).toBe(0);
+  });
+});
+
+describe("InternalHookHandlerConfig and HookInstallRecord", () => {
+  it("requires handler event and module", () => {
+    expectTypeOf<InternalHookHandlerConfig>().toEqualTypeOf<{
+      event: string;
+      module: string;
+      export?: string;
+    }>();
+    const handler: InternalHookHandlerConfig = {
+      event: "command:new",
+      module: "./handler.ts",
+    };
+    expect(handler.event).toBe("command:new");
+    expect(handler.export).toBeUndefined();
+  });
+
+  it("requires install source and keeps hook lists empty, single, or ordered", () => {
+    expectTypeOf<HookInstallRecord["source"]>().toEqualTypeOf<
+      "npm" | "archive" | "path"
+    >();
+    const emptyHooks: HookInstallRecord = { source: "path", hooks: [] };
+    expect(emptyHooks.hooks).toEqual([]);
+    const one: HookInstallRecord = {
+      source: "npm",
+      spec: "pack@1",
+      hooks: ["a"],
+    };
+    expect(one.hooks).toEqual(["a"]);
+    const ordered: HookInstallRecord = {
+      source: "archive",
+      hooks: ["b", "a", "b"],
+    };
+    expect(ordered.hooks).toEqual(["b", "a", "b"]);
+  });
+});
+
+describe("HookConfig index signature", () => {
+  it("keeps enabled and env optional and allows extra keys", () => {
+    const empty: HookConfig = {};
+    expect(empty.enabled).toBeUndefined();
+    expect(empty.env).toBeUndefined();
+    const extra: HookConfig = { enabled: true, custom: 1 };
+    expect(extra.enabled).toBe(true);
+    expect(extra.custom).toBe(1);
+  });
+
+  it("treats an empty env map as a missing lookup for every key", () => {
+    const hook: HookConfig = { env: {} };
+    expect(Object.keys(hook.env ?? {})).toEqual([]);
+    expect(hook.env?.HOOK_TOKEN).toBeUndefined();
+  });
+});
+
+describe("InternalHooksConfig", () => {
+  it("accepts an empty internal block because every field is optional", () => {
+    const empty: InternalHooksConfig = {};
+    expect(empty.handlers).toBeUndefined();
+    expect(empty.entries).toBeUndefined();
+    expect(empty.installs).toBeUndefined();
+  });
+
+  it("preserves handler queue order, including adjacent event ties", () => {
+    const internal: InternalHooksConfig = {
+      handlers: [
+        { event: "command:new", module: "./a.ts" },
+        { event: "command:new", module: "./b.ts" },
+      ],
+      load: { extraDirs: [] },
+    };
+    expect(internal.handlers?.map((handler) => handler.module)).toEqual([
+      "./a.ts",
+      "./b.ts",
+    ]);
+    expect(internal.load?.extraDirs).toEqual([]);
+  });
+
+  it("stores a single extraDir and a missing-key install lookup as undefined", () => {
+    const internal: InternalHooksConfig = {
+      load: { extraDirs: ["/hooks"] },
+      installs: { pack: { source: "path" } },
+    };
+    expect(internal.load?.extraDirs).toEqual(["/hooks"]);
+    expect(internal.installs?.pack?.source).toBe("path");
+    expect(internal.installs?.missing).toBeUndefined();
+    delete internal.installs?.missing;
+    expect(internal.installs?.missing).toBeUndefined();
+    expect(Object.keys(internal.installs ?? {})).toEqual(["pack"]);
+  });
+});
+
+describe("HooksConfig", () => {
+  it("accepts an empty hooks object because every field is optional", () => {
+    const empty: HooksConfig = {};
+    expect(empty.mappings).toBeUndefined();
+    expect(empty.gmail).toBeUndefined();
+    expect(empty.internal).toBeUndefined();
+  });
+
+  it("accepts an empty mappings queue, a single mapping, and overflow order", () => {
+    const none: HooksConfig = { mappings: [] };
+    expect(none.mappings).toEqual([]);
+    const one: HooksConfig = { mappings: [{ id: "only", action: "agent" }] };
+    expect(one.mappings).toHaveLength(1);
+    const overflow: HooksConfig = {
+      mappings: Array.from({ length: 12 }, (_, index) => ({
+        id: `m-${index}`,
+      })),
+      presets: ["a", "b"],
+      maxBodyBytes: 0,
+    };
+    expect(overflow.mappings).toHaveLength(12);
+    expect(overflow.mappings?.[0]?.id).toBe("m-0");
+    expect(overflow.mappings?.[11]?.id).toBe("m-11");
+    expect(overflow.maxBodyBytes).toBe(0);
+  });
+});
+
+describe("resolveHookConfig against InternalHooksConfig.entries", () => {
+  it("returns undefined for a missing config, empty entries, or a missing key", () => {
+    expect(resolveHookConfig(undefined, "gmail")).toBeUndefined();
+    expect(resolveHookConfig({}, "gmail")).toBeUndefined();
+    expect(resolveHookConfig({ entries: {} }, "gmail")).toBeUndefined();
+    expect(
+      resolveHookConfig({ entries: { other: { enabled: true } } }, "gmail"),
+    ).toBeUndefined();
+  });
+
+  it("returns the single stored entry and leaves other keys missing", () => {
+    const internal: InternalHooksConfig = {
+      entries: { gmail: { enabled: true, env: { TOKEN: "x" } } },
+    };
+    expect(resolveHookConfig(internal, "gmail")).toEqual({
+      enabled: true,
+      env: { TOKEN: "x" },
+    });
+    expect(resolveHookConfig(internal, "slack")).toBeUndefined();
+  });
+
+  it("preserves insertion order of entry keys when looking up one of several", () => {
+    const internal: InternalHooksConfig = {
+      entries: {
+        telegram: { enabled: false },
+        gmail: { enabled: true },
+        discord: { enabled: true },
+      },
+    };
+    expect(Object.keys(internal.entries ?? {})).toEqual([
+      "telegram",
+      "gmail",
+      "discord",
+    ]);
+    expect(resolveHookConfig(internal, "gmail")?.enabled).toBe(true);
+  });
+});
+
+describe("checkEligibility against HookConfig", () => {
+  it("treats missing metadata as eligible regardless of hookConfig", () => {
+    expect(checkEligibility(undefined, undefined)).toEqual({
+      eligible: true,
+      missing: [],
+    });
+    expect(checkEligibility(undefined, { enabled: false })).toEqual({
+      eligible: true,
+      missing: [],
+    });
+  });
+
+  it("does not treat enabled=false as ineligible", () => {
+    expect(checkEligibility(BASE_METADATA, { enabled: false })).toEqual({
+      eligible: true,
+      missing: [],
+    });
+  });
+
+  it("accepts a required env var from HookConfig.env when process.env lacks it", () => {
+    const previous = process.env[UNIQUE_ENV_KEY];
+    delete process.env[UNIQUE_ENV_KEY];
+    try {
+      const requiresEnv: ElizaHookMetadata = {
+        events: ["command:new"],
+        requires: { env: [UNIQUE_ENV_KEY] },
+      };
+      expect(checkEligibility(requiresEnv, {})).toEqual({
+        eligible: false,
+        missing: [`Env missing: ${UNIQUE_ENV_KEY}`],
+      });
+      expect(
+        checkEligibility(requiresEnv, { env: { [UNIQUE_ENV_KEY]: "set" } }),
+      ).toEqual({ eligible: true, missing: [] });
+    } finally {
+      if (previous === undefined) {
+        delete process.env[UNIQUE_ENV_KEY];
+      } else {
+        process.env[UNIQUE_ENV_KEY] = previous;
+      }
+    }
+  });
+});


### PR DESCRIPTION

# Relates to

No linked issue. Operator-requested unit coverage for `packages/agent/src/config/types.hooks.ts`, which had no same-named test file.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets `develop` and was rebased onto the latest fetched `origin/develop` before the focused proof.
- [x] Reviewers can confirm the changed behavior from the committed focused test.

# Sync with develop

- [x] Branched from fetched `origin/develop` at `72bae36c493fdfc6e32d054871bd735156badfbd`; zero conflicts.
- [x] Focused vitest / biome / tsc on the new file (full `bun run verify` is out of scope for this test-only diff; hosted CI does not run on this fork).

# Risks

Low. Production `types.hooks.ts` is unchanged. The suite imports the real barrel (`export * from "@elizaos/shared"`) and drives the hook-config shapes that barrel exists to surface: mapping unions, Gmail/tailscale/thinking discriminators, internal handler/install queues, `HookConfig` env lookup, empty/missing/single/overflow collections, and identity of runtime re-exports. `checkEligibility` and `resolveHookConfig` are the production consumers of these types.

# Background

## What does this PR do?

Adds `packages/agent/src/config/types.hooks.test.ts` next to `types.hooks.ts`. Import path is `./types.hooks.ts`. Layout, `vitest` imports, and `expectTypeOf` contract checks match the colocated config-barrel convention used by sibling agent config tests.

Covered behaviour:

- Barrel identity: `CONNECTOR_IDS` and `AgentDefaultsSchema` re-exported from this path are the same objects as `@elizaos/shared`
- `HookMappingMatch` / `HookMappingTransform`: all match fields optional; `module` required; `export` optional
- `HookMappingConfig`: empty mapping; `action`/`wakeMode` unions; delivery-channel union; `thinking` is a free string (unlike Gmail); `timeoutSeconds` 0 allowed at the type layer; empty mappings queue, single mapping, equal-id ties preserve order, overflow of 12 mappings
- `HooksGmailConfig`: optional nested serve/tailscale; `HooksGmailTailscaleMode` and gmail `thinking` unions; zero `maxBytes`/`renewEveryMinutes` allowed at the type layer
- `InternalHookHandlerConfig`: required `event` and `module`
- `HookInstallRecord`: required `source` union; empty / single / ordered-with-ties hook lists
- `HookConfig`: optional `enabled`/`env`, extra keys via index signature, empty env map is a miss for every key
- `InternalHooksConfig`: empty block; handler queue order with adjacent event ties; empty `extraDirs`; single extraDir; missing install key; delete of a missing key
- `HooksConfig`: empty object; empty/single/overflow mappings; `maxBodyBytes` 0
- `resolveHookConfig`: undefined config, empty entries, missing key, single stored entry, insertion-order lookup among several keys
- `checkEligibility`: missing metadata is eligible; `enabled: false` is not treated as ineligible; required env is satisfied from `HookConfig.env` when `process.env` lacks the key

## What kind of change is this?

Tests only. Non-breaking. No production export or runtime path changed.

# Documentation changes needed?

No. Test-only.

# Testing

## Where should a reviewer start?

`packages/agent/src/config/types.hooks.test.ts` — colocated with `types.hooks.ts`. Import path is `./types.hooks.ts`.

## Detailed testing steps

```bash
bunx vitest run packages/agent/src/config/types.hooks.test.ts
bunx biome check --write packages/agent/src/config/types.hooks.test.ts
cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'types.hooks.test.ts'
```

Focused proof at the pushed head `33b44e0a7e4ffd795853675a5b85864662c76bce`:

```text
RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/lane-agent-typeshooks-coverage
 ✓ packages/agent/src/config/types.hooks.test.ts (26 tests) 6ms

 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  13:42:16
   Duration  11.52s (transform 8.85s, setup 0ms, import 11.26s, tests 6ms, environment 0ms)
```

`bunx biome check --write` on the test file: checked 1 file in 116ms. Fixed 1 file (formatting). The formatted file is the one at this head.

`bunx tsc --noEmit` in `packages/agent`: `types.hooks.test.ts` appears nowhere in the output. Pre-existing errors elsewhere in the package/graph are unrelated (missing sibling-package modules in this checkout). This file adds zero new TypeScript errors.

The diff touches only `packages/agent/src/config/types.hooks.test.ts`.

Hosted GitHub Actions CI does **not** run on this fork contributor PR. The counts above are local proof only; do not infer that Actions passed.

# Evidence Gate

<!-- evidence-head:33b44e0a7e4ffd795853675a5b85864662c76bce -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic unit tests; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] Inline above - focused Vitest output at the pushed head (26 passed / 26).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - unattended session cannot finalize an interactive identity.slop.cash OAuth trace.
<!-- evidence-row:domain-artifacts -->
- [x] Concrete: test file diff in this PR (26 tests driving the real types.hooks barrel and its production consumers).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - test-only change; no agent/action/provider/prompt/model production path changed.

## Backend + frontend logs

N/A - no server or UI code changed. Focused Vitest output is quoted in Testing.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changes.

## Audio / voice walkthrough

N/A - not a voice/transcript/TTS/STT change.

## Known gaps / failures

Full `bun run verify` was not run; this PR adds tests only. Focused vitest (26/26), biome, and `tsc --noEmit` grepped for `types.hooks.test.ts` (empty) are the complete evidence set.

Hosted GitHub Actions CI does not run on this fork contributor's pull requests.

## Maintainer CI exception record

N/A - no exception requested

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
