### PR TITLE
fix(devices): authenticate runtime callbacks and bind consent

### DIFF
--- a/packages/agent/src/api/runtime-management-routes.test.ts
+++ b/packages/agent/src/api/runtime-management-routes.test.ts
@@ -46,6 +46,24 @@ afterEach(() => {
 });
 
 describe("POST /api/runtime/manage", () => {
+  it.each(["/api/runtime/manage/claim", "/api/runtime/manage/result"])(
+    "rejects unauthenticated shell callbacks at %s",
+    async (pathname) => {
+      const request = makeContext("POST", pathname, {
+        requestId: "request-1",
+        claimToken: "claim-1",
+      });
+      request.ctx.callerAuthorization = { ok: false, role: "GUEST" };
+      await handleRuntimeManagementRoutes(request.ctx);
+      expect(request.error).toHaveBeenCalledWith(
+        expect.anything(),
+        "Runtime management authentication required.",
+        401,
+      );
+      expect(request.json).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects authenticated non-owner callers before shell delivery", async () => {
     const request = makeContext("POST", "/api/runtime/manage", { op: "list" });
     request.ctx.callerAuthorization = { ok: true, role: "USER" };

--- a/packages/ui/src/state/startup-phase-hydrate.switch.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.switch.test.ts
@@ -8,6 +8,7 @@
 // fetch (the result callback transport) are doubled.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
 import { shellLocalStorage } from "../surface-realm-channel";
 import { addAgentProfile } from "./agent-profiles";
 import { bindReadyPhase, type ReadyPhaseDeps } from "./startup-phase-hydrate";
@@ -268,6 +269,9 @@ describe("bindReadyPhase shell:manage-runtime handler", () => {
     clientMock.handlers.clear();
     executeRuntimeManagementCommand.mockClear();
     setActionNotice.mockClear();
+    setBootConfig({ branding: {}, apiToken: "runtime-owner-token" });
+    // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API.
+    document.cookie = "eliza_csrf=runtime-csrf-token; path=/";
   });
 
   it("claims before executing and reports the exact result", async () => {
@@ -296,6 +300,12 @@ describe("bindReadyPhase shell:manage-runtime handler", () => {
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
       "/api/runtime/manage/claim",
     );
+    for (const [, init] of fetchMock.mock.calls as [string, RequestInit][]) {
+      const headers = new Headers(init.headers);
+      expect(headers.get("authorization")).toBe("Bearer runtime-owner-token");
+      expect(headers.get("x-eliza-csrf")).toBe("runtime-csrf-token");
+      expect(init.credentials).toBe("include");
+    }
     expect(executeRuntimeManagementCommand).toHaveBeenCalledWith({
       op: "inspect_ssh",
       target: "user@host",
@@ -329,6 +339,26 @@ describe("bindReadyPhase shell:manage-runtime handler", () => {
       request: { op: "revoke", targetId: "host:mac" },
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(executeRuntimeManagementCommand).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("does not execute when the authenticated claim is rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+    clientMock.handlers.get("shell:manage-runtime")?.({
+      requestId: "request-auth-rejected",
+      request: { op: "remove", runtimeId: "vps-1" },
+    });
+    await vi.waitFor(() =>
+      expect(setActionNotice).toHaveBeenCalledWith(
+        expect.stringContaining("could not claim"),
+        "error",
+      ),
+    );
     expect(executeRuntimeManagementCommand).not.toHaveBeenCalled();
     cleanup();
   });

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -24,6 +24,7 @@ import {
   type StreamEventEnvelope,
 } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
+import { fetchWithCsrf } from "../api/csrf-client";
 import { mapServerTasksToSessions } from "../chat/coding-agent-session-state";
 import { dispatchCompletedActionNavigation } from "../completed-action-navigation";
 import { prefetchAppsCatalog } from "../components/apps/load-apps-catalog";
@@ -639,7 +640,7 @@ export function bindReadyPhase(
         typeof client.getBaseUrl === "function" ? client.getBaseUrl() : "";
 
       void (async () => {
-        const claimResponse = await fetch(
+        const claimResponse = await fetchWithCsrf(
           `${originBase}/api/runtime/manage/claim`,
           {
             method: "POST",
@@ -675,7 +676,7 @@ export function bindReadyPhase(
                 : "The runtime operation failed before it could start.",
           };
         }
-        const resultResponse = await fetch(
+        const resultResponse = await fetchWithCsrf(
           `${originBase}/api/runtime/manage/result`,
           {
             method: "POST",

--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.test.ts
@@ -1,0 +1,43 @@
+/** Adversarial coverage for fail-closed runtime mutation confirmation. */
+
+import { describe, expect, it } from "vitest";
+import { isUnambiguousRuntimeConfirmation } from "./runtime-management-confirmation.ts";
+
+describe("runtime mutation confirmation", () => {
+	it.each([
+		"No, don't do it",
+		"Yes, but do not proceed",
+		"I did not confirm",
+		"Never revoke it",
+		"Confirm after I check",
+		"Wait, yes",
+		"Don't stop host",
+		"Yes, confirm tomorrow",
+	])("rejects negated or ambiguous text: %s", (text) => {
+		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(false);
+	});
+
+	it.each([
+		"confirm the revocation",
+		"yes, confirm revoke",
+		"proceed with the revocation",
+	])("accepts an unambiguous complete confirmation: %s", (text) => {
+		expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(true);
+	});
+
+	it.each(["yes", "Yes, please", "confirm", "proceed", "go ahead", "do it"])(
+		"rejects generic approval that is not bound to the requested operation: %s",
+		(text) => {
+			expect(isUnambiguousRuntimeConfirmation(text, "revoke")).toBe(false);
+		},
+	);
+
+	it("binds subject-bearing confirmation to the requested operation", () => {
+		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "pair")).toBe(
+			true,
+		);
+		expect(isUnambiguousRuntimeConfirmation("confirm pairing", "revoke")).toBe(
+			false,
+		);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management-confirmation.ts
@@ -1,0 +1,53 @@
+/** Parses the fail-closed user confirmation required by runtime mutations. */
+
+import type { RuntimeManagementOperation } from "@elizaos/shared";
+
+export type ConfirmedRuntimeOperation = Exclude<
+	RuntimeManagementOperation,
+	"list" | "inspect_ssh"
+>;
+
+const CONFIRMATION_SUBJECTS: Record<
+	ConfirmedRuntimeOperation,
+	readonly string[]
+> = {
+	pair: ["pair", "pairing"],
+	revoke: ["revoke", "revocation"],
+	remove: ["remove", "removal", "remove it", "removing it"],
+	retry: ["retry"],
+	connect_ssh: ["connect ssh", "ssh connection"],
+	add_direct: ["add direct runtime", "direct runtime"],
+	enroll_host: ["enroll host", "host enrollment"],
+	approve_pairing: ["approve pairing", "pairing approval"],
+	start_host: ["start host", "host start"],
+	stop_host: ["stop host", "host stop"],
+	revoke_host: ["revoke host", "host revocation"],
+};
+
+export function isUnambiguousRuntimeConfirmation(
+	value: string,
+	op: ConfirmedRuntimeOperation,
+): boolean {
+	const text = value.toLowerCase().replace(/[’']/g, "'").trim();
+	if (
+		/\b(?:no|not|never|cancel|wait|hold|don't|dont|cannot|can't|cant|won't|wont)\b/.test(
+			text,
+		) ||
+		/\b(?:but|however|except|unless|after|before|later|tomorrow)\b/.test(text)
+	) {
+		return false;
+	}
+	const normalized = text
+		.replace(/[^a-z0-9]+/g, " ")
+		.trim()
+		.replace(/\s+/g, " ");
+	return CONFIRMATION_SUBJECTS[op].some(
+		(subject) =>
+			normalized === `confirm ${subject}` ||
+			normalized === `confirm the ${subject}` ||
+			normalized === `yes confirm ${subject}` ||
+			normalized === `yes confirm the ${subject}` ||
+			normalized === `proceed with ${subject}` ||
+			normalized === `proceed with the ${subject}`,
+	);
+}

--- a/plugins/plugin-app-control/src/actions/runtime-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.test.ts
@@ -88,6 +88,12 @@ describe("RUNTIMES action", () => {
 		"Can you confirm the runtime status?",
 		"I don't confirm removing it.",
 		"No, do not proceed.",
+		"No, don't do it",
+		"Yes, but do not proceed",
+		"I did not confirm",
+		"Never revoke it",
+		"Confirm after I check",
+		"Wait, yes",
 	])("rejects non-authorizing confirmation language: %s", async (text) => {
 		const manageRuntime = vi.fn();
 		const action = createRuntimeManagementAction({ manageRuntime });
@@ -105,6 +111,49 @@ describe("RUNTIMES action", () => {
 		expect(result?.success).toBe(false);
 		expect(manageRuntime).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		"confirm the removal",
+		"yes, confirm remove",
+		"proceed with the removal",
+	])("accepts exact operation-bound confirmation: %s", async (text) => {
+		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+			ok: true,
+			op: request.op,
+		}));
+		const action = createRuntimeManagementAction({ manageRuntime });
+		const result = await action.handler(
+			runtime,
+			{ content: { text } } as Memory,
+			undefined,
+			{ op: "remove", runtimeId: "runtime-1", confirm: "true" },
+			callback(),
+		);
+		expect(result?.success).toBe(true);
+		expect(manageRuntime).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(["yes", "Yes, please", "confirm", "proceed", "go ahead", "do it"])(
+		"rejects generic approval that is not bound to the requested operation: %s",
+		async (text) => {
+			const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({
+				ok: true,
+				op: request.op,
+			}));
+			const action = createRuntimeManagementAction({ manageRuntime });
+			const result = await action.handler(
+				runtime,
+				{ content: { text } } as Memory,
+				undefined,
+				{ op: "remove", runtimeId: "runtime-1", confirm: "true" },
+				callback(),
+			);
+			expect(result?.values).toEqual(
+				expect.objectContaining({ awaitingConfirmation: true }),
+			);
+			expect(manageRuntime).not.toHaveBeenCalled();
+		},
+	);
 
 	it("dispatches a confirmed pairing and narrates the one-use receipt", async () => {
 		const manageRuntime: RuntimeManagementFn = vi.fn(async (request) => ({

--- a/plugins/plugin-app-control/src/actions/runtime-management.ts
+++ b/plugins/plugin-app-control/src/actions/runtime-management.ts
@@ -21,6 +21,10 @@ import {
 	readStringOption,
 	userRequestMessageText,
 } from "../params.js";
+import {
+	type ConfirmedRuntimeOperation,
+	isUnambiguousRuntimeConfirmation,
+} from "./runtime-management-confirmation.js";
 import { readViewInteractionClientId } from "./view-delivery.js";
 import { createViewsRequestHeaders } from "./views-request-auth.js";
 
@@ -39,6 +43,12 @@ const CONFIRMATION_REQUIRED: ReadonlySet<RuntimeManagementRequest["op"]> =
 			(op) => op !== "list" && op !== "inspect_ssh",
 		),
 	);
+
+function requiresConfirmation(
+	op: RuntimeManagementRequest["op"],
+): op is ConfirmedRuntimeOperation {
+	return CONFIRMATION_REQUIRED.has(op);
+}
 
 const SECRET_OPTION_NAMES = new Set([
 	"accesstoken",
@@ -101,18 +111,6 @@ export function parseRuntimeManagementRequest(
 		sessionId: readStringOption(options, "sessionId") ?? undefined,
 		code: readStringOption(options, "code") ?? undefined,
 	};
-}
-
-function userExplicitlyConfirmed(message: Memory): boolean {
-	const text = userRequestMessageText(message).trim();
-	if (
-		/\b(?:cancel|decline|do not|don't|dont|never|no|refuse|stop)\b/i.test(text)
-	) {
-		return false;
-	}
-	return /^(?:please\s+)?(?:confirm(?:ed)?|yes|yep|proceed|do it|go ahead)(?:\b|[.!])/i.test(
-		text,
-	);
 }
 
 async function defaultManageRuntime(
@@ -338,8 +336,12 @@ export function createRuntimeManagementAction(
 			}
 			const normalized = normalizeActionOptions(options) ?? {};
 			if (
-				CONFIRMATION_REQUIRED.has(request.op) &&
-				(!isConfirmed(normalized) || !userExplicitlyConfirmed(message))
+				requiresConfirmation(request.op) &&
+				(!isConfirmed(normalized) ||
+					!isUnambiguousRuntimeConfirmation(
+						userRequestMessageText(message),
+						request.op,
+					))
 			) {
 				const reply = `Please confirm before I run the ${request.op} Devices & Runtimes operation.`;
 				await callback?.({ text: reply });


### PR DESCRIPTION
## Summary

Stacked correction for #25427 at parent `6596473a8abd5862bc7ac3dfc6d47f5e105c0d6c`.

- routes the renderer's runtime-operation claim and result callbacks through the canonical authenticated/CSRF/platform transport instead of raw `fetch`
- proves both callback requests carry the configured owner bearer token, CSRF mirror, and included credentials
- proves an authenticated claim rejection fails closed before any local runtime operation executes
- requires mutation confirmation to name the exact runtime operation; generic `yes`, `confirm`, `proceed`, `go ahead`, and mixed/negated phrases no longer authorize a planner-selected mutation
- preserves read-only `list` and `inspect_ssh` behavior and does not change #24829's two-phase activation scope

## Validation

Pinned Bun 1.3.14 and Node 24.15.0:

- `plugins/plugin-app-control`: focused Vitest, 45/45 passed
- `packages/ui`: focused startup transport Vitest, 12/12 passed
- `packages/agent`: focused route assertions, 8/8 passed; Bun then hit its repository-wide coverage reporter `WriteFailed` after all assertions completed
- Biome check on all seven touched files: passed
- `git diff --check`: passed

Package typechecks were run and remain blocked by existing parent/worktree failures outside this patch (missing generated workspace exports/modules plus unrelated existing test/type errors). No typecheck diagnostic points at a touched file.

## Evidence boundaries

This is transport and pure-parser hardening with no rendered UI change, so visual evidence is N/A. It does not claim native, deployed, or live-device evidence; all external evidence holds on #25427 remain in force.
