### PR TITLE
chore(agent): format route dispatch tests

### DIFF
--- a/packages/agent/src/api/server-route-dispatch.test.ts
+++ b/packages/agent/src/api/server-route-dispatch.test.ts
@@ -15,26 +15,26 @@ import type { AgentRuntime, Route } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createIntegrationTelemetrySpan } from "../diagnostics/integration-observability.ts";
 import {
-	handleCloudAndCoreRouteGroup,
-	handleConversationRouteGroup,
-	handleDatabaseRouteGroup,
-	handleInboxAndCloudRelayRouteGroup,
-	handleLifeOpsRuntimePluginRoute,
-	handleSandboxRouteGroup,
+  handleCloudAndCoreRouteGroup,
+  handleConversationRouteGroup,
+  handleDatabaseRouteGroup,
+  handleInboxAndCloudRelayRouteGroup,
+  handleLifeOpsRuntimePluginRoute,
+  handleSandboxRouteGroup,
 } from "./server-route-dispatch.ts";
 
 type PluginHandler = (...args: unknown[]) => Promise<boolean>;
 
 const { cloudHost, computeUse } = vi.hoisted(() => ({
-	cloudHost: {
-		handleCloudRelayRoute: vi.fn<PluginHandler>(async () => true),
-		handleCloudBillingRoute: vi.fn<PluginHandler>(async () => false),
-		handleCloudCompatRoute: vi.fn<PluginHandler>(async () => false),
-		handleCloudRoute: vi.fn<PluginHandler>(async () => true),
-	},
-	computeUse: {
-		handleSandboxRoute: vi.fn<PluginHandler>(async () => true),
-	},
+  cloudHost: {
+    handleCloudRelayRoute: vi.fn<PluginHandler>(async () => true),
+    handleCloudBillingRoute: vi.fn<PluginHandler>(async () => false),
+    handleCloudCompatRoute: vi.fn<PluginHandler>(async () => false),
+    handleCloudRoute: vi.fn<PluginHandler>(async () => true),
+  },
+  computeUse: {
+    handleSandboxRoute: vi.fn<PluginHandler>(async () => true),
+  },
 }));
 
 vi.mock("@elizaos/plugin-elizacloud/host-routes", () => cloudHost);
@@ -48,563 +48,563 @@ type ConversationCtx = Parameters<typeof handleConversationRouteGroup>[0];
 type LifeOpsCtx = Parameters<typeof handleLifeOpsRuntimePluginRoute>[0];
 
 function makeRes(): http.ServerResponse {
-	const headers: Record<string, string> = {};
-	const res = {
-		statusCode: 200,
-		headersSent: false,
-		writableEnded: false,
-		setHeader(key: string, value: string | number) {
-			headers[key.toLowerCase()] = String(value);
-		},
-		getHeader(key: string) {
-			return headers[key.toLowerCase()];
-		},
-		writeHead(status: number) {
-			res.statusCode = status;
-			return res;
-		},
-		write() {
-			return true;
-		},
-		end() {
-			res.headersSent = true;
-			res.writableEnded = true;
-		},
-	};
-	return res as unknown as http.ServerResponse;
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    writableEnded: false,
+    setHeader(key: string, value: string | number) {
+      headers[key.toLowerCase()] = String(value);
+    },
+    getHeader(key: string) {
+      return headers[key.toLowerCase()];
+    },
+    writeHead(status: number) {
+      res.statusCode = status;
+      return res;
+    },
+    write() {
+      return true;
+    },
+    end() {
+      res.headersSent = true;
+      res.writableEnded = true;
+    },
+  };
+  return res as unknown as http.ServerResponse;
 }
 
 function makeReq(method: string, pathname: string): http.IncomingMessage {
-	return {
-		method,
-		url: pathname,
-		headers: { host: "localhost" },
-	} as http.IncomingMessage;
+  return {
+    method,
+    url: pathname,
+    headers: { host: "localhost" },
+  } as http.IncomingMessage;
 }
 
 function dispatchState(
-	overrides: {
-		runtime?: AgentRuntime | null;
-		sandboxManager?: unknown;
-		cloudManager?: unknown;
-		config?: unknown;
-		agentName?: string;
-	} = {},
+  overrides: {
+    runtime?: AgentRuntime | null;
+    sandboxManager?: unknown;
+    cloudManager?: unknown;
+    config?: unknown;
+    agentName?: string;
+  } = {},
 ): InboxCtx["state"] {
-	return {
-		runtime: overrides.runtime ?? null,
-		sandboxManager: overrides.sandboxManager ?? null,
-		cloudManager: overrides.cloudManager ?? null,
-		config: overrides.config ?? {},
-		agentName: overrides.agentName ?? "Eliza",
-		conversations: new Map(),
-		deletedConversationIds: new Set(),
-		conversationRestorePromise: null,
-	} as InboxCtx["state"];
+  return {
+    runtime: overrides.runtime ?? null,
+    sandboxManager: overrides.sandboxManager ?? null,
+    cloudManager: overrides.cloudManager ?? null,
+    config: overrides.config ?? {},
+    agentName: overrides.agentName ?? "Eliza",
+    conversations: new Map(),
+    deletedConversationIds: new Set(),
+    conversationRestorePromise: null,
+  } as InboxCtx["state"];
 }
 
 function helpers() {
-	return {
-		json: vi.fn(),
-		error: vi.fn(),
-		readJsonBody: vi.fn(async () => null),
-	};
+  return {
+    json: vi.fn(),
+    error: vi.fn(),
+    readJsonBody: vi.fn(async () => null),
+  };
 }
 
 beforeEach(() => {
-	cloudHost.handleCloudRelayRoute.mockClear();
-	cloudHost.handleCloudBillingRoute.mockClear();
-	cloudHost.handleCloudCompatRoute.mockClear();
-	cloudHost.handleCloudRoute.mockClear();
-	cloudHost.handleCloudRelayRoute.mockResolvedValue(true);
-	cloudHost.handleCloudBillingRoute.mockResolvedValue(false);
-	cloudHost.handleCloudCompatRoute.mockResolvedValue(false);
-	cloudHost.handleCloudRoute.mockResolvedValue(true);
-	computeUse.handleSandboxRoute.mockClear();
-	computeUse.handleSandboxRoute.mockResolvedValue(true);
+  cloudHost.handleCloudRelayRoute.mockClear();
+  cloudHost.handleCloudBillingRoute.mockClear();
+  cloudHost.handleCloudCompatRoute.mockClear();
+  cloudHost.handleCloudRoute.mockClear();
+  cloudHost.handleCloudRelayRoute.mockResolvedValue(true);
+  cloudHost.handleCloudBillingRoute.mockResolvedValue(false);
+  cloudHost.handleCloudCompatRoute.mockResolvedValue(false);
+  cloudHost.handleCloudRoute.mockResolvedValue(true);
+  computeUse.handleSandboxRoute.mockClear();
+  computeUse.handleSandboxRoute.mockResolvedValue(true);
 });
 
 describe("handleInboxAndCloudRelayRouteGroup", () => {
-	function ctx(
-		pathname: string,
-		extra: {
-			method?: string;
-			runtime?: AgentRuntime | null;
-			inboxCallerAuthorization?: InboxCtx["inboxCallerAuthorization"];
-		} = {},
-	): InboxCtx {
-		const method = extra.method ?? "GET";
-		const h = helpers();
-		return {
-			req: makeReq(method, pathname),
-			res: makeRes(),
-			method,
-			pathname,
-			url: new URL(pathname, "http://localhost"),
-			state: dispatchState({ runtime: extra.runtime }),
-			inboxCallerAuthorization: extra.inboxCallerAuthorization,
-			...h,
-		};
-	}
+  function ctx(
+    pathname: string,
+    extra: {
+      method?: string;
+      runtime?: AgentRuntime | null;
+      inboxCallerAuthorization?: InboxCtx["inboxCallerAuthorization"];
+    } = {},
+  ): InboxCtx {
+    const method = extra.method ?? "GET";
+    const h = helpers();
+    return {
+      req: makeReq(method, pathname),
+      res: makeRes(),
+      method,
+      pathname,
+      url: new URL(pathname, "http://localhost"),
+      state: dispatchState({ runtime: extra.runtime }),
+      inboxCallerAuthorization: extra.inboxCallerAuthorization,
+      ...h,
+    };
+  }
 
-	it("handles /api/notifications/push-tokens before the notification catch-all", async () => {
-		const args = ctx("/api/notifications/push-tokens");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.error).toHaveBeenCalledWith(
-			args.res,
-			"push delivery service not ready",
-			503,
-		);
-		expect(args.json).not.toHaveBeenCalled();
-	});
+  it("handles /api/notifications/push-tokens before the notification catch-all", async () => {
+    const args = ctx("/api/notifications/push-tokens");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.error).toHaveBeenCalledWith(
+      args.res,
+      "push delivery service not ready",
+      503,
+    );
+    expect(args.json).not.toHaveBeenCalled();
+  });
 
-	it("handles a nested push-token path the same way (prefix, not exact)", async () => {
-		const args = ctx("/api/notifications/push-tokens/abc");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.error).toHaveBeenCalledWith(
-			args.res,
-			"push delivery service not ready",
-			503,
-		);
-	});
+  it("handles a nested push-token path the same way (prefix, not exact)", async () => {
+    const args = ctx("/api/notifications/push-tokens/abc");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.error).toHaveBeenCalledWith(
+      args.res,
+      "push delivery service not ready",
+      503,
+    );
+  });
 
-	it("handles GET /api/notifications with a retryable not-ready payload", async () => {
-		const args = ctx("/api/notifications");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(
-			args.res,
-			{
-				error: "Notification service is still starting",
-				code: "NOTIFICATION_SERVICE_NOT_READY",
-				retryAfter: 1,
-			},
-			503,
-		);
-		expect(args.error).not.toHaveBeenCalled();
-	});
+  it("handles GET /api/notifications with a retryable not-ready payload", async () => {
+    const args = ctx("/api/notifications");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(
+      args.res,
+      {
+        error: "Notification service is still starting",
+        code: "NOTIFICATION_SERVICE_NOT_READY",
+        retryAfter: 1,
+      },
+      503,
+    );
+    expect(args.error).not.toHaveBeenCalled();
+  });
 
-	it("handles GET /api/approvals as an empty queue when no runtime is attached", async () => {
-		const args = ctx("/api/approvals");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(args.res, {
-			approvals: [],
-			pending: [],
-			pendingUserActions: [],
-		});
-	});
+  it("handles GET /api/approvals as an empty queue when no runtime is attached", async () => {
+    const args = ctx("/api/approvals");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(args.res, {
+      approvals: [],
+      pending: [],
+      pendingUserActions: [],
+    });
+  });
 
-	it("404s unknown approval subpaths instead of falling through", async () => {
-		const args = ctx("/api/approvals/missing", { method: "POST" });
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.error).toHaveBeenCalledWith(
-			args.res,
-			"approval route not found",
-			404,
-		);
-	});
+  it("404s unknown approval subpaths instead of falling through", async () => {
+    const args = ctx("/api/approvals/missing", { method: "POST" });
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.error).toHaveBeenCalledWith(
+      args.res,
+      "approval route not found",
+      404,
+    );
+  });
 
-	it("handles GET /api/inbox/messages with an empty feed when runtime is null", async () => {
-		const args = ctx("/api/inbox/messages");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(args.res, {
-			messages: [],
-			count: 0,
-		});
-	});
+  it("handles GET /api/inbox/messages with an empty feed when runtime is null", async () => {
+    const args = ctx("/api/inbox/messages");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(args.res, {
+      messages: [],
+      count: 0,
+    });
+  });
 
-	it("forwards inboxCallerAuthorization into the inbox handler context", async () => {
-		const inboxCallerAuthorization = {
-			ok: true,
-			role: "owner",
-		} as unknown as InboxCtx["inboxCallerAuthorization"];
-		const args = ctx("/api/inbox/messages", { inboxCallerAuthorization });
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(args.res, {
-			messages: [],
-			count: 0,
-		});
-	});
+  it("forwards inboxCallerAuthorization into the inbox handler context", async () => {
+    const inboxCallerAuthorization = {
+      ok: true,
+      role: "owner",
+    } as unknown as InboxCtx["inboxCallerAuthorization"];
+    const args = ctx("/api/inbox/messages", { inboxCallerAuthorization });
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(args.res, {
+      messages: [],
+      count: 0,
+    });
+  });
 
-	it("dispatches the exact /api/cloud/relay-status path to the cloud plugin", async () => {
-		const args = ctx("/api/cloud/relay-status");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		expect(cloudHost.handleCloudRelayRoute).toHaveBeenCalledTimes(1);
-		const call = cloudHost.handleCloudRelayRoute.mock.calls[0];
-		expect(call?.[2]).toBe("/api/cloud/relay-status");
-		expect(call?.[3]).toBe("GET");
-		expect(call?.[4]).toEqual({ runtime: undefined });
-		expect(call?.[5]).toEqual({
-			json: args.json,
-			error: args.error,
-			readJsonBody: args.readJsonBody,
-		});
-	});
+  it("dispatches the exact /api/cloud/relay-status path to the cloud plugin", async () => {
+    const args = ctx("/api/cloud/relay-status");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    expect(cloudHost.handleCloudRelayRoute).toHaveBeenCalledTimes(1);
+    const call = cloudHost.handleCloudRelayRoute.mock.calls[0];
+    expect(call?.[2]).toBe("/api/cloud/relay-status");
+    expect(call?.[3]).toBe("GET");
+    expect(call?.[4]).toEqual({ runtime: undefined });
+    expect(call?.[5]).toEqual({
+      json: args.json,
+      error: args.error,
+      readJsonBody: args.readJsonBody,
+    });
+  });
 
-	it("wraps a live runtime's getService for the relay handler", async () => {
-		const getService = vi.fn((type: string) => `svc:${type}`);
-		const runtime = { getService } as unknown as AgentRuntime;
-		const args = ctx("/api/cloud/relay-status", { runtime });
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
-		const pluginState = cloudHost.handleCloudRelayRoute.mock.calls[0]?.[4] as
-			| {
-					runtime?: { getService: (type: string) => unknown };
-			  }
-			| undefined;
-		expect(pluginState?.runtime?.getService("cloud")).toBe("svc:cloud");
-		expect(getService).toHaveBeenCalledWith("cloud");
-	});
+  it("wraps a live runtime's getService for the relay handler", async () => {
+    const getService = vi.fn((type: string) => `svc:${type}`);
+    const runtime = { getService } as unknown as AgentRuntime;
+    const args = ctx("/api/cloud/relay-status", { runtime });
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(true);
+    const pluginState = cloudHost.handleCloudRelayRoute.mock.calls[0]?.[4] as
+      | {
+          runtime?: { getService: (type: string) => unknown };
+        }
+      | undefined;
+    expect(pluginState?.runtime?.getService("cloud")).toBe("svc:cloud");
+    expect(getService).toHaveBeenCalledWith("cloud");
+  });
 
-	it("does not treat /api/cloud/relay-status/nested as the relay route", async () => {
-		const args = ctx("/api/cloud/relay-status/nested");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(false);
-		expect(cloudHost.handleCloudRelayRoute).not.toHaveBeenCalled();
-		expect(args.json).not.toHaveBeenCalled();
-		expect(args.error).not.toHaveBeenCalled();
-	});
+  it("does not treat /api/cloud/relay-status/nested as the relay route", async () => {
+    const args = ctx("/api/cloud/relay-status/nested");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(false);
+    expect(cloudHost.handleCloudRelayRoute).not.toHaveBeenCalled();
+    expect(args.json).not.toHaveBeenCalled();
+    expect(args.error).not.toHaveBeenCalled();
+  });
 
-	it("returns false for namespaces this group does not own", async () => {
-		const args = ctx("/api/conversations");
-		await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(false);
-		expect(args.json).not.toHaveBeenCalled();
-		expect(args.error).not.toHaveBeenCalled();
-	});
+  it("returns false for namespaces this group does not own", async () => {
+    const args = ctx("/api/conversations");
+    await expect(handleInboxAndCloudRelayRouteGroup(args)).resolves.toBe(false);
+    expect(args.json).not.toHaveBeenCalled();
+    expect(args.error).not.toHaveBeenCalled();
+  });
 });
 
 describe("handleCloudAndCoreRouteGroup", () => {
-	function ctx(pathname: string): CloudCtx {
-		return {
-			req: makeReq("GET", pathname),
-			res: makeRes(),
-			method: "GET",
-			pathname,
-			state: dispatchState({
-				config: { cloud: true },
-				cloudManager: { id: "cm" },
-			}),
-			restartRuntime: vi.fn(async () => true),
-			saveConfig: vi.fn(),
-		};
-	}
+  function ctx(pathname: string): CloudCtx {
+    return {
+      req: makeReq("GET", pathname),
+      res: makeRes(),
+      method: "GET",
+      pathname,
+      state: dispatchState({
+        config: { cloud: true },
+        cloudManager: { id: "cm" },
+      }),
+      restartRuntime: vi.fn(async () => true),
+      saveConfig: vi.fn(),
+    };
+  }
 
-	it("returns false when the path is not under /api/cloud/", async () => {
-		await expect(handleCloudAndCoreRouteGroup(ctx("/api/cloud"))).resolves.toBe(
-			false,
-		);
-		expect(cloudHost.handleCloudBillingRoute).not.toHaveBeenCalled();
-	});
+  it("returns false when the path is not under /api/cloud/", async () => {
+    await expect(handleCloudAndCoreRouteGroup(ctx("/api/cloud"))).resolves.toBe(
+      false,
+    );
+    expect(cloudHost.handleCloudBillingRoute).not.toHaveBeenCalled();
+  });
 
-	it("stops at billing when billing handles the request", async () => {
-		cloudHost.handleCloudBillingRoute.mockResolvedValueOnce(true);
-		const args = ctx("/api/cloud/billing/balance");
-		await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
-		expect(cloudHost.handleCloudBillingRoute).toHaveBeenCalledTimes(1);
-		expect(cloudHost.handleCloudCompatRoute).not.toHaveBeenCalled();
-		expect(cloudHost.handleCloudRoute).not.toHaveBeenCalled();
-	});
+  it("stops at billing when billing handles the request", async () => {
+    cloudHost.handleCloudBillingRoute.mockResolvedValueOnce(true);
+    const args = ctx("/api/cloud/billing/balance");
+    await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
+    expect(cloudHost.handleCloudBillingRoute).toHaveBeenCalledTimes(1);
+    expect(cloudHost.handleCloudCompatRoute).not.toHaveBeenCalled();
+    expect(cloudHost.handleCloudRoute).not.toHaveBeenCalled();
+  });
 
-	it("falls through billing to compat when billing declines", async () => {
-		cloudHost.handleCloudCompatRoute.mockResolvedValueOnce(true);
-		const args = ctx("/api/cloud/compat/foo");
-		await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
-		expect(cloudHost.handleCloudBillingRoute).toHaveBeenCalledTimes(1);
-		expect(cloudHost.handleCloudCompatRoute).toHaveBeenCalledTimes(1);
-		expect(cloudHost.handleCloudRoute).not.toHaveBeenCalled();
-	});
+  it("falls through billing to compat when billing declines", async () => {
+    cloudHost.handleCloudCompatRoute.mockResolvedValueOnce(true);
+    const args = ctx("/api/cloud/compat/foo");
+    await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
+    expect(cloudHost.handleCloudBillingRoute).toHaveBeenCalledTimes(1);
+    expect(cloudHost.handleCloudCompatRoute).toHaveBeenCalledTimes(1);
+    expect(cloudHost.handleCloudRoute).not.toHaveBeenCalled();
+  });
 
-	it("falls through billing and compat to handleCloudRoute", async () => {
-		const args = ctx("/api/cloud/core");
-		await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
-		expect(cloudHost.handleCloudBillingRoute).toHaveBeenCalledTimes(1);
-		expect(cloudHost.handleCloudCompatRoute).toHaveBeenCalledTimes(1);
-		expect(cloudHost.handleCloudRoute).toHaveBeenCalledTimes(1);
-		const pluginState = cloudHost.handleCloudRoute.mock.calls[0]?.[4] as
-			| {
-					config: unknown;
-					cloudManager: unknown;
-					saveConfig: CloudCtx["saveConfig"];
-					restartRuntime: CloudCtx["restartRuntime"];
-					createTelemetrySpan: typeof createIntegrationTelemetrySpan;
-			  }
-			| undefined;
-		expect(pluginState?.config).toEqual({ cloud: true });
-		expect(pluginState?.cloudManager).toEqual({ id: "cm" });
-		expect(pluginState?.saveConfig).toBe(args.saveConfig);
-		expect(pluginState?.restartRuntime).toBe(args.restartRuntime);
-		expect(pluginState?.createTelemetrySpan).toBe(
-			createIntegrationTelemetrySpan,
-		);
-	});
+  it("falls through billing and compat to handleCloudRoute", async () => {
+    const args = ctx("/api/cloud/core");
+    await expect(handleCloudAndCoreRouteGroup(args)).resolves.toBe(true);
+    expect(cloudHost.handleCloudBillingRoute).toHaveBeenCalledTimes(1);
+    expect(cloudHost.handleCloudCompatRoute).toHaveBeenCalledTimes(1);
+    expect(cloudHost.handleCloudRoute).toHaveBeenCalledTimes(1);
+    const pluginState = cloudHost.handleCloudRoute.mock.calls[0]?.[4] as
+      | {
+          config: unknown;
+          cloudManager: unknown;
+          saveConfig: CloudCtx["saveConfig"];
+          restartRuntime: CloudCtx["restartRuntime"];
+          createTelemetrySpan: typeof createIntegrationTelemetrySpan;
+        }
+      | undefined;
+    expect(pluginState?.config).toEqual({ cloud: true });
+    expect(pluginState?.cloudManager).toEqual({ id: "cm" });
+    expect(pluginState?.saveConfig).toBe(args.saveConfig);
+    expect(pluginState?.restartRuntime).toBe(args.restartRuntime);
+    expect(pluginState?.createTelemetrySpan).toBe(
+      createIntegrationTelemetrySpan,
+    );
+  });
 
-	it("returns handleCloudRoute's false when nothing in the cascade claims the path", async () => {
-		cloudHost.handleCloudRoute.mockResolvedValueOnce(false);
-		await expect(
-			handleCloudAndCoreRouteGroup(ctx("/api/cloud/x/tweets")),
-		).resolves.toBe(false);
-		expect(cloudHost.handleCloudRoute).toHaveBeenCalledTimes(1);
-	});
+  it("returns handleCloudRoute's false when nothing in the cascade claims the path", async () => {
+    cloudHost.handleCloudRoute.mockResolvedValueOnce(false);
+    await expect(
+      handleCloudAndCoreRouteGroup(ctx("/api/cloud/x/tweets")),
+    ).resolves.toBe(false);
+    expect(cloudHost.handleCloudRoute).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("handleSandboxRouteGroup", () => {
-	it("returns false outside the /api/sandbox prefix", async () => {
-		const args: SandboxCtx = {
-			req: makeReq("GET", "/api/sand"),
-			res: makeRes(),
-			method: "GET",
-			pathname: "/api/sand",
-			state: dispatchState(),
-		};
-		await expect(handleSandboxRouteGroup(args)).resolves.toBe(false);
-		expect(computeUse.handleSandboxRoute).not.toHaveBeenCalled();
-	});
+  it("returns false outside the /api/sandbox prefix", async () => {
+    const args: SandboxCtx = {
+      req: makeReq("GET", "/api/sand"),
+      res: makeRes(),
+      method: "GET",
+      pathname: "/api/sand",
+      state: dispatchState(),
+    };
+    await expect(handleSandboxRouteGroup(args)).resolves.toBe(false);
+    expect(computeUse.handleSandboxRoute).not.toHaveBeenCalled();
+  });
 
-	it("forwards /api/sandbox to the compute-use plugin with sandboxManager", async () => {
-		const sandboxManager = { id: "box" };
-		const args: SandboxCtx = {
-			req: makeReq("POST", "/api/sandbox/session"),
-			res: makeRes(),
-			method: "POST",
-			pathname: "/api/sandbox/session",
-			state: dispatchState({ sandboxManager }),
-		};
-		await expect(handleSandboxRouteGroup(args)).resolves.toBe(true);
-		expect(computeUse.handleSandboxRoute).toHaveBeenCalledWith(
-			args.req,
-			args.res,
-			"/api/sandbox/session",
-			"POST",
-			{ sandboxManager },
-		);
-	});
+  it("forwards /api/sandbox to the compute-use plugin with sandboxManager", async () => {
+    const sandboxManager = { id: "box" };
+    const args: SandboxCtx = {
+      req: makeReq("POST", "/api/sandbox/session"),
+      res: makeRes(),
+      method: "POST",
+      pathname: "/api/sandbox/session",
+      state: dispatchState({ sandboxManager }),
+    };
+    await expect(handleSandboxRouteGroup(args)).resolves.toBe(true);
+    expect(computeUse.handleSandboxRoute).toHaveBeenCalledWith(
+      args.req,
+      args.res,
+      "/api/sandbox/session",
+      "POST",
+      { sandboxManager },
+    );
+  });
 
-	it("matches any path that starts with /api/sandbox, including a glued suffix", async () => {
-		const args: SandboxCtx = {
-			req: makeReq("GET", "/api/sandbox-extra"),
-			res: makeRes(),
-			method: "GET",
-			pathname: "/api/sandbox-extra",
-			state: dispatchState(),
-		};
-		await expect(handleSandboxRouteGroup(args)).resolves.toBe(true);
-		expect(computeUse.handleSandboxRoute).toHaveBeenCalledTimes(1);
-	});
+  it("matches any path that starts with /api/sandbox, including a glued suffix", async () => {
+    const args: SandboxCtx = {
+      req: makeReq("GET", "/api/sandbox-extra"),
+      res: makeRes(),
+      method: "GET",
+      pathname: "/api/sandbox-extra",
+      state: dispatchState(),
+    };
+    await expect(handleSandboxRouteGroup(args)).resolves.toBe(true);
+    expect(computeUse.handleSandboxRoute).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("handleDatabaseRouteGroup", () => {
-	function ctx(pathname: string, method = "GET"): DatabaseCtx {
-		return {
-			req: makeReq(method, pathname),
-			res: makeRes(),
-			pathname,
-			state: dispatchState(),
-		};
-	}
+  function ctx(pathname: string, method = "GET"): DatabaseCtx {
+    return {
+      req: makeReq(method, pathname),
+      res: makeRes(),
+      pathname,
+      state: dispatchState(),
+    };
+  }
 
-	it("returns false for /api/database without the trailing-slash prefix", async () => {
-		await expect(handleDatabaseRouteGroup(ctx("/api/database"))).resolves.toBe(
-			false,
-		);
-	});
+  it("returns false for /api/database without the trailing-slash prefix", async () => {
+    await expect(handleDatabaseRouteGroup(ctx("/api/database"))).resolves.toBe(
+      false,
+    );
+  });
 
-	it("returns false for a lookalike /api/databases path", async () => {
-		await expect(handleDatabaseRouteGroup(ctx("/api/databases"))).resolves.toBe(
-			false,
-		);
-	});
+  it("returns false for a lookalike /api/databases path", async () => {
+    await expect(handleDatabaseRouteGroup(ctx("/api/databases"))).resolves.toBe(
+      false,
+    );
+  });
 
-	it("GET /api/database/status reports disconnected when no adapter is attached", async () => {
-		const args = ctx("/api/database/status");
-		await expect(handleDatabaseRouteGroup(args)).resolves.toBe(true);
-		await vi.waitFor(() => {
-			expect(args.res.statusCode).toBe(200);
-			expect(args.res.getHeader("Content-Type")).toBe("application/json");
-		});
-	});
+  it("GET /api/database/status reports disconnected when no adapter is attached", async () => {
+    const args = ctx("/api/database/status");
+    await expect(handleDatabaseRouteGroup(args)).resolves.toBe(true);
+    await vi.waitFor(() => {
+      expect(args.res.statusCode).toBe(200);
+      expect(args.res.getHeader("Content-Type")).toBe("application/json");
+    });
+  });
 
-	it("still handles unknown /api/database/* paths (prefix admitted, handler 503s)", async () => {
-		const args = ctx("/api/database/no-such-route");
-		await expect(handleDatabaseRouteGroup(args)).resolves.toBe(true);
-		await vi.waitFor(() => {
-			expect(args.res.statusCode).toBe(503);
-		});
-	});
+  it("still handles unknown /api/database/* paths (prefix admitted, handler 503s)", async () => {
+    const args = ctx("/api/database/no-such-route");
+    await expect(handleDatabaseRouteGroup(args)).resolves.toBe(true);
+    await vi.waitFor(() => {
+      expect(args.res.statusCode).toBe(503);
+    });
+  });
 });
 
 describe("handleConversationRouteGroup", () => {
-	function ctx(
-		method: string,
-		pathname: string,
-		extra: { runtime?: AgentRuntime | null } = {},
-	): ConversationCtx {
-		const h = helpers();
-		return {
-			req: makeReq(method, pathname),
-			res: makeRes(),
-			method,
-			pathname,
-			url: new URL(pathname, "http://localhost"),
-			state: dispatchState({
-				runtime: extra.runtime,
-				agentName: "TestAgent",
-			}),
-			...h,
-		};
-	}
+  function ctx(
+    method: string,
+    pathname: string,
+    extra: { runtime?: AgentRuntime | null } = {},
+  ): ConversationCtx {
+    const h = helpers();
+    return {
+      req: makeReq(method, pathname),
+      res: makeRes(),
+      method,
+      pathname,
+      url: new URL(pathname, "http://localhost"),
+      state: dispatchState({
+        runtime: extra.runtime,
+        agentName: "TestAgent",
+      }),
+      ...h,
+    };
+  }
 
-	it("lists conversations from the in-memory map", async () => {
-		const args = ctx("GET", "/api/conversations");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(args.res, { conversations: [] });
-	});
+  it("lists conversations from the in-memory map", async () => {
+    const args = ctx("GET", "/api/conversations");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(args.res, { conversations: [] });
+  });
 
-	it("serves GET /v1/models through chat-routes", async () => {
-		const args = ctx("GET", "/v1/models");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(
-			args.res,
-			expect.objectContaining({
-				object: "list",
-				data: expect.arrayContaining([
-					expect.objectContaining({ id: "eliza", object: "model" }),
-					expect.objectContaining({ id: "TestAgent", object: "model" }),
-				]),
-			}),
-		);
-	});
+  it("serves GET /v1/models through chat-routes", async () => {
+    const args = ctx("GET", "/v1/models");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(
+      args.res,
+      expect.objectContaining({
+        object: "list",
+        data: expect.arrayContaining([
+          expect.objectContaining({ id: "eliza", object: "model" }),
+          expect.objectContaining({ id: "TestAgent", object: "model" }),
+        ]),
+      }),
+    );
+  });
 
-	it("POST /api/agents/:id/message with no runtime fails closed 503", async () => {
-		const args = ctx("POST", "/api/agents/agent-1/message");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(true);
-		expect(args.json).toHaveBeenCalledWith(
-			args.res,
-			{ error: "Agent is not running" },
-			503,
-		);
-	});
+  it("POST /api/agents/:id/message with no runtime fails closed 503", async () => {
+    const args = ctx("POST", "/api/agents/agent-1/message");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(true);
+    expect(args.json).toHaveBeenCalledWith(
+      args.res,
+      { error: "Agent is not running" },
+      503,
+    );
+  });
 
-	it("does not dispatch GET /api/agents/:id/message (POST-only regex)", async () => {
-		const args = ctx("GET", "/api/agents/agent-1/message");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
-		expect(args.json).not.toHaveBeenCalled();
-	});
+  it("does not dispatch GET /api/agents/:id/message (POST-only regex)", async () => {
+    const args = ctx("GET", "/api/agents/agent-1/message");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
+    expect(args.json).not.toHaveBeenCalled();
+  });
 
-	it("does not dispatch a trailing extra segment on the agent message route", async () => {
-		const args = ctx("POST", "/api/agents/agent-1/message/extra");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
-	});
+  it("does not dispatch a trailing extra segment on the agent message route", async () => {
+    const args = ctx("POST", "/api/agents/agent-1/message/extra");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
+  });
 
-	it("does not dispatch POST /api/agents/message (missing agent id segment)", async () => {
-		const args = ctx("POST", "/api/agents/message");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
-	});
+  it("does not dispatch POST /api/agents/message (missing agent id segment)", async () => {
+    const args = ctx("POST", "/api/agents/message");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
+  });
 
-	it("returns false for /v1 without the trailing slash prefix", async () => {
-		const args = ctx("GET", "/v1");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
-	});
+  it("returns false for /v1 without the trailing slash prefix", async () => {
+    const args = ctx("GET", "/v1");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
+  });
 
-	it("returns false for unrelated paths", async () => {
-		const args = ctx("GET", "/api/inbox/messages");
-		await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
-	});
+  it("returns false for unrelated paths", async () => {
+    const args = ctx("GET", "/api/inbox/messages");
+    await expect(handleConversationRouteGroup(args)).resolves.toBe(false);
+  });
 });
 
 describe("handleLifeOpsRuntimePluginRoute", () => {
-	function ctx(
-		pathname: string,
-		extra: {
-			method?: string;
-			runtime?: AgentRuntime | null;
-			isAuthorizedRequest?: LifeOpsCtx["isAuthorizedRequest"];
-		} = {},
-	): LifeOpsCtx {
-		const method = extra.method ?? "GET";
-		const req = makeReq(method, pathname);
-		return {
-			req,
-			res: makeRes(),
-			method,
-			pathname,
-			url: new URL(pathname, "http://localhost"),
-			state: dispatchState({ runtime: extra.runtime }),
-			isAuthorizedRequest: extra.isAuthorizedRequest ?? (() => false),
-		};
-	}
+  function ctx(
+    pathname: string,
+    extra: {
+      method?: string;
+      runtime?: AgentRuntime | null;
+      isAuthorizedRequest?: LifeOpsCtx["isAuthorizedRequest"];
+    } = {},
+  ): LifeOpsCtx {
+    const method = extra.method ?? "GET";
+    const req = makeReq(method, pathname);
+    return {
+      req,
+      res: makeRes(),
+      method,
+      pathname,
+      url: new URL(pathname, "http://localhost"),
+      state: dispatchState({ runtime: extra.runtime }),
+      isAuthorizedRequest: extra.isAuthorizedRequest ?? (() => false),
+    };
+  }
 
-	it("returns false when the runtime has no plugin routes", async () => {
-		const runtime = { routes: [] } as unknown as AgentRuntime;
-		await expect(
-			handleLifeOpsRuntimePluginRoute(ctx("/lifeops/ping", { runtime })),
-		).resolves.toBe(false);
-	});
+  it("returns false when the runtime has no plugin routes", async () => {
+    const runtime = { routes: [] } as unknown as AgentRuntime;
+    await expect(
+      handleLifeOpsRuntimePluginRoute(ctx("/lifeops/ping", { runtime })),
+    ).resolves.toBe(false);
+  });
 
-	it("returns false when runtime is null", async () => {
-		await expect(
-			handleLifeOpsRuntimePluginRoute(ctx("/lifeops/ping")),
-		).resolves.toBe(false);
-	});
+  it("returns false when runtime is null", async () => {
+    await expect(
+      handleLifeOpsRuntimePluginRoute(ctx("/lifeops/ping")),
+    ).resolves.toBe(false);
+  });
 
-	it("401s a private matching route when isAuthorizedRequest is false", async () => {
-		const isAuthorizedRequest = vi.fn((incoming: http.IncomingMessage) => {
-			expect(incoming.url).toBe("/lifeops/private");
-			return false;
-		});
-		const runtime = {
-			routes: [
-				{
-					type: "GET",
-					path: "/lifeops/private",
-					handler: vi.fn(),
-				},
-			] as unknown as Route[],
-		} as unknown as AgentRuntime;
-		const args = ctx("/lifeops/private", { runtime, isAuthorizedRequest });
-		await expect(handleLifeOpsRuntimePluginRoute(args)).resolves.toBe(true);
-		expect(isAuthorizedRequest).toHaveBeenCalledWith(args.req);
-		expect(args.res.statusCode).toBe(401);
-	});
+  it("401s a private matching route when isAuthorizedRequest is false", async () => {
+    const isAuthorizedRequest = vi.fn((incoming: http.IncomingMessage) => {
+      expect(incoming.url).toBe("/lifeops/private");
+      return false;
+    });
+    const runtime = {
+      routes: [
+        {
+          type: "GET",
+          path: "/lifeops/private",
+          handler: vi.fn(),
+        },
+      ] as unknown as Route[],
+    } as unknown as AgentRuntime;
+    const args = ctx("/lifeops/private", { runtime, isAuthorizedRequest });
+    await expect(handleLifeOpsRuntimePluginRoute(args)).resolves.toBe(true);
+    expect(isAuthorizedRequest).toHaveBeenCalledWith(args.req);
+    expect(args.res.statusCode).toBe(401);
+  });
 
-	it("invokes a matching public GET handler", async () => {
-		const handler = vi.fn(async (_req: unknown, res: unknown) => {
-			(res as http.ServerResponse).end(JSON.stringify({ ok: true }));
-		});
-		const runtime = {
-			routes: [
-				{
-					type: "GET",
-					path: "/lifeops/ping",
-					public: true,
-					publicReason: "test ping",
-					handler,
-				},
-			] as unknown as Route[],
-		} as unknown as AgentRuntime;
-		const args = ctx("/lifeops/ping", {
-			runtime,
-			isAuthorizedRequest: vi.fn(() => false),
-		});
-		await expect(handleLifeOpsRuntimePluginRoute(args)).resolves.toBe(true);
-		expect(handler).toHaveBeenCalledTimes(1);
-		expect(args.isAuthorizedRequest).not.toHaveBeenCalled();
-	});
+  it("invokes a matching public GET handler", async () => {
+    const handler = vi.fn(async (_req: unknown, res: unknown) => {
+      (res as http.ServerResponse).end(JSON.stringify({ ok: true }));
+    });
+    const runtime = {
+      routes: [
+        {
+          type: "GET",
+          path: "/lifeops/ping",
+          public: true,
+          publicReason: "test ping",
+          handler,
+        },
+      ] as unknown as Route[],
+    } as unknown as AgentRuntime;
+    const args = ctx("/lifeops/ping", {
+      runtime,
+      isAuthorizedRequest: vi.fn(() => false),
+    });
+    await expect(handleLifeOpsRuntimePluginRoute(args)).resolves.toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(args.isAuthorizedRequest).not.toHaveBeenCalled();
+  });
 
-	it("does not match a GET route against POST", async () => {
-		const handler = vi.fn();
-		const runtime = {
-			routes: [
-				{
-					type: "GET",
-					path: "/lifeops/ping",
-					public: true,
-					publicReason: "test ping",
-					handler,
-				},
-			] as unknown as Route[],
-		} as unknown as AgentRuntime;
-		await expect(
-			handleLifeOpsRuntimePluginRoute(
-				ctx("/lifeops/ping", { method: "POST", runtime }),
-			),
-		).resolves.toBe(false);
-		expect(handler).not.toHaveBeenCalled();
-	});
+  it("does not match a GET route against POST", async () => {
+    const handler = vi.fn();
+    const runtime = {
+      routes: [
+        {
+          type: "GET",
+          path: "/lifeops/ping",
+          public: true,
+          publicReason: "test ping",
+          handler,
+        },
+      ] as unknown as Route[],
+    } as unknown as AgentRuntime;
+    await expect(
+      handleLifeOpsRuntimePluginRoute(
+        ctx("/lifeops/ping", { method: "POST", runtime }),
+      ),
+    ).resolves.toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent/src/api/task-agent-message-routing.test.ts
+++ b/packages/agent/src/api/task-agent-message-routing.test.ts
@@ -6,16 +6,16 @@
  * module with an in-memory runtime; no live model or network.
  */
 import {
-	type AgentRuntime,
-	type SendHandlerOutcome,
-	SWARM_COORDINATOR_SERVICE_TYPE,
-	type SwarmCoordinatorTaskContext,
-	type UUID,
+  type AgentRuntime,
+  type SendHandlerOutcome,
+  SWARM_COORDINATOR_SERVICE_TYPE,
+  type SwarmCoordinatorTaskContext,
+  type UUID,
 } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
-	routeTaskAgentTextToConnector,
-	type TaskAgentChatRouting,
+  routeTaskAgentTextToConnector,
+  type TaskAgentChatRouting,
 } from "./task-agent-message-routing";
 
 const ROOM_ID = "00000000-0000-4000-8000-0000000000b1" as UUID;
@@ -24,519 +24,519 @@ const THREAD_ID = "thread-1";
 const SESSION_ID = "session-1";
 
 function confirmedDelivery(): SendHandlerOutcome {
-	return {
-		kind: "delivered",
-		receipt: {
-			providerMessageIds: ["task-agent-provider-1"],
-			acceptedAt: 1_780_000_000_000,
-			persistence: { status: "persisted", memoryIds: [] },
-		},
-		memories: [],
-	};
+  return {
+    kind: "delivered",
+    receipt: {
+      providerMessageIds: ["task-agent-provider-1"],
+      acceptedAt: 1_780_000_000_000,
+      persistence: { status: "persisted", memoryIds: [] },
+    },
+    memories: [],
+  };
 }
 
 function task(
-	overrides: SwarmCoordinatorTaskContext = {},
+  overrides: SwarmCoordinatorTaskContext = {},
 ): SwarmCoordinatorTaskContext {
-	return { ...overrides };
+  return { ...overrides };
 }
 
 function makeCoordinator(
-	options: {
-		tasks?: SwarmCoordinatorTaskContext[];
-		contextBySession?: Record<string, SwarmCoordinatorTaskContext | null>;
-		threadById?: Record<
-			string,
-			{ roomId?: string | number | null } | null | undefined
-		>;
-		omitAllTasks?: boolean;
-		omitContext?: boolean;
-		omitThread?: boolean;
-	} = {},
+  options: {
+    tasks?: SwarmCoordinatorTaskContext[];
+    contextBySession?: Record<string, SwarmCoordinatorTaskContext | null>;
+    threadById?: Record<
+      string,
+      { roomId?: string | number | null } | null | undefined
+    >;
+    omitAllTasks?: boolean;
+    omitContext?: boolean;
+    omitThread?: boolean;
+  } = {},
 ) {
-	return {
-		getAllTaskContexts: options.omitAllTasks
-			? undefined
-			: vi.fn(() => options.tasks ?? []),
-		getTaskContext: options.omitContext
-			? undefined
-			: vi.fn(
-					(sessionId: string) => options.contextBySession?.[sessionId] ?? null,
-				),
-		getTaskThread: options.omitThread
-			? undefined
-			: vi.fn(async (threadId: string) =>
-					Object.hasOwn(options.threadById ?? {}, threadId)
-						? (options.threadById?.[threadId] ?? null)
-						: null,
-				),
-	};
+  return {
+    getAllTaskContexts: options.omitAllTasks
+      ? undefined
+      : vi.fn(() => options.tasks ?? []),
+    getTaskContext: options.omitContext
+      ? undefined
+      : vi.fn(
+          (sessionId: string) => options.contextBySession?.[sessionId] ?? null,
+        ),
+    getTaskThread: options.omitThread
+      ? undefined
+      : vi.fn(async (threadId: string) =>
+          Object.hasOwn(options.threadById ?? {}, threadId)
+            ? (options.threadById?.[threadId] ?? null)
+            : null,
+        ),
+  };
 }
 
 function makeRuntime(options: {
-	coordinator?: ReturnType<typeof makeCoordinator> | null;
-	room?: {
-		id: UUID;
-		source?: string;
-		channelId?: string;
-		serverId?: string | null;
-	} | null;
-	getRoomError?: Error;
-	sendOutcome?: SendHandlerOutcome;
-	returnUnconfirmedSend?: boolean;
+  coordinator?: ReturnType<typeof makeCoordinator> | null;
+  room?: {
+    id: UUID;
+    source?: string;
+    channelId?: string;
+    serverId?: string | null;
+  } | null;
+  getRoomError?: Error;
+  sendOutcome?: SendHandlerOutcome;
+  returnUnconfirmedSend?: boolean;
 }): AgentRuntime {
-	const getRoom = vi.fn(async (_roomId: UUID) => {
-		if (options.getRoomError) throw options.getRoomError;
-		return options.room === undefined
-			? { id: ROOM_ID, source: "discord", channelId: "channel-1" }
-			: options.room;
-	});
-	const sendMessageToTarget = vi.fn(async () =>
-		options.returnUnconfirmedSend
-			? undefined
-			: (options.sendOutcome ?? confirmedDelivery()),
-	);
-	const getService = vi.fn((serviceType: string) =>
-		serviceType === SWARM_COORDINATOR_SERVICE_TYPE
-			? (options.coordinator ?? null)
-			: null,
-	);
-	return {
-		getRoom,
-		getService,
-		sendMessageToTarget,
-	} as unknown as AgentRuntime;
+  const getRoom = vi.fn(async (_roomId: UUID) => {
+    if (options.getRoomError) throw options.getRoomError;
+    return options.room === undefined
+      ? { id: ROOM_ID, source: "discord", channelId: "channel-1" }
+      : options.room;
+  });
+  const sendMessageToTarget = vi.fn(async () =>
+    options.returnUnconfirmedSend
+      ? undefined
+      : (options.sendOutcome ?? confirmedDelivery()),
+  );
+  const getService = vi.fn((serviceType: string) =>
+    serviceType === SWARM_COORDINATOR_SERVICE_TYPE
+      ? (options.coordinator ?? null)
+      : null,
+  );
+  return {
+    getRoom,
+    getService,
+    sendMessageToTarget,
+  } as unknown as AgentRuntime;
 }
 
 describe("routeTaskAgentTextToConnector — admission and room resolution", () => {
-	it("returns false when the runtime is missing", async () => {
-		await expect(
-			routeTaskAgentTextToConnector(null, "hello", "task-agent"),
-		).resolves.toBe(false);
-	});
+  it("returns false when the runtime is missing", async () => {
+    await expect(
+      routeTaskAgentTextToConnector(null, "hello", "task-agent"),
+    ).resolves.toBe(false);
+  });
 
-	it("returns false when no room can be resolved from routing or tasks", async () => {
-		const runtime = makeRuntime({
-			coordinator: makeCoordinator({ tasks: [] }),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "hello", "task-agent"),
-		).resolves.toBe(false);
-		expect(runtime.sendMessageToTarget).not.toHaveBeenCalled();
-	});
+  it("returns false when no room can be resolved from routing or tasks", async () => {
+    const runtime = makeRuntime({
+      coordinator: makeCoordinator({ tasks: [] }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "hello", "task-agent"),
+    ).resolves.toBe(false);
+    expect(runtime.sendMessageToTarget).not.toHaveBeenCalled();
+  });
 
-	it("returns false when getRoom rejects or the room has no source", async () => {
-		const thrown = makeRuntime({
-			getRoomError: new Error("room store down"),
-			coordinator: makeCoordinator(),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(thrown, "hello", "task-agent", {
-				roomId: ROOM_ID,
-			}),
-		).resolves.toBe(false);
-		expect(thrown.sendMessageToTarget).not.toHaveBeenCalled();
+  it("returns false when getRoom rejects or the room has no source", async () => {
+    const thrown = makeRuntime({
+      getRoomError: new Error("room store down"),
+      coordinator: makeCoordinator(),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(thrown, "hello", "task-agent", {
+        roomId: ROOM_ID,
+      }),
+    ).resolves.toBe(false);
+    expect(thrown.sendMessageToTarget).not.toHaveBeenCalled();
 
-		const sourceless = makeRuntime({
-			room: { id: ROOM_ID },
-		});
-		await expect(
-			routeTaskAgentTextToConnector(sourceless, "hello", "task-agent", {
-				roomId: ROOM_ID,
-			}),
-		).resolves.toBe(false);
-		expect(sourceless.sendMessageToTarget).not.toHaveBeenCalled();
-	});
+    const sourceless = makeRuntime({
+      room: { id: ROOM_ID },
+    });
+    await expect(
+      routeTaskAgentTextToConnector(sourceless, "hello", "task-agent", {
+        roomId: ROOM_ID,
+      }),
+    ).resolves.toBe(false);
+    expect(sourceless.sendMessageToTarget).not.toHaveBeenCalled();
+  });
 
-	it("returns false for a blank explicit roomId and for a whitespace thread room", async () => {
-		const blankRoom = makeRuntime({ coordinator: makeCoordinator() });
-		await expect(
-			routeTaskAgentTextToConnector(blankRoom, "hello", "task-agent", {
-				roomId: "",
-			}),
-		).resolves.toBe(false);
+  it("returns false for a blank explicit roomId and for a whitespace thread room", async () => {
+    const blankRoom = makeRuntime({ coordinator: makeCoordinator() });
+    await expect(
+      routeTaskAgentTextToConnector(blankRoom, "hello", "task-agent", {
+        roomId: "",
+      }),
+    ).resolves.toBe(false);
 
-		const whitespace = makeRuntime({
-			coordinator: makeCoordinator({
-				threadById: { [THREAD_ID]: { roomId: "   " } },
-			}),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(whitespace, "hello", "task-agent", {
-				threadId: THREAD_ID,
-			}),
-		).resolves.toBe(false);
-		expect(whitespace.sendMessageToTarget).not.toHaveBeenCalled();
-	});
+    const whitespace = makeRuntime({
+      coordinator: makeCoordinator({
+        threadById: { [THREAD_ID]: { roomId: "   " } },
+      }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(whitespace, "hello", "task-agent", {
+        threadId: THREAD_ID,
+      }),
+    ).resolves.toBe(false);
+    expect(whitespace.sendMessageToTarget).not.toHaveBeenCalled();
+  });
 
-	it("returns false when the thread roomId is missing or not a string", async () => {
-		const missing = makeRuntime({
-			coordinator: makeCoordinator({
-				threadById: { [THREAD_ID]: {} },
-			}),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(missing, "hello", "task-agent", {
-				threadId: THREAD_ID,
-			}),
-		).resolves.toBe(false);
+  it("returns false when the thread roomId is missing or not a string", async () => {
+    const missing = makeRuntime({
+      coordinator: makeCoordinator({
+        threadById: { [THREAD_ID]: {} },
+      }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(missing, "hello", "task-agent", {
+        threadId: THREAD_ID,
+      }),
+    ).resolves.toBe(false);
 
-		const numeric = makeRuntime({
-			coordinator: makeCoordinator({
-				threadById: { [THREAD_ID]: { roomId: 42 } },
-			}),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(numeric, "hello", "task-agent", {
-				threadId: THREAD_ID,
-			}),
-		).resolves.toBe(false);
-	});
+    const numeric = makeRuntime({
+      coordinator: makeCoordinator({
+        threadById: { [THREAD_ID]: { roomId: 42 } },
+      }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(numeric, "hello", "task-agent", {
+        threadId: THREAD_ID,
+      }),
+    ).resolves.toBe(false);
+  });
 });
 
 describe("routeTaskAgentTextToConnector — explicit routing", () => {
-	it("delivers through the room's source connector when roomId is given", async () => {
-		const runtime = makeRuntime({
-			room: {
-				id: ROOM_ID,
-				source: "discord",
-				channelId: "channel-1",
-				serverId: "server-1",
-			},
-		});
+  it("delivers through the room's source connector when roomId is given", async () => {
+    const runtime = makeRuntime({
+      room: {
+        id: ROOM_ID,
+        source: "discord",
+        channelId: "channel-1",
+        serverId: "server-1",
+      },
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "task done", "task-agent", {
-				roomId: ROOM_ID,
-			}),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "task done", "task-agent", {
+        roomId: ROOM_ID,
+      }),
+    ).resolves.toBe(true);
 
-		expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
-		expect(runtime.sendMessageToTarget).toHaveBeenCalledOnce();
-		expect(runtime.sendMessageToTarget).toHaveBeenCalledWith(
-			{
-				source: "discord",
-				roomId: ROOM_ID,
-				channelId: "channel-1",
-				serverId: "server-1",
-			},
-			{ text: "task done", source: "task-agent", agentVoiced: true },
-		);
-	});
+    expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
+    expect(runtime.sendMessageToTarget).toHaveBeenCalledOnce();
+    expect(runtime.sendMessageToTarget).toHaveBeenCalledWith(
+      {
+        source: "discord",
+        roomId: ROOM_ID,
+        channelId: "channel-1",
+        serverId: "server-1",
+      },
+      { text: "task done", source: "task-agent", agentVoiced: true },
+    );
+  });
 
-	it("falls back to room.id as channelId and omits a null serverId", async () => {
-		const runtime = makeRuntime({
-			room: { id: ROOM_ID, source: "telegram", serverId: null },
-		});
+  it("falls back to room.id as channelId and omits a null serverId", async () => {
+    const runtime = makeRuntime({
+      room: { id: ROOM_ID, source: "telegram", serverId: null },
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "ping", "swarm", {
-				roomId: ROOM_ID,
-			}),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "ping", "swarm", {
+        roomId: ROOM_ID,
+      }),
+    ).resolves.toBe(true);
 
-		expect(runtime.sendMessageToTarget).toHaveBeenCalledWith(
-			{
-				source: "telegram",
-				roomId: ROOM_ID,
-				channelId: ROOM_ID,
-				serverId: undefined,
-			},
-			{ text: "ping", source: "swarm", agentVoiced: true },
-		);
-	});
+    expect(runtime.sendMessageToTarget).toHaveBeenCalledWith(
+      {
+        source: "telegram",
+        roomId: ROOM_ID,
+        channelId: ROOM_ID,
+        serverId: undefined,
+      },
+      { text: "ping", source: "swarm", agentVoiced: true },
+    );
+  });
 
-	it("fills threadId from getTaskContext when only sessionId is given", async () => {
-		const coordinator = makeCoordinator({
-			contextBySession: {
-				[SESSION_ID]: task({ threadId: THREAD_ID }),
-			},
-			threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
-		});
-		const runtime = makeRuntime({ coordinator });
+  it("fills threadId from getTaskContext when only sessionId is given", async () => {
+    const coordinator = makeCoordinator({
+      contextBySession: {
+        [SESSION_ID]: task({ threadId: THREAD_ID }),
+      },
+      threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
+    });
+    const runtime = makeRuntime({ coordinator });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "update", "task-agent", {
-				sessionId: SESSION_ID,
-			}),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "update", "task-agent", {
+        sessionId: SESSION_ID,
+      }),
+    ).resolves.toBe(true);
 
-		expect(coordinator.getTaskContext).toHaveBeenCalledWith(SESSION_ID);
-		expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
-		expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
-	});
+    expect(coordinator.getTaskContext).toHaveBeenCalledWith(SESSION_ID);
+    expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
+    expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
+  });
 
-	it("does not consult getTaskContext when threadId is already present", async () => {
-		const coordinator = makeCoordinator({
-			threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
-		});
-		const runtime = makeRuntime({ coordinator });
+  it("does not consult getTaskContext when threadId is already present", async () => {
+    const coordinator = makeCoordinator({
+      threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
+    });
+    const runtime = makeRuntime({ coordinator });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "update", "task-agent", {
-				sessionId: SESSION_ID,
-				threadId: THREAD_ID,
-			}),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "update", "task-agent", {
+        sessionId: SESSION_ID,
+        threadId: THREAD_ID,
+      }),
+    ).resolves.toBe(true);
 
-		expect(coordinator.getTaskContext).not.toHaveBeenCalled();
-		expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
-	});
+    expect(coordinator.getTaskContext).not.toHaveBeenCalled();
+    expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
+  });
 
-	it("prefers an explicit roomId over thread lookup", async () => {
-		const coordinator = makeCoordinator({
-			threadById: { [THREAD_ID]: { roomId: OTHER_ROOM_ID } },
-		});
-		const runtime = makeRuntime({
-			coordinator,
-			room: { id: ROOM_ID, source: "discord" },
-		});
+  it("prefers an explicit roomId over thread lookup", async () => {
+    const coordinator = makeCoordinator({
+      threadById: { [THREAD_ID]: { roomId: OTHER_ROOM_ID } },
+    });
+    const runtime = makeRuntime({
+      coordinator,
+      room: { id: ROOM_ID, source: "discord" },
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "update", "task-agent", {
-				roomId: ROOM_ID,
-				threadId: THREAD_ID,
-			}),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "update", "task-agent", {
+        roomId: ROOM_ID,
+        threadId: THREAD_ID,
+      }),
+    ).resolves.toBe(true);
 
-		expect(coordinator.getTaskThread).not.toHaveBeenCalled();
-		expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
-	});
+    expect(coordinator.getTaskThread).not.toHaveBeenCalled();
+    expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
+  });
 
-	it("returns false when the coordinator lacks getTaskThread or getTaskContext", async () => {
-		const noThread = makeRuntime({
-			coordinator: makeCoordinator({ omitThread: true }),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(noThread, "hello", "task-agent", {
-				threadId: THREAD_ID,
-			}),
-		).resolves.toBe(false);
+  it("returns false when the coordinator lacks getTaskThread or getTaskContext", async () => {
+    const noThread = makeRuntime({
+      coordinator: makeCoordinator({ omitThread: true }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(noThread, "hello", "task-agent", {
+        threadId: THREAD_ID,
+      }),
+    ).resolves.toBe(false);
 
-		const noContext = makeRuntime({
-			coordinator: makeCoordinator({ omitContext: true }),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(noContext, "hello", "task-agent", {
-				sessionId: SESSION_ID,
-			}),
-		).resolves.toBe(false);
-	});
+    const noContext = makeRuntime({
+      coordinator: makeCoordinator({ omitContext: true }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(noContext, "hello", "task-agent", {
+        sessionId: SESSION_ID,
+      }),
+    ).resolves.toBe(false);
+  });
 });
 
 describe("routeTaskAgentTextToConnector — inferred in-flight task routing", () => {
-	it("uses the single in-flight task when the queue has one element", async () => {
-		const coordinator = makeCoordinator({
-			tasks: [
-				task({
-					label: "coder",
-					sessionId: SESSION_ID,
-					threadId: THREAD_ID,
-				}),
-			],
-			threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
-		});
-		const runtime = makeRuntime({ coordinator });
+  it("uses the single in-flight task when the queue has one element", async () => {
+    const coordinator = makeCoordinator({
+      tasks: [
+        task({
+          label: "coder",
+          sessionId: SESSION_ID,
+          threadId: THREAD_ID,
+        }),
+      ],
+      threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
+    });
+    const runtime = makeRuntime({ coordinator });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "here is the patch", "task-agent"),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "here is the patch", "task-agent"),
+    ).resolves.toBe(true);
 
-		expect(coordinator.getAllTaskContexts).toHaveBeenCalledOnce();
-		expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
-		expect(runtime.sendMessageToTarget).toHaveBeenCalledOnce();
-	});
+    expect(coordinator.getAllTaskContexts).toHaveBeenCalledOnce();
+    expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
+    expect(runtime.sendMessageToTarget).toHaveBeenCalledOnce();
+  });
 
-	it("returns false for an empty queue and for a non-array task list", async () => {
-		const empty = makeRuntime({
-			coordinator: makeCoordinator({ tasks: [] }),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(empty, "hello", "task-agent"),
-		).resolves.toBe(false);
+  it("returns false for an empty queue and for a non-array task list", async () => {
+    const empty = makeRuntime({
+      coordinator: makeCoordinator({ tasks: [] }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(empty, "hello", "task-agent"),
+    ).resolves.toBe(false);
 
-		const coordinator = makeCoordinator({ omitAllTasks: true });
-		coordinator.getAllTaskContexts = vi.fn(
-			() => ({ not: "an-array" }) as unknown as SwarmCoordinatorTaskContext[],
-		);
-		const bogus = makeRuntime({ coordinator });
-		await expect(
-			routeTaskAgentTextToConnector(bogus, "hello", "task-agent"),
-		).resolves.toBe(false);
-		expect(bogus.sendMessageToTarget).not.toHaveBeenCalled();
-	});
+    const coordinator = makeCoordinator({ omitAllTasks: true });
+    coordinator.getAllTaskContexts = vi.fn(
+      () => ({ not: "an-array" }) as unknown as SwarmCoordinatorTaskContext[],
+    );
+    const bogus = makeRuntime({ coordinator });
+    await expect(
+      routeTaskAgentTextToConnector(bogus, "hello", "task-agent"),
+    ).resolves.toBe(false);
+    expect(bogus.sendMessageToTarget).not.toHaveBeenCalled();
+  });
 
-	it("returns false when several tasks are in flight and the text names none", async () => {
-		const runtime = makeRuntime({
-			coordinator: makeCoordinator({
-				tasks: [
-					task({ label: "coder", sessionId: "s1", threadId: "t1" }),
-					task({ label: "reviewer", sessionId: "s2", threadId: "t2" }),
-				],
-				threadById: { t1: { roomId: ROOM_ID }, t2: { roomId: OTHER_ROOM_ID } },
-			}),
-		});
+  it("returns false when several tasks are in flight and the text names none", async () => {
+    const runtime = makeRuntime({
+      coordinator: makeCoordinator({
+        tasks: [
+          task({ label: "coder", sessionId: "s1", threadId: "t1" }),
+          task({ label: "reviewer", sessionId: "s2", threadId: "t2" }),
+        ],
+        threadById: { t1: { roomId: ROOM_ID }, t2: { roomId: OTHER_ROOM_ID } },
+      }),
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "status?", "task-agent"),
-		).resolves.toBe(false);
-		expect(runtime.sendMessageToTarget).not.toHaveBeenCalled();
-	});
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "status?", "task-agent"),
+    ).resolves.toBe(false);
+    expect(runtime.sendMessageToTarget).not.toHaveBeenCalled();
+  });
 
-	it("routes by a unique login-label match among several tasks", async () => {
-		const coordinator = makeCoordinator({
-			tasks: [
-				task({ label: "coder", sessionId: "s1", threadId: "t1" }),
-				task({
-					label: "reviewer",
-					sessionId: SESSION_ID,
-					threadId: THREAD_ID,
-				}),
-			],
-			threadById: {
-				t1: { roomId: OTHER_ROOM_ID },
-				[THREAD_ID]: { roomId: ROOM_ID },
-			},
-		});
-		const runtime = makeRuntime({ coordinator });
+  it("routes by a unique login-label match among several tasks", async () => {
+    const coordinator = makeCoordinator({
+      tasks: [
+        task({ label: "coder", sessionId: "s1", threadId: "t1" }),
+        task({
+          label: "reviewer",
+          sessionId: SESSION_ID,
+          threadId: THREAD_ID,
+        }),
+      ],
+      threadById: {
+        t1: { roomId: OTHER_ROOM_ID },
+        [THREAD_ID]: { roomId: ROOM_ID },
+      },
+    });
+    const runtime = makeRuntime({ coordinator });
 
-		await expect(
-			routeTaskAgentTextToConnector(
-				runtime,
-				`"reviewer" needs a provider login to continue`,
-				"task-agent",
-			),
-		).resolves.toBe(true);
+    await expect(
+      routeTaskAgentTextToConnector(
+        runtime,
+        `"reviewer" needs a provider login to continue`,
+        "task-agent",
+      ),
+    ).resolves.toBe(true);
 
-		expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
-		expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
-	});
+    expect(coordinator.getTaskThread).toHaveBeenCalledWith(THREAD_ID);
+    expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
+  });
 
-	it("returns false when the login label is missing or tied across tasks", async () => {
-		const tasks = [
-			task({ label: "coder", sessionId: "s1", threadId: "t1" }),
-			task({ label: "coder", sessionId: "s2", threadId: "t2" }),
-		];
-		const missing = makeRuntime({
-			coordinator: makeCoordinator({
-				tasks,
-				threadById: { t1: { roomId: ROOM_ID } },
-			}),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(
-				missing,
-				`"reviewer" needs a provider login`,
-				"task-agent",
-			),
-		).resolves.toBe(false);
+  it("returns false when the login label is missing or tied across tasks", async () => {
+    const tasks = [
+      task({ label: "coder", sessionId: "s1", threadId: "t1" }),
+      task({ label: "coder", sessionId: "s2", threadId: "t2" }),
+    ];
+    const missing = makeRuntime({
+      coordinator: makeCoordinator({
+        tasks,
+        threadById: { t1: { roomId: ROOM_ID } },
+      }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(
+        missing,
+        `"reviewer" needs a provider login`,
+        "task-agent",
+      ),
+    ).resolves.toBe(false);
 
-		const tied = makeRuntime({
-			coordinator: makeCoordinator({
-				tasks,
-				threadById: { t1: { roomId: ROOM_ID }, t2: { roomId: OTHER_ROOM_ID } },
-			}),
-		});
-		await expect(
-			routeTaskAgentTextToConnector(
-				tied,
-				`"coder" needs a provider login`,
-				"task-agent",
-			),
-		).resolves.toBe(false);
-		expect(tied.sendMessageToTarget).not.toHaveBeenCalled();
-	});
+    const tied = makeRuntime({
+      coordinator: makeCoordinator({
+        tasks,
+        threadById: { t1: { roomId: ROOM_ID }, t2: { roomId: OTHER_ROOM_ID } },
+      }),
+    });
+    await expect(
+      routeTaskAgentTextToConnector(
+        tied,
+        `"coder" needs a provider login`,
+        "task-agent",
+      ),
+    ).resolves.toBe(false);
+    expect(tied.sendMessageToTarget).not.toHaveBeenCalled();
+  });
 
-	it("does not infer from a login line that is not anchored at the start", async () => {
-		const runtime = makeRuntime({
-			coordinator: makeCoordinator({
-				tasks: [
-					task({ label: "coder", sessionId: "s1", threadId: "t1" }),
-					task({ label: "reviewer", sessionId: "s2", threadId: THREAD_ID }),
-				],
-				threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
-			}),
-		});
+  it("does not infer from a login line that is not anchored at the start", async () => {
+    const runtime = makeRuntime({
+      coordinator: makeCoordinator({
+        tasks: [
+          task({ label: "coder", sessionId: "s1", threadId: "t1" }),
+          task({ label: "reviewer", sessionId: "s2", threadId: THREAD_ID }),
+        ],
+        threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
+      }),
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(
-				runtime,
-				`note: "reviewer" needs a provider login`,
-				"task-agent",
-			),
-		).resolves.toBe(false);
-	});
+    await expect(
+      routeTaskAgentTextToConnector(
+        runtime,
+        `note: "reviewer" needs a provider login`,
+        "task-agent",
+      ),
+    ).resolves.toBe(false);
+  });
 
-	it("skips inference when an explicit routing object is provided", async () => {
-		const coordinator = makeCoordinator({
-			tasks: [
-				task({
-					label: "coder",
-					sessionId: SESSION_ID,
-					threadId: THREAD_ID,
-				}),
-			],
-			threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
-		});
-		const runtime = makeRuntime({ coordinator });
-		const routing: TaskAgentChatRouting = {};
+  it("skips inference when an explicit routing object is provided", async () => {
+    const coordinator = makeCoordinator({
+      tasks: [
+        task({
+          label: "coder",
+          sessionId: SESSION_ID,
+          threadId: THREAD_ID,
+        }),
+      ],
+      threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
+    });
+    const runtime = makeRuntime({ coordinator });
+    const routing: TaskAgentChatRouting = {};
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "hello", "task-agent", routing),
-		).resolves.toBe(false);
-		expect(coordinator.getAllTaskContexts).not.toHaveBeenCalled();
-	});
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "hello", "task-agent", routing),
+    ).resolves.toBe(false);
+    expect(coordinator.getAllTaskContexts).not.toHaveBeenCalled();
+  });
 
-	it("fills threadId from the session after inferring a session-only task", async () => {
-		const coordinator = makeCoordinator({
-			tasks: [task({ label: "coder", sessionId: SESSION_ID })],
-			contextBySession: {
-				[SESSION_ID]: task({ threadId: THREAD_ID }),
-			},
-			threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
-		});
-		const runtime = makeRuntime({ coordinator });
+  it("fills threadId from the session after inferring a session-only task", async () => {
+    const coordinator = makeCoordinator({
+      tasks: [task({ label: "coder", sessionId: SESSION_ID })],
+      contextBySession: {
+        [SESSION_ID]: task({ threadId: THREAD_ID }),
+      },
+      threadById: { [THREAD_ID]: { roomId: ROOM_ID } },
+    });
+    const runtime = makeRuntime({ coordinator });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "hello", "task-agent"),
-		).resolves.toBe(true);
-		expect(coordinator.getTaskContext).toHaveBeenCalledWith(SESSION_ID);
-		expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
-	});
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "hello", "task-agent"),
+    ).resolves.toBe(true);
+    expect(coordinator.getTaskContext).toHaveBeenCalledWith(SESSION_ID);
+    expect(runtime.getRoom).toHaveBeenCalledWith(ROOM_ID);
+  });
 });
 
 describe("routeTaskAgentTextToConnector — delivery confirmation", () => {
-	it("propagates when the connector send is not confirmed", async () => {
-		const runtime = makeRuntime({
-			returnUnconfirmedSend: true,
-		});
+  it("propagates when the connector send is not confirmed", async () => {
+    const runtime = makeRuntime({
+      returnUnconfirmedSend: true,
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "hello", "task-agent", {
-				roomId: ROOM_ID,
-			}),
-		).rejects.toThrow(/not confirmed/i);
-	});
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "hello", "task-agent", {
+        roomId: ROOM_ID,
+      }),
+    ).rejects.toThrow(/not confirmed/i);
+  });
 
-	it("rejects a partially delivered send before reporting success", async () => {
-		const runtime = makeRuntime({
-			sendOutcome: {
-				kind: "partially_delivered",
-				receipt: {
-					providerMessageIds: ["task-agent-provider-1"],
-					acceptedAt: 1_780_000_000_000,
-					persistence: { status: "persisted", memoryIds: [] },
-				},
-				memories: [],
-				code: "PARTIAL",
-				message: "second chunk failed",
-			},
-		});
+  it("rejects a partially delivered send before reporting success", async () => {
+    const runtime = makeRuntime({
+      sendOutcome: {
+        kind: "partially_delivered",
+        receipt: {
+          providerMessageIds: ["task-agent-provider-1"],
+          acceptedAt: 1_780_000_000_000,
+          persistence: { status: "persisted", memoryIds: [] },
+        },
+        memories: [],
+        code: "PARTIAL",
+        message: "second chunk failed",
+      },
+    });
 
-		await expect(
-			routeTaskAgentTextToConnector(runtime, "hello", "task-agent", {
-				roomId: ROOM_ID,
-			}),
-		).rejects.toThrow(/not confirmed/i);
-	});
+    await expect(
+      routeTaskAgentTextToConnector(runtime, "hello", "task-agent", {
+        roomId: ROOM_ID,
+      }),
+    ).rejects.toThrow(/not confirmed/i);
+  });
 });


### PR DESCRIPTION
## Summary

- apply the pinned formatter to the server route-dispatch and task-agent routing suites
- preserve the complete code token stream; `git diff -w` is empty for both files

Closes #25476.

## Verification

- `bun install`
- clean-checkout core/shared prerequisite builds
- two focused route suites — 57 tests passed
- pinned Biome check on both files — clean
- `git diff -w --exit-code` and `git diff --check`
- full agent lint will be measured in the composed integration stack because current `develop` still needs #25443 and #25448

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
