### PR TITLE
fix(scenario-runner): separate fixture plugin requirements

### DIFF
--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -49,6 +49,19 @@ export default {
 } satisfies ScenarioDefinition;
 ```
 
+### Plugin requirements
+
+Declare npm plugin import specifiers in `requires.plugins`; the runner passes
+each value to the runtime module resolver and registers the exported plugin
+before startup. This supports scoped or unscoped packages and package subpath
+exports without guessing from the spelling. Relative, absolute, `file:`, and
+`workspace:` specifiers fail preflight with a typed error because they are not
+portable runtime package requirements.
+
+If a scenario seed registers an in-file fixture plugin, declare its runtime
+plugin name in `requires.fixturePlugins` instead. Fixture names are verified
+after seeding and are never treated as module specifiers.
+
 ### Turn kinds
 
 | Kind | What it does |

--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -576,8 +576,10 @@ export type ScenarioPersonalityExpect = {
 
 /** Runtime capabilities that must be ready before scenario turns execute. */
 export type ScenarioRequirements = {
-  /** Plugin packages that the runner may load when they are not registered. */
+  /** Import specifiers for plugin packages the runner loads before execution. */
   plugins?: readonly string[];
+  /** Plugin names that this scenario's seed registers locally. */
+  fixturePlugins?: readonly string[];
   /**
    * Service types whose startup must complete successfully before execution.
    * Services omitted here are optional even when a required plugin declares them.

--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -293,10 +293,16 @@ function validateScenarioRequirements(value) {
     Array.isArray(requires)
   ) {
     throw new Error(
-      `scenario "${value?.id ?? "<unknown>"}" has invalid requires; expected { plugins?: string[], services?: string[], credentials?: string[], os?: string }`,
+      `scenario "${value?.id ?? "<unknown>"}" has invalid requires; expected { plugins?: string[], fixturePlugins?: string[], services?: string[], credentials?: string[], os?: string }`,
     );
   }
-  const knownKeys = ["plugins", "services", "credentials", "os"];
+  const knownKeys = [
+    "plugins",
+    "fixturePlugins",
+    "services",
+    "credentials",
+    "os",
+  ];
   const unknownKeys = Object.keys(requires).filter(
     (key) => !knownKeys.includes(key),
   );
@@ -313,7 +319,7 @@ function validateScenarioRequirements(value) {
       `scenario "${value?.id ?? "<unknown>"}" has invalid requires.os; expected a non-empty string`,
     );
   }
-  for (const key of ["plugins", "services", "credentials"]) {
+  for (const key of ["plugins", "fixturePlugins", "services", "credentials"]) {
     const requirements = requires[key];
     if (requirements === undefined) {
       continue;

--- a/packages/scenario-runner/src/executor.encoding.test.ts
+++ b/packages/scenario-runner/src/executor.encoding.test.ts
@@ -1,7 +1,8 @@
 /** Malformed scenario route path percent-encoding must not throw. */
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@elizaos/core", () => ({
+vi.mock("@elizaos/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/core")>()),
   ChannelType: {},
   createMessageMemory: vi.fn(),
   ElizaError: class ElizaError extends Error {},
@@ -30,9 +31,9 @@ vi.mock("./redaction.ts", () => ({
 }));
 vi.mock("./required-plugins.ts", () => ({
   assertProviderQualifiedPluginPackages: vi.fn(),
-  isResolvablePluginPackage: (name: string) => name.startsWith("@"),
   loadScenarioRequiredPlugin: vi.fn(),
   pluginPackageIsRegistered: () => false,
+  resolveRequiredFixturePlugins: () => [],
   resolveRequiredPluginPackages: () => [],
 }));
 vi.mock("./required-services.ts", () => ({

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -67,9 +67,9 @@ import {
 import { redactForScenarioReport } from "./redaction.ts";
 import {
   assertProviderQualifiedPluginPackages,
-  isResolvablePluginPackage,
   loadScenarioRequiredPlugin,
   pluginPackageIsRegistered,
+  resolveRequiredFixturePlugins,
   resolveRequiredPluginPackages,
 } from "./required-plugins.ts";
 import { waitForScenarioRequiredServices } from "./required-services.ts";
@@ -192,11 +192,18 @@ export function providerQualifiedScenarioProblems(
   scenario: ScenarioDefinition,
 ): string[] {
   const problems: string[] = [];
-  const requiredPlugins = resolveRequiredPluginPackages(scenario);
+  let requiredPlugins: string[] = [];
+  const requiredFixturePlugins = resolveRequiredFixturePlugins(scenario);
   try {
+    requiredPlugins = resolveRequiredPluginPackages(scenario);
     assertProviderQualifiedPluginPackages(requiredPlugins);
   } catch (error) {
     problems.push(error instanceof Error ? error.message : String(error));
+  }
+  if (requiredFixturePlugins.length > 0) {
+    problems.push(
+      `provider-qualified scenarios cannot declare seed fixture plugins: ${requiredFixturePlugins.join(", ")}`,
+    );
   }
   if ((scenario.seed?.length ?? 0) > 0) {
     problems.push(
@@ -2879,16 +2886,16 @@ export async function runScenario(
       return report;
     }
 
-    // Seeds may register fixture plugins, so check declared plugin requirements
-    // after seeding and try to load package-named requirements that are present.
-    const requiredPlugins = resolveRequiredPluginPackages(scenario);
+    // Seeds may register fixture plugins, so verify both requirement classes
+    // after seeding while importing only the explicitly declared packages.
+    const requiredPluginPackages = resolveRequiredPluginPackages(scenario);
+    const requiredFixturePlugins = resolveRequiredFixturePlugins(scenario);
     // Track packages we successfully auto-loaded: a plugin's internal
     // `plugin.name` often differs from its package name (e.g. "plugin-health",
     // "@elizaos/plugin-linear-ts"), so a post-load name check can falsely report
     // it as missing and skip a scenario whose required plugin is in fact loaded.
     const autoLoaded = new Set<string>();
-    for (const pkg of requiredPlugins) {
-      if (!isResolvablePluginPackage(pkg)) continue;
+    for (const pkg of requiredPluginPackages) {
       if (pluginPackageIsRegistered(runtime, pkg)) continue;
       try {
         const candidate = await loadScenarioRequiredPlugin(pkg, "simulated");
@@ -2905,9 +2912,16 @@ export async function runScenario(
         });
       }
     }
-    const missing = requiredPlugins.filter(
-      (p) => !pluginPackageIsRegistered(runtime, p) && !autoLoaded.has(p),
-    );
+    const missing = [
+      ...requiredPluginPackages.filter(
+        (plugin) =>
+          !pluginPackageIsRegistered(runtime, plugin) &&
+          !autoLoaded.has(plugin),
+      ),
+      ...requiredFixturePlugins.filter(
+        (plugin) => !pluginPackageIsRegistered(runtime, plugin),
+      ),
+    ];
     if (missing.length > 0) {
       report.status = "skipped";
       report.skipReason = `required plugin(s) not registered: ${missing.join(",")}`;

--- a/packages/scenario-runner/src/required-plugins.test.ts
+++ b/packages/scenario-runner/src/required-plugins.test.ts
@@ -1,15 +1,16 @@
 /**
  * Tests declared production-plugin resolution and pre-initialization runtime
- * registration, including the fixture-name skip the runtime factory and the
- * executor share. Real package imports against a fake runtime.
+ * registration and the explicit package-versus-seed-fixture declaration.
+ * Real package imports against a fake runtime.
  */
 
-import type { AgentRuntime, Plugin } from "@elizaos/core";
+import { type AgentRuntime, ElizaError, type Plugin } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  assertScenarioPluginPackageSpecifier,
   assertSharedRuntimePluginBatchSafe,
-  isResolvablePluginPackage,
   registerScenarioRequiredPlugins,
+  resolveRequiredFixturePlugins,
   resolveRequiredPluginPackages,
 } from "./required-plugins.ts";
 
@@ -38,12 +39,7 @@ describe("scenario required plugin registration", () => {
     );
   });
 
-  // Scenario-local fixture plugins (packages/test/scenarios/convo/*.scenario.ts
-  // declare "echo-test" and "greet-test"; the orchestrator scenarios declare
-  // "orchestrator-*-scenario") exist only once the scenario's seed runs, so
-  // importing them at factory time aborted the whole batch before any
-  // scenario executed.
-  it("skips scenario-local fixture plugin names instead of importing them", async () => {
+  it("keeps package import specifiers separate from seed fixture names", async () => {
     const scenario = {
       id: "fixture-plugin",
       title: "fixture plugin",
@@ -51,10 +47,12 @@ describe("scenario required plugin registration", () => {
       turns: [],
       requires: {
         plugins: [
-          "echo-test",
-          "orchestrator-watchdog-scenario",
+          "unscoped-plugin",
           "@elizaos/plugin-maps",
+          "@elizaos/plugin-meetings/test-support",
+          "unscoped-plugin/test-support",
         ],
+        fixturePlugins: ["echo-test", "orchestrator-watchdog-scenario"],
       },
     } as const;
     const plugins: Plugin[] = [];
@@ -66,15 +64,57 @@ describe("scenario required plugin registration", () => {
       "plugins" | "registerPlugin"
     >;
 
+    expect(resolveRequiredPluginPackages(scenario)).toEqual([
+      "unscoped-plugin",
+      "@elizaos/plugin-maps",
+      "@elizaos/plugin-meetings/test-support",
+      "unscoped-plugin/test-support",
+    ]);
+    expect(resolveRequiredFixturePlugins(scenario)).toEqual([
+      "echo-test",
+      "orchestrator-watchdog-scenario",
+    ]);
     await expect(
       registerScenarioRequiredPlugins(
         runtime,
-        resolveRequiredPluginPackages(scenario),
+        ["@elizaos/plugin-maps"],
         "simulated",
       ),
     ).resolves.toEqual(["@elizaos/plugin-maps"]);
     expect(registerPlugin).toHaveBeenCalledOnce();
     expect(plugins.map((plugin) => plugin.name)).toEqual(["maps"]);
+  });
+
+  it.each([
+    "./scenario-plugin.ts",
+    "../scenario-plugin.ts",
+    "/tmp/scenario-plugin.mjs",
+    "file:///tmp/scenario-plugin.mjs",
+    "workspace:@example/scenario-plugin",
+  ])("typed-rejects unsupported package specifier %s", (packageName) => {
+    expect(() => assertScenarioPluginPackageSpecifier(packageName)).toThrow(
+      ElizaError,
+    );
+    try {
+      assertScenarioPluginPackageSpecifier(packageName);
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "SCENARIO_PLUGIN_PACKAGE_SPECIFIER_INVALID",
+        context: { packageName },
+      });
+    }
+  });
+
+  it.each([
+    "unscoped-plugin",
+    "unscoped-plugin/test-support",
+    "@example/plugin",
+    "@example/plugin/test-support",
+    "@example/plugin/exports/feature+node",
+  ])("accepts portable npm package specifier %s", (packageName) => {
+    expect(() =>
+      assertScenarioPluginPackageSpecifier(packageName),
+    ).not.toThrow();
   });
 
   it("still fails clearly on a genuinely missing package plugin", async () => {
@@ -94,16 +134,54 @@ describe("scenario required plugin registration", () => {
     expect(registerPlugin).not.toHaveBeenCalled();
   });
 
-  it("classifies declared names the same way the executor guard does", () => {
-    expect(isResolvablePluginPackage("@elizaos/plugin-maps")).toBe(true);
-    expect(
-      isResolvablePluginPackage("@elizaos/plugin-meetings/test-support"),
-    ).toBe(true);
-    expect(isResolvablePluginPackage("echo-test")).toBe(false);
-    expect(isResolvablePluginPackage("greet-test")).toBe(false);
-    expect(
-      isResolvablePluginPackage("orchestrator-completion-residuals-scenario"),
-    ).toBe(false);
+  it("attempts unscoped package imports instead of silently treating them as fixtures", async () => {
+    const registerPlugin = vi.fn(async (_plugin: Plugin) => undefined);
+    const runtime = { plugins: [], registerPlugin } as unknown as Pick<
+      AgentRuntime,
+      "plugins" | "registerPlugin"
+    >;
+
+    await expect(
+      registerScenarioRequiredPlugins(
+        runtime,
+        ["unscoped-plugin-does-not-exist"],
+        "simulated",
+      ),
+    ).rejects.toThrow(/unscoped-plugin-does-not-exist/u);
+    expect(registerPlugin).not.toHaveBeenCalled();
+  });
+
+  it("resolves installed unscoped packages before validating their Plugin export", async () => {
+    const registerPlugin = vi.fn(async (_plugin: Plugin) => undefined);
+    const runtime = { plugins: [], registerPlugin } as unknown as Pick<
+      AgentRuntime,
+      "plugins" | "registerPlugin"
+    >;
+
+    await expect(
+      registerScenarioRequiredPlugins(runtime, ["ws"], "simulated"),
+    ).rejects.toThrow(/ws did not export a Plugin/u);
+    expect(registerPlugin).not.toHaveBeenCalled();
+  });
+
+  it("loads an exported package subpath", async () => {
+    const plugins: Plugin[] = [];
+    const registerPlugin = vi.fn(async (plugin: Plugin) => {
+      plugins.push(plugin);
+    });
+    const runtime = { plugins, registerPlugin } as unknown as Pick<
+      AgentRuntime,
+      "plugins" | "registerPlugin"
+    >;
+
+    await expect(
+      registerScenarioRequiredPlugins(
+        runtime,
+        ["@elizaos/plugin-maps/plugin"],
+        "simulated",
+      ),
+    ).resolves.toEqual(["@elizaos/plugin-maps/plugin"]);
+    expect(plugins.map((plugin) => plugin.name)).toEqual(["maps"]);
   });
 
   it("does not register an already-present declared plugin twice", async () => {

--- a/packages/scenario-runner/src/required-plugins.ts
+++ b/packages/scenario-runner/src/required-plugins.ts
@@ -4,14 +4,17 @@
  * registers them before runtime initialization; simulated runs retain the
  * small compatibility wrapper needed by existing app-control fixtures.
  *
- * A scenario's `requires.plugins` mixes two kinds of name: resolvable package
- * names the runner imports and registers, and scenario-local fixture plugin
- * names that only the scenario's own seed can register (isResolvablePluginPackage
- * tells them apart). Fixture names are never imported here; the executor
- * verifies them after seeding.
+ * Package import specifiers and scenario-local fixture plugin names are
+ * declared separately. Packages are imported here before runtime startup;
+ * fixture names are verified by the executor after the scenario seed runs.
  */
 
-import type { Action, AgentRuntime, Plugin } from "@elizaos/core";
+import {
+  type Action,
+  type AgentRuntime,
+  ElizaError,
+  type Plugin,
+} from "@elizaos/core";
 import type {
   ScenarioDefinition,
   ScenarioExecutionProfile,
@@ -23,7 +26,20 @@ const MEETINGS_TEST_SUPPORT_PACKAGE = "@elizaos/plugin-meetings/test-support";
 const NON_PRODUCTION_PACKAGE_PATTERN =
   /(?:^|[/._-])(?:mock|mocks|fixture|fixtures|test|tests|test-harness)(?:$|[/._-])/iu;
 const PACKAGE_NAME_PATTERN =
-  /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+  /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)(?:\/(?!\.{1,2}(?:\/|$))[^/\\\s]+)*$/iu;
+
+export function assertScenarioPluginPackageSpecifier(
+  packageName: string,
+): void {
+  if (PACKAGE_NAME_PATTERN.test(packageName)) return;
+  throw new ElizaError(
+    `Scenario plugin package "${packageName}" is not a supported npm import specifier`,
+    {
+      code: "SCENARIO_PLUGIN_PACKAGE_SPECIFIER_INVALID",
+      context: { packageName },
+    },
+  );
+}
 
 function isPlugin(value: unknown): value is Plugin {
   if (value === null || typeof value !== "object") return false;
@@ -42,21 +58,22 @@ function isPlugin(value: unknown): value is Plugin {
   );
 }
 
-/**
- * Whether a declared plugin name is a resolvable package (scoped, importable,
- * registered by the runner before runtime initialization) rather than a
- * scenario-local fixture plugin (a bare name such as "echo-test" that only the
- * scenario's seed can register, so importing it can only fail). Shared by the
- * runtime factory and the executor so both skip the same names.
- */
-export function isResolvablePluginPackage(packageName: string): boolean {
-  return packageName.startsWith("@");
-}
-
 export function resolveRequiredPluginPackages(
   scenario: ScenarioDefinition,
 ): string[] {
   const plugins = scenario.requires?.plugins;
+  if (!Array.isArray(plugins)) return [];
+  const normalized = plugins.map((plugin) => plugin.trim()).filter(Boolean);
+  for (const packageName of normalized) {
+    assertScenarioPluginPackageSpecifier(packageName);
+  }
+  return [...new Set(normalized)];
+}
+
+export function resolveRequiredFixturePlugins(
+  scenario: ScenarioDefinition,
+): string[] {
+  const plugins = scenario.requires?.fixturePlugins;
   if (!Array.isArray(plugins)) return [];
   const normalized = plugins.map((plugin) => plugin.trim()).filter(Boolean);
   return [...new Set(normalized)];
@@ -98,7 +115,7 @@ export function providerQualifiedPluginPackageProblem(
   packageName: string,
 ): string | null {
   if (!PACKAGE_NAME_PATTERN.test(packageName)) {
-    return `required plugin "${packageName}" is not a bare npm package name`;
+    return `required plugin "${packageName}" is not a supported npm import specifier`;
   }
   if (NON_PRODUCTION_PACKAGE_PATTERN.test(packageName)) {
     return `required plugin "${packageName}" names a test, mock, or fixture package`;
@@ -207,9 +224,9 @@ export async function loadScenarioRequiredPlugin(
 }
 
 /**
- * Registers every declared resolvable package once before scenario runtime
- * startup and returns the names that are registered afterwards. Scenario-local
- * fixture names are skipped, not reported: their seed has not run yet.
+ * Registers every declared package once before scenario runtime startup and
+ * returns the names that are registered afterwards. Fixture plugin names are
+ * a separate declaration and never reach this import boundary.
  */
 export async function registerScenarioRequiredPlugins(
   runtime: Pick<AgentRuntime, "plugins" | "registerPlugin">,
@@ -218,7 +235,7 @@ export async function registerScenarioRequiredPlugins(
 ): Promise<string[]> {
   const registered: string[] = [];
   for (const packageName of packageNames) {
-    if (!isResolvablePluginPackage(packageName)) continue;
+    assertScenarioPluginPackageSpecifier(packageName);
     if (!pluginPackageIsRegistered(runtime, packageName)) {
       const plugin = await loadScenarioRequiredPlugin(
         packageName,

--- a/packages/scenario-runner/src/required-services.test.ts
+++ b/packages/scenario-runner/src/required-services.test.ts
@@ -59,11 +59,20 @@ describe("scenario required-service contract", () => {
       domain: "required-service-preflight",
       requires: {
         plugins: ["@elizaos/plugin-wallet"],
+        fixturePlugins: ["wallet-seed-fixture"],
         services: ["wallet-backend"],
       },
       turns: [],
     });
     expect(resolveRequiredServiceTypes(definition)).toEqual(["wallet-backend"]);
+
+    expect(() =>
+      scenario({
+        ...definition,
+        id: "malformed-fixture-plugins",
+        requires: { fixturePlugins: ["wallet-seed-fixture", ""] },
+      } as unknown as ScenarioDefinition),
+    ).toThrow("invalid requires.fixturePlugins");
 
     expect(() =>
       scenario({

--- a/packages/scenario-runner/src/schema-strict.test.ts
+++ b/packages/scenario-runner/src/schema-strict.test.ts
@@ -357,6 +357,10 @@ describe("provider-qualified data boundary", () => {
     const unsafe = {
       ...trustedScenario,
       isolation: "shared-runtime",
+      requires: {
+        ...trustedScenario.requires,
+        fixturePlugins: ["forged-provider-fixture"],
+      },
       rooms: [{ id: "forged-owner", account: "admin" }],
       mockoon: ["google"],
       seed: [{ type: "advanceClock", by: "PT1H" }],
@@ -380,6 +384,7 @@ describe("provider-qualified data boundary", () => {
 
     const problems = providerQualifiedScenarioProblems(unsafe).join("\n");
     expect(problems).toContain("seed steps");
+    expect(problems).toContain("seed fixture plugins");
     expect(problems).toContain("isolation=per-scenario");
     expect(problems).toContain("Mockoon");
     expect(problems).toContain("operator-signed run manifest");

--- a/packages/scenario-runner/test/scenarios/live-plugin-enable-toggle-verb.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-plugin-enable-toggle-verb.scenario.ts
@@ -231,7 +231,7 @@ export default scenario({
   tags: ["live", "app-control", "plugins", "views", "plugin-toggle"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/packages/test/scenarios/convo/echo-self-test.scenario.ts
+++ b/packages/test/scenarios/convo/echo-self-test.scenario.ts
@@ -101,7 +101,7 @@ export default scenario({
     "Registers a trivial ECHO_TEST plugin and verifies the scripted runner captures the action call with success=true.",
 
   requires: {
-    plugins: ["echo-test"],
+    fixturePlugins: ["echo-test"],
   },
   isolation: "per-scenario",
 

--- a/packages/test/scenarios/convo/greeting-dynamic.scenario.ts
+++ b/packages/test/scenarios/convo/greeting-dynamic.scenario.ts
@@ -98,7 +98,7 @@ export default scenario({
     "Scripted port of the dynamic greeting scenario: sends a single greeting and verifies the GREET_USER action is captured with success=true.",
 
   requires: {
-    plugins: ["greet-test"],
+    fixturePlugins: ["greet-test"],
   },
   isolation: "per-scenario",
 

--- a/packages/test/scenarios/payments/payments.agent-charge-five-dollar.scenario.ts
+++ b/packages/test/scenarios/payments/payments.agent-charge-five-dollar.scenario.ts
@@ -1,11 +1,13 @@
 /** Scenario fixture for payments agent charge five dollar; runs through scenario-runner with deterministic services unless the scenario name marks an external-service gate. */
 import type { AgentRuntime, Plugin } from "@elizaos/core";
 import {
+  expectScenarioActionResultData,
+  expectTurnToCallAction,
+} from "@elizaos/scenario-runner/scenario-assertions";
+import {
   type ScenarioContext,
   scenario,
 } from "@elizaos/scenario-runner/schema";
-import { expectTurnToCallAction } from "@elizaos/scenario-runner/scenario-assertions";
-import { expectScenarioActionResultData } from "@elizaos/scenario-runner/scenario-assertions";
 import { appChargeTestPlugin } from "./_fixtures/app-charge-test-plugin.ts";
 
 function asRuntime(value: unknown): AgentRuntime {
@@ -53,7 +55,7 @@ export default scenario({
     "Registers app-charge test actions, asks the agent to create a $5 payment request, then verifies payment confirmation produces the initiating-channel callback payload.",
 
   requires: {
-    plugins: ["app-charge-test"],
+    fixturePlugins: ["app-charge-test"],
   },
   isolation: "per-scenario",
 

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-completion-residuals.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-completion-residuals.scenario.ts
@@ -269,7 +269,7 @@ export default scenario({
   tags: ["orchestrator", "residuals", "completion", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [PLUGIN_NAME],
+    fixturePlugins: [PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-concurrency-admission.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-concurrency-admission.scenario.ts
@@ -431,7 +431,7 @@ export default scenario({
   ],
   isolation: "shared-runtime",
   requires: {
-    plugins: [CONCURRENCY_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [CONCURRENCY_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-device-modality-reach.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-device-modality-reach.scenario.ts
@@ -54,7 +54,7 @@ export default scenario({
   ],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-evidence-bundle.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-evidence-bundle.scenario.ts
@@ -30,7 +30,7 @@ export default scenario({
   tags: ["orchestrator", "evidence", "verification", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-follow-up-forwarding.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-follow-up-forwarding.scenario.ts
@@ -190,7 +190,7 @@ export default scenario({
   tags: ["orchestrator", "forwarding", "follow-up", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [PLUGIN_NAME],
+    fixturePlugins: [PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-grilling-happy-path.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-grilling-happy-path.scenario.ts
@@ -31,7 +31,7 @@ export default scenario({
   tags: ["orchestrator", "grilling", "multi-agent", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-failure-isolation.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-failure-isolation.scenario.ts
@@ -517,7 +517,7 @@ export default scenario({
   ],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ISOLATION_PLUGIN_NAME],
+    fixturePlugins: [ISOLATION_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-portfolio.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-portfolio.scenario.ts
@@ -383,7 +383,7 @@ export default scenario({
   ],
   isolation: "shared-runtime",
   requires: {
-    plugins: [PORTFOLIO_PLUGIN_NAME],
+    fixturePlugins: [PORTFOLIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-task-supervisor.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-task-supervisor.scenario.ts
@@ -29,7 +29,7 @@ export default scenario({
   tags: ["orchestrator", "multi-task", "supervisor", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-question-for-creator.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-question-for-creator.scenario.ts
@@ -212,7 +212,7 @@ export default scenario({
   tags: ["orchestrator", "routing", "question", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [PLUGIN_NAME],
+    fixturePlugins: [PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-reflexion-respawn.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-reflexion-respawn.scenario.ts
@@ -34,7 +34,7 @@ export default scenario({
   tags: ["orchestrator", "reflexion", "respawn", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-view-cloud-deploy.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-view-cloud-deploy.scenario.ts
@@ -77,7 +77,7 @@ export default scenario({
   ],
   isolation: "shared-runtime",
   requires: {
-    plugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [ORCHESTRATOR_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-watchdog-stall.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-watchdog-stall.scenario.ts
@@ -275,7 +275,7 @@ export default scenario({
   tags: ["orchestrator", "watchdog", "stall", "caps", "pr", "deterministic"],
   isolation: "shared-runtime",
   requires: {
-    plugins: [WATCHDOG_SCENARIO_PLUGIN_NAME],
+    fixturePlugins: [WATCHDOG_SCENARIO_PLUGIN_NAME],
   },
   seed: [
     {

--- a/plugins/plugin-personal-assistant/test/scenarios/corpus/lifeops.planner/planner.action-timeout.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/corpus/lifeops.planner/planner.action-timeout.scenario.ts
@@ -129,7 +129,7 @@ export default scenario({
   tags: ["lifeops", "planner", "action-timeout", "robustness", "negative-path"],
   isolation: "per-scenario",
   requires: {
-    plugins: ["scenario-hang-test"],
+    fixturePlugins: ["scenario-hang-test"],
   },
   rooms: [
     {


### PR DESCRIPTION
## Summary

Corrects the merged #25353 package-name heuristic by making seed-local fixture plugins an explicit scenario contract.

- adds requires.fixturePlugins for plugins registered by scenario seed code
- keeps requires.plugins exclusively for npm import specifiers, including scoped and unscoped packages and exported subpaths
- rejects relative, absolute, file:, and workspace: specs with a typed SCENARIO_PLUGIN_PACKAGE_SPECIFIER_INVALID error
- updates provider-qualified preflight, schema declarations, callers, corpus fixtures, and documentation
- preserves the full declarations without prompt or context truncation

## Validation

- exact base: c556bc4645fd9b914702c6e0fd3f8ec882cc1e34
- exact head: 2a589d976522456a91b5a403772998d464a6bd4b
- 51/51 focused required-plugin, schema, preflight, and executor tests pass
- actual unscoped ws package resolution and @elizaos/plugin-maps/plugin export-subpath loading are exercised
- all 3,553 corpus scenarios validate with unique IDs and matching expansion
- Biome and git diff checks pass
- affected 152-package Turbo lane reached 89 successful tasks before stopping on unrelated current app-core/agent baseline type errors; no corrective-source type error was reported
- owning package typechecks are likewise blocked only by those same baseline agent errors plus existing missing built plugin declarations
- the broader scenario-runner unit lane was bounded after exposing its existing echo-assertion-integrity failure and 120-second production-manifest skip; focused changed-contract suites are green

## Evidence

This is a schema and harness-boundary correction; UI, hardware, and live-model evidence are not applicable. The package-resolution tests exercise real installed package/export boundaries, and corpus validation exercises every declared scenario.