### PR TITLE
test(agent): cover agent-event-service

### DIFF
--- a/packages/agent/src/runtime/agent-event-service.test.ts
+++ b/packages/agent/src/runtime/agent-event-service.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit coverage for getAgentEventService: duck-typed lookup across the
+ * published service-type aliases. Drives the real resolver with an in-memory
+ * runtime map and a subscribe-capable service — no production-module mocks.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_EVENT_SERVICE_TYPES,
+  type AgentEventPayloadLike,
+  type AgentEventServiceLike,
+  getAgentEventService,
+} from "./agent-event-service.ts";
+
+type RuntimeLike = {
+  getService: (serviceType: string) => unknown | null;
+};
+
+function makeEventService(): AgentEventServiceLike & {
+  eventListeners: Array<(event: AgentEventPayloadLike) => void>;
+} {
+  const eventListeners: Array<(event: AgentEventPayloadLike) => void> = [];
+  return {
+    eventListeners,
+    subscribe(listener) {
+      eventListeners.push(listener);
+      return () => {
+        const index = eventListeners.indexOf(listener);
+        if (index === -1) {
+          return;
+        }
+        eventListeners.splice(index, 1);
+      };
+    },
+    subscribeHeartbeat() {
+      return () => {};
+    },
+    getLastHeartbeat() {
+      return null;
+    },
+  };
+}
+
+function makeRuntime(
+  services: Record<string, unknown | null> = {},
+): RuntimeLike & { probed: string[] } {
+  const probed: string[] = [];
+  return {
+    probed,
+    getService(serviceType: string) {
+      probed.push(serviceType);
+      if (!Object.hasOwn(services, serviceType)) {
+        return null;
+      }
+      return services[serviceType];
+    },
+  };
+}
+
+describe("AGENT_EVENT_SERVICE_TYPES", () => {
+  it("probes the lowercase alias before the uppercase alias", () => {
+    expect(AGENT_EVENT_SERVICE_TYPES).toEqual(["agent_event", "AGENT_EVENT"]);
+  });
+});
+
+describe("getAgentEventService", () => {
+  it("returns null when the runtime is missing", () => {
+    expect(getAgentEventService(null)).toBeNull();
+    expect(getAgentEventService(undefined)).toBeNull();
+  });
+
+  it("returns null when the registry is empty", () => {
+    const runtime = makeRuntime();
+    expect(getAgentEventService(runtime)).toBeNull();
+    expect(runtime.probed).toEqual(["agent_event", "AGENT_EVENT"]);
+  });
+
+  it("returns the lowercase-alias service without probing the uppercase alias", () => {
+    const service = makeEventService();
+    const runtime = makeRuntime({ agent_event: service });
+    expect(getAgentEventService(runtime)).toBe(service);
+    expect(runtime.probed).toEqual(["agent_event"]);
+  });
+
+  it("falls through to AGENT_EVENT when agent_event is unregistered", () => {
+    const service = makeEventService();
+    const runtime = makeRuntime({ AGENT_EVENT: service });
+    expect(getAgentEventService(runtime)).toBe(service);
+    expect(runtime.probed).toEqual(["agent_event", "AGENT_EVENT"]);
+  });
+
+  it("treats a falsy getService result as unregistered and keeps probing", () => {
+    const fallback = makeEventService();
+    const runtime = makeRuntime({
+      agent_event: null,
+      AGENT_EVENT: fallback,
+    });
+    expect(getAgentEventService(runtime)).toBe(fallback);
+    expect(runtime.probed).toEqual(["agent_event", "AGENT_EVENT"]);
+  });
+
+  it("skips a registered object that is missing subscribe", () => {
+    const fallback = makeEventService();
+    const runtime = makeRuntime({
+      agent_event: { subscribeHeartbeat: () => () => {} },
+      AGENT_EVENT: fallback,
+    });
+    expect(getAgentEventService(runtime)).toBe(fallback);
+  });
+
+  it("skips a subscribe property that is not a function", () => {
+    const fallback = makeEventService();
+    const runtime = makeRuntime({
+      agent_event: { subscribe: "listen" },
+      AGENT_EVENT: fallback,
+    });
+    expect(getAgentEventService(runtime)).toBe(fallback);
+  });
+
+  it("prefers the first alias when both aliases expose a valid service", () => {
+    const first = makeEventService();
+    const second = makeEventService();
+    const runtime = makeRuntime({
+      agent_event: first,
+      AGENT_EVENT: second,
+    });
+    expect(getAgentEventService(runtime)).toBe(first);
+    expect(runtime.probed).toEqual(["agent_event"]);
+  });
+
+  it("accepts a service that only implements subscribe", () => {
+    const service = { subscribe: () => () => {} };
+    const runtime = makeRuntime({ agent_event: service });
+    expect(getAgentEventService(runtime)).toBe(service);
+  });
+
+  it("returns the live service identity so subscribe reaches the same listeners", () => {
+    const service = makeEventService();
+    const runtime = makeRuntime({ agent_event: service });
+    const resolved = getAgentEventService(runtime);
+    expect(resolved).toBe(service);
+    if (!resolved) {
+      throw new Error("getAgentEventService returned null");
+    }
+
+    const received: AgentEventPayloadLike[] = [];
+    const unsubscribe = resolved.subscribe((event) => {
+      received.push(event);
+    });
+    const payload: AgentEventPayloadLike = {
+      runId: "run-1",
+      seq: 1,
+      stream: "thought",
+      ts: 1,
+      data: { text: "hello" },
+    };
+    for (const listener of service.eventListeners) {
+      listener(payload);
+    }
+    expect(received).toEqual([payload]);
+
+    unsubscribe();
+    expect(service.eventListeners).toEqual([]);
+  });
+});


### PR DESCRIPTION

## Summary

Adds real unit coverage for `packages/agent/src/runtime/agent-event-service.ts`, which had no same-named test file. The suite drives the real `getAgentEventService` resolver with an in-memory runtime registry and a subscribe-capable service. Production code is unchanged.

Covered branches:

- missing runtime (`null` / `undefined`)
- empty registry
- lowercase `agent_event` hit (short-circuits; does not probe `AGENT_EVENT`)
- fallthrough to `AGENT_EVENT` when the first alias is unregistered or falsy
- skip a registered object missing `subscribe`, or whose `subscribe` is not a function
- first-alias wins when both aliases expose a valid service
- duck-type match on `subscribe` alone
- returned service is the live identity (subscribe reaches the same listeners)

This resolver has no queue, capacity, or comparator; those cases do not apply.

## Evidence

1. `bunx vitest run packages/agent/src/runtime/agent-event-service.test.ts`

```
Test Files  1 passed (1)
     Tests  11 passed (11)
```

2. `bunx biome check --write packages/agent/src/runtime/agent-event-service.test.ts`

```
Checked 1 file in 127ms. No fixes applied.
```

`biome.json` exists at the checkout root. Sparse-checkout is enabled on this tree but does materialise `biome.json` and the agent package.

3. `cd packages/agent && bunx tsc --noEmit 2>&1 | grep 'agent-event-service.test.ts'`

empty — the new test file appears nowhere in tsc output.

4. Diff touches only `packages/agent/src/runtime/agent-event-service.test.ts`.

We are a fork contributor: hosted CI does not run on this PR. Do not treat missing GitHub Actions as a pass.

## Test plan

- [x] vitest 11/11 on the new file
- [x] biome clean
- [x] tsc: no errors in the new file

# Relates to

# Evidence Gate

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: grok
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:474ccde2cce82b948f7c52e81ccef522f442aafc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: grok
Contribution skill revision: SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza
Attribution status: self-reported
— [grok-fleet-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"grok","skill_revision":"SlopDotCash/slopdotcash@e66845aeb536c08ab484296cbd8565e17c484c8c:skills/contribute-to-eliza"} -->
