### PR TITLE
chore(cloud-shared): restore safety regression formatter closure

### DIFF
--- a/packages/cloud/shared/src/lib/queue/redis-queue.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/queue/redis-queue.surrogate.test.ts
@@ -1,15 +1,18 @@
 /**
  * Surrogate-safe truncation for Redis queue unparseable envelope sample.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("redis-queue surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
   });
   it("caps at 200", () => {
     expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);

--- a/packages/cloud/shared/src/lib/queue/redis-queue.ts
+++ b/packages/cloud/shared/src/lib/queue/redis-queue.ts
@@ -12,9 +12,9 @@
  * Wadis locally) and circuit-breaker behavior.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { cache } from "../cache/client";
 import { logger } from "../utils/logger";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 interface Envelope<T> {
   body: T;

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.safe-sort.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.safe-sort.test.ts
@@ -13,7 +13,28 @@ function safeSort(nodes: { createdAtMs: number; id: string }[]) {
 }
 
 describe("backup-diff safe-sort", () => {
-  it("sorts descending", () => { expect(safeSort([{createdAtMs:1,id:"a"},{createdAtMs:2,id:"b"}])[0].id).toBe("b"); });
-  it("NaN fallback", () => { expect(safeSort([{createdAtMs:NaN,id:"a"},{createdAtMs:1,id:"b"}])[0].id).toBe("b"); });
-  it("tiebreak", () => { expect(safeSort([{createdAtMs:1,id:"b"},{createdAtMs:1,id:"a"}])[0].id).toBe("a"); });
+  it("sorts descending", () => {
+    expect(
+      safeSort([
+        { createdAtMs: 1, id: "a" },
+        { createdAtMs: 2, id: "b" },
+      ])[0].id,
+    ).toBe("b");
+  });
+  it("NaN fallback", () => {
+    expect(
+      safeSort([
+        { createdAtMs: NaN, id: "a" },
+        { createdAtMs: 1, id: "b" },
+      ])[0].id,
+    ).toBe("b");
+  });
+  it("tiebreak", () => {
+    expect(
+      safeSort([
+        { createdAtMs: 1, id: "b" },
+        { createdAtMs: 1, id: "a" },
+      ])[0].id,
+    ).toBe("a");
+  });
 });

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/docker-stats.surrogate.test.ts
@@ -1,11 +1,20 @@
 /**
  * Surrogate-safe truncation for docker stats parse error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("docker-stats surrogate-safe", () => {
-  it("replaces lone surrogate", () => { expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb"); });
-  it("does not split astral at 200", () => { expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199)+"🦊"),200)).toBe("x".repeat(199)); });
-  it("caps at 200", () => { expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)),200).length).toBe(200); });
+  it("replaces lone surrogate", () => {
+    expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
+  });
+  it("does not split astral at 200", () => {
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
+  });
+  it("caps at 200", () => {
+    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.surrogate.test.ts
@@ -1,15 +1,18 @@
 /**
  * Surrogate-safe truncation for onboarding memory copy error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("onboarding-chat surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
   });
   it("caps at 200", () => {
     expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -1547,7 +1547,9 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
         });
         return "";
       });
-      throw new Error(`memory copy failed (${rememberResponse.status}) ${truncateWellFormed(toWellFormedUnicode(body), 200)}`);
+      throw new Error(
+        `memory copy failed (${rememberResponse.status}) ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+      );
     }
 
     return {

--- a/packages/cloud/shared/src/lib/services/eliza-managed-launch.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-managed-launch.surrogate.test.ts
@@ -1,15 +1,18 @@
 /**
  * Surrogate-safe truncation for managed onboarding bootstrap error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("managed-launch surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
   });
   it("caps at 200", () => {
     expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);

--- a/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-managed-launch.ts
@@ -2,6 +2,8 @@
  * Coordinates managed agent launch, credential refresh, provisioning, and
  * onboarding behind Cloud route handlers.
  */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type AgentSandbox,
   CONTAINER_BACKED_EXECUTION_TIERS,
@@ -9,7 +11,6 @@ import {
 import { cache } from "../cache/client";
 import { CEREBRAS_DEFAULT_TEXT_LARGE_MODEL, CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../models";
 import { logger } from "../utils/logger";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { decryptAgentEnvVars } from "./agent-env-crypto";
 import { elizaSandboxService } from "./eliza-sandbox";
 import {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.surrogate.test.ts
@@ -1,15 +1,18 @@
 /**
  * Surrogate-safe truncation for agent sandbox restore error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("eliza-sandbox surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
   });
   it("caps at 200", () => {
     expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -12153,7 +12153,9 @@ export class ElizaSandboxService {
         });
         return "";
       });
-      throw new Error(`State restore failed: HTTP ${res.status} ${truncateWellFormed(toWellFormedUnicode(text), 200)}`);
+      throw new Error(
+        `State restore failed: HTTP ${res.status} ${truncateWellFormed(toWellFormedUnicode(text), 200)}`,
+      );
     }
   }
 }

--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.surrogate.test.ts
@@ -1,15 +1,18 @@
 /**
  * Surrogate-safe truncation for WhatsApp token error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("whatsapp automation surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe("x".repeat(199));
+    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(199) + "🦊"), 200)).toBe(
+      "x".repeat(199),
+    );
   });
   it("caps at 200", () => {
     expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);

--- a/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/whatsapp-automation/index.ts
@@ -9,6 +9,7 @@
  * with credentials stored in the secrets service.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import crypto from "crypto";
 import { timingSafeEqualSecret } from "../../auth/cron";
 import { cache } from "../../cache/client";
@@ -19,7 +20,6 @@ import {
   WHATSAPP_PHONE_NUMBER_ID,
   WHATSAPP_VERIFY_TOKEN,
 } from "../../constants/secrets";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "../../utils/logger";
 import {
   sendWhatsAppMessage,

--- a/packages/cloud/shared/src/lib/utils/ai-json-parse.surrogate.test.ts
+++ b/packages/cloud/shared/src/lib/utils/ai-json-parse.surrogate.test.ts
@@ -1,8 +1,9 @@
 /**
  * Surrogate-safe truncation for AI JSON parse error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("ai-json-parse surrogate-safe", () => {
   it("replaces lone surrogate", () => {


### PR DESCRIPTION
## Summary

- apply the pinned formatter/import-order fixes to thirteen newly landed cloud-shared safety source/test files
- preserve queue, service, container, onboarding, sandbox, WhatsApp, and JSON-parse behavior exactly

Closes #25525.

## Verification

- pinned Biome exact-file check — 13/13 files pass
- `git diff --check` — pass
- focused cloud-shared tests — 24/24 pass across 8 files
- cloud-shared lint — 2,358 files pass
- cloud-shared typecheck — pass
- root verification is being rerun on the composed integration branch

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
