### PR TITLE
feat(core): group-chat anxiety + anti-loop bot-awareness providers (+ deterministic bot-loop gate)

### DIFF
--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -147,7 +147,9 @@ import { CHANNEL_TOPICS_ROUTES } from "./channel-topics-routes.ts";
 import { linkExtractionEvaluator } from "./evaluators/link-extraction.ts";
 import { actionStateProvider } from "./providers/actionState.ts";
 import { actionsProvider } from "./providers/actions.ts";
+import { anxietyProvider } from "./providers/anxiety.ts";
 import { attachmentsProvider } from "./providers/attachments.ts";
+import { botAwarenessProvider } from "./providers/botAwareness.ts";
 import { channelTopicsProvider } from "./providers/channelTopics.ts";
 import { characterProvider } from "./providers/character.ts";
 import { choiceProvider } from "./providers/choice.ts";
@@ -1417,7 +1419,9 @@ const events: PluginEvents = {
 export const basicProviders = [
 	actionsProvider,
 	actionStateProvider,
+	anxietyProvider,
 	attachmentsProvider,
+	botAwarenessProvider,
 	channelTopicsProvider,
 	characterProvider,
 	choiceProvider,

--- a/packages/core/src/features/basic-capabilities/providers/anxiety.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/anxiety.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Tests for the ANXIETY and BOT_AWARENESS group-channel providers.
+ *
+ * ANXIETY: pressure rises with the agent's share of recent turns and with
+ * agent↔single-participant ping-pong, stays at zero when the agent has been
+ * quiet, is damped when a human just directly addressed the agent, and is
+ * INERT in DMs (bidirectional: the DM path returns the empty result even
+ * under maximum-pressure history). Room-awareness: the same agent turn count
+ * produces more pressure in a crowded room than a two-person group.
+ *
+ * BOT_AWARENESS: fires when the latest interlocutor is connector-stamped
+ * `fromBot` and the bot↔agent exchange has no intervening human turn; stays
+ * quiet when a human is active in the gap, when the interlocutor is human,
+ * and in DMs.
+ *
+ * Deterministic: real AgentRuntime + InMemoryDatabaseAdapter; providers read
+ * either the composed RECENT_MESSAGES state or the coalesced room scan; no
+ * model calls.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { createCharacter } from "../../../character";
+import { InMemoryDatabaseAdapter } from "../../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../../runtime";
+import type { Memory, State, UUID } from "../../../types/index";
+import { ChannelType } from "../../../types/index";
+import {
+	anxietyProvider,
+	computeAnxietyPressure,
+	DEFAULT_ANXIETY_CALIBRATION,
+} from "./anxiety";
+import { assessBotLoop, botAwarenessProvider } from "./botAwareness";
+import { computeGroupConversationMetrics } from "./group-conversation-signals";
+
+const WORLD_ID = "77777777-7777-7777-7777-777777777770" as UUID;
+const GROUP_ROOM = "77777777-7777-7777-7777-777777777771" as UUID;
+const DM_ROOM = "77777777-7777-7777-7777-777777777772" as UUID;
+const HUMAN_A = "88888888-8888-8888-8888-888888888881" as UUID;
+const HUMAN_B = "88888888-8888-8888-8888-888888888882" as UUID;
+const HUMAN_C = "88888888-8888-8888-8888-888888888883" as UUID;
+const OTHER_BOT = "88888888-8888-8888-8888-8888888888bb" as UUID;
+
+const activeRuntimes: AgentRuntime[] = [];
+
+afterEach(async () => {
+	while (activeRuntimes.length > 0) {
+		const runtime = activeRuntimes.pop();
+		await runtime?.stop();
+	}
+});
+
+async function makeRuntime(): Promise<{
+	runtime: AgentRuntime;
+	adapter: InMemoryDatabaseAdapter;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	const runtime = new AgentRuntime({
+		character: createCharacter({ name: "Eliza" }),
+		adapter,
+		logLevel: "fatal",
+		enableAutonomy: false,
+	});
+	await runtime.initialize();
+	await adapter.createWorlds([
+		{
+			id: WORLD_ID,
+			agentId: runtime.agentId,
+			name: "anxiety world",
+			metadata: { roles: {} },
+		},
+	]);
+	await adapter.createRooms([
+		{
+			id: GROUP_ROOM,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.GROUP,
+			worldId: WORLD_ID,
+		},
+		{
+			id: DM_ROOM,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.DM,
+			worldId: WORLD_ID,
+		},
+	]);
+	activeRuntimes.push(runtime);
+	return { runtime, adapter };
+}
+
+let rowCounter = 0;
+
+function makeRow(args: {
+	roomId: UUID;
+	entityId: UUID;
+	text: string;
+	fromBot?: boolean;
+	channelType?: ChannelType;
+}): Memory {
+	rowCounter += 1;
+	const suffix = rowCounter.toString(16).padStart(12, "0");
+	return {
+		id: `99999999-9999-9999-9999-${suffix}` as UUID,
+		entityId: args.entityId,
+		roomId: args.roomId,
+		worldId: WORLD_ID,
+		createdAt: 10_000 + rowCounter,
+		content: {
+			text: args.text,
+			source: "test",
+			...(args.channelType ? { channelType: args.channelType } : {}),
+		},
+		...(args.fromBot ? { metadata: { fromBot: true } } : {}),
+	} as Memory;
+}
+
+async function seed(
+	adapter: InMemoryDatabaseAdapter,
+	rows: Memory[],
+): Promise<void> {
+	await adapter.createMemories(
+		rows.map((memory) => ({ memory, tableName: "messages" })),
+	);
+}
+
+/** Alternating agent↔human history: pure ping-pong of the given length. */
+function pingPongRows(
+	agentId: UUID,
+	other: UUID,
+	pairs: number,
+	roomId: UUID = GROUP_ROOM,
+): Memory[] {
+	const rows: Memory[] = [];
+	for (let i = 0; i < pairs; i += 1) {
+		rows.push(
+			makeRow({ roomId, entityId: other, text: `ping ${i}` }),
+			makeRow({ roomId, entityId: agentId, text: `pong ${i}` }),
+		);
+	}
+	return rows;
+}
+
+const EMPTY_STATE = {} as State;
+
+describe("ANXIETY provider", () => {
+	it("stays silent in a group where the agent has been quiet", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, [
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "hey all" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_B, text: "morning" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "plans today?" }),
+		]);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN_B,
+			text: "coffee first",
+			channelType: ChannelType.GROUP,
+		});
+		const result = await anxietyProvider.get(runtime, inbound, EMPTY_STATE);
+		expect(result.text).toBe("");
+		expect(result.values).toEqual({});
+	});
+
+	it("rises with agent-turn dominance and renders the yield-the-floor guidance", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		const rows: Memory[] = [
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "question" }),
+		];
+		for (let i = 0; i < 8; i += 1) {
+			rows.push(
+				makeRow({
+					roomId: GROUP_ROOM,
+					entityId: runtime.agentId,
+					text: `agent monologue ${i}`,
+				}),
+			);
+		}
+		await seed(adapter, rows);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN_B,
+			text: "anyway",
+			channelType: ChannelType.GROUP,
+		});
+		const result = await anxietyProvider.get(runtime, inbound, EMPTY_STATE);
+		expect(result.text).toContain("Others should have the floor");
+		expect(result.text).toContain("IGNORE");
+		expect(result.values?.anxietyPressure as number).toBeGreaterThanOrEqual(
+			DEFAULT_ANXIETY_CALIBRATION.highWatermark,
+		);
+	});
+
+	it("ramps on sustained ping-pong with a single participant", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, [
+			// A third participant exists but the tail is pure agent↔HUMAN_A.
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_B, text: "lurking" }),
+			...pingPongRows(runtime.agentId, HUMAN_A, 5),
+		]);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN_A,
+			text: "ping again",
+			channelType: ChannelType.GROUP,
+		});
+		const result = await anxietyProvider.get(runtime, inbound, EMPTY_STATE);
+		expect(result.text).not.toBe("");
+		expect(result.values?.anxietyPingPongRun as number).toBeGreaterThanOrEqual(
+			3,
+		);
+		expect(result.text).toMatch(/back-and-forth|trading messages/);
+	});
+
+	it("is damped (not silenced) when a human directly addresses the agent by name", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, pingPongRows(runtime.agentId, HUMAN_A, 6));
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN_A,
+			text: "Eliza can you summarize the thread?",
+			channelType: ChannelType.GROUP,
+		});
+		const undamped = await anxietyProvider.get(
+			runtime,
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: HUMAN_A,
+				text: "just chatting along",
+				channelType: ChannelType.GROUP,
+			}),
+			EMPTY_STATE,
+		);
+		const damped = await anxietyProvider.get(runtime, inbound, EMPTY_STATE);
+		const undampedPressure = (undamped.values?.anxietyPressure as number) ?? 0;
+		if (damped.text === "") {
+			// Fully below the notice floor after damping — acceptable outcome.
+			expect(undampedPressure).toBeGreaterThan(0);
+		} else {
+			expect(damped.values?.anxietyDampedByAddress).toBe(true);
+			expect(damped.values?.anxietyPressure as number).toBeLessThan(
+				undampedPressure,
+			);
+			expect(damped.text).toContain("directly addressed");
+		}
+	});
+
+	it("is INERT in DMs even with maximum-pressure history (bidirectional)", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		const rows: Memory[] = [];
+		for (let i = 0; i < 10; i += 1) {
+			rows.push(
+				makeRow({
+					roomId: DM_ROOM,
+					entityId: runtime.agentId,
+					text: `dm monologue ${i}`,
+				}),
+			);
+		}
+		await seed(adapter, rows);
+		// Sanity: the same shape in a GROUP room does produce pressure.
+		const groupResult = await anxietyProvider.get(
+			runtime,
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: HUMAN_A,
+				text: "hm",
+				channelType: ChannelType.GROUP,
+			}),
+			{
+				data: {
+					providers: {
+						RECENT_MESSAGES: { data: { recentMessages: rows } },
+					},
+				},
+			} as unknown as State,
+		);
+		expect(groupResult.text).not.toBe("");
+		// The DM path returns the empty result: explicit channelType on content…
+		const explicit = await anxietyProvider.get(
+			runtime,
+			makeRow({
+				roomId: DM_ROOM,
+				entityId: HUMAN_A,
+				text: "hm",
+				channelType: ChannelType.DM,
+			}),
+			EMPTY_STATE,
+		);
+		expect(explicit).toEqual({ text: "", values: {}, data: {} });
+		// …and via room-row type resolution when content omits it.
+		const resolved = await anxietyProvider.get(
+			runtime,
+			makeRow({ roomId: DM_ROOM, entityId: HUMAN_A, text: "hm" }),
+			EMPTY_STATE,
+		);
+		expect(resolved).toEqual({ text: "", values: {}, data: {} });
+	});
+
+	it("reads the composed RECENT_MESSAGES state on a turn recompose instead of refetching", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		let scans = 0;
+		const realGetMemories = adapter.getMemories.bind(adapter);
+		adapter.getMemories = async (
+			params: Parameters<InMemoryDatabaseAdapter["getMemories"]>[0],
+		) => {
+			if (params.tableName === "messages") scans += 1;
+			return realGetMemories(params);
+		};
+		const rows = pingPongRows(runtime.agentId, HUMAN_A, 6);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN_A,
+			text: "again",
+			channelType: ChannelType.GROUP,
+		});
+		const state = {
+			data: {
+				providers: {
+					RECENT_MESSAGES: { data: { recentMessages: rows } },
+				},
+			},
+		} as unknown as State;
+		const result = await anxietyProvider.get(runtime, inbound, state);
+		expect(result.text).not.toBe("");
+		expect(scans).toBe(0);
+	});
+
+	it("is room-aware: identical agent activity pressures higher in a crowded room", () => {
+		// Pure-function proof of the crowd calibration: same agent share and
+		// window, more distinct participants → more pressure.
+		const base = {
+			windowSize: 10,
+			agentTurns: 5,
+			agentShare: 0.5,
+			pingPongRun: 0,
+			latestFromBot: false,
+			agentTurnsSinceLastHuman: 0,
+			botTurnsSinceLastHuman: 0,
+			humanInWindow: true,
+		};
+		const quiet = computeAnxietyPressure(
+			{ ...base, participantCount: 1 },
+			false,
+		);
+		const crowded = computeAnxietyPressure(
+			{ ...base, participantCount: 6 },
+			false,
+		);
+		expect(crowded.pressure).toBeGreaterThan(quiet.pressure);
+		// Fair share shrinks as the room fills up.
+		expect(crowded.fairShare).toBeLessThan(quiet.fairShare);
+	});
+
+	it("registers group-only advisory metadata", () => {
+		expect(anxietyProvider.name).toBe("ANXIETY");
+		expect(anxietyProvider.alwaysInResponseState).toBe(true);
+		expect(anxietyProvider.dynamic).toBe(true);
+	});
+});
+
+describe("BOT_AWARENESS provider", () => {
+	it("fires when the interlocutor is a bot with no intervening human turn", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, [
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "hi bots" }),
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: OTHER_BOT,
+				text: "hello!",
+				fromBot: true,
+			}),
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: runtime.agentId,
+				text: "hello to you too!",
+			}),
+		]);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: OTHER_BOT,
+			text: "and hello again! anything I can help with?",
+			fromBot: true,
+			channelType: ChannelType.GROUP,
+		});
+		const result = await botAwarenessProvider.get(
+			runtime,
+			inbound,
+			EMPTY_STATE,
+		);
+		expect(result.text).toContain("another bot");
+		expect(result.text).toContain("IGNORE");
+		expect(result.values?.botLoopActive).toBe(true);
+	});
+
+	it("escalates to let-it-drop wording when the human-free exchange is deep", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		const rows: Memory[] = [
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "kick off" }),
+		];
+		for (let i = 0; i < 3; i += 1) {
+			rows.push(
+				makeRow({
+					roomId: GROUP_ROOM,
+					entityId: OTHER_BOT,
+					text: `bot volley ${i}`,
+					fromBot: true,
+				}),
+				makeRow({
+					roomId: GROUP_ROOM,
+					entityId: runtime.agentId,
+					text: `agent volley ${i}`,
+				}),
+			);
+		}
+		await seed(adapter, rows);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: OTHER_BOT,
+			text: "one more volley",
+			fromBot: true,
+			channelType: ChannelType.GROUP,
+		});
+		const result = await botAwarenessProvider.get(
+			runtime,
+			inbound,
+			EMPTY_STATE,
+		);
+		expect(result.text).toContain("Let it drop");
+		expect(result.values?.botLoopDeep).toBe(true);
+		expect(
+			result.values?.botLoopExchangeDepth as number,
+		).toBeGreaterThanOrEqual(4);
+	});
+
+	it("stays quiet when a human turn sits between the bot exchanges", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, [
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: OTHER_BOT,
+				text: "bot says a thing",
+				fromBot: true,
+			}),
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: runtime.agentId,
+				text: "agent replies",
+			}),
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: HUMAN_A,
+				text: "human steps in with a real question",
+			}),
+		]);
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: OTHER_BOT,
+			text: "bot answers the human",
+			fromBot: true,
+			channelType: ChannelType.GROUP,
+		});
+		const result = await botAwarenessProvider.get(
+			runtime,
+			inbound,
+			EMPTY_STATE,
+		);
+		// Latest turn is a bot, but the agent has not replied since the last
+		// human turn — no agent↔bot loop is in progress.
+		expect(result).toEqual({ text: "", values: {}, data: {} });
+	});
+
+	it("stays quiet when the interlocutor is human", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, pingPongRows(runtime.agentId, HUMAN_A, 4));
+		const inbound = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN_A,
+			text: "humans keep talking",
+			channelType: ChannelType.GROUP,
+		});
+		const result = await botAwarenessProvider.get(
+			runtime,
+			inbound,
+			EMPTY_STATE,
+		);
+		expect(result).toEqual({ text: "", values: {}, data: {} });
+	});
+
+	it("is INERT in DMs even for a bot interlocutor", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, [
+			makeRow({
+				roomId: DM_ROOM,
+				entityId: OTHER_BOT,
+				text: "bot dm",
+				fromBot: true,
+			}),
+			makeRow({ roomId: DM_ROOM, entityId: runtime.agentId, text: "reply" }),
+		]);
+		const inbound = makeRow({
+			roomId: DM_ROOM,
+			entityId: OTHER_BOT,
+			text: "bot dm again",
+			fromBot: true,
+			channelType: ChannelType.DM,
+		});
+		const result = await botAwarenessProvider.get(
+			runtime,
+			inbound,
+			EMPTY_STATE,
+		);
+		expect(result).toEqual({ text: "", values: {}, data: {} });
+	});
+
+	it("assessBotLoop requires both bot and agent turns in the human-free tail", () => {
+		const base = {
+			windowSize: 6,
+			agentTurns: 2,
+			agentShare: 0.33,
+			participantCount: 2,
+			pingPongRun: 0,
+			humanInWindow: true,
+		};
+		expect(
+			assessBotLoop({
+				...base,
+				latestFromBot: true,
+				agentTurnsSinceLastHuman: 1,
+				botTurnsSinceLastHuman: 2,
+			}).active,
+		).toBe(true);
+		// Bot posted but agent never engaged: not a loop.
+		expect(
+			assessBotLoop({
+				...base,
+				latestFromBot: true,
+				agentTurnsSinceLastHuman: 0,
+				botTurnsSinceLastHuman: 3,
+			}).active,
+		).toBe(false);
+		// Agent talked but latest turn is human-authored: not a loop.
+		expect(
+			assessBotLoop({
+				...base,
+				latestFromBot: false,
+				agentTurnsSinceLastHuman: 2,
+				botTurnsSinceLastHuman: 1,
+			}).active,
+		).toBe(false);
+	});
+
+	it("computeGroupConversationMetrics counts the ping-pong tail strictly", () => {
+		const agent = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+		const window = [
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_C, text: "old" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "a1" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: agent, text: "r1" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "a2" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: agent, text: "r2" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_A, text: "a3" }),
+			makeRow({ roomId: GROUP_ROOM, entityId: agent, text: "r3" }),
+		];
+		const metrics = computeGroupConversationMetrics(window, agent);
+		expect(metrics.pingPongRun).toBe(3);
+		expect(metrics.participantCount).toBe(2);
+		// A third party breaking the tail resets the run: the strict suffix is
+		// now just agent↔HUMAN_B (one agent turn), well below the ping-pong
+		// threshold — the deep alternation with HUMAN_A no longer counts.
+		const broken = [
+			...window,
+			makeRow({ roomId: GROUP_ROOM, entityId: HUMAN_B, text: "interrupt" }),
+		];
+		expect(computeGroupConversationMetrics(broken, agent).pingPongRun).toBe(1);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/anxiety.ts
+++ b/packages/core/src/features/basic-capabilities/providers/anxiety.ts
@@ -1,0 +1,237 @@
+/**
+ * ANXIETY — evidence-based social-cost signal for multi-party channels.
+ *
+ * Modernizes the original bootstrap anxiety provider (which returned three
+ * RANDOM canned "you are too verbose" lines regardless of what was happening
+ * in the room). This version computes rising pressure from LIVE room state:
+ *
+ *   - talked-too-much: the agent's share of the recent dialogue window versus
+ *     its fair share of the floor (1 / (participants + 1)), so the same
+ *     number of agent turns weighs heavier in a crowded room — the
+ *     "anxiety based on room" calibration,
+ *   - ping-pong: a strict tail alternation between the agent and one other
+ *     sender (A→B→A→B) ramps pressure even at moderate overall share,
+ *   - dampeners: zero pressure when the agent has been quiet, and strong
+ *     damping when a human just directly addressed the agent — genuine
+ *     engagement is never suppressed.
+ *
+ * Output is advisory prompt text only (soft signal, like the original): at
+ * low pressure a light "brevity is welcome" note, at high pressure a strong
+ * "you have been dominating the floor — prefer IGNORE / a reaction / silence"
+ * instruction. IGNORE-as-valid-response framing is kept from the original.
+ *
+ * Strictly group-only: DMs, voice DMs, API and unknown channels return the
+ * empty result ("just group chat" — Shaw + Shadow, 2026-08-23). Cheap on the
+ * hot path: reads the already-composed RECENT_MESSAGES state, falling back to
+ * the runtime's coalesced room messages-scan; no model calls, no embeddings,
+ * no new query shapes.
+ *
+ * Calibration is a plain exported constant consumed through a parameter, so a
+ * host can compute per-room calibration later without changing the provider
+ * contract. No agent- or deployment-specific values are hardcoded.
+ */
+
+import type {
+	IAgentRuntime,
+	Memory,
+	Provider,
+	State,
+} from "../../../types/index.ts";
+import { addHeader } from "../../../utils.ts";
+import {
+	computeGroupConversationMetrics,
+	type GroupConversationMetrics,
+	humanDirectlyAddressesAgent,
+	isMultiPartyChannel,
+	loadDialogueWindow,
+	resolveChannelType,
+} from "./group-conversation-signals.ts";
+
+const EMPTY_RESULT = { text: "", values: {}, data: {} } as const;
+
+export interface AnxietyCalibration {
+	/** Excess-share multiplier: how fast pressure grows past fair share. */
+	excessShareGain: number;
+	/** Agent turns in the tail alternation before ping-pong pressure starts. */
+	pingPongThreshold: number;
+	/** Pressure added per agent turn past the ping-pong threshold. */
+	pingPongGain: number;
+	/** Cap on the crowd multiplier applied to excess share. */
+	maxCrowdFactor: number;
+	/** Pressure below this renders nothing (quiet rooms stay unprompted). */
+	noticeFloor: number;
+	/** Pressure at or above this renders the strong yield-the-floor text. */
+	highWatermark: number;
+	/** Multiplier applied when a human just directly addressed the agent. */
+	addressedDamping: number;
+}
+
+export const DEFAULT_ANXIETY_CALIBRATION: AnxietyCalibration = {
+	excessShareGain: 2.5,
+	pingPongThreshold: 2,
+	pingPongGain: 0.2,
+	maxCrowdFactor: 2,
+	noticeFloor: 0.15,
+	highWatermark: 0.7,
+	addressedDamping: 0.25,
+};
+
+export interface AnxietyPressure {
+	/** Final pressure in [0, 1]. */
+	pressure: number;
+	/** Component: excess-share (talked-too-much) contribution before damping. */
+	talkPressure: number;
+	/** Component: ping-pong contribution before damping. */
+	pingPongPressure: number;
+	/** The fair floor share used for the excess computation. */
+	fairShare: number;
+	/** Whether the addressed-by-a-human dampener applied. */
+	dampedByAddress: boolean;
+}
+
+/**
+ * Pure pressure computation over the room metrics. Exported for tests and for
+ * hosts that want to feed per-room calibration.
+ */
+export function computeAnxietyPressure(
+	metrics: GroupConversationMetrics,
+	addressedByHuman: boolean,
+	calibration: AnxietyCalibration = DEFAULT_ANXIETY_CALIBRATION,
+): AnxietyPressure {
+	// A silent agent has no social cost to manage.
+	if (metrics.windowSize === 0 || metrics.agentTurns === 0) {
+		return {
+			pressure: 0,
+			talkPressure: 0,
+			pingPongPressure: 0,
+			fairShare: 1,
+			dampedByAddress: false,
+		};
+	}
+
+	// Fair share of the floor: one voice among the humans present. More
+	// participants → smaller fair share → the same agent turn count produces
+	// more excess. This is the room-aware core.
+	const fairShare = 1 / (metrics.participantCount + 1);
+	const excess = Math.max(0, metrics.agentShare - fairShare);
+	// Crowd factor: busier rooms (more distinct participants) ramp faster.
+	const crowdFactor = Math.min(
+		calibration.maxCrowdFactor,
+		1 + Math.max(0, metrics.participantCount - 1) / 4,
+	);
+	const talkPressure = Math.min(
+		1,
+		excess * calibration.excessShareGain * crowdFactor,
+	);
+
+	const pingPongPressure = Math.min(
+		1,
+		Math.max(0, metrics.pingPongRun - calibration.pingPongThreshold) *
+			calibration.pingPongGain,
+	);
+
+	let pressure = Math.min(1, talkPressure + pingPongPressure);
+	const dampedByAddress = addressedByHuman && pressure > 0;
+	if (dampedByAddress) {
+		pressure *= calibration.addressedDamping;
+	}
+
+	return {
+		pressure,
+		talkPressure,
+		pingPongPressure,
+		fairShare,
+		dampedByAddress,
+	};
+}
+
+function renderAnxietyText(
+	metrics: GroupConversationMetrics,
+	result: AnxietyPressure,
+	calibration: AnxietyCalibration,
+): string {
+	const sharePct = Math.round(metrics.agentShare * 100);
+	const lines: string[] = [];
+	if (result.pressure >= calibration.highWatermark) {
+		lines.push(
+			`You have sent ${metrics.agentTurns} of the last ${metrics.windowSize} messages in this group (${sharePct}% of the floor). That is a lot. Others should have the floor now.`,
+		);
+		if (result.pingPongPressure > 0) {
+			lines.push(
+				"You are in a rapid back-and-forth with a single participant. Step out of the exchange rather than extending it.",
+			);
+		}
+		lines.push(
+			"Strongly prefer IGNORE, a brief reaction, or silence over another reply. Only respond if directly asked something new.",
+		);
+	} else {
+		lines.push(
+			`You have been fairly active here (${metrics.agentTurns} of the last ${metrics.windowSize} messages). Keep replies short and let the conversation breathe.`,
+		);
+		if (result.pingPongPressure > 0) {
+			lines.push(
+				"You are trading messages with one participant repeatedly — avoid turning the group channel into a two-way thread.",
+			);
+		}
+		lines.push(
+			"IGNORE is a valid and often better response than a marginal reply.",
+		);
+	}
+	if (result.dampedByAddress) {
+		lines.push(
+			"That said, you were just directly addressed — a focused, concise answer to that is appropriate.",
+		);
+	}
+	return addHeader("# Group conversation awareness", lines.join("\n"));
+}
+
+export const anxietyProvider: Provider = {
+	name: "ANXIETY",
+	description:
+		"Evidence-based social-cost signal for group channels: rises with the agent's share of recent turns and ping-pong exchanges; inert in DMs. Advisory only — never gates action selection.",
+	dynamic: true,
+	position: -3,
+	contexts: ["general"],
+	contextGate: { anyOf: ["general"] },
+	cacheStable: false,
+	cacheScope: "turn",
+	// Reach the Stage-1 response state regardless of selected contexts (like
+	// CHANNEL_TOPICS): the whole point is to shape shouldRespond on ambient
+	// group turns.
+	alwaysInResponseState: true,
+	roleGate: { minRole: "GUEST" },
+
+	get: async (runtime: IAgentRuntime, message: Memory, state: State) => {
+		try {
+			const channelType = await resolveChannelType(runtime, message);
+			if (!isMultiPartyChannel(channelType)) {
+				// "Just group chat": DMs and private channels stay inert.
+				return { ...EMPTY_RESULT };
+			}
+			const window = await loadDialogueWindow(runtime, message, state);
+			const metrics = computeGroupConversationMetrics(window, runtime.agentId);
+			const addressed = humanDirectlyAddressesAgent(runtime, message);
+			const calibration = DEFAULT_ANXIETY_CALIBRATION;
+			const result = computeAnxietyPressure(metrics, addressed, calibration);
+			if (result.pressure < calibration.noticeFloor) {
+				return { ...EMPTY_RESULT };
+			}
+			const text = renderAnxietyText(metrics, result, calibration);
+			return {
+				text,
+				values: {
+					anxietyPressure: Number(result.pressure.toFixed(3)),
+					anxietyAgentShare: Number(metrics.agentShare.toFixed(3)),
+					anxietyPingPongRun: metrics.pingPongRun,
+					anxietyParticipantCount: metrics.participantCount,
+					anxietyDampedByAddress: result.dampedByAddress,
+				},
+				data: { metrics, pressure: result },
+			};
+		} catch {
+			// Advisory signal only: any failure degrades to no guidance rather
+			// than disturbing the turn.
+			return { ...EMPTY_RESULT };
+		}
+	},
+};

--- a/packages/core/src/features/basic-capabilities/providers/botAwareness.ts
+++ b/packages/core/src/features/basic-capabilities/providers/botAwareness.ts
@@ -1,0 +1,145 @@
+/**
+ * BOT_AWARENESS — anti-loop signal for agent-to-agent exchanges in group
+ * channels.
+ *
+ * Two agents that both reply to replies can trap each other in an endless
+ * mutual-acknowledgement loop with no human in the exchange. This provider
+ * gives the model explicit awareness that a recent interlocutor is another
+ * bot, using the connector-stamped `fromBot` metadata (the same ground truth
+ * the transcript formatter renders as "Name (bot)" and the bot-noise triage
+ * gate reads — never name-guessing).
+ *
+ * Fires only when BOTH hold:
+ *   - the latest inbound turn is bot-authored, and
+ *   - there has been agent↔bot back-and-forth with NO human turn in between
+ *     (bot turns + own turns since the last human message).
+ *
+ * The guidance escalates with the depth of the human-free bot exchange, from
+ * "you're talking to another bot — don't mirror its conversational reflexes"
+ * to "let it drop: prefer IGNORE / silence until a human advances the
+ * conversation." Soft signal only: when a human is active in the gap, or the
+ * interlocutor is human, the provider renders nothing and behavior is normal.
+ *
+ * Group-only like ANXIETY (Shaw framed these as two separate things, so it is
+ * a separate provider — they share the room-signal helpers). Same hot-path
+ * discipline: composed recent-messages state or the coalesced room scan; no
+ * model calls, no embeddings, no new DB query shapes.
+ */
+
+import type {
+	IAgentRuntime,
+	Memory,
+	Provider,
+	State,
+} from "../../../types/index.ts";
+import { addHeader } from "../../../utils.ts";
+import {
+	computeGroupConversationMetrics,
+	type GroupConversationMetrics,
+	isBotAuthoredMessage,
+	isMultiPartyChannel,
+	loadDialogueWindow,
+	resolveChannelType,
+} from "./group-conversation-signals.ts";
+
+const EMPTY_RESULT = { text: "", values: {}, data: {} } as const;
+
+/**
+ * Bot-loop assessment: fires when the newest turn is bot-authored and the
+ * agent has already replied at least once inside the human-free tail — i.e.
+ * an actual bot↔agent exchange, not merely a bot posting into the room.
+ */
+export interface BotLoopAssessment {
+	active: boolean;
+	/** Human-free exchange depth (agent turns + bot turns since last human). */
+	exchangeDepth: number;
+	/** Whether the loop has gone deep (escalated wording). */
+	deep: boolean;
+}
+
+/** Exchange depth at which the wording escalates to "let it drop". */
+export const DEEP_BOT_LOOP_DEPTH = 4;
+
+export function assessBotLoop(
+	metrics: GroupConversationMetrics,
+): BotLoopAssessment {
+	const exchangeDepth =
+		metrics.agentTurnsSinceLastHuman + metrics.botTurnsSinceLastHuman;
+	const active =
+		metrics.latestFromBot &&
+		metrics.botTurnsSinceLastHuman > 0 &&
+		metrics.agentTurnsSinceLastHuman > 0;
+	return {
+		active,
+		exchangeDepth,
+		deep: active && exchangeDepth >= DEEP_BOT_LOOP_DEPTH,
+	};
+}
+
+function renderBotAwarenessText(assessment: BotLoopAssessment): string {
+	const lines: string[] = [
+		"The message you are looking at was written by another bot/agent, and no human has spoken since this exchange began.",
+	];
+	if (assessment.deep) {
+		lines.push(
+			`This bot-to-bot exchange is already ${assessment.exchangeDepth} messages deep with no human input. Let it drop: do not reply to its reply. Prefer IGNORE or silence until a human advances the conversation.`,
+		);
+	} else {
+		lines.push(
+			"Do not get pulled into a loop: another agent will answer politeness with politeness and questions with questions indefinitely. If its message contains nothing a human asked for, there is no obligation to respond — IGNORE is the right move.",
+		);
+	}
+	lines.push(
+		"Never reply-to-a-reply between bots without a human advancing the conversation in between.",
+	);
+	return addHeader("# Talking to another bot", lines.join("\n"));
+}
+
+export const botAwarenessProvider: Provider = {
+	name: "BOT_AWARENESS",
+	description:
+		"Anti-loop awareness for group channels: flags when the current interlocutor is another bot and the exchange has had no intervening human turn. Advisory only — never gates action selection.",
+	dynamic: true,
+	position: -3,
+	contexts: ["general"],
+	contextGate: { anyOf: ["general"] },
+	cacheStable: false,
+	cacheScope: "turn",
+	// Must reach Stage-1 response state on ambient group turns — that is where
+	// bot-to-bot loops form.
+	alwaysInResponseState: true,
+	roleGate: { minRole: "GUEST" },
+
+	get: async (runtime: IAgentRuntime, message: Memory, state: State) => {
+		try {
+			const channelType = await resolveChannelType(runtime, message);
+			if (!isMultiPartyChannel(channelType)) {
+				// Group chat only — inert in DMs like ANXIETY.
+				return { ...EMPTY_RESULT };
+			}
+			// Cheap precondition: if the inbound turn itself is not bot-authored
+			// there is no loop to warn about, skip the window load entirely.
+			if (!isBotAuthoredMessage(message)) {
+				return { ...EMPTY_RESULT };
+			}
+			const window = await loadDialogueWindow(runtime, message, state);
+			const metrics = computeGroupConversationMetrics(window, runtime.agentId);
+			const assessment = assessBotLoop(metrics);
+			if (!assessment.active) {
+				return { ...EMPTY_RESULT };
+			}
+			return {
+				text: renderBotAwarenessText(assessment),
+				values: {
+					botLoopActive: true,
+					botLoopExchangeDepth: assessment.exchangeDepth,
+					botLoopDeep: assessment.deep,
+				},
+				data: { metrics, assessment },
+			};
+		} catch {
+			// Advisory only — degrade to silence on any failure.
+			return { ...EMPTY_RESULT };
+		}
+	},
+};

--- a/packages/core/src/features/basic-capabilities/providers/group-conversation-signals.ts
+++ b/packages/core/src/features/basic-capabilities/providers/group-conversation-signals.ts
@@ -1,0 +1,270 @@
+/**
+ * Shared room-state signal helpers for the group-chat social providers
+ * (ANXIETY and BOT_AWARENESS). Everything here is deterministic arithmetic
+ * over the already-composed recent-messages window — no model calls, no
+ * embeddings, and no new DB round-trips on the hot path: when the turn state
+ * does not yet carry RECENT_MESSAGES data (first compose of a turn), the
+ * fallback `runtime.getMemories` room-scan is exactly the shape the runtime's
+ * turn-scoped single-flight memo coalesces (see
+ * `runtime.ts#coalesceRoomMessagesScan`), so it shares the one superset fetch
+ * RECENT_MESSAGES/FACTS/ATTACHMENTS already issue instead of adding a query.
+ *
+ * Multi-party eligibility is deliberately group-only: Shaw + Shadow's ask was
+ * "just group chat" — DMs must stay inert, so both consumers gate on
+ * `isMultiPartyChannel` before computing anything.
+ */
+
+import { isInternalBridgeMessage } from "../../../messaging/automated-turns.ts";
+import { getRecentMessagesData } from "../../../recent-messages-state.ts";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.ts";
+import { ChannelType } from "../../../types/index.ts";
+
+/**
+ * Channel types where more than two parties can hold the floor. Mirrors the
+ * Stage-1 text-group set (stage1-prompt-tier.ts) minus FEED (post-style, no
+ * turn-taking) plus VOICE_GROUP (multi-party voice rooms have the same
+ * talked-too-much failure mode). DM / VOICE_DM / SELF / API are deliberately
+ * absent: these signals must never fire in private conversations.
+ */
+const MULTI_PARTY_CHANNEL_TYPES: ReadonlySet<string> = new Set([
+	String(ChannelType.GROUP),
+	String(ChannelType.VOICE_GROUP),
+	String(ChannelType.THREAD),
+	String(ChannelType.WORLD),
+	String(ChannelType.FORUM),
+]);
+
+/** Bounded evidence window; matches the coalesced-scan floor so the fallback
+ * fetch never widens the shared superset window. */
+export const GROUP_SIGNAL_WINDOW = 20;
+
+function metadataRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+/**
+ * Connector-stamped bot authorship — the same ground-truth signal the
+ * transcript formatter (`utils.ts#formatMessages` "Name (bot)" tag) and the
+ * bot-noise triage gate read. Untagged senders are treated as human, so a
+ * connector that omits the stamp degrades to normal behavior.
+ */
+export function isBotAuthoredMessage(message: Memory): boolean {
+	return (
+		metadataRecord(message.metadata)?.fromBot === true ||
+		metadataRecord(message.content?.metadata)?.fromBot === true
+	);
+}
+
+/** Resolve the effective channel type: inbound content first, room row second. */
+export async function resolveChannelType(
+	runtime: IAgentRuntime,
+	message: Memory,
+): Promise<string> {
+	const fromContent = message.content?.channelType;
+	if (typeof fromContent === "string" && fromContent.trim() !== "") {
+		return fromContent.trim().toUpperCase();
+	}
+	if (!message.roomId) return "";
+	try {
+		// Coalesced by the runtime's turn-scoped getRoom memo — no extra
+		// round-trip within a compose fan-out.
+		const room = await runtime.getRoom(message.roomId);
+		return room?.type ? String(room.type).trim().toUpperCase() : "";
+	} catch {
+		return "";
+	}
+}
+
+export function isMultiPartyChannel(channelType: string): boolean {
+	return MULTI_PARTY_CHANNEL_TYPES.has(channelType);
+}
+
+function isDialogueMessage(memory: Memory): boolean {
+	return (
+		memory.content?.type !== "action_result" && !isInternalBridgeMessage(memory)
+	);
+}
+
+/**
+ * Load the bounded dialogue window for signal computation. Prefers the
+ * RECENT_MESSAGES provider's already-composed array (turn recompose); falls
+ * back to the coalesced room messages-scan on the first compose of a turn.
+ * The current inbound message is appended when the stored window does not
+ * already contain it, so tail signals always see the live turn.
+ */
+export async function loadDialogueWindow(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State,
+): Promise<Memory[]> {
+	const composed = getRecentMessagesData(state);
+	let source: Memory[];
+	if (composed.length > 0) {
+		source = composed;
+	} else if (message.roomId) {
+		try {
+			source = await runtime.getMemories({
+				tableName: "messages",
+				roomId: message.roomId,
+				limit: GROUP_SIGNAL_WINDOW,
+				unique: false,
+			});
+		} catch {
+			source = [];
+		}
+	} else {
+		source = [];
+	}
+	const window = source
+		.filter(isDialogueMessage)
+		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+		.slice(-GROUP_SIGNAL_WINDOW);
+	const hasInbound =
+		message.id !== undefined && window.some((entry) => entry.id === message.id);
+	if (!hasInbound && isDialogueMessage(message)) {
+		window.push(message);
+	}
+	return window.slice(-GROUP_SIGNAL_WINDOW);
+}
+
+export interface GroupConversationMetrics {
+	/** Dialogue turns considered (bounded by GROUP_SIGNAL_WINDOW). */
+	windowSize: number;
+	/** Turns in the window authored by this agent. */
+	agentTurns: number;
+	/** agentTurns / windowSize (0 when the window is empty). */
+	agentShare: number;
+	/** Distinct non-agent senders seen in the window. */
+	participantCount: number;
+	/** Agent turns inside the strict agent↔single-other alternation ending the window. */
+	pingPongRun: number;
+	/** Whether the latest inbound turn is connector-stamped bot-authored. */
+	latestFromBot: boolean;
+	/** Agent turns since the last human (non-agent, non-bot) turn in the window. */
+	agentTurnsSinceLastHuman: number;
+	/** Bot-authored turns since the last human turn in the window. */
+	botTurnsSinceLastHuman: number;
+	/** Whether any human turn exists inside the window at all. */
+	humanInWindow: boolean;
+}
+
+/**
+ * Compute the evidence signals both providers read. Pure function over the
+ * dialogue window; the agent's own turns are identified by entityId.
+ */
+export function computeGroupConversationMetrics(
+	window: Memory[],
+	agentId: UUID,
+): GroupConversationMetrics {
+	const windowSize = window.length;
+	let agentTurns = 0;
+	const participants = new Set<string>();
+	for (const entry of window) {
+		if (entry.entityId === agentId) {
+			agentTurns += 1;
+		} else if (entry.entityId) {
+			participants.add(String(entry.entityId));
+		}
+	}
+
+	// Strict tail alternation between the agent and ONE other sender:
+	// … agent, X, agent, X — the ping-pong shape. Counts the agent's turns in
+	// that suffix; breaks on any third party or a repeated speaker.
+	let pingPongRun = 0;
+	let otherParty: string | null = null;
+	let previousWasAgent: boolean | null = null;
+	for (let i = window.length - 1; i >= 0; i -= 1) {
+		const entry = window[i];
+		const isAgent = entry.entityId === agentId;
+		if (!isAgent) {
+			const sender = entry.entityId ? String(entry.entityId) : null;
+			if (!sender) break;
+			if (otherParty === null) {
+				otherParty = sender;
+			} else if (otherParty !== sender) {
+				break;
+			}
+		}
+		if (previousWasAgent !== null && previousWasAgent === isAgent) {
+			break;
+		}
+		previousWasAgent = isAgent;
+		if (isAgent) pingPongRun += 1;
+	}
+
+	// Gap since the last human turn (human = not this agent, not bot-stamped).
+	let agentTurnsSinceLastHuman = 0;
+	let botTurnsSinceLastHuman = 0;
+	let humanInWindow = false;
+	for (let i = window.length - 1; i >= 0; i -= 1) {
+		const entry = window[i];
+		if (entry.entityId === agentId) {
+			agentTurnsSinceLastHuman += 1;
+			continue;
+		}
+		if (isBotAuthoredMessage(entry)) {
+			botTurnsSinceLastHuman += 1;
+			continue;
+		}
+		humanInWindow = true;
+		break;
+	}
+	if (!humanInWindow) {
+		humanInWindow = window.some(
+			(entry) => entry.entityId !== agentId && !isBotAuthoredMessage(entry),
+		);
+	}
+
+	const latest = window[window.length - 1];
+	return {
+		windowSize,
+		agentTurns,
+		agentShare: windowSize > 0 ? agentTurns / windowSize : 0,
+		participantCount: participants.size,
+		pingPongRun,
+		latestFromBot: latest ? isBotAuthoredMessage(latest) : false,
+		agentTurnsSinceLastHuman,
+		botTurnsSinceLastHuman,
+		humanInWindow,
+	};
+}
+
+/**
+ * Structural "a human just addressed the agent" dampener: platform mention or
+ * reply, or the agent's configured name appearing as a whole word in the
+ * inbound text — and the inbound sender is not itself a bot. Deliberately a
+ * lightweight mirror of the Stage-1 addressing signal (services/message.ts):
+ * providers cannot import that module without an import cycle, and this
+ * dampener only relaxes advisory guidance, never gates a response.
+ */
+export function humanDirectlyAddressesAgent(
+	runtime: IAgentRuntime,
+	message: Memory,
+): boolean {
+	if (isBotAuthoredMessage(message)) return false;
+	const mentionContext = message.content?.mentionContext;
+	if (mentionContext?.isMention === true || mentionContext?.isReply === true) {
+		return true;
+	}
+	const text = message.content?.text;
+	if (!text) return false;
+	const names = [runtime.character?.name, runtime.character?.username];
+	for (const name of names) {
+		const candidate = typeof name === "string" ? name.trim() : "";
+		if (candidate.length < 2) continue;
+		const escaped = candidate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const pattern = new RegExp(
+			`(^|[^\\p{L}\\p{N}])${escaped}(?=$|[^\\p{L}\\p{N}])`,
+			"iu",
+		);
+		if (pattern.test(text)) return true;
+	}
+	return false;
+}

--- a/packages/core/src/features/basic-capabilities/providers/index.ts
+++ b/packages/core/src/features/basic-capabilities/providers/index.ts
@@ -6,7 +6,9 @@
 
 export { actionStateProvider } from "./actionState.ts";
 export { actionsProvider } from "./actions.ts";
+export { anxietyProvider } from "./anxiety.ts";
 export { attachmentsProvider } from "./attachments.ts";
+export { botAwarenessProvider } from "./botAwareness.ts";
 export { channelTopicsProvider } from "./channelTopics.ts";
 export { characterProvider } from "./character.ts";
 export { choiceProvider } from "./choice.ts";
@@ -40,7 +42,9 @@ import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // when a consumer dereferences a re-exported binding at runtime.
 import { actionStateProvider as _bs_1_actionStateProvider } from "./actionState.ts";
 import { actionsProvider as _bs_2_actionsProvider } from "./actions.ts";
+import { anxietyProvider as _bs_21_anxietyProvider } from "./anxiety.ts";
 import { attachmentsProvider as _bs_3_attachmentsProvider } from "./attachments.ts";
+import { botAwarenessProvider as _bs_22_botAwarenessProvider } from "./botAwareness.ts";
 import { channelTopicsProvider as _bs_19_channelTopicsProvider } from "./channelTopics.ts";
 import { characterProvider as _bs_4_characterProvider } from "./character.ts";
 import { choiceProvider as _bs_5_choiceProvider } from "./choice.ts";
@@ -82,4 +86,6 @@ anchorBundleSafety("FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX", [
 	_bs_18_runtimeModelContextProvider,
 	_bs_19_channelTopicsProvider,
 	_bs_20_replyContextProvider,
+	_bs_21_anxietyProvider,
+	_bs_22_botAwarenessProvider,
 ]);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -349,6 +349,7 @@ import { toWellFormedUnicode } from "../utils/well-formed";
 import { maybeHandleAnalysisActivation } from "./analysis-mode-handler";
 import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
+import { runBotLoopGate } from "./message/bot-loop-gate";
 import { runBotNoiseTriage } from "./message/bot-noise-triage";
 import {
 	type DirectCurrentRequestCandidateInference,
@@ -13536,6 +13537,37 @@ export class DefaultMessageService implements IMessageService {
 				"Unaddressed bot/webhook message ignored by small-model triage (skipped Stage 1)",
 			);
 			runTerminalOwner.request("bot_noise_triage");
+			return {
+				didRespond: false,
+				responseContent: null,
+				responseMessages: [],
+				state: { values: {}, data: {}, text: "" } as State,
+				mode: "none",
+			};
+		}
+
+		// Deterministic bot-to-bot loop gate — the model-size-independent floor
+		// beneath the soft ANXIETY / BOT_AWARENESS providers and the #25405
+		// shouldRespond restraint rules. Small models (gemma-class) do not
+		// reliably follow those prompt signals, so the hard stop lives here in
+		// code: a bot-authored group turn arriving after the agent has already
+		// produced N consecutive turns with no intervening human message ends
+		// deterministically with IGNORE before any model call. Every
+		// unverifiable input (untagged sender, unknown channel, read failure)
+		// fails OPEN — the gate only ever biases toward silence, never speech.
+		const botLoopGate = await runBotLoopGate({ runtime, message });
+		if (botLoopGate.ignored) {
+			runtime.logger.info(
+				{
+					src: "service:message",
+					agentId: runtime.agentId,
+					roomId: message.roomId,
+					entityId: message.entityId,
+					agentTurnsSinceLastHuman: botLoopGate.agentTurnsSinceLastHuman,
+				},
+				"Bot-to-bot exchange with no intervening human turn — deterministic IGNORE (bot-loop gate)",
+			);
+			runTerminalOwner.request("bot_loop_gate");
 			return {
 				didRespond: false,
 				responseContent: null,

--- a/packages/core/src/services/message/bot-loop-gate.test.ts
+++ b/packages/core/src/services/message/bot-loop-gate.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Deterministic bot-loop gate tests — the proof that the anti-loop floor
+ * works INDEPENDENT of model instruction-following: `runBotLoopGate` is pure
+ * code over the room window, so these assertions hold identically for a
+ * gemma-class small model and a frontier model (the model is never invoked;
+ * there is nothing for it to obey or ignore).
+ *
+ * Covered:
+ *  - trips (IGNORE) for an all-bot back-and-forth with no intervening human
+ *    turn once the agent has produced >= N consecutive turns,
+ *  - does NOT trip when a human has spoken since the agent's last turn,
+ *  - does NOT trip for human-authored or untagged inbound (fail-open),
+ *  - inert in DMs (group-only scoping),
+ *  - first bot contact is allowed (the agent may answer a bot once; the gate
+ *    stops the reply-to-a-reply),
+ *  - opt-out setting and threshold clamping,
+ *  - read failure fails open (a DB error never mutes the agent).
+ *
+ * Deterministic: real AgentRuntime + InMemoryDatabaseAdapter, zero model
+ * calls (asserted via a throwing useModel stub).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { createCharacter } from "../../character";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import type { Memory, UUID } from "../../types/index";
+import { ChannelType } from "../../types/index";
+import {
+	botLoopMaxAgentTurns,
+	DEFAULT_BOT_LOOP_MAX_AGENT_TURNS,
+	isBotLoopGateEnabled,
+	runBotLoopGate,
+} from "./bot-loop-gate";
+
+const WORLD_ID = "66666666-6666-6666-6666-666666666660" as UUID;
+const GROUP_ROOM = "66666666-6666-6666-6666-666666666661" as UUID;
+const DM_ROOM = "66666666-6666-6666-6666-666666666662" as UUID;
+const HUMAN = "66666666-6666-6666-6666-6666666666aa" as UUID;
+const OTHER_BOT = "66666666-6666-6666-6666-6666666666bb" as UUID;
+
+const activeRuntimes: AgentRuntime[] = [];
+
+afterEach(async () => {
+	while (activeRuntimes.length > 0) {
+		await activeRuntimes.pop()?.stop();
+	}
+});
+
+async function makeRuntime(settings?: Record<string, string>): Promise<{
+	runtime: AgentRuntime;
+	adapter: InMemoryDatabaseAdapter;
+}> {
+	const adapter = new InMemoryDatabaseAdapter();
+	const runtime = new AgentRuntime({
+		character: createCharacter({
+			name: "GateAgent",
+			...(settings ? { settings } : {}),
+		}),
+		adapter,
+		logLevel: "fatal",
+		enableAutonomy: false,
+	});
+	await runtime.initialize();
+	// Model-independence proof: any model call during the gate is a failure.
+	runtime.useModel = (async () => {
+		throw new Error("bot-loop gate must not call a model");
+	}) as typeof runtime.useModel;
+	await adapter.createWorlds([
+		{
+			id: WORLD_ID,
+			agentId: runtime.agentId,
+			name: "gate world",
+			metadata: { roles: {} },
+		},
+	]);
+	await adapter.createRooms([
+		{
+			id: GROUP_ROOM,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.GROUP,
+			worldId: WORLD_ID,
+		},
+		{
+			id: DM_ROOM,
+			agentId: runtime.agentId,
+			source: "test",
+			type: ChannelType.DM,
+			worldId: WORLD_ID,
+		},
+	]);
+	activeRuntimes.push(runtime);
+	return { runtime, adapter };
+}
+
+let rowCounter = 0;
+
+function makeRow(args: {
+	roomId: UUID;
+	entityId: UUID;
+	text: string;
+	fromBot?: boolean;
+	channelType?: ChannelType;
+}): Memory {
+	rowCounter += 1;
+	const suffix = rowCounter.toString(16).padStart(12, "0");
+	return {
+		id: `abababab-abab-abab-abab-${suffix}` as UUID,
+		entityId: args.entityId,
+		roomId: args.roomId,
+		worldId: WORLD_ID,
+		createdAt: 50_000 + rowCounter,
+		content: {
+			text: args.text,
+			source: "test",
+			...(args.channelType ? { channelType: args.channelType } : {}),
+		},
+		...(args.fromBot ? { metadata: { fromBot: true } } : {}),
+	} as Memory;
+}
+
+async function seed(
+	adapter: InMemoryDatabaseAdapter,
+	rows: Memory[],
+): Promise<void> {
+	await adapter.createMemories(
+		rows.map((memory) => ({ memory, tableName: "messages" })),
+	);
+}
+
+/** History: human kicks off, then `volleys` bot→agent pairs (no human since). */
+function botExchangeRows(
+	agentId: UUID,
+	volleys: number,
+	roomId: UUID = GROUP_ROOM,
+): Memory[] {
+	const rows: Memory[] = [
+		makeRow({ roomId, entityId: HUMAN, text: "hello agents" }),
+	];
+	for (let i = 0; i < volleys; i += 1) {
+		rows.push(
+			makeRow({
+				roomId,
+				entityId: OTHER_BOT,
+				text: `bot volley ${i}`,
+				fromBot: true,
+			}),
+			makeRow({ roomId, entityId: agentId, text: `agent volley ${i}` }),
+		);
+	}
+	return rows;
+}
+
+function botInbound(
+	roomId: UUID = GROUP_ROOM,
+	channelType?: ChannelType,
+): Memory {
+	return makeRow({
+		roomId,
+		entityId: OTHER_BOT,
+		text: "and another thing!",
+		fromBot: true,
+		...(channelType ? { channelType } : {}),
+	});
+}
+
+describe("runBotLoopGate — deterministic anti-loop floor", () => {
+	it("returns IGNORE for an all-bot back-and-forth with no human turn (model never consulted)", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		// Agent already sent 2 consecutive turns into the human-free exchange.
+		await seed(adapter, botExchangeRows(runtime.agentId, 2));
+		const result = await runBotLoopGate({
+			runtime,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		expect(result.ignored).toBe(true);
+		expect(result.agentTurnsSinceLastHuman).toBeGreaterThanOrEqual(
+			DEFAULT_BOT_LOOP_MAX_AGENT_TURNS,
+		);
+	});
+
+	it("does NOT trip when a human has spoken since the agent's last turn", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, [
+			...botExchangeRows(runtime.agentId, 2),
+			// Human advances the conversation — counters reset.
+			makeRow({
+				roomId: GROUP_ROOM,
+				entityId: HUMAN,
+				text: "ok you two, actual question:",
+			}),
+		]);
+		const result = await runBotLoopGate({
+			runtime,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		expect(result.ignored).toBe(false);
+		expect(result.reason).toBe("below_threshold");
+	});
+
+	it("allows the FIRST reply to a bot (loop starts at the reply-to-a-reply)", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		// Only one agent turn so far in the human-free tail — below N=2.
+		await seed(adapter, botExchangeRows(runtime.agentId, 1));
+		const result = await runBotLoopGate({
+			runtime,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		expect(result.ignored).toBe(false);
+		expect(result.reason).toBe("below_threshold");
+	});
+
+	it("fails open for human-authored and untagged inbound messages", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, botExchangeRows(runtime.agentId, 3));
+		const humanMessage = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: HUMAN,
+			text: "a human speaks",
+			channelType: ChannelType.GROUP,
+		});
+		expect(
+			(await runBotLoopGate({ runtime, message: humanMessage })).ignored,
+		).toBe(false);
+		// Untagged sender (connector omitted fromBot): treated as human.
+		const untagged = makeRow({
+			roomId: GROUP_ROOM,
+			entityId: OTHER_BOT,
+			text: "no stamp on this one",
+			channelType: ChannelType.GROUP,
+		});
+		const untaggedResult = await runBotLoopGate({
+			runtime,
+			message: untagged,
+		});
+		expect(untaggedResult.ignored).toBe(false);
+		expect(untaggedResult.reason).toBe("not_bot_authored");
+	});
+
+	it("is inert in DMs regardless of exchange depth (group-only scoping)", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, botExchangeRows(runtime.agentId, 5, DM_ROOM));
+		const result = await runBotLoopGate({
+			runtime,
+			message: botInbound(DM_ROOM, ChannelType.DM),
+		});
+		expect(result.ignored).toBe(false);
+		expect(result.reason).toBe("not_group_channel");
+	});
+
+	it("respects the opt-out setting and clamps the threshold", async () => {
+		const { runtime, adapter } = await makeRuntime({
+			ELIZA_BOT_LOOP_GATE: "off",
+		});
+		await seed(adapter, botExchangeRows(runtime.agentId, 4));
+		expect(isBotLoopGateEnabled(runtime)).toBe(false);
+		const result = await runBotLoopGate({
+			runtime,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		expect(result.ignored).toBe(false);
+		expect(result.reason).toBe("disabled");
+
+		// Threshold clamp: junk and sub-1 values fall back to the default.
+		const { runtime: clamped } = await makeRuntime({
+			ELIZA_BOT_LOOP_MAX_AGENT_TURNS: "0",
+		});
+		expect(botLoopMaxAgentTurns(clamped)).toBe(
+			DEFAULT_BOT_LOOP_MAX_AGENT_TURNS,
+		);
+		const { runtime: junk } = await makeRuntime({
+			ELIZA_BOT_LOOP_MAX_AGENT_TURNS: "banana",
+		});
+		expect(botLoopMaxAgentTurns(junk)).toBe(DEFAULT_BOT_LOOP_MAX_AGENT_TURNS);
+		const { runtime: raised } = await makeRuntime({
+			ELIZA_BOT_LOOP_MAX_AGENT_TURNS: "5",
+		});
+		expect(botLoopMaxAgentTurns(raised)).toBe(5);
+	});
+
+	it("honors a raised threshold before tripping", async () => {
+		const { runtime, adapter } = await makeRuntime({
+			ELIZA_BOT_LOOP_MAX_AGENT_TURNS: "4",
+		});
+		await seed(adapter, botExchangeRows(runtime.agentId, 3));
+		const below = await runBotLoopGate({
+			runtime,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		expect(below.ignored).toBe(false);
+
+		const { runtime: runtime2, adapter: adapter2 } = await makeRuntime({
+			ELIZA_BOT_LOOP_MAX_AGENT_TURNS: "4",
+		});
+		await seed(adapter2, botExchangeRows(runtime2.agentId, 4));
+		const at = await runBotLoopGate({
+			runtime: runtime2,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		expect(at.ignored).toBe(true);
+	});
+
+	it("fails open when the room window read throws (never mutes on error)", async () => {
+		const { runtime, adapter } = await makeRuntime();
+		await seed(adapter, botExchangeRows(runtime.agentId, 3));
+		const realGetMemories = adapter.getMemories.bind(adapter);
+		// Scoped failure: only the gate's own bounded room-window scan throws, so
+		// unrelated background services (relationships graph builder etc.) keep
+		// working and cannot surface unhandled rejections into the test run.
+		adapter.getMemories = async (
+			params: Parameters<InMemoryDatabaseAdapter["getMemories"]>[0],
+		) => {
+			if (params.tableName === "messages" && params.roomId === GROUP_ROOM) {
+				throw new Error("db unavailable");
+			}
+			return realGetMemories(params);
+		};
+		const result = await runBotLoopGate({
+			runtime,
+			message: botInbound(GROUP_ROOM, ChannelType.GROUP),
+		});
+		adapter.getMemories = realGetMemories;
+		expect(result.ignored).toBe(false);
+		expect(result.reason).toBe("window_unavailable");
+	});
+});

--- a/packages/core/src/services/message/bot-loop-gate.ts
+++ b/packages/core/src/services/message/bot-loop-gate.ts
@@ -1,0 +1,165 @@
+/**
+ * Deterministic bot-to-bot loop gate — the model-size-independent floor
+ * beneath the soft ANXIETY / BOT_AWARENESS prompt signals.
+ *
+ * Why code, not prompt: the multi-agent "endless hell loop" is worst on
+ * agents running SMALL models (remilio on gemma-4), and small models do not
+ * reliably follow soft prompt guidance — so a purely advisory fix would be
+ * ignored by exactly the agent most likely to cause the loop. This gate trips
+ * in the message-handling decision path BEFORE any model call, so it behaves
+ * identically on gemma-4 and on frontier models: the model never gets the
+ * chance to loop.
+ *
+ * Trip condition (ALL must hold; anything unverifiable fails OPEN into the
+ * normal pipeline):
+ *   - the inbound message is positively bot-authored (connector-stamped
+ *     `fromBot` — the same ground truth the transcript formatter and the
+ *     bot-noise triage read; never name-guessing),
+ *   - the room is a multi-party text/voice-group channel (group chat only —
+ *     DMs are never gated),
+ *   - the agent has already produced >= N consecutive turns since the last
+ *     human message in the room (default N=2, configurable), i.e. an actual
+ *     agent↔bot exchange with no human advancing the conversation.
+ *
+ * When tripped the turn ends with a deterministic IGNORE: no composeState, no
+ * Stage-1 call, no reply. A human speaking in the room resets the counter
+ * naturally (their message becomes the newest human turn), so human-driven
+ * conversation is never suppressed — the gate only ever biases toward
+ * silence, never toward speaking, and it strictly ADDS to existing gating
+ * (personality reply-gate, mute, bot-noise triage all still run).
+ *
+ * Layering with PR #25405 (register-aware + restraint defaults): #25405 adds
+ * IGNORE-biased multi-agent rules to the shouldRespond PROMPTS ("never reply
+ * to another bot's reply", "one speaker per human message"). Those are the
+ * soft layer for models that read; this gate is the hard floor for models
+ * that don't. Same policy, two enforcement strengths.
+ *
+ * Cost: one room messages-scan bounded to the signal window, issued only for
+ * bot-authored group turns — exactly the query shape the runtime's
+ * turn-scoped single-flight memo coalesces with the compose fan-out, so no
+ * new query load on the hot path. No model calls, no embeddings.
+ */
+
+import {
+	computeGroupConversationMetrics,
+	GROUP_SIGNAL_WINDOW,
+	isBotAuthoredMessage,
+	isMultiPartyChannel,
+	resolveChannelType,
+} from "../../features/basic-capabilities/providers/group-conversation-signals.ts";
+import { isInternalBridgeMessage } from "../../messaging/automated-turns.ts";
+import type { Memory } from "../../types/memory";
+import type { IAgentRuntime } from "../../types/runtime";
+
+/** Default max consecutive agent turns into a human-free bot exchange. */
+export const DEFAULT_BOT_LOOP_MAX_AGENT_TURNS = 2;
+
+export interface BotLoopGateResult {
+	/** True when the deterministic gate trips: end the turn with IGNORE. */
+	ignored: boolean;
+	/** Agent turns since the last human message (when computed). */
+	agentTurnsSinceLastHuman?: number;
+	/** Why the gate did not apply, for debug logging. */
+	reason?:
+		| "disabled"
+		| "not_bot_authored"
+		| "not_group_channel"
+		| "below_threshold"
+		| "window_unavailable";
+}
+
+/** The gate is ON by default; opt out with ELIZA_BOT_LOOP_GATE=0|false|off. */
+export function isBotLoopGateEnabled(runtime: IAgentRuntime): boolean {
+	const raw = runtime.getSetting("ELIZA_BOT_LOOP_GATE");
+	if (raw === undefined || raw === null) return true;
+	const normalized = String(raw).trim().toLowerCase();
+	return !["0", "false", "no", "off"].includes(normalized);
+}
+
+/**
+ * Consecutive agent turns allowed into a human-free bot exchange before the
+ * hard stop. Clamped to >= 1 so the agent can always answer a bot once (a
+ * single bot question deserves a single answer; the loop starts at the
+ * reply-to-a-reply).
+ */
+export function botLoopMaxAgentTurns(runtime: IAgentRuntime): number {
+	const raw = runtime.getSetting("ELIZA_BOT_LOOP_MAX_AGENT_TURNS");
+	const parsed =
+		raw === undefined || raw === null
+			? Number.NaN
+			: Number.parseInt(String(raw), 10);
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		return DEFAULT_BOT_LOOP_MAX_AGENT_TURNS;
+	}
+	return parsed;
+}
+
+/**
+ * Run the deterministic gate. Pure decision logic over the bounded room
+ * window; every uncertain path fails OPEN (`ignored: false`).
+ */
+export async function runBotLoopGate(args: {
+	runtime: IAgentRuntime;
+	message: Memory;
+}): Promise<BotLoopGateResult> {
+	const { runtime, message } = args;
+	if (!isBotLoopGateEnabled(runtime)) {
+		return { ignored: false, reason: "disabled" };
+	}
+	// Positively bot-authored inbound only. Human and untagged senders never
+	// enter the gate — a connector that omits `fromBot` degrades to normal
+	// behavior, exactly like the transcript "(bot)" tag.
+	if (!isBotAuthoredMessage(message)) {
+		return { ignored: false, reason: "not_bot_authored" };
+	}
+	// Group chat only. Unknown/missing channel type fails open.
+	const channelType = await resolveChannelType(runtime, message);
+	if (!isMultiPartyChannel(channelType)) {
+		return { ignored: false, reason: "not_group_channel" };
+	}
+	if (!message.roomId) {
+		return { ignored: false, reason: "window_unavailable" };
+	}
+	let window: Memory[];
+	try {
+		// Coalesced by the runtime's turn-scoped room-scan memo — shares the
+		// superset fetch the compose fan-out issues anyway.
+		window = await runtime.getMemories({
+			tableName: "messages",
+			roomId: message.roomId,
+			limit: GROUP_SIGNAL_WINDOW,
+			unique: false,
+		});
+	} catch {
+		// error-policy: a read failure must never mute the agent — fail open.
+		return { ignored: false, reason: "window_unavailable" };
+	}
+	const dialogue = window
+		.filter(
+			(entry) =>
+				entry.content?.type !== "action_result" &&
+				!isInternalBridgeMessage(entry),
+		)
+		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+		.slice(-GROUP_SIGNAL_WINDOW);
+	const metrics = computeGroupConversationMetrics(dialogue, runtime.agentId);
+	const maxAgentTurns = botLoopMaxAgentTurns(runtime);
+	// The agent must ALREADY be a participant in the human-free tail: at least
+	// one bot turn and >= maxAgentTurns agent turns since the last human. A
+	// human message anywhere newer than the agent's turns resets both counters
+	// to zero, so an active human conversation can never trip this.
+	if (
+		metrics.botTurnsSinceLastHuman > 0 &&
+		metrics.agentTurnsSinceLastHuman >= maxAgentTurns
+	) {
+		return {
+			ignored: true,
+			agentTurnsSinceLastHuman: metrics.agentTurnsSinceLastHuman,
+		};
+	}
+	return {
+		ignored: false,
+		reason: "below_threshold",
+		agentTurnsSinceLastHuman: metrics.agentTurnsSinceLastHuman,
+	};
+}

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -258,6 +258,7 @@ export type RunEventStatus =
 	| "muted"
 	| "personality_gate"
 	| "bot_noise_triage"
+	| "bot_loop_gate"
 	| "replaced"
 	| "noMessageId";
 


### PR DESCRIPTION
## What

Fixes the multi-agent "endless hell loop" in group channels with a layered design: two advisory providers (soft signal, graceful behavior for capable models) plus a deterministic decision-path gate (hard floor that works identically regardless of model size). Direct ask from Shaw + Shadow in #cc-eliza (2026-08-23): revive/modernize the old ANXIETY provider for group chat, add bot-awareness so agents don't loop with each other, and make the anti-loop guarantee hold for small models (gemma-class) that don't reliably follow prompt guidance.

## The three pieces

### 1. `ANXIETY` provider (soft, group-only)

`packages/core/src/features/basic-capabilities/providers/anxiety.ts`

Shaw's original anxiety provider picked 3 RANDOM canned "you are too verbose" strings per channel type — static, evidence-free. This reimplementation computes pressure from LIVE room state:

- **Talked-too-much:** the agent's share of the recent dialogue window vs its fair share of the floor (`1 / (participants + 1)`). Room-aware by construction: the same agent turn count produces more pressure in a crowded room, and a crowd factor ramps busier rooms faster ("anxiety based on room").
- **Ping-pong:** a strict tail alternation between the agent and ONE other sender (A→B→A→B) adds pressure even at moderate overall share.
- **Dampeners:** zero pressure when the agent has been quiet; strong damping when a human just directly addressed the agent — genuine engagement is never suppressed.

Output is dynamic guidance text that scales with computed pressure — light "keep it short" at low pressure, "you have sent 8 of the last 12 messages, others should have the floor, prefer IGNORE / a reaction / silence" at high pressure. IGNORE-as-valid-response framing kept from the original. Calibration is an exported constant passed by parameter, so hosts can add per-room calibration later without changing the provider contract; no agent-specific hardcoding.

**Group-only:** GROUP / VOICE_GROUP / THREAD / WORLD / FORUM. DMs return the empty result — asserted bidirectionally in tests (same history that fires in a group is inert in a DM, both via explicit `content.channelType` and via room-row type resolution).

### 2. `BOT_AWARENESS` provider (soft, group-only, separate per Shaw's framing)

`packages/core/src/features/basic-capabilities/providers/botAwareness.ts`

Explicit "you are talking to another bot" awareness. Bot detection uses the connector-stamped `fromBot` metadata — the same ground truth the transcript formatter renders as `Name (bot)` and the bot-noise triage gate reads. Never name-guessing. Fires only when the latest inbound turn is bot-authored AND there has been bot↔agent back-and-forth with NO intervening human turn; escalates from "don't mirror its conversational reflexes" to "this exchange is N messages deep with no human — let it drop" as the human-free exchange deepens. Renders nothing when a human is active, so it degrades to normal behavior.

### 3. Deterministic bot-loop gate (hard floor, model-size independent)

`packages/core/src/services/message/bot-loop-gate.ts`, wired into `MessageService` immediately after the bot-noise triage.

**Why code, not prompt:** the loop is worst on agents running small models (remilio on gemma-4), and small models do not reliably follow soft prompt guidance — a purely advisory fix would be ignored by exactly the agent most likely to cause the loop. This gate trips BEFORE any model call, so it behaves identically on gemma-4 and frontier models: the model never gets the chance to loop.

Trip condition (all must hold; anything unverifiable fails OPEN):
- inbound message is positively bot-authored (`fromBot`),
- multi-party channel (group-only, same scoping as the providers),
- the agent has already produced ≥ N consecutive turns since the last human message in the room (default N=2, `ELIZA_BOT_LOOP_MAX_AGENT_TURNS`, clamped ≥1 so the agent can always answer a bot once — the loop starts at the reply-to-a-reply).

When tripped: deterministic IGNORE, run terminalized with status `bot_loop_gate`, zero model calls. A human speaking resets the counters naturally, so human conversation is never suppressed. **Strictly additive:** all existing gates (mute, personality reply-gate, bot-noise triage) run unchanged; this only ever biases toward silence, never speech. Opt-out: `ELIZA_BOT_LOOP_GATE=0`.

## Layering with existing work

- **#25405 (register-aware + restraint defaults):** added IGNORE-biased multi-agent rules to the shouldRespond prompts ("never reply to another bot's reply", "one speaker per human message") in both `packages/prompts` and the cloud-bootstrap planner template. Those prompt rules are the soft layer for models that read; the bot-loop gate here is the hard floor beneath them for models that don't. Same policy, two enforcement strengths — the gate does not duplicate the prompt text and cannot fight it (both bias the same direction).
- **#25283 / successor #25356 (engagement gate, classifyLeadingVocative, agent-name-match):** those decide ADDRESSING (is this message for me). These providers compose advisory STATE (how much have I been talking, is my interlocutor a bot). Orthogonal by design: the providers' human-addressed dampener reads platform mention/reply + whole-word name match (a deliberately lightweight mirror — providers can't import services/message without a cycle), and never gates a response. Since #25283 closed superseded by draft #25356, nothing here reuses its unmerged utils; if #25356 lands, its addressing classifier can replace the dampener's name check in a follow-up.

## Hot-path cost

No model calls, no embeddings, no new DB query shapes. Providers read the composed `RECENT_MESSAGES` state on turn recompose (asserted: zero adapter scans); on first compose and in the gate, the fallback room-scan uses exactly the newest-first shape the runtime's turn-scoped single-flight memo coalesces (`coalesceRoomMessagesScan`), sharing the superset fetch RECENT_MESSAGES/FACTS/ATTACHMENTS already issue. `BOT_AWARENESS` short-circuits before any window load when the inbound turn isn't bot-authored.

## Proof

`anxiety.test.ts` (15) + `bot-loop-gate.test.ts` (8), all deterministic (real `AgentRuntime` + `InMemoryDatabaseAdapter`, throwing `useModel` stub in the gate tests proves zero model involvement):

- anxiety rises with agent-turn dominance (high-watermark text + pressure value asserted)
- anxiety ramps on sustained single-participant ping-pong
- anxiety stays silent when the agent has been quiet
- anxiety damped (not silenced) when a human addresses the agent by name
- anxiety INERT in DMs bidirectionally: same max-pressure history fires in GROUP, returns `{text:"",values:{},data:{}}` in DM via both channelType paths
- room-awareness: identical agent activity → more pressure with more participants (pure-function proof)
- recompose path: composed state consumed with zero adapter scans
- bot-awareness fires on bot interlocutor + no intervening human; escalates at depth ≥4; quiet when a human spoke in the gap; quiet for human interlocutors; inert in DMs
- **gate: deterministic IGNORE for an all-bot back-and-forth with no human turn — with `useModel` stubbed to throw, proving the verdict cannot depend on model instruction-following (the gemma-4 coverage proof)**
- gate does NOT trip when a human has spoken since the agent's last turn
- gate allows the first reply to a bot; fails open for human/untagged senders, unknown channels, DB read failure; honors opt-out + threshold clamping/raising

No-regression: recentMessages, channelTopics, userEmotionSignal, provider-descriptions, bot-noise-triage, compose-state-provider-purity, message-runtime-stage1 (180), message-stage1-prompt-tier — all green (the one turn-read-coalescing failure is pre-existing on develop, verified by stashing this change). `tsc --noEmit` clean, Biome clean on touched files.

Sol
