### PR TITLE
test(plugin-openai): register model regression tests

### DIFF
--- a/plugins/plugin-openai/models/text.surrogate.test.ts
+++ b/plugins/plugin-openai/models/text.surrogate.test.ts
@@ -1,15 +1,16 @@
 /**
  * Surrogate-safe truncation for provider error body excerpt.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("openai provider error surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 300", () => {
-    const atBoundary = "x".repeat(299) + "🦊";
+    const atBoundary = `${"x".repeat(299)}🦊`;
     expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 300)).toBe("x".repeat(299));
   });
   it("caps at 300", () => {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -31,6 +31,7 @@ import {
   resolveEffectiveSystemPrompt,
   sanitizeFunctionNameForCerebras,
   toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   generateText,

--- a/plugins/plugin-openai/vitest.config.ts
+++ b/plugins/plugin-openai/vitest.config.ts
@@ -37,7 +37,11 @@ export default defineConfig({
 	},
 	test: {
 		environment: "node",
-		include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
+		include: [
+			"__tests__/**/*.test.ts",
+			"models/**/*.test.ts",
+			"src/**/*.test.ts",
+		],
 		// `*.real.test.ts` are kept in: they self-skip keyless (describe.skipIf)
 		// and run live only in the nightly external-api-live-drift lane.
 		// `*.real.test.ts` boot a real PGLite runtime and need the workspace


### PR DESCRIPTION
## Summary

- register colocated `models/**/*.test.ts` files in plugin-openai's default Vitest lane
- restore the missing `truncateWellFormed` production import from #25421
- format the newly reachable surrogate regression test to the plugin's lint contract

Closes #25497.

## Verification

- `bun packages/scripts/ensure-plugin-test-conventions.mjs --check` — pass
- `bunx vitest run models/text.surrogate.test.ts --config ./vitest.config.ts` — 3/3 pass
- `bun run lint:check` in `plugins/plugin-openai` — 66 files pass
- `bun run typecheck` in `plugins/plugin-openai` — pass
- `bun run test` in `plugins/plugin-openai` — 394/404 pass; 10 pre-existing current-develop failures remain in Cerebras reasoning-field/deep-schema suites and are being tracked separately

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
