### PR TITLE
fix(ui): restore the transparent resting pill; add desktop clean-state tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dev:desktop": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",
     "dev:desktop:watch": "ELIZA_DEV_SOURCE=1 ELIZA_NAMESPACE=eliza ELIZA_DESKTOP_VITE_WATCH=1 bun --conditions=eliza-source packages/app-core/scripts/dev-platform.mjs",
     "desktop:stack-status": "bun --conditions=eliza-source packages/app-core/scripts/desktop-stack-status.mjs",
+    "desktop:clean-install-state": "node scripts/desktop-clean-install-state.mjs",
     "dev:harness": "bun packages/scripts/dev-harness.mjs",
     "dev:all": "node packages/scripts/dev-all.mjs",
     "voice-models:publish-all": "node packages/app-core/scripts/voice/voice-models-publish-all.mjs",

--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -149,7 +149,9 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
         shellPresent: true,
         pillLabel: "Open Eliza",
         pillText: "",
-        pillHeight: 32,
+        // The resting button spans the full 44px native window (#21876 hit
+        // bounds) while painting nothing itself; only the mark paints.
+        pillHeight: 44,
         pillBackground: "rgba(0, 0, 0, 0)",
         markWidth: 48,
         markHeight: 10,

--- a/packages/ui/src/components/settings/cloud-panel/nuphy-settings-primitives.tsx
+++ b/packages/ui/src/components/settings/cloud-panel/nuphy-settings-primitives.tsx
@@ -587,7 +587,7 @@ export function NuphyModal({
     >
       <DialogContent
         showCloseButton={false}
-        overlayClassName="bg-black/40 backdrop-blur-[2px]"
+        overlayClassName="bg-black/40"
         onCloseAutoFocus={(event) => {
           event.preventDefault();
           returnFocusRef.current?.focus();

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -340,12 +340,24 @@ export function HomePill({
       onWheel={() => setPreviewHover(false)}
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
-        "group pointer-events-auto relative flex items-center justify-center rounded-full border border-white/20 bg-[#181a20]/95 p-0 shadow-none backdrop-blur-xl",
+        // The resting launcher is deliberately transparent: only the white
+        // handle (shell-home-pill-mark) paints, so the pill reads as a
+        // floating handle over the desktop. The button still fills the 64x44
+        // native window, so the #21876 hit-bounds contract (native bounds ==
+        // interactive surface) is preserved without an opaque backdrop.
+        // When a run must prove the window itself composited (packaged pixel
+        // proofs, manual QA on hard-to-read wallpapers), temporarily swap in a
+        // painted surface — e.g. "border border-white/20 bg-[#181a20]/95"
+        // plus a frosted blur utility — instead of asserting on transparent
+        // pixels. The shipped default stays transparent, and a permanent blur
+        // here would fail the battery gate (see the blur allowlist test in
+        // packages/ui/src).
+        "group pointer-events-auto relative flex items-center justify-center rounded-full bg-transparent p-0 shadow-none",
         composerSized ? "h-16 w-[36rem]" : "h-11 w-16",
         "transition-[width,height,transform] duration-200 motion-reduce:transition-none",
-        "hover:bg-[#202228]/95",
+        "hover:bg-transparent",
         needsAuth ? "active:scale-[0.96]" : "active:scale-95",
-        "focus-visible:bg-[#181a20]/95 focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
+        "focus-visible:bg-transparent focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
       )}
     >
       <span

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -33,7 +33,9 @@ describe("HomePill", () => {
     expect(mark.className).toContain("w-12");
     expect(mark.className).toContain("shadow-[0_0_0_1px_rgba(0,0,0,0.12)]");
     expect(btn.textContent).toBe("");
-    expect(btn.className).toContain("bg-[#181a20]/95");
+    // Transparent resting surface: the handle is the only painted pixel run;
+    // the button still spans the full 64x44 native window for hit bounds.
+    expect(btn.className).toContain("bg-transparent");
     expect(btn.className).toContain("h-11");
     expect(btn.className).not.toContain("mb-2");
   });

--- a/scripts/desktop-clean-install-state.mjs
+++ b/scripts/desktop-clean-install-state.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Removes every persistence surface a macOS Eliza desktop install can leave
+ * behind, so a fresh build genuinely starts from first-run. Filesystem wipes
+ * alone are not enough: the shell keeps runtime/session records in the macOS
+ * Keychain (services `eliza` and `ai.elizaos.agent.vault`), and a surviving
+ * `runtime.active_server` record makes a "fresh" install restore a stale cloud
+ * agent target while the auth gate still demands sign-in — the pill then
+ * silently no-ops (the state contradiction behind the 2026-08-23 dead-pill
+ * debugging session). Default is a dry run that lists findings; pass --apply
+ * to delete. --keep-keychain / --keep-files scope the wipe.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const HOME = os.homedir();
+
+/** Keychain generic-password services the desktop stack writes. */
+export const ELIZA_KEYCHAIN_SERVICES = Object.freeze([
+  // Electrobun shell secure store: runtime.active_server, session.steward_token,
+  // session.device_auth, runtime.agent_profiles (account = local username).
+  "eliza",
+  // Per-install agent secret vault (accounts are derived `mldy1-…` handles).
+  "ai.elizaos.agent.vault",
+]);
+
+/** Filesystem roots an install writes, resolved per app id / namespace. */
+export function elizaStateLocations({ home = HOME, env = process.env } = {}) {
+  const appSupport = path.join(home, "Library", "Application Support");
+  const xdgStateHome = env.XDG_STATE_HOME?.trim()
+    ? path.isAbsolute(env.XDG_STATE_HOME.trim())
+      ? env.XDG_STATE_HOME.trim()
+      : path.join(home, env.XDG_STATE_HOME.trim())
+    : path.join(home, ".local", "state");
+  return [
+    // WKWebView/renderer storage keyed by bundle id.
+    path.join(appSupport, "ai.elizaos.app"),
+    // Brand configDirName (packaged brand-config.json `configDirName: "Eliza"`).
+    path.join(appSupport, "Eliza"),
+    path.join(home, "Library", "WebKit", "ai.elizaos.app"),
+    path.join(home, "Library", "HTTPStorages", "ai.elizaos.app"),
+    path.join(home, "Library", "Caches", "ai.elizaos.app"),
+    path.join(home, "Library", "Preferences", "ai.elizaos.app.plist"),
+    path.join(
+      home,
+      "Library",
+      "Saved Application State",
+      "ai.elizaos.app.savedState",
+    ),
+    path.join(home, "Library", "Logs", "Eliza"),
+    // Canonical agent state dir (ELIZA_STATE_DIR > XDG default). Holds the
+    // agent database, media store, and the input from which vault account
+    // handles are derived.
+    env.ELIZA_STATE_DIR?.trim() ||
+      path.join(xdgStateHome, env.ELIZA_NAMESPACE?.trim() || "eliza"),
+  ];
+}
+
+/** Installed app bundles (any Eliza*.app in /Applications and ~/Applications). */
+export function installedElizaBundles({ home = HOME } = {}) {
+  const roots = ["/Applications", path.join(home, "Applications")];
+  const bundles = [];
+  for (const root of roots) {
+    let names;
+    try {
+      names = fs.readdirSync(root);
+    } catch {
+      continue; // error-policy:J4 unreadable root — nothing to list there
+    }
+    for (const name of names) {
+      if (/^Eliza.*\.app$/.test(name)) bundles.push(path.join(root, name));
+    }
+  }
+  return bundles;
+}
+
+function listKeychainItems(service) {
+  // `security find-generic-password` returns one match; dump-keychain lists
+  // all. Filter dump output for the service to count matching items.
+  const dump = spawnSync("security", ["dump-keychain"], { encoding: "utf8" });
+  if (dump.status !== 0) return null;
+  const needle = `"svce"<blob>="${service}"`;
+  return dump.stdout
+    .split("keychain:")
+    .filter((entry) => entry.includes(needle)).length;
+}
+
+function deleteKeychainService(service) {
+  // Items under one service can differ by account; loop until none remain.
+  // Bounded so a permission-denied item cannot loop forever.
+  for (let i = 0; i < 64; i += 1) {
+    const res = spawnSync(
+      "security",
+      ["delete-generic-password", "-s", service],
+      { encoding: "utf8" },
+    );
+    if (res.status !== 0) return i; // no more matches (or denied) — report count
+  }
+  return 64;
+}
+
+function quitElizaProcesses({ apply }) {
+  const probe = spawnSync("pgrep", ["-fl", "Eliza"], { encoding: "utf8" });
+  const lines = (probe.stdout ?? "")
+    .split("\n")
+    .filter((line) => /Eliza[^/]*\.app/.test(line));
+  if (lines.length === 0) return { running: 0 };
+  if (apply) {
+    spawnSync("pkill", ["-f", "Eliza.*\\.app"], { encoding: "utf8" });
+  }
+  return { running: lines.length };
+}
+
+export function parseCleanArgs(argv) {
+  const args = {
+    apply: false,
+    keepKeychain: false,
+    keepFiles: false,
+    keepBundles: true,
+  };
+  for (const arg of argv) {
+    if (arg === "--apply") args.apply = true;
+    else if (arg === "--keep-keychain") args.keepKeychain = true;
+    else if (arg === "--keep-files") args.keepFiles = true;
+    else if (arg === "--delete-bundles") args.keepBundles = false;
+    else if (arg === "--help" || arg === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/desktop-clean-install-state.mjs [options]
+
+Wipes macOS Eliza desktop install state: app data, WebKit storage, caches,
+preferences, the agent state dir, AND the Keychain records (the part a
+filesystem wipe misses — a stale runtime.active_server Keychain record makes
+a fresh install restore a dead cloud target and silently break sign-in).
+
+Default is a DRY RUN. Nothing is deleted without --apply.
+
+Options:
+  --apply            Actually delete (default: list what would be deleted)
+  --keep-keychain    Skip Keychain services (${ELIZA_KEYCHAIN_SERVICES.join(", ")})
+  --keep-files       Skip filesystem state
+  --delete-bundles   Also remove Eliza*.app bundles from /Applications
+  -h, --help         Show this help
+`);
+}
+
+function main() {
+  let args;
+  try {
+    args = parseCleanArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(String(error instanceof Error ? error.message : error));
+    printUsage();
+    process.exit(2);
+  }
+  if (args.help) {
+    printUsage();
+    return;
+  }
+  if (process.platform !== "darwin") {
+    console.error("This cleanup targets macOS desktop installs only.");
+    process.exit(1);
+  }
+
+  const mode = args.apply ? "APPLY" : "DRY RUN";
+  console.log(`[desktop-clean] ${mode}`);
+
+  const procs = quitElizaProcesses({ apply: args.apply });
+  if (procs.running > 0) {
+    console.log(
+      `[desktop-clean] ${procs.running} running Eliza process(es)${args.apply ? " — terminated" : " (would terminate)"}`,
+    );
+  }
+
+  if (!args.keepFiles) {
+    for (const location of elizaStateLocations()) {
+      if (!fs.existsSync(location)) continue;
+      if (args.apply) {
+        fs.rmSync(location, { recursive: true, force: true });
+        console.log(`[desktop-clean] removed ${location}`);
+      } else {
+        console.log(`[desktop-clean] would remove ${location}`);
+      }
+    }
+  }
+
+  if (!args.keepBundles) {
+    for (const bundle of installedElizaBundles()) {
+      if (args.apply) {
+        fs.rmSync(bundle, { recursive: true, force: true });
+        console.log(`[desktop-clean] removed ${bundle}`);
+      } else {
+        console.log(`[desktop-clean] would remove ${bundle}`);
+      }
+    }
+  } else {
+    const bundles = installedElizaBundles();
+    if (bundles.length > 0) {
+      console.log(
+        `[desktop-clean] leaving ${bundles.length} app bundle(s) installed (pass --delete-bundles to remove): ${bundles.join(", ")}`,
+      );
+    }
+  }
+
+  if (!args.keepKeychain) {
+    for (const service of ELIZA_KEYCHAIN_SERVICES) {
+      const count = listKeychainItems(service);
+      if (count === null) {
+        console.log(
+          `[desktop-clean] could not inspect Keychain for service "${service}" (security dump failed)`,
+        );
+        continue;
+      }
+      if (count === 0) continue;
+      if (args.apply) {
+        const deleted = deleteKeychainService(service);
+        console.log(
+          `[desktop-clean] deleted ${deleted} Keychain item(s) for service "${service}"`,
+        );
+      } else {
+        console.log(
+          `[desktop-clean] would delete ${count} Keychain item(s) for service "${service}"`,
+        );
+      }
+    }
+  }
+
+  if (!args.apply) {
+    console.log(
+      "[desktop-clean] dry run complete — re-run with --apply to delete",
+    );
+  } else {
+    console.log(
+      "[desktop-clean] done — next launch starts from a genuine first run",
+    );
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === new URL(import.meta.url).pathname;
+if (invokedDirectly) main();

--- a/scripts/desktop-clean-install-state.test.mjs
+++ b/scripts/desktop-clean-install-state.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * Verifies the desktop clean-install script's pure decision logic: argument
+ * parsing boundaries, state-location resolution (env precedence), and bundle
+ * discovery filtering. Deterministic — no Keychain or filesystem mutation.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  ELIZA_KEYCHAIN_SERVICES,
+  elizaStateLocations,
+  installedElizaBundles,
+  parseCleanArgs,
+} from "./desktop-clean-install-state.mjs";
+
+describe("parseCleanArgs", () => {
+  it("defaults to a dry run keeping bundles", () => {
+    const args = parseCleanArgs([]);
+    assert.equal(args.apply, false);
+    assert.equal(args.keepKeychain, false);
+    assert.equal(args.keepFiles, false);
+    assert.equal(args.keepBundles, true);
+  });
+
+  it("parses every supported flag", () => {
+    const args = parseCleanArgs([
+      "--apply",
+      "--keep-keychain",
+      "--keep-files",
+      "--delete-bundles",
+    ]);
+    assert.equal(args.apply, true);
+    assert.equal(args.keepKeychain, true);
+    assert.equal(args.keepFiles, true);
+    assert.equal(args.keepBundles, false);
+  });
+
+  it("rejects unknown arguments instead of silently ignoring them", () => {
+    assert.throws(() => parseCleanArgs(["--nuke"]), /Unknown argument/);
+  });
+});
+
+describe("elizaStateLocations", () => {
+  it("honors ELIZA_STATE_DIR over the XDG default", () => {
+    const locations = elizaStateLocations({
+      home: "/Users/example",
+      env: { ELIZA_STATE_DIR: "/custom/state" },
+    });
+    assert.ok(locations.includes("/custom/state"));
+    assert.ok(!locations.some((l) => l.endsWith(".local/state/eliza")));
+  });
+
+  it("falls back to XDG state home with the namespace", () => {
+    const locations = elizaStateLocations({
+      home: "/Users/example",
+      env: {},
+    });
+    assert.ok(locations.includes("/Users/example/.local/state/eliza"));
+  });
+
+  it("covers the Keychain-adjacent filesystem surfaces that a naive wipe misses", () => {
+    const locations = elizaStateLocations({ home: "/Users/example", env: {} });
+    for (const suffix of [
+      "Library/Application Support/ai.elizaos.app",
+      "Library/WebKit/ai.elizaos.app",
+      "Library/HTTPStorages/ai.elizaos.app",
+      "Library/Preferences/ai.elizaos.app.plist",
+    ]) {
+      assert.ok(
+        locations.some((l) => l.endsWith(suffix)),
+        `expected a location ending in ${suffix}`,
+      );
+    }
+  });
+});
+
+describe("installedElizaBundles", () => {
+  it("matches only Eliza*.app names in the user Applications dir", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "clean-test-"));
+    const apps = path.join(home, "Applications");
+    fs.mkdirSync(apps);
+    for (const name of [
+      "Eliza.app",
+      "Eliza-canary.app",
+      "NotEliza.app",
+      "Elizax",
+    ]) {
+      fs.mkdirSync(path.join(apps, name));
+    }
+    try {
+      const bundles = installedElizaBundles({ home }).filter((b) =>
+        b.startsWith(apps),
+      );
+      const names = bundles.map((b) => path.basename(b)).sort();
+      assert.deepEqual(names, ["Eliza-canary.app", "Eliza.app"]);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ELIZA_KEYCHAIN_SERVICES", () => {
+  it("pins both services the desktop stack writes", () => {
+    assert.deepEqual([...ELIZA_KEYCHAIN_SERVICES].sort(), [
+      "ai.elizaos.agent.vault",
+      "eliza",
+    ]);
+  });
+});


### PR DESCRIPTION
# Relates to

Follow-up to #24672 (HomePill bounds/lifecycle, merged 2026-08-22) plus a cleanup tool for the stale-Keychain debugging session it took to find these. The companion settings-gate fix already landed separately as #25461.

# Risks

Low–medium. One renderer-only UI change (pill paint) plus a new standalone macOS cleanup script. No API, schema, cloud, or mobile changes. The pill's native hit-bounds contract from #24672 is preserved unchanged.

# Background

## What does this PR do?

Two commits:

1. **`fix(ui): restore the transparent resting pill surface`** — #24672 fixed the pill's native hit bounds by painting the entire 64×44 window as an opaque dark capsule, which reads as a box around the pill. This keeps the hit-bounds contract (the button still spans the full native window) but paints nothing on the button itself; only the white handle mark paints, as before #24672. The painted style is documented in-place for packaged pixel-proof/QA runs. Also removes the two backdrop blurs #24672/#24433 introduced without allowlisting, which had `no-backdrop-blur-gate.test.ts` failing on clean develop (HomePill `backdrop-blur-xl`; cloud-panel dialog scrim blur — the `bg-black/40` scrim is kept). The packaged bottom-bar e2e oracle moves from the stale `pillHeight: 32` to the painted-window `44` (it already expected a transparent pill background, which #24672's shipped style contradicted).

2. **`chore(scripts): add macOS desktop clean-install-state tool`** — filesystem wipes of a desktop install leave macOS Keychain records behind (services `eliza` + `ai.elizaos.agent.vault`). A surviving `runtime.active_server` record makes a "fresh" install restore a stale cloud agent target while the auth gate still demands sign-in, so the pill's sign-in click silently no-ops in `handleCloudLogin`'s already-authenticated guard. `bun run desktop:clean-install-state` wipes app data, WebKit storage, caches, preferences, the XDG agent state dir, AND the Keychain records; dry-run by default, `--apply` to delete, `--delete-bundles` for app bundles. Unit-tested.

## What kind of change is this?

Bug fixes (blur-gate violations, stale e2e oracle, pill paint regression) + a developer tool.

# Documentation changes needed?

None; the script carries its own `--help` and header rationale.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/shell/HomePill.tsx` (the paint + in-place testing note), `scripts/desktop-clean-install-state.mjs`.

## Detailed testing steps

All on the rebased head (base `324990de5d`):

- `packages/ui` focused vitest (blur gate, HomePill, cloud panel, SettingsView): 99/99 passed. The blur gate FAILS on clean develop today (two unallowlisted blurs); this PR makes it pass.
- `packages/ui` `tsc --noEmit`: clean. Biome: clean on touched files.
- Cleanup script `node --test`: 8/8 passed. Real dry run on a machine with live state correctly enumerated 2 running processes, 3 filesystem roots, 1 `eliza` + 11 vault Keychain items, deleting nothing.
- Packaged verification (same diff, pre-rebase): built the cloud-only mac app, launched it, DOM probe showed pill 64×44 with `rgba(0,0,0,0)` background + painted 48px mark; screen pixel sampling showed window corners matching the desktop behind (no dark capsule) with the handle painted white.
- Auth ui-smoke sweep on the same changes (pre-rebase): 12/12 passed including the `cloud-login-callsite-popup` lane restored by #25461.

Known pre-existing failures NOT from this PR (confirmed identical on clean develop): `DefaultHomeWidgets` clock tests + `ChatOverlay.fuzz` drag test in packages/ui; `ensure-plugin-test-conventions:check` (llama.cpp submodule webui tests) in `bun run verify`; 18 `TS2307` shim-test errors in packages/app typecheck.

## Note for reviewers

The pill paint change intentionally diverges from #24672's shipped visual contract (opaque capsule) while preserving its actual bug fix (native bounds == interactive surface). If the opaque capsule was a deliberate design decision rather than a means to the hit-bounds end, that's a product call — happy to drop commit 1 and keep the cleanup tool.
