### PR TITLE
fix(auth): fail closed on incomplete membership evidence

### DIFF
--- a/packages/core/src/types/membership.ts
+++ b/packages/core/src/types/membership.ts
@@ -111,6 +111,13 @@ export interface ApplyCompleteMembershipSnapshotCommand
 	completeness: "complete";
 	members: readonly MembershipSnapshotMember[];
 }
+export interface ReportIncompleteMembershipSnapshotCommand
+	extends MembershipCommandBase,
+		MembershipPublisherBinding {
+	evidenceMode: "complete_snapshot" | "ordered_delta";
+	completeness: "incomplete";
+	reason: string;
+}
 export interface ApplyMembershipCommand extends MembershipEvidenceCommand {
 	evidenceMode: "ordered_delta" | "point_query";
 	canonicalPrincipalId: UUID;
@@ -177,6 +184,7 @@ export type MembershipAuthorizationDecision =
 				| "authority_unsupported"
 				| "authority_expired"
 				| "membership_evidence_expired"
+				| "membership_evidence_mismatch"
 				| "no_membership"
 				| "membership_revoked";
 			generation: number | null;
@@ -193,6 +201,9 @@ export abstract class MembershipService extends Service {
 	): Promise<MembershipMutationReceipt>;
 	abstract applyCompleteSnapshot(
 		command: ApplyCompleteMembershipSnapshotCommand,
+	): Promise<MembershipMutationReceipt>;
+	abstract reportIncompleteSnapshot(
+		command: ReportIncompleteMembershipSnapshotCommand,
 	): Promise<MembershipMutationReceipt>;
 	abstract applyMembership(
 		command: ApplyMembershipCommand,

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -44,7 +44,10 @@ Every authorization rechecks persisted `validUntil` values against the trusted
 service clock. Missing, expired, stale, unavailable, and unsupported authority
 deny explicitly. Complete snapshots atomically upsert observed members and
 retain absent active members as revoked facts; incomplete or failed pagination
-changes no roster. Point proof for one principal creates no fact about another.
+atomically marks the scope stale without changing the roster or advancing its
+durable cursor. Authorization also requires a membership fact to match the
+scope's current publisher generation. Point proof for one principal creates no
+fact about another.
 The service invalidates registered dependent caches before notifying observers.
 Connector composition and document authorization remain separate slices, and
 the service exposes no model-callable mutation action.

--- a/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/membership-authority.real.test.ts
@@ -4,6 +4,7 @@
  */
 import type { MembershipScope, UUID } from "@elizaos/core";
 import { count, eq } from "drizzle-orm";
+import fc from "fast-check";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connectorAccountsTable } from "../../schema/connectorAccounts";
 import { entityTable } from "../../schema/entity";
@@ -177,29 +178,98 @@ describe("SqlMembershipService real authority", () => {
     });
   });
 
-  it("accepts an explicitly complete empty roster but rejects incomplete/paginated input without changing facts", async () => {
+  it("property-checks complete-snapshot replacement across roster subsets", async () => {
+    let run = 0;
+    const roster = fc.uniqueArray(fc.constantFrom(principalId, secondPrincipalId), {
+      maxLength: 2,
+    });
+    await fc.assert(
+      fc.asyncProperty(roster, roster, async (first, second) => {
+        run += 1;
+        const propertyScope = { ...scope, externalRoomId: `property-room-${run}` };
+        await service.registerPublisher({
+          ...propertyScope,
+          ...publisher,
+          expectedGeneration: 0,
+          idempotencyKey: `property-register-${run}`,
+          observedAt: observedAt(),
+        });
+        await service.applyCompleteSnapshot({
+          ...propertyScope,
+          ...publisher,
+          completeness: "complete",
+          members: first.map(member),
+          expectedGeneration: 1,
+          sourceVersion: 0,
+          previousSourceCursor: null,
+          sourceCursor: `property-${run}-0`,
+          validUntil: validUntil(),
+          idempotencyKey: `property-snapshot-${run}-0`,
+          observedAt: observedAt(),
+        });
+        await service.applyCompleteSnapshot({
+          ...propertyScope,
+          ...publisher,
+          completeness: "complete",
+          members: second.map(member),
+          expectedGeneration: 2,
+          sourceVersion: 1,
+          previousSourceCursor: `property-${run}-0`,
+          sourceCursor: `property-${run}-1`,
+          validUntil: validUntil(),
+          idempotencyKey: `property-snapshot-${run}-1`,
+          observedAt: observedAt(),
+        });
+        for (const principal of [principalId, secondPrincipalId]) {
+          const fact = await service.getMembership(propertyScope, principal);
+          if (second.includes(principal)) expect(fact?.state).toBe("active");
+          else if (first.includes(principal)) expect(fact?.state).toBe("revoked");
+          else expect(fact).toBeNull();
+        }
+      }),
+      { numRuns: 12, seed: 23_101 }
+    );
+  });
+
+  it("accepts an explicitly complete empty roster but makes incomplete/paginated input stale without changing facts", async () => {
     await register();
     await snapshot();
+    const incomplete = await service.reportIncompleteSnapshot({
+      ...scope,
+      ...publisher,
+      completeness: "incomplete",
+      reason: "pagination_failed",
+      expectedGeneration: 2,
+      idempotencyKey: "partial",
+      observedAt: observedAt(),
+    });
+    expect(incomplete).toMatchObject({
+      operation: "health",
+      committedGeneration: 3,
+      health: { health: "stale", reason: "pagination_failed", sourceCursor: "snapshot-0" },
+    });
     await expect(
-      service.applyCompleteSnapshot({
+      service.reportIncompleteSnapshot({
         ...scope,
         ...publisher,
-        completeness: "partial",
-        members: [],
+        completeness: "incomplete",
+        reason: "pagination_failed",
         expectedGeneration: 2,
-        sourceVersion: 1,
-        previousSourceCursor: "snapshot-0",
-        sourceCursor: "page-1",
-        validUntil: validUntil(),
         idempotencyKey: "partial",
         observedAt: observedAt(),
-      } as never)
-    ).rejects.toMatchObject({ code: "MEMBERSHIP_SNAPSHOT_INCOMPLETE" });
+      })
+    ).resolves.toEqual({ ...incomplete, idempotentReplay: true });
     await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
-      decision: "allowed",
-      generation: 2,
+      decision: "denied",
+      reason: "authority_stale",
+      generation: 3,
     });
-    const empty = await snapshot([], 2, 1, "snapshot-0", "empty-complete");
+    expect(await service.getMembership(scope, principalId)).toMatchObject({
+      state: "active",
+      generation: 2,
+      sourceCursor: "snapshot-0",
+    });
+    const empty = await snapshot([], 3, 1, "snapshot-0", "empty-complete");
     expect(empty).toMatchObject({
       operation: "snapshot",
       memberships: [],
@@ -231,6 +301,41 @@ describe("SqlMembershipService real authority", () => {
       reason: "authority_expired",
     });
     await restarted.stop();
+  });
+
+  it("rejects validity windows that are expired or unbounded relative to observation time", async () => {
+    await register();
+    await expect(
+      service.applyCompleteSnapshot({
+        ...scope,
+        ...publisher,
+        completeness: "complete",
+        members: [member(principalId)],
+        expectedGeneration: 1,
+        sourceVersion: 0,
+        previousSourceCursor: null,
+        sourceCursor: "expired",
+        observedAt: new Date(nowMs - 60_000).toISOString(),
+        validUntil: new Date(nowMs).toISOString(),
+        idempotencyKey: "expired",
+      })
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    await expect(
+      service.applyCompleteSnapshot({
+        ...scope,
+        ...publisher,
+        completeness: "complete",
+        members: [member(principalId)],
+        expectedGeneration: 1,
+        sourceVersion: 0,
+        previousSourceCursor: null,
+        sourceCursor: "old-observation",
+        observedAt: new Date(nowMs - 2 * 24 * 60 * 60 * 1_000).toISOString(),
+        validUntil: new Date(nowMs + 60_000).toISOString(),
+        idempotencyKey: "old-observation",
+      })
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_COMMAND_INVALID" });
+    expect(await db.select().from(membershipAuthorityTable)).toHaveLength(0);
   });
 
   it("binds evidence to publisher instance, generation, mode, and exact cursor continuity", async () => {
@@ -407,6 +512,29 @@ describe("SqlMembershipService real authority", () => {
     expect(await db.select().from(membershipAuthorityTable)).toHaveLength(0);
   });
 
+  it("rejects an overlong persisted evidence window at the database boundary", async () => {
+    await register();
+    await expect(
+      db.insert(membershipAuthorityTable).values({
+        ...scope,
+        canonicalPrincipalId: principalId,
+        state: "active",
+        reason: "joined",
+        roles: ["member"],
+        permissionSnapshot: {},
+        publisherInstanceId: publisher.publisherInstanceId,
+        publisherGeneration: publisher.publisherGeneration,
+        evidenceMode: publisher.evidenceMode,
+        generation: 1,
+        sourceVersion: 0,
+        sourceCursor: "forged-long-window",
+        observedAt: new Date(nowMs),
+        validUntil: new Date(nowMs + 24 * 60 * 60 * 1_000 + 1),
+      })
+    ).rejects.toThrow();
+    expect(await db.select().from(membershipAuthorityTable)).toHaveLength(0);
+  });
+
   it("supports bounded point-query proof without claiming connector or document integration", async () => {
     const pointPublisher = {
       publisherInstanceId: "point-query",
@@ -439,5 +567,79 @@ describe("SqlMembershipService real authority", () => {
       reason: "no_membership",
     });
     await expect(service.getMembership(scope, secondPrincipalId)).resolves.toBeNull();
+  });
+
+  it("does not let a new point-query publisher inherit an old publisher's active fact", async () => {
+    const firstPublisher = {
+      publisherInstanceId: "point-query-a",
+      publisherGeneration: 0,
+      evidenceMode: "point_query" as const,
+    };
+    await register(0, "point-register-a", firstPublisher);
+    await service.applyMembership({
+      ...scope,
+      ...firstPublisher,
+      canonicalPrincipalId: principalId,
+      state: "active",
+      reason: "reconciled_present",
+      roles: ["member"],
+      permissionSnapshot: { canRead: true },
+      runtime: { worldId: null, roomId: null, entityId: principalId },
+      expectedGeneration: 1,
+      sourceVersion: 0,
+      previousSourceCursor: null,
+      sourceCursor: "point-a-0",
+      validUntil: validUntil(),
+      idempotencyKey: "point-a-proof",
+      observedAt: observedAt(),
+    });
+    const replacementPublisher = {
+      publisherInstanceId: "point-query-b",
+      publisherGeneration: 1,
+      evidenceMode: "point_query" as const,
+    };
+    await register(2, "point-register-b", replacementPublisher);
+    await service.applyMembership({
+      ...scope,
+      ...replacementPublisher,
+      canonicalPrincipalId: secondPrincipalId,
+      state: "active",
+      reason: "reconciled_present",
+      roles: ["member"],
+      permissionSnapshot: { canRead: true },
+      runtime: { worldId: null, roomId: null, entityId: secondPrincipalId },
+      expectedGeneration: 3,
+      sourceVersion: 0,
+      previousSourceCursor: null,
+      sourceCursor: "point-b-0",
+      validUntil: validUntil(),
+      idempotencyKey: "point-b-proof",
+      observedAt: observedAt(),
+    });
+    await expect(service.authorize(scope, principalId)).resolves.toMatchObject({
+      decision: "denied",
+      reason: "membership_evidence_mismatch",
+      generation: 4,
+    });
+    await expect(service.authorize(scope, secondPrincipalId)).resolves.toMatchObject({
+      decision: "allowed",
+      generation: 4,
+    });
+  });
+
+  it("fails closed before reading or writing a different runtime tenant", async () => {
+    const foreignScope = { ...scope, agentId: crypto.randomUUID() as UUID };
+    await expect(service.authorize(foreignScope, principalId)).rejects.toMatchObject({
+      code: "MEMBERSHIP_TENANT_MISMATCH",
+    });
+    await expect(
+      service.registerPublisher({
+        ...foreignScope,
+        ...publisher,
+        expectedGeneration: 0,
+        idempotencyKey: "foreign-tenant",
+        observedAt: observedAt(),
+      })
+    ).rejects.toMatchObject({ code: "MEMBERSHIP_TENANT_MISMATCH" });
   });
 });

--- a/plugins/plugin-sql/src/schema/membershipAuthority.ts
+++ b/plugins/plugin-sql/src/schema/membershipAuthority.ts
@@ -78,7 +78,7 @@ export const membershipAuthorityScopeTable = pgTable(
     ),
     check(
       "membership_authority_scope_current_check",
-      sql`${table.health} <> 'current' OR (${table.validUntil} IS NOT NULL AND ${table.validUntil} > ${table.observedAt} AND ${table.publisherInstanceId} IS NOT NULL AND ${table.sourceVersion} >= 0 AND ${table.sourceCursor} IS NOT NULL)`
+      sql`${table.health} <> 'current' OR (${table.validUntil} IS NOT NULL AND ${table.validUntil} > ${table.observedAt} AND ${table.validUntil} <= ${table.observedAt} + INTERVAL '24 hours' AND ${table.publisherInstanceId} IS NOT NULL AND ${table.sourceVersion} >= 0 AND ${table.sourceCursor} IS NOT NULL)`
     ),
   ]
 );
@@ -149,7 +149,7 @@ export const membershipAuthorityTable = pgTable(
     ),
     check(
       "membership_authority_version_check",
-      sql`${table.generation} > 0 AND ${table.sourceVersion} >= 0 AND ${table.validUntil} > ${table.observedAt}`
+      sql`${table.generation} > 0 AND ${table.sourceVersion} >= 0 AND ${table.validUntil} > ${table.observedAt} AND ${table.validUntil} <= ${table.observedAt} + INTERVAL '24 hours'`
     ),
   ]
 );

--- a/plugins/plugin-sql/src/services/sql-membership.ts
+++ b/plugins/plugin-sql/src/services/sql-membership.ts
@@ -24,6 +24,7 @@ import {
   MembershipService,
   type MembershipSnapshotMember,
   type RegisterMembershipPublisherCommand,
+  type ReportIncompleteMembershipSnapshotCommand,
   type Service,
   type SetMembershipHealthCommand,
   type UUID,
@@ -159,6 +160,18 @@ function mapScope(row: ScopeRow): MembershipScopeHealth {
     !MEMBERSHIP_EVIDENCE_MODES.includes(row.evidenceMode as MembershipEvidenceMode)
   )
     fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted evidence mode is invalid.");
+  if (
+    row.health === "current" &&
+    (row.validUntil === null ||
+      row.validUntil <= row.observedAt ||
+      row.validUntil.getTime() - row.observedAt.getTime() > MAX_VALIDITY_MS ||
+      row.publisherInstanceId === null ||
+      row.publisherGeneration === null ||
+      row.evidenceMode === null ||
+      row.sourceVersion < 0 ||
+      row.sourceCursor === null)
+  )
+    fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted current scope is not authoritative.");
   return {
     contractVersion: 1,
     agentId: row.agentId as UUID,
@@ -185,7 +198,8 @@ function mapMember(row: MembershipRow): MembershipRecord {
     !MEMBERSHIP_REASONS.includes(row.reason as MembershipRecord["reason"]) ||
     !MEMBERSHIP_EVIDENCE_MODES.includes(row.evidenceMode as MembershipEvidenceMode) ||
     (row.state === "active") !== ACTIVE_REASONS.has(row.reason) ||
-    row.validUntil <= row.observedAt
+    row.validUntil <= row.observedAt ||
+    row.validUntil.getTime() - row.observedAt.getTime() > MAX_VALIDITY_MS
   )
     fail("MEMBERSHIP_PERSISTED_STATE_INVALID", "Persisted membership enum is invalid.");
   assertRoles(row.roles);
@@ -365,10 +379,13 @@ export class SqlMembershipService extends MembershipService {
     if (typeof command.validUntil !== "string")
       fail("MEMBERSHIP_COMMAND_INVALID", "Evidence validity must be a string.");
     const validUntil = new Date(command.validUntil);
+    const now = this.clock().getTime();
     if (
       !Number.isFinite(validUntil.getTime()) ||
       validUntil <= observed ||
-      validUntil.getTime() > this.clock().getTime() + MAX_VALIDITY_MS
+      validUntil.getTime() <= now ||
+      validUntil.getTime() > now + MAX_VALIDITY_MS ||
+      validUntil.getTime() - observed.getTime() > MAX_VALIDITY_MS
     )
       fail("MEMBERSHIP_COMMAND_INVALID", "Evidence validity is invalid.");
     return validUntil;
@@ -887,6 +904,88 @@ export class SqlMembershipService extends MembershipService {
     return receipt;
   }
 
+  async reportIncompleteSnapshot(
+    command: ReportIncompleteMembershipSnapshotCommand
+  ): Promise<MembershipMutationReceipt> {
+    const observed = this.assertBase(command, [
+      "agentId",
+      "connectorId",
+      "connectorAccountId",
+      "externalWorldId",
+      "externalRoomId",
+      "expectedGeneration",
+      "idempotencyKey",
+      "observedAt",
+      "publisherInstanceId",
+      "publisherGeneration",
+      "evidenceMode",
+      "completeness",
+      "reason",
+    ]);
+    this.assertPublisher(command);
+    if (
+      command.completeness !== "incomplete" ||
+      !["complete_snapshot", "ordered_delta"].includes(command.evidenceMode) ||
+      typeof command.reason !== "string" ||
+      command.reason.trim().length === 0 ||
+      command.reason.length > MAX_IDENTIFIER_LENGTH
+    )
+      fail(
+        "MEMBERSHIP_COMMAND_INVALID",
+        "Incomplete snapshot reports require a snapshot-capable publisher and reason."
+      );
+    const requestDigest = digest("health", command);
+    const receipt = await this.db.transaction(async (tx) => {
+      const replay = await this.replay(tx, command, requestDigest);
+      if (replay) return replay;
+      await this.assertAccount(tx, command);
+      const current = await this.row(tx, command);
+      if (current.generation !== command.expectedGeneration) {
+        const concurrentReplay = await this.replay(tx, command, requestDigest);
+        if (concurrentReplay) return concurrentReplay;
+        fail("MEMBERSHIP_GENERATION_MISMATCH", "Membership scope generation changed.");
+      }
+      if (
+        current.publisherInstanceId !== command.publisherInstanceId ||
+        current.publisherGeneration !== command.publisherGeneration ||
+        current.evidenceMode !== command.evidenceMode
+      )
+        fail(
+          "MEMBERSHIP_PUBLISHER_MISMATCH",
+          "Incomplete snapshot does not match the registered publisher generation and mode."
+        );
+      const [advanced] = await tx
+        .update(membershipAuthorityScopeTable)
+        .set({
+          generation: current.generation + 1,
+          health: "stale",
+          reason: command.reason,
+          observedAt: observed,
+          updatedAt: this.clock(),
+        })
+        .where(
+          and(scopeWhere(command), eq(membershipAuthorityScopeTable.generation, current.generation))
+        )
+        .returning();
+      if (!advanced) {
+        const concurrentReplay = await this.replay(tx, command, requestDigest);
+        if (concurrentReplay) return concurrentReplay;
+        fail("MEMBERSHIP_GENERATION_MISMATCH", "Concurrent membership command committed first.");
+      }
+      const result: MembershipMutationReceipt = {
+        contractVersion: 1,
+        operation: "health",
+        idempotentReplay: false,
+        committedGeneration: advanced.generation,
+        health: mapScope(advanced),
+      };
+      await this.record(tx, "health", command, requestDigest, result);
+      return result;
+    });
+    if (!receipt.idempotentReplay) await this.publish(command, receipt);
+    return receipt;
+  }
+
   async applyMembership(command: ApplyMembershipCommand): Promise<MembershipMutationReceipt> {
     const observed = this.assertBase(command, [
       "agentId",
@@ -1045,9 +1144,35 @@ export class SqlMembershipService extends MembershipService {
     canonicalPrincipalId: UUID
   ): Promise<MembershipAuthorizationDecision> {
     this.assertScope(scope);
-    const health = await this.getScopeHealth(scope);
-    if (!health)
+    assertUuid(canonicalPrincipalId, "canonicalPrincipalId");
+    const [authority] = await this.db
+      .select({
+        scope: membershipAuthorityScopeTable,
+        membership: membershipAuthorityTable,
+      })
+      .from(membershipAuthorityScopeTable)
+      .leftJoin(
+        membershipAuthorityTable,
+        and(
+          eq(membershipAuthorityTable.agentId, membershipAuthorityScopeTable.agentId),
+          eq(membershipAuthorityTable.connectorId, membershipAuthorityScopeTable.connectorId),
+          eq(
+            membershipAuthorityTable.connectorAccountId,
+            membershipAuthorityScopeTable.connectorAccountId
+          ),
+          eq(
+            membershipAuthorityTable.externalWorldId,
+            membershipAuthorityScopeTable.externalWorldId
+          ),
+          eq(membershipAuthorityTable.externalRoomId, membershipAuthorityScopeTable.externalRoomId),
+          eq(membershipAuthorityTable.canonicalPrincipalId, canonicalPrincipalId)
+        )
+      )
+      .where(scopeWhere(scope))
+      .limit(1);
+    if (!authority)
       return { decision: "denied", reason: "no_scope_evidence", generation: null, health: null };
+    const health = mapScope(authority.scope);
     if (health.health !== "current")
       return {
         decision: "denied",
@@ -1063,7 +1188,7 @@ export class SqlMembershipService extends MembershipService {
         generation: health.generation,
         health: "current",
       };
-    const membership = await this.getMembership(scope, canonicalPrincipalId);
+    const membership = authority.membership ? mapMember(authority.membership) : null;
     if (!membership)
       return {
         decision: "denied",
@@ -1075,6 +1200,17 @@ export class SqlMembershipService extends MembershipService {
       return {
         decision: "denied",
         reason: "membership_revoked",
+        generation: health.generation,
+        health: "current",
+      };
+    if (
+      membership.publisherInstanceId !== health.publisherInstanceId ||
+      membership.publisherGeneration !== health.publisherGeneration ||
+      membership.evidenceMode !== health.evidenceMode
+    )
+      return {
+        decision: "denied",
+        reason: "membership_evidence_mismatch",
         generation: health.generation,
         health: "current",
       };


### PR DESCRIPTION
Closes the remaining fail-closed gaps identified in #23101 comment 5384669794 after #25379 merged.

## What changed

- adds a publisher-generation-fenced incomplete-snapshot report that atomically marks the scope stale without changing roster facts or advancing the durable cursor
- authorizes from one joined scope/member read and rejects membership facts from a prior publisher instance, generation, or evidence mode
- bounds evidence validity both against the trusted current clock and the observation timestamp
- enforces the 24-hour observation-to-validity bound in persisted schema checks and read-time validation
- preserves retained active/revoked facts while incomplete pagination fails closed

## Verification

- real PGlite authority suite: 15/15 passed, including property-generated roster replacements, empty-complete vs incomplete, exact retry, concurrent snapshot/revocation, cursor/generation collisions, expiry, persisted TTL rejection, restart, point-query publisher replacement, and tenant isolation
- plugin-sql default suite: 29 files passed, 1 skipped; 183 tests passed, 3 skipped
- plugin-sql schema suite: 3/3 passed on exact rebased head
- plugin-sql and core typechecks passed on exact rebased head
- core full Node/browser/edge/testing build passed; plugin-sql build passed
- focused Biome checks and diff checks passed
- frozen Bun install passed

Root `bun run verify` reaches the repository's existing `check:i18n` failure: five missing English connector-card keys plus the already-reported locale backlog. This change does not touch application translations.

No connector cutover, document-grant behavior, or compatibility fallback is included.
