### PR TITLE
fix(cloud): fence inbound media claim identity

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.inbound-media.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import { logger } from "@/lib/utils/logger";
 
 let activeTarget: {
@@ -361,6 +362,7 @@ describe("blooio inbound media enrichment at the messaging route", () => {
     const denials: LedgerAdmission[] = [
       { kind: "in_flight" },
       { kind: "previously_failed", reason: "media_fetch_failed" },
+      { kind: "identity_mismatch" },
       { kind: "media_mismatch" },
       { kind: "exhausted", scope: "sender", limit: 20, used: 20, requested: 1 },
       {
@@ -383,9 +385,25 @@ describe("blooio inbound media enrichment at the messaging route", () => {
     expect(ledgerFail).not.toHaveBeenCalled();
   });
 
+  test("a lost settlement keeps the raw turn instead of using uncommitted OCR text", async () => {
+    describeInboundImageMedia.mockResolvedValue("must not enter the turn");
+    ledgerComplete.mockResolvedValue(false);
+    const response = await request(blooioDelivery());
+    expect(response.status).toBe(200);
+    expect(deliveredMessage()).toBe(RAW_MEDIA_MESSAGE);
+    expect(ledgerComplete).toHaveBeenCalledWith(
+      LEDGER_CLAIM,
+      "must not enter the turn",
+    );
+  });
+
   test("a missing admission decision fails closed: raw turn, no spend, no 500", async () => {
     describeInboundImageMedia.mockResolvedValue("must not be used");
-    ledgerAdmit.mockRejectedValue(new Error("primary database unreachable"));
+    ledgerAdmit.mockRejectedValue(
+      new ElizaError("primary database unreachable", {
+        code: "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE",
+      }),
+    );
     const response = await request(blooioDelivery());
     expect(response.status).toBe(200);
     expect(response.headers.get("X-Eliza-Failure-Stage")).toBeNull();

--- a/packages/cloud/shared/docs/inbound-media-vision-promotion.md
+++ b/packages/cloud/shared/docs/inbound-media-vision-promotion.md
@@ -1,0 +1,19 @@
+# Inbound media vision promotion gate
+
+`ELIZA_APP_INBOUND_MEDIA_VISION` must remain unset outside tests. The default
+raw-media path is the supported deployment posture until every gate below has
+reviewable evidence:
+
+- a bounded retention policy and scheduled purge for stored image descriptions,
+  with tenant-deletion and expiry tests;
+- real PostgreSQL concurrent admission/reclaim coverage that exercises row-lock
+  interleaving rather than PGlite's serialized transaction harness;
+- a live signed Blooio delivery through the gateway, Worker, media fetch, vision
+  provider, settlement ledger, and reply path, including redelivery evidence;
+- confirmed Cloudflare egress enforcement for the documented `safeFetch`
+  DNS-rebinding residual on workerd; and
+- operator-approved daily ceilings with explicit nonblank bindings.
+
+Enabling the flag is a deployment change, not evidence that these gates passed.
+The gateway and Worker bindings must be promoted together only after the same
+exact source revision has satisfied the checklist.

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
@@ -60,11 +60,13 @@ async function ledgerRow(sourceMessageId: string) {
     attempt_count: number;
     claim_token: string;
     media_digest: string;
+    image_count: number;
     organization_id: string;
+    user_id: string;
     completed_at: string | null;
   }>(
     `SELECT state, description, failure_reason, attempt_count, claim_token,
-       media_digest, organization_id, completed_at
+       media_digest, image_count, organization_id, user_id, completed_at
      FROM personal_shared_inbound_media_descriptions
      WHERE source_message_id = $1`,
     [sourceMessageId],
@@ -187,6 +189,111 @@ describe("personalSharedInboundMediaRepository admission ledger", () => {
     expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([1, 1]);
   });
 
+  test("tenant and user identity stay immutable across pending, described, and failed rows", async () => {
+    const pending = await claimOf("msg-identity-pending");
+    const described = await claimOf("msg-identity-described");
+    const failed = await claimOf("msg-identity-failed");
+    const expired = await claimOf("msg-identity-expired");
+    expect(await repository.complete(described, "private visible text")).toBe(true);
+    expect(await repository.fail(failed, "media_fetch_failed")).toBe(true);
+    await getPgliteClientForTests().query(
+      `UPDATE personal_shared_inbound_media_descriptions
+       SET lease_expires_at = now() - interval '1 second'
+       WHERE source_message_id = $1`,
+      ["msg-identity-expired"],
+    );
+
+    expect(
+      await admission({
+        sourceMessageId: "msg-identity-pending",
+        userId: USER_B,
+      }),
+    ).toEqual({ kind: "identity_mismatch" });
+    expect(
+      await admission({
+        sourceMessageId: "msg-identity-described",
+        organizationId: ORG_B,
+        userId: USER_B,
+      }),
+    ).toEqual({ kind: "identity_mismatch" });
+    expect(
+      await admission({
+        sourceMessageId: "msg-identity-failed",
+        organizationId: ORG_B,
+        userId: USER_B,
+      }),
+    ).toEqual({ kind: "identity_mismatch" });
+    expect(
+      await admission({
+        sourceMessageId: "msg-identity-expired",
+        organizationId: ORG_B,
+        userId: USER_B,
+      }),
+    ).toEqual({ kind: "identity_mismatch" });
+
+    for (const [sourceMessageId, claim] of [
+      ["msg-identity-pending", pending],
+      ["msg-identity-described", described],
+      ["msg-identity-failed", failed],
+      ["msg-identity-expired", expired],
+    ] as const) {
+      expect(await ledgerRow(sourceMessageId)).toMatchObject({
+        organization_id: ORG_A,
+        user_id: USER_A,
+        media_digest: DIGEST_A,
+        image_count: 1,
+        claim_token: claim.claimToken,
+        attempt_count: 1,
+      });
+    }
+    // Four original claims spent once; the mismatched replays spent nothing.
+    expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([4, 4]);
+  });
+
+  test("payload identity is checked before every state decision and expired reclaim", async () => {
+    const pending = await claimOf("msg-payload-pending");
+    const described = await claimOf("msg-payload-described");
+    const failed = await claimOf("msg-payload-failed");
+    const expired = await claimOf("msg-payload-expired");
+    expect(await repository.complete(described, "stored description")).toBe(true);
+    expect(await repository.fail(failed, "media_fetch_failed")).toBe(true);
+    await getPgliteClientForTests().query(
+      `UPDATE personal_shared_inbound_media_descriptions
+       SET lease_expires_at = now() - interval '1 second'
+       WHERE source_message_id = $1`,
+      ["msg-payload-expired"],
+    );
+
+    for (const sourceMessageId of [
+      "msg-payload-pending",
+      "msg-payload-described",
+      "msg-payload-failed",
+      "msg-payload-expired",
+    ]) {
+      expect(await admission({ sourceMessageId, mediaDigest: DIGEST_B })).toEqual({
+        kind: "media_mismatch",
+      });
+    }
+    expect(await admission({ sourceMessageId: "msg-payload-pending", imageCount: 2 })).toEqual({
+      kind: "media_mismatch",
+    });
+
+    for (const [sourceMessageId, claim] of [
+      ["msg-payload-pending", pending],
+      ["msg-payload-described", described],
+      ["msg-payload-failed", failed],
+      ["msg-payload-expired", expired],
+    ] as const) {
+      expect(await ledgerRow(sourceMessageId)).toMatchObject({
+        media_digest: DIGEST_A,
+        image_count: 1,
+        claim_token: claim.claimToken,
+        attempt_count: 1,
+      });
+    }
+    expect((await quotaRows()).map(({ image_count }) => image_count)).toEqual([4, 4]);
+  });
+
   test("settlement is fenced to the live claim token and pending state", async () => {
     const claim = await claimOf("msg-5");
     const stale = { ...claim, claimToken: "00000000-0000-4000-8000-0000000000ff" };
@@ -211,20 +318,22 @@ describe("personalSharedInboundMediaRepository admission ledger", () => {
       ["msg-6"],
     );
 
-    const reclaimed = await claimOf("msg-6", { organizationId: ORG_B, userId: USER_B });
+    const reclaimed = await claimOf("msg-6");
     expect(reclaimed.id).toBe(dead.id);
     expect(reclaimed.attempt).toBe(2);
     expect(reclaimed.claimToken).not.toBe(dead.claimToken);
     expect(await ledgerRow("msg-6")).toMatchObject({
       state: "pending",
       attempt_count: 2,
-      organization_id: ORG_B,
+      organization_id: ORG_A,
+      user_id: USER_A,
+      media_digest: DIGEST_A,
+      image_count: 1,
     });
     // The reclaim is a new attempt and pays the ceilings again.
     expect(await quotaRows()).toEqual([
       { scope: "connector", scope_key: `blooio:eliza-app:${CONNECTOR_ID}`, image_count: 2 },
-      { scope: "sender", scope_key: ORG_A, image_count: 1 },
-      { scope: "sender", scope_key: ORG_B, image_count: 1 },
+      { scope: "sender", scope_key: ORG_A, image_count: 2 },
     ]);
 
     // The dead claimant's late settlement is rejected; the live one lands.

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.integration.test.ts
@@ -26,6 +26,8 @@ let closeDatabaseConnectionsForTests:
   | undefined;
 let getPgliteClientForTests: typeof import("../client").getPgliteClientForTests;
 let repository: typeof import("./personal-shared-inbound-media").personalSharedInboundMediaRepository;
+let PersonalSharedInboundMediaRepository: typeof import("./personal-shared-inbound-media").PersonalSharedInboundMediaRepository;
+let dbWrite: typeof import("../helpers").dbWrite;
 let INBOUND_MEDIA_DESCRIPTION_LEASE_MS: number;
 
 function admission(
@@ -88,8 +90,12 @@ async function quotaRows() {
 
 beforeAll(async () => {
   ({ closeDatabaseConnectionsForTests, getPgliteClientForTests } = await import("../client"));
-  ({ personalSharedInboundMediaRepository: repository, INBOUND_MEDIA_DESCRIPTION_LEASE_MS } =
-    await import("./personal-shared-inbound-media"));
+  ({
+    personalSharedInboundMediaRepository: repository,
+    PersonalSharedInboundMediaRepository,
+    INBOUND_MEDIA_DESCRIPTION_LEASE_MS,
+  } = await import("./personal-shared-inbound-media"));
+  ({ dbWrite } = await import("../helpers"));
   const database = getPgliteClientForTests();
   await database.exec(`
     CREATE TABLE organizations (id uuid PRIMARY KEY);
@@ -347,6 +353,65 @@ describe("personalSharedInboundMediaRepository admission ledger", () => {
 
   test("the lease horizon outlives the gateway media-turn budget", () => {
     expect(INBOUND_MEDIA_DESCRIPTION_LEASE_MS).toBeGreaterThan(90_000);
+  });
+
+  test("renews the committed lease from the clock after quota contention", async () => {
+    const startedAt = new Date("2026-08-23T12:00:00.000Z");
+    const afterQuotaLocks = new Date(
+      startedAt.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS + 30_000,
+    );
+    const clocks = [startedAt, afterQuotaLocks];
+    const timedRepository = new PersonalSharedInboundMediaRepository(dbWrite, async () => {
+      const next = clocks.shift();
+      if (!next) throw new Error("unexpected database clock read");
+      return next;
+    });
+
+    const result = await timedRepository.admit({
+      platform: "blooio",
+      project: "eliza-app",
+      connectorAccountId: CONNECTOR_ID,
+      sourceMessageId: "msg-delayed-quota",
+      organizationId: ORG_A,
+      userId: USER_A,
+      mediaDigest: DIGEST_A,
+      imageCount: 1,
+      ceilings: CEILINGS,
+    });
+    expect(result.kind).toBe("claimed");
+    const { rows } = await getPgliteClientForTests().query<{ lease_expires_at: string }>(
+      `SELECT lease_expires_at FROM personal_shared_inbound_media_descriptions
+       WHERE source_message_id = $1`,
+      ["msg-delayed-quota"],
+    );
+    expect(new Date(rows[0]!.lease_expires_at).getTime()).toBe(
+      afterQuotaLocks.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS,
+    );
+  });
+
+  test("fails closed and rolls back when quota admission crosses a UTC day", async () => {
+    const clocks = [new Date("2026-08-23T23:59:59.999Z"), new Date("2026-08-24T00:00:00.001Z")];
+    const timedRepository = new PersonalSharedInboundMediaRepository(dbWrite, async () => {
+      const next = clocks.shift();
+      if (!next) throw new Error("unexpected database clock read");
+      return next;
+    });
+
+    await expect(
+      timedRepository.admit({
+        platform: "blooio",
+        project: "eliza-app",
+        connectorAccountId: CONNECTOR_ID,
+        sourceMessageId: "msg-utc-rollover",
+        organizationId: ORG_A,
+        userId: USER_A,
+        mediaDigest: DIGEST_A,
+        imageCount: 1,
+        ceilings: CEILINGS,
+      }),
+    ).rejects.toMatchObject({ code: "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE" });
+    expect(await ledgerRow("msg-utc-rollover")).toBeUndefined();
+    expect(await quotaRows()).toEqual([]);
   });
 
   test("an exhausted sender ceiling denies the claim and rolls the ledger back", async () => {

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
@@ -62,6 +62,7 @@ export type InboundMediaDescriptionAdmission =
   | { kind: "reused"; description: string }
   | { kind: "in_flight" }
   | { kind: "previously_failed"; reason: string }
+  | { kind: "identity_mismatch" }
   | { kind: "media_mismatch" }
   | {
       kind: "exhausted";
@@ -78,11 +79,16 @@ class QuotaExhaustedSignal extends Error {
   }
 }
 
-function storageFailure(message: string, context: Record<string, unknown>): ElizaError {
+function storageFailure(
+  message: string,
+  context: Record<string, unknown>,
+  cause?: unknown,
+): ElizaError {
   return new ElizaError(message, {
     code: "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE",
     severity: "fatal",
     context,
+    cause,
   });
 }
 
@@ -180,10 +186,23 @@ export class PersonalSharedInboundMediaRepository {
               sourceMessageId: input.sourceMessageId,
             });
           }
+          // The connector message key identifies one immutable tenant, user,
+          // and media payload. A later resolver result or replay must never
+          // inherit stored OCR text or rewrite a claim that belongs to a
+          // different account/payload.
+          if (
+            existing.organization_id !== input.organizationId ||
+            existing.user_id !== input.userId
+          ) {
+            return { kind: "identity_mismatch" };
+          }
+          if (
+            existing.media_digest !== input.mediaDigest ||
+            existing.image_count !== input.imageCount
+          ) {
+            return { kind: "media_mismatch" };
+          }
           if (existing.state === "described") {
-            if (existing.media_digest !== input.mediaDigest) {
-              return { kind: "media_mismatch" };
-            }
             if (existing.description === null) {
               throw storageFailure("Described inbound media row carries no description", {
                 id: existing.id,
@@ -202,10 +221,6 @@ export class PersonalSharedInboundMediaRepository {
           const [reclaimed] = await tx
             .update(personalSharedInboundMediaDescriptions)
             .set({
-              organization_id: input.organizationId,
-              user_id: input.userId,
-              media_digest: input.mediaDigest,
-              image_count: input.imageCount,
               claim_token: claimToken,
               lease_expires_at: leaseExpiresAt,
               attempt_count: sql`${personalSharedInboundMediaDescriptions.attempt_count} + 1`,
@@ -215,6 +230,7 @@ export class PersonalSharedInboundMediaRepository {
               and(
                 eq(personalSharedInboundMediaDescriptions.id, existing.id),
                 eq(personalSharedInboundMediaDescriptions.state, "pending"),
+                eq(personalSharedInboundMediaDescriptions.claim_token, existing.claim_token),
               ),
             )
             .returning({ attempt_count: personalSharedInboundMediaDescriptions.attempt_count });
@@ -250,7 +266,16 @@ export class PersonalSharedInboundMediaRepository {
         // any sender increment never became visible.
         return error.denial;
       }
-      throw error;
+      if (error instanceof ElizaError && error.code === "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE") {
+        throw error;
+      }
+      // error-policy:J2 repository failures become the typed storage boundary
+      // consumed by the fail-closed enrichment orchestrator.
+      throw storageFailure(
+        "Inbound media admission transaction failed",
+        { sourceMessageId: input.sourceMessageId },
+        error,
+      );
     }
   }
 
@@ -276,19 +301,25 @@ export class PersonalSharedInboundMediaRepository {
       | { state: "described"; description: string; failure_reason: null }
       | { state: "failed"; description: null; failure_reason: string },
   ): Promise<boolean> {
-    const now = new Date();
-    const [settled] = await this.database
-      .update(personalSharedInboundMediaDescriptions)
-      .set({ ...outcome, completed_at: now, updated_at: now })
-      .where(
-        and(
-          eq(personalSharedInboundMediaDescriptions.id, claim.id),
-          eq(personalSharedInboundMediaDescriptions.claim_token, claim.claimToken),
-          eq(personalSharedInboundMediaDescriptions.state, "pending"),
-        ),
-      )
-      .returning({ id: personalSharedInboundMediaDescriptions.id });
-    return settled !== undefined;
+    try {
+      const now = new Date();
+      const [settled] = await this.database
+        .update(personalSharedInboundMediaDescriptions)
+        .set({ ...outcome, completed_at: now, updated_at: now })
+        .where(
+          and(
+            eq(personalSharedInboundMediaDescriptions.id, claim.id),
+            eq(personalSharedInboundMediaDescriptions.claim_token, claim.claimToken),
+            eq(personalSharedInboundMediaDescriptions.state, "pending"),
+          ),
+        )
+        .returning({ id: personalSharedInboundMediaDescriptions.id });
+      return settled !== undefined;
+    } catch (error) {
+      // error-policy:J2 callers distinguish an unavailable settlement store
+      // from an unowned claim token and fail closed on either result.
+      throw storageFailure("Inbound media claim settlement failed", { claimId: claim.id }, error);
+    }
   }
 }
 

--- a/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-inbound-media.ts
@@ -120,7 +120,12 @@ export function inboundMediaConnectorQuotaKey(
 }
 
 export class PersonalSharedInboundMediaRepository {
-  constructor(private readonly database: Database) {}
+  constructor(
+    private readonly database: Database,
+    private readonly readDatabaseNow: (
+      tx: DbTransaction,
+    ) => Promise<Date> = readPostLockDatabaseNow,
+  ) {}
 
   /**
    * Claims the connector message id and consumes both per-day ceilings in one
@@ -138,9 +143,11 @@ export class PersonalSharedInboundMediaRepository {
     }
     try {
       return await this.database.transaction(async (tx) => {
-        const now = await readPostLockDatabaseNow(tx);
+        const transactionStartedAt = await this.readDatabaseNow(tx);
         const claimToken = crypto.randomUUID();
-        const leaseExpiresAt = new Date(now.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS);
+        const preliminaryLeaseExpiresAt = new Date(
+          transactionStartedAt.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS,
+        );
         const [inserted] = await tx
           .insert(personalSharedInboundMediaDescriptions)
           .values({
@@ -154,9 +161,9 @@ export class PersonalSharedInboundMediaRepository {
             image_count: input.imageCount,
             state: "pending",
             claim_token: claimToken,
-            lease_expires_at: leaseExpiresAt,
-            created_at: now,
-            updated_at: now,
+            lease_expires_at: preliminaryLeaseExpiresAt,
+            created_at: transactionStartedAt,
+            updated_at: transactionStartedAt,
           })
           .onConflictDoNothing({
             target: [
@@ -171,6 +178,7 @@ export class PersonalSharedInboundMediaRepository {
             attempt_count: personalSharedInboundMediaDescriptions.attempt_count,
           });
         let claim: InboundMediaDescriptionClaim;
+        let admissionClock = transactionStartedAt;
         if (inserted) {
           claim = { id: inserted.id, claimToken, attempt: inserted.attempt_count };
         } else {
@@ -186,6 +194,10 @@ export class PersonalSharedInboundMediaRepository {
               sourceMessageId: input.sourceMessageId,
             });
           }
+          // The insert/conflict path and row lock may have waited behind
+          // another transaction. Lease and UTC-day decisions must use a fresh
+          // primary-database clock after that wait, not transaction entry time.
+          admissionClock = await this.readDatabaseNow(tx);
           // The connector message key identifies one immutable tenant, user,
           // and media payload. A later resolver result or replay must never
           // inherit stored OCR text or rewrite a claim that belongs to a
@@ -213,7 +225,7 @@ export class PersonalSharedInboundMediaRepository {
           if (existing.state === "failed") {
             return { kind: "previously_failed", reason: existing.failure_reason ?? "unknown" };
           }
-          if (existing.lease_expires_at.getTime() > now.getTime()) {
+          if (existing.lease_expires_at.getTime() > admissionClock.getTime()) {
             return { kind: "in_flight" };
           }
           // The previous claimant is dead (its lease lapsed without a terminal
@@ -222,9 +234,11 @@ export class PersonalSharedInboundMediaRepository {
             .update(personalSharedInboundMediaDescriptions)
             .set({
               claim_token: claimToken,
-              lease_expires_at: leaseExpiresAt,
+              lease_expires_at: new Date(
+                admissionClock.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS,
+              ),
               attempt_count: sql`${personalSharedInboundMediaDescriptions.attempt_count} + 1`,
-              updated_at: now,
+              updated_at: admissionClock,
             })
             .where(
               and(
@@ -241,12 +255,12 @@ export class PersonalSharedInboundMediaRepository {
           }
           claim = { id: existing.id, claimToken, attempt: reclaimed.attempt_count };
         }
-        const day = now.toISOString().slice(0, 10);
+        const day = admissionClock.toISOString().slice(0, 10);
         await consumeQuota(tx, {
           scope: "sender",
           scopeKey: input.organizationId,
           day,
-          now,
+          now: admissionClock,
           requested: input.imageCount,
           limit: input.ceilings.senderDailyImages,
         });
@@ -254,10 +268,40 @@ export class PersonalSharedInboundMediaRepository {
           scope: "connector",
           scopeKey: inboundMediaConnectorQuotaKey(input),
           day,
-          now,
+          now: admissionClock,
           requested: input.imageCount,
           limit: input.ceilings.connectorDailyImages,
         });
+        const finalClock = await this.readDatabaseNow(tx);
+        if (finalClock.toISOString().slice(0, 10) !== day) {
+          throw storageFailure("UTC quota day changed during inbound media admission", {
+            sourceMessageId: input.sourceMessageId,
+            admissionDay: day,
+            finalDay: finalClock.toISOString().slice(0, 10),
+          });
+        }
+        // Quota-row contention can outlive the preliminary lease. Renew from
+        // the post-lock clock before commit so a caller always receives a full
+        // lease and cannot be reclaimed while its provider call is still live.
+        const [renewed] = await tx
+          .update(personalSharedInboundMediaDescriptions)
+          .set({
+            lease_expires_at: new Date(finalClock.getTime() + INBOUND_MEDIA_DESCRIPTION_LEASE_MS),
+            updated_at: finalClock,
+          })
+          .where(
+            and(
+              eq(personalSharedInboundMediaDescriptions.id, claim.id),
+              eq(personalSharedInboundMediaDescriptions.state, "pending"),
+              eq(personalSharedInboundMediaDescriptions.claim_token, claim.claimToken),
+            ),
+          )
+          .returning({ id: personalSharedInboundMediaDescriptions.id });
+        if (!renewed) {
+          throw storageFailure("Inbound media claim could not renew its committed lease", {
+            id: claim.id,
+          });
+        }
         return { kind: "claimed", claim };
       });
     } catch (error) {

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
@@ -7,6 +7,7 @@
  * fakes; the helper's real typed errors drive the settlement branches.
  */
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import type {
   AdmitInboundMediaDescriptionInput,
   InboundMediaDescriptionAdmission,
@@ -77,7 +78,7 @@ beforeEach(() => {
 });
 
 describe("resolveInboundMediaVisionCeilings", () => {
-  test("unset or blank bindings keep the defaults", () => {
+  test("unset bindings keep the defaults, while explicit blank bindings fail closed", () => {
     expect(resolveInboundMediaVisionCeilings({})).toEqual({
       senderDailyImages: DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
       connectorDailyImages: DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
@@ -85,12 +86,13 @@ describe("resolveInboundMediaVisionCeilings", () => {
     expect(
       resolveInboundMediaVisionCeilings({
         ELIZA_APP_INBOUND_MEDIA_VISION_SENDER_DAILY_IMAGES: "  ",
+      }),
+    ).toBeNull();
+    expect(
+      resolveInboundMediaVisionCeilings({
         ELIZA_APP_INBOUND_MEDIA_VISION_CONNECTOR_DAILY_IMAGES: "",
       }),
-    ).toEqual({
-      senderDailyImages: DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
-      connectorDailyImages: DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
-    });
+    ).toBeNull();
   });
 
   test("non-negative integer bindings tune each ceiling, zero included", () => {
@@ -169,7 +171,11 @@ describe("enrichInboundImageMedia — gates before the ledger", () => {
 
   test("an unavailable ledger skips without spending and reports the fault", async () => {
     const errorSpy = spyOn(logger, "error");
-    admit.mockRejectedValue(new Error("connection refused"));
+    admit.mockRejectedValue(
+      new ElizaError("connection refused", {
+        code: "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE",
+      }),
+    );
     expect(await enrich()).toEqual({ kind: "skipped", reason: "admission_unavailable" });
     expect(describeMedia).not.toHaveBeenCalled();
     expect(complete).not.toHaveBeenCalled();
@@ -198,6 +204,7 @@ describe("enrichInboundImageMedia — ledger decisions", () => {
     const cases: Array<[InboundMediaDescriptionAdmission, string]> = [
       [{ kind: "in_flight" }, "in_flight"],
       [{ kind: "previously_failed", reason: "media_fetch_failed" }, "previously_failed"],
+      [{ kind: "identity_mismatch" }, "identity_mismatch"],
       [{ kind: "media_mismatch" }, "media_mismatch"],
       [{ kind: "exhausted", scope: "sender", limit: 20, used: 20, requested: 2 }, "exhausted"],
       [
@@ -266,25 +273,21 @@ describe("enrichInboundImageMedia — behind a claim", () => {
     expect(fail).not.toHaveBeenCalled();
   });
 
-  test("a lost or unwritable settlement never discards a paid-for description", async () => {
+  test("a lost or unwritable settlement cannot inject an uncommitted description", async () => {
     const errorSpy = spyOn(logger, "error");
     const warnSpy = spyOn(logger, "warn");
     complete.mockResolvedValue(false);
-    expect(await enrich()).toEqual({
-      kind: "described",
-      description: "a cat on a keyboard",
-      reused: false,
-    });
+    expect(await enrich()).toEqual({ kind: "skipped", reason: "settlement_failed" });
     expect(
       warnSpy.mock.calls.some(([message]) => String(message).includes("reclaimed before")),
     ).toBe(true);
 
-    complete.mockRejectedValue(new Error("ledger down"));
-    expect(await enrich()).toEqual({
-      kind: "described",
-      description: "a cat on a keyboard",
-      reused: false,
-    });
+    complete.mockRejectedValue(
+      new ElizaError("ledger down", {
+        code: "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE",
+      }),
+    );
+    expect(await enrich()).toEqual({ kind: "skipped", reason: "settlement_failed" });
     const settlementFault = errorSpy.mock.calls.find(([message]) =>
       String(message).includes("failed to settle"),
     );

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.test.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_INBOUND_MEDIA_SENDER_DAILY_IMAGES,
   enrichInboundImageMedia,
   type InboundMediaEnrichmentEnv,
+  inboundMediaDigest,
   resolveInboundMediaVisionCeilings,
 } from "./inbound-media-enrichment";
 
@@ -160,13 +161,19 @@ describe("enrichInboundImageMedia — gates before the ledger", () => {
       sourceMessageId: "blooio:eliza-app:message-42",
       organizationId: "00000000-0000-4000-8000-000000000001",
       userId: "00000000-0000-4000-8000-000000000002",
-      mediaDigest: await sha256Hex(`${URL_A}\n${URL_B}`),
+      mediaDigest: await sha256Hex(JSON.stringify([URL_A, URL_B])),
       imageCount: 2,
       ceilings: {
         senderDailyImages: 3,
         connectorDailyImages: DEFAULT_INBOUND_MEDIA_CONNECTOR_DAILY_IMAGES,
       },
     });
+  });
+
+  test("media-list framing cannot collide across URL boundaries", async () => {
+    expect(await inboundMediaDigest(["https://media.blooio.com/a\nb"])).not.toBe(
+      await inboundMediaDigest(["https://media.blooio.com/a", "b"]),
+    );
   });
 
   test("an unavailable ledger skips without spending and reports the fault", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
@@ -11,6 +11,7 @@
  * live claim, and never retries a terminal failure.
  */
 
+import { ElizaError } from "@elizaos/core";
 import {
   type InboundMediaDescriptionCeilings,
   type InboundMediaDescriptionClaim,
@@ -46,9 +47,11 @@ export type InboundMediaEnrichmentSkipReason =
   | "admission_unavailable"
   | "in_flight"
   | "previously_failed"
+  | "identity_mismatch"
   | "media_mismatch"
   | "exhausted"
-  | "description_failed";
+  | "description_failed"
+  | "settlement_failed";
 
 export type InboundMediaEnrichmentOutcome =
   | { kind: "described"; description: string; reused: boolean }
@@ -71,7 +74,7 @@ const LOG_PREFIX = "[inbound-media-enrichment]";
 function parseCeiling(raw: string | undefined, fallback: number): number | null {
   if (raw === undefined) return fallback;
   const trimmed = raw.trim();
-  if (trimmed === "") return fallback;
+  if (trimmed === "") return null;
   if (!/^\d{1,9}$/.test(trimmed)) return null;
   return Number(trimmed);
 }
@@ -103,23 +106,29 @@ export async function inboundMediaDigest(mediaUrls: readonly string[]): Promise<
 async function settleClaim(
   settle: () => Promise<boolean>,
   context: Record<string, unknown>,
-): Promise<void> {
+): Promise<boolean> {
   let settled: boolean;
   try {
     settled = await settle();
   } catch (error) {
-    // error-policy:J7 the provider outcome is already final for this turn; a
-    // ledger write failure is reported and the pending claim lapses with its
-    // lease instead of failing the delivery.
+    if (
+      !(error instanceof ElizaError) ||
+      error.code !== "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE"
+    ) {
+      throw error;
+    }
+    // error-policy:J4 settlement authority is unavailable, so the caller
+    // keeps the raw media turn instead of trusting an uncommitted description.
     logger.error(`${LOG_PREFIX} failed to settle the description claim`, {
       ...context,
       error: error instanceof Error ? error.message : String(error),
     });
-    return;
+    return false;
   }
   if (!settled) {
     logger.warn(`${LOG_PREFIX} description claim was reclaimed before settlement`, context);
   }
+  return settled;
 }
 
 export async function enrichInboundImageMedia(
@@ -162,6 +171,12 @@ export async function enrichInboundImageMedia(
       ceilings,
     });
   } catch (error) {
+    if (
+      !(error instanceof ElizaError) ||
+      error.code !== "INBOUND_MEDIA_ADMISSION_STORAGE_FAILURE"
+    ) {
+      throw error;
+    }
     // error-policy:J4 no admission decision means no spend: the turn keeps the
     // raw media text instead of failing or calling the provider ungated.
     logger.error(`${LOG_PREFIX} admission ledger unavailable; vision fails closed`, {
@@ -183,6 +198,12 @@ export async function enrichInboundImageMedia(
         failureReason: admission.reason,
       });
       return { kind: "skipped", reason: "previously_failed" };
+    case "identity_mismatch":
+      logger.error(
+        `${LOG_PREFIX} connector message identity belongs to a different account`,
+        context,
+      );
+      return { kind: "skipped", reason: "identity_mismatch" };
     case "media_mismatch":
       logger.warn(
         `${LOG_PREFIX} redelivery carries different media than the stored claim`,
@@ -236,7 +257,17 @@ async function describeBehindClaim(
     // An untyped failure is a bug; the pending claim lapses with its lease.
     throw error;
   }
-  await settleClaim(() => deps.repository.complete(claim, description), claimContext);
+  const settled = await settleClaim(
+    () => deps.repository.complete(claim, description),
+    claimContext,
+  );
+  if (!settled) {
+    logger.error(
+      `${LOG_PREFIX} description was not committed by the live claim; keeping raw media`,
+      claimContext,
+    );
+    return { kind: "skipped", reason: "settlement_failed" };
+  }
   logger.info(`${LOG_PREFIX} inbound media described`, claimContext);
   return { kind: "described", description, reused: false };
 }

--- a/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/inbound-media-enrichment.ts
@@ -98,9 +98,9 @@ export function resolveInboundMediaVisionCeilings(
   return { senderDailyImages, connectorDailyImages };
 }
 
-/** Canonical digest of the exact URL list so a reuse only matches the same media. */
+/** Canonical unambiguous digest of the ordered URL list. */
 export async function inboundMediaDigest(mediaUrls: readonly string[]): Promise<string> {
-  return sha256Hex(mediaUrls.join("\n"));
+  return sha256Hex(JSON.stringify(mediaUrls));
 }
 
 async function settleClaim(

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -487,6 +487,9 @@ export interface Bindings {
    * on Personal Shared turns; any other value keeps the raw media-URL text.
    * The gateway-webhook service reads the same variable to decide whether to
    * forward media URLs at all, so enable both deployments together.
+   * Keep this unset outside tests until the retention, real-PostgreSQL
+   * concurrency, signed Blooio/provider, and edge-egress promotion gates in
+   * `docs/inbound-media-vision-promotion.md` are complete.
    */
   ELIZA_APP_INBOUND_MEDIA_VISION?: string;
   /**


### PR DESCRIPTION
## Summary

Post-merge corrective for #25359. This keeps inbound-media vision fail-closed at the money/privacy boundary:

- treats connector message identity as immutable across tenant, user, ordered payload, image count, every terminal state, and expired reclaim
- requires a positive, live-token-owned settlement before provider text can enter a user turn
- refreshes the database clock after row/quota contention, renews the committed lease after quota locks, and aborts atomically if admission crosses a UTC quota day
- frames ordered media URLs unambiguously before hashing
- makes explicitly blank ceiling bindings invalid instead of silently substituting defaults
- documents the feature-dark promotion contract and remaining retention/integration work

## Validation

Pinned Bun `1.3.14` and Node `24.15.0` were used.

- repository/enrichment focused suites: 62 passed before the final mechanical rebase
- corrective repository suite at exact behavior patch: 17 passed, including delayed quota-lock lease renewal and UTC rollover rollback
- API route suites: 24 passed (17 deterministic route tests + 7 PGlite ledger tests)
- gateway suites: 11 passed
- `packages/cloud/shared` typecheck: passed
- `packages/cloud/services/gateway-webhook` typecheck: passed
- Cloud API `tsc6 --noEmit`: passed after building its declared workspace prerequisite
- Drizzle schema/migration check: passed
- Biome on every touched file: passed
- `git diff --check`: passed

One concurrent repository-wide performance assertion was observed outside this patch's files; it is unrelated to inbound-media admission and is not represented as a pass for this change. Full root `bun run verify` was not used as evidence for this bounded urgent correction.

## Promotion blockers / evidence

This PR is safe to merge only while `INBOUND_MEDIA_VISION_ENABLED` remains dark. I found no checked-in deploy/env configuration enabling it, and GitHub staging/production environment variables contain no `INBOUND_MEDIA_VISION*` entry. This environment has no Railway/Cloudflare deployment credential, so live service bindings could not be independently inspected.

The flag must remain unset until all of the following are attached and reviewed:

- bounded retention/purge for ledger descriptions and quota records
- real PostgreSQL contention/concurrency evidence
- a live signed Blooio delivery through the real provider with raw/enriched/settled-row evidence
- production workerd egress/SSRF enforcement evidence
- explicitly approved nonblank cost ceilings

No live Cerebras/Blooio/provider trajectory is claimed by this PR.

## Evidence matrix

| Surface | Evidence |
| --- | --- |
| Unit/integration | Exact commands and pass counts above |
| Live connector/provider | Blocked; mandatory before promotion |
| Real PostgreSQL concurrency | Blocked; mandatory before promotion |
| UI screenshots/video | N/A — no UI changes |
| Retention purge | Not implemented; mandatory before promotion |

Refs #25359
