### PR TITLE
fix(shared): close grounding privacy transport gaps

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-shared-stream-deferred-billing.test.ts
@@ -133,6 +133,44 @@ const RPC = {
 };
 
 describe("bridgeSharedMessageStream — billing tail deferred via executionCtx.waitUntil", () => {
+  test("persists complete grounding internally without emitting provider evidence in done SSE", async () => {
+    reset();
+    const providerBody = "PRIVATE_PROVIDER_BODY_MARKER";
+    const sourceExcerpt = "PRIVATE_SOURCE_EXCERPT_MARKER";
+    const internalGrounding = {
+      kind: "web_search" as const,
+      query: "what is btc price rn",
+      provider: "parallel" as const,
+      observedAt: Date.UTC(2026, 7, 23, 12, 0, 0),
+      sourceUrls: ["https://coin.example/bitcoin"],
+      sources: [{ url: "https://coin.example/bitcoin", text: sourceExcerpt }],
+      text: providerBody,
+      truncated: false,
+    };
+    streamTurnImpl = () => ({
+      model: "openai/gpt-oss-120b",
+      degraded: false,
+      internalGrounding,
+      parts: makeParts("Bitcoin is current. [Source](https://coin.example/bitcoin)"),
+    });
+    const svc = makeService();
+
+    const response = await svc.bridgeSharedMessageStream(REC, RPC);
+    const body = await drainSse(response);
+
+    expect(svc.saveSharedRuntimeHistory).toHaveBeenCalledTimes(1);
+    const persisted = (svc.saveSharedRuntimeHistory as ReturnType<typeof mock>).mock.calls[0]?.[2];
+    expect(persisted).toBeArray();
+    expect((persisted as Array<Record<string, unknown>>).at(-1)?.grounding).toEqual(
+      internalGrounding,
+    );
+    expect(body).toContain("event: done");
+    expect(body).toContain("Bitcoin is current.");
+    expect(body).not.toContain(providerBody);
+    expect(body).not.toContain(sourceExcerpt);
+    expect(body).not.toContain("internalGrounding");
+  });
+
   test("`done` frame flushes BEFORE the billing tail; deferred task settles at billing.totalCost", async () => {
     reset();
     // Gate billUsage so we can prove the stream completed without waiting on it.

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4604,6 +4604,7 @@ export class ElizaSandboxService {
         character,
         history,
         message: text,
+        capabilityText: text,
         execution: {
           agentKey: rec.id,
           roomKey: channelId,
@@ -4771,6 +4772,7 @@ export class ElizaSandboxService {
         character,
         history,
         message: text,
+        capabilityText: text,
         execution: {
           agentKey: rec.id,
           roomKey: channelId,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4827,7 +4827,12 @@ export class ElizaSandboxService {
               const nextHistory: SharedTurnMessage[] = [
                 ...history,
                 { role: "user", content: text.trim(), createdAt: sentAt },
-                { role: "assistant", content: finalReply, createdAt: sentAt + 1 },
+                {
+                  role: "assistant",
+                  content: finalReply,
+                  createdAt: sentAt + 1,
+                  ...(turn.internalGrounding ? { grounding: turn.internalGrounding } : {}),
+                },
               ];
               await this.saveSharedRuntimeHistory(rec.id, channelId, nextHistory);
               if (billingContext) {
@@ -12155,7 +12160,9 @@ export class ElizaSandboxService {
         });
         return "";
       });
-      throw new Error(`State restore failed: HTTP ${res.status} ${truncateWellFormed(toWellFormedUnicode(text), 200)}`);
+      throw new Error(
+        `State restore failed: HTTP ${res.status} ${truncateWellFormed(toWellFormedUnicode(text), 200)}`,
+      );
     }
   }
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.realtime-grounding.test.ts
@@ -103,6 +103,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
       character,
       history: [],
       message: "what is btc price rn",
+      capabilityText: "what is btc price rn",
       execution: {
         agentKey: "personal-shared:test",
         roomKey: "telegram:test",
@@ -118,11 +119,15 @@ describe("runSharedAgentTurn realtime grounding", () => {
       expect.objectContaining({
         success: true,
         data: expect.objectContaining({
-          originalModelReply: runtimeReply,
           deliveredReply: expect.stringContaining("Source: example.com"),
+          groundingStatus: "verified",
+          sourceUrls: ["https://example.com/markets/btc-usd"],
         }),
       }),
     ]);
+    expect(JSON.stringify(result.actionResults)).not.toContain("originalModelReply");
+    expect(JSON.stringify(result.actionResults)).not.toContain('"sources"');
+    expect(JSON.stringify(result.actionResults)).not.toContain('"excerpt"');
     expect(capturedRuntimeInput?.preflightActionResults).toEqual([searchResult]);
     if (!capturedRuntimeInput) throw new Error("runtime input was not captured");
     expect((capturedRuntimeInput.character as { system: string }).system).toContain(
@@ -130,7 +135,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
     );
   });
 
-  test("keeps a distinct runtime search receipt while deduplicating only the preflight query", async () => {
+  test("keeps all raw search receipts internal and exposes one safe public receipt", async () => {
     const followUpSearch: ActionResult = {
       success: true,
       text: JSON.stringify({ symbol: "ETH", value: "3,500", currency: "USD" }),
@@ -169,11 +174,13 @@ describe("runSharedAgentTurn realtime grounding", () => {
       character,
       history: [],
       message: "what is btc price rn",
+      capabilityText: "what is btc price rn",
     });
 
-    expect(result.actionResults).toHaveLength(2);
+    expect(result.actionResults).toHaveLength(1);
     expect(result.actionResults?.[0]?.data?.query).toBe("what is btc price rn");
-    expect(result.actionResults?.[1]).toEqual(followUpSearch);
+    expect(JSON.stringify(result.actionResults)).not.toContain("compare with ethereum price");
+    expect(JSON.stringify(result.actionResults)).not.toContain("3,500");
   });
 
   test("replaces a fabricated value and attribution with a safe answer", async () => {
@@ -182,12 +189,15 @@ describe("runSharedAgentTurn realtime grounding", () => {
       character,
       history: [],
       message: "what is btc price rn",
+      capabilityText: "what is btc price rn",
     });
 
     expect(result.reply).not.toContain("63,800");
     expect(result.reply).not.toContain("TradingView");
     expect(result.reply).toContain("couldn’t safely bind the requested claim");
     expect(result.reply).toContain("Source provider: parallel");
+    expect(JSON.stringify(result.actionResults)).not.toContain("63,800");
+    expect(JSON.stringify(result.actionResults)).not.toContain("TradingView");
   });
 
   test("fails closed when search has no traceable source", async () => {
@@ -206,6 +216,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
       character,
       history: [],
       message: "weather today",
+      capabilityText: "weather today",
     });
 
     expect(result.reply).toContain("can’t verify");
@@ -246,6 +257,16 @@ describe("runSharedAgentTurn realtime grounding", () => {
 
     searchQueries = [];
     capturedRuntimeInput = undefined;
+    await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "what is btc price rn",
+    });
+    expect(searchQueries).toEqual([]);
+    expect(capturedRuntimeInput?.preflightActionResults).toBeUndefined();
+
+    searchQueries = [];
+    capturedRuntimeInput = undefined;
     runtimeReply = "Your todos are available privately.";
     await runSharedAgentTurn({
       character,
@@ -257,7 +278,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
     expect(capturedRuntimeInput?.preflightActionResults).toBeUndefined();
   });
 
-  test("turns model silence into useful correction recovery", async () => {
+  test("does not export prior history for an ambiguous correction", async () => {
     runtimeReply = "";
     runtimeResponded = false;
     const result = await runSharedAgentTurn({
@@ -267,11 +288,12 @@ describe("runSharedAgentTurn realtime grounding", () => {
         { role: "assistant", content: "Bitcoin is 63,800 USD." },
       ],
       message: "wrong, check again",
+      capabilityText: "wrong, check again",
     });
 
-    expect(result.responded).toBe(true);
-    expect(result.reply).toContain("couldn’t safely bind the requested claim");
-    expect(result.reply).not.toMatch(/^\?+$/u);
+    expect(result.responded).toBe(false);
+    expect(searchQueries).toEqual([]);
+    expect(capturedRuntimeInput?.preflightActionResults).toBeUndefined();
   });
 
   test("buffers current-data streaming so no unverified prefix escapes", async () => {
@@ -279,6 +301,7 @@ describe("runSharedAgentTurn realtime grounding", () => {
       character,
       history: [],
       message: "latest ethereum price",
+      capabilityText: "latest ethereum price",
     });
     if (!result.parts) throw new Error("stream returned no parts");
     const parts = [];
@@ -296,5 +319,11 @@ describe("runSharedAgentTurn realtime grounding", () => {
         }),
       }),
     ]);
+    const terminalReceipt = JSON.stringify(
+      parts[1]?.type === "finish" ? parts[1].actionResults : undefined,
+    );
+    expect(terminalReceipt).not.toContain("originalModelReply");
+    expect(terminalReceipt).not.toContain('"sources"');
+    expect(terminalReceipt).not.toContain('"excerpt"');
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -50,7 +50,6 @@ import {
 import type { SharedMemoryStore } from "./shared-memory-store";
 import {
   finalizeSharedRealtimeReply,
-  isMatchingRealtimeSearchResult,
   requireTraceableRealtimeSearch,
   resolveSharedRealtimeRequirement,
   sharedRealtimePromptPolicy,
@@ -211,6 +210,8 @@ export interface RunSharedAgentTurnResult {
   usage?: SharedAgentTurnUsage;
   /** Genuine plugin results, including applied effect receipts, for clients and replay. */
   actionResults?: ActionResult[];
+  /** Complete current-turn evidence for internal persistence; transports must never serialize it. */
+  internalGrounding?: SharedRuntimePublicGrounding;
   /** Typed refusal for a tool or device action Shared cannot execute. */
   capabilityWall?: SharedCapabilityWall;
   /** Privacy-bounded provider timing exposed to Shared transports. */
@@ -239,6 +240,8 @@ export interface RunSharedAgentTurnStreamResult {
   history?: SharedTurnMessage[];
   /** Genuine plugin results preserved on the terminal SSE frame and replay. */
   actionResults?: ActionResult[];
+  /** Complete current-turn evidence for internal persistence; transports must never serialize it. */
+  internalGrounding?: SharedRuntimePublicGrounding;
   parts?: AsyncIterable<SharedAgentTurnStreamPart>;
   /** Cancels the AI SDK response reader in addition to aborting provider I/O. */
   cancel?: (reason?: unknown) => Promise<void>;
@@ -372,6 +375,43 @@ function hasRequiredActionResult(
   return Boolean(turn.actionResults?.some((result) => result.data?.actionName === actionName));
 }
 
+function isWebSearchActionResult(result: ActionResult): boolean {
+  return result.data?.actionName === "WEB_SEARCH";
+}
+
+function sharedRealtimeTransportReceipt(
+  grounding: SharedRuntimePublicGrounding,
+  deliveredReply: string,
+): ActionResult {
+  if (grounding.kind === "web_search_unavailable") {
+    return {
+      success: false,
+      text: deliveredReply,
+      error: "Live public data is temporarily unavailable.",
+      data: {
+        actionName: "WEB_SEARCH",
+        query: grounding.query,
+        observedAt: grounding.observedAt,
+        deliveredReply,
+        groundingStatus: "unavailable",
+      },
+    };
+  }
+  return {
+    success: true,
+    text: deliveredReply,
+    data: {
+      actionName: "WEB_SEARCH",
+      query: grounding.query,
+      provider: grounding.provider,
+      observedAt: grounding.observedAt,
+      sourceUrls: grounding.sourceUrls ?? [],
+      deliveredReply,
+      groundingStatus: "verified",
+    },
+  };
+}
+
 export function appendSharedTurn(
   history: SharedTurnMessage[],
   userMessage: string,
@@ -481,7 +521,7 @@ export async function runSharedAgentTurn(
   input: RunSharedAgentTurnInput,
 ): Promise<RunSharedAgentTurnResult> {
   const message = input.message.trim();
-  const publicSearchText = (input.capabilityText ?? message).trim();
+  const publicSearchText = input.capabilityText?.trim();
 
   const actionsEnabled = input.messageRole !== "system";
   const remindersEnabled = actionsEnabled && Boolean(input.execution?.reminders);
@@ -507,9 +547,10 @@ export async function runSharedAgentTurn(
     };
   }
 
-  const realtimeRequirement = actionsEnabled
-    ? resolveSharedRealtimeRequirement(publicSearchText, input.history)
-    : undefined;
+  const realtimeRequirement =
+    actionsEnabled && publicSearchText
+      ? resolveSharedRealtimeRequirement(publicSearchText, input.history)
+      : undefined;
   let realtimeActionResults: ActionResult[] | undefined;
   let realtimeGrounding: SharedRuntimePublicGrounding | undefined;
   if (realtimeRequirement) {
@@ -574,7 +615,7 @@ export async function runSharedAgentTurn(
     );
     if (realtimeActionResults) {
       const runtimeActionResults = (turn.actionResults ?? []).filter(
-        (result) => !isMatchingRealtimeSearchResult(result, realtimeRequirement?.query ?? ""),
+        (result) => !isWebSearchActionResult(result),
       );
       turn = { ...turn, actionResults: [...realtimeActionResults, ...runtimeActionResults] };
     }
@@ -592,7 +633,6 @@ export async function runSharedAgentTurn(
     );
   }
   if (realtimeRequirement) {
-    const originalModelReply = turn.reply;
     const groundedReply = finalizeSharedRealtimeReply(turn.reply, realtimeGrounding);
     const history = [...turn.history];
     let replaced = false;
@@ -615,19 +655,20 @@ export async function runSharedAgentTurn(
         ...(realtimeGrounding ? { grounding: realtimeGrounding } : {}),
       });
     }
-    const actionResults = (turn.actionResults ?? []).map((result) =>
-      isMatchingRealtimeSearchResult(result, realtimeRequirement.query)
-        ? {
-            ...result,
-            data: {
-              ...result.data,
-              originalModelReply,
-              deliveredReply: groundedReply,
-            },
-          }
-        : result,
-    );
-    turn = { ...turn, reply: groundedReply, responded: true, history, actionResults };
+    const actionResults = [
+      ...(realtimeGrounding
+        ? [sharedRealtimeTransportReceipt(realtimeGrounding, groundedReply)]
+        : []),
+      ...(turn.actionResults ?? []).filter((result) => !isWebSearchActionResult(result)),
+    ];
+    turn = {
+      ...turn,
+      reply: groundedReply,
+      responded: true,
+      history,
+      ...(actionResults.length ? { actionResults } : {}),
+      ...(realtimeGrounding ? { internalGrounding: realtimeGrounding } : {}),
+    };
   }
   // The durable memory commit runs OUTSIDE the provider try/catch: its failure
   // is a storage fault on an already-landed reply and must not be re-labeled
@@ -646,7 +687,7 @@ export async function runSharedAgentTurnStream(
   input: RunSharedAgentTurnStreamInput,
 ): Promise<RunSharedAgentTurnStreamResult> {
   const message = input.message.trim();
-  const publicSearchText = (input.capabilityText ?? message).trim();
+  const publicSearchText = input.capabilityText?.trim();
 
   const actionsEnabled = input.messageRole !== "system";
   const remindersEnabled = actionsEnabled && Boolean(input.execution?.reminders);
@@ -674,7 +715,11 @@ export async function runSharedAgentTurnStream(
 
   // Current-data answers are buffered until their complete grounded reply has
   // passed validation; streaming an unverified numeric claim cannot be undone.
-  if (actionsEnabled && resolveSharedRealtimeRequirement(publicSearchText, input.history)) {
+  if (
+    actionsEnabled &&
+    publicSearchText &&
+    resolveSharedRealtimeRequirement(publicSearchText, input.history)
+  ) {
     const turn = await runSharedAgentTurn(input);
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
       if (turn.reply) yield { type: "text-delta", text: turn.reply };
@@ -693,6 +738,7 @@ export async function runSharedAgentTurnStream(
       reply: turn.reply,
       history: turn.history,
       ...(turn.actionResults?.length ? { actionResults: turn.actionResults } : {}),
+      ...(turn.internalGrounding ? { internalGrounding: turn.internalGrounding } : {}),
       parts,
     };
   }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -1135,6 +1135,7 @@ describe("Shared Eliza Workerd runtime", () => {
       },
       history: [],
       message: "What is the latest ElizaOS news?",
+      capabilityText: "What is the latest ElizaOS news?",
       messageIds: {
         user: "6328e4cb-4a1f-4d9c-a2fd-769e5fd33aa1",
         assistant: "059e33bc-8215-49f4-841f-7642e7505bc7",
@@ -1160,15 +1161,13 @@ describe("Shared Eliza Workerd runtime", () => {
     const searchResults = result.actionResults?.filter(
       (action) => action.data?.actionName === "WEB_SEARCH",
     );
-    expect(searchResults).toHaveLength(2);
+    expect(searchResults).toHaveLength(1);
     expect(searchResults?.[0]).toMatchObject({
       success: true,
       data: { query: "What is the latest ElizaOS news?" },
     });
-    expect(searchResults?.[1]).toMatchObject({
-      success: false,
-      data: { query: "latest ElizaOS news" },
-    });
+    expect(JSON.stringify(searchResults)).not.toContain('"sources"');
+    expect(JSON.stringify(searchResults)).not.toContain("search_id");
     expect(modelRequests).toHaveLength(5);
     expect(result.usage).toMatchObject({
       promptTokens: 220,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -736,7 +736,9 @@ async function executeMeasuredSharedElizaRuntimeTurn(
   const actionsEnabled = input.messageRole !== "system";
   const webSearchEnabled =
     actionsEnabled &&
-    Boolean(resolveSharedRealtimeRequirement(input.capabilityText ?? input.message, input.history));
+    Boolean(
+      input.capabilityText && resolveSharedRealtimeRequirement(input.capabilityText, input.history),
+    );
   const reminderPlugin =
     actionsEnabled && input.execution?.reminders
       ? createSharedRemindersEdgePlugin({

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
@@ -5,6 +5,7 @@ import type { SharedRuntimePublicGrounding } from "../../../db/schemas/shared-ru
 import {
   createMatchingRealtimeSearchRunner,
   finalizeSharedRealtimeReply,
+  isSharedPublicSearchSafe,
   requireTraceableRealtimeSearch,
   resolveSharedRealtimeRequirement,
   validateSharedRealtimeReply,
@@ -124,12 +125,26 @@ describe("Shared realtime request classification", () => {
   for (const literal of [
     "what is the weather at 123 Main Street?",
     "what is the weather at (415) 555-1212?",
+    "what is the weather at 4155551212?",
+    "what is the weather at +14155551212?",
     "what is the weather at 37.7749, -122.4194?",
+    "what is the weather at 37.7749 N, 122.4194 W?",
   ]) {
     test(`rejects precise private literals from public lookup: ${literal}`, () => {
       expect(resolveSharedRealtimeRequirement(literal, [])).toBeUndefined();
     });
   }
+
+  test("does not mistake ordinary public dates and market values for private literals", () => {
+    for (const message of [
+      "what was the BTC price on 2026-08-23?",
+      "what is BTC market cap at 1,415,555,121.20 USD?",
+      "BTC is 77,357.93 USD and gold is 3,374.19 USD",
+      "compare 37.7749 USD with 122.4194 USD",
+    ]) {
+      expect(isSharedPublicSearchSafe(message)).toBe(true);
+    }
+  });
 
   test("does not revive an older public topic past a newer private turn", () => {
     const history = [

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.test.ts
@@ -99,22 +99,37 @@ describe("Shared realtime request classification", () => {
     });
   }
 
-  test("inherits a current-data requirement through correction and retry", () => {
+  test("never rebuilds a correction query from persisted or server-rendered history", () => {
     const history = [
-      { role: "user" as const, content: "what is btc price rn" },
+      {
+        role: "user" as const,
+        content: "[Public guild; speaker: Alice; channel: ops] what is btc price rn",
+      },
       {
         role: "assistant" as const,
         content: "Bitcoin is currently 63,800 USD according to TradingView",
       },
     ];
-    expect(resolveSharedRealtimeRequirement("that's wrong, check again", history)).toMatchObject({
+    expect(resolveSharedRealtimeRequirement("that's wrong, check again", history)).toBeUndefined();
+    expect(resolveSharedRealtimeRequirement("check the web", history)).toBeUndefined();
+    expect(
+      resolveSharedRealtimeRequirement("wrong — what is the current BTC price?", history),
+    ).toMatchObject({
       domain: "markets",
+      query: "wrong — what is the current BTC price?",
       correction: true,
     });
-    expect(resolveSharedRealtimeRequirement("check the web", history)?.query).toContain(
-      "what is btc price rn",
-    );
   });
+
+  for (const literal of [
+    "what is the weather at 123 Main Street?",
+    "what is the weather at (415) 555-1212?",
+    "what is the weather at 37.7749, -122.4194?",
+  ]) {
+    test(`rejects precise private literals from public lookup: ${literal}`, () => {
+      expect(resolveSharedRealtimeRequirement(literal, [])).toBeUndefined();
+    });
+  }
 
   test("does not revive an older public topic past a newer private turn", () => {
     const history = [

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
@@ -20,13 +20,16 @@ type SourceEvidence = { url: string; text: string };
 
 const FRESHNESS =
   /\b(?:now|rn|right now|current|currently|today|tonight|latest|live|recent|recently|up[- ]?to[- ]?date|this (?:morning|afternoon|evening|week|month|year))\b/i;
-const WEB_VERIFICATION =
-  /\b(?:check|search|browse|look(?:ed)? up|verify|fact[- ]?check)(?:\s+(?:it|that|this|again|online|the))?(?:\s+(?:web|internet|source|sources|news))?\b|\b(?:source|sources|citation|citations)\??$/i;
 const CORRECTION =
   /\b(?:wrong|incorrect|not right|made that up|hallucinat(?:e|ed|ion)|check again|try again|prove it|where did (?:that|you) (?:come|get) from)\b|^\s*\?+\s*$/i;
 const PRIVATE_STATE =
   /\b(?:my|mine|our|ours|todo|todos|reminder|reminders|calendar|schedule|meeting|meetings|order|account|email|inbox|messages|files|notes|contacts|password|passcode|secret|api[- ]?key|credential|ssn|social security|credit card|bank balance|phone number|home address|location)\b/i;
 const SENSITIVE_LITERAL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b\d{3}[- ]\d{2}[- ]\d{4}\b/i;
+const PHONE_LITERAL =
+  /(?:^|[^\p{L}\p{N}])(?:\+\d{1,3}[ .-]?)?(?:\(\d{2,4}\)|\d{2,4})[ .-]\d{3,4}[ .-]\d{3,4}(?:$|[^\p{L}\p{N}])/u;
+const STREET_ADDRESS_LITERAL =
+  /\b\d{1,6}\s+(?:[\p{L}\p{N}.'’-]+\s+){0,5}(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|court|ct|way|parkway|pkwy|highway|hwy)\b/iu;
+const COORDINATE_LITERAL = /[+-]?\d{1,2}\.\d{3,}\s*,\s*[+-]?\d{1,3}\.\d{3,}/u;
 const MARKETS =
   /\b(?:price|quote|exchange rate|market cap|market price|stock|share price|crypto|cryptocurrency|bitcoin|btc|ethereum|eth|forex|bond yield|commodity|gold price|oil price)\b/i;
 const NEWS = /\b(?:news|headline|breaking|announcement|announced|release today|current events)\b/i;
@@ -136,29 +139,25 @@ function classifyPublicStandalone(text: string): SharedRealtimeDomain | undefine
 
 /** Denies Shared public-network tools when the authenticated utterance is private or sensitive. */
 export function isSharedPublicSearchSafe(message: string): boolean {
-  return !PRIVATE_STATE.test(message) && !SENSITIVE_LITERAL.test(message);
+  return (
+    !PRIVATE_STATE.test(message) &&
+    !SENSITIVE_LITERAL.test(message) &&
+    !PHONE_LITERAL.test(message) &&
+    !STREET_ADDRESS_LITERAL.test(message) &&
+    !COORDINATE_LITERAL.test(message)
+  );
 }
 
-/** Identifies public current-data turns and corrections that inherit that exact public topic. */
+/** Identifies current public data solely from this authenticated raw utterance. */
 export function resolveSharedRealtimeRequirement(
   message: string,
-  history: readonly SharedTurnMessage[],
+  _history: readonly SharedTurnMessage[],
 ): SharedRealtimeRequirement | undefined {
   const normalized = message.trim();
   const direct = classifyPublicStandalone(normalized);
   const correction = CORRECTION.test(normalized);
   if (direct) return { domain: direct, query: normalized, correction };
-  if (PRIVATE_STATE.test(normalized) || (!correction && !WEB_VERIFICATION.test(normalized))) {
-    return undefined;
-  }
-  const prior = [...history].reverse().find((turn) => turn.role === "user");
-  const priorDomain = prior ? classifyPublicStandalone(prior.content) : undefined;
-  if (!prior || !priorDomain) return undefined;
-  return {
-    domain: priorDomain,
-    query: `${prior.content}\n${normalized}\nVerify against current public sources.`,
-    correction: true,
-  };
+  return undefined;
 }
 
 function canonicalPublicUrl(value: unknown): string | undefined {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-realtime-grounding.ts
@@ -26,10 +26,11 @@ const PRIVATE_STATE =
   /\b(?:my|mine|our|ours|todo|todos|reminder|reminders|calendar|schedule|meeting|meetings|order|account|email|inbox|messages|files|notes|contacts|password|passcode|secret|api[- ]?key|credential|ssn|social security|credit card|bank balance|phone number|home address|location)\b/i;
 const SENSITIVE_LITERAL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b|\b\d{3}[- ]\d{2}[- ]\d{4}\b/i;
 const PHONE_LITERAL =
-  /(?:^|[^\p{L}\p{N}])(?:\+\d{1,3}[ .-]?)?(?:\(\d{2,4}\)|\d{2,4})[ .-]\d{3,4}[ .-]\d{3,4}(?:$|[^\p{L}\p{N}])/u;
+  /(?:^|[^\p{L}\p{N}])(?:(?:\+[1-9]\d{9,14})|(?:1?[2-9]\d{2}[2-9]\d{6})|(?:\+\d{1,3}[ .-]?)?(?:\(\d{2,4}\)|\d{2,4})[ .-]\d{3,4}[ .-]\d{3,4})(?:$|[^\p{L}\p{N}])/u;
 const STREET_ADDRESS_LITERAL =
   /\b\d{1,6}\s+(?:[\p{L}\p{N}.'’-]+\s+){0,5}(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|court|ct|way|parkway|pkwy|highway|hwy)\b/iu;
-const COORDINATE_LITERAL = /[+-]?\d{1,2}\.\d{3,}\s*,\s*[+-]?\d{1,3}\.\d{3,}/u;
+const COORDINATE_LITERAL =
+  /(?:[+-]?\d{1,2}\.\d{3,}\s*,\s*[+-]?\d{1,3}\.\d{3,})|(?:\d{1,2}\.\d{3,}\s*[NS]\s*,?\s*\d{1,3}\.\d{3,}\s*[EW])/iu;
 const MARKETS =
   /\b(?:price|quote|exchange rate|market cap|market price|stock|share price|crypto|cryptocurrency|bitcoin|btc|ethereum|eth|forex|bond yield|commodity|gold price|oil price)\b/i;
 const NEWS = /\b(?:news|headline|breaking|announcement|announced|release today|current events)\b/i;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -251,7 +251,24 @@ describe("shared-rest-adapter — messages", () => {
     const before = Date.now();
     coordinateSharedHistory.mockResolvedValue([
       { id: "user-message-1", role: "user", content: "hi", createdAt: 1_783_382_400_000 },
-      { id: "assistant-message-1", role: "assistant", content: "Hello!", interrupted: true },
+      {
+        id: "assistant-message-1",
+        role: "assistant",
+        content: "Hello!",
+        interrupted: true,
+        grounding: {
+          kind: "web_search",
+          query: "current greeting",
+          provider: "parallel",
+          observedAt: 1_783_382_400_000,
+          sourceUrls: ["https://source.example/result"],
+          sources: [
+            { url: "https://source.example/result", text: "PRIVATE_SOURCE_EXCERPT_MARKER" },
+          ],
+          text: "PRIVATE_PROVIDER_BODY_MARKER",
+          truncated: false,
+        },
+      },
     ]);
     const { messages } = await sharedRestMessagesGet(AGENT, AGENT, NAMESPACE);
     expect(messages[0]).toEqual({
@@ -268,6 +285,9 @@ describe("shared-rest-adapter — messages", () => {
     });
     expect(typeof messages[1]?.timestamp).toBe("number");
     expect(messages[1]?.timestamp).toBeLessThan(before - 60_000);
+    expect(JSON.stringify(messages)).not.toContain("PRIVATE_PROVIDER_BODY_MARKER");
+    expect(JSON.stringify(messages)).not.toContain("PRIVATE_SOURCE_EXCERPT_MARKER");
+    expect(JSON.stringify(messages)).not.toContain("grounding");
     expect(coordinateSharedHistory).toHaveBeenCalledWith(AGENT, AGENT, {
       namespace: NAMESPACE,
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -433,6 +433,8 @@ type TestMessage = {
         provider: "parallel" | "exa";
         text: string;
         observedAt: number;
+        sourceUrls?: string[];
+        sources?: Array<{ url: string; text: string }>;
         truncated: boolean;
       }
     | {
@@ -711,6 +713,13 @@ describe("SharedRuntimeChatService", () => {
           provider: "parallel",
           text: "Tessera validates ARC resources through an origin guard.",
           observedAt: Date.now(),
+          sourceUrls: ["https://example.com/tessera"],
+          sources: [
+            {
+              url: "https://example.com/tessera",
+              text: "Tessera validates ARC resources through an origin guard.",
+            },
+          ],
           truncated: false,
         },
       },
@@ -1114,6 +1123,21 @@ describe("SharedRuntimeChatService", () => {
     const h = harness();
     streamTurn = {
       degraded: false,
+      internalGrounding: {
+        kind: "web_search",
+        query: "NubsCarson Tessera GitHub",
+        provider: "parallel",
+        text: "Tessera validates ARC resources through an origin guard.",
+        observedAt: Date.now(),
+        sourceUrls: ["https://example.com/tessera"],
+        sources: [
+          {
+            url: "https://example.com/tessera",
+            text: "Tessera validates ARC resources through an origin guard.",
+          },
+        ],
+        truncated: false,
+      },
       parts: (async function* () {
         yield { type: "text-delta", text: "hello " };
         yield {
@@ -1123,12 +1147,13 @@ describe("SharedRuntimeChatService", () => {
           actionResults: [
             {
               success: true,
-              text: "Tessera validates ARC resources through an origin guard.",
+              text: "hello back",
               data: {
                 actionName: "WEB_SEARCH",
                 query: "NubsCarson Tessera GitHub",
                 provider: "parallel",
-                answer: "Tessera validates ARC resources through an origin guard.",
+                sourceUrls: ["https://example.com/tessera"],
+                groundingStatus: "verified",
               },
             },
           ],
@@ -1146,6 +1171,13 @@ describe("SharedRuntimeChatService", () => {
       provider: "parallel",
       text: "Tessera validates ARC resources through an origin guard.",
       observedAt: expect.any(Number),
+      sourceUrls: ["https://example.com/tessera"],
+      sources: [
+        {
+          url: "https://example.com/tessera",
+          text: "Tessera validates ARC resources through an origin guard.",
+        },
+      ],
       truncated: false,
     });
     expect(memoryPairs).toEqual([
@@ -1870,6 +1902,64 @@ describe("SharedRuntimeChatService", () => {
     expect(secondDone.fullText).toBe("hello back");
     expect(secondDone.messageId).toBe(firstDone.messageId);
     expect(secondDone.userMessageId).toBe(firstDone.userMessageId);
+  });
+
+  test("never serializes internal grounding evidence into terminal or replay action results", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    const { store } = memoryTurnClaims();
+    const observedAt = Date.now();
+    streamTurn = {
+      degraded: false,
+      internalGrounding: {
+        kind: "web_search",
+        query: "current BTC price",
+        provider: "parallel",
+        text: "RAW_PROVIDER_BODY_SHOULD_NOT_ESCAPE",
+        observedAt,
+        sourceUrls: ["https://example.com/btc"],
+        sources: [
+          {
+            url: "https://example.com/btc",
+            text: "RAW_SOURCE_EXCERPT_SHOULD_NOT_ESCAPE",
+          },
+        ],
+        truncated: false,
+      },
+      parts: (async function* () {
+        yield { type: "text-delta", text: "BTC is 70,000 USD. " };
+        yield {
+          type: "finish",
+          text: "BTC is 70,000 USD. Source: example.com — https://example.com/btc",
+          actionResults: [
+            {
+              success: true,
+              text: "BTC is 70,000 USD. Source: example.com — https://example.com/btc",
+              data: {
+                actionName: "WEB_SEARCH",
+                query: "current BTC price",
+                provider: "parallel",
+                observedAt,
+                sourceUrls: ["https://example.com/btc"],
+                groundingStatus: "verified",
+              },
+            },
+          ],
+        };
+      })(),
+    };
+
+    const options = { ...h, turnClaims: store };
+    const firstBody = await (await service.stream(agent, keyedRpc, options)).text();
+    const replayBody = await (await service.stream(agent, keyedRpc, options)).text();
+
+    for (const body of [firstBody, replayBody]) {
+      expect(body).toContain("https://example.com/btc");
+      expect(body).not.toContain("RAW_PROVIDER_BODY_SHOULD_NOT_ESCAPE");
+      expect(body).not.toContain("RAW_SOURCE_EXCERPT_SHOULD_NOT_ESCAPE");
+      expect(body).not.toContain("originalModelReply");
+      expect(body).not.toContain('"sources"');
+    }
   });
 
   test("claim completion failure retries to one canonical history, memory, and replay result", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -90,10 +90,7 @@ import {
 } from "./shared-recall";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
-import {
-  sharedPublicWebGrounding,
-  sharedRuntimeModelHistoryMessages,
-} from "./shared-runtime-history-policy";
+import { sharedRuntimeModelHistoryMessages } from "./shared-runtime-history-policy";
 import { normalizeSharedRuntimeRoom } from "./shared-runtime-room-identity";
 import {
   replayedSharedProviderTiming,
@@ -1874,7 +1871,7 @@ export class SharedRuntimeChatService {
                   );
                 }
               },
-              sharedPublicWebGrounding(actionResults),
+              turn.internalGrounding,
             );
             const done = actionResults
               ? {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
@@ -206,6 +206,13 @@ describe("shared runtime long-term transcript context", () => {
         truncated: false,
       }),
     ).toBeUndefined();
+    expect(
+      parseSharedPublicWebGrounding({
+        kind: "web_search_unavailable",
+        query: "current value",
+        observedAt: Date.now() + MAX_PUBLIC_WEB_GROUNDING_FUTURE_SKEW_MS + 60_000,
+      }),
+    ).toBeUndefined();
   });
 
   test("encodes result injection as data-only JSON", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -106,7 +106,8 @@ export function parseSharedPublicWebGrounding(
     typeof candidate.query === "string" &&
     typeof candidate.observedAt === "number" &&
     Number.isSafeInteger(candidate.observedAt) &&
-    candidate.observedAt >= 0
+    candidate.observedAt >= 0 &&
+    candidate.observedAt <= Date.now() + MAX_PUBLIC_WEB_GROUNDING_FUTURE_SKEW_MS
   ) {
     const query = candidate.query.trim();
     return query


### PR DESCRIPTION
## Summary

Non-draft stacked correction for #25433, based exactly on parent head `cb2e71a30a642c24e5f1ae6657fee0c05c8778ba`.

- authorize public lookup only from the current authenticated `capabilityText`; persisted/server-rendered history cannot become a correction query
- keep complete provider/source evidence in internal history while terminal SSE, durable claim replay, and REST history expose only safe reply/receipt fields
- reject exact street addresses, formatted/contiguous/E.164 phone literals, decimal coordinate pairs, and hemisphere coordinate pairs before public egress
- preserve ordinary dates and formatted/decimal market values
- bound future-skew for unavailable tombstones

## Exact-head validation

Corrective head: `a8e5f2f0b0e5ea9f228ab8ef37a4b118eb7a5f2d`

Pinned Bun `1.3.14`, Node `24.15.0`, after `bun install --frozen-lockfile`:

- realtime classifier/receipt: **49 passed, 0 failed, 92 expectations**
- buffered run-turn/safe receipt: **13 passed, 0 failed, 64 expectations**
- history/grounding policy: **31 passed, 0 failed, 83 expectations**
- Shared transport/SSE/durable replay: **39 passed, 0 failed, 241 expectations**
- genuine Shared AgentRuntime: **26 passed, 0 failed, 172 expectations**
- sandbox streaming persistence/transport: **5 passed, 0 failed, 23 expectations**
- REST replay projection: **32 passed, 0 failed, 64 expectations**
- aggregate focused result: **195 passed, 0 failed, 739 expectations** (each global-mock suite isolated in its own Bun process)
- `bun run --cwd packages/cloud/shared typecheck`: passed
- Biome on all 13 changed files: passed
- `git diff --check`: passed

Production caller audit: `shared-runtime-chat.ts` and `eliza-sandbox.ts` are the only production `runSharedAgentTurn`/`runSharedAgentTurnStream` callers. Both non-stream paths persist canonical `turn.history`; shared-runtime-chat streaming already stores `turn.internalGrounding` and exposes receipt-shaped action results; sandbox streaming now stores the same grounding. Sandbox done SSE is explicit-field-only, and the REST replay adapter projects only id/role/text/timestamp/interrupted.

## Evidence and promotion hold

This PR supplies deterministic correction evidence only. It does **not** claim signed Telegram delivery or a new live full-path provider/model capture. Parent #25433 must remain draft and must not merge or deploy until this correction is integrated and the resulting exact parent head has reviewed signed Telegram ingress-to-egress plus full supported-provider/model evidence.