### PR TITLE
test(agent): cover user-name

### DIFF
--- a/packages/agent/src/providers/user-name.test.ts
+++ b/packages/agent/src/providers/user-name.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit coverage for createUserNameProvider: registration metadata, app-chat
+ * source gating (empty context for Telegram/Discord/missing source so the
+ * display name never leaks into other connectors), stored-name interpolation,
+ * and the admin fallback when no preferred name is configured. The provider
+ * is real; only fetchConfiguredOwnerName is stubbed at its service boundary.
+ */
+import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import { MESSAGE_SOURCE_CLIENT_CHAT } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ownerNameMock = vi.hoisted(() => ({
+  fetchConfiguredOwnerName: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("../services/owner-name.ts", () => ownerNameMock);
+
+import { createUserNameProvider } from "./user-name.ts";
+
+const EMPTY_STATE: State = { values: {}, data: {}, text: "" };
+const AGENT_ID = "00000000-0000-4000-8000-0000000000aa" as UUID;
+const ENTITY_ID = "00000000-0000-4000-8000-0000000000bb" as UUID;
+const ROOM_ID = "00000000-0000-4000-8000-0000000000cc" as UUID;
+const MESSAGE_ID = "00000000-0000-4000-8000-0000000000dd" as UUID;
+
+const FALLBACK_TEXT =
+  "No preferred user name is stored yet. The current fallback label is admin. " +
+  "If it comes up naturally in conversation, you can ask what " +
+  "they'd like to be called and use the SETTINGS action with op=set_owner_name to remember it.";
+
+function makeRuntime(): IAgentRuntime {
+  return { agentId: AGENT_ID } as IAgentRuntime;
+}
+
+function makeMessage(content: Record<string, unknown> | undefined): Memory {
+  return {
+    id: MESSAGE_ID,
+    agentId: AGENT_ID,
+    entityId: ENTITY_ID,
+    roomId: ROOM_ID,
+    content: content as Memory["content"],
+  } as Memory;
+}
+
+beforeEach(() => {
+  ownerNameMock.fetchConfiguredOwnerName.mockReset();
+});
+
+describe("createUserNameProvider metadata", () => {
+  it("registers as a dynamic turn-scoped OWNER-gated general provider", () => {
+    const provider = createUserNameProvider();
+    expect(provider.name).toBe("userName");
+    expect(provider.description).toBe(
+      "Injects the app user's display name into context (app chat only).",
+    );
+    expect(provider.descriptionCompressed).toBe(
+      "inject app user display name context (app chat)",
+    );
+    expect(provider.position).toBe(10);
+    expect(provider.dynamic).toBe(true);
+    expect(provider.contexts).toEqual(["general"]);
+    expect(provider.contextGate).toEqual({ anyOf: ["general"] });
+    expect(provider.cacheStable).toBe(false);
+    expect(provider.cacheScope).toBe("turn");
+    expect(provider.roleGate).toEqual({ minRole: "OWNER" });
+  });
+});
+
+describe("createUserNameProvider source gating", () => {
+  it("returns empty text for telegram so the name never leaks into connectors", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("Alice");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({ text: "hello", source: "telegram" }),
+      EMPTY_STATE,
+    );
+    expect(result).toEqual({ text: "" });
+    expect(ownerNameMock.fetchConfiguredOwnerName).not.toHaveBeenCalled();
+  });
+
+  it("returns empty text for discord", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("Alice");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({ text: "hello", source: "discord" }),
+      EMPTY_STATE,
+    );
+    expect(result).toEqual({ text: "" });
+    expect(ownerNameMock.fetchConfiguredOwnerName).not.toHaveBeenCalled();
+  });
+
+  it("returns empty text when content.source is missing", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("Alice");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({ text: "hello" }),
+      EMPTY_STATE,
+    );
+    expect(result).toEqual({ text: "" });
+    expect(ownerNameMock.fetchConfiguredOwnerName).not.toHaveBeenCalled();
+  });
+
+  it("returns empty text when message.content is undefined", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("Alice");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage(undefined),
+      EMPTY_STATE,
+    );
+    expect(result).toEqual({ text: "" });
+    expect(ownerNameMock.fetchConfiguredOwnerName).not.toHaveBeenCalled();
+  });
+
+  it("returns empty text for the hyphenated client-chat lookalike", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("Alice");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({ text: "hello", source: "client-chat" }),
+      EMPTY_STATE,
+    );
+    expect(MESSAGE_SOURCE_CLIENT_CHAT).toBe("client_chat");
+    expect(result).toEqual({ text: "" });
+    expect(ownerNameMock.fetchConfiguredOwnerName).not.toHaveBeenCalled();
+  });
+});
+
+describe("createUserNameProvider app chat", () => {
+  it("interpolates the stored owner name into prompt text and values", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("Ada Lovelace");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({
+        text: "hello",
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+      }),
+      EMPTY_STATE,
+    );
+    expect(result).toEqual({
+      text: "The user's name is Ada Lovelace.",
+      values: { userName: "Ada Lovelace" },
+    });
+    expect(result.values).not.toHaveProperty("userNameFallback");
+    expect(ownerNameMock.fetchConfiguredOwnerName).toHaveBeenCalledTimes(1);
+  });
+
+  it("interpolates a name with punctuation and spaces literally", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("O'Brien, Jr.");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({
+        text: "hello",
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+      }),
+      EMPTY_STATE,
+    );
+    expect(result.text).toBe("The user's name is O'Brien, Jr..");
+    expect(result.values).toEqual({ userName: "O'Brien, Jr." });
+  });
+
+  it("falls back to admin when no preferred name is stored", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue(null);
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({
+        text: "hello",
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+      }),
+      EMPTY_STATE,
+    );
+    expect(result).toEqual({
+      text: FALLBACK_TEXT,
+      values: { userName: "admin", userNameFallback: true },
+    });
+    expect(ownerNameMock.fetchConfiguredOwnerName).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to admin when the stored name is an empty string", async () => {
+    ownerNameMock.fetchConfiguredOwnerName.mockResolvedValue("");
+    const result = await createUserNameProvider().get(
+      makeRuntime(),
+      makeMessage({
+        text: "hello",
+        source: MESSAGE_SOURCE_CLIENT_CHAT,
+      }),
+      EMPTY_STATE,
+    );
+    expect(result.text).toBe(FALLBACK_TEXT);
+    expect(result.values).toEqual({
+      userName: "admin",
+      userNameFallback: true,
+    });
+  });
+});


### PR DESCRIPTION

## Summary

Adds a colocated vitest suite for `packages/agent/src/providers/user-name.ts`, which had no same-named test file.

`createUserNameProvider` injects the app user's display name into the system prompt **only** for `source === "client_chat"`. The suite drives the real factory and `get()`; `fetchConfiguredOwnerName` is stubbed at the owner-name service boundary so tests do not read host config.

Covered behavior:

- Registration metadata: name `userName`, position 10, dynamic, turn-scoped cache, `contexts`/`contextGate` `general`, OWNER `roleGate`
- Source gating: Telegram, Discord, missing `source`, undefined `content`, and the hyphenated `client-chat` lookalike all return `{ text: "" }` and never call the name fetch — so the display name cannot leak into other connectors
- App chat with a stored name interpolates it into prompt text and `values.userName` (including punctuation); `userNameFallback` is omitted
- App chat with `null` or `""` returns the admin fallback copy and `{ userName: "admin", userNameFallback: true }`

This is a test-only change. It does not alter production behavior.

## Evidence

1. `bunx vitest run packages/agent/src/providers/user-name.test.ts`: **Test Files 1 passed (1), Tests 10 passed (10)**. Duration 11.68s. Vitest v4.1.10.
2. `bunx biome check --write packages/agent/src/providers/user-name.test.ts`: **Checked 1 file in 1001ms. Fixed 1 file.** Config was `biome.json` at the repo root (not a vacuous no-config pass).
3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'user-name.test.ts'`: **empty** (grep EXIT:1). The new test file added no TypeScript diagnostics.
4. Diff touches **only** `packages/agent/src/providers/user-name.test.ts`.

Hosted CI does **not** run on this PR. We are a fork contributor (`ss251/eliza`); GitHub Actions on `elizaOS/eliza` do not execute for this head. Do not treat a missing check as a pass.

Provider `xai`, model `grok-4.6`, client `grok`.

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fbb2bc40cc86c600d6d3062799e8363707bfa036 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
