### PR TITLE
fix(ci): close merged static-smoke gaps

### DIFF
--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/browser-tabs-renderer-registry.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/browser-tabs-renderer-registry.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Exercises the renderer registry's unattached, attached, and detached states.
+ */
+
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 beforeAll(() => {
@@ -7,9 +11,7 @@ beforeAll(() => {
 import {
   getBrowserTabsRendererImpl,
   setBrowserTabsRendererImpl,
-} from "./browser-tabs-renderer-registry.ts";
-
-const KEY = "__ELIZA_BROWSER_TABS_REGISTRY__";
+} from "../browser-tabs-renderer-registry.ts";
 
 const fakeImpl = {
   evaluate: async () => ({ ok: true }),
@@ -18,8 +20,7 @@ const fakeImpl = {
 
 describe("browser-tabs-renderer-registry", () => {
   afterEach(() => {
-    // @ts-expect-error window 类型收窄
-    delete window[KEY];
+    setBrowserTabsRendererImpl(null);
   });
 
   it("returns a not-attached fallback before any impl is set", () => {

--- a/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
+++ b/packages/app-core/src/api/auth/__tests__/auth-tokens.test.ts
@@ -1,9 +1,13 @@
+/**
+ * Exercises the API authentication token helpers with deterministic request headers.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   extractHeaderValue,
   getProvidedApiToken,
   tokenMatches,
-} from "./tokens.ts";
+} from "../tokens.ts";
 
 describe("tokenMatches", () => {
   it("matches equal tokens", () => {

--- a/packages/app/src/ios-attachment-smoke.surrogate.test.ts
+++ b/packages/app/src/ios-attachment-smoke.surrogate.test.ts
@@ -1,17 +1,22 @@
 /**
  * Surrogate-safe truncation for iOS attachment smoke upload error.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("ios-attachment-smoke surrogate-safe", () => {
   it("replaces lone surrogate", () => {
     expect(toWellFormedUnicode("a\uD800b")).toBe("a\uFFFDb");
   });
   it("does not split astral at 500", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(499) + "🦊"), 500)).toBe("x".repeat(499));
+    expect(
+      truncateWellFormed(toWellFormedUnicode("x".repeat(499) + "🦊"), 500),
+    ).toBe("x".repeat(499));
   });
   it("caps at 500", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(800)), 500).length).toBe(500);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(800)), 500).length,
+    ).toBe(500);
   });
 });

--- a/packages/app/src/ios-attachment-smoke.ts
+++ b/packages/app/src/ios-attachment-smoke.ts
@@ -13,8 +13,8 @@
  */
 import { Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
-import { shellLocalStorage } from "@elizaos/ui/bridge";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { shellLocalStorage } from "@elizaos/ui/bridge";
 
 const IOS_ATTACHMENT_SMOKE_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const IOS_ATTACHMENT_SMOKE_RESULT_KEY = "eliza:ios-attachment-smoke:result";

--- a/packages/ui/src/state/startup-phase-poll.surrogate.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.surrogate.test.ts
@@ -1,8 +1,9 @@
 /**
  * Surrogate-safe truncation for startup-phase-poll boot traces.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("startup-phase-poll surrogate-safe", () => {
   it("replaces lone surrogate", () => {
@@ -11,10 +12,16 @@ describe("startup-phase-poll surrogate-safe", () => {
   it("does not split astral at 300 boundary", () => {
     const astral = "🧠";
     const atBoundary = "x".repeat(299) + astral;
-    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 300)).toBe("x".repeat(299));
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(298) + astral), 300)).toBe("x".repeat(298) + astral);
+    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 300)).toBe(
+      "x".repeat(299),
+    );
+    expect(
+      truncateWellFormed(toWellFormedUnicode("x".repeat(298) + astral), 300),
+    ).toBe("x".repeat(298) + astral);
   });
   it("caps at 300", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(500)), 300).length).toBe(300);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(500)), 300).length,
+    ).toBe(300);
   });
 });

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -1050,7 +1050,10 @@ export async function runPollingBackend(
         );
         appendIosBootTrace("agent-error-terminal", {
           baseUrl: client.getBaseUrl(),
-          message: truncateWellFormed(toWellFormedUnicode(terminalMessage), 300),
+          message: truncateWellFormed(
+            toWellFormedUnicode(terminalMessage),
+            300,
+          ),
           path: ae?.path ?? null,
         });
         deps.setStartupError({

--- a/packages/ui/src/voice/local-asr-transcribe.surrogate.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.surrogate.test.ts
@@ -1,8 +1,9 @@
 /**
  * Surrogate-safe truncation for Cloud and Local ASR error bodies.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("local-asr-transcribe surrogate-safe", () => {
   it("replaces lone surrogate", () => {
@@ -11,10 +12,16 @@ describe("local-asr-transcribe surrogate-safe", () => {
   it("does not split astral at 200 boundary", () => {
     const astral = "🦊";
     const atBoundary = "x".repeat(199) + astral;
-    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe("x".repeat(199));
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200)).toBe("x".repeat(198) + astral);
+    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe(
+      "x".repeat(199),
+    );
+    expect(
+      truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200),
+    ).toBe("x".repeat(198) + astral);
   });
   it("caps at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length,
+    ).toBe(200);
   });
 });

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -445,7 +445,9 @@ export async function transcribeLocalInferenceWav(
     // error-policy:J6 the error body is diagnostic-only; a failed read must not
     // mask the real signal (the HTTP status the throw below already carries).
     const body = await res.text().catch(() => "");
-    throw new Error(`Local inference ASR ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`);
+    throw new Error(
+      `Local inference ASR ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+    );
   }
   // error-policy:J3 unparseable body falls through to the explicit
   // empty-transcript throw below

--- a/plugins/plugin-discord/__tests__/service.surrogate.test.ts
+++ b/plugins/plugin-discord/__tests__/service.surrogate.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 
 describe("discord service surrogate-safe truncation (200)", () => {
 	it("does not split astral pair at 200", () => {
-		const text = "a".repeat(199) + "🦊" + "b".repeat(10);
+		const text = `${"a".repeat(199)}🦊${"b".repeat(10)}`;
 		const normalized = text.replace(/\s+/g, " ").trim();
 		const truncated = truncateWellFormed(toWellFormedUnicode(normalized), 200);
 		expect(truncated.length).toBe(199);
@@ -30,7 +30,7 @@ describe("discord service surrogate-safe truncation (200)", () => {
 	});
 
 	it("old slice splits but guard does not", () => {
-		const text = "a".repeat(199) + "🦊";
+		const text = `${"a".repeat(199)}🦊`;
 		const old = text.replace(/\s+/g, " ").trim().slice(0, 200);
 		expect(old.charCodeAt(199)).toBe(0xd83e);
 		const fixed = truncateWellFormed(toWellFormedUnicode(text), 200);


### PR DESCRIPTION
Closes #25482.

## Summary

- applies the repository-pinned Biome formatter to recently merged regression and safety coverage
- repairs two newly merged nested test imports in app-core and Electrobun
- replaces an unnecessary TypeScript suppression with cleanup through the registry public API
- clears the read-only lint and affected typecheck failures that were surfacing sequentially on current `develop`

## Validation

- `bun install --frozen-lockfile` with Bun 1.3.14 — pass
- forced root writing lint — 141/141 tasks pass
- forced affected non-writing `lint:check` — 143/143 tasks pass, cache disabled
- app-core typecheck — pass
- Electrobun typecheck — pass
- auth-token focused Vitest — 6/6 pass
- renderer-registry focused Vitest — 3/3 pass
- `git diff --check` — pass

A full affected typecheck before the two import repairs completed 230/232 and identified exactly those two packages; an exact-head rerun is required before merge.

No UI behavior changes. Screenshots/video: N/A because this is formatting and test-contract repair only.

## Merge gate

Keep draft until exact-head affected typecheck, hosted static smoke, and independent review are green.