### PR TITLE
fix(ui): safe NaN handling in conversation sidebar model and group rows sort comparators

### DIFF
--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -799,7 +799,9 @@ export function ConversationsSidebar({
             />
           ),
           rows: [...group.rows].sort(
-            (left, right) => right.sortKey - left.sortKey,
+            (left, right) =>
+              (Number.isFinite(right.sortKey) ? right.sortKey : 0) -
+              (Number.isFinite(left.sortKey) ? left.sortKey : 0),
           ),
           serverMuted: group.rows.some(
             (row) => row.muted && row.mutedScope === "server",

--- a/packages/ui/src/components/conversations/conversation-sidebar-model.safe-sort.test.ts
+++ b/packages/ui/src/components/conversations/conversation-sidebar-model.safe-sort.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Verifies safe sorting in conversation sidebar model when updatedAt or lastMessageAt contains NaN or invalid timestamps.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ALL_CONNECTORS_SOURCE_SCOPE,
+  ALL_WORLDS_SCOPE,
+  buildConversationsSidebarModel,
+  ELIZA_SOURCE_SCOPE,
+  type InboxChatSidebarRow,
+} from "./conversation-sidebar-model.js";
+import type { Conversation } from "../../api/client-types-chat.js";
+
+const t = (key: string, opts?: { defaultValue?: string }) =>
+  opts?.defaultValue ?? key;
+
+describe("conversation-sidebar-model safe sort", () => {
+  it("safely handles conversations with invalid updatedAt dates without crashing or producing NaN sort order", () => {
+    const conversations: Conversation[] = [
+      {
+        id: "conv-1",
+        title: "Valid Conv 1",
+        createdAt: "2026-08-20T10:00:00.000Z",
+        updatedAt: "2026-08-23T10:00:00.000Z",
+        messages: [],
+      } as unknown as Conversation,
+      {
+        id: "conv-invalid",
+        title: "Invalid Date Conv",
+        createdAt: "invalid-date",
+        updatedAt: "not-a-valid-date",
+        messages: [],
+      } as unknown as Conversation,
+      {
+        id: "conv-2",
+        title: "Valid Conv 2",
+        createdAt: "2026-08-21T10:00:00.000Z",
+        updatedAt: "2026-08-22T10:00:00.000Z",
+        messages: [],
+      } as unknown as Conversation,
+    ];
+
+    const model = buildConversationsSidebarModel({
+      conversations,
+      inboxChats: [],
+      searchQuery: "",
+      sourceScope: ELIZA_SOURCE_SCOPE,
+      worldScope: ALL_WORLDS_SCOPE,
+      t,
+    });
+
+    expect(model.sections).toBeDefined();
+    const rows = model.sections.flatMap((s) => s.rows);
+    expect(rows).toHaveLength(3);
+    // Valid dates with higher timestamp should come first
+    expect(rows[0].id).toBe("conv-1");
+    expect(rows[1].id).toBe("conv-2");
+    expect(rows[2].id).toBe("conv-invalid");
+  });
+
+  it("safely handles inbox chats with NaN or non-finite lastMessageAt", () => {
+    const inboxChats: InboxChatSidebarRow[] = [
+      {
+        id: "chat-nan",
+        title: "NaN Chat",
+        source: "telegram",
+        lastMessageAt: NaN,
+      } as unknown as InboxChatSidebarRow,
+      {
+        id: "chat-valid",
+        title: "Valid Chat",
+        source: "telegram",
+        lastMessageAt: 10000,
+      } as unknown as InboxChatSidebarRow,
+    ];
+
+    const model = buildConversationsSidebarModel({
+      conversations: [],
+      inboxChats,
+      searchQuery: "",
+      sourceScope: ALL_CONNECTORS_SOURCE_SCOPE,
+      worldScope: ALL_WORLDS_SCOPE,
+      t,
+    });
+
+    expect(model.sections).toBeDefined();
+    const rows = model.sections.flatMap((s) => s.rows);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("safely computes non-finite sort subtraction without producing NaN", () => {
+    const safeDiff =
+      (Number.isFinite(NaN) ? NaN : 0) - (Number.isFinite(500) ? 500 : 0);
+    expect(safeDiff).toBe(-500);
+  });
+});

--- a/packages/ui/src/components/conversations/conversation-sidebar-model.ts
+++ b/packages/ui/src/components/conversations/conversation-sidebar-model.ts
@@ -148,16 +148,24 @@ function buildConversationRows(
 ): ConversationsSidebarRow[] {
   return conversations
     .filter(isMainChatConversation)
-    .map((conversation) => ({
-      id: conversation.id,
-      kind: "conversation" as const,
-      sortKey: new Date(conversation.updatedAt).getTime(),
-      sourceKey: ELIZA_SOURCE_SCOPE,
-      title: getLocalizedConversationTitle(conversation.title, t),
-      updatedAtLabel: formatRelativeTime(conversation.updatedAt, t),
-      worldKey: null,
-    }))
-    .sort((left, right) => right.sortKey - left.sortKey);
+    .map((conversation) => {
+      const parsedTime = new Date(conversation.updatedAt).getTime();
+      const sortKey = Number.isFinite(parsedTime) ? parsedTime : 0;
+      return {
+        id: conversation.id,
+        kind: "conversation" as const,
+        sortKey,
+        sourceKey: ELIZA_SOURCE_SCOPE,
+        title: getLocalizedConversationTitle(conversation.title, t),
+        updatedAtLabel: formatRelativeTime(conversation.updatedAt, t),
+        worldKey: null,
+      };
+    })
+    .sort(
+      (left, right) =>
+        (Number.isFinite(right.sortKey) ? right.sortKey : 0) -
+        (Number.isFinite(left.sortKey) ? left.sortKey : 0),
+    );
 }
 
 function buildInboxRows(
@@ -166,9 +174,11 @@ function buildInboxRows(
 ): ConversationsSidebarRow[] {
   return inboxChats
     .map((chat) => {
-      const sortKey = Number.isFinite(chat.lastMessageAt)
-        ? chat.lastMessageAt
-        : Date.now();
+      const sortKey =
+        typeof chat.lastMessageAt === "number" &&
+        Number.isFinite(chat.lastMessageAt)
+          ? chat.lastMessageAt
+          : Date.now();
       const isoDate = new Date(sortKey).toISOString();
       const normalizedSource = normalizeConnectorSource(chat.source);
       const normalizedWorldLabel = normalizeWorldLabel(chat, t);
@@ -190,7 +200,11 @@ function buildInboxRows(
         worldLabel: normalizedWorldLabel,
       };
     })
-    .sort((left, right) => right.sortKey - left.sortKey);
+    .sort(
+      (left, right) =>
+        (Number.isFinite(right.sortKey) ? right.sortKey : 0) -
+        (Number.isFinite(left.sortKey) ? left.sortKey : 0),
+    );
 }
 
 function buildSourceOptions(
@@ -465,10 +479,16 @@ function buildSections(
       label: section.label,
       rank: section.rank,
       rows: [...section.rows].sort(
-        (left, right) => right.sortKey - left.sortKey,
+        (left, right) =>
+          (Number.isFinite(right.sortKey) ? right.sortKey : 0) -
+          (Number.isFinite(left.sortKey) ? left.sortKey : 0),
       ),
     }))
-    .sort((left, right) => right.rank - left.rank)
+    .sort(
+      (left, right) =>
+        (Number.isFinite(right.rank) ? right.rank : 0) -
+        (Number.isFinite(left.rank) ? left.rank : 0),
+    )
     .map(({ rank: _rank, ...section }) => section);
 }
 


### PR DESCRIPTION
## Summary
Guards numeric sort comparators against `NaN` and non-finite timestamps/values across `packages/ui` conversation sidebar:

- **Conversation Rows**: Protect `updatedAt` parsing in `buildConversationRows` against invalid date strings yielding `NaN` sort keys.
- **Inbox Rows**: Protect `lastMessageAt` and sortKey subtraction against non-finite values in `buildInboxRows`.
- **Section Ordering & Groups**: Protect `rank` sorting and group rows sorting in `buildSections` and `ConversationsSidebar` from `NaN` instability.

## Verification
- Added dedicated regression unit tests:
  - `packages/ui/src/components/conversations/conversation-sidebar-model.safe-sort.test.ts`
- Verified unit test suites pass with Vitest:
  ```
  ✓ packages/ui/src/components/conversations/conversation-sidebar-model.safe-sort.test.ts (3 tests)
  ✓ packages/ui/src/components/conversations/conversation-sidebar-model.test.ts (9 tests)
  ```