### PR TITLE
chore(app): restore mobile smoke lint closure

### DIFF
--- a/packages/app/src/ios-attachment-smoke.surrogate.test.ts
+++ b/packages/app/src/ios-attachment-smoke.surrogate.test.ts
@@ -1,17 +1,22 @@
 /**
  * Surrogate-safe truncation for iOS attachment smoke upload error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("ios-attachment-smoke surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 500", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(499) + "🦊"), 500)).toBe("x".repeat(499));
+    expect(
+      truncateWellFormed(toWellFormedUnicode(`${"x".repeat(499)}🦊`), 500),
+    ).toBe("x".repeat(499));
   });
   it("caps at 500", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(800)), 500).length).toBe(500);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(800)), 500).length,
+    ).toBe(500);
   });
 });

--- a/packages/app/src/ios-attachment-smoke.ts
+++ b/packages/app/src/ios-attachment-smoke.ts
@@ -13,8 +13,8 @@
  */
 import { Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
-import { shellLocalStorage } from "@elizaos/ui/bridge";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { shellLocalStorage } from "@elizaos/ui/bridge";
 
 const IOS_ATTACHMENT_SMOKE_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const IOS_ATTACHMENT_SMOKE_RESULT_KEY = "eliza:ios-attachment-smoke:result";

--- a/packages/app/src/native/__tests__/keyboard-dictation-bridge.test.ts
+++ b/packages/app/src/native/__tests__/keyboard-dictation-bridge.test.ts
@@ -12,8 +12,6 @@ vi.mock("@capacitor/core", () => ({
   },
 }));
 
-import { getKeyboardDictationBridge } from "./keyboard-dictation-bridge.ts";
-
 describe("getKeyboardDictationBridge", () => {
   beforeEach(() => {
     mocks.getPlatform.mockReset();
@@ -23,7 +21,7 @@ describe("getKeyboardDictationBridge", () => {
 
   it("returns null off iOS", async () => {
     const { getKeyboardDictationBridge: g } = await import(
-      "./keyboard-dictation-bridge.ts"
+      "../keyboard-dictation-bridge.ts"
     );
     mocks.getPlatform.mockReturnValue("android");
     expect(g()).toBeNull();
@@ -32,7 +30,7 @@ describe("getKeyboardDictationBridge", () => {
 
   it("registers and caches the plugin on iOS", async () => {
     const { getKeyboardDictationBridge: g } = await import(
-      "./keyboard-dictation-bridge.ts"
+      "../keyboard-dictation-bridge.ts"
     );
     mocks.getPlatform.mockReturnValue("ios");
     const bridge = { setDictationState: async () => ({ saved: true }) };


### PR DESCRIPTION
## Summary

- apply the pinned Biome formatting/import-order fixes to the iOS attachment smoke implementation and surrogate regression test
- remove the unused keyboard-dictation bridge import
- correct both fresh-module dynamic imports to resolve from the test's `__tests__` directory

Closes #25507.

## Verification

- focused Vitest: `ios-attachment-smoke.surrogate.test.ts` + `keyboard-dictation-bridge.test.ts` — 5/5 pass
- `bun run lint:check` in `packages/app` — 330 files pass
- app visual audit — N/A: no rendered UI, styles, copy, interaction, or runtime behavior changed
- direct fresh-worktree app typecheck is prerequisite-blocked by unbuilt workspace declaration exports and unrelated current-develop errors; repository-orchestrated verification is being run on the composed integration branch

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
