### PR TITLE
fix(shared): repair speaker name tiebreak typecheck

### DIFF
--- a/packages/shared/src/speaker-name-inference.test.ts
+++ b/packages/shared/src/speaker-name-inference.test.ts
@@ -52,35 +52,20 @@ describe("inferSpeakerName borrowed-device precedence", () => {
     expect(result.bindingPlan.action).toBe("create_entity");
   });
 
-  it("sorts speaker name candidates deterministically with score and candidateName tiebreaker", () => {
-    const candidates = [
-      { candidateName: "B Speaker", score: 0.8, confidence: 0.8 },
-      { candidateName: "A Speaker", score: 0.8, confidence: 0.8 },
-      { candidateName: "C Speaker", score: 0.9, confidence: 0.9 },
-    ];
-
-    candidates.sort((a, b) => {
-      const bScore =
-        typeof b.score === "number" && Number.isFinite(b.score) ? b.score : 0;
-      const aScore =
-        typeof a.score === "number" && Number.isFinite(a.score) ? a.score : 0;
-      const bConf =
-        typeof b.confidence === "number" && Number.isFinite(b.confidence)
-          ? b.confidence
-          : 0;
-      const aConf =
-        typeof a.confidence === "number" && Number.isFinite(a.confidence)
-          ? a.confidence
-          : 0;
-      return (
-        bScore - aScore ||
-        bConf - aConf ||
-        a.candidateName.localeCompare(b.candidateName)
-      );
+  it("sorts equal-score candidates deterministically by normalized name", () => {
+    const result = inferSpeakerName({
+      speakerId: "speaker-1",
+      evidence: [
+        { source: "platform_roster", confidence: 0.8, name: "B Speaker" },
+        { source: "platform_roster", confidence: 0.8, name: "A Speaker" },
+        { source: "platform_roster", confidence: 0.9, name: "C Speaker" },
+      ],
     });
 
-    expect(candidates[0]?.candidateName).toBe("C Speaker");
-    expect(candidates[1]?.candidateName).toBe("A Speaker");
-    expect(candidates[2]?.candidateName).toBe("B Speaker");
+    expect(result.candidateNames.map((candidate) => candidate.name)).toEqual([
+      "C Speaker",
+      "A Speaker",
+      "B Speaker",
+    ]);
   });
 });

--- a/packages/shared/src/speaker-name-inference.ts
+++ b/packages/shared/src/speaker-name-inference.ts
@@ -257,7 +257,7 @@ function groupCandidates(
       return (
         bScore - aScore ||
         bConf - aConf ||
-        a.candidateName.localeCompare(b.candidateName)
+        a.normalizedName.localeCompare(b.normalizedName)
       );
     });
 }


### PR DESCRIPTION
## Summary

- fix the production speaker-name candidate comparator to use the real `normalizedName` field
- replace the ad hoc fake comparator test with an `inferSpeakerName` integration test
- keep this baseline repair separate from Shared realtime-grounding PR #25433

## Root cause

Merged PR #25426 added a deterministic tiebreak using nonexistent `candidateName` fields. Production candidates expose `name` and `normalizedName`, so `@elizaos/shared` typecheck fails before #25433 can receive meaningful exact-head CI.

## Exact source

- current develop merged forward: `182721a36128212411b234a07779847ea642565c`
- PR head: `595b72dda345a3ee060ee4bf6a06fde1058017c6`
- repair commit: `db2321d4a4fe02fed5dec366b2b54766ed24ace1`
- changed files versus current develop: `packages/shared/src/speaker-name-inference.ts`, `packages/shared/src/speaker-name-inference.test.ts`
- repair patch is range-diff identical to preserved checkpoint `c5810650b7a59a01abf9bc4a94f8e332b0fb4df4`

## Verification

- direct production-path proof: `candidate_order=C Speaker,A Speaker,B Speaker`
- focused standalone TypeScript check: pass
- Biome on both changed files: pass
- `git diff --check`: pass
- gitleaks on the repair range: no leaks
- repository-native Vitest is delegated to PR Static Smoke because this isolated checkout cannot complete the frozen workspace install under the current host disk-capacity gate; no dependency tree was borrowed from another worktree

This is a narrow baseline fix that unblocks #25433 without changing its grounding implementation.