### PR TITLE
chore(ui): restore runtime surrogate formatter closure

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.surrogate.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.surrogate.test.ts
@@ -1,8 +1,9 @@
 /**
  * Surrogate-safe truncation for startup-phase-poll boot traces.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("startup-phase-poll surrogate-safe", () => {
   it("replaces lone surrogate", () => {
@@ -11,10 +12,16 @@ describe("startup-phase-poll surrogate-safe", () => {
   it("does not split astral at 300 boundary", () => {
     const astral = "🧠";
     const atBoundary = "x".repeat(299) + astral;
-    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 300)).toBe("x".repeat(299));
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(298) + astral), 300)).toBe("x".repeat(298) + astral);
+    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 300)).toBe(
+      "x".repeat(299),
+    );
+    expect(
+      truncateWellFormed(toWellFormedUnicode("x".repeat(298) + astral), 300),
+    ).toBe("x".repeat(298) + astral);
   });
   it("caps at 300", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(500)), 300).length).toBe(300);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(500)), 300).length,
+    ).toBe(300);
   });
 });

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -1050,7 +1050,10 @@ export async function runPollingBackend(
         );
         appendIosBootTrace("agent-error-terminal", {
           baseUrl: client.getBaseUrl(),
-          message: truncateWellFormed(toWellFormedUnicode(terminalMessage), 300),
+          message: truncateWellFormed(
+            toWellFormedUnicode(terminalMessage),
+            300,
+          ),
           path: ae?.path ?? null,
         });
         deps.setStartupError({

--- a/packages/ui/src/voice/local-asr-transcribe.surrogate.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.surrogate.test.ts
@@ -1,8 +1,9 @@
 /**
  * Surrogate-safe truncation for Cloud and Local ASR error bodies.
  */
-import { describe, expect, it } from "vitest";
+
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
 
 describe("local-asr-transcribe surrogate-safe", () => {
   it("replaces lone surrogate", () => {
@@ -11,10 +12,16 @@ describe("local-asr-transcribe surrogate-safe", () => {
   it("does not split astral at 200 boundary", () => {
     const astral = "🦊";
     const atBoundary = "x".repeat(199) + astral;
-    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe("x".repeat(199));
-    expect(truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200)).toBe("x".repeat(198) + astral);
+    expect(truncateWellFormed(toWellFormedUnicode(atBoundary), 200)).toBe(
+      "x".repeat(199),
+    );
+    expect(
+      truncateWellFormed(toWellFormedUnicode("x".repeat(198) + astral), 200),
+    ).toBe("x".repeat(198) + astral);
   });
   it("caps at 200", () => {
-    expect(truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length).toBe(200);
+    expect(
+      truncateWellFormed(toWellFormedUnicode("a".repeat(300)), 200).length,
+    ).toBe(200);
   });
 });

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -445,7 +445,9 @@ export async function transcribeLocalInferenceWav(
     // error-policy:J6 the error body is diagnostic-only; a failed read must not
     // mask the real signal (the HTTP status the throw below already carries).
     const body = await res.text().catch(() => "");
-    throw new Error(`Local inference ASR ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`);
+    throw new Error(
+      `Local inference ASR ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+    );
   }
   // error-policy:J3 unparseable body falls through to the explicit
   // empty-transcript throw below


### PR DESCRIPTION
## Summary

- apply pinned formatting/import ordering to startup boot-trace and local-ASR surrogate-safety paths
- format their two focused regression tests without changing assertions
- preserve runtime and rendered UI behavior exactly

Closes #25540.

## Verification

- pinned Biome exact-file check — 4/4 files pass
- `git diff --check` — pass
- focused UI runtime tests — 6/6 pass
- UI lint — 3,207 files pass (5 pre-existing cookie advisories only)
- UI typecheck — pass
- root verification is being rerun on the composed integration branch
- full app visual audit — N/A: no component tree, styles, copy, state transition, layout, or interaction changed

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->
