### PR TITLE
fix(devices): reject ambiguous runtime confirmation

### DIFF
--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
@@ -1,0 +1,41 @@
+/** Adversarial coverage for fail-closed runtime mutation confirmation. */
+
+import { describe, expect, it } from "vitest";
+import { isUnambiguousRuntimeConfirmation } from "./runtime-management-confirmation.ts";
+
+describe("runtime mutation confirmation", () => {
+	it.each([
+		"No, don't do it",
+		"Yes, but do not proceed",
+		"I did not confirm",
+		"Never revoke it",
+		"Confirm after I check",
+		"Wait, yes",
+		"Don't stop host",
+		"Yes, confirm tomorrow",
+	])("rejects negated or ambiguous text: %s", (text) => {
+		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(false);
+	});
+
+	it.each([
+		"yes",
+		"Yes, please",
+		"confirm",
+		"proceed",
+		"go ahead",
+		"do it",
+		"confirm the revocation",
+		"yes, confirm revoke",
+	])("accepts an unambiguous complete confirmation: %s", (text) => {
+		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(true);
+	});
+
+	it("binds subject-bearing confirmation to the requested operation", () => {
+		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "pair")).toBe(
+			true,
+		);
+		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "revoke")).toBe(
+			false,
+		);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
@@ -1,0 +1,58 @@
+/** Parses the fail-closed user confirmation required by runtime mutations. */
+
+import type { RuntimeManagementOperation } from "@elizaos/shared";
+
+export type ConfirmedRuntimeOperation = Exclude<
+	RuntimeManagementOperation,
+	"list" | "inspect_ssh"
+>;
+
+const CONFIRMATION_SUBJECTS: Record<
+	ConfirmedRuntimeOperation,
+	readonly string[]
+> = {
+	pair: ["pair", "pairing"],
+	revoke: ["revoke", "revocation"],
+	remove: ["remove", "removal", "remove it", "removing it"],
+	retry: ["retry"],
+	connect_ssh: ["connect ssh", "ssh connection"],
+	add_direct: ["add direct runtime", "direct runtime"],
+	enroll_host: ["enroll host", "host enrollment"],
+	approve_pairing: ["approve pairing", "pairing approval"],
+	start_host: ["start host", "host start"],
+	stop_host: ["stop host", "host stop"],
+	revoke_host: ["revoke host", "host revocation"],
+};
+
+export function isUnambiguousRuntimeConfirmation(
+	value: string,
+	op: ConfirmedRuntimeOperation,
+): boolean {
+	const text = value.toLowerCase().replace(/[’']/g, "'").trim();
+	if (
+		/\b(?:no|not|never|cancel|wait|hold|don't|dont|cannot|can't|cant|won't|wont)\b/.test(
+			text,
+		) ||
+		/\b(?:but|however|except|unless|after|before|later|tomorrow)\b/.test(text)
+	) {
+		return false;
+	}
+	const normalized = text
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+		.replace(/\s+/g, " ");
+	if (
+		/^(?:yes|yes please|yep|confirm|confirmed|proceed|go ahead|do it)$/.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	return CONFIRMATION_SUBJECTS[op].some(
+		(subject) =>
+			normalized === `confirm ${subject}` ||
+			normalized === `confirm the ${subject}` ||
+			normalized === `yes confirm ${subject}` ||
+			normalized === `yes confirm the ${subject}`,
+	);
+}

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -84,6 +84,58 @@ describe("RUNTIMES action", () => {
 		expect(manageRuntime).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		"No, don't do it",
+		"Yes, but do not proceed",
+		"I did not confirm",
+		"Never revoke it",
+		"Confirm after I check",
+		"Wait, yes",
+	])("rejects negated or ambiguous confirmation text: %s", async (text) => {
+		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+			ok: true,
+			op: request.op,
+		}));
+		const action = createRuntimeManagementAction({ manageRuntime });
+		const result = await action.handler(
+			runtime,
+			{ content: { text } } as Memory,
+			undefined,
+			{ op: "revoke", targetId: "host:mac", confirm: "true" },
+			callback(),
+		);
+		expect(result?.values).toEqual(
+			expect.objectContaining({ awaitingConfirmation: true }),
+		);
+		expect(manageRuntime).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		"yes",
+		"Yes, please",
+		"confirm",
+		"proceed",
+		"go ahead",
+		"do it",
+		"confirm the revocation",
+		"yes, confirm revoke",
+	])("accepts an unambiguous complete confirmation: %s", async (text) => {
+		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+			ok: true,
+			op: request.op,
+		}));
+		const action = createRuntimeManagementAction({ manageRuntime });
+		const result = await action.handler(
+			runtime,
+			{ content: { text } } as Memory,
+			undefined,
+			{ op: "revoke", targetId: "host:mac", confirm: "true" },
+			callback(),
+		);
+		expect(result?.success).toBe(true);
+		expect(manageRuntime).toHaveBeenCalledTimes(1);
+	});
+
 	it("dispatches a confirmed pairing and narrates the one-use receipt", async () => {
 		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
 			ok: true,

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -21,6 +21,10 @@ import {
 	readStringOption,
 	userRequestMessageText,
 } from "../params.js";
+import {
+	type ConfirmedRuntimeOperation,
+	isUnambiguousRuntimeConfirmation,
+} from "./runtime-management-confirmation.js";
 import { readViewInteractionClientId } from "./view-delivery.js";
 import { createViewsRequestHeaders } from "./views-request-auth.js";
 
@@ -39,6 +43,12 @@ const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 			(op) => op !== "list" && op !== "inspect_ssh",
 		),
 	);
+
+function requiresConfirmation(
+	op: RuntimeManagementRequest["op"],
+): op is ConfirmedRuntimeOperation {
+	return CONFIRMATION_REQUIRED.has(op);
+}
 
 const SECRET_OPTION_NAMES = new Set([
 	"accesstoken",
@@ -101,13 +111,6 @@ export function parseRuntimeManagementRequest(
 		sessionId: readStringOption(options, "sessionId") ?? undefined,
 		code: readStringOption(options, "code") ?? undefined,
 	};
-}
-
-function userExplicitlyConfirmed(message: Memory): boolean {
-	const text = userRequestMessageText(message).trim();
-	return /(?:^|\b)(?:confirm(?:ed)?|yes|yep|proceed|do it|go ahead)(?:\b|$)/i.test(
-		text,
-	);
 }
 
 async function defaultManageRuntime(
@@ -332,8 +335,12 @@ export function createRuntimeManagementAction(
 			}
 			const normalized = normalizeActionOptions(options) ?? {};
 			if (
-				CONFIRMATION_REQUIRED.has(request.op) &&
-				(!isConfirmed(normalized) || !userExplicitlyConfirmed(message))
+				requiresConfirmation(request.op) &&
+				(!isConfirmed(normalized) ||
+					!isUnambiguousRuntimeConfirmation(
+						userRequestMessageText(message),
+						request.op,
+					))
 			) {
 				const reply = `Please confirm before I run the ${request.op} Devices & Runtimes operation.`;
 				await callback?.({ text: reply });


### PR DESCRIPTION
## Summary

Stacked security correction for #24830 exact parent head `88ca1690c48babe5d1f7b99c87a18ff0bfccffb8`.

The existing confirmation gate searched for positive substrings, so model options with `confirm: true` plus user text such as “No, don't do it” could dispatch a runtime mutation. This change:

- moves confirmation parsing into a small fail-closed pure boundary;
- accepts only complete, unambiguous confirmations;
- rejects negation, cancellation, delay, and mixed-intent conjunctions before positive matching;
- binds subject-bearing confirmation to the requested operation;
- preserves the separate model-option confirmation, owner role gate, renderer binding, and secret rejection.

## Adversarial evidence

Pinned Bun 1.3.14 / Node 24.15.0:

- Vitest pure parser + real action handler: **40/40 passed**;
- pure parser direct coverage: 17/17, 18 assertions, 100% lines/functions;
- focused Biome on all four touched files: clean;
- `git diff --check`: clean.

The package typecheck reaches only inherited parent/base failures: missing built workspace exports plus the pre-existing speaker-name `candidateName` error independently fixed on `develop` by #25489. It reports no error in this correction's files.

UI/live-device evidence: N/A for this parser-only correction. The parent PR's physical/deployed evidence gates remain unchanged.