### PR TITLE
fix(desktop): make remote activation two phase

### DIFF
--- a/packages/app-core/platforms/electrobun/src/remote-target-boundaries.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-boundaries.test.ts
@@ -237,6 +237,26 @@ describe("remote target native boundaries", () => {
     const transport = new HttpRemoteTargetRelayTransport(
       async (input, init) => {
         requests.push(new Request(input, init));
+        if (init?.method === "DELETE") {
+          return jsonResponse({
+            success: true,
+            data: {
+              sessionId: "22222222-2222-4222-8222-222222222222",
+              status: "revoked",
+              alreadyCompensated: false,
+            },
+          });
+        }
+        if (init?.method === "PUT") {
+          return jsonResponse({
+            success: true,
+            data: {
+              sessionId: "22222222-2222-4222-8222-222222222222",
+              status: "active",
+              alreadyCommitted: false,
+            },
+          });
+        }
         return jsonResponse({
           success: true,
           data: {
@@ -254,7 +274,7 @@ describe("remote target native boundaries", () => {
             targetRuntimeId: enrollment.identity.runtimeId,
             targetKeyId: enrollment.identity.keyId,
             grantExpiresAt: new Date(2_000_000_300_000).toISOString(),
-            status: "active",
+            status: "activating",
           },
         });
       },
@@ -264,7 +284,7 @@ describe("remote target native boundaries", () => {
       transport.activate({ enrollment, code: "123456" }),
     ).resolves.toMatchObject({
       sessionId: "22222222-2222-4222-8222-222222222222",
-      status: "active",
+      status: "activating",
     });
     expect(requests[0]?.url).toBe(
       "https://api.example.test/api/v1/remote/sessions/activate",
@@ -276,6 +296,31 @@ describe("remote target native boundaries", () => {
       `Bearer ${enrollment.hostToken}`,
     );
     expect(await requests[0]?.json()).toEqual({ code: "123456" });
+    await expect(
+      transport.compensateActivation({
+        enrollment,
+        sessionId: "22222222-2222-4222-8222-222222222222",
+      }),
+    ).resolves.toEqual({
+      sessionId: "22222222-2222-4222-8222-222222222222",
+      status: "revoked",
+      alreadyCompensated: false,
+    });
+    expect(requests[1]?.method).toBe("DELETE");
+    expect(requests[1]?.url).toBe(
+      "https://api.example.test/api/v1/remote/sessions/22222222-2222-4222-8222-222222222222/activate",
+    );
+    await expect(
+      transport.commitActivation({
+        enrollment,
+        sessionId: "22222222-2222-4222-8222-222222222222",
+      }),
+    ).resolves.toEqual({
+      sessionId: "22222222-2222-4222-8222-222222222222",
+      status: "active",
+      alreadyCommitted: false,
+    });
+    expect(requests[2]?.method).toBe("PUT");
   });
 
   it("rejects insecure API URLs and private/public secure-store tampering", async () => {

--- a/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-rpc.ts
@@ -6,6 +6,7 @@
 import { createHash } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
 import type { RemoteTargetPublicIdentity } from "@elizaos/shared/contracts/remote-control";
+import { logger } from "./logger";
 import {
   LoopbackRemoteTargetExecutor,
   normalizeRemoteTargetLoopbackBase,
@@ -39,16 +40,33 @@ export interface DesktopRemoteTargetIdentityResult {
   identity?: RemoteTargetPublicIdentity;
 }
 
-export interface DesktopRemoteTargetActivationResult {
-  sessionId: string;
-  status: "active";
-  controllerDisplayName: string;
-  grantExpiresAt: number;
-}
+export type DesktopRemoteTargetActivationResult =
+  | {
+      sessionId: string;
+      status: "active";
+      controllerDisplayName: string;
+      grantExpiresAt: number;
+    }
+  | {
+      sessionId: string;
+      status: "compensation_required";
+      errorCode: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED";
+      retryRpc: "remoteTargetCompensateActivation";
+    }
+  | {
+      sessionId: string;
+      status: "commit_required";
+      errorCode: "REMOTE_ACTIVATION_COMMIT_REQUIRED";
+      retryRpc: "remoteTargetCommitActivation";
+    };
 
 export interface DesktopRemoteTargetResumeResult {
   resumed: boolean;
-  reason: "active_authority" | "not_enrolled" | "no_active_authority";
+  reason:
+    | "active_authority"
+    | "activation_recovery"
+    | "not_enrolled"
+    | "no_active_authority";
 }
 
 interface RemoteTargetLoopbackConfiguration {
@@ -169,16 +187,27 @@ export class RemoteTargetDesktopService {
     const prepared = this.prepareLoopbackConfiguration(input);
     return this.enqueueConfiguration(async () => {
       const runner = await this.installLoopbackConfiguration(prepared);
+      const enrollmentBeforeRecovery = await this.vault.load();
+      if (enrollmentBeforeRecovery?.status === "enrolled") {
+        await runner.recoverStagedActivations();
+      }
       const [enrollment, state] = await Promise.all([
         this.vault.load(),
         this.stateStore.read(),
       ]);
       const activeSessions = Object.values(state.sessions).filter(
         (session) =>
+          session.activationState !== "staged" &&
           session.stoppedAt === null &&
           session.grant.revokedAt === null &&
           (session.grant.expiresAt === null ||
             session.grant.expiresAt >= this.now()),
+      );
+      const stagedSessions = Object.values(state.sessions).filter(
+        (session) =>
+          session.activationState === "staged" &&
+          session.stoppedAt === null &&
+          session.grant.revokedAt === null,
       );
       if (enrollment?.status !== "enrolled") {
         if (activeSessions.length > 0) {
@@ -192,6 +221,10 @@ export class RemoteTargetDesktopService {
         };
       }
       if (activeSessions.length === 0) {
+        if (stagedSessions.length > 0) {
+          await runner.start();
+          return { resumed: true, reason: "activation_recovery" as const };
+        }
         return {
           resumed: false,
           reason: "no_active_authority" as const,
@@ -300,13 +333,119 @@ export class RemoteTargetDesktopService {
           },
           { now: this.now },
         );
-      await installer.installActivation(activation);
+      this.runner ??= installer;
+      try {
+        await installer.installActivation(activation);
+      } catch (installError) {
+        try {
+          await this.transport.compensateActivation({
+            enrollment,
+            sessionId: activation.sessionId,
+          });
+        } catch (compensationError) {
+          // error-policy:J2 preserve both failures and expose the exact,
+          // idempotently retryable session without claiming local authority.
+          const failure = new ElizaError(
+            "Remote activation failed locally and Cloud compensation is required",
+            {
+              code: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED",
+              context: { sessionId: activation.sessionId },
+              cause: new AggregateError([installError, compensationError]),
+            },
+          );
+          logger.error(
+            "[RemoteTargetDesktopService] Activation compensation requires retry",
+            failure,
+          );
+          // The typed non-authoritative response preserves the exact session
+          // required by the idempotent retry RPC. The local journal remains
+          // empty, so this is never presented as active authority.
+          return {
+            sessionId: activation.sessionId,
+            status: "compensation_required" as const,
+            errorCode: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED" as const,
+            retryRpc: "remoteTargetCompensateActivation" as const,
+          };
+        }
+        throw new ElizaError(
+          "Remote activation failed locally and was rolled back in Cloud",
+          {
+            code: "REMOTE_ACTIVATION_LOCAL_INSTALL_FAILED",
+            context: { sessionId: activation.sessionId },
+            cause: installError,
+          },
+        );
+      }
+      try {
+        await this.transport.commitActivation({
+          enrollment,
+          sessionId: activation.sessionId,
+        });
+        await installer.commitLocalActivation(activation.sessionId);
+      } catch (commitError) {
+        // error-policy:J4 the durable local staged grant remains
+        // non-executable while exact-session commit is retried idempotently.
+        logger.warn(
+          "[RemoteTargetDesktopService] Activation commit requires retry",
+          { sessionId: activation.sessionId, error: commitError },
+        );
+        return {
+          sessionId: activation.sessionId,
+          status: "commit_required" as const,
+          errorCode: "REMOTE_ACTIVATION_COMMIT_REQUIRED" as const,
+          retryRpc: "remoteTargetCommitActivation" as const,
+        };
+      }
       return {
         sessionId: activation.sessionId,
         status: "active" as const,
         controllerDisplayName: activation.controller.displayName,
         grantExpiresAt: activation.grantExpiresAt,
       };
+    });
+  }
+
+  async compensateActivation(params: unknown): Promise<{
+    sessionId: string;
+    status: "denied" | "revoked";
+    alreadyCompensated: boolean;
+  }> {
+    const value = requireObject(params);
+    const sessionId = requireString(value.sessionId, "session id", 256);
+    return this.enqueueConfiguration(async () => {
+      const enrollment = await this.vault.load();
+      if (enrollment?.status !== "enrolled") {
+        throw new ElizaError("Remote host enrollment is unavailable", {
+          code: "REMOTE_HOST_ENROLLMENT_UNAVAILABLE",
+          context: { sessionId },
+        });
+      }
+      return this.transport.compensateActivation({ enrollment, sessionId });
+    });
+  }
+
+  async commitActivation(params: unknown): Promise<{
+    sessionId: string;
+    status: "active";
+    alreadyCommitted: boolean;
+  }> {
+    const value = requireObject(params);
+    const sessionId = requireString(value.sessionId, "session id", 256);
+    return this.enqueueConfiguration(async () => {
+      const enrollment = await this.vault.load();
+      if (enrollment?.status !== "enrolled") {
+        throw new ElizaError("Remote host enrollment is unavailable", {
+          code: "REMOTE_HOST_ENROLLMENT_UNAVAILABLE",
+          context: { sessionId },
+        });
+      }
+      const response = await this.transport.commitActivation({
+        enrollment,
+        sessionId,
+      });
+      const runner = this.requireRunner();
+      await runner.commitLocalActivation(sessionId);
+      return response;
     });
   }
 
@@ -331,7 +470,9 @@ export class RemoteTargetDesktopService {
       enrolled: identity.enrolled,
       activeSessions: Object.values(state.sessions).filter(
         (session) =>
-          session.stoppedAt === null && session.grant.revokedAt === null,
+          session.activationState !== "staged" &&
+          session.stoppedAt === null &&
+          session.grant.revokedAt === null,
       ).length,
       pendingResults: Object.values(state.commands).filter(
         (command) => command.resultEnvelope && !command.resultDelivered,
@@ -442,6 +583,24 @@ export function desktopRemoteTargetActivate(
   params: unknown,
 ): Promise<DesktopRemoteTargetActivationResult> {
   return desktopRemoteTargetService.activate(params);
+}
+
+export function desktopRemoteTargetCompensateActivation(
+  params: unknown,
+): Promise<{
+  sessionId: string;
+  status: "denied" | "revoked";
+  alreadyCompensated: boolean;
+}> {
+  return desktopRemoteTargetService.compensateActivation(params);
+}
+
+export function desktopRemoteTargetCommitActivation(params: unknown): Promise<{
+  sessionId: string;
+  status: "active";
+  alreadyCommitted: boolean;
+}> {
+  return desktopRemoteTargetService.commitActivation(params);
 }
 
 export function desktopRemoteTargetStart(): Promise<{ running: true }> {

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.test.ts
@@ -123,6 +123,31 @@ class DeferredReadStateStore implements RemoteTargetStateStore {
   }
 }
 
+class FailingTransactionStateStore implements RemoteTargetStateStore {
+  private readonly delegate = new MemoryRemoteTargetStateStore();
+  private transactionCount = 0;
+
+  constructor(private readonly failTransactionNumber = 1) {}
+
+  read(): Promise<RemoteTargetDurableState> {
+    return this.delegate.read();
+  }
+
+  clear(): Promise<void> {
+    return this.delegate.clear();
+  }
+
+  transact<T>(
+    operation: (state: RemoteTargetDurableState) => T | Promise<T>,
+  ): Promise<T> {
+    this.transactionCount += 1;
+    if (this.transactionCount === this.failTransactionNumber) {
+      return Promise.reject(new Error("local-journal-write-failed"));
+    }
+    return this.delegate.transact(operation);
+  }
+}
+
 class FakeRelay implements RemoteTargetRelayTransport {
   claimRequests = 0;
   readonly claims: RemoteTargetClaim[] = [];
@@ -136,6 +161,10 @@ class FakeRelay implements RemoteTargetRelayTransport {
   }[] = [];
   startFailure: Error | null = null;
   completionFailure: Error | null = null;
+  compensationFailure: Error | null = null;
+  readonly compensations: string[] = [];
+  commitFailure: Error | null = null;
+  readonly commits: string[] = [];
   readonly revocations: Array<{
     hostId: string;
     status: "revoked";
@@ -151,6 +180,34 @@ class FakeRelay implements RemoteTargetRelayTransport {
 
   async activate(): Promise<RemoteTargetActivationResponse> {
     throw new Error("unused");
+  }
+
+  async compensateActivation(
+    input: Parameters<RemoteTargetRelayTransport["compensateActivation"]>[0],
+  ): Promise<
+    Awaited<ReturnType<RemoteTargetRelayTransport["compensateActivation"]>>
+  > {
+    this.compensations.push(input.sessionId);
+    if (this.compensationFailure) throw this.compensationFailure;
+    return {
+      sessionId: input.sessionId,
+      status: "revoked",
+      alreadyCompensated: this.compensations.length > 1,
+    };
+  }
+
+  async commitActivation(
+    input: Parameters<RemoteTargetRelayTransport["commitActivation"]>[0],
+  ): Promise<
+    Awaited<ReturnType<RemoteTargetRelayTransport["commitActivation"]>>
+  > {
+    this.commits.push(input.sessionId);
+    if (this.commitFailure) throw this.commitFailure;
+    return {
+      sessionId: input.sessionId,
+      status: "active",
+      alreadyCommitted: this.commits.length > 1,
+    };
   }
 
   async claimNext(
@@ -280,6 +337,47 @@ class DeferredActivationRelay extends FakeRelay {
   }
 }
 
+class ImmediateActivationRelay extends FakeRelay {
+  constructor(private readonly activation: RemoteTargetActivationResponse) {
+    super();
+  }
+
+  override async activate(): Promise<RemoteTargetActivationResponse> {
+    return this.activation;
+  }
+}
+
+class DeferredCompensationRelay extends ImmediateActivationRelay {
+  readonly compensationRequested: Promise<void>;
+  private markCompensationRequested: () => void = () => undefined;
+  private releaseCompensation: () => void = () => undefined;
+  private readonly deferredCompensation: Promise<void>;
+
+  constructor(activation: RemoteTargetActivationResponse) {
+    super(activation);
+    this.compensationRequested = new Promise((resolve) => {
+      this.markCompensationRequested = resolve;
+    });
+    this.deferredCompensation = new Promise((resolve) => {
+      this.releaseCompensation = resolve;
+    });
+  }
+
+  override async compensateActivation(
+    input: Parameters<RemoteTargetRelayTransport["compensateActivation"]>[0],
+  ): Promise<
+    Awaited<ReturnType<RemoteTargetRelayTransport["compensateActivation"]>>
+  > {
+    this.markCompensationRequested();
+    await this.deferredCompensation;
+    return super.compensateActivation(input);
+  }
+
+  resolveCompensation(): void {
+    this.releaseCompensation();
+  }
+}
+
 function privateKey(): JsonWebKey {
   return generateKeyPairSync("ec", {
     namedCurve: "prime256v1",
@@ -340,7 +438,7 @@ async function createHarness(): Promise<Harness> {
     targetRuntimeId: HOST_ID,
     targetKeyId: enrolled.identity.keyId,
     grantExpiresAt: NOW + 3_600_000,
-    status: "active",
+    status: "activating",
   };
   return {
     vault,
@@ -422,6 +520,7 @@ async function createRunner(
     { now: () => NOW, hooks, pollIntervalMs },
   );
   await runner.installActivation(harness.activation);
+  await runner.commitLocalActivation(harness.activation.sessionId);
   return runner;
 }
 
@@ -739,6 +838,7 @@ describe("remote target durable runner", () => {
       sessionId: deadSessionId,
       grantId: "11111111-3333-4111-8111-111111111111",
     });
+    await runner.commitLocalActivation(deadSessionId);
     const claim = claimFor(harness);
     harness.relay.claims.push(claim);
     expect(await runner.pollOnce()).toBe("completed");
@@ -1154,6 +1254,257 @@ describe("remote target durable runner", () => {
       sessions: {},
       commands: {},
     });
+  });
+
+  it("compensates Cloud when local activation installation fails", async () => {
+    const harness = await createHarness();
+    const relay = new ImmediateActivationRelay(harness.activation);
+    const state = new FailingTransactionStateStore();
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      state,
+      relay,
+      () => NOW,
+    );
+
+    await expect(service.activate({ code: "123456" })).rejects.toMatchObject({
+      code: "REMOTE_ACTIVATION_LOCAL_INSTALL_FAILED",
+      context: { sessionId: SESSION_ID },
+    });
+    expect(relay.compensations).toEqual([SESSION_ID]);
+    expect((await state.read()).sessions).toEqual({});
+  });
+
+  it("exposes failed compensation for exact-session retry without authority", async () => {
+    const harness = await createHarness();
+    const relay = new ImmediateActivationRelay(harness.activation);
+    relay.compensationFailure = new Error("cloud-compensation-unavailable");
+    const state = new FailingTransactionStateStore();
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      state,
+      relay,
+      () => NOW,
+    );
+
+    await expect(service.activate({ code: "123456" })).resolves.toEqual({
+      sessionId: SESSION_ID,
+      status: "compensation_required",
+      errorCode: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED",
+      retryRpc: "remoteTargetCompensateActivation",
+    });
+    expect((await state.read()).sessions).toEqual({});
+
+    relay.compensationFailure = null;
+    await expect(
+      service.compensateActivation({ sessionId: SESSION_ID }),
+    ).resolves.toEqual({
+      sessionId: SESSION_ID,
+      status: "revoked",
+      alreadyCompensated: true,
+    });
+  });
+
+  it("keeps a staged grant non-authoritative until exact-session commit retry succeeds", async () => {
+    const harness = await createHarness();
+    const relay = new ImmediateActivationRelay(harness.activation);
+    relay.commitFailure = new RemoteTargetTransportError(
+      "NETWORK_UNAVAILABLE",
+      0,
+    );
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      relay,
+      () => NOW,
+    );
+
+    await expect(service.activate({ code: "123456" })).resolves.toEqual({
+      sessionId: SESSION_ID,
+      status: "commit_required",
+      errorCode: "REMOTE_ACTIVATION_COMMIT_REQUIRED",
+      retryRpc: "remoteTargetCommitActivation",
+    });
+    expect(
+      (await harness.state.read()).sessions[SESSION_ID]?.activationState,
+    ).toBe("staged");
+    expect((await service.status()).activeSessions).toBe(0);
+
+    relay.commitFailure = null;
+    await expect(
+      service.commitActivation({ sessionId: SESSION_ID }),
+    ).resolves.toMatchObject({
+      sessionId: SESSION_ID,
+      status: "active",
+    });
+    expect(
+      (await harness.state.read()).sessions[SESSION_ID]?.activationState,
+    ).toBe("active");
+    expect(relay.commits).toEqual([SESSION_ID, SESSION_ID]);
+  });
+
+  it("recovers a process exit after durable staging but before Cloud commit", async () => {
+    const harness = await createHarness();
+    const relay = new ImmediateActivationRelay(harness.activation);
+    relay.commitFailure = new RemoteTargetTransportError(
+      "NETWORK_UNAVAILABLE",
+      0,
+    );
+    const interrupted = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      relay,
+      () => NOW,
+    );
+    await expect(
+      interrupted.activate({ code: "123456" }),
+    ).resolves.toMatchObject({
+      status: "commit_required",
+    });
+
+    relay.commitFailure = null;
+    const restarted = new RemoteTargetDesktopService(
+      harness.vault,
+      harness.state,
+      relay,
+      () => NOW,
+    );
+    await expect(
+      restarted.resumeEligibleLoopback({
+        apiBase: "http://127.0.0.1:31337",
+        apiToken: "restart-local-token-123456789",
+        pollIntervalMs: 60_000,
+      }),
+    ).resolves.toEqual({ resumed: true, reason: "active_authority" });
+    expect(
+      (await harness.state.read()).sessions[SESSION_ID]?.activationState,
+    ).toBe("active");
+    expect(relay.commits).toEqual([SESSION_ID, SESSION_ID]);
+    await restarted.stop();
+  });
+
+  it("recovers a process exit after Cloud commit but before the local active mark", async () => {
+    const harness = await createHarness();
+    const relay = new ImmediateActivationRelay(harness.activation);
+    const state = new FailingTransactionStateStore(2);
+    const interrupted = new RemoteTargetDesktopService(
+      harness.vault,
+      state,
+      relay,
+      () => NOW,
+    );
+    await expect(
+      interrupted.activate({ code: "123456" }),
+    ).resolves.toMatchObject({
+      status: "commit_required",
+    });
+    expect((await state.read()).sessions[SESSION_ID]?.activationState).toBe(
+      "staged",
+    );
+
+    const restarted = new RemoteTargetDesktopService(
+      harness.vault,
+      state,
+      relay,
+      () => NOW,
+    );
+    await expect(
+      restarted.resumeEligibleLoopback({
+        apiBase: "http://127.0.0.1:31337",
+        apiToken: "restart-local-token-123456789",
+        pollIntervalMs: 60_000,
+      }),
+    ).resolves.toEqual({ resumed: true, reason: "active_authority" });
+    expect((await state.read()).sessions[SESSION_ID]?.activationState).toBe(
+      "active",
+    );
+    expect(relay.commits).toEqual([SESSION_ID, SESSION_ID]);
+    await restarted.stop();
+  });
+
+  it("keeps active work running and retries an offline staged commit on the poll lifecycle", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = await createHarness();
+      const relay = new ImmediateActivationRelay(harness.activation);
+      const activeRunner = await createRunner(harness, () => undefined);
+      await activeRunner.installActivation({
+        ...harness.activation,
+        sessionId: "11111111-2222-4111-8111-111111111111",
+        grantId: "11111111-3333-4111-8111-111111111111",
+      });
+      await activeRunner.stop();
+      relay.commitFailure = new RemoteTargetTransportError(
+        "NETWORK_UNAVAILABLE",
+        0,
+      );
+      const restarted = new RemoteTargetDesktopService(
+        harness.vault,
+        harness.state,
+        relay,
+        () => NOW,
+      );
+
+      await expect(
+        restarted.resumeEligibleLoopback({
+          apiBase: "http://127.0.0.1:31337",
+          apiToken: "restart-local-token-123456789",
+          pollIntervalMs: 250,
+        }),
+      ).resolves.toEqual({ resumed: true, reason: "active_authority" });
+      expect(await restarted.status()).toMatchObject({
+        running: true,
+        activeSessions: 1,
+        lastErrorCode: "NETWORK_UNAVAILABLE",
+      });
+
+      relay.commitFailure = null;
+      await vi.advanceTimersByTimeAsync(250);
+      expect(await restarted.status()).toMatchObject({
+        running: true,
+        activeSessions: 2,
+        lastErrorCode: null,
+      });
+      await restarted.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps finalization queued through local-failure compensation", async () => {
+    const harness = await createHarness();
+    const relay = new DeferredCompensationRelay(harness.activation);
+    relay.revocations.push({
+      hostId: HOST_ID,
+      status: "revoked",
+      alreadyRevoked: false,
+      cleanup: { sessions: 0, commands: 0, more: false },
+    });
+    const state = new FailingTransactionStateStore();
+    const service = new RemoteTargetDesktopService(
+      harness.vault,
+      state,
+      relay,
+      () => NOW,
+    );
+
+    const activating = service.activate({ code: "123456" });
+    await relay.compensationRequested;
+    let finalized = false;
+    const finalizing = service
+      .finalizeHostRevoke({ hostId: HOST_ID })
+      .then((result) => {
+        finalized = true;
+        return result;
+      });
+    await Promise.resolve();
+    expect(finalized).toBe(false);
+
+    relay.resolveCompensation();
+    await expect(activating).rejects.toMatchObject({
+      code: "REMOTE_ACTIVATION_LOCAL_INSTALL_FAILED",
+    });
+    await expect(finalizing).resolves.toEqual({ cleaned: true });
   });
 
   it("requires authoritative host revocation before deleting native credentials", async () => {

--- a/packages/app-core/platforms/electrobun/src/remote-target-runner.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-runner.ts
@@ -25,6 +25,7 @@ import {
   signRemoteCommandStartReceipt,
   verifyRemoteCommandAuthenticity,
 } from "../../../src/security/remote-control-crypto";
+import { logger } from "./logger";
 import type {
   RemoteTargetStateStore,
   RemoteTargetStoredCommand,
@@ -75,6 +76,10 @@ type PollDisposition =
   | "duplicate"
   | "delivery_pending"
   | "offline";
+
+function isCommittedSession(session: RemoteTargetStoredSession): boolean {
+  return session.activationState !== "staged";
+}
 
 function errorCode(error: unknown): string {
   if (
@@ -158,11 +163,15 @@ export class RemoteTargetRunner {
   private pollTail: Promise<void> = Promise.resolve();
   private loopGeneration = 0;
 
-  private stopFailedLoop(generation: number): void {
+  private stopFailedLoop(generation: number, error: unknown): void {
     if (generation !== this.loopGeneration) return;
     this.running = false;
     this.pollTimer = null;
     this.lastErrorCode = "REMOTE_TARGET_LOOP_FAILED";
+    logger.error("[RemoteTargetRunner] Background polling loop failed", {
+      generation,
+      error,
+    });
   }
 
   constructor(
@@ -232,8 +241,81 @@ export class RemoteTargetRunner {
         lastSequence: current?.lastSequence ?? 0,
         nonces: current?.nonces ?? {},
         stoppedAt: null,
+        activationState:
+          current?.activationState === "active" ? "active" : "staged",
       };
     });
+  }
+
+  async commitLocalActivation(sessionId: string): Promise<void> {
+    await this.stateStore.transact((state) => {
+      const session = state.sessions[sessionId];
+      if (
+        !session ||
+        session.stoppedAt !== null ||
+        session.grant.revokedAt !== null
+      ) {
+        throw new Error("Staged remote activation is unavailable.");
+      }
+      session.activationState = "active";
+    });
+  }
+
+  async recoverStagedActivations(): Promise<string | null> {
+    const enrollment = await this.requireEnrollment();
+    const state = await this.stateStore.read();
+    const staged = Object.values(state.sessions)
+      .filter(
+        (session) =>
+          session.activationState === "staged" &&
+          session.stoppedAt === null &&
+          session.grant.revokedAt === null,
+      )
+      .sort((a, b) => a.grant.sessionId.localeCompare(b.grant.sessionId));
+    let transientErrorCode: string | null = null;
+    for (const session of staged) {
+      try {
+        await this.transport.commitActivation({
+          enrollment,
+          sessionId: session.grant.sessionId,
+        });
+        await this.commitLocalActivation(session.grant.sessionId);
+      } catch (error) {
+        if (
+          error instanceof RemoteTargetTransportError &&
+          (error.status === 404 || error.status === 409 || error.status === 410)
+        ) {
+          await this.stateStore.transact((candidate) => {
+            const current = candidate.sessions[session.grant.sessionId];
+            if (current?.activationState === "staged") {
+              delete candidate.sessions[session.grant.sessionId];
+            }
+          });
+          continue;
+        }
+        if (
+          error instanceof RemoteTargetTransportError &&
+          (error.status === 0 ||
+            error.status === 408 ||
+            error.status === 429 ||
+            error.status >= 500)
+        ) {
+          // error-policy:J4 an expected relay outage leaves the staged grant
+          // non-executable and visible while the polling lifecycle retries it.
+          transientErrorCode ??= error.code;
+          logger.warn(
+            "[RemoteTargetRunner] Staged activation commit is offline",
+            {
+              sessionId: session.grant.sessionId,
+              error,
+            },
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+    return transientErrorCode;
   }
 
   async pollOnce(expectedGeneration?: number): Promise<PollDisposition> {
@@ -255,11 +337,13 @@ export class RemoteTargetRunner {
     const enrollment = await this.requireEnrollment();
     this.lastPollAt = this.now();
     try {
+      const recoveryErrorCode = await this.recoverStagedActivations();
       await this.flushPending(enrollment);
       const state = await this.stateStore.read();
       const sessions = Object.values(state.sessions)
         .filter(
           (session) =>
+            isCommittedSession(session) &&
             session.stoppedAt === null &&
             session.grant.revokedAt === null &&
             (session.grant.expiresAt === null ||
@@ -297,10 +381,10 @@ export class RemoteTargetRunner {
           claim,
           expectedGeneration,
         );
-        this.lastErrorCode = null;
+        this.lastErrorCode = recoveryErrorCode;
         return disposition;
       }
-      this.lastErrorCode = null;
+      this.lastErrorCode = recoveryErrorCode;
       return "empty";
     } catch (error) {
       if (error instanceof RemoteTargetTransportError) {
@@ -366,6 +450,7 @@ export class RemoteTargetRunner {
       const authority = state.sessions[opened.body.sessionId];
       if (
         !authority ||
+        !isCommittedSession(authority) ||
         authority.stoppedAt !== null ||
         authority.grant.revokedAt !== null ||
         authority.grant.revision !== opened.body.grantRevision ||
@@ -824,6 +909,7 @@ export class RemoteTargetRunner {
 
   async start(): Promise<void> {
     if (this.running) return;
+    await this.recoverStagedActivations();
     const generation = ++this.loopGeneration;
     this.running = true;
     const startup = this.pollTail.then(async () => {
@@ -843,10 +929,10 @@ export class RemoteTargetRunner {
       this.pollTimer = setTimeout(
         () => {
           this.pollTimer = null;
-          void loop().catch(() => {
+          void loop().catch((error) => {
             // error-policy:J4 a background integrity failure becomes a
             // distinct stopped/error status instead of an unhandled promise.
-            this.stopFailedLoop(generation);
+            this.stopFailedLoop(generation, error);
           });
         },
         Math.max(250, this.options.pollIntervalMs ?? 1_000),
@@ -855,7 +941,7 @@ export class RemoteTargetRunner {
     try {
       await loop();
     } catch (error) {
-      this.stopFailedLoop(generation);
+      this.stopFailedLoop(generation, error);
       throw error;
     }
   }
@@ -878,7 +964,9 @@ export class RemoteTargetRunner {
       enrolled: enrollment?.status === "enrolled",
       activeSessions: Object.values(state.sessions).filter(
         (session) =>
-          session.stoppedAt === null && session.grant.revokedAt === null,
+          isCommittedSession(session) &&
+          session.stoppedAt === null &&
+          session.grant.revokedAt === null,
       ).length,
       pendingResults: Object.values(state.commands).filter(
         (record) => record.resultEnvelope && !record.resultDelivered,

--- a/packages/app-core/platforms/electrobun/src/remote-target-same-host.integration.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-same-host.integration.test.ts
@@ -230,7 +230,31 @@ class DeterministicRelay implements RemoteTargetRelayTransport {
       targetRuntimeId: HOST_ID,
       targetKeyId: input.enrollment.identity.keyId,
       grantExpiresAt: NOW + 3_600_000,
+      status: "activating",
+    };
+  }
+
+  async compensateActivation(
+    input: Parameters<RemoteTargetRelayTransport["compensateActivation"]>[0],
+  ): Promise<
+    Awaited<ReturnType<RemoteTargetRelayTransport["compensateActivation"]>>
+  > {
+    return {
+      sessionId: input.sessionId,
+      status: "revoked",
+      alreadyCompensated: false,
+    };
+  }
+
+  async commitActivation(
+    input: Parameters<RemoteTargetRelayTransport["commitActivation"]>[0],
+  ): Promise<
+    Awaited<ReturnType<RemoteTargetRelayTransport["commitActivation"]>>
+  > {
+    return {
+      sessionId: input.sessionId,
       status: "active",
+      alreadyCommitted: false,
     };
   }
 

--- a/packages/app-core/platforms/electrobun/src/remote-target-store.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-store.ts
@@ -36,6 +36,8 @@ export interface RemoteTargetStoredSession {
   lastSequence: number;
   nonces: Record<string, number>;
   stoppedAt: number | null;
+  /** Absent legacy rows are committed; new two-phase rows stage explicitly. */
+  activationState?: "staged" | "active";
 }
 
 export interface RemoteTargetStoredCommand {
@@ -134,7 +136,10 @@ function assertState(
       ) ||
       (session.stoppedAt !== null &&
         (!Number.isSafeInteger(session.stoppedAt) ||
-          (session.stoppedAt as number) <= 0))
+          (session.stoppedAt as number) <= 0)) ||
+      (session.activationState !== undefined &&
+        session.activationState !== "staged" &&
+        session.activationState !== "active")
     ) {
       throw new Error("Remote target journal is corrupt.");
     }

--- a/packages/app-core/platforms/electrobun/src/remote-target-transport.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-transport.ts
@@ -69,7 +69,19 @@ export interface RemoteTargetActivationResponse {
   targetRuntimeId: string;
   targetKeyId: string;
   grantExpiresAt: number;
+  status: "activating";
+}
+
+export interface RemoteTargetActivationCompensationResponse {
+  sessionId: string;
+  status: "denied" | "revoked";
+  alreadyCompensated: boolean;
+}
+
+export interface RemoteTargetActivationCommitResponse {
+  sessionId: string;
   status: "active";
+  alreadyCommitted: boolean;
 }
 
 export interface RemoteTargetClaim {
@@ -97,6 +109,14 @@ export interface RemoteTargetRelayTransport {
     sessionId?: string;
     code: string;
   }): Promise<RemoteTargetActivationResponse>;
+  compensateActivation(input: {
+    enrollment: EnrolledRemoteTargetVaultRecord;
+    sessionId: string;
+  }): Promise<RemoteTargetActivationCompensationResponse>;
+  commitActivation(input: {
+    enrollment: EnrolledRemoteTargetVaultRecord;
+    sessionId: string;
+  }): Promise<RemoteTargetActivationCommitResponse>;
   claimNext(input: {
     enrollment: EnrolledRemoteTargetVaultRecord;
     sessionId: string;
@@ -428,7 +448,7 @@ export class HttpRemoteTargetRelayTransport
     const sessionId = requireUuid(data.sessionId);
     if (
       (expectedSessionId !== null && sessionId !== expectedSessionId) ||
-      data.status !== "active" ||
+      data.status !== "activating" ||
       !Number.isSafeInteger(data.grantRevision) ||
       (data.grantRevision as number) < 1 ||
       !isRemoteControllerPublicIdentity(controller)
@@ -450,7 +470,65 @@ export class HttpRemoteTargetRelayTransport
               throw new Error("Remote activation target key is invalid.");
             })(),
       grantExpiresAt: requireTimestamp(data.grantExpiresAt),
+      status: "activating",
+    };
+  }
+
+  async commitActivation(input: {
+    enrollment: EnrolledRemoteTargetVaultRecord;
+    sessionId: string;
+  }): Promise<RemoteTargetActivationCommitResponse> {
+    const sessionId = requireUuid(input.sessionId);
+    const data = requireObject(
+      await this.request(
+        input.enrollment.apiBaseUrl,
+        `/api/v1/remote/sessions/${encodeURIComponent(sessionId)}/activate`,
+        {
+          method: "PUT",
+          headers: this.hostHeaders(input.enrollment),
+        },
+      ),
+    );
+    if (
+      requireUuid(data.sessionId) !== sessionId ||
+      data.status !== "active" ||
+      typeof data.alreadyCommitted !== "boolean"
+    ) {
+      throw new Error("Remote activation commit response is invalid.");
+    }
+    return {
+      sessionId,
       status: "active",
+      alreadyCommitted: data.alreadyCommitted,
+    };
+  }
+
+  async compensateActivation(input: {
+    enrollment: EnrolledRemoteTargetVaultRecord;
+    sessionId: string;
+  }): Promise<RemoteTargetActivationCompensationResponse> {
+    const sessionId = requireUuid(input.sessionId);
+    const data = requireObject(
+      await this.request(
+        input.enrollment.apiBaseUrl,
+        `/api/v1/remote/sessions/${encodeURIComponent(sessionId)}/activate`,
+        {
+          method: "DELETE",
+          headers: this.hostHeaders(input.enrollment),
+        },
+      ),
+    );
+    if (
+      requireUuid(data.sessionId) !== sessionId ||
+      (data.status !== "denied" && data.status !== "revoked") ||
+      typeof data.alreadyCompensated !== "boolean"
+    ) {
+      throw new Error("Remote activation compensation response is invalid.");
+    }
+    return {
+      sessionId,
+      status: data.status,
+      alreadyCompensated: data.alreadyCompensated,
     };
   }
 

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
@@ -134,6 +134,8 @@ import {
 import {
   configureDesktopRemoteTarget,
   desktopRemoteTargetActivate,
+  desktopRemoteTargetCommitActivation,
+  desktopRemoteTargetCompensateActivation,
   desktopRemoteTargetEnroll,
   desktopRemoteTargetFinalizeHostRevoke,
   desktopRemoteTargetGetIdentity,
@@ -1446,6 +1448,10 @@ export function buildBunRpcHandlers({
       await configureRemoteTargetForCurrentLoopback();
       return desktopRemoteTargetActivate(params);
     },
+    remoteTargetCompensateActivation: async (params) =>
+      desktopRemoteTargetCompensateActivation(params),
+    remoteTargetCommitActivation: async (params) =>
+      desktopRemoteTargetCommitActivation(params),
     remoteTargetStart: async () => {
       await configureRemoteTargetForCurrentLoopback();
       return desktopRemoteTargetStart();

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -2294,11 +2294,40 @@ export type ElizaDesktopRPCSchema = {
       };
       remoteTargetActivate: {
         params: { sessionId?: string; code: string };
+        response:
+          | {
+              sessionId: string;
+              status: "active";
+              controllerDisplayName: string;
+              grantExpiresAt: number;
+            }
+          | {
+              sessionId: string;
+              status: "compensation_required";
+              errorCode: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED";
+              retryRpc: "remoteTargetCompensateActivation";
+            }
+          | {
+              sessionId: string;
+              status: "commit_required";
+              errorCode: "REMOTE_ACTIVATION_COMMIT_REQUIRED";
+              retryRpc: "remoteTargetCommitActivation";
+            };
+      };
+      remoteTargetCompensateActivation: {
+        params: { sessionId: string };
+        response: {
+          sessionId: string;
+          status: "denied" | "revoked";
+          alreadyCompensated: boolean;
+        };
+      };
+      remoteTargetCommitActivation: {
+        params: { sessionId: string };
         response: {
           sessionId: string;
           status: "active";
-          controllerDisplayName: string;
-          grantExpiresAt: number;
+          alreadyCommitted: boolean;
         };
       };
       remoteTargetStart: {
@@ -2970,6 +2999,8 @@ export const CHANNEL_TO_RPC_METHOD: Record<string, string> = {
   "remoteTarget:enroll": "remoteTargetEnroll",
   "remoteTarget:getIdentity": "remoteTargetGetIdentity",
   "remoteTarget:activate": "remoteTargetActivate",
+  "remoteTarget:compensateActivation": "remoteTargetCompensateActivation",
+  "remoteTarget:commitActivation": "remoteTargetCommitActivation",
   "remoteTarget:start": "remoteTargetStart",
   "remoteTarget:stop": "remoteTargetStop",
   "remoteTarget:status": "remoteTargetStatus",

--- a/packages/cloud/api/v1/remote/relay-routes.test.ts
+++ b/packages/cloud/api/v1/remote/relay-routes.test.ts
@@ -1,7 +1,8 @@
 /**
  * Exercises secure remote relay HTTP boundaries with deterministic persistence
  * collaborators, covering owner scope, one-use activation, replay mapping,
- * host authentication, start fencing, ambiguity, and idempotent revocation.
+ * host authentication, activation compensation, start fencing, ambiguity, and
+ * idempotent revocation.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -42,6 +43,8 @@ const createPendingForOwnedAgent = mock();
 const createPendingForOwnedHost = mock();
 const activatePendingHost = mock();
 const activatePendingHostByCode = mock();
+const compensateHostActivation = mock();
+const commitHostActivation = mock();
 const listActiveByOwnedAgent = mock();
 const listByOwnedHost = mock();
 const revokeSession = mock();
@@ -78,6 +81,8 @@ mock.module("@/db/repositories/remote-sessions", () => ({
     createPendingForOwnedHost,
     activatePendingHost,
     activatePendingHostByCode,
+    compensateHostActivation,
+    commitHostActivation,
     listActiveByOwnedAgent,
     listByOwnedHost,
     revoke: revokeSession,
@@ -184,14 +189,18 @@ function hostHeaders() {
 
 function request(
   path: string,
-  body: unknown,
+  body: unknown = undefined,
   headers: Record<string, string> = {},
+  method = "POST",
 ) {
   return app.fetch(
     new Request(`https://api.example.test${path}`, {
-      method: "POST",
-      headers: { "content-type": "application/json", ...headers },
-      body: JSON.stringify(body),
+      method,
+      headers: {
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+        ...headers,
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
     }),
     {
       REMOTE_PAIRING_HMAC_SECRET:
@@ -211,6 +220,8 @@ beforeEach(() => {
     createPendingForOwnedHost,
     activatePendingHost,
     activatePendingHostByCode,
+    compensateHostActivation,
+    commitHostActivation,
     listActiveByOwnedAgent,
     listByOwnedHost,
     revokeSession,
@@ -272,7 +283,7 @@ describe("secure remote relay routes", () => {
         signing_public_jwk: publicJwk,
         encryption_public_jwk: publicJwk,
         host_token_hash: "sha256:must-not-leak",
-        status: "active",
+        status: "activating",
         last_seen_at: new Date(),
         created_at: new Date(),
         revoked_at: null,
@@ -421,6 +432,55 @@ describe("secure remote relay routes", () => {
     expect(persisted.pairing_token_hash).not.toContain(body.data.code);
   });
 
+  test("commits only the exact host-authenticated staged activation and maps replay", async () => {
+    commitHostActivation.mockResolvedValueOnce({
+      kind: "committed",
+      session: { id: sessionId, status: "active" },
+      alreadyCommitted: false,
+    });
+    const first = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "PUT",
+    );
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toEqual({
+      success: true,
+      data: { sessionId, status: "active", alreadyCommitted: false },
+    });
+    expect(commitHostActivation).toHaveBeenCalledWith({
+      sessionId,
+      hostId,
+      hostToken,
+    });
+
+    commitHostActivation.mockResolvedValueOnce({
+      kind: "committed",
+      session: { id: sessionId, status: "active" },
+      alreadyCommitted: true,
+    });
+    const replay = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "PUT",
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      data: { alreadyCommitted: true },
+    });
+
+    commitHostActivation.mockResolvedValueOnce({ kind: "conflict" });
+    const conflict = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "PUT",
+    );
+    expect(conflict.status).toBe(409);
+  });
+
   test("maps reused or expired host pairing to an oracle-safe not-found response", async () => {
     activatePendingHost.mockResolvedValue({ kind: "invalid_pairing" });
     const response = await request(
@@ -457,7 +517,7 @@ describe("secure remote relay routes", () => {
         target_key_id: targetKeyId,
         grant_expires_at: new Date("2026-08-22T14:30:00.000Z"),
         created_at: createdAt,
-        status: "active",
+        status: "activating",
       },
     });
     const response = await request(
@@ -468,6 +528,7 @@ describe("secure remote relay routes", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       data: {
+        status: "activating",
         controllerDeviceId: "controller-one",
         controllerKeyId,
         controllerDisplayName: "Controller One",
@@ -477,6 +538,67 @@ describe("secure remote relay routes", () => {
         controllerCreatedAt: createdAt.toISOString(),
       },
     });
+  });
+
+  test("compensates only the exact host-authenticated activation and maps replay", async () => {
+    compensateHostActivation.mockResolvedValueOnce({
+      kind: "compensated",
+      session: { id: sessionId, status: "revoked" },
+      alreadyCompensated: false,
+    });
+    const first = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "DELETE",
+    );
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toEqual({
+      success: true,
+      data: { sessionId, status: "revoked", alreadyCompensated: false },
+    });
+    expect(compensateHostActivation).toHaveBeenCalledWith({
+      sessionId,
+      hostId,
+      hostToken,
+    });
+
+    compensateHostActivation.mockResolvedValueOnce({
+      kind: "compensated",
+      session: { id: sessionId, status: "revoked" },
+      alreadyCompensated: true,
+    });
+    const replay = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "DELETE",
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      data: { alreadyCompensated: true },
+    });
+
+    compensateHostActivation.mockResolvedValueOnce({ kind: "conflict" });
+    const conflict = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "DELETE",
+    );
+    expect(conflict.status).toBe(409);
+
+    compensateHostActivation.mockRejectedValueOnce(
+      new Error("compensation-storage-unavailable"),
+    );
+    const unavailable = await request(
+      `/api/v1/remote/sessions/${sessionId}/activate`,
+      undefined,
+      hostHeaders(),
+      "DELETE",
+    );
+    expect(unavailable.status).toBe(500);
+    await expect(unavailable.json()).resolves.toMatchObject({ success: false });
   });
 
   test("discovers a pairing session by code only through the authenticated host", async () => {

--- a/packages/cloud/api/v1/remote/sessions/[id]/activate/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/[id]/activate/route.ts
@@ -1,4 +1,7 @@
-/** Atomically consumes one host-bound pairing code and returns grant material. */
+/**
+ * Stages one exact host-bound pairing session, then exposes authenticated,
+ * idempotent commit or rollback after the target durably installs authority.
+ */
 
 import { Hono } from "hono";
 import { isRemotePairingUuid } from "@/db/crypto/remote-pairing-code";
@@ -8,6 +11,104 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 import { parseRemoteHostCredential } from "../../../host-auth";
 
 const app = new Hono<AppEnv>();
+
+app.put("/", async (c) => {
+  try {
+    const sessionId = c.req.param("id")?.trim() ?? "";
+    if (!isRemotePairingUuid(sessionId)) {
+      return c.json(
+        { success: false, error: "Session id must be a UUID" },
+        400,
+      );
+    }
+    const credential = parseRemoteHostCredential(c.req.raw);
+    if (!credential) {
+      return c.json(
+        { success: false, error: "Remote host authentication required" },
+        401,
+      );
+    }
+    const result = await remoteSessionsRepository.commitHostActivation({
+      sessionId,
+      hostId: credential.hostId,
+      hostToken: credential.token,
+    });
+    if (result.kind === "not_found") {
+      return c.json({ success: false, error: "Remote session not found" }, 404);
+    }
+    if (result.kind === "conflict") {
+      return c.json(
+        {
+          success: false,
+          error: "Remote activation is no longer committable",
+          code: "REMOTE_ACTIVATION_COMMIT_CONFLICT",
+        },
+        409,
+      );
+    }
+    c.header("Cache-Control", "no-store");
+    return c.json({
+      success: true,
+      data: {
+        sessionId: result.session.id,
+        status: result.session.status,
+        alreadyCommitted: result.alreadyCommitted,
+      },
+    });
+  } catch (error) {
+    // error-policy:J1 the HTTP boundary translates typed/internal failures.
+    return failureResponse(c, error);
+  }
+});
+
+app.delete("/", async (c) => {
+  try {
+    const sessionId = c.req.param("id")?.trim() ?? "";
+    if (!isRemotePairingUuid(sessionId)) {
+      return c.json(
+        { success: false, error: "Session id must be a UUID" },
+        400,
+      );
+    }
+    const credential = parseRemoteHostCredential(c.req.raw);
+    if (!credential) {
+      return c.json(
+        { success: false, error: "Remote host authentication required" },
+        401,
+      );
+    }
+    const result = await remoteSessionsRepository.compensateHostActivation({
+      sessionId,
+      hostId: credential.hostId,
+      hostToken: credential.token,
+    });
+    if (result.kind === "not_found") {
+      return c.json({ success: false, error: "Remote session not found" }, 404);
+    }
+    if (result.kind === "conflict") {
+      return c.json(
+        {
+          success: false,
+          error: "Remote session is not an active activation",
+          code: "REMOTE_ACTIVATION_COMPENSATION_CONFLICT",
+        },
+        409,
+      );
+    }
+    c.header("Cache-Control", "no-store");
+    return c.json({
+      success: true,
+      data: {
+        sessionId: result.session.id,
+        status: result.session.status,
+        alreadyCompensated: result.alreadyCompensated,
+      },
+    });
+  } catch (error) {
+    // error-policy:J1 the HTTP boundary translates typed/internal failures.
+    return failureResponse(c, error);
+  }
+});
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/shared/src/db/migrations/0311_remote_session_two_phase_activation.sql
+++ b/packages/cloud/shared/src/db/migrations/0311_remote_session_two_phase_activation.sql
@@ -1,0 +1,6 @@
+-- Keep consumed remote-target grants non-authoritative until the target proves
+-- that the exact grant is durable in its local replay journal.
+ALTER TABLE "remote_sessions" DROP CONSTRAINT IF EXISTS "remote_sessions_status_check";
+--> statement-breakpoint
+ALTER TABLE "remote_sessions" ADD CONSTRAINT "remote_sessions_status_check"
+  CHECK ("status" IN ('pending', 'activating', 'active', 'denied', 'revoked', 'expired'));

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2059,6 +2059,13 @@
       "when": 1794254400001,
       "tag": "0310_personal_shared_inbound_media_admission",
       "breakpoints": true
+    },
+    {
+      "idx": 294,
+      "version": "7",
+      "when": 1794254400002,
+      "tag": "0311_remote_session_two_phase_activation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/remote-sessions-first-class-expiry.test.ts
+++ b/packages/cloud/shared/src/db/migrations/remote-sessions-first-class-expiry.test.ts
@@ -10,6 +10,7 @@ import { PGlite } from "@electric-sql/pglite";
 
 const createUrl = new URL("./0068_add_remote_sessions.sql", import.meta.url);
 const expiryUrl = new URL("./0275_remote_sessions_first_class_expiry.sql", import.meta.url);
+const twoPhaseUrl = new URL("./0311_remote_session_two_phase_activation.sql", import.meta.url);
 
 const organizationId = "10000000-0000-4000-8000-000000000001";
 const userId = "20000000-0000-4000-8000-000000000001";
@@ -18,6 +19,7 @@ const agentId = "30000000-0000-4000-8000-000000000001";
 let pg: PGlite;
 let createSource = "";
 let expirySource = "";
+let twoPhaseSource = "";
 
 async function apply(source: string, target: PGlite = pg): Promise<void> {
   for (const statement of source.split("--> statement-breakpoint")) {
@@ -50,6 +52,7 @@ beforeAll(async () => {
   pg = new PGlite();
   createSource = await Bun.file(createUrl).text();
   expirySource = await Bun.file(expiryUrl).text();
+  twoPhaseSource = await Bun.file(twoPhaseUrl).text();
   await createReferencedTables();
   await apply(createSource);
   await apply(expirySource);
@@ -114,5 +117,20 @@ describe("remote session first-class expiry migration", () => {
        WHERE table_name = 'remote_sessions' AND column_name = 'expires_at'`,
     );
     expect(columns.rows).toHaveLength(1);
+  });
+
+  test("0311 admits only the non-authoritative activating phase and remains idempotent", async () => {
+    await insertPending("40000000-0000-4000-8000-000000000004");
+    await apply(twoPhaseSource);
+    await pg.exec("UPDATE remote_sessions SET status = 'activating' WHERE status = 'pending'");
+    await expect(pg.exec("UPDATE remote_sessions SET status = 'committing'")).rejects.toThrow(
+      /remote_sessions_status_check/,
+    );
+    await apply(twoPhaseSource);
+    const constraints = await pg.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM pg_constraint
+       WHERE conname = 'remote_sessions_status_check'`,
+    );
+    expect(constraints.rows[0]?.count).toBe("1");
   });
 });

--- a/packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-command-envelopes.pglite.test.ts
@@ -1,7 +1,8 @@
 /**
  * Exercises the production remote host/session/command repositories against
  * real PGlite transactions, including one-use pairing, replay fencing,
- * pre-start lease recovery, post-start ambiguity, and revocation cleanup.
+ * activation compensation, pre-start lease recovery, post-start ambiguity,
+ * and revocation cleanup.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
@@ -174,7 +175,11 @@ async function enrollAndPair(activate = true): Promise<void> {
         code,
         pairingSecret,
       }),
-    ).toMatchObject({ kind: "activated", session: { status: "active" } });
+    ).toMatchObject({ kind: "activated", session: { status: "activating" } });
+    expect(await sessions.commitHostActivation({ sessionId, hostId, hostToken })).toMatchObject({
+      kind: "committed",
+      session: { status: "active" },
+    });
   }
 }
 
@@ -208,6 +213,7 @@ beforeAll(async () => {
     "0275_remote_sessions_first_class_expiry",
     "0305_secure_remote_hosts",
     "0306_secure_remote_command_relay",
+    "0311_remote_session_two_phase_activation",
   ]) {
     await applyMigration(migration);
   }
@@ -326,7 +332,7 @@ describe("secure remote relay repositories", () => {
       }),
     ).toMatchObject({
       kind: "activated",
-      session: { id: sessionId, status: "active" },
+      session: { id: sessionId, status: "activating" },
     });
     expect(
       await sessions.activatePendingHostByCode({
@@ -336,6 +342,116 @@ describe("secure remote relay repositories", () => {
         pairingSecret,
       }),
     ).toEqual({ kind: "invalid_pairing" });
+  });
+
+  it("commits an exact staged activation idempotently without admitting pre-commit commands", async () => {
+    await enrollAndPair(false);
+    await sessions.activatePendingHost({
+      sessionId,
+      hostId,
+      hostToken,
+      code: "123456",
+      pairingSecret,
+    });
+    expect((await commands.claimNext({ sessionId, hostId, hostToken })).kind).toBe("not_found");
+    await expect(
+      sessions.commitHostActivation({
+        sessionId,
+        hostId,
+        hostToken: `rhost_v1_${"Z".repeat(43)}`,
+      }),
+    ).resolves.toEqual({ kind: "not_found" });
+    await expect(
+      sessions.commitHostActivation({ sessionId, hostId, hostToken }),
+    ).resolves.toMatchObject({
+      kind: "committed",
+      session: { id: sessionId, status: "active" },
+      alreadyCommitted: false,
+    });
+    await expect(
+      sessions.commitHostActivation({ sessionId, hostId, hostToken }),
+    ).resolves.toMatchObject({ kind: "committed", alreadyCommitted: true });
+  });
+
+  it("serializes staged commit against host finalization", async () => {
+    await enrollAndPair(false);
+    await sessions.activatePendingHost({
+      sessionId,
+      hostId,
+      hostToken,
+      code: "123456",
+      pairingSecret,
+    });
+    const [commit, finalization] = await Promise.all([
+      sessions.commitHostActivation({ sessionId, hostId, hostToken }),
+      hosts.revokeAuthenticated(hostId, hostToken),
+    ]);
+    expect(finalization).toMatchObject({ host: { status: "revoked" } });
+    expect(["committed", "conflict"]).toContain(commit.kind);
+    const [stored] = await database.select().from(remoteSessions);
+    expect(["denied", "revoked"]).toContain(stored?.status);
+  });
+
+  it("compensates an exact activation idempotently under host finalization", async () => {
+    await enrollAndPair(false);
+    await sessions.activatePendingHost({
+      sessionId,
+      hostId,
+      hostToken,
+      code: "123456",
+      pairingSecret,
+    });
+    await expect(
+      sessions.compensateHostActivation({
+        sessionId,
+        hostId,
+        hostToken: `rhost_v1_${"Z".repeat(43)}`,
+      }),
+    ).resolves.toEqual({ kind: "not_found" });
+    const first = await sessions.compensateHostActivation({
+      sessionId,
+      hostId,
+      hostToken,
+    });
+    expect(first).toMatchObject({
+      kind: "compensated",
+      session: { id: sessionId, status: "denied" },
+      alreadyCompensated: false,
+    });
+    await expect(
+      sessions.compensateHostActivation({ sessionId, hostId, hostToken }),
+    ).resolves.toMatchObject({
+      kind: "compensated",
+      session: { id: sessionId, status: "denied" },
+      alreadyCompensated: true,
+    });
+  });
+
+  it("serializes activation compensation with host finalization", async () => {
+    await enrollAndPair(false);
+    await sessions.activatePendingHost({
+      sessionId,
+      hostId,
+      hostToken,
+      code: "123456",
+      pairingSecret,
+    });
+    const [compensation, finalization] = await Promise.all([
+      sessions.compensateHostActivation({ sessionId, hostId, hostToken }),
+      hosts.revokeAuthenticated(hostId, hostToken),
+    ]);
+    expect(compensation).toMatchObject({
+      kind: "compensated",
+      session: { id: sessionId, status: "denied" },
+    });
+    expect(finalization).toMatchObject({
+      host: { id: hostId, status: "revoked" },
+    });
+    const [stored] = await database
+      .select()
+      .from(remoteSessions)
+      .where(eq(remoteSessions.id, sessionId));
+    expect(["denied", "revoked"]).toContain(stored?.status);
   });
 
   it("serializes sequence, nonce, and idempotency under the session lock", async () => {

--- a/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
@@ -24,7 +24,7 @@ import {
 } from "../schemas/remote-sessions";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
-const ACTIVE_STATUSES: RemoteSessionStatus[] = ["pending", "active"];
+const OPEN_STATUSES: RemoteSessionStatus[] = ["pending", "activating", "active"];
 
 export interface RevokeRemoteSessionResult {
   session: RemoteSession;
@@ -36,6 +36,16 @@ export type ActivateRemoteHostSessionResult =
   | { kind: "activated"; session: RemoteSession }
   | { kind: "not_found" }
   | { kind: "invalid_pairing" };
+
+export type CompensateRemoteHostActivationResult =
+  | { kind: "compensated"; session: RemoteSession; alreadyCompensated: boolean }
+  | { kind: "conflict" }
+  | { kind: "not_found" };
+
+export type CommitRemoteHostActivationResult =
+  | { kind: "committed"; session: RemoteSession; alreadyCommitted: boolean }
+  | { kind: "conflict" }
+  | { kind: "not_found" };
 
 const SESSION_COMMAND_CLEANUP_BATCH = 500;
 const CODE_ACTIVATION_CANDIDATE_LIMIT = 32;
@@ -274,7 +284,7 @@ export class RemoteSessionsRepository {
       const [activated] = await tx
         .update(remoteSessions)
         .set({
-          status: "active",
+          status: "activating",
           pairing_token_hash: null,
           pairing_consumed_at: now,
           updated_at: now,
@@ -375,7 +385,7 @@ export class RemoteSessionsRepository {
       const [activated] = await tx
         .update(remoteSessions)
         .set({
-          status: "active",
+          status: "activating",
           pairing_token_hash: null,
           pairing_consumed_at: now,
           updated_at: now,
@@ -388,6 +398,163 @@ export class RemoteSessionsRepository {
         });
       }
       return { kind: "activated", session: activated };
+    });
+  }
+
+  /**
+   * Commits one locally durable staged grant into Cloud authority. Replays are
+   * idempotent for the exact active session, while host revocation or expiry
+   * wins under the same host/session lock order.
+   */
+  async commitHostActivation(input: {
+    sessionId: string;
+    hostId: string;
+    hostToken: string;
+  }): Promise<CommitRemoteHostActivationResult> {
+    let tokenHash: string;
+    try {
+      tokenHash = await hashRemoteHostToken(input.hostToken);
+    } catch {
+      // error-policy:J3 malformed bearer material is an explicit auth miss.
+      return { kind: "not_found" };
+    }
+    return this.database.transaction(async (tx) => {
+      const [host] = await tx
+        .select({
+          id: remoteHosts.id,
+          organizationId: remoteHosts.organization_id,
+          userId: remoteHosts.user_id,
+          status: remoteHosts.status,
+        })
+        .from(remoteHosts)
+        .where(and(eq(remoteHosts.id, input.hostId), eq(remoteHosts.host_token_hash, tokenHash)))
+        .for("update");
+      if (!host) return { kind: "not_found" };
+
+      const [session] = await tx
+        .select()
+        .from(remoteSessions)
+        .where(
+          and(
+            eq(remoteSessions.id, input.sessionId),
+            eq(remoteSessions.host_id, host.id),
+            eq(remoteSessions.organization_id, host.organizationId),
+            eq(remoteSessions.user_id, host.userId),
+          ),
+        )
+        .for("update");
+      if (!session) return { kind: "not_found" };
+      if (session.status === "active" && host.status === "active") {
+        return { kind: "committed", session, alreadyCommitted: true };
+      }
+      if (session.status !== "activating" || host.status !== "active") {
+        return { kind: "conflict" };
+      }
+      const now = await readPostLockDatabaseNow(tx);
+      if (
+        !session.expires_at ||
+        session.expires_at.getTime() <= now.getTime() ||
+        !session.grant_expires_at ||
+        session.grant_expires_at.getTime() <= now.getTime()
+      ) {
+        const [expired] = await tx
+          .update(remoteSessions)
+          .set({ status: "expired", ended_at: now, updated_at: now })
+          .where(and(eq(remoteSessions.id, session.id), eq(remoteSessions.status, "activating")))
+          .returning();
+        if (!expired) {
+          throw storageFailure("Locked remote host activation could not expire", {
+            sessionId: session.id,
+          });
+        }
+        return { kind: "conflict" };
+      }
+      const [committed] = await tx
+        .update(remoteSessions)
+        .set({ status: "active", updated_at: now })
+        .where(and(eq(remoteSessions.id, session.id), eq(remoteSessions.status, "activating")))
+        .returning();
+      if (!committed) {
+        throw storageFailure("Locked remote host activation could not be committed", {
+          sessionId: session.id,
+        });
+      }
+      return { kind: "committed", session: committed, alreadyCommitted: false };
+    });
+  }
+
+  /**
+   * Denies exactly one non-authoritative staged activation after the target
+   * failed local installation. Host/session locks serialize rollback with
+   * commit and host finalization; exact terminal replays are successful.
+   */
+  async compensateHostActivation(input: {
+    sessionId: string;
+    hostId: string;
+    hostToken: string;
+  }): Promise<CompensateRemoteHostActivationResult> {
+    let tokenHash: string;
+    try {
+      tokenHash = await hashRemoteHostToken(input.hostToken);
+    } catch {
+      // error-policy:J3 malformed bearer material is an explicit auth miss.
+      return { kind: "not_found" };
+    }
+    return this.database.transaction(async (tx) => {
+      const [host] = await tx
+        .select({
+          id: remoteHosts.id,
+          organizationId: remoteHosts.organization_id,
+          userId: remoteHosts.user_id,
+        })
+        .from(remoteHosts)
+        .where(and(eq(remoteHosts.id, input.hostId), eq(remoteHosts.host_token_hash, tokenHash)))
+        .for("update");
+      if (!host) return { kind: "not_found" };
+
+      const [session] = await tx
+        .select()
+        .from(remoteSessions)
+        .where(
+          and(
+            eq(remoteSessions.id, input.sessionId),
+            eq(remoteSessions.host_id, host.id),
+            eq(remoteSessions.organization_id, host.organizationId),
+            eq(remoteSessions.user_id, host.userId),
+          ),
+        )
+        .for("update");
+      if (!session) return { kind: "not_found" };
+      if (session.status === "denied" || session.status === "revoked") {
+        return {
+          kind: "compensated",
+          session,
+          alreadyCompensated: true,
+        };
+      }
+      if (session.status !== "activating") return { kind: "conflict" };
+
+      const now = await readPostLockDatabaseNow(tx);
+      const [compensated] = await tx
+        .update(remoteSessions)
+        .set({
+          status: "denied",
+          pairing_token_hash: null,
+          ended_at: now,
+          updated_at: now,
+        })
+        .where(and(eq(remoteSessions.id, session.id), eq(remoteSessions.status, "activating")))
+        .returning();
+      if (!compensated) {
+        throw storageFailure("Locked remote host activation could not be compensated", {
+          sessionId: session.id,
+        });
+      }
+      return {
+        kind: "compensated",
+        session: compensated,
+        alreadyCompensated: false,
+      };
     });
   }
 
@@ -417,7 +584,7 @@ export class RemoteSessionsRepository {
             eq(remoteSessions.host_id, host.id),
             eq(remoteSessions.organization_id, organizationId),
             eq(remoteSessions.user_id, userId),
-            inArray(remoteSessions.status, ["pending", "active"]),
+            inArray(remoteSessions.status, ["pending", "activating", "active"]),
           ),
         )
         .orderBy(desc(remoteSessions.created_at));
@@ -471,6 +638,7 @@ export class RemoteSessionsRepository {
       return rows.filter(
         (row) =>
           row.expires_at !== null ||
+          row.status !== "pending" ||
           isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, nowMs),
       );
     });
@@ -503,7 +671,7 @@ export class RemoteSessionsRepository {
   }
 
   /**
-   * Terminalizes one already-locked pending row whose grant has run out.
+   * Terminalizes one already-locked pre-authority row whose grant has run out.
    * A run-out pairing challenge must never be reported as freshly revoked, so
    * this runs inside the caller's lock before any terminal decision. Rows
    * predating the first-class column carry NULL and are judged by the signed
@@ -514,23 +682,29 @@ export class RemoteSessionsRepository {
     row: RemoteSession,
     now: Date,
   ): Promise<RemoteSession | undefined> {
-    if (row.status !== "pending") return undefined;
+    if (row.status !== "pending" && row.status !== "activating") return undefined;
     const runOut =
       row.expires_at !== null
         ? row.expires_at.getTime() <= now.getTime()
-        : !isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, now.getTime());
+        : row.status === "activating" ||
+          !isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, now.getTime());
     if (!runOut) return undefined;
 
     const [expired] = await tx
       .update(remoteSessions)
       .set({ status: "expired", updated_at: now, ended_at: now })
-      .where(and(eq(remoteSessions.id, row.id), eq(remoteSessions.status, "pending")))
+      .where(
+        and(
+          eq(remoteSessions.id, row.id),
+          inArray(remoteSessions.status, ["pending", "activating"]),
+        ),
+      )
       .returning();
     return expired;
   }
 
   /**
-   * Terminalizes run-out pending grants without requiring current ownership.
+   * Terminalizes run-out pending and staged grants without requiring ownership.
    *
    * Every request-path predicate is scoped to the agent's present owner, so an
    * ownership transfer strands the previous owner's pending row as `pending`
@@ -547,7 +721,12 @@ export class RemoteSessionsRepository {
       const candidates = await tx
         .select({ id: remoteSessions.id })
         .from(remoteSessions)
-        .where(and(eq(remoteSessions.status, "pending"), lte(remoteSessions.expires_at, now)))
+        .where(
+          and(
+            inArray(remoteSessions.status, ["pending", "activating"]),
+            lte(remoteSessions.expires_at, now),
+          ),
+        )
         .orderBy(remoteSessions.expires_at)
         .limit(limit)
         .for("update", { skipLocked: true });
@@ -562,7 +741,7 @@ export class RemoteSessionsRepository {
               remoteSessions.id,
               candidates.map((candidate) => candidate.id),
             ),
-            eq(remoteSessions.status, "pending"),
+            inArray(remoteSessions.status, ["pending", "activating"]),
           ),
         )
         .returning({ id: remoteSessions.id });
@@ -649,7 +828,7 @@ export class RemoteSessionsRepository {
             eq(remoteSessions.organization_id, orgId),
             eq(remoteSessions.user_id, userId),
             eq(remoteSessions.agent_id, authorizedAgentId),
-            inArray(remoteSessions.status, ACTIVE_STATUSES),
+            inArray(remoteSessions.status, OPEN_STATUSES),
           ),
         )
         .returning();
@@ -692,9 +871,9 @@ export class RemoteSessionsRepository {
       if (!current) return undefined;
 
       const now = await readPostLockDatabaseNow(tx);
-      let alreadyEnded = !ACTIVE_STATUSES.includes(current.status);
+      let alreadyEnded = !OPEN_STATUSES.includes(current.status);
       let session = current;
-      if (ACTIVE_STATUSES.includes(current.status)) {
+      if (OPEN_STATUSES.includes(current.status)) {
         const terminalStatus =
           current.status === "pending" &&
           (!current.expires_at || current.expires_at.getTime() <= now.getTime())
@@ -710,7 +889,7 @@ export class RemoteSessionsRepository {
             updated_at: now,
           })
           .where(
-            and(eq(remoteSessions.id, current.id), inArray(remoteSessions.status, ACTIVE_STATUSES)),
+            and(eq(remoteSessions.id, current.id), inArray(remoteSessions.status, OPEN_STATUSES)),
           )
           .returning();
         if (!ended) {

--- a/packages/cloud/shared/src/db/schemas/remote-sessions.ts
+++ b/packages/cloud/shared/src/db/schemas/remote-sessions.ts
@@ -28,6 +28,7 @@ import { users } from "./users";
 
 export const REMOTE_SESSION_STATUSES = [
   "pending",
+  "activating",
   "active",
   "denied",
   "revoked",

--- a/packages/ui/src/platform/remote-target.ts
+++ b/packages/ui/src/platform/remote-target.ts
@@ -50,18 +50,84 @@ export async function getRemoteTargetIdentity(): Promise<{
 export async function activateRemoteTarget(input: {
   sessionId?: string;
   code: string;
-}): Promise<{ controllerDisplayName: string; grantExpiresAt: number }> {
-  const result = await invokeDesktopBridgeRequest<{
-    sessionId: string;
-    status: "active";
-    controllerDisplayName: string;
-    grantExpiresAt: number;
-  }>({
+}): Promise<
+  | {
+      sessionId: string;
+      status: "active";
+      controllerDisplayName: string;
+      grantExpiresAt: number;
+    }
+  | {
+      sessionId: string;
+      status: "compensation_required";
+      errorCode: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED";
+    }
+  | {
+      sessionId: string;
+      status: "commit_required";
+      errorCode: "REMOTE_ACTIVATION_COMMIT_REQUIRED";
+    }
+> {
+  const result = await invokeDesktopBridgeRequest<
+    | {
+        sessionId: string;
+        status: "active";
+        controllerDisplayName: string;
+        grantExpiresAt: number;
+      }
+    | {
+        sessionId: string;
+        status: "compensation_required";
+        errorCode: "REMOTE_ACTIVATION_COMPENSATION_REQUIRED";
+      }
+    | {
+        sessionId: string;
+        status: "commit_required";
+        errorCode: "REMOTE_ACTIVATION_COMMIT_REQUIRED";
+      }
+  >({
     rpcMethod: "remoteTargetActivate",
     ipcChannel: "remoteTarget:activate",
     params: input,
   });
   if (!result) throw new Error("Remote-target activation is unavailable.");
+  return result;
+}
+
+export async function compensateRemoteTargetActivation(
+  sessionId: string,
+): Promise<{
+  status: "denied" | "revoked";
+  alreadyCompensated: boolean;
+}> {
+  const result = await invokeDesktopBridgeRequest<{
+    sessionId: string;
+    status: "denied" | "revoked";
+    alreadyCompensated: boolean;
+  }>({
+    rpcMethod: "remoteTargetCompensateActivation",
+    ipcChannel: "remoteTarget:compensateActivation",
+    params: { sessionId },
+  });
+  if (!result)
+    throw new Error("Remote-target activation compensation is unavailable.");
+  return result;
+}
+
+export async function commitRemoteTargetActivation(
+  sessionId: string,
+): Promise<{ status: "active"; alreadyCommitted: boolean }> {
+  const result = await invokeDesktopBridgeRequest<{
+    sessionId: string;
+    status: "active";
+    alreadyCommitted: boolean;
+  }>({
+    rpcMethod: "remoteTargetCommitActivation",
+    ipcChannel: "remoteTarget:commitActivation",
+    params: { sessionId },
+  });
+  if (!result)
+    throw new Error("Remote-target activation commit is unavailable.");
   return result;
 }
 

--- a/packages/ui/src/platform/runtime-management.ts
+++ b/packages/ui/src/platform/runtime-management.ts
@@ -331,6 +331,13 @@ async function execute(
         : {}),
       code: requiredString(request.code, "code"),
     });
+    if (result.status !== "active") {
+      throw new Error(
+        result.status === "commit_required"
+          ? `Local activation is staged and Cloud commit must be retried for session ${result.sessionId}.`
+          : `Local activation failed and Cloud rollback must be retried for session ${result.sessionId}.`,
+      );
+    }
     await startRemoteTarget();
     return { controllerDisplayName: result.controllerDisplayName };
   }


### PR DESCRIPTION
Stacked correction for #25427 after #25526 was absorbed into its draft parent.

Exact stack
- Parent head: `b1f32cdebbc02c4142f2d46a9abc2e318c77715d`
- Corrective head: `e0d442ace15707e570cba33a00adcaf92c6ea012`
- Base branch: `fix/linux-cef-devices-runtimes-parity`

Correction
- Introduces an explicit Cloud lifecycle `pending -> activating -> active`. Consuming the one-use pairing code now creates only a non-authoritative `activating` row.
- Persists the exact grant locally as `staged` before an authenticated, exact-session `PUT` commits Cloud authority. Staged grants cannot claim or execute commands and are excluded from active status.
- Makes commit idempotent under the host/session lock order. Response loss and process exit after Cloud commit recover by replaying the exact commit, then durably marking the local grant active.
- Makes pre-commit local failure compensate only the non-authoritative `activating` row. Compensation is exact-session, authenticated, idempotent, and serialized with commit and host finalization.
- Retries transient staged commits on the bounded polling lifecycle without blocking existing active sessions. Offline state remains visible; terminal 404/409/410 responses fence the staged journal entry.
- Includes `activating` in expiry, listing, owner revocation, and host finalization while preserving the relay's existing `status = active` data-plane gate.
- Adds typed desktop retry results/RPCs and renderer contracts for compensation-required and commit-required states.
- Drops the older auth/confirmation commits from this diff because #25551 is already integrated into the exact parent.

Pinned validation (Bun 1.3.14 / Node 24.15.0)
- Canonical app-core Vitest command: 2 discovered files, 42/42 passed. This covers local failure, compensation failure, commit retry, both process-crash windows, replay/idempotency, concurrent finalization, and offline-to-online poll recovery.
- Same-host integration also passed independently; the combined root Vitest invocation reported 3 files, 43/43 passed.
- Cloud relay routes: 20/20 passed.
- Migration lifecycle: 5/5 passed, including idempotent CHECK widening for `activating`.
- Real PGlite repository: all 17 assertions passed, including pre-commit command denial, idempotent commit, wrong bearer, commit/finalization serialization, and compensation/finalization serialization. Bun's repository-wide coverage reporter did not terminate promptly after the assertions and was bounded rather than treated as a clean lane exit.
- Biome: all 17 TypeScript files in the corrective diff clean.
- `git diff --check`: clean.
- Cloud shared/API typechecks have no corrective-source diagnostics. They remain baseline-blocked by `packages/shared/src/speaker-name-inference.ts`; Cloud API also lacks the built `@elizaos/plugin-doordash` declaration. App-core/UI typechecks remain blocked by the same baseline plus missing built workspace/native declarations and existing unrelated agent/app errors.

Evidence boundary
This correction does not claim the physical/deployed evidence still required by #25427: physical GNOME/Wayland package installation, real Secret Service behavior, deployed relay, second-machine SSH/WAN, signed-device, or supported Headscale evidence. The parent remains draft and must not merge until those gates are captured and reviewed.
