### PR TITLE
fix(devices): close runtime management authority gaps

### DIFF
--- a/packages/agent/src/api/runtime-management-routes.test.ts
+++ b/packages/agent/src/api/runtime-management-routes.test.ts
@@ -18,6 +18,9 @@ function makeContext(method: string, pathname: string, body: Body | null) {
   const json = vi.fn();
   const error = vi.fn();
   const broadcastWs = vi.fn();
+  const broadcastWsToClientId = vi.fn(
+    (_clientId: string, _frame: object): number => 1,
+  );
   const ctx: RuntimeManagementRouteContext = {
     req,
     res: {} as http.ServerResponse,
@@ -26,8 +29,10 @@ function makeContext(method: string, pathname: string, body: Body | null) {
     json,
     error,
     broadcastWs,
+    broadcastWsToClientId,
+    callerAuthorization: { ok: true, role: "OWNER" },
   };
-  return { ctx, json, error, broadcastWs };
+  return { ctx, json, error, broadcastWs, broadcastWsToClientId };
 }
 
 async function flushUntil(predicate: () => boolean): Promise<void> {
@@ -41,6 +46,19 @@ afterEach(() => {
 });
 
 describe("POST /api/runtime/manage", () => {
+  it("rejects authenticated non-owner callers before shell delivery", async () => {
+    const request = makeContext("POST", "/api/runtime/manage", { op: "list" });
+    request.ctx.callerAuthorization = { ok: true, role: "USER" };
+    await handleRuntimeManagementRoutes(request.ctx);
+    expect(request.error).toHaveBeenCalledWith(
+      expect.anything(),
+      "Runtime management requires owner authority.",
+      403,
+    );
+    expect(request.broadcastWs).not.toHaveBeenCalled();
+    expect(request.broadcastWsToClientId).not.toHaveBeenCalled();
+  });
+
   it("lets exactly one shell claim and resolve an operation", async () => {
     const manage = makeContext("POST", "/api/runtime/manage", {
       op: "inspect_ssh",
@@ -104,6 +122,53 @@ describe("POST /api/runtime/manage", () => {
       400,
     );
     expect(request.broadcastWs).not.toHaveBeenCalled();
+
+    const aliased = makeContext("POST", "/api/runtime/manage", {
+      op: "list",
+      access_token: "must-not-cross",
+    });
+    await handleRuntimeManagementRoutes(aliased.ctx);
+    expect(aliased.error).toHaveBeenCalledWith(
+      expect.anything(),
+      "Invalid runtime operation or secret-bearing field.",
+      400,
+    );
+    expect(aliased.broadcastWs).not.toHaveBeenCalled();
+  });
+
+  it("targets the renderer that originated an app-chat action", async () => {
+    const manage = makeContext("POST", "/api/runtime/manage", {
+      op: "list",
+      clientId: "origin-renderer",
+    });
+    const waiting = handleRuntimeManagementRoutes(manage.ctx);
+    await flushUntil(
+      () => manage.broadcastWsToClientId.mock.calls.length === 1,
+    );
+    expect(manage.broadcastWs).not.toHaveBeenCalled();
+    expect(manage.broadcastWsToClientId.mock.calls[0]?.[0]).toBe(
+      "origin-renderer",
+    );
+    const frame = manage.broadcastWsToClientId.mock.calls[0]?.[1] as {
+      requestId: string;
+    };
+    const claim = makeContext("POST", "/api/runtime/manage/claim", {
+      requestId: frame.requestId,
+    });
+    await handleRuntimeManagementRoutes(claim.ctx);
+    const claimBody = claim.json.mock.calls[0]?.[1] as { claimToken: string };
+    const result = makeContext("POST", "/api/runtime/manage/result", {
+      requestId: frame.requestId,
+      claimToken: claimBody.claimToken,
+      ok: true,
+      data: { runtimes: [] },
+    });
+    await handleRuntimeManagementRoutes(result.ctx);
+    await waiting;
+    expect(manage.json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: true, op: "list" }),
+    );
   });
 
   it("rejects a result without the winning claim token", async () => {
@@ -117,6 +182,38 @@ describe("POST /api/runtime/manage", () => {
       expect.anything(),
       "Unknown or unclaimed runtime operation.",
       409,
+    );
+  });
+
+  it("preserves the complete shell failure for the planner", async () => {
+    const manage = makeContext("POST", "/api/runtime/manage", {
+      op: "inspect_ssh",
+      runtimeId: "probe-1",
+      target: "user@host",
+      sshPort: 22,
+    });
+    const waiting = handleRuntimeManagementRoutes(manage.ctx);
+    await flushUntil(() => manage.broadcastWs.mock.calls.length === 1);
+    const frame = manage.broadcastWs.mock.calls[0]?.[0] as {
+      requestId: string;
+    };
+    const claim = makeContext("POST", "/api/runtime/manage/claim", {
+      requestId: frame.requestId,
+    });
+    await handleRuntimeManagementRoutes(claim.ctx);
+    const claimBody = claim.json.mock.calls[0]?.[1] as { claimToken: string };
+    const completeError = `failure:${"x".repeat(800)}`;
+    const result = makeContext("POST", "/api/runtime/manage/result", {
+      requestId: frame.requestId,
+      claimToken: claimBody.claimToken,
+      ok: false,
+      error: completeError,
+    });
+    await handleRuntimeManagementRoutes(result.ctx);
+    await waiting;
+    expect(manage.json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ error: completeError }),
     );
   });
 });

--- a/packages/agent/src/api/runtime-management-routes.ts
+++ b/packages/agent/src/api/runtime-management-routes.ts
@@ -8,6 +8,7 @@ import {
   type RuntimeManagementResult,
   readJsonBody,
 } from "@elizaos/shared";
+import type { AgentHttpRequestAuthorization } from "../runtime/host-bridge.ts";
 import { PendingRequestMap } from "./pending-request-map.ts";
 
 const PREFIX = "/api/runtime/manage";
@@ -23,6 +24,8 @@ export interface RuntimeManagementRouteContext {
   json: (res: http.ServerResponse, data: unknown, status?: number) => void;
   error: (res: http.ServerResponse, message: string, status?: number) => void;
   broadcastWs?: (payload: object) => void;
+  broadcastWsToClientId?: (clientId: string, payload: object) => number;
+  callerAuthorization: AgentHttpRequestAuthorization;
 }
 
 function boundedString(value: unknown, max = 512): string | undefined {
@@ -43,11 +46,20 @@ function parseRequest(
   body: Record<string, unknown>,
 ): RuntimeManagementRequest | null {
   if (!isRuntimeManagementOperation(body.op)) return null;
+  const normalizedKeys = new Set(
+    Object.keys(body).map((key) => key.replace(/[-_]/g, "").toLowerCase()),
+  );
   if (
-    "accessToken" in body ||
-    "privateKey" in body ||
-    "password" in body ||
-    "credential" in body
+    [
+      "accesstoken",
+      "apikey",
+      "bearertoken",
+      "credential",
+      "password",
+      "privatekey",
+      "secret",
+      "token",
+    ].some((key) => normalizedKeys.has(key))
   ) {
     return null;
   }
@@ -78,6 +90,14 @@ export async function handleRuntimeManagementRoutes(
 ): Promise<boolean> {
   const { req, res, method, pathname, json, error } = ctx;
   if (!pathname.startsWith(PREFIX)) return false;
+  if (!ctx.callerAuthorization.ok) {
+    error(res, "Runtime management authentication required.", 401);
+    return true;
+  }
+  if (ctx.callerAuthorization.role !== "OWNER") {
+    error(res, "Runtime management requires owner authority.", 403);
+    return true;
+  }
   purgeExpiredClaims();
 
   if (method === "POST" && pathname === PREFIX) {
@@ -90,7 +110,12 @@ export async function handleRuntimeManagementRoutes(
       error(res, "Invalid runtime operation or secret-bearing field.", 400);
       return true;
     }
-    if (!ctx.broadcastWs) {
+    const clientId = boundedString(body.clientId, 128);
+    if (clientId && !/^[A-Za-z0-9._-]{1,128}$/.test(clientId)) {
+      error(res, "Invalid runtime client id.", 400);
+      return true;
+    }
+    if (!ctx.broadcastWs && !ctx.broadcastWsToClientId) {
       json(res, { ok: false, op: request.op, error: "no-shell" });
       return true;
     }
@@ -101,7 +126,21 @@ export async function handleRuntimeManagementRoutes(
       expiresAt: Date.now() + SHELL_TIMEOUT_MS,
     });
     const outcome = pending.waitFor(requestId, SHELL_TIMEOUT_MS);
-    ctx.broadcastWs({ type: "shell:manage-runtime", requestId, request });
+    const frame = { type: "shell:manage-runtime", requestId, request };
+    let delivered: number | undefined;
+    if (clientId) {
+      delivered = ctx.broadcastWsToClientId?.(clientId, frame);
+    } else if (ctx.broadcastWs) {
+      ctx.broadcastWs(frame);
+      delivered = 1;
+    }
+    if (!delivered) {
+      claims.delete(requestId);
+      pending.resolve(requestId, { requestId, success: false });
+      await outcome;
+      json(res, { ok: false, op: request.op, error: "no-shell" });
+      return true;
+    }
     try {
       const resolved = await outcome;
       const detail =
@@ -171,9 +210,7 @@ export async function handleRuntimeManagementRoutes(
       success: body.ok === true,
       result: {
         ...(data ? { data } : {}),
-        ...(typeof body.error === "string"
-          ? { error: body.error.slice(0, 512) }
-          : {}),
+        ...(typeof body.error === "string" ? { error: body.error } : {}),
       },
     });
     json(res, { accepted: true });

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -3317,6 +3317,12 @@ async function handleRequest(
   }
 
   // ── Runtime switch routes (/api/runtime/model-switch, /agent-switch) ──────
+  const runtimeManagementCallerAuthorization = resolveInboxRequestAuthorization(
+    req,
+    method,
+    pathname,
+    await resolveHostSessionAuthorization(),
+  );
   if (
     await handleRuntimeManagementRoutes({
       req,
@@ -3326,6 +3332,8 @@ async function handleRequest(
       json,
       error,
       broadcastWs: state.broadcastWs ?? undefined,
+      broadcastWsToClientId: state.broadcastWsToClientId ?? undefined,
+      callerAuthorization: runtimeManagementCallerAuthorization,
     })
   ) {
     return;

--- a/packages/app-core/docs/devices-runtimes-unified-reconciliation.md
+++ b/packages/app-core/docs/devices-runtimes-unified-reconciliation.md
@@ -80,8 +80,8 @@ The exact publication head must pass:
    integration, and Electrobun typecheck.
 3. Cloud remote API tests, shared repository/Headscale/PGlite tests, and both
    Cloud typechecks.
-4. Disposable real PostgreSQL composition of migrations 0305-0309, including
-   upstream 0307 and 0308 before the Devices managed-network suffix.
+4. Disposable real PostgreSQL composition of migrations 0305-0311, including
+   upstream 0307 through 0310 before the Devices managed-network suffix.
 5. Production story build plus responsive interaction at 380x844 and
    1440x1000 with no horizontal overflow and 44-point actions.
 6. An exact-head unsigned iOS Simulator build whose cloud-only attestation

--- a/packages/cloud/api/v1/remote/hosts/route.ts
+++ b/packages/cloud/api/v1/remote/hosts/route.ts
@@ -31,27 +31,29 @@ app.get("/", async (c) => {
       success: true,
       data: {
         ownerId: user.id,
-        hosts: hosts.map((host) => ({
-          id: host.id,
-          deviceId: host.device_id,
-          displayName: host.display_name,
-          platform: host.platform,
-          connectionMode: host.connection_mode,
-          runtimeKeyId: host.runtime_key_id,
-          signingPublicKeyJwk: host.signing_public_jwk,
-          encryptionPublicKeyJwk: host.encryption_public_jwk,
-          status:
-            host.status === "revoked"
-              ? "revoked"
-              : host.last_seen_at &&
-                  Date.now() - host.last_seen_at.getTime() <=
-                    REMOTE_HOST_ONLINE_WINDOW_MS
-                ? "active"
-                : "offline",
-          lastSeenAt: host.last_seen_at,
-          createdAt: host.created_at,
-          revokedAt: host.revoked_at,
-        })),
+        hosts: hosts
+          .filter((host) => host.status !== "pending")
+          .map((host) => ({
+            id: host.id,
+            deviceId: host.device_id,
+            displayName: host.display_name,
+            platform: host.platform,
+            connectionMode: host.connection_mode,
+            runtimeKeyId: host.runtime_key_id,
+            signingPublicKeyJwk: host.signing_public_jwk,
+            encryptionPublicKeyJwk: host.encryption_public_jwk,
+            status:
+              host.status === "revoked"
+                ? "revoked"
+                : host.last_seen_at &&
+                    Date.now() - host.last_seen_at.getTime() <=
+                      REMOTE_HOST_ONLINE_WINDOW_MS
+                  ? "active"
+                  : "offline",
+            lastSeenAt: host.last_seen_at,
+            createdAt: host.created_at,
+            revokedAt: host.revoked_at,
+          })),
       },
     });
   } catch (error) {
@@ -189,7 +191,7 @@ app.post("/", async (c) => {
           signing_public_jwk: identity.signingPublicKeyJwk,
           encryption_public_jwk: identity.encryptionPublicKeyJwk,
           host_token_hash: hostTokenHash,
-          status: "active",
+          status: networkConfig ? "pending" : "active",
         });
     if (result.kind === "conflict") {
       return c.json(
@@ -247,7 +249,7 @@ app.post("/", async (c) => {
           hostId: result.host.id,
           hostToken: token,
           runtimeKeyId: result.host.runtime_key_id,
-          status: result.host.status,
+          status: managedNetworkEnrollment ? "active" : result.host.status,
           createdAt: result.host.created_at,
           recovered: result.kind === "recovered",
           managedNetworkEnrollment,

--- a/packages/cloud/api/v1/remote/managed-network.test.ts
+++ b/packages/cloud/api/v1/remote/managed-network.test.ts
@@ -11,6 +11,7 @@ import {
 function repository(): ManagedNetworkRepository {
   return {
     recordManagedEnrollment: mock(async () => undefined),
+    recordManagedCleanupPending: mock(async () => undefined),
     recordManagedCleanupFailure: mock(async () => undefined),
     completeManagedCleanup: mock(async () => undefined),
   };
@@ -28,7 +29,7 @@ function client(overrides: Record<string, unknown> = {}): HeadscaleClient {
     })),
     expirePreAuthKey: mock(async () => undefined),
     deletePreAuthKey: mock(async () => undefined),
-    getNodeByNameStrict: mock(async () => null),
+    listNodesStrict: mock(async () => []),
     deleteNode: mock(async () => undefined),
     ...overrides,
   } as unknown as HeadscaleClient;
@@ -111,14 +112,62 @@ describe("remote host managed-network lifecycle", () => {
     expect(headscale.deletePreAuthKey).toHaveBeenCalledWith("123");
   });
 
+  test("records cleanup state without activating when key compensation also fails", async () => {
+    const repo = repository();
+    repo.recordManagedEnrollment = mock(async () => {
+      throw new Error("database activation unavailable");
+    });
+    const headscale = client({
+      expirePreAuthKey: mock(async () => {
+        throw new Error("Headscale unavailable");
+      }),
+    });
+    await expect(
+      enrollManagedNetwork({
+        hostId: "host-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        config,
+        repository: repo,
+        client: headscale,
+      }),
+    ).rejects.toThrow(/compensation is pending/);
+    expect(repo.recordManagedCleanupPending).toHaveBeenCalledWith({
+      hostId: "host-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      hostname: managedNetworkInternals.hostnameForHost("host-1"),
+      preAuthKeyId: "123",
+      message: "Managed-network enrollment compensation is pending retry.",
+    });
+    expect(repo.recordManagedEnrollment).toHaveBeenCalledTimes(1);
+  });
+
   test("cleans key and node idempotently before clearing durable retry state", async () => {
     const repo = repository();
     const headscale = client({
-      getNodeByNameStrict: mock(async () => ({ id: "9" })),
+      listNodesStrict: mock(async () => [
+        {
+          id: "8",
+          name: "eliza-host-one-deadbeef",
+          createdAt: "2026-08-22T11:59:59.000Z",
+        },
+        {
+          id: "9",
+          name: "eliza-host-one",
+          createdAt: "2026-08-22T12:00:01.000Z",
+        },
+        {
+          id: "10",
+          name: "eliza-host-one-cafebabe",
+          createdAt: "2026-08-22T12:00:01.000Z",
+        },
+      ]),
     });
     await cleanupManagedNetwork({
       host: {
         id: "host-1",
+        created_at: new Date("2026-08-22T12:00:00.000Z"),
         headscale_hostname: "eliza-host-one",
         headscale_preauth_key_id: "123",
         headscale_cleanup_pending: true,
@@ -131,6 +180,8 @@ describe("remote host managed-network lifecycle", () => {
     });
     expect(headscale.expirePreAuthKey).toHaveBeenCalledWith("123");
     expect(headscale.deleteNode).toHaveBeenCalledWith("9");
+    expect(headscale.deleteNode).toHaveBeenCalledWith("10");
+    expect(headscale.deleteNode).not.toHaveBeenCalledWith("8");
     expect(headscale.deletePreAuthKey).toHaveBeenCalledWith("123");
     expect(repo.completeManagedCleanup).toHaveBeenCalledTimes(1);
   });

--- a/packages/cloud/api/v1/remote/managed-network.ts
+++ b/packages/cloud/api/v1/remote/managed-network.ts
@@ -13,6 +13,7 @@ export interface ManagedNetworkConfig {
 
 export interface ManagedNetworkHost {
   id: string;
+  created_at: Date;
   headscale_hostname?: string | null;
   headscale_preauth_key_id?: string | null;
   headscale_cleanup_pending?: boolean;
@@ -30,6 +31,14 @@ export interface ManagedNetworkRepository {
     hostId: string;
     organizationId: string;
     userId: string;
+    message: string;
+  }): Promise<unknown>;
+  recordManagedCleanupPending(input: {
+    hostId: string;
+    organizationId: string;
+    userId: string;
+    hostname: string;
+    preAuthKeyId: string;
     message: string;
   }): Promise<unknown>;
   completeManagedCleanup(input: {
@@ -147,17 +156,12 @@ export async function enrollManagedNetwork(input: {
     }
     if (cleanupFailures.length > 0) {
       try {
-        await input.repository.recordManagedEnrollment({
+        await input.repository.recordManagedCleanupPending({
           hostId: input.hostId,
           organizationId: input.organizationId,
           userId: input.userId,
           hostname,
           preAuthKeyId: preAuthKey.id,
-        });
-        await input.repository.recordManagedCleanupFailure({
-          hostId: input.hostId,
-          organizationId: input.organizationId,
-          userId: input.userId,
           message: "Managed-network enrollment compensation is pending retry.",
         });
       } catch (trackingCause) {
@@ -201,8 +205,17 @@ export async function cleanupManagedNetwork(input: {
   const hostname = input.host.headscale_hostname;
   if (hostname) {
     try {
-      const node = await client.getNodeByNameStrict(hostname);
-      if (node) await client.deleteNode(node.id);
+      const escapedHostname = hostname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const collisionName = new RegExp(`^${escapedHostname}-[a-z0-9]{8}$`);
+      const createdAtMs = input.host.created_at.getTime();
+      const nodes = await client.listNodesStrict();
+      const cleanupNodes = nodes.filter(
+        (node) =>
+          node.name === hostname ||
+          (collisionName.test(node.name) &&
+            Date.parse(node.createdAt) >= createdAtMs),
+      );
+      for (const node of cleanupNodes) await client.deleteNode(node.id);
     } catch (cause) {
       failures.push(cause);
     }

--- a/packages/cloud/api/v1/remote/relay-routes.test.ts
+++ b/packages/cloud/api/v1/remote/relay-routes.test.ts
@@ -39,12 +39,13 @@ const listOwned = mock();
 const revokeHost = mock();
 const revokeAuthenticatedHost = mock();
 const recordManagedEnrollment = mock();
+const recordManagedCleanupPending = mock();
 const recordManagedCleanupFailure = mock();
 const completeManagedCleanup = mock();
 const createPreAuthKey = mock();
 const expirePreAuthKey = mock();
 const deletePreAuthKey = mock();
-const getNodeByNameStrict = mock();
+const listNodesStrict = mock();
 const deleteNode = mock();
 const createPendingForOwnedAgent = mock();
 const createPendingForOwnedHost = mock();
@@ -69,6 +70,7 @@ mock.module("@/db/repositories/remote-hosts", () => ({
     revoke: revokeHost,
     revokeAuthenticated: revokeAuthenticatedHost,
     recordManagedEnrollment,
+    recordManagedCleanupPending,
     recordManagedCleanupFailure,
     completeManagedCleanup,
   },
@@ -78,7 +80,7 @@ mock.module("@/lib/services/headscale-client", () => ({
     createPreAuthKey = createPreAuthKey;
     expirePreAuthKey = expirePreAuthKey;
     deletePreAuthKey = deletePreAuthKey;
-    getNodeByNameStrict = getNodeByNameStrict;
+    listNodesStrict = listNodesStrict;
     deleteNode = deleteNode;
   },
 }));
@@ -208,12 +210,13 @@ beforeEach(() => {
     revokeHost,
     revokeAuthenticatedHost,
     recordManagedEnrollment,
+    recordManagedCleanupPending,
     recordManagedCleanupFailure,
     completeManagedCleanup,
     createPreAuthKey,
     expirePreAuthKey,
     deletePreAuthKey,
-    getNodeByNameStrict,
+    listNodesStrict,
     deleteNode,
     createPendingForOwnedAgent,
     createPendingForOwnedHost,
@@ -243,7 +246,7 @@ beforeEach(() => {
   });
   expirePreAuthKey.mockResolvedValue(undefined);
   deletePreAuthKey.mockResolvedValue(undefined);
-  getNodeByNameStrict.mockResolvedValue(null);
+  listNodesStrict.mockResolvedValue([]);
   deleteNode.mockResolvedValue(undefined);
 });
 
@@ -309,9 +312,12 @@ describe("secure remote relay routes", () => {
     const body = (await response.json()) as {
       data: {
         hostToken: string;
+        status: string;
         managedNetworkEnrollment: { authKey: string; hostname: string };
       };
     };
+    expect(createOwned.mock.calls[0]?.[0]).toMatchObject({ status: "pending" });
+    expect(body.data.status).toBe("active");
     expect(body.data.managedNetworkEnrollment.authKey).toBe(
       "hskey-auth-one-use-secret",
     );
@@ -387,6 +393,11 @@ describe("secure remote relay routes", () => {
         revoked_at: null,
       },
       {
+        id: "40000000-0000-4000-8000-000000000003",
+        status: "pending",
+        created_at: new Date(),
+      },
+      {
         id: staleHostId,
         device_id: "linux-stale",
         display_name: "Linux Stale",
@@ -418,6 +429,7 @@ describe("secure remote relay routes", () => {
       encryptionPublicKeyJwk: publicJwk,
       status: "active",
     });
+    expect(body.data.hosts).toHaveLength(2);
     expect(body.data.hosts[1]).toMatchObject({
       id: staleHostId,
       status: "offline",
@@ -779,11 +791,18 @@ describe("secure remote relay routes", () => {
         headscale_hostname: "eliza-host-one",
         headscale_preauth_key_id: "123",
         headscale_cleanup_pending: true,
+        created_at: new Date(0),
       },
       alreadyRevoked: true,
       cleanup: { sessions: 0, commands: 0, more: false },
     });
-    getNodeByNameStrict.mockResolvedValue({ id: "9" });
+    listNodesStrict.mockResolvedValue([
+      {
+        id: "9",
+        name: "eliza-host-one",
+        createdAt: new Date(0).toISOString(),
+      },
+    ]);
     const response = await request(
       `/api/v1/remote/hosts/${hostId}/revoke`,
       {},

--- a/packages/cloud/shared/src/db/migrations/0311_remote_host_managed_network.sql
+++ b/packages/cloud/shared/src/db/migrations/0311_remote_host_managed_network.sql
@@ -4,5 +4,12 @@ ALTER TABLE "remote_hosts"
   ADD COLUMN IF NOT EXISTS "headscale_cleanup_pending" boolean NOT NULL DEFAULT false,
   ADD COLUMN IF NOT EXISTS "headscale_cleanup_error" text;
 --> statement-breakpoint
+ALTER TABLE "remote_hosts" DROP CONSTRAINT IF EXISTS "remote_hosts_status_check";
+--> statement-breakpoint
+ALTER TABLE "remote_hosts" ADD CONSTRAINT "remote_hosts_status_check" CHECK (
+  ("status" IN ('pending', 'active') AND "revoked_at" IS NULL)
+  OR ("status" = 'revoked' AND "revoked_at" IS NOT NULL)
+);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "remote_hosts_headscale_cleanup_pending_idx"
   ON "remote_hosts" ("headscale_cleanup_pending");

--- a/packages/cloud/shared/src/db/remote-control-migrations.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/remote-control-migrations.postgres.integration.test.ts
@@ -15,6 +15,7 @@ const migrations = [
   "0306_secure_remote_command_relay",
   "0307_twilio_outbound_call_audit",
   "0308_remove_conversation_token_default",
+  "0309_retire_legacy_bluebubbles_gateways",
   "0310_personal_shared_inbound_media_admission",
   "0311_remote_host_managed_network",
 ] as const;
@@ -44,6 +45,19 @@ realPostgresTest(
           settings jsonb NOT NULL DEFAULT
             '{"temperature":0.7,"maxTokens":2000,"topP":1,"frequencyPenalty":0,"presencePenalty":0,"systemPrompt":"You are a helpful AI assistant."}'::jsonb
         );
+        CREATE TABLE phone_gateway_devices (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          send_method text,
+          metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+          is_active boolean NOT NULL DEFAULT true,
+          can_send_sms boolean NOT NULL DEFAULT true,
+          can_receive_sms boolean NOT NULL DEFAULT true,
+          can_send_imessage boolean NOT NULL DEFAULT true,
+          can_receive_imessage boolean NOT NULL DEFAULT true,
+          updated_at timestamptz NOT NULL DEFAULT now()
+        );
+        INSERT INTO phone_gateway_devices (send_method)
+        VALUES ('bluebubbles-local-bridge');
       `);
 
       for (const migration of migrations) {
@@ -103,17 +117,71 @@ realPostgresTest(
         WHERE conname IN (
           'remote_sessions_exactly_one_target_check',
           'remote_sessions_host_authority_shape_check',
+          'remote_hosts_status_check',
           'remote_command_envelopes_lifecycle_shape_check'
         )
         ORDER BY conname
       `);
-      expect(constraints.rows).toHaveLength(3);
+      expect(constraints.rows).toHaveLength(4);
       const definitions = constraints.rows
         .map((row) => `${row.name}: ${row.definition}`)
         .join("\n");
       expect(definitions).toContain("execution_ambiguous");
       expect(definitions).toContain("controller_device_id");
       expect(definitions).toContain("host_id");
+      expect(definitions).toContain("pending");
+
+      await client.query(`
+        INSERT INTO organizations VALUES ('10000000-0000-4000-8000-000000000001');
+        INSERT INTO users VALUES ('20000000-0000-4000-8000-000000000001');
+        INSERT INTO remote_hosts (
+          id, organization_id, user_id, device_id, display_name, platform,
+          connection_mode, runtime_key_id, signing_public_jwk,
+          encryption_public_jwk, host_token_hash, status
+        ) VALUES (
+          '40000000-0000-4000-8000-000000000001',
+          '10000000-0000-4000-8000-000000000001',
+          '20000000-0000-4000-8000-000000000001',
+          'device-one', 'Device One', 'linux', 'relay', 'runtime-key-one',
+          '{}'::jsonb, '{}'::jsonb, 'host-token-hash', 'pending'
+        );
+      `);
+      const pendingHost = await client.query<{ status: string; revoked_at: Date | null }>(`
+        SELECT status, revoked_at FROM remote_hosts
+        WHERE id = '40000000-0000-4000-8000-000000000001'
+      `);
+      expect(pendingHost.rows).toEqual([{ status: "pending", revoked_at: null }]);
+      await expect(
+        client.query(`
+          UPDATE remote_hosts SET revoked_at = now()
+          WHERE id = '40000000-0000-4000-8000-000000000001'
+        `),
+      ).rejects.toThrow();
+
+      const retiredGateway = await client.query<{
+        is_active: boolean;
+        can_send_sms: boolean;
+        can_receive_sms: boolean;
+        can_send_imessage: boolean;
+        can_receive_imessage: boolean;
+      }>(`
+        SELECT
+          is_active,
+          can_send_sms,
+          can_receive_sms,
+          can_send_imessage,
+          can_receive_imessage
+        FROM phone_gateway_devices
+      `);
+      expect(retiredGateway.rows).toEqual([
+        {
+          is_active: false,
+          can_send_sms: false,
+          can_receive_sms: false,
+          can_send_imessage: false,
+          can_receive_imessage: false,
+        },
+      ]);
     } finally {
       await client.end().catch(() => undefined);
       await postgres.stop();

--- a/packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts
@@ -233,7 +233,52 @@ afterAll(async () => {
 
 describe("secure remote relay repositories", () => {
   it("persists and clears managed-network compensation without storing an auth key", async () => {
-    await enrollAndPair(false);
+    hostToken = generateRemoteHostToken();
+    expect(
+      await hosts.createOwned({
+        id: hostId,
+        organization_id: organizationId,
+        user_id: ownerId,
+        device_id: "linux-one",
+        display_name: "Linux One",
+        platform: "linux",
+        connection_mode: "relay",
+        runtime_key_id: targetKeyId,
+        signing_public_jwk: ecPublicJwk,
+        encryption_public_jwk: ecPublicJwk,
+        host_token_hash: await hashRemoteHostToken(hostToken),
+        status: "pending",
+      }),
+    ).toMatchObject({ kind: "created", host: { status: "pending" } });
+    expect(await hosts.authenticate(hostId, hostToken)).toBeUndefined();
+    const pairingExpiry = new Date(Date.now() + 5 * 60_000);
+    expect(
+      await sessions.createPendingForOwnedHost({
+        id: sessionId,
+        organization_id: organizationId,
+        user_id: ownerId,
+        host_id: hostId,
+        grant_id: grantId,
+        grant_revision: 1,
+        status: "pending",
+        requester_identity: ownerId,
+        pairing_token_hash: await deriveRemotePairingCodeVerifier(
+          pairingSecret,
+          { organizationId, userId: ownerId, hostId, sessionId },
+          "123456",
+          pairingExpiry,
+        ),
+        controller_device_id: controllerDeviceId,
+        controller_key_id: controllerKeyId,
+        controller_display_name: "Controller",
+        controller_platform: "linux",
+        controller_signing_public_jwk: ecPublicJwk,
+        controller_encryption_public_jwk: ecPublicJwk,
+        target_key_id: targetKeyId,
+        expires_at: pairingExpiry,
+        grant_expires_at: new Date(Date.now() + 60 * 60_000),
+      }),
+    ).toBeUndefined();
     await hosts.recordManagedEnrollment({
       hostId,
       organizationId,
@@ -246,6 +291,7 @@ describe("secure remote relay repositories", () => {
       headscale_hostname: "eliza-host-test",
       headscale_preauth_key_id: "123",
       headscale_cleanup_pending: true,
+      status: "active",
     });
     expect(JSON.stringify(host)).not.toContain("hskey-");
 

--- a/packages/cloud/shared/src/db/repositories/remote-hosts.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-hosts.ts
@@ -140,6 +140,7 @@ export class RemoteHostsRepository {
     const [host] = await this.database
       .update(remoteHosts)
       .set({
+        status: "active",
         headscale_hostname: input.hostname,
         headscale_preauth_key_id: input.preAuthKeyId,
         headscale_cleanup_pending: true,
@@ -151,7 +152,7 @@ export class RemoteHostsRepository {
           eq(remoteHosts.id, input.hostId),
           eq(remoteHosts.organization_id, input.organizationId),
           eq(remoteHosts.user_id, input.userId),
-          eq(remoteHosts.status, "active"),
+          eq(remoteHosts.status, "pending"),
         ),
       )
       .returning();
@@ -161,6 +162,39 @@ export class RemoteHostsRepository {
       });
     }
     return host;
+  }
+
+  async recordManagedCleanupPending(input: {
+    hostId: string;
+    organizationId: string;
+    userId: string;
+    hostname: string;
+    preAuthKeyId: string;
+    message: string;
+  }): Promise<void> {
+    const [host] = await this.database
+      .update(remoteHosts)
+      .set({
+        headscale_hostname: input.hostname,
+        headscale_preauth_key_id: input.preAuthKeyId,
+        headscale_cleanup_pending: true,
+        headscale_cleanup_error: managedCleanupErrorPreview(input.message),
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(remoteHosts.id, input.hostId),
+          eq(remoteHosts.organization_id, input.organizationId),
+          eq(remoteHosts.user_id, input.userId),
+          eq(remoteHosts.status, "pending"),
+        ),
+      )
+      .returning({ id: remoteHosts.id });
+    if (!host) {
+      throw storageFailure("Pending managed-network cleanup could not be recorded", {
+        hostId: input.hostId,
+      });
+    }
   }
 
   async recordManagedCleanupFailure(input: {
@@ -340,7 +374,9 @@ export class RemoteHostsRepository {
         const [revoked] = await tx
           .update(remoteHosts)
           .set({ status: "revoked", revoked_at: now, updated_at: now })
-          .where(and(eq(remoteHosts.id, hostId), eq(remoteHosts.status, "active")))
+          .where(
+            and(eq(remoteHosts.id, hostId), inArray(remoteHosts.status, ["pending", "active"])),
+          )
           .returning();
         if (!revoked) {
           throw storageFailure("Locked remote host could not be revoked", { hostId });

--- a/packages/cloud/shared/src/db/schemas/remote-hosts.ts
+++ b/packages/cloud/shared/src/db/schemas/remote-hosts.ts
@@ -18,7 +18,7 @@ import {
 import { organizations } from "./organizations";
 import { users } from "./users";
 
-export const REMOTE_HOST_STATUSES = ["active", "revoked"] as const;
+export const REMOTE_HOST_STATUSES = ["pending", "active", "revoked"] as const;
 export type RemoteHostStatus = (typeof REMOTE_HOST_STATUSES)[number];
 
 export const remoteHosts = pgTable(

--- a/packages/ui/src/platform/runtime-management.ts
+++ b/packages/ui/src/platform/runtime-management.ts
@@ -339,6 +339,8 @@ export async function executeRuntimeManagementCommand(
   try {
     return { ok: true, op: request.op, data: await execute(request) };
   } catch (cause) {
+    // error-policy:J1 the renderer command boundary returns an explicit failure
+    // to the waiting agent route; it never reports a failed mutation as success.
     return {
       ok: false,
       op: request.op,

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -27,7 +27,7 @@ describe("RUNTIMES action", () => {
 		);
 	});
 
-	it("parses only the public SSH trust material", () => {
+	it("rejects secret-bearing action options instead of silently discarding them", () => {
 		expect(
 			parseRuntimeManagementRequest({
 				op: "connect_ssh",
@@ -39,20 +39,10 @@ describe("RUNTIMES action", () => {
 				identityFile: "/Users/me/.ssh/id_ed25519",
 				accessToken: "must-not-cross-the-action",
 			}),
-		).toEqual({
-			op: "connect_ssh",
-			runtimeId: "vps-1",
-			target: "user@host",
-			sshPort: 22,
-			remoteApiPort: 2138,
-			expectedFingerprint: "SHA256:verified",
-			identityFile: "/Users/me/.ssh/id_ed25519",
-			targetId: undefined,
-			label: undefined,
-			apiBase: undefined,
-			sessionId: undefined,
-			code: undefined,
-		});
+		).toBeNull();
+		expect(
+			parseRuntimeManagementRequest({ op: "list", access_token: "secret" }),
+		).toBeNull();
 	});
 
 	it("does not dispatch a mutation without explicit confirmation", async () => {
@@ -75,6 +65,25 @@ describe("RUNTIMES action", () => {
 		expect(manageRuntime).not.toHaveBeenCalled();
 	});
 
+	it("does not trust a model-authored confirm flag absent user confirmation", async () => {
+		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+			ok: true,
+			op: request.op,
+		}));
+		const action = createRuntimeManagementAction({ manageRuntime });
+		const result = await action.handler(
+			runtime,
+			message,
+			undefined,
+			{ op: "revoke", targetId: "host:mac", confirm: "true" },
+			callback(),
+		);
+		expect(result?.values).toEqual(
+			expect.objectContaining({ awaitingConfirmation: true }),
+		);
+		expect(manageRuntime).not.toHaveBeenCalled();
+	});
+
 	it("dispatches a confirmed pairing and narrates the one-use receipt", async () => {
 		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
 			ok: true,
@@ -90,7 +99,7 @@ describe("RUNTIMES action", () => {
 		const action = createRuntimeManagementAction({ manageRuntime });
 		const result = await action.handler(
 			runtime,
-			message,
+			{ content: { text: "Yes, confirm pairing" } } as Memory,
 			undefined,
 			{ op: "pair", targetId: "host:mac", confirm: "true" },
 			callback(),
@@ -113,11 +122,44 @@ describe("RUNTIMES action", () => {
 		expect(result?.text).toContain("123456");
 	});
 
+	it("returns every saved runtime in model-visible text and structured data", async () => {
+		const runtimes = [
+			{ id: "local", label: "This Mac", kind: "local", active: true },
+			{ id: "vps", label: "Home VPS", connectionMode: "ssh", active: false },
+		];
+		const action = createRuntimeManagementAction({
+			manageRuntime: vi.fn(async () => ({
+				ok: true,
+				op: "list",
+				data: { runtimes },
+			})),
+		});
+		const result = await action.handler(
+			runtime,
+			message,
+			undefined,
+			{ op: "list" },
+			callback(),
+		);
+		expect(result?.text).toContain("This Mac (local)");
+		expect(result?.text).toContain("Home VPS (vps)");
+		expect(JSON.parse(String(result?.values?.resultJson))).toEqual({
+			runtimes,
+		});
+	});
+
 	it("allows read-only SSH inspection without a mutation confirmation", async () => {
 		const manageRuntime: RuntimeManagementFn = vi.fn(async () => ({
 			ok: true,
 			op: "inspect_ssh",
-			data: { inspection: { fingerprints: ["SHA256:observed"] } },
+			data: {
+				inspection: {
+					fingerprints: [
+						{ algorithm: "ssh-ed25519", fingerprint: "SHA256:observed" },
+					],
+					preferredFingerprint: "SHA256:observed",
+				},
+			},
 		}));
 		const action = createRuntimeManagementAction({ manageRuntime });
 		const result = await action.handler(
@@ -128,6 +170,62 @@ describe("RUNTIMES action", () => {
 			callback(),
 		);
 		expect(result?.success).toBe(true);
+		expect(result?.text).toContain("ssh-ed25519: SHA256:observed");
+		expect(result?.text).toContain("Preferred fingerprint: SHA256:observed");
 		expect(manageRuntime).toHaveBeenCalledTimes(1);
+	});
+
+	it("binds the default HTTP handoff to the originating renderer", async () => {
+		const fetchMock = vi.fn(
+			async (_url: string | URL | Request, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({ ok: true, op: "list", data: { runtimes: [] } }),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		try {
+			const action = createRuntimeManagementAction();
+			const result = await action.handler(
+				runtime,
+				{
+					content: {
+						text: "list my runtimes",
+						metadata: { viewClientId: "origin-renderer" },
+					},
+				} as Memory,
+				undefined,
+				{ op: "list" },
+				callback(),
+			);
+			expect(result?.success).toBe(true);
+			const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+			expect(body).toEqual({ op: "list", clientId: "origin-renderer" });
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it("refuses an unbound mutation instead of racing arbitrary connected shells", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		try {
+			const action = createRuntimeManagementAction();
+			const result = await action.handler(
+				runtime,
+				{ content: { text: "Yes, confirm removing it" } } as Memory,
+				undefined,
+				{ op: "remove", runtimeId: "vps-1", confirm: "true" },
+				callback(),
+			);
+			expect(result?.success).toBe(false);
+			expect(result?.text).toContain("bound to that device");
+			expect(fetchMock).not.toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -16,7 +16,12 @@ import {
 	type RuntimeManagementResult,
 } from "@elizaos/shared";
 import { getAppControlApiBase } from "../loopback-api.js";
-import { normalizeActionOptions, readStringOption } from "../params.js";
+import {
+	normalizeActionOptions,
+	readStringOption,
+	userRequestMessageText,
+} from "../params.js";
+import { readViewInteractionClientId } from "./view-delivery.js";
 import { createViewsRequestHeaders } from "./views-request-auth.js";
 
 export type RuntimeManagementFn = (
@@ -34,6 +39,21 @@ const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 			(op) => op !== "list" && op !== "inspect_ssh",
 		),
 	);
+
+const SECRET_OPTION_NAMES = new Set([
+	"accesstoken",
+	"apikey",
+	"bearertoken",
+	"credential",
+	"password",
+	"privatekey",
+	"secret",
+	"token",
+]);
+
+function isSecretOptionName(key: string): boolean {
+	return SECRET_OPTION_NAMES.has(key.replace(/[-_]/g, "").toLowerCase());
+}
 
 function readNumberOption(
 	options: Record<string, unknown>,
@@ -60,6 +80,9 @@ export function parseRuntimeManagementRequest(
 	optionsValue?: Record<string, unknown>,
 ): RuntimeManagementRequest | null {
 	const options = normalizeActionOptions(optionsValue) ?? {};
+	if (Object.keys(options).some(isSecretOptionName)) {
+		return null;
+	}
 	const opValue =
 		readStringOption(options, "op") ?? readStringOption(options, "action");
 	if (!isRuntimeManagementOperation(opValue)) return null;
@@ -80,13 +103,30 @@ export function parseRuntimeManagementRequest(
 	};
 }
 
+function userExplicitlyConfirmed(message: Memory): boolean {
+	const text = userRequestMessageText(message).trim();
+	return /(?:^|\b)(?:confirm(?:ed)?|yes|yep|proceed|do it|go ahead)(?:\b|$)/i.test(
+		text,
+	);
+}
+
 async function defaultManageRuntime(
 	request: RuntimeManagementRequest,
+	message: Memory,
 ): Promise<RuntimeManagementResult> {
+	const clientId = readViewInteractionClientId(message);
+	if (!clientId) {
+		return {
+			ok: false,
+			op: request.op,
+			error:
+				"open the Eliza app and send this request from its chat so the operation is bound to that device",
+		};
+	}
 	const response = await fetch(`${getAppControlApiBase()}/api/runtime/manage`, {
 		method: "POST",
 		headers: createViewsRequestHeaders(),
-		body: JSON.stringify(request),
+		body: JSON.stringify({ ...request, clientId }),
 		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 	});
 	const body = (await response
@@ -107,7 +147,18 @@ function successText(result: RuntimeManagementResult): string {
 		const runtimes = Array.isArray(result.data?.runtimes)
 			? result.data.runtimes
 			: [];
-		return `Found ${runtimes.length} saved runtime${runtimes.length === 1 ? "" : "s"}.`;
+		if (runtimes.length === 0) return "No saved runtimes were found.";
+		const rows = runtimes.map((runtime) => {
+			if (!runtime || typeof runtime !== "object" || Array.isArray(runtime)) {
+				return `- ${JSON.stringify(runtime)}`;
+			}
+			const item = runtime as Record<string, unknown>;
+			const label = String(item.label ?? "Unnamed runtime");
+			const id = String(item.id ?? "unknown-id");
+			const kind = String(item.connectionMode ?? item.kind ?? "unknown");
+			return `- ${label} (${id}) — ${kind}${item.active === true ? ", active" : ""}`;
+		});
+		return `Saved runtimes (${runtimes.length}):\n${rows.join("\n")}`;
 	}
 	if (result.op === "pair") {
 		const receipt =
@@ -117,7 +168,24 @@ function successText(result: RuntimeManagementResult): string {
 		return `Pairing is ready. Session ${String(receipt.sessionId ?? "unknown")}, one-use code ${String(receipt.code ?? "unknown")}, expires ${String(receipt.expiresAt ?? "soon")}.`;
 	}
 	if (result.op === "inspect_ssh") {
-		return "Read the SSH host keys without trusting or connecting to the host. Verify the fingerprint out of band before connecting.";
+		const inspection =
+			result.data?.inspection &&
+			typeof result.data.inspection === "object" &&
+			!Array.isArray(result.data.inspection)
+				? (result.data.inspection as Record<string, unknown>)
+				: {};
+		const fingerprints = Array.isArray(inspection.fingerprints)
+			? inspection.fingerprints
+			: [];
+		const rows = fingerprints.map((entry) => {
+			if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+				return `- ${JSON.stringify(entry)}`;
+			}
+			const key = entry as Record<string, unknown>;
+			return `- ${String(key.algorithm ?? "unknown")}: ${String(key.fingerprint ?? "unknown")}`;
+		});
+		const preferred = String(inspection.preferredFingerprint ?? "unavailable");
+		return `SSH host keys read without trusting or connecting:\n${rows.join("\n")}\nPreferred fingerprint: ${preferred}\nVerify it out of band before connecting.`;
 	}
 	const labels: Record<string, string> = {
 		revoke: "Revoked the selected controller session.",
@@ -138,7 +206,7 @@ function successText(result: RuntimeManagementResult): string {
 export function createRuntimeManagementAction(
 	deps: RuntimeManagementActionDeps = {},
 ): Action {
-	const manageRuntime = deps.manageRuntime ?? defaultManageRuntime;
+	const manageRuntime = deps.manageRuntime;
 	return {
 		name: "RUNTIMES",
 		contexts: ["general", "settings", "admin", "system"],
@@ -250,19 +318,23 @@ export function createRuntimeManagementAction(
 		validate: async (): Promise<boolean> => true,
 		handler: async (
 			_runtime: IAgentRuntime,
-			_message: Memory,
+			message: Memory,
 			_state?: State,
 			options?: Record<string, unknown>,
 			callback?: HandlerCallback,
 		): Promise<ActionResult> => {
 			const request = parseRuntimeManagementRequest(options);
 			if (!request) {
-				const reply = "Tell me which Devices & Runtimes operation to perform.";
+				const reply =
+					"Tell me which Devices & Runtimes operation to perform, without including passwords, private keys, tokens, API keys, or credentials.";
 				await callback?.({ text: reply });
 				return { success: false, text: reply };
 			}
 			const normalized = normalizeActionOptions(options) ?? {};
-			if (CONFIRMATION_REQUIRED.has(request.op) && !isConfirmed(normalized)) {
+			if (
+				CONFIRMATION_REQUIRED.has(request.op) &&
+				(!isConfirmed(normalized) || !userExplicitlyConfirmed(message))
+			) {
 				const reply = `Please confirm before I run the ${request.op} Devices & Runtimes operation.`;
 				await callback?.({ text: reply });
 				return {
@@ -275,7 +347,9 @@ export function createRuntimeManagementAction(
 			}
 
 			logger.info(`[plugin-app-control] RUNTIMES op=${request.op}`);
-			const result = await manageRuntime(request);
+			const result = manageRuntime
+				? await manageRuntime(request)
+				: await defaultManageRuntime(request, message);
 			if (!result.ok) {
 				const reply = `I couldn't complete ${request.op}: ${result.error ?? "the connected app refused the operation"}.`;
 				await callback?.({ text: reply });
@@ -289,7 +363,10 @@ export function createRuntimeManagementAction(
 				userFacingText: reply,
 				verifiedUserFacing: true,
 				turnComplete: true,
-				values: { op: request.op },
+				values: {
+					op: request.op,
+					...(result.data ? { resultJson: JSON.stringify(result.data) } : {}),
+				},
 			};
 		},
 	};


### PR DESCRIPTION
## Scope

Stacked corrective for #24830 exact head `f1b721ffaedaa1f91b4d98adf8bb58b11e05924c`.

- Makes Headscale-backed host enrollment a two-phase authority transition: new managed hosts remain `pending`, cannot authenticate, pair, or appear in the directory, and become `active` only in the durable enrollment write.
- Records failed compensation on the non-authoritative pending row without calling the activation path.
- Cleans exact and fresh collision-suffixed Headscale nodes while preserving older suffixes.
- Binds semantic runtime mutations to the originating renderer and authenticated owner, requires confirmation in the actual user message, rejects secret-bearing tool parameters, and preserves complete model-visible results/errors.
- Updates the canonical 0305–0311 migration proof, including upstream 0309/0310.

## Exact-head verification

Pinned Bun 1.3.14 / Node 24.15.0:

- `bun install --frozen-lockfile`: pass
- plugin action Vitest: 9/9
- agent route Vitest: 6/6
- UI Devices/runtime suites: 21/21
- Electrobun target/SSH suites, including disposable real `sshd`: 42/42
- Cloud managed-network/relay routes: 22/22
- PGlite remote repository suite: 13/13
- disposable real PostgreSQL migration/constraint test: 1/1
- plugin, UI, and Cloud shared typechecks: pass
- focused Biome and `git diff --check`: pass

The agent package typecheck still reports current branch/base failures in untouched tests and optional workspace exports; it reports no error in the corrective files.

## External evidence boundary

This corrective does not fill #24830's physical or deployed acceptance rows. The current environment has no configured SSH target/identity, no complete Headscale configuration, and no connected physical device. Real Headscale, independently verified second-machine/VPS SSH, physical iPhone, restart/no-resurrection, exact packaged visual evidence, and hosted exact-head gates remain required before #24830 can leave draft or merge.
