### PR TITLE
chore(plugin-mcp): restore type formatter closure

### DIFF
--- a/plugins/plugin-mcp/src/types.ts
+++ b/plugins/plugin-mcp/src/types.ts
@@ -106,11 +106,7 @@ export function isMcpSettings(value: unknown): value is McpSettings {
   );
 }
 
-export type McpServerStatus =
-  | "connecting"
-  | "connected"
-  | "disconnected"
-  | "error";
+export type McpServerStatus = "connecting" | "connected" | "disconnected" | "error";
 
 export interface McpServer {
   readonly name: string;


### PR DESCRIPTION
## Summary

- format the exported `McpServerStatus` union with the pinned repository formatter
- preserve all four status literals and runtime behavior exactly

Closes #25513.

## Verification

- pinned Biome exact-file check — pass
- `git diff --check` — pass
- plugin MCP lint — 56 files pass
- plugin MCP typecheck — pass
- plugin MCP tests — 126 pass, 3 skipped
- root verification is being rerun on the composed integration branch

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
