### PR TITLE
fix(ci): close post-merge affected typecheck gaps

### DIFF
--- a/packages/agent/src/actions/terminal.test.ts
+++ b/packages/agent/src/actions/terminal.test.ts
@@ -7,6 +7,7 @@
  */
 import {
   _resetBuildVariantForTests,
+  type ActionParameters,
   ElizaError,
   type HandlerOptions,
   type IAgentRuntime,
@@ -39,9 +40,9 @@ function message(): Memory {
 }
 
 function options(
-  parameters: Record<string, unknown> = { command: "echo hello" },
+  parameters: unknown = { command: "echo hello" },
 ): HandlerOptions {
-  return { parameters };
+  return { parameters: parameters as ActionParameters };
 }
 
 function terminalResponse(

--- a/packages/agent/src/api/__tests__/server-autonomy-helpers.test.ts
+++ b/packages/agent/src/api/__tests__/server-autonomy-helpers.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@elizaos/core", () => ({
-  MESSAGE_SOURCE_CLIENT_CHAT: "client-chat",
-}));
-
-const routeAutonomyTextToUser = vi.fn(async () => undefined);
-vi.mock("./server-helpers-swarm.ts", () => ({
-  routeAutonomyTextToUser: (...args: unknown[]) =>
-    routeAutonomyTextToUser(...args),
+const routeAutonomyTextToUser = vi.fn(
+  async (_state: unknown, _text: string, _source: string) => undefined,
+);
+vi.mock("../server-helpers-swarm.ts", () => ({
+  routeAutonomyTextToUser: (state: unknown, text: string, source: string) =>
+    routeAutonomyTextToUser(state, text, source),
 }));
 
 import {
@@ -51,7 +49,7 @@ describe("maybeRouteAutonomyEventToConversation", () => {
   it("drops client-chat echoes", async () => {
     await maybeRouteAutonomyEventToConversation(state, {
       stream: "assistant",
-      data: { text: "hi", source: "client-chat" },
+      data: { text: "hi", source: "client_chat" },
     } as never);
     expect(routeAutonomyTextToUser).not.toHaveBeenCalled();
   });

--- a/packages/agent/src/config/__tests__/plugin-widgets.test.ts
+++ b/packages/agent/src/config/__tests__/plugin-widgets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getPluginWidgets } from "./plugin-widgets.ts";
+import { getPluginWidgets } from "../plugin-widgets.ts";
 
 const mkPlugin = (name: string, widgets?: unknown[]) =>
   ({ name, widgets }) as never;

--- a/packages/agent/src/providers/__tests__/session-utils.test.ts
+++ b/packages/agent/src/providers/__tests__/session-utils.test.ts
@@ -6,8 +6,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@elizaos/core", () => ({
-  getSessionProviders: (...a: unknown[]) => mocks.getSessionProviders(...a),
-  resolveStateDir: (...a: unknown[]) => mocks.resolveStateDir(...a),
+  getSessionProviders: () => mocks.getSessionProviders(),
+  resolveStateDir: () => mocks.resolveStateDir(),
 }));
 
 import {

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -153,8 +153,14 @@ export const recentConversationsProvider: Provider = {
             Boolean(m.content.text) || (m.content.attachments?.length ?? 0) > 0,
         )
         .sort((a, b) => {
-          const aTime = Number.isFinite(a.createdAt) ? a.createdAt : 0;
-          const bTime = Number.isFinite(b.createdAt) ? b.createdAt : 0;
+          const aTime =
+            typeof a.createdAt === "number" && Number.isFinite(a.createdAt)
+              ? a.createdAt
+              : 0;
+          const bTime =
+            typeof b.createdAt === "number" && Number.isFinite(b.createdAt)
+              ? b.createdAt
+              : 0;
           return bTime - aTime;
         });
 

--- a/packages/agent/src/runtime/tool-call-cache/__tests__/tool-cache-key.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/__tests__/tool-cache-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCacheKey, canonicalizeJson } from "./key.ts";
+import { buildCacheKey, canonicalizeJson } from "../key.ts";
 
 describe("canonicalizeJson", () => {
   it("sorts object keys recursively", () => {

--- a/packages/agent/src/services/knowledge-graph/__tests__/entity-store.test.ts
+++ b/packages/agent/src/services/knowledge-graph/__tests__/entity-store.test.ts
@@ -13,7 +13,6 @@ describe("EntityStore.resolve confidence sorting", () => {
 
     const entity1: Entity = {
       entityId: "ent-1",
-      agentId: "test-agent",
       type: "person",
       preferredName: "Alice",
       identities: [],
@@ -26,7 +25,6 @@ describe("EntityStore.resolve confidence sorting", () => {
 
     const entity2: Entity = {
       entityId: "ent-2",
-      agentId: "test-agent",
       type: "person",
       preferredName: "Alice Smith",
       identities: [],
@@ -39,8 +37,8 @@ describe("EntityStore.resolve confidence sorting", () => {
 
     const entity3: Entity = {
       entityId: "ent-3",
-      agentId: "test-agent",
       type: "person",
+      preferredName: "",
       identities: [],
       tags: [],
       visibility: "owner_only",

--- a/packages/agent/src/services/permissions/probers/__tests__/accessibility.test.ts
+++ b/packages/agent/src/services/permissions/probers/__tests__/accessibility.test.ts
@@ -5,46 +5,47 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./services/permissions/probers/_bridge.js", () => ({
-  IS_DARWIN: true,
+const mockPlatform = vi.hoisted(() => ({ isDarwin: true }));
+
+vi.mock("../_bridge.js", () => ({
+  get IS_DARWIN() {
+    return mockPlatform.isDarwin;
+  },
   buildState: (
     id: string,
-    state: string,
+    status: string,
     extra: Record<string, unknown> = {},
   ) => ({
     id,
-    state,
+    status,
     ...extra,
   }),
   getNativeDylib: vi.fn(),
-  platformUnsupportedState: (id: string) => ({ id, state: "unsupported" }),
+  platformUnsupportedState: (id: string) => ({
+    id,
+    status: "not-applicable",
+  }),
   queryTccStatus: vi.fn(),
   resolveBundleId: vi.fn(() => "com.example.app"),
 }));
 
-import {
-  getNativeDylib,
-  IS_DARWIN,
-  queryTccStatus,
-} from "./services/permissions/probers/_bridge.js";
-import { accessibilityProber } from "./services/permissions/probers/accessibility.ts";
+import { getNativeDylib, queryTccStatus } from "../_bridge.js";
+import { accessibilityProber } from "../accessibility.ts";
 
 const mockGetDylib = vi.mocked(getNativeDylib);
 const mockQueryTcc = vi.mocked(queryTccStatus);
 
 describe("accessibilityProber.check", () => {
   beforeEach(() => {
+    mockPlatform.isDarwin = true;
     mockGetDylib.mockReset();
     mockQueryTcc.mockReset();
   });
 
   it("returns unsupported on non-Darwin platforms", async () => {
-    // biome-ignore lint/suspicious/noImportAssign: test mutates mocked import to simulate platform
-    (IS_DARWIN as unknown as boolean) = false;
+    mockPlatform.isDarwin = false;
     const state = await accessibilityProber.check();
-    expect(state.state).toBe("unsupported");
-    // biome-ignore lint/suspicious/noImportAssign: restore mocked import
-    (IS_DARWIN as unknown as boolean) = true;
+    expect(state.status).toBe("not-applicable");
   });
 
   it("returns granted when the native check is true", async () => {
@@ -52,7 +53,7 @@ describe("accessibilityProber.check", () => {
       checkAccessibilityPermission: () => true,
     } as never);
     const state = await accessibilityProber.check();
-    expect(state.state).toBe("granted");
+    expect(state.status).toBe("granted");
     expect(state.canRequest).toBe(false);
     expect(mockQueryTcc).not.toHaveBeenCalled();
   });
@@ -61,7 +62,7 @@ describe("accessibilityProber.check", () => {
     mockGetDylib.mockResolvedValue(null);
     mockQueryTcc.mockResolvedValue("not-determined" as never);
     const state = await accessibilityProber.check();
-    expect(state.state).toBe("not-determined");
+    expect(state.status).toBe("not-determined");
     expect(state.canRequest).toBe(true);
   });
 
@@ -71,7 +72,7 @@ describe("accessibilityProber.check", () => {
     } as never);
     mockQueryTcc.mockResolvedValue("denied" as never);
     const state = await accessibilityProber.check();
-    expect(state.state).toBe("denied");
+    expect(state.status).toBe("denied");
     expect(state.canRequest).toBe(false);
   });
 
@@ -81,23 +82,21 @@ describe("accessibilityProber.check", () => {
     } as never);
     mockQueryTcc.mockResolvedValue("granted" as never);
     const state = await accessibilityProber.check();
-    expect(state.state).toBe("granted");
+    expect(state.status).toBe("granted");
   });
 });
 
 describe("accessibilityProber.request", () => {
   beforeEach(() => {
+    mockPlatform.isDarwin = true;
     mockGetDylib.mockReset();
     mockQueryTcc.mockReset();
   });
 
   it("returns unsupported on non-Darwin", async () => {
-    // biome-ignore lint/suspicious/noImportAssign: test mutates mocked import to simulate platform
-    (IS_DARWIN as unknown as boolean) = false;
+    mockPlatform.isDarwin = false;
     const state = await accessibilityProber.request({ reason: "test" });
-    expect(state.state).toBe("unsupported");
-    // biome-ignore lint/suspicious/noImportAssign: restore mocked import
-    (IS_DARWIN as unknown as boolean) = true;
+    expect(state.status).toBe("not-applicable");
   });
 
   it("invokes the native request and returns the re-checked state with lastRequested", async () => {
@@ -109,7 +108,7 @@ describe("accessibilityProber.request", () => {
     mockQueryTcc.mockResolvedValue("not-determined" as never);
     const state = await accessibilityProber.request({ reason: "test" });
     expect(requestAccessibilityPermission).toHaveBeenCalledTimes(1);
-    expect(state.state).toBe("not-determined");
+    expect(state.status).toBe("not-determined");
     expect(state.lastRequested).toBeTypeOf("number");
   });
 });

--- a/packages/app-core/platforms/electrobun/src/launch/__tests__/launch-dynamic-view.test.ts
+++ b/packages/app-core/platforms/electrobun/src/launch/__tests__/launch-dynamic-view.test.ts
@@ -3,27 +3,27 @@ import { describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   existsSync: vi.fn(),
   join: vi.fn((...p: string[]) => p.join("/")),
-  dirname: vi.fn(() => "/views"),
-  fileURLToPath: vi.fn(() => "/views/launch-dynamic-view.ts"),
+  dirname: vi.fn((_path: string) => "/views"),
+  fileURLToPath: vi.fn((_url: string | URL) => "/views/launch-dynamic-view.ts"),
   pathToFileURL: vi.fn((p: string) => ({ href: `file://${p}` })),
 }));
 
 vi.mock("node:fs", () => ({
-  existsSync: (...a: unknown[]) => mocks.existsSync(...a),
+  existsSync: (path: unknown) => mocks.existsSync(path),
 }));
 vi.mock("node:path", () => ({
-  join: (...a: unknown[]) => mocks.join(...(a as string[])),
-  dirname: (...a: unknown[]) => mocks.dirname(...a),
+  join: (...parts: string[]) => mocks.join(...parts),
+  dirname: (path: string) => mocks.dirname(path),
 }));
 vi.mock("node:url", () => ({
-  fileURLToPath: (...a: unknown[]) => mocks.fileURLToPath(...a),
-  pathToFileURL: (...a: unknown[]) => mocks.pathToFileURL(...a),
+  fileURLToPath: (url: string | URL) => mocks.fileURLToPath(url),
+  pathToFileURL: (path: string) => mocks.pathToFileURL(path),
 }));
 
 import {
   createLaunchDiagnosticsViewManifest,
   LAUNCH_DIAGNOSTICS_VIEW_ID,
-} from "./launch-dynamic-view.ts";
+} from "../launch-dynamic-view.ts";
 
 describe("createLaunchDiagnosticsViewManifest", () => {
   it("builds the launch diagnostics manifest with resolved entrypoint", () => {

--- a/packages/app-core/platforms/electrobun/src/trace/__tests__/trace-dynamic-view.test.ts
+++ b/packages/app-core/platforms/electrobun/src/trace/__tests__/trace-dynamic-view.test.ts
@@ -3,27 +3,27 @@ import { describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   existsSync: vi.fn(),
   join: vi.fn((...p: string[]) => p.join("/")),
-  dirname: vi.fn(() => "/views"),
-  fileURLToPath: vi.fn(() => "/views/trace-dynamic-view.ts"),
+  dirname: vi.fn((_path: string) => "/views"),
+  fileURLToPath: vi.fn((_url: string | URL) => "/views/trace-dynamic-view.ts"),
   pathToFileURL: vi.fn((p: string) => ({ href: `file://${p}` })),
 }));
 
 vi.mock("node:fs", () => ({
-  existsSync: (...a: unknown[]) => mocks.existsSync(...a),
+  existsSync: (path: unknown) => mocks.existsSync(path),
 }));
 vi.mock("node:path", () => ({
-  join: (...a: unknown[]) => mocks.join(...(a as string[])),
-  dirname: (...a: unknown[]) => mocks.dirname(...a),
+  join: (...parts: string[]) => mocks.join(...parts),
+  dirname: (path: string) => mocks.dirname(path),
 }));
 vi.mock("node:url", () => ({
-  fileURLToPath: (...a: unknown[]) => mocks.fileURLToPath(...a),
-  pathToFileURL: (...a: unknown[]) => mocks.pathToFileURL(...a),
+  fileURLToPath: (url: string | URL) => mocks.fileURLToPath(url),
+  pathToFileURL: (path: string) => mocks.pathToFileURL(path),
 }));
 
 import {
   createTraceDynamicViewManifest,
   TRACE_DYNAMIC_VIEW_ID,
-} from "./trace-dynamic-view.ts";
+} from "../trace-dynamic-view.ts";
 
 describe("createTraceDynamicViewManifest", () => {
   it("builds the trace view manifest with resolved entrypoint", () => {

--- a/packages/app-core/src/api/__tests__/server-security.test.ts
+++ b/packages/app-core/src/api/__tests__/server-security.test.ts
@@ -26,11 +26,13 @@ import {
 describe("server-security wrappers", () => {
   it("forwards MCP terminal authorization rejection through compat context", () => {
     const req = { headers: {} } as never;
+    const servers = { local: { type: "stdio" } };
+    const body = { terminalToken: "token" };
     upstreamFns.resolveMcpTerminalAuthorizationRejection.mockReturnValue("rej");
-    const out = resolveMcpTerminalAuthorizationRejection(req);
+    const out = resolveMcpTerminalAuthorizationRejection(req, servers, body);
     expect(
       upstreamFns.resolveMcpTerminalAuthorizationRejection,
-    ).toHaveBeenCalledWith(req);
+    ).toHaveBeenCalledWith(req, servers, body);
     expect(compat.runWithCompatAuthContext).toHaveBeenCalled();
     expect(compat.normalizeCompatRejection).toHaveBeenCalledWith("rej");
     expect(out).toBe("rej");
@@ -38,16 +40,34 @@ describe("server-security wrappers", () => {
 
   it("forwards terminal run rejection", () => {
     upstreamFns.resolveTerminalRunRejection.mockReturnValue("run-rej");
-    expect(resolveTerminalRunRejection({} as never)).toBe("run-rej");
+    const req = {} as never;
+    const body = { terminalToken: "token" };
+    expect(resolveTerminalRunRejection(req, body)).toBe("run-rej");
+    expect(upstreamFns.resolveTerminalRunRejection).toHaveBeenCalledWith(
+      req,
+      body,
+    );
   });
 
   it("forwards websocket upgrade rejection", () => {
     upstreamFns.resolveWebSocketUpgradeRejection.mockReturnValue("ws-rej");
-    expect(resolveWebSocketUpgradeRejection({} as never)).toBe("ws-rej");
+    const req = {} as never;
+    const url = new URL("ws://localhost/ws");
+    expect(resolveWebSocketUpgradeRejection(req, url)).toBe("ws-rej");
+    expect(upstreamFns.resolveWebSocketUpgradeRejection).toHaveBeenCalledWith(
+      req,
+      url,
+    );
   });
 
   it("forwards terminal run client id", () => {
     upstreamFns.resolveTerminalRunClientId.mockReturnValue("client-1");
-    expect(resolveTerminalRunClientId({} as never)).toBe("client-1");
+    const req = {} as never;
+    const body = { clientId: "client-1" };
+    expect(resolveTerminalRunClientId(req, body)).toBe("client-1");
+    expect(upstreamFns.resolveTerminalRunClientId).toHaveBeenCalledWith(
+      req,
+      body,
+    );
   });
 });

--- a/packages/app-core/src/services/__tests__/update-notifier.test.ts
+++ b/packages/app-core/src/services/__tests__/update-notifier.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   checkForUpdate: vi.fn(),
   loadElizaConfig: vi.fn(),
-  resolveChannel: vi.fn(() => "stable"),
+  resolveChannel: vi.fn((_config?: unknown) => "stable"),
   theme: {
     accent: vi.fn((t: string) => `a(${t})`),
     muted: vi.fn((t: string) => `m(${t})`),
@@ -13,16 +13,16 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@elizaos/agent", () => ({
-  checkForUpdate: (...a: unknown[]) => mocks.checkForUpdate(...a),
-  loadElizaConfig: (...a: unknown[]) => mocks.loadElizaConfig(...a),
-  resolveChannel: (...a: unknown[]) => mocks.resolveChannel(...a),
+  checkForUpdate: () => mocks.checkForUpdate(),
+  loadElizaConfig: () => mocks.loadElizaConfig(),
+  resolveChannel: (config?: unknown) => mocks.resolveChannel(config),
 }));
 vi.mock("@elizaos/shared", () => ({ theme: mocks.theme }));
 
 describe("scheduleUpdateNotification", () => {
   let originalIsTTY: boolean | undefined;
   let originalCI: string | undefined;
-  let mod: typeof import("./update-notifier.ts");
+  let mod: typeof import("../update-notifier.ts");
 
   beforeEach(async () => {
     vi.resetModules();
@@ -32,7 +32,7 @@ describe("scheduleUpdateNotification", () => {
     mocks.resolveChannel.mockReturnValue("stable");
     originalIsTTY = (process.stderr as { isTTY?: boolean }).isTTY;
     originalCI = process.env.CI;
-    mod = await import("./update-notifier.ts");
+    mod = await import("../update-notifier.ts");
   });
 
   afterEach(() => {

--- a/packages/app/src/__tests__/host-externals.test.ts
+++ b/packages/app/src/__tests__/host-externals.test.ts
@@ -5,8 +5,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@elizaos/ui/app-shell-registry", () => ({
-  registerHostExternalImporter: (...a: unknown[]) =>
-    mocks.registerHostExternalImporter(...a),
+  registerHostExternalImporter: (
+    specifier: string,
+    importer: () => Promise<Record<string, unknown>>,
+  ) => mocks.registerHostExternalImporter(specifier, importer),
 }));
 
 describe("registerAppHostExternalImporters", () => {
@@ -17,7 +19,7 @@ describe("registerAppHostExternalImporters", () => {
 
   it("registers the plugin-browser and health specifiers once", async () => {
     const { registerAppHostExternalImporters } = await import(
-      "./host-externals.ts"
+      "../host-externals.ts"
     );
     registerAppHostExternalImporters();
     registerAppHostExternalImporters(); // second call is a no-op
@@ -31,12 +33,8 @@ describe("registerAppHostExternalImporters", () => {
   });
 
   it("registers thunks that return promises", async () => {
-    const { registerAppHostExternalImporter } = await import(
-      "./host-externals.ts"
-    );
-    void registerAppHostExternalImporter;
     const { registerAppHostExternalImporters } = await import(
-      "./host-externals.ts"
+      "../host-externals.ts"
     );
     registerAppHostExternalImporters();
     for (const call of mocks.registerHostExternalImporter.mock.calls) {

--- a/packages/app/src/native/__tests__/keyboard-dictation-bridge.test.ts
+++ b/packages/app/src/native/__tests__/keyboard-dictation-bridge.test.ts
@@ -8,11 +8,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: () => mocks.getPlatform(),
-    registerPlugin: (...a: unknown[]) => mocks.registerPlugin(...a),
+    registerPlugin: (name: string) => mocks.registerPlugin(name),
   },
 }));
-
-import { getKeyboardDictationBridge } from "./keyboard-dictation-bridge.ts";
 
 describe("getKeyboardDictationBridge", () => {
   beforeEach(() => {
@@ -23,7 +21,7 @@ describe("getKeyboardDictationBridge", () => {
 
   it("returns null off iOS", async () => {
     const { getKeyboardDictationBridge: g } = await import(
-      "./keyboard-dictation-bridge.ts"
+      "../keyboard-dictation-bridge.ts"
     );
     mocks.getPlatform.mockReturnValue("android");
     expect(g()).toBeNull();
@@ -32,7 +30,7 @@ describe("getKeyboardDictationBridge", () => {
 
   it("registers and caches the plugin on iOS", async () => {
     const { getKeyboardDictationBridge: g } = await import(
-      "./keyboard-dictation-bridge.ts"
+      "../keyboard-dictation-bridge.ts"
     );
     mocks.getPlatform.mockReturnValue("ios");
     const bridge = { setDictationState: async () => ({ saved: true }) };

--- a/packages/cloud/services/_common/src/text.test.ts
+++ b/packages/cloud/services/_common/src/text.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Exercises service-local Unicode normalization with native well-formed string
+ * helpers disabled so the compatibility algorithm is covered deterministically.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toWellFormedUnicode, truncateWellFormed } from "./text";
+
+function withoutNativeWellFormed<T>(run: () => T): T {
+  const toWellFormed = Object.getOwnPropertyDescriptor(
+    String.prototype,
+    "toWellFormed",
+  );
+  const isWellFormed = Object.getOwnPropertyDescriptor(
+    String.prototype,
+    "isWellFormed",
+  );
+  Object.defineProperty(String.prototype, "toWellFormed", {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(String.prototype, "isWellFormed", {
+    configurable: true,
+    value: undefined,
+  });
+  try {
+    return run();
+  } finally {
+    if (toWellFormed) {
+      Object.defineProperty(String.prototype, "toWellFormed", toWellFormed);
+    } else {
+      Reflect.deleteProperty(String.prototype, "toWellFormed");
+    }
+    if (isWellFormed) {
+      Object.defineProperty(String.prototype, "isWellFormed", isWellFormed);
+    } else {
+      Reflect.deleteProperty(String.prototype, "isWellFormed");
+    }
+  }
+}
+
+describe("service Unicode compatibility helpers", () => {
+  it("replaces lone surrogates while preserving valid pairs without natives", () => {
+    withoutNativeWellFormed(() => {
+      expect(toWellFormedUnicode("a\uD800b\uDC00c🦊")).toBe("a�b�c🦊");
+    });
+  });
+
+  it("does not split a surrogate pair at the truncation boundary", () => {
+    expect(truncateWellFormed(`${"x".repeat(9)}🦊tail`, 10)).toBe(
+      "x".repeat(9),
+    );
+  });
+});

--- a/packages/scenario-runner/src/cerebras-judge.surrogate.test.ts
+++ b/packages/scenario-runner/src/cerebras-judge.surrogate.test.ts
@@ -2,8 +2,8 @@
  * Verifies surrogate-safe truncation for Cerebras judge error bodies.
  */
 
-import { describe, expect, it } from "vitest";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("cerebras-judge surrogate-safe truncation", () => {
   it("replaces lone high surrogate with replacement character", () => {
@@ -33,10 +33,11 @@ describe("cerebras-judge surrogate-safe truncation", () => {
   });
 
   it("handles lone surrogate at boundary without producing invalid JSON", () => {
-    const loneAtBoundary = "a".repeat(299) + String.fromCharCode(0xd800) + "b".repeat(200);
+    const loneAtBoundary =
+      "a".repeat(299) + String.fromCharCode(0xd800) + "b".repeat(200);
     const result = truncateWellFormed(toWellFormedUnicode(loneAtBoundary), 300);
     expect(result.length).toBeLessThanOrEqual(300);
-    expect(result.isWellFormed?.() ?? !result.includes("\uD800")).toBe(true);
+    expect(toWellFormedUnicode(result)).toBe(result);
     expect(() => JSON.stringify(result)).not.toThrow();
   });
 });

--- a/packages/vault/src/__tests__/vault-internal-utils.test.ts
+++ b/packages/vault/src/__tests__/vault-internal-utils.test.ts
@@ -1,5 +1,15 @@
+/**
+ * Verifies vault input helpers and the leaf-local Unicode compatibility path,
+ * including runtimes without native well-formed string methods.
+ */
+
 import { describe, expect, it } from "vitest";
-import { assertKey, optsCaller } from "../internal-utils.js";
+import {
+  assertKey,
+  optsCaller,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "../internal-utils.js";
 
 describe("assertKey", () => {
   it("accepts valid keys", () => {
@@ -28,8 +38,6 @@ describe("optsCaller", () => {
   });
 });
 
-import { toWellFormedUnicode, truncateWellFormed } from "../internal-utils.js";
-
 describe("well-formed truncation", () => {
   it("normalizes lone surrogate to U+FFFD", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
@@ -41,5 +49,38 @@ describe("well-formed truncation", () => {
     expect(truncateWellFormed(`${"x".repeat(198)}🦊`, 200)).toBe(
       `${"x".repeat(198)}🦊`,
     );
+  });
+
+  it("uses the compatibility normalizer when native helpers are unavailable", () => {
+    const toWellFormed = Object.getOwnPropertyDescriptor(
+      String.prototype,
+      "toWellFormed",
+    );
+    const isWellFormed = Object.getOwnPropertyDescriptor(
+      String.prototype,
+      "isWellFormed",
+    );
+    Object.defineProperty(String.prototype, "toWellFormed", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(String.prototype, "isWellFormed", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      expect(toWellFormedUnicode("a\uD800b\uDC00c🦊")).toBe("a�b�c🦊");
+    } finally {
+      if (toWellFormed) {
+        Object.defineProperty(String.prototype, "toWellFormed", toWellFormed);
+      } else {
+        Reflect.deleteProperty(String.prototype, "toWellFormed");
+      }
+      if (isWellFormed) {
+        Object.defineProperty(String.prototype, "isWellFormed", isWellFormed);
+      } else {
+        Reflect.deleteProperty(String.prototype, "isWellFormed");
+      }
+    }
   });
 });

--- a/plugins/plugin-mcp/src/types.ts
+++ b/plugins/plugin-mcp/src/types.ts
@@ -106,7 +106,11 @@ export function isMcpSettings(value: unknown): value is McpSettings {
   );
 }
 
-export type McpServerStatus = "connecting" | "connected" | "disconnected";
+export type McpServerStatus =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
 
 export interface McpServer {
   readonly name: string;

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -31,6 +31,7 @@ import {
   resolveEffectiveSystemPrompt,
   sanitizeFunctionNameForCerebras,
   toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   generateText,


### PR DESCRIPTION
Closes #25482.

## Summary

- repairs the typed agent and app-core contracts exposed by the merged #25333 static-smoke run
- adds committed native-disabled Unicode fallback coverage for cloud text and vault truncation
- widens the MCP lifecycle status contract to include its already-persisted `error` state
- fixes nested test imports and stale permission/message-source assertions without adding runtime mocks

## Validation

Exact PR head/base validation is in progress after the final rebase.

Already green on the repaired branch:

- affected typecheck: 232/232 tasks across 152 packages (before the final unrelated base advance)
- agent focused Vitest: 7 files, 63 tests
- app-core server-security Vitest: 4 tests
- cloud/vault Unicode fallback Vitest: 10 tests
- plugin-mcp lifecycle Vitest: 2 tests
- app and desktop focused tests/typechecks from the original repair sweep

No UI behavior changes. Screenshots and video: N/A.

## Merge gate

Keep draft until exact-head affected typecheck, forced lint, hosted static smoke, and independent review are green.
