### PR TITLE
fix(sql): upgrade existing membership TTL constraints

### DIFF
--- a/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-upgrade.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-upgrade.real.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Real-PGlite upgrade coverage proving startup replaces the exact pre-#25474
+ * membership TTL checks while preserving existing authority rows.
+ */
+import type { UUID } from "@elizaos/core";
+import { sql } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { plugin as sqlPlugin } from "../../index";
+import { DatabaseMigrationService } from "../../migration-service";
+import { connectorAccountsTable } from "../../schema/connectorAccounts";
+import { entityTable } from "../../schema/entity";
+import {
+  membershipAuthorityScopeTable,
+  membershipAuthorityTable,
+} from "../../schema/membershipAuthority";
+import { type DrizzleDatabase, getDb } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+interface ConstraintRow {
+  name: string;
+  definition: string;
+}
+
+describe("membership authority TTL constraint upgrade", () => {
+  let cleanup: () => Promise<void>;
+  let db: DrizzleDatabase;
+  let agentId: UUID;
+  const accountId = crypto.randomUUID() as UUID;
+  const principalId = crypto.randomUUID() as UUID;
+  const observedAt = new Date("2026-08-23T00:00:00.000Z");
+  const legacyValidUntil = new Date("2026-08-25T00:00:00.000Z");
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("membership_ttl_upgrade");
+    cleanup = setup.cleanup;
+    db = getDb(setup.adapter);
+    agentId = setup.testAgentId;
+
+    await db.execute(sql`
+      ALTER TABLE membership_authority_scopes
+        DROP CONSTRAINT membership_authority_scope_current_check
+    `);
+    await db.execute(sql`
+      ALTER TABLE membership_authority_scopes
+        ADD CONSTRAINT membership_authority_scope_current_check
+        CHECK (
+          health <> 'current'
+          OR (
+            valid_until IS NOT NULL
+            AND valid_until > observed_at
+            AND publisher_instance_id IS NOT NULL
+            AND source_version >= 0
+            AND source_cursor IS NOT NULL
+          )
+        )
+    `);
+    await db.execute(sql`
+      ALTER TABLE membership_authority
+        DROP CONSTRAINT membership_authority_version_check
+    `);
+    await db.execute(sql`
+      ALTER TABLE membership_authority
+        ADD CONSTRAINT membership_authority_version_check
+        CHECK (generation > 0 AND source_version >= 0 AND valid_until > observed_at)
+    `);
+
+    await db.insert(connectorAccountsTable).values({
+      id: accountId,
+      agentId,
+      provider: "upgrade-test",
+      accountKey: "legacy-account",
+    });
+    await db.insert(entityTable).values({
+      id: principalId,
+      agentId,
+      names: ["Retained principal"],
+    });
+    const scope = {
+      agentId,
+      connectorId: "upgrade-test",
+      connectorAccountId: accountId,
+      externalWorldId: "legacy-world",
+      externalRoomId: "legacy-room",
+    };
+    await db.insert(membershipAuthorityScopeTable).values({
+      ...scope,
+      health: "current",
+      reason: "complete_snapshot",
+      generation: 2,
+      sourceVersion: 0,
+      sourceCursor: "legacy-cursor",
+      validUntil: legacyValidUntil,
+      publisherInstanceId: "legacy-publisher",
+      publisherGeneration: 0,
+      evidenceMode: "complete_snapshot",
+      observedAt,
+      updatedAt: observedAt,
+    });
+    await db.insert(membershipAuthorityTable).values({
+      ...scope,
+      canonicalPrincipalId: principalId,
+      state: "active",
+      reason: "reconciled_present",
+      roles: ["member"],
+      permissionSnapshot: { canRead: true },
+      publisherInstanceId: "legacy-publisher",
+      publisherGeneration: 0,
+      evidenceMode: "complete_snapshot",
+      generation: 2,
+      sourceVersion: 0,
+      sourceCursor: "legacy-cursor",
+      observedAt,
+      validUntil: legacyValidUntil,
+      createdAt: observedAt,
+      updatedAt: observedAt,
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("replaces same-named legacy checks on restart without deleting or fabricating rows", async () => {
+    const before = await db.execute<ConstraintRow>(sql`
+      SELECT conname AS name, pg_get_constraintdef(oid) AS definition
+        FROM pg_constraint
+       WHERE conname IN (
+         'membership_authority_scope_current_check',
+         'membership_authority_version_check'
+       )
+       ORDER BY conname
+    `);
+    expect(before.rows).toHaveLength(2);
+    expect(before.rows.every((row) => !row.definition.includes("24:00:00"))).toBe(true);
+
+    const migrationService = new DatabaseMigrationService({ databaseBackend: "pglite" });
+    await migrationService.initializeWithDatabase(db);
+    migrationService.discoverAndRegisterPluginSchemas([sqlPlugin]);
+    await migrationService.runAllPluginMigrations({ verbose: false });
+
+    const after = await db.execute<ConstraintRow>(sql`
+      SELECT conname AS name, pg_get_constraintdef(oid) AS definition
+        FROM pg_constraint
+       WHERE conname IN (
+         'membership_authority_scope_current_check',
+         'membership_authority_version_check'
+       )
+       ORDER BY conname
+    `);
+    expect(after.rows).toHaveLength(2);
+    expect(after.rows.every((row) => row.definition.includes("24:00:00"))).toBe(true);
+
+    const scopes = await db.select().from(membershipAuthorityScopeTable);
+    const memberships = await db.select().from(membershipAuthorityTable);
+    expect(scopes).toHaveLength(1);
+    expect(memberships).toHaveLength(1);
+    expect(scopes[0]).toMatchObject({
+      agentId,
+      connectorAccountId: accountId,
+      health: "current",
+      generation: 2,
+      sourceCursor: "legacy-cursor",
+    });
+    expect(memberships[0]).toMatchObject({
+      agentId,
+      connectorAccountId: accountId,
+      canonicalPrincipalId: principalId,
+      state: "active",
+      roles: ["member"],
+      permissionSnapshot: { canRead: true },
+      generation: 2,
+      sourceCursor: "legacy-cursor",
+    });
+    const boundedValidUntil = new Date("2026-08-24T00:00:00.000Z").getTime();
+    expect(scopes[0]?.validUntil?.getTime()).toBe(boundedValidUntil);
+    expect(memberships[0]?.validUntil.getTime()).toBe(boundedValidUntil);
+
+    await expect(
+      db.execute(sql`
+        UPDATE membership_authority_scopes
+           SET valid_until = observed_at + INTERVAL '48 hours'
+         WHERE connector_account_id = ${accountId}
+      `)
+    ).rejects.toThrow();
+    await expect(
+      db.execute(sql`
+        UPDATE membership_authority
+           SET valid_until = observed_at + INTERVAL '48 hours'
+         WHERE canonical_principal_id = ${principalId}
+      `)
+    ).rejects.toThrow();
+  }, 30_000);
+});

--- a/plugins/plugin-sql/src/membership-authority-ttl-constraints.ts
+++ b/plugins/plugin-sql/src/membership-authority-ttl-constraints.ts
@@ -1,0 +1,77 @@
+/**
+ * Repairs membership authority freshness checks that runtime schema diffing
+ * cannot update when an existing constraint keeps the same name.
+ */
+import { sql } from "drizzle-orm";
+import type { DrizzleDatabase } from "./types";
+
+function rows(value: unknown): readonly unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "object" || value === null) return [];
+  const resultRows = (value as { rows?: unknown }).rows;
+  return Array.isArray(resultRows) ? resultRows : [];
+}
+
+/** Atomically enforce observation-relative 24-hour membership evidence windows. */
+export async function applyMembershipAuthorityTtlConstraints(
+  db: DrizzleDatabase
+): Promise<boolean> {
+  const tables = await db.execute(sql`
+    SELECT table_name
+      FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_name IN ('membership_authority_scopes', 'membership_authority')
+  `);
+  if (rows(tables).length !== 2) return false;
+
+  await db.transaction(async (tx) => {
+    // Evidence that exceeded the newly bounded contract was never safe to keep
+    // authoritative. Shorten only its expiry; preserve the retained fact.
+    await tx.execute(sql`
+      UPDATE membership_authority_scopes
+         SET valid_until = observed_at + INTERVAL '24 hours'
+       WHERE valid_until > observed_at + INTERVAL '24 hours'
+    `);
+    await tx.execute(sql`
+      UPDATE membership_authority
+         SET valid_until = observed_at + INTERVAL '24 hours'
+       WHERE valid_until > observed_at + INTERVAL '24 hours'
+    `);
+
+    await tx.execute(sql`
+      ALTER TABLE membership_authority_scopes
+        DROP CONSTRAINT IF EXISTS membership_authority_scope_current_check
+    `);
+    await tx.execute(sql`
+      ALTER TABLE membership_authority_scopes
+        ADD CONSTRAINT membership_authority_scope_current_check
+        CHECK (
+          health <> 'current'
+          OR (
+            valid_until IS NOT NULL
+            AND valid_until > observed_at
+            AND valid_until <= observed_at + INTERVAL '24 hours'
+            AND publisher_instance_id IS NOT NULL
+            AND source_version >= 0
+            AND source_cursor IS NOT NULL
+          )
+        )
+    `);
+    await tx.execute(sql`
+      ALTER TABLE membership_authority
+        DROP CONSTRAINT IF EXISTS membership_authority_version_check
+    `);
+    await tx.execute(sql`
+      ALTER TABLE membership_authority
+        ADD CONSTRAINT membership_authority_version_check
+        CHECK (
+          generation > 0
+          AND source_version >= 0
+          AND valid_until > observed_at
+          AND valid_until <= observed_at + INTERVAL '24 hours'
+        )
+    `);
+  });
+
+  return true;
+}

--- a/plugins/plugin-sql/src/migration-service.ts
+++ b/plugins/plugin-sql/src/migration-service.ts
@@ -9,6 +9,7 @@
  */
 import { type IDatabaseAdapter, logger, type Plugin } from "@elizaos/core";
 import { applyIdentityPersonLinkAttestationGuard } from "./identity-person-link-attestation-guard";
+import { applyMembershipAuthorityTtlConstraints } from "./membership-authority-ttl-constraints";
 import { applyMessageSearchObjects, messageSearchTableExists } from "./message-search";
 import { migrateToEntityRLS } from "./migrations";
 import { applyEntityRLSToAllTables, applyRLSToNewTables, installRLSFunctions } from "./rls";
@@ -42,6 +43,7 @@ export class DatabaseMigrationService {
   private readonly databaseBackend: DatabaseBackend;
   private messageSearchObjectsSettled = false;
   private identityPersonLinkGuardSettled = false;
+  private membershipAuthorityTtlConstraintsSettled = false;
 
   constructor(options: DatabaseMigrationServiceOptions = {}) {
     this.databaseBackend = options.databaseBackend ?? "unknown";
@@ -151,6 +153,11 @@ export class DatabaseMigrationService {
 
     if (failureCount === 0) {
       logger.info({ src: "plugin:sql", successCount }, "All migrations completed successfully");
+
+      if (!migrationOptions.dryRun && !this.membershipAuthorityTtlConstraintsSettled) {
+        this.membershipAuthorityTtlConstraintsSettled =
+          await applyMembershipAuthorityTtlConstraints(this.db);
+      }
 
       if (!this.identityPersonLinkGuardSettled) {
         this.identityPersonLinkGuardSettled = await applyIdentityPersonLinkAttestationGuard(


### PR DESCRIPTION
## Summary

- repair existing databases whose same-named membership authority CHECK constraints retained the pre-#25474 definitions
- transactionally clamp only overlong legacy evidence expiries to `observed_at + 24 hours`, then replace both named constraints
- add a real PGlite restart/upgrade test that demonstrates the runtime diff reports no schema changes while the explicit repair still installs and enforces the bounded definitions

Closes the post-merge defect recorded on #23101; the broader connector lifecycle issue remains open.

## Why an explicit repair

The runtime migrator snapshots schema shape but does not replace a CHECK when only its expression changes under the same name. Broad generic altered-CHECK support would expand this urgent security repair into migration-engine policy. The narrow post-schema repair is idempotent, skipped for dry runs, waits until both authority tables exist, and executes value clamping plus both replacements in one database transaction.

## Real upgrade evidence

The new test starts with the exact pre-#25474 definitions for:

- `membership_authority_scope_current_check`
- `membership_authority_version_check`

It persists a current scope and active fact with a 48-hour legacy window, simulates restart through a fresh `DatabaseMigrationService`, observes the runtime migrator log `No changes detected, skipping migration`, and then verifies:

- both `pg_constraint` definitions contain the 24-hour observation-relative bound
- exactly one scope and one membership fact remain
- agent/account/principal, state, roles, permission snapshot, generation, and cursor are unchanged
- only each unsafe expiry is shortened from 48 hours to 24 hours
- both tables reject a later attempt to restore a 48-hour window

## Exact-head validation

Validated head: `922420116a0ac62b86162b2c6abd3e25e3d294db`
Validated base: `08a654a7e8f144ecc3770ac52ac80963976c053f`

- `bun install --frozen-lockfile` using repository-pinned Bun 1.3.14: pass, no lock changes
- `bun run --cwd packages/core build`: pass (including packed edge/node/browser/Vite consumers)
- `bun run --cwd plugins/plugin-sql typecheck`: pass
- `bun run --cwd plugins/plugin-sql build`: pass
- `bun run test:real:files __tests__/migration/membership-authority-ttl-upgrade.real.test.ts`: 1/1 pass on exact head
- `bun run test:real:files __tests__/integration/membership-authority.real.test.ts`: 15/15 pass on exact head
- `bun run --cwd plugins/plugin-sql test -- __tests__/membership-authority-schema.test.ts`: 3/3 pass on exact head
- focused `biome check`: pass
- `git diff --check origin/develop...HEAD`: pass

One combined invocation of the two real suites had the new upgrade test pass 1/1 and 14/15 existing service scenarios pass, with the property scenario failing only because its 20-second `beforeEach` PGlite setup hook timed out under host load (including retry). Running the existing service suite alone immediately afterward passed 15/15 in 41.44 seconds, including that property scenario in 4.317 seconds. No behavior assertion failed.

## Evidence scope / limits

This PR proves the real PGlite schema upgrade and database enforcement path. The existing 15-scenario authority suite remains service/schema evidence only:

- pagination: explicit incomplete-snapshot command, not real connector page traversal/failure
- restart: service re-instantiation over the same database, not process/connector restart
- tenant: foreign-agent guard case, not a multi-tenant connector integration
- concurrency: in-process `Promise.all` race, not multi-process/independent-connection contention

No live Telegram/Slack/Discord/iMessage evidence, final protected document read/send cutover, or missed-event connector restart repair is claimed. Those #23101 acceptance items remain open.

## Evidence matrix

- DB artifact: real PGlite `pg_constraint` readback plus retained/clamped rows, asserted in the upgrade test
- UI screenshots/video/OCR: N/A — no rendered UI changes
- frontend console/network/backend request logs: N/A — no frontend or HTTP path changes
- live-model trajectory: N/A — no model, prompt, action, or planner behavior changes
- native/device capture: N/A — no native or device changes
- live connector evidence: N/A for this narrowly scoped schema-upgrade repair; broader connector acceptance remains on #23101

<!-- evidence-head:922420116a0ac62b86162b2c6abd3e25e3d294db -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI or interactive flow changes

<!-- evidence-row:backend-logs -->
- [ ] N/A - no HTTP or deployed backend request path changes

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network path changes

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or planner behavior changes

<!-- evidence-row:domain-artifacts -->
- [x] [membership-authority-ttl-upgrade.real.test.ts](https://github.com/elizaOS/eliza/blob/922420116a0ac62b86162b2c6abd3e25e3d294db/plugins/plugin-sql/src/__tests__/migration/membership-authority-ttl-upgrade.real.test.ts)


<details>
<summary>Exact-head real PGlite constraint readback</summary>

```text
Validated head: 922420116a0ac62b86162b2c6abd3e25e3d294db
Before restart: two exact pre-#25474 named CHECK definitions had no 24-hour interval.
Runtime diff: No changes detected, skipping migration (hash 6ae4f94f02e855a5dfee97d3bbb6856b).
After repair: two CHECK definitions include 24:00:00; one scope and one fact remain; both 48-hour UPDATE attempts are rejected.
Vitest result: membership-authority-ttl-upgrade.real.test.ts — 1 test passed.
```
</details>
