### PR TITLE
chore(agent-orchestrator): restore safe-sort test formatter closure

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/curated-coding-memory.safe-sort.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/curated-coding-memory.safe-sort.test.ts
@@ -2,6 +2,7 @@
  * Verifies safe sorting in curated coding memory candidates harvesting when lastActivityAt or timestamp contains NaN.
  */
 
+import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { harvestCodingMemoryCandidates } from "../../src/services/curated-coding-memory.js";
 import type {
@@ -9,7 +10,6 @@ import type {
   OrchestratorTaskMessage,
   OrchestratorTaskSession,
 } from "../../src/services/orchestrator-task-types.js";
-import type { IAgentRuntime } from "@elizaos/core";
 
 const ISO = "2026-08-23T00:00:00.000Z";
 

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-registry.safe-sort.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-registry.safe-sort.test.ts
@@ -4,7 +4,12 @@
 
 import { describe, expect, it } from "vitest";
 
-type WorkspaceRecord = { path: string; kind: string; createdAt: number; live: boolean };
+type WorkspaceRecord = {
+  path: string;
+  kind: string;
+  createdAt: number;
+  live: boolean;
+};
 
 function sortCandidates(records: WorkspaceRecord[]): WorkspaceRecord[] {
   return [...records]
@@ -21,17 +26,37 @@ describe("workspace-registry safe sort", () => {
     const records: WorkspaceRecord[] = [
       { path: "/tmp/a", kind: "git-workspace", live: false, createdAt: NaN },
       { path: "/tmp/b", kind: "git-workspace", live: false, createdAt: 1000 },
-      { path: "/tmp/c", kind: "git-workspace", live: false, createdAt: undefined as unknown as number },
+      {
+        path: "/tmp/c",
+        kind: "git-workspace",
+        live: false,
+        createdAt: undefined as unknown as number,
+      },
       { path: "/tmp/d", kind: "git-workspace", live: false, createdAt: 500 },
     ];
     const sorted = sortCandidates(records);
-    expect(sorted.map((r) => r.path)).toEqual(["/tmp/a", "/tmp/c", "/tmp/d", "/tmp/b"]);
+    expect(sorted.map((r) => r.path)).toEqual([
+      "/tmp/a",
+      "/tmp/c",
+      "/tmp/d",
+      "/tmp/b",
+    ]);
   });
 
   it("handles Infinity by falling back to 0", () => {
     const records: WorkspaceRecord[] = [
-      { path: "/tmp/inf", kind: "git-workspace", live: false, createdAt: Infinity },
-      { path: "/tmp/valid", kind: "git-workspace", live: false, createdAt: 100 },
+      {
+        path: "/tmp/inf",
+        kind: "git-workspace",
+        live: false,
+        createdAt: Infinity,
+      },
+      {
+        path: "/tmp/valid",
+        kind: "git-workspace",
+        live: false,
+        createdAt: 100,
+      },
     ];
     const sorted = sortCandidates(records);
     expect(sorted[0].path).toBe("/tmp/inf");
@@ -39,8 +64,18 @@ describe("workspace-registry safe sort", () => {
   });
 
   it("old comparator would return NaN for NaN inputs", () => {
-    const a: WorkspaceRecord = { path: "/tmp/a", kind: "git-workspace", live: false, createdAt: NaN };
-    const b: WorkspaceRecord = { path: "/tmp/b", kind: "git-workspace", live: false, createdAt: 100 };
+    const a: WorkspaceRecord = {
+      path: "/tmp/a",
+      kind: "git-workspace",
+      live: false,
+      createdAt: NaN,
+    };
+    const b: WorkspaceRecord = {
+      path: "/tmp/b",
+      kind: "git-workspace",
+      live: false,
+      createdAt: 100,
+    };
     const oldResult = a.createdAt - b.createdAt;
     expect(Number.isNaN(oldResult)).toBe(true);
     const fixed = sortCandidates([a, b]);


### PR DESCRIPTION
## Summary

- restore import ordering in the curated coding-memory safe-sort test
- apply pinned formatter output to the workspace-registry safe-sort test
- preserve coding-agent behavior and assertions exactly

Closes #25536.

## Verification

- pinned Biome exact-file check — 2/2 files pass
- `git diff --check` — pass
- focused orchestrator tests — 4/4 pass
- orchestrator lint — 439 files pass
- direct typecheck reaches only an unbuilt `@elizaos/vault` declaration export; repository-orchestrated typecheck is being run on the composed integration branch
- root verification is being rerun on the composed integration branch

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
