### PR TITLE
fix(desktop): close Linux remote lifecycle gaps

### DIFF
--- a/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
@@ -276,36 +276,38 @@ export class RemoteTargetDesktopService {
     if (!/^\d{6}$/.test(code)) {
       throw new Error("Pairing code must contain exactly six digits.");
     }
-    const enrollment = await this.vault.load();
-    if (enrollment?.status !== "enrolled") {
-      throw new Error("Remote target is not enrolled.");
-    }
-    const activation = await this.transport.activate({
-      enrollment,
-      ...(sessionId ? { sessionId } : {}),
-      code,
+    return this.enqueueConfiguration(async () => {
+      const enrollment = await this.vault.load();
+      if (enrollment?.status !== "enrolled") {
+        throw new Error("Remote target is not enrolled.");
+      }
+      const activation = await this.transport.activate({
+        enrollment,
+        ...(sessionId ? { sessionId } : {}),
+        code,
+      });
+      const installer =
+        this.runner ??
+        new RemoteTargetRunner(
+          this.vault,
+          this.stateStore,
+          this.transport,
+          {
+            execute: async () => ({
+              status: "rejected",
+              errorCode: "REMOTE_TARGET_NOT_STARTED",
+            }),
+          },
+          { now: this.now },
+        );
+      await installer.installActivation(activation);
+      return {
+        sessionId: activation.sessionId,
+        status: "active" as const,
+        controllerDisplayName: activation.controller.displayName,
+        grantExpiresAt: activation.grantExpiresAt,
+      };
     });
-    const installer =
-      this.runner ??
-      new RemoteTargetRunner(
-        this.vault,
-        this.stateStore,
-        this.transport,
-        {
-          execute: async () => ({
-            status: "rejected",
-            errorCode: "REMOTE_TARGET_NOT_STARTED",
-          }),
-        },
-        { now: this.now },
-      );
-    await installer.installActivation(activation);
-    return {
-      sessionId: activation.sessionId,
-      status: "active",
-      controllerDisplayName: activation.controller.displayName,
-      grantExpiresAt: activation.grantExpiresAt,
-    };
   }
 
   async start(): Promise<{ running: true }> {

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
@@ -9,7 +9,7 @@ import {
   type RemoteControllerPublicIdentity,
   type RemoteTargetPublicIdentity,
 } from "@elizaos/shared/contracts/remote-control";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   PlatformSecureStore,
   SecureStoreDeleteResult,
@@ -243,6 +243,43 @@ class DeferredClaimRelay extends FakeRelay {
   }
 }
 
+class BackgroundFailureRelay extends FakeRelay {
+  override async claimNext(
+    input: Parameters<RemoteTargetRelayTransport["claimNext"]>[0],
+  ): Promise<RemoteTargetClaim | null> {
+    if (this.claimRequests > 0) throw new Error("journal-integrity-failed");
+    return super.claimNext(input);
+  }
+}
+
+class DeferredActivationRelay extends FakeRelay {
+  readonly activationRequested: Promise<void>;
+  private markActivationRequested: () => void = () => undefined;
+  private releaseActivation: (
+    activation: RemoteTargetActivationResponse,
+  ) => void = () => undefined;
+  private readonly deferredActivation: Promise<RemoteTargetActivationResponse>;
+
+  constructor() {
+    super();
+    this.activationRequested = new Promise((resolve) => {
+      this.markActivationRequested = resolve;
+    });
+    this.deferredActivation = new Promise((resolve) => {
+      this.releaseActivation = resolve;
+    });
+  }
+
+  override async activate(): Promise<RemoteTargetActivationResponse> {
+    this.markActivationRequested();
+    return this.deferredActivation;
+  }
+
+  resolveActivation(activation: RemoteTargetActivationResponse): void {
+    this.releaseActivation(activation);
+  }
+}
+
 function privateKey(): JsonWebKey {
   return generateKeyPairSync("ec", {
     namedCurve: "prime256v1",
@@ -363,6 +400,7 @@ async function createRunner(
   harness: Harness,
   execute: () => Promise<void> | void,
   hooks: RemoteTargetRunnerHooks = {},
+  pollIntervalMs?: number,
 ): Promise<RemoteTargetRunner> {
   const runner = new RemoteTargetRunner(
     harness.vault,
@@ -381,7 +419,7 @@ async function createRunner(
         };
       },
     },
-    { now: () => NOW, hooks },
+    { now: () => NOW, hooks, pollIntervalMs },
   );
   await runner.installActivation(harness.activation);
   return runner;
@@ -780,6 +818,30 @@ describe("remote target durable runner", () => {
     expect((await runner.status()).running).toBe(false);
   });
 
+  it("observes a rejected background poll and stops reporting the loop as running", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = await createHarness();
+      harness.relay = new BackgroundFailureRelay();
+      const runner = await createRunner(harness, () => undefined, {}, 250);
+
+      await runner.start();
+      expect(await runner.status()).toMatchObject({
+        running: true,
+        lastErrorCode: null,
+      });
+
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(await runner.status()).toMatchObject({
+        running: false,
+        lastErrorCode: "REMOTE_TARGET_LOOP_FAILED",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("auto-resumes one runner from durable enrollment and active authority", async () => {
     const harness = await createHarness();
     await createRunner(harness, () => undefined);
@@ -1050,6 +1112,48 @@ describe("remote target durable runner", () => {
     await service.configureLoopback(secondConfiguration);
     expect((await service.status()).running).toBe(true);
     await service.stop();
+  });
+
+  it("serializes activation before authoritative host finalization", async () => {
+    const harness = await createHarness();
+    const relay = new DeferredActivationRelay();
+    relay.revocations.push({
+      hostId: HOST_ID,
+      status: "revoked",
+      alreadyRevoked: false,
+      cleanup: { sessions: 1, commands: 0, more: false },
+    });
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      relay,
+      () => NOW,
+    );
+
+    const activating = service.activate({ code: "123456" });
+    await relay.activationRequested;
+    let finalized = false;
+    const finalizing = service
+      .finalizeHostRevoke({ hostId: HOST_ID })
+      .then((result) => {
+        finalized = true;
+        return result;
+      });
+    await Promise.resolve();
+    expect(finalized).toBe(false);
+
+    relay.resolveActivation(harness.activation);
+    await expect(activating).resolves.toMatchObject({
+      sessionId: SESSION_ID,
+      status: "active",
+    });
+    await expect(finalizing).resolves.toEqual({ cleaned: true });
+    await expect(harness.vault.load()).resolves.toBeNull();
+    await expect(harness.state.read()).resolves.toEqual({
+      version: 1,
+      sessions: {},
+      commands: {},
+    });
   });
 
   it("requires authoritative host revocation before deleting native credentials", async () => {

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.ts
@@ -158,6 +158,13 @@ export class RemoteTargetRunner {
   private pollTail: Promise<void> = Promise.resolve();
   private loopGeneration = 0;
 
+  private stopFailedLoop(generation: number): void {
+    if (generation !== this.loopGeneration) return;
+    this.running = false;
+    this.pollTimer = null;
+    this.lastErrorCode = "REMOTE_TARGET_LOOP_FAILED";
+  }
+
   constructor(
     private readonly vault: RemoteTargetVault,
     private readonly stateStore: RemoteTargetStateStore,
@@ -834,11 +841,23 @@ export class RemoteTargetRunner {
       await this.pollOnce(generation);
       if (!this.running || generation !== this.loopGeneration) return;
       this.pollTimer = setTimeout(
-        () => void loop(),
+        () => {
+          this.pollTimer = null;
+          void loop().catch(() => {
+            // error-policy:J4 a background integrity failure becomes a
+            // distinct stopped/error status instead of an unhandled promise.
+            this.stopFailedLoop(generation);
+          });
+        },
         Math.max(250, this.options.pollIntervalMs ?? 1_000),
       );
     };
-    await loop();
+    try {
+      await loop();
+    } catch (error) {
+      this.stopFailedLoop(generation);
+      throw error;
+    }
   }
 
   async stop(): Promise<void> {

--- a/packages/app-core/platforms/electrobun/src/ssh-runtime-rpc.test.ts
+++ b/packages/app-core/platforms/electrobun/src/ssh-runtime-rpc.test.ts
@@ -230,6 +230,45 @@ describe("SSH runtime RPC", () => {
     });
   });
 
+  it("removes the private known-hosts directory when process creation throws", async () => {
+    let temporaryDirectory = "";
+
+    await expect(
+      sshRuntimeInternals.createSshTunnelChild(
+        `[host.example]:22 ssh-ed25519 ${ED25519_KEY}`,
+        (knownHostsPath) => {
+          temporaryDirectory = path.dirname(knownHostsPath);
+          throw new Error("spawn rejected arguments");
+        },
+      ),
+    ).rejects.toThrow("spawn rejected arguments");
+
+    expect(temporaryDirectory).not.toBe("");
+    await expect(fs.stat(temporaryDirectory)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("observes spontaneous-exit cleanup failure without an unhandled rejection", async () => {
+    const child = fakeTunnelChild();
+    const tunnel = await createFakeTunnel(child as unknown as ChildProcess);
+    const recordCleanupFailure = vi.fn();
+
+    sshRuntimeInternals.observeTunnelExit("vps", tunnel, {
+      dispose: async () => {
+        throw new Error("temporary directory is busy");
+      },
+      recordCleanupFailure,
+    });
+    child.exitCode = 255;
+    child.emit("exit", 255, null);
+
+    await vi.waitFor(() => {
+      expect(recordCleanupFailure).toHaveBeenCalledWith("vps");
+    });
+    await fs.rm(tunnel.tempDir, { force: true, recursive: true });
+  });
+
   it("rehydrates restart intent only after secure pin and identity validation", async () => {
     const starts: unknown[] = [];
     await sshRuntimeInternals.rehydrateSshRuntimeIntent(RESTART_INTENT, {

--- a/packages/app-core/platforms/electrobun/src/ssh-runtime-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/ssh-runtime-rpc.ts
@@ -492,6 +492,72 @@ function sshExecutable(): string {
   return "/usr/bin/ssh";
 }
 
+type SshPreparationFileSystem = Pick<
+  typeof fs,
+  "mkdtemp" | "chmod" | "writeFile" | "rm"
+>;
+
+async function createSshTunnelChild(
+  knownHostLine: string,
+  start: (knownHostsPath: string) => ChildProcess,
+  fileSystem: SshPreparationFileSystem = fs,
+): Promise<{ child: ChildProcess; tempDir: string }> {
+  const tempDir = await fileSystem.mkdtemp(
+    path.join(os.tmpdir(), "eliza-ssh-"),
+  );
+  try {
+    await fileSystem.chmod(tempDir, 0o700);
+    const knownHostsPath = path.join(tempDir, `known-hosts-${randomUUID()}`);
+    await fileSystem.writeFile(knownHostsPath, `${knownHostLine}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    return { child: start(knownHostsPath), tempDir };
+  } catch (error) {
+    // error-policy:J2 remove private preparation state before preserving the
+    // process-start failure for the native RPC boundary.
+    try {
+      await fileSystem.rm(tempDir, { recursive: true, force: true });
+    } catch (cleanupError) {
+      // error-policy:J2 preserve both the startup and cleanup failures.
+      throw new Error(
+        "SSH tunnel preparation failed and its private directory could not be removed.",
+        { cause: new AggregateError([error, cleanupError]) },
+      );
+    }
+    throw error;
+  }
+}
+
+interface TunnelExitObserverDependencies {
+  dispose: (tunnel: SshTunnel) => Promise<void>;
+  recordCleanupFailure: (runtimeId: string) => void;
+}
+
+function observeTunnelExit(
+  runtimeId: string,
+  tunnel: SshTunnel,
+  dependencies: TunnelExitObserverDependencies = {
+    dispose: disposeTunnel,
+    recordCleanupFailure: (failedRuntimeId) => {
+      reconnectErrors.set(
+        failedRuntimeId,
+        "The previous SSH tunnel exited, but its private temporary directory could not be removed.",
+      );
+    },
+  },
+): void {
+  tunnel.child.once("exit", () => {
+    if (tunnels.get(runtimeId) === tunnel) tunnels.delete(runtimeId);
+    void dependencies.dispose(tunnel).catch(() => {
+      // error-policy:J6 spontaneous process teardown has no awaiting caller;
+      // retain a visible blocked diagnostic instead of rejecting globally.
+      dependencies.recordCleanupFailure(runtimeId);
+    });
+  });
+}
+
 function toConnectionIntent(
   input: ParsedSshRuntimeParams,
 ): SshRuntimeConnectionIntent {
@@ -568,46 +634,43 @@ async function startParsedSshRuntime(
   }
 
   const localPort = await reserveLoopbackPort();
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-ssh-"));
-  await fs.chmod(tempDir, 0o700);
-  const knownHostsPath = path.join(tempDir, `known-hosts-${randomUUID()}`);
-  await fs.writeFile(knownHostsPath, `${selected.knownHostLine}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-    flag: "wx",
-  });
-  const args = [
-    "-N",
-    "-T",
-    "-p",
-    String(input.sshPort),
-    "-L",
-    `127.0.0.1:${localPort}:127.0.0.1:${input.remoteApiPort}`,
-    "-o",
-    "BatchMode=yes",
-    "-o",
-    "ExitOnForwardFailure=yes",
-    "-o",
-    "StrictHostKeyChecking=yes",
-    "-o",
-    `UserKnownHostsFile=${knownHostsPath}`,
-    "-o",
-    `HostKeyAlgorithms=${selected.algorithm}`,
-    "-o",
-    "ConnectTimeout=8",
-    ...(process.platform === "win32"
-      ? []
-      : ["-o", "GlobalKnownHostsFile=/dev/null"]),
-    ...(input.identityFile
-      ? ["-o", "IdentitiesOnly=yes", "-i", input.identityFile]
-      : []),
-    "--",
-    input.target,
-  ];
-  const child = spawn(sshExecutable(), args, {
-    shell: false,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const { child, tempDir } = await createSshTunnelChild(
+    selected.knownHostLine,
+    (knownHostsPath) => {
+      const args = [
+        "-N",
+        "-T",
+        "-p",
+        String(input.sshPort),
+        "-L",
+        `127.0.0.1:${localPort}:127.0.0.1:${input.remoteApiPort}`,
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        `UserKnownHostsFile=${knownHostsPath}`,
+        "-o",
+        `HostKeyAlgorithms=${selected.algorithm}`,
+        "-o",
+        "ConnectTimeout=8",
+        ...(process.platform === "win32"
+          ? []
+          : ["-o", "GlobalKnownHostsFile=/dev/null"]),
+        ...(input.identityFile
+          ? ["-o", "IdentitiesOnly=yes", "-i", input.identityFile]
+          : []),
+        "--",
+        input.target,
+      ];
+      return spawn(sshExecutable(), args, {
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    },
+  );
   let spawnError: Error | null = null;
   let diagnosticStderrTail = "";
   child.once("error", (error) => {
@@ -643,12 +706,7 @@ async function startParsedSshRuntime(
     startedAt: Date.now(),
   };
   tunnels.set(input.runtimeId, tunnel);
-  child.once("exit", () => {
-    if (tunnels.get(input.runtimeId) === tunnel) {
-      tunnels.delete(input.runtimeId);
-    }
-    void disposeTunnel(tunnel);
-  });
+  observeTunnelExit(input.runtimeId, tunnel);
   if (options.persistIntent) {
     try {
       await connectionIntents.upsert(toConnectionIntent(input));
@@ -1051,7 +1109,9 @@ export async function desktopSshRuntimeRequest(params: unknown): Promise<{
 }
 
 export const sshRuntimeInternals = {
+  createSshTunnelChild,
   disposeTunnel,
+  observeTunnelExit,
   rehydrateSshRuntimeIntent,
   waitForChildExit,
   parseStartParams,

--- a/packages/app-core/scripts/__tests__/package-electrobun-linux.test.ts
+++ b/packages/app-core/scripts/__tests__/package-electrobun-linux.test.ts
@@ -39,6 +39,7 @@ import {
   sha256File,
   stageAppImageMetadata,
   stagePackageRoot,
+  validateLinuxDisplayName,
   withStagingCleanup,
 } from "../package-electrobun-linux.mjs";
 
@@ -76,6 +77,20 @@ afterEach(() => {
 });
 
 describe("direct Linux package format selection", () => {
+  it("accepts a human display label and rejects path or metadata injection", () => {
+    expect(validateLinuxDisplayName("  Eliza Desktop  ")).toBe("Eliza Desktop");
+    for (const value of [
+      "../Eliza",
+      "Eliza/Desktop",
+      "Eliza\\Desktop",
+      "Eliza\nExec=unexpected",
+      "Eliza\r%post",
+      "%{lua:unexpected}",
+    ]) {
+      expect(() => validateLinuxDisplayName(value)).toThrow(/ELIZA_APP_NAME/);
+    }
+  });
+
   it("preserves the historical all-format default and explicit all alias", () => {
     expect(resolveLinuxPackageFormats(undefined)).toEqual([
       "deb",

--- a/packages/app-core/scripts/package-electrobun-flatpak.mjs
+++ b/packages/app-core/scripts/package-electrobun-flatpak.mjs
@@ -122,6 +122,27 @@ function lstatIfPresent(targetPath) {
   }
 }
 
+/** Canonicalize the stable /var alias that macOS exposes as /private/var. */
+export function canonicalizePlatformPathAlias(
+  targetPath,
+  platform = process.platform,
+) {
+  const resolved = path.resolve(targetPath);
+  if (platform !== "darwin") return resolved;
+  const aliasRoot = path.parse(resolved).root === "/" ? "/var" : null;
+  if (!aliasRoot) return resolved;
+  const relative = path.relative(aliasRoot, resolved);
+  if (
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return resolved;
+  }
+  const canonicalRoot = realpathSync(aliasRoot);
+  return path.join(canonicalRoot, relative);
+}
+
 /**
  * Resolve an optional artifact directory and the existing directory whose
  * filesystem capacity represents it. Explicit paths reject symlink traversal,
@@ -164,7 +185,9 @@ export function resolveFlatpakArtifactDirectory(
 
   let capacityDirectory = artifactDirectory;
   while (true) {
-    const stats = lstatIfPresent(capacityDirectory);
+    const canonicalCapacityDirectory =
+      canonicalizePlatformPathAlias(capacityDirectory);
+    const stats = lstatIfPresent(canonicalCapacityDirectory);
     if (stats) {
       if (stats.isSymbolicLink()) {
         throw new Error(
@@ -176,7 +199,9 @@ export function resolveFlatpakArtifactDirectory(
           `Flatpak artifact directory component is not a directory: ${capacityDirectory}`,
         );
       }
-      if (realpathSync(capacityDirectory) !== capacityDirectory) {
+      if (
+        realpathSync(canonicalCapacityDirectory) !== canonicalCapacityDirectory
+      ) {
         throw new Error(
           `Flatpak artifact directory must not traverse a symlink: ${capacityDirectory}`,
         );
@@ -200,8 +225,15 @@ export function assertFlatpakArtifactDirectoryOutsideBuild(
   artifactDirectory,
   buildDirectory,
 ) {
-  const canonicalBuildDirectory = realpathSync(buildDirectory);
-  const relative = path.relative(canonicalBuildDirectory, artifactDirectory);
+  const canonicalBuildDirectory = realpathSync(
+    canonicalizePlatformPathAlias(buildDirectory),
+  );
+  const canonicalArtifactDirectory =
+    canonicalizePlatformPathAlias(artifactDirectory);
+  const relative = path.relative(
+    canonicalBuildDirectory,
+    canonicalArtifactDirectory,
+  );
   if (
     relative === "" ||
     (!relative.startsWith(`..${path.sep}`) &&

--- a/packages/app-core/scripts/package-electrobun-linux.mjs
+++ b/packages/app-core/scripts/package-electrobun-linux.mjs
@@ -196,7 +196,30 @@ export function resolveLinuxPackageFormats(requestedFormat) {
 // App identity is env-driven (mirroring the Electrobun shell's brand-config
 // resolution) and defaults to the existing elizaOS values when unset, so the
 // produced packages stay byte-identical unless the brand env is provided.
-const displayName = (process.env.ELIZA_APP_NAME ?? "").trim() || "Eliza";
+export function validateLinuxDisplayName(value) {
+  const displayName = value.trim();
+  const hasControlCharacter = Array.from(displayName).some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || code === 0x7f;
+  });
+  if (
+    displayName.length === 0 ||
+    Buffer.byteLength(displayName, "utf8") > 128 ||
+    displayName === "." ||
+    displayName === ".." ||
+    /[\\/%]/u.test(displayName) ||
+    hasControlCharacter
+  ) {
+    throw new Error(
+      "ELIZA_APP_NAME must be a 1-128 byte display label without path separators, control characters, or RPM macro markers.",
+    );
+  }
+  return displayName;
+}
+
+const displayName = validateLinuxDisplayName(
+  (process.env.ELIZA_APP_NAME ?? "").trim() || "Eliza",
+);
 // Lowercase slug used for install paths, the launcher wrapper, the .desktop
 // file, the icon, and (suffixed with `-app`) the deb/rpm package name.
 // Defaults to "eliza". It must satisfy Debian package-name policy — start with


### PR DESCRIPTION
Stacked corrective for #25427 and the blocking review at https://github.com/elizaOS/eliza/pull/25427#issuecomment-5385116109.

Exact stack
- Parent head: `8baffa422d033ac2d296e09736cc5ef02b56f23d`
- Corrective head: `a71565445be23299b5aab6950c4083ef02205289`
- Base branch: `fix/linux-cef-devices-runtimes-parity`

Corrections
- Observe scheduler-loop rejections and expose stopped/error state instead of leaving `running: true` or producing an unhandled rejection.
- Serialize activation and local install with finalization/configuration authority.
- Observe spontaneous SSH teardown failures and remove private pre-spawn directories on setup/start failures.
- Canonicalize the macOS `/var` alias before Flatpak containment and symlink checks.
- Validate `ELIZA_APP_NAME` against traversal, control/newline metadata injection, and RPM macro injection.

Validation on the exact corrective head with Bun 1.3.14 and Node 24.15.0
- Electrobun remote/SSH focused suite: 6 files, 57/57 tests passed.
- Linux/Flatpak packaging suite: 2 files, 31 passed, 1 Linux-only skip.
- Biome: 8 changed files clean.
- `git diff --check`: clean.
- Owning Electrobun typecheck was run but remains blocked by the parent/repository baseline: missing built workspace declarations plus unrelated existing errors in agent recent-conversations and dynamic-view tests. No diagnostic points to a corrective file.

Evidence boundary
This correction does not provide or claim the physical/deployed proof still required by #25427: physical GNOME/Wayland package installation, real Secret Service behavior, deployed relay, and second-machine SSH/WAN evidence remain open. The parent PR must remain draft and must not merge until those gates are captured and reviewed.