### PR TITLE
test(app-core): cover browser tabs renderer registry

### DIFF
--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/browser-tabs-renderer-registry.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/browser-tabs-renderer-registry.test.ts
@@ -1,4 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).window = {};
+});
 
 import {
   getBrowserTabsRendererImpl,

--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/browser-tabs-renderer-registry.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/browser-tabs-renderer-registry.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getBrowserTabsRendererImpl,
+  setBrowserTabsRendererImpl,
+} from "./browser-tabs-renderer-registry.ts";
+
+const KEY = "__ELIZA_BROWSER_TABS_REGISTRY__";
+
+const fakeImpl = {
+  evaluate: async () => ({ ok: true }),
+  getTabRect: async () => ({ x: 0, y: 0, width: 10, height: 10 }),
+};
+
+describe("browser-tabs-renderer-registry", () => {
+  afterEach(() => {
+    // @ts-expect-error window 类型收窄
+    delete window[KEY];
+  });
+
+  it("returns a not-attached fallback before any impl is set", () => {
+    const impl = getBrowserTabsRendererImpl();
+    expect(impl.evaluate).toBeDefined();
+  });
+
+  it("stores and retrieves the attached implementation", () => {
+    setBrowserTabsRendererImpl(fakeImpl);
+    expect(getBrowserTabsRendererImpl()).toBe(fakeImpl);
+  });
+
+  it("clears the registry when detached", () => {
+    setBrowserTabsRendererImpl(fakeImpl);
+    setBrowserTabsRendererImpl(null);
+    expect(getBrowserTabsRendererImpl()).not.toBe(fakeImpl);
+  });
+});


### PR DESCRIPTION
# Relates to

<!-- No issue; test-only coverage for an existing pure helper module. -->

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun run verify` equivalent (focused vitest) was run in isolation; see evidence.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification passed post-sync (see evidence).

# Risks

Low. Test-only addition: a new `__tests__` file exercising existing exported
pure functions. No production code is modified, no runtime behavior changes.

# Evidence

| Row | Status |
|---|---|
| Focused tests (vitest, isolated) | Concrete: `isolated npx vitest run -> 3 passed` |
| before-screenshots | N/A - pure-function unit tests, no UI |
| after-screenshots | N/A - pure-function unit tests, no UI |
| walkthrough-video | N/A - pure-function unit tests, no UI |
| backend-logs | N/A - no runtime/service path exercised |
| frontend-logs | N/A - no frontend path exercised |
| llm-trajectory | N/A - deterministic unit tests, no model call |
| domain-artifacts | Concrete: test file diff in this PR |

# Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash
- skill revision: 92d692518c3d832ac9b203076ef691a54e61a9fa
