### PR TITLE
fix(training): read authoritative completion reasons from Tinker and MLX

### DIFF
--- a/packages/training/scripts/lib/test_local_inference_mlx_contract.py
+++ b/packages/training/scripts/lib/test_local_inference_mlx_contract.py
@@ -1,0 +1,174 @@
+"""MLX contract tests: authoritative finish_reason drives admission (#25157).
+
+Mocks mlx_lm.stream_generate with responses shaped exactly like the upstream
+GenerationResponse (mlx_lm/generate.py @ d78bf58e):
+  - token: single int per response
+  - finish_reason: None on intermediate responses; "stop"/"length" on the final one
+
+The LocalTextGenerator under test is exercised through generate_messages() with
+backend="mlx"; mlx_lm itself is stubbed before import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+TRAINING_SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+class FakeTokenizer:
+    eos_token_id = 2
+
+    def encode(self, text, *, add_special_tokens=True):
+        del add_special_tokens
+        return [ord(ch) % 256 for ch in text]
+
+    def decode(self, ids, skip_special_tokens=True):
+        del skip_special_tokens
+        return "".join(chr(i % 256) for i in ids)
+
+    def apply_chat_template(self, messages, *, tokenize, add_generation_prompt):
+        assert tokenize is False
+        return "|".join(m["content"] for m in messages)
+
+
+def install_mlx_stub(monkeypatch, segments, final_reason):
+    """Stub mlx_lm modules so local_inference can import without the real package."""
+
+    class FakeDetokenizer:
+        def __init__(self):
+            self.text = ""
+
+        def add_token(self, token):
+            self.text += chr(token % 256)
+
+    class FakeTokenizerWrapper:
+        def __init__(self, inner):
+            self.inner = inner
+            self.eos_token_ids = {inner.eos_token_id}
+            self.detokenizer = FakeDetokenizer()
+
+    def stream_generate(model, tokenizer, prompt=None, max_tokens=256, sampler=None, **kw):
+        del prompt, max_tokens, sampler, kw
+        wrapped = tokenizer if isinstance(tokenizer, FakeTokenizerWrapper) else FakeTokenizerWrapper(tokenizer)
+        for tok in segments:
+            yield SimpleNamespace(
+                text=chr(tok % 256),
+                token=tok,
+                logprobs=None,
+                from_draft=False,
+                prompt_tokens=1,
+                prompt_tps=1.0,
+                generation_tokens=len(segments),
+                generation_tps=1.0,
+                peak_memory=0.0,
+                finish_reason=None,
+            )
+        # Final response repeats the last token and carries the authoritative reason.
+        yield SimpleNamespace(
+            text="",
+            token=segments[-1] if segments else 0,
+            logprobs=None,
+            from_draft=False,
+            prompt_tokens=1,
+            prompt_tps=1.0,
+            generation_tokens=len(segments),
+            generation_tps=1.0,
+            peak_memory=0.0,
+            finish_reason=final_reason,
+        )
+
+    mlx_lm = SimpleNamespace(generate=lambda *a, **k: "", load=lambda *a, **k: (None, None))
+    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm)
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_lm.generate",
+        SimpleNamespace(stream_generate=stream_generate),
+    )
+    monkeypatch.setitem(sys.modules, "mlx_lm.sample_utils", SimpleNamespace())
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "local_inference_subject_25157",
+        TRAINING_SCRIPTS / "rl" / "local_inference.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def local_module():
+    return load_module()
+
+
+def make_generator(local_module, tokenizer):
+    gen = local_module.LocalTextGenerator.__new__(local_module.LocalTextGenerator)
+    gen.backend = "mlx"
+    gen.model_ref = "fake/model"
+    gen.model = SimpleNamespace(config=SimpleNamespace(), generation_config=None)
+    gen.tokenizer = tokenizer
+    gen.device = "cpu"
+    gen.adapter_path = None
+    gen.cache_implementation = "dynamic"
+    gen.turboquant_settings = None
+    gen._sampler = None
+    return gen
+
+
+class TestMlxAuthoritativeFinishReason:
+    def test_terminal_length_is_rejected_even_when_text_roundtrips_short(
+        self, local_module, monkeypatch
+    ):
+        # Capped response whose decoded text would re-encode BELOW max_new_tokens:
+        # only the authoritative "length" proves truncation.
+        tokenizer = FakeTokenizer()
+        install_mlx_stub(monkeypatch, [104, 105], final_reason="length")
+        gen = make_generator(local_module, tokenizer)
+        with pytest.raises(local_module.IncompleteGenerationError):
+            gen.generate_messages([{"role": "user", "content": "hi"}], max_new_tokens=120)
+
+    def test_terminal_stop_is_accepted(self, local_module, monkeypatch):
+        tokenizer = FakeTokenizer()
+        install_mlx_stub(monkeypatch, [104, 105, 2], final_reason="stop")
+        gen = make_generator(local_module, tokenizer)
+        out = gen.generate_messages([{"role": "user", "content": "hi"}], max_new_tokens=120)
+        assert isinstance(out, str)
+
+    def test_missing_final_reason_counts_as_unproven_budget_stop(
+        self, local_module, monkeypatch
+    ):
+        # If no authoritative terminal signal ever arrives, the existing token
+        # budget gate must fire on real ids rather than re-encoded text.
+        tokenizer = FakeTokenizer()
+        install_mlx_stub(monkeypatch, list(range(50)), final_reason=None)
+        gen = make_generator(local_module, tokenizer)
+        with pytest.raises(local_module.IncompleteGenerationError):
+            gen.generate_messages([{"role": "user", "content": "hi"}], max_new_tokens=10)
+
+    def test_token_ids_come_from_responses_not_reencoded_text(
+        self, local_module, monkeypatch, capsys
+    ):
+        # The gate must consume the streamed token ints; if it re-encoded text,
+        # a stripped/normalized decode would change the count and could pass.
+        tokenizer = FakeTokenizer()
+        captured: dict[str, object] = {}
+        original_gate = local_module.require_complete_generated_tokens
+
+        def spy(ids, **kw):
+            captured["ids"] = list(ids)
+            return original_gate(ids, **kw)
+
+        monkeypatch.setattr(local_module, "require_complete_generated_tokens", spy)
+        install_mlx_stub(monkeypatch, [104, 105], final_reason="stop")
+        gen = make_generator(local_module, tokenizer)
+        gen.generate_messages([{"role": "user", "content": "hi"}], max_new_tokens=120)
+        assert captured["ids"] == [104, 105]

--- a/packages/training/scripts/rl/local_inference.py
+++ b/packages/training/scripts/rl/local_inference.py
@@ -5,7 +5,10 @@ import inspect
 import re
 from dataclasses import dataclass
 
-from lib.generation_integrity import require_complete_generated_tokens
+from lib.generation_integrity import (
+    IncompleteGenerationError,
+    require_complete_generated_tokens,
+)
 from typing import TYPE_CHECKING, Any, Literal
 
 BackendName = Literal["mlx", "cuda", "cpu"]
@@ -130,19 +133,17 @@ class LocalTextGenerator:
         self.model: Any | None = None
         self.tokenizer: Any | None = None
         self.device: str = "cpu"
-        self._generate = None
         self._sampler = None
         self._load()
 
     def _load(self) -> None:
         if self.backend == "mlx":
-            from mlx_lm import generate, load  # type: ignore
+            from mlx_lm import load  # type: ignore
 
             self.model, self.tokenizer = load(
                 self.model_ref,
                 adapter_path=self.adapter_path,
             )
-            self._generate = generate
             try:
                 from mlx_lm.sample_utils import make_sampler  # type: ignore
 
@@ -191,7 +192,6 @@ class LocalTextGenerator:
     ) -> str | GenerationResult:
         if self.backend == "mlx":
             assert self.tokenizer is not None
-            assert self._generate is not None
             rendered = format_messages_as_text(
                 self.tokenizer,
                 messages,
@@ -201,16 +201,42 @@ class LocalTextGenerator:
             kwargs: dict[str, Any] = {
                 "prompt": rendered,
                 "max_tokens": max_new_tokens,
-                "verbose": False,
             }
             if self._sampler is not None:
                 kwargs["sampler"] = self._sampler
-            raw_generated = str(self._generate(self.model, self.tokenizer, **kwargs)).strip()
+            # stream_generate exposes the authoritative terminal reason; the
+            # convenience generate() returns only text, which cannot prove
+            # whether generation hit EOS or the token budget (#25157).
+            # Note: stream_generate has no `verbose` parameter — generate()
+            # consumed it before forwarding, so it must be dropped here.
+            from mlx_lm.generate import stream_generate  # type: ignore
+
+            generated_ids: list[int] = []
+            finish_reason: str | None = None
+            for response in stream_generate(
+                self.model,
+                self.tokenizer,
+                **kwargs,
+            ):
+                # Upstream contract (mlx_lm/generate.py @ d78bf58e): every
+                # generated token is yielded once as an intermediate response
+                # with finish_reason=None; the FINAL response REPEATS the last
+                # token and carries the authoritative finish_reason
+                # ("stop" | "length"). Append only intermediates to avoid
+                # double-counting the repeated final token.
+                if response.finish_reason is None:
+                    generated_ids.append(response.token)
+                else:
+                    finish_reason = response.finish_reason
             require_complete_generated_tokens(
-                self.tokenizer.encode(raw_generated),
+                generated_ids,
                 max_new_tokens=max_new_tokens,
                 source="local_inference.mlx",
+                terminal_token_ids=self._eos_token_ids(),
             )
+            if finish_reason == "length":
+                raise IncompleteGenerationError("local_inference.mlx", "length")
+            raw_generated = self.tokenizer.decode(generated_ids, skip_special_tokens=True).strip()
             generated = clean_generated_text(raw_generated)
             restored = restore_assistant_prefix(generated, assistant_prefix)
             if return_details:
@@ -277,12 +303,31 @@ class LocalTextGenerator:
             )
         return restored
 
+    def _eos_token_ids(self) -> set[int]:
+        """Collect every EOS/eos-variant token id the tokenizer exposes."""
+
+        ids: set[int] = set()
+        for attr in ("eos_token_id",):
+            value = getattr(self.tokenizer, attr, None)
+            if isinstance(value, int):
+                ids.add(value)
+        generation_config = getattr(self.model, "generation_config", None)
+        eos_list = getattr(generation_config, "eos_token_id", None) if generation_config else None
+        if eos_list is None:
+            return ids
+        if isinstance(eos_list, int):
+            ids.add(eos_list)
+        else:
+            for value in eos_list:
+                if isinstance(value, int):
+                    ids.add(value)
+        return ids
+
     def close(self) -> None:
         model = self.model
         tokenizer = self.tokenizer
         self.model = None
         self.tokenizer = None
-        self._generate = None
         self._sampler = None
         del model
         del tokenizer

--- a/packages/training/scripts/rl/tinker/test_tinker_stop_reason_contract.py
+++ b/packages/training/scripts/rl/tinker/test_tinker_stop_reason_contract.py
@@ -1,0 +1,157 @@
+"""Provider-contract tests for Tinker/MLX completion integrity (#25157).
+
+Covers the acceptance matrix from the issue:
+- Tinker stop_reason="length" rejection and "stop" acceptance
+- missing Tinker completion metadata -> rejected (unproven)
+- unknown completion reason -> rejected (unproven)
+- MLX terminal "length" and "stop" responses
+- a capped MLX response whose decoded text re-encodes below budget is still rejected
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+TRAINING_SCRIPTS = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(TRAINING_SCRIPTS))
+
+from lib.generation_integrity import IncompleteGenerationError  # noqa: E402
+
+MODULE_PATH = Path(__file__).with_name("tinker_client.py")
+SPEC = importlib.util.spec_from_file_location("tinker_integrity_subject_25157", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+try:
+    SPEC.loader.exec_module(MODULE)
+except Exception as exc:  # pragma: no cover - numpy present in CI
+    pytest.skip(f"tinker_client import failed: {exc}", allow_module_level=False)
+
+FeedTinkerClient = MODULE.FeedTinkerClient
+
+
+class CharacterTokenizer:
+    def apply_chat_template(self, messages, *, tokenize, add_generation_prompt):
+        assert tokenize is False
+        return "|".join(m["content"] for m in messages) + "|assistant:"
+
+    def encode(self, text, *, add_special_tokens=True):
+        del add_special_tokens
+        return [ord(ch) % 256 for ch in text]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+class StubSamplingClient:
+    """Returns canned SampledSequence-shaped objects."""
+
+    def __init__(self, sequences):
+        self._sequences = sequences
+        self.calls = 0
+
+    def sample(self, *, prompt, sampling_params, num_samples, include_prompt_logprobs):
+        self.calls += 1
+        return SimpleNamespace(
+            result=lambda: SimpleNamespace(sequences=list(self._sequences), prompt_logprobs=None)
+        )
+
+    async def sample_async(self, *, prompt, sampling_params, num_samples, include_prompt_logprobs):
+        self.calls += 1
+        return SimpleNamespace(sequences=list(self._sequences), prompt_logprobs=None)
+
+
+def make_client(sequences) -> FeedTinkerClient:
+    client = FeedTinkerClient.__new__(FeedTinkerClient)
+    client._tokenizer = CharacterTokenizer()
+    client._sampling_client = StubSamplingClient(sequences)
+    # Stub the lazy tinker_types module: only ModelInput/SamplingParams shapes
+    # are needed before the stop_reason boundary under test.
+    if MODULE.tinker_types is None:
+        MODULE.tinker_types = SimpleNamespace(
+            ModelInput=SimpleNamespace(from_ints=lambda tokens: {"tokens": tokens}),
+            SamplingParams=lambda **kw: kw,
+        )
+    cfg = SimpleNamespace(
+        default_max_tokens=16,
+        default_temperature=0.0,
+        stop_sequences=[],
+        sampling_timeout_seconds=5,
+        download_timeout_seconds=5,
+        capabilities_timeout_seconds=5,
+    )
+    client.config = cfg
+    return client
+
+
+def _install_module_stub(client) -> None:
+    """Attach a minimal tinker_types stub on the instance if the real SDK is absent."""
+
+
+def seq(*, stop_reason=None, finish_reason=None):
+    """Build an object shaped like upstream SampledSequence."""
+
+    kwargs = {"tokens": [104, 105]}
+    if stop_reason is not None:
+        kwargs["stop_reason"] = stop_reason
+    if finish_reason is not None:
+        kwargs["finish_reason"] = finish_reason
+    return SimpleNamespace(**kwargs)
+
+
+class TestTinkerAuthoritativeStopReason:
+    def test_length_stop_reason_is_rejected_sync(self):
+        client = make_client([seq(stop_reason="length")])
+        with pytest.raises(IncompleteGenerationError):
+            client.sample([{"role": "user", "content": "hi"}])
+
+    def test_stop_stop_reason_is_accepted_sync(self):
+        client = make_client([seq(stop_reason="stop")])
+        result = client.sample([{"role": "user", "content": "hi"}])
+        assert result.finish_reasons == ["stop"]
+
+    def test_missing_completion_metadata_is_rejected_not_synthesized(self):
+        # The old code synthesized "stop" via getattr(seq, "finish_reason", "stop").
+        # A sequence without any completion field must now be unproven -> reject.
+        client = make_client([seq()])
+        with pytest.raises(IncompleteGenerationError):
+            client.sample([{"role": "user", "content": "hi"}])
+
+    def test_unknown_completion_reason_is_rejected_async(self):
+        client = make_client([seq(stop_reason="server_exploded")])
+        import asyncio
+
+        with pytest.raises(IncompleteGenerationError):
+            asyncio.run(client.sample_async([{"role": "user", "content": "hi"}]))
+
+    def test_missing_metadata_is_rejected_async(self):
+        client = make_client([seq()])
+        import asyncio
+
+        with pytest.raises(IncompleteGenerationError):
+            asyncio.run(client.sample_async([{"role": "user", "content": "hi"}]))
+
+    def test_legacy_finish_reason_attribute_does_not_satisfy_the_contract(self):
+        # An object exposing only the non-contract `finish_reason` attribute must
+        # still be treated as unproven: upstream never sets that field.
+        client = make_client([seq(finish_reason="stop")])
+        with pytest.raises(IncompleteGenerationError):
+            client.sample([{"role": "user", "content": "hi"}])
+
+
+class TestSharedGateStillWorks:
+    def test_gate_rejects_authoritative_length_reasons(self):
+        from lib.generation_integrity import require_complete_finish_reasons
+
+        with pytest.raises(IncompleteGenerationError):
+            require_complete_finish_reasons(["stop", "length"], source="fixture")
+
+    def test_gate_accepts_all_stop(self):
+        from lib.generation_integrity import require_complete_finish_reasons
+
+        require_complete_finish_reasons(["stop", "stop"], source="fixture")

--- a/packages/training/scripts/rl/tinker/tinker_client.py
+++ b/packages/training/scripts/rl/tinker/tinker_client.py
@@ -25,7 +25,10 @@ from typing import Literal
 
 import numpy as np
 
-from lib.generation_integrity import require_complete_finish_reasons
+from lib.generation_integrity import (
+    IncompleteGenerationError,
+    require_complete_finish_reasons,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1024,8 +1027,22 @@ class FeedTinkerClient:
         if include_logprobs and hasattr(result, "prompt_logprobs"):
             logprobs = [result.prompt_logprobs] * n
 
-        # Extract finish reasons
-        finish_reasons = [getattr(seq, "finish_reason", "stop") for seq in result.sequences]
+        # Read the authoritative Tinker stop_reason. SampledSequence exposes
+        # `stop_reason` ("stop" | "length"); it has no `finish_reason` field, so
+        # a missing value means completion state is unproven — reject instead of
+        # synthesizing "stop" (#25157).
+        finish_reasons: list[str] = []
+        for seq in result.sequences:
+            reason = getattr(seq, "stop_reason", None)
+            if reason is None:
+                raise IncompleteGenerationError(
+                    "tinker.sample",
+                    "missing_stop_reason",
+                )
+            normalized = str(reason).strip().lower()
+            if normalized not in ("stop", "length"):
+                raise IncompleteGenerationError("tinker.sample", normalized or "unknown")
+            finish_reasons.append(normalized)
         require_complete_finish_reasons(finish_reasons, source="tinker.sample")
 
         return SampleResult(
@@ -1074,7 +1091,21 @@ class FeedTinkerClient:
         logprobs = []
         if include_logprobs and hasattr(result, "prompt_logprobs"):
             logprobs = [result.prompt_logprobs] * n
-        finish_reasons = [getattr(seq, "finish_reason", "stop") for seq in result.sequences]
+
+        # Same authoritative stop_reason read as sample(): missing or unknown
+        # completion state is unproven and rejected, never synthesized (#25157).
+        finish_reasons: list[str] = []
+        for seq in result.sequences:
+            reason = getattr(seq, "stop_reason", None)
+            if reason is None:
+                raise IncompleteGenerationError(
+                    "tinker.sample_async",
+                    "missing_stop_reason",
+                )
+            normalized = str(reason).strip().lower()
+            if normalized not in ("stop", "length"):
+                raise IncompleteGenerationError("tinker.sample_async", normalized or "unknown")
+            finish_reasons.append(normalized)
         require_complete_finish_reasons(finish_reasons, source="tinker.sample_async")
 
         return SampleResult(


### PR DESCRIPTION
## Summary

Fixes #25157.

The generation-admission boundary never received real completion evidence from two adapters:

- **Tinker** `sample()`/`sample_async()` read `seq.finish_reason`, a field that does not exist on upstream `SampledSequence` (thinking-machines-lab/tinker @ `d595dc2b`, `sampled_sequence.py` L22 exposes `stop_reason: Literal["stop","length"]`). The `getattr(..., "stop")` default synthesized `"stop"` for every sequence, so length-stopped generations were admitted as complete and `require_complete_finish_reasons` was dead code for this provider.
- **MLX** inferred budget exhaustion by stripping generated text and re-encoding it. Decoded text is not a lossless token record, so its re-encoded length cannot distinguish EOS from a truncated budget stop. The convenience `generate()` (mlx-lm @ `d78bf58e`, L747) also discards the authoritative `finish_reason` carried by `stream_generate()`'s final `GenerationResponse`.

## Changes

- Both Tinker paths read `seq.stop_reason`; missing or unknown completion state raises the typed `IncompleteGenerationError` — nothing is synthesized.
- MLX branch is driven by `stream_generate()`: intermediate responses are appended (the final response repeats the last token together with the authoritative reason), the existing token-budget gate consumes the original streamed ids, and `finish_reason="length"` rejects through the typed error.
- Unused `generate` import/handle removed.

## Evidence Gate

<!-- evidence-head:192a03e4318b518f168d02a67f6ec380696cf6f6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; the changed surface is Python generation-admission logic.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; behavior change is proven by executed tests.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow; deterministic test coverage proves the boundary.
<!-- evidence-row:backend-logs -->
- [x] Exact-head validation run at `192a03e4318b518f168d02a67f6ec380696cf6f6`:

```
$ python3 -m pytest scripts/lib/test_local_inference_mlx_contract.py scripts/rl/tinker/test_tinker_stop_reason_contract.py scripts/rl/tinker/test_tinker_client_integrity.py scripts/lib/test_generation_integrity.py
21 passed, 1 warning in 0.60s

$ python3 -m py_compile packages/training/scripts/rl/local_inference.py packages/training/scripts/rl/tinker/tinker_client.py
(compile OK)

$ git diff --check
(diff-check OK)
```

The 12 new contract tests encode the upstream provider contracts verified at pinned commits: Tinker `SampledSequence.stop_reason: Literal["stop","length"]` (no `finish_reason` field exists), and mlx-lm @ `d78bf58e` `GenerationResponse` semantics (single-int `token`, `finish_reason=None` on intermediates, final response repeats the last token with `"stop"`/`"length"`).

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - provider-contract admission logic; no live LLM execution involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced; unit coverage proves the behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or scanned artifacts in this change.

## Attribution

<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2

<!-- attribution-row:models -->
z.ai/glm-5.2

<!-- attribution-row:client -->
Hermes Agent

<!-- attribution-row:skill-revision -->
elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
self-reported
