### PR TITLE
test(app-core): cover cli banner formatting

### DIFF
--- a/packages/app-core/src/cli/__tests__/banner.test.ts
+++ b/packages/app-core/src/cli/__tests__/banner.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isRich: vi.fn(),
+  theme: {
+    heading: vi.fn((t: string) => `h(${t})`),
+    info: vi.fn((t: string) => `i(${t})`),
+    muted: vi.fn((t: string) => `m(${t})`),
+  },
+  resolveCommitHash: vi.fn(() => "abc1234"),
+}));
+
+vi.mock("@elizaos/shared", () => ({
+  isRich: (...a: unknown[]) => mocks.isRich(...a),
+  theme: mocks.theme,
+}));
+vi.mock("./git-commit", () => ({
+  resolveCommitHash: (...a: unknown[]) => mocks.resolveCommitHash(...a),
+}));
+
+describe("formatCliBannerLine", () => {
+  beforeEach(() => {
+    mocks.isRich.mockReset();
+    mocks.isRich.mockReturnValue(true);
+  });
+
+  it("formats a themed banner on rich tty", async () => {
+    const { formatCliBannerLine } = await import("./banner.ts");
+    expect(formatCliBannerLine("1.0.0", { commit: "c1" })).toBe(
+      "h(Eliza) i(1.0.0) m((c1))",
+    );
+  });
+
+  it("formats a plain banner off rich tty", async () => {
+    const { formatCliBannerLine } = await import("./banner.ts");
+    expect(formatCliBannerLine("1.0.0", { richTty: false, commit: null })).toBe(
+      "Eliza 1.0.0 (unknown)",
+    );
+  });
+
+  it("uppercases the configured app name", async () => {
+    const { formatCliBannerLine } = await import("./banner.ts");
+    expect(
+      formatCliBannerLine("2.0.0", {
+        env: { APP_CLI_NAME: "hermes" },
+        richTty: false,
+        commit: null,
+      }),
+    ).toBe("Hermes 2.0.0 (unknown)");
+  });
+});

--- a/packages/app-core/src/cli/__tests__/banner.test.ts
+++ b/packages/app-core/src/cli/__tests__/banner.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for the CLI startup banner formatter. The theme layer and the
+ * git-commit resolver are mocked so the assertions pin the banner's own
+ * composition (title casing, version, commit label) instead of the checkout's
+ * real HEAD; everything else runs the shipped module.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -14,7 +20,7 @@ vi.mock("@elizaos/shared", () => ({
   isRich: (...a: unknown[]) => mocks.isRich(...a),
   theme: mocks.theme,
 }));
-vi.mock("./git-commit", () => ({
+vi.mock("../git-commit", () => ({
   resolveCommitHash: (...a: unknown[]) => mocks.resolveCommitHash(...a),
 }));
 
@@ -26,14 +32,14 @@ describe("formatCliBannerLine", () => {
   });
 
   it("formats a themed banner on rich tty", async () => {
-    const { formatCliBannerLine } = await import("./banner.ts");
+    const { formatCliBannerLine } = await import("../banner.ts");
     expect(formatCliBannerLine("1.0.0", { commit: "c1" })).toBe(
       "h(Eliza) i(1.0.0) m((c1))",
     );
   });
 
   it("formats a plain banner off rich tty", async () => {
-    const { formatCliBannerLine } = await import("./banner.ts");
+    const { formatCliBannerLine } = await import("../banner.ts");
     mocks.resolveCommitHash.mockReturnValue(null);
     expect(formatCliBannerLine("1.0.0", { richTty: false })).toBe(
       "Eliza 1.0.0 (unknown)",
@@ -41,7 +47,7 @@ describe("formatCliBannerLine", () => {
   });
 
   it("uppercases the configured app name", async () => {
-    const { formatCliBannerLine } = await import("./banner.ts");
+    const { formatCliBannerLine } = await import("../banner.ts");
     mocks.resolveCommitHash.mockReturnValue(null);
     expect(
       formatCliBannerLine("2.0.0", {

--- a/packages/app-core/src/cli/__tests__/banner.test.ts
+++ b/packages/app-core/src/cli/__tests__/banner.test.ts
@@ -22,6 +22,7 @@ describe("formatCliBannerLine", () => {
   beforeEach(() => {
     mocks.isRich.mockReset();
     mocks.isRich.mockReturnValue(true);
+    mocks.resolveCommitHash.mockReset();
   });
 
   it("formats a themed banner on rich tty", async () => {
@@ -33,18 +34,19 @@ describe("formatCliBannerLine", () => {
 
   it("formats a plain banner off rich tty", async () => {
     const { formatCliBannerLine } = await import("./banner.ts");
-    expect(formatCliBannerLine("1.0.0", { richTty: false, commit: null })).toBe(
+    mocks.resolveCommitHash.mockReturnValue(null);
+    expect(formatCliBannerLine("1.0.0", { richTty: false })).toBe(
       "Eliza 1.0.0 (unknown)",
     );
   });
 
   it("uppercases the configured app name", async () => {
     const { formatCliBannerLine } = await import("./banner.ts");
+    mocks.resolveCommitHash.mockReturnValue(null);
     expect(
       formatCliBannerLine("2.0.0", {
         env: { APP_CLI_NAME: "hermes" },
         richTty: false,
-        commit: null,
       }),
     ).toBe("Hermes 2.0.0 (unknown)");
   });


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
