### PR TITLE
chore(cloud-api): restore Headscale surrogate lint closure

### DIFF
--- a/packages/cloud/api/v1/admin/headscale/route.surrogate.test.ts
+++ b/packages/cloud/api/v1/admin/headscale/route.surrogate.test.ts
@@ -1,17 +1,22 @@
 /**
  * Surrogate-safe truncation for Headscale admin error body.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("headscale surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 500", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(499) + "🦊"), 500)).toBe("x".repeat(499));
+    expect(
+      truncateWellFormed(toWellFormedUnicode(`${"x".repeat(499)}🦊`), 500),
+    ).toBe("x".repeat(499));
   });
   it("caps at 500", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(800)), 500).length).toBe(500);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(800)), 500).length,
+    ).toBe(500);
   });
 });

--- a/packages/cloud/api/v1/admin/headscale/route.ts
+++ b/packages/cloud/api/v1/admin/headscale/route.ts
@@ -7,11 +7,11 @@
  * Requires super_admin role.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireAdmin } from "@/lib/auth/workers-hono-auth";
 import { logger } from "@/lib/utils/logger";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 interface HeadscaleNode {


### PR DESCRIPTION
## Summary

- apply the pinned formatter/import-order fixes to the Headscale admin route
- format the new surrogate-safety regression test without changing its assertions

Closes #25521.

## Verification

- pinned Biome exact-file check — 2/2 files pass
- `git diff --check` — pass
- focused Headscale surrogate tests — 3/3 pass
- Cloud API lint — 1,403 files pass
- direct Cloud API typecheck reaches an unrelated missing `@elizaos/plugin-doordash` declaration prerequisite; repository-orchestrated typecheck is being run on the composed integration branch
- root verification is being rerun on the composed integration branch

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
