### PR TITLE
fix(wallet): safe NaN handling in inventory balance summary, movers, and allocation sort comparators

### DIFF
--- a/plugins/plugin-wallet/src/ui/InventoryView.helpers.ts
+++ b/plugins/plugin-wallet/src/ui/InventoryView.helpers.ts
@@ -25,14 +25,14 @@ export function resolveWalletAddresses({
   };
 }
 
-function parseUsd(value: string | number | null | undefined): number {
+export function parseUsd(value: string | number | null | undefined): number {
   if (typeof value === "number") return Number.isFinite(value) ? value : 0;
   if (typeof value !== "string") return 0;
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function summarizeWalletBalances(
+export function summarizeWalletBalances(
   walletBalances: WalletBalancesResponse | null,
 ): {
   totalUsd: number;
@@ -109,7 +109,11 @@ function summarizeWalletBalances(
     }
   }
 
-  tokens.sort((a, b) => b.valueUsd - a.valueUsd);
+  tokens.sort(
+    (a, b) =>
+      (Number.isFinite(b.valueUsd) ? b.valueUsd : 0) -
+      (Number.isFinite(a.valueUsd) ? a.valueUsd : 0),
+  );
   return {
     totalUsd: tokens.reduce((sum, token) => sum + token.valueUsd, 0),
     tokens,

--- a/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
+++ b/plugins/plugin-wallet/src/ui/components/InventoryAppView.tsx
@@ -331,8 +331,12 @@ function tokenHasInventory(row: TokenRow): boolean {
 
 function assetAllocationRows(rows: TokenRow[]): TokenRow[] {
   return rows
-    .filter((row) => row.valueUsd > 0)
-    .sort((left, right) => right.valueUsd - left.valueUsd)
+    .filter((row) => Number.isFinite(row.valueUsd) && row.valueUsd > 0)
+    .sort(
+      (left, right) =>
+        (Number.isFinite(right.valueUsd) ? right.valueUsd : 0) -
+        (Number.isFinite(left.valueUsd) ? left.valueUsd : 0),
+    )
     .slice(0, 5);
 }
 
@@ -723,16 +727,30 @@ function PortfolioMoversPanel({
   const gainers = useMemo(
     () =>
       movers
-        .filter((mover) => mover.realizedPnlBnb > 0)
-        .sort((left, right) => right.realizedPnlBnb - left.realizedPnlBnb)
+        .filter(
+          (mover) =>
+            Number.isFinite(mover.realizedPnlBnb) && mover.realizedPnlBnb > 0,
+        )
+        .sort(
+          (left, right) =>
+            (Number.isFinite(right.realizedPnlBnb) ? right.realizedPnlBnb : 0) -
+            (Number.isFinite(left.realizedPnlBnb) ? left.realizedPnlBnb : 0),
+        )
         .slice(0, 3),
     [movers],
   );
   const losers = useMemo(
     () =>
       movers
-        .filter((mover) => mover.realizedPnlBnb < 0)
-        .sort((left, right) => left.realizedPnlBnb - right.realizedPnlBnb)
+        .filter(
+          (mover) =>
+            Number.isFinite(mover.realizedPnlBnb) && mover.realizedPnlBnb < 0,
+        )
+        .sort(
+          (left, right) =>
+            (Number.isFinite(left.realizedPnlBnb) ? left.realizedPnlBnb : 0) -
+            (Number.isFinite(right.realizedPnlBnb) ? right.realizedPnlBnb : 0),
+        )
         .slice(0, 3),
     [movers],
   );

--- a/plugins/plugin-wallet/src/ui/inventory.safe-sort.test.ts
+++ b/plugins/plugin-wallet/src/ui/inventory.safe-sort.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Verifies safe sorting and NaN-handling in wallet inventory helpers and components.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseUsd, summarizeWalletBalances } from "./InventoryView.helpers.js";
+import type { WalletBalancesResponse } from "@elizaos/shared";
+
+describe("wallet inventory safe sort", () => {
+  it("parses USD values safely for NaN and Infinity", () => {
+    expect(parseUsd(NaN)).toBe(0);
+    expect(parseUsd(Infinity)).toBe(0);
+    expect(parseUsd(-Infinity)).toBe(0);
+    expect(parseUsd("invalid-number")).toBe(0);
+    expect(parseUsd("123.45")).toBe(123.45);
+    expect(parseUsd(50.5)).toBe(50.5);
+    expect(parseUsd(null)).toBe(0);
+    expect(parseUsd(undefined)).toBe(0);
+  });
+
+  it("safely summarizes and sorts wallet balances when token values contain NaN or malformed numbers", () => {
+    const mockBalances: WalletBalancesResponse = {
+      evm: {
+        chains: [
+          {
+            chain: "Ethereum",
+            nativeSymbol: "ETH",
+            nativeBalance: "1.5",
+            nativeValueUsd: "NaN",
+            tokens: [
+              {
+                symbol: "USDC",
+                name: "USD Coin",
+                contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                balance: "1000",
+                valueUsd: 1000,
+              },
+              {
+                symbol: "BAD",
+                name: "Bad Token",
+                contractAddress: "0xbad",
+                balance: "10",
+                valueUsd: "invalid-usd",
+              },
+            ],
+          },
+        ],
+      },
+      solana: {
+        solBalance: "10",
+        solValueUsd: 1500,
+        tokens: [
+          {
+            symbol: "JUP",
+            name: "Jupiter",
+            mint: "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+            balance: "500",
+            valueUsd: 500,
+          },
+        ],
+      },
+    } as unknown as WalletBalancesResponse;
+
+    const summary = summarizeWalletBalances(mockBalances);
+
+    expect(summary.tokens).toHaveLength(5);
+    // Highest value first: SOL ($1500) -> USDC ($1000) -> JUP ($500) -> ETH native ($0) -> BAD ($0)
+    expect(summary.tokens[0].symbol).toBe("SOL");
+    expect(summary.tokens[1].symbol).toBe("USDC");
+    expect(summary.tokens[2].symbol).toBe("JUP");
+    expect(summary.totalUsd).toBe(3000);
+  });
+
+  it("safely handles non-finite subtraction in value sort comparators", () => {
+    const aVal = NaN;
+    const bVal = 500;
+    const oldDiff = aVal - bVal;
+    expect(Number.isNaN(oldDiff)).toBe(true);
+
+    const safeA = Number.isFinite(aVal) ? aVal : 0;
+    const safeB = Number.isFinite(bVal) ? bVal : 0;
+    const safeDiff = safeB - safeA;
+    expect(safeDiff).toBe(500);
+  });
+});

--- a/plugins/plugin-wallet/src/ui/inventory/useInventoryData.ts
+++ b/plugins/plugin-wallet/src/ui/inventory/useInventoryData.ts
@@ -241,9 +241,13 @@ export function useInventoryData({
     const asc = inventorySortDirection === "asc";
     if (inventorySort === "value") {
       sorted.sort((a, b) => {
-        const diff = a.valueUsd - b.valueUsd;
+        const aVal = Number.isFinite(a.valueUsd) ? a.valueUsd : 0;
+        const bVal = Number.isFinite(b.valueUsd) ? b.valueUsd : 0;
+        const diff = aVal - bVal;
         if (diff !== 0) return asc ? diff : -diff;
-        const diff2 = a.balanceRaw - b.balanceRaw;
+        const aRaw = Number.isFinite(a.balanceRaw) ? a.balanceRaw : 0;
+        const bRaw = Number.isFinite(b.balanceRaw) ? b.balanceRaw : 0;
+        const diff2 = aRaw - bRaw;
         return asc ? diff2 : -diff2;
       });
     } else if (inventorySort === "chain") {


### PR DESCRIPTION
## Summary
Guards numeric sort comparators against `NaN` and non-finite values in `plugin-wallet`:

- **Inventory Summary**: Protect token `valueUsd` sorting against `NaN` values in `summarizeWalletBalances`.
- **Inventory Hook**: Guard `valueUsd` and `balanceRaw` subtractions in `useInventoryData` against non-finite values to prevent undefined list ordering.
- **Inventory App View**: Guard `valueUsd` sorting in `assetAllocationRows` and `realizedPnlBnb` sorting in portfolio `gainers` / `losers` against `NaN`.

## Verification
- Added dedicated regression unit test:
  - `plugins/plugin-wallet/src/ui/inventory.safe-sort.test.ts`
- Verified unit test suite passes with Vitest:
  ```
  ✓ plugins/plugin-wallet/src/ui/inventory.safe-sort.test.ts (3 tests)
  ```