### PR TITLE
fix(devices): bind confirmation to runtime operation

### DIFF
--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
@@ -18,17 +18,19 @@ describe("runtime mutation confirmation", () => {
 	});
 
 	it.each([
-		"yes",
-		"Yes, please",
-		"confirm",
-		"proceed",
-		"go ahead",
-		"do it",
 		"confirm the revocation",
 		"yes, confirm revoke",
+		"proceed with the revocation",
 	])("accepts an unambiguous complete confirmation: %s", (text) => {
 		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(true);
 	});
+
+	it.each(["yes", "Yes, please", "confirm", "proceed", "go ahead", "do it"])(
+		"rejects generic approval that is not bound to the requested operation: %s",
+		(text) => {
+			expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(false);
+		},
+	);
 
 	it("binds subject-bearing confirmation to the requested operation", () => {
 		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "pair")).toBe(

--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
@@ -41,18 +41,13 @@ export function isUnambiguousRuntimeConfirmation(
 		.replace(/[^a-z0-9]+/g, " ")
 		.trim()
 		.replace(/\s+/g, " ");
-	if (
-		/^(?:yes|yes please|yep|confirm|confirmed|proceed|go ahead|do it)$/.test(
-			normalized,
-		)
-	) {
-		return true;
-	}
 	return CONFIRMATION_SUBJECTS[op].some(
 		(subject) =>
 			normalized === `confirm ${subject}` ||
 			normalized === `confirm the ${subject}` ||
 			normalized === `yes confirm ${subject}` ||
-			normalized === `yes confirm the ${subject}`,
+			normalized === `yes confirm the ${subject}` ||
+			normalized === `proceed with ${subject}` ||
+			normalized === `proceed with the ${subject}`,
 	);
 }

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -111,14 +111,9 @@ describe("RUNTIMES action", () => {
 	});
 
 	it.each([
-		"yes",
-		"Yes, please",
-		"confirm",
-		"proceed",
-		"go ahead",
-		"do it",
 		"confirm the revocation",
 		"yes, confirm revoke",
+		"proceed with the revocation",
 	])("accepts an unambiguous complete confirmation: %s", async (text) => {
 		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
 			ok: true,
@@ -135,6 +130,28 @@ describe("RUNTIMES action", () => {
 		expect(result?.success).toBe(true);
 		expect(manageRuntime).toHaveBeenCalledTimes(1);
 	});
+
+	it.each(["yes", "Yes, please", "confirm", "proceed", "go ahead", "do it"])(
+		"rejects generic approval that is not bound to the requested operation: %s",
+		async (text) => {
+			const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+				ok: true,
+				op: request.op,
+			}));
+			const action = createRuntimeManagementAction({ manageRuntime });
+			const result = await action.handler(
+				runtime,
+				{ content: { text } } as Memory,
+				undefined,
+				{ op: "revoke", targetId: "host:mac", confirm: "true" },
+				callback(),
+			);
+			expect(result?.values).toEqual(
+				expect.objectContaining({ awaitingConfirmation: true }),
+			);
+			expect(manageRuntime).not.toHaveBeenCalled();
+		},
+	);
 
 	it("dispatches a confirmed pairing and narrates the one-use receipt", async () => {
 		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({


### PR DESCRIPTION
## Summary

Second stacked confirmation correction for #24830, based on exact parent head `fa0c7718729fd13a286bf6efe487f05e14ff3962`.

The previous fail-closed parser rejected negation, but still accepted a generic “yes”, “confirm”, “proceed”, “go ahead”, or “do it” for whatever mutation the planner selected in the current turn. Because the parent has no durable nonce-bound proposal record, that generic approval is not proof that the user approved the selected operation.

This correction:

- rejects every generic approval phrase;
- requires the user text to name the exact requested mutation subject;
- permits narrow forms such as “confirm the revocation”, “yes, confirm pairing”, or “proceed with host enrollment”;
- keeps negation/mixed-intent denial and operation-subject binding.

## Validation

Pinned Bun 1.3.14:

- pure parser + real action handler Vitest: **42/42 passed**;
- focused Biome on all touched files: clean;
- `git diff --check`: clean.

UI/live evidence: N/A for this parser-only branch correction. Parent external gates remain unchanged.
