### PR TITLE
fix(gateway-discord): verify Opus in Railway images

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -637,7 +637,7 @@
       "name": "@elizaos/gateway-discord",
       "version": "1.0.0",
       "dependencies": {
-        "@discordjs/opus": "^0.10.0",
+        "@discordjs/opus": "0.10.0",
         "@discordjs/voice": "^0.19.2",
         "@elizaos/cloud-services-common": "workspace:*",
         "@elizaos/core": "workspace:*",

--- a/packages/cloud/services/gateway-discord/Dockerfile
+++ b/packages/cloud/services/gateway-discord/Dockerfile
@@ -15,9 +15,9 @@
 # BUN_BASE selects the Bun base image. Default targets linux/amd64 + linux/arm64
 # via upstream oven/bun, pinned to the canonical version in
 # .github/ci-bun-version.json so the deployed runtime is the one CI validates.
-# For linux/riscv64 (no upstream image — oven-sh/bun#6266, #21923), build a local
-# Bun image via elizaOS/os packages/os/toolchains/bun-riscv64/build.sh and pass
-# --build-arg BUN_BASE=<local-tag>.
+# The verified @discordjs/opus release used below publishes Alpine binaries for
+# amd64 and arm64 only. A different architecture fails closed in the selector;
+# do not treat a custom Bun base as sufficient native-addon evidence.
 ARG BUN_BASE=oven/bun:1.3.14-alpine
 
 FROM ${BUN_BASE} AS base
@@ -43,8 +43,10 @@ ARG COMMON_DIR
 ARG SHARED_DIR
 ARG CORE_DIR
 ARG OPUS_PREBUILD_NODE_TARGET
+ARG TARGETARCH
 RUN apk add --no-cache python3 make g++ pkgconf opus-dev
 COPY ${SERVICE_DIR}/package.json ${SERVICE_DIR}/
+COPY ${SERVICE_DIR}/scripts/select-opus-prebuild.ts ${SERVICE_DIR}/scripts/
 COPY ${COMMON_DIR}/package.json ${COMMON_DIR}/
 COPY ${SHARED_DIR}/package.json ${SHARED_DIR}/
 COPY ${CORE_DIR}/package.json ${CORE_DIR}/
@@ -52,7 +54,7 @@ RUN bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).
     && bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./errors":"./src/errors.ts"}}));' "${CORE_DIR}/package.json" \
     && printf '{"name":"gateway-discord-build","private":true,"workspaces":["packages/shared","packages/cloud/services/*","packages/core"]}\n' > package.json \
     && npm_config_target="${OPUS_PREBUILD_NODE_TARGET}" bun install --production \
-    && bun -e 'import { existsSync, readdirSync } from "node:fs"; const root = `${Bun.argv.at(-1)}/node_modules/@discordjs/opus`; const builds = readdirSync(`${root}/prebuild`).filter((entry) => existsSync(`${root}/prebuild/${entry}/opus.node`)); if (builds.length !== 1) throw new Error(`expected one installed Opus N-API build, found ${builds.length}`); const path = `${root}/package.json`; const manifest = await Bun.file(path).json(); const modulePath = builds[0].replace(/napi-v\d+/, "napi-v{napi_build_version}"); if (modulePath === builds[0]) throw new Error("installed Opus build lacks an N-API version segment"); manifest.binary.module_path = `./prebuild/${modulePath}/`; await Bun.write(path, JSON.stringify(manifest));' "${SERVICE_DIR}"
+    && bun "${SERVICE_DIR}/scripts/select-opus-prebuild.ts" "${SERVICE_DIR}" "${TARGETARCH}"
 
 # Build stage
 FROM deps AS builder

--- a/packages/cloud/services/gateway-discord/Dockerfile
+++ b/packages/cloud/services/gateway-discord/Dockerfile
@@ -28,6 +28,13 @@ ARG SERVICE_DIR=packages/cloud/services/gateway-discord
 ARG COMMON_DIR=packages/cloud/services/_common
 ARG SHARED_DIR=packages/shared
 ARG CORE_DIR=packages/core
+# @discordjs/opus publishes portable N-API v3 Alpine binaries, but its bundled
+# legacy node-pre-gyp crosswalk stops at Node 18 while Bun 1.3.14 identifies its
+# compatibility ABI as 137. Selecting the published Node 18 ABI only for native
+# dependency installation lets amd64 and arm64 use that N-API artifact instead
+# of entering the upstream ARM64-musl source-build failure. The service itself
+# still runs on the pinned Bun image above.
+ARG OPUS_PREBUILD_NODE_TARGET=18.4.0
 
 # Install dependencies
 FROM base AS deps
@@ -35,6 +42,7 @@ ARG SERVICE_DIR
 ARG COMMON_DIR
 ARG SHARED_DIR
 ARG CORE_DIR
+ARG OPUS_PREBUILD_NODE_TARGET
 RUN apk add --no-cache python3 make g++ pkgconf opus-dev
 COPY ${SERVICE_DIR}/package.json ${SERVICE_DIR}/
 COPY ${COMMON_DIR}/package.json ${COMMON_DIR}/
@@ -43,7 +51,8 @@ COPY ${CORE_DIR}/package.json ${CORE_DIR}/
 RUN bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./discord-dm-policy":"./src/discord-dm-policy.ts"}}));' "${SHARED_DIR}/package.json" \
     && bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); await Bun.write(path, JSON.stringify({name:manifest.name,version:manifest.version,type:"module",exports:{"./errors":"./src/errors.ts"}}));' "${CORE_DIR}/package.json" \
     && printf '{"name":"gateway-discord-build","private":true,"workspaces":["packages/shared","packages/cloud/services/*","packages/core"]}\n' > package.json \
-    && bun install --production
+    && npm_config_target="${OPUS_PREBUILD_NODE_TARGET}" bun install --production \
+    && bun -e 'import { existsSync, readdirSync } from "node:fs"; const root = `${Bun.argv.at(-1)}/node_modules/@discordjs/opus`; const builds = readdirSync(`${root}/prebuild`).filter((entry) => existsSync(`${root}/prebuild/${entry}/opus.node`)); if (builds.length !== 1) throw new Error(`expected one installed Opus N-API build, found ${builds.length}`); const path = `${root}/package.json`; const manifest = await Bun.file(path).json(); const modulePath = builds[0].replace(/napi-v\d+/, "napi-v{napi_build_version}"); if (modulePath === builds[0]) throw new Error("installed Opus build lacks an N-API version segment"); manifest.binary.module_path = `./prebuild/${modulePath}/`; await Bun.write(path, JSON.stringify(manifest));' "${SERVICE_DIR}"
 
 # Build stage
 FROM deps AS builder

--- a/packages/cloud/services/gateway-discord/package.json
+++ b/packages/cloud/services/gateway-discord/package.json
@@ -26,7 +26,7 @@
     "deploy:railway": "bash scripts/deploy-railway.sh"
   },
   "dependencies": {
-    "@discordjs/opus": "^0.10.0",
+    "@discordjs/opus": "0.10.0",
     "@discordjs/voice": "^0.19.2",
     "@elizaos/cloud-services-common": "workspace:*",
     "@elizaos/core": "workspace:*",

--- a/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
+++ b/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
@@ -2,12 +2,11 @@
 # Reproducible Railway deploy for gateway-discord.
 #
 # WHY THIS EXISTS
-# The in-repo Dockerfile does `bun install --frozen-lockfile` against this
-# package's own context, which can't resolve the `@elizaos/cloud-services-common`
-# workspace:* dependency when `railway up` uploads only the package directory
-# (no monorepo). `bun build` (the `build` script) DOES resolve + inline that dep
-# from the monorepo, producing a self-contained bundle — so we build the bundle
-# here and ship a runtime-only image.
+# The tracked Dockerfile builds from the repository root, but the operator-owned
+# Railway upload stages a self-contained bundle so it can ship without uploading
+# the monorepo. Native dependency selection in the staged Dockerfile must use the
+# same verified helper as the tracked image; `--container-build-only` exercises
+# that exact staged boundary without contacting Railway.
 #
 # The Railway service currently has no connected repository source. Until a
 # protected deploy workflow owns exact-source uploads, an authorized operator
@@ -20,16 +19,18 @@
 # WS lib (lazy require -> graceful fallback to no compression).
 set -euo pipefail
 BUILD_ONLY=0
+CONTAINER_BUILD_ONLY=0
 case "${1:-}" in
   "") ;;
   --build-only) BUILD_ONLY=1 ;;
+  --container-build-only) CONTAINER_BUILD_ONLY=1 ;;
   *)
-    echo "usage: $0 [--build-only]" >&2
+    echo "usage: $0 [--build-only|--container-build-only]" >&2
     exit 2
     ;;
 esac
 if [ "$#" -gt 1 ]; then
-  echo "usage: $0 [--build-only]" >&2
+  echo "usage: $0 [--build-only|--container-build-only]" >&2
   exit 2
 fi
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
@@ -56,7 +57,7 @@ cat > "$STAGE/package.json" <<'JSON'
   "private": true,
   "type": "module",
   "dependencies": {
-    "@discordjs/opus": "^0.10.0",
+    "@discordjs/opus": "0.10.0",
     "@discordjs/voice": "^0.19.2",
     "libsodium-wrappers": "^0.8.0",
     "prism-media": "1.3.5"
@@ -64,12 +65,18 @@ cat > "$STAGE/package.json" <<'JSON'
 }
 JSON
 
+cp "$HERE/scripts/select-opus-prebuild.ts" "$STAGE/select-opus-prebuild.ts"
+
 cat > "$STAGE/Dockerfile" <<'DOCKER'
 FROM oven/bun:1.3.14-alpine AS deps
 WORKDIR /app
+ARG OPUS_PREBUILD_NODE_TARGET=18.4.0
+ARG TARGETARCH
 RUN apk add --no-cache python3 make g++ pkgconf opus-dev
 COPY package.json ./
-RUN bun install --production
+COPY select-opus-prebuild.ts ./
+RUN npm_config_target="${OPUS_PREBUILD_NODE_TARGET}" bun install --production \
+    && bun ./select-opus-prebuild.ts . "${TARGETARCH}"
 
 FROM oven/bun:1.3.14-alpine
 WORKDIR /app
@@ -87,6 +94,17 @@ CMD ["bun", "run", "dist/index.js"]
 DOCKER
 
 cp "$HERE/railway.toml" "$STAGE/railway.toml" 2>/dev/null || true
+
+if [ "$CONTAINER_BUILD_ONLY" = "1" ]; then
+  GATEWAY_DISCORD_BUILD_PLATFORM="${GATEWAY_DISCORD_BUILD_PLATFORM:-linux/amd64}"
+  GATEWAY_DISCORD_BUILD_TAG="${GATEWAY_DISCORD_BUILD_TAG:-gateway-discord:build-only}"
+  docker build \
+    --platform "$GATEWAY_DISCORD_BUILD_PLATFORM" \
+    --tag "$GATEWAY_DISCORD_BUILD_TAG" \
+    "$STAGE"
+  echo "[deploy] container build-only proof passed: $GATEWAY_DISCORD_BUILD_TAG ($GATEWAY_DISCORD_BUILD_PLATFORM)"
+  exit 0
+fi
 
 if [ "$BUILD_ONLY" = "1" ]; then
   echo "[deploy] build-only proof passed"

--- a/packages/cloud/services/gateway-discord/scripts/select-opus-prebuild.ts
+++ b/packages/cloud/services/gateway-discord/scripts/select-opus-prebuild.ts
@@ -1,0 +1,94 @@
+/**
+ * Selects and verifies the pinned Discord Opus N-API artifact for a Linux
+ * container install, then preserves that selection for Bun's runtime loader.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const OPUS_VERSION = "0.10.0";
+
+const OPUS_ASSETS = {
+  amd64: {
+    directory: "node-v108-napi-v3-linux-x64-musl-1.2.5",
+    sha256: "d5396d0f6ba4f07851c8fa0f98183b19bb856c9bfbb150d02984ebb54a2140df",
+  },
+  arm64: {
+    directory: "node-v108-napi-v3-linux-arm64-musl-1.2.5",
+    sha256: "cb9194a8a785434918a42312d4d9f04167f7e316cf577f487c8e2ebfbdd12080",
+  },
+} as const;
+
+type SupportedDockerArch = keyof typeof OPUS_ASSETS;
+
+function supportedDockerArch(value: string): SupportedDockerArch {
+  if (value === "amd64" || value === "arm64") return value;
+  throw new Error(
+    `@discordjs/opus ${OPUS_VERSION} has no verified Alpine prebuild for Docker architecture ${value}`,
+  );
+}
+
+export async function selectOpusPrebuild(
+  serviceDirectory: string,
+  dockerArchitecture: string,
+): Promise<void> {
+  const asset = OPUS_ASSETS[supportedDockerArch(dockerArchitecture)];
+  const packageRoot = path.join(
+    serviceDirectory,
+    "node_modules",
+    "@discordjs",
+    "opus",
+  );
+  const manifestPath = path.join(packageRoot, "package.json");
+  const manifest = (await Bun.file(manifestPath).json()) as {
+    version?: string;
+    binary?: { module_path?: string };
+  };
+  if (manifest.version !== OPUS_VERSION) {
+    throw new Error(
+      `expected @discordjs/opus ${OPUS_VERSION}, found ${manifest.version ?? "unknown"}`,
+    );
+  }
+  if (!manifest.binary) {
+    throw new Error("installed @discordjs/opus manifest lacks binary metadata");
+  }
+
+  const prebuildRoot = path.join(packageRoot, "prebuild");
+  const installed = readdirSync(prebuildRoot).filter((entry) =>
+    existsSync(path.join(prebuildRoot, entry, "opus.node")),
+  );
+  if (installed.length !== 1 || installed[0] !== asset.directory) {
+    throw new Error(
+      `expected only verified Opus build ${asset.directory}, found ${installed.join(", ") || "none"}`,
+    );
+  }
+
+  const binaryPath = path.join(prebuildRoot, asset.directory, "opus.node");
+  const digest = createHash("sha256")
+    .update(new Uint8Array(await Bun.file(binaryPath).arrayBuffer()))
+    .digest("hex");
+  if (digest !== asset.sha256) {
+    throw new Error(
+      `Opus prebuild integrity mismatch for ${asset.directory}: expected ${asset.sha256}, found ${digest}`,
+    );
+  }
+
+  const runtimeDirectory = asset.directory.replace(
+    "napi-v3",
+    "napi-v{napi_build_version}",
+  );
+  manifest.binary.module_path = `./prebuild/${runtimeDirectory}/`;
+  await Bun.write(manifestPath, JSON.stringify(manifest));
+}
+
+if (import.meta.main) {
+  const serviceDirectory = Bun.argv[2];
+  const dockerArchitecture = Bun.argv[3];
+  if (!serviceDirectory || !dockerArchitecture) {
+    throw new Error(
+      "usage: bun select-opus-prebuild.ts <service-directory> <docker-architecture>",
+    );
+  }
+  await selectOpusPrebuild(serviceDirectory, dockerArchitecture);
+}

--- a/packages/cloud/services/gateway-discord/tests/deploy-railway.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/deploy-railway.test.ts
@@ -1,6 +1,12 @@
 /** Exercises the package-owned Railway bundle boundary without contacting Railway. */
 
 import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const deployScript = readFileSync(
+  `${import.meta.dir}/../scripts/deploy-railway.sh`,
+  "utf8",
+);
 
 test("the Railway deploy script builds the source-form workspace bundle", async () => {
   const process = Bun.spawn(
@@ -39,4 +45,22 @@ test("the Railway deploy script rejects unknown modes before building", async ()
 
   expect(exitCode).toBe(2);
   expect(stderr).toContain("usage:");
+});
+
+test("the staged Railway image uses the verified shared Opus selector", () => {
+  expect(deployScript).toContain('"@discordjs/opus": "0.10.0"');
+  expect(deployScript).toContain(
+    'cp "$HERE/scripts/select-opus-prebuild.ts" "$STAGE/select-opus-prebuild.ts"',
+  );
+  expect(deployScript).toContain(
+    'npm_config_target="$' +
+      '{OPUS_PREBUILD_NODE_TARGET}" bun install --production',
+  );
+  expect(deployScript).toContain(
+    'bun ./select-opus-prebuild.ts . "$' + '{TARGETARCH}"',
+  );
+  expect(deployScript).toContain(
+    '--platform "$GATEWAY_DISCORD_BUILD_PLATFORM"',
+  );
+  expect(deployScript).toContain('--tag "$GATEWAY_DISCORD_BUILD_TAG"');
 });

--- a/packages/cloud/services/gateway-discord/tests/select-opus-prebuild.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/select-opus-prebuild.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Exercises the fail-closed validation around the shared Opus container
+ * selector with synthetic manifests and binaries; real addons run in Docker.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { selectOpusPrebuild } from "../scripts/select-opus-prebuild";
+
+const temporaryDirectories: string[] = [];
+
+async function fakeService(version = "0.10.0"): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "gateway-opus-selector-"));
+  temporaryDirectories.push(root);
+  const packageRoot = path.join(root, "node_modules", "@discordjs", "opus");
+  const prebuild = path.join(
+    packageRoot,
+    "prebuild",
+    "node-v108-napi-v3-linux-x64-musl-1.2.5",
+  );
+  await mkdir(prebuild, { recursive: true });
+  await Bun.write(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({ version, binary: { module_path: "untrusted" } }),
+  );
+  await Bun.write(path.join(prebuild, "opus.node"), "not an Opus addon");
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+test("rejects unsupported container architectures before inspecting files", async () => {
+  await expect(selectOpusPrebuild("missing", "riscv64")).rejects.toThrow(
+    /no verified Alpine prebuild.*riscv64/i,
+  );
+});
+
+test("rejects dependency version drift", async () => {
+  const service = await fakeService("0.10.1");
+  await expect(selectOpusPrebuild(service, "amd64")).rejects.toThrow(
+    /expected @discordjs\/opus 0\.10\.0, found 0\.10\.1/,
+  );
+});
+
+test("rejects a selected binary whose digest is not pinned", async () => {
+  const service = await fakeService();
+  await expect(selectOpusPrebuild(service, "amd64")).rejects.toThrow(
+    /integrity mismatch/i,
+  );
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
@@ -151,6 +151,25 @@ describe("service Dockerfiles can resolve their workspace dependencies", () => {
     expect(installAt).toBeGreaterThan(pruneAt ?? Number.MAX_SAFE_INTEGER);
   });
 
+  test("gateway-discord selects a published N-API Opus prebuild", () => {
+    const gateway = services.find(
+      (service) => service.name === "gateway-discord",
+    );
+    expect(gateway?.dockerfile).toContain(
+      "ARG OPUS_PREBUILD_NODE_TARGET=18.4.0",
+    );
+    expect(gateway?.dockerfile).toContain(
+      'npm_config_target="$' +
+        '{OPUS_PREBUILD_NODE_TARGET}" bun install --production',
+    );
+    expect(gateway?.dockerfile).toContain(
+      'builds[0].replace(/napi-v\\d+/, "napi-v{napi_build_version}")',
+    );
+    expect(gateway?.dockerfile).toContain(
+      "manifest.binary.module_path = `./prebuild/$" + "{modulePath}/`",
+    );
+  });
+
   for (const service of services.filter((s) => s.workspaceDeps.length > 0)) {
     const shouldPass = !LOCKFILE_BLIND.has(service.name);
 

--- a/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
@@ -163,10 +163,15 @@ describe("service Dockerfiles can resolve their workspace dependencies", () => {
         '{OPUS_PREBUILD_NODE_TARGET}" bun install --production',
     );
     expect(gateway?.dockerfile).toContain(
-      'builds[0].replace(/napi-v\\d+/, "napi-v{napi_build_version}")',
+      "COPY $" +
+        "{SERVICE_DIR}/scripts/select-opus-prebuild.ts $" +
+        "{SERVICE_DIR}/scripts/",
     );
     expect(gateway?.dockerfile).toContain(
-      "manifest.binary.module_path = `./prebuild/$" + "{modulePath}/`",
+      'bun "$' +
+        '{SERVICE_DIR}/scripts/select-opus-prebuild.ts" "$' +
+        '{SERVICE_DIR}" "$' +
+        '{TARGETARCH}"',
     );
   });
 


### PR DESCRIPTION
## Summary

Non-draft successor to #25414. The original tracked-Dockerfile selector worked, but the documented Railway operator path generates a separate staged Dockerfile and remained unfixed. This change makes both production image paths use one fail-closed selector.

- pins `@discordjs/opus` to exactly `0.10.0` in the service, root lock, and staged Railway manifest;
- uses one shared selector from the tracked repository Dockerfile and the generated Railway Dockerfile;
- selects the published Node-v108 / N-API-v3 Alpine artifact for Bun 1.3.14, then preserves that selected ABI path for the runtime loader;
- requires the exact expected architecture/directory and verifies the downloaded native binary's SHA-256 before mutating the installed manifest;
- fails closed on unsupported architectures, dependency-version drift, extra/missing prebuilds, or digest drift;
- adds an explicit `--container-build-only` deploy-script mode that builds the exact staged Railway boundary without contacting Railway;
- adds adversarial selector tests and owning contracts for both Docker paths.

## Exact revision

- base: `b8400b770566d71e239b55086da94a3a5cc77028`
- head: `a07c5bce121d38f4aed16ff71504486bfe44733c`
- supersedes reviewed draft head: #25414 at `c70678bb1c685de73bcff75aeebba783cfde2a9b`

## Native artifact contract

Pinned official `@discordjs/opus` v0.10.0 release assets:

- linux/arm64/musl 1.2.5: `cb9194a8a785434918a42312d4d9f04167f7e316cf577f487c8e2ebfbdd12080`
- linux/x64/musl 1.2.5: `d5396d0f6ba4f07851c8fa0f98183b19bb856c9bfbb150d02984ebb54a2140df`

The selector verifies these exact binary digests inside the dependency-install stage before the image can continue.

## Exact-head validation

Pinned Bun 1.3.14 and Node 24.15.0:

- gateway-discord full suite: **179/179**, 502 assertions
- selector + Railway deploy focused tests: **6/6**
- cross-service Dockerfile contract: **10/10**
- gateway-discord typecheck: pass
- gateway-discord build: pass
- Biome on all changed TS/JSON: clean
- shell syntax and `git diff --check`: clean

Actual generated Railway staged images from the final head:

- `linux/arm64`: build pass; exact pinned hash; Bun ABI 137 / N-API 10 loads N-API v3; real encode/decode `packetBytes=3`, `decodedBytes=3840`
- `linux/amd64`: build pass; exact pinned hash; Bun ABI 137 / N-API 10 loads N-API v3; real encode/decode `packetBytes=3`, `decodedBytes=3840`

The tracked repo-root Dockerfile was also built successfully for both `linux/arm64` and `linux/amd64` with the same shared selector.

No Railway upload, deployment, Discord/provider traffic, secret read, or production mutation was performed.
