### PR TITLE
fix(cloud): make group room simulation fail closed

### DIFF
--- a/packages/cloud/scripts/group-room-sim/README.md
+++ b/packages/cloud/scripts/group-room-sim/README.md
@@ -19,7 +19,7 @@ The room script is read at runtime from
 `landingDemoStepText`, the `UNSUPPORTED_CLAIM_RULES` matcher and its
 per-capability allow-list), so the rooms cannot drift from what the homepage
 animates; there is no frozen copy to regenerate. Only the per-room key facts
-and their word-bounded matchers (`room-facts.ts`) are hand-written, and the
+and their relation/attribution/polarity matchers (`room-facts.ts`) are hand-written, and the
 tests fail if the homepage gains a room that has no entry there.
 
 The driver mirrors the real product flow in
@@ -38,7 +38,7 @@ The driver mirrors the real product flow in
    for replies; after every other line it holds a bounded `SILENCE_MS`
    window and anything that arrives counts as **unsolicited**.
 
-Seven assertions, all of which must pass for a PASS verdict:
+Eight assertions, all of which must pass for a PASS verdict:
 
 | Assertion | Rule |
 | --- | --- |
@@ -46,8 +46,9 @@ Seven assertions, all of which must pass for a PASS verdict:
 | `silentUntilLinked` | zero group sends during the pre-link probe window |
 | `restraintAtUnscriptedPoints` | unsolicited sends across all silent windows plus a trailing sweep are at most `UNSOLICITED_MAX` (default 2) |
 | `noEchoedHumanText` | no Eliza output is a near-copy of a human line already sent (exact, containment of a 4+ token line, or token-Jaccard >= 0.8 against a 3+ token line) |
-| `keyFactsReferenced` | at least `FACTS_MIN` distinct room facts appear across non-echo replies (default 2, floor 1) |
-| `zeroForbiddenClaims` | no output (link/ambient acks included) trips a homepage forbidden-claim rule inside a first-person span, outside the categories the room's scripted capabilities allow (for example `reminder` in Community, `web-search` in Friends and Trip). A span is where Eliza asserts or offers her own capability: "I can", "I'll", "I could", "let me", "want me to", "shall I", "I'm able", "I sent", "I checked", "I booked", "I added it to your order". Rule vocabulary in a human's clause ("if you send the address", "you could buy", "set up your personal workspace"), in a todo or quoted line ("Created: [ ] Buy coffee"), or under a negation ("I can't book") does not count; "Want me to check if any of these take reservations?" does. `first-person-claims.ts` documents the markers, the subject switches that end a span and the accepted blind spots (elided "Booked.", third-person self-reference) |
+| `keyFactsReferenced` | at least `FACTS_MIN` distinct relation/attribution/polarity matchers appear at at least `FACTS_MIN` expected beats; a fact is eligible only where the homepage's expected beat contains the same structured evidence (default 2, floor 1) |
+| `distinctExpectedReplies` | every non-echo expected reply is textually distinct, so one canned response cannot satisfy several beats |
+| `noDetectedUnsupportedFirstPersonClaims` | no output (link/ambient acks included) trips the scoped first-person detector outside the categories the room's scripted capabilities allow. This is deliberately named as detection, not proof of absence: the parser handles explicit offers, completed acts, selected elided/passive completions, attribution switches and negation, while documented third-person/unlisted-verb blind spots remain. |
 | `speakerAwareness` | some non-echo reply names a room member |
 
 Anti-gaming rules, adversarially reviewed so a broken, echoing or
@@ -57,7 +58,7 @@ ever scored and human text never enters a matcher; acks are scanned for
 forbidden claims; the first-person filter narrows where the homepage rules
 run, never what they match (the rule set is imported untouched); `FACTS_MIN`
 and `MIN_RESPONSES` cannot be zeroed. A
-canned-reply bot, an echo bot and a chatty bot all fail in the test suite, and
+a noun-stuffing bot, a repeated-canned-reply bot, an echo bot and a chatty bot all fail in the test suite, and
 a spec-faithful bot passes every room (the positive control).
 
 ## Files
@@ -91,7 +92,7 @@ need none of it and make no network calls.
 | --- | --- |
 | `BASE_URL` | required. Webhook endpoint the synthetic Blooio deliveries are POSTed to, e.g. `http://127.0.0.1:48803/api/eliza-app/webhook/blooio` (through the cloud API) or `http://127.0.0.1:3002/webhook/eliza-app/blooio` (straight at the gateway). |
 | `SIGNING` | how to sign `x-blooio-signature`: `env:<VAR>` (HMAC secret read from that env var; header `t=<unix>,v1=<hex hmac-sha256 of "<t>.<body>">`, the shape `_forward.ts` and the gateway adapter verify), `cmd:<shell template>` (run via `sh -c` with the raw body in `$BODY`; stdout is the header), `none`/unset (no header), anything else is used directly as the secret. |
-| `OUTBOUND_CAPTURE` | required. Where Eliza's outbound sends land: an http(s) URL whose GET returns a JSON array (or `{messages:[...]}`), or a file path (JSON array or JSONL). Entries carry text under `text|body|message` and a chat id under `chat_id|chatId|chat|to`. Entries without a chat id are ignored and counted (the DM and group streams must be distinguishable or the scoring is unsound); entries with `direction:"inbound"` or whose `sender|from` is one of the run's synthetic human handles are ignored, so only Eliza outputs are scored. |
+| `OUTBOUND_CAPTURE` | required. Where Eliza's outbound sends land: an http(s) URL whose GET returns a JSON array (or `{messages:[...]}`), or a file path (JSON array or JSONL). Entries carry text under `text|body|message` and a chat id under `chat_id|chatId|chat|to`. Entries without a chat id are ignored and counted (the DM and group streams must be distinguishable or the scoring is unsound); entries with `direction:"inbound"` or whose `sender|from` is one of the run's synthetic human handles are ignored, so only Eliza outputs are scored. Invalid payload/JSONL/message-send JSON is a harness error rather than silence, and common credential forms are redacted before text reaches logs or result artifacts. |
 | `LINK_CODE_REGEX` | optional override (first capture group = code) for parsing the link code out of the `/group` DM reply. Default matches the product command `Eliza link <8 chars of 2-9A-HJ-NP-Z>`. |
 | `WAIT_MS` | bounded wait per expected Eliza point (default 45000). |
 | `POLL_MS` | capture poll interval (default 1500). |

--- a/packages/cloud/scripts/group-room-sim/first-person-claims.ts
+++ b/packages/cloud/scripts/group-room-sim/first-person-claims.ts
@@ -14,9 +14,9 @@
  * and double-quoted or backticked text are masked out first, so a todo
  * receipt or a quoted human line never counts.
  *
- * Accepted blind spots, traded for precision: elided-subject reports
- * ("Booked.", "Reminder set for 9am"), third-person self-reference ("Eliza
- * can book") and an unlisted action verb ("I snagged a table") open no span.
+ * Accepted blind spots, traded for precision: third-person self-reference
+ * ("Eliza can book"), elided verbs outside the explicit completion list and
+ * unlisted action verbs ("I snagged a table") open no span.
  */
 
 /**
@@ -84,6 +84,7 @@ const ACTION_VERBS: readonly string[] = [
   "found",
   "grab",
   "grabbed",
+  "got",
   "handle",
   "handled",
   "keep",
@@ -208,14 +209,17 @@ const ADVERBS = "just|already|also|actually|even|now|then|quickly";
 const FIRST_PERSON_MARKER = new RegExp(
   [
     `\\bi\\s+(?:${MODALS})${NOT_NEGATED}\\b`,
-    "\\bi'(?:ll|d)\\b",
-    "\\bi(?:'m|\\s+am)\\b(?!\\s+(?:not|unable|never)\\b)",
+    "\\bi'(?:ll|d)\\b(?!\\s+(?:not|never)\\b)",
+    `\\bi(?:'m|\\s+am)\\s+(?!not\\b|never\\b|unable\\b)(?:able\\s+to|going\\s+to|(?:${ACTION_VERBS.join("|")})ing)\\b`,
     "\\bi(?:\\s+have|'ve)\\s+been\\s+able\\b",
-    "\\blet\\s+me\\b(?!\\s+know\\b)",
+    "\\blet\\s+me\\b(?!\\s+(?:know|not|never)\\b)",
     "\\b(?:want|need|like|allow|prefer|tell|ask|trust|wish)\\s+me\\s+to\\b",
     `\\b(?:${MODALS}|do\\s+you\\s+want)\\s+i\\b`,
     "\\b(?:happy|glad)\\s+to\\b",
     `\\bi(?:\\s+have|\\s+had|'ve)?(?:\\s+(?:${ADVERBS}|went\\s+ahead\\s+and))*\\s+(?:${ACTION_VERBS.join("|")})\\b`,
+    `\\bwe(?:'ve|\\s+have)\\s+(?:${ACTION_VERBS.join("|")})\\b`,
+    "(?:^|[.!?]\\s+)(?:done\\s*[—:-]?\\s*)?(?:booked|reserved|confirmed|scheduled|sent|emailed|ordered|purchased)\\b",
+    "(?:^|[.!?]\\s+)your\\s+(?:reservation|booking|order|appointment)\\s+(?:is\\s+)?(?:booked|reserved|confirmed|scheduled)\\b",
   ].join("|"),
   "gi",
 );
@@ -228,7 +232,7 @@ const FIRST_PERSON_MARKER = new RegExp(
  */
 const SWITCH_LEADS =
   "and|but|or|so|then|if|when|whenever|unless|once|after|before|until|while|whether|that|which|what|whatever|where|who|whoever|because|since|as|though|although|" +
-  "think|thought|guess|bet|hope|assume|suggest|suggested|recommend|recommended|say|said|expect|know|knew|see|saw|hear|heard|notice|noticed|mean|wish|figure|imagine|sure|glad|let";
+  "think|thought|guess|bet|hope|assume|suggest|suggested|recommend|recommended|say|said|expect|know|knew|see|saw|hear|heard|notice|noticed|mean|wish|figure|imagine|sure|glad|let|how";
 const SWITCH_LEAD = `(?:[,;:(]|\\b(?:${SWITCH_LEADS})\\b)\\s*`;
 const OTHER_SUBJECTS =
   "you(?:'ll|'d|'re|'ve)?|they(?:'ll|'d|'re|'ve)?|he(?:'s|'ll|'d)?|she(?:'s|'ll|'d)?|we(?:'ll|'d|'re|'ve)?|it(?:'s|'ll|'d)?|someone|somebody|anyone|anybody|everyone|everybody|nobody|no one|people";
@@ -236,6 +240,8 @@ const PRONOUN_SWITCH = new RegExp(
   `${SWITCH_LEAD}(?:${OTHER_SUBJECTS})\\b`,
   "i",
 );
+const SECOND_PERSON_ACTOR_SWITCH =
+  /\byou(?:'ll|'d)?\s+(?:can|could|will|would|should|must|need\s+to|have\s+to|had\s+to)\b/i;
 /** A capitalized name after a lead; case-sensitive so ordinary words stay. */
 const NAME_SWITCH = new RegExp(`${SWITCH_LEAD}[A-Z][a-z]+\\b`);
 
@@ -245,7 +251,7 @@ const SENTENCE_BREAK = /\n+|(?<=[.!?])\s+/;
 
 function firstSwitchIndex(rest: string): number {
   let end = rest.length;
-  for (const re of [PRONOUN_SWITCH, NAME_SWITCH]) {
+  for (const re of [PRONOUN_SWITCH, SECOND_PERSON_ACTOR_SWITCH, NAME_SWITCH]) {
     const i = rest.search(re);
     if (i >= 0 && i < end) end = i;
   }

--- a/packages/cloud/scripts/group-room-sim/mock-blooio-provider.ts
+++ b/packages/cloud/scripts/group-room-sim/mock-blooio-provider.ts
@@ -68,24 +68,34 @@ export function isMessageSend(method: string, path: string): boolean {
  */
 export function captureFromOutbox(jsonl: string): CapturedSend[] {
   const out: CapturedSend[] = [];
-  for (const line of jsonl.split("\n")) {
+  for (const [index, line] of jsonl.split("\n").entries()) {
     if (!line.trim()) continue;
     let entry: Partial<OutboxEntry>;
     try {
       entry = JSON.parse(line);
-    } catch {
-      // error-policy:J3 untrusted-input sanitizing: a corrupt outbox line is
-      // skipped; it can never become a fabricated send.
-      continue;
+    } catch (error) {
+      // error-policy:J3 untrusted-input sanitizing: capture corruption is a
+      // harness error, never silently converted into apparent model silence.
+      throw new Error(`corrupt mock Blooio outbox JSON at line ${index + 1}`, {
+        cause: error,
+      });
     }
     if (entry.method !== "POST" || typeof entry.path !== "string") continue;
     let parsedBody: Record<string, unknown> = {};
     if (typeof entry.body === "string") {
       try {
         parsedBody = JSON.parse(entry.body);
-      } catch {
-        // error-policy:J3 untrusted-input sanitizing: a non-JSON body has no
-        // text/to, so the entry drops out below as a non-send.
+      } catch (error) {
+        if (isMessageSend(entry.method, entry.path)) {
+          // error-policy:J3 untrusted-input sanitizing: a corrupt message-send
+          // body could hide model output, so the capture must fail closed.
+          throw new Error(
+            `corrupt mock Blooio message body at line ${index + 1}`,
+            {
+              cause: error,
+            },
+          );
+        }
       }
     }
     let chat: string | undefined;
@@ -135,8 +145,10 @@ function startMockBlooioProvider(options: {
         method: req.method,
         path: url.pathname,
         headers: {
-          authorization: req.headers.get("authorization"),
-          "idempotency-key": req.headers.get("idempotency-key"),
+          authorization: req.headers.has("authorization") ? "[REDACTED]" : null,
+          "idempotency-key": req.headers.has("idempotency-key")
+            ? "[REDACTED]"
+            : null,
           "x-from-number": req.headers.get("x-from-number"),
         },
         body: body || null,
@@ -152,7 +164,9 @@ function startMockBlooioProvider(options: {
 }
 
 if (import.meta.main) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: direct CLI env documented in README, outside Turbo tasks
   const port = Number(process.env.PORT ?? DEFAULT_MOCK_BLOOIO_PORT);
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: direct CLI env documented in README, outside Turbo tasks
   const outboxPath = process.env.ROOM_SIM_OUTBOX ?? DEFAULT_OUTBOX_PATH;
   startMockBlooioProvider({ port, outboxPath });
   console.log(

--- a/packages/cloud/scripts/group-room-sim/room-facts.ts
+++ b/packages/cloud/scripts/group-room-sim/room-facts.ts
@@ -1,7 +1,8 @@
 /**
  * Hand-written per-room knowledge for the group-room simulation: the facts a
  * live Eliza should pick up from each room's human messages, and the
- * word-bounded matchers that give fact credit for mentioning them. This is the
+ * word-bounded relation, attribution, and polarity matchers that give fact
+ * credit only for a correctly connected claim. This is the
  * only part of the spec that is not derived from the homepage module, so the
  * tool's tests fail if the homepage ever adds a room that has no entry here.
  *
@@ -15,6 +16,8 @@ import type { LandingDemoScenarioId } from "../../../homepage/src/lib/landing-de
 export interface FactPattern {
   label: string;
   re: RegExp;
+  /** Independent relation/attribution/polarity terms required for credit. */
+  required?: readonly RegExp[];
 }
 
 export const FACT_PATTERNS: Record<LandingDemoScenarioId, FactPattern[]> = {
@@ -22,79 +25,190 @@ export const FACT_PATTERNS: Record<LandingDemoScenarioId, FactPattern[]> = {
     {
       label: "tomatoes/parmesan already home",
       re: /\btomato(?:es)?\b|\bparmesan\b/i,
+      required: [/\b(?:have|has|home|already|still)\b/i],
     },
-    { label: "coffee low", re: /\bcoffee\b/i },
-    { label: "oat milk", re: /\boat\s*milk\b/i },
-    { label: "trash bags", re: /\btrash\s*bags?\b/i },
-    { label: "recycling done", re: /\brecycl(?:e|ed|es|ing)\b/i },
-    { label: "plants done", re: /\bplants?\b/i },
-    { label: "dishwasher clean", re: /\bdishwasher\b/i },
-    { label: "pasta dinner", re: /\bpasta\b/i },
+    {
+      label: "coffee low",
+      re: /\bcoffee\b/i,
+      required: [/\b(?:low|out|need|you)\b/i],
+    },
+    {
+      label: "oat milk",
+      re: /\boat\s*milk\b/i,
+      required: [/\b(?:need|buy|run|Noor)\b/i],
+    },
+    { label: "trash bags", re: /\btrash\s*bags?\b/i, required: [/\bEli\b/i] },
+    {
+      label: "recycling done",
+      re: /\brecycl(?:e|ed|es|ing)\b/i,
+      required: [/\bEli\b/i, /\b(?:did|done|took|counts|already)\b/i],
+    },
+    {
+      label: "plants done",
+      re: /\bplants?\b/i,
+      required: [/\bJules\b/i, /\b(?:did|done|finished|has)\b/i],
+    },
+    {
+      label: "dishwasher clean",
+      re: /\bdishwasher\b/i,
+      required: [/\bNoor\b/i, /\b(?:clean|unload|does|has)\b/i],
+    },
+    {
+      label: "pasta dinner",
+      re: /\bpasta\b/i,
+      required: [/\b(?:Jules|Noor|cook|run)\b/i],
+    },
     {
       label: "two jobs each / even split",
       re: /\b(?:two|2)\s+(?:jobs|each|chores|tasks)\b|\beven(?:ly)?\b[^.\n]{0,16}\bsplit\b|\bsplit\b[^.\n]{0,16}\beven(?:ly)?\b|\bfair\s+(?:split|share|shake)\b|\bthat'?s\s+even\b/i,
     },
   ],
   "co-parenting": [
-    { label: "front pocket (inhaler)", re: /\bfront\s*pocket\b/i },
-    { label: "inhaler", re: /\binhaler\b/i },
-    { label: "blue bag/backpack", re: /\bblue\s*(?:bag|backpack)\b/i },
+    {
+      label: "front pocket (inhaler)",
+      re: /\bfront\s*pocket\b/i,
+      required: [/\binhaler\b/i],
+    },
+    {
+      label: "inhaler",
+      re: /\binhaler\b/i,
+      required: [/\b(?:Ava|front\s+pocket|blue\s+backpack)\b/i],
+    },
+    {
+      label: "blue bag/backpack",
+      re: /\bblue\s*(?:bag|backpack)\b/i,
+      required: [/\b(?:Ava|inhaler|front\s+pocket)\b/i],
+    },
     {
       label: "permission slip / side pocket",
       re: /\bpermission\s*slip\b|\bside\s*pocket\b/i,
+      required: [/\b(?:permission\s+slip|side\s+pocket)\b/i],
     },
-    { label: "thursday 5 / 5:30 fallback", re: /\b5:30\b|\bthursday\b/i },
-    { label: "saturday soccer", re: /\bsoccer\b/i },
-    { label: "cleats", re: /\bcleats?\b/i },
-    { label: "friday pickup/handoff", re: /\bfriday\b/i },
+    {
+      label: "thursday 5 / 5:30 fallback",
+      re: /\b5:30\b|\bthursday\b/i,
+      required: [/\bNina\b/i],
+    },
+    {
+      label: "saturday soccer",
+      re: /\bsoccer\b/i,
+      required: [/\b(?:Saturday|Nina|9)\b/i],
+    },
+    {
+      label: "cleats",
+      re: /\bcleats?\b/i,
+      required: [/\b(?:car|Friday|you)\b/i],
+    },
+    {
+      label: "friday pickup/handoff",
+      re: /\bfriday\b/i,
+      required: [/\b(?:pickup|handoff|you|4:30)\b/i],
+    },
   ],
   friends: [
-    { label: "vegetarian (Priya)", re: /\bvegetarian\b|\bveggie\b/i },
-    { label: "peanut allergy (Jamie)", re: /\bpeanuts?\b/i },
+    {
+      label: "vegetarian (Priya)",
+      re: /\bvegetarian\b|\bveggie\b/i,
+      required: [/\bPriya\b/i],
+    },
+    {
+      label: "peanut allergy (Jamie)",
+      re: /\bpeanuts?\b/i,
+      required: [/\bJamie\b/i, /\ballerg(?:y|ic|en|ens)\b/i],
+    },
     {
       label: "saturday after 7 / 7:30",
       re: /\b7:30\b|\bafter\s*7\b|\bsaturday\b/i,
+      required: [/\b(?:works|overlap|time|everyone|Saturday)\b/i],
     },
-    { label: "quiet / not loud", re: /\bquiet\b|\bloud\b/i },
-    { label: "noe valley", re: /\bnoe\b/i },
+    {
+      label: "quiet / not loud",
+      re: /\bquiet\b|\bnot\s+loud\b/i,
+      required: [/\b(?:Priya|Leo|place|patio)\b/i],
+    },
+    {
+      label: "noe valley",
+      re: /\bnoe\b/i,
+      required: [/\b(?:Maya|Cypress|Valley|place)\b/i],
+    },
     {
       label: "patio / outdoor seating",
       re: /\bpatio\b|\boutdoor\b|\boutside\b/i,
+      required: [/\b(?:quiet|seating|warm|Cypress)\b/i],
     },
     {
       label: "cross-contact/allergy protocol",
       re: /\bcross[- ]contact\b|\bprotocols?\b|\ballerg(?:y|ies|ic|en|ens)\b/i,
+      required: [
+        /\bpeanuts?\b/i,
+        /\b(?:protocol|separate|manager|cross[- ]contact)\b/i,
+      ],
     },
   ],
   trip: [
-    { label: "arrivals meet ~10:20", re: /\b10:20\b|\barrivals?\b/i },
-    { label: "red suitcase (Emi)", re: /\bred\s*suitcase\b/i },
-    { label: "keys with Samira", re: /\bkeys?\b/i },
+    {
+      label: "arrivals meet ~10:20",
+      re: /\b10:20\b|\barrivals?\b/i,
+      required: [/\b(?:meet|overlap|arrivals)\b/i],
+    },
+    {
+      label: "red suitcase (Emi)",
+      re: /\bred\s*suitcase\b/i,
+      required: [/\bEmi\b/i],
+    },
+    { label: "keys with Samira", re: /\bkeys?\b/i, required: [/\bSamira\b/i] },
     {
       label: "check-in at 3",
       re: /\b3:00\b|\b3\s*pm\b|\b(?:at|til|till|until)\s+3\b|check[- ]?in\b[^.\n]{0,24}\b3\b/i,
+      required: [/\b(?:apartment|check[- ]?in|get\s+in)\b/i],
     },
     {
       label: "bag drop",
       re: /\bbag\s*drop\b|\bluggage\b|\bstore\b[^.\n]{0,12}\bbags\b/i,
+      required: [/\b(?:staffed|apartment|blocks?|drop)\b/i],
     },
-    { label: "10:45 cutoff for Emi", re: /\b10:45\b/i },
-    { label: "veggie food (Emi)", re: /\bveggie\b|\bvegetarian\b/i },
-    { label: "rain / covered route", re: /\brain\b|\bcovered\b/i },
+    { label: "10:45 cutoff for Emi", re: /\b10:45\b/i, required: [/\bEmi\b/i] },
+    {
+      label: "veggie food (Emi)",
+      re: /\bveggie\b|\bvegetarian\b/i,
+      required: [/\bEmi\b/i],
+    },
+    {
+      label: "rain / covered route",
+      re: /\brain\b|\bcovered\b/i,
+      required: [/\b(?:route|walk|around\s+2)\b/i],
+    },
   ],
   community: [
-    { label: "tuesday Rosa", re: /\btuesday\b/i },
-    { label: "thursday Dev", re: /\bthursday\b/i },
-    { label: "saturday user round", re: /\bsaturday\b/i },
-    { label: "north bed", re: /\bnorth\s*bed\b/i },
-    { label: "west bed", re: /\bwest\s*bed\b/i },
-    { label: "shade cloth", re: /\bshade\b/i },
+    { label: "tuesday Rosa", re: /\btuesday\b/i, required: [/\bRosa\b/i] },
+    { label: "thursday Dev", re: /\bthursday\b/i, required: [/\bDev\b/i] },
+    {
+      label: "saturday user round",
+      re: /\bsaturday\b/i,
+      required: [/\b(?:you|your)\b/i],
+    },
+    { label: "north bed", re: /\bnorth\s*bed\b/i, required: [/\bRosa\b/i] },
+    {
+      label: "west bed",
+      re: /\bwest\s*bed\b/i,
+      required: [/\b(?:you|your|Saturday)\b/i],
+    },
+    {
+      label: "shade cloth",
+      re: /\bshade(?:\s+cloth|\s+thing)?\b/i,
+      required: [/\b(?:Wednesday|Thursday|seedlings|you|Dev)\b/i],
+    },
     {
       label: "seedlings extra water / heat",
       re: /\bseedlings?\b|\bheat\b|\bhot\b/i,
+      required: [/\b(?:extra|more|heat|hot|Saturday)\b/i],
     },
-    { label: "hose by the gate", re: /\bhose\b|\bgate\b/i },
-    { label: "mulch", re: /\bmulch\b/i },
+    {
+      label: "hose by the gate",
+      re: /\bhose\b|\bgate\b/i,
+      required: [/\bTasha\b/i, /\b(?:hose|gate)\b/i],
+    },
+    { label: "mulch", re: /\bmulch\b/i, required: [/\bRosa\b/i] },
   ],
 };
 

--- a/packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
+++ b/packages/cloud/scripts/group-room-sim/run-room-sim.test.ts
@@ -231,8 +231,9 @@ describe("forbidden claims count only on first-person capability claims", () => 
       "filesystem",
     ]);
     expect(forbiddenHits(any, text)).toEqual([]);
-    // "I can't" opens no span; "I can see" closes at "when you're".
-    expect(firstPersonClaimSpans(text)).toEqual(["I'm down.", "I can see"]);
+    // "I can't" and the state "I'm down" open no span; "I can see" closes
+    // at "when you're".
+    expect(firstPersonClaimSpans(text)).toEqual(["I can see"]);
   });
 
   test("an offer to check reservations is still a booking overclaim", () => {
@@ -295,7 +296,33 @@ describe("forbidden claims count only on first-person capability claims", () => 
       forbiddenHits(any, "I have a few options that take reservations."),
     ).toEqual([]);
     expect(forbiddenHits(any, "Let me know once you've sent it.")).toEqual([]);
-    expect(forbiddenHits(any, "Booked.")).toEqual([]);
+    expect(forbiddenHits(any, "Booked.")).toEqual(["booking"]);
+  });
+
+  test("adversarial attribution, polarity, and elided claims are classified", () => {
+    for (const text of [
+      "I can find restaurants you can book yourself.",
+      "I can explain how you can book the table.",
+      "I'll never book a table for you.",
+      "Let me not book anything yet.",
+      "I'm sorry you had to book it yourself.",
+    ]) {
+      expect({ text, hits: forbiddenHits(any, text) }).toEqual({
+        text,
+        hits: [],
+      });
+    }
+    for (const text of [
+      "Done — booked a table for 7.",
+      "Your reservation is confirmed for Saturday.",
+      "I got you a reservation at 7.",
+      "We've booked a table for you.",
+    ]) {
+      expect({ text, hits: forbiddenHits(any, text) }).toEqual({
+        text,
+        hits: ["booking"],
+      });
+    }
   });
 
   test("a subject switch hands the rest of the sentence to the human", () => {
@@ -693,6 +720,34 @@ describe("choreography against a synthetic stack", () => {
     expect(echoed.every((s) => s.matchedFacts?.length === 0)).toBe(true);
   });
 
+  test("noun stuffing and repeated canned replies cannot pass fact scoring", async () => {
+    const room = spec.rooms.find((r) => r.id === "friends") as RoomSpec;
+    const nounStuffed = await simulate(
+      "friends",
+      scriptedBot(room, { onExpected: () => ["Maya: vegetarian peanuts."] }),
+    );
+    expect(nounStuffed.result.assertions.keyFactsReferenced).toMatchObject({
+      pass: false,
+      matched: [],
+      factfulExpectedPoints: 0,
+    });
+    expect(nounStuffed.result.verdict).toBe("FAIL");
+
+    const repeated = await simulate(
+      "friends",
+      scriptedBot(room, {
+        onExpected: () => [
+          "Priya is vegetarian and Jamie has a peanut allergy.",
+        ],
+      }),
+    );
+    expect(repeated.result.assertions.distinctExpectedReplies).toMatchObject({
+      pass: false,
+      distinct: 1,
+    });
+    expect(repeated.result.verdict).toBe("FAIL");
+  });
+
   test("a reply-to-everything bot fails restraintAtUnscriptedPoints even when its scripted replies are perfect", async () => {
     const room = spec.rooms.find((r) => r.id === "friends") as RoomSpec;
     const { result, plan } = await simulate(
@@ -711,7 +766,9 @@ describe("choreography against a synthetic stack", () => {
     // The failure is isolated: everything else about the bot was fine.
     expect(result.assertions.respondedAtExpectedPoints.pass).toBe(true);
     expect(result.assertions.noEchoedHumanText.pass).toBe(true);
-    expect(result.assertions.zeroForbiddenClaims.pass).toBe(true);
+    expect(result.assertions.noDetectedUnsupportedFirstPersonClaims.pass).toBe(
+      true,
+    );
     expect(result.steps.filter((s) => s.unsolicited)).toHaveLength(10);
   });
 
@@ -734,7 +791,7 @@ describe("choreography against a synthetic stack", () => {
     });
   });
 
-  test("a forbidden-claim reply fails zeroForbiddenClaims; allowed categories do not count", async () => {
+  test("a forbidden-claim reply fails the scoped detector; allowed categories do not count", async () => {
     const room = spec.rooms.find((r) => r.id === "household") as RoomSpec;
     let injected = false;
     const { result } = await simulate(
@@ -748,7 +805,9 @@ describe("choreography against a synthetic stack", () => {
       }),
     );
     expect(result.verdict).toBe("FAIL");
-    expect(result.assertions.zeroForbiddenClaims).toMatchObject({
+    expect(
+      result.assertions.noDetectedUnsupportedFirstPersonClaims,
+    ).toMatchObject({
       pass: false,
       hits: ["email", "booking"],
       allowedCategories: ["durable-memory"],
@@ -779,7 +838,9 @@ describe("choreography against a synthetic stack", () => {
         linkAck: ["Linked. I will email everyone a summary."],
       }),
     );
-    expect(result.assertions.zeroForbiddenClaims).toMatchObject({
+    expect(
+      result.assertions.noDetectedUnsupportedFirstPersonClaims,
+    ).toMatchObject({
       pass: false,
       hits: ["email"],
     });
@@ -878,6 +939,25 @@ describe("capture filtering", () => {
     expect(() => normalizeCapturePayload({ nope: true }, humans)).toThrow(
       RoomSimError,
     );
+  });
+
+  test("redacts credentials before captured output can reach artifacts", () => {
+    expect(
+      normalizeCapturePayload(
+        [
+          {
+            text: "Bearer abcdefghijklmnop https://x.test/?token=secret-value",
+            chat_id: "c",
+          },
+        ],
+        humans,
+      ).entries,
+    ).toEqual([
+      {
+        text: "Bearer [REDACTED] https://x.test/?token=[REDACTED]",
+        chat: "c",
+      },
+    ]);
   });
 });
 
@@ -1028,13 +1108,6 @@ describe("mock provider capture", () => {
         path: "/v4/chats/chat_sim_trip/typing",
         body: null,
       }),
-      JSON.stringify({
-        n: 6,
-        method: "POST",
-        path: "/v4/chats/chat%5Fsim/messages",
-        body: "not json",
-      }),
-      "garbage line",
     ].join("\n");
     expect(captureFromOutbox(jsonl)).toEqual([
       {
@@ -1052,5 +1125,21 @@ describe("mock provider capture", () => {
     expect(isMessageSend("POST", "/v4/chats/chat_x/messages")).toBe(true);
     expect(isMessageSend("POST", "/v4/chats/chat_x/typing")).toBe(false);
     expect(isMessageSend("GET", "/v4/messages")).toBe(false);
+  });
+
+  test("corrupt outbox lines and message bodies fail closed", () => {
+    expect(() => captureFromOutbox("garbage line")).toThrow(
+      /outbox JSON at line 1/,
+    );
+    expect(() =>
+      captureFromOutbox(
+        JSON.stringify({
+          n: 1,
+          method: "POST",
+          path: "/v4/chats/chat%5Fsim/messages",
+          body: "not json",
+        }),
+      ),
+    ).toThrow(/message body at line 1/);
   });
 });

--- a/packages/cloud/scripts/group-room-sim/run-room-sim.ts
+++ b/packages/cloud/scripts/group-room-sim/run-room-sim.ts
@@ -118,10 +118,16 @@ export interface Assertions {
   keyFactsReferenced: {
     pass: boolean;
     matched: string[];
+    factfulExpectedPoints: number;
     minRequired: number;
     available: number;
   };
-  zeroForbiddenClaims: {
+  distinctExpectedReplies: {
+    pass: boolean;
+    replies: number;
+    distinct: number;
+  };
+  noDetectedUnsupportedFirstPersonClaims: {
     pass: boolean;
     hits: string[];
     allowedCategories: string[];
@@ -182,6 +188,20 @@ function tokenSet(s: string): Set<string> {
   return new Set(normText(s).split(" ").filter(Boolean));
 }
 
+/** Remove common credential forms before capture text reaches logs/artifacts. */
+export function redactCredentials(text: string): string {
+  return text
+    .replace(
+      /\b(bearer|basic)\s+[a-z0-9._~+/=-]+/gi,
+      (_match, scheme: string) => `${scheme} [REDACTED]`,
+    )
+    .replace(
+      /([?&](?:api[_-]?key|token|secret|signature|password)=)[^&#\s]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(/\b(?:sk|key|token|secret)[-_][a-z0-9_-]{12,}\b/gi, "[REDACTED]");
+}
+
 /**
  * Returns the human message this output near-copies, or null. An echo is an
  * exact normalized match, containment of a >=4-token human line, or a
@@ -213,9 +233,20 @@ export function echoOfHuman(
 
 // ── Scoring (pure) ─────────────────────────────────────────────────────────
 
-function matchFacts(roomId: RoomSpec["id"], text: string): string[] {
+function matchFacts(
+  roomId: RoomSpec["id"],
+  text: string,
+  expectedText?: string,
+): string[] {
   return FACT_PATTERNS[roomId]
-    .filter((f) => f.re.test(text))
+    .filter((fact) => {
+      const matches = (candidate: string) =>
+        fact.re.test(candidate) &&
+        (fact.required ?? []).every((required) => required.test(candidate));
+      return (
+        matches(text) && (expectedText === undefined || matches(expectedText))
+      );
+    })
     .map((f) => f.label);
 }
 
@@ -228,13 +259,14 @@ export function scoreElizaOutput(
   allowedCategories: ReadonlySet<string>,
   humanTextsSent: readonly string[],
   text: string,
+  expectedText?: string,
 ): StepRecord {
   const echo = echoOfHuman(text, humanTextsSent);
   return {
     eliza: true,
     text,
     ...(echo ? { echoOf: echo } : {}),
-    matchedFacts: echo ? [] : matchFacts(roomId, text),
+    matchedFacts: echo ? [] : matchFacts(roomId, text, expectedText),
     forbiddenHits: forbiddenHits(allowedCategories, text),
   };
 }
@@ -265,6 +297,8 @@ export function computeAssertions(input: AssertionInputs): Assertions {
   const allForbidden: string[] = [...input.ackForbidden];
   const echoes: string[] = [];
   const nonEchoOutputs: string[] = [];
+  const factfulExpectedPoints = new Set<number>();
+  const expectedReplies: string[] = [];
   for (const s of input.steps) {
     if (!s.eliza || s.silent || s.matchedFacts === undefined) continue; // humans, acks, DM
     if (s.echoOf) {
@@ -272,6 +306,10 @@ export function computeAssertions(input: AssertionInputs): Assertions {
     } else {
       nonEchoOutputs.push(s.text);
       for (const f of s.matchedFacts) allFacts.add(f);
+      if (s.expected && s.position !== undefined) {
+        expectedReplies.push(normText(s.text));
+        if (s.matchedFacts.length > 0) factfulExpectedPoints.add(s.position);
+      }
     }
     allForbidden.push(...(s.forbiddenHits ?? []));
   }
@@ -300,12 +338,20 @@ export function computeAssertions(input: AssertionInputs): Assertions {
       samples: echoes.slice(0, 3),
     },
     keyFactsReferenced: {
-      pass: allFacts.size >= thresholds.factsMin,
+      pass:
+        allFacts.size >= thresholds.factsMin &&
+        factfulExpectedPoints.size >= thresholds.factsMin,
       matched: [...allFacts],
+      factfulExpectedPoints: factfulExpectedPoints.size,
       minRequired: thresholds.factsMin,
       available: FACT_PATTERNS[room.id].length,
     },
-    zeroForbiddenClaims: {
+    distinctExpectedReplies: {
+      pass: new Set(expectedReplies).size === expectedReplies.length,
+      replies: expectedReplies.length,
+      distinct: new Set(expectedReplies).size,
+    },
+    noDetectedUnsupportedFirstPersonClaims: {
       pass: allForbidden.length === 0,
       hits: allForbidden,
       allowedCategories: [...input.allowedCategories],
@@ -544,11 +590,17 @@ function createHttpIo(env: NodeJS.ProcessEnv): RunIo {
         );
       }
       if (!res.ok) {
-        // error-policy:J7 diagnostics must not kill the loop: the rejection
-        // body is only quoted into the failure; an unreadable body still fails
-        // on the status.
-        const text = await res.text().catch(() => "");
-        fail(`webhook POST rejected: ${res.status} ${text.slice(0, 300)}`);
+        let text: string;
+        try {
+          text = await res.text();
+        } catch (error) {
+          // error-policy:J1 boundary translation: preserve an unreadable error
+          // body as the cause while still reporting the authoritative status.
+          fail(`webhook POST rejected: ${res.status} (unreadable body)`, error);
+        }
+        fail(
+          `webhook POST rejected: ${res.status} ${redactCredentials(text).slice(0, 300)}`,
+        );
       }
     },
 
@@ -624,7 +676,7 @@ function normalizeCaptureEntry(
   if (!chat) {
     return { entry: null, untagged: true }; // without chat attribution DM/group scoring is unsound
   }
-  return { entry: { text, chat }, untagged: false };
+  return { entry: { text: redactCredentials(text), chat }, untagged: false };
 }
 
 export function normalizeCapturePayload(
@@ -753,8 +805,17 @@ export async function runRoom(
 
   const steps: StepRecord[] = [];
   const humanTextsSent: string[] = [];
-  const scoreEliza = (text: string): StepRecord =>
-    scoreElizaOutput(room.id, allowedCategories, humanTextsSent, text);
+  const expectedTextAt = new Map(
+    room.elizaSteps.map((step) => [step.position, step.text]),
+  );
+  const scoreEliza = (text: string, position?: number): StepRecord =>
+    scoreElizaOutput(
+      room.id,
+      allowedCategories,
+      humanTextsSent,
+      text,
+      position === undefined ? undefined : expectedTextAt.get(position),
+    );
 
   let seq = 0;
   const send = async (
@@ -883,7 +944,7 @@ export async function runRoom(
       if (replies.length > 0) {
         respondedPoints += 1;
         for (const t of replies) {
-          steps.push({ ...scoreEliza(t), position: pos, expected: true });
+          steps.push({ ...scoreEliza(t, pos), position: pos, expected: true });
         }
       } else {
         steps.push({
@@ -943,8 +1004,9 @@ export function renderMarkdown(result: RunResult): string {
     `- Pre-link probe sends: ${a.silentUntilLinked.preLinkSends} (must be 0)`,
     `- Unsolicited sends (silent windows + trailing): ${a.restraintAtUnscriptedPoints.unsolicitedSends} (max ${a.restraintAtUnscriptedPoints.maxAllowed})`,
     `- Echoed-human outputs: ${a.noEchoedHumanText.echoes} (must be 0)`,
-    `- Distinct key facts referenced (non-echo replies): ${a.keyFactsReferenced.matched.length} (min ${a.keyFactsReferenced.minRequired}): ${a.keyFactsReferenced.matched.join("; ") || "none"}`,
-    `- Forbidden-claim hits (incl. acks): ${a.zeroForbiddenClaims.hits.length ? a.zeroForbiddenClaims.hits.join(", ") : "none"}`,
+    `- Correctly related key facts at expected beats: ${a.keyFactsReferenced.matched.length} across ${a.keyFactsReferenced.factfulExpectedPoints} beats (min ${a.keyFactsReferenced.minRequired} each): ${a.keyFactsReferenced.matched.join("; ") || "none"}`,
+    `- Repeated expected replies: ${a.distinctExpectedReplies.replies - a.distinctExpectedReplies.distinct}`,
+    `- Detected unsupported first-person claim hits (incl. acks): ${a.noDetectedUnsupportedFirstPersonClaims.hits.length ? a.noDetectedUnsupportedFirstPersonClaims.hits.join(", ") : "none"}`,
     "",
     "## Transcript",
     "",
@@ -1009,6 +1071,7 @@ function printableSpec(spec: RoomsSpec): Record<string, unknown> {
       factPatterns: FACT_PATTERNS[room.id].map((f) => ({
         label: f.label,
         pattern: f.re.source,
+        required: (f.required ?? []).map((required) => required.source),
       })),
     })),
   };


### PR DESCRIPTION
## Summary

Post-merge corrective for #25350. The original harness could award room-fact credit to disconnected nouns, silently turn corrupt capture into model silence, and overstate its first-person unsupported-capability check.

This correction:

- requires relation, attribution, and polarity evidence for facts, and only awards it at a homepage beat whose expected response carries the same structured fact
- requires fact credit across distinct expected beats and rejects identical canned replies
- closes first-person parser false positives around human-attributed/negated booking and false negatives for elided, passive, `I got`, and `we've` completion claims
- renames the unsupported-capability assertion to the honest scoped `noDetectedUnsupportedFirstPersonClaims`
- makes corrupt JSONL and corrupt outbound message bodies fail the harness instead of disappearing
- redacts authorization/idempotency headers in the mock outbox and common credentials before captured text reaches logs/results
- removes the prohibited swallow-catch on webhook rejection bodies
- documents the revised evidence boundary without claiming an unattached live run

## Adversarial coverage

The deterministic suite now proves that:

- `Maya: vegetarian peanuts.` earns no fact credit
- a semantically plausible but repeated canned response cannot pass
- all five spec-faithful room bots still pass
- echo, chatty, pre-link, forbidden-claim, and silent bots still fail
- human-attributed and negated booking forms do not trip the parser
- elided/passive/plural-agent completed booking forms do trip it
- corrupt outbox lines/message bodies throw a harness error
- Bearer/query credentials are redacted in capture normalization

## Validation

At exact commit `f72b0fbe082959f22361f15bf98719a4aef06455`, with pinned Bun `1.3.14` and Node `24.15.0`:

- `bun test ./packages/cloud/scripts/group-room-sim/run-room-sim.test.ts`: **45 passed, 0 failed, 551 assertions**
- standalone strict TypeScript command from the tool README: passed
- Biome on all touched TypeScript: passed with no diagnostics
- `bun run cloud:group-room-sim -- --room household --dry-run`: passed
- `git diff --check`: passed

## Evidence boundary

No live Cerebras/model/Blooio result is claimed here. The correction is deterministic harness work. A future live evaluation must attach its exact transcript/result artifacts, stack/model revision, signed connector trace, and capture provenance before making behavioral evidence claims.

UI evidence: N/A — no UI changes.

Refs #25350
