### PR TITLE
chore(lint): restore safety static smoke

### DIFF
--- a/plugins/plugin-agent-skills/src/services/install.surrogate.test.ts
+++ b/plugins/plugin-agent-skills/src/services/install.surrogate.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 
 describe("skill install surrogate-safe truncation (200)", () => {
   it("does not split astral pair at 200", () => {
-    const text = "a".repeat(199) + "🦊" + "b".repeat(10);
+    const text = `${"a".repeat(199)}🦊${"b".repeat(10)}`;
     const truncated = truncateWellFormed(toWellFormedUnicode(text), 200);
     expect(truncated.length).toBe(199);
     expect(truncated).toBe("a".repeat(199));
@@ -23,7 +23,7 @@ describe("skill install surrogate-safe truncation (200)", () => {
   });
 
   it("old slice splits but guard backs off", () => {
-    const text = "a".repeat(199) + "🦊";
+    const text = `${"a".repeat(199)}🦊`;
     const old = text.slice(0, 200);
     expect(old.charCodeAt(199)).toBe(0xd83e);
     const fixed = truncateWellFormed(toWellFormedUnicode(text), 200);

--- a/plugins/plugin-wallet/src/ui/inventory.safe-sort.test.ts
+++ b/plugins/plugin-wallet/src/ui/inventory.safe-sort.test.ts
@@ -2,9 +2,9 @@
  * Verifies safe sorting and NaN-handling in wallet inventory helpers and components.
  */
 
+import type { WalletBalancesResponse } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import { parseUsd, summarizeWalletBalances } from "./InventoryView.helpers.js";
-import type { WalletBalancesResponse } from "@elizaos/shared";
 
 describe("wallet inventory safe sort", () => {
   it("parses USD values safely for NaN and Infinity", () => {


### PR DESCRIPTION
## Summary

- apply the two Biome-prescribed template-literal fixes to the agent-skills surrogate test
- restore import ordering in the wallet inventory safe-sort test
- keep runtime, UI, and assertion behavior unchanged

Closes #25516.

## Verification

- pinned Biome exact-file check — 2/2 files pass
- `git diff --check` — pass
- agent-skills focused test — 4/4 pass; lint — 72 files pass
- wallet focused test — 3/3 pass; lint — 299 files pass
- direct plugin typechecks reach only unbuilt workspace declaration exports (`@elizaos/shared`, `@elizaos/skills`, and `@elizaos/plugin-elizacloud`); repository-orchestrated typecheck is being run on the composed integration branch
- root verification is being rerun on the composed integration branch
- visual audit — N/A: only test source changed; no rendered view, widget, style, copy, or interaction changed

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
