### PR TITLE
chore(app-core): format auth audit diagnostics

### DIFF
--- a/packages/app-core/src/api/auth/audit.surrogate.test.ts
+++ b/packages/app-core/src/api/auth/audit.surrogate.test.ts
@@ -1,8 +1,9 @@
 /**
  * Surrogate-safe truncation for auth audit User-Agent.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("auth audit userAgent surrogate-safe", () => {
   it("replaces lone surrogate", () => {
@@ -11,13 +12,21 @@ describe("auth audit userAgent surrogate-safe", () => {
   it("does not split astral at 200", () => {
     const astral = "🦊";
     const atBoundary = "x".repeat(199) + astral;
-    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe("x".repeat(199));
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200)).toBe("x".repeat(198) + astral);
+    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe(
+      "x".repeat(199),
+    );
+    expect(
+      truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200),
+    ).toBe("x".repeat(198) + astral);
   });
   it("caps at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length,
+    ).toBe(200);
   });
   it("preserves short", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("Mozilla/5.0"), 200)).toBe("Mozilla/5.0");
+    expect(truncateWellFormed(toWellFormedUnicode("Mozilla/5.0"), 200)).toBe(
+      "Mozilla/5.0",
+    );
   });
 });

--- a/packages/app-core/src/api/auth/audit.ts
+++ b/packages/app-core/src/api/auth/audit.ts
@@ -45,7 +45,9 @@ export interface AuditEmitterOptions {
 
 function truncateUserAgent(value: string | null): string | null {
   if (!value) return null;
-  return value.length > 200 ? truncateWellFormed(toWellFormedUnicode(value), 200) : value;
+  return value.length > 200
+    ? truncateWellFormed(toWellFormedUnicode(value), 200)
+    : value;
 }
 
 /**


### PR DESCRIPTION
## Summary

- restore pinned Biome import order and line wrapping in auth-audit surrogate coverage
- wrap the production User-Agent truncation expression without changing its behavior

Closes #25464.

## Verification

- `bun install`
- clean-checkout core/shared prerequisite builds
- `bun run --cwd packages/app-core lint:check` — 380 files clean
- auth-audit surrogate suite — 4 tests passed
- `git diff --check`
- package typecheck reaches unrelated missing optional-plugin/native subpaths and existing test signature errors; no diagnostic references either touched file

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
